### PR TITLE
Revert "feat(wallet): Wired up Create Solana Account in UI"

### DIFF
--- a/browser/about_flags.cc
+++ b/browser/about_flags.cc
@@ -242,10 +242,6 @@ constexpr char kBraveWalletFilecoinName[] =
 constexpr char kBraveWalletFilecoinDescription[] =
     "Filecoin support for native Brave Wallet";
 
-constexpr char kBraveWalletSolanaName[] = "Enable Brave Wallet Solana support";
-constexpr char kBraveWalletSolanaDescription[] =
-    "Solana support for native Brave Wallet";
-
 constexpr char kBraveNewsName[] = "Enable Brave News";
 constexpr char kBraveNewsDescription[] =
     "Brave News is completely private and includes anonymized ads matched on "
@@ -365,22 +361,17 @@ const flags_ui::FeatureEntry::Choice kBraveSkusEnvChoices[] = {
 #define BRAVE_IPFS_FEATURE_ENTRIES
 #endif
 
-#define BRAVE_NATIVE_WALLET_FEATURE_ENTRIES                                    \
-    {"native-brave-wallet",                                                    \
-     flag_descriptions::kNativeBraveWalletName,                                \
-     flag_descriptions::kNativeBraveWalletDescription,                         \
-     kOsDesktop | flags_ui::kOsAndroid,                                        \
-     FEATURE_VALUE_TYPE(brave_wallet::features::kNativeBraveWalletFeature)},   \
-    {"brave-wallet-filecoin",                                                  \
-     flag_descriptions::kBraveWalletFilecoinName,                              \
-     flag_descriptions::kBraveWalletFilecoinDescription,                       \
-     kOsDesktop | flags_ui::kOsAndroid,                                        \
-     FEATURE_VALUE_TYPE(brave_wallet::features::kBraveWalletFilecoinFeature)}, \
-    {"brave-wallet-solana",                                                    \
-     flag_descriptions::kBraveWalletSolanaName,                                \
-     flag_descriptions::kBraveWalletSolanaDescription,                         \
-     kOsDesktop | flags_ui::kOsAndroid,                                        \
-     FEATURE_VALUE_TYPE(brave_wallet::features::kBraveWalletSolanaFeature)},
+#define BRAVE_NATIVE_WALLET_FEATURE_ENTRIES                                  \
+    {"native-brave-wallet",                                                  \
+     flag_descriptions::kNativeBraveWalletName,                              \
+     flag_descriptions::kNativeBraveWalletDescription,                       \
+     kOsDesktop | flags_ui::kOsAndroid,                                      \
+     FEATURE_VALUE_TYPE(brave_wallet::features::kNativeBraveWalletFeature)}, \
+    {"brave-wallet-filecoin",                                                \
+     flag_descriptions::kBraveWalletFilecoinName,                            \
+     flag_descriptions::kBraveWalletFilecoinDescription,                     \
+     kOsDesktop | flags_ui::kOsAndroid,                                      \
+     FEATURE_VALUE_TYPE(brave_wallet::features::kBraveWalletFilecoinFeature)},
 
 #define BRAVE_NEWS_FEATURE_ENTRIES                                  \
     {"brave-news",                                                  \

--- a/browser/ui/webui/brave_wallet/common_handler/wallet_handler.cc
+++ b/browser/ui/webui/brave_wallet/common_handler/wallet_handler.cc
@@ -46,12 +46,10 @@ void WalletHandler::OnConnectionError() {
 
 void WalletHandler::GetWalletInfo(GetWalletInfoCallback callback) {
   EnsureConnected();
-  std::vector<std::string> ids = {brave_wallet::mojom::kDefaultKeyringId};
-  if (brave_wallet::IsFilecoinEnabled())
+  std::vector<std::string> ids(1, brave_wallet::mojom::kDefaultKeyringId);
+  if (brave_wallet::IsFilecoinEnabled()) {
     ids.push_back(brave_wallet::mojom::kFilecoinKeyringId);
-  if (brave_wallet::IsSolanaEnabled())
-    ids.push_back(brave_wallet::mojom::kSolanaKeyringId);
-
+  }
   keyring_service_->GetKeyringsInfo(
       ids, base::BindOnce(&WalletHandler::OnGetWalletInfo,
                           weak_ptr_factory_.GetWeakPtr(), std::move(callback)));
@@ -79,8 +77,7 @@ void WalletHandler::OnGetWalletInfo(
   std::move(callback).Run(
       default_keyring->is_keyring_created, default_keyring->is_locked,
       std::move(favorite_apps_copy), default_keyring->is_backed_up,
-      std::move(account_infos), brave_wallet::IsFilecoinEnabled(),
-      brave_wallet::IsSolanaEnabled());
+      std::move(account_infos), brave_wallet::IsFilecoinEnabled());
 }
 
 void WalletHandler::AddFavoriteApp(

--- a/components/brave_wallet/browser/brave_wallet_utils.cc
+++ b/components/brave_wallet/browser/brave_wallet_utils.cc
@@ -247,17 +247,10 @@ bool IsNativeWalletEnabled() {
   return base::FeatureList::IsEnabled(
       brave_wallet::features::kNativeBraveWalletFeature);
 }
-
 bool IsFilecoinEnabled() {
   return base::FeatureList::IsEnabled(
       brave_wallet::features::kBraveWalletFilecoinFeature);
 }
-
-bool IsSolanaEnabled() {
-  return base::FeatureList::IsEnabled(
-      brave_wallet::features::kBraveWalletSolanaFeature);
-}
-
 const std::vector<brave_wallet::mojom::EthereumChain>
 GetAllKnownNetworksForTesting() {
   std::vector<brave_wallet::mojom::EthereumChain> result;

--- a/components/brave_wallet/browser/brave_wallet_utils.h
+++ b/components/brave_wallet/browser/brave_wallet_utils.h
@@ -25,7 +25,6 @@ namespace brave_wallet {
 
 bool IsNativeWalletEnabled();
 bool IsFilecoinEnabled();
-bool IsSolanaEnabled();
 
 // Generate mnemonic from random entropy following BIP39.
 // |entropy_size| should be specify in bytes

--- a/components/brave_wallet/browser/json_rpc_service.cc
+++ b/components/brave_wallet/browser/json_rpc_service.cc
@@ -525,8 +525,6 @@ void JsonRpcService::GetBalance(const std::string& address,
                        weak_ptr_factory_.GetWeakPtr(), std::move(callback));
     return Request(fil_getBalance(address), true, std::move(internal_callback));
   }
-  std::move(callback).Run("", mojom::ProviderError::kInternalError,
-                          l10n_util::GetStringUTF8(IDS_WALLET_INTERNAL_ERROR));
 }
 
 void JsonRpcService::OnEthGetBalance(

--- a/components/brave_wallet/browser/solana_transaction_unittest.cc
+++ b/components/brave_wallet/browser/solana_transaction_unittest.cc
@@ -8,14 +8,11 @@
 #include <memory>
 
 #include "base/base64.h"
-#include "base/test/bind.h"
-#include "base/test/scoped_feature_list.h"
 #include "brave/components/brave_wallet/browser/brave_wallet_constants.h"
 #include "brave/components/brave_wallet/browser/brave_wallet_prefs.h"
 #include "brave/components/brave_wallet/browser/keyring_service.h"
 #include "brave/components/brave_wallet/browser/solana_account_meta.h"
 #include "brave/components/brave_wallet/browser/solana_instruction.h"
-#include "brave/components/brave_wallet/common/features.h"
 #include "components/prefs/testing_pref_service.h"
 #include "components/sync_preferences/testing_pref_service_syncable.h"
 #include "components/user_prefs/user_prefs.h"
@@ -46,35 +43,6 @@ class SolanaTransactionUnitTest : public testing::Test {
 
   KeyringService* keyring_service() { return keyring_service_.get(); }
 
-  static bool RestoreWallet(KeyringService* service,
-                            const std::string& mnemonic,
-                            const std::string& password,
-                            bool is_legacy_brave_wallet) {
-    bool success = false;
-    base::RunLoop run_loop;
-    service->RestoreWallet(mnemonic, password, is_legacy_brave_wallet,
-                           base::BindLambdaForTesting([&](bool v) {
-                             success = v;
-                             run_loop.Quit();
-                           }));
-    run_loop.Run();
-    return success;
-  }
-
-  static bool AddAccount(KeyringService* service,
-                         const std::string& account_name,
-                         mojom::CoinType coin) {
-    bool success = false;
-    base::RunLoop run_loop;
-    service->AddAccount(account_name, coin,
-                        base::BindLambdaForTesting([&](bool v) {
-                          success = v;
-                          run_loop.Quit();
-                        }));
-    run_loop.Run();
-    return success;
-  }
-
  private:
   content::BrowserTaskEnvironment browser_task_environment_;
   std::unique_ptr<content::TestBrowserContext> browser_context_;
@@ -83,13 +51,13 @@ class SolanaTransactionUnitTest : public testing::Test {
 };
 
 TEST_F(SolanaTransactionUnitTest, GetSignedTransaction) {
-  base::test::ScopedFeatureList feature_list;
-  feature_list.InitAndEnableFeature(
-      brave_wallet::features::kBraveWalletSolanaFeature);
-  ASSERT_TRUE(RestoreWallet(keyring_service(), kMnemonic, "brave", false));
-
-  ASSERT_TRUE(AddAccount(keyring_service(), "Account 1", mojom::CoinType::SOL));
-  ASSERT_TRUE(AddAccount(keyring_service(), "Account 2", mojom::CoinType::SOL));
+  keyring_service()->RestoreWallet(kMnemonic, "brave", false,
+                                   base::DoNothing());
+  base::RunLoop().RunUntilIdle();
+  keyring_service()->AddAccount("Account 1", mojom::CoinType::SOL,
+                                base::DoNothing());
+  keyring_service()->AddAccount("Account 2", mojom::CoinType::SOL,
+                                base::DoNothing());
 
   std::string from_account = "BrG44HdsEhzapvs8bEqzvkq4egwevS3fRE6ze2ENo6S8";
   std::string to_account = "JDqrvDz8d8tFCADashbUKQDKfJZFobNy13ugN65t1wvV";

--- a/components/brave_wallet/common/brave_wallet.mojom
+++ b/components/brave_wallet/common/brave_wallet.mojom
@@ -301,8 +301,7 @@ interface WalletHandler {
                       array<AppItem> favoriteApps,
                       bool isWalletBackedUp,
                       array<AccountInfo> accountInfos,
-                      bool isFilecoinEnabled,
-                      bool isSolanaEnabled);
+                      bool IsFilecoinEnabled);
 
   // Adds a favorite app to the apps list
   AddFavoriteApp(AppItem appItem);

--- a/components/brave_wallet/common/features.cc
+++ b/components/brave_wallet/common/features.cc
@@ -14,8 +14,6 @@ const base::Feature kNativeBraveWalletFeature{"NativeBraveWallet",
                                               base::FEATURE_ENABLED_BY_DEFAULT};
 const base::Feature kBraveWalletFilecoinFeature{
     "BraveWalletFilecoin", base::FEATURE_DISABLED_BY_DEFAULT};
-const base::Feature kBraveWalletSolanaFeature{
-    "BraveWalletSolana", base::FEATURE_DISABLED_BY_DEFAULT};
 
 }  // namespace features
 }  // namespace brave_wallet

--- a/components/brave_wallet/common/features.h
+++ b/components/brave_wallet/common/features.h
@@ -15,7 +15,6 @@ namespace features {
 
 extern const base::Feature kNativeBraveWalletFeature;
 extern const base::Feature kBraveWalletFilecoinFeature;
-extern const base::Feature kBraveWalletSolanaFeature;
 
 }  // namespace features
 }  // namespace brave_wallet

--- a/components/brave_wallet_ui/common/reducers/wallet_reducer.ts
+++ b/components/brave_wallet_ui/common/reducers/wallet_reducer.ts
@@ -39,7 +39,6 @@ import Amount from '../../utils/amount'
 const defaultState: WalletState = {
   hasInitialized: false,
   isFilecoinEnabled: false,
-  isSolanaEnabled: false,
   isWalletCreated: false,
   isWalletLocked: true,
   favoriteApps: [],
@@ -111,7 +110,6 @@ reducer.on(WalletActions.initialized, (state: any, payload: WalletInfo) => {
     hasInitialized: true,
     isWalletCreated: payload.isWalletCreated,
     isFilecoinEnabled: payload.isFilecoinEnabled,
-    isSolanaEnabled: payload.isSolanaEnabled,
     isWalletLocked: payload.isWalletLocked,
     favoriteApps: payload.favoriteApps,
     accounts,
@@ -182,7 +180,7 @@ reducer.on(WalletActions.nativeAssetBalancesUpdated, (state: WalletState, payloa
 
   // Refresh selectedAccount object
   const selectedAccount = accounts.find(
-    account => account === state.selectedAccount
+      account => account === state.selectedAccount
   ) ?? state.selectedAccount
 
   return {

--- a/components/brave_wallet_ui/components/desktop/popup-modals/add-account-modal/index.tsx
+++ b/components/brave_wallet_ui/components/desktop/popup-modals/add-account-modal/index.tsx
@@ -42,7 +42,6 @@ export interface Props {
   onCreateAccount: (name: string, coin: BraveWallet.CoinType) => void
   onImportAccount: (accountName: string, privateKey: string, coin: BraveWallet.CoinType) => void
   isFilecoinEnabled: boolean
-  isSolanaEnabled: boolean
   onImportFilecoinAccount: (accountName: string, key: string, network: FilecoinNetwork, protocol: BraveWallet.FilecoinAddressProtocol) => void
   onImportAccountFromJson: (accountName: string, password: string, json: string) => void
   onConnectHardwareWallet: (opts: HardwareWalletConnectOpts) => Promise<BraveWallet.HardwareWalletAccount[]>
@@ -61,7 +60,6 @@ const AddAccountModal = (props: Props) => {
     accounts,
     selectedNetwork,
     isFilecoinEnabled,
-    isSolanaEnabled,
     hasImportError,
     tab,
     onClose,
@@ -75,21 +73,16 @@ const AddAccountModal = (props: Props) => {
     onSetImportError,
     onRouteBackToAccounts
   } = props
-
+  const suggestedAccountName = `${getLocale('braveWalletAccount')} ${accounts.length + 1}`
   const [importOption, setImportOption] = React.useState<string>('key')
   const [file, setFile] = React.useState<HTMLInputElement['files']>()
-  const [accountName, setAccountName] = React.useState<string>('')
+  const [accountName, setAccountName] = React.useState<string>(suggestedAccountName)
   const [privateKey, setPrivateKey] = React.useState<string>('')
   const [password, setPassword] = React.useState<string>('')
   const [selectedAccountType, setSelectedAccountType] = React.useState<CreateAccountOptionsType | undefined>(undefined)
   const passwordInputRef = React.useRef<HTMLInputElement>(null)
   const [filecoinNetwork, setFilecoinNetwork] = React.useState<FilecoinNetwork>('f')
   const [filecoinAddressProtocol, setFilecoinAddressProtocol] = React.useState<BraveWallet.FilecoinAddressProtocol>(BraveWallet.FilecoinAddressProtocol.BLS)
-
-  const suggestedAccountName = React.useMemo(() => {
-    const accountTypeLength = accounts.filter((account) => account.coin === selectedAccountType?.coin).length + 1
-    return `${selectedAccountType?.name} ${getLocale('braveWalletAccount')} ${accountTypeLength}`
-  }, [accounts, selectedAccountType])
 
   const onChangeFilecoinNetwork = (network: FilecoinNetwork) => {
     setFilecoinNetwork(network)
@@ -195,7 +188,8 @@ const AddAccountModal = (props: Props) => {
   const modalTitle = React.useMemo((): string => {
     switch (tab) {
       case 'create':
-        setAccountName(suggestedAccountName)
+        // Will need different logic here to determine how many accounts a user has for each network.
+        setAccountName(selectedAccountType?.name + ' ' + suggestedAccountName)
         return selectedAccountType
           ? getLocale('braveWalletCreateAccount').replace('$1', selectedAccountType.name)
           : getLocale('braveWalletCreateAccountButton')
@@ -267,23 +261,19 @@ const AddAccountModal = (props: Props) => {
                   </SelectWrapper>
                 </>
               ) : (
-                <>
-                  {selectedAccountType?.coin === BraveWallet.CoinType.ETH &&
-                    <SelectWrapper>
-                      <Select
-                        value={importOption}
-                        onChange={onImportOptionChange}
-                      >
-                        <div data-value='key'>
-                          {getLocale('braveWalletImportAccountKey')}
-                        </div>
-                        <div data-value='file'>
-                          {getLocale('braveWalletImportAccountFile')}
-                        </div>
-                      </Select>
-                    </SelectWrapper>
-                  }
-                </>
+                <SelectWrapper>
+                  <Select
+                    value={importOption}
+                    onChange={onImportOptionChange}
+                  >
+                    <div data-value='key'>
+                      {getLocale('braveWalletImportAccountKey')}
+                    </div>
+                    <div data-value='file'>
+                      {getLocale('braveWalletImportAccountFile')}
+                    </div>
+                  </Select>
+                </SelectWrapper>
               )
               }
               {importError &&
@@ -359,7 +349,7 @@ const AddAccountModal = (props: Props) => {
         <SelectAccountTypeWrapper>
           <SelectAccountTitle>{getLocale('braveWalletCreateAccountTitle')}</SelectAccountTitle>
           <DividerLine />
-          {CreateAccountOptions(isFilecoinEnabled, isSolanaEnabled).map((network) =>
+          {CreateAccountOptions(isFilecoinEnabled).map((network) =>
             <SelectAccountItemWrapper key={network.coin}>
               <AccountTypeItem
                 onClickCreate={onSelectAccountType(network)}

--- a/components/brave_wallet_ui/components/desktop/views/crypto/index.tsx
+++ b/components/brave_wallet_ui/components/desktop/views/crypto/index.tsx
@@ -71,7 +71,6 @@ export interface Props {
   userAssetList: UserAssetInfoType[]
   isLoading: boolean
   isFilecoinEnabled: boolean
-  isSolanaEnabled: boolean
   showAddModal: boolean
   selectedNetwork: BraveWallet.EthereumChain
   isFetchingPortfolioPriceHistory: boolean
@@ -136,7 +135,6 @@ const CryptoView = (props: Props) => {
     selectedAssetFiatPrice,
     selectedAssetCryptoPrice,
     isFilecoinEnabled,
-    isSolanaEnabled,
     isLoading,
     showAddModal,
     isFetchingPortfolioPriceHistory,
@@ -372,7 +370,6 @@ const CryptoView = (props: Props) => {
           onCreateAccount={onCreateAccount}
           onImportAccount={onImportAccount}
           isFilecoinEnabled={isFilecoinEnabled}
-          isSolanaEnabled={isSolanaEnabled}
           onImportFilecoinAccount={onImportFilecoinAccount}
           onConnectHardwareWallet={onConnectHardwareWallet}
           onAddHardwareAccounts={onAddHardwareAccounts}

--- a/components/brave_wallet_ui/constants/types.ts
+++ b/components/brave_wallet_ui/constants/types.ts
@@ -186,7 +186,6 @@ export interface DefaultCurrencies {
 export interface WalletState {
   hasInitialized: boolean
   isFilecoinEnabled: boolean
-  isSolanaEnabled: boolean
   isWalletCreated: boolean
   isWalletLocked: boolean
   favoriteApps: BraveWallet.AppItem[]
@@ -285,7 +284,6 @@ export interface WalletInfoBase {
   isWalletBackedUp: boolean
   accountInfos: AccountInfo[]
   isFilecoinEnabled: boolean
-  isSolanaEnabled: boolean
 }
 
 export interface WalletInfo extends WalletInfoBase {

--- a/components/brave_wallet_ui/options/create-account-options.ts
+++ b/components/brave_wallet_ui/options/create-account-options.ts
@@ -1,12 +1,12 @@
 import { BraveWallet, CreateAccountOptionsType } from '../constants/types'
 import {
   ETHIconUrl,
-  SOLIconUrl,
+  // SOLIconUrl,
   FILECOINIconUrl
 } from '../assets/asset-icons'
 import { getLocale } from '../../common/locale'
 
-export const CreateAccountOptions = (isFilecoinEnabled: boolean, isSolanaEnabled: boolean): CreateAccountOptionsType[] => {
+export const CreateAccountOptions = (isFilecoinEnabled: boolean): CreateAccountOptionsType[] => {
   let accounts = [
     {
       description: getLocale('braveWalletCreateAccountEthereumDescription'),
@@ -14,22 +14,22 @@ export const CreateAccountOptions = (isFilecoinEnabled: boolean, isSolanaEnabled
       coin: BraveWallet.CoinType.ETH,
       icon: ETHIconUrl
     }
+    // Commented out until we have support for these networks
+    // {
+    //   description: getLocale('braveWalletCreateAccountSolanaDescription'),
+    //   name: 'Solana',
+    //   network: 'solana',
+    //   icon: SOLIconUrl
+    // },
   ]
-  if (isSolanaEnabled) {
-    accounts.push({
-      description: getLocale('braveWalletCreateAccountSolanaDescription'),
-      name: 'Solana',
-      coin: BraveWallet.CoinType.SOL,
-      icon: SOLIconUrl
-    })
-  }
   if (isFilecoinEnabled) {
     accounts.push({
-      description: getLocale('braveWalletCreateAccountFilecoinDescription'),
-      name: 'Filecoin',
-      coin: BraveWallet.CoinType.FIL,
-      icon: FILECOINIconUrl
-    })
+        description: getLocale('braveWalletCreateAccountFilecoinDescription'),
+        name: 'Filecoin',
+        coin: BraveWallet.CoinType.FIL,
+        icon: FILECOINIconUrl
+      }
+    )
   }
   return accounts
 }

--- a/components/brave_wallet_ui/page/container.tsx
+++ b/components/brave_wallet_ui/page/container.tsx
@@ -77,7 +77,6 @@ function Container (props: Props) {
   // Wallet Props
   const {
     isFilecoinEnabled,
-    isSolanaEnabled,
     isWalletCreated,
     isWalletLocked,
     isWalletBackedUp,
@@ -646,7 +645,6 @@ function Container (props: Props) {
                 onImportAccount={onImportAccount}
                 onImportFilecoinAccount={onImportFilecoinAccount}
                 isFilecoinEnabled={isFilecoinEnabled}
-                isSolanaEnabled={isSolanaEnabled}
                 isLoading={isFetchingPriceHistory}
                 showAddModal={showAddModal}
                 onHideAddModal={onHideAddModal}

--- a/components/brave_wallet_ui/stories/locale.ts
+++ b/components/brave_wallet_ui/stories/locale.ts
@@ -176,7 +176,7 @@ provideStrings({
   braveWalletCreateAccountImportAccount: 'Import $1 account',
   braveWalletCreateAccountTitle: 'Select one of the following account types',
   braveWalletCreateAccountEthereumDescription: 'Supports EVM compatible assets on the Ethereum blockchain (ERC-20, ERC-721, ERC-1551, ERC-1155)',
-  braveWalletCreateAccountSolanaDescription: 'Supports SPL compatible assets on the Solana blockchain',
+  braveWalletCreateAccountSolanaDescription: 'Supports SLP compatible assets on the Solana blockchain',
   braveWalletCreateAccountFilecoinDescription: 'Store FIL asset',
   braveWalletFilecoinPrivateKeyProtocol: 'Private key $1',
 

--- a/components/brave_wallet_ui/stories/screens/crypto-story-view.tsx
+++ b/components/brave_wallet_ui/stories/screens/crypto-story-view.tsx
@@ -54,7 +54,6 @@ export interface Props {
   transactionSpotPrices: BraveWallet.AssetPrice[]
   hasImportError: boolean
   isFilecoinEnabled: boolean
-  isSolanaEnabled: boolean
   onUpdateVisibleAssets: (updatedTokensList: BraveWallet.BlockchainToken[]) => void
   onAddCustomAsset: (token: BraveWallet.BlockchainToken) => void
   onLockWallet: () => void
@@ -108,7 +107,6 @@ const CryptoStoryView = (props: Props) => {
     isFetchingPortfolioPriceHistory,
     showVisibleAssetsModal,
     isFilecoinEnabled,
-    isSolanaEnabled,
     onShowVisibleAssetsModal,
     onLockWallet,
     onShowBackup,
@@ -356,7 +354,6 @@ const CryptoStoryView = (props: Props) => {
           onImportAccount={onImportAccount}
           onImportFilecoinAccount={onImportFilecoinAccount}
           isFilecoinEnabled={isFilecoinEnabled}
-          isSolanaEnabled={isSolanaEnabled}
           onConnectHardwareWallet={onConnectHardwareWallet}
           onAddHardwareAccounts={onAddHardwareAccounts}
           getBalance={getBalance}

--- a/components/brave_wallet_ui/stories/wallet-concept.tsx
+++ b/components/brave_wallet_ui/stories/wallet-concept.tsx
@@ -250,8 +250,7 @@ export const _DesktopWalletConcept = (args: { onboarding: boolean, locked: boole
     locked
   } = args
   const [view] = React.useState<NavTypes>('crypto')
-  const [isFilecoinEnabled] = React.useState<boolean>(true)
-  const [isSolanaEnabled] = React.useState<boolean>(true)
+  const [isFilecoinEnabled, setIsFilecoinEnabled] = React.useState<boolean>(true)
   const [needsOnboarding, setNeedsOnboarding] = React.useState<boolean>(onboarding)
   const [walletLocked, setWalletLocked] = React.useState<boolean>(locked)
   const [needsBackup, setNeedsBackup] = React.useState<boolean>(true)
@@ -502,6 +501,7 @@ export const _DesktopWalletConcept = (args: { onboarding: boolean, locked: boole
 
   const onImportAccountFromJson = (name: string, password: string, json: string) => {
     // doesnt do anything in storybook
+    setIsFilecoinEnabled(true)
   }
 
   const onToggleAddModal = () => {
@@ -775,7 +775,6 @@ export const _DesktopWalletConcept = (args: { onboarding: boolean, locked: boole
                               onCreateAccount={onCreateAccount}
                               onImportAccount={onImportAccount}
                               isFilecoinEnabled={isFilecoinEnabled}
-                              isSolanaEnabled={isSolanaEnabled}
                               onImportFilecoinAccount={onImportFilecoinAccount}
                               onConnectHardwareWallet={onConnectHardwareWallet}
                               onAddHardwareAccounts={onAddHardwareAccounts}

--- a/components/resources/wallet_strings.grdp
+++ b/components/resources/wallet_strings.grdp
@@ -147,7 +147,7 @@
   <message name="IDS_BRAVE_WALLET_CREATE_ACCOUNT_IMPORT_ACCOUNT" desc="Add account modal import account header title">Import <ph name="BLOCKCHAIN_NETWORK"><ex>Ethereum</ex>$1</ph> account</message>
   <message name="IDS_BRAVE_WALLET_CREATE_ACCOUNT_TITLE" desc="Add account modal create account title">Select one of the following account types</message>
   <message name="IDS_BRAVE_WALLET_CREATE_ACCOUNT_ETHEREUM_DESCRIPTION" desc="Add account modal create account Ethereum description">Supports EVM compatible assets on the Ethereum blockchain (ERC-20, ERC-721, ERC-1551, ERC-1155)</message>
-  <message name="IDS_BRAVE_WALLET_CREATE_ACCOUNT_SOLANA_DESCRIPTION" desc="Add account modal create account Solana description">Supports SPL compatible assets on the Solana blockchain</message>
+  <message name="IDS_BRAVE_WALLET_CREATE_ACCOUNT_SOLANA_DESCRIPTION" desc="Add account modal create account Solana description">Supports SLP compatible assets on the Solana blockchain</message>
   <message name="IDS_BRAVE_WALLET_CREATE_ACCOUNT_FILECOIN_DESCRIPTION" desc="Add account modal create account Filecoin description">Store FIL asset</message>
   <message name="IDS_BRAVE_WALLET_FILECOIN_PRIVATE_KEY_PROTOCOL" desc="Add account modal filecoin private key protocol">Private key <ph name="PROTOCOL"><ex>BLS12-381</ex>$1</ph></message>
   <message name="IDS_BRAVE_WALLET_ADD_ACCOUNT_IMPORT" desc="Add account modal import button">Import</message>


### PR DESCRIPTION
Reverts brave/brave-core#12236

This will cause error of 
```
[ RUN      ] KeyringServiceUnitTest.GetPrivateKeyForKeyringAccount
../../brave/browser/brave_wallet/keyring_service_unittest.cc:1640: Failure
Value of: AddAccount(&service, "Account 1", mojom::CoinType::SOL)
 Actual: false
Expected: true
Stack trace:
0   brave_unit_tests                    0x000000010908a215 brave_wallet::KeyringServiceUnitTest_GetPrivateKeyForKeyringAccount_Test::TestBody() + 4469
```
because it wasn't rebased before merging 