### PR TITLE
MigrateUserAssetEthContractAddress should finish migration right away…

### DIFF
--- a/browser/brave_wallet/brave_wallet_service_unittest.cc
+++ b/browser/brave_wallet/brave_wallet_service_unittest.cc
@@ -1319,6 +1319,18 @@ TEST_F(BraveWalletServiceUnitTest, SolanaTokenUserAssetsAPI) {
   EXPECT_FALSE(success);
 }
 
+TEST_F(BraveWalletServiceUnitTest, MigrateUserAssetsDefaultPrefs) {
+  EXPECT_FALSE(
+      GetPrefs()->GetBoolean(kBraveWalletUserAssetEthContractAddressMigrated));
+  EXPECT_FALSE(GetPrefs()->HasPrefPath(kBraveWalletUserAssetsDeprecated));
+  BraveWalletService::MigrateUserAssetEthContractAddress(GetPrefs());
+  BraveWalletService::MigrateMultichainUserAssets(GetPrefs());
+  EXPECT_TRUE(
+      GetPrefs()->GetBoolean(kBraveWalletUserAssetEthContractAddressMigrated));
+  EXPECT_FALSE(GetPrefs()->HasPrefPath(kBraveWalletUserAssetsDeprecated));
+  EXPECT_FALSE(GetPrefs()->HasPrefPath(kBraveWalletUserAssets));
+}
+
 TEST_F(BraveWalletServiceUnitTest, MigrateUserAssetEthContractAddress) {
   EXPECT_FALSE(
       GetPrefs()->GetBoolean(kBraveWalletUserAssetEthContractAddressMigrated));

--- a/components/brave_wallet/browser/brave_wallet_service.cc
+++ b/components/brave_wallet/browser/brave_wallet_service.cc
@@ -574,6 +574,11 @@ void BraveWalletService::MigrateUserAssetEthContractAddress(
   if (prefs->GetBoolean(kBraveWalletUserAssetEthContractAddressMigrated))
     return;
 
+  if (!prefs->HasPrefPath(kBraveWalletUserAssetsDeprecated)) {
+    prefs->SetBoolean(kBraveWalletUserAssetEthContractAddressMigrated, true);
+    return;
+  }
+
   DictionaryPrefUpdate update(prefs, kBraveWalletUserAssetsDeprecated);
   base::Value* user_assets_pref = update.Get();
 


### PR DESCRIPTION
… when user assets deprecated pref is default value

<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/22156

The bug happens because in `MigrateUserAssetEthContractAddress`, kBraveWalletUserAssetsDeprecated will become non-default after we did 
```
  DictionaryPrefUpdate update(prefs, kBraveWalletUserAssetsDeprecated);
  base::Value* user_assets_pref = update.Get();
```

The value stays as empty dict but kBraveWalletUserAssetsDeprecated is now non-default, so we'll migrate this empty dict to the new pref for ethereum coin type later in `MigrateMultichainUserAssets`.

The fix here is to finish migration in `MigrateUserAssetEthContractAddress` right away when kBraveWalletUserAssetsDeprecated is default value. Which we should probably do so before already because we don't need to change the user assets pref when it's default.

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
1. Open Brave with fresh profile
2. Go to brave://wallet and create new wallet
3. Check if visible tokens are as expected.
<img width="1217" alt="Screen Shot 2022-04-07 at 9 58 22 AM" src="https://user-images.githubusercontent.com/4730197/162257640-5bd31010-4835-4d64-a1df-da0ed683f166.png">
<img width="564" alt="Screen Shot 2022-04-07 at 9 58 55 AM" src="https://user-images.githubusercontent.com/4730197/162257653-2bf41bce-10b9-4560-9fbc-4d0b98ef183b.png">
<img width="587" alt="Screen Shot 2022-04-07 at 9 59 15 AM" src="https://user-images.githubusercontent.com/4730197/162257666-0463366e-c927-4f71-92c3-beb86194e762.png">

