### PR TITLE
fix(wallet): Swap Container Dynamic Sizing Bug

### DIFF
--- a/components/brave_wallet_ui/components/buy-send-swap/buy-send-swap-layout/style.ts
+++ b/components/brave_wallet_ui/components/buy-send-swap/buy-send-swap-layout/style.ts
@@ -43,7 +43,6 @@ export const MainContainer = styled.div<Partial<StyleProps>>`
   border: ${(p) => `2px solid ${p.theme.color.divider01}`};
   border-radius: ${(p) =>
     p.selectedTab === 'buy' ? '0px 8px 8px 8px' : p.selectedTab === 'swap' ? '8px 0px 8px 8px' : '8px'};
-  max-height: 550px;
 `
 
 export const ButtonRow = styled.div`

--- a/components/brave_wallet_ui/components/buy-send-swap/tabs/swap-tab.tsx
+++ b/components/brave_wallet_ui/components/buy-send-swap/tabs/swap-tab.tsx
@@ -178,7 +178,7 @@ function SwapTab (props: Props) {
           />
         </>
       }
-      {swapView !== 'send' &&
+      {swapView !== 'swap' &&
         <AccountsAssetsNetworks
           selectedAccount={selectedAccount}
           selectedNetwork={selectedNetwork}


### PR DESCRIPTION
## Description 
Fixed Swap Containers Dynamic Sizing Bug

The issue was we had a wrong conditional value wrapping the `AccountsAssetsNetworks` component in the `Swap` tab view.
It was set to `send` and should have been `swap`, so as a side effect a fixed height in a style for the `AccountsAssetsNetworks` was effecting the height of the swap container to be really long. 
We also had `max-height` value in the `buy-send-swap-layout` component that preventing the swap container to grow dynamically.

<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves <https://github.com/brave/brave-browser/issues/21061>

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/handbook/blob/master/development/security.md#when-is-a-security-review-needed), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/handbook/blob/master/development/security.md#when-is-a-security-review-needed), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

Before:

https://user-images.githubusercontent.com/40611140/154193282-4fa28103-1c7c-4817-a5a2-386765a997a9.mov

After:

https://user-images.githubusercontent.com/40611140/154193305-b1b96028-b9da-4e4f-b829-ced74e41ba7f.mov
