### PR TITLE
Support building Static instead of Release for PRs (uplift to 1.35.x)

### DIFF
--- a/build/commands/lib/config.js
+++ b/build/commands/lib/config.js
@@ -247,7 +247,7 @@ Config.prototype.buildArgs = function () {
     target_cpu: this.targetArch,
     is_official_build: this.isOfficialBuild() && !this.isAsan(),
     is_debug: this.isDebug(),
-    dcheck_always_on: getNPMConfig(['dcheck_always_on']) || this.buildConfig !== 'Release',
+    dcheck_always_on: getNPMConfig(['dcheck_always_on']) || this.isComponentBuild(),
     brave_channel: this.channel,
     brave_google_api_key: this.braveGoogleApiKey,
     brave_google_api_endpoint: this.googleApiEndpoint,

--- a/build/config.gni
+++ b/build/config.gni
@@ -10,7 +10,7 @@ declare_args() {
   brave_channel = ""
   is_release_channel = false
   base_sparkle_update_url = ""
-  enable_sparkle = is_official_build && is_mac
+  enable_sparkle = !is_component_build && is_mac
 
   sparkle_dsa_private_key_file = ""
   sparkle_eddsa_private_key = ""
@@ -54,16 +54,21 @@ if (is_win) {
       "_$brave_version_minor" + "_$brave_version_build"
   _channel = ""
   brave_app_guid = "{AFE6A462-C574-4B8A-AF43-4CC60DF4563B}"
-  if (is_official_build) {
+  if (brave_channel == "nightly") {
+    # Temporary support PR's non-Release builds on nightly channel.
+    # CI expect the installer files (*Setup.exe) in the output dir are
+    # correspond passed brave_channel. Therefore to make Static+nightly work
+    # we should set _channel to "Nightly".
+    # TODO(atuchin): revert after PRs start to use the development channel.
+    _channel = "Nightly"
+    brave_app_guid = "{C6CB981E-DB30-4876-8639-109F8933582C}"
+  } else if (is_official_build) {
     if (brave_channel == "beta") {
       _channel = "Beta"
       brave_app_guid = "{103BD053-949B-43A8-9120-2E424887DE11}"
     } else if (brave_channel == "dev") {
       _channel = "Dev"
       brave_app_guid = "{CB2150F2-595F-4633-891A-E39720CE0531}"
-    } else if (brave_channel == "nightly") {
-      _channel = "Nightly"
-      brave_app_guid = "{C6CB981E-DB30-4876-8639-109F8933582C}"
     } else {
       assert(brave_channel == "", "Unknown channel name")
     }


### PR DESCRIPTION
Uplift of #11921
Resolves https://github.com/brave/brave-browser/issues/20932

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.