### PR TITLE
[Android] Fixes crash on trying to send url via sync (uplift to 1.35.x)

### DIFF
--- a/chromium_src/components/send_tab_to_self/features.cc
+++ b/chromium_src/components/send_tab_to_self/features.cc
@@ -1,0 +1,20 @@
+/* Copyright (c) 2022 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "src/components/send_tab_to_self/features.cc"
+
+#include "base/feature_override.h"
+
+namespace send_tab_to_self {
+
+OVERRIDE_FEATURE_DEFAULT_STATES({{
+#if defined(OS_ANDROID)
+    // This feature requires Google account at the moment, which causes crash on
+    // trying to create 'Manage Devices' link.
+    {kSendTabToSelfManageDevicesLink, base::FEATURE_DISABLED_BY_DEFAULT},
+#endif
+}});
+
+}  // namespace send_tab_to_self


### PR DESCRIPTION
Uplift of #12232
Resolves https://github.com/brave/brave-browser/issues/21035

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.