### PR TITLE
Added sanitizer step for api helper

### DIFF
--- a/browser/brave_wallet/brave_wallet_provider_impl_unittest.cc
+++ b/browser/brave_wallet/brave_wallet_provider_impl_unittest.cc
@@ -55,6 +55,7 @@
 #include "content/public/test/browser_task_environment.h"
 #include "content/public/test/test_web_contents_factory.h"
 #include "content/test/test_web_contents.h"
+#include "services/data_decoder/public/cpp/test_support/in_process_data_decoder.h"
 #include "services/network/public/cpp/weak_wrapper_shared_url_loader_factory.h"
 #include "services/network/test/test_url_loader_factory.h"
 #include "testing/gtest/include/gtest/gtest.h"
@@ -761,6 +762,7 @@ class BraveWalletProviderImplUnitTest : public testing::Test {
   std::unique_ptr<content::TestWebContents> web_contents_;
   std::unique_ptr<BraveWalletProviderImpl> provider_;
   network::TestURLLoaderFactory url_loader_factory_;
+  data_decoder::test::InProcessDataDecoder in_process_data_decoder_;
   scoped_refptr<network::SharedURLLoaderFactory> shared_url_loader_factory_;
   base::ScopedTempDir temp_dir_;
   TestingProfile profile_;

--- a/browser/brave_wallet/eth_nonce_tracker_unittest.cc
+++ b/browser/brave_wallet/eth_nonce_tracker_unittest.cc
@@ -26,6 +26,7 @@
 #include "components/prefs/pref_service.h"
 #include "components/sync_preferences/testing_pref_service_syncable.h"
 #include "content/public/test/browser_task_environment.h"
+#include "services/data_decoder/public/cpp/test_support/in_process_data_decoder.h"
 #include "services/network/public/cpp/weak_wrapper_shared_url_loader_factory.h"
 #include "services/network/test/test_url_loader_factory.h"
 #include "testing/gtest/include/gtest/gtest.h"
@@ -81,6 +82,7 @@ class EthNonceTrackerUnitTest : public testing::Test {
   scoped_refptr<network::SharedURLLoaderFactory> shared_url_loader_factory_;
   content::BrowserTaskEnvironment task_environment_;
   std::unique_ptr<TestingProfile> profile_;
+  data_decoder::test::InProcessDataDecoder in_process_data_decoder_;
 };
 
 TEST_F(EthNonceTrackerUnitTest, GetNonce) {

--- a/browser/brave_wallet/eth_pending_tx_tracker_unittest.cc
+++ b/browser/brave_wallet/eth_pending_tx_tracker_unittest.cc
@@ -25,6 +25,7 @@
 #include "components/prefs/pref_service.h"
 #include "components/sync_preferences/testing_pref_service_syncable.h"
 #include "content/public/test/browser_task_environment.h"
+#include "services/data_decoder/public/cpp/test_support/in_process_data_decoder.h"
 #include "services/network/public/cpp/weak_wrapper_shared_url_loader_factory.h"
 #include "services/network/test/test_url_loader_factory.h"
 #include "testing/gtest/include/gtest/gtest.h"
@@ -65,6 +66,7 @@ class EthPendingTxTrackerUnitTest : public testing::Test {
   scoped_refptr<network::SharedURLLoaderFactory> shared_url_loader_factory_;
   content::BrowserTaskEnvironment task_environment_;
   std::unique_ptr<TestingProfile> profile_;
+  data_decoder::test::InProcessDataDecoder in_process_data_decoder_;
 };
 
 TEST_F(EthPendingTxTrackerUnitTest, IsNonceTaken) {

--- a/browser/ui/webui/settings/brave_wallet_handler_unittest.cc
+++ b/browser/ui/webui/settings/brave_wallet_handler_unittest.cc
@@ -34,6 +34,7 @@
 #include "content/public/browser/web_contents.h"
 #include "content/public/test/browser_task_environment.h"
 #include "content/public/test/test_web_ui.h"
+#include "services/data_decoder/public/cpp/test_support/in_process_data_decoder.h"
 #include "services/network/public/cpp/weak_wrapper_shared_url_loader_factory.h"
 #include "services/network/test/test_url_loader_factory.h"
 #include "testing/gtest/include/gtest/gtest.h"
@@ -130,6 +131,7 @@ class TestBraveWalletHandler : public BraveWalletHandler {
   std::unique_ptr<content::WebContents> web_contents_;
   network::TestURLLoaderFactory url_loader_factory_;
   scoped_refptr<network::SharedURLLoaderFactory> shared_url_loader_factory_;
+  data_decoder::test::InProcessDataDecoder in_process_data_decoder_;
   content::TestWebUI test_web_ui_;
 };
 

--- a/chromium_src/services/data_decoder/public/cpp/data_decoder.cc
+++ b/chromium_src/services/data_decoder/public/cpp/data_decoder.cc
@@ -1,0 +1,12 @@
+/* Copyright (c) 2022 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "base/json/json_reader.h"
+
+#include "src/services/data_decoder/public/cpp/data_decoder.h"
+
+#define JSON_PARSE_RFC JSON_PARSE_RFC | base::JSON_ALLOW_TRAILING_COMMAS
+#include "src/services/data_decoder/public/cpp/data_decoder.cc"
+#undef JSON_PARSE_RFC

--- a/components/api_request_helper/BUILD.gn
+++ b/components/api_request_helper/BUILD.gn
@@ -3,6 +3,9 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this file,
 # You can obtain one at http://mozilla.org/MPL/2.0/.
 
+import("//brave/build/config.gni")
+import("//testing/test.gni")
+
 static_library("api_request_helper") {
   sources = [
     "api_request_helper.cc",
@@ -12,7 +15,25 @@ static_library("api_request_helper") {
   deps = [
     "//base",
     "//net",
+    "//services/data_decoder/public/cpp",
     "//services/network/public/cpp",
     "//url",
+  ]
+}
+
+source_set("api_request_helper_unit_tests") {
+  testonly = true
+  sources =
+      [ "//brave/components/api_request_helper/api_request_helper_unittest.cc" ]
+  deps = [
+    ":api_request_helper",
+    "//base/test:test_support",
+    "//net/traffic_annotation:test_support",
+    "//net/traffic_annotation:traffic_annotation",
+    "//services/data_decoder/public/cpp",
+    "//services/data_decoder/public/cpp:test_support",
+    "//services/network:test_support",
+    "//services/network/public/cpp",
+    "//testing/gtest:gtest",
   ]
 }

--- a/components/api_request_helper/DEPS
+++ b/components/api_request_helper/DEPS
@@ -2,5 +2,6 @@ include_rules = [
   "+net",
   "+services/data_decoder/public",
   "+services/network/public/cpp",
-  "+services/network/public/mojom"
+  "+services/network/public/mojom",
+  "+third_party/abseil-cpp/absl"
 ]

--- a/components/api_request_helper/DEPS
+++ b/components/api_request_helper/DEPS
@@ -1,5 +1,6 @@
 include_rules = [
   "+net",
+  "+services/data_decoder/public",
   "+services/network/public/cpp",
-  "+services/network/public/mojom",
+  "+services/network/public/mojom"
 ]

--- a/components/api_request_helper/api_request_helper.cc
+++ b/components/api_request_helper/api_request_helper.cc
@@ -23,13 +23,16 @@ void OnSanitize(const int http_code,
                 APIRequestHelper::ResultCallback result_callback,
                 data_decoder::JsonSanitizer::Result result) {
   std::string response_body;
-  if (result.value.has_value())
-    response_body = result.value.value();
   if (result.error) {
     VLOG(1) << "Response validation error:" << *result.error;
     std::move(result_callback).Run(http_code, "", headers);
     return;
   }
+
+  if (result.value.has_value()) {
+    response_body = result.value.value();
+  }
+
   std::move(result_callback).Run(http_code, response_body, headers);
 }
 

--- a/components/api_request_helper/api_request_helper.cc
+++ b/components/api_request_helper/api_request_helper.cc
@@ -129,9 +129,11 @@ void APIRequestHelper::OnResponse(
   auto raw_body = *response_body;
   if (conversion_callback) {
     auto converted_body = std::move(conversion_callback).Run(raw_body);
-    if (converted_body) {
-      raw_body = converted_body.value();
+    if (!converted_body) {
+      std::move(callback).Run(422, raw_body, headers);
+      return;
     }
+    raw_body = converted_body.value();
   }
 
   data_decoder::JsonSanitizer::Sanitize(

--- a/components/api_request_helper/api_request_helper.cc
+++ b/components/api_request_helper/api_request_helper.cc
@@ -125,8 +125,7 @@ void APIRequestHelper::OnResponse(
     std::move(callback).Run(response_code, "", headers);
     return;
   }
-
-  auto raw_body = *response_body;
+  auto& raw_body = *response_body;
   if (conversion_callback) {
     auto converted_body = std::move(conversion_callback).Run(raw_body);
     if (!converted_body) {

--- a/components/api_request_helper/api_request_helper.h
+++ b/components/api_request_helper/api_request_helper.h
@@ -14,15 +14,13 @@
 #include "base/callback_helpers.h"
 #include "base/containers/flat_map.h"
 #include "net/traffic_annotation/network_traffic_annotation.h"
-#include "services/data_decoder/public/cpp/json_sanitizer.h"
+#include "third_party/abseil-cpp/absl/types/optional.h"
 #include "url/gurl.h"
 
 namespace network {
 class SharedURLLoaderFactory;
 class SimpleURLLoader;
 }  // namespace network
-
-namespace data_decoder {}
 
 namespace api_request_helper {
 
@@ -68,10 +66,6 @@ class APIRequestHelper {
                   ResultCallback callback,
                   ResponseConversionCallback conversion_callback,
                   const std::unique_ptr<std::string> response_body);
-  void OnSanitize(const int http_code,
-                  const base::flat_map<std::string, std::string>& headers,
-                  ResultCallback result_callback,
-                  data_decoder::JsonSanitizer::Result result);
 
   net::NetworkTrafficAnnotationTag annotation_tag_;
   SimpleURLLoaderList url_loaders_;

--- a/components/api_request_helper/api_request_helper.h
+++ b/components/api_request_helper/api_request_helper.h
@@ -11,14 +11,18 @@
 #include <string>
 
 #include "base/callback.h"
+#include "base/callback_helpers.h"
 #include "base/containers/flat_map.h"
 #include "net/traffic_annotation/network_traffic_annotation.h"
+#include "services/data_decoder/public/cpp/json_sanitizer.h"
 #include "url/gurl.h"
 
 namespace network {
 class SharedURLLoaderFactory;
 class SimpleURLLoader;
 }  // namespace network
+
+namespace data_decoder {}
 
 namespace api_request_helper {
 
@@ -34,14 +38,26 @@ class APIRequestHelper {
       base::OnceCallback<void(const int,
                               const std::string&,
                               const base::flat_map<std::string, std::string>&)>;
-  void Request(const std::string& method,
-               const GURL& url,
-               const std::string& payload,
-               const std::string& payload_content_type,
-               bool auto_retry_on_network_change,
-               ResultCallback callback,
-               const base::flat_map<std::string, std::string>& headers = {},
-               size_t max_body_size = -1u);
+  using ResponseConversionCallback =
+      base::OnceCallback<absl::optional<std::string>(
+          const std::string& raw_response)>;
+
+  // Each response is expected in json format and will be validated through
+  // JsonSanitizer. In cases where json contains values that are not supported
+  // by the standard base/json parser it is necessary to convert such values
+  // into string before validating the response. For these purposes
+  // conversion_callback is added which receives raw response and can perform
+  // necessary conversions.
+  void Request(
+      const std::string& method,
+      const GURL& url,
+      const std::string& payload,
+      const std::string& payload_content_type,
+      bool auto_retry_on_network_change,
+      ResultCallback callback,
+      const base::flat_map<std::string, std::string>& headers = {},
+      size_t max_body_size = -1u,
+      ResponseConversionCallback conversion_callback = base::NullCallback());
 
  private:
   APIRequestHelper(const APIRequestHelper&) = delete;
@@ -50,11 +66,17 @@ class APIRequestHelper {
       std::list<std::unique_ptr<network::SimpleURLLoader>>;
   void OnResponse(SimpleURLLoaderList::iterator iter,
                   ResultCallback callback,
+                  ResponseConversionCallback conversion_callback,
                   const std::unique_ptr<std::string> response_body);
+  void OnSanitize(const int http_code,
+                  const base::flat_map<std::string, std::string>& headers,
+                  ResultCallback result_callback,
+                  data_decoder::JsonSanitizer::Result result);
 
   net::NetworkTrafficAnnotationTag annotation_tag_;
   SimpleURLLoaderList url_loaders_;
   scoped_refptr<network::SharedURLLoaderFactory> url_loader_factory_;
+  base::WeakPtrFactory<APIRequestHelper> weak_ptr_factory_{this};
 };
 
 }  // namespace api_request_helper

--- a/components/api_request_helper/api_request_helper_unittest.cc
+++ b/components/api_request_helper/api_request_helper_unittest.cc
@@ -110,7 +110,10 @@ TEST_F(ApiRequestHelperUnitTest, SanitizedRequest) {
   SendRequest("{", "");
   SendRequest("0", "");
   SendRequest("a", "");
-  SendRequest("{\"a\":1,}", "");
+  // Android's sanitizer doesn't support trailing commas.
+#if !BUILDFLAG(IS_ANDROID)
+  SendRequest("{\"a\":1,}", "{\"a\":1}");
+#endif
 }
 
 TEST_F(ApiRequestHelperUnitTest, RequestWithConversion) {

--- a/components/api_request_helper/api_request_helper_unittest.cc
+++ b/components/api_request_helper/api_request_helper_unittest.cc
@@ -97,7 +97,11 @@ class ApiRequestHelperUnitTest : public testing::Test {
 
 TEST_F(ApiRequestHelperUnitTest, SanitizedRequest) {
   std::string expected_sanitized_response =
+#if BUILDFLAG(IS_ANDROID)
+      "{\"id\":1,\"jsonrpc\":\"2.0\",\"result\":1.8446744073709552E19}";
+#else
       "{\"id\":1,\"jsonrpc\":\"2.0\",\"result\":1.8446744073709552e+19}";
+#endif
   std::string server_raw_response =
       "{\"id\":1,\"jsonrpc\":\"2.0\",\"result\":18446744073709551615}";
   SendRequest(server_raw_response, expected_sanitized_response);
@@ -106,6 +110,7 @@ TEST_F(ApiRequestHelperUnitTest, SanitizedRequest) {
   SendRequest("{", "");
   SendRequest("0", "");
   SendRequest("a", "");
+  SendRequest("{\"a\":1,}", "");
 }
 
 TEST_F(ApiRequestHelperUnitTest, RequestWithConversion) {

--- a/components/api_request_helper/api_request_helper_unittest.cc
+++ b/components/api_request_helper/api_request_helper_unittest.cc
@@ -126,6 +126,13 @@ TEST_F(ApiRequestHelperUnitTest, RequestWithConversion) {
   // expecting empty response body after sanitization
   SendRequest(server_raw_response, "",
               base::BindOnce(&ConversionCallback, server_raw_response, ""));
+
+  // Returning absl::nullopt in conversion callback doesn't override the
+  // response
+  server_raw_response = "{}";
+  SendRequest(
+      server_raw_response, server_raw_response,
+      base::BindOnce(&ConversionCallback, server_raw_response, absl::nullopt));
 }
 
 }  // namespace api_request_helper

--- a/components/api_request_helper/api_request_helper_unittest.cc
+++ b/components/api_request_helper/api_request_helper_unittest.cc
@@ -1,0 +1,131 @@
+/* Copyright (c) 2022 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "brave/components/api_request_helper/api_request_helper.h"
+
+#include <utility>
+
+#include "base/callback.h"
+#include "base/test/bind.h"
+#include "base/test/task_environment.h"
+#include "net/traffic_annotation/network_traffic_annotation.h"
+#include "net/traffic_annotation/network_traffic_annotation_test_helper.h"
+#include "services/data_decoder/public/cpp/test_support/in_process_data_decoder.h"
+#include "services/network/public/cpp/weak_wrapper_shared_url_loader_factory.h"
+#include "services/network/test/test_url_loader_factory.h"
+#include "testing/gtest/include/gtest/gtest.h"
+
+namespace api_request_helper {
+
+namespace {
+absl::optional<std::string> ConversionCallback(
+    const std::string& expected_raw_response,
+    const absl::optional<std::string>& converted_response,
+    const std::string& raw_response) {
+  EXPECT_EQ(expected_raw_response, raw_response);
+  return converted_response;
+}
+}  // namespace
+
+class ApiRequestHelperUnitTest : public testing::Test {
+ public:
+  ApiRequestHelperUnitTest()
+      : shared_url_loader_factory_(
+            base::MakeRefCounted<network::WeakWrapperSharedURLLoaderFactory>(
+                &url_loader_factory_)) {
+    api_request_helper_.reset(new APIRequestHelper(
+        net::NetworkTrafficAnnotationTag(TRAFFIC_ANNOTATION_FOR_TESTS),
+        shared_url_loader_factory_));
+  }
+  ~ApiRequestHelperUnitTest() override = default;
+
+  void SetInterceptor(const std::string& expected_method,
+                      const GURL& expected_url,
+                      const std::string& content_to_respond) {
+    url_loader_factory_.SetInterceptor(base::BindLambdaForTesting(
+        [&, expected_method, expected_url,
+         content_to_respond](const network::ResourceRequest& request) {
+          url_loader_factory_.ClearResponses();
+          EXPECT_EQ(request.url, expected_url);
+          EXPECT_EQ(request.method, expected_method);
+          url_loader_factory_.AddResponse(request.url.spec(),
+                                          content_to_respond);
+        }));
+  }
+
+  void OnRequestResponse(
+      bool* callback_called,
+      bool expected_success,
+      const std::string& expected_response,
+      const int http_code,
+      const std::string& body,
+      const base::flat_map<std::string, std::string>& headers) {
+    *callback_called = true;
+    bool success = http_code == 200;
+    EXPECT_EQ(expected_success, success);
+    EXPECT_EQ(expected_response, body);
+  }
+
+  void SendRequest(const std::string& server_raw_response,
+                   const std::string& expected_sanitized_response,
+                   APIRequestHelper::ResponseConversionCallback
+                       conversion_callback = base::NullCallback()) {
+    bool callback_called = false;
+    GURL network_url("http://localhost/");
+    SetInterceptor("POST", network_url, server_raw_response);
+    api_request_helper_->Request(
+        "POST", network_url, "", "application/json", false,
+        base::BindOnce(&ApiRequestHelperUnitTest::OnRequestResponse,
+                       base::Unretained(this), &callback_called,
+                       true /* success */, expected_sanitized_response),
+        {}, -1u, std::move(conversion_callback));
+    base::RunLoop().RunUntilIdle();
+    EXPECT_TRUE(callback_called);
+  }
+
+ protected:
+  std::unique_ptr<APIRequestHelper> api_request_helper_;
+
+ private:
+  base::test::TaskEnvironment task_environment_;
+  network::TestURLLoaderFactory url_loader_factory_;
+  scoped_refptr<network::SharedURLLoaderFactory> shared_url_loader_factory_;
+  data_decoder::test::InProcessDataDecoder in_process_data_decoder_;
+};
+
+TEST_F(ApiRequestHelperUnitTest, SanitizedRequest) {
+  std::string expected_sanitized_response =
+      "{\"id\":1,\"jsonrpc\":\"2.0\",\"result\":1.8446744073709552e+19}";
+  std::string server_raw_response =
+      "{\"id\":1,\"jsonrpc\":\"2.0\",\"result\":18446744073709551615}";
+  SendRequest(server_raw_response, expected_sanitized_response);
+  SendRequest("", "");
+  SendRequest("{}", "{}");
+  SendRequest("{", "");
+  SendRequest("0", "");
+  SendRequest("a", "");
+}
+
+TEST_F(ApiRequestHelperUnitTest, RequestWithConversion) {
+  std::string expected_sanitized_response =
+      "{\"id\":1,\"jsonrpc\":\"2.0\",\"result\":\"18446744073709551615\"}";
+  std::string server_raw_response =
+      "{\"id\":1,\"jsonrpc\":\"2.0\",\"result\":18446744073709551615}";
+  SendRequest(server_raw_response, expected_sanitized_response,
+              base::BindOnce(&ConversionCallback, server_raw_response,
+                             expected_sanitized_response));
+
+  // Broken json after conversion
+  // expecting empty response body after sanitization
+  SendRequest(
+      server_raw_response, "",
+      base::BindOnce(&ConversionCallback, server_raw_response, "broken json"));
+  // Empty json after conversion
+  // expecting empty response body after sanitization
+  SendRequest(server_raw_response, "",
+              base::BindOnce(&ConversionCallback, server_raw_response, ""));
+}
+
+}  // namespace api_request_helper

