### PR TITLE
Bump rust regex crate to 1.5.5.

### DIFF
--- a/build/rust/Cargo.lock
+++ b/build/rust/Cargo.lock
@@ -1573,9 +1573,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.5.4"
+version = "1.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d07a8629359eb56f1e2fb1652bb04212c072a87ba68546a04065d525673ac461"
+checksum = "1a11647b6b25ff05a515cb92c365cec08801e83423a235b51e231e1808747286"
 dependencies = [
  "aho-corasick",
  "memchr",

--- a/components/brave_today/rust/Cargo.lock
+++ b/components/brave_today/rust/Cargo.lock
@@ -67,7 +67,7 @@ dependencies = [
 
 [[package]]
 name = "cxx"
-version = "1.0.56"
+version = "1.0.57"
 dependencies = [
  "cxxbridge-macro",
  "link-cplusplus",
@@ -90,9 +90,9 @@ dependencies = [
 
 [[package]]
 name = "cxxbridge-macro"
-version = "1.0.56"
+version = "1.0.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04f5cb3b337856fe25282ca3c8ae58ae688adb956ab96c39af159b04b190ea52"
+checksum = "8907c4ff452ac2efc5edfe3fd2c5dfcf63ea3a9b402bb6d357a29ed5f9bbb07d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -266,9 +266,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.5.4"
+version = "1.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d07a8629359eb56f1e2fb1652bb04212c072a87ba68546a04065d525673ac461"
+checksum = "1a11647b6b25ff05a515cb92c365cec08801e83423a235b51e231e1808747286"
 dependencies = [
  "aho-corasick",
  "memchr",

--- a/components/brave_today/rust/Cargo.toml
+++ b/components/brave_today/rust/Cargo.toml
@@ -10,7 +10,7 @@ cxx = { path = "../../../../third_party/rust/cxx/v1/crate"}
 feed-rs = { git = "https://github.com/feed-rs/feed-rs", rev = "b8298033d7d5146232a49e2f5d0e1e34427f5dac" }
 log = "0.4.14"
 lazy_static = "1.4.0"
-regex = "1.5.4"
+regex = "1.5.5"
 voca_rs = "1.14.0"
 
 [build-dependencies]


### PR DESCRIPTION
Address `cargo audit` warnings about CVE-2022-24713 by updating
our version of the regex crate to the current release.

We only use static regular expressions with this crate, so we
are not vulnerable to the issue with 1.5.4.

See https://rustsec.org/advisories/RUSTSEC-2022-0013 for more info.

Port of #12527 to release

<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves brave/brave-browser#21545
