### PR TITLE
Fixed inactive tab color is unreadable with accent color (uplift to 1.38.x)

### DIFF
--- a/chromium_src/chrome/browser/ui/color/win/native_chrome_color_mixer_win.cc
+++ b/chromium_src/chrome/browser/ui/color/win/native_chrome_color_mixer_win.cc
@@ -1,0 +1,44 @@
+/* Copyright (c) 2022 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "base/callback_list.h"
+#include "base/no_destructor.h"
+#include "third_party/abseil-cpp/absl/types/optional.h"
+#include "third_party/skia/include/core/SkColor.h"
+#include "ui/color/win/accent_color_observer.h"
+
+namespace ui {
+
+class FakeAccentColorObserver {
+ public:
+  static FakeAccentColorObserver* Get() {
+    static base::NoDestructor<FakeAccentColorObserver> observer;
+    return observer.get();
+  }
+
+  FakeAccentColorObserver() {}
+  FakeAccentColorObserver(const FakeAccentColorObserver&) = delete;
+  FakeAccentColorObserver& operator=(const FakeAccentColorObserver&) = delete;
+  ~FakeAccentColorObserver() {}
+
+  base::CallbackListSubscription Subscribe(base::RepeatingClosure callback) {
+    return callbacks_.Add(std::move(callback));
+  }
+
+  absl::optional<SkColor> accent_color() const { return absl::nullopt; }
+  absl::optional<SkColor> accent_color_inactive() const {
+    return absl::nullopt;
+  }
+  absl::optional<SkColor> accent_border_color() const { return absl::nullopt; }
+
+ private:
+  base::RepeatingClosureList callbacks_;
+};
+
+}  // namespace ui
+
+#define AccentColorObserver FakeAccentColorObserver
+#include "src/chrome/browser/ui/color/win/native_chrome_color_mixer_win.cc"
+#undef AccentColorObserver


### PR DESCRIPTION
Uplift of #12946
fix https://github.com/brave/brave-browser/issues/22027

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.