### PR TITLE
Add support for same-directory mojo imports when generating Obj-C wrappers

### DIFF
--- a/build/ios/mojom/mojom_objc_generator.py
+++ b/build/ios/mojom/mojom_objc_generator.py
@@ -393,8 +393,12 @@ class Generator(generator.Generator):
             "under_to_camel": UnderToCamel,
             "under_to_lower_camel": UnderToLowerCamel,
             "interface_remote_sets": self._GetInterfaceRemoteSets,
+            "objc_import_module_name": self._GetObjCImportModuleName,
         }
         return objc_filters
+
+    def _GetObjCImportModuleName(self, module):
+        return os.path.basename(module.path)
 
     def _GetInterfaceRemoteSets(self, interface):
         remotes = []
@@ -575,12 +579,17 @@ class Generator(generator.Generator):
                     if mojom.IsPendingRemoteKind(param.kind):
                         receivers.add(param.kind.kind)
 
+        # We handle imports from mojo base types with custom typemaps, so only
+        # other Brave imports should only be included
+        brave_imports = [i for i in self.module.imports if
+                         i.path.startswith('brave/')]
+
         for interface in self.module.interfaces:
             all_enums.extend(interface.enums)
         return {
             "all_enums": all_enums,
             "enums": self.module.enums,
-            "imports": self.module.imports,
+            "imports": brave_imports,
             "interfaces": all_interfaces,
             "interface_bridges": receivers,
             "kinds": self.module.kinds,

--- a/build/ios/mojom/mojom_wrappers.gni
+++ b/build/ios/mojom/mojom_wrappers.gni
@@ -11,41 +11,38 @@ import("//build/config/ios/ios_sdk.gni")
 #
 #   mojom_target
 #     the target which generates C++ mojom files
-#   mojom_file
-#     path to the .mojom file
 #   exclude_types
 #     a list of types to exclude from within the mojom file provided
 #
-template("mojom_wrappers") {
+template("ios_objc_mojom_wrappers") {
+  assert(defined(invoker.sources) && invoker.sources != [],
+         "sources must be defined for $target_name")
   assert(defined(invoker.mojom_target) && invoker.mojom_target != "",
          "mojom_target must be defined for $target_name")
-  assert(defined(invoker.mojom_file) && invoker.mojom_file != "",
-         "mojom_file must be defined for $target_name")
-
-  _mojom_target = invoker.mojom_target
-  _mojom_target_path = get_label_info(_mojom_target, "dir")
-  _mojom_target_name = get_label_info(_mojom_target, "name")
-  _mojom_target_parser =
-      get_path_info("${_mojom_target_path}:${_mojom_target_name}__parser",
+  mojom_target = invoker.mojom_target
+  mojom_target_path = get_label_info(mojom_target, "dir")
+  mojom_target_name = get_label_info(mojom_target, "name")
+  mojom_target_parser =
+      get_path_info("${mojom_target_path}:${mojom_target_name}__parser",
                     "abspath")
-  _mojom_target_parser_gen_dir =
-      get_label_info(_mojom_target_parser, "target_gen_dir")
-  _mojom_output_dir = rebase_path(target_gen_dir)
-  _mojom_filename = get_path_info(invoker.mojom_file, "file")
-  _mojom_module =
-      rebase_path("$_mojom_target_parser_gen_dir/$_mojom_filename-module")
+  mojom_output_dir = rebase_path(target_gen_dir)
+  dep_target_gen = get_label_info(mojom_target, "target_gen_dir")
 
-  _generate_wrappers_target = "${target_name}_generate_wrappers"
-  _generate_wrappers_output = [
-    "$target_gen_dir/$_mojom_filename.objc.h",
-    "$target_gen_dir/$_mojom_filename.objc+private.h",
-    "$target_gen_dir/$_mojom_filename.objc.mm",
-  ]
+  generate_wrappers_output = []
+  foreach(source, invoker.sources) {
+    _file = get_path_info(source, "file")
+    generate_wrappers_output += [
+      "$target_gen_dir/${_file}.objc.h",
+      "$target_gen_dir/${_file}.objc+private.h",
+      "$target_gen_dir/${_file}.objc.mm",
+    ]
+  }
 
-  action(_generate_wrappers_target) {
+  generate_wrappers_target = "${target_name}_generate_wrappers"
+
+  action_foreach(generate_wrappers_target) {
     script = "//brave/build/ios/mojom/gen_model_wrappers.py"
     inputs = [
-      _mojom_module,
       "//brave/build/ios/mojom/cpp_transformations.h",
       "//brave/build/ios/mojom/mojom_objc_generator.py",
       "//brave/build/ios/mojom/objc_templates/enum.tmpl",
@@ -67,10 +64,16 @@ template("mojom_wrappers") {
       "//brave/build/ios/mojom/objc_templates/private_union_implementation.tmpl",
       "//brave/build/ios/mojom/objc_templates/union_declaration.tmpl",
     ]
-    outputs = _generate_wrappers_output
+    sources = invoker.sources
+    outputs = [
+      "$target_gen_dir/{{source_file_part}}.objc.h",
+      "$target_gen_dir/{{source_file_part}}.objc+private.h",
+      "$target_gen_dir/{{source_file_part}}.objc.mm",
+    ]
+    _module_path = rebase_path("$dep_target_gen/{{source_file_part}}-module")
     args = [
-      "--mojom-module=$_mojom_module",
-      "--output-dir=$_mojom_output_dir",
+      "--mojom-module=$_module_path",
+      "--output-dir=$mojom_output_dir",
     ]
     if (defined(invoker.exclude_types)) {
       _excluded_types = string_join(",", invoker.exclude_types)
@@ -78,7 +81,8 @@ template("mojom_wrappers") {
     }
     deps = [
       "//mojo/public/cpp/bindings",
-      _mojom_target_parser,
+      mojom_target,
+      mojom_target_parser,
     ]
   }
 
@@ -86,21 +90,20 @@ template("mojom_wrappers") {
     forward_variables_from(invoker,
                            "*",
                            [
-                             "mojom_file",
                              "mojom_target",
                              "sources",
                            ])
     if (!defined(public_deps)) {
       public_deps = []
     }
-    sources = _generate_wrappers_output
+    sources = generate_wrappers_output
     configs += [ "//build/config/compiler:enable_arc" ]
     public_deps += [
-      ":$_generate_wrappers_target",
+      ":$generate_wrappers_target",
       "//base",
       "//brave/build/ios/mojom/util",
       "//net",
-      _mojom_target,
+      mojom_target,
     ]
   }
 }

--- a/build/ios/mojom/objc_templates/module.h.tmpl
+++ b/build/ios/mojom/objc_templates/module.h.tmpl
@@ -16,6 +16,10 @@
 #error "This file requires ARC support."
 #endif
 
+{% for import in imports %}
+#include "{{import|objc_import_module_name}}.objc.h"
+{% endfor %}
+
 {# Enum Decls #}
 {%- for enum in all_enums %}
 {%   include "enum.tmpl" %}
@@ -39,10 +43,12 @@ NS_ASSUME_NONNULL_BEGIN
 OBJC_EXPORT {{const.kind|objc_wrapper_type}} const {{class_prefix}}{{name}} NS_SWIFT_NAME({{class_prefix}}.{{name}});
 {% endfor -%}
 
-{# Define a namespace class for Swift types to use #}
+{# Define a namespace class for Swift types to use.
+   We have to define the type as unique to this module even though the renamed Swift type will be
+   the same for all wrappers that use the same namespace #}
 OBJC_EXPORT
 NS_SWIFT_NAME({{class_prefix}})
-@interface _{{class_prefix}} : NSObject
+@interface _{{class_prefix}}{{module_name|replace(".mojom","Mojom")|under_to_camel}} : NSObject
 - (instancetype)init NS_UNAVAILABLE;
 @end
 

--- a/build/ios/mojom/objc_templates/module.mm.tmpl
+++ b/build/ios/mojom/objc_templates/module.mm.tmpl
@@ -13,6 +13,10 @@
 #include "mojo/public/cpp/bindings/remote.h"
 #include "net/base/mac/url_conversions.h"
 
+{% for import in imports %}
+#include "{{import|objc_import_module_name}}.objc+private.h"
+{% endfor %}
+
 #if !defined(__has_feature) || !__has_feature(objc_arc)
 #error "This file requires ARC support."
 #endif
@@ -23,7 +27,7 @@
 {{const.kind|objc_wrapper_type}} const {{class_prefix}}{{name}} = {{const|const_objc_assign}};
 {% endfor %}
 
-@implementation _{{class_prefix}}
+@implementation _{{class_prefix}}{{module_name|replace(".mojom","Mojom")|under_to_camel}}
 @end
 
 {%- for struct in structs %}

--- a/ios/BUILD.gn
+++ b/ios/BUILD.gn
@@ -3,7 +3,11 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+import("//brave/ios/browser/api/ads/headers.gni")
+import("//brave/ios/browser/api/brave_wallet/headers.gni")
 import("//brave/ios/browser/api/certificate/headers.gni")
+import("//brave/ios/browser/api/ledger/headers.gni")
+import("//brave/ios/browser/api/skus/headers.gni")
 import("//build/config/compiler/compiler.gni")
 import("//build/config/ios/rules.gni")
 
@@ -34,9 +38,6 @@ brave_core_public_headers = [
   "//brave/ios/browser/api/bookmarks/brave_bookmarks_observer.h",
   "//brave/ios/browser/api/bookmarks/importer/brave_bookmarks_importer.h",
   "//brave/ios/browser/api/bookmarks/exporter/brave_bookmarks_exporter.h",
-  "$root_gen_dir/brave/ios/browser/api/brave_wallet/brave_wallet.mojom.objc.h",
-  "//brave/ios/browser/api/brave_wallet/brave_wallet_provider_delegate_ios.h",
-  "//brave/ios/browser/api/brave_wallet/token_registry_utils.h",
   "//brave/ios/browser/api/history/brave_history_api.h",
   "//brave/ios/browser/api/history/brave_history_observer.h",
   "//brave/ios/browser/api/password/brave_password_api.h",
@@ -44,21 +45,15 @@ brave_core_public_headers = [
   "//brave/ios/browser/api/sync/brave_sync_api.h",
   "//brave/ios/browser/api/sync/brave_sync_internals.h",
   "//brave/ios/browser/api/sync/driver/brave_sync_profile_service.h",
-  "//brave/ios/browser/api/ads/brave_ads.h",
-  "//brave/ios/browser/api/ads/ad_notification_ios.h",
-  "//brave/ios/browser/api/ads/inline_content_ad_ios.h",
-  "$root_gen_dir/brave/ios/browser/api/ads/ads.mojom.objc.h",
-  "//brave/ios/browser/api/ledger/brave_ledger.h",
-  "//brave/ios/browser/api/ledger/brave_ledger_observer.h",
-  "//brave/ios/browser/api/ledger/rewards_notification.h",
-  "//brave/ios/browser/api/ledger/promotion_solution.h",
-  "$root_gen_dir/brave/ios/browser/api/ledger/ledger.mojom.objc.h",
   "//brave/ios/browser/keyed_service/keyed_service_factory_wrapper.h",
-  "$root_gen_dir/brave/ios/browser/api/skus/skus_sdk.mojom.objc.h",
   "//brave/ios/browser/api/version_info/version_info_ios.h",
 ]
 
+brave_core_public_headers += ads_public_headers
+brave_core_public_headers += brave_wallet_public_headers
 brave_core_public_headers += browser_api_certificate_public_headers
+brave_core_public_headers += ledger_public_headers
+brave_core_public_headers += skus_public_headers
 
 action("brave_core_umbrella_header") {
   script = "//build/config/ios/generate_umbrella_header.py"
@@ -87,11 +82,12 @@ ios_framework_bundle("brave_core_ios_framework") {
     ":brave_core_umbrella_header",
     "//brave/components/adblock_rust_ffi",
     "//brave/ios/app",
-    "//brave/ios/browser/api/ads:ads_mojom_wrappers",
-    "//brave/ios/browser/api/brave_wallet:wallet_mojom_wrappers",
-    "//brave/ios/browser/api/ledger:ledger_mojom_wrappers",
-    "//brave/ios/browser/api/skus:skus_mojom_wrappers",
   ]
+
+  deps += ads_public_deps
+  deps += brave_wallet_public_deps
+  deps += ledger_public_deps
+  deps += skus_public_deps
 
   sources = brave_core_public_headers
 

--- a/ios/browser/api/ads/BUILD.gn
+++ b/ios/browser/api/ads/BUILD.gn
@@ -44,10 +44,12 @@ source_set("ads") {
   ]
 }
 
-mojom_wrappers("ads_mojom_wrappers") {
+ios_objc_mojom_wrappers("ads_mojom_wrappers") {
   mojom_target =
       "//brave/vendor/bat-native-ads/include/bat/ads/public/interfaces"
-  mojom_file = "//brave/vendor/bat-native-ads/include/bat/ads/public/interfaces/ads.mojom"
+  sources = [
+    "//brave/vendor/bat-native-ads/include/bat/ads/public/interfaces/ads.mojom",
+  ]
   exclude_types = [
     "DBCommand",
     "DBCommandBinding",

--- a/ios/browser/api/ads/headers.gni
+++ b/ios/browser/api/ads/headers.gni
@@ -1,0 +1,7 @@
+ads_public_headers = [
+  "//brave/ios/browser/api/ads/brave_ads.h",
+  "//brave/ios/browser/api/ads/ad_notification_ios.h",
+  "//brave/ios/browser/api/ads/inline_content_ad_ios.h",
+  "$root_gen_dir/brave/ios/browser/api/ads/ads.mojom.objc.h",
+]
+ads_public_deps = [ "//brave/ios/browser/api/ads:ads_mojom_wrappers" ]

--- a/ios/browser/api/brave_wallet/BUILD.gn
+++ b/ios/browser/api/brave_wallet/BUILD.gn
@@ -37,9 +37,9 @@ source_set("brave_wallet") {
   ]
 }
 
-mojom_wrappers("wallet_mojom_wrappers") {
+ios_objc_mojom_wrappers("wallet_mojom_wrappers") {
   mojom_target = "//brave/components/brave_wallet/common:mojom"
-  mojom_file = "//brave/components/brave_wallet/common/brave_wallet.mojom"
+  sources = [ "//brave/components/brave_wallet/common/brave_wallet.mojom" ]
   exclude_types = [
     "PageHandlerFactory",
     "PanelHandlerFactory",

--- a/ios/browser/api/brave_wallet/headers.gni
+++ b/ios/browser/api/brave_wallet/headers.gni
@@ -1,0 +1,7 @@
+brave_wallet_public_headers = [
+  "//brave/ios/browser/api/brave_wallet/brave_wallet_provider_delegate_ios.h",
+  "//brave/ios/browser/api/brave_wallet/token_registry_utils.h",
+  "$root_gen_dir/brave/ios/browser/api/brave_wallet/brave_wallet.mojom.objc.h",
+]
+brave_wallet_public_deps =
+    [ "//brave/ios/browser/api/brave_wallet:wallet_mojom_wrappers" ]

--- a/ios/browser/api/ledger/BUILD.gn
+++ b/ios/browser/api/ledger/BUILD.gn
@@ -50,8 +50,8 @@ source_set("ledger") {
   ]
 }
 
-mojom_wrappers("ledger_mojom_wrappers") {
+ios_objc_mojom_wrappers("ledger_mojom_wrappers") {
   mojom_target =
       "//brave/vendor/bat-native-ledger/include/bat/ledger/public/interfaces"
-  mojom_file = "//brave/vendor/bat-native-ledger/include/bat/ledger/public/interfaces/ledger.mojom"
+  sources = [ "//brave/vendor/bat-native-ledger/include/bat/ledger/public/interfaces/ledger.mojom" ]
 }

--- a/ios/browser/api/ledger/headers.gni
+++ b/ios/browser/api/ledger/headers.gni
@@ -1,0 +1,8 @@
+ledger_public_headers = [
+  "//brave/ios/browser/api/ledger/brave_ledger.h",
+  "//brave/ios/browser/api/ledger/brave_ledger_observer.h",
+  "//brave/ios/browser/api/ledger/rewards_notification.h",
+  "//brave/ios/browser/api/ledger/promotion_solution.h",
+  "$root_gen_dir/brave/ios/browser/api/ledger/ledger.mojom.objc.h",
+]
+ledger_public_deps = [ "//brave/ios/browser/api/ledger:ledger_mojom_wrappers" ]

--- a/ios/browser/api/skus/BUILD.gn
+++ b/ios/browser/api/skus/BUILD.gn
@@ -15,7 +15,7 @@ config("mojom_header_config") {
   include_dirs = [ "$target_gen_dir" ]
 }
 
-mojom_wrappers("skus_mojom_wrappers") {
+ios_objc_mojom_wrappers("skus_mojom_wrappers") {
   mojom_target = "//brave/components/skus/common:mojom"
-  mojom_file = "//brave/components/skus/common/skus_sdk.mojom"
+  sources = [ "//brave/components/skus/common/skus_sdk.mojom" ]
 }

--- a/ios/browser/api/skus/headers.gni
+++ b/ios/browser/api/skus/headers.gni
@@ -1,0 +1,3 @@
+skus_public_headers =
+    [ "$root_gen_dir/brave/ios/browser/api/skus/skus_sdk.mojom.objc.h" ]
+skus_public_deps = [ "//brave/ios/browser/api/skus:skus_mojom_wrappers" ]


### PR DESCRIPTION
This adds initial support for `import` within mojom files. Due to limitations with where the generated files are written too and that we cannot use full paths within the the headers because generated headers are copied into a flat Headers directory within the compiled framework. With those things in mind, there are two restrictions in place:

1. Only imports of Brave mojom files are considered, base mojom ones are handled manually via custom typemaps within the generator code
2. All `sources` in a `mojom` target must exist in the same directory.

This PR also cleans up mojo-related headers/deps and improves the template to generate the wrappers since supporting imports mean we must support all `sources` in the original `mojom` target. 

Resolves  https://github.com/brave/brave-browser/issues/21592

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

