### PR TITLE
[Android] Brave news - Disables Opt-in card and leaves only "Show news" switch

### DIFF
--- a/android/java/org/chromium/chrome/browser/settings/BraveNewsPreferences.java
+++ b/android/java/org/chromium/chrome/browser/settings/BraveNewsPreferences.java
@@ -196,43 +196,30 @@ public class BraveNewsPreferences extends BravePreferenceFragment
             mAddSource.setText("");
         }
 
-        boolean isNewsOn = BravePrefServiceBridge.getInstance().getNewsOptIn();
-
-        if (!isNewsOn) {
-            mTurnOnNews.setChecked(false);
-            mShowNews.setVisible(false);
-            setSourcesVisibility(BravePrefServiceBridge.getInstance().getNewsOptIn());
-        } else {
-            mTurnOnNews.setChecked(true);
-            mTurnOnNews.setVisible(false);
-            mShowNews.setVisible(true);
-            if (BravePrefServiceBridge.getInstance().getShowNews()) {
-                mShowNews.setChecked(true);
-            } else {
-                mShowNews.setChecked(false);
-            }
-            setSourcesVisibility(BravePrefServiceBridge.getInstance().getShowNews());
+        // Ensure the shownews pref is false when it's unchechecked
+        if (!mShowNews.isChecked()) {
+            BravePrefServiceBridge.getInstance().setShowNews(false);
         }
+        mTurnOnNews.setVisible(false);
+        setSourcesVisibility(BravePrefServiceBridge.getInstance().getShowNews());
     }
 
     @Override
     public boolean onPreferenceChange(Preference preference, Object newValue) {
         String key = preference.getKey();
         if (PREF_TURN_ON_NEWS.equals(key)) {
-            BravePrefServiceBridge.getInstance().setNewsOptIn((boolean) newValue);
+            // Unused for now as we temporarly remove the Enable switch
             BravePrefServiceBridge.getInstance().setShowNews(false);
-            if ((boolean) newValue) {
-                mShowNews.setVisible(true);
-                mShowNews.setChecked(false);
-            } else {
-                mShowNews.setVisible(false);
-            }
         } else if (PREF_SHOW_NEWS.equals(key)) {
             SharedPreferences.Editor sharedPreferencesEditor =
                     ContextUtils.getAppSharedPreferences().edit();
             sharedPreferencesEditor.putBoolean(BraveNewsPreferences.PREF_SHOW_OPTIN, false);
             sharedPreferencesEditor.apply();
             BravePrefServiceBridge.getInstance().setShowNews((boolean) newValue);
+            // Sets Enable switch to the same value to keep the conditions in BraveNewTabLayout.java
+            // valid
+            BravePrefServiceBridge.getInstance().setNewsOptIn((boolean) newValue);
+
         } else if (PREF_RSS_SOURCES.equals(key)) {
             if (((String) newValue).equals("")) {
                 return true;

--- a/android/java/res/xml/brave_news_preferences.xml
+++ b/android/java/res/xml/brave_news_preferences.xml
@@ -15,7 +15,6 @@
     <org.chromium.components.browser_ui.settings.ChromeSwitchPreference
         android:key="kNewTabPageShowToday"
         android:title="@string/news_show"
-        android:dependency="kBraveTodayOptedIn"
         android:summaryOn="@string/brave_news_optin_subtitle"
         android:summaryOff="@string/brave_news_optin_subtitle" />
 


### PR DESCRIPTION
<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/21660

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

1. Clean install,then from the NTP go to Brave News in settings
2. The Show news switch should be the only one visible and be disabled. Enable the switch
3. All the other settings should become visible . Close the settings
4. The news feed should peek at the bottom of the NTP.
5. Try switching back off and it should go to the initial state. 