### PR TITLE
Enforce using a publisher proof for CRX3

### DIFF
--- a/chromium_src/components/component_updater/component_updater_service.cc
+++ b/chromium_src/components/component_updater/component_updater_service.cc
@@ -3,7 +3,24 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * you can obtain one at http://mozilla.org/MPL/2.0/. */
 
-#include "components/crx_file/crx_verifier.h"
-#define CRX3_WITH_PUBLISHER_PROOF CRX3
+#include "base/feature_list.h"
+#include "components/update_client/update_client.h"
+
+namespace {
+const base::Feature kEnforceCRX3PublisherProof{
+    "EnforceCRX3PublisherProof", base::FEATURE_ENABLED_BY_DEFAULT};
+
+crx_file::VerifierFormat GetVerifierFormat() {
+  if (base::FeatureList::IsEnabled(kEnforceCRX3PublisherProof))
+    return crx_file::VerifierFormat::CRX3_WITH_PUBLISHER_PROOF;
+
+  return crx_file::VerifierFormat::CRX3;
+}
+}  // namespace
+#define crx_format_requirement                  \
+  crx_format_requirement = GetVerifierFormat(); \
+  crx_file::VerifierFormat _temp_var;           \
+  ALLOW_UNUSED_LOCAL(_temp_var);                \
+  _temp_var
 #include "src/components/component_updater/component_updater_service.cc"
-#undef CRX3_WITH_PUBLISHER_PROOF
+#undef crx_format_requirement

--- a/chromium_src/components/component_updater/component_updater_service.cc
+++ b/chromium_src/components/component_updater/component_updater_service.cc
@@ -17,6 +17,7 @@ crx_file::VerifierFormat GetVerifierFormat() {
   return crx_file::VerifierFormat::CRX3;
 }
 }  // namespace
+
 #define crx_format_requirement                  \
   crx_format_requirement = GetVerifierFormat(); \
   crx_file::VerifierFormat _temp_var;           \


### PR DESCRIPTION
<!-- Add brave-browser issue bellow that this PR will resolve -->
For https://github.com/brave/brave-browser/issues/873

This reverts CRX3 back to using CRX3_WITH_PUBLISHER_PROOF => enforce to check the extra signature.
The feature is added just in case to have ability to disable this verification remotely. I suggest deleting in a few weeks.

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

