### PR TITLE
Add window.ethereum object when reloading pages (uplift to 1.36.x)

### DIFF
--- a/renderer/brave_content_renderer_client.cc
+++ b/renderer/brave_content_renderer_client.cc
@@ -69,7 +69,8 @@ void BraveContentRendererClient::RenderFrameCreated(
   if (base::FeatureList::IsEnabled(
           brave_wallet::features::kNativeBraveWalletFeature)) {
     new brave_wallet::BraveWalletRenderFrameObserver(
-        render_frame, BraveRenderThreadObserver::GetDynamicParams());
+        render_frame,
+        base::BindRepeating(&BraveRenderThreadObserver::GetDynamicParams));
   }
 
   if (brave_search::IsDefaultAPIEnabled()) {

--- a/renderer/brave_wallet/brave_wallet_render_frame_observer.h
+++ b/renderer/brave_wallet/brave_wallet_render_frame_observer.h
@@ -20,9 +20,12 @@ namespace brave_wallet {
 
 class BraveWalletRenderFrameObserver : public content::RenderFrameObserver {
  public:
+  using GetDynamicParamsCallback =
+      base::RepeatingCallback<const brave::mojom::DynamicParams&()>;
+
   explicit BraveWalletRenderFrameObserver(
       content::RenderFrame* render_frame,
-      brave::mojom::DynamicParams dynamic_params);
+      GetDynamicParamsCallback get_dynamic_params_callback);
   ~BraveWalletRenderFrameObserver() override;
 
   // RenderFrameObserver implementation.
@@ -40,7 +43,7 @@ class BraveWalletRenderFrameObserver : public content::RenderFrameObserver {
   std::unique_ptr<BraveWalletJSHandler> native_javascript_handle_;
 
   GURL url_;
-  const brave::mojom::DynamicParams dynamic_params_;
+  GetDynamicParamsCallback get_dynamic_params_callback_;
 };
 
 }  // namespace brave_wallet

--- a/renderer/test/BUILD.gn
+++ b/renderer/test/BUILD.gn
@@ -9,6 +9,7 @@ source_set("browser_tests") {
   testonly = true
 
   sources = [
+    "brave_wallet_js_handler_browsertest.cc",
     "digital_goods_api_browsertest.cc",
     "file_system_access_browsertest.cc",
     "navigator_connection_attribute_browsertest.cc",
@@ -21,7 +22,9 @@ source_set("browser_tests") {
   deps = [
     "//base/test:test_support",
     "//brave/common",
+    "//brave/components/brave_wallet/browser",
     "//chrome/browser/ui",
+    "//chrome/common",
     "//chrome/test:test_support_ui",
     "//components/embedder_support",
     "//components/web_package",

--- a/renderer/test/brave_wallet_js_handler_browsertest.cc
+++ b/renderer/test/brave_wallet_js_handler_browsertest.cc
@@ -1,0 +1,103 @@
+/* Copyright (c) 2022 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "base/path_service.h"
+#include "brave/common/brave_paths.h"
+#include "brave/components/brave_wallet/browser/brave_wallet_utils.h"
+#include "build/build_config.h"
+#include "chrome/browser/ui/browser.h"
+#include "chrome/browser/ui/browser_commands.h"
+#include "chrome/browser/ui/tabs/tab_strip_model.h"
+#include "chrome/common/chrome_isolated_world_ids.h"
+#include "chrome/test/base/in_process_browser_test.h"
+#include "chrome/test/base/ui_test_utils.h"
+#include "content/public/browser/web_contents.h"
+#include "content/public/test/browser_test.h"
+#include "content/public/test/browser_test_utils.h"
+#include "net/dns/mock_host_resolver.h"
+#include "net/test/embedded_test_server/embedded_test_server.h"
+#include "url/gurl.h"
+
+class BraveWalletJSHandlerBrowserTest : public InProcessBrowserTest {
+ public:
+  BraveWalletJSHandlerBrowserTest()
+      : https_server_(net::EmbeddedTestServer::TYPE_HTTPS) {
+    brave::RegisterPathProvider();
+    base::FilePath test_data_dir;
+    base::PathService::Get(brave::DIR_TEST_DATA, &test_data_dir);
+    https_server_.SetSSLConfig(net::EmbeddedTestServer::CERT_OK);
+    https_server_.ServeFilesFromDirectory(test_data_dir);
+  }
+
+  ~BraveWalletJSHandlerBrowserTest() override = default;
+
+  void SetUpOnMainThread() override {
+    InProcessBrowserTest::SetUpOnMainThread();
+
+    EXPECT_TRUE(https_server_.Start());
+    // Map all hosts to localhost.
+    host_resolver()->AddRule("*", "127.0.0.1");
+  }
+
+  content::WebContents* web_contents() {
+    return browser()->tab_strip_model()->GetActiveWebContents();
+  }
+
+  content::RenderFrameHost* main_frame() {
+    return web_contents()->GetMainFrame();
+  }
+
+ protected:
+  net::EmbeddedTestServer https_server_;
+};
+
+IN_PROC_BROWSER_TEST_F(BraveWalletJSHandlerBrowserTest, AttachOnReload) {
+  brave_wallet::SetDefaultWallet(browser()->profile()->GetPrefs(),
+                                 brave_wallet::mojom::DefaultWallet::None);
+  const GURL url = https_server_.GetURL("/simple.html");
+  ASSERT_TRUE(ui_test_utils::NavigateToURL(browser(), url));
+
+  std::string command = "window.ethereum.isMetaMask";
+  EXPECT_TRUE(content::EvalJs(main_frame(), command)
+                  .error.find("Cannot read properties of undefined") !=
+              std::string::npos);
+  EXPECT_EQ(browser()->tab_strip_model()->GetTabCount(), 1);
+  brave_wallet::SetDefaultWallet(
+      browser()->profile()->GetPrefs(),
+      brave_wallet::mojom::DefaultWallet::BraveWallet);
+  chrome::Reload(browser(), WindowOpenDisposition::CURRENT_TAB);
+  EXPECT_TRUE(content::WaitForLoadStop(web_contents()));
+  auto result = content::EvalJs(main_frame(), command);
+  EXPECT_EQ(result.error, "");
+  ASSERT_TRUE(result.ExtractBool());
+  EXPECT_EQ(browser()->tab_strip_model()->GetTabCount(), 1);
+}
+
+IN_PROC_BROWSER_TEST_F(BraveWalletJSHandlerBrowserTest,
+                       DoNotAttachToChromePages) {
+  brave_wallet::SetDefaultWallet(browser()->profile()->GetPrefs(),
+                                 brave_wallet::mojom::DefaultWallet::None);
+  ASSERT_TRUE(
+      ui_test_utils::NavigateToURL(browser(), GURL("chrome://newtab/")));
+
+  std::string command = "window.ethereum.isMetaMask";
+  EXPECT_TRUE(content::EvalJs(main_frame(), command,
+                              content::EXECUTE_SCRIPT_DEFAULT_OPTIONS,
+                              ISOLATED_WORLD_ID_TRANSLATE)
+                  .error.find("Cannot read properties of undefined") !=
+              std::string::npos);
+  EXPECT_EQ(browser()->tab_strip_model()->GetTabCount(), 1);
+  brave_wallet::SetDefaultWallet(
+      browser()->profile()->GetPrefs(),
+      brave_wallet::mojom::DefaultWallet::BraveWallet);
+  chrome::Reload(browser(), WindowOpenDisposition::CURRENT_TAB);
+  EXPECT_TRUE(content::WaitForLoadStop(web_contents()));
+  EXPECT_TRUE(content::EvalJs(main_frame(), command,
+                              content::EXECUTE_SCRIPT_DEFAULT_OPTIONS,
+                              ISOLATED_WORLD_ID_TRANSLATE)
+                  .error.find("Cannot read properties of undefined") !=
+              std::string::npos);
+  EXPECT_EQ(browser()->tab_strip_model()->GetTabCount(), 1);
+}


### PR DESCRIPTION
Uplift of #12193
Resolves https://github.com/brave/brave-browser/issues/20993

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.