### PR TITLE
Fixed SuggestPermissionIfWidevineDetected failure on Windows

### DIFF
--- a/browser/widevine/widevine_permission_request_browsertest.cc
+++ b/browser/widevine/widevine_permission_request_browsertest.cc
@@ -218,6 +218,7 @@ class ScriptTriggerWidevinePermissionRequestBrowserTest
   }
 
   void SetUpDefaultCommandLine(base::CommandLine* command_line) override {
+    CertVerifierBrowserTest::SetUpDefaultCommandLine(command_line);
     command_line->AppendSwitchASCII(
         "enable-blink-features",
         "EncryptedMediaEncryptionSchemeQuery");


### PR DESCRIPTION
fix https://github.com/brave/brave-browser/issues/21702

In browser test, FirstRun dialog should be disabled by default.

InProcessBrowserTest::SetUpDefaultCommandLine() does it by calling
test_launcher_utils::PrepareBrowserCommandLineForTests(command_line).
However, ScriptTriggerWidevinePermissionRequestBrowserTest subclassed
InProcessBrowserTest but doesn't call base class' SetUpDefaultCommandLine().
Because of this, FirstRun dialog was launched.
<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves 

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

```
npm run test brave_browser_tests Release -- --filter=*SuggestPermissionIfWidevineDetected*
```