### PR TITLE
Add support for checking de_amp_enabled user pref in cosmetic js filter

### DIFF
--- a/browser/brave_shields/ad_block_service_browsertest.cc
+++ b/browser/brave_shields/ad_block_service_browsertest.cc
@@ -33,6 +33,7 @@
 #include "brave/components/brave_shields/common/brave_shield_constants.h"
 #include "brave/components/brave_shields/common/features.h"
 #include "brave/components/brave_shields/common/pref_names.h"
+#include "brave/components/de_amp/common/pref_names.h"
 #include "build/build_config.h"
 #include "chrome/browser/browser_process.h"
 #include "chrome/browser/content_settings/host_content_settings_map_factory.h"
@@ -101,6 +102,10 @@ void AdBlockServiceTest::SetUp() {
 void AdBlockServiceTest::PreRunTestOnMainThread() {
   ExtensionBrowserTest::PreRunTestOnMainThread();
   WaitForAdBlockServiceThreads();
+}
+
+content::WebContents* AdBlockServiceTest::web_contents() {
+  return browser()->tab_strip_model()->GetActiveWebContents();
 }
 
 HostContentSettingsMap* AdBlockServiceTest::content_settings() {
@@ -2085,26 +2090,23 @@ IN_PROC_BROWSER_TEST_F(AdBlockServiceTest, CosmeticFilteringUnhide) {
 // Test scriptlet injection that modifies window attributes
 IN_PROC_BROWSER_TEST_F(AdBlockServiceTest, CosmeticFilteringWindowScriptlet) {
   ASSERT_TRUE(InstallDefaultAdBlockExtension());
-  /* "content" below corresponds to the following scriptlet:
-   * ```
-   * (function() {
-   *   const send = window.getComputedStyle;
-   *   window.getComputedStyle = function(selector) {
-   *     return { 'color': 'Impossible value' };
-   *   }
-   * })();
-   * ```
-   */
+  std::string scriptlet =
+      "(function() {"
+      "  const send = window.getComputedStyle;"
+      "  window.getComputedStyle = function(selector) {"
+      "    return { 'color': 'Impossible value' };"
+      "  }"
+      "})();";
+  std::string scriptlet_base64;
+  base::Base64Encode(scriptlet, &scriptlet_base64);
   UpdateAdBlockInstanceWithRules(
       "b.com##+js(hjt)",
       "[{"
       "\"name\": \"hijacktest\","
       "\"aliases\": [\"hjt\"],"
       "\"kind\": {\"mime\": \"application/javascript\"},"
-      "\"content\": \"KGZ1bmN0aW9uKCkgewogIGNvbnN0IHNlbmQgPSB3aW5kb3cuZ2V0"
-      "Q29tcHV0ZWRTdHlsZTsKICB3aW5kb3cuZ2V0Q29tcHV0ZWRTdHlsZSA9IGZ1bmN0aW9"
-      "uKHNlbGVjdG9yKSB7CiAgICByZXR1cm4geyAnY29sb3InOiAnSW1wb3NzaWJsZSB2YW"
-      "x1ZScgfTsKICB9Cn0pKCk7Cg==\"}]");
+      "\"content\": \"" +
+          scriptlet_base64 + "\"}]");
 
   GURL tab_url =
       embedded_test_server()->GetURL("b.com", "/cosmetic_filtering.html");
@@ -2125,6 +2127,67 @@ IN_PROC_BROWSER_TEST_F(AdBlockServiceTest, CosmeticFilteringWindowScriptlet) {
                        content::EXECUTE_SCRIPT_USE_MANUAL_REPLY);
   ASSERT_TRUE(result.error.empty());
   EXPECT_EQ(base::Value(true), result.value);
+}
+
+// Test scriptlet injection with DeAMP enabled
+IN_PROC_BROWSER_TEST_F(AdBlockServiceTest, CheckForDeAmpPref) {
+  std::string scriptlet =
+      "(function() {"
+      " if (deAmpEnabled) {"
+      "   window.getComputedStyle = function(selector) {"
+      "     return { 'color': 'green' };"
+      "   }"
+      " } else {"
+      "   window.getComputedStyle = function(selector) {"
+      "     return { 'color': 'red' };"
+      "   }"
+      " }"
+      "})();";
+  std::string scriptlet_base64;
+  base::Base64Encode(scriptlet, &scriptlet_base64);
+  UpdateAdBlockInstanceWithRules(
+      "b.*##+js(deamp)",
+      "[{"
+      "\"name\": \"deamp\","
+      "\"aliases\": [\"deamp\"],"
+      "\"kind\": {\"mime\": \"application/javascript\"},"
+      "\"content\": \"" +
+          scriptlet_base64 + "\"}]");
+
+  GURL url =
+      embedded_test_server()->GetURL("b.com", "/cosmetic_filtering.html");
+  ASSERT_TRUE(ui_test_utils::NavigateToURL(browser(), url));
+  auto result1 = EvalJs(web_contents(),
+                        R"(async function waitCSSSelector() {
+          if (await checkSelector('body', 'color', 'green')) {
+            window.domAutomationController.send(true);
+          } else {
+            console.log('still waiting for css selector');
+            setTimeout(waitCSSSelector, 200);
+          }
+        } waitCSSSelector())",
+                        content::EXECUTE_SCRIPT_USE_MANUAL_REPLY);
+  ASSERT_TRUE(result1.error.empty());
+  EXPECT_EQ(base::Value(true), result1.value);
+
+  PrefService* prefs = browser()->profile()->GetPrefs();
+  prefs->SetBoolean(de_amp::kDeAmpPrefEnabled, false);
+
+  web_contents()->GetController().Reload(content::ReloadType::NORMAL, true);
+  EXPECT_TRUE(WaitForLoadStop(web_contents()));
+
+  auto result2 = EvalJs(web_contents(),
+                        R"(async function waitCSSSelector() {
+          if (await checkSelector('body', 'color', 'red')) {
+            window.domAutomationController.send(true);
+          } else {
+            console.log('still waiting for css selector');
+            setTimeout(waitCSSSelector, 200);
+          }
+        } waitCSSSelector())",
+                        content::EXECUTE_SCRIPT_USE_MANUAL_REPLY);
+  ASSERT_TRUE(result2.error.empty());
+  EXPECT_EQ(base::Value(true), result2.value);
 }
 
 // Test scriptlet injection that modifies window attributes

