### PR TITLE
Allow to overwrite ethereum object after reload

### DIFF
--- a/components/brave_wallet/renderer/brave_wallet_js_handler.cc
+++ b/components/brave_wallet/renderer/brave_wallet_js_handler.cc
@@ -419,6 +419,10 @@ BraveWalletJSHandler::BraveWalletJSHandler(content::RenderFrame* render_frame,
 
 BraveWalletJSHandler::~BraveWalletJSHandler() = default;
 
+void BraveWalletJSHandler::AllowOverwriteWindowEthereum(bool allow) {
+  allow_overwrite_window_ethereum_ = allow;
+}
+
 bool BraveWalletJSHandler::EnsureConnected() {
   if (brave_use_native_wallet_ && !brave_wallet_provider_.is_bound()) {
     render_frame_->GetBrowserInterfaceBroker()->GetInterface(

--- a/components/brave_wallet/renderer/brave_wallet_js_handler.h
+++ b/components/brave_wallet/renderer/brave_wallet_js_handler.h
@@ -37,6 +37,7 @@ class BraveWalletJSHandler : public mojom::EventsListener {
   void DisconnectEvent(const std::string& message);
   void AccountsChangedEvent(const std::vector<std::string>& accounts) override;
   void ChainChangedEvent(const std::string& chain_id) override;
+  void AllowOverwriteWindowEthereum(bool allow);
 
  private:
   void BindFunctionsToObject(v8::Isolate* isolate,

--- a/renderer/brave_wallet/brave_wallet_render_frame_observer.cc
+++ b/renderer/brave_wallet/brave_wallet_render_frame_observer.cc
@@ -50,6 +50,8 @@ void BraveWalletRenderFrameObserver::DidCreateScriptContext(
   }
   native_javascript_handle_->AddJavaScriptObjectToFrame(context);
   native_javascript_handle_->ConnectEvent();
+  native_javascript_handle_->AllowOverwriteWindowEthereum(
+      dynamic_params.allow_overwrite_window_ethereum);
 }
 
 void BraveWalletRenderFrameObserver::OnDestruct() {

--- a/renderer/test/brave_wallet_js_handler_browsertest.cc
+++ b/renderer/test/brave_wallet_js_handler_browsertest.cc
@@ -73,6 +73,17 @@ IN_PROC_BROWSER_TEST_F(BraveWalletJSHandlerBrowserTest, AttachOnReload) {
   EXPECT_EQ(result.error, "");
   ASSERT_TRUE(result.ExtractBool());
   EXPECT_EQ(browser()->tab_strip_model()->GetTabCount(), 1);
+  // unable to overwrite
+  std::string overwrite = "window.ethereum = ['test'];window.ethereum[0]";
+  EXPECT_EQ(content::EvalJs(main_frame(), overwrite).error, "");
+  ASSERT_TRUE(content::EvalJs(main_frame(), command).ExtractBool());
+  brave_wallet::SetDefaultWallet(
+      browser()->profile()->GetPrefs(),
+      brave_wallet::mojom::DefaultWallet::BraveWalletPreferExtension);
+  chrome::Reload(browser(), WindowOpenDisposition::CURRENT_TAB);
+  EXPECT_TRUE(content::WaitForLoadStop(web_contents()));
+  // overwrite successfully
+  EXPECT_EQ(content::EvalJs(main_frame(), overwrite).ExtractString(), "test");
 }
 
 IN_PROC_BROWSER_TEST_F(BraveWalletJSHandlerBrowserTest,


### PR DESCRIPTION
<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/21571

https://user-images.githubusercontent.com/2965009/157699099-ea5f1232-84e6-4b82-a171-ab1dc9da8885.mp4

## Submitter Checklist:

- [ ] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

