### PR TITLE
Do not allow unlocking without the device id and fix error message for Ledger

### DIFF
--- a/components/brave_wallet_ui/components/desktop/popup-modals/add-account-modal/hardware-wallet-connect/index.tsx
+++ b/components/brave_wallet_ui/components/desktop/popup-modals/add-account-modal/hardware-wallet-connect/index.tsx
@@ -53,9 +53,9 @@ export default function (props: Props) {
     LedgerDerivationPaths.LedgerLive
   )
   const [showAccountsList, setShowAccountsList] = React.useState<boolean>(false)
-  const getErrorMessage = (error: any) => {
+  const getErrorMessage = (error: any, accountTypeName: string) => {
     if (error.statusCode && error.statusCode === 27404) { // Unknown Error
-      return { error: getLocale('braveWalletConnectHardwareInfo2'), userHint: '' }
+      return { error: getLocale('braveWalletConnectHardwareInfo2').replace('$1', accountTypeName), userHint: '' }
     }
 
     if (error.statusCode && (error.statusCode === 27904 || error.statusCode === 26368)) { // INCORRECT_LENGTH or INS_NOT_SUPPORTED
@@ -81,7 +81,7 @@ export default function (props: Props) {
     }).then((result) => {
       setAccounts(result)
     }).catch((error) => {
-      setConnectionError(getErrorMessage(error))
+      setConnectionError(getErrorMessage(error, selectedAccountType.name))
       setShowAccountsList(false)
     }).finally(
       () => setIsConnecting(false)
@@ -150,7 +150,7 @@ export default function (props: Props) {
       setAccounts([...accounts, ...result])
       setShowAccountsList(true)
     }).catch((error) => {
-      setConnectionError(getErrorMessage(error))
+      setConnectionError(getErrorMessage(error, selectedAccountType.name))
       setShowAccountsList(false)
     }).finally(
       () => setIsConnecting(false)


### PR DESCRIPTION
<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/21137

This happens only when importing accounts first time and only if Ledger device is locked at that time. We throw wrong error and then user cannot import accounts as result of the previous error, retries will be successful

<img width="434" alt="image" src="https://user-images.githubusercontent.com/2965009/154243760-e9eecb1d-33c5-499b-b07d-8e50481a55ba.png">
<img width="558" alt="image" src="https://user-images.githubusercontent.com/2965009/154243880-791d3710-4bc6-4337-a1fc-ed4b2b64ccb6.png">

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

   1. Clean profile after install
   2. Connect and lock ledger
   3. Create/Restore Brave Wallet
   4. Try to import accounts when device locked
   5. See error message with $1
   6. Unlock Ledger and import accounts
   7. Import failed