### PR TITLE
Add GetERC721Metadata to JsonRpcService

### DIFF
--- a/components/brave_wallet/browser/BUILD.gn
+++ b/components/brave_wallet/browser/BUILD.gn
@@ -133,6 +133,7 @@ static_library("browser") {
     "//brave/components/brave_wallet/common:common_constants",
     "//brave/components/brave_wallet/common:mojom",
     "//brave/components/brave_wallet/common:solana_utils",
+    "//brave/components/ipfs",
     "//brave/components/json/rs:cxx",
     "//brave/components/json/rs:cxx_gen",
     "//brave/components/resources:strings_grit",

--- a/components/brave_wallet/browser/brave_wallet_constants.h
+++ b/components/brave_wallet/browser/brave_wallet_constants.h
@@ -626,8 +626,9 @@ const int64_t kBlockTrackerDefaultTimeInSeconds = 20;
 constexpr char kCryptoEthAddressKey[] = "crypto.ETH.address";
 
 // ERC-165 identifier for ERC721 interface.
-constexpr char kERC721InterfaceId[] = "0x80ac58cd";
 constexpr char kERC1155InterfaceId[] = "0xd9b67a26";
+constexpr char kERC721InterfaceId[] = "0x80ac58cd";
+constexpr char kERC721MetadataInterfaceId[] = "0x5b5e139f";
 
 constexpr char kEthereumPrefKey[] = "ethereum";
 constexpr char kFilecoinPrefKey[] = "filecoin";

--- a/components/brave_wallet/browser/eth_data_builder.cc
+++ b/components/brave_wallet/browser/eth_data_builder.cc
@@ -123,6 +123,17 @@ bool OwnerOf(uint256_t token_id, std::string* data) {
   return brave_wallet::ConcatHexStrings(function_hash, padded_token_id, data);
 }
 
+bool TokenUri(uint256_t token_id, std::string* data) {
+  const std::string function_hash = GetFunctionHash("tokenURI(uint256)");
+
+  std::string padded_token_id;
+  if (!PadHexEncodedParameter(Uint256ValueToHex(token_id), &padded_token_id)) {
+    return false;
+  }
+
+  return brave_wallet::ConcatHexStrings(function_hash, padded_token_id, data);
+}
+
 }  // namespace erc721
 
 namespace erc1155 {

--- a/components/brave_wallet/browser/eth_data_builder.h
+++ b/components/brave_wallet/browser/eth_data_builder.h
@@ -44,6 +44,9 @@ bool TransferFromOrSafeTransferFrom(bool is_safe_transfer_from,
 // Find the owner of an NFT.
 bool OwnerOf(uint256_t token_id, std::string* data);
 
+// Get the URI of an NFT.
+bool TokenUri(uint256_t token_id, std::string* data);
+
 }  // namespace erc721
 
 namespace erc1155 {

--- a/components/brave_wallet/browser/eth_data_builder_unittest.cc
+++ b/components/brave_wallet/browser/eth_data_builder_unittest.cc
@@ -87,6 +87,16 @@ TEST(EthCallDataBuilderTest, OwnerOf) {
             "0000000f");
 }
 
+TEST(EthCallDataBuilderTest, TokenUri) {
+  std::string data;
+  uint256_t token_id;
+  ASSERT_TRUE(HexValueToUint256("0xf", &token_id));
+  TokenUri(token_id, &data);
+  ASSERT_EQ(data,
+            "0xc87b56dd00000000000000000000000000000000000000000000000000000000"
+            "0000000f");
+}
+
 }  // namespace erc721
 
 namespace erc1155 {

--- a/components/brave_wallet/browser/eth_response_parser.cc
+++ b/components/brave_wallet/browser/eth_response_parser.cc
@@ -12,10 +12,22 @@
 #include "brave/components/brave_wallet/browser/json_rpc_response_parser.h"
 #include "brave/components/brave_wallet/common/eth_address.h"
 #include "brave/components/brave_wallet/common/hex_utils.h"
+#include "net/base/data_url.h"
 
 namespace brave_wallet {
 
 namespace eth {
+
+bool ParseStringResult(const std::string& json, std::string* value) {
+  DCHECK(value);
+
+  std::string result;
+  if (!ParseSingleStringResult(json, &result))
+    return false;
+
+  size_t offset = 2 /* len of "0x" */ + 64 /* len of offset to array */;
+  return brave_wallet::DecodeString(offset, result, value);
+}
 
 bool ParseAddressResult(const std::string& json, std::string* address) {
   DCHECK(address);
@@ -221,14 +233,7 @@ bool ParseEthGasPrice(const std::string& json, std::string* result) {
 
 bool ParseEnsResolverContentHash(const std::string& json,
                                  std::string* content_hash) {
-  DCHECK(content_hash);
-
-  std::string result;
-  if (!ParseSingleStringResult(json, &result))
-    return false;
-
-  size_t offset = 2 /* len of "0x" */ + 64 /* len of offset to array */;
-  return brave_wallet::DecodeString(offset, result, content_hash);
+  return ParseStringResult(json, content_hash);
 }
 
 bool ParseUnstoppableDomainsProxyReaderGetMany(
@@ -249,17 +254,41 @@ bool ParseUnstoppableDomainsProxyReaderGetMany(
 
 absl::optional<std::string> ParseUnstoppableDomainsProxyReaderGet(
     const std::string& json) {
-  std::string result;
-  if (!ParseSingleStringResult(json, &result))
-    return absl::nullopt;
-
-  size_t offset = 2 /* len of "0x" */ + 64 /* len of offset to array */;
   std::string value;
-  if (!brave_wallet::DecodeString(offset, result, &value)) {
+  if (!ParseStringResult(json, &value)) {
     return absl::nullopt;
   }
 
   return value;
+}
+
+bool ParseERC721TokenUri(const std::string& json, GURL* url) {
+  std::string result;
+  if (!ParseStringResult(json, &result)) {
+    return false;
+  }
+
+  GURL result_url = GURL(result);
+  if (!result_url.is_valid()) {
+    return false;
+  }
+
+  *url = result_url;
+  return true;
+}
+
+bool ParseDataURIAndExtractJSON(const GURL url, std::string* json) {
+  std::string mime_type, charset, data;
+  if (!net::DataURL::Parse(url, &mime_type, &charset, &data) || data.empty()) {
+    return false;
+  }
+
+  if (mime_type != "application/json") {
+    return false;
+  }
+
+  *json = data;
+  return true;
 }
 
 }  // namespace eth

--- a/components/brave_wallet/browser/eth_response_parser.h
+++ b/components/brave_wallet/browser/eth_response_parser.h
@@ -17,6 +17,7 @@ namespace brave_wallet {
 
 namespace eth {
 
+bool ParseStringResult(const std::string& json, std::string* value);
 bool ParseAddressResult(const std::string& json, std::string* address);
 bool ParseEthGetBlockNumber(const std::string& json, uint256_t* block_num);
 bool ParseEthGetFeeHistory(const std::string& json,
@@ -42,6 +43,11 @@ bool ParseUnstoppableDomainsProxyReaderGetMany(
 
 absl::optional<std::string> ParseUnstoppableDomainsProxyReaderGet(
     const std::string& json);
+
+bool ParseERC721TokenUri(const std::string& json, GURL* url);
+
+// Get the JSON included in a data URI with a mime type application/json
+bool ParseDataURIAndExtractJSON(const GURL url, std::string* json);
 
 }  // namespace eth
 

--- a/components/brave_wallet/browser/eth_response_parser_unittest.cc
+++ b/components/brave_wallet/browser/eth_response_parser_unittest.cc
@@ -454,6 +454,122 @@ TEST(EthResponseParserUnitTest, ParseEthGetFeeHistory) {
                                      &oldest_block, &reward));
 }
 
+TEST(EthResponseParserUnitTest, ParseDataURIAndExtractJSON) {
+  std::string json;
+  std::string url;
+  // Invalid URL
+  EXPECT_FALSE(ParseDataURIAndExtractJSON(GURL(""), &json));
+  // Valid URL, incorrect scheme
+  EXPECT_FALSE(ParseDataURIAndExtractJSON(GURL("https://brave.com"),
+                                          &json));  // Incorrect scheme
+  // Valid URL and scheme, invalid mime_type
+  EXPECT_FALSE(ParseDataURIAndExtractJSON(
+      GURL("data:text/vnd-example+xyz;foo=bar;base64,R0lGODdh"),
+      &json));  // Incorrect mime type
+
+  // All valid
+  std::string expected =
+      R"({"attributes":"","description":"Non fungible lion","image":"data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCA1MDAgNTAwIj48cGF0aCBkPSIiLz48L3N2Zz4=","name":"NFL"})";
+  url =
+      "data:application/"
+      "json;base64,"
+      "eyJhdHRyaWJ1dGVzIjoiIiwiZGVzY3JpcHRpb24iOiJOb24gZnVuZ2libGUgbGlvbiIsImlt"
+      "YWdlIjoiZGF0YTppbWFnZS9zdmcreG1sO2Jhc2U2NCxQSE4yWnlCNGJXeHVjejBpYUhSMGNE"
+      "b3ZMM2QzZHk1M015NXZjbWN2TWpBd01DOXpkbWNpSUhacFpYZENiM2c5SWpBZ01DQTFNREFn"
+      "TlRBd0lqNDhjR0YwYUNCa1BTSWlMejQ4TDNOMlp6ND0iLCJuYW1lIjoiTkZMIn0=";
+  EXPECT_TRUE(ParseDataURIAndExtractJSON(GURL(url), &json));
+  EXPECT_EQ(json, expected);
+}
+
+TEST(EthResponseParserUnitTest, ParseERC721TokenUri) {
+  GURL url;
+
+  // Valid (3 total)
+  // (1/3) Valid IPFS URLs
+  std::string body = R"({
+      "jsonrpc":"2.0",
+      "id":1,
+      "result":"0x0000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000003a697066733a2f2f516d65536a53696e4870506e6d586d73704d6a776958794e367a533445397a63636172694752336a7863615774712f31383137000000000000"
+  })";
+  EXPECT_TRUE(eth::ParseERC721TokenUri(body, &url));
+  EXPECT_EQ(url.spec(),
+            "ipfs://QmeSjSinHpPnmXmspMjwiXyN6zS4E9zccariGR3jxcaWtq/1817");
+
+  // (2/3) Data URIs are parsed
+  body = R"({
+      "jsonrpc":"2.0",
+      "id":1,
+      "result":"0x00000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000135646174613a6170706c69636174696f6e2f6a736f6e3b6261736536342c65794a686448527961574a316447567a496a6f69496977695a47567a59334a7063485270623234694f694a4f623234675a6e56755a326c696247556762476c7662694973496d6c745957646c496a6f695a474630595470706257466e5a53397a646d6372654731734f324a68633255324e43785153453479576e6c434e474a586548566a656a4270595568534d474e4562335a4d4d32517a5a486b314d3031354e585a6a62574e3254577042643031444f58706b62574e7053556861634670595a454e694d326335535770425a3031445154464e5245466e546c524264306c714e44686a5230597759554e436131425453576c4d656a513454444e4f4d6c70364e4430694c434a755957316c496a6f69546b5a4d496e303d0000000000000000000000"
+  })";
+  EXPECT_TRUE(eth::ParseERC721TokenUri(body, &url));
+  EXPECT_EQ(
+      url.spec(),
+      R"(data:application/json;base64,eyJhdHRyaWJ1dGVzIjoiIiwiZGVzY3JpcHRpb24iOiJOb24gZnVuZ2libGUgbGlvbiIsImltYWdlIjoiZGF0YTppbWFnZS9zdmcreG1sO2Jhc2U2NCxQSE4yWnlCNGJXeHVjejBpYUhSMGNEb3ZMM2QzZHk1M015NXZjbWN2TWpBd01DOXpkbWNpSUhacFpYZENiM2c5SWpBZ01DQTFNREFnTlRBd0lqNDhjR0YwYUNCa1BTSWlMejQ4TDNOMlp6ND0iLCJuYW1lIjoiTkZMIn0=)");
+
+  // (3/3) HTTP URLs are parsed
+  body = R"({
+      "jsonrpc":"2.0",
+      "id":1,
+      "result":"0x0000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000002468747470733a2f2f696e76697369626c65667269656e64732e696f2f6170692f3138313700000000000000000000000000000000000000000000000000000000"
+  })";
+  EXPECT_TRUE(eth::ParseERC721TokenUri(body, &url));
+  EXPECT_EQ(url.spec(), "https://invisiblefriends.io/api/1817");
+
+  // Invalid (2 total)
+  // (1/2) Invalid provider response returns false
+  url = GURL();
+  body = R"({
+   "jsonrpc":"2.0",
+   "id":1,
+   "error": {
+     "code":-32005,
+     "message": "Request exceeds defined limit"
+   }
+ })";
+  EXPECT_FALSE(eth::ParseERC721TokenUri(body, &url));
+  EXPECT_EQ(url.spec(), "");
+
+  // (2/2) Invalid URL returns false (https//brave.com)
+  body = R"({
+      "jsonrpc":"2.0",
+      "id":1,
+      "result":"0x0000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000001068747470732f2f62726176652e636f6d00000000000000000000000000000000"
+  })";
+  EXPECT_FALSE(eth::ParseERC721TokenUri(body, &url));
+  EXPECT_EQ(url.spec(), "");
+}
+
+TEST(EthResponseParserUnitTest, ParseStringResult) {
+  std::string value;
+
+  // Valid
+  std::string json = R"({
+      "jsonrpc":"2.0",
+      "id":1,
+      "result": "0x000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000455468652054696d65732030332f4a616e2f32303039204368616e63656c6c6f72206f6e206272696e6b206f66207365636f6e64206261696c6f757420666f722062616e6b73000000000000000000000000000000000000000000000000000000"
+  })";
+  EXPECT_TRUE(eth::ParseStringResult(json, &value));
+  EXPECT_EQ(
+      value,
+      "The Times 03/Jan/2009 Chancellor on brink of second bailout for banks");
+
+  // Invalid JSON
+  json = "Invalid JSON";
+  value = "";
+  EXPECT_FALSE(eth::ParseStringResult(json, &value));
+  EXPECT_TRUE(value.empty());
+
+  // Valid JSON, invalid result (too short)
+  value = "";
+  json = R"({
+      "jsonrpc":"2.0",
+      "id":1,
+      "result":"0x00000000000000000000000000000007"
+  })";
+  EXPECT_FALSE(eth::ParseStringResult(json, &value));
+  EXPECT_TRUE(value.empty());
+}
+
 }  // namespace eth
 
 }  // namespace brave_wallet

