### PR TITLE
[Android] Fixed background for NTP on private tabs (uplift to 1.38.x)

### DIFF
--- a/android/java/org/chromium/chrome/browser/ntp/BraveNewTabPageLayout.java
+++ b/android/java/org/chromium/chrome/browser/ntp/BraveNewTabPageLayout.java
@@ -260,6 +260,8 @@ public class BraveNewTabPageLayout
     private boolean mTouchScroll;
     private boolean mComesFromNewTab;
 
+    private Supplier<Tab> mTabProvider;
+
     public BraveNewTabPageLayout(Context context, AttributeSet attrs) {
         super(context, attrs);
         mProfile = Profile.getLastUsedRegularProfile();
@@ -1521,6 +1523,7 @@ public class BraveNewTabPageLayout
 
         assert (activity instanceof BraveActivity);
         mActivity = activity;
+        mTabProvider = tabProvider;
         ((BraveActivity) mActivity).dismissShieldsTooltip();
     }
 
@@ -1708,11 +1711,13 @@ public class BraveNewTabPageLayout
         } 
     };
 
-    private FetchWallpaperWorkerTask.WallpaperRetrievedCallback wallpaperRetrievedCallback = new FetchWallpaperWorkerTask.WallpaperRetrievedCallback() {
+    private FetchWallpaperWorkerTask.WallpaperRetrievedCallback
+            wallpaperRetrievedCallback = new FetchWallpaperWorkerTask.WallpaperRetrievedCallback() {
         @Override
         public void bgWallpaperRetrieved(Bitmap bgWallpaper) {
             if (ChromeFeatureList.isEnabled(BraveFeatureList.BRAVE_NEWS)) {
-                if (BraveActivity.getBraveActivity() != null) {
+                if (BraveActivity.getBraveActivity() != null && mTabProvider.get() != null
+                        && !mTabProvider.get().isIncognito()) {
                     BraveActivity.getBraveActivity().setBackground(bgWallpaper);
                 }
                 try {


### PR DESCRIPTION
Uplift of #12758
Resolves https://github.com/brave/brave-browser/issues/21877

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.