### PR TITLE
Reduce TileFavicon sizes in "New Tab"

### DIFF
--- a/components/brave_new_tab_ui/components/default/gridSites/index.ts
+++ b/components/brave_new_tab_ui/components/default/gridSites/index.ts
@@ -185,8 +185,8 @@ export const TileAction = styled('button')<{}>`
 export const TileFavicon = styled('img')<{}>`
   display: block;
   padding: 16px;
-  width: 70px;
-  height: 70px;
+  width: 64px;
+  height: 64px;
   box-shadow: 0px 1px 4px 0px rgba(0, 0, 0, 0.3);
   border-radius: 8px;
   object-fit: contain;


### PR DESCRIPTION
Reducing the aspect from pixelated (low resolution) favicon in New Tab.

I'm proposing this change after see some favicons as pixelated in "New Tab" from Brave.

After inspect it, I've realized that the size of the rendered favicon is 64px, but the style is forcing to scale up to 70px, giving the pixelated aspect.

I know that Brave use the chrome directory to get the visited favicons, and some favicons will be small no matter what, but I think this will reduce the impact.

<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves brave/brave-browser#20784

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

