### PR TITLE
Fixed DCHECK failure while resizing sidebar panel

### DIFF
--- a/app/brave_generated_resources.grd
+++ b/app/brave_generated_resources.grd
@@ -1438,6 +1438,12 @@ Are you sure you want to do this?
         <message name="IDS_SIDEBAR_ADDED_FEEDBACK_TITLE_2" desc="Label for second row text in item added feedback bubble">
           Right-click to remove
         </message>
+        <message name="IDS_SIDEBAR_ITEMS_SCROLL_UP_BUTTON_ACCESSIBLE_NAME" desc="Text to be spoken when scroll up button is shown">
+          Scroll up
+        </message>
+        <message name="IDS_SIDEBAR_ITEMS_SCROLL_DOWN_BUTTON_ACCESSIBLE_NAME" desc="Text to be spoken when scroll down button is shown">
+          Scroll down
+        </message>
       </if>
 
       <!-- Speedreader -->

--- a/browser/ui/views/sidebar/bubble_border_with_arrow.cc
+++ b/browser/ui/views/sidebar/bubble_border_with_arrow.cc
@@ -16,9 +16,10 @@
 gfx::RectF BubbleBorderWithArrow::GetArrowRect(
     const gfx::RectF& contents_bounds,
     views::BubbleBorder::Arrow arrow) {
-  // sidebar bubble border only support these two arrow types now.
+  // sidebar bubble border only support left-side arrow types now.
   DCHECK(arrow == views::BubbleBorder::LEFT_TOP ||
-         arrow == views::BubbleBorder::LEFT_CENTER);
+         arrow == views::BubbleBorder::LEFT_CENTER ||
+         arrow == views::BubbleBorder::LEFT_BOTTOM);
 
   gfx::RectF arrow_rect(
       gfx::SizeF(kBubbleArrowBoundsWidth, kBubbleArrowBoundsHeight));
@@ -27,12 +28,29 @@ gfx::RectF BubbleBorderWithArrow::GetArrowRect(
     arrow_rect.set_origin(
         gfx::PointF(contents_bounds.x() - kBubbleArrowBoundsWidth,
                     contents_bounds.y() + kBubbleArrowOffsetFromTop));
-  } else {
+    return arrow_rect;
+  }
+
+  if (arrow == views::BubbleBorder::LEFT_CENTER) {
     arrow_rect.set_origin(gfx::PointF(
         contents_bounds.x() - kBubbleArrowBoundsWidth,
         contents_bounds.y() +
             (contents_bounds.height() - kBubbleArrowBoundsHeight) / 2));
+    return arrow_rect;
   }
+
+  // On some platform, arrow is changed from TOP to BOTTOM implicitely
+  // when browser window doesn't have enought space to show bubble
+  // at top left anchor.
+  if (arrow == views::BubbleBorder::LEFT_BOTTOM) {
+    constexpr int kBubbleArrowOffsetFromBottom = 11;
+    arrow_rect.set_origin(gfx::PointF(
+        contents_bounds.x() - kBubbleArrowBoundsWidth,
+        contents_bounds.bottom_left().y() - kBubbleArrowBoundsHeight -
+            kBubbleArrowOffsetFromBottom));
+    return arrow_rect;
+  }
+
   return arrow_rect;
 }
 

--- a/browser/ui/views/sidebar/sidebar_add_item_bubble_delegate_view.cc
+++ b/browser/ui/views/sidebar/sidebar_add_item_bubble_delegate_view.cc
@@ -21,6 +21,7 @@
 #include "chrome/browser/ui/views/frame/browser_view.h"
 #include "content/public/browser/web_contents.h"
 #include "ui/base/l10n/l10n_util.h"
+#include "ui/base/metadata/metadata_impl_macros.h"
 #include "ui/base/resource/resource_bundle.h"
 #include "ui/base/theme_provider.h"
 #include "ui/gfx/canvas.h"
