### PR TITLE
Fix front-end bug with max fee not updating with base fee  (uplift to 1.36.x)

### DIFF
--- a/components/brave_wallet_ui/components/extension/edit-gas/index.tsx
+++ b/components/brave_wallet_ui/components/extension/edit-gas/index.tsx
@@ -85,6 +85,14 @@ const EditGas = (props: Props) => {
   const [maxPriorityFeePerGas, setMaxPriorityFeePerGas] = React.useState<string>(toGWei(transactionFees.maxPriorityFeePerGas))
   const [maxFeePerGas, setMaxFeePerGas] = React.useState<string>(toGWei(transactionFees.maxFeePerGas))
 
+  React.useEffect(
+    () => {
+      const maxWeiValue = addNumericValues(baseFeePerGas, gWeiToWei(maxPriorityFeePerGas))
+      setMaxFeePerGas(toGWei(maxWeiValue))
+    },
+    [baseFeePerGas]
+  )
+
   const handleGasPriceInputChanged = (event: React.ChangeEvent<HTMLInputElement>) => {
     setGasPrice(event.target.value)
   }


### PR DESCRIPTION
Uplift of https://github.com/brave/brave-core/pull/12054/commits/af20334847dcac173f3e6afce5dcf654c35dc8d7 to **`1.36.x`** (cherry-picked from https://github.com/brave/brave-core/pull/12054).

Resolves https://github.com/brave/brave-browser/issues/21105.

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.