### PR TITLE
[Android] Brave news - fixes load new button staying on screen (uplift to 1.36.x)

### DIFF
--- a/android/java/org/chromium/chrome/browser/ntp/BraveNewTabPageLayout.java
+++ b/android/java/org/chromium/chrome/browser/ntp/BraveNewTabPageLayout.java
@@ -625,23 +625,10 @@ public class BraveNewTabPageLayout
                     }
                 }
             }
-
-            mPreferenceObserver = (key) -> {
-                if (TextUtils.equals(key, BravePreferenceKeys.BRAVE_NEWS_CHANGE_SOURCE)) {
-                    if (mNewContentButton != null) {
-                        mNewContentButton.setVisibility(View.VISIBLE);
-                    } else {
-                        mNewContentButton =
-                                mCompositorView.findViewById(R.id.new_content_layout_id);
-                        if (mNewContentButton != null) {
-                            mNewContentButton.setVisibility(View.VISIBLE);
-                        }
-                    }
-                } else if (TextUtils.equals(key, BravePreferenceKeys.BRAVE_NEWS_PREF_SHOW_NEWS)) {
-                    refreshFeed();
-                }
-            };
-            SharedPreferencesManager.getInstance().addObserver(mPreferenceObserver);
+            initPreferenceObserver();
+            if (mPreferenceObserver != null) {
+                SharedPreferencesManager.getInstance().addObserver(mPreferenceObserver);
+            }
         }
         showWidgets();
         if (BinanceWidgetManager.getInstance().isUserAuthenticatedForBinance()) {
@@ -652,6 +639,28 @@ public class BraveNewTabPageLayout
         }
         mBinanceNativeWorker.AddObserver(mBinanaceObserver);
         startTimer();
+    }
+
+    private void initPreferenceObserver() {
+        mPreferenceObserver = (key) -> {
+            if (TextUtils.equals(key, BravePreferenceKeys.BRAVE_NEWS_CHANGE_SOURCE)) {
+                if (mNewContentButton != null) {
+                    mNewContentButton.setVisibility(View.VISIBLE);
+                } else {
+                    mNewContentButton = mCompositorView.findViewById(R.id.new_content_layout_id);
+                    if (mNewContentButton != null) {
+                        mNewContentButton.setVisibility(View.VISIBLE);
+                    }
+                }
+            } else if (TextUtils.equals(key, BravePreferenceKeys.BRAVE_NEWS_PREF_SHOW_NEWS)) {
+                if (BravePrefServiceBridge.getInstance().getShowNews()) {
+                    if (BraveActivity.getBraveActivity() != null) {
+                        BraveActivity.getBraveActivity().inflateNewsSettingsBar();
+                    }
+                }
+                refreshFeed();
+            }
+        };
     }
 
     @Override
@@ -876,8 +885,17 @@ public class BraveNewTabPageLayout
             if (mRecyclerView != null) {
                 mRecyclerView.setVisibility(View.GONE);
             }
+            if (mNewContentButton != null) {
+                mNewContentButton.setVisibility(View.INVISIBLE);
+            }
             mImageCreditLayout.setAlpha(1.0f);
             return;
+        } else {
+            SharedPreferencesManager.getInstance().removeObserver(mPreferenceObserver);
+            initPreferenceObserver();
+            if (mPreferenceObserver != null) {
+                SharedPreferencesManager.getInstance().addObserver(mPreferenceObserver);
+            }
         }
         getFeed();
     }


### PR DESCRIPTION
Uplift of #12349
Resolves https://github.com/brave/brave-browser/issues/21204

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.