--- a/browser/brave_shields/ad_block_service_browsertest.h
+++ b/browser/brave_shields/ad_block_service_browsertest.h
@@ -56,6 +56,7 @@ class AdBlockServiceTest : public extensions::ExtensionBrowserTest {
   void ShieldsDown(const GURL& url);
   void LoadDAT(base::FilePath path);
   void EnableRedirectUrlParsing();
+  content::WebContents* web_contents();
 
   std::vector<std::unique_ptr<brave_shields::TestFiltersProvider>>
       source_providers_;

--- a/browser/profiles/brave_renderer_updater.cc
+++ b/browser/profiles/brave_renderer_updater.cc
@@ -12,6 +12,7 @@
 #include "brave/common/brave_renderer_configuration.mojom.h"
 #include "brave/components/brave_wallet/browser/pref_names.h"
 #include "brave/components/brave_wallet/common/brave_wallet.mojom.h"
+#include "brave/components/de_amp/browser/de_amp_util.h"
 #include "brave/components/de_amp/common/pref_names.h"
 #include "build/build_config.h"
 #include "chrome/browser/profiles/profile.h"
@@ -110,7 +111,7 @@ void BraveRendererUpdater::UpdateRenderer(
       brave_wallet::mojom::DefaultWallet::BraveWalletPreferExtension;
 
   PrefService* pref_service = profile_->GetPrefs();
-  bool de_amp_enabled = pref_service->GetBoolean(de_amp::kDeAmpPrefEnabled);
+  bool de_amp_enabled = de_amp::IsDeAmpEnabled(pref_service);
 
   (*renderer_configuration)
       ->SetConfiguration(brave::mojom::DynamicParams::New(

--- a/browser/profiles/brave_renderer_updater.h
+++ b/browser/profiles/brave_renderer_updater.h
@@ -52,6 +52,7 @@ class BraveRendererUpdater : public KeyedService {
 
   // Prefs that we sync to the renderers.
   IntegerPrefMember brave_wallet_web3_provider_;
+  BooleanPrefMember de_amp_enabled_;
   bool is_wallet_allowed_for_context_;
 };
 

--- a/common/brave_renderer_configuration.mojom
+++ b/common/brave_renderer_configuration.mojom
@@ -9,6 +9,7 @@ module brave.mojom;
 struct DynamicParams {
   bool brave_use_native_wallet = false;
   bool allow_overwrite_window_web3_provider = true;
+  bool de_amp_enabled = true;
 };
 
 // Configures the renderer.

--- a/components/cosmetic_filters/renderer/BUILD.gn
+++ b/components/cosmetic_filters/renderer/BUILD.gn
@@ -17,9 +17,11 @@ source_set("renderer") {
 
   deps = [
     "//base",
+    "//brave/common:mojo_bindings",
     "//brave/components/brave_shields/common",
     "//brave/components/cosmetic_filters/common:mojom",
     "//brave/components/cosmetic_filters/resources/data:generated_resources",
+    "//brave/components/de_amp/common",
     "//components/content_settings/renderer:renderer",
     "//content/public/renderer",
     "//gin",

--- a/components/cosmetic_filters/renderer/DEPS
+++ b/components/cosmetic_filters/renderer/DEPS
@@ -1,4 +1,5 @@
 include_rules = [
+  "+brave/common",
   "+content/public/renderer",
   "+gin",
   "+third_party/blink/public",

--- a/components/cosmetic_filters/renderer/DEPS
+++ b/components/cosmetic_filters/renderer/DEPS
@@ -1,5 +1,4 @@
 include_rules = [
-  "+brave/common",
   "+content/public/renderer",
   "+gin",
   "+third_party/blink/public",

--- a/components/cosmetic_filters/renderer/cosmetic_filters_js_handler.cc
+++ b/components/cosmetic_filters/renderer/cosmetic_filters_js_handler.cc
@@ -41,12 +41,12 @@ const char kObservingScriptletEntryPoint[] =
 
 const char kScriptletInitScript[] =
     R"((function() {
-          let text = %s;
+          let text = '(function() {\nlet deAmpEnabled = %s;\n' + %s + '})()';
           let script;
           try {
             script = document.createElement('script');
             const textNode = document.createTextNode(text);
-            script.appendChild(textNode);;
+            script.appendChild(textNode);
             (document.head || document.documentElement).appendChild(script);
           } catch (ex) {
             /* Unused catch */
@@ -335,7 +335,7 @@ void CosmeticFiltersJSHandler::OnUrlCosmeticResources(
   std::move(callback).Run();
 }
 
-void CosmeticFiltersJSHandler::ApplyRules() {
+void CosmeticFiltersJSHandler::ApplyRules(bool de_amp_enabled) {
   blink::WebLocalFrame* web_frame = render_frame_->GetWebFrame();
   if (!resources_dict_ || web_frame->IsProvisional())
     return;
@@ -344,8 +344,9 @@ void CosmeticFiltersJSHandler::ApplyRules() {
   base::Value* injected_script = resources_dict_->FindPath("injected_script");
   if (injected_script &&
       base::JSONWriter::Write(*injected_script, &scriptlet_script)) {
-    scriptlet_script =
-        base::StringPrintf(kScriptletInitScript, scriptlet_script.c_str());
+    scriptlet_script = base::StringPrintf(kScriptletInitScript,
+                                          de_amp_enabled ? "true" : "false",
+                                          scriptlet_script.c_str());
   }
   if (!scriptlet_script.empty()) {
     web_frame->ExecuteScriptInIsolatedWorld(

--- a/components/cosmetic_filters/renderer/cosmetic_filters_js_handler.h
+++ b/components/cosmetic_filters/renderer/cosmetic_filters_js_handler.h
@@ -40,7 +40,7 @@ class CosmeticFiltersJSHandler {
   // filtering is enabled, and returns whether or not to proceed with cosmetic
   // filtering.
   bool ProcessURL(const GURL& url, absl::optional<base::OnceClosure> callback);
-  void ApplyRules();
+  void ApplyRules(bool de_amp_enabled);
 
  private:
   void BindFunctionsToObject(v8::Isolate* isolate,

--- a/components/cosmetic_filters/renderer/cosmetic_filters_js_render_frame_observer.cc
+++ b/components/cosmetic_filters/renderer/cosmetic_filters_js_render_frame_observer.cc
@@ -52,14 +52,14 @@ void EnsureIsolatedWorldInitialized(int world_id) {
 CosmeticFiltersJsRenderFrameObserver::CosmeticFiltersJsRenderFrameObserver(
     content::RenderFrame* render_frame,
     const int32_t isolated_world_id,
-    GetDynamicParamsCallback get_dynamic_params_callback)
+    base::RepeatingCallback<bool(void)> get_de_amp_enabled_closure)
     : RenderFrameObserver(render_frame),
       RenderFrameObserverTracker<CosmeticFiltersJsRenderFrameObserver>(
           render_frame),
       isolated_world_id_(isolated_world_id),
       native_javascript_handle_(
           new CosmeticFiltersJSHandler(render_frame, isolated_world_id)),
-      get_dynamic_params_callback_(std::move(get_dynamic_params_callback)),
+      get_de_amp_enabled_closure_(std::move(get_de_amp_enabled_closure)),
       ready_(new base::OneShotEvent()) {}
 
 CosmeticFiltersJsRenderFrameObserver::~CosmeticFiltersJsRenderFrameObserver() {}
@@ -111,10 +111,7 @@ void CosmeticFiltersJsRenderFrameObserver::RunScriptsAtDocumentStart() {
 }
 
 void CosmeticFiltersJsRenderFrameObserver::ApplyRules() {
-  auto dynamic_params = get_dynamic_params_callback_.Run();
-  bool de_amp_enabled =
-      base::FeatureList::IsEnabled(de_amp::features::kBraveDeAMP) &&
-      dynamic_params.de_amp_enabled;
+  bool de_amp_enabled = get_de_amp_enabled_closure_.Run();
   native_javascript_handle_->ApplyRules(de_amp_enabled);
 }
 

--- a/components/cosmetic_filters/renderer/cosmetic_filters_js_render_frame_observer.h
+++ b/components/cosmetic_filters/renderer/cosmetic_filters_js_render_frame_observer.h
@@ -10,6 +10,7 @@
 
 #include "base/memory/weak_ptr.h"
 #include "base/one_shot_event.h"
+#include "brave/common/brave_renderer_configuration.mojom.h"
 #include "brave/components/cosmetic_filters/renderer/cosmetic_filters_js_handler.h"
 #include "content/public/renderer/render_frame.h"
 #include "content/public/renderer/render_frame_observer.h"
@@ -28,8 +29,13 @@ class CosmeticFiltersJsRenderFrameObserver
       public content::RenderFrameObserverTracker<
           CosmeticFiltersJsRenderFrameObserver> {
  public:
-  CosmeticFiltersJsRenderFrameObserver(content::RenderFrame* render_frame,
-                                       const int32_t isolated_world_id);
+  using GetDynamicParamsCallback =
+      base::RepeatingCallback<const brave::mojom::DynamicParams&()>;
+
+  CosmeticFiltersJsRenderFrameObserver(
+      content::RenderFrame* render_frame,
+      const int32_t isolated_world_id,
+      GetDynamicParamsCallback get_dynamic_params_callback);
   ~CosmeticFiltersJsRenderFrameObserver() override;
 
   CosmeticFiltersJsRenderFrameObserver(
@@ -64,6 +70,7 @@ class CosmeticFiltersJsRenderFrameObserver
   std::unique_ptr<CosmeticFiltersJSHandler> native_javascript_handle_;
 
   GURL url_;
+  GetDynamicParamsCallback get_dynamic_params_callback_;
 
   std::unique_ptr<base::OneShotEvent> ready_;
 

--- a/components/cosmetic_filters/renderer/cosmetic_filters_js_render_frame_observer.h
+++ b/components/cosmetic_filters/renderer/cosmetic_filters_js_render_frame_observer.h
@@ -10,7 +10,6 @@
 
 #include "base/memory/weak_ptr.h"
 #include "base/one_shot_event.h"
-#include "brave/common/brave_renderer_configuration.mojom.h"
 #include "brave/components/cosmetic_filters/renderer/cosmetic_filters_js_handler.h"
 #include "content/public/renderer/render_frame.h"
 #include "content/public/renderer/render_frame_observer.h"
@@ -29,13 +28,10 @@ class CosmeticFiltersJsRenderFrameObserver
       public content::RenderFrameObserverTracker<
           CosmeticFiltersJsRenderFrameObserver> {
  public:
-  using GetDynamicParamsCallback =
-      base::RepeatingCallback<const brave::mojom::DynamicParams&()>;
-
   CosmeticFiltersJsRenderFrameObserver(
       content::RenderFrame* render_frame,
       const int32_t isolated_world_id,
-      GetDynamicParamsCallback get_dynamic_params_callback);
+      base::RepeatingCallback<bool(void)> get_de_amp_enabled_closure_);
   ~CosmeticFiltersJsRenderFrameObserver() override;
 
   CosmeticFiltersJsRenderFrameObserver(
@@ -70,7 +66,7 @@ class CosmeticFiltersJsRenderFrameObserver
   std::unique_ptr<CosmeticFiltersJSHandler> native_javascript_handle_;
 
   GURL url_;
-  GetDynamicParamsCallback get_dynamic_params_callback_;
+  base::RepeatingCallback<bool(void)> get_de_amp_enabled_closure_;
 
   std::unique_ptr<base::OneShotEvent> ready_;
 

--- a/components/de_amp/browser/de_amp_util.cc
+++ b/components/de_amp/browser/de_amp_util.cc
@@ -5,7 +5,11 @@
 
 #include "brave/components/de_amp/browser/de_amp_util.h"
 
+#include "base/feature_list.h"
 #include "base/no_destructor.h"
+#include "brave/components/de_amp/common/features.h"
+#include "brave/components/de_amp/common/pref_names.h"
+#include "components/prefs/pref_service.h"
 #include "third_party/re2/src/re2/re2.h"
 
 namespace de_amp {
@@ -21,6 +25,11 @@ constexpr char kFindCanonicalLinkTagPattern[] =
     "(<\\s*link\\s[^>]*rel=(?:\"|')canonical(?:\"|')(?:\\s[^>]*>|>|/>))";
 constexpr char kFindCanonicalHrefInTagPattern[] = "href=(?:\"|')(.*?)(?:\"|')";
 }  // namespace
+
+bool IsDeAmpEnabled(PrefService* prefs) {
+  return base::FeatureList::IsEnabled(features::kBraveDeAMP) &&
+         prefs->GetBoolean(de_amp::kDeAmpPrefEnabled);
+}
 
 bool VerifyCanonicalAmpUrl(const GURL& canonical_link,
                            const GURL& original_url) {

--- a/components/de_amp/browser/de_amp_util.h
+++ b/components/de_amp/browser/de_amp_util.h
@@ -8,9 +8,11 @@
 
 #include <string>
 
+#include "components/prefs/pref_service.h"
 #include "url/gurl.h"
 
 namespace de_amp {
+bool IsDeAmpEnabled(PrefService* prefs);
 bool MaybeFindCanonicalAmpUrl(const std::string& body,
                               std::string* canonical_url);
 bool VerifyCanonicalAmpUrl(const GURL& canonical_url, const GURL& original_url);

--- a/renderer/brave_content_renderer_client.cc
+++ b/renderer/brave_content_renderer_client.cc
@@ -63,7 +63,8 @@ void BraveContentRendererClient::RenderFrameCreated(
   if (base::FeatureList::IsEnabled(
           brave_shields::features::kBraveAdblockCosmeticFiltering)) {
     new cosmetic_filters::CosmeticFiltersJsRenderFrameObserver(
-        render_frame, ISOLATED_WORLD_ID_BRAVE_INTERNAL);
+        render_frame, ISOLATED_WORLD_ID_BRAVE_INTERNAL,
+        base::BindRepeating(&BraveRenderThreadObserver::GetDynamicParams));
   }
 
   if (base::FeatureList::IsEnabled(

--- a/renderer/brave_content_renderer_client.cc
+++ b/renderer/brave_content_renderer_client.cc
@@ -62,9 +62,13 @@ void BraveContentRendererClient::RenderFrameCreated(
 
   if (base::FeatureList::IsEnabled(
           brave_shields::features::kBraveAdblockCosmeticFiltering)) {
+    auto dynamic_params_closure = base::BindRepeating([]() {
+      auto dynamic_params = BraveRenderThreadObserver::GetDynamicParams();
+      return dynamic_params.de_amp_enabled;
+    });
+
     new cosmetic_filters::CosmeticFiltersJsRenderFrameObserver(
-        render_frame, ISOLATED_WORLD_ID_BRAVE_INTERNAL,
-        base::BindRepeating(&BraveRenderThreadObserver::GetDynamicParams));
+        render_frame, ISOLATED_WORLD_ID_BRAVE_INTERNAL, dynamic_params_closure);
   }
 
   if (base::FeatureList::IsEnabled(

--- a/test/BUILD.gn
+++ b/test/BUILD.gn
@@ -785,6 +785,7 @@ if (!is_android) {
       "//brave/components/brave_wallet/common:mojom",
       "//brave/components/brave_wallet/common:solana_utils",
       "//brave/components/de_amp/browser/test:browser_tests",
+      "//brave/components/de_amp/common:common",
       "//brave/components/debounce/browser",
       "//brave/components/debounce/common",
       "//brave/components/resources:strings_grit",


### PR DESCRIPTION
<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/22228

This PR adds support for a new scriptlet that will remove `jsaction` attribute from anchor tags on SERPs, if DeAmp flag and pref is enabled. After this PR we will merge in https://github.com/brave/adblock-resources/pull/63 (for the de-amp resource) and https://github.com/brave/adblock-lists/pull/818 (for the rule)

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

