### PR TITLE
Implement solid color background for NTP

### DIFF
--- a/browser/brave_profile_prefs.cc
+++ b/browser/brave_profile_prefs.cc
@@ -336,7 +336,14 @@ void RegisterProfilePrefs(user_prefs::PrefRegistrySyncable* registry) {
       static_cast<int>(NewTabPageShowsOptions::kDashboard));
 
 #if BUILDFLAG(ENABLE_CUSTOM_BACKGROUND)
+
+  // TODO(sangwoo.ko) If this feature is still under development, consider
+  // migrating two prefs into single prefs with enum. This would require us to
+  // modify related mojom too.
   registry->RegisterBooleanPref(kNewTabPageCustomBackgroundEnabled, false);
+  registry->RegisterBooleanPref(kNewTabPageSolidColorBackgroundEnabled, false);
+  registry->RegisterStringPref(kNewTabPageSelectedSolidColorBackground,
+                               "#151E9A");
 #endif
 
 #if BUILDFLAG(ETHEREUM_REMOTE_CLIENT_ENABLED)

--- a/browser/ui/webui/new_tab_page/brave_new_tab_page_handler.h
+++ b/browser/ui/webui/new_tab_page/brave_new_tab_page_handler.h
@@ -55,6 +55,7 @@ class BraveNewTabPageHandler : public brave_new_tab_page::mojom::PageHandler,
   // brave_new_tab_page::mojom::PageHandler overrides:
   void ChooseLocalCustomBackground() override;
   void UseBraveBackground() override;
+  void UseSolidColorBackground(const std::string& color) override;
 
   // Observe NTPCustomBackgroundImagesService.
   void OnCustomBackgroundImageUpdated();
@@ -65,7 +66,8 @@ class BraveNewTabPageHandler : public brave_new_tab_page::mojom::PageHandler,
                     void* params) override;
   void FileSelectionCanceled(void* params) override;
 
-  bool IsCustomBackgroundEnabled() const;
+  bool IsCustomBackgroundImageEnabled() const;
+  bool IsSolidColorBackgroundEnabled() const;
   image_fetcher::ImageDecoder* GetImageDecoder();
   void ConvertSelectedImageFileAndSave(const base::FilePath& image_file);
   void OnGotImageFile(absl::optional<std::string> input);

--- a/common/pref_names.cc
+++ b/common/pref_names.cc
@@ -66,6 +66,10 @@ const char kNewTabPageHideAllWidgets[] = "brave.new_tab_page.hide_all_widgets";
 const char kNewTabPageShowsOptions[] = "brave.new_tab_page.shows_options";
 const char kNewTabPageCustomBackgroundEnabled[] =
     "brave.new_tab_page.custom_background_enabled";
+const char kNewTabPageSolidColorBackgroundEnabled[] =
+    "brave.new_tab_page.solid_color_background_enabled";
+const char kNewTabPageSelectedSolidColorBackground[] =
+    "brave.new_tab_page.selected_solid_color_background";
 const char kBraveTodayIntroDismissed[] = "brave.today.intro_dismissed";
 const char kBinanceAccessToken[] = "brave.binance.access_token";
 const char kBinanceRefreshToken[] = "brave.binance.refresh_token";

--- a/common/pref_names.h
+++ b/common/pref_names.h
@@ -57,6 +57,8 @@ extern const char kNewTabPageShowBraveTalk[];
 extern const char kNewTabPageHideAllWidgets[];
 extern const char kNewTabPageShowsOptions[];
 extern const char kNewTabPageCustomBackgroundEnabled[];
+extern const char kNewTabPageSolidColorBackgroundEnabled[];
+extern const char kNewTabPageSelectedSolidColorBackground[];
 extern const char kBraveTodayIntroDismissed[];
 extern const char kAlwaysShowBookmarkBarOnNTP[];
 extern const char kAutocompleteEnabled[];

--- a/components/brave_new_tab_ui/brave_new_tab_page.mojom
+++ b/components/brave_new_tab_ui/brave_new_tab_page.mojom
@@ -9,6 +9,7 @@ import "url/mojom/url.mojom";
 
 struct CustomBackground {
   url.mojom.Url url;
+  string solid_color;
 };
 
 // Used by the WebUI page to bootstrap bidirectional communication.
@@ -24,6 +25,7 @@ interface PageHandler {
   // Choose custom background from local file system.
   ChooseLocalCustomBackground();
   UseBraveBackground();
+  UseSolidColorBackground(string color);
 };
 
 // WebUI-side handler for requests from the browser.