@@ -42,6 +43,7 @@ sidebar::SidebarService* GetSidebarService(Browser* browser) {
 
 class SidebarAddItemButton : public views::LabelButton {
  public:
+  METADATA_HEADER(SidebarAddItemButton);
   // Get theme provider to use browser's theme color in this dialog.
   SidebarAddItemButton(bool bold, const ui::ThemeProvider* theme_provider)
       : theme_provider_(theme_provider) {
@@ -94,6 +96,9 @@ class SidebarAddItemButton : public views::LabelButton {
  private:
   const ui::ThemeProvider* theme_provider_;
 };
+
+BEGIN_METADATA(SidebarAddItemButton, views::LabelButton)
+END_METADATA
 
 }  // namespace
 
@@ -216,3 +221,7 @@ void SidebarAddItemBubbleDelegateView::OnCurrentItemButtonPressed() {
   if (children().size() == 1)
     GetWidget()->CloseWithReason(views::Widget::ClosedReason::kUnspecified);
 }
+
+BEGIN_METADATA(SidebarAddItemBubbleDelegateView,
+               views::BubbleDialogDelegateView)
+END_METADATA

--- a/browser/ui/views/sidebar/sidebar_add_item_bubble_delegate_view.h
+++ b/browser/ui/views/sidebar/sidebar_add_item_bubble_delegate_view.h
@@ -20,6 +20,7 @@ struct SidebarItem;
 class SidebarAddItemBubbleDelegateView
     : public views::BubbleDialogDelegateView {
  public:
+  METADATA_HEADER(SidebarAddItemBubbleDelegateView);
   SidebarAddItemBubbleDelegateView(BraveBrowser* browser,
                                    views::View* anchor_view);
   ~SidebarAddItemBubbleDelegateView() override;

--- a/browser/ui/views/sidebar/sidebar_button_view.cc
+++ b/browser/ui/views/sidebar/sidebar_button_view.cc
@@ -4,6 +4,7 @@
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 #include "brave/browser/ui/views/sidebar/sidebar_button_view.h"
+#include "ui/base/metadata/metadata_impl_macros.h"
 #include "ui/gfx/color_palette.h"
 #include "ui/views/controls/focus_ring.h"
 
@@ -33,3 +34,6 @@ std::u16string SidebarButtonView::GetTooltipText(const gfx::Point& p) const {
 
   return delegate_->GetTooltipTextFor(this);
 }
+
+BEGIN_METADATA(SidebarButtonView, views::ImageButton)
+END_METADATA

--- a/browser/ui/views/sidebar/sidebar_button_view.h
+++ b/browser/ui/views/sidebar/sidebar_button_view.h
@@ -12,6 +12,7 @@
 
 class SidebarButtonView : public views::ImageButton {
  public:
+  METADATA_HEADER(SidebarButtonView);
   static const int kSidebarButtonSize = 42;
 
   class Delegate {

--- a/browser/ui/views/sidebar/sidebar_container_view.cc
+++ b/browser/ui/views/sidebar/sidebar_container_view.cc
@@ -21,6 +21,7 @@
 #include "chrome/browser/ui/views/frame/browser_view.h"
 #include "content/public/browser/browser_context.h"
 #include "content/public/browser/web_contents.h"
+#include "ui/base/metadata/metadata_impl_macros.h"
 #include "ui/base/models/menu_model.h"
 #include "ui/base/theme_provider.h"
 #include "ui/events/event_observer.h"
@@ -314,3 +315,6 @@ void SidebarContainerView::StartBrowserWindowEventMonitoring() {
 void SidebarContainerView::StopBrowserWindowEventMonitoring() {
   browser_window_event_monitor_.reset();
 }
+
+BEGIN_METADATA(SidebarContainerView, views::View)
+END_METADATA

--- a/browser/ui/views/sidebar/sidebar_container_view.h
+++ b/browser/ui/views/sidebar/sidebar_container_view.h
@@ -42,6 +42,7 @@ class SidebarContainerView
       public SidebarShowOptionsEventDetectWidget::Delegate,
       public sidebar::SidebarModel::Observer {
  public:
+  METADATA_HEADER(SidebarContainerView);
   explicit SidebarContainerView(BraveBrowser* browser);
   ~SidebarContainerView() override;
 

--- a/browser/ui/views/sidebar/sidebar_control_view.cc
+++ b/browser/ui/views/sidebar/sidebar_control_view.cc
@@ -18,6 +18,7 @@
 #include "brave/grit/brave_theme_resources.h"
 #include "chrome/common/webui_url_constants.h"
 #include "ui/base/l10n/l10n_util.h"
+#include "ui/base/metadata/metadata_impl_macros.h"
 #include "ui/base/resource/resource_bundle.h"
 #include "ui/base/theme_provider.h"
 #include "ui/gfx/paint_vector_icon.h"
@@ -256,3 +257,6 @@ bool SidebarControlView::IsBubbleWidgetVisible() const {
 
   return false;
 }
+
+BEGIN_METADATA(SidebarControlView, views::View)
+END_METADATA

--- a/browser/ui/views/sidebar/sidebar_control_view.h
+++ b/browser/ui/views/sidebar/sidebar_control_view.h
@@ -33,6 +33,7 @@ class SidebarControlView : public views::View,
                            public SidebarButtonView::Delegate,
                            public sidebar::SidebarModel::Observer {
  public:
+  METADATA_HEADER(SidebarControlView);
   explicit SidebarControlView(BraveBrowser* browser);
   ~SidebarControlView() override;
 

--- a/browser/ui/views/sidebar/sidebar_item_add_button.cc
+++ b/browser/ui/views/sidebar/sidebar_item_add_button.cc
@@ -11,6 +11,7 @@
 #include "brave/browser/themes/theme_properties.h"
 #include "brave/browser/ui/views/sidebar/sidebar_add_item_bubble_delegate_view.h"
 #include "brave/grit/brave_theme_resources.h"
+#include "ui/base/metadata/metadata_impl_macros.h"
 #include "ui/base/resource/resource_bundle.h"
 #include "ui/base/theme_provider.h"
 #include "ui/gfx/paint_vector_icon.h"
@@ -112,3 +113,6 @@ void SidebarItemAddButton::UpdateButtonImages() {
              gfx::CreateVectorIcon(kSidebarAddItemIcon, button_disabled_color));
   }
 }
+
+BEGIN_METADATA(SidebarItemAddButton, SidebarButtonView)
+END_METADATA

--- a/browser/ui/views/sidebar/sidebar_item_add_button.h
+++ b/browser/ui/views/sidebar/sidebar_item_add_button.h
@@ -20,6 +20,7 @@ class BraveBrowser;
 class SidebarItemAddButton : public SidebarButtonView,
                              public views::WidgetObserver {
  public:
+  METADATA_HEADER(SidebarItemAddButton);
   explicit SidebarItemAddButton(BraveBrowser* browser,
                                 const std::u16string& accessible_name);
   ~SidebarItemAddButton() override;

--- a/browser/ui/views/sidebar/sidebar_item_added_feedback_bubble.cc
+++ b/browser/ui/views/sidebar/sidebar_item_added_feedback_bubble.cc
@@ -12,6 +12,7 @@
 #include "brave/browser/ui/views/sidebar/sidebar_item_added_feedback_bubble.h"
 #include "brave/grit/brave_generated_resources.h"
 #include "ui/base/l10n/l10n_util.h"
+#include "ui/base/metadata/metadata_impl_macros.h"
 #include "ui/compositor/layer.h"
 #include "ui/gfx/paint_vector_icon.h"
 #include "ui/views/background.h"
@@ -129,3 +130,6 @@ void SidebarItemAddedFeedbackBubble::AddChildViews() {
   label->SetAutoColorReadabilityEnabled(false);
   label->SetEnabledColor(SK_ColorWHITE);
 }
+
+BEGIN_METADATA(SidebarItemAddedFeedbackBubble, views::BubbleDialogDelegateView)
+END_METADATA

--- a/browser/ui/views/sidebar/sidebar_item_added_feedback_bubble.h
+++ b/browser/ui/views/sidebar/sidebar_item_added_feedback_bubble.h
@@ -24,6 +24,7 @@ class SidebarItemAddedFeedbackBubble : public views::BubbleDialogDelegateView,
                                        public views::ViewObserver,
                                        public gfx::AnimationDelegate {
  public:
+  METADATA_HEADER(SidebarItemAddedFeedbackBubble);
   SidebarItemAddedFeedbackBubble(views::View* anchor_view,
                                  views::View* items_contents_view);
   ~SidebarItemAddedFeedbackBubble() override;

--- a/browser/ui/views/sidebar/sidebar_item_view.cc
+++ b/browser/ui/views/sidebar/sidebar_item_view.cc
@@ -8,6 +8,7 @@
 #include "brave/browser/themes/theme_properties.h"
 #include "brave/grit/brave_theme_resources.h"
 #include "chrome/browser/ui/views/event_utils.h"
+#include "ui/base/metadata/metadata_impl_macros.h"
 #include "ui/base/resource/resource_bundle.h"
 #include "ui/base/theme_provider.h"
 #include "ui/gfx/canvas.h"
@@ -79,3 +80,6 @@ void SidebarItemView::OnPaintBackground(gfx::Canvas* canvas) {
     }
   }
 }
+
+BEGIN_METADATA(SidebarItemView, SidebarButtonView)
+END_METADATA

--- a/browser/ui/views/sidebar/sidebar_item_view.h
+++ b/browser/ui/views/sidebar/sidebar_item_view.h
@@ -12,6 +12,7 @@
 
 class SidebarItemView : public SidebarButtonView {
  public:
+  METADATA_HEADER(SidebarItemView);
   explicit SidebarItemView(Delegate* delegate,
                            const std::u16string& accessible_name);
   ~SidebarItemView() override;

--- a/browser/ui/views/sidebar/sidebar_items_contents_view.cc
+++ b/browser/ui/views/sidebar/sidebar_items_contents_view.cc
@@ -29,6 +29,7 @@
 #include "components/prefs/pref_service.h"
 #include "ui/base/default_style.h"
 #include "ui/base/l10n/l10n_util.h"
+#include "ui/base/metadata/metadata_impl_macros.h"
 #include "ui/base/resource/resource_bundle.h"
 #include "ui/base/theme_provider.h"
 #include "ui/base/window_open_disposition.h"
@@ -454,3 +455,6 @@ bool SidebarItemsContentsView::IsBubbleVisible() const {
 
   return false;
 }
+
+BEGIN_METADATA(SidebarItemsContentsView, views::View)
+END_METADATA

--- a/browser/ui/views/sidebar/sidebar_items_contents_view.h
+++ b/browser/ui/views/sidebar/sidebar_items_contents_view.h
@@ -31,6 +31,7 @@ class SidebarItemsContentsView : public views::View,
                                  public views::WidgetObserver,
                                  public ui::SimpleMenuModel::Delegate {
  public:
+  METADATA_HEADER(SidebarItemsContentsView);
   SidebarItemsContentsView(BraveBrowser* browser,
                            views::DragController* drag_controller);
   ~SidebarItemsContentsView() override;

--- a/browser/ui/views/sidebar/sidebar_items_scroll_view.cc
+++ b/browser/ui/views/sidebar/sidebar_items_scroll_view.cc
@@ -5,6 +5,8 @@
 
 #include "brave/browser/ui/views/sidebar/sidebar_items_scroll_view.h"
 
+#include <string>
+
 #include "base/bind.h"
 #include "base/threading/sequenced_task_runner_handle.h"
 #include "base/time/time.h"
@@ -17,12 +19,15 @@
 #include "brave/browser/ui/views/sidebar/sidebar_item_view.h"
 #include "brave/browser/ui/views/sidebar/sidebar_items_contents_view.h"
 #include "brave/components/sidebar/sidebar_service.h"
+#include "brave/grit/brave_generated_resources.h"
 #include "cc/paint/paint_flags.h"
 #include "chrome/browser/ui/browser_list.h"
 #include "ui/base/clipboard/clipboard.h"
 #include "ui/base/clipboard/clipboard_format_type.h"
 #include "ui/base/dragdrop/drag_drop_types.h"
 #include "ui/base/dragdrop/mojom/drag_drop_types.mojom.h"
+#include "ui/base/l10n/l10n_util.h"
+#include "ui/base/metadata/metadata_impl_macros.h"
 #include "ui/base/theme_provider.h"
 #include "ui/events/event.h"
 #include "ui/gfx/canvas.h"
@@ -38,11 +43,13 @@ constexpr char kSidebarItemDragType[] = "brave/sidebar-item";
 
 class SidebarItemsArrowView : public views::ImageButton {
  public:
-  SidebarItemsArrowView() {
+  METADATA_HEADER(SidebarItemsArrowView);
+  explicit SidebarItemsArrowView(const std::u16string& accessible_name) {
     SetImageHorizontalAlignment(views::ImageButton::ALIGN_CENTER);
     SetImageVerticalAlignment(views::ImageButton::ALIGN_MIDDLE);
     DCHECK(GetInstallFocusRingOnFocus());
     views::FocusRing::Get(this)->SetColor(gfx::kBraveBlurple300);
+    SetAccessibleName(accessible_name);
   }
 
   ~SidebarItemsArrowView() override = default;
@@ -75,6 +82,9 @@ class SidebarItemsArrowView : public views::ImageButton {
   }
 };
 
+BEGIN_METADATA(SidebarItemsArrowView, views::ImageButton)
+END_METADATA
+
 }  // namespace
 
 SidebarItemsScrollView::SidebarItemsScrollView(BraveBrowser* browser)
@@ -89,11 +99,15 @@ SidebarItemsScrollView::SidebarItemsScrollView(BraveBrowser* browser)
   bounds_animator_observed_.AddObservation(scroll_animator_for_smooth_.get());
   contents_view_ =
       AddChildView(std::make_unique<SidebarItemsContentsView>(browser_, this));
-  up_arrow_ = AddChildView(std::make_unique<SidebarItemsArrowView>());
+  up_arrow_ = AddChildView(
+      std::make_unique<SidebarItemsArrowView>(l10n_util::GetStringUTF16(
+          IDS_SIDEBAR_ITEMS_SCROLL_UP_BUTTON_ACCESSIBLE_NAME)));
   up_arrow_->SetCallback(
       base::BindRepeating(&SidebarItemsScrollView::OnButtonPressed,
                           base::Unretained(this), up_arrow_));
-  down_arrow_ = AddChildView(std::make_unique<SidebarItemsArrowView>());
+  down_arrow_ = AddChildView(
+      std::make_unique<SidebarItemsArrowView>(l10n_util::GetStringUTF16(
+          IDS_SIDEBAR_ITEMS_SCROLL_DOWN_BUTTON_ACCESSIBLE_NAME)));
   down_arrow_->SetCallback(
       base::BindRepeating(&SidebarItemsScrollView::OnButtonPressed,
                           base::Unretained(this), down_arrow_));
@@ -476,3 +490,6 @@ bool SidebarItemsScrollView::IsBubbleVisible() const {
 void SidebarItemsScrollView::Update() {
   contents_view_->Update();
 }
+
+BEGIN_METADATA(SidebarItemsScrollView, views::View)
+END_METADATA

--- a/browser/ui/views/sidebar/sidebar_items_scroll_view.h
+++ b/browser/ui/views/sidebar/sidebar_items_scroll_view.h
@@ -37,6 +37,7 @@ class SidebarItemsScrollView : public views::View,
                                public views::DragController,
                                public sidebar::SidebarModel::Observer {
  public:
+  METADATA_HEADER(SidebarItemsScrollView);
   explicit SidebarItemsScrollView(BraveBrowser* browser);
   ~SidebarItemsScrollView() override;
 


### PR DESCRIPTION
fix https://github.com/brave/brave-browser/issues/21150
fix https://github.com/brave/brave-browser/issues/21151

First commit fixes DCHECK failure from up/down button.
When sidebar panel's up/down button is visible, got DCHECK failure
because up/down button doesn't have accessible name.
Also added missing view metadata from sidebar views control.

Second commit fixes DCHECK failure and wrong anchor position.
When sidebar panel doesn't have enough space, bubble anchor is changed.
So, left bottom anchor position should be handled.

Because of first commit's dcheck failure, second commit's failure is hidden in dev build.
So, two fixes are handled in this one PR.

<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves 

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

See STR in the linked issues.