### PR TITLE
Fix tab mouseover for webpages that start with chrome (uplift to 1.37.x)

### DIFF
--- a/chromium_src/chrome/browser/ui/views/tabs/tab_hover_card_bubble_view.cc
+++ b/chromium_src/chrome/browser/ui/views/tabs/tab_hover_card_bubble_view.cc
@@ -5,6 +5,7 @@
 
 #include <string>
 
+#include "base/strings/strcat.h"
 #include "base/strings/string_util.h"
 #include "base/strings/utf_string_conversions.h"
 #include "chrome/browser/ui/views/tabs/tab.h"
@@ -21,7 +22,7 @@ void TabHoverCardBubbleView_ChromiumImpl::BraveUpdateCardContent(
   TabHoverCardBubbleView_ChromiumImpl::UpdateCardContent(tab);
   const std::u16string& domain = domain_label_->GetText();
   const std::u16string kChromeUISchemeU16 =
-      base::ASCIIToUTF16(content::kChromeUIScheme);
+      base::ASCIIToUTF16(base::StrCat({content::kChromeUIScheme, "://"}));
   // Replace chrome:// with brave://. Since this is purely in the UI we can
   // just do a sub-string replacement instead of parsing into GURL.
   if (base::StartsWith(domain, kChromeUISchemeU16,
@@ -29,7 +30,7 @@ void TabHoverCardBubbleView_ChromiumImpl::BraveUpdateCardContent(
     std::u16string new_domain = domain;
     base::ReplaceFirstSubstringAfterOffset(
         &new_domain, 0ul, kChromeUISchemeU16,
-        base::ASCIIToUTF16(content::kBraveUIScheme));
+        base::ASCIIToUTF16(base::StrCat({content::kBraveUIScheme, "://"})));
     domain_label_->SetText(new_domain, /*is_filename*/ false);
   }
 }


### PR DESCRIPTION
Uplift of #12882
Resolves https://github.com/brave/brave-browser/issues/22069

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.