### PR TITLE
Fix wrong legacy derivation path (uplift to 1.35.x) 

### DIFF
--- a/components/brave_wallet_ui/common/hardware/ledgerjs/eth_ledger_bridge_keyring.test.ts
+++ b/components/brave_wallet_ui/common/hardware/ledgerjs/eth_ledger_bridge_keyring.test.ts
@@ -65,8 +65,8 @@ test('Extracting accounts from legacy device', () => {
           'deviceId': 'device1'
         },
         {
-          'address': 'address for m/44\'/60\'/1\'/0',
-          'derivationPath': 'm/44\'/60\'/1\'/0',
+          'address': 'address for m/44\'/60\'/0\'/1',
+          'derivationPath': 'm/44\'/60\'/0\'/1',
           'hardwareVendor': 'Ledger',
           'name': 'Ledger',
           'deviceId': 'device1'

--- a/components/brave_wallet_ui/common/hardware/ledgerjs/eth_ledger_bridge_keyring.ts
+++ b/components/brave_wallet_ui/common/hardware/ledgerjs/eth_ledger_bridge_keyring.ts
@@ -143,6 +143,6 @@ export default class LedgerBridgeKeyring extends LedgerKeyring {
       return `m/44'/60'/${index}'/0/0`
     }
     assert(scheme === LedgerDerivationPaths.Legacy)
-    return `m/44'/60'/${index}'/0`
+    return `m/44'/60'/0'/${index}`
   }
 }


### PR DESCRIPTION
Uplift of #12314
Resolves https://github.com/brave/brave-browser/issues/19883

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [ ] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.