### PR TITLE
fix(wallet): Disabled Connect Button for Chrome Origins (uplift to 1.36.x)

### DIFF
--- a/components/brave_wallet_ui/components/extension/connected-panel/index.tsx
+++ b/components/brave_wallet_ui/components/extension/connected-panel/index.tsx
@@ -46,7 +46,6 @@ import {
   BraveWallet,
   BuySupportedChains,
   SwapSupportedChains,
-  WalletOrigin,
   DefaultCurrencies
 } from '../../../constants/types'
 import { create, background } from 'ethereum-blockies'
@@ -146,7 +145,7 @@ const ConnectedPanel = (props: Props) => {
       />
       <CenterColumn>
         <StatusRow>
-          {activeOrigin !== WalletOrigin ? (
+          {!activeOrigin.startsWith('chrome://') ? (
             <OvalButton onClick={onShowSitePermissions}>
               {isConnected && <BigCheckMark />}
               <OvalButtonText>{isConnected ? getLocale('braveWalletPanelConnected') : getLocale('braveWalletPanelNotConnected')}</OvalButtonText>


### PR DESCRIPTION
Uplift of #12183
Resolves https://github.com/brave/brave-browser/issues/20973

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.