### PR TITLE
Limit action_pool_depth to cpu cores. (uplift to 1.38.x)

### DIFF
--- a/build/commands/lib/config.js
+++ b/build/commands/lib/config.js
@@ -273,6 +273,10 @@ Config.prototype.buildArgs = function () {
     dcheck_always_on:
       getNPMConfig(['dcheck_always_on'], this.isComponentBuild()),
     brave_channel: this.channel,
+    // Limit action pool (non-compile actions) to amount of CPU cores.
+    // This prevents machine overload during builds with high -j value (goma for ex.).
+    // We set it for all builds to not regen GN with/without goma.
+    action_pool_depth: os.cpus().length,
     brave_google_api_key: this.braveGoogleApiKey,
     brave_google_api_endpoint: this.googleApiEndpoint,
     google_default_client_id: this.googleDefaultClientId,


### PR DESCRIPTION
Uplift of #12715
Resolves https://github.com/brave/brave-browser/issues/21828

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.