### PR TITLE
fix: swap sweepstakes close icon color (Uplift to 1.37.x)

### DIFF
--- a/components/brave_wallet_ui/components/desktop/sweepstakes-banner/style.ts
+++ b/components/brave_wallet_ui/components/desktop/sweepstakes-banner/style.ts
@@ -1,5 +1,10 @@
 import styled from 'styled-components'
-export { CloseButton } from '../popup-modals/style'
+import { CloseButton as OriginalCloseButton } from '../popup-modals/style'
+
+export const CloseButton = styled(OriginalCloseButton)`
+    color: #212529;
+    background-color: #212529;
+`
 
 export const Card = styled.div`
     display: flex;


### PR DESCRIPTION
Fixes the "close" icon's color in dark mode. 

<!-- Add brave-browser issue bellow that this PR will resolve -->

Resolves https://github.com/brave/brave-browser/issues/21574
Uplift based on: https://github.com/brave/brave-core/pull/12504

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
<img width="301" alt="Screen Shot 2022-03-07 at 8 18 56 AM" src="https://user-images.githubusercontent.com/30185185/157063000-b070161e-a7ef-46ed-a7ef-48cfab6f51de.png">
<img width="305" alt="Screen Shot 2022-03-07 at 8 19 19 AM" src="https://user-images.githubusercontent.com/30185185/157063006-04dc859c-a227-4ced-b3f3-254b65a5b4ed.png">

