### PR TITLE
Disable kSendTabToSelfManageDevicesLink also for desktop (uplift to 1.35.x)

### DIFF
--- a/chromium_src/components/send_tab_to_self/features.cc
+++ b/chromium_src/components/send_tab_to_self/features.cc
@@ -10,11 +10,9 @@
 namespace send_tab_to_self {
 
 OVERRIDE_FEATURE_DEFAULT_STATES({{
-#if defined(OS_ANDROID)
     // This feature requires Google account at the moment, which causes crash on
     // trying to create 'Manage Devices' link.
     {kSendTabToSelfManageDevicesLink, base::FEATURE_DISABLED_BY_DEFAULT},
-#endif
 }});
 
 }  // namespace send_tab_to_self


### PR DESCRIPTION
Uplift of #12244
Resolves https://github.com/brave/brave-browser/issues/21082

Pre-approval checklist: 
- [ ] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [ ] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [ ] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [ ] The associated issue milestone is set to the smallest version that the changes is landed on.