### PR TITLE
[Android] Brave news - fixes opt-in card still showing after already opted-in (Uplift to 1.36.x)

### DIFF
--- a/android/java/org/chromium/chrome/browser/settings/BraveNewsPreferences.java
+++ b/android/java/org/chromium/chrome/browser/settings/BraveNewsPreferences.java
@@ -6,6 +6,7 @@
 
 package org.chromium.chrome.browser.settings;
 
+import android.content.SharedPreferences;
 import android.os.Bundle;
 import android.widget.EditText;
 
@@ -159,6 +160,10 @@ public class BraveNewsPreferences extends BravePreferenceFragment
                 mShowNews.setVisible(false);
             }
         } else if (PREF_SHOW_NEWS.equals(key)) {
+            SharedPreferences.Editor sharedPreferencesEditor =
+                    ContextUtils.getAppSharedPreferences().edit();
+            sharedPreferencesEditor.putBoolean(BraveNewsPreferences.PREF_SHOW_OPTIN, false);
+            sharedPreferencesEditor.apply();
             BravePrefServiceBridge.getInstance().setShowNews((boolean) newValue);
         }
         setSourcesVisibility((boolean) newValue);


### PR DESCRIPTION
Uplift of #12508
Resolves https://github.com/brave/brave-browser/issues/21493

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.