### PR TITLE
Brave News: Peek card on NTP (desktop)

### DIFF
--- a/browser/about_flags.cc
+++ b/browser/about_flags.cc
@@ -269,6 +269,12 @@ constexpr char kBraveNewsDescription[] =
     "Brave News is completely private and includes anonymized ads matched on "
     "your device.";
 
+constexpr char kBraveNewsCardPeekFeatureName[] =
+    "Brave News prompts on New Tab Page";
+constexpr char kBraveNewsCardPeekFeatureDescription[] =
+    "Prompt Brave News via the top featured article peeking up from the bottom "
+    "of the New Tab Page, after a short delay.";
+
 constexpr char kCryptoWalletsForNewInstallsName[] =
     "Enable Crypto Wallets option in settings";
 constexpr char kCryptoWalletsForNewInstallsDescription[] =
@@ -400,12 +406,17 @@ const flags_ui::FeatureEntry::Choice kBraveSkusEnvChoices[] = {
      FEATURE_VALUE_TYPE(                                                       \
       brave_wallet::features::kBraveWalletSolanaProviderFeature)},
 
-#define BRAVE_NEWS_FEATURE_ENTRIES                                  \
-    {"brave-news",                                                  \
-     flag_descriptions::kBraveNewsName,                             \
-     flag_descriptions::kBraveNewsDescription,                      \
-     kOsDesktop | kOsAndroid,                                       \
-     FEATURE_VALUE_TYPE(brave_today::features::kBraveNewsFeature)},
+#define BRAVE_NEWS_FEATURE_ENTRIES                                         \
+    {"brave-news",                                                         \
+     flag_descriptions::kBraveNewsName,                                    \
+     flag_descriptions::kBraveNewsDescription,                             \
+     kOsDesktop | kOsAndroid,                                              \
+     FEATURE_VALUE_TYPE(brave_today::features::kBraveNewsFeature)},        \
+    {"brave-news-peek",                                                    \
+     flag_descriptions::kBraveNewsCardPeekFeatureName,                     \
+     flag_descriptions::kBraveNewsCardPeekFeatureDescription,              \
+     kOsDesktop,                                                           \
+     FEATURE_VALUE_TYPE(brave_today::features::kBraveNewsCardPeekFeature)},
 
 #if BUILDFLAG(ETHEREUM_REMOTE_CLIENT_ENABLED)
 #define CRYPTO_WALLETS_FEATURE_ENTRIES                                       \

--- a/browser/ui/webui/new_tab_page/brave_new_tab_ui.cc
+++ b/browser/ui/webui/new_tab_page/brave_new_tab_ui.cc
@@ -59,6 +59,9 @@ BraveNewTabUI::BraveNewTabUI(content::WebUI* web_ui, const std::string& name)
   source->AddBoolean(
       "featureFlagBraveNewsEnabled",
       base::FeatureList::IsEnabled(brave_today::features::kBraveNewsFeature));
