### PR TITLE
Revert "Merge pull request #12517 from brave/encryption-key"

### DIFF
--- a/components/brave_wallet/browser/brave_wallet_provider_impl.h
+++ b/components/brave_wallet/browser/brave_wallet_provider_impl.h
@@ -83,9 +83,6 @@ class BraveWalletProviderImpl final
                       RequestCallback callback,
                       base::Value id);
 
-  void GetEncryptionPublicKey(const std::string& address,
-                              RequestCallback callback,
-                              base::Value id);
   // Used for eth_signTypedData
   // message is for displaying the sign request to users
   // message_to_sign is the hex representation without 0x for eip712 hash
@@ -225,14 +222,6 @@ class BraveWalletProviderImpl final
                                      base::Value id,
                                      const std::string& normalized_json_request,
                                      mojom::NetworkInfoPtr chain);
-  void ContinueGetEncryptionPublicKey(
-      RequestCallback callback,
-      base::Value id,
-      const std::string& address,
-      const std::vector<std::string>& allowed_accounts,
-      mojom::ProviderError error,
-      const std::string& error_message);
-
   void OnGetNetworkAndDefaultKeyringInfo(
       RequestCallback callback,
       base::Value id,

--- a/components/brave_wallet/browser/brave_wallet_service.cc
+++ b/components/brave_wallet/browser/brave_wallet_service.cc
@@ -748,7 +748,7 @@ void BraveWalletService::AddSignMessageRequest(
 
 void BraveWalletService::AddSuggestTokenRequest(
     mojom::AddSuggestTokenRequestPtr request,
-    mojom::BraveWalletProvider::RequestCallback callback,
+    RequestNewCallback callback,
     base::Value id) {
   // wallet_watchAsset currently only expect non-empty contract address and
   // only ERC20 type.
@@ -789,37 +789,6 @@ void BraveWalletService::AddSuggestTokenRequest(
   add_suggest_token_ids_[addr] = std::move(id);
 }
 
-void BraveWalletService::AddGetPublicKeyRequest(
-    const std::string& address,
-    const GURL& origin,
-    mojom::BraveWalletProvider::RequestCallback callback,
-    base::Value id) {
-  // There can be only 1 request per origin
-  if (add_get_encryption_public_key_requests_.contains(origin)) {
-    std::unique_ptr<base::Value> formed_response;
-    bool reject = true;
-    formed_response = GetProviderErrorDictionary(
-        mojom::ProviderError::kUserRejectedRequest,
-        l10n_util::GetStringUTF8(IDS_WALLET_ALREADY_IN_PROGRESS_ERROR));
-    std::move(callback).Run(std::move(id), std::move(*formed_response), reject,
-                            "", false);
-    return;
-  }
-  add_get_encryption_public_key_requests_[origin] = address;
-  add_get_encryption_public_key_callbacks_[origin] = std::move(callback);
-  get_encryption_public_key_ids_[origin] = std::move(id);
-}
-
-void BraveWalletService::GetPendingGetEncryptionPublicKeyRequests(
-    GetPendingGetEncryptionPublicKeyRequestsCallback callback) {
-  std::vector<mojom::GetEncryptionPublicKeyRequestPtr> requests;
-  for (const auto& request : add_get_encryption_public_key_requests_) {
-    requests.push_back(mojom::GetEncryptionPublicKeyRequest::New(
-        request.first, request.second, ""));
-  }
-  std::move(callback).Run(std::move(requests));
-}
-
 void BraveWalletService::GetPendingAddSuggestTokenRequests(
     GetPendingAddSuggestTokenRequestsCallback callback) {
   std::vector<mojom::AddSuggestTokenRequestPtr> requests;
@@ -838,7 +807,6 @@ void BraveWalletService::NotifyAddSuggestTokenRequestsProcessed(
         add_suggest_token_callbacks_.contains(addr) &&
         add_suggest_token_ids_.contains(addr)) {
       auto callback = std::move(add_suggest_token_callbacks_[addr]);
-      base::Value id = std::move(add_suggest_token_ids_[addr]);
 
       std::unique_ptr<base::Value> formed_response;
       bool reject = false;
@@ -855,8 +823,8 @@ void BraveWalletService::NotifyAddSuggestTokenRequestsProcessed(
             mojom::ProviderError::kInternalError,
             l10n_util::GetStringUTF8(IDS_WALLET_INTERNAL_ERROR));
         reject = true;
-        std::move(callback).Run(std::move(id), std::move(*formed_response),
-                                reject, "", false);
+        std::move(callback).Run(std::move(add_suggest_token_ids_[addr]),
+                                std::move(*formed_response), reject, "", false);
         continue;
       }
 
@@ -865,55 +833,9 @@ void BraveWalletService::NotifyAddSuggestTokenRequestsProcessed(
       add_suggest_token_ids_.erase(addr);
       formed_response = base::Value::ToUniquePtrValue(base::Value(approved));
       reject = false;
-      std::move(callback).Run(std::move(id), std::move(*formed_response),
-                              reject, "", false);
+      std::move(callback).Run(std::move(add_suggest_token_ids_[addr]),
+                              std::move(*formed_response), reject, "", false);
     }
-  }
-}
-
-void BraveWalletService::NotifyGetPublicKeyRequestProcessed(
-    bool approved,
-    const GURL& origin) {
-  if (!add_get_encryption_public_key_requests_.contains(origin) ||
-      !add_get_encryption_public_key_callbacks_.contains(origin) ||
-      !get_encryption_public_key_ids_.contains(origin)) {
-    return;
-  }
-  auto callback = std::move(add_get_encryption_public_key_callbacks_[origin]);
-  base::Value id = std::move(get_encryption_public_key_ids_[origin]);
-
-  std::string address = add_get_encryption_public_key_requests_[origin];
-  add_get_encryption_public_key_requests_.erase(origin);
-  add_get_encryption_public_key_callbacks_.erase(origin);
-  get_encryption_public_key_ids_.erase(origin);
-
-  bool reject = true;
-  if (approved) {
-    std::string key;
-    if (!keyring_service_
-             ->GetPublicKeyFromX25519_XSalsa20_Poly1305ByDefaultKeyring(address,
-                                                                        &key)) {
-      std::unique_ptr<base::Value> formed_response;
-      formed_response = GetProviderErrorDictionary(
-          mojom::ProviderError::kInternalError,
-          l10n_util::GetStringUTF8(IDS_WALLET_INTERNAL_ERROR));
-      std::move(callback).Run(std::move(id), std::move(*formed_response),
-                              reject, "", false);
-      return;
-    }
-
-    std::unique_ptr<base::Value> formed_response;
-    formed_response = base::Value::ToUniquePtrValue(base::Value(key));
-    reject = false;
-    std::move(callback).Run(std::move(id), std::move(*formed_response), reject,
-                            "", false);
-  } else {
-    std::unique_ptr<base::Value> formed_response;
-    formed_response = GetProviderErrorDictionary(
-        mojom::ProviderError::kUserRejectedRequest,
-        l10n_util::GetStringUTF8(IDS_WALLET_USER_REJECTED_REQUEST));
-    std::move(callback).Run(std::move(id), std::move(*formed_response), reject,
-                            "", false);
   }
 }
 
@@ -943,22 +865,6 @@ void BraveWalletService::CancelAllSignMessageCallbacks() {
   }
 }
 
-void BraveWalletService::CancelAllGetEncryptionPublicKeyCallbacks() {
-  add_get_encryption_public_key_requests_.clear();
-  std::unique_ptr<base::Value> formed_response;
-  bool reject = true;
-  for (auto& callback : add_get_encryption_public_key_callbacks_) {
-    formed_response = GetProviderErrorDictionary(
-        mojom::ProviderError::kUserRejectedRequest,
-        l10n_util::GetStringUTF8(IDS_WALLET_USER_REJECTED_REQUEST));
-    std::move(callback.second)
-        .Run(std::move(get_encryption_public_key_ids_[callback.first]),
-             std::move(*formed_response), reject, "", false);
-  }
-  add_get_encryption_public_key_callbacks_.clear();
-  get_encryption_public_key_ids_.clear();
-}
-
 void BraveWalletService::OnNetworkChanged() {
   CancelAllSuggestedTokenCallbacks();
 }
@@ -973,7 +879,6 @@ void BraveWalletService::Reset() {
   ClearBraveWalletServicePrefs(prefs_);
   CancelAllSuggestedTokenCallbacks();
   CancelAllSignMessageCallbacks();
-  CancelAllGetEncryptionPublicKeyCallbacks();
 
   if (keyring_service_)
     keyring_service_->Reset();

--- a/components/brave_wallet/browser/brave_wallet_service.h
+++ b/components/brave_wallet/browser/brave_wallet_service.h
@@ -47,6 +47,8 @@ class BraveWalletService : public KeyedService,
       base::OnceCallback<void(bool, const std::string&, const std::string&)>;
   using AddSuggestTokenCallback =
       base::OnceCallback<void(bool, mojom::ProviderError, const std::string&)>;
+  using RequestNewCallback = base::OnceCallback<
+      void(base::Value, base::Value, bool, const std::string&, bool)>;
 
   BraveWalletService(std::unique_ptr<BraveWalletServiceDelegate> delegate,
                      KeyringService* keyring_service,
@@ -118,13 +120,9 @@ class BraveWalletService : public KeyedService,
       const std::string& error) override;
   void GetPendingAddSuggestTokenRequests(
       GetPendingAddSuggestTokenRequestsCallback callback) override;
-  void GetPendingGetEncryptionPublicKeyRequests(
-      GetPendingGetEncryptionPublicKeyRequestsCallback callback) override;
   void NotifyAddSuggestTokenRequestsProcessed(
       bool approved,
       const std::vector<std::string>& contract_addresses) override;
-  void NotifyGetPublicKeyRequestProcessed(bool approved,
-                                          const GURL& origin) override;
 
   // BraveWalletServiceDelegate::Observer:
   void OnActiveOriginChanged(const std::string& origin) override;
@@ -135,15 +133,9 @@ class BraveWalletService : public KeyedService,
 
   void AddSignMessageRequest(mojom::SignMessageRequestPtr request,
                              SignMessageRequestCallback callback);
-  void AddSuggestTokenRequest(
-      mojom::AddSuggestTokenRequestPtr request,
-      mojom::BraveWalletProvider::RequestCallback callback,
-      base::Value id);
-  void AddGetPublicKeyRequest(
-      const std::string& address,
-      const GURL& origin,
-      mojom::BraveWalletProvider::RequestCallback callback,
-      base::Value id);
+  void AddSuggestTokenRequest(mojom::AddSuggestTokenRequestPtr request,
+                              RequestNewCallback callback,
+                              base::Value id);
 
   void RemovePrefListenersForTests();
 
@@ -197,19 +189,13 @@ class BraveWalletService : public KeyedService,
   void OnNetworkChanged();
   void CancelAllSuggestedTokenCallbacks();
   void CancelAllSignMessageCallbacks();
-  void CancelAllGetEncryptionPublicKeyCallbacks();
 
   base::circular_deque<mojom::SignMessageRequestPtr> sign_message_requests_;
   base::circular_deque<SignMessageRequestCallback> sign_message_callbacks_;
-  base::flat_map<std::string, mojom::BraveWalletProvider::RequestCallback>
-      add_suggest_token_callbacks_;
+  base::flat_map<std::string, RequestNewCallback> add_suggest_token_callbacks_;
   base::flat_map<std::string, base::Value> add_suggest_token_ids_;
   base::flat_map<std::string, mojom::AddSuggestTokenRequestPtr>
       add_suggest_token_requests_;
-  base::flat_map<GURL, std::string> add_get_encryption_public_key_requests_;
-  base::flat_map<GURL, mojom::BraveWalletProvider::RequestCallback>
-      add_get_encryption_public_key_callbacks_;
-  base::flat_map<GURL, base::Value> get_encryption_public_key_ids_;
   mojo::RemoteSet<mojom::BraveWalletServiceObserver> observers_;
   std::unique_ptr<BraveWalletServiceDelegate> delegate_;
   raw_ptr<KeyringService> keyring_service_ = nullptr;

--- a/components/brave_wallet/browser/ethereum_keyring.cc
+++ b/components/brave_wallet/browser/ethereum_keyring.cc
@@ -5,7 +5,6 @@
 
 #include "brave/components/brave_wallet/browser/ethereum_keyring.h"
 
-#include "base/base64.h"
 #include "base/strings/string_number_conversions.h"
 #include "brave/components/brave_wallet/browser/eth_transaction.h"
 #include "brave/components/brave_wallet/common/eth_address.h"
@@ -128,20 +127,6 @@ std::string EthereumKeyring::GetAddressInternal(HDKeyBase* hd_key_base) const {
 
   // TODO(darkdh): chain id op code
   return addr.ToChecksumAddress();
-}
-
-bool EthereumKeyring::GetPublicKeyFromX25519_XSalsa20_Poly1305(
-    const std::string& address,
-    std::string* key) {
-  HDKey* hd_key = static_cast<HDKey*>(GetHDKeyFromAddress(address));
-  if (!hd_key)
-    return false;
-  const std::vector<uint8_t> public_key =
-      hd_key->GetPublicKeyFromX25519_XSalsa20_Poly1305();
-  if (!public_key.size())
-    return false;
-  *key = base::Base64Encode(public_key);
-  return true;
 }
 
 }  // namespace brave_wallet

--- a/components/brave_wallet/browser/ethereum_keyring.h
+++ b/components/brave_wallet/browser/ethereum_keyring.h
@@ -37,9 +37,6 @@ class EthereumKeyring : public HDKeyring {
                        EthTransaction* tx,
                        uint256_t chain_id);
 
-  bool GetPublicKeyFromX25519_XSalsa20_Poly1305(const std::string& address,
-                                                std::string* key);
-
  private:
   std::string GetAddressInternal(HDKeyBase* hd_key) const override;
 };

