### PR TITLE
Introduced Windows specific FirstRun dialog

### DIFF
--- a/app/brave_generated_resources.grd
+++ b/app/brave_generated_resources.grd
@@ -1656,6 +1656,20 @@ Are you sure you want to do this?
       <message name="IDS_FIRSTRUN_DLG_COMPLETE_INSTALLATION_LABEL_BRAVE" desc="Label at top of Dialog noting what's going to happen">
         To ensure the best privacy online, consider setting Brave as the default browser on your computer. With Brave as default, any web link you click will open with Brave's privacy protections.
       </message>
+      <if expr="is_win">
+        <message name="IDS_FIRSTRUN_DLG_WIN_HEADER_TEXT" desc="Text for FirstRun dialog header">
+          Ready for the best privacy online?
+        </message>
+        <message name="IDS_FIRSTRUN_DLG_WIN_CONTENTS_TEXT" desc="Text for FirstRun dialog contents">
+          Set Brave as your default browser to get Brave's privacy protections on every web page you open.
+        </message>
+        <message name="IDS_FIRSTRUN_DLG_WIN_OK_BUTTON_LABEL" desc="Text for FirstRun dialog ok button">
+          Set Brave as default
+        </message>
+        <message name="IDS_FIRSTRUN_DLG_WIN_CANCEL_BUTTON_LABEL" desc="Text for FirstRun dialog cancel button">
+          Maybe later
+        </message>
+      </if>
       <message name="IDS_SETTINGS_WALLET_NETWORKS_ITEM" desc="The label for opening wallet networks list">
         Networks
       </message>

--- a/app/brave_generated_resources.grd
+++ b/app/brave_generated_resources.grd
@@ -1656,9 +1656,6 @@ Are you sure you want to do this?
       <message name="IDS_FIRSTRUN_DLG_COMPLETE_INSTALLATION_LABEL_BRAVE" desc="Label at top of Dialog noting what's going to happen">
         To ensure the best privacy online, consider setting Brave as the default browser on your computer. With Brave as default, any web link you click will open with Brave's privacy protections.
       </message>
-      <message name="IDS_FIRSTRUN_DIALOG_WINDOW_TITLE_BRAVE" desc="Window title of First Run dialog, displayed in title bar">
-        Welcome to Brave
-      </message>
       <message name="IDS_SETTINGS_WALLET_NETWORKS_ITEM" desc="The label for opening wallet networks list">
         Networks
       </message>

--- a/browser/ui/BUILD.gn
+++ b/browser/ui/BUILD.gn
@@ -182,12 +182,12 @@ source_set("ui") {
       "views/web_discovery_dialog_view.h",
     ]
 
-    # Enable FirstRun dialog on Win.
+    # Use different FirstRun dialog UI on Win.
     # Upstream only includes it on mac/Linux.
     if (is_win) {
       sources += [
-        "//chrome/browser/ui/views/first_run_dialog.cc",
-        "//chrome/browser/ui/views/first_run_dialog.h",
+        "views/first_run_dialog_win.cc",
+        "views/first_run_dialog_win.h",
       ]
     }
 

