### PR TITLE
Revert DEP Omaha to rev. a199d4

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -6,7 +6,7 @@ deps = {
   "vendor/requests": "https://github.com/kennethreitz/requests@e4d59bedfd3c7f4f254f4f5d036587bcd8152458",
   "vendor/boto": "https://github.com/boto/boto@f7574aa6cc2c819430c1f05e9a1a1a666ef8169b",
   "vendor/python-patch": "https://github.com/brave/python-patch@d8880110be6554686bc08261766538c2926d4e82",
-  "vendor/omaha": "https://github.com/brave/omaha.git@a9e19fc0a5cb0d43893e4e419891a80fc2ea083d",
+  "vendor/omaha": "https://github.com/brave/omaha.git@a199d4a386798c4ecc1a29f1a80f58a1da4755ff",
   "vendor/sparkle": "https://github.com/brave/Sparkle.git@57fb153bea4c71ed10102d50e68ead89ca483b49",
   "vendor/bat-native-rapidjson": "https://github.com/brave-intl/bat-native-rapidjson.git@60b7e4574cebdd79f441bdd6f0f3ab469fd7e04c",
   "vendor/bip39wally-core-native": "https://github.com/brave-intl/bat-native-bip39wally-core.git@0d3a8713a2b388d2156fe49a70ef3f7cdb44b190",


### PR DESCRIPTION
There are too many intermittent build failures related to this DEP in CI.

```
06:59:02  go: cannot find GOROOT directory: C:\go
06:59:02  scons: *** [scons-out\opt-win\obj\standalone\UNOFFICIAL_BraveBrowserStandaloneUntaggedNightlySetup_99_1_38_52.exe] Error 2
06:59:02  scons: building terminated because of errors.
06:59:02  Error in hammer.bat:96.
06:59:02  Traceback (most recent call last):
06:59:02    File "../../brave/vendor/omaha/build_omaha.py", line 206, in <module>
06:59:02      sys.exit(main())
06:59:02    File "../../brave/vendor/omaha/build_omaha.py", line 193, in main
06:59:02      build(omaha_dir, installer_metadata_dir, False)
06:59:02    File "../../brave/vendor/omaha/build_omaha.py", line 37, in build
06:59:02      sp.check_call(command, stderr=sp.STDOUT)
06:59:02    File "C:\ws\src\brave\vendor\depot_tools\bootstrap-2@3_8_10_chromium_23_bin\python3\bin\lib\subprocess.py", line 364, in check_call
06:59:02      raise CalledProcessError(retcode, cmd)
06:59:02 
 subprocess.CalledProcessError: Command '['hammer.bat', 'MODE=opt-win', '--all', '--standalone_installers_dir=C:/ws/src/out/Static\\..\\..\\brave\\vendor\\omaha\\omaha\\scons-out\\opt-win\\Brave_Installers\\standalone', '-j32', '--authenticode_file=C:\\jenkins\\digicert.pfx', '--sha1_authenticode_file=C:\\jenkins\\digicert.pfx', '--sha2_authenticode_file=C:\\jenkins\\digicert.pfx', '--authenticode_password=****', '--sha1_authenticode_password=****', '--sha2_authenticode_password=****']' returned non-zero exit status 2.
```