--- a/components/brave_new_tab_ui/components/default/page/index.tsx
+++ b/components/brave_new_tab_ui/components/default/page/index.tsx
@@ -20,6 +20,7 @@ interface HasImageProps {
   hasImage: boolean
   imageHasLoaded: boolean
   imageSrc?: string
+  solidColor?: string
 }
 
 type AppProps = {
@@ -307,12 +308,15 @@ function getPageBackground (p: HasImageProps) {
       right: 0;
       display: block;
       transition: opacity .5s ease-in-out;
-      ${p => !p.hasImage && css`
+      ${p => !p.hasImage && !p.solidColor && css`
         background: linear-gradient(
             to bottom right,
             #4D54D1,
             #A51C7B 50%,
             #EE4A37 100%);
+      `};
+      ${p => !p.hasImage && p.solidColor && css`
+        background-color: ${p.solidColor}
       `};
       ${p => p.hasImage && p.imageSrc && css`
         opacity: var(--bg-opacity);

--- a/components/brave_new_tab_ui/components/default/settings/index.ts
+++ b/components/brave_new_tab_ui/components/default/settings/index.ts
@@ -613,6 +613,12 @@ export const StyledCustomBackgroundOptionImage = styled('img')<{}>`
   border-radius: 10.8718px;
 `
 
+export const StyledCustomBackgroundOptionSolidColor = styled('div')<{}>`
+  width: 100%;
+  height: 160px;
+  border-radius: 10.8718px;
+`
+
 export const StyledUploadLabel = styled('div')<{}>`
 font-style: normal;
 font-weight: 400;

--- a/components/brave_new_tab_ui/containers/newTab/index.tsx
+++ b/components/brave_new_tab_ui/containers/newTab/index.tsx
@@ -119,6 +119,7 @@ class NewTabPage extends React.Component<Props, State> {
 
   hasInitBraveToday: boolean = false
   imageSource?: string = undefined
+  solidBackgroundColor?: string = undefined
   timerIdForBrandedWallpaperNotification?: number = undefined
   onVisiblityTimerExpired = () => {
     this.dismissBrandedWallpaperNotification(false)
@@ -130,6 +131,7 @@ class NewTabPage extends React.Component<Props, State> {
     // if a notification is open at component mounting time, close it
     this.props.actions.showTilesRemovedNotice(false)
     this.imageSource = GetBackgroundImageSrc(this.props)
+    this.solidBackgroundColor = this.props.newTabData.backgroundWallpaper?.wallpaperSolidColor
     this.trackCachedImage()
     if (GetShouldShowBrandedWallpaperNotification(this.props)) {
       this.trackBrandedWallpaperNotificationAutoDismiss()
@@ -141,6 +143,7 @@ class NewTabPage extends React.Component<Props, State> {
     const oldImageSource = GetBackgroundImageSrc(prevProps)
     const newImageSource = GetBackgroundImageSrc(this.props)
     this.imageSource = newImageSource
+    this.solidBackgroundColor = this.props.newTabData.backgroundWallpaper?.wallpaperSolidColor
     if (newImageSource && oldImageSource !== newImageSource) {
       this.trackCachedImage()
     }
@@ -413,6 +416,10 @@ class NewTabPage extends React.Component<Props, State> {
     } else {
       getNTPBrowserAPI().pageHandler.useBraveBackground()
     }
+  }
+
+  useSolidColorBackground = (color: string) => {
+    getNTPBrowserAPI().pageHandler.useSolidColorBackground(color)
   }
 
   startRewards = () => {
@@ -1100,6 +1107,7 @@ class NewTabPage extends React.Component<Props, State> {
         hasImage={hasImage}
         imageSrc={this.imageSource}
         imageHasLoaded={this.state.backgroundHasLoaded}
+        solidColor={this.solidBackgroundColor}
       >
         <Page.Page
             hasImage={hasImage}
@@ -1243,6 +1251,7 @@ class NewTabPage extends React.Component<Props, State> {
           setMostVisitedSettings={this.setMostVisitedSettings}
           toggleBrandedWallpaperOptIn={this.toggleShowBrandedWallpaper}
           useCustomBackgroundImage={this.useCustomBackgroundImage}
+          useSolidColorBackground={this.useSolidColorBackground}
           showBackgroundImage={newTabData.showBackgroundImage}
           showClock={newTabData.showClock}
           clockFormat={newTabData.clockFormat}

--- a/components/brave_new_tab_ui/containers/newTab/settings.tsx
+++ b/components/brave_new_tab_ui/containers/newTab/settings.tsx
@@ -66,6 +66,7 @@ export interface Props {
   toggleBrandedWallpaperOptIn: () => void
   toggleCards: (show: boolean) => void
   useCustomBackgroundImage: (useCustom: boolean) => void
+  useSolidColorBackground: (color: string) => void
   showBackgroundImage: boolean
   showStats: boolean
   showToday: boolean
@@ -183,6 +184,10 @@ export default class Settings extends React.PureComponent<Props, State> {
 
   useCustomBackgroundImage = (useCustom: boolean) => {
     this.props.useCustomBackgroundImage(useCustom)
+  }
+
+  useSolidColorBackground = (color: string) => {
+    this.props.useSolidColorBackground(color);
   }
 
   setActiveTab (activeTab: TabType) {
@@ -346,6 +351,7 @@ export default class Settings extends React.PureComponent<Props, State> {
                     toggleBrandedWallpaperOptIn={toggleBrandedWallpaperOptIn}
                     toggleShowBackgroundImage={this.toggleShowBackgroundImage}
                     useCustomBackgroundImage={this.useCustomBackgroundImage}
+                    useSolidColorBackground={this.useSolidColorBackground}
                     brandedWallpaperOptIn={brandedWallpaperOptIn}
                     showBackgroundImage={showBackgroundImage}
                     featureCustomBackgroundEnabled={featureCustomBackgroundEnabled}

--- a/components/brave_new_tab_ui/containers/newTab/settings/backgroundImage.tsx
+++ b/components/brave_new_tab_ui/containers/newTab/settings/backgroundImage.tsx
@@ -21,10 +21,13 @@ import { Toggle } from '../../../components/toggle'
 
 import { getLocale } from '../../../../common/locale'
 
+import SolidColorBackgroundOption from './solidColorBackgroundOption'
+
 interface Props {
   toggleBrandedWallpaperOptIn: () => void
   toggleShowBackgroundImage: () => void
   useCustomBackgroundImage: (useCustom: boolean) => void
+  useSolidColorBackground: (color: string) => void
   brandedWallpaperOptIn: boolean
   showBackgroundImage: boolean
   featureCustomBackgroundEnabled: boolean
@@ -39,7 +42,7 @@ class BackgroundImageSettings extends React.PureComponent<Props, {}> {
     this.props.useCustomBackgroundImage(false)
   }
 
-  render () {
+  render() {
     const {
       toggleShowBackgroundImage,
       toggleBrandedWallpaperOptIn,
@@ -94,6 +97,7 @@ class BackgroundImageSettings extends React.PureComponent<Props, {}> {
                 {getLocale('braveBackgroundImageOptionTitle')}
               </StyledCustomBackgroundOptionLabel>
             </StyledCustomBackgroundOption>
+            <SolidColorBackgroundOption color="#151E9A" name="Solid color" useSolidColorBackground={this.props.useSolidColorBackground} />
           </StyledCustomBackgroundSettings>
         }
       </div>

--- a/components/brave_new_tab_ui/containers/newTab/settings/solidColorBackgroundOption.tsx
+++ b/components/brave_new_tab_ui/containers/newTab/settings/solidColorBackgroundOption.tsx
@@ -1,0 +1,32 @@
+import * as React from 'react'
+
+import {
+  StyledCustomBackgroundOption,
+  StyledCustomBackgroundOptionSolidColor,
+  StyledCustomBackgroundOptionLabel,
+} from '../../../components/default'
+
+interface Props {
+  color: string
+  name: string
+  useSolidColorBackground: (color: string) => void
+}
+
+class SolidColorBackgroundOption extends React.PureComponent<Props, {}> {
+  onClickColor = () => {
+    this.props.useSolidColorBackground(this.props.color);
+  }
+
+  render() {
+    const { color } = this.props
+
+    return (<StyledCustomBackgroundOption onClick={this.onClickColor}>
+              <StyledCustomBackgroundOptionSolidColor style={{ backgroundColor: color }} />
+              <StyledCustomBackgroundOptionLabel>
+                {this.props.name}
+              </StyledCustomBackgroundOptionLabel>
+            </StyledCustomBackgroundOption>)
+  }
+}
+
+export default SolidColorBackgroundOption

--- a/components/brave_new_tab_ui/reducers/new_tab_reducer.ts
+++ b/components/brave_new_tab_ui/reducers/new_tab_reducer.ts
@@ -114,9 +114,14 @@ export const newTabReducer: Reducer<NewTab.State | undefined> = (state: NewTab.S
       }
       // Empty custom bg url means using brave background.
       const url = payload.customBackground.url.url
-      state.backgroundWallpaper =
-          url === '' ? backgroundAPI.randomBackgroundImage()
-                     : { wallpaperImageUrl: url }
+      const solidColor = payload.customBackground.solidColor
+      if (url !== '') {
+        state.backgroundWallpaper = { wallpaperImageUrl: url, wallpaperSolidColor: undefined }
+      } else if (solidColor !== '') {
+        state.backgroundWallpaper = { wallpaperImageUrl: undefined, wallpaperSolidColor: solidColor }
+      } else {
+        state.backgroundWallpaper = backgroundAPI.randomBackgroundImage();
+      }
       break
 
     case types.NEW_TAB_PRIVATE_TAB_DATA_UPDATED:

--- a/components/definitions/newTab.d.ts
+++ b/components/definitions/newTab.d.ts
@@ -7,7 +7,8 @@ declare namespace NewTab {
   // Type for custom background and brave background.
   // Custom background uses only image url prop.
   export type BackgroundWallpaper = {
-    wallpaperImageUrl: string
+    wallpaperImageUrl?: string
+    wallpaperSolidColor?: string
     author?: string
     link?: string
     originalUrl?: string


### PR DESCRIPTION
Give users an option to set solid color as their background for NTP.

Fix https://docs.google.com/document/d/1aTChFJIhqI7910NMOEOaqkf6O9yoU5ZtBeOJMCq-_IY/

<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves 

## Submitter Checklist:

- [ ] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

