### PR TITLE
Allow opposite order of params for personalSign (uplift to 1.36.x)

### DIFF
--- a/components/brave_wallet/common/eth_request_helper.cc
+++ b/components/brave_wallet/common/eth_request_helper.cc
@@ -288,6 +288,16 @@ bool ParsePersonalSignParams(const std::string& json,
   if (!address_str || !message_str)
     return false;
 
+  // MetaMask accepts input in the wrong order, so we try for the right order
+  // but if it's invalid then we allow it to be swapped if the other combination
+  // is valid
+  if (!EthAddress::IsValidAddress(*address_str) &&
+      EthAddress::IsValidAddress(*message_str)) {
+    const std::string* temp = address_str;
+    address_str = message_str;
+    message_str = temp;
+  }
+
   *address = *address_str;
   // MM encodes 0x as a string and not an empty value
   if (IsValidHexString(*message_str) && *message_str != "0x") {


### PR DESCRIPTION
Uplift of #12134
Resolves https://github.com/brave/brave-browser/issues/20600

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.