### PR TITLE
Send P2A json messages to the P3A endpoint.

### DIFF
--- a/components/p3a/brave_p3a_new_uploader.cc
+++ b/components/p3a/brave_p3a_new_uploader.cc
@@ -71,25 +71,19 @@ net::NetworkTrafficAnnotationTag GetNetworkTrafficAnnotation(
 
 BraveP3ANewUploader::BraveP3ANewUploader(
     scoped_refptr<network::SharedURLLoaderFactory> url_loader_factory,
-    const GURL& p3a_endpoint,
-    const GURL& p2a_endpoint)
-    : url_loader_factory_(url_loader_factory),
-      p3a_endpoint_(p3a_endpoint),
-      p2a_endpoint_(p2a_endpoint) {}
+    const GURL& p3a_endpoint)
+    : url_loader_factory_(url_loader_factory), p3a_endpoint_(p3a_endpoint) {}
 
 BraveP3ANewUploader::~BraveP3ANewUploader() = default;
 
 void BraveP3ANewUploader::UploadLog(const std::string& compressed_log_data,
                                     const std::string& upload_type) {
   auto resource_request = std::make_unique<network::ResourceRequest>();
-  if (upload_type == "p2a") {
-    resource_request->url = p2a_endpoint_;
-    resource_request->headers.SetHeader("X-Brave-P2A", "?1");
-    // TODO(issues/20478): Re-enable once backend is ready.
-    return;
-  } else if (upload_type == "p3a") {
-    resource_request->url = p3a_endpoint_;
+  resource_request->url = p3a_endpoint_;
+  if (upload_type == "p3a") {
     resource_request->headers.SetHeader("X-Brave-P3A", "?1");
+  } else if (upload_type == "p2a") {
+    resource_request->headers.SetHeader("X-Brave-P2A", "?1");
   } else {
     NOTREACHED();
   }

--- a/components/p3a/brave_p3a_new_uploader.h
+++ b/components/p3a/brave_p3a_new_uploader.h
@@ -27,8 +27,7 @@ class BraveP3ANewUploader {
  public:
   BraveP3ANewUploader(
       scoped_refptr<network::SharedURLLoaderFactory> url_loader_factory,
-      const GURL& p3a_endpoint,
-      const GURL& p2a_endpoint);
+      const GURL& p3a_endpoint);
 
   BraveP3ANewUploader(const BraveP3ANewUploader&) = delete;
   BraveP3ANewUploader& operator=(const BraveP3ANewUploader&) = delete;
@@ -44,7 +43,6 @@ class BraveP3ANewUploader {
  private:
   scoped_refptr<network::SharedURLLoaderFactory> url_loader_factory_;
   const GURL p3a_endpoint_;
-  const GURL p2a_endpoint_;
   std::unique_ptr<network::SimpleURLLoader> url_loader_;
 };
 

--- a/components/p3a/brave_p3a_service.cc
+++ b/components/p3a/brave_p3a_service.cc
@@ -56,7 +56,6 @@ constexpr char kP3AServerUrl[] = "https://p3a.brave.com/";
 constexpr char kP2AServerUrl[] = "https://p2a.brave.com/";
 
 constexpr char kP3AJsonServerUrl[] = "https://p3a-json.brave.com/";
-constexpr char kP2AJsonServerUrl[] = "https://p2a-json.brave.com/";
 
 constexpr uint64_t kDefaultUploadIntervalSeconds = 60;  // 1 minute.
 
@@ -292,8 +291,8 @@ void BraveP3AService::Init(
       url_loader_factory, upload_server_url_, GURL(kP2AServerUrl),
       base::BindRepeating(&BraveP3AService::OnLogUploadComplete, this)));
 
-  new_uploader_.reset(new BraveP3ANewUploader(
-      url_loader_factory, GURL(kP3AJsonServerUrl), GURL(kP2AJsonServerUrl)));
+  new_uploader_.reset(
+      new BraveP3ANewUploader(url_loader_factory, GURL(kP3AJsonServerUrl)));
 
   upload_scheduler_.reset(new BraveP3AScheduler(
       base::BindRepeating(&BraveP3AService::StartScheduledUpload, this),


### PR DESCRIPTION
These are handled with the same reporting software and privacy
protections on the server-side, so there's no value to maintaining
a separate endpoint for the P2A message type. Instead, send them
all to p3a-json.brave.com and sort into the approprate queue
on the back end.

<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/20478


## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

Launch browser with a network proxy. **Observe P2A messages being sent**.
- protobuf-encoded messages should be sent to p2a.brave.com as before
- json-encoded messages should also be sent to p3a-json.brave.com alongside P3A messages (new behaviour)
- P2A messages can be identified by the `Brave.P2A` prefix in the metric name
- P2A messages should have the `X-Brave-P2A` http header set.

I'm not sure how to trigger P2A reporting. Maybe something like this would work?
- Launch browser
- Enable rewards
- Browse long enough for ads to be presented e.g. enable Brave News and scroll until an ad is shown, open new tabs until the new tab page shows a paid image, click on the embedded link.
- Confirm `Brave.P2A` metrics are listed under `brave.p3a` in brave://local-state
- If metrics have already been sent on the profile, advance system clock to midnight on a future Sunday night to trigger a new round of submissions. Sometimes I've been able to get a few P2A reports sent on first launch.
- Wait ~10 minutes for reports to be sent over the network.