### PR TITLE
Solana keyring mojo

### DIFF
--- a/browser/brave_wallet/brave_wallet_provider_delegate_impl.cc
+++ b/browser/brave_wallet/brave_wallet_provider_delegate_impl.cc
@@ -162,7 +162,8 @@ void BraveWalletProviderDelegateImpl::
     ContinueRequestEthereumPermissionsKeyringInfo(
         RequestEthereumPermissionsCallback callback,
         brave_wallet::mojom::KeyringInfoPtr keyring_info) {
-  if (!keyring_info->is_default_keyring_created) {
+  DCHECK_EQ(keyring_info->id, brave_wallet::mojom::kDefaultKeyringId);
+  if (!keyring_info->is_keyring_created) {
     ShowWalletOnboarding(web_contents_);
     std::move(callback).Run(
         std::vector<std::string>(), mojom::ProviderError::kInternalError,

--- a/browser/brave_wallet/keyring_service_unittest.cc
+++ b/browser/brave_wallet/keyring_service_unittest.cc
@@ -2949,6 +2949,9 @@ TEST_F(KeyringServiceUnitTest, PreCreateFilecoinEncryptor) {
     base::RunLoop().RunUntilIdle();
     EXPECT_NE(service.encryptors_.at(mojom::kDefaultKeyringId), nullptr);
     EXPECT_NE(service.encryptors_.at(mojom::kFilecoinKeyringId), nullptr);
+    // filecoin keyring won't be created
+    EXPECT_FALSE(
+        service.IsKeyringCreated(brave_wallet::mojom::kFilecoinKeyringId));
   }
 }
 

--- a/browser/brave_wallet/keyring_service_unittest.cc
+++ b/browser/brave_wallet/keyring_service_unittest.cc
@@ -785,7 +785,8 @@ TEST_F(KeyringServiceUnitTest, GetDefaultKeyringInfo) {
   service.GetKeyringInfo(
       mojom::kDefaultKeyringId,
       base::BindLambdaForTesting([&](mojom::KeyringInfoPtr keyring_info) {
-        EXPECT_FALSE(keyring_info->is_default_keyring_created);
+        EXPECT_EQ(keyring_info->id, mojom::kDefaultKeyringId);
+        EXPECT_FALSE(keyring_info->is_keyring_created);
         EXPECT_TRUE(keyring_info->is_locked);
         EXPECT_FALSE(keyring_info->is_backed_up);
         EXPECT_TRUE(keyring_info->account_infos.empty());
@@ -801,7 +802,8 @@ TEST_F(KeyringServiceUnitTest, GetDefaultKeyringInfo) {
   service.GetKeyringInfo(
       mojom::kDefaultKeyringId,
       base::BindLambdaForTesting([&](mojom::KeyringInfoPtr keyring_info) {
-        EXPECT_TRUE(keyring_info->is_default_keyring_created);
+        EXPECT_EQ(keyring_info->id, mojom::kDefaultKeyringId);
+        EXPECT_TRUE(keyring_info->is_keyring_created);
         EXPECT_FALSE(keyring_info->is_locked);
         EXPECT_FALSE(keyring_info->is_backed_up);
         EXPECT_EQ(keyring_info->account_infos.size(), 1u);
@@ -821,7 +823,8 @@ TEST_F(KeyringServiceUnitTest, GetDefaultKeyringInfo) {
   service.GetKeyringInfo(
       brave_wallet::mojom::kDefaultKeyringId,
       base::BindLambdaForTesting([&](mojom::KeyringInfoPtr keyring_info) {
-        EXPECT_TRUE(keyring_info->is_default_keyring_created);
+        EXPECT_EQ(keyring_info->id, mojom::kDefaultKeyringId);
+        EXPECT_TRUE(keyring_info->is_keyring_created);
         EXPECT_FALSE(keyring_info->is_locked);
         EXPECT_TRUE(keyring_info->is_backed_up);
         EXPECT_EQ(keyring_info->account_infos.size(), 2u);
@@ -1289,7 +1292,8 @@ TEST_F(KeyringServiceUnitTest, ImportedAccounts) {
   service.GetKeyringInfo(
       brave_wallet::mojom::kDefaultKeyringId,
       base::BindLambdaForTesting([&](mojom::KeyringInfoPtr keyring_info) {
-        EXPECT_TRUE(keyring_info->is_default_keyring_created);
+        EXPECT_EQ(keyring_info->id, mojom::kDefaultKeyringId);
+        EXPECT_TRUE(keyring_info->is_keyring_created);
         EXPECT_FALSE(keyring_info->is_locked);
         EXPECT_FALSE(keyring_info->is_backed_up);
         EXPECT_EQ(keyring_info->account_infos.size(), 3u);
@@ -1754,7 +1758,8 @@ TEST_F(KeyringServiceUnitTest, SetDefaultKeyringImportedAccountName) {
   service.GetKeyringInfo(
       brave_wallet::mojom::kDefaultKeyringId,
       base::BindLambdaForTesting([&](mojom::KeyringInfoPtr keyring_info) {
-        EXPECT_TRUE(keyring_info->is_default_keyring_created);
+        EXPECT_EQ(keyring_info->id, mojom::kDefaultKeyringId);
+        EXPECT_TRUE(keyring_info->is_keyring_created);
         EXPECT_FALSE(keyring_info->is_locked);
         EXPECT_FALSE(keyring_info->is_backed_up);
         EXPECT_EQ(keyring_info->account_infos.size(), 4u);
@@ -2118,7 +2123,8 @@ TEST_F(KeyringServiceUnitTest, AddAccountsWithDefaultName) {
   service.GetKeyringInfo(
       mojom::kDefaultKeyringId,
       base::BindLambdaForTesting([&](mojom::KeyringInfoPtr keyring_info) {
-        EXPECT_TRUE(keyring_info->is_default_keyring_created);
+        EXPECT_EQ(keyring_info->id, mojom::kDefaultKeyringId);
+        EXPECT_TRUE(keyring_info->is_keyring_created);
         EXPECT_EQ(keyring_info->account_infos.size(), 5u);
         EXPECT_FALSE(keyring_info->account_infos[0]->address.empty());
         EXPECT_EQ(keyring_info->account_infos[0]->name, "Account 1");
@@ -2296,7 +2302,8 @@ TEST_F(KeyringServiceUnitTest, SetDefaultKeyringHardwareAccountName) {
   service.GetKeyringInfo(
       mojom::kDefaultKeyringId,
       base::BindLambdaForTesting([&](mojom::KeyringInfoPtr keyring_info) {
-        EXPECT_TRUE(keyring_info->is_default_keyring_created);
+        EXPECT_EQ(keyring_info->id, mojom::kDefaultKeyringId);
+        EXPECT_TRUE(keyring_info->is_keyring_created);
         EXPECT_FALSE(keyring_info->is_locked);
         EXPECT_FALSE(keyring_info->is_backed_up);
         EXPECT_EQ(keyring_info->account_infos.size(), 4u);
@@ -2423,7 +2430,8 @@ TEST_F(KeyringServiceUnitTest, LazilyCreateKeyring) {
   service.GetKeyringInfo(
       brave_wallet::mojom::kFilecoinKeyringId,
       base::BindLambdaForTesting([&](mojom::KeyringInfoPtr keyring_info) {
-        EXPECT_FALSE(keyring_info->is_default_keyring_created);
+        EXPECT_EQ(keyring_info->id, mojom::kFilecoinKeyringId);
+        EXPECT_FALSE(keyring_info->is_keyring_created);
         EXPECT_FALSE(keyring_info->is_locked);
         EXPECT_FALSE(keyring_info->is_backed_up);
         ASSERT_TRUE(keyring_info->account_infos.empty());
@@ -2438,7 +2446,8 @@ TEST_F(KeyringServiceUnitTest, LazilyCreateKeyring) {
   service.GetKeyringInfo(
       brave_wallet::mojom::kFilecoinKeyringId,
       base::BindLambdaForTesting([&](mojom::KeyringInfoPtr keyring_info) {
-        EXPECT_FALSE(keyring_info->is_default_keyring_created);
+        EXPECT_EQ(keyring_info->id, mojom::kFilecoinKeyringId);
+        EXPECT_FALSE(keyring_info->is_keyring_created);
         EXPECT_FALSE(keyring_info->is_locked);
         EXPECT_FALSE(keyring_info->is_backed_up);
         ASSERT_TRUE(keyring_info->account_infos.empty());
@@ -2467,7 +2476,8 @@ TEST_F(KeyringServiceUnitTest, LazilyCreateKeyring) {
   service.GetKeyringInfo(
       mojom::kDefaultKeyringId,
       base::BindLambdaForTesting([&](mojom::KeyringInfoPtr keyring_info) {
-        EXPECT_TRUE(keyring_info->is_default_keyring_created);
+        EXPECT_EQ(keyring_info->id, mojom::kDefaultKeyringId);
+        EXPECT_TRUE(keyring_info->is_keyring_created);
         EXPECT_FALSE(keyring_info->is_locked);
         EXPECT_FALSE(keyring_info->is_backed_up);
         EXPECT_EQ(keyring_info->account_infos.size(), 4u);
@@ -2600,7 +2610,8 @@ TEST_F(KeyringServiceUnitTest, ImportedFilecoinAccounts) {
   service.GetKeyringInfo(
       brave_wallet::mojom::kFilecoinKeyringId,
       base::BindLambdaForTesting([&](mojom::KeyringInfoPtr keyring_info) {
-        EXPECT_TRUE(keyring_info->is_default_keyring_created);
+        EXPECT_EQ(keyring_info->id, mojom::kFilecoinKeyringId);
+        EXPECT_TRUE(keyring_info->is_keyring_created);
         EXPECT_FALSE(keyring_info->is_locked);
         EXPECT_FALSE(keyring_info->is_backed_up);
         EXPECT_EQ(keyring_info->account_infos.size(), 3u);
@@ -3007,6 +3018,8 @@ TEST_F(KeyringServiceUnitTest, SolanaKeyring) {
     service.GetKeyringInfo(
         brave_wallet::mojom::kSolanaKeyringId,
         base::BindLambdaForTesting([&](mojom::KeyringInfoPtr keyring_info) {
+          EXPECT_EQ(keyring_info->id, mojom::kSolanaKeyringId);
+          EXPECT_TRUE(keyring_info->is_keyring_created);
           EXPECT_EQ(keyring_info->account_infos.size(), 2u);
           EXPECT_EQ(keyring_info->account_infos[0]->name, "Account 1");
           EXPECT_FALSE(keyring_info->account_infos[0]->is_imported);
@@ -3041,6 +3054,8 @@ TEST_F(KeyringServiceUnitTest, SolanaKeyring) {
     service.GetKeyringInfo(
         brave_wallet::mojom::kSolanaKeyringId,
         base::BindLambdaForTesting([&](mojom::KeyringInfoPtr keyring_info) {
+          EXPECT_EQ(keyring_info->id, mojom::kSolanaKeyringId);
+          EXPECT_TRUE(keyring_info->is_keyring_created);
           EXPECT_EQ(keyring_info->account_infos.size(), 1u);
           EXPECT_EQ(keyring_info->account_infos[0]->name, "Account 1");
           EXPECT_EQ(keyring_info->account_infos[0]->address,

--- a/browser/ui/webui/brave_wallet/common_handler/wallet_handler.cc
+++ b/browser/ui/webui/brave_wallet/common_handler/wallet_handler.cc
@@ -75,7 +75,7 @@ void WalletHandler::OnGetWalletInfo(
   const auto& default_keyring = keyring_infos.front();
   DCHECK_EQ(default_keyring->id, brave_wallet::mojom::kDefaultKeyringId);
   std::move(callback).Run(
-      default_keyring->is_default_keyring_created, default_keyring->is_locked,
+      default_keyring->is_keyring_created, default_keyring->is_locked,
       std::move(favorite_apps_copy), default_keyring->is_backed_up,
       std::move(account_infos), brave_wallet::IsFilecoinEnabled());
 }

--- a/components/brave_wallet/browser/filecoin_keyring.cc
+++ b/components/brave_wallet/browser/filecoin_keyring.cc
@@ -112,6 +112,13 @@ std::string FilecoinKeyring::GetAddressInternal(HDKeyBase* hd_key_base) const {
          CreateAddressWithProtocol(payload, protocol);
 }
 
+std::vector<uint8_t> FilecoinKeyring::SignMessage(
+    const std::string& address,
+    const std::vector<uint8_t>& message) {
+  // NOT IMPLEMENTED
+  return std::vector<uint8_t>();
+}
+
 std::string FilecoinKeyring::CreateAddressWithProtocol(
     const std::vector<uint8_t>& payload,
     int protocol_index) const {

--- a/components/brave_wallet/browser/filecoin_keyring.h
+++ b/components/brave_wallet/browser/filecoin_keyring.h
@@ -37,6 +37,10 @@ class FilecoinKeyring : public HDKeyring {
                              const std::string& address);
   std::string GetAddressInternal(HDKeyBase* hd_key_base) const override;
 
+  std::vector<uint8_t> SignMessage(
+      const std::string& address,
+      const std::vector<uint8_t>& message) override;
+
  private:
   std::string CreateAddressWithProtocol(const std::vector<uint8_t>& payload,
                                         int protocol) const;

--- a/components/brave_wallet/browser/hd_keyring.cc
+++ b/components/brave_wallet/browser/hd_keyring.cc
@@ -160,6 +160,13 @@ void HDKeyring::SignTransaction(const std::string& address,
   tx->ProcessSignature(signature, recid, chain_id);
 }
 
+std::vector<uint8_t> HDKeyring::SignMessage(
+    const std::string& address,
+    const std::vector<uint8_t>& message) {
+  NOTREACHED() << "ETH shouldn't use this signing function";
+  return std::vector<uint8_t>();
+}
+
 std::vector<uint8_t> HDKeyring::SignMessage(const std::string& address,
                                             const std::vector<uint8_t>& message,
                                             uint256_t chain_id,

--- a/components/brave_wallet/browser/hd_keyring.h
+++ b/components/brave_wallet/browser/hd_keyring.h
@@ -62,6 +62,9 @@ class HDKeyring {
                                            const std::vector<uint8_t>& message,
                                            uint256_t chain_id,
                                            bool is_eip712);
+  // for non-ETH keyring signing
+  virtual std::vector<uint8_t> SignMessage(const std::string& address,
+                                           const std::vector<uint8_t>& message);
   // Obtains the address that signed the message
   // message: The keccak256 hash of the message (33 bytes = 04 prefix + 32
   // bytes)

--- a/components/brave_wallet/browser/keyring_service.cc
+++ b/components/brave_wallet/browser/keyring_service.cc
@@ -1333,6 +1333,18 @@ bool KeyringService::RecoverAddressByDefaultKeyring(
   return HDKeyring::RecoverAddress(message, signature, address);
 }
 
+std::vector<uint8_t> KeyringService::SignMessage(
+    const std::string& keyring_id,
+    const std::string& address,
+    const std::vector<uint8_t>& message) {
+  auto* keyring = GetHDKeyringById(keyring_id);
+  if (!keyring || keyring_id == mojom::kDefaultKeyringId) {
+    return std::vector<uint8_t>();
+  }
+
+  return keyring->SignMessage(address, message);
+}
+
 void KeyringService::AddAccountsWithDefaultName(size_t number) {
   auto* keyring = GetHDKeyringById(mojom::kDefaultKeyringId);
   if (!keyring) {

--- a/components/brave_wallet/browser/keyring_service.cc
+++ b/components/brave_wallet/browser/keyring_service.cc
@@ -11,6 +11,7 @@
 #include "base/base64.h"
 #include "base/hash/hash.h"
 #include "base/logging.h"
+#include "base/strings/strcat.h"
 #include "base/strings/string_number_conversions.h"
 #include "base/strings/string_util.h"
 #include "base/strings/utf_string_conversions.h"
@@ -23,6 +24,7 @@
 #include "brave/components/brave_wallet/browser/hd_keyring.h"
 #include "brave/components/brave_wallet/browser/json_rpc_service.h"
 #include "brave/components/brave_wallet/browser/pref_names.h"
+#include "brave/components/brave_wallet/browser/solana_keyring.h"
 #include "brave/components/brave_wallet/common/brave_wallet.mojom-forward.h"
 #include "brave/components/brave_wallet/common/brave_wallet.mojom-shared.h"
 #include "brave/components/brave_wallet/common/eth_address.h"
@@ -108,7 +110,7 @@ namespace brave_wallet {
 namespace {
 const size_t kSaltSize = 32;
 const size_t kNonceSize = 12;
-const char kRootPath[] = "m/44'/{coin}'/0'/0";
+const char kRootPath[] = "m/44'/{coin}'";
 const char kPasswordEncryptorSalt[] = "password_encryptor_salt";
 const char kPasswordEncryptorNonce[] = "password_encryptor_nonce";
 const char kEncryptedMnemonic[] = "encrypted_mnemonic";
@@ -124,25 +126,21 @@ const char kLegacyBraveWallet[] = "legacy_brave_wallet";
 const char kHardwareKeyrings[] = "hardware";
 const char kHardwareDerivationPath[] = "derivation_path";
 
-std::string GetRootPath(const std::string& keyring_id) {
-  std::string root(kRootPath);
-  auto coin = (keyring_id == mojom::kFilecoinKeyringId) ? mojom::CoinType::FIL
-                                                        : mojom::CoinType::ETH;
-  base::ReplaceSubstringsAfterOffset(
-      &root, 0, "{coin}", std::to_string(static_cast<int32_t>(coin)));
-  return root;
-}
-
 std::string GetKeyringId(HDKeyring::Type type) {
   if (type == HDKeyring::kFilecoin)
     return mojom::kFilecoinKeyringId;
+  else if (type == HDKeyring::kSolana)
+    return mojom::kSolanaKeyringId;
   return mojom::kDefaultKeyringId;
 }
 
 mojom::CoinType GetCoinForKeyring(const std::string& keyring_id) {
   if (keyring_id == mojom::kFilecoinKeyringId) {
     return mojom::CoinType::FIL;
+  } else if (keyring_id == mojom::kSolanaKeyringId) {
+    return mojom::CoinType::SOL;
   }
+
   DCHECK_EQ(keyring_id, mojom::kDefaultKeyringId);
   return mojom::CoinType::ETH;
 }
@@ -150,9 +148,22 @@ mojom::CoinType GetCoinForKeyring(const std::string& keyring_id) {
 std::string GetKeyringIdForCoin(mojom::CoinType coin) {
   if (coin == mojom::CoinType::FIL) {
     return mojom::kFilecoinKeyringId;
+  } else if (coin == mojom::CoinType::SOL) {
+    return mojom::kSolanaKeyringId;
   }
   DCHECK_EQ(coin, mojom::CoinType::ETH);
   return mojom::kDefaultKeyringId;
+}
+
+std::string GetRootPath(const std::string& keyring_id) {
+  std::string root(kRootPath);
+  auto coin = GetCoinForKeyring(keyring_id);
+  base::ReplaceSubstringsAfterOffset(
+      &root, 0, "{coin}", std::to_string(static_cast<int32_t>(coin)));
+  if (coin == mojom::CoinType::ETH || coin == mojom::CoinType::FIL) {
+    base::StrAppend(&root, {"/0'/0"});
+  }
+  return root;
 }
 
 static base::span<const uint8_t> ToSpan(base::StringPiece sp) {
@@ -435,7 +446,14 @@ std::string KeyringService::GetAccountAddressForKeyring(
 std::string KeyringService::GetAccountPathByIndex(
     size_t index,
     const std::string& keyring_id) {
-  return GetRootPath(keyring_id) + "/" + base::NumberToString(index);
+  std::string path =
+      base::StrCat({GetRootPath(keyring_id), "/", base::NumberToString(index)});
+  auto coin = GetCoinForKeyring(keyring_id);
+  if (coin == mojom::CoinType::SOL) {
+    base::StrAppend(&path, {"'/0'"});
+  }
+
+  return path;
 }
 
 // static
@@ -515,7 +533,8 @@ void KeyringService::RemoveImportedAccountForKeyring(PrefService* prefs,
 HDKeyring* KeyringService::CreateKeyring(const std::string& keyring_id,
                                          const std::string& password) {
   if (keyring_id != mojom::kDefaultKeyringId &&
-      keyring_id != mojom::kFilecoinKeyringId) {
+      keyring_id != mojom::kFilecoinKeyringId &&
+      keyring_id != mojom::kSolanaKeyringId) {
     VLOG(1) << "Unknown keyring id " << keyring_id;
     return nullptr;
   }
@@ -667,6 +686,7 @@ void KeyringService::GetKeyringsInfo(const std::vector<std::string>& keyrings,
   if (IsFilecoinEnabled()) {
     result.push_back(GetKeyringInfoSync(mojom::kFilecoinKeyringId));
   }
+  result.push_back(GetKeyringInfoSync(mojom::kSolanaKeyringId));
   std::move(callback).Run(std::move(result));
 }
 
@@ -689,6 +709,9 @@ void KeyringService::CreateWallet(const std::string& password,
       VLOG(1) << "Unable to create filecoin encryptor";
     }
   }
+  if (!CreateEncryptorForKeyring(password, mojom::kSolanaKeyringId)) {
+    VLOG(1) << "Unable to create solana encryptor";
+  }
 
   std::move(callback).Run(GetMnemonicForKeyringImpl(mojom::kDefaultKeyringId));
 }
@@ -709,6 +732,11 @@ void KeyringService::RestoreWallet(const std::string& mnemonic,
     if (filecoin_keyring && !filecoin_keyring->GetAccountsNumber())
       AddAccountForKeyring(mojom::kFilecoinKeyringId, GetAccountName(1));
   }
+
+  auto* solana_keyring = RestoreKeyring(mojom::kSolanaKeyringId, mnemonic,
+                                        password, is_legacy_brave_wallet);
+  if (solana_keyring && !solana_keyring->GetAccountsNumber())
+    AddAccountForKeyring(mojom::kSolanaKeyringId, GetAccountName(1));
 
   // TODO(darkdh): add account discovery mechanism
 
@@ -747,9 +775,14 @@ void KeyringService::AddAccount(const std::string& account_name,
       std::move(callback).Run(false);
       return;
     }
-    if (!IsKeyringExist(mojom::kFilecoinKeyringId) &&
-        !CreateFilecoinKeyring()) {
+    if (!LazilyCreateKeyring(mojom::kFilecoinKeyringId)) {
       VLOG(1) << "Unable to create Filecoin keyring";
+      std::move(callback).Run(false);
+      return;
+    }
+  } else if (keyring_id == mojom::kSolanaKeyringId) {
+    if (!LazilyCreateKeyring(mojom::kSolanaKeyringId)) {
+      VLOG(1) << "Unable to create Solana keyring";
       std::move(callback).Run(false);
       return;
     }
@@ -801,11 +834,9 @@ void KeyringService::ImportFilecoinSECP256K1Account(
     const std::string& network,
     ImportFilecoinSECP256K1AccountCallback callback) {
   DCHECK(IsFilecoinEnabled());
-  if (!IsKeyringExist(mojom::kFilecoinKeyringId)) {
-    if (!CreateFilecoinKeyring()) {
-      VLOG(1) << "Unable to create Filecoin keyring";
-      return;
-    }
+  if (!LazilyCreateKeyring(mojom::kFilecoinKeyringId)) {
+    VLOG(1) << "Unable to create Filecoin keyring";
+    return;
   }
 
   if (account_name.empty() || private_key_hex.empty() ||
@@ -835,11 +866,9 @@ void KeyringService::ImportFilecoinBLSAccount(
     const std::string& network,
     ImportFilecoinBLSAccountCallback callback) {
   DCHECK(IsFilecoinEnabled());
-  if (!IsKeyringExist(mojom::kFilecoinKeyringId)) {
-    if (!CreateFilecoinKeyring()) {
-      VLOG(1) << "Unable to create Filecoin keyring";
-      return;
-    }
+  if (!LazilyCreateKeyring(mojom::kFilecoinKeyringId)) {
+    VLOG(1) << "Unable to create Filecoin keyring";
+    return;
   }
 
   if (account_name.empty() || private_key_hex.empty() ||
@@ -1375,6 +1404,14 @@ void KeyringService::Unlock(const std::string& password,
       }
     }
   }
+  if (!ResumeKeyring(mojom::kSolanaKeyringId, password)) {
+    if (IsKeyringExist(mojom::kSolanaKeyringId)) {
+      VLOG(1) << __func__ << " Unable to unlock Solana keyring";
+      encryptors_.erase(mojom::kSolanaKeyringId);
+      std::move(callback).Run(false);
+      return;
+    }
+  }
 
   UpdateLastUnlockPref(prefs_);
   request_unlock_pending_ = false;
@@ -1513,6 +1550,8 @@ bool KeyringService::CreateKeyringInternal(const std::string& keyring_id,
   } else if (keyring_id == mojom::kFilecoinKeyringId) {
     DCHECK(::brave_wallet::IsFilecoinEnabled());
     keyrings_[mojom::kFilecoinKeyringId] = std::make_unique<FilecoinKeyring>();
+  } else if (keyring_id == mojom::kSolanaKeyringId) {
+    keyrings_[mojom::kSolanaKeyringId] = std::make_unique<SolanaKeyring>();
   }
   auto* keyring = GetHDKeyringById(keyring_id);
   DCHECK(keyring) << "No HDKeyring for " << keyring_id;
@@ -1539,11 +1578,14 @@ void KeyringService::NotifyUserInteraction() {
   }
 }
 
-bool KeyringService::CreateFilecoinKeyring() {
-  // If user enabled filecoin keyring with existing wallet
-  // we use existing mnemonic for new keyring
+bool KeyringService::LazilyCreateKeyring(const std::string& keyring_id) {
+  if (keyring_id == mojom::kDefaultKeyringId)
+    return false;
+  if (IsKeyringExist(keyring_id))
+    return true;
+  // we use same mnemonic from default keyring for non default keyrings
   auto mnemonic = GetMnemonicForKeyringImpl(mojom::kDefaultKeyringId);
-  return CreateKeyringInternal(mojom::kFilecoinKeyringId, mnemonic, false);
+  return CreateKeyringInternal(keyring_id, mnemonic, false);
 }
 
 void KeyringService::GetSelectedAccount(GetSelectedAccountCallback callback) {

--- a/components/brave_wallet/browser/keyring_service.cc
+++ b/components/brave_wallet/browser/keyring_service.cc
@@ -1597,7 +1597,14 @@ bool KeyringService::LazilyCreateKeyring(const std::string& keyring_id) {
     return true;
   // we use same mnemonic from default keyring for non default keyrings
   auto mnemonic = GetMnemonicForKeyringImpl(mojom::kDefaultKeyringId);
-  return CreateKeyringInternal(keyring_id, mnemonic, false);
+  if (!CreateKeyringInternal(keyring_id, mnemonic, false))
+    return false;
+
+  for (const auto& observer : observers_) {
+    observer->KeyringCreated(keyring_id);
+  }
+
+  return true;
 }
 
 void KeyringService::GetSelectedAccount(GetSelectedAccountCallback callback) {

--- a/components/brave_wallet/browser/keyring_service.cc
+++ b/components/brave_wallet/browser/keyring_service.cc
@@ -662,7 +662,7 @@ mojom::KeyringInfoPtr KeyringService::GetKeyringInfoSync(
     const std::string& keyring_id) {
   mojom::KeyringInfoPtr keyring_info = mojom::KeyringInfo::New();
   keyring_info->id = keyring_id;
-  keyring_info->is_default_keyring_created = IsKeyringCreated(keyring_id);
+  keyring_info->is_keyring_created = IsKeyringCreated(keyring_id);
   keyring_info->is_locked = IsLocked(keyring_id);
   bool backup_complete = false;
   const base::Value* value =

--- a/components/brave_wallet/browser/keyring_service.h
+++ b/components/brave_wallet/browser/keyring_service.h
@@ -195,6 +195,9 @@ class KeyringService : public KeyedService, public mojom::KeyringService {
       const std::string& address,
       const std::vector<uint8_t>& message,
       bool is_eip712 = false);
+  std::vector<uint8_t> SignMessage(const std::string& keyring_id,
+                                   const std::string& address,
+                                   const std::vector<uint8_t>& message);
   bool RecoverAddressByDefaultKeyring(const std::vector<uint8_t>& message,
                                       const std::vector<uint8_t>& signature,
                                       std::string* address);

--- a/components/brave_wallet/browser/keyring_service.h
+++ b/components/brave_wallet/browser/keyring_service.h
@@ -222,11 +222,6 @@ class KeyringService : public KeyedService, public mojom::KeyringService {
   void HasPendingUnlockRequest(
       HasPendingUnlockRequestCallback callback) override;
 
-  /* TODO(darkdh): For other keyrings support
-  void DeleteKeyring(size_t index);
-  HDKeyring* GetKeyring(size_t index);
-  */
-
  private:
   FRIEND_TEST_ALL_PREFIXES(KeyringServiceUnitTest, GetPrefInBytesForKeyring);
   FRIEND_TEST_ALL_PREFIXES(KeyringServiceUnitTest, SetPrefInBytesForKeyring);
@@ -234,8 +229,6 @@ class KeyringService : public KeyedService, public mojom::KeyringService {
   FRIEND_TEST_ALL_PREFIXES(KeyringServiceUnitTest, CreateEncryptorForKeyring);
   FRIEND_TEST_ALL_PREFIXES(KeyringServiceUnitTest, CreateDefaultKeyring);
   FRIEND_TEST_ALL_PREFIXES(KeyringServiceUnitTest, CreateFilecoinKeyring);
-  FRIEND_TEST_ALL_PREFIXES(KeyringServiceUnitTest,
-                           LockAndUnlockWithMultipleKeyrings);
   FRIEND_TEST_ALL_PREFIXES(KeyringServiceUnitTest,
                            LazyCreateFilecoinKeyringFromImport);
   FRIEND_TEST_ALL_PREFIXES(KeyringServiceUnitTest,
@@ -260,7 +253,7 @@ class KeyringService : public KeyedService, public mojom::KeyringService {
   FRIEND_TEST_ALL_PREFIXES(KeyringServiceUnitTest, LazilyCreateKeyring);
   FRIEND_TEST_ALL_PREFIXES(KeyringServiceUnitTest, ImportedFilecoinAccounts);
   FRIEND_TEST_ALL_PREFIXES(KeyringServiceUnitTest, CreateFilecoinEncryptor);
-  FRIEND_TEST_ALL_PREFIXES(KeyringServiceUnitTest, PreCreateFilecoinEncryptor);
+  FRIEND_TEST_ALL_PREFIXES(KeyringServiceUnitTest, PreCreateEncryptors);
   friend class BraveWalletProviderImplUnitTest;
   friend class EthTxServiceUnitTest;
 
@@ -288,7 +281,7 @@ class KeyringService : public KeyedService, public mojom::KeyringService {
       const std::string& network);
   bool IsFilecoinAccount(const std::string& account) const;
   bool IsKeyringExist(const std::string& keyring_id) const;
-  bool CreateFilecoinKeyring();
+  bool LazilyCreateKeyring(const std::string& keyring_id);
   size_t GetAccountMetasNumberForKeyring(const std::string& id);
 
   std::vector<mojom::AccountInfoPtr> GetAccountInfosForKeyring(

--- a/components/brave_wallet/browser/solana_keyring.cc
+++ b/components/brave_wallet/browser/solana_keyring.cc
@@ -35,6 +35,16 @@ void SolanaKeyring::AddAccounts(size_t number) {
   }
 }
 
+std::vector<uint8_t> SolanaKeyring::SignMessage(
+    const std::string& address,
+    const std::vector<uint8_t>& message) {
+  HDKeyBase* hd_key = GetHDKeyFromAddress(address);
+  if (!hd_key)
+    return std::vector<uint8_t>();
+
+  return hd_key->Sign(message);
+}
+
 std::string SolanaKeyring::GetAddressInternal(HDKeyBase* hd_key_base) const {
   if (!hd_key_base)
     return std::string();

--- a/components/brave_wallet/browser/solana_keyring.h
+++ b/components/brave_wallet/browser/solana_keyring.h
@@ -25,6 +25,10 @@ class SolanaKeyring : public HDKeyring {
                           const std::string& hd_path) override;
   void AddAccounts(size_t number = 1) override;
 
+  std::vector<uint8_t> SignMessage(
+      const std::string& address,
+      const std::vector<uint8_t>& message) override;
+
  private:
   std::string GetAddressInternal(HDKeyBase* hd_key) const override;
 };

--- a/components/brave_wallet/browser/solana_keyring_unittest.cc
+++ b/components/brave_wallet/browser/solana_keyring_unittest.cc
@@ -89,4 +89,27 @@ TEST(SolanaKeyringUnitTest, Accounts) {
   EXPECT_TRUE(keyring.GetEncodedPrivateKey("brave").empty());
 }
 
+TEST(SolanaKeyringUnitTest, SignMessage) {
+  SolanaKeyring keyring;
+  std::unique_ptr<std::vector<uint8_t>> seed =
+      MnemonicToSeed(std::string(mnemonic), "");
+  keyring.ConstructRootHDKey(*seed, "m/44'/501'");
+
+  keyring.AddAccounts();
+  EXPECT_EQ(keyring.GetAddress(0),
+            "8J7fu34oNJSKXcauNQMXRdKAHY7zQ7rEaQng8xtQNpSu");
+
+  // Message: Hello Brave
+  const std::vector<uint8_t> message = {72, 101, 108, 108, 111, 32,
+                                        66, 114, 97,  118, 101};
+  const std::vector<uint8_t> expected_signature = {
+      2,   179, 226, 40,  228, 8,   248, 176, 39,  21,  205, 26,  136,
+      7,   92,  162, 178, 18,  181, 212, 58,  93,  159, 167, 207, 74,
+      58,  102, 213, 60,  21,  217, 236, 188, 90,  75,  120, 116, 130,
+      104, 20,  185, 45,  50,  115, 244, 223, 167, 114, 6,   225, 189,
+      103, 51,  156, 215, 22,  207, 130, 197, 57,  39,  186, 12};
+  auto signature = keyring.SignMessage(keyring.GetAddress(0), message);
+  EXPECT_EQ(signature, expected_signature);
+}
+
 }  // namespace brave_wallet

--- a/components/brave_wallet/common/brave_wallet.mojom
+++ b/components/brave_wallet/common/brave_wallet.mojom
@@ -253,6 +253,7 @@ const string kFilecoinTestnet = "t";
 const string kFilecoinMainnet = "f";
 
 const string kFilecoinKeyringId = "filecoin";
+const string kSolanaKeyringId = "solana";
 const string kDefaultKeyringId = "default";
 
 enum FilecoinAddressProtocol {

--- a/components/brave_wallet/common/brave_wallet.mojom
+++ b/components/brave_wallet/common/brave_wallet.mojom
@@ -286,7 +286,7 @@ struct AccountInfo {
 
 struct KeyringInfo {
   string id;
-  bool is_default_keyring_created;
+  bool is_keyring_created;
   bool is_locked;
   bool is_backed_up;
   array<AccountInfo> account_infos;


### PR DESCRIPTION
<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/20602

1. Fix a bug that non default keyrings being created when restoring from mnemonics
2. We can now lazily create Solana keyring when SOL account is being added (import would lazily create one too, will be addressed in different PR)
3. KeyringService now has SignMessage for non ETH use 
4. We currently use different signature for SignMessage for non-ETH keyring but we should consider [abstract HDKeyring](https://github.com/brave/brave-browser/issues/20837) because we have too many ETH logics embedded in current HDKeyring now

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

