### PR TITLE
Disable flaky rewards contribution browser tests (uplift to 1.35.x)

### DIFF
--- a/components/brave_rewards/browser/test/rewards_contribution_browsertest.cc
+++ b/components/brave_rewards/browser/test/rewards_contribution_browsertest.cc
@@ -696,9 +696,9 @@ IN_PROC_BROWSER_TEST_F(
       contents(), "[data-test-id=rewards-summary-ac]", "-5.00 BAT");
 }
 
-IN_PROC_BROWSER_TEST_F(
-    RewardsContributionBrowserTest,
-    SplitProcessorAutoContribution) {
+// TODO(zenparsing): Reimplement this as a unit test (#20473)
+IN_PROC_BROWSER_TEST_F(RewardsContributionBrowserTest,
+                       DISABLED_SplitProcessorAutoContribution) {
   response_->SetVerifiedWallet(true);
   rewards_browsertest_util::StartProcess(rewards_service_);
   rewards_browsertest_util::CreateWallet(rewards_service_);
@@ -829,9 +829,9 @@ IN_PROC_BROWSER_TEST_F(
   run_loop_second.Run();
 }
 
-IN_PROC_BROWSER_TEST_F(
-    RewardsContributionBrowserTest,
-    SplitProcessOneTimeTip) {
+// TODO(zenparsing): Reimplement this as a unit test (#20473)
+IN_PROC_BROWSER_TEST_F(RewardsContributionBrowserTest,
+                       DISABLED_SplitProcessOneTimeTip) {
   response_->SetVerifiedWallet(true);
   rewards_browsertest_util::StartProcess(rewards_service_);
   rewards_browsertest_util::CreateWallet(rewards_service_);


### PR DESCRIPTION
Uplift of #11826

Resolves https://github.com/brave/brave-browser/issues/13883
Resolves https://github.com/brave/brave-browser/issues/13884

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.