### PR TITLE
fix(wallet): remove TAG param from eth_estimateGas RPC  (uplift to 1.35.x)

### DIFF
--- a/components/brave_wallet/browser/eth_json_rpc_controller.cc
+++ b/components/brave_wallet/browser/eth_json_rpc_controller.cc
@@ -915,9 +915,9 @@ void EthJsonRpcController::GetEstimateGas(const std::string& from_address,
   auto internal_callback =
       base::BindOnce(&EthJsonRpcController::OnGetEstimateGas,
                      weak_ptr_factory_.GetWeakPtr(), std::move(callback));
-  return Request(eth_estimateGas(from_address, to_address, gas, gas_price,
-                                 value, data, "latest"),
-                 true, std::move(internal_callback));
+  return Request(
+      eth_estimateGas(from_address, to_address, gas, gas_price, value, data),
+      true, std::move(internal_callback));
 }
 
 void EthJsonRpcController::OnGetEstimateGas(

--- a/components/brave_wallet/browser/eth_requests.cc
+++ b/components/brave_wallet/browser/eth_requests.cc
@@ -249,8 +249,7 @@ std::string eth_estimateGas(const std::string& from_address,
                             const std::string& gas,
                             const std::string& gas_price,
                             const std::string& val,
-                            const std::string& data,
-                            const std::string& quantity_tag) {
+                            const std::string& data) {
   base::Value params(base::Value::Type::LIST);
   base::Value transaction(base::Value::Type::DICTIONARY);
   AddKeyIfNotEmpty(&transaction, "data", data);
@@ -260,7 +259,6 @@ std::string eth_estimateGas(const std::string& from_address,
   transaction.SetKey("to", base::Value(to_address));
   AddKeyIfNotEmpty(&transaction, "value", val);
   params.Append(std::move(transaction));
-  params.Append(std::move(quantity_tag));
   base::Value dictionary = GetJsonRpcDictionary("eth_estimateGas", &params);
   return GetJSON(dictionary);
 }

--- a/components/brave_wallet/browser/eth_requests.h
+++ b/components/brave_wallet/browser/eth_requests.h
@@ -106,13 +106,17 @@ std::string eth_call(const std::string& from_address,
 // Note that the estimate may be significantly more than the amount of gas
 // actually used by the transaction, for a variety of reasons including EVM
 // mechanics and node performance.
+//
+// Some EVM clients allow passing an optional block parameter called
+// QUANTITY|TAG, however the official specs in github.com/ethereum/eth1.0-specs
+// do not. Therefore to support chains that follow the official specs, we do not
+// allow specifying this parameter.
 std::string eth_estimateGas(const std::string& from_address,
                             const std::string& to_address,
                             const std::string& gas,
                             const std::string& gas_price,
                             const std::string& value,
-                            const std::string& data,
-                            const std::string& quantity_tag);
+                            const std::string& data);
 // Returns information about a block by hash.
 std::string eth_getBlockByHash(const std::string& block_hash,
                                bool full_transaction_object);

--- a/components/brave_wallet/browser/eth_requests_unittest.cc
+++ b/components/brave_wallet/browser/eth_requests_unittest.cc
@@ -179,9 +179,8 @@ TEST(EthRequestUnitTest, eth_estimateGas) {
                       "0xd46e8dd67c5d32be8058bb8eb970870f07244567", "0x76c0",
                       "0x9184e72a000", "0x9184e72a",
                       "0xd46e8dd67c5d32be8d46e8dd67c5d32be8058bb8eb970870f07244"
-                      "5675058bb8eb970870f072445675",
-                      "latest"),
-      R"({"id":1,"jsonrpc":"2.0","method":"eth_estimateGas","params":[{"data":"0xd46e8dd67c5d32be8d46e8dd67c5d32be8058bb8eb970870f072445675058bb8eb970870f072445675","from":"0xb60e8dd61c5d32be8058bb8eb970870f07233155","gas":"0x76c0","gasPrice":"0x9184e72a000","to":"0xd46e8dd67c5d32be8058bb8eb970870f07244567","value":"0x9184e72a"},"latest"]})");  // NOLINT
+                      "5675058bb8eb970870f072445675"),
+      R"({"id":1,"jsonrpc":"2.0","method":"eth_estimateGas","params":[{"data":"0xd46e8dd67c5d32be8d46e8dd67c5d32be8058bb8eb970870f072445675058bb8eb970870f072445675","from":"0xb60e8dd61c5d32be8058bb8eb970870f07233155","gas":"0x76c0","gasPrice":"0x9184e72a000","to":"0xd46e8dd67c5d32be8058bb8eb970870f07244567","value":"0x9184e72a"}]})");  // NOLINT
 }
 
 TEST(EthRequestUnitTest, eth_getBlockByHash) {


### PR DESCRIPTION
Uplift of https://github.com/brave/brave-core/pull/12267 (only commit be46e5696751aa1790c73a85abaf0d8b27eb43aa) to **`1.35.x`**.

Resolves https://github.com/brave/brave-browser/issues/21084.

- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR.
- [x] You have tested your change on Nightly. 
- [x] The PR milestones match the branch they are landing to. 

After you merge: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.
