### PR TITLE
Implement SolanaTxManagerProxy::GetEstimatedTxFee API for UI to use

### DIFF
--- a/components/brave_wallet/browser/json_rpc_service.h
+++ b/components/brave_wallet/browser/json_rpc_service.h
@@ -273,6 +273,12 @@ class JsonRpcService : public KeyedService, public mojom::JsonRpcService {
                               const std::string& error_message)>;
   void GetSolanaAccountInfo(const std::string& pubkey,
                             GetSolanaAccountInfoCallback callback);
+  using GetSolanaFeeForMessageCallback =
+      base::OnceCallback<void(uint64_t fee,
+                              mojom::SolanaProviderError error,
+                              const std::string& error_message)>;
+  void GetSolanaFeeForMessage(const std::string& message,  // base64 encoded
+                              GetSolanaFeeForMessageCallback callback);
 
  private:
   void FireNetworkChanged(mojom::CoinType coin);
@@ -457,6 +463,11 @@ class JsonRpcService : public KeyedService, public mojom::JsonRpcService {
       const base::flat_map<std::string, std::string>& headers);
   void OnGetSolanaAccountInfo(
       GetSolanaAccountInfoCallback callback,
+      const int status,
+      const std::string& body,
+      const base::flat_map<std::string, std::string>& headers);
+  void OnGetSolanaFeeForMessage(
+      GetSolanaFeeForMessageCallback callback,
       const int status,
       const std::string& body,
       const base::flat_map<std::string, std::string>& headers);

--- a/components/brave_wallet/browser/solana_block_tracker.cc
+++ b/components/brave_wallet/browser/solana_block_tracker.cc
@@ -5,11 +5,21 @@
 
 #include "brave/components/brave_wallet/browser/solana_block_tracker.h"
 
+#include <utility>
+
 #include "base/bind.h"
+#include "base/callback_helpers.h"
 #include "base/logging.h"
 #include "brave/components/brave_wallet/browser/json_rpc_service.h"
 
 namespace brave_wallet {
+
+namespace {
+
+constexpr base::TimeDelta kExpiredTimeDelta =
+    base::Seconds(kBlockTrackerDefaultTimeInSeconds);
+
+}
 
 SolanaBlockTracker::SolanaBlockTracker(JsonRpcService* json_rpc_service)
     : BlockTracker(json_rpc_service), weak_ptr_factory_(this) {}
@@ -17,27 +27,38 @@ SolanaBlockTracker::SolanaBlockTracker(JsonRpcService* json_rpc_service)
 SolanaBlockTracker::~SolanaBlockTracker() = default;
 
 void SolanaBlockTracker::Start(base::TimeDelta interval) {
-  latest_blockhash_.clear();
   timer_.Start(FROM_HERE, interval,
                base::BindRepeating(&SolanaBlockTracker::GetLatestBlockhash,
-                                   weak_ptr_factory_.GetWeakPtr()));
+                                   weak_ptr_factory_.GetWeakPtr(),
+                                   base::NullCallback(), false));
 }
 
 void SolanaBlockTracker::Stop() {
   BlockTracker::Stop();
-  latest_blockhash_.clear();
 }
 