--- a/components/brave_wallet/browser/asset_ratio_service_unittest.cc
+++ b/components/brave_wallet/browser/asset_ratio_service_unittest.cc
@@ -11,6 +11,7 @@
 #include "brave/components/brave_wallet/browser/asset_ratio_service.h"
 #include "brave/components/brave_wallet/browser/brave_wallet_constants.h"
 #include "brave/components/brave_wallet/common/brave_wallet.mojom.h"
+#include "services/data_decoder/public/cpp/test_support/in_process_data_decoder.h"
 #include "services/network/public/cpp/weak_wrapper_shared_url_loader_factory.h"
 #include "services/network/test/test_url_loader_factory.h"
 #include "testing/gtest/include/gtest/gtest.h"
@@ -104,6 +105,7 @@ class AssetRatioServiceUnitTest : public testing::Test {
   base::test::TaskEnvironment task_environment_;
   network::TestURLLoaderFactory url_loader_factory_;
   scoped_refptr<network::SharedURLLoaderFactory> shared_url_loader_factory_;
+  data_decoder::test::InProcessDataDecoder in_process_data_decoder_;
 };
 
 TEST_F(AssetRatioServiceUnitTest, GetPrice) {

--- a/components/brave_wallet/browser/eth_block_tracker_unittest.cc
+++ b/components/brave_wallet/browser/eth_block_tracker_unittest.cc
@@ -14,6 +14,7 @@
 #include "brave/components/brave_wallet/browser/json_rpc_service.h"
 #include "brave/components/brave_wallet/common/hex_utils.h"
 #include "components/sync_preferences/testing_pref_service_syncable.h"
+#include "services/data_decoder/public/cpp/test_support/in_process_data_decoder.h"
 #include "services/network/public/cpp/weak_wrapper_shared_url_loader_factory.h"
 #include "services/network/test/test_url_loader_factory.h"
 #include "testing/gtest/include/gtest/gtest.h"
@@ -62,6 +63,7 @@ class EthBlockTrackerUnitTest : public testing::Test {
   base::test::TaskEnvironment task_environment_;
   sync_preferences::TestingPrefServiceSyncable prefs_;
   network::TestURLLoaderFactory url_loader_factory_;
+  data_decoder::test::InProcessDataDecoder in_process_data_decoder_;
   scoped_refptr<network::SharedURLLoaderFactory> shared_url_loader_factory_;
   std::unique_ptr<JsonRpcService> json_rpc_service_;
 };

--- a/components/brave_wallet/browser/eth_tx_manager_unittest.cc
+++ b/components/brave_wallet/browser/eth_tx_manager_unittest.cc
@@ -33,6 +33,7 @@
 #include "components/sync_preferences/testing_pref_service_syncable.h"
 #include "mojo/public/cpp/bindings/pending_remote.h"
 #include "mojo/public/cpp/bindings/receiver.h"
+#include "services/data_decoder/public/cpp/test_support/in_process_data_decoder.h"
 #include "services/network/public/cpp/resource_request.h"
 #include "services/network/public/cpp/weak_wrapper_shared_url_loader_factory.h"
 #include "services/network/test/test_url_loader_factory.h"
@@ -388,7 +389,7 @@ class EthTxManagerUnitTest : public testing::Test {
   sync_preferences::TestingPrefServiceSyncable prefs_;
   network::TestURLLoaderFactory url_loader_factory_;
   scoped_refptr<network::SharedURLLoaderFactory> shared_url_loader_factory_;
-
+  data_decoder::test::InProcessDataDecoder in_process_data_decoder_;
   std::unique_ptr<JsonRpcService> json_rpc_service_;
   std::unique_ptr<KeyringService> keyring_service_;
   std::unique_ptr<TxService> tx_service_;

--- a/components/brave_wallet/browser/json_rpc_service_unittest.cc
+++ b/components/brave_wallet/browser/json_rpc_service_unittest.cc
@@ -31,6 +31,7 @@
 #include "net/test/embedded_test_server/embedded_test_server.h"
 #include "net/test/embedded_test_server/http_request.h"
 #include "net/test/embedded_test_server/http_response.h"
+#include "services/data_decoder/public/cpp/test_support/in_process_data_decoder.h"
 #include "services/network/public/cpp/weak_wrapper_shared_url_loader_factory.h"
 #include "services/network/test/test_url_loader_factory.h"
 #include "testing/gtest/include/gtest/gtest.h"
@@ -578,6 +579,7 @@ class JsonRpcServiceUnitTest : public testing::Test {
   sync_preferences::TestingPrefServiceSyncable prefs_;
   network::TestURLLoaderFactory url_loader_factory_;
   scoped_refptr<network::SharedURLLoaderFactory> shared_url_loader_factory_;
+  data_decoder::test::InProcessDataDecoder in_process_data_decoder_;
 };
 
 TEST_F(JsonRpcServiceUnitTest, SetNetwork) {

--- a/components/brave_wallet/browser/solana_block_tracker_unittest.cc
+++ b/components/brave_wallet/browser/solana_block_tracker_unittest.cc
@@ -13,6 +13,7 @@
 #include "brave/components/brave_wallet/browser/brave_wallet_prefs.h"
 #include "brave/components/brave_wallet/browser/json_rpc_service.h"
 #include "components/sync_preferences/testing_pref_service_syncable.h"
+#include "services/data_decoder/public/cpp/test_support/in_process_data_decoder.h"
 #include "services/network/public/cpp/weak_wrapper_shared_url_loader_factory.h"
 #include "services/network/test/test_url_loader_factory.h"
 #include "testing/gtest/include/gtest/gtest.h"
@@ -69,6 +70,7 @@ class SolanaBlockTrackerUnitTest : public testing::Test {
   network::TestURLLoaderFactory url_loader_factory_;
   scoped_refptr<network::SharedURLLoaderFactory> shared_url_loader_factory_;
   std::unique_ptr<JsonRpcService> json_rpc_service_;
+  data_decoder::test::InProcessDataDecoder in_process_data_decoder_;
 };
 
 TEST_F(SolanaBlockTrackerUnitTest, GetLatestBlockhash) {

--- a/components/brave_wallet/browser/solana_tx_manager_unittest.cc
+++ b/components/brave_wallet/browser/solana_tx_manager_unittest.cc
@@ -22,6 +22,7 @@
 #include "brave/components/brave_wallet/common/brave_wallet_types.h"
 #include "brave/components/brave_wallet/common/features.h"
 #include "components/sync_preferences/testing_pref_service_syncable.h"
+#include "services/data_decoder/public/cpp/test_support/in_process_data_decoder.h"
 #include "services/network/public/cpp/weak_wrapper_shared_url_loader_factory.h"
 #include "services/network/test/test_url_loader_factory.h"
 #include "testing/gtest/include/gtest/gtest.h"
@@ -268,7 +269,7 @@ class SolanaTxManagerUnitTest : public testing::Test {
   sync_preferences::TestingPrefServiceSyncable prefs_;
   network::TestURLLoaderFactory url_loader_factory_;
   scoped_refptr<network::SharedURLLoaderFactory> shared_url_loader_factory_;
-
+  data_decoder::test::InProcessDataDecoder in_process_data_decoder_;
   std::unique_ptr<JsonRpcService> json_rpc_service_;
   std::unique_ptr<KeyringService> keyring_service_;
   std::unique_ptr<TxService> tx_service_;

--- a/components/brave_wallet/browser/swap_service_unittest.cc
+++ b/components/brave_wallet/browser/swap_service_unittest.cc
@@ -13,6 +13,7 @@
 #include "brave/components/brave_wallet/browser/swap_service.h"
 #include "brave/components/brave_wallet/common/brave_wallet.mojom.h"
 #include "components/sync_preferences/testing_pref_service_syncable.h"
+#include "services/data_decoder/public/cpp/test_support/in_process_data_decoder.h"
 #include "services/network/public/cpp/weak_wrapper_shared_url_loader_factory.h"
 #include "services/network/test/test_url_loader_factory.h"
 #include "testing/gtest/include/gtest/gtest.h"
@@ -102,6 +103,7 @@ class SwapServiceUnitTest : public testing::Test {
   base::test::TaskEnvironment task_environment_;
   network::TestURLLoaderFactory url_loader_factory_;
   scoped_refptr<network::SharedURLLoaderFactory> shared_url_loader_factory_;
+  data_decoder::test::InProcessDataDecoder in_process_data_decoder_;
 };
 
 TEST_F(SwapServiceUnitTest, GetPriceQuote) {
@@ -154,7 +156,7 @@ TEST_F(SwapServiceUnitTest, GetPriceQuote) {
 
 TEST_F(SwapServiceUnitTest, GetPriceQuoteError) {
   std::string error =
-      R"({"code":100,"reason":"Validation Failed","validationErrors":[{"field":"sellAmount","code":1000,"reason":"should have required property 'sellAmount'"},{"field":"buyAmount","code":1000,"reason":"should have required property 'buyAmount'"},{"field":"","code":1001,"reason":"should match exactly one schema in oneOf"}]})";
+      R"({"code":100,"reason":"Validation Failed","validationErrors":[{"code":1000,"field":"sellAmount","reason":"should have required property 'sellAmount'"},{"code":1000,"field":"buyAmount","reason":"should have required property 'buyAmount'"},{"code":1001,"field":"","reason":"should match exactly one schema in oneOf"}]})";
   SetErrorInterceptor(error);
   bool callback_run = false;
   swap_service_->GetPriceQuote(
@@ -165,8 +167,8 @@ TEST_F(SwapServiceUnitTest, GetPriceQuoteError) {
 }
 
 TEST_F(SwapServiceUnitTest, GetPriceQuoteUnexpectedReturn) {
-  std::string error = "Could not parse response body: Woot";
-  std::string unexpected_return = "Woot";
+  std::string error = "Could not parse response body: ";
+  std::string unexpected_return = "";
   SetInterceptor(unexpected_return);
   bool callback_run = false;
   swap_service_->GetPriceQuote(
@@ -231,25 +233,8 @@ TEST_F(SwapServiceUnitTest, GetTransactionPayload) {
 }
 
 TEST_F(SwapServiceUnitTest, GetTransactionPayloadError) {
-  std::string error = R"(
-    {
-      "code": 100,
-      "reason": "Validation Failed",
-      "validationErrors": [{
-        "code": 1000,
-        "field": "sellAmount",
-        "reason": "should have required property 'sellAmount'"
-      }, {
-        "code": 1000,
-        "field": "buyAmount",
-        "reason": "should have required property 'buyAmount'"
-      }, {
-        "code": 1001,
-        "field": "",
-        "reason": "should match exactly one schema in oneOf"
-      }]
-    })";
-
+  std::string error =
+      R"({"code":100,"reason":"Validation Failed","validationErrors":[{"code":1000,"field":"sellAmount","reason":"should have required property 'sellAmount'"},{"code":1000,"field":"buyAmount","reason":"should have required property 'buyAmount'"},{"code":1001,"field":"","reason":"should match exactly one schema in oneOf"}]})";
   SetErrorInterceptor(error);
   bool callback_run = false;
   swap_service_->GetTransactionPayload(
@@ -260,7 +245,7 @@ TEST_F(SwapServiceUnitTest, GetTransactionPayloadError) {
 }
 
 TEST_F(SwapServiceUnitTest, GetTransactionPayloadUnexpectedReturn) {
-  std::string error = "Could not parse response body: Woot";
+  std::string error = "Could not parse response body: ";
   std::string unexpected_return = "Woot";
   SetInterceptor(unexpected_return);
   bool callback_run = false;

--- a/components/brave_wallet/browser/swap_service_unittest.cc
+++ b/components/brave_wallet/browser/swap_service_unittest.cc
@@ -168,7 +168,7 @@ TEST_F(SwapServiceUnitTest, GetPriceQuoteError) {
 
 TEST_F(SwapServiceUnitTest, GetPriceQuoteUnexpectedReturn) {
   std::string error = "Could not parse response body: ";
-  std::string unexpected_return = "";
+  std::string unexpected_return = "Woot";
   SetInterceptor(unexpected_return);
   bool callback_run = false;
   swap_service_->GetPriceQuote(

--- a/components/brave_wallet/browser/test/BUILD.gn
+++ b/components/brave_wallet/browser/test/BUILD.gn
@@ -78,6 +78,7 @@ source_set("brave_wallet_unit_tests") {
     "//components/sync_preferences:test_support",
     "//content/test:test_support",
     "//net:test_support",
+    "//services/data_decoder/public/cpp:test_support",
     "//services/network:test_support",
     "//testing/gtest",
     "//url",

--- a/test/BUILD.gn
+++ b/test/BUILD.gn
@@ -182,6 +182,7 @@ test("brave_unit_tests") {
     "//brave/common:network_constants",
     "//brave/common:pref_names",
     "//brave/components/adblock_rust_ffi",
+    "//brave/components/api_request_helper:api_request_helper_unit_tests",
     "//brave/components/brave_adaptive_captcha/buildflags",
     "//brave/components/brave_ads/test:brave_ads_unit_tests",
     "//brave/components/brave_component_updater/browser",


### PR DESCRIPTION
<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/21831

Added `JsonSanitizer` to `ApiRequestHelper` to validate server responses. It sanitizes and normalizes JSON by parsing it in a safe environment and re-serializing it. Parsing the sanitized JSON should result in a value identical to parsing the original JSON.
For those cases where we expect data that cannot be correctly processed by the `JsonSanitizer` and `base/json` parser, a preprocessing callback for the response text was added to convert the necessary values into strings by using safe parsers.
Example can be seen in [this test](https://github.com/brave/brave-core/pull/12685/files#diff-53d589d30e83d38ae4446c78a942a1e1dfc10667148f3b2de217f5f7e662e3f6R124).

Mandatory updates in unittests:
- `data_decoder::test::InProcessDataDecoder in_process_data_decoder_;` is required to be created for tests that use `JsonSanitizer`
- `JsonSerializer` removes spaces, some testing payloads have been fixed due to the requirement.
- For desktops added a flag to allow trailing commas in json, but it doesn't work in Android. Android implementation will treat it as  invalid json.

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

- `APIRequestHelper` is used in `BraveWallet`, `BraveAdaptiveCaptcha`, `BraveToday`, need to check that these components work as expected