### PR TITLE
[Rewards] Modified adaptive captcha error message style.

### DIFF
--- a/components/brave_rewards/resources/adaptive_captcha/components/adaptive_captcha_view.style.ts
+++ b/components/brave_rewards/resources/adaptive_captcha/components/adaptive_captcha_view.style.ts
@@ -24,6 +24,7 @@ export const root = styled.div`
 `
 
 export const title = styled.div`
+  display: flex;
   margin-top: 16px;
   font-weight: 600;
   font-size: 22px;
@@ -34,7 +35,8 @@ export const title = styled.div`
     height: 24px;
     margin-right: 8px;
     vertical-align: middle;
-    margin-bottom: 3px;
+    margin-top: auto;
+    margin-bottom: auto;
   }
 
   &.long {
@@ -77,7 +79,7 @@ export const helpAction = styled.div`
 
   button {
     display: block;
-    height: 40px;
+    height: auto;
     margin: 0 auto;
     padding: 10px 22px;
     font-weight: 600;

--- a/components/brave_rewards/resources/extension/brave_rewards/_locales/pl/messages.json
+++ b/components/brave_rewards/resources/extension/brave_rewards/_locales/pl/messages.json
@@ -607,7 +607,7 @@
     "description": ""
   },
   "captchaContactSupport": {
-    "message": "Skontaktuj się z działem pomocy technicznej!",
+    "message": "Skontaktuj się z pomocą techniczną",
     "description": ""
   },
   "captchaDismiss": {


### PR DESCRIPTION
Fixes brave/brave-browser#18971

Changed:
 * the button to grow vertically with the text
 * the header to align with the sad face image when the text exceeds 1 line
 * the sad face image to center vertically with the header.

The localization change has been made in Transifex, but is also being
applied here preemptively.

## Submitter Checklist:

- [ ] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

