### PR TITLE
[Android] hides rewards banner when news is present

### DIFF
--- a/android/java/org/chromium/chrome/browser/ntp/BraveNewTabPageLayout.java
+++ b/android/java/org/chromium/chrome/browser/ntp/BraveNewTabPageLayout.java
@@ -1598,7 +1598,8 @@ public class BraveNewTabPageLayout
                              Profile.getLastUsedRegularProfile())
                             && BraveRewardsHelper.shouldShowBraveRewardsOnboardingModal())
                         || BraveAdsNativeHelper.nativeIsBraveAdsEnabled(
-                                Profile.getLastUsedRegularProfile()))) {
+                                Profile.getLastUsedRegularProfile()))
+                && (!mIsShowOptin && !mIsShowNewsOn)) {
             NTPUtil.showNonDisruptiveBanner((BraveActivity) mActivity, this, brOption,
                                              sponsoredTab, newTabPageListener);
         }


### PR DESCRIPTION
Uplift of #12577
Resolves https://github.com/brave/brave-browser/issues/21321

Pre-approval checklist: 
- [ ] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [ ] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [ ] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [ ] The associated issue milestone is set to the smallest version that the changes is landed on.