### PR TITLE
Fix crash when pressing music/playlist button

### DIFF
--- a/chromium_src/chrome/browser/media/router/media_router_feature.cc
+++ b/chromium_src/chrome/browser/media/router/media_router_feature.cc
@@ -9,7 +9,10 @@
 #include "content/public/browser/browser_context.h"
 
 #define MediaRouterEnabled MediaRouterEnabled_ChromiumImpl
+#define GlobalMediaControlsCastStartStopEnabled \
+  GlobalMediaControlsCastStartStopEnabled_ChromiumImpl
 #include "src/chrome/browser/media/router/media_router_feature.cc"
+#undef GlobalMediaControlsCastStartStopEnabled
 #undef MediaRouterEnabled
 
 namespace media_router {
@@ -26,5 +29,15 @@ bool MediaRouterEnabled(content::BrowserContext* context) {
   return pref->GetValue()->GetBool();
 #endif
 }
+
+#if !BUILDFLAG(IS_ANDROID)
+// This override forces GlobalMediaControlsCastStartStopEnabled to use our
+// version of MediaRouterEnabled, rather than the original. The implementation
+// of this function must be kept in sync with the original implementation.
+bool GlobalMediaControlsCastStartStopEnabled(content::BrowserContext* context) {
+  return base::FeatureList::IsEnabled(kGlobalMediaControlsCastStartStop) &&
+         MediaRouterEnabled(context);
+}
+#endif
 
 }  // namespace media_router


### PR DESCRIPTION
<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/21816

Ensure that we use our override of `MediaRouterEnabled` in `GlobalMediaControlsCastStartStopEnabled`, since we disable the media router by default and thus want this function to return `false` in that scenario.

We were ending up in a situation where Media Router is disabled (our default setting), but `GlobalMediaControlsCastStartStopEnabled` was returning `true`. This led to Chromium creating a `MediaRouterUI` object which eventually wanted to call `ChromeMediaRouterFactory::BuildServiceInstanceFor` to create a Media Router. But that was failing and returning `nullptr` due to https://chromium-review.googlesource.com/c/chromium/src/+/2612268.

## Submitter Checklist:

- [ ] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

- New profile
- Launch browser
- Visit brave://settings/extensions and ensure that Media Router is disabled
- Visit a YouTube video
- Press the playlist/media control button in the toolbar
- Verify that there's no crash and the playlist/media controls appear