### PR TITLE
Allow to overwrite ethereum object after reload (uplift to 1.37.x)

### DIFF
--- a/components/brave_wallet/renderer/brave_wallet_js_handler.cc
+++ b/components/brave_wallet/renderer/brave_wallet_js_handler.cc
@@ -419,6 +419,10 @@ BraveWalletJSHandler::BraveWalletJSHandler(content::RenderFrame* render_frame,
 
 BraveWalletJSHandler::~BraveWalletJSHandler() = default;
 
+void BraveWalletJSHandler::AllowOverwriteWindowEthereum(bool allow) {
+  allow_overwrite_window_ethereum_ = allow;
+}
+
 bool BraveWalletJSHandler::EnsureConnected() {
   if (brave_use_native_wallet_ && !brave_wallet_provider_.is_bound()) {
     render_frame_->GetBrowserInterfaceBroker()->GetInterface(

--- a/components/brave_wallet/renderer/brave_wallet_js_handler.h
+++ b/components/brave_wallet/renderer/brave_wallet_js_handler.h
@@ -37,6 +37,7 @@ class BraveWalletJSHandler : public mojom::EventsListener {
   void DisconnectEvent(const std::string& message);
   void AccountsChangedEvent(const std::vector<std::string>& accounts) override;
   void ChainChangedEvent(const std::string& chain_id) override;
+  void AllowOverwriteWindowEthereum(bool allow);
 
  private:
   void BindFunctionsToObject(v8::Isolate* isolate,

--- a/renderer/brave_wallet/brave_wallet_render_frame_observer.cc
+++ b/renderer/brave_wallet/brave_wallet_render_frame_observer.cc
@@ -50,6 +50,8 @@ void BraveWalletRenderFrameObserver::DidCreateScriptContext(
   }
   native_javascript_handle_->AddJavaScriptObjectToFrame(context);
   native_javascript_handle_->ConnectEvent();
+  native_javascript_handle_->AllowOverwriteWindowEthereum(
+      dynamic_params.allow_overwrite_window_ethereum);
 }
 
 void BraveWalletRenderFrameObserver::OnDestruct() {

--- a/renderer/test/brave_wallet_js_handler_browsertest.cc
+++ b/renderer/test/brave_wallet_js_handler_browsertest.cc
@@ -73,6 +73,17 @@ IN_PROC_BROWSER_TEST_F(BraveWalletJSHandlerBrowserTest, AttachOnReload) {
   EXPECT_EQ(result.error, "");
   ASSERT_TRUE(result.ExtractBool());
   EXPECT_EQ(browser()->tab_strip_model()->GetTabCount(), 1);
+  // unable to overwrite
+  std::string overwrite = "window.ethereum = ['test'];window.ethereum[0]";
+  EXPECT_EQ(content::EvalJs(main_frame(), overwrite).error, "");
+  ASSERT_TRUE(content::EvalJs(main_frame(), command).ExtractBool());
+  brave_wallet::SetDefaultWallet(
+      browser()->profile()->GetPrefs(),
+      brave_wallet::mojom::DefaultWallet::BraveWalletPreferExtension);
+  chrome::Reload(browser(), WindowOpenDisposition::CURRENT_TAB);
+  EXPECT_TRUE(content::WaitForLoadStop(web_contents()));
+  // overwrite successfully
+  EXPECT_EQ(content::EvalJs(main_frame(), overwrite).ExtractString(), "test");
 }
 
 IN_PROC_BROWSER_TEST_F(BraveWalletJSHandlerBrowserTest,


### PR DESCRIPTION
Uplift of #12561
Resolves https://github.com/brave/brave-browser/issues/21571

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.