### PR TITLE
Enable feature flag for brave news by default on android (now all platforms) (uplift to 1.36.x)

### DIFF
--- a/components/brave_today/common/features.cc
+++ b/components/brave_today/common/features.cc
@@ -10,15 +10,8 @@
 namespace brave_today {
 namespace features {
 
-const base::Feature kBraveNewsFeature {
-  "BraveNews",
-
-#if (!defined(OS_ANDROID) || (defined(OS_ANDROID) && !defined(OFFICIAL_BUILD)))
-      base::FEATURE_ENABLED_BY_DEFAULT
-#else
-      base::FEATURE_DISABLED_BY_DEFAULT
-#endif
-};
+const base::Feature kBraveNewsFeature{"BraveNews",
+                                      base::FEATURE_ENABLED_BY_DEFAULT};
 
 }  // namespace features
 }  // namespace brave_today


### PR DESCRIPTION
Uplift of #11983
Resolves https://github.com/brave/brave-browser/issues/20875

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.