### PR TITLE
Improve build error message when Windows delta update generation fails

### DIFF
--- a/patches/chrome-tools-build-win-create_installer_archive.py.patch
+++ b/patches/chrome-tools-build-win-create_installer_archive.py.patch
@@ -1,16 +1,17 @@
 diff --git a/chrome/tools/build/win/create_installer_archive.py b/chrome/tools/build/win/create_installer_archive.py
-index 732479bbf5975289bd251ab6d41c8dda7e808a50..d568442da2dc1a096b8f6dc7e4e59547007d942e 100755
+index 732479bbf5975289bd251ab6d41c8dda7e808a50..989e950be7450d8ae80cb2c8fc507db048392f14 100755
 --- a/chrome/tools/build/win/create_installer_archive.py
 +++ b/chrome/tools/build/win/create_installer_archive.py
-@@ -42,6 +42,7 @@ SETUP_PATCH_FILE_PREFIX = "setup_patch"
+@@ -42,6 +42,8 @@ SETUP_PATCH_FILE_PREFIX = "setup_patch"
  TEMP_ARCHIVE_DIR = "temp_installer_archive"
  VERSION_FILE = "VERSION"
  
-+from create_installer_archive_helper import SignAndCopyPreSignedBinaries, BraveCopyAllFilesToStagingDir
++from create_installer_archive_helper import SignAndCopyPreSignedBinaries, \
++  BraveCopyAllFilesToStagingDir, CheckDeltaUpdatePrecondition
  
  g_archive_inputs = []
  
-@@ -113,6 +114,7 @@ def CopyAllFilesToStagingDir(config, distribution, staging_dir, build_dir,
+@@ -113,6 +115,7 @@ def CopyAllFilesToStagingDir(config, distribution, staging_dir, build_dir,
    if enable_hidpi == '1':
      CopySectionFilesToStagingDir(config, 'HIDPI', staging_dir, build_dir,
                                   verbose)
@@ -18,7 +19,7 @@ index 732479bbf5975289bd251ab6d41c8dda7e808a50..d568442da2dc1a096b8f6dc7e4e59547
  
    if include_snapshotblob == '1':
      CopySectionFilesToStagingDir(config, 'SNAPSHOTBLOB', staging_dir, build_dir,
-@@ -184,7 +186,7 @@ def GetPrevVersion(build_dir, temp_dir, last_chrome_installer, output_name):
+@@ -184,7 +187,7 @@ def GetPrevVersion(build_dir, temp_dir, last_chrome_installer, output_name):
                                     output_name + ARCHIVE_SUFFIX)
    cmd = [lzma_exec,
           'x',
@@ -27,15 +28,16 @@ index 732479bbf5975289bd251ab6d41c8dda7e808a50..d568442da2dc1a096b8f6dc7e4e59547
           prev_archive_file,
           'Chrome-bin/*/chrome.dll',]
    RunSystemCommand(cmd, options.verbose)
-@@ -559,6 +561,7 @@ def main(options):
+@@ -559,6 +562,8 @@ def main(options):
    if prev_version:
      version_numbers = prev_version.split('.')
      prev_build_number = version_numbers[2] + '.' + version_numbers[3]
++  CheckDeltaUpdatePrecondition(options.last_chrome_installer, prev_version, current_version)
 +  SignAndCopyPreSignedBinaries(options.skip_signing, options.output_dir, staging_dir, current_version)
  
    # Name of the archive file built (for example - chrome.7z or
    # patch-<old_version>-<new_version>.7z or patch-<new_version>.7z
-@@ -632,6 +635,7 @@ def _ParseOptions():
+@@ -632,6 +637,7 @@ def _ParseOptions():
             'with the installer archive {x86|x64}.')
    parser.add_option('-v', '--verbose', action='store_true', dest='verbose',
                      default=False)

--- a/script/create_installer_archive_helper.py
+++ b/script/create_installer_archive_helper.py
@@ -11,6 +11,15 @@ import shutil
 CHROME_DIR = "Chrome-bin"
 
 
+def CheckDeltaUpdatePrecondition(last_chrome_installer, prev_version, curr_version):
+    if last_chrome_installer and prev_version == curr_version:
+        raise Exception("Cannot create delta update files between the same source "
+                        "and target version %s. Please increment the Chrome "
+                        "version (for instance by rebasing your changes against a "
+                        "later upstream version). Or pass files representing a "
+                        "lower version to --last_chrome_installer." % prev_version)
+
+
 def SignAndCopyPreSignedBinaries(skip_signing, output_dir, staging_dir, current_version):
     if not skip_signing:
         from sign_binaries import sign_binaries, sign_binary

--- a/script/create_installer_archive_helper.py
+++ b/script/create_installer_archive_helper.py
@@ -11,23 +11,26 @@ import shutil
 CHROME_DIR = "Chrome-bin"
 
 
-def CheckDeltaUpdatePrecondition(last_chrome_installer, prev_version, curr_version):
+def CheckDeltaUpdatePrecondition(last_chrome_installer, prev_version,
+                                 curr_version):
     if last_chrome_installer and prev_version == curr_version:
-        raise Exception("Cannot create delta update files between the same source "
-                        "and target version %s. Please increment the Chrome "
-                        "version (for instance by rebasing your changes against a "
-                        "later upstream version). Or pass files representing a "
-                        "lower version to --last_chrome_installer." % prev_version)
+        raise Exception("Cannot create delta update files between the same "
+                        "source and target version %s. Please increment the "
+                        "Chrome version (for instance by rebasing your changes "
+                        "against a later upstream version). Or pass files "
+                        "representing a lower version to "
+                        "--last_chrome_installer." % prev_version)
 
 
-def SignAndCopyPreSignedBinaries(skip_signing, output_dir, staging_dir, current_version):
+def SignAndCopyPreSignedBinaries(skip_signing, output_dir, staging_dir,
+                                 current_version):
     if not skip_signing:
         from sign_binaries import sign_binaries, sign_binary
         sign_binaries(staging_dir)
         sign_binary(os.path.join(output_dir, 'setup.exe'))
-        """Copies already signed three binaries - brave.exe and chrome.dll
-        These files are signed during the build phase to create widevine sig files.
-        """
+        # Copies already signed three binaries - brave.exe and chrome.dll
+        # These files are signed during the build phase to create widevine sig
+        # files.
         src_dir = os.path.join(output_dir, 'signed_binaries')
         chrome_dir = os.path.join(staging_dir, CHROME_DIR)
         version_dir = os.path.join(chrome_dir, current_version)
@@ -40,33 +43,38 @@ def BraveCopyAllFilesToStagingDir(config, staging_dir, g_archive_inputs):
 
     brave_extension_locales_src_dir_path = os.path.realpath(
         os.path.join(current_dir, os.pardir, 'components',
-                     'brave_extension', 'extension', 'brave_extension', '_locales'))
-    CopyExtensionLocalization('brave_extension', brave_extension_locales_src_dir_path,
+                     'brave_extension', 'extension', 'brave_extension',
+                     '_locales'))
+    CopyExtensionLocalization('brave_extension',
+                              brave_extension_locales_src_dir_path,
                               config, staging_dir, g_archive_inputs)
 
     brave_rewards_locales_src_dir_path = os.path.realpath(
         os.path.join(current_dir, os.pardir, 'components',
-                     'brave_rewards', 'resources', 'extension', 'brave_rewards', '_locales'))
-    CopyExtensionLocalization('brave_rewards', brave_rewards_locales_src_dir_path,
+                     'brave_rewards', 'resources', 'extension', 'brave_rewards',
+                     '_locales'))
+    CopyExtensionLocalization('brave_rewards',
+                              brave_rewards_locales_src_dir_path,
                               config, staging_dir, g_archive_inputs)
 
 
