### PR TITLE
Open Rewards onboarding tour from the NTP

### DIFF
--- a/components/brave_new_tab_ui/components/default/rewards/index.tsx
+++ b/components/brave_new_tab_ui/components/default/rewards/index.tsx
@@ -11,6 +11,7 @@ import { StyledTitleTab } from '../widgetTitleTab'
 import { LocaleContext } from '../../../../brave_rewards/resources/shared/lib/locale_context'
 import { WithThemeVariables } from '../../../../brave_rewards/resources/shared/components/with_theme_variables'
 import { GrantInfo } from '../../../../brave_rewards/resources/shared/lib/grant_info'
+import { OnboardingCompletedStore } from '../../../../brave_rewards/resources/shared/lib/onboarding_completed_store'
 
 import {
   RewardsCard,
@@ -21,6 +22,14 @@ import {
 export { SponsoredImageTooltip }
 
 const locale = { getString: (key: string) => getLocale(key) }
+const onboardingCompleted = new OnboardingCompletedStore()
+
+export function showRewardsOnboarding () {
+  if (!onboardingCompleted.load()) {
+    onboardingCompleted.save()
+    chrome.braveRewards.openBrowserActionUI('brave_rewards_panel.html#tour')
+  }
+}
 
 export function RewardsContextAdapter (props: { children: React.ReactNode }) {
   return (

--- a/components/brave_new_tab_ui/containers/newTab/index.tsx
+++ b/components/brave_new_tab_ui/containers/newTab/index.tsx
@@ -26,7 +26,7 @@ import BrandedWallpaperLogo from '../../components/default/brandedWallpaper/logo
 import { brandedWallpaperLogoClicked } from '../../api/wallpaper'
 import BraveTodayHint from '../../components/default/braveToday/hint'
 import BraveToday, { GetDisplayAdContent } from '../../components/default/braveToday'
-import { SponsoredImageTooltip } from '../../components/default/rewards'
+import { SponsoredImageTooltip, showRewardsOnboarding } from '../../components/default/rewards'
 import { addNewTopSite, editTopSite } from '../../api/topSites'
 import getNTPBrowserAPI from '../../api/background'
 
@@ -417,6 +417,7 @@ class NewTabPage extends React.Component<Props, State> {
 
   startRewards = () => {
     chrome.braveRewards.enableRewards()
+    showRewardsOnboarding()
   }
 
   dismissBrandedWallpaperNotification = (isUserAction: boolean) => {


### PR DESCRIPTION
<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/21811

## Submitter Checklist:

- [ ] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

## Scenario 1: Tour shown from Rewards NTP widget

- Given that Ads are disabled for the user,
- And the user has not pressed the Rewards widget's "Start Using Rewards" button previously,
- And the user has not pressed the sponsored image tooltip's "Start Using Rewards" button previously,
- When the user clicks the "Start Using Rewards" button on the Rewards widget,
- Then the rewards panel should open and display the rewards tour.

## Scenario 1: Tour shown from NTP sponsored image tooltip

- Given that Ads are disabled for the user,
- And the user has not pressed the Rewards widget's "Start Using Rewards" button previously,
- And the user has not pressed the sponsored image tooltip's "Start Using Rewards" button previously,
- When the user clicks the "Start Using Rewards" button on the sponsored image tooltip,
- Then the rewards panel should open and display the rewards tour.

## Limitations

- If the user has completed the rewards tour from a different location (for example, by enabling rewards from the rewards panel or from the rewards page), then disables Ads, and then clicks "Start Using Rewards" on the NTP, they *will* see the rewards onboarding tour.