### PR TITLE
Replace button text for unverified Rewards profiles (uplift to 1.37.x)

### DIFF
--- a/browser/ui/webui/brave_webui_source.cc
+++ b/browser/ui/webui/brave_webui_source.cc
@@ -771,16 +771,15 @@ void CustomizeWebUIHTMLSource(const std::string &name,
         { "walletEstimatedEarnings", IDS_REWARDS_WALLET_ESTIMATED_EARNINGS },
         { "walletLogIntoYourAccount", IDS_REWARDS_WALLET_LOG_INTO_YOUR_ACCOUNT },  // NOLINT
         { "walletMonthlyTips", IDS_REWARDS_WALLET_MONTHLY_TIPS },
-        { "walletMyWallet", IDS_REWARDS_WALLET_MY_WALLET },
         { "walletOneTimeTips", IDS_REWARDS_WALLET_ONE_TIME_TIPS },
         { "walletPending", IDS_REWARDS_WALLET_PENDING },
         { "walletPendingContributions", IDS_REWARDS_WALLET_PENDING_CONTRIBUTIONS },  // NOLINT
         { "walletRewardsFromAds", IDS_REWARDS_WALLET_REWARDS_FROM_ADS },
         { "walletRewardsSummary", IDS_REWARDS_WALLET_REWARDS_SUMMARY },
         { "walletSeeAll", IDS_REWARDS_WALLET_SEE_ALL },
+        { "walletUnverified", IDS_REWARDS_WALLET_UNVERIFIED },
         { "walletViewStatement", IDS_REWARDS_WALLET_VIEW_STATEMENT },
         { "walletVerified", IDS_REWARDS_WALLET_VERIFIED },
-        { "walletVerify", IDS_REWARDS_WALLET_VERIFY },
         { "walletYourBalance", IDS_REWARDS_WALLET_YOUR_BALANCE },
       }
     }, {

--- a/components/brave_rewards/resources/extension/brave_rewards/_locales/en_US/messages.json
+++ b/components/brave_rewards/resources/extension/brave_rewards/_locales/en_US/messages.json
@@ -235,10 +235,6 @@
     "message": "Monthly Tips",
     "description": ""
   },
-  "walletMyWallet": {
-    "message": "Verified",
-    "description": ""
-  },
   "walletOneTimeTips": {
     "message": "One-Time Tips",
     "description": ""
@@ -255,12 +251,12 @@
     "message": "Rewards Summary",
     "description": ""
   },
-  "walletVerified": {
-    "message": "Verified",
+  "walletUnverified": {
+    "message": "Unverified",
     "description": ""
   },
-  "walletVerify": {
-    "message": "Verify",
+  "walletVerified": {
+    "message": "Verified",
     "description": ""
   },
   "walletYourBalance": {

--- a/components/brave_rewards/resources/shared/components/wallet_card/external_wallet_view.tsx
+++ b/components/brave_rewards/resources/shared/components/wallet_card/external_wallet_view.tsx
@@ -54,7 +54,7 @@ export function ExternalWalletView (props: Props) {
         <style.verifyWallet>
           <button className='connect' onClick={actionHandler('verify')} >
             <style.buttonText>
-              {getString('walletVerify')}
+              {getString('walletUnverified')}
             </style.buttonText>
             <style.buttonIcons>
               <ArrowCircleIcon />
@@ -71,7 +71,7 @@ export function ExternalWalletView (props: Props) {
             {
               getString(externalWallet.status === 'disconnected'
                 ? 'walletDisconnected'
-                : 'walletMyWallet')
+                : 'walletVerified')
             }
           </style.buttonText>
           <style.buttonIcons>

--- a/components/brave_rewards/resources/shared/components/wallet_card/stories/locale_strings.ts
+++ b/components/brave_rewards/resources/shared/components/wallet_card/stories/locale_strings.ts
@@ -13,15 +13,14 @@ export const localeStrings = {
   walletEstimatedEarnings: 'Estimated Earnings',
   walletLogIntoYourAccount: 'Log into your $1 account',
   walletMonthlyTips: 'Monthly Tips',
-  walletMyWallet: 'Verified',
   walletOneTimeTips: 'One-Time Tips',
   walletPending: 'Pending',
   walletPendingContributions: 'Pending contributions',
   walletRewardsFromAds: 'Rewards from Ads',
   walletRewardsSummary: 'Rewards Summary',
   walletSeeAll: 'See all',
+  walletUnverified: 'Unverified',
   walletViewStatement: 'View statement',
   walletVerified: 'Verified',
-  walletVerify: 'Verify',
   walletYourBalance: 'Your Balance'
 }

--- a/components/resources/rewards_strings.grdp
+++ b/components/resources/rewards_strings.grdp
@@ -43,9 +43,6 @@
   <message name="IDS_REWARDS_WALLET_MONTHLY_TIPS" desc="">
     Monthly Tips
   </message>
-  <message name="IDS_REWARDS_WALLET_MY_WALLET" desc="">
-    Verified
-  </message>
   <message name="IDS_REWARDS_WALLET_ONE_TIME_TIPS" desc="">
     One-Time Tips
   </message>
@@ -64,14 +61,14 @@
   <message name="IDS_REWARDS_WALLET_SEE_ALL" desc="">
     See all
   </message>
+  <message name="IDS_REWARDS_WALLET_UNVERIFIED" desc="">
+    Unverified
+  </message>
   <message name="IDS_REWARDS_WALLET_VIEW_STATEMENT" desc="">
     View statement
   </message>
   <message name="IDS_REWARDS_WALLET_VERIFIED" desc="">
     Verified
-  </message>
-  <message name="IDS_REWARDS_WALLET_VERIFY" desc="">
-    Verify
   </message>
   <message name="IDS_REWARDS_WALLET_YOUR_BALANCE" desc="">
     Your Balance


### PR DESCRIPTION
Uplift of #12445
Resolves https://github.com/brave/brave-browser/issues/21315

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [x] This contains text which needs to be translated. 
    - [x] There are more than 7 days before the release. 
    - [x] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.