### PR TITLE
Workaround spare renderer process host issue in test. (uplift to 1.35.x)

### DIFF
--- a/browser/extensions/api/brave_shields_api_browsertest.cc
+++ b/browser/extensions/api/brave_shields_api_browsertest.cc
@@ -201,9 +201,17 @@ IN_PROC_BROWSER_TEST_F(BraveShieldsAPIBrowserTest, AllowScriptsOnceDataURL) {
       << "Scripts from a.test and data URL should be temporarily allowed.";
 }
 
-IN_PROC_BROWSER_TEST_F(BraveShieldsAPIBrowserTest, AllowScriptsOnceIframe) {
+IN_PROC_BROWSER_TEST_F(BraveShieldsAPIBrowserTest, PRE_AllowScriptsOnceIframe) {
+  // Block scripts in a PRE_ test to workaround an upstream bug [1] when a spare
+  // renderer process doesn't receive ContentSettings updates after being
+  // created.
+  // Workaround should be removed when upstream will be fixed.
+  //
+  // 1. https://bugs.chromium.org/p/chromium/issues/detail?id=1294211
   BlockScripts();
+}
 
+IN_PROC_BROWSER_TEST_F(BraveShieldsAPIBrowserTest, AllowScriptsOnceIframe) {
   EXPECT_TRUE(NavigateToURLUntilLoadStop("a.com", "/remote_iframe.html"));
   EXPECT_EQ(GetActiveRenderFrameHosts().size(), 2u)
       << "All script loadings should be blocked.";


### PR DESCRIPTION
Uplift of #12332
Fixes https://github.com/brave/brave-browser/issues/20785

Pre-approval checklist: 
- [ ] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [ ] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [ ] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [ ] The associated issue milestone is set to the smallest version that the changes is landed on.