### PR TITLE
Fixes payment pending message is showing up the incorrect BAT amount if there are any unreconciled ads in the previous month - 1.36.x

### DIFF
--- a/vendor/bat-native-ads/src/bat/ads/internal/account/account_unittest.cc
+++ b/vendor/bat-native-ads/src/bat/ads/internal/account/account_unittest.cc
@@ -533,7 +533,7 @@ TEST_F(BatAdsAccountTest, GetStatement) {
         expected_statement.next_payment_date = TimestampFromString(
             "5 January 2021 23:59:59.999", /* is_local */ false);
         expected_statement.earnings_this_month = 0.05;
-        expected_statement.earnings_last_month = 0.02;
+        expected_statement.earnings_last_month = 0.01;
         expected_statement.ads_received_this_month = 3;
 
         EXPECT_EQ(expected_statement, statement);

--- a/vendor/bat-native-ads/src/bat/ads/internal/account/statement/earnings_util.cc
+++ b/vendor/bat-native-ads/src/bat/ads/internal/account/statement/earnings_util.cc
@@ -57,4 +57,19 @@ double GetUnreconciledEarningsForDateRange(const TransactionList& transactions,
   return earnings;
 }
 
+double GetReconciledEarningsForDateRange(const TransactionList& transactions,
+                                         const base::Time& from_time,
+                                         const base::Time& to_time) {
+  double earnings = 0.0;
+
+  for (const auto& transaction : transactions) {
+    if (WasCreatedWithinDateRange(transaction, from_time, to_time) &&
+        DidReconcileTransaction(transaction)) {
+      earnings += transaction.value;
+    }
+  }
+
+  return earnings;
+}
+
 }  // namespace ads

--- a/vendor/bat-native-ads/src/bat/ads/internal/account/statement/earnings_util.h
+++ b/vendor/bat-native-ads/src/bat/ads/internal/account/statement/earnings_util.h
@@ -22,6 +22,10 @@ double GetUnreconciledEarningsForDateRange(const TransactionList& transactions,
                                            const base::Time& from_time,
                                            const base::Time& to_time);
 
+double GetReconciledEarningsForDateRange(const TransactionList& transactions,
+                                         const base::Time& from_time,
+                                         const base::Time& to_time);
+
 }  // namespace ads
 
 #endif  // BRAVE_VENDOR_BAT_NATIVE_ADS_SRC_BAT_ADS_INTERNAL_ACCOUNT_STATEMENT_EARNINGS_UTIL_H_

--- a/vendor/bat-native-ads/src/bat/ads/internal/account/statement/earnings_util_unittest.cc
+++ b/vendor/bat-native-ads/src/bat/ads/internal/account/statement/earnings_util_unittest.cc
@@ -188,4 +188,95 @@ TEST_F(BatAdsEarningsUtilTest, GetUnreconciledEarningsForNoTransactions) {
   EXPECT_TRUE(DoubleEquals(expected_earnings, earnings));
 }
 
