### PR TITLE
Fix wallet usage ping parameter after updating to 1.36.x

### DIFF
--- a/browser/brave_stats/brave_stats_updater_params.cc
+++ b/browser/brave_stats/brave_stats_updater_params.cc
@@ -105,8 +105,11 @@ std::string BraveStatsUpdaterParams::GetProcessArchParam() const {
 }
 
 std::string BraveStatsUpdaterParams::GetWalletEnabledParam() const {
-  uint8_t usage_bitset = UsageBitfieldFromTimestamp(
-      wallet_last_unlocked_, last_reported_wallet_unlock_);
+  uint8_t usage_bitset = 0;
+  if (wallet_last_unlocked_ > last_reported_wallet_unlock_) {
+    usage_bitset = UsageBitfieldFromTimestamp(wallet_last_unlocked_,
+                                              last_reported_wallet_unlock_);
+  }
   return std::to_string(usage_bitset);
 }
 
@@ -219,7 +222,7 @@ GURL BraveStatsUpdaterParams::GetUpdateURL(
   update_url =
       net::AppendQueryParameter(update_url, "arch", GetProcessArchParam());
   update_url =
-      net::AppendQueryParameter(update_url, "wallet", GetWalletEnabledParam());
+      net::AppendQueryParameter(update_url, "wallet2", GetWalletEnabledParam());
   return update_url;
 }
 

--- a/browser/brave_stats/brave_stats_updater_unittest.cc
+++ b/browser/brave_stats/brave_stats_updater_unittest.cc
@@ -656,7 +656,7 @@ TEST_F(BraveStatsUpdaterTest, UsageURLFlags) {
   url = params->GetUpdateURL(base_url, "", "", "");
   EXPECT_TRUE(url.query().find("daily=true&weekly=true&monthly=true") !=
               std::string::npos);
-  EXPECT_TRUE(url.query().find("wallet=0") != std::string::npos);
+  EXPECT_TRUE(url.query().find("wallet2=0") != std::string::npos);
   params->SavePrefs();
 
   task_environment_.AdvanceClock(base::Days(1));
@@ -666,7 +666,7 @@ TEST_F(BraveStatsUpdaterTest, UsageURLFlags) {
   url = params->GetUpdateURL(base_url, "", "", "");
   EXPECT_NE(url.query().find("daily=true&weekly=false&monthly=false"),
             std::string::npos);
-  EXPECT_NE(url.query().find("wallet=7"), std::string::npos);
+  EXPECT_NE(url.query().find("wallet2=7"), std::string::npos);
   params->SavePrefs();
 
   task_environment_.AdvanceClock(base::Days(6));
@@ -675,7 +675,7 @@ TEST_F(BraveStatsUpdaterTest, UsageURLFlags) {
   url = params->GetUpdateURL(base_url, "", "", "");
   EXPECT_NE(url.query().find("daily=true&weekly=true&monthly=false"),
             std::string::npos);
-  EXPECT_NE(url.query().find("wallet=3"), std::string::npos);
+  EXPECT_NE(url.query().find("wallet2=3"), std::string::npos);
   params->SavePrefs();
 
   task_environment_.AdvanceClock(base::Days(1));
@@ -684,7 +684,7 @@ TEST_F(BraveStatsUpdaterTest, UsageURLFlags) {
   url = params->GetUpdateURL(base_url, "", "", "");
   EXPECT_NE(url.query().find("daily=true&weekly=false&monthly=false"),
             std::string::npos);
-  EXPECT_NE(url.query().find("wallet=1"), std::string::npos);
+  EXPECT_NE(url.query().find("wallet2=1"), std::string::npos);
   params->SavePrefs();
 }
 

--- a/components/brave_wallet/browser/pref_names.cc
+++ b/components/brave_wallet/browser/pref_names.cc
@@ -13,7 +13,7 @@ const char kBraveWalletTransactions[] = "brave.wallet.transactions";
 const char kShowWalletIconOnToolbar[] =
     "brave.wallet.show_wallet_icon_on_toolbar";
 const char kBraveWalletLastUnlockTime[] =
-    "brave.wallet.wallet_last_unlock_time";
+    "brave.wallet.wallet_last_unlock_time_v2";
 const char kBraveWalletPingReportedUnlockTime[] =
     "brave.wallet.wallet_report_unlock_time_ping";
 const char kBraveWalletP3ALastReportTime[] =


### PR DESCRIPTION
<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves brave/brave-browser#21476

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [x] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [x] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

0. Set date to March 2.
1. Install 1.35.x. Use the wallet.
2. Advance system time by one day, open browser, verify wallet param in usage ping is 7
3. Upgrade to 1.36.x with hotfix. Advance system time by one day. Open the browser.
4. Using MITM proxy, verify that the wallet parameter of the usage ping is set to 0.
5. Use wallet. Close browser.
6. Advance system time by one day, open browser, verify wallet parameter is set to 7.


Another one:

0. Set date to March 2.
1. Install nightly version which does not include this change. Use the wallet. Close browser
2. Advance system time by one day, open browser, verify wallet param in usage ping is 7.
3. Upgrade to nightly which includes this change. Advance system time by one day. Open the browser.
4. Using MITM proxy, verify that the wallet parameter of the usage ping is set to 0.
5. Use wallet. Close browser.
6. Advance system time by one day, open browser, verify wallet parameter is set to 7.

Regression testing of brave/brave-browser#20956 recommended