### PR TITLE
[Android] Fixed crash on sending tabs to another device (uplift to 1.38.x)

### DIFF
--- a/android/brave_java_sources.gni
+++ b/android/brave_java_sources.gni
@@ -6,6 +6,7 @@
 import("//brave/android/features/tab_ui/brave_tab_management_java_sources.gni")
 import("//brave/android/feed/brave_feed_java_sources.gni")
 import("//brave/browser/brave_ads/android/java_sources.gni")
+import("//brave/browser/share/android/java_sources.gni")
 import("//brave/components/brave_referrals/buildflags/buildflags.gni")
 import("//brave/components/permissions/android/java_sources.gni")
 import("//brave/components/safetynet/java_sources.gni")
@@ -339,6 +340,7 @@ brave_java_sources += brave_ads_java_sources
 brave_java_sources += brave_rewards_java_sources
 brave_java_sources += brave_feed_java_sources
 brave_java_sources += brave_public_tab_management_java_sources
+brave_java_sources += brave_share_java_sources
 
 if (enable_brave_referrals) {
   brave_java_sources += [ "../../brave/android/java/org/chromium/chrome/browser/util/BraveReferrer.java" ]

--- a/android/java/apk_for_test.flags
+++ b/android/java/apk_for_test.flags
@@ -452,3 +452,13 @@
 -keep class org.chromium.components.variations.firstrun.VariationsSeedFetcher {
     *** get(...);
 }
+
+-keep class org.chromium.chrome.browser.share.send_tab_to_self.DevicePickerBottomSheetContent {
+    public <init>(...);
+    *** createManageDevicesLink(...);
+}
+
+-keep class org.chromium.chrome.browser.share.send_tab_to_self.BraveDevicePickerBottomSheetContent {
+    public <init>(...);
+    *** createManageDevicesLink(...);
+}

--- a/android/javatests/org/chromium/chrome/browser/BytecodeTest.java
+++ b/android/javatests/org/chromium/chrome/browser/BytecodeTest.java
@@ -11,6 +11,7 @@ import android.content.res.Resources;
 import android.os.Handler;
 import android.view.View;
 import android.view.ViewGroup;
+import android.widget.ListView;
 
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.preference.Preference;
@@ -220,6 +221,10 @@ public class BytecodeTest {
                 classExists("org/chromium/chrome/browser/autofill/BraveAutofillPopupBridge"));
         Assert.assertTrue(
                 classExists("org/chromium/components/variations/firstrun/VariationsSeedFetcher"));
+        Assert.assertTrue(classExists(
+                "org/chromium/chrome/browser/share/send_tab_to_self/DevicePickerBottomSheetContent"));
+        Assert.assertTrue(classExists(
+                "org/chromium/chrome/browser/share/send_tab_to_self/BraveDevicePickerBottomSheetContent"));
     }
 
     @Test
@@ -351,6 +356,9 @@ public class BytecodeTest {
         Assert.assertTrue(
                 methodExists("org/chromium/components/variations/firstrun/VariationsSeedFetcher",
                         "get", false, null));
+        Assert.assertTrue(methodExists(
+                "org/chromium/chrome/browser/share/send_tab_to_self/DevicePickerBottomSheetContent",
+                "createManageDevicesLink", true, void.class, ListView.class));
     }
 
     @Test
@@ -527,6 +535,11 @@ public class BytecodeTest {
                 FeedSurfaceCoordinator.class, Context.class, SnapScrollHelper.class,
                 PropertyModel.class, int.class, FeedActionDelegate.class,
                 FeedOptionsCoordinator.class));
+        Assert.assertTrue(constructorsMatch(
+                "org/chromium/chrome/browser/share/send_tab_to_self/DevicePickerBottomSheetContent",
+                "org/chromium/chrome/browser/share/send_tab_to_self/BraveDevicePickerBottomSheetContent",
+                Context.class, String.class, String.class, long.class, BottomSheetController.class,
+                boolean.class));
     }
 
     @Test