+TEST_F(BatAdsEarningsUtilTest, GetReconciledEarningsForDateRange) {
+  // Arrange
+  AdvanceClock(TimeFromString("5 November 2020", /* is_local */ true));
+
+  TransactionList transactions;
+
+  const TransactionInfo& transaction_1 =
+      BuildTransaction(0.01, ConfirmationType::kViewed, Now());
+  transactions.push_back(transaction_1);
+
+  const TransactionInfo& transaction_2 =
+      BuildTransaction(0.01, ConfirmationType::kViewed);
+  transactions.push_back(transaction_2);
+
+  AdvanceClock(TimeFromString("25 December 2020", /* is_local */ true));
+
+  const base::Time& from_time = Now();
+
+  const TransactionInfo& transaction_3 =
+      BuildTransaction(0.03, ConfirmationType::kViewed, Now());
+  transactions.push_back(transaction_3);
+
+  AdvanceClock(TimeFromString("1 January 2021", /* is_local */ true));
+
+  const TransactionInfo& transaction_4 =
+      BuildTransaction(0.02, ConfirmationType::kViewed);
+  transactions.push_back(transaction_4);
+
+  const TransactionInfo& transaction_5 =
+      BuildTransaction(0.02, ConfirmationType::kViewed, Now());
+  transactions.push_back(transaction_5);
+
+  const base::Time& to_time = DistantFuture();
+
+  // Act
+  const double earnings =
+      GetReconciledEarningsForDateRange(transactions, from_time, to_time);
+
+  // Assert
+  const double expected_earnings = 0.05;
+  EXPECT_TRUE(DoubleEquals(expected_earnings, earnings));
+}
+
+TEST_F(BatAdsEarningsUtilTest, DoNotGetReconciledEarningsForDateRange) {
+  // Arrange
+  AdvanceClock(TimeFromString("5 November 2020", /* is_local */ true));
+
+  TransactionList transactions;
+
+  const TransactionInfo& transaction_1 =
+      BuildTransaction(0.01, ConfirmationType::kViewed, Now());
+  transactions.push_back(transaction_1);
+
+  const TransactionInfo& transaction_2 =
+      BuildTransaction(0.03, ConfirmationType::kViewed);
+  transactions.push_back(transaction_2);
+
+  const TransactionInfo& transaction_3 =
+      BuildTransaction(0.02, ConfirmationType::kViewed, Now());
+  transactions.push_back(transaction_3);
+
+  AdvanceClock(TimeFromString("1 January 2021", /* is_local */ true));
+
+  const base::Time& from_time = Now();
+  const base::Time& to_time = DistantFuture();
+
+  // Act
+  const double earnings =
+      GetReconciledEarningsForDateRange(transactions, from_time, to_time);
+
+  // Assert
+  const double expected_earnings = 0.0;
+  EXPECT_TRUE(DoubleEquals(expected_earnings, earnings));
+}
+
+TEST_F(BatAdsEarningsUtilTest, GetReconciledEarningsForNoTransactions) {
+  // Arrange
+  const TransactionList transactions;
+
+  const base::Time& from_time = DistantPast();
+  const base::Time& to_time = DistantFuture();
+
+  // Act
+  const double earnings =
+      GetReconciledEarningsForDateRange(transactions, from_time, to_time);
+
+  // Assert
+  const double expected_earnings = 0.0;
+  EXPECT_TRUE(DoubleEquals(expected_earnings, earnings));
+}
+
 }  // namespace ads