--- a/components/brave_wallet/browser/ethereum_keyring_unittest.cc
+++ b/components/brave_wallet/browser/ethereum_keyring_unittest.cc
@@ -10,7 +10,6 @@
 
 #include "base/strings/string_number_conversions.h"
 #include "base/strings/string_util.h"
-#include "brave/components/brave_wallet/browser/brave_wallet_utils.h"
 #include "brave/components/brave_wallet/browser/eth_transaction.h"
 #include "testing/gtest/include/gtest/gtest.h"
 
@@ -235,29 +234,6 @@ TEST(EthereumKeyringUnitTest, ImportedAccounts) {
   std::vector<uint8_t> private_key;
   EXPECT_TRUE(base::HexStringToBytes(account_0_pri_key, &private_key));
   EXPECT_TRUE(keyring.ImportAccount(private_key).empty());
-}
-
-TEST(EthereumKeyringUnitTest, GetPublicKeyFromX25519_XSalsa20_Poly1305) {
-  EthereumKeyring keyring;
-  const char kMnemonic[] =
-      "home various adjust motion canvas stand combine gravity cluster behave "
-      "despair dove";
-  std::unique_ptr<std::vector<uint8_t>> seed = MnemonicToSeed(kMnemonic, "");
-  ASSERT_TRUE(seed);
-  keyring.ConstructRootHDKey(*seed, "m/44'/60'/0'/0");
-  keyring.AddAccounts(1);
-  std::string public_encryption_key;
-  EXPECT_TRUE(keyring.GetPublicKeyFromX25519_XSalsa20_Poly1305(
-      keyring.GetAddress(0), &public_encryption_key));
-  EXPECT_EQ(public_encryption_key,
-            "eui9/fqCHT7aSUkKK9eooQFnOCD9COK9Mi1ZtOxIj2A=");
-
-  // Incorrect address
-  EXPECT_FALSE(keyring.GetPublicKeyFromX25519_XSalsa20_Poly1305(
-      "0xbE93f9BacBcFFC8ee6663f2647917ed7A20a57BB", &public_encryption_key));
-  // Invalid address
-  EXPECT_FALSE(keyring.GetPublicKeyFromX25519_XSalsa20_Poly1305(
-      "", &public_encryption_key));
 }
 
 }  // namespace brave_wallet