--- a/components/brave_wallet/browser/eth_tx_manager.cc
+++ b/components/brave_wallet/browser/eth_tx_manager.cc
@@ -662,9 +662,11 @@ void EthTxManager::MakeERC721TransferFromData(
     return;
   }
 
+  const std::string chain_id =
+      json_rpc_service_->GetChainId(mojom::CoinType::ETH);
   // Check if safeTransferFrom is supported first.
   json_rpc_service_->GetSupportsInterface(
-      contract_address, kERC721InterfaceId,
+      contract_address, kERC721InterfaceId, chain_id,
       base::BindOnce(&EthTxManager::ContinueMakeERC721TransferFromData,
                      weak_factory_.GetWeakPtr(), from, to, token_id_uint,
                      std::move(callback)));

--- a/components/brave_wallet/browser/json_rpc_service.cc
+++ b/components/brave_wallet/browser/json_rpc_service.cc
@@ -34,6 +34,8 @@
 #include "brave/components/brave_wallet/common/hex_utils.h"
 #include "brave/components/brave_wallet/common/value_conversion_utils.h"
 #include "brave/components/brave_wallet/common/web3_provider_constants.h"
+#include "brave/components/ipfs/ipfs_service.h"
+#include "brave/components/ipfs/ipfs_utils.h"
 #include "components/grit/brave_components_strings.h"
 #include "components/prefs/pref_service.h"
 #include "components/prefs/scoped_user_pref_update.h"