+  source->AddBoolean("featureFlagBraveNewsPromptEnabled",
+                     base::FeatureList::IsEnabled(
+                         brave_today::features::kBraveNewsCardPeekFeature));
   web_ui->AddMessageHandler(
       base::WrapUnique(BraveNewTabMessageHandler::Create(source, profile)));
   web_ui->AddMessageHandler(

--- a/components/brave_new_tab_ui/actions/today_actions.ts
+++ b/components/brave_new_tab_ui/actions/today_actions.ts
@@ -78,4 +78,7 @@ export const isUpdateAvailable = createAction<IsUpdateAvailablePayload>('isUpdat
 
 export const resetTodayPrefsToDefault = createAction('resetTodayPrefsToDefault')
 
-export const refresh = createAction('refresh')
+export type RefreshPayload = {
+  isFirstInteraction: boolean
+} | void
+export const refresh = createAction<RefreshPayload>('refresh')

--- a/components/brave_new_tab_ui/components/default/braveToday/default.ts
+++ b/components/brave_new_tab_ui/components/default/braveToday/default.ts
@@ -24,6 +24,10 @@ export const Section = styled('section')`
   display: flex;
   align-items: center;
   flex-direction: column;
+  transition: margin 2s ease-out;
+  [data-show-news-prompt] & {
+    margin-top: -100px;
+  }
 `
 
 export const ArticlesGroup = styled('section')`

--- a/components/brave_new_tab_ui/components/default/page/index.tsx
+++ b/components/brave_new_tab_ui/components/default/page/index.tsx
@@ -67,7 +67,7 @@ const StyledPage = styled('div')<PageProps>`
   -webkit-font-smoothing: antialiased;
   box-sizing: border-box;
   position: relative;
-  z-index: 3;
+  z-index: 6;
   width: 100%;
   display: grid;
   grid-template-rows: repeat(calc(var(--ntp-page-rows) - 1), min-content) auto;
@@ -85,6 +85,7 @@ const StyledPage = styled('div')<PageProps>`
   NTP items remain in the same place, and still allows NTP
   Page to scroll to the bottom before that starts happening. */
   .${CLASSNAME_PAGE_STUCK} & {
+    z-index: 3;
     position: fixed;
     bottom: 0;
     /* Blur out the content when Brave Today is interacted
@@ -255,6 +256,10 @@ export const GridItemNavigationBraveToday = styled('div')<{}>`
   left: 50%;
   transform: translate(-50%, 0);
   margin: 0 auto;
+  transition: bottom 2s ease-out;
+  [data-show-news-prompt] & {
+    bottom: 120px;
+  }
 `
 
 export const Footer = styled('footer')<{}>`

--- a/components/brave_new_tab_ui/components/default/settings/index.ts
+++ b/components/brave_new_tab_ui/components/default/settings/index.ts
@@ -341,7 +341,7 @@ export const SettingsWrapper = styled('div')<SettingsWrapperProps>`
   left: 0;
   width: 100%;
   height: 100%;
-  z-index: 5;
+  z-index: 7;
   display: flex;
   justify-content: center;
   align-items: center;

--- a/components/brave_new_tab_ui/reducers/today/index.ts
+++ b/components/brave_new_tab_ui/reducers/today/index.ts
@@ -42,6 +42,7 @@ const defaultState: BraveTodayState = {
 if (history.state && (history.state.todayArticle || history.state.todayAdPosition)) {
   // TODO(petemill): Type this history.state data and put in an API module
   // see `async/today`.
+  defaultState.hasInteracted = true
   defaultState.currentPageIndex = history.state.todayPageIndex as number || 0
   defaultState.articleScrollTo = history.state.todayArticle
   if (!defaultState.articleScrollTo) {
@@ -67,8 +68,7 @@ export default reducer
 
 reducer.on(Actions.interactionBegin, (state, payload) => ({
   ...state,
-  hasInteracted: true,
-  isFetching: true
+  hasInteracted: true
 }))
 
 reducer.on(Actions.errorGettingDataFromBackground, (state, payload) => ({
@@ -171,10 +171,14 @@ reducer.on(Actions.isUpdateAvailable, (state, payload) => {
   }
 })
 
-reducer.on(Actions.refresh, (state) => {
-  return {
+reducer.on(Actions.refresh, (state, payload) => {
+  state = {
     ...state,
     isFetching: true,
     articleScrollTo: undefined
   }
+  if (payload && payload.isFirstInteraction) {
+    state.hasInteracted = true
+  }
+  return state
 })

--- a/components/brave_new_tab_ui/storage/new_tab_storage.ts
+++ b/components/brave_new_tab_ui/storage/new_tab_storage.ts
@@ -14,6 +14,7 @@ export const defaultState: NewTab.State = {
   textDirection: loadTimeData.getString('textdirection'),
   featureFlagBraveNTPSponsoredImagesWallpaper: loadTimeData.getBoolean('featureFlagBraveNTPSponsoredImagesWallpaper'),
   featureFlagBraveNewsEnabled: loadTimeData.getBoolean('featureFlagBraveNewsEnabled'),
+  featureFlagBraveNewsPromptEnabled: loadTimeData.getBoolean('featureFlagBraveNewsPromptEnabled'),
   featureCustomBackgroundEnabled: loadTimeData.getBoolean('featureCustomBackgroundEnabled'),
   showBackgroundImage: false,
   showStats: false,

--- a/components/brave_new_tab_ui/stories/default/data/storybookState.ts
+++ b/components/brave_new_tab_ui/stories/default/data/storybookState.ts
@@ -67,6 +67,7 @@ export const getNewTabData = (state: NewTab.State = defaultState): NewTab.State 
   ),
   customLinksEnabled: boolean('CustomLinks Enabled?', false),
   featureFlagBraveNewsEnabled: true,
+  featureFlagBraveNewsPromptEnabled: true,
   forceSettingsTab: select('Open settings tab?', [undefined, ...Object.keys(SettingsTabType)], undefined),
   showBackgroundImage: boolean('Show background image?', true),
   showStats: boolean('Show stats?', true),

--- a/components/brave_new_tab_ui/stories/default/data/todayStorybookState.ts
+++ b/components/brave_new_tab_ui/stories/default/data/todayStorybookState.ts
@@ -31,7 +31,7 @@ export default function getTodayState (): BraveTodayState {
   const hasDataError = boolean('Today data fetch error?', false)
   return {
     isFetching: boolean('Today is fetching?', false),
-    hasInteracted: boolean('Today has interacted?', true),
+    hasInteracted: boolean('Today has interacted?', false),
     isUpdateAvailable: boolean('Is Today update available?', false),
     currentPageIndex: 10,
     cardsViewed: 0,
@@ -146,7 +146,7 @@ export default function getTodayState (): BraveTodayState {
           data: {
             categoryName: 'Top News',
             description: 'Here\'s everything you need to know about the Haunted Hallows event, including how to unlock the Batmobile.',
-            image: { imageUrl: undefined, paddedImageUrl: { url: 'https://pcdn.brave.com/brave-today/cache/fe949032ae151bb1257fd5301c5af8c1822982876b26739f92a5e71c5f06a2ec.jpg.pad' } },
+            image: { imageUrl: { url: 'https://placekitten.com/1360/912' }, paddedImageUrl: undefined },
             publishTime: { internalValue: BigInt('13278618001000000') },
             publisherId: 'd75d65f0f747650ef1ea11adb0029f9d577c629a080b5f60ec80d125b2bf205b',
             publisherName: 'Newsweek',

--- a/components/brave_new_tab_ui/stories/regular.tsx
+++ b/components/brave_new_tab_ui/stories/regular.tsx
@@ -12,6 +12,8 @@ import store from '../store'
 import { getNewTabData, getGridSitesData } from './default/data/storybookState'
 import getTodayState from './default/data/todayStorybookState'
 import getBraveNewsDisplayAd from './default/data/getBraveNewsDisplayAd'
+import { getDataUrl, getUnpaddedAsDataUrl } from '../../common/privateCDN'
+import getFTXStorybookState from '../widgets/ftx/ftx_storybook_state'
 
 const doNothingDispatch: Dispatch = (action: any) => action
 
@@ -19,17 +21,16 @@ function getActions () {
   return getActionsForDispatch(doNothingDispatch)
 }
 
-// TODO(petemill): privateCDN should be in /common/
-import { getUnpaddedAsDataUrl } from '../../common/privateCDN'
-import getFTXStorybookState from '../widgets/ftx/ftx_storybook_state'
-
 // @ts-expect-error
 window.braveStorybookUnpadUrl = async function UnpadUrl (paddedUrl: string, mimeType = 'image/jpg'): Promise<string> {
   const response = await fetch(paddedUrl)
   const blob = await response.blob()
   const buffer = await blob.arrayBuffer()
-  const dataUrl = await getUnpaddedAsDataUrl(buffer, mimeType)
-  return dataUrl
+  if (paddedUrl.endsWith('.pad')) {
+    return await getUnpaddedAsDataUrl(buffer, mimeType)
+  }
+  // Image is already unpadded
+  return await getDataUrl(buffer)
 }
 
 const StoreProvider: React.FunctionComponent = ({ children }) => {

--- a/components/brave_today/common/features.cc
+++ b/components/brave_today/common/features.cc
@@ -12,6 +12,8 @@ namespace features {
 
 const base::Feature kBraveNewsFeature{"BraveNews",
                                       base::FEATURE_ENABLED_BY_DEFAULT};
+const base::Feature kBraveNewsCardPeekFeature{"BraveNewsCardPeek",
+                                              base::FEATURE_ENABLED_BY_DEFAULT};
 
 }  // namespace features
 }  // namespace brave_today

--- a/components/brave_today/common/features.h
+++ b/components/brave_today/common/features.h
@@ -14,6 +14,7 @@ namespace brave_today {
 namespace features {
 
 extern const base::Feature kBraveNewsFeature;
+extern const base::Feature kBraveNewsCardPeekFeature;
 
 }  // namespace features
 }  // namespace brave_today

--- a/components/definitions/newTab.d.ts
+++ b/components/definitions/newTab.d.ts
@@ -126,6 +126,7 @@ declare namespace NewTab {
     textDirection: string
     featureFlagBraveNTPSponsoredImagesWallpaper: boolean
     featureFlagBraveNewsEnabled: boolean
+    featureFlagBraveNewsPromptEnabled: boolean
     featureCustomBackgroundEnabled: boolean
     isIncognito: boolean
     useAlternativePrivateSearchEngine: boolean


### PR DESCRIPTION
<!-- Add brave-browser issue bellow that this PR will resolve -->
Adds a prompt to the Desktop NTP where the first Brave News card (a feature article or the "opt-in" card) will _peek_ up after a short delay. This action happens with a slow-ish transition.

Resolves https://github.com/brave/brave-browser/issues/20129

Aims:

With the feature flag on (the default):
- Brave News JS code is still loaded dynamically
- The feed is only requested over mojom IPC once the _peek_ action starts
- The "interaction" event only happens when user scrolls down
- The subsequent items (including and especially the first Ad) are not rendered until the user interacts (scrolls down past the first card)
- Opt-in still works and content is fetched and rendered after opt-in
- Visiting an article and then navigating "back" still scrolls the user down to the visited article in the Brave News feed

With the feature flag off:
- The card does not peek
- The content only loads when the user scrolls down
- The interaction event is still recorded at the same scroll-down gesture


## Submitter Checklist:

- [ ] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

