### PR TITLE
Fix text color of inactive tabs

### DIFF
--- a/browser/themes/theme_properties.cc
+++ b/browser/themes/theme_properties.cc
@@ -36,10 +36,8 @@ absl::optional<SkColor> MaybeGetDefaultColorForBraveLightUi(int id) {
     case ThemeProperties::COLOR_TAB_BACKGROUND_ACTIVE_FRAME_ACTIVE:
     case ThemeProperties::COLOR_TAB_BACKGROUND_ACTIVE_FRAME_INACTIVE:
       return kLightToolbar;
-    case ThemeProperties::COLOR_TAB_FOREGROUND_ACTIVE_FRAME_ACTIVE:
     case ThemeProperties::COLOR_BOOKMARK_TEXT:
     case BraveThemeProperties::COLOR_BOOKMARK_BAR_INSTRUCTIONS_TEXT:
-    case ThemeProperties::COLOR_TAB_FOREGROUND_INACTIVE_FRAME_ACTIVE:
     case ThemeProperties::COLOR_TOOLBAR_BUTTON_ICON:
       return kLightToolbarIcon;
     case ThemeProperties::COLOR_TOOLBAR_BUTTON_ICON_INACTIVE:
@@ -130,11 +128,8 @@ absl::optional<SkColor> MaybeGetDefaultColorForBraveDarkUi(int id) {
     case ThemeProperties::COLOR_TAB_BACKGROUND_ACTIVE_FRAME_ACTIVE:
     case ThemeProperties::COLOR_TAB_BACKGROUND_ACTIVE_FRAME_INACTIVE:
       return kDarkToolbar;
-    case ThemeProperties::COLOR_TAB_FOREGROUND_ACTIVE_FRAME_ACTIVE:
-      return SkColorSetRGB(0xF3, 0xF3, 0xF3);
     case ThemeProperties::COLOR_BOOKMARK_TEXT:
     case BraveThemeProperties::COLOR_BOOKMARK_BAR_INSTRUCTIONS_TEXT:
-    case ThemeProperties::COLOR_TAB_FOREGROUND_INACTIVE_FRAME_ACTIVE:
       return SkColorSetRGB(0xFF, 0xFF, 0xFF);
     case ThemeProperties::COLOR_TOOLBAR_BUTTON_ICON:
       return kDarkToolbarIcon;
@@ -223,11 +218,8 @@ absl::optional<SkColor> MaybeGetDefaultColorForPrivateUi(int id) {
     case ThemeProperties::COLOR_TAB_BACKGROUND_ACTIVE_FRAME_ACTIVE:
     case ThemeProperties::COLOR_TAB_BACKGROUND_ACTIVE_FRAME_INACTIVE:
       return kPrivateToolbar;
-    case ThemeProperties::COLOR_TAB_FOREGROUND_ACTIVE_FRAME_ACTIVE:
-      return SkColorSetRGB(0xF3, 0xF3, 0xF3);
     case ThemeProperties::COLOR_BOOKMARK_TEXT:
     case BraveThemeProperties::COLOR_BOOKMARK_BAR_INSTRUCTIONS_TEXT:
-    case ThemeProperties::COLOR_TAB_FOREGROUND_INACTIVE_FRAME_ACTIVE:
       return SkColorSetRGB(0xFF, 0xFF, 0xFF);
     case ThemeProperties::COLOR_TOOLBAR_BUTTON_ICON:
       return kDarkToolbarIcon;

--- a/chromium_src/chrome/browser/ui/color/tab_strip_color_mixer.cc
+++ b/chromium_src/chrome/browser/ui/color/tab_strip_color_mixer.cc
@@ -1,0 +1,36 @@
+/* Copyright (c) 2022 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "chrome/browser/ui/color/tab_strip_color_mixer.h"
+
+#define AddTabStripColorMixer AddTabStripColorMixer_ChromiumImpl
+#include "src/chrome/browser/ui/color/tab_strip_color_mixer.cc"
+#undef AddTabStripColorMixer
+
+namespace {
+
+const SkColor kLightToolbarIcon = SkColorSetRGB(0x42, 0x42, 0x42);
+
+void AddBraveTabStripColorMixer(ui::ColorProvider* provider,
+                                const ui::ColorProviderManager::Key& key) {
+  ui::ColorMixer& mixer = provider->AddMixer();
+
+  // Tab text colors.
+  if (key.color_mode == ui::ColorProviderManager::ColorMode::kDark) {
+    mixer[kColorTabForegroundInactiveFrameActive] = {SK_ColorWHITE};
+    mixer[kColorTabForegroundInactiveFrameInactive] = {SK_ColorWHITE};
+  } else {
+    mixer[kColorTabForegroundInactiveFrameActive] = {kLightToolbarIcon};
+    mixer[kColorTabForegroundInactiveFrameInactive] = {kLightToolbarIcon};
+  }
+}
+
+}  // namespace
+
+void AddTabStripColorMixer(ui::ColorProvider* provider,
+                           const ui::ColorProviderManager::Key& key) {
+  AddTabStripColorMixer_ChromiumImpl(provider, key);
+  AddBraveTabStripColorMixer(provider, key);
+}


### PR DESCRIPTION
This regression, which caused inactive tabs under certain dark/light mode conditions on Windows to have very low contrast, was cause by the Chromium 100 change below. This fix was modelled after 5c145e99.

> https://chromium.googlesource.com/chromium/src/+/23a6ae6a05ef9407f56c29cbbbb133463c734099
>
> Remove use of HasCustomColor in TabStrip and use ColorProvider.
>
> Systematized all the ChromeColorIds used for the tab strip.
>
> Bug: 1292176
> Change-Id: I9dbed732cd977a184c59e45d53b918774a44799d
> Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/3425646
> Reviewed-by: Peter Kasting <pkasting@chromium.org>
> Reviewed-by: Thomas Lukaszewicz <tluk@chromium.org>
> Commit-Queue: Allen Bauer <kylixrd@chromium.org>
> Cr-Commit-Position: refs/heads/main@{#967904}


#### Notes ####

Setting both `kColorTabForegroundInactiveFrameActive` and `kColorTabForegroundInactiveFrameInactive` were required for this to work under all conditions. Setting `kColorTabForegroundActiveFrameActive` and `kColorTabForegroundActiveFrameInactive` were apparently not required, so I didn't include them.

I verified in a debugger that `MaybeGetDefaultColorForBraveUi()` is no longer called after that Chromium change with either of the two IDs that I removed (`COLOR_TAB_FOREGROUND_ACTIVE_FRAME_ACTIVE` and `COLOR_TAB_FOREGROUND_INACTIVE_FRAME_ACTIVE`).

I manually tested (the cross product of) all of the following combinations on (only) Windows 10 x64 19044.1586.

Tab state: Active/Inactive
Frame state: Active/Inactive
Window type: Normal/Private/Tor
Mouse state: Hovered/Not
Color mode: Light/Dark
Show accent color on "Title bars and window borders" Windows 10 setting: Enabled/Disabled
"Choose your accent color" Windows 10 setting: Light gray/Dark gray

To reproduce the issue on a non-patched version, enable the Show accent color on "Title bars and window borders" Windows 10 setting, choose a ~light~ dark accent color in Windows, and choose Light mode (or choose a ~dark~ light accent color and Dark mode), and then view an inactive tab.

Full disclosure: I have zero experience w/the Chromium source, so I very well could have missed something.

<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves brave/brave-browser#22027

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