--- a/browser/ui/views/first_run_dialog_win.cc
+++ b/browser/ui/views/first_run_dialog_win.cc
@@ -1,0 +1,16 @@
+/* Copyright (c) 2022 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "brave/browser/ui/views/first_run_dialog_win.h"
+
+#include "chrome/browser/first_run/first_run_dialog.h"
+
+namespace first_run {
+
+void ShowFirstRunDialog(Profile* profile) {
+  // TODO(simonhong): Launch FirstRunDialogWin.
+}
+
+}  // namespace first_run

--- a/browser/ui/views/first_run_dialog_win.cc
+++ b/browser/ui/views/first_run_dialog_win.cc
@@ -5,12 +5,107 @@
 
 #include "brave/browser/ui/views/first_run_dialog_win.h"
 
-#include "chrome/browser/first_run/first_run_dialog.h"
+#include <memory>
+#include <utility>
+
+#include "base/bind.h"
+#include "base/memory/scoped_refptr.h"
+#include "base/run_loop.h"
+#include "brave/browser/brave_shell_integration.h"
+#include "brave/grit/brave_generated_resources.h"
+#include "chrome/browser/first_run/first_run.h"
+#include "ui/base/l10n/l10n_util.h"
+#include "ui/base/metadata/metadata_impl_macros.h"
+#include "ui/gfx/font.h"
+#include "ui/gfx/geometry/insets.h"
+#include "ui/views/controls/label.h"
+#include "ui/views/layout/box_layout.h"
+#include "ui/views/window/dialog_delegate.h"
 
 namespace first_run {
 
 void ShowFirstRunDialog(Profile* profile) {
-  // TODO(simonhong): Launch FirstRunDialogWin.
+  base::RunLoop run_loop(base::RunLoop::Type::kNestableTasksAllowed);
+  FirstRunDialogWin::Show(run_loop.QuitClosure());
+  run_loop.Run();
 }
 
 }  // namespace first_run
+
+// static
+void FirstRunDialogWin::Show(base::RepeatingClosure quit_runloop) {
+  FirstRunDialogWin* dialog = new FirstRunDialogWin(std::move(quit_runloop));
+  views::DialogDelegate::CreateDialogWidget(dialog, NULL, NULL)->Show();
+}
+
+FirstRunDialogWin::FirstRunDialogWin(base::RepeatingClosure quit_runloop)
+    : quit_runloop_(quit_runloop) {
+  set_should_ignore_snapping(true);
+  SetButtonLabel(
+      ui::DIALOG_BUTTON_OK,
+      l10n_util::GetStringUTF16(IDS_FIRSTRUN_DLG_WIN_OK_BUTTON_LABEL));
+  SetButtonLabel(
+      ui::DIALOG_BUTTON_CANCEL,
+      l10n_util::GetStringUTF16(IDS_FIRSTRUN_DLG_WIN_CANCEL_BUTTON_LABEL));
+  constexpr int kChildSpacing = 16;
+  constexpr int kPadding = 24;
+  constexpr int kTopPadding = 20;
+  constexpr int kBottomPadding = 55;
+
+  SetLayoutManager(std::make_unique<views::BoxLayout>(
+      views::BoxLayout::Orientation::kVertical,
+      gfx::Insets(kTopPadding, kPadding, kBottomPadding, kPadding),
+      kChildSpacing));
+
+  constexpr int kHeaderFontSize = 16;
+  int size_diff =
+      kHeaderFontSize - views::Label::GetDefaultFontList().GetFontSize();
+  views::Label::CustomFont header_font = {
+      views::Label::GetDefaultFontList()
+          .DeriveWithSizeDelta(size_diff)
+          .DeriveWithWeight(gfx::Font::Weight::SEMIBOLD)};
+  auto* header_label = AddChildView(std::make_unique<views::Label>(
+      l10n_util::GetStringUTF16(IDS_FIRSTRUN_DLG_WIN_HEADER_TEXT),
+      header_font));
+  header_label->SetHorizontalAlignment(gfx::ALIGN_LEFT);
+
+  constexpr int kContentFontSize = 15;
+  size_diff =
+      kContentFontSize - views::Label::GetDefaultFontList().GetFontSize();
+  views::Label::CustomFont contents_font = {
+      views::Label::GetDefaultFontList()
+          .DeriveWithSizeDelta(size_diff)
+          .DeriveWithWeight(gfx::Font::Weight::NORMAL)};
+  auto* contents_label = AddChildView(std::make_unique<views::Label>(
+      l10n_util::GetStringUTF16(IDS_FIRSTRUN_DLG_WIN_CONTENTS_TEXT),
+      contents_font));
+  contents_label->SetHorizontalAlignment(gfx::ALIGN_LEFT);
+  contents_label->SetMultiLine(true);
+  constexpr int kMaxWidth = 350;
+  contents_label->SetMaximumWidth(kMaxWidth);
+}
+
+FirstRunDialogWin::~FirstRunDialogWin() = default;
+
+void FirstRunDialogWin::Done() {
+  CHECK(!quit_runloop_.is_null());
+  quit_runloop_.Run();
+}
+
+bool FirstRunDialogWin::Accept() {
+  GetWidget()->Hide();
+
+  base::MakeRefCounted<shell_integration::BraveDefaultBrowserWorker>()
+      ->StartSetAsDefault(base::NullCallback());
+
+  Done();
+  return true;
+}
+
+void FirstRunDialogWin::WindowClosing() {
+  first_run::SetShouldShowWelcomePage();
+  Done();
+}
+
+BEGIN_METADATA(FirstRunDialogWin, views::DialogDelegateView)
+END_METADATA

--- a/browser/ui/views/first_run_dialog_win.h
+++ b/browser/ui/views/first_run_dialog_win.h
@@ -1,0 +1,11 @@
+/* Copyright (c) 2022 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_BROWSER_UI_VIEWS_FIRST_RUN_DIALOG_WIN_H_
+#define BRAVE_BROWSER_UI_VIEWS_FIRST_RUN_DIALOG_WIN_H_
+
+// TODO(simonhong): Implement FirstRunDialogWin.
+
+#endif  // BRAVE_BROWSER_UI_VIEWS_FIRST_RUN_DIALOG_WIN_H_

--- a/browser/ui/views/first_run_dialog_win.h
+++ b/browser/ui/views/first_run_dialog_win.h
@@ -6,6 +6,33 @@
 #ifndef BRAVE_BROWSER_UI_VIEWS_FIRST_RUN_DIALOG_WIN_H_
 #define BRAVE_BROWSER_UI_VIEWS_FIRST_RUN_DIALOG_WIN_H_
 
-// TODO(simonhong): Implement FirstRunDialogWin.
+#include "base/callback.h"
+#include "ui/base/metadata/metadata_header_macros.h"
+#include "ui/views/window/dialog_delegate.h"
+
+class FirstRunDialogWin : public views::DialogDelegateView {
+ public:
+  METADATA_HEADER(FirstRunDialogWin);
+
+  FirstRunDialogWin(const FirstRunDialogWin&) = delete;
+  FirstRunDialogWin& operator=(const FirstRunDialogWin&) = delete;
+
+  static void Show(base::RepeatingClosure quit_runloop);
+
+ private:
+  explicit FirstRunDialogWin(base::RepeatingClosure quit_runloop);
+  ~FirstRunDialogWin() override;
+
+  // This terminates the nested message-loop.
+  void Done();
+
+  // views::DialogDelegate overrides:
+  bool Accept() override;
+
+  // views::WidgetDelegate overrides:
+  void WindowClosing() override;
+
+  base::RepeatingClosure quit_runloop_;
+};
 
 #endif  // BRAVE_BROWSER_UI_VIEWS_FIRST_RUN_DIALOG_WIN_H_

--- a/chromium_src/chrome/browser/first_run/first_run_dialog.h
+++ b/chromium_src/chrome/browser/first_run/first_run_dialog.h
@@ -19,7 +19,6 @@ namespace first_run {
 // Enable first run dialog on Win also.
 // Upstream only uses it for macOS/Linux.
 void ShowFirstRunDialog(Profile* profile);
-void ShowFirstRunDialogViews(Profile* profile);
 
 }  // namespace first_run
 

--- a/chromium_src/chrome/browser/ui/views/first_run_dialog.cc
+++ b/chromium_src/chrome/browser/ui/views/first_run_dialog.cc
@@ -8,7 +8,6 @@
 #include <string>
 
 #include "base/bind.h"
-#include "base/memory/scoped_refptr.h"
 #include "base/run_loop.h"
 #include "brave/grit/brave_generated_resources.h"
 #include "build/build_config.h"
@@ -30,10 +29,6 @@
 #include "ui/views/layout/box_layout.h"
 #include "ui/views/widget/widget.h"
 #include "ui/views/window/dialog_delegate.h"
-
-#if BUILDFLAG(IS_WIN)
-#include "brave/browser/brave_shell_integration.h"
-#endif
 
 namespace first_run {
 
@@ -77,7 +72,7 @@ FirstRunDialog::FirstRunDialog(base::RepeatingClosure learn_more_callback,
   if (report_crashes_)
     report_crashes_->GetChecked();
 
-  SetTitle(l10n_util::GetStringUTF16(IDS_FIRSTRUN_DIALOG_WINDOW_TITLE_BRAVE));
+  SetTitle(l10n_util::GetStringUTF16(IDS_FIRST_RUN_DIALOG_WINDOW_TITLE));
   SetButtons(ui::DIALOG_BUTTON_OK);
   SetExtraView(
       std::make_unique<views::Link>(l10n_util::GetStringUTF16(IDS_LEARN_MORE)))
@@ -122,17 +117,8 @@ void FirstRunDialog::Done() {
 bool FirstRunDialog::Accept() {
   GetWidget()->Hide();
 
-  if (make_default_->GetChecked()) {
-    // shell_integration::SetAsDefaultBrowser() doesn't work on Windows 8+.
-    // Upstream will use DefaultBrowserWorker when it's available on all OSs.
-    // See the comments of shell_integration::SetAsDefaultBrowser().
-#if BUILDFLAG(IS_WIN)
-    base::MakeRefCounted<shell_integration::BraveDefaultBrowserWorker>()
-        ->StartSetAsDefault(base::NullCallback());
-#else
+  if (make_default_->GetChecked())
     shell_integration::SetAsDefaultBrowser();
-#endif
-  }
 
   Done();
   return true;


### PR DESCRIPTION
Use our own FirstRun dialog on Windows.
No functional change.

fix https://github.com/brave/brave-browser/issues/21694

![Screenshot 2022-03-18 121657](https://user-images.githubusercontent.com/6786187/158931105-bf6518bd-35e5-4f6f-bc87-87e213876986.png)
![Screenshot 2022-03-18 121612](https://user-images.githubusercontent.com/6786187/158931117-3b2fcb2a-f320-4639-bb2d-0f4eab4f7aa4.png)


<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves 

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