@@ -218,7 +220,6 @@ void JsonRpcService::RequestInternal(
     env->GetVar("BRAVE_SERVICES_KEY", &brave_key);
   }
   request_headers["x-brave-key"] = std::move(brave_key);
-
   api_request_helper_->Request("POST", network_url, json_payload,
                                "application/json", auto_retry_on_network_change,
                                std::move(callback), request_headers, -1u,
@@ -1620,6 +1621,186 @@ void JsonRpcService::ContinueGetERC721TokenBalance(
                           mojom::ProviderError::kSuccess, "");
 }
 
+void JsonRpcService::GetERC721Metadata(const std::string& contract_address,
+                                       const std::string& token_id,
+                                       const std::string& chain_id,
+                                       GetERC721MetadataCallback callback) {
+  auto network_url = GetNetworkURL(prefs_, chain_id, mojom::CoinType::ETH);
+  if (!network_url.is_valid()) {
+    std::move(callback).Run(
+        "", mojom::ProviderError::kInvalidParams,
+        l10n_util::GetStringUTF8(IDS_WALLET_INVALID_PARAMETERS));
+    return;
+  }
+
+  if (!EthAddress::IsValidAddress(contract_address)) {
+    std::move(callback).Run(
+        "", mojom::ProviderError::kInvalidParams,
+        l10n_util::GetStringUTF8(IDS_WALLET_INVALID_PARAMETERS));
+    return;
+  }
+
+  uint256_t token_id_uint = 0;
+  if (!HexValueToUint256(token_id, &token_id_uint)) {
+    std::move(callback).Run(
+        "", mojom::ProviderError::kInvalidParams,
+        l10n_util::GetStringUTF8(IDS_WALLET_INVALID_PARAMETERS));
+    return;
+  }
+
+  std::string function_signature;
+  if (!erc721::TokenUri(token_id_uint, &function_signature)) {
+    std::move(callback).Run(
+        "", mojom::ProviderError::kInvalidParams,
+        l10n_util::GetStringUTF8(IDS_WALLET_INVALID_PARAMETERS));
+    return;
+  }
+
+  auto internal_callback =
+      base::BindOnce(&JsonRpcService::OnGetSupportsInterfaceERC721Metadata,
+                     weak_ptr_factory_.GetWeakPtr(), contract_address,
+                     function_signature, network_url, std::move(callback));
+
+  GetSupportsInterface(contract_address, kERC721MetadataInterfaceId, chain_id,
+                       std::move(internal_callback));
+}
+
+void JsonRpcService::OnGetSupportsInterfaceERC721Metadata(
+    const std::string& contract_address,
+    const std::string& function_signature,
+    const GURL& network_url,
+    GetERC721MetadataCallback callback,
+    bool is_supported,
+    mojom::ProviderError error,
+    const std::string& error_message) {
+  if (error != mojom::ProviderError::kSuccess) {
+    std::move(callback).Run("", error, error_message);
+    return;
+  }
+
+  if (!is_supported) {
+    std::move(callback).Run(
+        "", mojom::ProviderError::kMethodNotSupported,
+        l10n_util::GetStringUTF8(IDS_WALLET_METHOD_NOT_SUPPORTED_ERROR));
+    return;
+  }
+
+  auto internal_callback =
+      base::BindOnce(&JsonRpcService::OnGetERC721TokenUri,
+                     weak_ptr_factory_.GetWeakPtr(), std::move(callback));
+
+  // Call tokenURI on the ERC721 contract
+  RequestInternal(eth::eth_call("", contract_address, "", "", "",
+                                function_signature, "latest"),
+                  true, network_url, std::move(internal_callback));
+}
+
+void JsonRpcService::OnGetERC721TokenUri(
+    GetERC721MetadataCallback callback,
+    const int status,
+    const std::string& body,
+    const base::flat_map<std::string, std::string>& headers) {
+  if (status < 200 || status > 299) {
+    std::move(callback).Run(
+        "", mojom::ProviderError::kInternalError,
+        l10n_util::GetStringUTF8(IDS_WALLET_INTERNAL_ERROR));
+    return;
+  }
+
+  // Parse response JSON that wraps the result
+  GURL url;
+  if (!eth::ParseERC721TokenUri(body, &url)) {
+    mojom::ProviderError error;
+    std::string error_message;
+    ParseErrorResult<mojom::ProviderError>(body, &error, &error_message);
+    std::move(callback).Run("", error, error_message);
+    return;
+  }
+
+  // Obtain JSON from the URL depending on the scheme.
+  // IPFS, HTTPS, and data URIs are supported.
+  // IPFS and HTTPS URIs require an additional request to fetch the metadata.
+  std::string metadata_json;
+  std::string scheme = url.scheme();
+  if (scheme != url::kDataScheme && scheme != url::kHttpsScheme &&
+      scheme != ipfs::kIPFSScheme) {
+    std::move(callback).Run(
+        "", mojom::ProviderError::kMethodNotSupported,
+        l10n_util::GetStringUTF8(IDS_WALLET_METHOD_NOT_SUPPORTED_ERROR));
+    return;
+  }
+
+  if (scheme == url::kDataScheme) {
+    if (!eth::ParseDataURIAndExtractJSON(url, &metadata_json)) {
+      std::move(callback).Run(
+          "", mojom::ProviderError::kParsingError,
+          l10n_util::GetStringUTF8(IDS_WALLET_PARSING_ERROR));
+      return;
+    }
+
+    // Sanitize JSON
+    data_decoder::JsonSanitizer::Sanitize(
+        std::move(metadata_json),
+        base::BindOnce(&JsonRpcService::OnSanitizeERC721Metadata,
+                       weak_ptr_factory_.GetWeakPtr(), std::move(callback)));
+    return;
+  }
+
+  if (scheme == ipfs::kIPFSScheme &&
+      !ipfs::TranslateIPFSURI(url, &url, ipfs::GetDefaultIPFSGateway(prefs_),
+                              false)) {
+    std::move(callback).Run("", mojom::ProviderError::kParsingError,
+                            l10n_util::GetStringUTF8(IDS_WALLET_PARSING_ERROR));
+    return;
+  }
+
+  auto internal_callback =
+      base::BindOnce(&JsonRpcService::OnGetERC721MetadataPayload,
+                     weak_ptr_factory_.GetWeakPtr(), std::move(callback));
+  api_request_helper_->Request("GET", url, "", "", true,
+                               std::move(internal_callback));
+}
+
+void JsonRpcService::OnSanitizeERC721Metadata(
+    GetERC721MetadataCallback callback,
+    data_decoder::JsonSanitizer::Result result) {
+  if (result.error) {
+    VLOG(1) << "Data URI JSON validation error:" << *result.error;
+    std::move(callback).Run("", mojom::ProviderError::kParsingError,
+                            l10n_util::GetStringUTF8(IDS_WALLET_PARSING_ERROR));
+    return;
+  }
+
+  std::string metadata_json;
+  if (result.value.has_value()) {
+    metadata_json = result.value.value();
+  }
+
+  std::move(callback).Run(metadata_json, mojom::ProviderError::kSuccess, "");
+}
+
+void JsonRpcService::OnGetERC721MetadataPayload(
+    GetERC721MetadataCallback callback,
+    const int status,
+    const std::string& body,
+    const base::flat_map<std::string, std::string>& headers) {
+  if (status < 200 || status > 299) {
+    std::move(callback).Run(
+        "", mojom::ProviderError::kInternalError,
+        l10n_util::GetStringUTF8(IDS_WALLET_INTERNAL_ERROR));
+    return;
+  }
+
+  // Invalid JSON becomes an empty string after sanitization
+  if (body.empty()) {
+    std::move(callback).Run("", mojom::ProviderError::kParsingError,
+                            l10n_util::GetStringUTF8(IDS_WALLET_PARSING_ERROR));
+    return;
+  }
+
+  std::move(callback).Run(body, mojom::ProviderError::kSuccess, "");
+}
+
 void JsonRpcService::GetERC1155TokenBalance(
     const std::string& contract_address,
     const std::string& token_id,
@@ -1658,7 +1839,6 @@ void JsonRpcService::GetERC1155TokenBalance(
         l10n_util::GetStringUTF8(IDS_WALLET_INVALID_PARAMETERS));
     return;
   }
