### PR TITLE
[Android] Brave news - disables default peeking card

### DIFF
--- a/android/java/org/chromium/chrome/browser/preferences/BravePreferenceKeys.java
+++ b/android/java/org/chromium/chrome/browser/preferences/BravePreferenceKeys.java
@@ -29,6 +29,7 @@ public final class BravePreferenceKeys {
     public static final String BRAVE_NEWS_CHANGE_SOURCE = "brave_news_change_source";
     public static final String BRAVE_NEWS_FEED_HASH = "brave_news_feed_hash";
     public static final String BRAVE_NEWS_PREF_SHOW_NEWS = "kNewTabPageShowToday";
+    public static final String BRAVE_NEWS_PREF_TURN_ON_NEWS = "kBraveTodayOptedIn";
     public static final String BRAVE_USE_BIOMETRICS_FOR_WALLET =
             "org.chromium.chrome.browser.Brave_Use_Biometrics_For_Wallet";
     public static final String BRAVE_BIOMETRICS_FOR_WALLET_IV =

--- a/android/java/org/chromium/chrome/browser/settings/BraveNewsPreferences.java
+++ b/android/java/org/chromium/chrome/browser/settings/BraveNewsPreferences.java
@@ -132,6 +132,7 @@ public class BraveNewsPreferences extends BravePreferenceFragment
         if (!isNewsOn) {
             mTurnOnNews.setChecked(false);
             mShowNews.setVisible(false);
+            setSourcesVisibility(BravePrefServiceBridge.getInstance().getNewsOptIn());
         } else {
             mTurnOnNews.setChecked(true);
             mTurnOnNews.setVisible(false);
@@ -150,10 +151,10 @@ public class BraveNewsPreferences extends BravePreferenceFragment
         String key = preference.getKey();
         if (PREF_TURN_ON_NEWS.equals(key)) {
             BravePrefServiceBridge.getInstance().setNewsOptIn((boolean) newValue);
+            BravePrefServiceBridge.getInstance().setShowNews(false);
             if ((boolean) newValue) {
                 mShowNews.setVisible(true);
-                mShowNews.setChecked(true);
-                BravePrefServiceBridge.getInstance().setShowNews(true);
+                mShowNews.setChecked(false);
             } else {
                 mShowNews.setVisible(false);
             }

--- a/browser/ui/android/strings/android_brave_strings.grd
+++ b/browser/ui/android/strings/android_brave_strings.grd
@@ -271,7 +271,7 @@ This file contains all "about" strings.  It is set to NOT be translated, in tran
         More Brave Offers
       </message>
       <message name="IDS_NEWS_TURN_ON_BUTTON" desc="Text for turn on button">
-        Show Brave News
+        Enable Brave News
       </message>
 <!--   // for RSS
       <message name="IDS_NEWS_YOUR_SOURCES_SECTION" desc="Text for custom sources section">


### PR DESCRIPTION
Uplift of #12489
Resolves https://github.com/brave/brave-browser/issues/21477

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.