### PR TITLE
P3A: Don't report Brave.Rewards.EnabledDuration

### DIFF
--- a/components/p3a/brave_p3a_service.cc
+++ b/components/p3a/brave_p3a_service.cc
@@ -83,7 +83,6 @@ constexpr const char* kCollectedHistograms[] = {
     "Brave.Rewards.AdsState.2",
     "Brave.Rewards.AutoContributionsState.2",
     "Brave.Rewards.TipsState.2",
-    "Brave.Rewards.EnabledDuration",
     "Brave.Rewards.WalletBalance.3",
     "Brave.Rewards.WalletState",
     "Brave.Savings.BandwidthSavingsMB",


### PR DESCRIPTION
This metric is buggy and is being removed in favor of a better-defined
metric focussed on how long ads were enabled. As such collecting the
data is no longer neccessary.

This disabled sending the report while leaving the measurement code
in-tree so it's easier to repurpose for the ads-focussed question.

Resolves brave/brave-browser#21232

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

Verify the `Brave.Rewards.EnabledDuration` report is not sent.
- On a fresh profile, brave://local-state shouldn't show the key under `brave.p3a.logs`
- On an established profile, which previously showed a `Brave.Rewards.EnabledDuration` measurement, confirm the key is no longer present in brave://local-state after starting the browser with this change.
- Confirm no p3a metric message is sent over the network for `Brave.Rewards.EnabledDuration`.
  - This can be done on a fresh profile, waiting 10-30 minutes until all the reported p3a measurements in brave://local-state are marked `"sent": true`.
  - On an established profile, set the system clock forward past midnight on a future Sunday night to trigger a new P3A reporting period.