### PR TITLE
completely disable deletion of shield created cookie rules for now

### DIFF
--- a/components/content_settings/core/browser/brave_content_settings_pref_provider.cc
+++ b/components/content_settings/core/browser/brave_content_settings_pref_provider.cc
@@ -399,7 +399,8 @@ bool BravePrefProvider::SetWebsiteSetting(
   //     // change to type ContentSettingsType::BRAVE_COOKIES
   //     return SetWebsiteSettingInternal(
   //         plugin_primary_pattern, plugin_secondary_pattern,
-  //         ContentSettingsType::BRAVE_COOKIES, std::move(in_value), constraints);
+  //         ContentSettingsType::BRAVE_COOKIES, std::move(in_value),
+  //         constraints);
   //   }
   // }
 

--- a/components/content_settings/core/browser/brave_content_settings_pref_provider.cc
+++ b/components/content_settings/core/browser/brave_content_settings_pref_provider.cc
@@ -369,34 +369,39 @@ bool BravePrefProvider::SetWebsiteSetting(
     ContentSettingsType content_type,
     std::unique_ptr<base::Value>&& in_value,
     const ContentSettingConstraints& constraints) {
+  // TODO(bridiver) - this is currently broken in ways that can cause real
+  // problems if people try to use it so disable completely until we migrate
+  // the brave cookie settings to use CookieControlsMode::kBlockThirdParty
+  // https://github.com/brave/brave-browser/issues/16127
+  //
   // handle changes to brave cookie settings from chromium cookie settings UI
-  if (content_type == ContentSettingsType::COOKIES) {
-    auto* value = in_value.get();
-    auto match = std::find_if(
-        brave_cookie_rules_[off_the_record_].begin(),
-        brave_cookie_rules_[off_the_record_].end(),
-        [primary_pattern, secondary_pattern, value](const auto& rule) {
-          return rule.primary_pattern == primary_pattern &&
-                 rule.secondary_pattern == secondary_pattern &&
-                 ValueToContentSetting(&rule.value) !=
-                    ValueToContentSetting(value); });
-    if (match != brave_cookie_rules_[off_the_record_].end()) {
-      // swap primary/secondary pattern - see CloneRule
-      auto plugin_primary_pattern = secondary_pattern;
-      auto plugin_secondary_pattern = primary_pattern;
+  // if (content_type == ContentSettingsType::COOKIES) {
+  //   auto* value = in_value.get();
+  //   auto match = std::find_if(
+  //       brave_cookie_rules_[off_the_record_].begin(),
+  //       brave_cookie_rules_[off_the_record_].end(),
+  //       [primary_pattern, secondary_pattern, value](const auto& rule) {
+  //         return rule.primary_pattern == primary_pattern &&
+  //                rule.secondary_pattern == secondary_pattern &&
+  //                ValueToContentSetting(&rule.value) !=
+  //                   ValueToContentSetting(value); });
+  //   if (match != brave_cookie_rules_[off_the_record_].end()) {
+  //     // swap primary/secondary pattern - see CloneRule
+  //     auto plugin_primary_pattern = secondary_pattern;
+  //     auto plugin_secondary_pattern = primary_pattern;
 
-      // convert to legacy firstParty format for brave plugin settings
-      if (plugin_primary_pattern == plugin_secondary_pattern) {
-        plugin_secondary_pattern =
-            ContentSettingsPattern::FromString("https://firstParty/*");
-      }
+  //     // convert to legacy firstParty format for brave plugin settings
+  //     if (plugin_primary_pattern == plugin_secondary_pattern) {
+  //       plugin_secondary_pattern =
+  //           ContentSettingsPattern::FromString("https://firstParty/*");
+  //     }
 
-      // change to type ContentSettingsType::BRAVE_COOKIES
-      return SetWebsiteSettingInternal(
-          plugin_primary_pattern, plugin_secondary_pattern,
-          ContentSettingsType::BRAVE_COOKIES, std::move(in_value), constraints);
-    }
-  }
+  //     // change to type ContentSettingsType::BRAVE_COOKIES
+  //     return SetWebsiteSettingInternal(
+  //         plugin_primary_pattern, plugin_secondary_pattern,
+  //         ContentSettingsType::BRAVE_COOKIES, std::move(in_value), constraints);
+  //   }
+  // }
 
   return SetWebsiteSettingInternal(primary_pattern, secondary_pattern,
                                    content_type, std::move(in_value),


### PR DESCRIPTION
This can cause problems that are impossible to recover from. This "fix" is not ideal as non-deletable settings shouldn't have a trash icon, but that change is more complicated and it would be better to just migrate brave cookies settings to use to use CookieControlsMode::kBlockThirdParty and make it actually work again.

Resolves https://github.com/brave/brave-browser/issues/20858

## Submitter Checklist:

- [ ] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