-def CopyExtensionLocalization(extension_name, locales_src_dir_path, config, staging_dir, g_archive_inputs):
+def CopyExtensionLocalization(extension_name, locales_src_dir_path, config,
+                              staging_dir, g_archive_inputs):
     """Copies extension localization files from locales_src_dir_path to
-    \\<out_gen_dir>\\chrome\\installer\\mini_installer\\mini_installer\\temp_installer_archive
-        \\Chrome-bin\\<version>\\resources\\extension_name\\_locales
+    \\<out_gen_dir>\\chrome\\installer\\mini_installer\\mini_installer
+    \\temp_installer_archive\\Chrome-bin\\<version>\\resources\\extension_name
+    \\_locales
     """
     locales_dest_path = staging_dir
-    locales_dest_path = os.path.join(locales_dest_path, config.get('GENERAL', 'brave_resources.pak'),
+    locales_dest_path = os.path.join(locales_dest_path,
+                                     config.get('GENERAL',
+                                                'brave_resources.pak'),
                                      'resources', extension_name, '_locales')
     locales_dest_path = os.path.realpath(locales_dest_path)
-    try:
-        shutil.rmtree(locales_dest_path)
-    except Exception as e:
-        pass
+    shutil.rmtree(locales_dest_path, ignore_errors=True)
     shutil.copytree(locales_src_dir_path, locales_dest_path)
     # Files are copied, but we need to inform g_archive_inputs about that
-    for root, dirs, files in os.walk(locales_dest_path):
+    for root, _, files in os.walk(locales_dest_path):
         for name in files:
             rel_dir = os.path.relpath(root, locales_dest_path)
             rel_file = os.path.join(rel_dir, name)


### PR DESCRIPTION
Previously, trying to generate a delta update with `--last_chrome_installer` from the same source and target versions gave:

    ...
    Did not find an archive input file for ".../chrome.dll"

Now we get:

    Cannot create delta update files between the same source and target
    version 99.1.38.5. Please increment the Chrome version (for
    instance by rebasing your changes against a later upstream
    version). Or pass files representing a lower version to
    --last_chrome_installer.

Resolves https://github.com/brave/brave-browser/issues/21294. in the sense that developers now get the above more meaningful error message. A recent change to our CI pipelines further should have made the problem occur much more rarely. So together, these changes (in my opinion) represent a good solution to the problem.

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

These changes only affect the build process and are thus tested every time a Windows CI build runs.