### PR TITLE
Force hide cosmetic filters from regional lists in Standard Shields mode (uplift to 1.38.x)

### DIFF
--- a/components/brave_shields/browser/ad_block_service.cc
+++ b/components/brave_shields/browser/ad_block_service.cc
@@ -181,7 +181,7 @@ absl::optional<base::Value> AdBlockService::UrlCosmeticResources(
 
   if (regional_resources && regional_resources->is_dict()) {
     MergeResourcesInto(std::move(*regional_resources), &*resources,
-                       /*force_hide=*/false);
+                       /*force_hide=*/true);
   }
 
   absl::optional<base::Value> custom_resources =


### PR DESCRIPTION
Uplift of #12917
Resolves https://github.com/brave/brave-browser/issues/22032

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.