--- a/vendor/bat-native-ads/src/bat/ads/internal/account/statement/statement.cc
+++ b/vendor/bat-native-ads/src/bat/ads/internal/account/statement/statement.cc
@@ -33,7 +33,8 @@ void BuildStatement(StatementCallback callback) {
             GetEarningsForThisMonth(transactions) +
             GetUnreconciledEarningsForPreviousMonths(transactions);
 
-        statement.earnings_last_month = GetEarningsForLastMonth(transactions);
+        statement.earnings_last_month =
+            GetReconciledEarningsForLastMonth(transactions);
 
         const base::Time& next_payment_date = GetNextPaymentDate(transactions);
         statement.next_payment_date = next_payment_date.ToDoubleT();

--- a/vendor/bat-native-ads/src/bat/ads/internal/account/statement/statement_unittest.cc
+++ b/vendor/bat-native-ads/src/bat/ads/internal/account/statement/statement_unittest.cc
@@ -110,7 +110,7 @@ TEST_F(BatAdsStatementTest, GetForTransactionsSplitOverThreeConsecutiveMonths) {
     expected_statement.next_payment_date = TimestampFromString(
         "5 January 2021 23:59:59.999", /* is_local */ false);
     expected_statement.earnings_this_month = 0.05;
-    expected_statement.earnings_last_month = 0.02;
+    expected_statement.earnings_last_month = 0.01;
     expected_statement.ads_received_this_month = 3;
 
     EXPECT_EQ(expected_statement, statement);
@@ -161,7 +161,7 @@ TEST_F(BatAdsStatementTest, GetForTransactionsSplitOverTwoYears) {
     expected_statement.next_payment_date = TimestampFromString(
         "5 January 2021 23:59:59.999", /* is_local */ false);
     expected_statement.earnings_this_month = 0.04;
-    expected_statement.earnings_last_month = 0.02;
+    expected_statement.earnings_last_month = 0.01;
     expected_statement.ads_received_this_month = 3;
 
     EXPECT_EQ(expected_statement, statement);

--- a/vendor/bat-native-ads/src/bat/ads/internal/account/statement/statement_util.cc
+++ b/vendor/bat-native-ads/src/bat/ads/internal/account/statement/statement_util.cc
@@ -41,11 +41,11 @@ double GetUnreconciledEarningsForPreviousMonths(
   return GetUnreconciledEarningsForDateRange(transactions, from_time, to_time);
 }
 
-double GetEarningsForLastMonth(const TransactionList& transactions) {
+double GetReconciledEarningsForLastMonth(const TransactionList& transactions) {
   const base::Time& from_time = GetTimeAtBeginningOfLastMonth();
   const base::Time& to_time = GetTimeAtEndOfLastMonth();
 
-  return GetEarningsForDateRange(transactions, from_time, to_time);
+  return GetReconciledEarningsForDateRange(transactions, from_time, to_time);
 }
 
 int GetAdsReceivedForThisMonth(const TransactionList& transactions) {

--- a/vendor/bat-native-ads/src/bat/ads/internal/account/statement/statement_util.h
+++ b/vendor/bat-native-ads/src/bat/ads/internal/account/statement/statement_util.h
@@ -19,7 +19,7 @@ base::Time GetNextPaymentDate(const TransactionList& transactions);
 double GetEarningsForThisMonth(const TransactionList& transactions);
 double GetUnreconciledEarningsForPreviousMonths(
     const TransactionList& transactions);
-double GetEarningsForLastMonth(const TransactionList& transactions);
+double GetReconciledEarningsForLastMonth(const TransactionList& transactions);
 
 int GetAdsReceivedForThisMonth(const TransactionList& transactions);
 

--- a/vendor/bat-native-ads/src/bat/ads/internal/account/statement/statement_util_unittest.cc
+++ b/vendor/bat-native-ads/src/bat/ads/internal/account/statement/statement_util_unittest.cc
@@ -125,32 +125,36 @@ TEST_F(BatAdsStatementUtilTest, GetUnreconciledEarningsForPreviousMonths) {
   EXPECT_TRUE(DoubleEquals(expected_earnings, earnings));
 }
 
-TEST_F(BatAdsStatementUtilTest, GetEarningsForLastMonth) {
+TEST_F(BatAdsStatementUtilTest, GetReconciledEarningsForLastMonth) {
   // Arrange
   AdvanceClock(TimeFromString("5 November 2020", /* is_local */ true));
 
   TransactionList transactions;
 
   const TransactionInfo& transaction_1 =
-      BuildTransaction(0.01, ConfirmationType::kViewed);
+      BuildTransaction(0.01, ConfirmationType::kViewed, Now());
   transactions.push_back(transaction_1);
+
+  const TransactionInfo& transaction_2 =
+      BuildTransaction(0.01, ConfirmationType::kViewed);
+  transactions.push_back(transaction_2);
 
   AdvanceClock(TimeFromString("25 December 2020", /* is_local */ true));
 
-  const TransactionInfo& transaction_2 =
-      BuildTransaction(0.0, ConfirmationType::kClicked);
-  transactions.push_back(transaction_2);
-
   const TransactionInfo& transaction_3 =
-      BuildTransaction(0.03, ConfirmationType::kViewed);
+      BuildTransaction(0.0, ConfirmationType::kClicked);
   transactions.push_back(transaction_3);
 
   const TransactionInfo& transaction_4 =
-      BuildTransaction(0.02, ConfirmationType::kViewed);
+      BuildTransaction(0.03, ConfirmationType::kViewed);
   transactions.push_back(transaction_4);
 
+  const TransactionInfo& transaction_5 =
+      BuildTransaction(0.02, ConfirmationType::kViewed);
+  transactions.push_back(transaction_5);
+
   // Act
-  const double earnings = GetEarningsForLastMonth(transactions);
+  const double earnings = GetReconciledEarningsForLastMonth(transactions);
 
   // Assert
   const double expected_earnings = 0.01;


### PR DESCRIPTION
Uplift of https://github.com/brave/brave-core/pull/12070
Resolves https://github.com/brave/brave-browser/issues/20803

- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR.
- [x] You have tested your change on Nightly. 
- [x] The PR milestones match the branch they are landing to. 

After you merge: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.