-
   auto internal_callback =
       base::BindOnce(&JsonRpcService::OnEthGetBalance,
                      weak_ptr_factory_.GetWeakPtr(), std::move(callback));
@@ -1670,8 +1850,11 @@ void JsonRpcService::GetERC1155TokenBalance(
 void JsonRpcService::GetSupportsInterface(
     const std::string& contract_address,
     const std::string& interface_id,
+    const std::string& chain_id,
     GetSupportsInterfaceCallback callback) {
-  if (!EthAddress::IsValidAddress(contract_address)) {
+  auto network_url = GetNetworkURL(prefs_, chain_id, mojom::CoinType::ETH);
+  if (!EthAddress::IsValidAddress(contract_address) ||
+      !network_url.is_valid()) {
     std::move(callback).Run(
         false, mojom::ProviderError::kInvalidParams,
         l10n_util::GetStringUTF8(IDS_WALLET_INVALID_PARAMETERS));
@@ -1688,9 +1871,10 @@ void JsonRpcService::GetSupportsInterface(
   auto internal_callback =
       base::BindOnce(&JsonRpcService::OnGetSupportsInterface,
                      weak_ptr_factory_.GetWeakPtr(), std::move(callback));
+  DCHECK(network_urls_.contains(mojom::CoinType::ETH));
   RequestInternal(
       eth::eth_call("", contract_address, "", "", "", data, "latest"), true,
-      network_urls_[mojom::CoinType::ETH], std::move(internal_callback));
+      network_url, std::move(internal_callback));
 }
 
 void JsonRpcService::OnGetSupportsInterface(

--- a/components/brave_wallet/browser/json_rpc_service.h
+++ b/components/brave_wallet/browser/json_rpc_service.h
@@ -25,6 +25,7 @@
 #include "mojo/public/cpp/bindings/receiver_set.h"
 #include "mojo/public/cpp/bindings/remote.h"
 #include "mojo/public/cpp/bindings/remote_set.h"
+#include "services/data_decoder/public/cpp/json_sanitizer.h"
 #include "url/gurl.h"
 #include "url/origin.h"
 
@@ -247,17 +248,22 @@ class JsonRpcService : public KeyedService, public mojom::JsonRpcService {
                         const std::string& chain_id,
                         GetERC721OwnerOfCallback callback) override;
 
+  void GetERC1155TokenBalance(const std::string& contract_address,
+                              const std::string& owner_address,
+                              const std::string& token_id,
+                              const std::string& chain_id,
+                              GetERC1155TokenBalanceCallback callback) override;
+
   void GetERC721TokenBalance(const std::string& contract_address,
                              const std::string& token_id,
                              const std::string& account_address,
                              const std::string& chain_id,
                              GetERC721TokenBalanceCallback callback) override;
 
-  void GetERC1155TokenBalance(const std::string& contract_address,
-                              const std::string& owner_address,
-                              const std::string& token_id,
-                              const std::string& chain_id,
-                              GetERC1155TokenBalanceCallback callback) override;
+  void GetERC721Metadata(const std::string& contract_address,
+                         const std::string& token_id,
+                         const std::string& chain_id,
+                         GetERC721MetadataCallback callback) override;
 
   // Resets things back to the original state of BraveWalletService.
   // To be used when the Wallet is reset / erased
@@ -267,8 +273,10 @@ class JsonRpcService : public KeyedService, public mojom::JsonRpcService {
       base::OnceCallback<void(bool is_supported,
                               mojom::ProviderError error,
                               const std::string& error_message)>;
+
   void GetSupportsInterface(const std::string& contract_address,
                             const std::string& interface_id,
+                            const std::string& chain_id,
                             GetSupportsInterfaceCallback callback);
 
   using SwitchEthereumChainRequestCallback =
@@ -498,11 +506,33 @@ class JsonRpcService : public KeyedService, public mojom::JsonRpcService {
       const std::string& body,
       const base::flat_map<std::string, std::string>& headers);
 
+  void OnGetSupportsInterfaceERC721Metadata(const std::string& contract_address,
+                                            const std::string& signature,
+                                            const GURL& network_url,
+                                            GetERC721MetadataCallback callback,
+                                            bool is_supported,
+                                            mojom::ProviderError error,
+                                            const std::string& error_message);
+
   void ContinueGetERC721TokenBalance(const std::string& account_address,
                                      GetERC721TokenBalanceCallback callback,
                                      const std::string& owner_address,
                                      mojom::ProviderError error,
                                      const std::string& error_message);
+  void OnGetERC721TokenUri(
+      GetERC721MetadataCallback callback,
+      const int status,
+      const std::string& body,
+      const base::flat_map<std::string, std::string>& headers);
+
+  void OnGetERC721MetadataPayload(
+      GetERC721MetadataCallback callback,
+      const int status,
+      const std::string& body,
+      const base::flat_map<std::string, std::string>& headers);
+
+  void OnSanitizeERC721Metadata(GetERC721MetadataCallback callback,
+                                data_decoder::JsonSanitizer::Result result);
 
   void OnGetSupportsInterface(
       GetSupportsInterfaceCallback callback,

--- a/components/brave_wallet/browser/json_rpc_service_unittest.cc
+++ b/components/brave_wallet/browser/json_rpc_service_unittest.cc
@@ -30,7 +30,9 @@
 #include "brave/components/brave_wallet/common/brave_wallet.mojom.h"
 #include "brave/components/brave_wallet/common/hash_utils.h"
 #include "brave/components/brave_wallet/common/value_conversion_utils.h"
+#include "brave/components/ipfs/ipfs_service.h"
 #include "brave/components/ipfs/ipfs_utils.h"
+#include "brave/components/ipfs/pref_names.h"
 #include "components/prefs/scoped_user_pref_update.h"
 #include "components/sync_preferences/testing_pref_service_syncable.h"
 #include "content/public/browser/storage_partition.h"
@@ -330,7 +332,7 @@ class JsonRpcServiceUnitTest : public testing::Test {
 
     brave_wallet::RegisterProfilePrefs(prefs_.registry());
     brave_wallet::RegisterProfilePrefsForMigration(prefs_.registry());
-
+    ipfs::IpfsService::RegisterProfilePrefs(prefs_.registry());
     json_rpc_service_.reset(
         new JsonRpcService(shared_url_loader_factory_, &prefs_));
     SetNetwork(mojom::kLocalhostChainId, mojom::CoinType::ETH);
@@ -403,11 +405,11 @@ class JsonRpcServiceUnitTest : public testing::Test {
           }
         }));
   }
+
   void SetUDENSInterceptor(const std::string& chain_id) {
     GURL network_url =
         brave_wallet::GetNetworkURL(prefs(), chain_id, mojom::CoinType::ETH);
     ASSERT_TRUE(network_url.is_valid());
-
     url_loader_factory_.SetInterceptor(base::BindLambdaForTesting(
         [&, network_url](const network::ResourceRequest& request) {
           base::StringPiece request_string(request.request_body->elements()
@@ -453,6 +455,57 @@ class JsonRpcServiceUnitTest : public testing::Test {
             url_loader_factory_.AddResponse(request.url.spec(), "",
                                             net::HTTP_REQUEST_TIMEOUT);
           }
+        }));
+  }
+
+  void SetERC721MetadataInterceptor(
+      const std::string& chain_id,
+      const std::string& supports_interface_provider_response,
+      const std::string& token_uri_provider_response = "",
+      const std::string& metadata_response = "",
+      net::HttpStatusCode supports_interface_status = net::HTTP_OK,
+      net::HttpStatusCode token_uri_status = net::HTTP_OK,
+      net::HttpStatusCode metadata_status = net::HTTP_OK) {
+    GURL network_url =
+        brave_wallet::GetNetworkURL(prefs(), chain_id, mojom::CoinType::ETH);
+    ASSERT_TRUE(network_url.is_valid());
+    url_loader_factory_.SetInterceptor(base::BindLambdaForTesting(
+        [&, supports_interface_status, token_uri_status, metadata_status,
+         network_url](const network::ResourceRequest& request) {
+          url_loader_factory_.ClearResponses();
+          if (request.method ==
+              "POST") {  // An eth_call, either to supportsInterface or tokenURI
+            base::StringPiece request_string(
+                request.request_body->elements()
+                    ->at(0)
+                    .As<network::DataElementBytes>()
+                    .AsStringPiece());
+            bool is_supports_interface_req =
+                request_string.find(GetFunctionHash(
+                    "supportsInterface(bytes4)")) != std::string::npos;
+            bool is_token_uri_req =
+                request_string.find(GetFunctionHash("tokenURI(uint256)")) !=
+                std::string::npos;
+            if (is_supports_interface_req) {
+              EXPECT_EQ(request.url.spec(), network_url);
+              url_loader_factory_.AddResponse(
+                  network_url.spec(), supports_interface_provider_response,
+                  supports_interface_status);
+              return;
+            } else if (is_token_uri_req) {
+              url_loader_factory_.AddResponse(network_url.spec(),
+                                              token_uri_provider_response,
+                                              token_uri_status);
+              return;
+            }
+          } else {  // A HTTP GET to fetch the metadata json from the web
+            url_loader_factory_.AddResponse(request.url.spec(),
+                                            metadata_response, metadata_status);
+            return;
+          }
+
+          url_loader_factory_.AddResponse(request.url.spec(), "",
+                                          net::HTTP_REQUEST_TIMEOUT);
         }));
   }
 
@@ -584,6 +637,26 @@ class JsonRpcServiceUnitTest : public testing::Test {
     base::RunLoop run_loop;
     json_rpc_service_->GetERC1155TokenBalance(
         contract, token_id, account_address, chain_id,
+        base::BindLambdaForTesting([&](const std::string& response,
+                                       mojom::ProviderError error,
+                                       const std::string& error_message) {
+          EXPECT_EQ(response, expected_response);
+          EXPECT_EQ(error, expected_error);
+          EXPECT_EQ(error_message, expected_error_message);
+          run_loop.Quit();
+        }));
+    run_loop.Run();
+  }
+
+  void TestGetERC721Metadata(const std::string& contract,
+                             const std::string& token_id,
+                             const std::string& chain_id,
+                             const std::string& expected_response,
+                             mojom::ProviderError expected_error,
+                             const std::string& expected_error_message) {
+    base::RunLoop run_loop;
+    json_rpc_service_->GetERC721Metadata(
+        contract, token_id, chain_id,
         base::BindLambdaForTesting([&](const std::string& response,
                                        mojom::ProviderError error,
                                        const std::string& error_message) {
@@ -2349,6 +2422,214 @@ TEST_F(JsonRpcServiceUnitTest, GetERC721OwnerOf) {
   EXPECT_TRUE(callback_called);
 }
 
+TEST_F(JsonRpcServiceUnitTest, GetERC721Metadata) {
+  const std::string https_token_uri_response = R"({
+      "jsonrpc":"2.0",
+      "id":1,
+      "result":"0x0000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000002468747470733a2f2f696e76697369626c65667269656e64732e696f2f6170692f3138313700000000000000000000000000000000000000000000000000000000"
+  })";
+  const std::string http_token_uri_response = R"({
+      "jsonrpc":"2.0",
+      "id":1,
+      "result":"0x00000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000020687474703a2f2f696e76697369626c65667269656e64732e696f2f6170692f31"
+  })";
+  const std::string data_token_uri_response = R"({
+      "jsonrpc":"2.0",
+      "id":1,
+      "result": "0x00000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000135646174613a6170706c69636174696f6e2f6a736f6e3b6261736536342c65794a686448527961574a316447567a496a6f69496977695a47567a59334a7063485270623234694f694a4f623234675a6e56755a326c696247556762476c7662694973496d6c745957646c496a6f695a474630595470706257466e5a53397a646d6372654731734f324a68633255324e43785153453479576e6c434e474a586548566a656a4270595568534d474e4562335a4d4d32517a5a486b314d3031354e585a6a62574e3254577042643031444f58706b62574e7053556861634670595a454e694d326335535770425a3031445154464e5245466e546c524264306c714e44686a5230597759554e436131425453576c4d656a513454444e4f4d6c70364e4430694c434a755957316c496a6f69546b5a4d496e303d0000000000000000000000"
+  })";
+  const std::string data_token_uri_response_invalid_json = R"({
+    "jsonrpc":"2.0",
+    "id":1,
+    "result":"0x00000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000085646174613a6170706c69636174696f6e2f6a736f6e3b6261736536342c65794a755957316c496a6f69546b5a4d49697767496d526c63324e796158423061573975496a6f69546d397549475a31626d6470596d786c49477870623234694c43416959585230636d6c696458526c637949364969497349434a706257466e5a5349364969493d000000000000000000000000000000000000000000000000000000"
+  })";
+  const std::string data_token_uri_response_empty_string = R"({
+    "jsonrpc":"2.0",
+    "id":1,
+    "result":"0x0000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000001d646174613a6170706c69636174696f6e2f6a736f6e3b6261736536342c000000"
+  })";
+  const std::string interface_supported_response = R"({
+      "jsonrpc":"2.0",
+      "id":1,
+      "result": "0x0000000000000000000000000000000000000000000000000000000000000001"
+  })";
+  const std::string exceeds_limit_json = R"({
+    "jsonrpc":"2.0",
+    "id":1,
+    "error": {
+      "code":-32005,
+      "message": "Request exceeds defined limit"
+    }
+  })";
+  const std::string interface_not_supported_response = R"({
+      "jsonrpc":"2.0",
+      "id":1,
+      "result":"0x0000000000000000000000000000000000000000000000000000000000000000"
+  })";
+  const std::string invalid_json =
+      "It might make sense just to get some in case it catches on";
+  const std::string https_metadata_response =
+      R"({"attributes":[{"trait_type":"Feet","value":"Green Shoes"},{"trait_type":"Legs","value":"Tan Pants"},{"trait_type":"Suspenders","value":"White Suspenders"},{"trait_type":"Upper Body","value":"Indigo Turtleneck"},{"trait_type":"Sleeves","value":"Long Sleeves"},{"trait_type":"Hat","value":"Yellow / Blue Pointy Beanie"},{"trait_type":"Eyes","value":"White Nerd Glasses"},{"trait_type":"Mouth","value":"Toothpick"},{"trait_type":"Ears","value":"Bing Bong Stick"},{"trait_type":"Right Arm","value":"Swinging"},{"trait_type":"Left Arm","value":"Diamond Hand"},{"trait_type":"Background","value":"Blue"}],"description":"5,000 animated Invisible Friends hiding in the metaverse. A collection by Markus Magnusson & Random Character Collective.","image":"https://rcc.mypinata.cloud/ipfs/QmXmuSenZRnofhGMz2NyT3Yc4Zrty1TypuiBKDcaBsNw9V/1817.gif","name":"Invisible Friends #1817"})";
+  const std::string ipfs_token_uri_response = R"({
+      "jsonrpc":"2.0",
+      "id":1,
+      "result":"0x0000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000003a697066733a2f2f516d65536a53696e4870506e6d586d73704d6a776958794e367a533445397a63636172694752336a7863615774712f31383137000000000000"
+  })";
+  const std::string ipfs_metadata_response =
+      R"({"attributes":[{"trait_type":"Mouth","value":"Bored Cigarette"},{"trait_type":"Fur","value":"Gray"},{"trait_type":"Background","value":"Aquamarine"},{"trait_type":"Clothes","value":"Tuxedo Tee"},{"trait_type":"Hat","value":"Bayc Hat Black"},{"trait_type":"Eyes","value":"Coins"}],"image":"ipfs://QmQ82uDT3JyUMsoZuaFBYuEucF654CYE5ktPUrnA5d4VDH"})";
+
+  // Invalid inputs
+  // (1/3) Invalid contract address
+  TestGetERC721Metadata(
+      "", "0x1", mojom::kMainnetChainId, "",
+      mojom::ProviderError::kInvalidParams,
+      l10n_util::GetStringUTF8(IDS_WALLET_INVALID_PARAMETERS));
+
+  // (2/3) Invalid token ID
+  TestGetERC721Metadata(
+      "0x06012c8cf97BEaD5deAe237070F9587f8E7A266d", "", mojom::kMainnetChainId,
+      "", mojom::ProviderError::kInvalidParams,
+      l10n_util::GetStringUTF8(IDS_WALLET_INVALID_PARAMETERS));
+
+  // (3/3) Invalid chain ID
+  TestGetERC721Metadata(
+      "0x06012c8cf97BEaD5deAe237070F9587f8E7A266d", "0x1", "", "",
+      mojom::ProviderError::kInvalidParams,
+      l10n_util::GetStringUTF8(IDS_WALLET_INVALID_PARAMETERS));
+
+  // Valid inputs
+  // (1/3) HTTP URI
+  SetERC721MetadataInterceptor(
+      mojom::kMainnetChainId, interface_supported_response,
+      https_token_uri_response, https_metadata_response);
+  TestGetERC721Metadata("0x59468516a8259058bad1ca5f8f4bff190d30e066", "0x719",
+                        mojom::kMainnetChainId, https_metadata_response,
+                        mojom::ProviderError::kSuccess, "");
+
+  // (2/3) IPFS URI
+  SetERC721MetadataInterceptor(mojom::kLocalhostChainId,
+                               interface_supported_response,
+                               ipfs_token_uri_response, ipfs_metadata_response);
+  TestGetERC721Metadata("0xbc4ca0eda7647a8ab7c2061c2e118a18a936f13d", "0x719",
+                        mojom::kLocalhostChainId, ipfs_metadata_response,
+                        mojom::ProviderError::kSuccess, "");
+
+  // (3/3) Data URI
+  SetERC721MetadataInterceptor(mojom::kMainnetChainId,
+                               interface_supported_response,
+                               data_token_uri_response);
+  TestGetERC721Metadata(
+      "0xbc4ca0eda7647a8ab7c2061c2e118a18a936f13d", "0x719",
+      mojom::kMainnetChainId,
+      R"({"attributes":"","description":"Non fungible lion","image":"data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCA1MDAgNTAwIj48cGF0aCBkPSIiLz48L3N2Zz4=","name":"NFL"})",
+      mojom::ProviderError::kSuccess, "");
+
+  // Invalid supportsInterface response
+  // (1/4) Timeout
+  SetERC721MetadataInterceptor(
+      mojom::kMainnetChainId, interface_supported_response,
+      https_token_uri_response, "", net::HTTP_REQUEST_TIMEOUT);
+  TestGetERC721Metadata("0xbc4ca0eda7647a8ab7c2061c2e118a18a936f13d", "0x719",
+                        mojom::kMainnetChainId, "",
+                        mojom::ProviderError::kInternalError,
+                        l10n_util::GetStringUTF8(IDS_WALLET_INTERNAL_ERROR));
+
+  // (2/4) Invalid JSON
+  SetERC721MetadataInterceptor(mojom::kMainnetChainId, invalid_json);
+  TestGetERC721Metadata("0xbc4ca0eda7647a8ab7c2061c2e118a18a936f13d", "0x719",
+                        mojom::kMainnetChainId, "",
+                        mojom::ProviderError::kParsingError,
+                        l10n_util::GetStringUTF8(IDS_WALLET_PARSING_ERROR));
+
+  // (3/4) Request exceeds provider limit
+  SetERC721MetadataInterceptor(mojom::kMainnetChainId, exceeds_limit_json);
+  TestGetERC721Metadata("0xbc4ca0eda7647a8ab7c2061c2e118a18a936f13d", "0x719",
+                        mojom::kMainnetChainId, "",
+                        mojom::ProviderError::kLimitExceeded,
+                        "Request exceeds defined limit");
+
+  // (4/4) Interface not supported
+  SetERC721MetadataInterceptor(mojom::kMainnetChainId,
+                               interface_not_supported_response);
+  TestGetERC721Metadata(
+      "0xbc4ca0eda7647a8ab7c2061c2e118a18a936f13d", "0x719",
+      mojom::kMainnetChainId, "", mojom::ProviderError::kMethodNotSupported,
+      l10n_util::GetStringUTF8(IDS_WALLET_METHOD_NOT_SUPPORTED_ERROR));
+
+  // Invalid tokenURI response (6 total)
+  // (1/6) Timeout
+  SetERC721MetadataInterceptor(
+      mojom::kMainnetChainId, interface_supported_response,
+      https_token_uri_response, "", net::HTTP_OK, net::HTTP_REQUEST_TIMEOUT);
+  TestGetERC721Metadata("0x59468516a8259058bad1ca5f8f4bff190d30e066", "0x719",
+                        mojom::kMainnetChainId, "",
+                        mojom::ProviderError::kInternalError,
+                        l10n_util::GetStringUTF8(IDS_WALLET_INTERNAL_ERROR));
+
+  // (2/6) Invalid Provider JSON
+  SetERC721MetadataInterceptor(mojom::kMainnetChainId,
+                               interface_supported_response, invalid_json);
+  TestGetERC721Metadata("0x59468516a8259058bad1ca5f8f4bff190d30e066", "0x719",
+                        mojom::kMainnetChainId, "",
+                        mojom::ProviderError::kParsingError,
+                        l10n_util::GetStringUTF8(IDS_WALLET_PARSING_ERROR));
+
+  // (3/6) Invalid JSON in data URI
+  SetERC721MetadataInterceptor(mojom::kMainnetChainId,
+                               interface_supported_response,
+                               data_token_uri_response_invalid_json);
+  TestGetERC721Metadata("0x59468516a8259058bad1ca5f8f4bff190d30e066", "0x719",
+                        mojom::kMainnetChainId, "",
+                        mojom::ProviderError::kParsingError,
+                        l10n_util::GetStringUTF8(IDS_WALLET_PARSING_ERROR));
+
+  // (4/6) Empty string as JSON in data URI
+  SetERC721MetadataInterceptor(mojom::kMainnetChainId,
+                               interface_supported_response,
+                               data_token_uri_response_empty_string);
+  TestGetERC721Metadata("0x59468516a8259058bad1ca5f8f4bff190d30e066", "0x719",
+                        mojom::kMainnetChainId, "",
+                        mojom::ProviderError::kParsingError,
+                        l10n_util::GetStringUTF8(IDS_WALLET_PARSING_ERROR));
+
+  // (5/6) Request exceeds limit
+  SetERC721MetadataInterceptor(
+      mojom::kMainnetChainId, interface_supported_response, exceeds_limit_json);
+  TestGetERC721Metadata("0x59468516a8259058bad1ca5f8f4bff190d30e066", "0x719",
+                        mojom::kMainnetChainId, "",
+                        mojom::ProviderError::kLimitExceeded,
+                        "Request exceeds defined limit");
+
+  // (6/6) URI scheme is not suported (HTTP)
+  SetERC721MetadataInterceptor(mojom::kMainnetChainId,
+                               interface_supported_response,
+                               http_token_uri_response);
+  TestGetERC721Metadata(
+      "0x59468516a8259058bad1ca5f8f4bff190d30e066", "0x719",
+      mojom::kMainnetChainId, "", mojom::ProviderError::kMethodNotSupported,
+      l10n_util::GetStringUTF8(IDS_WALLET_METHOD_NOT_SUPPORTED_ERROR));
+
+  // Invalid metadata response (2 total)
+  // (1/2) Timeout
+  SetERC721MetadataInterceptor(
+      mojom::kMainnetChainId, interface_supported_response,
+      https_token_uri_response, https_metadata_response, net::HTTP_OK,
+      net::HTTP_OK, net::HTTP_REQUEST_TIMEOUT);
+  TestGetERC721Metadata("0x59468516a8259058bad1ca5f8f4bff190d30e066", "0x719",
+                        mojom::kMainnetChainId, "",
+                        mojom::ProviderError::kInternalError,
+                        l10n_util::GetStringUTF8(IDS_WALLET_INTERNAL_ERROR));
+
+  // (2/2) Invalid JSON
+  SetERC721MetadataInterceptor(mojom::kMainnetChainId,
+                               interface_supported_response,
+                               ipfs_token_uri_response, invalid_json);
+  TestGetERC721Metadata("0x59468516a8259058bad1ca5f8f4bff190d30e066", "0x719",
+                        mojom::kMainnetChainId, "",
+                        mojom::ProviderError::kParsingError,
+                        l10n_util::GetStringUTF8(IDS_WALLET_PARSING_ERROR));
+}
+
 TEST_F(JsonRpcServiceUnitTest, GetERC721Balance) {
   bool callback_called = false;
 
@@ -2519,13 +2800,14 @@ TEST_F(JsonRpcServiceUnitTest, GetERC1155TokenBalance) {
 TEST_F(JsonRpcServiceUnitTest, GetSupportsInterface) {
   // Successful, and does support the interface
   bool callback_called = false;
-  SetInterceptor(GetNetwork(mojom::kLocalhostChainId, mojom::CoinType::ETH),
+  SetInterceptor(GetNetwork(mojom::kMainnetChainId, mojom::CoinType::ETH),
                  "eth_call", "",
                  "{\"jsonrpc\":\"2.0\",\"id\":1,\"result\":"
                  "\"0x000000000000000000000000000000000000000000000000000000000"
                  "0000001\"}");
   json_rpc_service_->GetSupportsInterface(
       "0x06012c8cf97BEaD5deAe237070F9587f8E7A266d", "0x80ac58cd",
+      mojom::kMainnetChainId,
       base::BindOnce(&OnBoolResponse, &callback_called,
                      mojom::ProviderError::kSuccess, "", true));
   base::RunLoop().RunUntilIdle();
@@ -2533,13 +2815,14 @@ TEST_F(JsonRpcServiceUnitTest, GetSupportsInterface) {
 
   // Successful, but does not support the interface
   callback_called = false;
-  SetInterceptor(GetNetwork(mojom::kLocalhostChainId, mojom::CoinType::ETH),
+  SetInterceptor(GetNetwork(mojom::kMainnetChainId, mojom::CoinType::ETH),
                  "eth_call", "",
                  "{\"jsonrpc\":\"2.0\",\"id\":1,\"result\":"
                  "\"0x000000000000000000000000000000000000000000000000000000000"
                  "0000000\"}");
   json_rpc_service_->GetSupportsInterface(
       "0x06012c8cf97BEaD5deAe237070F9587f8E7A266d", "0x80ac58cd",
+      mojom::kMainnetChainId,
       base::BindOnce(&OnBoolResponse, &callback_called,
                      mojom::ProviderError::kSuccess, "", false));
   base::RunLoop().RunUntilIdle();
@@ -2548,11 +2831,12 @@ TEST_F(JsonRpcServiceUnitTest, GetSupportsInterface) {
   // Invalid result, should be in hex form
   // todo can remove this one if we have checks for parsing errors
   callback_called = false;
-  SetInterceptor(GetNetwork(mojom::kLocalhostChainId, mojom::CoinType::ETH),
+  SetInterceptor(GetNetwork(mojom::kMainnetChainId, mojom::CoinType::ETH),
                  "eth_call", "",
                  "{\"jsonrpc\":\"2.0\",\"id\":1,\"result\":\"0\"}");
   json_rpc_service_->GetSupportsInterface(
       "0x06012c8cf97BEaD5deAe237070F9587f8E7A266d", "0x80ac58cd",
+      mojom::kMainnetChainId,
       base::BindOnce(&OnBoolResponse, &callback_called,
                      mojom::ProviderError::kParsingError,
                      l10n_util::GetStringUTF8(IDS_WALLET_PARSING_ERROR),
@@ -2564,6 +2848,7 @@ TEST_F(JsonRpcServiceUnitTest, GetSupportsInterface) {
   SetHTTPRequestTimeoutInterceptor();
   json_rpc_service_->GetSupportsInterface(
       "0x06012c8cf97BEaD5deAe237070F9587f8E7A266d", "0x80ac58cd",
+      mojom::kMainnetChainId,
       base::BindOnce(&OnBoolResponse, &callback_called,
                      mojom::ProviderError::kInternalError,
                      l10n_util::GetStringUTF8(IDS_WALLET_INTERNAL_ERROR),
@@ -2575,6 +2860,7 @@ TEST_F(JsonRpcServiceUnitTest, GetSupportsInterface) {
   SetInvalidJsonInterceptor();
   json_rpc_service_->GetSupportsInterface(
       "0x06012c8cf97BEaD5deAe237070F9587f8E7A266d", "0x80ac58cd",
+      mojom::kMainnetChainId,
       base::BindOnce(&OnBoolResponse, &callback_called,
                      mojom::ProviderError::kParsingError,
                      l10n_util::GetStringUTF8(IDS_WALLET_PARSING_ERROR),
@@ -2586,6 +2872,7 @@ TEST_F(JsonRpcServiceUnitTest, GetSupportsInterface) {
   SetLimitExceededJsonErrorResponse();
   json_rpc_service_->GetSupportsInterface(
       "0x06012c8cf97BEaD5deAe237070F9587f8E7A266d", "0x80ac58cd",
+      mojom::kMainnetChainId,
       base::BindOnce(&OnBoolResponse, &callback_called,
                      mojom::ProviderError::kLimitExceeded,
                      "Request exceeds defined limit", false));

--- a/components/brave_wallet/common/brave_wallet.mojom
+++ b/components/brave_wallet/common/brave_wallet.mojom
@@ -742,6 +742,9 @@ interface JsonRpcService {
   GetERC20TokenAllowance(string contract,
                          string owner_address, string spender_address) => (string allowance, ProviderError error, string error_message);
 
+  // Obtains the metadata JSON for a token ID of an ERC721 contract
+  GetERC721Metadata(string contract, string token_id, string chain_id) => (string response, ProviderError error, string error_message);
+
   // ENS lookups
   EnsGetEthAddr(string domain) => (string address, ProviderError error, string error_message);
 

--- a/components/ipfs/ipfs_utils.h
+++ b/components/ipfs/ipfs_utils.h
@@ -63,6 +63,7 @@ bool IsAPIGateway(const GURL& url, version_info::Channel channel);
 bool IsIpfsResolveMethodDisabled(PrefService* prefs);
 std::string GetRegistryDomainFromIPNS(const GURL& url);
 bool IsValidCIDOrDomain(const std::string& value);
+
 }  // namespace ipfs
 
 #endif  // BRAVE_COMPONENTS_IPFS_IPFS_UTILS_H_

--- a/components/resources/wallet_strings.grdp
+++ b/components/resources/wallet_strings.grdp
@@ -9,6 +9,7 @@
   <message name="IDS_WALLET_EXPECTED_SINGLE_PARAMETER" desc="The text of the response for wallet_addEthereumChain call with empty parameters">Expected single, object parameter.</message>
   <message name="IDS_WALLET_CHAIN_EXISTS" desc="The text of the response for wallet_addEthereumChain call with existing chain id">This Chain ID is currently used</message>
   <message name="IDS_WALLET_INTERNAL_ERROR" desc="The text of the response for wallet_addEthereumChain call with internal error">An internal error has occurred</message>
+  <message name="IDS_WALLET_METHOD_NOT_SUPPORTED_ERROR" desc="The text of response when an RPC method is not supported">This RPC method is not supported.</message>
   <message name="IDS_WALLET_PARSING_ERROR" desc="There was a parsing error">A response parsing error has occurred</message>
   <message name="IDS_WALLET_INVALID_MNEMONIC_ERROR" desc="The text for invalid mnemonic being imported error">The mnemonic being imported is not valid for Brave Wallet</message>
   <message name="IDS_WALLET_ALREADY_IN_PROGRESS_ERROR" desc="The text of the response for wallet_(add|switch)EthereumChain call for existing request">A request is already in progress</message>


### PR DESCRIPTION
<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/20604

Adds a GetERC721Metadata function to the JsonRpcInterface that allows frontends to get the "metadata" for a given token ID, ERC721 contract address, and chain ID by calling the token contract's `tokenURI` function using `eth_call`, and parsing / following the result to get the metadata.

This adds support for ERC721s that implement the optional metadata extension (see [spec](https://eips.ethereum.org/EIPS/eip-721)), and whose tokenURIs have IPFS, HTTPS, or data schemes.  We can support other formats in the future.

There can be up to three requests made by GetERC721Metadata - one eth_call to the supportsInterface function, one eth_call to tokenURI function, and one HTTP GET to the tokenURI to get the metadata JSON (IPFS and HTTPS only).

The GetERC721Metadata interface will return the JSON metadata for the token, e.g.
```
{"image":"ipfs://QmPbxeGcXhYQQNgsC6a36dDyYUcHgMLnGKnF8pVFmGsvqi","attributes":[{"trait_type":"Mouth","value":"Grin"},{"trait_type":"Clothes","value":"Vietnam Jacket"},{"trait_type":"Background","value":"Orange"},{"trait_type":"Eyes","value":"Blue Beams"},{"trait_type":"Fur","value":"Robot"}]}
```

## Submitter Checklist:

- [ ] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

