### PR TITLE
[iOS] Add ability to fetch Brave & Chromium version info (uplift to 1.36.x)

### DIFF
--- a/ios/BUILD.gn
+++ b/ios/BUILD.gn
@@ -52,6 +52,7 @@ brave_core_public_headers = [
   "$root_gen_dir/brave/ios/browser/api/ledger/ledger.mojom.objc.h",
   "//brave/ios/browser/keyed_service/keyed_service_factory_wrapper.h",
   "$root_gen_dir/brave/ios/browser/api/skus/skus_sdk.mojom.objc.h",
+  "//brave/ios/browser/api/version_info/version_info_ios.h",
 ]
 
 action("brave_core_umbrella_header") {

--- a/ios/browser/BUILD.gn
+++ b/ios/browser/BUILD.gn
@@ -23,6 +23,7 @@ source_set("browser") {
     "api/brave_wallet:wallet_mojom_wrappers",
     "api/history",
     "api/sync",
+    "api/version_info",
     "brave_wallet",
     "metrics",
     "//base",

--- a/ios/browser/api/version_info/BUILD.gn
+++ b/ios/browser/api/version_info/BUILD.gn
@@ -1,0 +1,16 @@
+# Copyright (c) 2022 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at http://mozilla.org/MPL/2.0/.
+
+source_set("version_info") {
+  configs += [ "//build/config/compiler:enable_arc" ]
+  sources = [
+    "version_info_ios.h",
+    "version_info_ios.mm",
+  ]
+  deps = [
+    "//base",
+    "//brave/components/version_info",
+  ]
+}

--- a/ios/browser/api/version_info/version_info_ios.h
+++ b/ios/browser/api/version_info/version_info_ios.h
@@ -1,0 +1,22 @@
+/* Copyright (c) 2022 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_IOS_BROWSER_API_VERSION_INFO_VERSION_INFO_IOS_H_
+#define BRAVE_IOS_BROWSER_API_VERSION_INFO_VERSION_INFO_IOS_H_
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+OBJC_EXPORT
+@interface BraveCoreVersionInfo : NSObject
+@property(class, readonly) NSString* braveCoreVersion;
+@property(class, readonly) NSString* chromiumVersion;
+- (instancetype)init NS_UNAVAILABLE;
+@end
+
+NS_ASSUME_NONNULL_END
+
+#endif  // BRAVE_IOS_BROWSER_API_VERSION_INFO_VERSION_INFO_IOS_H_

--- a/ios/browser/api/version_info/version_info_ios.mm
+++ b/ios/browser/api/version_info/version_info_ios.mm
@@ -1,0 +1,26 @@
+/* Copyright (c) 2022 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "brave/ios/browser/api/version_info/version_info_ios.h"
+
+#include "base/strings/sys_string_conversions.h"
+#include "brave/components/version_info/version_info.h"
+
+#if !defined(__has_feature) || !__has_feature(objc_arc)
+#error "This file requires ARC support."
+#endif
+
+@implementation BraveCoreVersionInfo
+
++ (NSString*)braveCoreVersion {
+  return base::SysUTF8ToNSString(
+      version_info::GetBraveVersionWithoutChromiumMajorVersion());
+}
+
++ (NSString*)chromiumVersion {
+  return base::SysUTF8ToNSString(version_info::GetBraveChromiumVersionNumber());
+}
+
+@end


### PR DESCRIPTION
Uplift of #12147
Resolves https://github.com/brave/brave-browser/issues/20896

Pre-approval checklist: 
- [ ] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [ ] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [ ] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [ ] The associated issue milestone is set to the smallest version that the changes is landed on.