### PR TITLE
Added deprecated derivation path to Ledger devices (uplift 1.35.x)

### DIFF
--- a/components/brave_wallet_ui/common/hardware/ledgerjs/eth_ledger_bridge_keyring.test.ts
+++ b/components/brave_wallet_ui/common/hardware/ledgerjs/eth_ledger_bridge_keyring.test.ts
@@ -76,6 +76,31 @@ test('Extracting accounts from legacy device', () => {
     )
 })
 
+test('Extracting accounts with deprecated derivation paths', () => {
+  return expect(createLedgerKeyring().getAccounts(-2, 1, LedgerDerivationPaths.Deprecated))
+    .resolves.toStrictEqual({
+      payload: [
+        {
+          'address': 'address for m/44\'/60\'/0\'/0',
+          'derivationPath': 'm/44\'/60\'/0\'/0',
+          'hardwareVendor': 'Ledger',
+          'name': 'Ledger',
+          'deviceId': 'device1',
+          'coin': BraveWallet.CoinType.ETH
+        },
+        {
+          'address': 'address for m/44\'/60\'/1\'/0',
+          'derivationPath': 'm/44\'/60\'/1\'/0',
+          'hardwareVendor': 'Ledger',
+          'name': 'Ledger',
+          'deviceId': 'device1',
+          'coin': BraveWallet.CoinType.ETH
+        }],
+      success: true
+    }
+    )
+})
+
 test('Check ledger bridge type', () => {
   const ledgerHardwareKeyring = new LedgerBridgeKeyring()
   return expect(ledgerHardwareKeyring.type()).toStrictEqual(BraveWallet.LEDGER_HARDWARE_VENDOR)

--- a/components/brave_wallet_ui/common/hardware/ledgerjs/eth_ledger_bridge_keyring.test.ts
+++ b/components/brave_wallet_ui/common/hardware/ledgerjs/eth_ledger_bridge_keyring.test.ts
@@ -85,16 +85,14 @@ test('Extracting accounts with deprecated derivation paths', () => {
           'derivationPath': 'm/44\'/60\'/0\'/0',
           'hardwareVendor': 'Ledger',
           'name': 'Ledger',
-          'deviceId': 'device1',
-          'coin': BraveWallet.CoinType.ETH
+          'deviceId': 'device1'
         },
         {
           'address': 'address for m/44\'/60\'/1\'/0',
           'derivationPath': 'm/44\'/60\'/1\'/0',
           'hardwareVendor': 'Ledger',
           'name': 'Ledger',
-          'deviceId': 'device1',
-          'coin': BraveWallet.CoinType.ETH
+          'deviceId': 'device1'
         }],
       success: true
     }

--- a/components/brave_wallet_ui/common/hardware/ledgerjs/eth_ledger_bridge_keyring.ts
+++ b/components/brave_wallet_ui/common/hardware/ledgerjs/eth_ledger_bridge_keyring.ts
@@ -142,6 +142,10 @@ export default class LedgerBridgeKeyring extends LedgerKeyring {
     if (scheme === LedgerDerivationPaths.LedgerLive) {
       return `m/44'/60'/${index}'/0/0`
     }
+    if (scheme === LedgerDerivationPaths.Deprecated) {
+      return `m/44'/60'/${index}'/0`
+    }
+
     assert(scheme === LedgerDerivationPaths.Legacy)
     return `m/44'/60'/${index}'/0`
   }

--- a/components/brave_wallet_ui/common/hardware/types.ts
+++ b/components/brave_wallet_ui/common/hardware/types.ts
@@ -45,14 +45,15 @@ export interface TrezorBridgeAccountsPayload {
 
 export enum LedgerDerivationPaths {
   LedgerLive = 'ledger-live',
-  Legacy = 'legacy'
+  Legacy = 'legacy',
+  Deprecated = 'deprecated'
 }
 
 export enum TrezorDerivationPaths {
   Default = 'trezor'
 }
 
-const DerivationSchemeTypes = [LedgerDerivationPaths.LedgerLive, LedgerDerivationPaths.Legacy, TrezorDerivationPaths.Default] as const
+const DerivationSchemeTypes = [LedgerDerivationPaths.LedgerLive, LedgerDerivationPaths.Legacy, LedgerDerivationPaths.Deprecated, TrezorDerivationPaths.Default] as const
 export type HardwareDerivationScheme = typeof DerivationSchemeTypes[number]
 
 export type GetAccountsHardwareOperationResult = HardwareOperationResult & {

--- a/components/brave_wallet_ui/components/desktop/popup-modals/add-account-modal/hardware-wallet-connect/style.ts
+++ b/components/brave_wallet_ui/components/desktop/popup-modals/add-account-modal/hardware-wallet-connect/style.ts
@@ -184,7 +184,7 @@ export const DisclaimerWrapper = styled(DisclaimerWrapperBase)`
 export const SelectWrapper = styled.div`
   margin-bottom: 10px;
   margin-left: -300px;
-  width: 250px;
+  width: 300px;
 `
 
 export const ErrorText = styled.span`

--- a/components/brave_wallet_ui/components/desktop/popup-modals/add-account-modal/hardware-wallet-connect/types.ts
+++ b/components/brave_wallet_ui/components/desktop/popup-modals/add-account-modal/hardware-wallet-connect/types.ts
@@ -10,6 +10,7 @@ import { HardwareVendor } from '../../../../../common/api/hardware_keyrings'
 export const HardwareWalletDerivationPathLocaleMapping = {
   [LedgerDerivationPaths.LedgerLive]: 'Ledger Live',
   [LedgerDerivationPaths.Legacy]: 'Legacy (MEW/MyCrypto)',
+  [LedgerDerivationPaths.Deprecated]: 'Deprecated (Not recommended)',
   [TrezorDerivationPaths.Default]: 'Default'
 }
 


### PR DESCRIPTION
Uplift of #12319
Resolves https://github.com/brave/brave-browser/issues/21171

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [ ] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.