--- a/browser/share/android/java/src/org/chromium/chrome/browser/share/send_tab_to_self/BraveDevicePickerBottomSheetContent.java
+++ b/browser/share/android/java/src/org/chromium/chrome/browser/share/send_tab_to_self/BraveDevicePickerBottomSheetContent.java
@@ -1,0 +1,22 @@
+/* Copyright (c) 2022 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.chromium.chrome.browser.share.send_tab_to_self;
+
+import android.content.Context;
+import android.widget.ListView;
+
+import org.chromium.components.browser_ui.bottomsheet.BottomSheetController;
+
+public class BraveDevicePickerBottomSheetContent extends DevicePickerBottomSheetContent {
+    public BraveDevicePickerBottomSheetContent(Context context, String url, String title,
+            long navigationTime, BottomSheetController controller, boolean isSyncEnabled) {
+        super(context, url, title, navigationTime, controller, isSyncEnabled);
+    }
+
+    public void createManageDevicesLink(ListView deviceListView) {
+        // Do nothing as this feature requires Google account.
+    }
+}

--- a/browser/share/android/java_sources.gni
+++ b/browser/share/android/java_sources.gni
@@ -1,0 +1,5 @@
+# Copyright 2022 The Brave Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+brave_share_java_sources = [ "//brave/browser/share/android/java/src/org/chromium/chrome/browser/share/send_tab_to_self/BraveDevicePickerBottomSheetContent.java" ]

--- a/build/android/bytecode/BUILD.gn
+++ b/build/android/bytecode/BUILD.gn
@@ -20,6 +20,7 @@ java_binary("java_bytecode_rewriter") {
     "//brave/build/android/bytecode/java/org/brave/bytecode/BraveCommandLineInitUtilClassAdapter.java",
     "//brave/build/android/bytecode/java/org/brave/bytecode/BraveContentSettingsResourcesClassAdapter.java",
     "//brave/build/android/bytecode/java/org/brave/bytecode/BraveDefaultBrowserPromoUtilsClassAdapter.java",
+    "//brave/build/android/bytecode/java/org/brave/bytecode/BraveDevicePickerBottomSheetContentClassAdapter.java",
     "//brave/build/android/bytecode/java/org/brave/bytecode/BraveEditUrlSuggestionProcessorClassAdapter.java",
     "//brave/build/android/bytecode/java/org/brave/bytecode/BraveFeedSurfaceCoordinatorClassAdapter.java",
     "//brave/build/android/bytecode/java/org/brave/bytecode/BraveFeedSurfaceMediatorClassAdapter.java",

--- a/build/android/bytecode/java/org/brave/bytecode/BraveClassAdapter.java
+++ b/build/android/bytecode/java/org/brave/bytecode/BraveClassAdapter.java
@@ -19,6 +19,7 @@ public class BraveClassAdapter {
         chain = new BraveCommandLineInitUtilClassAdapter(chain);
         chain = new BraveContentSettingsResourcesClassAdapter(chain);
         chain = new BraveDefaultBrowserPromoUtilsClassAdapter(chain);
+        chain = new BraveDevicePickerBottomSheetContentClassAdapter(chain);
         chain = new BraveEditUrlSuggestionProcessorClassAdapter(chain);
         chain = new BraveFeedSurfaceCoordinatorClassAdapter(chain);
         chain = new BraveFeedSurfaceMediatorClassAdapter(chain);

--- a/build/android/bytecode/java/org/brave/bytecode/BraveDevicePickerBottomSheetContentClassAdapter.java
+++ b/build/android/bytecode/java/org/brave/bytecode/BraveDevicePickerBottomSheetContentClassAdapter.java
@@ -1,0 +1,25 @@
+/* Copyright (c) 2022 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.brave.bytecode;
+
+import org.objectweb.asm.ClassVisitor;
+
+public class BraveDevicePickerBottomSheetContentClassAdapter extends BraveClassVisitor {
+    static String sDevicePickerBottomSheetContent =
+            "org/chromium/chrome/browser/share/send_tab_to_self/DevicePickerBottomSheetContent";
+    static String sBraveDevicePickerBottomSheetContent =
+            "org/chromium/chrome/browser/share/send_tab_to_self/BraveDevicePickerBottomSheetContent";
+
+    public BraveDevicePickerBottomSheetContentClassAdapter(ClassVisitor visitor) {
+        super(visitor);
+
+        redirectConstructor(sDevicePickerBottomSheetContent, sBraveDevicePickerBottomSheetContent);
+
+        makePublicMethod(sDevicePickerBottomSheetContent, "createManageDevicesLink");
+        addMethodAnnotation(sBraveDevicePickerBottomSheetContent, "createManageDevicesLink",
+                "Ljava/lang/Override;");
+    }
+}


### PR DESCRIPTION
Uplift of #12920
Resolves https://github.com/brave/brave-browser/issues/22128

Pre-approval checklist: 
- [ ] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [ ] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [ ] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [ ] The associated issue milestone is set to the smallest version that the changes is landed on.