### PR TITLE
Picked brave vpn button colors based on toolbar color

### DIFF
--- a/browser/themes/sources.gni
+++ b/browser/themes/sources.gni
@@ -28,8 +28,12 @@ if (!is_android) {
     "//brave/app:brave_generated_resources_grit",
     "//brave/common:pref_names",
     "//brave/common:switches",
+    "//brave/components/brave_vpn/buildflags",
+    "//brave/components/sidebar/buildflags",
     "//chrome/common",
-    "//components/prefs",
     "//components/pref_registry",
+    "//components/prefs",
+    "//ui/gfx",
+    "//ui/native_theme",
   ]
 }


### PR DESCRIPTION
fix https://github.com/brave/brave-browser/issues/21242

VPN Button's colors are selected by choosing most contrasted colors
based on current toolbar color.

<img width="79" alt="Screen Shot 2022-03-20 at 10 08 04 PM" src="https://user-images.githubusercontent.com/6786187/159163818-c53ee6af-fc84-43a7-b7b4-9da9d6ff55b4.png"> <img width="81" alt="Screen Shot 2022-03-20 at 10 08 12 PM" src="https://user-images.githubusercontent.com/6786187/159163820-2df02b30-9ca1-4a90-ba3b-169d56ea2f8e.png"> <img width="87" alt="Screen Shot 2022-03-20 at 10 08 45 PM" src="https://user-images.githubusercontent.com/6786187/159163824-b83f7c6c-e733-469e-94c6-1ef85c11be73.png">
<img width="80" alt="Screen Shot 2022-03-20 at 10 08 17 PM" src="https://user-images.githubusercontent.com/6786187/159163821-2010b7cc-5a9a-4746-b616-39495aee4ba5.png"> <img width="83" alt="Screen Shot 2022-03-20 at 10 08 32 PM" src="https://user-images.githubusercontent.com/6786187/159163823-e2c291b9-82f1-4b06-9033-c5624366c6b9.png"> <img width="83" alt="Screen Shot 2022-03-20 at 10 08 24 PM" src="https://user-images.githubusercontent.com/6786187/159163822-3f7bdcd2-add9-4fda-842a-055a25a2d80a.png">


<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves 

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

1. Enable vpn from brave://flags and re-launch
2. Pick any custom theme at brave://settings/manageProfile and check vpn button's colors