### PR TITLE
Fix crash on epsilon greedy bandit initialization.

### DIFF
--- a/vendor/bat-native-ads/src/bat/ads/internal/ad_targeting/processors/behavioral/bandits/epsilon_greedy_bandit_processor.cc
+++ b/vendor/bat-native-ads/src/bat/ads/internal/ad_targeting/processors/behavioral/bandits/epsilon_greedy_bandit_processor.cc
@@ -59,17 +59,18 @@ EpsilonGreedyBanditArmMap MaybeDeleteArms(
     const EpsilonGreedyBanditArmMap& arms) {
   EpsilonGreedyBanditArmMap updated_arms = arms;
 
-  for (const auto& arm : updated_arms) {
-    const auto iter =
-        std::find(kSegments.cbegin(), kSegments.cend(), arm.first);
-    if (iter != kSegments.end()) {
+  for (auto arm_iter = updated_arms.begin(); arm_iter != updated_arms.end();) {
+    const auto segment_iter =
+        std::find(kSegments.cbegin(), kSegments.cend(), arm_iter->first);
+    if (segment_iter != kSegments.end()) {
+      ++arm_iter;
       continue;
     }
 
-    updated_arms.erase(arm.first);
-
-    BLOG(2, "Epsilon greedy bandit arm was deleted for " << arm.first
+    BLOG(2, "Epsilon greedy bandit arm was deleted for " << arm_iter->first
                                                          << " segment ");
+
+    arm_iter = updated_arms.erase(arm_iter);
   }
 
   return updated_arms;

--- a/vendor/bat-native-ads/src/bat/ads/internal/ad_targeting/processors/behavioral/bandits/epsilon_greedy_bandit_processor_unittest.cc
+++ b/vendor/bat-native-ads/src/bat/ads/internal/ad_targeting/processors/behavioral/bandits/epsilon_greedy_bandit_processor_unittest.cc
@@ -38,6 +38,16 @@ class BatAdsEpsilonGreedyBanditProcessorTest : public UnitTestBase {
 
 TEST_F(BatAdsEpsilonGreedyBanditProcessorTest, InitializeAllArmsFromResource) {
   // Arrange
+  EpsilonGreedyBanditArmMap prefs_arms;
+  EpsilonGreedyBanditArmInfo prefs_arm_info;
+  prefs_arm_info.segment = "foo";
+  prefs_arms["foo"] = prefs_arm_info;
+  prefs_arm_info.segment = "bar";
+  prefs_arms["bar"] = prefs_arm_info;
+
+  AdsClientHelper::Get()->SetStringPref(
+      prefs::kEpsilonGreedyBanditArms,
+      EpsilonGreedyBanditArms::ToJson(prefs_arms));
 
   // Act
   processor::EpsilonGreedyBandit processor;
@@ -48,6 +58,9 @@ TEST_F(BatAdsEpsilonGreedyBanditProcessorTest, InitializeAllArmsFromResource) {
   EpsilonGreedyBanditArmMap arms = EpsilonGreedyBanditArms::FromJson(json);
 
   EXPECT_EQ(30U, arms.size());
+
+  EXPECT_EQ(0u, arms.count("foo"));
+  EXPECT_EQ(0u, arms.count("bar"));
 }
 
 TEST_F(BatAdsEpsilonGreedyBanditProcessorTest, NeverProcessed) {


### PR DESCRIPTION
Crash happens if `brave.brave_ads.epsilon_greedy_bandit_arms` preference contains segments that are not listed in
[segments list](https://github.com/brave/brave-core/blob/master/vendor/bat-native-ads/src/bat/ads/internal/ad_targeting/data_types/behavioral/bandits/epsilon_greedy_bandit_segments.h)

<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/20853

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

Need to check if `epsilon greedy bandit arms` are initialized during Ads service initialization. There should be `Successfully initialized epsilon greedy bandit arms` record in rewards log.
