### PR TITLE
Refactoring to migrate hardware and selected accounts prefs under keyrings

### DIFF
--- a/android/java/org/chromium/chrome/browser/crypto_wallet/observers/KeyringServiceObserver.java
+++ b/android/java/org/chromium/chrome/browser/crypto_wallet/observers/KeyringServiceObserver.java
@@ -32,5 +32,5 @@ public interface KeyringServiceObserver
     default void autoLockMinutesChanged() {}
 
     @Override
-    default void selectedAccountChanged() {}
+    default void selectedAccountChanged(int coin) {}
 }

--- a/browser/brave_wallet/brave_wallet_provider_delegate_impl.cc
+++ b/browser/brave_wallet/brave_wallet_provider_delegate_impl.cc
@@ -185,7 +185,7 @@ void BraveWalletProviderDelegateImpl::
   permissions::BraveEthereumPermissionContext::RequestPermissions(
       content::RenderFrameHost::FromID(host_id_), addresses,
       base::BindOnce(&OnRequestEthereumPermissions, addresses,
-                     keyring_service_->GetSelectedAccount(),
+                     keyring_service_->GetSelectedAccount(mojom::CoinType::ETH),
                      std::move(callback)));
 }
 
@@ -193,7 +193,7 @@ void BraveWalletProviderDelegateImpl::GetAllowedAccounts(
     bool include_accounts_when_locked,
     GetAllowedAccountsCallback callback) {
   absl::optional<std::string> selected_account =
-      keyring_service_->GetSelectedAccount();
+      keyring_service_->GetSelectedAccount(mojom::CoinType::ETH);
   keyring_service_->GetKeyringInfo(
       brave_wallet::mojom::kDefaultKeyringId,
       base::BindOnce(

--- a/browser/brave_wallet/brave_wallet_provider_impl_unittest.cc
+++ b/browser/brave_wallet/brave_wallet_provider_impl_unittest.cc
@@ -251,10 +251,10 @@ class BraveWalletProviderImplUnitTest : public testing::Test {
     browser_task_environment_.RunUntilIdle();
   }
 
-  void SetSelectedAccount(const std::string& address) {
+  void SetSelectedAccount(const std::string& address, mojom::CoinType coin) {
     base::RunLoop run_loop;
     keyring_service_->SetSelectedAccount(
-        address, base::BindLambdaForTesting([&](bool success) {
+        address, coin, base::BindLambdaForTesting([&](bool success) {
           EXPECT_TRUE(success);
           run_loop.Quit();
         }));
@@ -1051,11 +1051,11 @@ TEST_F(BraveWalletProviderImplUnitTest,
 
   // Selected account should filter the accounts returned
   AddEthereumPermission(url, 1);
-  SetSelectedAccount(from(0));
+  SetSelectedAccount(from(0), mojom::CoinType::ETH);
   EXPECT_EQ(RequestEthereumPermissions(), std::vector<std::string>{from(0)});
-  SetSelectedAccount(from(1));
+  SetSelectedAccount(from(1), mojom::CoinType::ETH);
   EXPECT_EQ(RequestEthereumPermissions(), std::vector<std::string>{from(1)});
-  SetSelectedAccount(from(2));
+  SetSelectedAccount(from(2), mojom::CoinType::ETH);
   EXPECT_EQ(RequestEthereumPermissions(),
             (std::vector<std::string>{from(0), from(1)}));
 }
@@ -1481,7 +1481,7 @@ TEST_F(BraveWalletProviderImplUnitTest, AccountsChangedEvent) {
   // Does not fire for a different origin that has no permissions
   Navigate(GURL("https://bravesoftware.com"));
   AddEthereumPermission(url, 1);
-  SetSelectedAccount(from(0));
+  SetSelectedAccount(from(0), mojom::CoinType::ETH);
   EXPECT_FALSE(observer_->AccountsChangedFired());
 }
 
@@ -1501,19 +1501,19 @@ TEST_F(BraveWalletProviderImplUnitTest, AccountsChangedEventSelectedAccount) {
   observer_->Reset();
 
   // Changing the selected account only returns that account
-  SetSelectedAccount(from(0));
+  SetSelectedAccount(from(0), mojom::CoinType::ETH);
   EXPECT_TRUE(observer_->AccountsChangedFired());
   EXPECT_EQ((std::vector<std::string>{from(0)}), observer_->GetAccounts());
   observer_->Reset();
 
   // Changing to a different allowed account only returns that account
-  SetSelectedAccount(from(1));
+  SetSelectedAccount(from(1), mojom::CoinType::ETH);
   EXPECT_TRUE(observer_->AccountsChangedFired());
   EXPECT_EQ((std::vector<std::string>{from(1)}), observer_->GetAccounts());
   observer_->Reset();
 
   // Changing gto a not allowed account returns all allowed accounts
-  SetSelectedAccount(from(2));
+  SetSelectedAccount(from(2), mojom::CoinType::ETH);
   EXPECT_TRUE(observer_->AccountsChangedFired());
   EXPECT_EQ((std::vector<std::string>{from(0), from(1)}),
             observer_->GetAccounts());
@@ -1569,13 +1569,13 @@ TEST_F(BraveWalletProviderImplUnitTest, GetAllowedAccounts) {
 
   // Selected account should filter the accounts returned
   AddEthereumPermission(url, 1);
-  SetSelectedAccount(from(0));
+  SetSelectedAccount(from(0), mojom::CoinType::ETH);
   EXPECT_EQ(GetAllowedAccounts(false), std::vector<std::string>{account0});
   EXPECT_EQ(GetAllowedAccounts(true), std::vector<std::string>{account0});
-  SetSelectedAccount(from(1));
+  SetSelectedAccount(from(1), mojom::CoinType::ETH);
   EXPECT_EQ(GetAllowedAccounts(false), std::vector<std::string>{account1});
   EXPECT_EQ(GetAllowedAccounts(true), std::vector<std::string>{account1});
-  SetSelectedAccount(from(2));
+  SetSelectedAccount(from(2), mojom::CoinType::ETH);
   EXPECT_EQ(GetAllowedAccounts(false),
             (std::vector<std::string>{account0, account1}));
   EXPECT_EQ(GetAllowedAccounts(true),

--- a/browser/brave_wallet/keyring_service_unittest.cc
+++ b/browser/brave_wallet/keyring_service_unittest.cc
@@ -1967,7 +1967,10 @@ TEST_F(KeyringServiceUnitTest, HardwareAccounts) {
   service.AddObserver(observer.GetReceiver());
 
   ASSERT_TRUE(CreateWallet(&service, "brave"));
-
+  auto* default_keyring =
+      service.GetHDKeyringById(brave_wallet::mojom::kDefaultKeyringId);
+  std::string first_account = default_keyring->GetAddress(0);
+  EXPECT_FALSE(service.IsHardwareAccount(first_account));
   std::vector<mojom::HardwareWalletAccountPtr> new_accounts;
   new_accounts.push_back(mojom::HardwareWalletAccount::New(
       "0x111", "m/44'/60'/1'/0/0", "name 1", "Ledger", "device1",
@@ -1987,6 +1990,8 @@ TEST_F(KeyringServiceUnitTest, HardwareAccounts) {
 
   EXPECT_FALSE(observer.AccountsChangedFired());
   service.AddHardwareAccounts(std::move(new_accounts));
+  EXPECT_TRUE(service.IsHardwareAccount("0x111"));
+  EXPECT_TRUE(service.IsHardwareAccount("0x264"));
   base::RunLoop().RunUntilIdle();
   EXPECT_TRUE(observer.AccountsChangedFired());
   observer.Reset();

--- a/browser/brave_wallet/send_transaction_browsertest.cc
+++ b/browser/brave_wallet/send_transaction_browsertest.cc
@@ -22,7 +22,6 @@
 #include "brave/components/brave_wallet/browser/json_rpc_service.h"
 #include "brave/components/brave_wallet/browser/keyring_service.h"
 #include "brave/components/brave_wallet/browser/tx_service.h"
-#include "brave/components/brave_wallet/common/brave_wallet.mojom-shared.h"
 #include "brave/components/brave_wallet/common/brave_wallet.mojom.h"
 #include "brave/components/brave_wallet/common/features.h"
 #include "brave/components/brave_wallet/common/hex_utils.h"

--- a/browser/brave_wallet/send_transaction_browsertest.cc
+++ b/browser/brave_wallet/send_transaction_browsertest.cc
@@ -22,6 +22,7 @@
 #include "brave/components/brave_wallet/browser/json_rpc_service.h"
 #include "brave/components/brave_wallet/browser/keyring_service.h"
 #include "brave/components/brave_wallet/browser/tx_service.h"
+#include "brave/components/brave_wallet/common/brave_wallet.mojom-shared.h"
 #include "brave/components/brave_wallet/common/brave_wallet.mojom.h"
 #include "brave/components/brave_wallet/common/features.h"
 #include "brave/components/brave_wallet/common/hex_utils.h"
@@ -217,10 +218,10 @@ class SendTransactionBrowserTest : public InProcessBrowserTest {
     run_loop.Run();
   }
 
-  void SetSelectedAccount(const std::string& address) {
+  void SetSelectedAccount(const std::string& address, mojom::CoinType coin) {
     base::RunLoop run_loop;
     keyring_service_->SetSelectedAccount(
-        address, base::BindLambdaForTesting([&](bool success) {
+        address, coin, base::BindLambdaForTesting([&](bool success) {
           ASSERT_TRUE(success);
           run_loop.Quit();
         }));
@@ -635,7 +636,7 @@ IN_PROC_BROWSER_TEST_F(SendTransactionBrowserTest, SelectedAddress) {
 
   // Changing the selected account doesn't change selectedAddress property
   // because it's not allowed yet.
-  SetSelectedAccount(from(1));
+  SetSelectedAccount(from(1), mojom::CoinType::ETH);
   EXPECT_EQ(EvalJs(web_contents(), "getSelectedAddress()",
                    content::EXECUTE_SCRIPT_USE_MANUAL_REPLY)
                 .ExtractString(),

--- a/components/brave_wallet/browser/brave_wallet_p3a.h
+++ b/components/brave_wallet/browser/brave_wallet_p3a.h
@@ -40,7 +40,7 @@ class BraveWalletP3A : public mojom::BraveWalletServiceObserver,
   void BackedUp() override {}
   void AccountsChanged() override {}
   void AutoLockMinutesChanged() override {}
-  void SelectedAccountChanged() override {}
+  void SelectedAccountChanged(mojom::CoinType coin) override {}
 
   // BraveWalletServiceObserver
   void OnActiveOriginChanged(const std::string& origin) override {}

--- a/components/brave_wallet/browser/brave_wallet_provider_impl.cc
+++ b/components/brave_wallet/browser/brave_wallet_provider_impl.cc
@@ -724,7 +724,9 @@ void BraveWalletProviderImpl::OnTransactionStatusChanged(
   add_tx_callbacks_.erase(tx_meta_id);
 }
 
-void BraveWalletProviderImpl::SelectedAccountChanged() {
+void BraveWalletProviderImpl::SelectedAccountChanged(mojom::CoinType coin) {
+  if (coin != mojom::CoinType::ETH)
+    return;
   UpdateKnownAccounts();
 }
 

--- a/components/brave_wallet/browser/brave_wallet_provider_impl.h
+++ b/components/brave_wallet/browser/brave_wallet_provider_impl.h
@@ -214,7 +214,7 @@ class BraveWalletProviderImpl final
   void BackedUp() override {}
   void AccountsChanged() override {}
   void AutoLockMinutesChanged() override {}
-  void SelectedAccountChanged() override;
+  void SelectedAccountChanged(mojom::CoinType coin) override;
 
   int sign_message_id_ = 0;
   raw_ptr<HostContentSettingsMap> host_content_settings_map_ = nullptr;

--- a/components/brave_wallet/browser/eth_tx_manager.h
+++ b/components/brave_wallet/browser/eth_tx_manager.h
@@ -243,7 +243,7 @@ class EthTxManager : public TxManager,
   void BackedUp() override {}
   void AccountsChanged() override {}
   void AutoLockMinutesChanged() override {}
-  void SelectedAccountChanged() override {}
+  void SelectedAccountChanged(mojom::CoinType coin) override {}
 
   // EthBlockTracker::Observer:
   void OnLatestBlock(uint256_t block_num) override {}

--- a/components/brave_wallet/browser/keyring_service.h
+++ b/components/brave_wallet/browser/keyring_service.h
@@ -16,7 +16,6 @@
 #include "brave/components/brave_wallet/browser/hd_keyring.h"
 #include "brave/components/brave_wallet/browser/password_encryptor.h"
 #include "brave/components/brave_wallet/common/brave_wallet.mojom-forward.h"
-#include "brave/components/brave_wallet/common/brave_wallet.mojom-shared.h"
 #include "brave/components/brave_wallet/common/brave_wallet.mojom.h"
 #include "brave/components/brave_wallet/common/brave_wallet_types.h"
 #include "components/keyed_service/core/keyed_service.h"
@@ -213,12 +212,13 @@ class KeyringService : public KeyedService, public mojom::KeyringService {
   bool IsLocked(const std::string& keyring_id = mojom::kDefaultKeyringId) const;
   bool HasPendingUnlockRequest() const;
   void RequestUnlock();
-  absl::optional<std::string> GetSelectedAccount() const;
+  absl::optional<std::string> GetSelectedAccount(mojom::CoinType coin) const;
 
   void AddObserver(
       ::mojo::PendingRemote<mojom::KeyringServiceObserver> observer) override;
   void NotifyUserInteraction() override;
-  void GetSelectedAccount(GetSelectedAccountCallback callback) override;
+  void GetSelectedAccount(mojom::CoinType coin,
+                          GetSelectedAccountCallback callback) override;
   void SetSelectedAccount(const std::string& address,
                           mojom::CoinType coin,
                           SetSelectedAccountCallback callback) override;
@@ -327,7 +327,9 @@ class KeyringService : public KeyedService, public mojom::KeyringService {
   void StopAutoLockTimer();
   void ResetAutoLockTimer();
   void OnAutoLockPreferenceChanged();
-  void OnSelectedAccountPreferenceChanged();
+  void NotifySelectedAccountChanged(mojom::CoinType coin);
+  void SetSelectedAccountForCoin(mojom::CoinType coin,
+                                 const std::string& address);
 
   std::unique_ptr<base::OneShotTimer> auto_lock_timer_;
   std::unique_ptr<PrefChangeRegistrar> pref_change_registrar_;

--- a/components/brave_wallet/browser/keyring_service.h
+++ b/components/brave_wallet/browser/keyring_service.h
@@ -149,7 +149,8 @@ class KeyringService : public KeyedService, public mojom::KeyringService {
       ImportFilecoinBLSAccountCallback callback) override;
   void AddHardwareAccounts(
       std::vector<mojom::HardwareWalletAccountPtr> info) override;
-  void RemoveHardwareAccount(const std::string& address) override;
+  void RemoveHardwareAccount(const std::string& address,
+                             mojom::CoinType coin) override;
   void GetPrivateKeyForImportedAccount(
       const std::string& address,
       mojom::CoinType coin,
@@ -258,6 +259,7 @@ class KeyringService : public KeyedService, public mojom::KeyringService {
   FRIEND_TEST_ALL_PREFIXES(KeyringServiceUnitTest, SetSelectedAccount);
   FRIEND_TEST_ALL_PREFIXES(KeyringServiceUnitTest, ImportFilecoinAccounts);
   FRIEND_TEST_ALL_PREFIXES(KeyringServiceUnitTest, PreCreateEncryptors);
+  FRIEND_TEST_ALL_PREFIXES(KeyringServiceUnitTest, HardwareAccounts);
 
   friend class BraveWalletProviderImplUnitTest;
   friend class EthTxManagerUnitTest;
@@ -291,7 +293,8 @@ class KeyringService : public KeyedService, public mojom::KeyringService {
   std::vector<mojom::AccountInfoPtr> GetAccountInfosForKeyring(
       const std::string& id) const;
   bool UpdateNameForHardwareAccountSync(const std::string& address,
-                                        const std::string& name);
+                                        const std::string& name,
+                                        mojom::CoinType coin);
   const std::string GetMnemonicForKeyringImpl(const std::string& keyring_id);
 
   bool GetPrefInBytesForKeyring(const std::string& key,
@@ -306,7 +309,6 @@ class KeyringService : public KeyedService, public mojom::KeyringService {
   bool CreateKeyringInternal(const std::string& keyring_id,
                              const std::string& mnemonic,
                              bool is_legacy_brave_wallet);
-  std::string GetKeyringIdForHardwareAccount(const std::string& account) const;
 
   // Currently only support one default keyring, `CreateDefaultKeyring` and
   // `RestoreDefaultKeyring` will overwrite existing one if success

--- a/components/brave_wallet/browser/keyring_service.h
+++ b/components/brave_wallet/browser/keyring_service.h
@@ -16,6 +16,7 @@
 #include "brave/components/brave_wallet/browser/hd_keyring.h"
 #include "brave/components/brave_wallet/browser/password_encryptor.h"
 #include "brave/components/brave_wallet/common/brave_wallet.mojom-forward.h"
+#include "brave/components/brave_wallet/common/brave_wallet.mojom-shared.h"
 #include "brave/components/brave_wallet/common/brave_wallet.mojom.h"
 #include "brave/components/brave_wallet/common/brave_wallet_types.h"
 #include "components/keyed_service/core/keyed_service.h"
@@ -52,8 +53,6 @@ class KeyringService : public KeyedService, public mojom::KeyringService {
   static const base::Value* GetPrefForKeyring(PrefService* prefs,
                                               const std::string& key,
                                               const std::string& id);
-  static base::Value* GetPrefForHardwareKeyringUpdate(PrefService* prefs,
-                                                      const std::string& id);
   static base::Value* GetPrefForKeyringUpdate(PrefService* prefs,
                                               const std::string& key,
                                               const std::string& id);
@@ -164,10 +163,10 @@ class KeyringService : public KeyedService, public mojom::KeyringService {
                        GetKeyringsInfoCallback callback) override;
   void GetKeyringInfo(const std::string& keyring_id,
                       GetKeyringInfoCallback callback) override;
-  void SetDefaultKeyringHardwareAccountName(
-      const std::string& address,
-      const std::string& name,
-      SetDefaultKeyringHardwareAccountNameCallback callback) override;
+  void SetHardwareAccountName(const std::string& address,
+                              const std::string& name,
+                              mojom::CoinType coin,
+                              SetHardwareAccountNameCallback callback) override;
   void SetKeyringDerivedAccountName(
       const std::string& keyring_id,
       const std::string& address,
@@ -182,8 +181,6 @@ class KeyringService : public KeyedService, public mojom::KeyringService {
   void Reset(bool notify_observer = true);
   bool IsKeyringCreated(const std::string& keyring_id) const;
   bool IsHardwareAccount(const std::string& account) const;
-  std::string GetKeyringIdForHardwareAccount(const std::string& account) const;
-  std::string GetKeyringIdForAccount(const std::string& address) const;
   void SignTransactionByDefaultKeyring(const std::string& address,
                                        EthTransaction* tx,
                                        uint256_t chain_id);
@@ -222,6 +219,7 @@ class KeyringService : public KeyedService, public mojom::KeyringService {
   void NotifyUserInteraction() override;
   void GetSelectedAccount(GetSelectedAccountCallback callback) override;
   void SetSelectedAccount(const std::string& address,
+                          mojom::CoinType coin,
                           SetSelectedAccountCallback callback) override;
   void GetAutoLockMinutes(GetAutoLockMinutesCallback callback) override;
   void SetAutoLockMinutes(int32_t minutes,
@@ -260,6 +258,7 @@ class KeyringService : public KeyedService, public mojom::KeyringService {
   FRIEND_TEST_ALL_PREFIXES(KeyringServiceUnitTest, SetSelectedAccount);
   FRIEND_TEST_ALL_PREFIXES(KeyringServiceUnitTest, ImportFilecoinAccounts);
   FRIEND_TEST_ALL_PREFIXES(KeyringServiceUnitTest, PreCreateEncryptors);
+
   friend class BraveWalletProviderImplUnitTest;
   friend class EthTxManagerUnitTest;
 
@@ -307,6 +306,7 @@ class KeyringService : public KeyedService, public mojom::KeyringService {
   bool CreateKeyringInternal(const std::string& keyring_id,
                              const std::string& mnemonic,
                              bool is_legacy_brave_wallet);
+  std::string GetKeyringIdForHardwareAccount(const std::string& account) const;
 
   // Currently only support one default keyring, `CreateDefaultKeyring` and
   // `RestoreDefaultKeyring` will overwrite existing one if success

--- a/components/brave_wallet/browser/keyring_service.h
+++ b/components/brave_wallet/browser/keyring_service.h
@@ -52,10 +52,13 @@ class KeyringService : public KeyedService, public mojom::KeyringService {
   static const base::Value* GetPrefForKeyring(PrefService* prefs,
                                               const std::string& key,
                                               const std::string& id);
-  static base::Value* GetPrefForHardwareKeyringUpdate(PrefService* prefs);
+  static base::Value* GetPrefForHardwareKeyringUpdate(PrefService* prefs,
+                                                      const std::string& id);
   static base::Value* GetPrefForKeyringUpdate(PrefService* prefs,
                                               const std::string& key,
                                               const std::string& id);
+  static std::vector<std::string> GetAvailableKeyringsFromPrefs(
+      PrefService* prefs);
   // If keyring dicionary for id doesn't exist, it will be created.
   static void SetPrefForKeyring(PrefService* prefs,
                                 const std::string& key,
@@ -69,7 +72,7 @@ class KeyringService : public KeyedService, public mojom::KeyringService {
       const absl::optional<std::string> name,
       const absl::optional<std::string> address,
       const std::string& id);
-
+  static std::string GetKeyringIdForCoin(mojom::CoinType coin);
   static std::string GetAccountNameForKeyring(PrefService* prefs,
                                               const std::string& account_path,
                                               const std::string& id);
@@ -179,6 +182,8 @@ class KeyringService : public KeyedService, public mojom::KeyringService {
   void Reset(bool notify_observer = true);
   bool IsKeyringCreated(const std::string& keyring_id) const;
   bool IsHardwareAccount(const std::string& account) const;
+  std::string GetKeyringIdForHardwareAccount(const std::string& account) const;
+  std::string GetKeyringIdForAccount(const std::string& address) const;
   void SignTransactionByDefaultKeyring(const std::string& address,
                                        EthTransaction* tx,
                                        uint256_t chain_id);
@@ -263,7 +268,8 @@ class KeyringService : public KeyedService, public mojom::KeyringService {
   mojom::KeyringInfoPtr GetKeyringInfoSync(const std::string& keyring_id);
   void OnAutoLockFired();
   HDKeyring* GetHDKeyringById(const std::string& keyring_id) const;
-  std::vector<mojom::AccountInfoPtr> GetHardwareAccountsSync() const;
+  std::vector<mojom::AccountInfoPtr> GetHardwareAccountsSync(
+      const std::string& keyring_id) const;
   std::vector<uint8_t> GetPrivateKeyFromKeyring(const std::string& address,
                                                 const std::string& keyring_id);
   // Address will be returned when success
@@ -281,10 +287,10 @@ class KeyringService : public KeyedService, public mojom::KeyringService {
       const std::string& network);
   bool IsKeyringExist(const std::string& keyring_id) const;
   bool LazilyCreateKeyring(const std::string& keyring_id);
-  size_t GetAccountMetasNumberForKeyring(const std::string& id);
+  size_t GetAccountMetasNumberForKeyring(const std::string& id) const;
 
   std::vector<mojom::AccountInfoPtr> GetAccountInfosForKeyring(
-      const std::string& id);
+      const std::string& id) const;
   bool UpdateNameForHardwareAccountSync(const std::string& address,
                                         const std::string& name);
   const std::string GetMnemonicForKeyringImpl(const std::string& keyring_id);

--- a/components/brave_wallet/browser/pref_names.cc
+++ b/components/brave_wallet/browser/pref_names.cc
@@ -27,6 +27,7 @@ const char kSupportEip1559OnLocalhostChain[] =
     "brave.wallet.support_eip1559_on_localhost_chain";
 
 // DEPRECATED
+const char kBraveWalletHardwareKeyring[] = "brave.wallet.keyrings.hardware";
 const char kBraveWalletPasswordEncryptorSalt[] =
     "brave.wallet.password_encryptor.salt";
 const char kBraveWalletPasswordEncryptorNonce[] =

--- a/components/brave_wallet/browser/pref_names.cc
+++ b/components/brave_wallet/browser/pref_names.cc
@@ -27,7 +27,6 @@ const char kSupportEip1559OnLocalhostChain[] =
     "brave.wallet.support_eip1559_on_localhost_chain";
 
 // DEPRECATED
-const char kBraveWalletHardwareKeyring[] = "brave.wallet.keyrings.hardware";
 const char kBraveWalletPasswordEncryptorSalt[] =
     "brave.wallet.password_encryptor.salt";
 const char kBraveWalletPasswordEncryptorNonce[] =

--- a/components/brave_wallet/browser/pref_names.cc
+++ b/components/brave_wallet/browser/pref_names.cc
@@ -22,11 +22,11 @@ const char kBraveWalletUserAssets[] = "brave.wallet.user_assets";
 const char kBraveWalletUserAssetEthContractAddressMigrated[] =
     "brave.wallet.user.asset.eth_contract_address_migrated";
 const char kBraveWalletAutoLockMinutes[] = "brave.wallet.auto_lock_minutes";
-const char kBraveWalletSelectedAccount[] = "brave.wallet.selected_account";
 const char kSupportEip1559OnLocalhostChain[] =
     "brave.wallet.support_eip1559_on_localhost_chain";
 
 // DEPRECATED
+const char kBraveWalletSelectedAccount[] = "brave.wallet.selected_account";
 const char kBraveWalletPasswordEncryptorSalt[] =
     "brave.wallet.password_encryptor.salt";
 const char kBraveWalletPasswordEncryptorNonce[] =

--- a/components/brave_wallet/browser/pref_names.h
+++ b/components/brave_wallet/browser/pref_names.h
@@ -23,6 +23,7 @@ extern const char kBraveWalletSelectedAccount[];
 extern const char kSupportEip1559OnLocalhostChain[];
 
 // DEPRECATED
+extern const char kBraveWalletHardwareKeyring[];
 extern const char kBraveWalletWeb3ProviderDeprecated[];
 extern const char kDefaultWalletDeprecated[];
 extern const char kBraveWalletPasswordEncryptorSalt[];

--- a/components/brave_wallet/browser/pref_names.h
+++ b/components/brave_wallet/browser/pref_names.h
@@ -19,10 +19,10 @@ extern const char kBraveWalletUserAssets[];
 // Added 10/2021 to migrate contract address to an empty string for ETH.
 extern const char kBraveWalletUserAssetEthContractAddressMigrated[];
 extern const char kBraveWalletAutoLockMinutes[];
-extern const char kBraveWalletSelectedAccount[];
 extern const char kSupportEip1559OnLocalhostChain[];
 
 // DEPRECATED
+extern const char kBraveWalletSelectedAccount[];
 extern const char kBraveWalletWeb3ProviderDeprecated[];
 extern const char kDefaultWalletDeprecated[];
 extern const char kBraveWalletPasswordEncryptorSalt[];

--- a/components/brave_wallet/browser/pref_names.h
+++ b/components/brave_wallet/browser/pref_names.h
@@ -23,7 +23,6 @@ extern const char kBraveWalletSelectedAccount[];
 extern const char kSupportEip1559OnLocalhostChain[];
 
 // DEPRECATED
-extern const char kBraveWalletHardwareKeyring[];
 extern const char kBraveWalletWeb3ProviderDeprecated[];
 extern const char kDefaultWalletDeprecated[];
 extern const char kBraveWalletPasswordEncryptorSalt[];

--- a/components/brave_wallet/common/brave_wallet.mojom
+++ b/components/brave_wallet/common/brave_wallet.mojom
@@ -458,7 +458,7 @@ interface KeyringService {
   AddHardwareAccounts(array<HardwareWalletAccount> info);
 
   // Removes a hardware account
-  RemoveHardwareAccount(string address);
+  RemoveHardwareAccount(string address, CoinType coin);
 
   // Informs the user that user interaction occurred so auto-lock doesn't occur
   NotifyUserInteraction();

--- a/components/brave_wallet/common/brave_wallet.mojom
+++ b/components/brave_wallet/common/brave_wallet.mojom
@@ -452,7 +452,7 @@ interface KeyringService {
   SetKeyringImportedAccountName(string keyring_id, string address, string name) => (bool success);
 
   // Sets the account name for a hardware account
-  SetDefaultKeyringHardwareAccountName(string address, string name) => (bool success);
+  SetHardwareAccountName(string address, string name, CoinType coin) => (bool success);
 
   // Adds hardware accounts
   AddHardwareAccounts(array<HardwareWalletAccount> info);
@@ -467,7 +467,7 @@ interface KeyringService {
   GetSelectedAccount() => (string? address);
 
   // Sets the selected account
-  SetSelectedAccount(string address) => (bool success);
+  SetSelectedAccount(string address, CoinType coin) => (bool success);
 
   // Obtains the number of minutes that the keyring will auto-lock in
   GetAutoLockMinutes() => (int32 minutes);

--- a/components/brave_wallet/common/brave_wallet.mojom
+++ b/components/brave_wallet/common/brave_wallet.mojom
@@ -355,7 +355,7 @@ interface KeyringServiceObserver {
   AutoLockMinutesChanged();
 
   // Fired when the selected account setting changes
-  SelectedAccountChanged();
+  SelectedAccountChanged(CoinType coin);
 };
 
 // List of tokens and coins that are supported.
@@ -464,7 +464,7 @@ interface KeyringService {
   NotifyUserInteraction();
 
   // Obtains the selected account
-  GetSelectedAccount() => (string? address);
+  GetSelectedAccount(CoinType coin) => (string? address);
 
   // Sets the selected account
   SetSelectedAccount(string address, CoinType coin) => (bool success);

--- a/components/brave_wallet_ui/common/async/handlers.ts
+++ b/components/brave_wallet_ui/common/async/handlers.ts
@@ -194,7 +194,7 @@ handler.on(WalletActions.selectNetwork.getType(), async (store: Store, payload: 
 handler.on(WalletActions.selectAccount.getType(), async (store: Store, payload: WalletAccountType) => {
   const { keyringService } = getAPIProxy()
 
-  await keyringService.setSelectedAccount(payload.address)
+  await keyringService.setSelectedAccount(payload.address, payload.coin)
   store.dispatch(WalletActions.setSelectedAccount(payload))
   await store.dispatch(refreshTransactionHistory(payload.address))
 })

--- a/components/brave_wallet_ui/common/async/lib.ts
+++ b/components/brave_wallet_ui/common/async/lib.ts
@@ -350,7 +350,7 @@ export function refreshKeyringInfo () {
     }
 
     // Get selectedAccountAddress
-    const getSelectedAccount = await keyringService.getSelectedAccount()
+    const getSelectedAccount = await keyringService.getSelectedAccount(BraveWallet.CoinType.ETH)
     const selectedAddress = getSelectedAccount.address
 
     // Fallback account address if selectedAccount returns null

--- a/components/brave_wallet_ui/common/async/lib.ts
+++ b/components/brave_wallet_ui/common/async/lib.ts
@@ -354,12 +354,12 @@ export function refreshKeyringInfo () {
     const selectedAddress = getSelectedAccount.address
 
     // Fallback account address if selectedAccount returns null
-    const fallbackAddress = walletInfo.accountInfos[0].address
+    const fallbackAccount = walletInfo.accountInfos[0]
 
     // If selectedAccount is null will setSelectedAccount to fallback address
     if (!selectedAddress) {
-      await keyringService.setSelectedAccount(fallbackAddress)
-      walletInfo.selectedAccount = fallbackAddress
+      await keyringService.setSelectedAccount(fallbackAccount.address, fallbackAccount.coin)
+      walletInfo.selectedAccount = fallbackAccount.address
     } else {
       // If a user has already created an wallet but then chooses to restore
       // a different wallet, getSelectedAccount still returns the previous wallets
@@ -367,8 +367,8 @@ export function refreshKeyringInfo () {
       // This check looks to see if the returned selectedAccount exist in the accountInfos
       // payload, if not it will setSelectedAccount to the fallback address
       if (!walletInfo.accountInfos.find((account) => account.address.toLowerCase() === selectedAddress?.toLowerCase())) {
-        walletInfo.selectedAccount = fallbackAddress
-        await keyringService.setSelectedAccount(fallbackAddress)
+        walletInfo.selectedAccount = fallbackAccount.address
+        await keyringService.setSelectedAccount(fallbackAccount.address, fallbackAccount.coin)
       } else {
         walletInfo.selectedAccount = selectedAddress
       }

--- a/components/brave_wallet_ui/page/async/wallet_page_async_handler.ts
+++ b/components/brave_wallet_ui/page/async/wallet_page_async_handler.ts
@@ -171,7 +171,7 @@ handler.on(WalletPageActions.addHardwareAccounts.getType(), async (store: Store,
 
 handler.on(WalletPageActions.removeHardwareAccount.getType(), async (store: Store, payload: RemoveHardwareAccountPayloadType) => {
   const keyringService = getWalletPageApiProxy().keyringService
-  keyringService.removeHardwareAccount(payload.address)
+  keyringService.removeHardwareAccount(payload.address, payload.coin)
   store.dispatch(WalletPageActions.setShowAddModal(false))
 })
 

--- a/components/brave_wallet_ui/page/async/wallet_page_async_handler.ts
+++ b/components/brave_wallet_ui/page/async/wallet_page_async_handler.ts
@@ -153,7 +153,7 @@ handler.on(WalletPageActions.updateAccountName.getType(), async (store: Store, p
   const keyringService = getWalletPageApiProxy().keyringService
   const hardwareAccount = await findHardwareAccountInfo(payload.address)
   if (hardwareAccount && hardwareAccount.hardware) {
-    const result = await keyringService.setDefaultKeyringHardwareAccountName(payload.address, payload.name)
+    const result = await keyringService.setHardwareAccountName(payload.address, payload.name, hardwareAccount.coin)
     return result.success
   }
   const keyringId = await getKeyringIdFromAddress(payload.address)

--- a/components/brave_wallet_ui/page/constants/action_types.ts
+++ b/components/brave_wallet_ui/page/constants/action_types.ts
@@ -43,6 +43,7 @@ export type RemoveImportedAccountPayloadType = {
 
 export type RemoveHardwareAccountPayloadType = {
   address: string
+  coin: BraveWallet.CoinType
 }
 
 export type RestoreWalletPayloadType = {

--- a/components/brave_wallet_ui/page/container.tsx
+++ b/components/brave_wallet_ui/page/container.tsx
@@ -432,7 +432,7 @@ function Container (props: Props) {
 
   const onRemoveAccount = (address: string, hardware: boolean, coin: BraveWallet.CoinType) => {
     if (hardware) {
-      props.walletPageActions.removeHardwareAccount({ address })
+      props.walletPageActions.removeHardwareAccount({ address, coin })
       return
     }
     props.walletPageActions.removeImportedAccount({ address, coin })


### PR DESCRIPTION
<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/21015

- Fixed coin type save for hardware accounts
- Updated the API `SetDefaultKeyringHardwareAccountName` to `SetHardwareAccountName(string address, string name, CoinType coin)`
- Updated the API `SetSelectedAccount` to `SetSelectedAccount(string address, CoinType coin)`
- Updated the API `RemoveHardwareAccount` to `RemoveHardwareAccount(string address, CoinType coin)`
- Updated the API `SetSelectedAccount` to `SetSelectedAccount(string address, CoinType coin)`
- Selected accounts migrated under keyrings preferences to have separate accounts for each keyring. `GetSelectedAccount` requires `CoinType` as well.
- Moved hardware accounts into keyrings preferences. Migrated all obsolete prefs only to default keyring because we support only ETH hardware accounts at this time. New structure:
```
  "keyrings":
    {
        "default":
        {
            "selected_account": "0x..",
            "account_metas": {},
            "imported_accounts":[],
            "hardware": {
                "3939e7b....55157e81ae7": {
                      "account_metas": {},
                }
            },
        },
        "filecoin": {
            "selected_account": "t1...",
            "hardware": {
                "4939e7b....55157e81ae7": {
                      "account_metas": {},
                }
            },
        },
        "solana": {
            "selected_account": "xxx",
            "hardware": {
                "5939e7b....55157e81ae7": {
                      "account_metas": {},
                }
            },
        }
    }
```



## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

- Import hardware accounts in any browser without this code, beta/stable channels
- Enable either Solana or Filecoin keyring by creation/import accounts for them
- Open accounts page and check hardware accounts are duplicated
- Update to this build
- Check accounts page, duplication disappeared and in the preferences hardware accounts were moved to default keyring.
- Make sure main accounts selection works as expected for different keyrings(ETH/SOL/FIL) because we changed the interface
