### PR TITLE
Disable desktop sharing hub on stable channel (uplift to 1.35.x)

### DIFF
--- a/browser/brave_profile_prefs.cc
+++ b/browser/brave_profile_prefs.cc
@@ -43,6 +43,7 @@
 #include "chrome/browser/prefetch/prefetch_prefs.h"
 #include "chrome/browser/prefs/session_startup_pref.h"
 #include "chrome/browser/ui/webui/new_tab_page/ntp_pref_names.h"
+#include "chrome/common/channel_info.h"
 #include "chrome/common/pref_names.h"
 #include "components/autofill/core/common/autofill_prefs.h"
 #include "components/content_settings/core/common/pref_names.h"
@@ -55,6 +56,7 @@
 #include "components/search_engines/search_engines_pref_names.h"
 #include "components/signin/public/base/signin_pref_names.h"
 #include "components/sync/base/pref_names.h"
+#include "components/version_info/channel.h"
 #include "extensions/buildflags/buildflags.h"
 #include "third_party/widevine/cdm/buildflags.h"
 
@@ -224,6 +226,14 @@ void RegisterProfilePrefs(user_prefs::PrefRegistrySyncable* registry) {
 #if BUILDFLAG(BRAVE_ADAPTIVE_CAPTCHA_ENABLED)
   brave_adaptive_captcha::BraveAdaptiveCaptchaService::RegisterProfilePrefs(
       registry);
+#endif
+
+#if !defined(OS_ANDROID) && !defined(OS_CHROMEOS)
+  // Disable sharing hub on stable only.
+  if (chrome::GetChannel() == version_info::Channel::STABLE) {
+    registry->SetDefaultPrefValue(prefs::kDesktopSharingHubEnabled,
+                                  base::Value(false));
+  }
 #endif
 
 #if defined(OS_ANDROID)

--- a/browser/sources.gni
+++ b/browser/sources.gni
@@ -165,6 +165,7 @@ brave_chrome_browser_deps = [
   "//chrome/browser/profiles:profile",
   "//chrome/browser/ui",
   "//chrome/common",
+  "//chrome/common:channel_info",
   "//components/account_id",
   "//components/autofill/core/common",
   "//components/browsing_data/core",


### PR DESCRIPTION
Uplift of #12041
fix https://github.com/brave/brave-browser/issues/20757

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [ ] The associated issue milestone is set to the smallest version that the changes is landed on.