--- a/components/brave_wallet/browser/internal/BUILD.gn
+++ b/components/brave_wallet/browser/internal/BUILD.gn
@@ -17,7 +17,6 @@ source_set("hd_key") {
     "//brave/components/brave_wallet/common",
     "//brave/third_party/bitcoin-core",
     "//brave/third_party/bitcoin-core:secp256k1",
-    "//brave/vendor/bat-native-tweetnacl:tweetnacl",
     "//crypto",
     "//third_party/boringssl",
   ]

--- a/components/brave_wallet/browser/internal/hd_key.cc
+++ b/components/brave_wallet/browser/internal/hd_key.cc
@@ -16,7 +16,6 @@
 #include "brave/third_party/bitcoin-core/src/src/base58.h"
 #include "brave/third_party/bitcoin-core/src/src/crypto/ripemd160.h"
 #include "brave/third_party/bitcoin-core/src/src/secp256k1/include/secp256k1_recovery.h"
-#include "brave/vendor/bat-native-tweetnacl/tweetnacl.h"
 #include "crypto/encryptor.h"
 #include "crypto/sha2.h"
 #include "crypto/symmetric_key.h"
@@ -418,15 +417,6 @@ std::vector<uint8_t> HDKey::GetUncompressedPublicKey() const {
     LOG(ERROR) << __func__ << ": secp256k1_ec_pubkey_serialize failed";
   }
 
