### PR TITLE
Revert "Use brave search as a default search provider in tor window and update TorWindow NTP"

### DIFF
--- a/browser/search_engines/search_engine_provider_service_browsertest.cc
+++ b/browser/search_engines/search_engine_provider_service_browsertest.cc
@@ -168,8 +168,9 @@ IN_PROC_BROWSER_TEST_F(SearchEngineProviderServiceTest,
 
   auto* service = TemplateURLServiceFactory::GetForProfile(tor_profile);
 
-  const int default_provider_id =
-      TemplateURLPrepopulateData::PREPOPULATED_ENGINE_ID_BRAVE_TOR;
+  int default_provider_id = brave::IsRegionForQwant(tor_profile) ?
+      TemplateURLPrepopulateData::PREPOPULATED_ENGINE_ID_QWANT :
+      TemplateURLPrepopulateData::PREPOPULATED_ENGINE_ID_DUCKDUCKGO;
 
   // Check tor profile's search provider is set to ddg.
   EXPECT_EQ(service->GetDefaultSearchProvider()->data().prepopulate_id,
@@ -194,8 +195,10 @@ IN_PROC_BROWSER_TEST_F(SearchEngineProviderServiceTest,
   Profile* tor_profile = BrowserList::GetInstance()->GetLastActive()->profile();
   EXPECT_TRUE(tor_profile->IsTor());
 
-  const int default_provider_id =
-      TemplateURLPrepopulateData::PREPOPULATED_ENGINE_ID_BRAVE_TOR;
+  int default_provider_id =
+      brave::IsRegionForQwant(tor_profile)
+          ? TemplateURLPrepopulateData::PREPOPULATED_ENGINE_ID_QWANT
+          : TemplateURLPrepopulateData::PREPOPULATED_ENGINE_ID_DUCKDUCKGO;
   auto* service = TemplateURLServiceFactory::GetForProfile(tor_profile);
   EXPECT_EQ(service->GetDefaultSearchProvider()->data().prepopulate_id,
             default_provider_id);

--- a/browser/search_engines/tor_window_search_engine_provider_service.cc
+++ b/browser/search_engines/tor_window_search_engine_provider_service.cc
@@ -18,9 +18,9 @@ TorWindowSearchEngineProviderService(Profile* otr_profile)
     : SearchEngineProviderService(otr_profile) {
   DCHECK(otr_profile->IsTor());
 
-  auto provider_data = TemplateURLDataFromPrepopulatedEngine(
-      TemplateURLPrepopulateData::brave_search_tor);
-  default_template_url_for_tor_ = std::make_unique<TemplateURL>(*provider_data);
+  auto provider_data = GetInitialSearchEngineProvider(otr_profile->GetPrefs());
+  alternative_search_engine_url_for_tor_ =
+      std::make_unique<TemplateURL>(*provider_data);
 
   ConfigureSearchEngineProvider();
 
@@ -44,10 +44,25 @@ void TorWindowSearchEngineProviderService::ConfigureSearchEngineProvider() {
     UseExtensionSearchProvider();
   } else {
     otr_template_url_service_->SetUserSelectedDefaultSearchProvider(
-        default_template_url_for_tor_.get());
+        alternative_search_engine_url_for_tor_.get());
   }
 }
 
 void TorWindowSearchEngineProviderService::OnTemplateURLServiceChanged() {
   ConfigureSearchEngineProvider();
+}
+
+std::unique_ptr<TemplateURLData>
+TorWindowSearchEngineProviderService::GetInitialSearchEngineProvider(
+    PrefService* prefs) const {
+  std::unique_ptr<TemplateURLData> provider_data =
+      TemplateURLPrepopulateData::GetPrepopulatedDefaultSearch(
+          otr_profile_->GetPrefs());
+  if (provider_data->prepopulate_id ==
+      TemplateURLPrepopulateData::PREPOPULATED_ENGINE_ID_QWANT) {
+    return provider_data;
+  }
+
+  return TemplateURLDataFromPrepopulatedEngine(
+      TemplateURLPrepopulateData::duckduckgo);
 }

--- a/browser/search_engines/tor_window_search_engine_provider_service.h
+++ b/browser/search_engines/tor_window_search_engine_provider_service.h
@@ -37,9 +37,11 @@ class TorWindowSearchEngineProviderService : public SearchEngineProviderService,
   void OnTemplateURLServiceChanged() override;
 
  private:
+  std::unique_ptr<TemplateURLData> GetInitialSearchEngineProvider(
+      PrefService* prefs) const;
   void ConfigureSearchEngineProvider();
 
-  std::unique_ptr<TemplateURL> default_template_url_for_tor_;
+  std::unique_ptr<TemplateURL> alternative_search_engine_url_for_tor_;
   base::ScopedObservation<TemplateURLService, TemplateURLServiceObserver>
       observation_{this};
 };

--- a/browser/ui/webui/brave_webui_source.cc
+++ b/browser/ui/webui/brave_webui_source.cc
@@ -202,6 +202,7 @@ void CustomizeWebUIHTMLSource(const std::string &name,
         // Private Tab - General
         { "learnMore", IDS_BRAVE_PRIVATE_NEW_TAB_LEARN_MORE },
         { "done", IDS_BRAVE_PRIVATE_NEW_TAB_DONE },
+        { "searchSettings", IDS_BRAVE_PRIVATE_NEW_TAB_SEARCH_SETTINGS },
         { "headerLabel", IDS_BRAVE_PRIVATE_NEW_TAB_THIS_IS_A },
 
         // Private Tab - Header Private Window
@@ -214,10 +215,13 @@ void CustomizeWebUIHTMLSource(const std::string &name,
         // Private Tab - Header Private Window with Tor
         { "headerTorTitle", IDS_BRAVE_PRIVATE_NEW_TAB_PRIVATE_WINDOW_TOR },
         { "headerTorText", IDS_BRAVE_PRIVATE_NEW_TAB_PRIVATE_WINDOW_TOR_DESC },
-        { "headerTorText1", IDS_BRAVE_PRIVATE_NEW_TAB_PRIVATE_WINDOW_TOR_TEXT_1 },        // NOLINT
-        { "headerTorText2", IDS_BRAVE_PRIVATE_NEW_TAB_PRIVATE_WINDOW_TOR_TEXT_2 },        // NOLINT
+        { "headerTorButton", IDS_BRAVE_PRIVATE_NEW_TAB_PRIVATE_WIONDOW_TOR_BUTTON },             // NOLINT
 
         // Private Tab - Box for DDG
+        { "boxDdgLabel", IDS_BRAVE_PRIVATE_NEW_TAB_BOX_DDG_LABEL },
+        { "boxDdgTitle", IDS_BRAVE_PRIVATE_NEW_TAB_BOX_DDG_TITLE },
+        { "boxDdgText", IDS_BRAVE_PRIVATE_NEW_TAB_BOX_DDG_TEXT_1 },
+        { "boxDdgText2", IDS_BRAVE_PRIVATE_NEW_TAB_BOX_DDG_TEXT_2 },
         { "boxDdgButton", IDS_BRAVE_PRIVATE_NEW_TAB_BOX_DDG_BUTTON },
 
         // Private Tab - Box for Tor
@@ -237,9 +241,7 @@ void CustomizeWebUIHTMLSource(const std::string &name,
         { "torStatusConnected", IDS_BRAVE_PRIVATE_NEW_TAB_TOR_STATUS_CONNECTED },         // NOLINT
         { "torStatusDisconnected", IDS_BRAVE_PRIVATE_NEW_TAB_TOR_STATUS_DISCONNECTED },   // NOLINT
         { "torStatusInitializing", IDS_BRAVE_PRIVATE_NEW_TAB_TOR_STATUS_INITIALIZING },   // NOLINT
-        { "torHelpConnecting", IDS_BRAVE_PRIVATE_NEW_TAB_TOR_HELP_CONNECTING},
-        { "torHelpDisconnected", IDS_BRAVE_PRIVATE_NEW_TAB_TOR_HELP_DISCONNECTED},        // NOLINT
-        { "torHelpContactSupport", IDS_BRAVE_PRIVATE_NEW_TAB_TOR_HELP_CONTACT_SUPPORT},   // NOLINT
+        { "torTip", IDS_BRAVE_PRIVATE_NEW_TAB_TOR_TIP},
 
         // Brave Talk prompt
         { "braveTalkPromptTitle", IDS_BRAVE_TALK_PROMPT_TITLE },

--- a/components/brave_new_tab_ui/components/private/grid/index.ts
+++ b/components/brave_new_tab_ui/components/private/grid/index.ts
@@ -6,8 +6,6 @@ import styled, { css } from 'styled-components'
 
 interface Props {
   isStandalonePrivatePage?: boolean
-  isTorCircuitInitializing?: boolean
-  isTorCircuitEstablishedOrInitializing?: boolean
 }
 
 export const Grid = styled('section')<{}>`
@@ -186,50 +184,4 @@ export const IconText = styled('div')<{}>`
   display: flex;
   justify: space-between;
   align-items: center;
-`
-
-export const TorStatusGrid = styled('div')<{}>`
-  display: grid;
-  justify-content: center;
-`
-
-export const TorStatusContainer = styled('div')<Props>`
-  width: ${p => p.isTorCircuitEstablishedOrInitializing ? '246px' : '158px'};
-  height: 32px;
-  line-height: 32px;
-  background: rgba(227, 36, 68, 0.2);
-  border-radius: 39px;
-  margin-top: 70px;
-`
-
-export const TorStatusIndicator = styled('img')<Props>`
-  width: 10px;
-  height: 10px;
-  margin-left: ${p => p.isTorCircuitInitializing ? '30px' : '15px'};
-  margin-right: 11px;
-`
-
-export const TorStatusText = styled('div')<{}>`
-  display: inline-block;
-  text-align: center;
-  font-family: Poppins;
-  font-size: 14px;
-  font-weight: 500;
-  letter-spacing: 0.01em;
-  line-height: 20px;
-  color: #FFFFFF;
-`
-
-export const TorHelpText = styled('div')<{}>`
-  position: absolute;
-  left: 39.46%;
-  right: 39.52%;
-  text-align: center;
-  font-family: Poppins;
-  font-size: 12px;
-  font-weight: 500;
-  letter-spacing: 0.01em;
-  line-height: 18px;
-  margin-top: 17px;
-  color: #FFFFFF;
 `

--- a/components/brave_new_tab_ui/components/private/index.ts
+++ b/components/brave_new_tab_ui/components/private/index.ts
@@ -18,12 +18,7 @@ import {
   HeaderGrid,
   ButtonGroup,
   ToggleGroup,
-  IconText,
-  TorHelpText,
-  TorStatusContainer,
-  TorStatusGrid,
-  TorStatusIndicator,
-  TorStatusText
+  IconText
 } from './grid'
 import {
   Box,
@@ -76,10 +71,5 @@ export {
   Separator,
   FakeButton,
   PurpleButton,
-  Link,
-  TorHelpText,
-  TorStatusContainer,
-  TorStatusGrid,
-  TorStatusIndicator,
-  TorStatusText
+  Link
 }

--- a/components/brave_new_tab_ui/components/private/page/index.ts
+++ b/components/brave_new_tab_ui/components/private/page/index.ts
@@ -11,7 +11,7 @@ interface PageProps {
 export const Page = styled('div')<PageProps>`
   box-sizing: border-box;
   -webkit-font-smoothing: antialiased;
-  background: linear-gradient(${p => p.isPrivate ? '180deg, #0C041E -8.41%, #4E21B7 98.85%' : '#0C041E, #5F0D89'});
+  background: linear-gradient(${p => p.isPrivate ? '180deg, #0C041E -8.41%, #4E21B7 98.85%' : '#5F0C8A, #0C041E'});
   min-height: 100vh;
   height: initial;
 `

--- a/components/brave_new_tab_ui/containers/privateTab/index.tsx
+++ b/components/brave_new_tab_ui/containers/privateTab/index.tsx
@@ -10,6 +10,7 @@ import { Page, PageWrapper } from '../../components/private'
 // Components group
 import PrivateTab from './privateTab'
 import QwantTab from './qwantTab'
+import QwantTorTab from './qwantTorTab'
 import TorTab from './torTab'
 
 interface Props {
@@ -21,6 +22,9 @@ export default class NewPrivateTabPage extends React.PureComponent<Props, {}> {
   get currentWindowNewTabPage () {
     const { newTabData, actions } = this.props
     if (newTabData.isTor) {
+      if (newTabData.isQwant) {
+        return <QwantTorTab actions={actions} newTabData={newTabData} />
+      }
       return <TorTab actions={actions} newTabData={newTabData} />
     }
 

--- a/components/brave_new_tab_ui/containers/privateTab/qwantTorTab.tsx
+++ b/components/brave_new_tab_ui/containers/privateTab/qwantTorTab.tsx
@@ -6,25 +6,21 @@ import * as React from 'react'
 
 // Feature-specific components
 import {
-  Grid,
-  HeaderGrid,
-  ButtonGroup,
+  Grid2Columns,
   Box,
   Content,
   HeaderBox,
   Title,
   SubTitle,
   Text,
-  PrivateImage,
-  DuckDuckGoImage,
+  TorImage,
   TorLockImage,
   Separator,
-  FakeButton,
-  Link
+  FakeButton
 } from '../../components/private'
 
 // Helpers
-import { getLocale, getLocaleWithTag } from '../../../common/locale'
+import { getLocale } from '../../../common/locale'
 
 // Assets
 const privateWindowImg = require('../../../img/newtab/private-window-tor.svg')
@@ -34,7 +30,7 @@ interface Props {
   newTabData: NewTab.State
 }
 
-export default class TorTab extends React.PureComponent<Props, {}> {
+export default class QwantTorTab extends React.PureComponent<Props, {}> {
   get torStatus () {
     if (this.props.newTabData &&
         this.props.newTabData.torCircuitEstablished) {
@@ -48,59 +44,23 @@ export default class TorTab extends React.PureComponent<Props, {}> {
     return getLocale('torStatusDisconnected')
   }
 
-  renderTorTip () {
-    const { beforeTag, duringTag, afterTag } = getLocaleWithTag('torTip')
-    if (this.props.newTabData && !this.props.newTabData.torCircuitEstablished) {
-      return (
-        <Text>
-          {beforeTag}
-            <Link
-              href='chrome://settings/extensions'
-              style={{ margin: 0 }}
-            >
-            {duringTag}
-            </Link>
-          {afterTag}
-        </Text>
-      )
-    }
-    return ''
-  }
-
   render () {
     return (
-      <Grid>
+      <Grid2Columns>
         <HeaderBox>
-          <HeaderGrid>
-            <PrivateImage src={privateWindowImg} />
+          <div>
+            <TorImage src={privateWindowImg} />
             <div>
               <SubTitle>{getLocale('headerLabel')}</SubTitle>
               <Title>{getLocale('headerTorTitle')}</Title>
               <Text>{getLocale('headerTorText')}</Text>
             </div>
-          </HeaderGrid>
+          </div>
         </HeaderBox>
-        <Box style={{ minHeight: '471px' }}>
-          <Content>
-            <DuckDuckGoImage />
-            <SubTitle>{getLocale('boxDdgLabel')}</SubTitle>
-            <Title>{getLocale('boxDdgTitle')}</Title>
-            <Text>{getLocale('boxDdgText2')}</Text>
-          </Content>
-          <Separator />
-          <ButtonGroup>
-            <Link
-              href='https://support.brave.com/hc/en-us/articles/360018266171'
-              target='_blank'
-            >
-              {getLocale('learnMore')}
-            </Link>
-          </ButtonGroup>
-        </Box>
         <Box>
           <Content>
             <TorLockImage />
-            <SubTitle>{getLocale('boxTorLabel2')}</SubTitle>
+            <SubTitle>{getLocale('boxTorLabel')}</SubTitle>
             <Title>{getLocale('boxTorTitle')}</Title>
             <Text>{getLocale('boxTorText')}</Text>
           </Content>
@@ -115,9 +75,8 @@ export default class TorTab extends React.PureComponent<Props, {}> {
         <Box>
           <Title>{getLocale('torStatus')}</Title>
           <Text>{this.torStatus}</Text>
-          {this.renderTorTip()}
         </Box>
-      </Grid>
+      </Grid2Columns>
     )
   }
 }

--- a/components/brave_new_tab_ui/stories/privateNTP.tsx
+++ b/components/brave_new_tab_ui/stories/privateNTP.tsx
@@ -24,6 +24,12 @@ export const QwantWindow = () => {
   )
 }
 
+export const QwantTor = () => {
+  return (
+    <NewPrivateTab isQwant={boolean('Is Qwant?', true)} isTor={boolean('Enable Tor?', true)} />
+  )
+}
+
 export const TorWindow = () => {
   return (
     <NewPrivateTab isQwant={boolean('Is Qwant?', false)} isTor={boolean('Enable Tor?', true)} />

--- a/components/brave_new_tab_ui/stories/privateNTP/fakeLocale.ts
+++ b/components/brave_new_tab_ui/stories/privateNTP/fakeLocale.ts
@@ -6,6 +6,7 @@ const locale = {
   // General
   learnMore: 'Learn more',
   done: 'Done',
+  searchSettings: 'Search settings',
   headerLabel: 'This is a',
 
   // Header Private Window
@@ -17,10 +18,14 @@ const locale = {
 
   // Header Private Window with Tor
   headerTorTitle: 'Private Window with Tor Connectivity',
-  headerTorText1: 'Brave never remembers what you do in a Private Window. With Tor connectivity, you get two additional benefits: your IP address is hidden from the sites you visit, and the sites you visit are hidden from passive network observers. Note that Tor may slow down browsing, or break some websites.',
-  headerTorText2: 'A private window with Tor makes it more difficult, but not impossible, for your ISP or employer (if you\'re using a work machine or network) to see what sites you visit. However, even a private window with Tor won\'t fully defend against tracking. If your personal safety depends on remaining anonymous, use the Tor Browser instead. Learn more.',
+  headerTorText: 'Brave never remembers what you do in a Private Window. With Tor connectivity, your IP address is also hidden from the sites you visit. However, if your personal safety depends on remaining anonymous, use the Tor Browser instead.',
+  headerTorButton: 'Learn more about Private Windows with Tor',
 
   // Box for DDG
+  boxDdgLabel: 'Search Privately with',
+  boxDdgTitle: 'DuckDuckGo',
+  boxDdgText: 'With private search, Brave will use DuckDuckGo for searches in Private Windows. DuckDuckGo doesn’t track your search history, so you can search privately.',
+  boxDdgText2: 'In Private Windows with Tor, DuckDuckGo is the default search engine. Some of the other popular search engines are harder to use with Tor. DuckDuckGo doesn’t track your search history; with Tor, they don’t even know your IP address.',
   boxDdgButton: 'Search with DuckDuckGo',
 
   // Box for Tor
@@ -33,13 +38,18 @@ const locale = {
   boxTorText2: 'Using Private Windows only changes what Brave does on your device — it doesn\'t change anyone else\'s behavior. Tor hides your IP address from the sites you visit and makes it somewhat more difficult, but not impossible, for your ISP or employer to see what sites you are visiting. Open a Private Window with Tor from the menu, or with Alt+Shift+N or Option+Shift+N.',
   boxTorButton: 'Learn more about Tor in Brave',
 
-  // Tor connection
-  torStatus: 'Tor Status',
-  torStatusConnected: 'Tor connected successfully',
-  torStatusDisconnected: 'Disconnected',
-  torStatusInitializing: 'Tor is connecting... ',
-  torHelpConnecting: 'Having problems connecting? Try turning off Private Window with Tor and back on again in settings.',
-  torHelpDisconnected: 'Having trouble connecting? Open Brave Settings, disable Private Window with Tor, then re-enable. Still having trouble? Contact support.'
+  // Modal Private Window with Tor
+  modalPrivateWindowTorTitle: 'Link out to: https://support.brave.com/hc/en-us/articles/360018121491',
+
+  // Modal Private Window
+  modalPrivateWindowTitle: 'Link out to: https://support.brave.com/hc/en-us/articles/360017840332',
+
+  // Modal Tor in Brave
+  modalTorInBraveTitle: 'Link out to: https://support.brave.com/hc/en-us/articles/360018121491',
+
+  // Modal DuckDuckGo
+  modalDuckduckGoTitle: 'Link out to: TBD'
+
 }
 
 export default locale

--- a/components/brave_new_tab_ui/stories/privateNTP/index.tsx
+++ b/components/brave_new_tab_ui/stories/privateNTP/index.tsx
@@ -11,6 +11,7 @@ import { Page, PageWrapper } from '../../components/private'
 import PrivateWindow from './privateWindow'
 import QwantWindow from './qwantWindow'
 import TorWindow from './torWindow'
+import QwantTor from './qwantWindowWithTor'
 
 interface Props {
   isTor: boolean
@@ -20,9 +21,11 @@ interface Props {
 export default class NewPrivateTab extends React.PureComponent<Props, {}> {
   get currentWindow () {
     const { isTor, isQwant } = this.props
-    return isTor ? <TorWindow />
-                 : isQwant ? <QwantWindow />
-                           : <PrivateWindow />
+    return isQwant && isTor
+      ? <QwantTor />
+      : isQwant ? <QwantWindow />
+      : isTor ? <TorWindow />
+      : <PrivateWindow />
   }
 
   render () {

--- a/components/brave_new_tab_ui/stories/privateNTP/qwantWindowWithTor.tsx
+++ b/components/brave_new_tab_ui/stories/privateNTP/qwantWindowWithTor.tsx
@@ -1,0 +1,55 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import * as React from 'react'
+import {
+  Grid2Columns,
+  Box,
+  Content,
+  HeaderBox,
+  Title,
+  SubTitle,
+  Text,
+  TorImage,
+  TorLockImage,
+  Separator,
+  FakeButton
+} from '../../components/private'
+
+import locale from './fakeLocale'
+const privateWindowImg = require('../../../img/newtab/private-window-tor.svg')
+
+export default class QwantTab extends React.PureComponent<{}, {}> {
+  render () {
+    return (
+      <Grid2Columns>
+        <HeaderBox>
+          <div>
+            <TorImage src={privateWindowImg} />
+            <div>
+              <SubTitle>{locale.headerLabel}</SubTitle>
+              <Title>{locale.headerTorTitle}</Title>
+              <Text>{locale.headerTorText}</Text>
+            </div>
+          </div>
+        </HeaderBox>
+        <Box>
+          <Content>
+            <TorLockImage />
+            <SubTitle>{locale.boxTorLabel2}</SubTitle>
+            <Title>{locale.boxTorTitle}</Title>
+            <Text>{locale.boxTorText}</Text>
+          </Content>
+          <Separator />
+          <FakeButton
+            href='https://support.brave.com/hc/en-us/articles/360018121491'
+            target='_blank'
+          >
+            {locale.boxTorButton}
+          </FakeButton>
+        </Box>
+      </Grid2Columns>
+    )
+  }
+}

--- a/components/brave_new_tab_ui/stories/privateNTP/torWindow.tsx
+++ b/components/brave_new_tab_ui/stories/privateNTP/torWindow.tsx
@@ -3,76 +3,91 @@
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import * as React from 'react'
+import { OpenNewIcon } from 'brave-ui/components/icons'
 import {
-  Grid3Columns,
+  Grid,
   HeaderGrid,
+  ButtonGroup,
+  Box,
+  Content,
   HeaderBox,
   Title,
+  SubTitle,
   Text,
-  PrivacyEyeImage,
   PrivateImage,
-  TorHelpText,
-  TorStatusContainer,
-  TorStatusGrid,
-  TorStatusIndicator,
-  TorStatusText
+  DuckDuckGoImage,
+  TorLockImage,
+  Separator,
+  FakeButton
+  // Link
 } from '../../components/private'
 
 import locale from './fakeLocale'
-
 const privateWindowImg = require('../../../img/newtab/private-window-tor.svg')
-const privacyEyeImg = require('../../../img/newtab/privacy-eye.svg')
-const torConnectedImg = require('../../../img/newtab/tor-connected.svg')
-const torDisconnectedImg = require('../../../img/newtab/tor-disconnected.svg')
 
-export default class TorTab extends React.PureComponent<{}, {}> {
-  get torCircuitEstablished () {
-    return false
-  }
+interface State {
+  learnMoreAboutPrivateWindowsWithTor: boolean
+  learnMoreAboutDuckDuckGo: boolean
+  learnMoreAboutTorInBrave: boolean
+}
 
-  get torInitProgress () {
-    return 10
-  }
-
-  get torCircuitEstablishedOrInitializing () {
-    return this.torCircuitEstablished || !!this.torInitProgress
-  }
-
-  get torStatus () {
-    if (this.torCircuitEstablished) {
-      return locale.torStatusConnected
-    }
-    if (this.torInitProgress) {
-      return locale.torStatusInitializing + String(this.torInitProgress) + '%'
-    }
-    return locale.torStatusDisconnected
-  }
-
+export default class TorTab extends React.PureComponent<{}, State> {
   render () {
     return (
-      <>
-        <Grid3Columns>
-          <HeaderBox>
-            <HeaderGrid isStandalonePrivatePage={true}>
-              <PrivateImage src={privateWindowImg} isStandalonePrivatePage={true} />
-              <Title isStandalonePrivatePage={true}>{locale.headerTorTitle}</Title>
-            </HeaderGrid>
-          </HeaderBox>
-          <PrivacyEyeImage src={privacyEyeImg} />
-          <Text isStandalonePrivatePage={true}>{locale.headerTorText1}</Text>
-          <Text isStandalonePrivatePage={true}>{locale.headerTorText2}</Text>
-        </Grid3Columns>
-        <TorStatusGrid>
-          <TorStatusContainer isTorCircuitEstablishedOrInitializing={this.torCircuitEstablishedOrInitializing}>
-            <TorStatusIndicator
-              src={this.torCircuitEstablishedOrInitializing ? torConnectedImg : torDisconnectedImg}
-              isTorCircuitInitializing={!!this.torInitProgress}
-            />
-            <TorStatusText>{this.torStatus}</TorStatusText>
-          </TorStatusContainer>
-        </TorStatusGrid>
-        {!this.torCircuitEstablished && <TorHelpText>{this.torInitProgress ? locale.torHelpConnecting : locale.torHelpDisconnected}</TorHelpText>}
-      </>
+      <Grid>
+        <HeaderBox>
+          <HeaderGrid>
+            <PrivateImage src={privateWindowImg} />
+            <div>
+              <SubTitle>{locale.headerLabel}</SubTitle>
+              <Title>{locale.headerTorTitle}</Title>
+              <Text>{locale.headerTorText}</Text>
+              {/* <FakeButton
+                href='https://support.brave.com/hc/en-us/articles/360018121491'
+                target='_blank'
+              >
+                {locale.headerTorButton}
+              </FakeButton> */}
+            </div>
+          </HeaderGrid>
+        </HeaderBox>
+        <Box style={{ minHeight: '471px' }}>
+          <Content>
+            <DuckDuckGoImage />
+            <SubTitle>{locale.boxDdgLabel}</SubTitle>
+            <Title>{locale.boxDdgTitle}</Title>
+            <Text>{locale.boxDdgText2}</Text>
+          </Content>
+          <Separator />
+          <ButtonGroup>
+            <FakeButton settings={true} href='https://support.brave.com/hc/en-us/articles/360018266171' target='_blank'>
+              <span>{locale.learnMore}</span>
+              <OpenNewIcon />
+            </FakeButton>
+            {/* <Link
+              href='https://support.brave.com/hc/en-us/articles/360018266171'
+              target='_blank'
+            >
+              {locale.learnMore}
+            </Link> */}
+          </ButtonGroup>
+        </Box>
+        <Box>
+          <Content>
+            <TorLockImage />
+            <SubTitle>{locale.boxTorLabel2}</SubTitle>
+            <Title>{locale.boxTorTitle}</Title>
+            <Text>{locale.boxTorText}</Text>
+          </Content>
+          <Separator />
+          <FakeButton
+            href='https://support.brave.com/hc/en-us/articles/360018121491'
+            target='_blank'
+          >
+            {locale.boxTorButton}
+          </FakeButton>
+        </Box>
+      </Grid>
     )
   }
 }

--- a/components/img/newtab/private-window-tor.svg
+++ b/components/img/newtab/private-window-tor.svg
@@ -1,58 +1,217 @@
-<svg width="204" height="195" viewBox="0 0 204 195" fill="none" xmlns="http://www.w3.org/2000/svg">
-<g filter="url(#filter0_d_942_19477)">
-<path fill-rule="evenodd" clip-rule="evenodd" d="M21 21.8077H183V155.038C183 159.457 179.418 163.038 175 163.038H29C24.5817 163.038 21 159.457 21 155.038V21.8077Z" fill="white"/>
-</g>
-<path fill-rule="evenodd" clip-rule="evenodd" d="M21 8C21 3.58172 24.5817 0 29 0H175C179.418 0 183 3.58172 183 8V16.6154H21V8Z" fill="url(#paint0_linear_942_19477)"/>
-<path fill-rule="evenodd" clip-rule="evenodd" d="M21 21.8077H183V15.5769H21V21.8077Z" fill="url(#paint1_linear_942_19477)"/>
-<path fill-rule="evenodd" clip-rule="evenodd" d="M32.4596 11.9161C32.4596 7.66778 35.9036 4.22382 40.1519 4.22382H72.5365C76.7849 4.22382 80.2288 7.66778 80.2288 11.9161V16.6854H32.4596V11.9161Z" fill="url(#paint2_linear_942_19477)"/>
-<rect x="21" y="41" width="162" height="102" fill="#E6E8F5"/>
-<path fill-rule="evenodd" clip-rule="evenodd" d="M112.822 86.5701C113.143 86.8934 113.572 87.0012 114 87.0012C114.428 87.0012 114.857 86.8934 115.178 86.5701L121.497 80.2107C121.818 79.8874 122.032 79.4562 122.032 78.9173C122.032 78.7017 122.032 78.4862 121.925 78.2706C121.818 78.055 121.711 77.9472 121.604 77.7317L115.178 71.2645C114.536 70.6178 113.572 70.6178 112.929 71.2645C112.287 71.9113 112.287 72.8813 112.929 73.528L116.57 77.3005H90.9748H90.8677H90.7606C86.691 77.3005 83.4781 80.5341 83.4781 84.5221C83.4781 88.5102 86.691 91.7438 90.7606 91.7438H90.8677H90.9748H114.536C114.643 91.7438 114.643 91.7438 114.75 91.7438C114.857 91.7438 114.857 91.7438 114.964 91.7438C117.106 91.7438 118.926 93.5761 118.926 95.7318C118.926 97.9953 117.106 99.8277 114.964 99.8277C114.857 99.8277 114.857 99.8277 114.75 99.8277C114.643 99.8277 114.643 99.8277 114.536 99.8277H88.94H84.442L84.0136 100.259C83.9065 100.367 83.7994 100.582 83.6923 100.798C83.4781 101.121 83.4781 101.337 83.4781 101.552C83.4781 101.768 83.4781 101.983 83.5852 102.199C83.6923 102.415 83.7994 102.522 83.9065 102.738L84.442 103.169H99.8636H114.536C114.643 103.169 114.643 103.169 114.75 103.169C114.857 103.169 114.857 103.169 114.964 103.169C118.926 103.169 122.139 99.9355 122.139 95.8396C122.139 91.8516 118.926 88.618 114.964 88.618C114.857 88.618 114.857 88.618 114.75 88.618C114.643 88.618 114.643 88.618 114.536 88.618H90.9748H90.8677H90.7606C88.5116 88.618 86.691 86.7856 86.691 84.5221C86.691 82.3664 88.5116 80.5341 90.7606 80.5341C90.9748 80.5341 91.0819 80.5341 91.296 80.4263C91.4031 80.4263 91.4031 80.4263 91.5102 80.4263H116.677L112.929 84.1988C112.287 84.8455 112.287 85.9234 112.822 86.5701Z" fill="#737ADE"/>
-<circle cx="86.5874" cy="101.552" r="4.35287" fill="url(#paint3_linear_942_19477)"/>
-<circle cx="106.486" cy="90.1104" r="4.35287" fill="url(#paint4_linear_942_19477)"/>
-<circle cx="96.5367" cy="78.9173" r="4.35287" fill="url(#paint5_linear_942_19477)"/>
-<path fill-rule="evenodd" clip-rule="evenodd" d="M78.9883 109.764C78.5976 110.201 78.0374 110.451 77.4503 110.451H32.063C31.4759 110.451 30.9157 110.201 30.5251 109.764C30.1344 109.326 29.9483 108.743 30.0124 108.161L32.063 89.7066V67.1262C32.063 65.9853 32.987 65.0631 34.1259 65.0631H75.3874C76.5263 65.0631 77.4503 65.9853 77.4503 67.1262V89.7086L79.5009 108.161C79.567 108.743 79.3789 109.326 78.9883 109.764ZM73.3244 69.1892H36.1889V87.757H73.3244V69.1892ZM73.5414 91.8831H35.9718L34.3677 106.325H75.1455L73.5414 91.8831ZM42.3777 104.262H38.2518V100.135H42.3777V104.262ZM40.3148 93.9462H44.4408V98.0724H40.3148V93.9462ZM65.0725 104.262H44.4407V100.135H65.0725V104.262ZM71.2614 104.262H67.1354V100.135H71.2614V104.262ZM65.0726 93.9462H69.1985V98.0724H65.0726V93.9462ZM58.8836 93.9462H63.0096V98.0724H58.8836V93.9462ZM52.6927 93.9462H56.8207V98.0724H52.6927V93.9462ZM46.5038 93.9462H50.6297V98.0724H46.5038V93.9462Z" fill="url(#paint6_linear_942_19477)"/>
-<path d="M150.753 63C137.137 63 125.996 74.1406 125.996 87.757C125.996 101.373 137.137 112.514 150.753 112.514C164.37 112.514 175.51 101.373 175.51 87.757C175.51 74.1406 164.37 63 150.753 63ZM170.765 92.7083H160.243C160.243 92.502 160.45 92.0894 160.45 91.8831C160.862 88.7885 160.656 85.6939 160.243 83.0119H169.115C169.321 83.0119 169.527 83.0119 169.734 83.0119C170.146 83.0119 170.559 83.0119 170.559 83.0119C170.971 84.456 171.178 86.1065 171.178 87.757C171.384 89.4074 171.178 91.2642 170.765 92.7083ZM144.977 92.7083C144.977 92.2957 144.77 91.8831 144.77 91.4705C144.358 88.3759 144.564 85.6939 144.977 83.0119H150.341H156.324C156.736 85.6939 156.943 88.3759 156.53 91.4705C156.53 91.8831 156.324 92.2957 156.324 92.7083H144.977ZM155.292 96.8345C154.054 100.961 152.404 104.055 150.547 106.737C148.69 104.262 147.04 100.961 145.802 96.8345H155.292ZM130.122 87.757C130.122 86.1065 130.329 84.456 130.741 83.0119C130.948 83.0119 131.154 83.0119 131.36 83.0119H140.851C140.438 85.6939 140.232 88.7885 140.644 91.8831C140.644 92.0894 140.644 92.502 140.851 92.7083H130.741C130.329 91.2642 130.122 89.4074 130.122 87.757ZM145.802 78.8857C147.04 74.5532 148.897 71.2523 150.547 68.7766C152.197 71.2523 154.054 74.5532 155.292 78.8857H150.341H145.802ZM169.321 78.8857H159.418C158.18 74.1406 156.324 70.4271 154.467 67.5388C161.069 68.7766 166.639 73.1091 169.321 78.8857ZM146.421 67.5388C144.77 70.4271 142.707 74.1406 141.676 78.8857H132.186C134.868 73.1091 140.232 68.9829 146.421 67.5388ZM132.186 96.8345H141.469C142.501 101.167 144.358 104.881 146.215 107.975C140.232 106.531 135.074 102.405 132.186 96.8345ZM154.673 107.975C156.53 105.087 158.387 101.373 159.418 96.8345H169.321C166.433 102.611 161.069 106.737 154.673 107.975Z" fill="url(#paint7_linear_942_19477)"/>
-<defs>
-<filter id="filter0_d_942_19477" x="0" y="10.8077" width="204" height="183.231" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
-<feFlood flood-opacity="0" result="BackgroundImageFix"/>
-<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
-<feOffset dy="10"/>
-<feGaussianBlur stdDeviation="10.5"/>
-<feColorMatrix type="matrix" values="0 0 0 0 0.152941 0 0 0 0 0.180392 0 0 0 0 0.25098 0 0 0 0.2 0"/>
-<feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow_942_19477"/>
-<feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow_942_19477" result="shape"/>
-</filter>
-<linearGradient id="paint0_linear_942_19477" x1="-102.591" y1="9.23279" x2="-100.233" y2="55.3628" gradientUnits="userSpaceOnUse">
-<stop stop-color="#392DD1"/>
-<stop offset="1" stop-color="#FF4343"/>
-</linearGradient>
-<linearGradient id="paint1_linear_942_19477" x1="229.543" y1="14.9937" x2="229.588" y2="24.8054" gradientUnits="userSpaceOnUse">
-<stop stop-color="#150D7E"/>
-<stop offset="1" stop-color="#360A4C"/>
-</linearGradient>
-<linearGradient id="paint2_linear_942_19477" x1="76.3834" y1="17.1622" x2="127.808" y2="17.1622" gradientUnits="userSpaceOnUse">
-<stop stop-color="#150D7E"/>
-<stop offset="1" stop-color="#360A4C"/>
-</linearGradient>
-<linearGradient id="paint3_linear_942_19477" x1="80.6208" y1="104.238" x2="88.2214" y2="111.577" gradientUnits="userSpaceOnUse">
-<stop stop-color="#89079C"/>
-<stop offset="1" stop-color="#4348FF"/>
-</linearGradient>
-<linearGradient id="paint4_linear_942_19477" x1="100.52" y1="92.7966" x2="108.12" y2="100.136" gradientUnits="userSpaceOnUse">
-<stop stop-color="#89079C"/>
-<stop offset="1" stop-color="#4348FF"/>
-</linearGradient>
-<linearGradient id="paint5_linear_942_19477" x1="90.5702" y1="81.6035" x2="98.1707" y2="88.9425" gradientUnits="userSpaceOnUse">
-<stop stop-color="#89079C"/>
-<stop offset="1" stop-color="#4348FF"/>
-</linearGradient>
-<linearGradient id="paint6_linear_942_19477" x1="20.8222" y1="101.761" x2="60.4188" y2="143.471" gradientUnits="userSpaceOnUse">
-<stop stop-color="#89079C"/>
-<stop offset="1" stop-color="#4348FF"/>
-</linearGradient>
-<linearGradient id="paint7_linear_942_19477" x1="125.996" y1="63" x2="181.531" y2="103.099" gradientUnits="userSpaceOnUse">
-<stop stop-color="#392DD1"/>
-<stop offset="1" stop-color="#A91B78"/>
-</linearGradient>
-</defs>
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 296 217">
+  <defs>
+    <linearGradient id="private-window-tor-b" x1="5.709%" x2="101.747%" y1="-3.224%" y2="98.229%">
+      <stop offset="0%" stop-color="#8450FF"/>
+      <stop offset="100%" stop-color="#5C2FB4"/>
+    </linearGradient>
+    <path id="private-window-tor-a" d="M57.0329992,0.921964511 C92.8816191,9.81357982 119.861902,12.100959 137.973846,7.78410205 C165.141764,1.30881663 208.47628,1.9027386 230.284517,27.5955525 C252.092755,53.2883664 277.639726,87.0840763 249.792295,120.449369 C221.944865,153.814662 182.869233,166.004086 168.002127,143.646114 C153.135021,121.288142 112.935403,135.4668 97.199157,149.026208 C81.462911,162.585616 -11.8595643,147.914725 2.2851775,106.69307 C16.4299193,65.4714141 -8.02638454,54.8119253 2.90831964,25.0052367 C10.1981224,5.13411092 28.2396823,-2.89364646 57.0329992,0.921964511 Z"/>
+    <circle id="private-window-tor-e" cx="4.5" cy="22.5" r="21.5"/>
+    <filter id="private-window-tor-d" width="188.4%" height="188.4%" x="-44.2%" y="-32.6%" filterUnits="objectBoundingBox">
+      <feOffset dy="5" in="SourceAlpha" result="shadowOffsetOuter1"/>
+      <feGaussianBlur in="shadowOffsetOuter1" result="shadowBlurOuter1" stdDeviation="5.5"/>
+      <feColorMatrix in="shadowBlurOuter1" values="0 0 0 0 0.152941   0 0 0 0 0.180392   0 0 0 0 0.25098  0 0 0 0.2 0"/>
+    </filter>
+    <path id="private-window-tor-g" d="M223,62.8348028 C223,58.5077607 226.519664,55 230.842153,55 L267.257602,55 C271.588704,55 275.099755,58.5186027 275.099755,62.8348028 L275.099755,70.4992158 C275.099755,74.8262579 271.580091,78.3340186 267.257602,78.3340186 L230.842153,78.3340186 C226.511051,78.3340186 223,74.8154159 223,70.4992158 L223,62.8348028 Z"/>
+    <filter id="private-window-tor-f" width="240.1%" height="412.8%" x="-70.1%" y="-113.6%" filterUnits="objectBoundingBox">
+      <feOffset dy="10" in="SourceAlpha" result="shadowOffsetOuter1"/>
+      <feGaussianBlur in="shadowOffsetOuter1" result="shadowBlurOuter1" stdDeviation="10.5"/>
+      <feColorMatrix in="shadowBlurOuter1" values="0 0 0 0 0.152941   0 0 0 0 0.180392   0 0 0 0 0.25098  0 0 0 0.2 0"/>
+    </filter>
+    <path id="private-window-tor-i" d="M0.293749589,45.5882364 C-0.401535813,39.4549258 0.0113400532,32.9020546 2.90831964,25.0052367 C10.1981224,5.13411092 28.2396823,-2.89364646 57.0329992,0.921964511 C92.8816191,9.81357982 119.861902,12.100959 137.973846,7.78410205 C165.141764,1.30881663 208.47628,1.9027386 230.284517,27.5955525 C252.092755,53.2883664 277.639726,87.0840763 249.792295,120.449369 C221.944865,153.814662 182.869233,166.004086 168.002127,143.646114 C153.135021,121.288142 112.935403,135.4668 97.199157,149.026208 C81.462911,162.585616 -11.8595643,147.914725 2.2851775,106.69307 C7.90370014,90.3191543 7.43171795,78.7673628 5.50654399,68.9222539 L-3.59889516,68.9222539 C-7.9299966,68.9222539 -11.441048,65.4036512 -11.441048,61.0874511 L-11.441048,53.4230381 C-11.441048,49.095996 -7.92138406,45.5882353 -3.59889516,45.5882353 L0.293752591,45.5882353 Z"/>
+    <filter id="private-window-tor-h" width="101.8%" height="103.2%" x="-.9%" y="-1.6%" filterUnits="objectBoundingBox">
+      <feGaussianBlur in="SourceAlpha" result="shadowBlurInner1" stdDeviation="2.5"/>
+      <feOffset in="shadowBlurInner1" result="shadowOffsetInner1"/>
+      <feComposite in="shadowOffsetInner1" in2="SourceAlpha" k2="-1" k3="1" operator="arithmetic" result="shadowInnerInner1"/>
+      <feColorMatrix in="shadowInnerInner1" values="0 0 0 0 0   0 0 0 0 0   0 0 0 0 0  0 0 0 0.5 0"/>
+    </filter>
+    <filter id="private-window-tor-j" width="145.4%" height="131.5%" x="-22.7%" y="-15.7%" filterUnits="objectBoundingBox">
+      <feOffset dy="6" in="SourceAlpha" result="shadowOffsetOuter1"/>
+      <feGaussianBlur in="shadowOffsetOuter1" result="shadowBlurOuter1" stdDeviation="5"/>
+      <feColorMatrix in="shadowBlurOuter1" result="shadowMatrixOuter1" values="0 0 0 0 0.152941   0 0 0 0 0.180392   0 0 0 0 0.25098  0 0 0 0.2 0"/>
+      <feMerge>
+        <feMergeNode in="shadowMatrixOuter1"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
+    </filter>
+    <rect id="private-window-tor-l" width="39" height="20" y="10.693" rx="7.841"/>
+    <filter id="private-window-tor-k" width="202.6%" height="300%" x="-51.3%" y="-65%" filterUnits="objectBoundingBox">
+      <feOffset dy="7" in="SourceAlpha" result="shadowOffsetOuter1"/>
+      <feGaussianBlur in="shadowOffsetOuter1" result="shadowBlurOuter1" stdDeviation="5.5"/>
+      <feColorMatrix in="shadowBlurOuter1" values="0 0 0 0 0.152941176   0 0 0 0 0.180392157   0 0 0 0 0.250980392  0 0 0 0.2 0"/>
+    </filter>
+    <filter id="private-window-tor-m" width="188.6%" height="172.9%" x="-44.3%" y="-36.5%" filterUnits="objectBoundingBox">
+      <feOffset dy="5" in="SourceAlpha" result="shadowOffsetOuter1"/>
+      <feGaussianBlur in="shadowOffsetOuter1" result="shadowBlurOuter1" stdDeviation="5.5"/>
+      <feColorMatrix in="shadowBlurOuter1" result="shadowMatrixOuter1" values="0 0 0 0 0.152941   0 0 0 0 0.180392   0 0 0 0 0.25098  0 0 0 0.2 0"/>
+      <feMerge>
+        <feMergeNode in="shadowMatrixOuter1"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
+    </filter>
+    <linearGradient id="private-window-tor-n" x1="35.192%" x2="146.327%" y1="0%" y2="222.965%">
+      <stop offset="0%" stop-color="#392DD1"/>
+      <stop offset="100%" stop-color="#FF4343"/>
+    </linearGradient>
+    <linearGradient id="private-window-tor-q" x1="0%" x2="102%" y1="0%" y2="101%">
+      <stop offset="0%" stop-color="#3023AE"/>
+      <stop offset="100%" stop-color="#C86DD7"/>
+    </linearGradient>
+    <path id="private-window-tor-p" d="M36.2472769,5.78619062 L34.2335393,5.78619062 C25.7758413,5.78619062 21.9678635,0.967974385 21.8168332,0.772064626 C21.3899208,0.197913256 20.6971951,-0.0484287176 20.014538,0.00782259917 C19.4245129,0.0272196049 18.8445565,0.267742476 18.4639601,0.762366123 C18.3068886,0.967974385 14.4989107,5.78619062 6.04121281,5.78619062 L4.02747521,5.78619062 C1.80632263,5.78619062 4.61852778e-14,7.52610203 4.61852778e-14,9.66559177 L4.61852778e-14,15.4846935 C4.61852778e-14,16.5573479 0.010068688,18.3127769 0.0221511136,19.3854314 C0.0241648512,19.5871602 0.467187124,39.7522874 19.4486778,46.401581 C19.4627739,46.4054604 19.4768701,46.4054604 19.4909663,46.4093398 C19.6983812,46.479169 19.9138512,46.5199027 20.137376,46.5199027 C20.3609009,46.5199027 20.5763708,46.479169 20.7837858,46.4093398 C20.797882,46.4054604 20.8119781,46.4054604 20.8260743,46.401581 C39.8075649,39.7522874 40.2505872,19.5871602 40.252601,19.3854314 C40.2646834,18.3127769 40.2747521,16.5573479 40.2747521,15.4846935 L40.2747521,9.66559177 C40.2747521,7.52610203 38.4684294,5.78619062 36.2472769,5.78619062 Z"/>
+    <filter id="private-window-tor-o" width="194.4%" height="181.7%" x="-47.2%" y="-30.1%" filterUnits="objectBoundingBox">
+      <feOffset dy="5" in="SourceAlpha" result="shadowOffsetOuter1"/>
+      <feGaussianBlur in="shadowOffsetOuter1" result="shadowBlurOuter1" stdDeviation="5.5"/>
+      <feColorMatrix in="shadowBlurOuter1" values="0 0 0 0 0.152941   0 0 0 0 0.180392   0 0 0 0 0.25098  0 0 0 0.2 0"/>
+    </filter>
+    <circle id="private-window-tor-s" cx="230.5" cy="24.5" r="15.5"/>
+    <filter id="private-window-tor-r" width="222.6%" height="222.6%" x="-61.3%" y="-45.2%" filterUnits="objectBoundingBox">
+      <feOffset dy="5" in="SourceAlpha" result="shadowOffsetOuter1"/>
+      <feGaussianBlur in="shadowOffsetOuter1" result="shadowBlurOuter1" stdDeviation="5.5"/>
+      <feColorMatrix in="shadowBlurOuter1" values="0 0 0 0 0.152941   0 0 0 0 0.180392   0 0 0 0 0.25098  0 0 0 0.2 0"/>
+    </filter>
+    <path id="private-window-tor-t" d="M12.75,14.40625 C12.75,14.7685 12.4553438,15.0625 12.09375,15.0625 L2.90625,15.0625 C2.54465625,15.0625 2.25,14.7685 2.25,14.40625 L2.25,7.84375 C2.25,7.4815 2.54465625,7.1875 2.90625,7.1875 L12.09375,7.1875 C12.4553438,7.1875 12.75,7.4815 12.75,7.84375 L12.75,14.40625 Z M4.875,4.5625 C4.875,3.1148125 6.0523125,1.9375 7.5,1.9375 C8.9476875,1.9375 10.125,3.1148125 10.125,4.5625 L10.125,5.875 L4.875,5.875 L4.875,4.5625 Z M12.09375,5.875 L11.4375,5.875 L11.4375,4.5625 C11.4375,2.39096875 9.67153125,0.625 7.5,0.625 C5.32846875,0.625 3.5625,2.39096875 3.5625,4.5625 L3.5625,5.875 L2.90625,5.875 C1.8208125,5.875 0.9375,6.7583125 0.9375,7.84375 L0.9375,14.40625 C0.9375,15.4916875 1.8208125,16.375 2.90625,16.375 L12.09375,16.375 C13.1791875,16.375 14.0625,15.4916875 14.0625,14.40625 L14.0625,7.84375 C14.0625,6.7583125 13.1791875,5.875 12.09375,5.875 Z"/>
+    <circle id="private-window-tor-v" cx="161.5" cy="160.5" r="15.5"/>
+    <filter id="private-window-tor-u" width="222.6%" height="222.6%" x="-61.3%" y="-45.2%" filterUnits="objectBoundingBox">
+      <feOffset dy="5" in="SourceAlpha" result="shadowOffsetOuter1"/>
+      <feGaussianBlur in="shadowOffsetOuter1" result="shadowBlurOuter1" stdDeviation="5.5"/>
+      <feColorMatrix in="shadowBlurOuter1" values="0 0 0 0 0.152941   0 0 0 0 0.180392   0 0 0 0 0.25098  0 0 0 0.2 0"/>
+    </filter>
+    <circle id="private-window-tor-w" cx="10" cy="83" r="10"/>
+    <filter id="private-window-tor-x" width="110%" height="110%" x="-5%" y="-5%" filterUnits="objectBoundingBox">
+      <feGaussianBlur in="SourceAlpha" result="shadowBlurInner1" stdDeviation="1"/>
+      <feOffset in="shadowBlurInner1" result="shadowOffsetInner1"/>
+      <feComposite in="shadowOffsetInner1" in2="SourceAlpha" k2="-1" k3="1" operator="arithmetic" result="shadowInnerInner1"/>
+      <feColorMatrix in="shadowInnerInner1" values="0 0 0 0 0   0 0 0 0 0   0 0 0 0 0  0 0 0 0.5 0"/>
+    </filter>
+    <circle id="private-window-tor-y" cx="18.5" cy="112.5" r="7.5"/>
+    <filter id="private-window-tor-z" width="113.3%" height="113.3%" x="-6.7%" y="-6.7%" filterUnits="objectBoundingBox">
+      <feGaussianBlur in="SourceAlpha" result="shadowBlurInner1" stdDeviation="1"/>
+      <feOffset in="shadowBlurInner1" result="shadowOffsetInner1"/>
+      <feComposite in="shadowOffsetInner1" in2="SourceAlpha" k2="-1" k3="1" operator="arithmetic" result="shadowInnerInner1"/>
+      <feColorMatrix in="shadowInnerInner1" values="0 0 0 0 0   0 0 0 0 0   0 0 0 0 0  0 0 0 0.5 0"/>
+    </filter>
+    <circle id="private-window-tor-A" cx="267.5" cy="39.5" r="4.5"/>
+    <filter id="private-window-tor-B" width="122.2%" height="122.2%" x="-11.1%" y="-11.1%" filterUnits="objectBoundingBox">
+      <feGaussianBlur in="SourceAlpha" result="shadowBlurInner1" stdDeviation="1"/>
+      <feOffset in="shadowBlurInner1" result="shadowOffsetInner1"/>
+      <feComposite in="shadowOffsetInner1" in2="SourceAlpha" k2="-1" k3="1" operator="arithmetic" result="shadowInnerInner1"/>
+      <feColorMatrix in="shadowInnerInner1" values="0 0 0 0 0   0 0 0 0 0   0 0 0 0 0  0 0 0 0.5 0"/>
+    </filter>
+    <filter id="private-window-tor-C" width="260.7%" height="265%" x="-83.6%" y="-75%" filterUnits="objectBoundingBox">
+      <feOffset dy="7" in="SourceAlpha" result="shadowOffsetOuter1"/>
+      <feGaussianBlur in="shadowOffsetOuter1" result="shadowBlurOuter1" stdDeviation="5.5"/>
+      <feColorMatrix in="shadowBlurOuter1" result="shadowMatrixOuter1" values="0 0 0 0 0.152941   0 0 0 0 0.180392   0 0 0 0 0.25098  0 0 0 0.2 0"/>
+      <feMerge>
+        <feMergeNode in="shadowMatrixOuter1"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
+    </filter>
+    <polygon id="private-window-tor-E" points="30.383 7.035 46.646 13.771 53.383 30.035 46.646 46.298 30.383 53.035 14.119 46.298 7.383 30.035 14.119 13.771"/>
+    <filter id="private-window-tor-D" width="182.6%" height="182.6%" x="-41.3%" y="-30.4%" filterUnits="objectBoundingBox">
+      <feOffset dy="5" in="SourceAlpha" result="shadowOffsetOuter1"/>
+      <feGaussianBlur in="shadowOffsetOuter1" result="shadowBlurOuter1" stdDeviation="5.5"/>
+      <feColorMatrix in="shadowBlurOuter1" values="0 0 0 0 0.152941   0 0 0 0 0.180392   0 0 0 0 0.25098  0 0 0 0.2 0"/>
+    </filter>
+    <ellipse id="private-window-tor-G" cx="19" cy="18.902" rx="19" ry="18.902"/>
+    <filter id="private-window-tor-F" width="200%" height="200.5%" x="-50%" y="-37%" filterUnits="objectBoundingBox">
+      <feOffset dy="5" in="SourceAlpha" result="shadowOffsetOuter1"/>
+      <feGaussianBlur in="shadowOffsetOuter1" result="shadowBlurOuter1" stdDeviation="5.5"/>
+      <feColorMatrix in="shadowBlurOuter1" values="0 0 0 0 0.152941   0 0 0 0 0.180392   0 0 0 0 0.25098  0 0 0 0.2 0"/>
+    </filter>
+    <rect id="private-window-tor-I" width="39" height="20" x="246" y="147" rx="7.841"/>
+    <filter id="private-window-tor-H" width="202.6%" height="300%" x="-51.3%" y="-65%" filterUnits="objectBoundingBox">
+      <feOffset dy="7" in="SourceAlpha" result="shadowOffsetOuter1"/>
+      <feGaussianBlur in="shadowOffsetOuter1" result="shadowBlurOuter1" stdDeviation="5.5"/>
+      <feColorMatrix in="shadowBlurOuter1" values="0 0 0 0 0.152941176   0 0 0 0 0.180392157   0 0 0 0 0.250980392  0 0 0 0.2 0"/>
+    </filter>
+  </defs>
+  <g fill="none" fill-rule="evenodd" transform="translate(0 4)">
+    <g transform="translate(31 21)">
+      <mask id="private-window-tor-c" fill="#fff">
+        <use xlink:href="#private-window-tor-a"/>
+      </mask>
+      <use fill="url(#private-window-tor-b)" fill-rule="nonzero" xlink:href="#private-window-tor-a"/>
+      <g fill-rule="nonzero" mask="url(#private-window-tor-c)">
+        <use fill="#000" filter="url(#private-window-tor-d)" xlink:href="#private-window-tor-e"/>
+        <use fill="#3E1F85" xlink:href="#private-window-tor-e"/>
+      </g>
+      <g mask="url(#private-window-tor-c)">
+        <use fill="#000" filter="url(#private-window-tor-f)" xlink:href="#private-window-tor-g"/>
+        <use fill="#3E1F85" xlink:href="#private-window-tor-g"/>
+      </g>
+      <g fill="#000" mask="url(#private-window-tor-c)">
+        <use filter="url(#private-window-tor-h)" xlink:href="#private-window-tor-i"/>
+      </g>
+    </g>
+    <g filter="url(#private-window-tor-j)" transform="translate(62)">
+      <path fill="#FFF" d="M13,9.00901858 C13,4.03347501 17.0298771,0 22.0040966,0 L162.995903,0 C167.968729,0 172,4.02441948 172,9.00901858 L172,187.990981 C172,192.966525 167.970123,197 162.995903,197 L22.0040966,197 C17.0312714,197 13,192.975581 13,187.990981 L13,9.00901858 Z"/>
+      <g transform="translate(0 17)">
+        <rect width="134" height="9" x="29" y="70" fill="#F7F7F7" fill-rule="nonzero" rx="2"/>
+        <rect width="134" height="9" x="29" y="120" fill="#F7F7F7" fill-rule="nonzero" rx="2"/>
+        <rect width="159" height="6" x="13" fill="#E7DCFF" fill-rule="nonzero"/>
+        <rect width="94" height="9" x="29" y="86" fill="#F7F7F7" fill-rule="nonzero" rx="2"/>
+        <rect width="94" height="9" x="29" y="136" fill="#F7F7F7" fill-rule="nonzero" rx="2"/>
+        <rect width="93.964" height="9.055" x="29" y="36.73" fill="#F7F7F7" fill-rule="nonzero" rx="2"/>
+        <rect width="36" height="9" x="29" y="102" fill="#F7F7F7" fill-rule="nonzero" rx="2"/>
+        <rect width="60" height="9" x="71" y="102" fill="#F7F7F7" fill-rule="nonzero" rx="2"/>
+        <rect width="124" height="9" x="29" y="152" fill="#F7F7F7" fill-rule="nonzero" rx="2"/>
+        <rect width="95" height="9" x="57" y="20" fill="#F7F7F7" fill-rule="nonzero" rx="2"/>
+        <rect width="21" height="9" x="29" y="20" fill="#F7F7F7" fill-rule="nonzero" rx="2" transform="matrix(-1 0 0 1 79 0)"/>
+        <use fill="#000" filter="url(#private-window-tor-k)" xlink:href="#private-window-tor-l"/>
+        <use fill="#FFF" xlink:href="#private-window-tor-l"/>
+        <rect width="124.581" height="9.055" x="29" y="51.822" fill="#F7F7F7" fill-rule="nonzero" rx="2"/>
+      </g>
+      <path fill="#682BF4" d="M13,2.03355926 C13,0.927536465 13.8968109,0.0309278351 15.0017822,0.0309278351 L170.46421,0.0309278351 C171.569763,0.0309278351 172.465992,0.929622352 172.465992,2.03355926 L172.465992,17.1958763 L13,17.1958763 L13,2.03355926 Z"/>
+      <g filter="url(#private-window-tor-m)" transform="translate(57 38)">
+        <path fill="url(#private-window-tor-n)" d="M21.1627907,20.9061489 C21.1627907,13.0173786 27.3687791,6.60194175 35,6.60194175 C42.6312209,6.60194175 48.8372093,13.0173786 48.8372093,20.9061489 L48.8372093,28.0582524 L21.1627907,28.0582524 L21.1627907,20.9061489 Z M59.5,28.3333333 L56,28.3333333 L56,21.25 C56,9.530625 46.5815,0 35,0 C23.4185,0 14,9.530625 14,21.25 L14,28.3333333 L10.5,28.3333333 C4.711,28.3333333 0,33.1004167 0,38.9583333 L0,74.375 C0,80.2329167 4.711,85 10.5,85 L59.5,85 C65.289,85 70,80.2329167 70,74.375 L70,38.9583333 C70,33.1004167 65.289,28.3333333 59.5,28.3333333 Z"/>
+        <path fill="#FFF" d="M11,48.2172073 L11,44 L28.9596428,44 L28.9596428,48.2172073 L22.7353622,48.2172073 L22.7353622,66.7729196 L17.1918624,66.7729196 L17.1918624,48.2172073 L11,48.2172073 Z M30.3941449,64.4372355 C28.5787206,62.7287174 27.6710221,60.4795626 27.6710221,57.6897038 C27.6710221,54.899845 28.5787206,52.6669101 30.3941449,50.9908322 C32.2095691,49.3147542 34.4572035,48.4767278 37.1371155,48.4767278 C39.8170274,48.4767278 42.0592588,49.3147542 43.863877,50.9908322 C45.6684951,52.6669101 46.5707906,54.899845 46.5707906,57.6897038 C46.5707906,60.4795626 45.6738981,62.7287174 43.880086,64.4372355 C42.086274,66.1457537 39.8494455,67 37.1695336,67 C34.4896216,67 32.2311813,66.1457537 30.3941449,64.4372355 Z M39.8278201,61.0959097 C40.5626346,60.3173445 40.9300364,59.1927671 40.9300364,57.7221439 C40.9300364,56.2515206 40.5518287,55.1323499 39.7954019,54.364598 C39.0389752,53.5968462 38.1420826,53.212976 37.1046973,53.212976 C36.067312,53.212976 35.1758225,53.5968462 34.4302018,54.364598 C33.6845811,55.1323499 33.3117764,56.2515206 33.3117764,57.7221439 C33.3117764,59.1927671 33.6953871,60.3173445 34.4626199,61.0959097 C35.2298528,61.874475 36.1321483,62.2637518 37.1695336,62.2637518 C38.2069189,62.2637518 39.0930055,61.874475 39.8278201,61.0959097 Z M54.8130996,48.6713681 L54.8130996,52.045134 C56.1098312,49.6661846 57.8387807,48.4767278 60,48.4767278 L60,54.1212976 L58.6384386,54.1212976 C57.3633192,54.1212976 56.406994,54.4240684 55.7694343,55.0296192 C55.1318746,55.6351699 54.8130996,56.6948678 54.8130996,58.2087447 L54.8130996,66.7729196 L49.2695997,66.7729196 L49.2695997,48.6713681 L54.8130996,48.6713681 Z"/>
+      </g>
+      <g transform="translate(144 112)">
+        <use fill="#000" filter="url(#private-window-tor-o)" xlink:href="#private-window-tor-p"/>
+        <use fill="url(#private-window-tor-q)" xlink:href="#private-window-tor-p"/>
+        <polyline stroke="#FFF" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" points="14.226 13.774 27.726 24.774 24.251 29.726" transform="rotate(90 20.976 21.75)"/>
+      </g>
+    </g>
+    <g fill="#3C1B88" transform="translate(84 5)">
+      <ellipse cx="4.015" cy="4" rx="4.015" ry="4"/>
+      <ellipse cx="18.926" cy="4" rx="4.015" ry="4"/>
+      <ellipse cx="34.985" cy="4" rx="4.015" ry="4"/>
+    </g>
+    <g fill-rule="nonzero">
+      <use fill="#000" filter="url(#private-window-tor-r)" xlink:href="#private-window-tor-s"/>
+      <use fill="#FFF" xlink:href="#private-window-tor-s"/>
+    </g>
+    <use fill="#6035BD" transform="translate(223 16)" xlink:href="#private-window-tor-t"/>
+    <g fill-rule="nonzero">
+      <use fill="#000" filter="url(#private-window-tor-u)" xlink:href="#private-window-tor-v"/>
+      <use fill="#FFF" xlink:href="#private-window-tor-v"/>
+    </g>
+    <g fill-rule="nonzero">
+      <use fill="#6839CB" xlink:href="#private-window-tor-w"/>
+      <use fill="#000" filter="url(#private-window-tor-x)" xlink:href="#private-window-tor-w"/>
+    </g>
+    <g fill-rule="nonzero">
+      <use fill="#6839CB" xlink:href="#private-window-tor-y"/>
+      <use fill="#000" filter="url(#private-window-tor-z)" xlink:href="#private-window-tor-y"/>
+    </g>
+    <g fill-rule="nonzero">
+      <use fill="#6839CB" xlink:href="#private-window-tor-A"/>
+      <use fill="#000" filter="url(#private-window-tor-B)" xlink:href="#private-window-tor-A"/>
+    </g>
+    <g fill-rule="nonzero" filter="url(#private-window-tor-C)" transform="rotate(-23 382.288 -36.432)">
+      <use fill="#000" filter="url(#private-window-tor-D)" xlink:href="#private-window-tor-E"/>
+      <use fill="url(#private-window-tor-n)" xlink:href="#private-window-tor-E"/>
+    </g>
+    <g transform="translate(19 73)">
+      <g fill-rule="nonzero" transform="rotate(-45 32.642 13.178)">
+        <use fill="#000" filter="url(#private-window-tor-F)" xlink:href="#private-window-tor-G"/>
+        <use fill="#FFF" xlink:href="#private-window-tor-G"/>
+      </g>
+      <g transform="translate(16 17)">
+        <ellipse cx="10.957" cy="10" fill="#7E4BF3" rx="3.652" ry="3.6"/>
+        <path stroke="#7E4BF3" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.8" d="M0 9.97154515C7.05020725 1.60948495 14.0259843 1.60948495 20.927331 9.97154515 14.6117923 18.6476685 7.63601527 18.6476685 0 9.97154515zM2.5.5L19.5 19.5"/>
+      </g>
+    </g>
+    <use fill="#000" filter="url(#private-window-tor-H)" xlink:href="#private-window-tor-I"/>
+    <use fill="#FFF" xlink:href="#private-window-tor-I"/>
+  </g>
 </svg>

--- a/components/img/newtab/tor-connected.svg
+++ b/components/img/newtab/tor-connected.svg
@@ -1,3 +1,0 @@
-<svg width="10" height="10" viewBox="0 0 10 10" fill="none" xmlns="http://www.w3.org/2000/svg">
-<circle cx="5" cy="5" r="5" fill="#51CF66"/>
-</svg>

--- a/components/img/newtab/tor-disconnected.svg
+++ b/components/img/newtab/tor-disconnected.svg
@@ -1,3 +1,0 @@
-<svg width="10" height="10" viewBox="0 0 10 10" fill="none" xmlns="http://www.w3.org/2000/svg">
-<circle cx="5" cy="5" r="5" fill="#FF4B6A"/>
-</svg>

--- a/components/resources/brave_components_strings.grd
+++ b/components/resources/brave_components_strings.grd
@@ -327,6 +327,7 @@
       <!-- WebUI private tab resources -->
       <message name="IDS_BRAVE_PRIVATE_NEW_TAB_LEARN_MORE" desc="">Learn more</message>
       <message name="IDS_BRAVE_PRIVATE_NEW_TAB_DONE" desc="">Done</message>
+      <message name="IDS_BRAVE_PRIVATE_NEW_TAB_SEARCH_SETTINGS" desc="">Search settings</message>
       <message name="IDS_BRAVE_PRIVATE_NEW_TAB_THIS_IS_A" desc="">This is a</message>
       <message name="IDS_BRAVE_PRIVATE_NEW_TAB_PRIVATE_WINDOW" desc="">Private Window</message>
       <message name="IDS_BRAVE_PRIVATE_NEW_TAB_PRIVATE_WINDOW_DESC" desc="">Brave doesn’t remember what you do in a Private Window. Sites you visit won't show up in your history, and cookies vanish when you’re done. Private Windows don’t make you completely anonymous online, though.</message>
@@ -335,8 +336,7 @@
       <message name="IDS_BRAVE_PRIVATE_NEW_TAB_PRIVATE_WINDOW_BUTTON" desc="">Learn more.</message>
       <message name="IDS_BRAVE_PRIVATE_NEW_TAB_PRIVATE_WINDOW_TOR" desc="">Private Window with Tor Connectivity</message>
       <message name="IDS_BRAVE_PRIVATE_NEW_TAB_PRIVATE_WINDOW_TOR_DESC" desc="">Brave never remembers what you do in a Private Window. With Tor connectivity, your IP address is also hidden from the sites you visit. However, if your personal safety depends on remaining anonymous, use the Tor Browser instead.</message>
-      <message name="IDS_BRAVE_PRIVATE_NEW_TAB_PRIVATE_WINDOW_TOR_TEXT_1" desc="">Brave never remembers what you do in a Private Window. With Tor connectivity, you get two additional benefits: your IP address is hidden from the sites you visit, and the sites you visit are hidden from passive network observers. Note that Tor may slow down browsing, or break some websites.</message>
-      <message name="IDS_BRAVE_PRIVATE_NEW_TAB_PRIVATE_WINDOW_TOR_TEXT_2" desc="">A private window with Tor makes it more difficult, but not impossible, for your ISP or employer (if you're using a work machine or network) to see what sites you visit. However, even a private window with Tor won't fully defend against tracking. If your personal safety depends on remaining anonymous, use the Tor Browser instead.</message>
+      <message name="IDS_BRAVE_PRIVATE_NEW_TAB_PRIVATE_WIONDOW_TOR_BUTTON" desc="">Learn more about Private Windows with Tor</message>
       <message name="IDS_BRAVE_PRIVATE_NEW_TAB_BOX_DDG_LABEL" desc="">Search Privately with</message>
       <message name="IDS_BRAVE_PRIVATE_NEW_TAB_BOX_DDG_TITLE" desc="">DuckDuckGo</message>
       <message name="IDS_BRAVE_PRIVATE_NEW_TAB_BOX_DDG_TEXT_1" desc="">With private search, Brave will use DuckDuckGo for searches in Private Windows. DuckDuckGo doesn’t track your search history, so you can search privately.</message>
@@ -349,12 +349,10 @@
       <message name="IDS_BRAVE_PRIVATE_NEW_TAB_BOX_TOR_TEXT_2" desc="">Using Private Windows only changes what Brave does on your device — it doesn't change anyone else's behavior. Tor hides your IP address from the sites you visit and makes it somewhat more difficult, but not impossible, for your ISP or employer to see what sites you are visiting. Open a Private Window with Tor from the menu, or with [[ key ]].</message>
       <message name="IDS_BRAVE_PRIVATE_NEW_TAB_BOX_TOR_BUTTON" desc="">Learn more about Tor in Brave</message>
       <message name="IDS_BRAVE_PRIVATE_NEW_TAB_TOR_STATUS" desc="">Tor Status</message>
-      <message name="IDS_BRAVE_PRIVATE_NEW_TAB_TOR_STATUS_CONNECTED" desc="">Tor connected successfully</message>
+      <message name="IDS_BRAVE_PRIVATE_NEW_TAB_TOR_STATUS_CONNECTED" desc="">Connected</message>
       <message name="IDS_BRAVE_PRIVATE_NEW_TAB_TOR_STATUS_DISCONNECTED" desc="">Disconnected</message>
-      <message name="IDS_BRAVE_PRIVATE_NEW_TAB_TOR_STATUS_INITIALIZING" desc="">Tor is connecting... [[percentage]]%</message>
-      <message name="IDS_BRAVE_PRIVATE_NEW_TAB_TOR_HELP_CONNECTING" desc="">Having problems connecting? Try <ph name="BEGIN_LINK">$1</ph>turning off<ph name="END_LINK">$2</ph> Private Window with Tor and back on again in settings.</message>
-      <message name="IDS_BRAVE_PRIVATE_NEW_TAB_TOR_HELP_DISCONNECTED" desc="">Having trouble connecting? Open <ph name="BEGIN_LINK">$1</ph>Brave Settings<ph name="END_LINK">$2</ph>, disable Private Window with Tor, then re-enable. Still having trouble?</message>
-      <message name="IDS_BRAVE_PRIVATE_NEW_TAB_TOR_HELP_CONTACT_SUPPORT" desc="">Contact support.</message>
+      <message name="IDS_BRAVE_PRIVATE_NEW_TAB_TOR_STATUS_INITIALIZING" desc="">Initializing [[percentage]]%</message>
+      <message name="IDS_BRAVE_PRIVATE_NEW_TAB_TOR_TIP" desc="">Having problems with Tor? Try <ph name="BEGIN_LINK">$1</ph>disabling private window with Tor<ph name="END_LINK">$2</ph> and turning it back on again.</message>
 
       <!-- WebUI adblock resources -->
       <message name="IDS_ADBLOCK_ADDITIONAL_FILTERS_TITLE" desc="Title for additional filters section">Additional Filters</message>

--- a/components/search_engines/brave_prepopulated_engines.cc
+++ b/components/search_engines/brave_prepopulated_engines.cc
@@ -231,19 +231,6 @@ const PrepopulatedEngine brave_search = {
     PREPOPULATED_ENGINE_ID_BRAVE,
 };
 
-const PrepopulatedEngine brave_search_tor = ModifyEngineParams(
-    brave_search,
-    NULL,
-    NULL,
-    "https://"
-    "search.brave4u7jddbv7cyviptqjc7jusxh72uik7zt6adtckl5f4nwy2v72qd.onion/"
-    "search?q={searchTerms}",
-    "https://"
-    "search.brave4u7jddbv7cyviptqjc7jusxh72uik7zt6adtckl5f4nwy2v72qd.onion/api/"
-    "suggest?q={searchTerms}",
-    NULL,
-    PREPOPULATED_ENGINE_ID_BRAVE_TOR);
-
 const PrepopulatedEngine brave_bing = ModifyEngineParams(
     bing,
     NULL,

--- a/components/search_engines/brave_prepopulated_engines.h
+++ b/components/search_engines/brave_prepopulated_engines.h
@@ -91,7 +91,6 @@ enum BravePrepopulatedEngineID : unsigned int {
   PREPOPULATED_ENGINE_ID_YAHOO_VN,
 
   PREPOPULATED_ENGINE_ID_BRAVE,
-  PREPOPULATED_ENGINE_ID_BRAVE_TOR,
 };
 
 extern const PrepopulatedEngine duckduckgo;
@@ -105,7 +104,6 @@ extern const PrepopulatedEngine qwant;
 extern const PrepopulatedEngine startpage;
 extern const PrepopulatedEngine brave_yandex;
 extern const PrepopulatedEngine brave_search;
-extern const PrepopulatedEngine brave_search_tor;
 extern const PrepopulatedEngine brave_bing;
 
 const std::map<BravePrepopulatedEngineID, const PrepopulatedEngine*>&


### PR DESCRIPTION
Reverts brave/brave-core#11916

Reason:
Another brave search entry was added in search engine list and
normal/private profile also use brave search onion link instead of original one.