### PR TITLE
[Cr99 follow up] Disable paper-ripple effect in settings UI. (uplift to 1.37.x)

### DIFF
--- a/browser/resources/bookmarks/brave_overrides/folder_node.js
+++ b/browser/resources/bookmarks/brave_overrides/folder_node.js
@@ -42,6 +42,10 @@ RegisterStyleOverride(
           color: var(--cr-link-color) !important;
         }
       }
+
+      .cr-nav-menu-item paper-ripple {
+        display: none !important;
+      }
     </style>
   `
 )

--- a/browser/resources/history/brave_overrides/side_bar.js
+++ b/browser/resources/history/brave_overrides/side_bar.js
@@ -30,6 +30,10 @@ RegisterStyleOverride(
       .cr-nav-menu-item iron-icon {
         display: none !important;
       }
+
+      .cr-nav-menu-item paper-ripple {
+        display: none !important;
+      }
     </style>
   `
 )

--- a/browser/resources/settings/brave_overrides/settings_menu.js
+++ b/browser/resources/settings/brave_overrides/settings_menu.js
@@ -79,6 +79,10 @@ RegisterStyleOverride(
         background: transparent !important;
       }
 
+      .cr-nav-menu-item paper-ripple {
+        display: none !important;
+      }
+
       @media (prefers-color-scheme: dark) {
         :host {
           --settings-nav-item-color: #F4F4F4 !important;


### PR DESCRIPTION
Fixes https://github.com/brave/brave-browser/issues/21256
Uplift of #12385

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.