### PR TITLE
Fix pending transactions sometimes are not updated to confirmed

### DIFF
--- a/components/brave_wallet/browser/eth_tx_manager.cc
+++ b/components/brave_wallet/browser/eth_tx_manager.cc
@@ -811,9 +811,7 @@ void EthTxManager::UpdatePendingTransactions() {
   size_t num_pending;
   if (pending_tx_tracker_->UpdatePendingTransactions(&num_pending)) {
     known_no_pending_tx_ = num_pending == 0;
-    if (known_no_pending_tx_) {
-      CheckIfBlockTrackerShouldRun();
-    }
+    CheckIfBlockTrackerShouldRun();
   }
 }
 


### PR DESCRIPTION
<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/21300

We should check if block tracker should run when updating pending transactions no matter of the value of known_no_pending_tx_.
Currently when we submit a tx, known_no_pending_tx_ will be false, and if the block tracker is currently stopped, it won't trigger it to start here so we won't get the update of the tx.

## Submitter Checklist:

- [ ] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
(To have Binance Smart Chain Testnet ready to use, please add the network via https://chainlist.org/ and get fund from https://testnet.binance.org/faucet-smart.)

1. Switch to Binance Smart Chain Testnet
2. Visit brave://wallet/crypto/accounts and select the sender account to see it's page with transaction list.
3. Send 0.01 tBNB to your another account.
4. The tx should be updated from submitted to confirmed within 30s.
<img width="1439" alt="Screen Shot 2022-03-09 at 3 01 43 PM" src="https://user-images.githubusercontent.com/4730197/157553605-6f1d4bd1-70a1-49ac-a8fd-b42394d36d19.png">

