### PR TITLE
Android Fix NTP SI, imagecredit cutoff (uplift to 1.37.x)

### DIFF
--- a/android/java/org/chromium/chrome/browser/ntp_background_images/util/NTPUtil.java
+++ b/android/java/org/chromium/chrome/browser/ntp_background_images/util/NTPUtil.java
@@ -109,12 +109,11 @@ public class NTPUtil {
             // Correction defaults to tablet BackgroundImage
             imageCreditCorrection = isLandscape ? (int) (pxHeight * (isCompensate ? 0.48 : 0.54))
                                                 : (int) (pxHeight * (isCompensate ? 0.60 : 0.30));
-
             if (ntpImage instanceof BackgroundImage) {
                 if (!isTablet) {
                     imageCreditCorrection = isLandscape
                             ? (int) (pxHeight * (isCompensate ? 0.12 : 0.88))
-                            : (int) (pxHeight * (isCompensate ? 0.53 : 0.59));
+                            : (int) (pxHeight - dpToPx(activity, 355));
                 }
                 if (!ChromeFeatureList.isEnabled(BraveFeatureList.BRAVE_NEWS)) {
                     imageCreditCorrection = (int) imageCreditCorrection - (int) (pxHeight * 0.04);
@@ -123,7 +122,7 @@ public class NTPUtil {
                 if (!isTablet) {
                     imageCreditCorrection = isLandscape
                             ? (int) (pxHeight * (isCompensate ? 0.02 : 0.98))
-                            : (int) (pxHeight * (isCompensate ? 0.36 : 0.50));
+                            : (int) (pxHeight - dpToPx(activity, 480));
                 } else {
                     imageCreditCorrection = isLandscape
                             ? (int) (pxHeight * (isCompensate ? 0.28 : 0.72))
@@ -205,6 +204,7 @@ public class NTPUtil {
             layoutParams.gravity = Gravity.BOTTOM | Gravity.CENTER_HORIZONTAL;
             layoutParams.setMargins(0, 0, 0, dpToPx(context, 5));
         }
+
         parentLayout.setOrientation(LinearLayout.VERTICAL);
 
         imageCreditLayout.setLayoutParams(imageCreditLayoutParams);


### PR DESCRIPTION
Uplift of #12711
Resolves https://github.com/brave/brave-browser/issues/21736

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.