### PR TITLE
Use colored brave talk icon when windows has brave talk tab

### DIFF
--- a/browser/ui/brave_browser.cc
+++ b/browser/ui/brave_browser.cc
@@ -83,8 +83,13 @@ void BraveBrowser::OnTabStripModelChanged(
   Browser::OnTabStripModelChanged(tab_strip_model, change, selection);
 
 #if BUILDFLAG(ENABLE_SIDEBAR)
-  // We need to update sidebar UI whenever active tab is changed.
-  if (selection.active_tab_changed() && sidebar_controller_)
+  if (!sidebar_controller_)
+    return;
+  // We need to update sidebar UI whenever active tab is changed or
+  // inactive tab is added/removed.
+  if (change.type() == TabStripModelChange::Type::kInserted ||
+      change.type() == TabStripModelChange::Type::kRemoved ||
+      selection.active_tab_changed())
     sidebar_controller_->sidebar()->UpdateSidebar();
 #endif
 }

--- a/browser/ui/sidebar/sidebar_browsertest.cc
+++ b/browser/ui/sidebar/sidebar_browsertest.cc
@@ -155,9 +155,11 @@ IN_PROC_BROWSER_TEST_F(SidebarBrowserTest,
 
 IN_PROC_BROWSER_TEST_F(SidebarBrowserTest, IterateBuiltInWebTypeTest) {
   // Click builtin wallet item and it's loaded at current active tab.
-  controller()->ActivateItemAt(1);
-  EXPECT_EQ(0, tab_model()->active_index());
   auto item = model()->GetAllSidebarItems()[1];
+  EXPECT_FALSE(controller()->DoesBrowserHaveOpenedTabForItem(item));
+  controller()->ActivateItemAt(1);
+  EXPECT_TRUE(controller()->DoesBrowserHaveOpenedTabForItem(item));
+  EXPECT_EQ(0, tab_model()->active_index());
   EXPECT_EQ(tab_model()->GetWebContentsAt(0)->GetVisibleURL().host(),
             item.url.host());
 

--- a/browser/ui/sidebar/sidebar_controller.cc
+++ b/browser/ui/sidebar/sidebar_controller.cc
@@ -55,6 +55,12 @@ bool SidebarController::IsActiveIndex(int index) const {
   return sidebar_model_->active_index() == index;
 }
 
+bool SidebarController::DoesBrowserHaveOpenedTabForItem(
+    const SidebarItem& item) const {
+  DCHECK(!item.open_in_panel);
+  return !GetAllExistingTabIndexForHost(browser_, item.url.host()).empty();
+}
+
 void SidebarController::ActivateItemAt(int index) {
   // -1 means there is no active item.
   DCHECK_GE(index, -1);

--- a/browser/ui/sidebar/sidebar_controller.h
+++ b/browser/ui/sidebar/sidebar_controller.h
@@ -47,6 +47,8 @@ class SidebarController : public SidebarService::Observer {
 
   bool IsActiveIndex(int index) const;
 
+  bool DoesBrowserHaveOpenedTabForItem(const SidebarItem& item) const;
+
   void SetSidebar(Sidebar* sidebar);
   Sidebar* sidebar() const { return sidebar_; }
 

--- a/browser/ui/views/sidebar/sidebar_control_view.cc
+++ b/browser/ui/views/sidebar/sidebar_control_view.cc
@@ -210,6 +210,7 @@ void SidebarControlView::OnButtonPressed(views::View* view) {
 
 void SidebarControlView::Update() {
   UpdateItemAddButtonState();
+  sidebar_items_view_->Update();
 }
 
 void SidebarControlView::UpdateItemAddButtonState() {

--- a/browser/ui/views/sidebar/sidebar_items_contents_view.cc
+++ b/browser/ui/views/sidebar/sidebar_items_contents_view.cc
@@ -88,6 +88,11 @@ gfx::Size SidebarItemsContentsView::CalculatePreferredSize() const {
 void SidebarItemsContentsView::OnThemeChanged() {
   View::OnThemeChanged();
 
+  // BuiltIn items use different icon set based on theme.
+  UpdateAllBuiltInItemsViewState();
+}
+
+void SidebarItemsContentsView::Update() {
   UpdateAllBuiltInItemsViewState();
 }
 
@@ -97,13 +102,27 @@ void SidebarItemsContentsView::UpdateAllBuiltInItemsViewState() {
   if (children().size() != items.size())
     return;
 
-  // BuiltIn items different colored images depends on theme.
   const int active_index = sidebar_model_->active_index();
-  int index = 0;
-  for (const auto& item : items) {
-    if (sidebar::IsBuiltInType(item))
-      UpdateItemViewStateAt(index, index == active_index);
-    index++;
+  const int items_num = items.size();
+  for (int item_index = 0; item_index < items_num; ++item_index) {
+    const auto item = items[item_index];
+    if (!sidebar::IsBuiltInType(item))
+      continue;
+
+    if (item.open_in_panel) {
+      UpdateItemViewStateAt(item_index, item_index == active_index);
+      continue;
+    }
+
+    // If browser window has tab that loads brave talk, brave talk panel icon
+    // will use colored one for normal state also.
+    if (item.built_in_item_type ==
+        sidebar::SidebarItem::BuiltInItemType::kBraveTalk) {
+      UpdateItemViewStateAt(
+          item_index,
+          browser_->sidebar_controller()->DoesBrowserHaveOpenedTabForItem(
+              item));
+    }
   }
 }
 

--- a/browser/ui/views/sidebar/sidebar_items_contents_view.h
+++ b/browser/ui/views/sidebar/sidebar_items_contents_view.h
@@ -75,6 +75,7 @@ class SidebarItemsContentsView : public views::View,
   void ClearDragIndicator();
 
   bool IsBubbleVisible() const;
+  void Update();
 
  private:
   enum ContextMenuIDs {

--- a/browser/ui/views/sidebar/sidebar_items_scroll_view.cc
+++ b/browser/ui/views/sidebar/sidebar_items_scroll_view.cc
@@ -459,3 +459,7 @@ bool SidebarItemsScrollView::IsItemReorderingInProgress() const {
 bool SidebarItemsScrollView::IsBubbleVisible() const {
   return contents_view_->IsBubbleVisible();
 }
+
+void SidebarItemsScrollView::Update() {
+  contents_view_->Update();
+}

--- a/browser/ui/views/sidebar/sidebar_items_scroll_view.h
+++ b/browser/ui/views/sidebar/sidebar_items_scroll_view.h
@@ -81,6 +81,7 @@ class SidebarItemsScrollView : public views::View,
 
   bool IsItemReorderingInProgress() const;
   bool IsBubbleVisible() const;
+  void Update();
 
  private:
   void UpdateArrowViewsTheme();


### PR DESCRIPTION
fix https://github.com/brave/brave-browser/issues/20865

<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves 

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
`npm run test brave_browser_tests -- --filter=SidebarBrowserTest.*`

1. Launch browser and enable sidebar feature via brave://flags
2. Re-launch and click talk panel icon and check talk panel icon is colored on at normal state(not hovered)
3. Open NTP and close talk tab and check panel icon is changed to non-colored.
