### PR TITLE
Do not show Rewards panel notifications for inactive grants

### DIFF
--- a/components/brave_rewards/resources/rewards_panel/components/notification_overlay.style.ts
+++ b/components/brave_rewards/resources/rewards_panel/components/notification_overlay.style.ts
@@ -15,6 +15,16 @@ export const root = styled.div`
   right: 0;
   background: rgba(0, 0, 0, 0.15);
   overflow: hidden;
+
+  animation-name: dim-background;
+  animation-easing-function: ease-out;
+  animation-duration: 250ms;
+  animation-fill-mode: both;
+
+  @keyframes dim-background {
+    from { background: rgba(0, 0, 0, 0) }
+    to { background: rgba(0, 0, 0, 0.15) }
+  }
 `
 
 export const card = styled.div`


### PR DESCRIPTION
<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/22215

## Submitter Checklist:

- [ ] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

### Staging with UGP

On staging, the browser always fetches grants ("promotions") from the network. If the network is not available, the Rewards panel will have an empty grant list. We can use this property to simulate having a grant removed.

- Open browser with a new profile pointed to Rewards staging.
- Open the Rewards panel and enable rewards.
- Dismiss the onboarding tour.
- Do not click the "Claim" button in the UGP grant notification.
- Close the Rewards panel.
- Disconnect from the network.
- Open the rewards panel.
  - Verify that the grant notification is not displayed.
- Close the rewards panel.
- Connect to the network.
- Open the rewards panel.
  - Verify that the grant notification is displayed.
- Claim the grant.
  - Verify that captcha claiming is successful.

### Staging with Ad Grant

- Open browser with a new profile pointed to Rewards staging.
- Open the Rewards panel and enable rewards.
- Generate an Ad grant for the current rewards payment ID.
- Wait for the Ad grant to become available to the browser.
- Open the rewards panel.
  - Verify that the "Claim" notification is displayed.
- Do not click the "Claim" button.
- Close the Rewards panel.
- Have a server-side team member remove the Ad grant.
- Wait for the grant to disappear from the rewards page.
- Open the rewards panel.
  - Verify that the grant notification is not displayed.