-void SolanaBlockTracker::GetLatestBlockhash() {
+void SolanaBlockTracker::GetLatestBlockhash(GetLatestBlockhashCallback callback,
+                                            bool try_cached_value) {
+  if (try_cached_value && !latest_blockhash_.empty() &&
+      latest_blockhash_expired_time_ > base::Time::Now()) {
+    std::move(callback).Run(latest_blockhash_,
+                            mojom::SolanaProviderError::kSuccess, "");
+    return;
+  }
+
   json_rpc_service_->GetSolanaLatestBlockhash(
       base::BindOnce(&SolanaBlockTracker::OnGetLatestBlockhash,
-                     weak_ptr_factory_.GetWeakPtr()));
+                     weak_ptr_factory_.GetWeakPtr(), std::move(callback)));
 }
 
 void SolanaBlockTracker::OnGetLatestBlockhash(
+    GetLatestBlockhashCallback callback,
     const std::string& latest_blockhash,
     mojom::SolanaProviderError error,
     const std::string& error_message) {
+  if (callback)
+    std::move(callback).Run(latest_blockhash, error, error_message);
+
   if (error != mojom::SolanaProviderError::kSuccess) {
     VLOG(1) << __FUNCTION__ << ": Failed to get latest blockhash, error: "
             << static_cast<int>(error) << ", error_message: " << error_message;
@@ -48,6 +69,7 @@ void SolanaBlockTracker::OnGetLatestBlockhash(
     return;
 
   latest_blockhash_ = latest_blockhash;
+  latest_blockhash_expired_time_ = base::Time::Now() + kExpiredTimeDelta;
   for (auto& observer : observers_)
     observer.OnLatestBlockhashUpdated(latest_blockhash);
 }

--- a/components/brave_wallet/browser/solana_block_tracker.h
+++ b/components/brave_wallet/browser/solana_block_tracker.h
@@ -10,6 +10,7 @@
 
 #include "base/memory/weak_ptr.h"
 #include "base/observer_list.h"
+#include "base/time/time.h"
 #include "brave/components/brave_wallet/browser/block_tracker.h"
 #include "brave/components/brave_wallet/common/brave_wallet.mojom.h"
 
@@ -39,13 +40,21 @@ class SolanaBlockTracker : public BlockTracker {
 
   std::string latest_blockhash() const { return latest_blockhash_; }
 
+  using GetLatestBlockhashCallback =
+      base::OnceCallback<void(const std::string& latest_blockhash,
+                              mojom::SolanaProviderError error,
+                              const std::string& error_message)>;
+  void GetLatestBlockhash(GetLatestBlockhashCallback callback,
+                          bool try_cached_value);
+
  private:
-  void GetLatestBlockhash();
-  void OnGetLatestBlockhash(const std::string& latest_blockhash,
+  void OnGetLatestBlockhash(GetLatestBlockhashCallback callback,
+                            const std::string& latest_blockhash,
                             mojom::SolanaProviderError error,
                             const std::string& error_message);
 
   std::string latest_blockhash_;
+  base::Time latest_blockhash_expired_time_;
   base::ObserverList<Observer> observers_;
 
   base::WeakPtrFactory<SolanaBlockTracker> weak_ptr_factory_;

--- a/components/brave_wallet/browser/solana_block_tracker_unittest.cc
+++ b/components/brave_wallet/browser/solana_block_tracker_unittest.cc
@@ -17,6 +17,7 @@
 #include "services/network/public/cpp/weak_wrapper_shared_url_loader_factory.h"
 #include "services/network/test/test_url_loader_factory.h"
 #include "testing/gtest/include/gtest/gtest.h"
+#include "ui/base/l10n/l10n_util.h"
 
 namespace brave_wallet {
 
@@ -54,13 +55,32 @@ class SolanaBlockTrackerUnitTest : public testing::Test {
   void SetUp() override {
     brave_wallet::RegisterProfilePrefs(prefs_.registry());
     json_rpc_service_.reset(
-        new brave_wallet::JsonRpcService(shared_url_loader_factory_, &prefs_));
+        new JsonRpcService(shared_url_loader_factory_, &prefs_));
+    tracker_.reset(new SolanaBlockTracker(json_rpc_service_.get()));
   }
 
   std::string GetResponseString() const {
     return "{\"jsonrpc\":\"2.0\",\"id\":1,\"result\":"
            "{\"context\":{\"slot\":1069},\"value\":{\"blockhash\":\"" +
            response_blockhash_ + "\", \"lastValidBlockHeight\":3090}}}";
+  }
+
+  void TestGetLatestBlockhash(bool try_cached_value,
+                              const std::string& expected_latest_blockhash,
+                              mojom::SolanaProviderError expected_error,
+                              const std::string& expected_error_message) {
+    base::RunLoop run_loop;
+    tracker_->GetLatestBlockhash(
+        base::BindLambdaForTesting([&](const std::string& latest_blockhash,
+                                       mojom::SolanaProviderError error,
+                                       const std::string& error_message) {
+          EXPECT_EQ(latest_blockhash, expected_latest_blockhash);
+          EXPECT_EQ(error, expected_error);
+          EXPECT_EQ(error_message, expected_error_message);
+          run_loop.Quit();
+        }),
+        try_cached_value);
+    run_loop.Run();
   }
 
  protected:
@@ -70,11 +90,11 @@ class SolanaBlockTrackerUnitTest : public testing::Test {
   network::TestURLLoaderFactory url_loader_factory_;
   scoped_refptr<network::SharedURLLoaderFactory> shared_url_loader_factory_;
   std::unique_ptr<JsonRpcService> json_rpc_service_;
+  std::unique_ptr<SolanaBlockTracker> tracker_;
   data_decoder::test::InProcessDataDecoder in_process_data_decoder_;
 };
 
 TEST_F(SolanaBlockTrackerUnitTest, GetLatestBlockhash) {
-  SolanaBlockTracker tracker(json_rpc_service_.get());
   url_loader_factory_.SetInterceptor(
       base::BindLambdaForTesting([&](const network::ResourceRequest& request) {
         url_loader_factory_.ClearResponses();
@@ -83,30 +103,29 @@ TEST_F(SolanaBlockTrackerUnitTest, GetLatestBlockhash) {
       }));
   response_blockhash_ = "hash1";
   TrackerObserver observer;
-  tracker.AddObserver(&observer);
+  tracker_->AddObserver(&observer);
 
-  tracker.Start(base::Seconds(5));
+  tracker_->Start(base::Seconds(5));
   task_environment_.FastForwardBy(base::Seconds(5));
   EXPECT_EQ(observer.latest_blockhash(), "hash1");
   EXPECT_EQ(observer.latest_blockhash_updated_fired(), 1u);
-  EXPECT_EQ(tracker.latest_blockhash(), "hash1");
+  EXPECT_EQ(tracker_->latest_blockhash(), "hash1");
 
   response_blockhash_ = "hash2";
-  tracker.Start(base::Seconds(5));
+  tracker_->Start(base::Seconds(5));
   task_environment_.FastForwardBy(base::Seconds(5));
   EXPECT_EQ(observer.latest_blockhash(), "hash2");
   EXPECT_EQ(observer.latest_blockhash_updated_fired(), 2u);
-  EXPECT_EQ(tracker.latest_blockhash(), "hash2");
+  EXPECT_EQ(tracker_->latest_blockhash(), "hash2");
 
   // Still response_blockhash_ hash2, shouldn't fire updated event.
   task_environment_.FastForwardBy(base::Seconds(5));
   EXPECT_EQ(observer.latest_blockhash(), "hash2");
   EXPECT_EQ(observer.latest_blockhash_updated_fired(), 2u);
-  EXPECT_EQ(tracker.latest_blockhash(), "hash2");
+  EXPECT_EQ(tracker_->latest_blockhash(), "hash2");
 }
 
 TEST_F(SolanaBlockTrackerUnitTest, GetLatestBlockhashInvalidResponseJSON) {
-  SolanaBlockTracker tracker(json_rpc_service_.get());
   url_loader_factory_.SetInterceptor(
       base::BindLambdaForTesting([&](const network::ResourceRequest& request) {
         url_loader_factory_.ClearResponses();
@@ -116,17 +135,16 @@ TEST_F(SolanaBlockTrackerUnitTest, GetLatestBlockhashInvalidResponseJSON) {
 
   response_blockhash_ = "hash3";
   TrackerObserver observer;
-  tracker.AddObserver(&observer);
+  tracker_->AddObserver(&observer);
 
-  tracker.Start(base::Seconds(5));
+  tracker_->Start(base::Seconds(5));
   task_environment_.FastForwardBy(base::Seconds(5));
   EXPECT_EQ(observer.latest_blockhash(), "");
   EXPECT_EQ(observer.latest_blockhash_updated_fired(), 0u);
-  EXPECT_EQ(tracker.latest_blockhash(), "");
+  EXPECT_EQ(tracker_->latest_blockhash(), "");
 }
 
 TEST_F(SolanaBlockTrackerUnitTest, GetLatestBlockhashInternalError) {
-  SolanaBlockTracker tracker(json_rpc_service_.get());
   url_loader_factory_.SetInterceptor(
       base::BindLambdaForTesting([&](const network::ResourceRequest& request) {
         url_loader_factory_.ClearResponses();
@@ -143,17 +161,16 @@ TEST_F(SolanaBlockTrackerUnitTest, GetLatestBlockhashInternalError) {
 
   response_blockhash_ = "hash3";
   TrackerObserver observer;
-  tracker.AddObserver(&observer);
+  tracker_->AddObserver(&observer);
 
-  tracker.Start(base::Seconds(5));
+  tracker_->Start(base::Seconds(5));
   task_environment_.FastForwardBy(base::Seconds(5));
   EXPECT_EQ(observer.latest_blockhash(), "");
   EXPECT_EQ(observer.latest_blockhash_updated_fired(), 0u);
-  EXPECT_EQ(tracker.latest_blockhash(), "");
+  EXPECT_EQ(tracker_->latest_blockhash(), "");
 }
 
 TEST_F(SolanaBlockTrackerUnitTest, GetLatestBlockhashRequestTimeout) {
-  SolanaBlockTracker tracker(json_rpc_service_.get());
   url_loader_factory_.SetInterceptor(
       base::BindLambdaForTesting([&](const network::ResourceRequest& request) {
         url_loader_factory_.ClearResponses();
@@ -163,13 +180,63 @@ TEST_F(SolanaBlockTrackerUnitTest, GetLatestBlockhashRequestTimeout) {
 
   response_blockhash_ = "hash3";
   TrackerObserver observer;
-  tracker.AddObserver(&observer);
+  tracker_->AddObserver(&observer);
 
-  tracker.Start(base::Seconds(5));
+  tracker_->Start(base::Seconds(5));
   task_environment_.FastForwardBy(base::Seconds(5));
   EXPECT_EQ(observer.latest_blockhash(), "");
   EXPECT_EQ(observer.latest_blockhash_updated_fired(), 0u);
-  EXPECT_EQ(tracker.latest_blockhash(), "");
+  EXPECT_EQ(tracker_->latest_blockhash(), "");
+}
+
+TEST_F(SolanaBlockTrackerUnitTest, GetLatestBlockhashWithoutStartTracker) {
+  ASSERT_FALSE(tracker_->IsRunning());
+
+  url_loader_factory_.SetInterceptor(
+      base::BindLambdaForTesting([&](const network::ResourceRequest& request) {
+        url_loader_factory_.ClearResponses();
+        url_loader_factory_.AddResponse(request.url.spec(),
+                                        GetResponseString());
+      }));
+
+  response_blockhash_ = "hash1";
+  TestGetLatestBlockhash(false, "hash1", mojom::SolanaProviderError::kSuccess,
+                         "");
+
+  // Cached value would be used if it's not expired yet.
+  response_blockhash_ = "hash2";
+  TestGetLatestBlockhash(true, "hash1", mojom::SolanaProviderError::kSuccess,
+                         "");
+  TestGetLatestBlockhash(false, "hash2", mojom::SolanaProviderError::kSuccess,
+                         "");
+
+  // Cached value would expire after kBlockTrackerDefaultTimeInSeconds.
+  response_blockhash_ = "hash3";
+  task_environment_.FastForwardBy(
+      base::Seconds(kBlockTrackerDefaultTimeInSeconds));
+  TestGetLatestBlockhash(true, "hash3", mojom::SolanaProviderError::kSuccess,
+                         "");
+  TestGetLatestBlockhash(false, "hash3", mojom::SolanaProviderError::kSuccess,
+                         "");
+
+  // Callback should be called when JSON-RPC failed, cached blockhash won't be
+  // updated and can continue to be used until expired.
+  url_loader_factory_.SetInterceptor(
+      base::BindLambdaForTesting([&](const network::ResourceRequest& request) {
+        url_loader_factory_.ClearResponses();
+        url_loader_factory_.AddResponse(request.url.spec(), "",
+                                        net::HTTP_REQUEST_TIMEOUT);
+      }));
+  TestGetLatestBlockhash(false, "", mojom::SolanaProviderError::kInternalError,
+                         l10n_util::GetStringUTF8(IDS_WALLET_INTERNAL_ERROR));
+  TestGetLatestBlockhash(true, "hash3", mojom::SolanaProviderError::kSuccess,
+                         "");
+  task_environment_.FastForwardBy(
+      base::Seconds(kBlockTrackerDefaultTimeInSeconds));
+  TestGetLatestBlockhash(false, "", mojom::SolanaProviderError::kInternalError,
+                         l10n_util::GetStringUTF8(IDS_WALLET_INTERNAL_ERROR));
+  TestGetLatestBlockhash(true, "", mojom::SolanaProviderError::kInternalError,
+                         l10n_util::GetStringUTF8(IDS_WALLET_INTERNAL_ERROR));
 }
 
 }  // namespace brave_wallet

--- a/components/brave_wallet/browser/solana_message.cc
+++ b/components/brave_wallet/browser/solana_message.cc
@@ -119,10 +119,17 @@ absl::optional<std::vector<uint8_t>> SolanaMessage::Serialize(
     if (account_meta.is_signer) {
       if (signers)
         signers->push_back(account_meta.pubkey);
+      if (num_required_signatures == UINT8_MAX)
+        return absl::nullopt;
       num_required_signatures++;
-      if (!account_meta.is_writable)
+      if (!account_meta.is_writable) {
+        if (num_readonly_signed_accounts == UINT8_MAX)
+          return absl::nullopt;
         num_readonly_signed_accounts++;
+      }
     } else if (!account_meta.is_writable) {
+      if (num_readonly_unsigned_accounts == UINT8_MAX)
+        return absl::nullopt;
       num_readonly_unsigned_accounts++;
     }
   }

--- a/components/brave_wallet/browser/solana_requests.cc
+++ b/components/brave_wallet/browser/solana_requests.cc
@@ -73,6 +73,10 @@ std::string getAccountInfo(const std::string& pubkey) {
   return GetJSON(dictionary);
 }
 
+std::string getFeeForMessage(const std::string& message) {
+  return GetJsonRpc1Param("getFeeForMessage", message);
+}
+
 }  // namespace solana
 
 }  // namespace brave_wallet

--- a/components/brave_wallet/browser/solana_requests.h
+++ b/components/brave_wallet/browser/solana_requests.h
@@ -19,6 +19,7 @@ std::string sendTransaction(const std::string& signed_tx);
 std::string getLatestBlockhash();
 std::string getSignatureStatuses(const std::vector<std::string>& tx_signatures);
 std::string getAccountInfo(const std::string& pubkey);
+std::string getFeeForMessage(const std::string& message);
 
 }  // namespace solana
 

--- a/components/brave_wallet/browser/solana_requests_unittest.cc
+++ b/components/brave_wallet/browser/solana_requests_unittest.cc
@@ -68,6 +68,12 @@ TEST(SolanaRequestsUnitTest, getAccountInfo) {
       R"({"id":1,"jsonrpc":"2.0","method":"getAccountInfo","params":["pubkey",{"encoding":"base64"}]})");
 }
 
+TEST(SolanaRequestsUnitTest, getFeeForMessage) {
+  ASSERT_EQ(
+      getFeeForMessage("message"),
+      R"({"id":1,"jsonrpc":"2.0","method":"getFeeForMessage","params":["message"]})");
+}
+
 }  // namespace solana
 
 }  // namespace brave_wallet

--- a/components/brave_wallet/browser/solana_response_parser.cc
+++ b/components/brave_wallet/browser/solana_response_parser.cc
@@ -117,7 +117,7 @@ bool ParseGetLatestBlockhash(const std::string& json, std::string* hash) {
     return false;
 
   auto* hash_ptr = value->FindStringKey("blockhash");
-  if (!hash_ptr)
+  if (!hash_ptr || hash_ptr->empty())
     return false;
   *hash = *hash_ptr;
 
@@ -236,6 +236,16 @@ bool ParseGetAccountInfo(const std::string& json,
   *account_info_out = account_info;
 
   return true;
+}
+
+bool ParseGetFeeForMessage(const std::string& json, uint64_t* fee) {
+  DCHECK(fee);
+
+  base::Value result;
+  if (!ParseResult(json, &result) || !result.is_dict())
+    return false;
+
+  return GetUint64FromDictValue(result, "value", true, fee);
 }
 
 }  // namespace solana

--- a/components/brave_wallet/browser/solana_response_parser.h
+++ b/components/brave_wallet/browser/solana_response_parser.h
@@ -30,6 +30,7 @@ bool ParseGetSignatureStatuses(
     std::vector<absl::optional<SolanaSignatureStatus>>* statuses);
 bool ParseGetAccountInfo(const std::string& json,
                          absl::optional<SolanaAccountInfo>* account_info_out);
+bool ParseGetFeeForMessage(const std::string& json, uint64_t* fee);
 
 }  // namespace solana
 

--- a/components/brave_wallet/browser/solana_transaction.cc
+++ b/components/brave_wallet/browser/solana_transaction.cc
@@ -73,6 +73,17 @@ std::string SolanaTransaction::GetSignedTransaction(
   return base::Base64Encode(transaction_bytes);
 }
 
+std::string SolanaTransaction::GetBase64EncodedMessage(
+    const std::string& recent_blockhash) {
+  if (!recent_blockhash.empty())
+    message_.SetRecentBlockHash(recent_blockhash);
+  auto message_bytes = message_.Serialize(nullptr /* signers */);
+  if (!message_bytes)
+    return "";
+
+  return base::Base64Encode(*message_bytes);
+}
+
 mojom::SolanaTxDataPtr SolanaTransaction::ToSolanaTxData() const {
   auto solana_tx_data = message_.ToSolanaTxData();
   solana_tx_data->to_wallet_address = to_wallet_address_;

--- a/components/brave_wallet/browser/solana_transaction.h
+++ b/components/brave_wallet/browser/solana_transaction.h
@@ -10,6 +10,7 @@
 #include <string>
 #include <vector>
 
+#include "base/gtest_prod_util.h"
 #include "brave/components/brave_wallet/browser/solana_message.h"
 #include "brave/components/brave_wallet/common/brave_wallet.mojom.h"
 #include "third_party/abseil-cpp/absl/types/optional.h"
@@ -33,9 +34,13 @@ class SolanaTransaction {
   ~SolanaTransaction();
   bool operator==(const SolanaTransaction&) const;
 
-  // Serialize the message and sign it.
+  // Serialize the message and sign it. latest_blockhash_ will be updated if
+  // non-empty recent_blockhash is passed.
   std::string GetSignedTransaction(KeyringService* keyring_service,
                                    const std::string& recent_blockhash);
+  // Serialize and encode the message in Base64, latest_blockhash_ will be
+  // updated if non-empty recent_blockhash is passed.
+  std::string GetBase64EncodedMessage(const std::string& recent_blockhash);
 
   mojom::SolanaTxDataPtr ToSolanaTxData() const;
   base::Value ToValue() const;
@@ -61,6 +66,7 @@ class SolanaTransaction {
   void set_amount(uint64_t amount) { amount_ = amount; }
 
  private:
+  FRIEND_TEST_ALL_PREFIXES(SolanaTransactionUnitTest, GetBase64EncodedMessage);
   SolanaMessage message_;
 
   // Data fields to be used for UI, they are filled currently when we create

--- a/components/brave_wallet/browser/solana_tx_manager.cc
+++ b/components/brave_wallet/browser/solana_tx_manager.cc
@@ -85,17 +85,11 @@ void SolanaTxManager::ApproveTransaction(const std::string& tx_meta_id,
     return;
   }
 
-  // Try to use available latest blockhash from block tracker first.
-  std::string hash = GetSolanaBlockTracker()->latest_blockhash();
-  if (!hash.empty()) {
-    OnGetLatestBlockhash(std::move(meta), std::move(callback), hash,
-                         mojom::SolanaProviderError::kSuccess, "");
-    return;
-  }
-
-  json_rpc_service_->GetSolanaLatestBlockhash(base::BindOnce(
-      &SolanaTxManager::OnGetLatestBlockhash, weak_ptr_factory_.GetWeakPtr(),
-      std::move(meta), std::move(callback)));
+  GetSolanaBlockTracker()->GetLatestBlockhash(
+      base::BindOnce(&SolanaTxManager::OnGetLatestBlockhash,
+                     weak_ptr_factory_.GetWeakPtr(), std::move(meta),
+                     std::move(callback)),
+      true);
 }
 
 void SolanaTxManager::OnGetLatestBlockhash(std::unique_ptr<SolanaTxMeta> meta,

--- a/components/brave_wallet/browser/solana_tx_manager.h
+++ b/components/brave_wallet/browser/solana_tx_manager.h
@@ -58,6 +58,8 @@ class SolanaTxManager : public TxManager, public SolanaBlockTracker::Observer {
       mojom::SolanaTxManagerProxy::MakeSystemProgramTransferTxDataCallback;
   using MakeTokenProgramTransferTxDataCallback =
       mojom::SolanaTxManagerProxy::MakeTokenProgramTransferTxDataCallback;
+  using GetEstimatedTxFeeCallback =
+      mojom::SolanaTxManagerProxy::GetEstimatedTxFeeCallback;
   void MakeSystemProgramTransferTxData(
       const std::string& from,
       const std::string& to,
@@ -69,6 +71,8 @@ class SolanaTxManager : public TxManager, public SolanaBlockTracker::Observer {
       const std::string& to_wallet_address,
       uint64_t amount,
       MakeTokenProgramTransferTxDataCallback callback);
+  void GetEstimatedTxFee(const std::string& tx_meta_id,
+                         GetEstimatedTxFeeCallback callback);
 
   std::unique_ptr<SolanaTxMeta> GetTxForTesting(const std::string& tx_meta_id);
 
@@ -104,6 +108,16 @@ class SolanaTxManager : public TxManager, public SolanaBlockTracker::Observer {
                         absl::optional<SolanaAccountInfo> account_info,
                         mojom::SolanaProviderError error,
                         const std::string& error_message);
+  void OnGetLatestBlockhashForGetEstimatedTxFee(
+      std::unique_ptr<SolanaTxMeta> meta,
+      GetEstimatedTxFeeCallback callback,
+      const std::string& latest_blockhash,
+      mojom::SolanaProviderError error,
+      const std::string& error_message);
+  void OnGetFeeForMessage(GetEstimatedTxFeeCallback callback,
+                          uint64_t tx_fee,
+                          mojom::SolanaProviderError error,
+                          const std::string& error_message);
 
   // SolanaBlockTracker::Observer
   void OnLatestBlockhashUpdated(const std::string& blockhash) override;

--- a/components/brave_wallet/browser/tx_service.cc
+++ b/components/brave_wallet/browser/tx_service.cc
@@ -276,4 +276,9 @@ void TxService::MakeTokenProgramTransferTxData(
       std::move(callback));
 }
 
+void TxService::GetEstimatedTxFee(const std::string& tx_meta_id,
+                                  GetEstimatedTxFeeCallback callback) {
+  GetSolanaTxManager()->GetEstimatedTxFee(tx_meta_id, std::move(callback));
+}
+
 }  // namespace brave_wallet

--- a/components/brave_wallet/browser/tx_service.h
+++ b/components/brave_wallet/browser/tx_service.h
@@ -149,6 +149,8 @@ class TxService : public KeyedService,
       const std::string& to_wallet_address,
       uint64_t amount,
       MakeTokenProgramTransferTxDataCallback callback) override;
+  void GetEstimatedTxFee(const std::string& tx_meta_id,
+                         GetEstimatedTxFeeCallback callback) override;
 
  private:
   friend class EthTxManagerUnitTest;

--- a/components/brave_wallet/common/brave_wallet.mojom
+++ b/components/brave_wallet/common/brave_wallet.mojom
@@ -872,6 +872,8 @@ interface SolanaTxManagerProxy {
       string to_wallet_address,
       uint64 amount)
       => (SolanaTxData? tx_data, SolanaProviderError error, string error_message);
+
+  GetEstimatedTxFee(string tx_meta_id) => (uint64 fee, SolanaProviderError error, string error_message);
 };
 
 interface BraveWalletServiceObserver {


### PR DESCRIPTION
<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/21841

This PR implement and expose `SolanaTxManagerProxy::GetEstimatedTxFee` for UI to call whenever they need to display the latest estimation of transaction fee, which backend would help calling `getFeeForMessage` JSPN-RPC.
`getFeeForMessage` JSPN-RPC needs to be called with a base64 encoded message and a valid latest blockhash inside the message itself.
This PR also updates `SolanaBlockTracker::GetLatestBlockhash` for outside callers to be able to get the latest blockhash at any time, and the result will be cached for 30s.

## Submitter Checklist:

- [ ] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

