### PR TITLE
Prevent the "Update available" Sparkle popup on Mac

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -7,7 +7,7 @@ deps = {
   "vendor/boto": "https://github.com/boto/boto@f7574aa6cc2c819430c1f05e9a1a1a666ef8169b",
   "vendor/python-patch": "https://github.com/brave/python-patch@d8880110be6554686bc08261766538c2926d4e82",
   "vendor/omaha":  "https://github.com/brave/omaha.git@baf5b9977a49db893b557c7ceca18ab414fd2a08",
-  "vendor/sparkle": "https://github.com/brave/Sparkle.git@07933da3e178265d0f0ba86e02bbde38e701a04d",
+  "vendor/sparkle": "https://github.com/brave/Sparkle.git@57fb153bea4c71ed10102d50e68ead89ca483b49",
   "vendor/bat-native-rapidjson": "https://github.com/brave-intl/bat-native-rapidjson.git@60b7e4574cebdd79f441bdd6f0f3ab469fd7e04c",
   "vendor/bip39wally-core-native": "https://github.com/brave-intl/bat-native-bip39wally-core.git@0d3a8713a2b388d2156fe49a70ef3f7cdb44b190",
   "vendor/bat-native-anonize": "https://github.com/brave-intl/bat-native-anonize.git@e3742ba3e8942eea9e4755d91532491871bd3116",

--- a/browser/mac/sparkle_glue.mm
+++ b/browser/mac/sparkle_glue.mm
@@ -190,9 +190,16 @@ class PerformBridge : public base::RefCountedThreadSafe<PerformBridge> {
   // Background update check interval.
   constexpr NSTimeInterval kBraveUpdateCheckIntervalInSec = 3 * 60 * 60;
   [su_updater_ setUpdateCheckInterval:kBraveUpdateCheckIntervalInSec];
-  [su_updater_ setAutomaticallyChecksForUpdates:YES];
+
   [su_updater_ setAutomaticallyDownloadsUpdates:YES];
 
+  // We only want to perform automatic update checks if we have write
+  // access to the installation directory. Such access can be checked
+  // with SUSystemUpdateInfo:systemAllowsAutomaticUpdatesForHost.
+  // The following makes su_updater_ call this method for us because
+  // we setAutomaticallyDownloadUpdates:YES above.
+  if ([su_updater_ automaticallyDownloadsUpdates])
+    [su_updater_ setAutomaticallyChecksForUpdates:YES];
   [self updateStatus:kAutoupdateRegistered version:nil error:nil];
 }
 
@@ -229,7 +236,7 @@ class PerformBridge : public base::RefCountedThreadSafe<PerformBridge> {
 
   [self updateStatus:kAutoupdateChecking version:nil error:nil];
 
-  [su_updater_ checkForUpdatesInBackground];
+  [su_updater_ checkForUpdatesInBackgroundWithoutUi];
 }
 
 - (void)relaunch {
@@ -239,7 +246,7 @@ class PerformBridge : public base::RefCountedThreadSafe<PerformBridge> {
 
 - (void)checkForUpdatesInBackground {
   DCHECK(registered_);
-  [su_updater_ checkForUpdatesInBackground];
+  [su_updater_ checkForUpdatesInBackgroundWithoutUi];
 }
 
 - (void)updateStatus:(AutoupdateStatus)status

--- a/browser/mac/su_updater.h
+++ b/browser/mac/su_updater.h
@@ -1,4 +1,5 @@
-/* This Source Code Form is subject to the terms of the Mozilla Public
+/* Copyright 2022 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
@@ -16,16 +17,19 @@
 
 @interface SUUpdater : NSObject
 
-@property (strong) SUUpdateDriver *driver;
+@property(strong) SUUpdateDriver* driver;  // NOLINT
 
-+ (SUUpdater *)sharedUpdater;
++ (SUUpdater*)sharedUpdater;  // NOLINT
 
 - (void)checkForUpdates:(id)sender;
 - (void)setDelegate:(id)delegate;
 - (void)setAutomaticallyChecksForUpdates:(BOOL)enable;
 - (void)setAutomaticallyDownloadsUpdates:(BOOL)enable;
 - (void)checkForUpdatesInBackground;
+- (void)checkForUpdatesInBackgroundWithoutUi;
 - (void)setUpdateCheckInterval:(NSTimeInterval)interval;
+
+@property BOOL automaticallyDownloadsUpdates;
 
 @end
 


### PR DESCRIPTION
It was shown when Brave was run as non-admin user and tried to update a system-wide installation.

Resolves https://github.com/brave/brave-browser/issues/9562

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] **The associated commits in github.com/brave/Sparkle were merged into the main Git branch there.**
- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

**This PR has the potential to brick Brave's update fleet on macOS.** It is therefore very important to test it thoroughly.

### Affected functionality

This PR affects the following functionality:

 1. Silent, background updates. These take place _after the second time_ Brave is started on a user's system, and while Brave is running. The functionality silently downloads and applies updates in the background. On the next start of Brave, the new version should then be in effect.
 2. On-demand updates. These are kicked off when the user visits `brave://settings/help`.

Especially the first one 1. should be tested carefully. If this breaks, then Brave's entire macOS fleet will no longer receive updates and users would have to update manually.

### Scenarios to test

At least the following scenarios should be tested, with the most important ones listed first:

 1. Silent, background update when Brave is run as a user with admin rights.
 2. On-demand update when Brave is run as a user with admin rights.
 3. On-demand update when Brave is run as a guest user without admin rights.
 4. Silent, background update when Brave is run as a guest user should be disabled.

Here's how to test them:

"1.": Ideally, there is already a newer release of Brave. So say you have v1.2.3 (which includes the changes from this PR) and there is 1.2.4 on github.com/brave/brave-browser/releases. Then you would install v1.2.3 into /Applications. Start Brave once. Make sure brave://settings/help is not open. (Otherwise, that page would trigger an on-demand update check now or on the next launch of Brave). Close Brave. Wait for 3 hours. (Maybe it also works to change the system time.) Start Brave again and wait for a few minutes. Close Brave. Open brave://settings/help. It should now say it's at version 1.2.4. There should not have been any "Update available" popup as shown in the screenshots in https://github.com/brave/brave-browser/issues/9562.

If the above does not work, then you can inspect the logs by launching Brave with the following command in a terminal:

    /Applications/Brave\ Browser\ Nightly.app/Contents/MacOS/Brave\ Browser\ Nightly --enable-logging=stderr --vmodule=sparkle_glue=5,brave_relaunch_handler_mac=5 2>&1

The following command in a terminal should also show some interesting output if an update gets applied:

    log stream | grep -i sparkle

"2.": Install Brave "1.2.3" (see "1." above) into /Applications and (as a user with admin rights) open brave://settings/help. An update should be applied but no update popup should be visible. Relaunch Brave and check that brave://settings/help shows the new version. There should not have been any "Update available" popup as shown in the screenshots in https://github.com/brave/brave-browser/issues/9562.

"3.a)": Repeat "2." but execute Brave as a non-admin user. The update should be applied. Relaunch Brave. This should open a dialog asking you to grant admin permissions for the update modifications. Grant admin permissions. The new version of Brave should launch. `brave://settings/help` should show the new version. There should not have been any "Update available" popup as shown in the screenshots in https://github.com/brave/brave-browser/issues/9562.

"3.b)": Repeat "3.a)" but do not grant admin permissions after relaunching Brave. This will likely prevent Brave from opening on the first time. But when you open Brave again, it should work successfully and `brave://settings/help` should show the old version.

"4.": Repeat "1." but execute Brave as a non-admin user. No update should be applied. Be careful not to open `brave://settings/help`, because that would apply an update. There should also not be an "update available" popup.