### PR TITLE
Revert "Do not call eth_chainId for other than ETH networks (#11998)"

### DIFF
--- a/android/java/org/chromium/chrome/browser/settings/BraveWalletAddNetworksFragment.java
+++ b/android/java/org/chromium/chrome/browser/settings/BraveWalletAddNetworksFragment.java
@@ -283,7 +283,7 @@ public class BraveWalletAddNetworksFragment extends Fragment implements Connecti
 
     private void addEthereumChain(EthereumChain chain) {
         assert mJsonRpcService != null;
-        mJsonRpcService.addCustomChain(chain, (chainId, error, errorMessage) -> {
+        mJsonRpcService.addEthereumChain(chain, (chainId, error, errorMessage) -> {
             if (error != ProviderError.SUCCESS) {
                 return;
             }

--- a/browser/ui/webui/settings/brave_wallet_handler.cc
+++ b/browser/ui/webui/settings/brave_wallet_handler.cc
@@ -117,7 +117,7 @@ void BraveWalletHandler::GetCustomNetworksList(
   ResolveJavascriptCallback(args[0], base::Value(json_string));
 }
 
-void BraveWalletHandler::OnAddCustomChain(
+void BraveWalletHandler::OnAddEthereumChain(
     base::Value javascript_callback,
     const std::string& chain_id,
     brave_wallet::mojom::ProviderError error,
@@ -141,9 +141,9 @@ void BraveWalletHandler::AddEthereumChain(base::Value::ConstListView args) {
 
   auto chain = GetEthereumChain(args[1].GetString(), &error_message);
   if (chain && json_rpc_service) {
-    json_rpc_service->AddCustomChain(
+    json_rpc_service->AddEthereumChain(
         chain->Clone(),
-        base::BindOnce(&BraveWalletHandler::OnAddCustomChain,
+        base::BindOnce(&BraveWalletHandler::OnAddEthereumChain,
                        weak_ptr_factory_.GetWeakPtr(), args[0].Clone()));
     return;
   }

--- a/browser/ui/webui/settings/brave_wallet_handler.h
+++ b/browser/ui/webui/settings/brave_wallet_handler.h
@@ -42,10 +42,10 @@ class BraveWalletHandler : public settings::SettingsPageUIHandler {
   BraveWalletHandler(const BraveWalletHandler&) = delete;
   BraveWalletHandler& operator=(const BraveWalletHandler&) = delete;
 
-  void OnAddCustomChain(base::Value javascript_callback,
-                        const std::string& chain_id,
-                        brave_wallet::mojom::ProviderError error,
-                        const std::string& error_message);
+  void OnAddEthereumChain(base::Value javascript_callback,
+                          const std::string& chain_id,
+                          brave_wallet::mojom::ProviderError error,
+                          const std::string& error_message);
   base::OnceClosure chain_callback_for_testing_;
   base::WeakPtrFactory<BraveWalletHandler> weak_ptr_factory_{this};
 };

--- a/browser/ui/webui/settings/brave_wallet_handler_unittest.cc
+++ b/browser/ui/webui/settings/brave_wallet_handler_unittest.cc
@@ -131,13 +131,13 @@ TEST(TestBraveWalletHandler, RemoveEthereumChain) {
   std::vector<base::Value> values;
   brave_wallet::mojom::EthereumChain chain1(
       "chain_id", "chain_name", {"https://url1.com"}, {"https://url1.com"},
-      {"https://url1.com"}, "symbol_name", "symbol", 0, false);
+      {"https://url1.com"}, "symbol_name", "symbol", 11, false);
   auto chain_ptr1 = chain1.Clone();
   values.push_back(brave_wallet::EthereumChainToValue(chain_ptr1));
 
   brave_wallet::mojom::EthereumChain chain2(
       "chain_id2", "chain_name2", {"https://url2.com"}, {"https://url2.com"},
-      {"https://url2.com"}, "symbol_name2", "symbol2", 60, true);
+      {"https://url2.com"}, "symbol_name2", "symbol2", 22, true);
   auto chain_ptr2 = chain2.Clone();
   values.push_back(brave_wallet::EthereumChainToValue(chain_ptr2));
   UpdateCustomNetworks(handler.prefs(), &values);
@@ -167,7 +167,7 @@ TEST(TestBraveWalletHandler, AddEthereumChain) {
   TestBraveWalletHandler handler;
   brave_wallet::mojom::EthereumChain chain1(
       "0x999", "chain_name", {"https://url1.com"}, {"https://url1.com"},
-      {"https://url1.com"}, "symbol", "symbol_name", 0, false);
+      {"https://url1.com"}, "symbol", "symbol_name", 11, false);
   auto chain_ptr1 = chain1.Clone();
 
   {
@@ -206,7 +206,7 @@ TEST(TestBraveWalletHandler, AddEthereumChain) {
   EXPECT_EQ(*asset_list[0].FindStringKey("symbol"), "symbol");
   EXPECT_EQ(*asset_list[0].FindBoolKey("is_erc20"), false);
   EXPECT_EQ(*asset_list[0].FindBoolKey("is_erc721"), false);
-  EXPECT_EQ(*asset_list[0].FindIntKey("decimals"), 0);
+  EXPECT_EQ(*asset_list[0].FindIntKey("decimals"), 11);
   EXPECT_EQ(*asset_list[0].FindStringKey("logo"), "https://url1.com");
   EXPECT_EQ(*asset_list[0].FindBoolKey("visible"), true);
 
@@ -236,7 +236,7 @@ TEST(TestBraveWalletHandler, AddEthereumChainWrongNetwork) {
   TestBraveWalletHandler handler;
   brave_wallet::mojom::EthereumChain chain1(
       "0x999", "chain_name", {"https://url1.com"}, {"https://url2.com"},
-      {"https://url3.com"}, "symbol", "symbol_name", 0, false);
+      {"https://url3.com"}, "symbol", "symbol_name", 11, false);
   auto chain_ptr1 = chain1.Clone();
 
   {
@@ -315,13 +315,13 @@ TEST(TestBraveWalletHandler, GetNetworkList) {
   std::vector<base::Value> values;
   brave_wallet::mojom::EthereumChain chain1(
       "chain_id", "chain_name", {"https://url1.com"}, {"https://url1.com"},
-      {"https://url1.com"}, "symbol_name", "symbol", 0, false);
+      {"https://url1.com"}, "symbol_name", "symbol", 11, false);
   auto chain_ptr1 = chain1.Clone();
   values.push_back(brave_wallet::EthereumChainToValue(chain_ptr1));
 
   brave_wallet::mojom::EthereumChain chain2(
       "chain_id2", "chain_name2", {"https://url2.com"}, {"https://url2.com"},
-      {"https://url2.com"}, "symbol_name2", "symbol2", 60, true);
+      {"https://url2.com"}, "symbol_name2", "symbol2", 22, true);
   auto chain_ptr2 = chain2.Clone();
   values.push_back(brave_wallet::EthereumChainToValue(chain_ptr2));
   UpdateCustomNetworks(handler.prefs(), &values);
@@ -357,13 +357,13 @@ TEST(TestBraveWalletHandler, SetActiveNetwork) {
   std::vector<base::Value> values;
   brave_wallet::mojom::EthereumChain chain1(
       "chain_id", "chain_name", {"https://url1.com"}, {"https://url1.com"},
-      {"https://url1.com"}, "symbol_name", "symbol", 60, false);
+      {"https://url1.com"}, "symbol_name", "symbol", 11, false);
   auto chain_ptr1 = chain1.Clone();
   values.push_back(brave_wallet::EthereumChainToValue(chain_ptr1));
 
   brave_wallet::mojom::EthereumChain chain2(
       "chain_id2", "chain_name2", {"https://url2.com"}, {"https://url2.com"},
-      {"https://url2.com"}, "symbol_name2", "symbol2", 0, true);
+      {"https://url2.com"}, "symbol_name2", "symbol2", 22, true);
   auto chain_ptr2 = chain2.Clone();
   values.push_back(brave_wallet::EthereumChainToValue(chain_ptr2));
   UpdateCustomNetworks(handler.prefs(), &values);

--- a/components/brave_wallet/browser/json_rpc_service.cc
+++ b/components/brave_wallet/browser/json_rpc_service.cc
@@ -91,11 +91,6 @@ bool IsChainExist(PrefService* prefs, const std::string& chain_id) {
   return false;
 }
 
-bool ShouldValidateEthereumChain(int32_t decimals) {
-  return !decimals ||  // By default we assume user adds Eth network
-         decimals == static_cast<int32_t>(brave_wallet::mojom::CoinType::ETH);
-}
-
 }  // namespace
 
 namespace brave_wallet {
@@ -201,8 +196,8 @@ void JsonRpcService::GetPendingChainRequests(
   std::move(callback).Run(std::move(all_chains));
 }
 
-void JsonRpcService::AddCustomChain(mojom::EthereumChainPtr chain,
-                                    AddCustomChainCallback callback) {
+void JsonRpcService::AddEthereumChain(mojom::EthereumChainPtr chain,
+                                      AddEthereumChainCallback callback) {
   auto chain_id = chain->chain_id;
   auto url = chain->rpc_urls.size() ? GURL(chain->rpc_urls.front()) : GURL();
   if (!url.is_valid()) {
@@ -219,22 +214,18 @@ void JsonRpcService::AddCustomChain(mojom::EthereumChainPtr chain,
         l10n_util::GetStringUTF8(IDS_SETTINGS_WALLET_NETWORKS_EXISTS));
     return;
   }
-  bool run_validation = ShouldValidateEthereumChain(chain->decimals);
-  auto result = base::BindOnce(&JsonRpcService::OnCustomChainIdValidated,
+
+  auto result = base::BindOnce(&JsonRpcService::OnEthChainIdValidated,
                                weak_ptr_factory_.GetWeakPtr(), std::move(chain),
                                std::move(callback));
-  if (run_validation) {
-    RequestInternal(eth::eth_chainId(), true, url,
-                    base::BindOnce(&ChainIdValidationResponse,
-                                   std::move(result), chain_id));
-  } else {
-    std::move(result).Run(true);
-  }
+  RequestInternal(
+      eth::eth_chainId(), true, url,
+      base::BindOnce(&ChainIdValidationResponse, std::move(result), chain_id));
 }
 
-void JsonRpcService::OnCustomChainIdValidated(mojom::EthereumChainPtr chain,
-                                              AddCustomChainCallback callback,
-                                              bool success) {
+void JsonRpcService::OnEthChainIdValidated(mojom::EthereumChainPtr chain,
+                                           AddEthereumChainCallback callback,
+                                           bool success) {
   if (!success) {
     std::move(callback).Run(
         chain->chain_id, mojom::ProviderError::kUserRejectedRequest,
@@ -275,18 +266,14 @@ void JsonRpcService::AddEthereumChainForOrigin(
                                   base::ASCIIToUTF16(chain->rpc_urls.front())));
     return;
   }
-  bool run_validation = ShouldValidateEthereumChain(chain->decimals);
+
   auto result = base::BindOnce(&JsonRpcService::OnEthChainIdValidatedForOrigin,
                                weak_ptr_factory_.GetWeakPtr(), std::move(chain),
                                origin, std::move(callback));
 
-  if (run_validation) {
-    RequestInternal(eth::eth_chainId(), true, url,
-                    base::BindOnce(&ChainIdValidationResponse,
-                                   std::move(result), chain_id));
-  } else {
-    std::move(result).Run(true);
-  }
+  RequestInternal(
+      eth::eth_chainId(), true, url,
+      base::BindOnce(&ChainIdValidationResponse, std::move(result), chain_id));
 }
 
 void JsonRpcService::OnEthChainIdValidatedForOrigin(

--- a/components/brave_wallet/browser/json_rpc_service.h
+++ b/components/brave_wallet/browser/json_rpc_service.h
@@ -127,8 +127,8 @@ class JsonRpcService : public KeyedService, public mojom::JsonRpcService {
   void SetNetwork(const std::string& chain_id,
                   SetNetworkCallback callback) override;
   void GetNetwork(GetNetworkCallback callback) override;
-  void AddCustomChain(mojom::EthereumChainPtr chain,
-                      AddCustomChainCallback callback) override;
+  void AddEthereumChain(mojom::EthereumChainPtr chain,
+                        AddEthereumChainCallback callback) override;
   void AddEthereumChainForOrigin(
       mojom::EthereumChainPtr chain,
       const GURL& origin,
@@ -348,9 +348,9 @@ class JsonRpcService : public KeyedService, public mojom::JsonRpcService {
       AddEthereumChainForOriginCallback callback,
       bool success);
 
-  void OnCustomChainIdValidated(mojom::EthereumChainPtr chain,
-                                AddCustomChainCallback callback,
-                                bool success);
+  void OnEthChainIdValidated(mojom::EthereumChainPtr chain,
+                             AddEthereumChainCallback callback,
+                             bool success);
 
   FRIEND_TEST_ALL_PREFIXES(JsonRpcServiceUnitTest, IsValidDomain);
   FRIEND_TEST_ALL_PREFIXES(JsonRpcServiceUnitTest, Reset);

--- a/components/brave_wallet/browser/json_rpc_service_unittest.cc
+++ b/components/brave_wallet/browser/json_rpc_service_unittest.cc
@@ -494,13 +494,13 @@ TEST_F(JsonRpcServiceUnitTest, SetCustomNetwork) {
   std::vector<base::Value> values;
   brave_wallet::mojom::EthereumChain chain1(
       "chain_id", "chain_name", {"https://url1.com"}, {"https://url1.com"},
-      {"https://url1.com"}, "symbol_name", "symbol", 0, false);
+      {"https://url1.com"}, "symbol_name", "symbol", 11, false);
   auto chain_ptr1 = chain1.Clone();
   values.push_back(brave_wallet::EthereumChainToValue(chain_ptr1));
 
   brave_wallet::mojom::EthereumChain chain2(
       "chain_id2", "chain_name2", {"https://url2.com"}, {"https://url2.com"},
-      {"https://url2.com"}, "symbol_name2", "symbol2", 60, true);
+      {"https://url2.com"}, "symbol_name2", "symbol2", 22, true);
   auto chain_ptr2 = chain2.Clone();
   values.push_back(brave_wallet::EthereumChainToValue(chain_ptr2));
   UpdateCustomNetworks(prefs(), &values);
@@ -530,13 +530,13 @@ TEST_F(JsonRpcServiceUnitTest, GetAllNetworks) {
   std::vector<base::Value> values;
   brave_wallet::mojom::EthereumChain chain1(
       "chain_id", "chain_name", {"https://url1.com"}, {"https://url1.com"},
-      {"https://url1.com"}, "symbol_name", "symbol", 0, false);
+      {"https://url1.com"}, "symbol_name", "symbol", 11, false);
   auto chain_ptr1 = chain1.Clone();
   values.push_back(brave_wallet::EthereumChainToValue(chain_ptr1));
 
   brave_wallet::mojom::EthereumChain chain2(
       "chain_id2", "chain_name2", {"https://url2.com"}, {"https://url2.com"},
-      {"https://url2.com"}, "symbol_name2", "symbol2", 60, true);
+      {"https://url2.com"}, "symbol_name2", "symbol2", 22, true);
   auto chain_ptr2 = chain2.Clone();
   values.push_back(brave_wallet::EthereumChainToValue(chain_ptr2));
   UpdateCustomNetworks(prefs(), &values);
@@ -646,80 +646,16 @@ TEST_F(JsonRpcServiceUnitTest, EnsGetEthAddr) {
   EXPECT_TRUE(callback_called);
 }
 
-TEST_F(JsonRpcServiceUnitTest, AddFilecoinChainApproved) {
-  brave_wallet::mojom::EthereumChain chain(
-      "0x461", "Ganache", {"https://url1.com"}, {"https://url1.com"},
-      {"https://url1.com"}, "FIL", "Filecoin", 461, false);
-
-  bool callback_is_called = false;
-  mojom::ProviderError expected = mojom::ProviderError::kSuccess;
-  ASSERT_FALSE(brave_wallet::GetNetworkURL(prefs(), "0x461").is_valid());
-  json_rpc_service_->AddCustomChain(
-      chain.Clone(),
-      base::BindLambdaForTesting(
-          [&callback_is_called, &expected](const std::string& chain_id,
-                                           mojom::ProviderError error,
-                                           const std::string& error_message) {
-            ASSERT_FALSE(chain_id.empty());
-            EXPECT_EQ(error, expected);
-            ASSERT_TRUE(error_message.empty());
-            callback_is_called = true;
-          }));
-  base::RunLoop().RunUntilIdle();
-
-  bool failed_callback_is_called = false;
-  mojom::ProviderError expected_error =
-      mojom::ProviderError::kUserRejectedRequest;
-  json_rpc_service_->AddCustomChain(
-      chain.Clone(),
-      base::BindLambdaForTesting([&failed_callback_is_called, &expected_error](
-                                     const std::string& chain_id,
-                                     mojom::ProviderError error,
-                                     const std::string& error_message) {
-        ASSERT_FALSE(chain_id.empty());
-        EXPECT_EQ(error, expected_error);
-        ASSERT_FALSE(error_message.empty());
-        failed_callback_is_called = true;
-      }));
-  base::RunLoop().RunUntilIdle();
-  ASSERT_TRUE(failed_callback_is_called);
-
-  ASSERT_TRUE(callback_is_called);
-  ASSERT_TRUE(brave_wallet::GetNetworkURL(prefs(), "0x461").is_valid());
-
-  // Prefs should be updated.
-  std::vector<brave_wallet::mojom::EthereumChainPtr> custom_chains;
-  GetAllCustomChains(prefs(), &custom_chains);
-  ASSERT_EQ(custom_chains.size(), 1u);
-  EXPECT_EQ(custom_chains[0], chain.Clone());
-
-  const base::DictionaryValue* assets_pref =
-      prefs()->GetDictionary(kBraveWalletUserAssets);
-  const base::Value* list = assets_pref->FindKey("0x461");
-  ASSERT_TRUE(list->is_list());
-  base::Value::ConstListView asset_list = list->GetList();
-  ASSERT_EQ(asset_list.size(), 1u);
-
-  EXPECT_EQ(*asset_list[0].FindStringKey("contract_address"), "");
-  EXPECT_EQ(*asset_list[0].FindStringKey("name"), "Filecoin");
-  EXPECT_EQ(*asset_list[0].FindStringKey("symbol"), "FIL");
-  EXPECT_EQ(*asset_list[0].FindBoolKey("is_erc20"), false);
-  EXPECT_EQ(*asset_list[0].FindBoolKey("is_erc721"), false);
-  EXPECT_EQ(*asset_list[0].FindIntKey("decimals"), 461);
-  EXPECT_EQ(*asset_list[0].FindStringKey("logo"), "https://url1.com");
-  EXPECT_EQ(*asset_list[0].FindBoolKey("visible"), true);
-}
-
 TEST_F(JsonRpcServiceUnitTest, AddEthereumChainApproved) {
   brave_wallet::mojom::EthereumChain chain(
       "0x111", "chain_name", {"https://url1.com"}, {"https://url1.com"},
-      {"https://url1.com"}, "symbol", "symbol_name", 0, false);
+      {"https://url1.com"}, "symbol", "symbol_name", 11, false);
 
   bool callback_is_called = false;
   mojom::ProviderError expected = mojom::ProviderError::kSuccess;
   ASSERT_FALSE(brave_wallet::GetNetworkURL(prefs(), "0x111").is_valid());
   SetEthChainIdInterceptor(chain.rpc_urls.front(), "0x111");
-  json_rpc_service_->AddCustomChain(
+  json_rpc_service_->AddEthereumChain(
       chain.Clone(),
       base::BindLambdaForTesting(
           [&callback_is_called, &expected](const std::string& chain_id,
@@ -735,7 +671,7 @@ TEST_F(JsonRpcServiceUnitTest, AddEthereumChainApproved) {
   bool failed_callback_is_called = false;
   mojom::ProviderError expected_error =
       mojom::ProviderError::kUserRejectedRequest;
-  json_rpc_service_->AddCustomChain(
+  json_rpc_service_->AddEthereumChain(
       chain.Clone(),
       base::BindLambdaForTesting([&failed_callback_is_called, &expected_error](
                                      const std::string& chain_id,
@@ -772,7 +708,7 @@ TEST_F(JsonRpcServiceUnitTest, AddEthereumChainApproved) {
   EXPECT_EQ(*asset_list[0].FindStringKey("symbol"), "symbol");
   EXPECT_EQ(*asset_list[0].FindBoolKey("is_erc20"), false);
   EXPECT_EQ(*asset_list[0].FindBoolKey("is_erc721"), false);
-  EXPECT_EQ(*asset_list[0].FindIntKey("decimals"), 0);
+  EXPECT_EQ(*asset_list[0].FindIntKey("decimals"), 11);
   EXPECT_EQ(*asset_list[0].FindStringKey("logo"), "https://url1.com");
   EXPECT_EQ(*asset_list[0].FindBoolKey("visible"), true);
 
@@ -784,7 +720,7 @@ TEST_F(JsonRpcServiceUnitTest, AddEthereumChainApproved) {
 TEST_F(JsonRpcServiceUnitTest, AddEthereumChainApprovedForOrigin) {
   brave_wallet::mojom::EthereumChain chain(
       "0x111", "chain_name", {"https://url1.com"}, {"https://url1.com"},
-      {"https://url1.com"}, "symbol", "symbol_name", 60, false);
+      {"https://url1.com"}, "symbol", "symbol_name", 11, false);
 
   base::RunLoop loop;
   std::unique_ptr<TestJsonRpcServiceObserver> observer(
@@ -836,7 +772,7 @@ TEST_F(JsonRpcServiceUnitTest, AddEthereumChainApprovedForOrigin) {
   EXPECT_EQ(*asset_list[0].FindStringKey("symbol"), "symbol");
   EXPECT_EQ(*asset_list[0].FindBoolKey("is_erc20"), false);
   EXPECT_EQ(*asset_list[0].FindBoolKey("is_erc721"), false);
-  EXPECT_EQ(*asset_list[0].FindIntKey("decimals"), 60);
+  EXPECT_EQ(*asset_list[0].FindIntKey("decimals"), 11);
   EXPECT_EQ(*asset_list[0].FindStringKey("logo"), "https://url1.com");
   EXPECT_EQ(*asset_list[0].FindBoolKey("visible"), true);
 
@@ -960,7 +896,7 @@ TEST_F(JsonRpcServiceUnitTest, AddEthereumChainError) {
   // new chain, not valid rpc url
   brave_wallet::mojom::EthereumChain chain4(
       "0x444", "chain_name4", {"https://url4.com"}, {"https://url4.com"},
-      {"https://url4.com"}, "symbol_name", "symbol", 0, false);
+      {"https://url4.com"}, "symbol_name", "symbol", 11, false);
   bool fourth_callback_is_called = false;
   mojom::ProviderError fourth_expected =
       mojom::ProviderError::kUserRejectedRequest;
@@ -985,7 +921,7 @@ TEST_F(JsonRpcServiceUnitTest, AddEthereumChainError) {
   // new chain, broken validation response
   brave_wallet::mojom::EthereumChain chain5(
       "0x444", "chain_name5", {"https://url5.com"}, {"https://url5.com"},
-      {"https://url5.com"}, "symbol_name", "symbol", 0, false);
+      {"https://url5.com"}, "symbol_name", "symbol", 11, false);
   bool fifth_callback_is_called = false;
   mojom::ProviderError fifth_expected =
       mojom::ProviderError::kUserRejectedRequest;
@@ -1469,13 +1405,13 @@ TEST_F(JsonRpcServiceUnitTest, UpdateIsEip1559CustomChain) {
   std::vector<base::Value> values;
   brave_wallet::mojom::EthereumChain chain1(
       "chain_id", "chain_name", {"https://url1.com"}, {"https://url1.com"},
-      {"https://url1.com"}, "symbol_name", "symbol", 0, false);
+      {"https://url1.com"}, "symbol_name", "symbol", 11, false);
   auto chain_ptr1 = chain1.Clone();
   values.push_back(brave_wallet::EthereumChainToValue(chain_ptr1));
 
   brave_wallet::mojom::EthereumChain chain2(
       "chain_id2", "chain_name2", {"https://url2.com"}, {"https://url2.com"},
-      {"https://url2.com"}, "symbol_name2", "symbol2", 60, true);
+      {"https://url2.com"}, "symbol_name2", "symbol2", 22, true);
   auto chain_ptr2 = chain2.Clone();
   values.push_back(brave_wallet::EthereumChainToValue(chain_ptr2));
   UpdateCustomNetworks(prefs(), &values);

--- a/components/brave_wallet/common/brave_wallet.mojom
+++ b/components/brave_wallet/common/brave_wallet.mojom
@@ -592,7 +592,7 @@ struct SwitchChainRequest {
 // network.
 interface JsonRpcService {
   // Checks the chain ID for an ethereum chain that should be added
-  AddCustomChain(EthereumChain chain) => (string chain_id, ProviderError error, string error_message);
+  AddEthereumChain(EthereumChain chain) => (string chain_id, ProviderError error, string error_message);
   AddEthereumChainForOrigin(EthereumChain chain, url.mojom.Url origin) => (string chain_id, ProviderError error, string error_message);
   AddEthereumChainRequestCompleted(string chain_id, bool approved);
   RemoveEthereumChain(string chain_id) => (bool success);


### PR DESCRIPTION
Uplift of #12025 
Reverts https://github.com/brave/brave-browser/issues/20703

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.