-  return public_key;
-}
-
-std::vector<uint8_t> HDKey::GetPublicKeyFromX25519_XSalsa20_Poly1305() const {
-  size_t public_key_len = crypto_scalarmult_curve25519_tweet_BYTES;
-  std::vector<uint8_t> public_key(public_key_len);
-  if (crypto_scalarmult_curve25519_tweet_base(public_key.data(),
-                                              private_key_.data()) != 0)
-    return std::vector<uint8_t>();
   return public_key;
 }
 

--- a/components/brave_wallet/browser/internal/hd_key.h
+++ b/components/brave_wallet/browser/internal/hd_key.h
@@ -48,7 +48,6 @@ class HDKey : public HDKeyBase {
   // base58 encoded of hash160 of public key
   std::string GetPublicExtendedKey() const;
   std::vector<uint8_t> GetUncompressedPublicKey() const;
-  std::vector<uint8_t> GetPublicKeyFromX25519_XSalsa20_Poly1305() const;
 
   void SetChainCode(const std::vector<uint8_t>& value);
 

--- a/components/brave_wallet/browser/keyring_service.cc
+++ b/components/brave_wallet/browser/keyring_service.cc
@@ -1308,18 +1308,6 @@ bool KeyringService::RecoverAddressByDefaultKeyring(
   return EthereumKeyring::RecoverAddress(message, signature, address);
 }
 
-bool KeyringService::GetPublicKeyFromX25519_XSalsa20_Poly1305ByDefaultKeyring(
-    const std::string& address,
-    std::string* key) {
-  CHECK(key);
-  auto* keyring = GetHDKeyringById(mojom::kDefaultKeyringId);
-  if (!keyring)
-    return false;
-  return static_cast<EthereumKeyring*>(keyring)
-      ->GetPublicKeyFromX25519_XSalsa20_Poly1305(
-          EthAddress::FromHex(address).ToChecksumAddress(), key);
-}
-
 std::vector<uint8_t> KeyringService::SignMessage(
     const std::string& keyring_id,
     const std::string& address,

--- a/components/brave_wallet/browser/keyring_service.h
+++ b/components/brave_wallet/browser/keyring_service.h
@@ -200,9 +200,6 @@ class KeyringService : public KeyedService, public mojom::KeyringService {
   bool RecoverAddressByDefaultKeyring(const std::vector<uint8_t>& message,
                                       const std::vector<uint8_t>& signature,
                                       std::string* address);
-  bool GetPublicKeyFromX25519_XSalsa20_Poly1305ByDefaultKeyring(
-      const std::string& address,
-      std::string* key);
 
   void AddAccountsWithDefaultName(size_t number);
 

--- a/components/brave_wallet/common/brave_wallet.mojom
+++ b/components/brave_wallet/common/brave_wallet.mojom
@@ -596,13 +596,6 @@ struct SwitchChainRequest {
   string chain_id;
 };
 
-struct GetEncryptionPublicKeyRequest {
-  url.mojom.Url origin;
-  string address;
-  // TODO(bbondy): This field is used in the front-end but will be removed soon
-  string? message;
-};
-
 // Deals with the ETH JSON RPC API, as well as things like the user's current
 // network.
 interface JsonRpcService {
@@ -903,11 +896,6 @@ interface BraveWalletService {
   // Obtain the pending add suggest token requests for current chain, will be
   // cleared when user switch networks.
   GetPendingAddSuggestTokenRequests() => (array<AddSuggestTokenRequest> requests);
-
-  // This is used for UI notifying native when the user approves or
-  // rejects getting the public key for an origin
-  NotifyGetPublicKeyRequestProcessed(bool approved, url.mojom.Url origin);
-  GetPendingGetEncryptionPublicKeyRequests() => (array<GetEncryptionPublicKeyRequest> requests);
 
   // Resets the keyring and the related preferences
   Reset();

--- a/components/brave_wallet/common/eth_request_helper.cc
+++ b/components/brave_wallet/common/eth_request_helper.cc
@@ -315,24 +315,6 @@ bool ParsePersonalSignParams(const std::string& json,
   return true;
 }
 
-bool ParseEthGetEncryptionPublicKeyParams(const std::string& json,
-                                          std::string* address) {
-  if (!address)
-    return false;
-
-  // eth_getEncryptionPublicKey allows extra params
-  auto list = GetParamsList(json);
-  if (!list || list->size() < 1)
-    return false;
-
-  const std::string* address_str = (*list)[0].GetIfString();
-  if (!address_str)
-    return false;
-
-  *address = *address_str;
-  return true;
-}
-
 bool ParsePersonalEcRecoverParams(const std::string& json,
                                   std::string* message,
                                   std::string* signature) {

--- a/components/brave_wallet/common/eth_request_helper.h
+++ b/components/brave_wallet/common/eth_request_helper.h
@@ -40,8 +40,6 @@ bool ParsePersonalSignParams(const std::string& json,
 bool ParsePersonalEcRecoverParams(const std::string& json,
                                   std::string* message,
                                   std::string* signature);
-bool ParseEthGetEncryptionPublicKeyParams(const std::string& json,
-                                          std::string* address);
 
 bool ParseEthSignTypedDataParams(const std::string& json,
                                  std::string* address,

--- a/components/brave_wallet/common/eth_request_helper_unittest.cc
+++ b/components/brave_wallet/common/eth_request_helper_unittest.cc
@@ -34,7 +34,6 @@ TEST(EthRequestHelperUnitTest, CommonParseErrors) {
     std::string signature;
     EXPECT_FALSE(
         ParsePersonalEcRecoverParams(error_case, &message, &signature));
-    EXPECT_FALSE(ParseEthGetEncryptionPublicKeyParams(error_case, &address));
   }
 }
 
@@ -460,31 +459,6 @@ TEST(EthResponseHelperUnitTest, ParsePersonalEcRecoverParams) {
       signature,
       "0xeb0c4e96c69a98dbdd61ac6871e39c12c90e9fa4420a017a23c67f4cc4fd06f43c32ad"
       "e58cd19ed438ce7e2d7360b59020489e9ac05e56e8637d3e516165c3f11c");
-}
-
-TEST(EthResponseHelperUnitTest, ParseEthGetEncryptionPublicKeyParams) {
-  const std::string json(
-      R"({
-        "params": [
-          "0x9b2055d370f73ec7d8a03e965129118dc8f5bf83"
-        ]
-      })");
-  const std::string json_extra_entry(
-      R"({
-        "params": [
-          "0x9b2055d370f73ec7d8a03e965129118dc8f5bf83",
-          "12345",
-          null,
-          123
-        ]
-      })");
-
-  std::string address;
-  EXPECT_TRUE(ParseEthGetEncryptionPublicKeyParams(json, &address));
-  EXPECT_EQ(address, "0x9b2055d370f73ec7d8a03e965129118dc8f5bf83");
-
-  EXPECT_TRUE(ParseEthGetEncryptionPublicKeyParams(json_extra_entry, &address));
-  EXPECT_EQ(address, "0x9b2055d370f73ec7d8a03e965129118dc8f5bf83");
 }
 
 TEST(EthResponseHelperUnitTest, GetEthJsonRequestInfo) {

--- a/components/brave_wallet/common/web3_provider_constants.h
+++ b/components/brave_wallet/common/web3_provider_constants.h
@@ -23,7 +23,6 @@ constexpr char kEthBlockNumber[] = "eth_blockNumber";
 constexpr char kEthSign[] = "eth_sign";
 constexpr char kPersonalSign[] = "personal_sign";
 constexpr char kPersonalEcRecover[] = "personal_ecRecover";
-constexpr char kEthGetEncryptionPublicKey[] = "eth_getEncryptionPublicKey";
 constexpr char kWalletWatchAsset[] = "wallet_watchAsset";
 constexpr char kMetamaskWatchAsset[] = "metamask_watchAsset";
 // We currently don't handle it until MetaMask point it to v3 or v4 other than

--- a/components/brave_wallet_ui/components/extension/encryption-key-panel/index.tsx
+++ b/components/brave_wallet_ui/components/extension/encryption-key-panel/index.tsx
@@ -31,7 +31,7 @@ export interface Props {
   panelType: 'request' | 'read'
   accounts: WalletAccountType[]
   selectedNetwork: BraveWallet.NetworkInfo
-  encryptionKeyPayload: BraveWallet.GetEncryptionPublicKeyRequest
+  encryptionKeyPayload: BraveWallet.EncryptionKeyRequest
   onProvideOrAllow: () => void
   onCancel: () => void
 }
@@ -69,7 +69,7 @@ function EncryptionKeyPanel (props: Props) {
       <PanelTitle>
         {panelType === 'request'
           ? getLocale('braveWalletProvideEncryptionKeyTitle')
-          : getLocale('braveWalletReadEncryptedMessageTitle').replace('$1', encryptionKeyPayload.origin.url)}
+          : getLocale('braveWalletReadEncryptedMessageTitle').replace('$1', encryptionKeyPayload.origin)}
       </PanelTitle>
       <TabRow>
         <PanelTab
@@ -89,7 +89,7 @@ function EncryptionKeyPanel (props: Props) {
         ) : (
           <MessageText>
             {panelType === 'request'
-              ? getLocale('braveWalletProvideEncryptionKeyDescription').replace('$1', encryptionKeyPayload.origin.url)
+              ? getLocale('braveWalletProvideEncryptionKeyDescription').replace('$1', encryptionKeyPayload.origin)
               : encryptionKeyPayload.message}
           </MessageText>
         )}

--- a/components/brave_wallet_ui/constants/types.ts
+++ b/components/brave_wallet_ui/constants/types.ts
@@ -103,7 +103,7 @@ export type PanelTypes =
   | 'transactions'
   | 'transactionDetails'
   | 'assets'
-  | 'provideEncryptionKey' // For grep: 'getEncryptionPublicKey'
+  | 'provideEncryptionKey'
   | 'allowReadingEncryptedMessage'
 
 export type NavTypes =
@@ -231,7 +231,7 @@ export interface PanelState {
   swapQuote?: BraveWallet.SwapResponse
   swapError?: SwapErrorResponse
   signMessageData: BraveWallet.SignMessageRequest[]
-  getEncryptionPublicKeyRequest: BraveWallet.GetEncryptionPublicKeyRequest
+  publicEncryptionKeyData: BraveWallet.EncryptionKeyRequest
   switchChainRequest: BraveWallet.SwitchChainRequest
   hardwareWalletCode?: HardwareWalletResponseCodeType
   suggestedToken?: BraveWallet.BlockchainToken

--- a/components/brave_wallet_ui/panel/actions/wallet_panel_actions.ts
+++ b/components/brave_wallet_ui/panel/actions/wallet_panel_actions.ts
@@ -7,7 +7,6 @@ import { createAction } from 'redux-act'
 import {
   AccountPayloadType,
   AddSuggestTokenProcessedPayload,
-  GetEncryptionPublicKeyProcessedPayload,
   ShowConnectToSitePayload,
   EthereumChainPayload,
   EthereumChainRequestPayload,
@@ -51,5 +50,3 @@ export const setHardwareWalletInteractionError = createAction<HardwareWalletResp
 export const cancelConnectHardwareWallet = createAction<BraveWallet.TransactionInfo>('cancelConnectHardwareWallet')
 export const addSuggestToken = createAction<BraveWallet.AddSuggestTokenRequest>('addSuggestToken')
 export const addSuggestTokenProcessed = createAction<AddSuggestTokenProcessedPayload>('addSuggestTokenProcessed')
-export const getEncryptionPublicKey = createAction<BraveWallet.GetEncryptionPublicKeyRequest>('getEncryptionPublicKey')
-export const getEncryptionPublicKeyProcessed = createAction<GetEncryptionPublicKeyProcessedPayload>('getEncryptionPublicKeyProcessed')

--- a/components/brave_wallet_ui/panel/async/wallet_panel_async_handler.ts
+++ b/components/brave_wallet_ui/panel/async/wallet_panel_async_handler.ts
@@ -24,8 +24,7 @@ import {
   SignMessagePayload,
   SignMessageProcessedPayload,
   SignMessageHardwareProcessedPayload,
-  SwitchEthereumChainProcessedPayload,
-  GetEncryptionPublicKeyProcessedPayload
+  SwitchEthereumChainProcessedPayload
 } from '../constants/action_types'
 import {
   findHardwareAccountInfo,
@@ -83,16 +82,6 @@ async function getPendingSwitchChainRequest () {
   const jsonRpcService = getWalletPanelApiProxy().jsonRpcService
   const requests =
     (await jsonRpcService.getPendingSwitchChainRequests()).requests
-  if (requests && requests.length) {
-    return requests[0]
-  }
-  return null
-}
-
-async function getPendingGetEncryptionPublicKeyRequest () {
-  const braveWalletService = getWalletPanelApiProxy().braveWalletService
-  const requests =
-    (await braveWalletService.getPendingGetEncryptionPublicKeyRequests()).requests
   if (requests && requests.length) {
     return requests[0]
   }
@@ -187,11 +176,6 @@ handler.on(WalletActions.initialize.getType(), async (store) => {
     const addSuggestTokenRequest = await getPendingAddSuggestTokenRequest()
     if (addSuggestTokenRequest) {
       store.dispatch(PanelActions.addSuggestToken(addSuggestTokenRequest))
-      return
-    }
-    const getEncryptionPublicKeyRequest = await getPendingGetEncryptionPublicKeyRequest()
-    if (getEncryptionPublicKeyRequest) {
-      store.dispatch(PanelActions.getEncryptionPublicKey(getEncryptionPublicKeyRequest))
       return
     }
   }
@@ -341,12 +325,6 @@ handler.on(PanelActions.switchEthereumChain.getType(), async (store: Store, requ
   apiProxy.panelHandler.showUI()
 })
 
-handler.on(PanelActions.getEncryptionPublicKey.getType(), async (store: Store) => {
-  store.dispatch(PanelActions.navigateTo('provideEncryptionKey'))
-  const apiProxy = getWalletPanelApiProxy()
-  apiProxy.panelHandler.showUI()
-})
-
 handler.on(PanelActions.switchEthereumChainProcessed.getType(), async (store: Store, payload: SwitchEthereumChainProcessedPayload) => {
   const apiProxy = getWalletPanelApiProxy()
   const jsonRpcService = apiProxy.jsonRpcService
@@ -354,18 +332,6 @@ handler.on(PanelActions.switchEthereumChainProcessed.getType(), async (store: St
   const switchChainRequest = await getPendingSwitchChainRequest()
   if (switchChainRequest) {
     store.dispatch(PanelActions.switchEthereumChain(switchChainRequest))
-    return
-  }
-  apiProxy.panelHandler.closeUI()
-})
-
-handler.on(PanelActions.getEncryptionPublicKeyProcessed.getType(), async (store: Store, payload: GetEncryptionPublicKeyProcessedPayload) => {
-  const apiProxy = getWalletPanelApiProxy()
-  const braveWalletService = apiProxy.braveWalletService
-  braveWalletService.notifyGetPublicKeyRequestProcessed(payload.approved, payload.origin)
-  const getEncryptionPublicKeyRequest = await getPendingGetEncryptionPublicKeyRequest()
-  if (getEncryptionPublicKeyRequest) {
-    store.dispatch(PanelActions.getEncryptionPublicKey(getEncryptionPublicKeyRequest))
     return
   }
   apiProxy.panelHandler.closeUI()

--- a/components/brave_wallet_ui/panel/constants/action_types.ts
+++ b/components/brave_wallet_ui/panel/constants/action_types.ts
@@ -51,8 +51,3 @@ export type AddSuggestTokenProcessedPayload = {
   approved: boolean
   contractAddress: string
 }
-
-export type GetEncryptionPublicKeyProcessedPayload = {
-  approved: boolean
-  origin: Url
-}

--- a/components/brave_wallet_ui/panel/container.tsx
+++ b/components/brave_wallet_ui/panel/container.tsx
@@ -127,7 +127,7 @@ function Container (props: Props) {
     signMessageData,
     switchChainRequest,
     suggestedToken,
-    getEncryptionPublicKeyRequest
+    publicEncryptionKeyData
   } = props.panel
 
   // TODO(petemill): If initial data or UI takes a noticeable amount of time to arrive
@@ -567,20 +567,20 @@ function Container (props: Props) {
     props.walletPanelActions.navigateTo('transactions')
   }
 
-  const onProvideEncryptionKey = () => {
-    props.walletPanelActions.getEncryptionPublicKeyProcessed({ approved: true, origin: getEncryptionPublicKeyRequest.origin })
-  }
-
-  const onCancelProvideEncryptionKey = () => {
-    props.walletPanelActions.getEncryptionPublicKeyProcessed({ approved: false, origin: getEncryptionPublicKeyRequest.origin })
-  }
-
   const onAllowReadingEncryptedMessage = () => {
     // Logic here to allow reading encrypted message
   }
 
+  const onProvideEncryptionKey = () => {
+    // Logic here to provide encryption key
+  }
+
   const onCancelAllowReadingEncryptedMessage = () => {
     // Logic here to cancel allow reading encrypted message
+  }
+
+  const onCancelProvideEncryptionKey = () => {
+    // Logic here to cancel provide encryption key
   }
 
   const isConnectedToSite = React.useMemo((): boolean => {
@@ -752,7 +752,7 @@ function Container (props: Props) {
                 ? 'request'
                 : 'read'
             }
-            encryptionKeyPayload={getEncryptionPublicKeyRequest}
+            encryptionKeyPayload={publicEncryptionKeyData}
             accounts={accounts}
             selectedNetwork={selectedNetwork}
             onCancel={

--- a/components/brave_wallet_ui/panel/reducers/panel_reducer.ts
+++ b/components/brave_wallet_ui/panel/reducers/panel_reducer.ts
@@ -50,12 +50,10 @@ const defaultState: PanelState = {
     domainHash: '',
     primaryHash: ''
   }],
-  getEncryptionPublicKeyRequest: {
+  publicEncryptionKeyData: {
     address: '',
     message: '',
-    origin: {
-      url: ''
-    }
+    origin: ''
   },
   switchChainRequest: {
     origin: {
@@ -99,13 +97,6 @@ reducer.on(PanelActions.switchEthereumChain, (state: any, request: BraveWallet.S
   return {
     ...state,
     switchChainRequest: request
-  }
-})
-
-reducer.on(PanelActions.getEncryptionPublicKey, (state: any, request: BraveWallet.GetEncryptionPublicKeyRequest) => {
-  return {
-    ...state,
-    getEncryptionPublicKeyRequest: request
   }
 })
 

--- a/components/brave_wallet_ui/stories/wallet-extension-panels.tsx
+++ b/components/brave_wallet_ui/stories/wallet-extension-panels.tsx
@@ -286,9 +286,7 @@ _SignData.story = {
 const encryptionKeyMockPayload = {
   address: '0x3f29A1da97149722eB09c526E4eAd698895b426',
   message: 'This is a test message.',
-  origin: {
-    url: 'https://app.skiff.org'
-  }
+  origin: 'https://app.skiff.org'
 }
 
 export const _ProvideEncryptionKey = () => {


### PR DESCRIPTION
This reverts commit 6d5a311686676da05dcc4fb4a5e03a818d80df2a, reversing
changes made to 44b47c9ac229c7b037e44c4a7511fcdef31cfa6b.

Reverting from 1.38.x Beta to give more time for security review and so it lands with eth_decrypt

First landed (but now being reverted from 1.38.x only) https://github.com/brave/brave-core/pull/12517

<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/19276

## Submitter Checklist:

- [ ] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

