### PR TITLE
Fixes confirmations are not sent for Brave News ads if ads are disabled - 1.35.x

### DIFF
--- a/vendor/bat-native-ads/src/bat/ads/internal/tokens/redeem_unblinded_token/redeem_unblinded_token.cc
+++ b/vendor/bat-native-ads/src/bat/ads/internal/tokens/redeem_unblinded_token/redeem_unblinded_token.cc
@@ -16,6 +16,7 @@
 #include "base/values.h"
 #include "bat/ads/ads_client.h"
 #include "bat/ads/confirmation_type.h"
+#include "bat/ads/internal/account/account_util.h"
 #include "bat/ads/internal/account/confirmations/confirmation_info.h"
 #include "bat/ads/internal/account/confirmations/confirmations.h"
 #include "bat/ads/internal/ads_client_helper.h"
@@ -54,7 +55,8 @@ void RedeemUnblindedToken::Redeem(const ConfirmationInfo& confirmation) {
 
   BLOG(1, "Redeem unblinded token");
 
-  if (!IssuerExistsForType(IssuerType::kPayments)) {
+  if (ShouldRewardUser() && !IssuerExistsForType(IssuerType::kPayments)) {
+    BLOG(1, "Failed to redeem unblinded token due to missing payments issuer");
     OnFailedToRedeemUnblindedToken(confirmation, /* should_retry */ true);
     return;
   }


### PR DESCRIPTION
Uplift of https://github.com/brave/brave-core/pull/12303
Resolves https://github.com/brave/brave-browser/issues/21145

- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR.
- [x] You have tested your change on Nightly. 
- [x] The PR milestones match the branch they are landing to. 

After you merge: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.
