### PR TITLE
Test devops branch for Windows delta updates (do not merge)

### DIFF
--- a/build/commands/lib/util.js
+++ b/build/commands/lib/util.js
@@ -25,6 +25,7 @@ async function applyPatches() {
   Log.progress('Applying patches...')
   // Always detect if we need to apply patches, since user may have modified
   // either chromium source files, or .patch files manually
+  // Extra comment by mherrmann to test a PR CI build.
   const coreRepoPath = config.braveCoreDir
   const patchesPath = path.join(coreRepoPath, 'patches')
   const v8PatchesPath = path.join(patchesPath, 'v8')


### PR DESCRIPTION
The sole purpose of this PR is to kick off a CI build for testing devops branch `mplesa-jenkins-windows-delta-re-enable`. This is in the context of https://github.com/brave/brave-browser/issues/18696.