### PR TITLE
Don't add as a separate shortcut when built-in provide related item

### DIFF
--- a/browser/ui/sidebar/BUILD.gn
+++ b/browser/ui/sidebar/BUILD.gn
@@ -89,6 +89,7 @@ source_set("unit_tests") {
       "//base",
       "//brave/browser/ui",
       "//brave/browser/ui/sidebar",
+      "//brave/common",
       "//brave/components/sidebar",
       "//chrome/test:test_support",
       "//components/prefs",

--- a/browser/ui/sidebar/sidebar_model.cc
+++ b/browser/ui/sidebar/sidebar_model.cc
@@ -221,7 +221,7 @@ bool SidebarModel::IsLoadedAt(int index) const {
 }
 
 bool SidebarModel::IsSidebarHasAllBuiltiInItems() const {
-  return GetSidebarService(profile_)->GetNotAddedDefaultSidebarItems().empty();
+  return GetSidebarService(profile_)->GetHiddenDefaultSidebarItems().empty();
 }
 
 int SidebarModel::GetIndexOf(const SidebarItem& item) const {

--- a/browser/ui/sidebar/sidebar_unittest.cc
+++ b/browser/ui/sidebar/sidebar_unittest.cc
@@ -126,12 +126,12 @@ TEST_F(SidebarModelTest, ItemsChangedTest) {
 TEST_F(SidebarModelTest, CanUseNotAddedBuiltInItemInsteadOfTest) {
   GURL talk("https://talk.brave.com/1Ar1vHfLBWX2sAdi");
   // False because builtin talk item is already added.
-  EXPECT_FALSE(CanUseNotAddedBuiltInItemInsteadOf(service(), talk));
+  EXPECT_FALSE(HiddenDefaultSidebarItemsContains(service(), talk));
 
   // Remove builtin talk item and check builtin talk item will be used
   // instead of adding |talk| url.
   service()->RemoveItemAt(0);
-  EXPECT_TRUE(CanUseNotAddedBuiltInItemInsteadOf(service(), talk));
+  EXPECT_TRUE(HiddenDefaultSidebarItemsContains(service(), talk));
 }
 
 TEST(SidebarUtilTest, ConvertURLToBuiltInItemURLTest) {

--- a/browser/ui/sidebar/sidebar_utils.cc
+++ b/browser/ui/sidebar/sidebar_utils.cc
@@ -6,6 +6,8 @@
 #include "brave/browser/ui/sidebar/sidebar_utils.h"
 
 #include "brave/browser/ui/sidebar/sidebar_service_factory.h"
+#include "brave/common/webui_url_constants.h"
+#include "brave/components/sidebar/constants.h"
 #include "brave/components/sidebar/sidebar_item.h"
 #include "brave/components/sidebar/sidebar_service.h"
 #include "chrome/browser/search/search.h"
@@ -13,8 +15,10 @@
 #include "chrome/browser/ui/tabs/tab_strip_model.h"
 #include "chrome/browser/ui/webui/new_tab_page/new_tab_page_ui.h"
 #include "chrome/browser/ui/webui/ntp/new_tab_ui.h"
+#include "chrome/common/webui_url_constants.h"
 #include "content/public/browser/navigation_entry.h"
 #include "content/public/browser/web_contents.h"
+#include "content/public/common/url_constants.h"
 
 namespace sidebar {
 
@@ -24,24 +28,22 @@ SidebarService* GetSidebarService(Browser* browser) {
   return SidebarServiceFactory::GetForProfile(browser->profile());
 }
 
-bool IsActiveTabNTP(Browser* browser) {
-  auto* web_contents = browser->tab_strip_model()->GetActiveWebContents();
+bool IsActiveTabNTP(content::WebContents* active_web_contents) {
   content::NavigationEntry* entry =
-      web_contents->GetController().GetLastCommittedEntry();
+      active_web_contents->GetController().GetLastCommittedEntry();
   if (!entry)
-    entry = web_contents->GetController().GetVisibleEntry();
+    entry = active_web_contents->GetController().GetVisibleEntry();
   if (!entry)
     return false;
   const GURL url = entry->GetURL();
   return NewTabUI::IsNewTab(url) || NewTabPageUI::IsNewTabPageOrigin(url) ||
-         search::NavEntryIsInstantNTP(web_contents, entry);
+         search::NavEntryIsInstantNTP(active_web_contents, entry);
 }
 
-bool IsActiveTabAlreadyAddedToSidebar(Browser* browser) {
-  auto* web_contents = browser->tab_strip_model()->GetActiveWebContents();
-  const GURL url = web_contents->GetVisibleURL();
-  for (const auto& item : GetSidebarService(browser)->items()) {
-    if (item.url == url)
+bool IsURLAlreadyAddedToSidebar(SidebarService* service, const GURL& url) {
+  const GURL converted_url = ConvertURLToBuiltInItemURL(url);
+  for (const auto& item : service->items()) {
+    if (item.url == converted_url)
       return true;
   }
 
@@ -50,20 +52,59 @@ bool IsActiveTabAlreadyAddedToSidebar(Browser* browser) {
 
 }  // namespace
 
+bool CanUseNotAddedBuiltInItemInsteadOf(SidebarService* service,
+                                        const GURL& url) {
+  const auto not_added_default_items =
+      service->GetNotAddedDefaultSidebarItems();
+  if (not_added_default_items.empty())
+    return false;
+  const GURL converted_url = ConvertURLToBuiltInItemURL(url);
+  for (const auto& item : not_added_default_items) {
+    if (item.url == converted_url)
+      return true;
+  }
+  return false;
+}
+
 bool CanUseSidebar(Browser* browser) {
   DCHECK(browser);
   return browser->is_type_normal();
 }
 
+// If url is relavant with bulitin items, use builtin item's url.
+// Ex, we don't need to add bookmarks manager as a sidebar shortcut
+// if sidebar panel already has bookmarks item.
+GURL ConvertURLToBuiltInItemURL(const GURL& url) {
+  if (url == GURL(chrome::kChromeUIBookmarksURL))
+    return GURL(kSidebarBookmarksURL);
+
+  if (url.host() == "talk.brave.com")
+    return GURL(kBraveTalkURL);
+
+  if (url.SchemeIs(content::kChromeUIScheme) && url.host() == kWalletPageHost) {
+    return GURL(kBraveUIWalletPageURL);
+  }
+  return url;
+}
+
 bool CanAddCurrentActiveTabToSidebar(Browser* browser) {
-  auto* web_contents = browser->tab_strip_model()->GetActiveWebContents();
-  if (!web_contents)
+  auto* active_web_contents =
+      browser->tab_strip_model()->GetActiveWebContents();
+  if (!active_web_contents)
     return false;
 
-  if (IsActiveTabNTP(browser))
+  if (IsActiveTabNTP(active_web_contents))
     return false;
 
-  if (IsActiveTabAlreadyAddedToSidebar(browser))
+  const GURL url = active_web_contents->GetLastCommittedURL();
+  if (!url.is_valid())
+    return false;
+
+  auto* service = GetSidebarService(browser);
+  if (IsURLAlreadyAddedToSidebar(service, url))
+    return false;
+
+  if (CanUseNotAddedBuiltInItemInsteadOf(service, url))
     return false;
 
   return true;

--- a/browser/ui/sidebar/sidebar_utils.cc
+++ b/browser/ui/sidebar/sidebar_utils.cc
@@ -52,10 +52,9 @@ bool IsURLAlreadyAddedToSidebar(SidebarService* service, const GURL& url) {
 
 }  // namespace
 
-bool CanUseNotAddedBuiltInItemInsteadOf(SidebarService* service,
-                                        const GURL& url) {
-  const auto not_added_default_items =
-      service->GetNotAddedDefaultSidebarItems();
+bool HiddenDefaultSidebarItemsContains(SidebarService* service,
+                                       const GURL& url) {
+  const auto not_added_default_items = service->GetHiddenDefaultSidebarItems();
   if (not_added_default_items.empty())
     return false;
   const GURL converted_url = ConvertURLToBuiltInItemURL(url);
@@ -104,7 +103,7 @@ bool CanAddCurrentActiveTabToSidebar(Browser* browser) {
   if (IsURLAlreadyAddedToSidebar(service, url))
     return false;
 
-  if (CanUseNotAddedBuiltInItemInsteadOf(service, url))
+  if (HiddenDefaultSidebarItemsContains(service, url))
     return false;
 
   return true;

--- a/browser/ui/sidebar/sidebar_utils.cc
+++ b/browser/ui/sidebar/sidebar_utils.cc
@@ -77,7 +77,7 @@ GURL ConvertURLToBuiltInItemURL(const GURL& url) {
   if (url == GURL(chrome::kChromeUIBookmarksURL))
     return GURL(kSidebarBookmarksURL);
 
-  if (url.host() == "talk.brave.com")
+  if (url.host() == kBraveTalkHost)
     return GURL(kBraveTalkURL);
 
   if (url.SchemeIs(content::kChromeUIScheme) && url.host() == kWalletPageHost) {

--- a/browser/ui/sidebar/sidebar_utils.h
+++ b/browser/ui/sidebar/sidebar_utils.h
@@ -7,11 +7,19 @@
 #define BRAVE_BROWSER_UI_SIDEBAR_SIDEBAR_UTILS_H_
 
 class Browser;
+class GURL;
 
 namespace sidebar {
 
+class SidebarService;
+
 bool CanUseSidebar(Browser* browser);
 bool CanAddCurrentActiveTabToSidebar(Browser* browser);
+
+// Exported for testing.
+bool CanUseNotAddedBuiltInItemInsteadOf(SidebarService* service,
+                                        const GURL& url);
+GURL ConvertURLToBuiltInItemURL(const GURL& url);
 
 }  // namespace sidebar
 

--- a/browser/ui/sidebar/sidebar_utils.h
+++ b/browser/ui/sidebar/sidebar_utils.h
@@ -17,8 +17,8 @@ bool CanUseSidebar(Browser* browser);
 bool CanAddCurrentActiveTabToSidebar(Browser* browser);
 
 // Exported for testing.
-bool CanUseNotAddedBuiltInItemInsteadOf(SidebarService* service,
-                                        const GURL& url);
+bool HiddenDefaultSidebarItemsContains(SidebarService* service,
+                                       const GURL& url);
 GURL ConvertURLToBuiltInItemURL(const GURL& url);
 
 }  // namespace sidebar

--- a/browser/ui/views/sidebar/sidebar_add_item_bubble_delegate_view.cc
+++ b/browser/ui/views/sidebar/sidebar_add_item_bubble_delegate_view.cc
@@ -175,7 +175,7 @@ void SidebarAddItemBubbleDelegateView::AddChildViews() {
   }
 
   const auto not_added_default_items =
-      GetSidebarService(browser_)->GetNotAddedDefaultSidebarItems();
+      GetSidebarService(browser_)->GetHiddenDefaultSidebarItems();
   if (not_added_default_items.empty())
     return;
 

--- a/components/sidebar/constants.h
+++ b/components/sidebar/constants.h
@@ -19,6 +19,8 @@ constexpr char kSidebarItemOpenInPanelKey[] = "open_in_panel";
 constexpr char kSidebarBookmarksURL[] =
     "chrome://sidebar-bookmarks.top-chrome/";
 
+constexpr char kBraveTalkURL[] = "https://talk.brave.com/widget";
+
 }  // namespace sidebar
 
 #endif  // BRAVE_COMPONENTS_SIDEBAR_CONSTANTS_H_

--- a/components/sidebar/constants.h
+++ b/components/sidebar/constants.h
@@ -20,6 +20,7 @@ constexpr char kSidebarBookmarksURL[] =
     "chrome://sidebar-bookmarks.top-chrome/";
 
 constexpr char kBraveTalkURL[] = "https://talk.brave.com/widget";
+constexpr char kBraveTalkHost[] = "talk.brave.com";
 
 }  // namespace sidebar
 

--- a/components/sidebar/sidebar_service.cc
+++ b/components/sidebar/sidebar_service.cc
@@ -27,7 +27,7 @@ SidebarItem GetBuiltInItemForType(SidebarItem::BuiltInItemType type) {
   switch (type) {
     case SidebarItem::BuiltInItemType::kBraveTalk:
       return SidebarItem::Create(
-          GURL("https://talk.brave.com/widget"),
+          GURL(kBraveTalkURL),
           l10n_util::GetStringUTF16(IDS_SIDEBAR_BRAVE_TALK_ITEM_TITLE),
           SidebarItem::Type::kTypeBuiltIn,
           SidebarItem::BuiltInItemType::kBraveTalk, false);

--- a/components/sidebar/sidebar_service.cc
+++ b/components/sidebar/sidebar_service.cc
@@ -187,8 +187,7 @@ void SidebarService::RemoveObserver(Observer* observer) {
   observers_.RemoveObserver(observer);
 }
 
-std::vector<SidebarItem> SidebarService::GetNotAddedDefaultSidebarItems()
-    const {
+std::vector<SidebarItem> SidebarService::GetHiddenDefaultSidebarItems() const {
   auto default_items = GetDefaultSidebarItems();
   const auto added_default_items = GetDefaultSidebarItemsFromCurrentItems();
   for (const auto& added_item : added_default_items) {

--- a/components/sidebar/sidebar_service.h
+++ b/components/sidebar/sidebar_service.h
@@ -55,7 +55,7 @@ class SidebarService : public KeyedService {
   void AddObserver(Observer* observer);
   void RemoveObserver(Observer* observer);
 
-  std::vector<SidebarItem> GetNotAddedDefaultSidebarItems() const;
+  std::vector<SidebarItem> GetHiddenDefaultSidebarItems() const;
   ShowSidebarOption GetSidebarShowOption() const;
   void SetSidebarShowOption(ShowSidebarOption show_options);
 

--- a/components/sidebar/sidebar_service_unittest.cc
+++ b/components/sidebar/sidebar_service_unittest.cc
@@ -171,7 +171,7 @@ TEST_F(SidebarServiceTest, BuiltInItemUpdateTestWithBuiltInItemTypeKey) {
 
   // Check service has updated built-in item. Previously url was deprecated.xxx.
   EXPECT_EQ(1UL, service_->items().size());
-  EXPECT_EQ("https://talk.brave.com/widget", service_->items()[0].url);
+  EXPECT_EQ(GURL(kBraveTalkURL), service_->items()[0].url);
 
   // Simulate re-launch and check service has still updated items.
   service_->RemoveObserver(this);
@@ -181,7 +181,7 @@ TEST_F(SidebarServiceTest, BuiltInItemUpdateTestWithBuiltInItemTypeKey) {
 
   // Check service has updated built-in item. Previously url was deprecated.xxx.
   EXPECT_EQ(1UL, service_->items().size());
-  EXPECT_EQ("https://talk.brave.com/widget", service_->items()[0].url);
+  EXPECT_EQ(GURL(kBraveTalkURL), service_->items()[0].url);
 }
 
 TEST_F(SidebarServiceTest, BuiltInItemDoesntHaveHistoryItem) {

--- a/components/sidebar/sidebar_service_unittest.cc
+++ b/components/sidebar/sidebar_service_unittest.cc
@@ -78,7 +78,7 @@ TEST_F(SidebarServiceTest, AddRemoveItems) {
 
   // Check the default items count.
   EXPECT_EQ(3UL, service_->items().size());
-  EXPECT_EQ(0UL, service_->GetNotAddedDefaultSidebarItems().size());
+  EXPECT_EQ(0UL, service_->GetHiddenDefaultSidebarItems().size());
 
   // Cache 1st item to compare after removing.
   const SidebarItem item = service_->items()[0];
@@ -90,7 +90,7 @@ TEST_F(SidebarServiceTest, AddRemoveItems) {
 
   service_->RemoveItemAt(0);
   EXPECT_EQ(2UL, service_->items().size());
-  EXPECT_EQ(1UL, service_->GetNotAddedDefaultSidebarItems().size());
+  EXPECT_EQ(1UL, service_->GetHiddenDefaultSidebarItems().size());
   EXPECT_EQ(0, item_index_on_called_);
   EXPECT_TRUE(on_will_remove_item_called_);
   EXPECT_TRUE(on_item_removed_called_);
@@ -102,7 +102,7 @@ TEST_F(SidebarServiceTest, AddRemoveItems) {
   // New item will be added at last.
   EXPECT_EQ(2, item_index_on_called_);
   EXPECT_EQ(3UL, service_->items().size());
-  EXPECT_EQ(0UL, service_->GetNotAddedDefaultSidebarItems().size());
+  EXPECT_EQ(0UL, service_->GetHiddenDefaultSidebarItems().size());
   EXPECT_TRUE(on_item_added_called_);
   ClearState();
 
@@ -208,7 +208,7 @@ TEST_F(SidebarServiceTest, BuiltInItemDoesntHaveHistoryItem) {
   EXPECT_EQ(0UL, service_->items().size());
 
   // Make sure history is not included in the not added default items list.
-  auto not_added_default_items = service_->GetNotAddedDefaultSidebarItems();
+  auto not_added_default_items = service_->GetHiddenDefaultSidebarItems();
   EXPECT_EQ(3UL, not_added_default_items.size());
   for (const auto& item : not_added_default_items) {
     EXPECT_NE(SidebarItem::BuiltInItemType::kHistory, item.built_in_item_type);


### PR DESCRIPTION
fix https://github.com/brave/brave-browser/issues/21124

When bookmarks manager is loaded in active tab, user can add it
as a shortcut in sidebar. However, sidebar provides bookmarks panel
as a default items. So, we should add bookmarks builtin item
instead of shortcut if it's removed.
This can apply also to all other builtin items.(talk, wallet).

<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves 

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
`npm run test brave_unit_tests -- --filter=*Sidebar*`
See STR in the linked issue.