### PR TITLE
Update pending Solana Tx status to dropped when it's blockhash is not valid anymore

### DIFF
--- a/components/brave_wallet/browser/brave_wallet_constants.h
+++ b/components/brave_wallet/browser/brave_wallet_constants.h
@@ -472,6 +472,8 @@ constexpr webui::LocalizedString kLocalizedStrings[] = {
      IDS_BRAVE_WALLET_TRANSACTION_STATUS_CONFIRMED},
     {"braveWalletTransactionStatusError",
      IDS_BRAVE_WALLET_TRANSACTION_STATUS_ERROR},
+    {"braveWalletTransactionStatusDropped",
+     IDS_BRAVE_WALLET_TRANSACTION_STATUS_DROPPED},
     {"braveWalletRecentTransactions", IDS_BRAVE_WALLET_RECENT_TRANSACTIONS},
     {"braveWalletTransactionDetails", IDS_BRAVE_WALLET_TRANSACTION_DETAILS},
     {"braveWalletTransactionDetailDate",

--- a/components/brave_wallet/browser/fil_response_parser.cc
+++ b/components/brave_wallet/browser/fil_response_parser.cc
@@ -18,15 +18,17 @@ bool ParseFilGetBalance(const std::string& json, std::string* balance) {
 }
 
 bool ParseFilGetTransactionCount(const std::string& raw_json, uint64_t* count) {
+  DCHECK(count);
+
   if (raw_json.empty())
     return false;
-  std::string value;
-  auto converted_json = ConvertSingleUint64Result(raw_json);
-  if (!converted_json ||
-      !brave_wallet::ParseSingleStringResult(converted_json.value(), &value) ||
-      value.empty())
+
+  std::string count_string;
+  if (!brave_wallet::ParseSingleStringResult(raw_json, &count_string))
     return false;
-  return base::StringToUint64(value, count);
+  if (count_string.empty())
+    return false;
+  return base::StringToUint64(count_string, count);
 }
 
 }  // namespace brave_wallet

--- a/components/brave_wallet/browser/fil_response_parser_unittest.cc
+++ b/components/brave_wallet/browser/fil_response_parser_unittest.cc
@@ -28,15 +28,14 @@ TEST(FilResponseParserUnitTest, ParseFilGetBalance) {
 }
 
 TEST(FilResponseParserUnitTest, ParseFilGetTransactionCount) {
-  auto max_nonce = UINT64_MAX;
   std::string json =
-      "{\"jsonrpc\":\"2.0\",\"id\":1,\"result\":" + std::to_string(max_nonce) +
-      "}";
+      R"({"jsonrpc":2.0,"id":1,"result":"18446744073709551615"})";
+
   uint64_t value = 0;
   EXPECT_TRUE(brave_wallet::ParseFilGetTransactionCount(json, &value));
-  EXPECT_EQ(value, max_nonce);
+  EXPECT_EQ(value, UINT64_MAX);
 
-  json = "{\"jsonrpc\":\"2.0\",\"id\":1,\"result\":1}";
+  json = "{\"jsonrpc\":\"2.0\",\"id\":1,\"result\":\"1\"}";
   value = 0;
   EXPECT_TRUE(brave_wallet::ParseFilGetTransactionCount(json, &value));
   EXPECT_EQ(value, 1u);
@@ -52,7 +51,7 @@ TEST(FilResponseParserUnitTest, ParseFilGetTransactionCount) {
 
   EXPECT_FALSE(brave_wallet::ParseFilGetTransactionCount("", &value));
 
-  json = "{\"jsonrpc\":\"2.0\",\"id\":1,\"result\":\"1\"}";
+  json = "{\"jsonrpc\":\"2.0\",\"id\":1,\"result\":1}";
   EXPECT_FALSE(brave_wallet::ParseFilGetTransactionCount(json, &value));
 
   json = "{\"jsonrpc\":\"2.0\",\"id\":1,\"result\":{}}";

--- a/components/brave_wallet/browser/json_rpc_response_parser.cc
+++ b/components/brave_wallet/browser/json_rpc_response_parser.cc
@@ -71,13 +71,13 @@ bool ParseBoolResult(const std::string& json, bool* value) {
   return false;
 }
 
-absl::optional<std::string> ConvertSingleUint64Result(
-    const std::string& raw_json) {
-  if (raw_json.empty())
+absl::optional<std::string> ConvertUint64ToString(const std::string& path,
+                                                  const std::string& json) {
+  if (path.empty() || json.empty())
     return absl::nullopt;
+
   std::string converted_json(
-      json::convert_uint64_value_to_string("/result", raw_json.c_str())
-          .c_str());
+      json::convert_uint64_value_to_string(path, json, true));
   if (converted_json.empty())
     return absl::nullopt;
   return converted_json;

--- a/components/brave_wallet/browser/json_rpc_response_parser.h
+++ b/components/brave_wallet/browser/json_rpc_response_parser.h
@@ -64,7 +64,10 @@ void ParseErrorResult(const std::string& json,
 
 bool ParseResult(const std::string& json, base::Value* result);
 bool ParseBoolResult(const std::string& json, bool* value);
-absl::optional<std::string> ConvertSingleUint64Result(const std::string& json);
+
+absl::optional<std::string> ConvertUint64ToString(const std::string& path,
+                                                  const std::string& json);
+
 }  // namespace brave_wallet
 
 #endif  // BRAVE_COMPONENTS_BRAVE_WALLET_BROWSER_JSON_RPC_RESPONSE_PARSER_H_

--- a/components/brave_wallet/browser/json_rpc_response_parser_unittest.cc
+++ b/components/brave_wallet/browser/json_rpc_response_parser_unittest.cc
@@ -125,38 +125,50 @@ TEST(JsonRpcResponseParserUnitTest, ParseErrorResult) {
   }
 }
 
-TEST(JsonRpcResponseParserUnitTest, ConvertSingleUint64Result) {
+TEST(JsonRpcResponseParserUnitTest, ConvertUint64ToString) {
   std::string json =
       "{\"jsonrpc\":\"2.0\",\"id\":1,\"result\":" + std::to_string(UINT64_MAX) +
       "}";
 
-  EXPECT_EQ(brave_wallet::ConvertSingleUint64Result(json).value(),
+  EXPECT_EQ(ConvertUint64ToString("/result", json).value(),
             "{\"id\":1,\"jsonrpc\":\"2.0\",\"result\":\"" +
                 std::to_string(UINT64_MAX) + "\"}");
 
   json = "{\"jsonrpc\":\"2.0\",\"id\":1,\"result\":1}";
-  EXPECT_EQ(brave_wallet::ConvertSingleUint64Result(json).value(),
+  EXPECT_EQ(ConvertUint64ToString("/result", json).value(),
             "{\"id\":1,\"jsonrpc\":\"2.0\",\"result\":\"1\"}");
 
+  EXPECT_FALSE(ConvertUint64ToString("", json));
+
   json = "{\"jsonrpc\":\"2.0\",\"id\":1,\"result\":-1}";
-  EXPECT_FALSE(brave_wallet::ConvertSingleUint64Result(json));
+  EXPECT_FALSE(ConvertUint64ToString("/result", json));
 
   json = "{\"jsonrpc\":\"2.0\",\"id\":1,\"result\":1.2}";
-  EXPECT_FALSE(brave_wallet::ConvertSingleUint64Result(json));
+  EXPECT_FALSE(ConvertUint64ToString("/result", json));
 
   json = "bad json";
-  EXPECT_FALSE(brave_wallet::ConvertSingleUint64Result(json));
+  EXPECT_FALSE(ConvertUint64ToString("/result", json));
 
-  EXPECT_FALSE(brave_wallet::ConvertSingleUint64Result(""));
+  EXPECT_FALSE(ConvertUint64ToString("/result", ""));
 
   json = "{\"jsonrpc\":\"2.0\",\"id\":1,\"result\":\"1\"}";
-  EXPECT_FALSE(brave_wallet::ConvertSingleUint64Result(json));
+  EXPECT_FALSE(ConvertUint64ToString("/result", json));
 
   json = "{\"jsonrpc\":\"2.0\",\"id\":1,\"result\":{}}";
-  EXPECT_FALSE(brave_wallet::ConvertSingleUint64Result(json));
+  EXPECT_FALSE(ConvertUint64ToString("/result", json));
 
-  json = "{\"jsonrpc\":\"2.0\",\"id\":1}";
-  EXPECT_FALSE(brave_wallet::ConvertSingleUint64Result(json));
+  json = R"({"jsonrpc":"2.0","id":1,"result":{"value":18446744073709551615}})";
+  EXPECT_EQ(
+      *ConvertUint64ToString("/result/value", json),
+      R"({"id":1,"jsonrpc":"2.0","result":{"value":"18446744073709551615"}})");
+
+  json = R"({"jsonrpc": "2.0", "id": 1,
+             "error": {
+               "code":-32601,
+               "message":"method does not exist"
+             }
+            })";
+  EXPECT_EQ(*ConvertUint64ToString("/result", json), json);
 }
 
 }  // namespace brave_wallet

--- a/components/brave_wallet/browser/json_rpc_service.cc
+++ b/components/brave_wallet/browser/json_rpc_service.cc
@@ -179,34 +179,13 @@ void JsonRpcService::AddObserver(
   observers_.Add(std::move(observer));
 }
 
-void JsonRpcService::Request(const std::string& json_payload,
-                             bool auto_retry_on_network_change,
-                             base::Value id,
-                             mojom::CoinType coin,
-                             RequestCallback callback) {
-  RequestInternal(
-      json_payload, auto_retry_on_network_change, network_urls_[coin],
-      base::BindOnce(&JsonRpcService::OnRequestResult, base::Unretained(this),
-                     std::move(callback), std::move(id)));
-}
-
-void JsonRpcService::OnRequestResult(
-    RequestCallback callback,
-    base::Value id,
-    const int code,
-    const std::string& message,
-    const base::flat_map<std::string, std::string>& headers) {
-  bool reject;
-  std::unique_ptr<base::Value> formed_response =
-      GetProviderRequestReturnFromEthJsonResponse(code, message, &reject);
-  std::move(callback).Run(std::move(id), std::move(*formed_response), reject,
-                          "", false);
-}
-
-void JsonRpcService::RequestInternal(const std::string& json_payload,
-                                     bool auto_retry_on_network_change,
-                                     const GURL& network_url,
-                                     RequestIntermediateCallback callback) {
+void JsonRpcService::RequestInternal(
+    const std::string& json_payload,
+    bool auto_retry_on_network_change,
+    const GURL& network_url,
+    RequestIntermediateCallback callback,
+    api_request_helper::APIRequestHelper::ResponseConversionCallback
+        conversion_callback = base::NullCallback()) {
   DCHECK(network_url.is_valid());
 
   base::flat_map<std::string, std::string> request_headers;
@@ -231,7 +210,32 @@ void JsonRpcService::RequestInternal(const std::string& json_payload,
 
   api_request_helper_->Request("POST", network_url, json_payload,
                                "application/json", auto_retry_on_network_change,
-                               std::move(callback), request_headers);
+                               std::move(callback), request_headers, -1u,
+                               std::move(conversion_callback));
+}
+
+void JsonRpcService::Request(const std::string& json_payload,
+                             bool auto_retry_on_network_change,
+                             base::Value id,
+                             mojom::CoinType coin,
+                             RequestCallback callback) {
+  RequestInternal(
+      json_payload, auto_retry_on_network_change, network_urls_[coin],
+      base::BindOnce(&JsonRpcService::OnRequestResult, base::Unretained(this),
+                     std::move(callback), std::move(id)));
+}
+
+void JsonRpcService::OnRequestResult(
+    RequestCallback callback,
+    base::Value id,
+    const int code,
+    const std::string& message,
+    const base::flat_map<std::string, std::string>& headers) {
+  bool reject;
+  std::unique_ptr<base::Value> formed_response =
+      GetProviderRequestReturnFromEthJsonResponse(code, message, &reject);
+  std::move(callback).Run(std::move(id), std::move(*formed_response), reject,
+                          "", false);
 }
 
 void JsonRpcService::FirePendingRequestCompleted(const std::string& chain_id,
@@ -685,7 +689,8 @@ void JsonRpcService::GetFilTransactionCount(const std::string& address,
                      weak_ptr_factory_.GetWeakPtr(), std::move(callback));
 
   RequestInternal(fil::getTransactionCount(address), true, network_url,
-                  std::move(internal_callback));
+                  std::move(internal_callback),
+                  base::BindOnce(&ConvertUint64ToString, "/result"));
 }
 
 void JsonRpcService::GetEthTransactionCount(const std::string& address,
@@ -1769,7 +1774,9 @@ void JsonRpcService::GetSolanaLatestBlockhash(
                      weak_ptr_factory_.GetWeakPtr(), std::move(callback));
   RequestInternal(solana::getLatestBlockhash(), true,
                   network_urls_[mojom::CoinType::SOL],
-                  std::move(internal_callback));
+                  std::move(internal_callback),
+                  base::BindOnce(&ConvertUint64ToString,
+                                 "/result/value/lastValidBlockHeight"));
 }
 
 void JsonRpcService::OnGetSolanaLatestBlockhash(
@@ -1922,7 +1929,8 @@ void JsonRpcService::GetSolanaBlockHeight(
                      weak_ptr_factory_.GetWeakPtr(), std::move(callback));
   RequestInternal(solana::getBlockHeight(), true,
                   network_urls_[mojom::CoinType::SOL],
-                  std::move(internal_callback));
+                  std::move(internal_callback),
+                  base::BindOnce(&ConvertUint64ToString, "/result"));
 }
 
 void JsonRpcService::OnGetSolanaBlockHeight(

--- a/components/brave_wallet/browser/json_rpc_service.cc
+++ b/components/brave_wallet/browser/json_rpc_service.cc
@@ -1779,21 +1779,24 @@ void JsonRpcService::OnGetSolanaLatestBlockhash(
     const base::flat_map<std::string, std::string>& headers) {
   if (status < 200 || status > 299) {
     std::move(callback).Run(
-        "", mojom::SolanaProviderError::kInternalError,
+        "", 0, mojom::SolanaProviderError::kInternalError,
         l10n_util::GetStringUTF8(IDS_WALLET_INTERNAL_ERROR));
     return;
   }
 
   std::string blockhash;
-  if (!solana::ParseGetLatestBlockhash(body, &blockhash)) {
+  uint64_t last_valid_block_height = 0;
+  if (!solana::ParseGetLatestBlockhash(body, &blockhash,
+                                       &last_valid_block_height)) {
     mojom::SolanaProviderError error;
     std::string error_message;
     ParseErrorResult<mojom::SolanaProviderError>(body, &error, &error_message);
-    std::move(callback).Run("", error, error_message);
+    std::move(callback).Run("", 0, error, error_message);
     return;
   }
 
-  std::move(callback).Run(blockhash, mojom::SolanaProviderError::kSuccess, "");
+  std::move(callback).Run(blockhash, last_valid_block_height,
+                          mojom::SolanaProviderError::kSuccess, "");
 }
 
 void JsonRpcService::GetSolanaSignatureStatuses(

--- a/components/brave_wallet/browser/json_rpc_service.h
+++ b/components/brave_wallet/browser/json_rpc_service.h
@@ -265,6 +265,7 @@ class JsonRpcService : public KeyedService, public mojom::JsonRpcService {
                              SendSolanaTransactionCallback callback);
   using GetSolanaLatestBlockhashCallback =
       base::OnceCallback<void(const std::string& latest_blockhash,
+                              uint64_t last_valid_block_height,
                               mojom::SolanaProviderError error,
                               const std::string& error_message)>;
   void GetSolanaLatestBlockhash(GetSolanaLatestBlockhashCallback callback);

--- a/components/brave_wallet/browser/json_rpc_service.h
+++ b/components/brave_wallet/browser/json_rpc_service.h
@@ -287,6 +287,11 @@ class JsonRpcService : public KeyedService, public mojom::JsonRpcService {
                               const std::string& error_message)>;
   void GetSolanaFeeForMessage(const std::string& message,  // base64 encoded
                               GetSolanaFeeForMessageCallback callback);
+  using GetSolanaBlockHeightCallback =
+      base::OnceCallback<void(uint64_t block_height,
+                              mojom::SolanaProviderError error,
+                              const std::string& error_message)>;
+  void GetSolanaBlockHeight(GetSolanaBlockHeightCallback callback);
 
  private:
   void FireNetworkChanged(mojom::CoinType coin);
@@ -481,6 +486,11 @@ class JsonRpcService : public KeyedService, public mojom::JsonRpcService {
       const base::flat_map<std::string, std::string>& headers);
   void OnGetSolanaFeeForMessage(
       GetSolanaFeeForMessageCallback callback,
+      const int status,
+      const std::string& body,
+      const base::flat_map<std::string, std::string>& headers);
+  void OnGetSolanaBlockHeight(
+      GetSolanaBlockHeightCallback callback,
       const int status,
       const std::string& body,
       const base::flat_map<std::string, std::string>& headers);

--- a/components/brave_wallet/browser/json_rpc_service.h
+++ b/components/brave_wallet/browser/json_rpc_service.h
@@ -417,10 +417,13 @@ class JsonRpcService : public KeyedService, public mojom::JsonRpcService {
                        mojom::ProviderError error,
                        const std::string& error_message);
 
-  void RequestInternal(const std::string& json_payload,
-                       bool auto_retry_on_network_change,
-                       const GURL& network_url,
-                       RequestIntermediateCallback callback);
+  void RequestInternal(
+      const std::string& json_payload,
+      bool auto_retry_on_network_change,
+      const GURL& network_url,
+      RequestIntermediateCallback callback,
+      api_request_helper::APIRequestHelper::ResponseConversionCallback
+          conversion_callback);
   void OnEthChainIdValidatedForOrigin(
       mojom::NetworkInfoPtr chain,
       const url::Origin& origin,

--- a/components/brave_wallet/browser/json_rpc_service_unittest.cc
+++ b/components/brave_wallet/browser/json_rpc_service_unittest.cc
@@ -2355,10 +2355,11 @@ TEST_F(JsonRpcServiceUnitTest, GetSolanaLatestBlockhash) {
                  "{\"jsonrpc\":\"2.0\",\"id\":1,\"result\":"
                  "{\"context\":{\"slot\":1069},\"value\":{\"blockhash\":"
                  "\"EkSnNWid2cvwEVnVx9aBqawnmiCNiDgp3gUdkDPTKN1N\", "
-                 "\"lastValidBlockHeight\":3090}}}");
+                 "\"lastValidBlockHeight\":18446744073709551615}}}");
 
   TestGetSolanaLatestBlockhash("EkSnNWid2cvwEVnVx9aBqawnmiCNiDgp3gUdkDPTKN1N",
-                               3090, mojom::SolanaProviderError::kSuccess, "");
+                               UINT64_MAX, mojom::SolanaProviderError::kSuccess,
+                               "");
 
   // Response parsing error
   SetInterceptor(expected_network_url, "getLatestBlockhash", "",
@@ -2705,12 +2706,12 @@ TEST_F(JsonRpcServiceUnitTest, GetFilTransactionCount) {
   SetNetwork(mojom::kLocalhostChainId, mojom::CoinType::FIL);
   SetInterceptor(GetNetwork(mojom::kLocalhostChainId, mojom::CoinType::FIL),
                  "Filecoin.MpoolGetNonce", "",
-                 "{\"jsonrpc\":\"2.0\",\"id\":1,\"result\":1}");
+                 R"({"jsonrpc":"2.0","id":1,"result":18446744073709551615})");
 
   json_rpc_service_->GetFilTransactionCount(
       "t1h4n7rphclbmwyjcp6jrdiwlfcuwbroxy3jvg33q",
       base::BindOnce(&OnFilUint256Response, &callback_called,
-                     mojom::FilecoinProviderError::kSuccess, "", 1));
+                     mojom::FilecoinProviderError::kSuccess, "", UINT64_MAX));
   base::RunLoop().RunUntilIdle();
   EXPECT_TRUE(callback_called);
 
@@ -2725,7 +2726,8 @@ TEST_F(JsonRpcServiceUnitTest, GetFilTransactionCount) {
   EXPECT_TRUE(callback_called);
 
   callback_called = false;
-  SetInvalidJsonInterceptor();
+  SetInterceptor(GetNetwork(mojom::kLocalhostChainId, mojom::CoinType::FIL),
+                 "Filecoin.MpoolGetNonce", "", R"({"jsonrpc":"2.0","id":1})");
   json_rpc_service_->GetFilTransactionCount(
       "t1h4n7rphclbmwyjcp6jrdiwlfcuwbroxy3jvg33q",
       base::BindOnce(&OnFilUint256Response, &callback_called,
@@ -2750,13 +2752,14 @@ TEST_F(JsonRpcServiceUnitTest, GetSolanaBlockHeight) {
   auto expected_network_url =
       GetNetwork(mojom::kLocalhostChainId, mojom::CoinType::SOL);
   SetInterceptor(expected_network_url, "getBlockHeight", "",
-                 R"({"jsonrpc":"2.0", "id":1, "result":5566})");
+                 R"({"jsonrpc":"2.0", "id":1, "result":18446744073709551615})");
 
-  TestGetSolanaBlockHeight(5566, mojom::SolanaProviderError::kSuccess, "");
+  TestGetSolanaBlockHeight(UINT64_MAX, mojom::SolanaProviderError::kSuccess,
+                           "");
 
   // Response parsing error
   SetInterceptor(expected_network_url, "getBlockHeight", "",
-                 R"({"jsonrpc":"2.0","id":1,"result":"not expected"})");
+                 R"({"jsonrpc":"2.0","id":1})");
   TestGetSolanaBlockHeight(0, mojom::SolanaProviderError::kParsingError,
                            l10n_util::GetStringUTF8(IDS_WALLET_PARSING_ERROR));
 

--- a/components/brave_wallet/browser/solana_block_tracker.h
+++ b/components/brave_wallet/browser/solana_block_tracker.h
@@ -27,8 +27,8 @@ class SolanaBlockTracker : public BlockTracker {
 
   class Observer : public base::CheckedObserver {
    public:
-    virtual void OnLatestBlockhashUpdated(
-        const std::string& latest_blockhash) = 0;
+    virtual void OnLatestBlockhashUpdated(const std::string& latest_blockhash,
+                                          uint64_t last_valid_block_height) = 0;
   };
 
   void AddObserver(Observer* observer);
@@ -39,9 +39,11 @@ class SolanaBlockTracker : public BlockTracker {
   void Stop() override;
 
   std::string latest_blockhash() const { return latest_blockhash_; }
+  uint64_t last_valid_block_height() const { return last_valid_block_height_; }
 
   using GetLatestBlockhashCallback =
       base::OnceCallback<void(const std::string& latest_blockhash,
+                              uint64_t last_valid_block_height,
                               mojom::SolanaProviderError error,
                               const std::string& error_message)>;
   void GetLatestBlockhash(GetLatestBlockhashCallback callback,
@@ -50,10 +52,12 @@ class SolanaBlockTracker : public BlockTracker {
  private:
   void OnGetLatestBlockhash(GetLatestBlockhashCallback callback,
                             const std::string& latest_blockhash,
+                            uint64_t last_valid_block_height,
                             mojom::SolanaProviderError error,
                             const std::string& error_message);
 
   std::string latest_blockhash_;
+  uint64_t last_valid_block_height_ = 0;
   base::Time latest_blockhash_expired_time_;
   base::ObserverList<Observer> observers_;
 

--- a/components/brave_wallet/browser/solana_block_tracker_unittest.cc
+++ b/components/brave_wallet/browser/solana_block_tracker_unittest.cc
@@ -25,8 +25,10 @@ namespace {
 
 class TrackerObserver : public SolanaBlockTracker::Observer {
  public:
-  void OnLatestBlockhashUpdated(const std::string& latest_blockhash) override {
+  void OnLatestBlockhashUpdated(const std::string& latest_blockhash,
+                                uint64_t last_valid_block_height) override {
     latest_blockhash_ = latest_blockhash;
+    last_valid_block_height_ = last_valid_block_height;
     ++latest_blockhash_updated_fired_;
   }
 
@@ -34,10 +36,12 @@ class TrackerObserver : public SolanaBlockTracker::Observer {
     return latest_blockhash_updated_fired_;
   }
   std::string latest_blockhash() const { return latest_blockhash_; }
+  uint64_t last_valid_block_height() const { return last_valid_block_height_; }
 
  private:
   size_t latest_blockhash_updated_fired_ = 0;
   std::string latest_blockhash_;
+  uint64_t last_valid_block_height_ = 0;
 };
 
 }  // namespace
@@ -62,19 +66,23 @@ class SolanaBlockTrackerUnitTest : public testing::Test {
   std::string GetResponseString() const {
     return "{\"jsonrpc\":\"2.0\",\"id\":1,\"result\":"
            "{\"context\":{\"slot\":1069},\"value\":{\"blockhash\":\"" +
-           response_blockhash_ + "\", \"lastValidBlockHeight\":3090}}}";
+           response_blockhash_ + "\", \"lastValidBlockHeight\":" +
+           std::to_string(response_last_valid_block_height_) + "}}}";
   }
 
   void TestGetLatestBlockhash(bool try_cached_value,
                               const std::string& expected_latest_blockhash,
+                              uint64_t expected_last_valid_block_height,
                               mojom::SolanaProviderError expected_error,
                               const std::string& expected_error_message) {
     base::RunLoop run_loop;
     tracker_->GetLatestBlockhash(
         base::BindLambdaForTesting([&](const std::string& latest_blockhash,
+                                       uint64_t last_valid_block_height,
                                        mojom::SolanaProviderError error,
                                        const std::string& error_message) {
           EXPECT_EQ(latest_blockhash, expected_latest_blockhash);
+          EXPECT_EQ(last_valid_block_height, expected_last_valid_block_height);
           EXPECT_EQ(error, expected_error);
           EXPECT_EQ(error_message, expected_error_message);
           run_loop.Quit();
@@ -85,6 +93,7 @@ class SolanaBlockTrackerUnitTest : public testing::Test {
 
  protected:
   std::string response_blockhash_;
+  uint64_t response_last_valid_block_height_ = 0;
   base::test::TaskEnvironment task_environment_;
   sync_preferences::TestingPrefServiceSyncable prefs_;
   network::TestURLLoaderFactory url_loader_factory_;
@@ -102,27 +111,35 @@ TEST_F(SolanaBlockTrackerUnitTest, GetLatestBlockhash) {
                                         GetResponseString());
       }));
   response_blockhash_ = "hash1";
+  response_last_valid_block_height_ = 3090;
   TrackerObserver observer;
   tracker_->AddObserver(&observer);
 
   tracker_->Start(base::Seconds(5));
   task_environment_.FastForwardBy(base::Seconds(5));
   EXPECT_EQ(observer.latest_blockhash(), "hash1");
+  EXPECT_EQ(observer.last_valid_block_height(), 3090u);
   EXPECT_EQ(observer.latest_blockhash_updated_fired(), 1u);
   EXPECT_EQ(tracker_->latest_blockhash(), "hash1");
+  EXPECT_EQ(tracker_->last_valid_block_height(), 3090u);
 
   response_blockhash_ = "hash2";
+  response_last_valid_block_height_ = 3290;
   tracker_->Start(base::Seconds(5));
   task_environment_.FastForwardBy(base::Seconds(5));
   EXPECT_EQ(observer.latest_blockhash(), "hash2");
+  EXPECT_EQ(observer.last_valid_block_height(), 3290u);
   EXPECT_EQ(observer.latest_blockhash_updated_fired(), 2u);
   EXPECT_EQ(tracker_->latest_blockhash(), "hash2");
+  EXPECT_EQ(tracker_->last_valid_block_height(), 3290u);
 
   // Still response_blockhash_ hash2, shouldn't fire updated event.
   task_environment_.FastForwardBy(base::Seconds(5));
   EXPECT_EQ(observer.latest_blockhash(), "hash2");
+  EXPECT_EQ(observer.last_valid_block_height(), 3290u);
   EXPECT_EQ(observer.latest_blockhash_updated_fired(), 2u);
   EXPECT_EQ(tracker_->latest_blockhash(), "hash2");
+  EXPECT_EQ(tracker_->last_valid_block_height(), 3290u);
 }
 
 TEST_F(SolanaBlockTrackerUnitTest, GetLatestBlockhashInvalidResponseJSON) {
@@ -134,14 +151,17 @@ TEST_F(SolanaBlockTrackerUnitTest, GetLatestBlockhashInvalidResponseJSON) {
       }));
 
   response_blockhash_ = "hash3";
+  response_last_valid_block_height_ = 3290;
   TrackerObserver observer;
   tracker_->AddObserver(&observer);
 
   tracker_->Start(base::Seconds(5));
   task_environment_.FastForwardBy(base::Seconds(5));
   EXPECT_EQ(observer.latest_blockhash(), "");
+  EXPECT_EQ(observer.last_valid_block_height(), 0u);
   EXPECT_EQ(observer.latest_blockhash_updated_fired(), 0u);
   EXPECT_EQ(tracker_->latest_blockhash(), "");
+  EXPECT_EQ(tracker_->last_valid_block_height(), 0u);
 }
 
 TEST_F(SolanaBlockTrackerUnitTest, GetLatestBlockhashInternalError) {
@@ -160,14 +180,17 @@ TEST_F(SolanaBlockTrackerUnitTest, GetLatestBlockhashInternalError) {
       }));
 
   response_blockhash_ = "hash3";
+  response_last_valid_block_height_ = 3290;
   TrackerObserver observer;
   tracker_->AddObserver(&observer);
 
   tracker_->Start(base::Seconds(5));
   task_environment_.FastForwardBy(base::Seconds(5));
   EXPECT_EQ(observer.latest_blockhash(), "");
+  EXPECT_EQ(observer.last_valid_block_height(), 0u);
   EXPECT_EQ(observer.latest_blockhash_updated_fired(), 0u);
   EXPECT_EQ(tracker_->latest_blockhash(), "");
+  EXPECT_EQ(tracker_->last_valid_block_height(), 0u);
 }
 
 TEST_F(SolanaBlockTrackerUnitTest, GetLatestBlockhashRequestTimeout) {
@@ -179,14 +202,17 @@ TEST_F(SolanaBlockTrackerUnitTest, GetLatestBlockhashRequestTimeout) {
       }));
 
   response_blockhash_ = "hash3";
+  response_last_valid_block_height_ = 3290;
   TrackerObserver observer;
   tracker_->AddObserver(&observer);
 
   tracker_->Start(base::Seconds(5));
   task_environment_.FastForwardBy(base::Seconds(5));
   EXPECT_EQ(observer.latest_blockhash(), "");
+  EXPECT_EQ(observer.last_valid_block_height(), 0u);
   EXPECT_EQ(observer.latest_blockhash_updated_fired(), 0u);
   EXPECT_EQ(tracker_->latest_blockhash(), "");
+  EXPECT_EQ(tracker_->last_valid_block_height(), 0u);
 }
 
 TEST_F(SolanaBlockTrackerUnitTest, GetLatestBlockhashWithoutStartTracker) {
@@ -200,24 +226,27 @@ TEST_F(SolanaBlockTrackerUnitTest, GetLatestBlockhashWithoutStartTracker) {
       }));
 
   response_blockhash_ = "hash1";
-  TestGetLatestBlockhash(false, "hash1", mojom::SolanaProviderError::kSuccess,
-                         "");
+  response_last_valid_block_height_ = 3090;
+  TestGetLatestBlockhash(false, "hash1", 3090,
+                         mojom::SolanaProviderError::kSuccess, "");
 
   // Cached value would be used if it's not expired yet.
   response_blockhash_ = "hash2";
-  TestGetLatestBlockhash(true, "hash1", mojom::SolanaProviderError::kSuccess,
-                         "");
-  TestGetLatestBlockhash(false, "hash2", mojom::SolanaProviderError::kSuccess,
-                         "");
+  response_last_valid_block_height_ = 3290;
+  TestGetLatestBlockhash(true, "hash1", 3090,
+                         mojom::SolanaProviderError::kSuccess, "");
+  TestGetLatestBlockhash(false, "hash2", 3290,
+                         mojom::SolanaProviderError::kSuccess, "");
 
   // Cached value would expire after kBlockTrackerDefaultTimeInSeconds.
   response_blockhash_ = "hash3";
+  response_last_valid_block_height_ = 3490;
   task_environment_.FastForwardBy(
       base::Seconds(kBlockTrackerDefaultTimeInSeconds));
-  TestGetLatestBlockhash(true, "hash3", mojom::SolanaProviderError::kSuccess,
-                         "");
-  TestGetLatestBlockhash(false, "hash3", mojom::SolanaProviderError::kSuccess,
-                         "");
+  TestGetLatestBlockhash(true, "hash3", 3490,
+                         mojom::SolanaProviderError::kSuccess, "");
+  TestGetLatestBlockhash(false, "hash3", 3490,
+                         mojom::SolanaProviderError::kSuccess, "");
 
   // Callback should be called when JSON-RPC failed, cached blockhash won't be
   // updated and can continue to be used until expired.
@@ -227,15 +256,18 @@ TEST_F(SolanaBlockTrackerUnitTest, GetLatestBlockhashWithoutStartTracker) {
         url_loader_factory_.AddResponse(request.url.spec(), "",
                                         net::HTTP_REQUEST_TIMEOUT);
       }));
-  TestGetLatestBlockhash(false, "", mojom::SolanaProviderError::kInternalError,
+  TestGetLatestBlockhash(false, "", 0,
+                         mojom::SolanaProviderError::kInternalError,
                          l10n_util::GetStringUTF8(IDS_WALLET_INTERNAL_ERROR));
-  TestGetLatestBlockhash(true, "hash3", mojom::SolanaProviderError::kSuccess,
-                         "");
+  TestGetLatestBlockhash(true, "hash3", 3490,
+                         mojom::SolanaProviderError::kSuccess, "");
   task_environment_.FastForwardBy(
       base::Seconds(kBlockTrackerDefaultTimeInSeconds));
-  TestGetLatestBlockhash(false, "", mojom::SolanaProviderError::kInternalError,
+  TestGetLatestBlockhash(false, "", 0,
+                         mojom::SolanaProviderError::kInternalError,
                          l10n_util::GetStringUTF8(IDS_WALLET_INTERNAL_ERROR));
-  TestGetLatestBlockhash(true, "", mojom::SolanaProviderError::kInternalError,
+  TestGetLatestBlockhash(true, "", 0,
+                         mojom::SolanaProviderError::kInternalError,
                          l10n_util::GetStringUTF8(IDS_WALLET_INTERNAL_ERROR));
 }
 

--- a/components/brave_wallet/browser/solana_message.h
+++ b/components/brave_wallet/browser/solana_message.h
@@ -36,10 +36,12 @@ class SolanaMessage {
   void set_recent_blockhash(const std::string& recent_blockhash) {
     recent_blockhash_ = recent_blockhash;
   }
+  std::string recent_blockhash() { return recent_blockhash_; }
 
   void set_last_valid_block_height(uint64_t last_valid_block_height) {
     last_valid_block_height_ = last_valid_block_height;
   }
+  uint64_t last_valid_block_height() const { return last_valid_block_height_; }
 
   mojom::SolanaTxDataPtr ToSolanaTxData() const;
   base::Value ToValue() const;

--- a/components/brave_wallet/browser/solana_message.h
+++ b/components/brave_wallet/browser/solana_message.h
@@ -23,6 +23,7 @@ namespace brave_wallet {
 class SolanaMessage {
  public:
   SolanaMessage(const std::string& recent_blockhash,
+                uint64_t last_valid_block_height,
                 const std::string& fee_payer,
                 std::vector<SolanaInstruction>&& instructions);
   SolanaMessage(const SolanaMessage&);
@@ -32,8 +33,12 @@ class SolanaMessage {
   absl::optional<std::vector<uint8_t>> Serialize(
       std::vector<std::string>* signers) const;
 
-  void SetRecentBlockHash(const std::string& recent_blockhash) {
+  void set_recent_blockhash(const std::string& recent_blockhash) {
     recent_blockhash_ = recent_blockhash;
+  }
+
+  void set_last_valid_block_height(uint64_t last_valid_block_height) {
+    last_valid_block_height_ = last_valid_block_height;
   }
 
   mojom::SolanaTxDataPtr ToSolanaTxData() const;
@@ -48,6 +53,8 @@ class SolanaMessage {
       std::vector<SolanaAccountMeta>* unique_account_metas) const;
 
   std::string recent_blockhash_;
+  uint64_t last_valid_block_height_ = 0;
+
   // The account responsible for paying the cost of executing a transaction.
   std::string fee_payer_;
   std::vector<SolanaInstruction> instructions_;

--- a/components/brave_wallet/browser/solana_requests.cc
+++ b/components/brave_wallet/browser/solana_requests.cc
@@ -77,6 +77,10 @@ std::string getFeeForMessage(const std::string& message) {
   return GetJsonRpc1Param("getFeeForMessage", message);
 }
 
+std::string getBlockHeight() {
+  return GetJsonRpcNoParams("getBlockHeight");
+}
+
 }  // namespace solana
 
 }  // namespace brave_wallet

--- a/components/brave_wallet/browser/solana_requests.h
+++ b/components/brave_wallet/browser/solana_requests.h
@@ -20,6 +20,7 @@ std::string getLatestBlockhash();
 std::string getSignatureStatuses(const std::vector<std::string>& tx_signatures);
 std::string getAccountInfo(const std::string& pubkey);
 std::string getFeeForMessage(const std::string& message);
+std::string getBlockHeight();
 
 }  // namespace solana
 

--- a/components/brave_wallet/browser/solana_requests_unittest.cc
+++ b/components/brave_wallet/browser/solana_requests_unittest.cc
@@ -74,6 +74,12 @@ TEST(SolanaRequestsUnitTest, getFeeForMessage) {
       R"({"id":1,"jsonrpc":"2.0","method":"getFeeForMessage","params":["message"]})");
 }
 
+TEST(SolanaRequestsUnitTest, getBlockHeight) {
+  ASSERT_EQ(
+      getBlockHeight(),
+      R"({"id":1,"jsonrpc":"2.0","method":"getBlockHeight","params":[]})");
+}
+
 }  // namespace solana
 
 }  // namespace brave_wallet

--- a/components/brave_wallet/browser/solana_response_parser.cc
+++ b/components/brave_wallet/browser/solana_response_parser.cc
@@ -248,6 +248,21 @@ bool ParseGetFeeForMessage(const std::string& json, uint64_t* fee) {
   return GetUint64FromDictValue(result, "value", true, fee);
 }
 
+bool ParseGetBlockHeight(const std::string& json, uint64_t* block_height) {
+  DCHECK(block_height);
+
+  absl::optional<std::string> converted_json = ConvertSingleUint64Result(json);
+  std::string block_height_string;
+  if (!converted_json || !brave_wallet::ParseSingleStringResult(
+                             *converted_json, &block_height_string))
+    return false;
+
+  if (block_height_string.empty())
+    return false;
+
+  return base::StringToUint64(block_height_string, block_height);
+}
+
 }  // namespace solana
 
 }  // namespace brave_wallet

--- a/components/brave_wallet/browser/solana_response_parser.cc
+++ b/components/brave_wallet/browser/solana_response_parser.cc
@@ -111,13 +111,8 @@ bool ParseGetLatestBlockhash(const std::string& json,
                              uint64_t* last_valid_block_height) {
   DCHECK(hash && last_valid_block_height);
 
-  std::string converted_json(json::convert_uint64_value_to_string(
-      "/result/value/lastValidBlockHeight", json));
-  if (converted_json.empty())
-    return false;
-
   base::Value result;
-  if (!ParseResult(converted_json, &result) || !result.is_dict())
+  if (!ParseResult(json, &result) || !result.is_dict())
     return false;
 
   base::Value* value = result.FindDictKey("value");
@@ -265,10 +260,8 @@ bool ParseGetFeeForMessage(const std::string& json, uint64_t* fee) {
 bool ParseGetBlockHeight(const std::string& json, uint64_t* block_height) {
   DCHECK(block_height);
 
-  absl::optional<std::string> converted_json = ConvertSingleUint64Result(json);
   std::string block_height_string;
-  if (!converted_json || !brave_wallet::ParseSingleStringResult(
-                             *converted_json, &block_height_string))
+  if (!brave_wallet::ParseSingleStringResult(json, &block_height_string))
     return false;
 
   if (block_height_string.empty())

--- a/components/brave_wallet/browser/solana_response_parser.h
+++ b/components/brave_wallet/browser/solana_response_parser.h
@@ -24,7 +24,9 @@ bool ParseGetTokenAccountBalance(const std::string& json,
                                  uint8_t* decimals,
                                  std::string* ui_amount_string);
 bool ParseSendTransaction(const std::string& json, std::string* tx_id);
-bool ParseGetLatestBlockhash(const std::string& json, std::string* hash);
+bool ParseGetLatestBlockhash(const std::string& json,
+                             std::string* hash,
+                             uint64_t* last_valid_block_height);
 bool ParseGetSignatureStatuses(
     const std::string& json,
     std::vector<absl::optional<SolanaSignatureStatus>>* statuses);

--- a/components/brave_wallet/browser/solana_response_parser.h
+++ b/components/brave_wallet/browser/solana_response_parser.h
@@ -31,6 +31,7 @@ bool ParseGetSignatureStatuses(
 bool ParseGetAccountInfo(const std::string& json,
                          absl::optional<SolanaAccountInfo>* account_info_out);
 bool ParseGetFeeForMessage(const std::string& json, uint64_t* fee);
+bool ParseGetBlockHeight(const std::string& json, uint64_t* block_height);
 
 }  // namespace solana
 

--- a/components/brave_wallet/browser/solana_response_parser_unittest.cc
+++ b/components/brave_wallet/browser/solana_response_parser_unittest.cc
@@ -316,6 +316,27 @@ TEST(SolanaResponseParserUnitTest, ParseGetFeeForMessage) {
   EXPECT_DCHECK_DEATH(ParseGetFeeForMessage(json, nullptr));
 }
 
+TEST(SolanaResponseParserUnitTest, ParseGetBlockHeight) {
+  std::string json = R"({"jsonrpc":2.0,"id":1,"result":18446744073709551615})";
+
+  uint64_t block_height = 0;
+  EXPECT_TRUE(ParseGetBlockHeight(json, &block_height));
+  EXPECT_EQ(block_height, UINT64_MAX);
+
+  std::vector<std::string> invalid_jsons = {
+      R"({"jsonrpc":2.0, "id":1})",
+      R"({"jsonrpc":2.0, "id":1, "result":{}})",
+      R"({"jsonrpc":2.0, "id":1, "result":null})",
+      R"({"jsonrpc":2.0, "id":1, "result":-1})",
+      R"({"jsonrpc":2.0, "id":1, "result":1.2})",
+      R"({"jsonrpc":2.0, "id":1, "result":"1"})"};
+  for (const auto& invalid_json : invalid_jsons)
+    EXPECT_FALSE(ParseGetBlockHeight(invalid_json, &block_height))
+        << invalid_json;
+
+  EXPECT_DCHECK_DEATH(ParseGetBlockHeight(json, nullptr));
+}
+
 }  // namespace solana
 
 }  // namespace brave_wallet

--- a/components/brave_wallet/browser/solana_response_parser_unittest.cc
+++ b/components/brave_wallet/browser/solana_response_parser_unittest.cc
@@ -95,20 +95,35 @@ TEST(SolanaResponseParserUnitTest, ParseSendTransaction) {
 
 TEST(SolanaResponseParserUnitTest, ParseGetLatestBlockhash) {
   std::string json =
-      "{\"jsonrpc\":\"2.0\",\"id\":1,\"result\":"
-      "{\"context\":{\"slot\":1069},\"value\":{\"blockhash\":"
-      "\"EkSnNWid2cvwEVnVx9aBqawnmiCNiDgp3gUdkDPTKN1N\", "
-      "\"lastValidBlockHeight\":3090}}}";
+      R"({"jsonrpc":"2.0","id":1,
+          "result": {
+            "context":{
+              "slot":1069
+            },
+            "value": {
+              "blockhash":"EkSnNWid2cvwEVnVx9aBqawnmiCNiDgp3gUdkDPTKN1N",
+              "lastValidBlockHeight": 18446744073709551615
+            }
+          }
+         })";
   std::string hash;
-  EXPECT_TRUE(ParseGetLatestBlockhash(json, &hash));
+  uint64_t last_valid_block_height = 0;
+  EXPECT_TRUE(ParseGetLatestBlockhash(json, &hash, &last_valid_block_height));
   EXPECT_EQ(hash, "EkSnNWid2cvwEVnVx9aBqawnmiCNiDgp3gUdkDPTKN1N");
+  EXPECT_EQ(last_valid_block_height, UINT64_MAX);
 
   std::vector<std::string> invalid_jsons = {
-      R"({"jsonrpc":2.0, "id":1})", R"({"jsonrpc":2.0, "id":1, "result":{}})",
-      R"({"jsonrpc":2.0, "id":1, "result":{"value":{}}})",
-      R"({"jsonrpc":2.0, "id":1, "result":{"value":{"blockhash":""}}})"};
+      R"({"jsonrpc":"2.0", "id":1})",
+      R"({"jsonrpc":"2.0", "id":1, "result":{}})",
+      R"({"jsonrpc":"2.0", "id":1, "result":{"value":{}}})",
+      R"({"jsonrpc":"2.0", "id":1, "result":{"value":{"blockhash":""}}})",
+      R"({"jsonrpc":"2.0", "id":1, "result":{"value":{"blockhash":"EkSnNWid2cvwEVnVx9aBqawnmiCNiDgp3gUdkDPTKN1N"}}})",
+      R"({"jsonrpc":"2.0", "id":1, "result":{"value":{"lastValidBlockHeight: 3090}}})",
+  };
   for (const auto& invalid_json : invalid_jsons)
-    EXPECT_FALSE(ParseGetLatestBlockhash(invalid_json, &hash)) << invalid_json;
+    EXPECT_FALSE(
+        ParseGetLatestBlockhash(invalid_json, &hash, &last_valid_block_height))
+        << invalid_json;
 }
 
 TEST(SolanaResponseParserUnitTest, ParseGetSignatureStatuses) {

--- a/components/brave_wallet/browser/solana_response_parser_unittest.cc
+++ b/components/brave_wallet/browser/solana_response_parser_unittest.cc
@@ -102,7 +102,7 @@ TEST(SolanaResponseParserUnitTest, ParseGetLatestBlockhash) {
             },
             "value": {
               "blockhash":"EkSnNWid2cvwEVnVx9aBqawnmiCNiDgp3gUdkDPTKN1N",
-              "lastValidBlockHeight": 18446744073709551615
+              "lastValidBlockHeight": "18446744073709551615"
             }
           }
          })";
@@ -118,7 +118,7 @@ TEST(SolanaResponseParserUnitTest, ParseGetLatestBlockhash) {
       R"({"jsonrpc":"2.0", "id":1, "result":{"value":{}}})",
       R"({"jsonrpc":"2.0", "id":1, "result":{"value":{"blockhash":""}}})",
       R"({"jsonrpc":"2.0", "id":1, "result":{"value":{"blockhash":"EkSnNWid2cvwEVnVx9aBqawnmiCNiDgp3gUdkDPTKN1N"}}})",
-      R"({"jsonrpc":"2.0", "id":1, "result":{"value":{"lastValidBlockHeight: 3090}}})",
+      R"({"jsonrpc":"2.0", "id":1, "result":{"value":{"lastValidBlockHeight": "3090"}}})",
   };
   for (const auto& invalid_json : invalid_jsons)
     EXPECT_FALSE(
@@ -314,17 +314,18 @@ TEST(SolanaResponseParserUnitTest, ParseGetAccountInfo) {
 
 TEST(SolanaResponseParserUnitTest, ParseGetFeeForMessage) {
   uint64_t fee = 0u;
-  std::string json = R"({"jsonrpc":2.0, "id":1, "result":{"value":12345}})";
+  std::string json = R"({"jsonrpc":"2.0", "id":1, "result":{"value":12345}})";
   EXPECT_TRUE(ParseGetFeeForMessage(json, &fee));
   EXPECT_EQ(fee, 12345u);
 
   EXPECT_TRUE(ParseGetFeeForMessage(
-      R"({"jsonrpc":2.0, "id":1, "result":{"value":null}})", &fee));
+      R"({"jsonrpc":"2.0", "id":1, "result":{"value":null}})", &fee));
   EXPECT_EQ(fee, 0u);
 
   std::vector<std::string> invalid_jsons = {
-      R"({"jsonrpc":2.0, "id":1})", R"({"jsonrpc":2.0, "id":1, "result":{}})",
-      R"({"jsonrpc":2.0, "id":1, "result":{"value":{}}})"};
+      R"({"jsonrpc":"2.0", "id":1})",
+      R"({"jsonrpc":"2.0", "id":1, "result":{}})",
+      R"({"jsonrpc":"2.0", "id":1, "result":{"value":{}}})"};
   for (const auto& invalid_json : invalid_jsons)
     EXPECT_FALSE(ParseGetFeeForMessage(invalid_json, &fee)) << invalid_json;
 
@@ -332,19 +333,20 @@ TEST(SolanaResponseParserUnitTest, ParseGetFeeForMessage) {
 }
 
 TEST(SolanaResponseParserUnitTest, ParseGetBlockHeight) {
-  std::string json = R"({"jsonrpc":2.0,"id":1,"result":18446744073709551615})";
+  std::string json =
+      R"({"jsonrpc":"2.0","id":1,"result":"18446744073709551615"})";
 
   uint64_t block_height = 0;
   EXPECT_TRUE(ParseGetBlockHeight(json, &block_height));
   EXPECT_EQ(block_height, UINT64_MAX);
 
   std::vector<std::string> invalid_jsons = {
-      R"({"jsonrpc":2.0, "id":1})",
-      R"({"jsonrpc":2.0, "id":1, "result":{}})",
-      R"({"jsonrpc":2.0, "id":1, "result":null})",
-      R"({"jsonrpc":2.0, "id":1, "result":-1})",
-      R"({"jsonrpc":2.0, "id":1, "result":1.2})",
-      R"({"jsonrpc":2.0, "id":1, "result":"1"})"};
+      R"({"jsonrpc":"2.0", "id":1})",
+      R"({"jsonrpc":"2.0", "id":1, "result":{}})",
+      R"({"jsonrpc":"2.0", "id":1, "result":null})",
+      R"({"jsonrpc":"2.0", "id":1, "result":-1})",
+      R"({"jsonrpc":"2.0", "id":1, "result":1.2})",
+      R"({"jsonrpc":"2.0", "id":1, "result":1})"};
   for (const auto& invalid_json : invalid_jsons)
     EXPECT_FALSE(ParseGetBlockHeight(invalid_json, &block_height))
         << invalid_json;

--- a/components/brave_wallet/browser/solana_transaction.h
+++ b/components/brave_wallet/browser/solana_transaction.h
@@ -28,19 +28,17 @@ class SolanaTransaction {
  public:
   explicit SolanaTransaction(SolanaMessage&& message);
   SolanaTransaction(const std::string& recent_blockhash,
+                    uint64_t last_valid_block_height,
                     const std::string& fee_payer,
                     std::vector<SolanaInstruction>&& instructions);
   SolanaTransaction(const SolanaTransaction&);
   ~SolanaTransaction();
   bool operator==(const SolanaTransaction&) const;
 
-  // Serialize the message and sign it. latest_blockhash_ will be updated if
-  // non-empty recent_blockhash is passed.
-  std::string GetSignedTransaction(KeyringService* keyring_service,
-                                   const std::string& recent_blockhash);
-  // Serialize and encode the message in Base64, latest_blockhash_ will be
-  // updated if non-empty recent_blockhash is passed.
-  std::string GetBase64EncodedMessage(const std::string& recent_blockhash);
+  // Serialize the message and sign it.
+  std::string GetSignedTransaction(KeyringService* keyring_service) const;
+  // Serialize and encode the message in Base64.
+  std::string GetBase64EncodedMessage() const;
 
   mojom::SolanaTxDataPtr ToSolanaTxData() const;
   base::Value ToValue() const;
@@ -54,6 +52,7 @@ class SolanaTransaction {
   mojom::TransactionType tx_type() const { return tx_type_; }
   uint64_t lamports() const { return lamports_; }
   uint64_t amount() const { return amount_; }
+  SolanaMessage* message() { return &message_; }
 
   void set_to_wallet_address(const std::string& to_wallet_address) {
     to_wallet_address_ = to_wallet_address;

--- a/components/brave_wallet/browser/solana_transaction_unittest.cc
+++ b/components/brave_wallet/browser/solana_transaction_unittest.cc
@@ -103,6 +103,7 @@ TEST_F(SolanaTransactionUnitTest, GetSignedTransaction) {
   std::string from_account = "BrG44HdsEhzapvs8bEqzvkq4egwevS3fRE6ze2ENo6S8";
   std::string to_account = "JDqrvDz8d8tFCADashbUKQDKfJZFobNy13ugN65t1wvV";
   std::string recent_blockhash = "9sHcv6xwn9YkB8nxTUGKDwPwNnmqVp5oAXxU8Fdkm4J6";
+  uint64_t last_valid_block_height = 3090;
 
   SolanaInstruction instruction(
       // Program ID
@@ -112,7 +113,8 @@ TEST_F(SolanaTransactionUnitTest, GetSignedTransaction) {
        SolanaAccountMeta(to_account, false, true)},
       // Data
       {2, 0, 0, 0, 128, 150, 152, 0, 0, 0, 0, 0});
-  SolanaTransaction transaction(recent_blockhash, from_account, {instruction});
+  SolanaTransaction transaction(recent_blockhash, last_valid_block_height,
+                                from_account, {instruction});
 
   std::vector<uint8_t> expected_bytes = {
       // Signature compact array
@@ -153,8 +155,7 @@ TEST_F(SolanaTransactionUnitTest, GetSignedTransaction) {
       2, 0, 0, 0, 128, 150, 152, 0, 0, 0, 0, 0  // data
   };
   std::string expected_tx = base::Base64Encode(expected_bytes);
-  EXPECT_EQ(transaction.GetSignedTransaction(keyring_service(), ""),
-            expected_tx);
+  EXPECT_EQ(transaction.GetSignedTransaction(keyring_service()), expected_tx);
 
   // Test two signers.
   instruction = SolanaInstruction(
@@ -165,8 +166,8 @@ TEST_F(SolanaTransactionUnitTest, GetSignedTransaction) {
        SolanaAccountMeta(to_account, true, true)},
       // Data
       {2, 0, 0, 0, 128, 150, 152, 0, 0, 0, 0, 0});
-  transaction =
-      SolanaTransaction(recent_blockhash, from_account, {instruction});
+  transaction = SolanaTransaction(recent_blockhash, last_valid_block_height,
+                                  from_account, {instruction});
 
   expected_bytes = std::vector<uint8_t>({
       // Signature compact array
@@ -212,11 +213,10 @@ TEST_F(SolanaTransactionUnitTest, GetSignedTransaction) {
       2, 0, 0, 0, 128, 150, 152, 0, 0, 0, 0, 0  // data
   });
   expected_tx = base::Base64Encode(expected_bytes);
-  EXPECT_EQ(transaction.GetSignedTransaction(keyring_service(), ""),
-            expected_tx);
+  EXPECT_EQ(transaction.GetSignedTransaction(keyring_service()), expected_tx);
 
   // Test key_service is nullptr.
-  EXPECT_TRUE(transaction.GetSignedTransaction(nullptr, "").empty());
+  EXPECT_TRUE(transaction.GetSignedTransaction(nullptr).empty());
 
   std::vector<uint8_t> oversized_data(1232, 1);
   instruction = SolanaInstruction(
@@ -226,15 +226,16 @@ TEST_F(SolanaTransactionUnitTest, GetSignedTransaction) {
       {SolanaAccountMeta(from_account, true, true),
        SolanaAccountMeta(to_account, false, true)},
       oversized_data);
-  transaction =
-      SolanaTransaction(recent_blockhash, from_account, {instruction});
-  EXPECT_TRUE(transaction.GetSignedTransaction(keyring_service(), "").empty());
+  transaction = SolanaTransaction(recent_blockhash, last_valid_block_height,
+                                  from_account, {instruction});
+  EXPECT_TRUE(transaction.GetSignedTransaction(keyring_service()).empty());
 }
 
 TEST_F(SolanaTransactionUnitTest, FromToSolanaTxData) {
   std::string from_account = "BrG44HdsEhzapvs8bEqzvkq4egwevS3fRE6ze2ENo6S8";
   std::string to_account = "JDqrvDz8d8tFCADashbUKQDKfJZFobNy13ugN65t1wvV";
   std::string recent_blockhash = "9sHcv6xwn9YkB8nxTUGKDwPwNnmqVp5oAXxU8Fdkm4J6";
+  uint64_t last_valid_block_height = 3090;
   const std::vector<uint8_t> data = {2, 0, 0, 0, 128, 150, 152, 0, 0, 0, 0, 0};
 
   SolanaInstruction instruction(
@@ -244,7 +245,8 @@ TEST_F(SolanaTransactionUnitTest, FromToSolanaTxData) {
       {SolanaAccountMeta(from_account, true, true),
        SolanaAccountMeta(to_account, false, true)},
       data);
-  SolanaTransaction transaction(recent_blockhash, from_account, {instruction});
+  SolanaTransaction transaction(recent_blockhash, last_valid_block_height,
+                                from_account, {instruction});
   transaction.set_to_wallet_address(to_account);
   transaction.set_lamports(10000000u);
   transaction.set_tx_type(mojom::TransactionType::SolanaSystemTransfer);
@@ -252,6 +254,7 @@ TEST_F(SolanaTransactionUnitTest, FromToSolanaTxData) {
   auto solana_tx_data = transaction.ToSolanaTxData();
   ASSERT_TRUE(solana_tx_data);
   EXPECT_EQ(solana_tx_data->recent_blockhash, recent_blockhash);
+  EXPECT_EQ(solana_tx_data->last_valid_block_height, last_valid_block_height);
   EXPECT_EQ(solana_tx_data->fee_payer, from_account);
   EXPECT_EQ(solana_tx_data->to_wallet_address, to_account);
   EXPECT_EQ(solana_tx_data->spl_token_mint_address, "");
@@ -285,6 +288,7 @@ TEST_F(SolanaTransactionUnitTest, FromToValue) {
   std::string from_account = "BrG44HdsEhzapvs8bEqzvkq4egwevS3fRE6ze2ENo6S8";
   std::string to_account = "JDqrvDz8d8tFCADashbUKQDKfJZFobNy13ugN65t1wvV";
   std::string recent_blockhash = "9sHcv6xwn9YkB8nxTUGKDwPwNnmqVp5oAXxU8Fdkm4J6";
+  uint64_t last_valid_block_height = 3090;
   const std::vector<uint8_t> data = {2, 0, 0, 0, 128, 150, 152, 0, 0, 0, 0, 0};
 
   SolanaInstruction instruction(
@@ -294,7 +298,8 @@ TEST_F(SolanaTransactionUnitTest, FromToValue) {
       {SolanaAccountMeta(from_account, true, true),
        SolanaAccountMeta(to_account, false, true)},
       data);
-  SolanaTransaction transaction(recent_blockhash, from_account, {instruction});
+  SolanaTransaction transaction(recent_blockhash, last_valid_block_height,
+                                from_account, {instruction});
   transaction.set_to_wallet_address(to_account);
   transaction.set_lamports(10000000u);
   transaction.set_tx_type(mojom::TransactionType::SolanaSystemTransfer);
@@ -304,6 +309,7 @@ TEST_F(SolanaTransactionUnitTest, FromToValue) {
       {
         "message": {
           "recent_blockhash": "9sHcv6xwn9YkB8nxTUGKDwPwNnmqVp5oAXxU8Fdkm4J6",
+          "last_valid_block_height": "3090",
           "fee_payer": "BrG44HdsEhzapvs8bEqzvkq4egwevS3fRE6ze2ENo6S8",
           "instructions": [
             {
@@ -349,8 +355,8 @@ TEST_F(SolanaTransactionUnitTest, FromToValue) {
 }
 
 TEST_F(SolanaTransactionUnitTest, SetTxType) {
-  auto tx =
-      SolanaTransaction("", "BrG44HdsEhzapvs8bEqzvkq4egwevS3fRE6ze2ENo6S8", {});
+  auto tx = SolanaTransaction(
+      "", 0, "BrG44HdsEhzapvs8bEqzvkq4egwevS3fRE6ze2ENo6S8", {});
   int solana_min = static_cast<int>(mojom::TransactionType::Other);
   int solana_max = static_cast<int>(
       mojom::TransactionType::
@@ -371,6 +377,7 @@ TEST_F(SolanaTransactionUnitTest, GetBase64EncodedMessage) {
   std::string from_account = "BrG44HdsEhzapvs8bEqzvkq4egwevS3fRE6ze2ENo6S8";
   std::string to_account = "JDqrvDz8d8tFCADashbUKQDKfJZFobNy13ugN65t1wvV";
   std::string recent_blockhash = "9sHcv6xwn9YkB8nxTUGKDwPwNnmqVp5oAXxU8Fdkm4J6";
+  uint64_t last_valid_block_height = 3090;
 
   SolanaInstruction instruction(
       // Program ID
@@ -380,20 +387,22 @@ TEST_F(SolanaTransactionUnitTest, GetBase64EncodedMessage) {
        SolanaAccountMeta(to_account, false, true)},
       // Data
       {2, 0, 0, 0, 128, 150, 152, 0, 0, 0, 0, 0});
-  SolanaTransaction transaction("", from_account, {instruction});
+  SolanaTransaction transaction("", 0, from_account, {instruction});
 
   // Blockhash not available.
-  EXPECT_TRUE(transaction.GetBase64EncodedMessage("").empty());
+  EXPECT_TRUE(transaction.GetBase64EncodedMessage().empty());
 
-  // Blockhash is passed, will be stored in the message.
-  auto result = transaction.GetBase64EncodedMessage(recent_blockhash);
+  // Blockhash is set.
+  transaction.message()->set_recent_blockhash(recent_blockhash);
+  auto result = transaction.GetBase64EncodedMessage();
   auto serialized_msg = transaction.message_.Serialize(nullptr);
   ASSERT_TRUE(serialized_msg);
   EXPECT_EQ(result, base::Base64Encode(*serialized_msg));
 
   // Blockhash is stored in the message already.
-  SolanaTransaction transaction2(recent_blockhash, from_account, {instruction});
-  result = transaction2.GetBase64EncodedMessage("");
+  SolanaTransaction transaction2(recent_blockhash, last_valid_block_height,
+                                 from_account, {instruction});
+  result = transaction2.GetBase64EncodedMessage();
   serialized_msg = transaction2.message_.Serialize(nullptr);
   ASSERT_TRUE(serialized_msg);
   EXPECT_EQ(result, base::Base64Encode(*serialized_msg));

--- a/components/brave_wallet/browser/solana_tx_manager.cc
+++ b/components/brave_wallet/browser/solana_tx_manager.cc
@@ -95,6 +95,7 @@ void SolanaTxManager::ApproveTransaction(const std::string& tx_meta_id,
 void SolanaTxManager::OnGetLatestBlockhash(std::unique_ptr<SolanaTxMeta> meta,
                                            ApproveTransactionCallback callback,
                                            const std::string& latest_blockhash,
+                                           uint64_t last_valid_block_height,
                                            mojom::SolanaProviderError error,
                                            const std::string& error_message) {
   if (error != mojom::SolanaProviderError::kSuccess) {
@@ -370,6 +371,7 @@ void SolanaTxManager::OnGetLatestBlockhashForGetEstimatedTxFee(
     std::unique_ptr<SolanaTxMeta> meta,
     GetEstimatedTxFeeCallback callback,
     const std::string& latest_blockhash,
+    uint64_t last_valid_block_height,
     mojom::SolanaProviderError error,
     const std::string& error_message) {
   if (error != mojom::SolanaProviderError::kSuccess) {
@@ -392,7 +394,9 @@ void SolanaTxManager::OnGetFeeForMessage(GetEstimatedTxFeeCallback callback,
   std::move(callback).Run(tx_fee, error, error_message);
 }
 
-void SolanaTxManager::OnLatestBlockhashUpdated(const std::string& blockhash) {
+void SolanaTxManager::OnLatestBlockhashUpdated(
+    const std::string& blockhash,
+    uint64_t last_valid_block_height) {
   UpdatePendingTransactions();
 }
 

--- a/components/brave_wallet/browser/solana_tx_manager.h
+++ b/components/brave_wallet/browser/solana_tx_manager.h
@@ -78,9 +78,14 @@ class SolanaTxManager : public TxManager, public SolanaBlockTracker::Observer {
 
  private:
   FRIEND_TEST_ALL_PREFIXES(SolanaTxManagerUnitTest, AddAndApproveTransaction);
+  FRIEND_TEST_ALL_PREFIXES(SolanaTxManagerUnitTest, DropTxWithInvalidBlockhash);
 
   // TxManager
   void UpdatePendingTransactions() override;
+
+  void OnGetBlockHeight(uint64_t block_height,
+                        mojom::SolanaProviderError error,
+                        const std::string& error_message);
 
   void OnGetLatestBlockhash(std::unique_ptr<SolanaTxMeta> meta,
                             ApproveTransactionCallback callback,
@@ -95,6 +100,7 @@ class SolanaTxManager : public TxManager, public SolanaBlockTracker::Observer {
                                const std::string& error_message);
   void OnGetSignatureStatuses(
       const std::vector<std::string>& tx_meta_ids,
+      uint64_t block_height,
       const std::vector<absl::optional<SolanaSignatureStatus>>&
           signature_statuses,
       mojom::SolanaProviderError error,

--- a/components/brave_wallet/browser/solana_tx_manager.h
+++ b/components/brave_wallet/browser/solana_tx_manager.h
@@ -85,6 +85,7 @@ class SolanaTxManager : public TxManager, public SolanaBlockTracker::Observer {
   void OnGetLatestBlockhash(std::unique_ptr<SolanaTxMeta> meta,
                             ApproveTransactionCallback callback,
                             const std::string& latest_blockhash,
+                            uint64_t last_valid_block_height,
                             mojom::SolanaProviderError error,
                             const std::string& error_message);
   void OnSendSolanaTransaction(const std::string& tx_meta_id,
@@ -112,6 +113,7 @@ class SolanaTxManager : public TxManager, public SolanaBlockTracker::Observer {
       std::unique_ptr<SolanaTxMeta> meta,
       GetEstimatedTxFeeCallback callback,
       const std::string& latest_blockhash,
+      uint64_t last_valid_block_height,
       mojom::SolanaProviderError error,
       const std::string& error_message);
   void OnGetFeeForMessage(GetEstimatedTxFeeCallback callback,
@@ -120,7 +122,8 @@ class SolanaTxManager : public TxManager, public SolanaBlockTracker::Observer {
                           const std::string& error_message);
 
   // SolanaBlockTracker::Observer
-  void OnLatestBlockhashUpdated(const std::string& blockhash) override;
+  void OnLatestBlockhashUpdated(const std::string& blockhash,
+                                uint64_t last_valid_block_height) override;
 
   SolanaTxStateManager* GetSolanaTxStateManager();
   SolanaBlockTracker* GetSolanaBlockTracker();

--- a/components/brave_wallet/browser/solana_tx_manager_unittest.cc
+++ b/components/brave_wallet/browser/solana_tx_manager_unittest.cc
@@ -18,6 +18,7 @@
 #include "brave/components/brave_wallet/browser/solana_keyring.h"
 #include "brave/components/brave_wallet/browser/solana_transaction.h"
 #include "brave/components/brave_wallet/browser/solana_tx_meta.h"
+#include "brave/components/brave_wallet/browser/solana_tx_state_manager.h"
 #include "brave/components/brave_wallet/browser/tx_service.h"
 #include "brave/components/brave_wallet/common/brave_wallet_constants.h"
 #include "brave/components/brave_wallet/common/brave_wallet_types.h"
@@ -48,14 +49,17 @@ class SolanaTxManagerUnitTest : public testing::Test {
         "ENTkpA52YStRW5Dia7";
     latest_blockhash1_ = "EkSnNWid2cvwEVnVx9aBqawnmiCNiDgp3gUdkDPTKN1N";
     latest_blockhash2_ = "FkSnNWid2cvwEVnVx9aBqawnmiCNiDgp3gUdkDPTKN1N";
+    latest_blockhash3_ = "GkSnNWid2cvwEVnVx9aBqawnmiCNiDgp3gUdkDPTKN1N";
     last_valid_block_height1_ = 3090;
     last_valid_block_height2_ = 3290;
+    last_valid_block_height3_ = 3490;
 
     base::test::ScopedFeatureList feature_list;
     feature_list.InitAndEnableFeature(
         brave_wallet::features::kBraveWalletSolanaFeature);
 
-    SetInterceptor(latest_blockhash1_, last_valid_block_height1_, tx_hash1_);
+    SetInterceptor(latest_blockhash1_, last_valid_block_height1_, tx_hash1_, "",
+                   false, last_valid_block_height1_);
     brave_wallet::RegisterProfilePrefs(prefs_.registry());
     json_rpc_service_.reset(
         new JsonRpcService(shared_url_loader_factory_, &prefs_));
@@ -93,10 +97,13 @@ class SolanaTxManagerUnitTest : public testing::Test {
                       uint64_t last_valid_block_height,
                       const std::string& tx_hash,
                       const std::string& content = "",
-                      bool get_signature_statuses = false) {
+                      bool get_signature_statuses = false,
+                      uint64_t block_height = 0,
+                      bool get_null_signature_statuses = false) {
     url_loader_factory_.SetInterceptor(base::BindLambdaForTesting(
         [&, latest_blockhash, tx_hash, content, get_signature_statuses,
-         last_valid_block_height](const network::ResourceRequest& request) {
+         last_valid_block_height, block_height,
+         get_null_signature_statuses](const network::ResourceRequest& request) {
           url_loader_factory_.ClearResponses();
           base::StringPiece request_string(request.request_body->elements()
                                                ->at(0)
@@ -114,6 +121,10 @@ class SolanaTxManagerUnitTest : public testing::Test {
                 "{\"context\":{\"slot\":1069},\"value\":{\"blockhash\":\"" +
                     latest_blockhash + "\", \"lastValidBlockHeight\":" +
                     std::to_string(last_valid_block_height) + "}}}");
+          } else if (*method == "getBlockHeight") {
+            url_loader_factory_.AddResponse(
+                request.url.spec(), R"({"jsonrpc":"2.0", "id":1, "result":)" +
+                                        std::to_string(block_height) + "}");
           } else if (*method == "sendTransaction") {
             url_loader_factory_.AddResponse(
                 request.url.spec(),
@@ -128,6 +139,17 @@ class SolanaTxManagerUnitTest : public testing::Test {
                                               net::HTTP_REQUEST_TIMEOUT);
               return;
             }
+
+            if (get_null_signature_statuses) {
+              url_loader_factory_.AddResponse(request.url.spec(),
+                                              R"({"jsonrpc":"2.0", "id":1,
+                      "result": {
+                         "context": {"slot": 82},
+                         "value": [null, null]
+                      }})");
+              return;
+            }
+
             const base::Value* params_list =
                 request_value->FindListKey("params");
             ASSERT_TRUE(params_list && params_list->GetList()[0].is_list());
@@ -307,8 +329,10 @@ class SolanaTxManagerUnitTest : public testing::Test {
   std::string tx_hash2_;
   std::string latest_blockhash1_;
   std::string latest_blockhash2_;
+  std::string latest_blockhash3_;
   uint64_t last_valid_block_height1_ = 0;
   uint64_t last_valid_block_height2_ = 0;
+  uint64_t last_valid_block_height3_ = 0;
 };
 
 TEST_F(SolanaTxManagerUnitTest, AddAndApproveTransaction) {
@@ -376,7 +400,8 @@ TEST_F(SolanaTxManagerUnitTest, AddAndApproveTransaction) {
   EXPECT_EQ(tx_meta1->tx_hash(), tx_hash1_);
 
   // Send another tx.
-  SetInterceptor(latest_blockhash1_, last_valid_block_height1_, tx_hash2_);
+  SetInterceptor(latest_blockhash1_, last_valid_block_height1_, tx_hash2_, "",
+                 false, last_valid_block_height1_);
   ApproveTransaction(meta_id2);
   base::RunLoop().RunUntilIdle();
 
@@ -393,7 +418,7 @@ TEST_F(SolanaTxManagerUnitTest, AddAndApproveTransaction) {
       base::Seconds(kBlockTrackerDefaultTimeInSeconds));
 
   SetInterceptor(latest_blockhash2_, last_valid_block_height2_, tx_hash2_, "",
-                 true);
+                 true, last_valid_block_height1_);
 
   // Fast forward again to have block tracker run with the new interceptor.
   task_environment_.FastForwardBy(
@@ -642,6 +667,79 @@ TEST_F(SolanaTxManagerUnitTest, GetEstimatedTxFee) {
   SetInterceptor("", 0, "", json);
   TestGetEstimatedTxFee(system_transfer_meta_id, 12345,
                         mojom::SolanaProviderError::kSuccess, "");
+}
+
+TEST_F(SolanaTxManagerUnitTest, DropTxWithInvalidBlockhash) {
+  const std::string from = "BrG44HdsEhzapvs8bEqzvkq4egwevS3fRE6ze2ENo6S8";
+  const std::string to = "JDqrvDz8d8tFCADashbUKQDKfJZFobNy13ugN65t1wvV";
+  mojom::SolanaTxDataPtr system_transfer_data = nullptr;
+  TestMakeSystemProgramTransferTxData(from, to, 10000000, nullptr,
+                                      mojom::SolanaProviderError::kSuccess, "",
+                                      &system_transfer_data);
+  ASSERT_TRUE(system_transfer_data);
+
+  SetInterceptor(latest_blockhash1_, last_valid_block_height1_, tx_hash1_, "",
+                 false, last_valid_block_height1_, false);
+  std::string meta_id1;
+  AddUnapprovedTransaction(system_transfer_data.Clone(), from, &meta_id1);
+  ASSERT_FALSE(meta_id1.empty());
+  ApproveTransaction(meta_id1);
+
+  SetInterceptor(latest_blockhash2_, last_valid_block_height2_, tx_hash2_, "",
+                 false, last_valid_block_height1_, false);
+  // Fast forward to have block tracker run with the new interceptor.
+  task_environment_.FastForwardBy(
+      base::Seconds(kBlockTrackerDefaultTimeInSeconds));
+
+  std::string meta_id2;
+  AddUnapprovedTransaction(system_transfer_data.Clone(), from, &meta_id2);
+  ASSERT_FALSE(meta_id2.empty());
+  ApproveTransaction(meta_id2);
+
+  // Wait for tx to be updated.
+  base::RunLoop().RunUntilIdle();
+
+  // Check two submitted tx.
+  auto pending_transactions =
+      solana_tx_manager()->GetSolanaTxStateManager()->GetTransactionsByStatus(
+          mojom::TransactionStatus::Submitted, absl::nullopt);
+  EXPECT_EQ(pending_transactions.size(), 2u);
+  auto tx1 = solana_tx_manager()->GetTxForTesting(meta_id1);
+  ASSERT_TRUE(tx1);
+  EXPECT_EQ(tx1->status(), mojom::TransactionStatus::Submitted);
+  EXPECT_EQ(tx1->tx()->message()->recent_blockhash(), latest_blockhash1_);
+  EXPECT_EQ(tx1->tx()->message()->last_valid_block_height(),
+            last_valid_block_height1_);
+
+  auto tx2 = solana_tx_manager()->GetTxForTesting(meta_id2);
+  ASSERT_TRUE(tx2);
+  EXPECT_EQ(tx2->status(), mojom::TransactionStatus::Submitted);
+  EXPECT_EQ(tx2->tx()->message()->recent_blockhash(), latest_blockhash2_);
+  EXPECT_EQ(tx2->tx()->message()->last_valid_block_height(),
+            last_valid_block_height2_);
+
+  // Set Interceptor for return null signature statuses and block height only
+  // valid for blockhash2.
+  SetInterceptor(latest_blockhash3_, last_valid_block_height3_, "", "", true,
+                 last_valid_block_height2_, true);
+  // Fast forward to have block tracker run with the new interceptor.
+  task_environment_.FastForwardBy(
+      base::Seconds(kBlockTrackerDefaultTimeInSeconds));
+  // Wait for tx to be updated.
+  base::RunLoop().RunUntilIdle();
+
+  // Check blockhash1 should be dropped, blockhash2 stay as submitted.
+  auto dropped_transactions =
+      solana_tx_manager()->GetSolanaTxStateManager()->GetTransactionsByStatus(
+          mojom::TransactionStatus::Dropped, absl::nullopt);
+  ASSERT_EQ(dropped_transactions.size(), 1u);
+  EXPECT_EQ(dropped_transactions[0]->id(), meta_id1);
+
+  pending_transactions =
+      solana_tx_manager()->GetSolanaTxStateManager()->GetTransactionsByStatus(
+          mojom::TransactionStatus::Submitted, absl::nullopt);
+  ASSERT_EQ(pending_transactions.size(), 1u);
+  EXPECT_EQ(pending_transactions[0]->id(), meta_id2);
 }
 
 }  // namespace brave_wallet

--- a/components/brave_wallet/browser/solana_tx_meta_unittest.cc
+++ b/components/brave_wallet/browser/solana_tx_meta_unittest.cc
@@ -20,6 +20,7 @@ TEST(SolanaTxMetaUnitTest, ToTransactionInfo) {
   std::string from_account = "BrG44HdsEhzapvs8bEqzvkq4egwevS3fRE6ze2ENo6S8";
   std::string to_account = "JDqrvDz8d8tFCADashbUKQDKfJZFobNy13ugN65t1wvV";
   std::string recent_blockhash = "9sHcv6xwn9YkB8nxTUGKDwPwNnmqVp5oAXxU8Fdkm4J6";
+  uint64_t last_valid_block_height = 3090;
   const std::vector<uint8_t> data = {2, 0, 0, 0, 128, 150, 152, 0, 0, 0, 0, 0};
 
   SolanaInstruction instruction(
@@ -30,7 +31,7 @@ TEST(SolanaTxMetaUnitTest, ToTransactionInfo) {
        SolanaAccountMeta(to_account, false, true)},
       data);
   auto tx = std::make_unique<SolanaTransaction>(
-      recent_blockhash, from_account,
+      recent_blockhash, last_valid_block_height, from_account,
       std::vector<SolanaInstruction>({instruction}));
   tx->set_to_wallet_address(to_account);
   tx->set_lamports(10000000u);
@@ -84,11 +85,12 @@ TEST(SolanaTxMetaUnitTest, ToTransactionInfo) {
   instructions.push_back(std::move(mojom_instruction));
 
   ASSERT_TRUE(ti->tx_data_union->is_solana_tx_data());
-  EXPECT_EQ(ti->tx_data_union->get_solana_tx_data(),
-            mojom::SolanaTxData::New(
-                recent_blockhash, from_account, to_account, "", 10000000, 0,
-                mojom::TransactionType::SolanaSystemTransfer,
-                std::move(instructions)));
+  EXPECT_EQ(
+      ti->tx_data_union->get_solana_tx_data(),
+      mojom::SolanaTxData::New(recent_blockhash, last_valid_block_height,
+                               from_account, to_account, "", 10000000, 0,
+                               mojom::TransactionType::SolanaSystemTransfer,
+                               std::move(instructions)));
 }
 
 TEST(SolanaTxMetaUnitTest, ToValue) {
@@ -96,6 +98,7 @@ TEST(SolanaTxMetaUnitTest, ToValue) {
   std::string to_account = "JDqrvDz8d8tFCADashbUKQDKfJZFobNy13ugN65t1wvV";
   std::string recent_blockhash = "9sHcv6xwn9YkB8nxTUGKDwPwNnmqVp5oAXxU8Fdkm4J6";
   const std::vector<uint8_t> data = {2, 0, 0, 0, 128, 150, 152, 0, 0, 0, 0, 0};
+  uint64_t last_valid_block_height = 3090;
 
   SolanaInstruction instruction(
       // Program ID
@@ -105,7 +108,7 @@ TEST(SolanaTxMetaUnitTest, ToValue) {
        SolanaAccountMeta(to_account, false, true)},
       data);
   auto tx = std::make_unique<SolanaTransaction>(
-      recent_blockhash, from_account,
+      recent_blockhash, last_valid_block_height, from_account,
       std::vector<SolanaInstruction>({instruction}));
   tx->set_to_wallet_address(to_account);
   tx->set_lamports(10000000u);
@@ -141,6 +144,7 @@ TEST(SolanaTxMetaUnitTest, ToValue) {
       "tx": {
         "message": {
           "recent_blockhash": "9sHcv6xwn9YkB8nxTUGKDwPwNnmqVp5oAXxU8Fdkm4J6",
+          "last_valid_block_height": "3090",
           "fee_payer": "BrG44HdsEhzapvs8bEqzvkq4egwevS3fRE6ze2ENo6S8",
           "instructions": [
             {

--- a/components/brave_wallet/browser/solana_tx_state_manager_unittest.cc
+++ b/components/brave_wallet/browser/solana_tx_state_manager_unittest.cc
@@ -61,6 +61,7 @@ TEST_F(SolanaTxStateManagerUnitTest, SolanaTxMetaAndValue) {
   std::string from_account = "BrG44HdsEhzapvs8bEqzvkq4egwevS3fRE6ze2ENo6S8";
   std::string to_account = "JDqrvDz8d8tFCADashbUKQDKfJZFobNy13ugN65t1wvV";
   std::string recent_blockhash = "9sHcv6xwn9YkB8nxTUGKDwPwNnmqVp5oAXxU8Fdkm4J6";
+  uint64_t last_valid_block_height = 3090;
   const std::vector<uint8_t> data = {2, 0, 0, 0, 128, 150, 152, 0, 0, 0, 0, 0};
 
   SolanaInstruction instruction(
@@ -71,7 +72,7 @@ TEST_F(SolanaTxStateManagerUnitTest, SolanaTxMetaAndValue) {
        SolanaAccountMeta(to_account, false, true)},
       data);
   auto tx = std::make_unique<SolanaTransaction>(
-      recent_blockhash, from_account,
+      recent_blockhash, last_valid_block_height, from_account,
       std::vector<SolanaInstruction>({instruction}));
 
   SolanaTxMeta meta(std::move(tx));

--- a/components/brave_wallet/common/brave_wallet.mojom
+++ b/components/brave_wallet/common/brave_wallet.mojom
@@ -783,7 +783,8 @@ enum TransactionStatus {
   Rejected = 2,
   Submitted = 3,
   Confirmed = 4,
-  Error = 5
+  Error = 5,
+  Dropped = 6
 };
 
 enum TransactionType {

--- a/components/brave_wallet/common/brave_wallet.mojom
+++ b/components/brave_wallet/common/brave_wallet.mojom
@@ -1081,6 +1081,7 @@ struct SolanaInstruction {
 
 struct SolanaTxData {
   string recent_blockhash;
+  uint64 last_valid_block_height;
   string fee_payer;
   string to_wallet_address;
   string spl_token_mint_address;

--- a/components/brave_wallet_ui/components/desktop/portfolio-transaction-item/index.tsx
+++ b/components/brave_wallet_ui/components/desktop/portfolio-transaction-item/index.tsx
@@ -322,6 +322,7 @@ const PortfolioTransactionItem = (props: Props) => {
           {transactionDetails.status === BraveWallet.TransactionStatus.Submitted && getLocale('braveWalletTransactionStatusSubmitted')}
           {transactionDetails.status === BraveWallet.TransactionStatus.Confirmed && getLocale('braveWalletTransactionStatusConfirmed')}
           {transactionDetails.status === BraveWallet.TransactionStatus.Error && getLocale('braveWalletTransactionStatusError')}
+          {transactionDetails.status === BraveWallet.TransactionStatus.Dropped && getLocale('braveWalletTransactionStatusDropped')}
         </DetailTextDarkBold>
       </StatusRow>
       <DetailRow>
@@ -371,14 +372,14 @@ const PortfolioTransactionItem = (props: Props) => {
 
         {showTransactionPopup &&
           <TransactionPopup>
-            {[BraveWallet.TransactionStatus.Approved, BraveWallet.TransactionStatus.Submitted, BraveWallet.TransactionStatus.Confirmed].includes(transactionDetails.status) &&
+            {[BraveWallet.TransactionStatus.Approved, BraveWallet.TransactionStatus.Submitted, BraveWallet.TransactionStatus.Confirmed, BraveWallet.TransactionStatus.Dropped].includes(transactionDetails.status) &&
               <TransactionPopupItem
                 onClick={onClickViewOnBlockExplorer('tx', transaction.txHash)}
                 text={getLocale('braveWalletTransactionExplorer')}
               />
             }
 
-            {[BraveWallet.TransactionStatus.Approved, BraveWallet.TransactionStatus.Submitted, BraveWallet.TransactionStatus.Confirmed].includes(transactionDetails.status) &&
+            {[BraveWallet.TransactionStatus.Approved, BraveWallet.TransactionStatus.Submitted, BraveWallet.TransactionStatus.Confirmed, BraveWallet.TransactionStatus.Dropped].includes(transactionDetails.status) &&
               <TransactionPopupItem
                 onClick={() => onClickCopyTransactionHash(transaction.txHash)}
                 text={getLocale('braveWalletTransactionCopyHash')}

--- a/components/brave_wallet_ui/components/shared/style.tsx
+++ b/components/brave_wallet_ui/components/shared/style.tsx
@@ -26,7 +26,7 @@ export const StatusBubble = styled.div<Partial<StyleProps>>`
   };
   background-color: ${(p) => p.status === BraveWallet.TransactionStatus.Confirmed || p.status === BraveWallet.TransactionStatus.Approved
     ? p.theme.color.successBorder
-    : p.status === BraveWallet.TransactionStatus.Rejected || p.status === BraveWallet.TransactionStatus.Error ? p.theme.color.errorBorder
+    : p.status === BraveWallet.TransactionStatus.Rejected || p.status === BraveWallet.TransactionStatus.Error || p.status === BraveWallet.TransactionStatus.Dropped ? p.theme.color.errorBorder
       : p.status === BraveWallet.TransactionStatus.Unapproved ? p.theme.color.interactive08 : p.theme.color.warningIcon
   };
   margin-right: 6px;

--- a/components/brave_wallet_ui/stories/locale.ts
+++ b/components/brave_wallet_ui/stories/locale.ts
@@ -473,6 +473,7 @@ provideStrings({
   braveWalletTransactionStatusSubmitted: 'Submitted',
   braveWalletTransactionStatusConfirmed: 'Confirmed',
   braveWalletTransactionStatusError: 'Error',
+  braveWalletTransactionStatusDropped: 'Dropped',
 
   // NFT Details Page
   braveWalletNFTDetailBlockchain: 'Blockchain',

--- a/components/brave_wallet_ui/utils/tx-utils.test.ts
+++ b/components/brave_wallet_ui/utils/tx-utils.test.ts
@@ -24,7 +24,11 @@ describe('Check Transaction Status Strings Value', () => {
     expect(getTransactionStatusString(5)).toEqual('braveWalletTransactionStatusError')
   })
 
-  test('Transaction ID 6 should return an empty string', () => {
-    expect(getTransactionStatusString(6)).toEqual('')
+  test('Transaction ID 6 should return Dropped', () => {
+    expect(getTransactionStatusString(6)).toEqual('braveWalletTransactionStatusDropped')
+  })
+
+  test('Transaction ID 7 should return an empty string', () => {
+    expect(getTransactionStatusString(7)).toEqual('')
   })
 })

--- a/components/brave_wallet_ui/utils/tx-utils.ts
+++ b/components/brave_wallet_ui/utils/tx-utils.ts
@@ -25,6 +25,8 @@ export const getTransactionStatusString = (statusId: number) => {
       return getLocale('braveWalletTransactionStatusConfirmed')
     case BraveWallet.TransactionStatus.Error:
       return getLocale('braveWalletTransactionStatusError')
+    case BraveWallet.TransactionStatus.Dropped:
+      return getLocale('braveWalletTransactionStatusDropped')
     default:
       return ''
   }

--- a/components/json/json_parser_unittest.cc
+++ b/components/json/json_parser_unittest.cc
@@ -10,296 +10,417 @@ namespace brave_wallet {
 
 TEST(JsonParser, ConvertUint64ToString) {
   std::string json = "{\"a\": " + std::to_string(UINT64_MAX) + "}";
-  EXPECT_EQ(std::string(json::convert_uint64_value_to_string("/a", json)),
-            R"({"a":"18446744073709551615"})");
+  EXPECT_EQ(
+      std::string(json::convert_uint64_value_to_string("/a", json, false)),
+      R"({"a":"18446744073709551615"})");
 
   // UINT64_MAX + 1
   json = "{\"a\": 18446744073709551616 }";
   EXPECT_TRUE(
-      std::string(json::convert_uint64_value_to_string("/a", json)).empty());
+      std::string(json::convert_uint64_value_to_string("/a", json, false))
+          .empty());
 
   // INT64_MIN
   json = "{\"a\": " + std::to_string(INT64_MIN) + "}";
   EXPECT_TRUE(
-      std::string(json::convert_uint64_value_to_string("/a", json)).empty());
+      std::string(json::convert_uint64_value_to_string("/a", json, false))
+          .empty());
 
   json = R"({"a": { "b/a": 1, "c": 2 }, "d": "string"})";
-  EXPECT_EQ(std::string(json::convert_uint64_value_to_string("/a/b~1a", json)),
-            R"({"a":{"b/a":"1","c":2},"d":"string"})");
+  EXPECT_EQ(
+      std::string(json::convert_uint64_value_to_string("/a/b~1a", json, false)),
+      R"({"a":{"b/a":"1","c":2},"d":"string"})");
 
   json = R"({"a": { "b~a": 1, "c": 2 }, "d": "string"})";
-  EXPECT_EQ(std::string(json::convert_uint64_value_to_string("/a/b~0a", json)),
-            R"({"a":{"b~a":"1","c":2},"d":"string"})");
+  EXPECT_EQ(
+      std::string(json::convert_uint64_value_to_string("/a/b~0a", json, false)),
+      R"({"a":{"b~a":"1","c":2},"d":"string"})");
 
   json = R"({"a": { "b": 1, "c": 2 }, "d": "string"})";
-  EXPECT_EQ(std::string(json::convert_uint64_value_to_string("/a/b", json)),
-            R"({"a":{"b":"1","c":2},"d":"string"})");
+  EXPECT_EQ(
+      std::string(json::convert_uint64_value_to_string("/a/b", json, false)),
+      R"({"a":{"b":"1","c":2},"d":"string"})");
 
   json = R"({"a": { "b": [{"e":1}], "c": 2 }, "d": "string"})";
-  EXPECT_EQ(std::string(json::convert_uint64_value_to_string("/a/b/0/e", json)),
+  EXPECT_EQ(std::string(
+                json::convert_uint64_value_to_string("/a/b/0/e", json, false)),
             R"({"a":{"b":[{"e":"1"}],"c":2},"d":"string"})");
 
   json = R"({"a":[{"b":1}]})";
-  EXPECT_EQ(std::string(json::convert_uint64_value_to_string("/a/0/b", json)),
-            R"({"a":[{"b":"1"}]})");
+  EXPECT_EQ(
+      std::string(json::convert_uint64_value_to_string("/a/0/b", json, false)),
+      R"({"a":[{"b":"1"}]})");
 
   json = R"({"a":[1]})";
-  EXPECT_EQ(std::string(json::convert_uint64_value_to_string("/a/0", json)),
-            R"({"a":["1"]})");
+  EXPECT_EQ(
+      std::string(json::convert_uint64_value_to_string("/a/0", json, false)),
+      R"({"a":["1"]})");
 
   json = R"({"a": 0 })";
-  EXPECT_EQ(std::string(json::convert_uint64_value_to_string("/a", json)),
-            R"({"a":"0"})");
+  EXPECT_EQ(
+      std::string(json::convert_uint64_value_to_string("/a", json, false)),
+      R"({"a":"0"})");
 
   json = R"({"a": 0.1 })";
   EXPECT_TRUE(
-      std::string(json::convert_uint64_value_to_string("/a", json)).empty());
+      std::string(json::convert_uint64_value_to_string("/a", json, false))
+          .empty());
   json = R"({"a": "1" })";
   EXPECT_TRUE(
-      std::string(json::convert_uint64_value_to_string("/a", json)).empty());
+      std::string(json::convert_uint64_value_to_string("/a", json, false))
+          .empty());
   json = R"({"a": "" })";
   EXPECT_TRUE(
-      std::string(json::convert_uint64_value_to_string("/a", json)).empty());
+      std::string(json::convert_uint64_value_to_string("/a", json, false))
+          .empty());
   json = R"({"a": -1.0 })";
   EXPECT_TRUE(
-      std::string(json::convert_uint64_value_to_string("/a", json)).empty());
+      std::string(json::convert_uint64_value_to_string("/a", json, false))
+          .empty());
   json = R"({"a": "a" })";
   EXPECT_TRUE(
-      std::string(json::convert_uint64_value_to_string("/a", json)).empty());
+      std::string(json::convert_uint64_value_to_string("/a", json, false))
+          .empty());
   json = R"({"b": 1 })";
   EXPECT_TRUE(
-      std::string(json::convert_uint64_value_to_string("/a", json)).empty());
+      std::string(json::convert_uint64_value_to_string("/a", json, false))
+          .empty());
   json = R"({"a": [] })";
   EXPECT_TRUE(
-      std::string(json::convert_uint64_value_to_string("/a", json)).empty());
+      std::string(json::convert_uint64_value_to_string("/a", json, false))
+          .empty());
   json = R"({"a": {} })";
   EXPECT_TRUE(
-      std::string(json::convert_uint64_value_to_string("/a", json)).empty());
+      std::string(json::convert_uint64_value_to_string("/a", json, false))
+          .empty());
+
+  // Optional, unchanged if path not found or value is null.
+  json = R"({"b": 1 })";
+  EXPECT_EQ(std::string(json::convert_uint64_value_to_string("/a", json, true)),
+            json);
+  json = R"({"a": null })";
+  EXPECT_EQ(std::string(json::convert_uint64_value_to_string("/a", json, true)),
+            json);
+  // Wrong value type should still fail.
+  json = R"({"a": "1" })";
+  EXPECT_TRUE(
+      std::string(json::convert_uint64_value_to_string("/a", json, true))
+          .empty());
 }
 
 TEST(JsonParser, ConvertInt64ToString) {
   std::string json = "{\"a\": 18446744073709551615 }";
   EXPECT_TRUE(
-      std::string(json::convert_int64_value_to_string("/a", json)).empty());
+      std::string(json::convert_int64_value_to_string("/a", json, false))
+          .empty());
 
   // INT64_MIN
   json = "{\"a\": " + std::to_string(INT64_MIN) + "}";
-  EXPECT_EQ(std::string(json::convert_int64_value_to_string("/a", json)),
+  EXPECT_EQ(std::string(json::convert_int64_value_to_string("/a", json, false)),
             R"({"a":"-9223372036854775808"})");
 
   // INT64_MIN - 1
   json = "{\"a\": -9223372036854775809 }";
   EXPECT_TRUE(
-      std::string(json::convert_int64_value_to_string("/a", json)).empty());
+      std::string(json::convert_int64_value_to_string("/a", json, false))
+          .empty());
 
   // INT64_MAX
   json = "{\"a\": " + std::to_string(INT64_MAX) + "}";
-  EXPECT_EQ(std::string(json::convert_int64_value_to_string("/a", json)),
+  EXPECT_EQ(std::string(json::convert_int64_value_to_string("/a", json, false)),
             R"({"a":"9223372036854775807"})");
 
   json = R"({"a": { "b/a": 1, "c": 2 }, "d": "string"})";
-  EXPECT_EQ(std::string(json::convert_int64_value_to_string("/a/b~1a", json)),
-            R"({"a":{"b/a":"1","c":2},"d":"string"})");
+  EXPECT_EQ(
+      std::string(json::convert_int64_value_to_string("/a/b~1a", json, false)),
+      R"({"a":{"b/a":"1","c":2},"d":"string"})");
 
   json = R"({"a": { "b~a": 1, "c": 2 }, "d": "string"})";
-  EXPECT_EQ(std::string(json::convert_int64_value_to_string("/a/b~0a", json)),
-            R"({"a":{"b~a":"1","c":2},"d":"string"})");
+  EXPECT_EQ(
+      std::string(json::convert_int64_value_to_string("/a/b~0a", json, false)),
+      R"({"a":{"b~a":"1","c":2},"d":"string"})");
 
   json = R"({"a": { "b": 1, "c": 2 }, "d": "string"})";
-  EXPECT_EQ(std::string(json::convert_int64_value_to_string("/a/b", json)),
-            R"({"a":{"b":"1","c":2},"d":"string"})");
+  EXPECT_EQ(
+      std::string(json::convert_int64_value_to_string("/a/b", json, false)),
+      R"({"a":{"b":"1","c":2},"d":"string"})");
 
   json = R"({"a": { "b": [{"e":1}], "c": 2 }, "d": "string"})";
-  EXPECT_EQ(std::string(json::convert_int64_value_to_string("/a/b/0/e", json)),
-            R"({"a":{"b":[{"e":"1"}],"c":2},"d":"string"})");
+  EXPECT_EQ(
+      std::string(json::convert_int64_value_to_string("/a/b/0/e", json, false)),
+      R"({"a":{"b":[{"e":"1"}],"c":2},"d":"string"})");
 
   json = R"({"a":[{"b":1}]})";
-  EXPECT_EQ(std::string(json::convert_int64_value_to_string("/a/0/b", json)),
-            R"({"a":[{"b":"1"}]})");
+  EXPECT_EQ(
+      std::string(json::convert_int64_value_to_string("/a/0/b", json, false)),
+      R"({"a":[{"b":"1"}]})");
 
   json = R"({"a":[1]})";
-  EXPECT_EQ(std::string(json::convert_int64_value_to_string("/a/0", json)),
-            R"({"a":["1"]})");
+  EXPECT_EQ(
+      std::string(json::convert_int64_value_to_string("/a/0", json, false)),
+      R"({"a":["1"]})");
 
   json = R"({"a": 0 })";
-  EXPECT_EQ(std::string(json::convert_int64_value_to_string("/a", json)),
+  EXPECT_EQ(std::string(json::convert_int64_value_to_string("/a", json, false)),
             R"({"a":"0"})");
 
   json = R"({"a": 0.1 })";
   EXPECT_TRUE(
-      std::string(json::convert_int64_value_to_string("/a", json)).empty());
+      std::string(json::convert_int64_value_to_string("/a", json, false))
+          .empty());
   json = R"({"a": "1" })";
   EXPECT_TRUE(
-      std::string(json::convert_int64_value_to_string("/a", json)).empty());
+      std::string(json::convert_int64_value_to_string("/a", json, false))
+          .empty());
   json = R"({"a": "" })";
   EXPECT_TRUE(
-      std::string(json::convert_int64_value_to_string("/a", json)).empty());
+      std::string(json::convert_int64_value_to_string("/a", json, false))
+          .empty());
   json = R"({"a": -1.0 })";
   EXPECT_TRUE(
-      std::string(json::convert_int64_value_to_string("/a", json)).empty());
+      std::string(json::convert_int64_value_to_string("/a", json, false))
+          .empty());
   json = R"({"a": "a" })";
   EXPECT_TRUE(
-      std::string(json::convert_int64_value_to_string("/a", json)).empty());
+      std::string(json::convert_int64_value_to_string("/a", json, false))
+          .empty());
   json = R"({"b": 1 })";
   EXPECT_TRUE(
-      std::string(json::convert_int64_value_to_string("/a", json)).empty());
+      std::string(json::convert_int64_value_to_string("/a", json, false))
+          .empty());
   json = R"({"a": [] })";
   EXPECT_TRUE(
-      std::string(json::convert_int64_value_to_string("/a", json)).empty());
+      std::string(json::convert_int64_value_to_string("/a", json, false))
+          .empty());
   json = R"({"a": {} })";
   EXPECT_TRUE(
-      std::string(json::convert_int64_value_to_string("/a", json)).empty());
+      std::string(json::convert_int64_value_to_string("/a", json, false))
+          .empty());
+
+  // Optional, unchanged if path not found or value is null.
+  json = R"({"b": 1 })";
+  EXPECT_EQ(std::string(json::convert_int64_value_to_string("/a", json, true)),
+            json);
+  json = R"({"a": null })";
+  EXPECT_EQ(std::string(json::convert_int64_value_to_string("/a", json, true)),
+            json);
+
+  // Wrong value type should still fail.
+  json = R"({"a": "1" })";
+  EXPECT_TRUE(std::string(json::convert_int64_value_to_string("/a", json, true))
+                  .empty());
 }
 
 TEST(JsonParser, ConvertStringToUint64) {
   // UINT64_MAX
   std::string json = R"({"a":"18446744073709551615"})";
-  EXPECT_EQ(std::string(json::convert_string_value_to_uint64("/a", json)),
-            R"({"a":18446744073709551615})");
+  EXPECT_EQ(
+      std::string(json::convert_string_value_to_uint64("/a", json, false)),
+      R"({"a":18446744073709551615})");
 
   json = R"({"a":"-1"})";
   EXPECT_TRUE(
-      std::string(json::convert_string_value_to_uint64("/a", json)).empty());
+      std::string(json::convert_string_value_to_uint64("/a", json, false))
+          .empty());
   // UINT64_MAX + 1
   json = R"({\"a\":18446744073709551616})";
   EXPECT_TRUE(
-      std::string(json::convert_string_value_to_uint64("/a", json)).empty());
+      std::string(json::convert_string_value_to_uint64("/a", json, false))
+          .empty());
 
   json = R"({"a": { "b": "1", "c": 2 }, "d": "string"})";
-  EXPECT_EQ(std::string(json::convert_string_value_to_uint64("/a/b", json)),
-            R"({"a":{"b":1,"c":2},"d":"string"})");
+  EXPECT_EQ(
+      std::string(json::convert_string_value_to_uint64("/a/b", json, false)),
+      R"({"a":{"b":1,"c":2},"d":"string"})");
 
   json = R"({"a": { "b": [{"e":"1"}], "c": 2 }, "d": "string"})";
-  EXPECT_EQ(std::string(json::convert_string_value_to_uint64("/a/b/0/e", json)),
+  EXPECT_EQ(std::string(
+                json::convert_string_value_to_uint64("/a/b/0/e", json, false)),
             R"({"a":{"b":[{"e":1}],"c":2},"d":"string"})");
 
   json = R"({"a~c": { "b": "1", "c": 2 }, "d": "string"})";
-  EXPECT_EQ(std::string(json::convert_string_value_to_uint64("/a~0c/b", json)),
-            R"({"a~c":{"b":1,"c":2},"d":"string"})");
+  EXPECT_EQ(
+      std::string(json::convert_string_value_to_uint64("/a~0c/b", json, false)),
+      R"({"a~c":{"b":1,"c":2},"d":"string"})");
 
   json = R"({"a/d": { "b": [{"e":"1"}], "c": 2 }, "d": "string"})";
-  EXPECT_EQ(
-      std::string(json::convert_string_value_to_uint64("/a~1d/b/0/e", json)),
-      R"({"a/d":{"b":[{"e":1}],"c":2},"d":"string"})");
+  EXPECT_EQ(std::string(json::convert_string_value_to_uint64("/a~1d/b/0/e",
+                                                             json, false)),
+            R"({"a/d":{"b":[{"e":1}],"c":2},"d":"string"})");
 
   json = R"({"a": { "b": "1" }})";
-  EXPECT_EQ(std::string(json::convert_string_value_to_uint64("/a/b", json)),
-            R"({"a":{"b":1}})");
+  EXPECT_EQ(
+      std::string(json::convert_string_value_to_uint64("/a/b", json, false)),
+      R"({"a":{"b":1}})");
 
   json = R"({"a":[{"b":"1"}]})";
-  EXPECT_EQ(std::string(json::convert_string_value_to_uint64("/a/0/b", json)),
-            R"({"a":[{"b":1}]})");
+  EXPECT_EQ(
+      std::string(json::convert_string_value_to_uint64("/a/0/b", json, false)),
+      R"({"a":[{"b":1}]})");
 
   json = R"({"a":["1"]})";
-  EXPECT_EQ(std::string(json::convert_string_value_to_uint64("/a/0", json)),
-            R"({"a":[1]})");
+  EXPECT_EQ(
+      std::string(json::convert_string_value_to_uint64("/a/0", json, false)),
+      R"({"a":[1]})");
 
   json = R"({"a": "0" })";
-  EXPECT_EQ(std::string(json::convert_string_value_to_uint64("/a", json)),
-            R"({"a":0})");
+  EXPECT_EQ(
+      std::string(json::convert_string_value_to_uint64("/a", json, false)),
+      R"({"a":0})");
 
   json = R"({"a": 1 })";
   EXPECT_TRUE(
-      std::string(json::convert_string_value_to_uint64("/a", json)).empty());
+      std::string(json::convert_string_value_to_uint64("/a", json, false))
+          .empty());
   json = R"({"a": 0.1 })";
   EXPECT_TRUE(
-      std::string(json::convert_string_value_to_uint64("/a", json)).empty());
+      std::string(json::convert_string_value_to_uint64("/a", json, false))
+          .empty());
   json = R"({"a": "" })";
   EXPECT_TRUE(
-      std::string(json::convert_string_value_to_uint64("/a", json)).empty());
+      std::string(json::convert_string_value_to_uint64("/a", json, false))
+          .empty());
   json = R"({"a": -1.0 })";
   EXPECT_TRUE(
-      std::string(json::convert_string_value_to_uint64("/a", json)).empty());
+      std::string(json::convert_string_value_to_uint64("/a", json, false))
+          .empty());
   json = R"({"a": "a" })";
   EXPECT_TRUE(
-      std::string(json::convert_string_value_to_uint64("/a", json)).empty());
+      std::string(json::convert_string_value_to_uint64("/a", json, false))
+          .empty());
   json = R"({"b": 1 })";
   EXPECT_TRUE(
-      std::string(json::convert_string_value_to_uint64("/a", json)).empty());
+      std::string(json::convert_string_value_to_uint64("/a", json, false))
+          .empty());
   json = R"({"a": [] })";
   EXPECT_TRUE(
-      std::string(json::convert_string_value_to_uint64("/a", json)).empty());
+      std::string(json::convert_string_value_to_uint64("/a", json, false))
+          .empty());
   json = R"({"a": {} })";
   EXPECT_TRUE(
-      std::string(json::convert_string_value_to_uint64("/a", json)).empty());
+      std::string(json::convert_string_value_to_uint64("/a", json, false))
+          .empty());
+
+  // Optional, unchanged if path not found or value is null.
+  json = R"({"b": "1" })";
+  EXPECT_EQ(std::string(json::convert_string_value_to_uint64("/a", json, true)),
+            json);
+  json = R"({"a": null })";
+  EXPECT_EQ(std::string(json::convert_string_value_to_uint64("/a", json, true)),
+            json);
+
+  // Wrong value type should still fail.
+  json = R"({"a": 1 })";
+  EXPECT_TRUE(
+      std::string(json::convert_string_value_to_uint64("/a", json, true))
+          .empty());
 }
 
 TEST(JsonParser, ConvertStringToInt64) {
   // INT64_MIN
   std::string json = R"({"a":"-9223372036854775808"})";
-  EXPECT_EQ(std::string(json::convert_string_value_to_int64("/a", json)),
+  EXPECT_EQ(std::string(json::convert_string_value_to_int64("/a", json, false)),
             R"({"a":-9223372036854775808})");
   // INT64_MIN - 1
   json = R"({"a":"-9223372036854775809"})";
   EXPECT_TRUE(
-      std::string(json::convert_string_value_to_int64("/a", json)).empty());
+      std::string(json::convert_string_value_to_int64("/a", json, false))
+          .empty());
 
   // INT64_MAX
   json = "{\"a\": \"" + std::to_string(INT64_MAX) + "\"}";
-  EXPECT_EQ(std::string(json::convert_string_value_to_int64("/a", json)),
+  EXPECT_EQ(std::string(json::convert_string_value_to_int64("/a", json, false)),
             R"({"a":9223372036854775807})");
   // INT64_MAX + 1
   json = "{\"a\": \"9223372036854775808\"}";
   EXPECT_TRUE(
-      std::string(json::convert_string_value_to_int64("/a", json)).empty());
+      std::string(json::convert_string_value_to_int64("/a", json, false))
+          .empty());
 
   json = R"({"a": { "b": "1", "c": 2 }, "d": "string"})";
-  EXPECT_EQ(std::string(json::convert_string_value_to_int64("/a/b", json)),
-            R"({"a":{"b":1,"c":2},"d":"string"})");
+  EXPECT_EQ(
+      std::string(json::convert_string_value_to_int64("/a/b", json, false)),
+      R"({"a":{"b":1,"c":2},"d":"string"})");
 
   json = R"({"a": { "b": [{"e":"1"}], "c": 2 }, "d": "string"})";
-  EXPECT_EQ(std::string(json::convert_string_value_to_int64("/a/b/0/e", json)),
-            R"({"a":{"b":[{"e":1}],"c":2},"d":"string"})");
+  EXPECT_EQ(
+      std::string(json::convert_string_value_to_int64("/a/b/0/e", json, false)),
+      R"({"a":{"b":[{"e":1}],"c":2},"d":"string"})");
 
   json = R"({"a~e": { "b": "1", "c": 2 }, "d": "string"})";
-  EXPECT_EQ(std::string(json::convert_string_value_to_int64("/a~0e/b", json)),
-            R"({"a~e":{"b":1,"c":2},"d":"string"})");
+  EXPECT_EQ(
+      std::string(json::convert_string_value_to_int64("/a~0e/b", json, false)),
+      R"({"a~e":{"b":1,"c":2},"d":"string"})");
 
   json = R"({"a/e": { "b": [{"e":"1"}], "c": 2 }, "d": "string"})";
-  EXPECT_EQ(
-      std::string(json::convert_string_value_to_int64("/a~1e/b/0/e", json)),
-      R"({"a/e":{"b":[{"e":1}],"c":2},"d":"string"})");
+  EXPECT_EQ(std::string(json::convert_string_value_to_int64("/a~1e/b/0/e", json,
+                                                            false)),
+            R"({"a/e":{"b":[{"e":1}],"c":2},"d":"string"})");
 
   json = R"({"a": { "b": "1" }})";
-  EXPECT_EQ(std::string(json::convert_string_value_to_int64("/a/b", json)),
-            R"({"a":{"b":1}})");
+  EXPECT_EQ(
+      std::string(json::convert_string_value_to_int64("/a/b", json, false)),
+      R"({"a":{"b":1}})");
 
   json = R"({"a":[{"b":"1"}]})";
-  EXPECT_EQ(std::string(json::convert_string_value_to_int64("/a/0/b", json)),
-            R"({"a":[{"b":1}]})");
+  EXPECT_EQ(
+      std::string(json::convert_string_value_to_int64("/a/0/b", json, false)),
+      R"({"a":[{"b":1}]})");
 
   json = R"({"a":["1"]})";
-  EXPECT_EQ(std::string(json::convert_string_value_to_int64("/a/0", json)),
-            R"({"a":[1]})");
+  EXPECT_EQ(
+      std::string(json::convert_string_value_to_int64("/a/0", json, false)),
+      R"({"a":[1]})");
 
   json = R"({"a": "0" })";
-  EXPECT_EQ(std::string(json::convert_string_value_to_int64("/a", json)),
+  EXPECT_EQ(std::string(json::convert_string_value_to_int64("/a", json, false)),
             R"({"a":0})");
 
   json = R"({"a": 1 })";
   EXPECT_TRUE(
-      std::string(json::convert_string_value_to_int64("/a", json)).empty());
+      std::string(json::convert_string_value_to_int64("/a", json, false))
+          .empty());
   json = R"({"a": 0.1 })";
   EXPECT_TRUE(
-      std::string(json::convert_string_value_to_int64("/a", json)).empty());
+      std::string(json::convert_string_value_to_int64("/a", json, false))
+          .empty());
   json = R"({"a": "" })";
   EXPECT_TRUE(
-      std::string(json::convert_string_value_to_int64("/a", json)).empty());
+      std::string(json::convert_string_value_to_int64("/a", json, false))
+          .empty());
   json = R"({"a": -1.0 })";
   EXPECT_TRUE(
-      std::string(json::convert_string_value_to_int64("/a", json)).empty());
+      std::string(json::convert_string_value_to_int64("/a", json, false))
+          .empty());
   json = R"({"a": "a" })";
   EXPECT_TRUE(
-      std::string(json::convert_string_value_to_int64("/a", json)).empty());
+      std::string(json::convert_string_value_to_int64("/a", json, false))
+          .empty());
   json = R"({"b": 1 })";
   EXPECT_TRUE(
-      std::string(json::convert_string_value_to_int64("/a", json)).empty());
+      std::string(json::convert_string_value_to_int64("/a", json, false))
+          .empty());
   json = R"({"a": [] })";
   EXPECT_TRUE(
-      std::string(json::convert_string_value_to_int64("/a", json)).empty());
+      std::string(json::convert_string_value_to_int64("/a", json, false))
+          .empty());
   json = R"({"a": {} })";
   EXPECT_TRUE(
-      std::string(json::convert_string_value_to_int64("/a", json)).empty());
+      std::string(json::convert_string_value_to_int64("/a", json, false))
+          .empty());
+
+  // Optional, unchanged if path not found or value is null.
+  json = R"({"b": "1" })";
+  EXPECT_EQ(std::string(json::convert_string_value_to_int64("/a", json, true)),
+            json);
+  json = R"({"a": null })";
+  EXPECT_EQ(std::string(json::convert_string_value_to_int64("/a", json, true)),
+            json);
+
+  // Wrong value type should still fail.
+  json = R"({"a": 1 })";
+  EXPECT_TRUE(std::string(json::convert_string_value_to_int64("/a", json, true))
+                  .empty());
 }
 
 }  // namespace brave_wallet

--- a/components/json/rs/src/lib.rs
+++ b/components/json/rs/src/lib.rs
@@ -1,16 +1,17 @@
 #[cxx::bridge(namespace = json)]
 mod ffi {
     extern "Rust" {
-        fn convert_uint64_value_to_string(path: &str, json: &str) -> String;
-        fn convert_int64_value_to_string(path: &str, json: &str) -> String;
-        fn convert_string_value_to_uint64(path: &str, json: &str) -> String;
-        fn convert_string_value_to_int64(path: &str, json: &str) -> String;
+        fn convert_uint64_value_to_string(path: &str, json: &str, optional: bool) -> String;
+        fn convert_int64_value_to_string(path: &str, json: &str, optional: bool) -> String;
+        fn convert_string_value_to_uint64(path: &str, json: &str, optional: bool) -> String;
+        fn convert_string_value_to_int64(path: &str, json: &str, optional: bool) -> String;
     }
 }
 
 // Parses and re-serializes json with the value at path converted from a uint64
 // to a string representation of the same number.
 // Returns an empty String if such conversion is not possible.
+// When optional is false, return the original string if path not found or value is null.
 // A path is a Unicode string with the reference tokens separated by /.
 // Inside tokens / is replaced by ~1 and ~ is replaced by ~0.
 // For more information read [RFC6901](https://tools.ietf.org/html/rfc6901).
@@ -18,7 +19,7 @@ mod ffi {
 //           convert_uint64_value_to_string("/a/0", json) for { a : [ 1 ]}
 //           convert_uint64_value_to_string("/a~0b/0", json) for { "a~b" : [ 1 ]}
 //           convert_uint64_value_to_string("/a~1b/0", json) for { "a/b" : [ 1 ]}
-pub fn convert_uint64_value_to_string(path: &str, json: &str) -> String {
+pub fn convert_uint64_value_to_string(path: &str, json: &str, optional: bool) -> String {
     let result_value = serde_json::from_str(&json);
     if result_value.is_err() {
         return String::new();
@@ -26,9 +27,15 @@ pub fn convert_uint64_value_to_string(path: &str, json: &str) -> String {
     let mut unwrapped_value: serde_json::Value = result_value.unwrap();
     let mutable_pointer = unwrapped_value.pointer_mut(path);
     if mutable_pointer.is_none() {
+        if optional {
+            return json.to_string();
+        }
         return String::new();
     }
     let value = mutable_pointer.unwrap();
+    if value.is_null() && optional{
+        return json.to_string();
+    }
     if !value.is_u64() {
         return String::new();
     }
@@ -39,6 +46,7 @@ pub fn convert_uint64_value_to_string(path: &str, json: &str) -> String {
 // Parses and re-serializes json with the value at path converted from a int64
 // to a string representation of the same number.
 // Returns an empty String if such conversion is not possible.
+// When optional is false, return the original string if path not found or value is null.
 // A path is a Unicode string with the reference tokens separated by /.
 // Inside tokens / is replaced by ~1 and ~ is replaced by ~0.
 // For more information read [RFC6901](https://tools.ietf.org/html/rfc6901).
@@ -46,7 +54,7 @@ pub fn convert_uint64_value_to_string(path: &str, json: &str) -> String {
 //           convert_int64_to_unicode_string("/a/0", json) for { a : [ 1 ]}
 //           convert_int64_to_unicode_string("/a~0b/0", json) for { "a~b" : [ 1 ]}
 //           convert_int64_to_unicode_string("/a~1b/0", json) for { "a/b" : [ 1 ]}
-pub fn convert_int64_value_to_string(path: &str, json: &str) -> String {
+pub fn convert_int64_value_to_string(path: &str, json: &str, optional: bool) -> String {
     let result_value = serde_json::from_str(&json);
     if result_value.is_err() {
         return String::new();
@@ -55,9 +63,15 @@ pub fn convert_int64_value_to_string(path: &str, json: &str) -> String {
 
     let mutable_pointer = unwrapped_value.pointer_mut(path);
     if mutable_pointer.is_none() {
+        if optional {
+            return json.to_string();
+        }
         return String::new();
     }
     let value = mutable_pointer.unwrap();
+    if value.is_null() && optional{
+        return json.to_string();
+    }
     if !value.is_i64() {
         return String::new();
     }
@@ -68,6 +82,7 @@ pub fn convert_int64_value_to_string(path: &str, json: &str) -> String {
 // Parses and re-serializes json with the value at path converted from a string
 // to a uint64 representation of the same number.
 // Returns an empty String if such conversion is not possible.
+// When optional is false, return the original string if path not found or value is null.
 // A path is a Unicode string with the reference tokens separated by /.
 // Inside tokens / is replaced by ~1 and ~ is replaced by ~0.
 // For more information read [RFC6901](https://tools.ietf.org/html/rfc6901).
@@ -75,7 +90,7 @@ pub fn convert_int64_value_to_string(path: &str, json: &str) -> String {
 //           convert_string_value_to_uint64("/a/0", json) for { a : [ '1' ]} -> { a : [ 1 ]}
 //           convert_string_value_to_uint64("/a~0c/b", json) for { "a~c" : { b : '1' }} -> { "a~c" : { b : 1 }}
 //           convert_string_value_to_uint64("/a~1b/0", json) for { "a/b" : [ '1' ]} -> { "a/b" : [ 1 ]}
-pub fn convert_string_value_to_uint64(path: &str, json: &str) -> String {
+pub fn convert_string_value_to_uint64(path: &str, json: &str, optional: bool) -> String {
     let result_value = serde_json::from_str(&json);
     if result_value.is_err() {
         return String::new();
@@ -83,9 +98,15 @@ pub fn convert_string_value_to_uint64(path: &str, json: &str) -> String {
     let mut unwrapped_value: serde_json::Value = result_value.unwrap();
     let mutable_pointer = unwrapped_value.pointer_mut(path);
     if mutable_pointer.is_none() {
+        if optional {
+            return json.to_string();
+        }
         return String::new();
     }
     let value = mutable_pointer.unwrap();
+    if value.is_null() && optional{
+        return json.to_string();
+    }
     if !value.is_string() {
         return String::new();
     }
@@ -101,6 +122,7 @@ pub fn convert_string_value_to_uint64(path: &str, json: &str) -> String {
 // Parses and re-serializes json with the value at path converted from a string
 // to a int64 representation of the same number.
 // Returns an empty String if such conversion is not possible.
+// When optional is false, return the original string if path not found or value is null.
 // A path is a Unicode string with the reference tokens separated by /.
 // Inside tokens / is replaced by ~1 and ~ is replaced by ~0.
 // For more information read [RFC6901](https://tools.ietf.org/html/rfc6901).
@@ -108,7 +130,7 @@ pub fn convert_string_value_to_uint64(path: &str, json: &str) -> String {
 //           convert_string_value_to_int64("/a/0", json) for { a : [ '1' ]} -> { a : [ 1 ]}
 //           convert_string_value_to_uint64("/a~0c/b", json) for { "a~c" : { b : '1' }} -> { "a~c" : { b : 1 }}
 //           convert_string_value_to_uint64("/a~1b/0", json) for { "a/b" : [ '1' ]} -> { "a/b" : [ 1 ]}
-pub fn convert_string_value_to_int64(path: &str, json: &str) -> String {
+pub fn convert_string_value_to_int64(path: &str, json: &str, optional: bool) -> String {
     let result_value = serde_json::from_str(&json);
     if result_value.is_err() {
         return String::new();
@@ -116,9 +138,15 @@ pub fn convert_string_value_to_int64(path: &str, json: &str) -> String {
     let mut unwrapped_value: serde_json::Value = result_value.unwrap();
     let mutable_pointer = unwrapped_value.pointer_mut(path);
     if mutable_pointer.is_none() {
+        if optional {
+            return json.to_string();
+        }
         return String::new();
     }
     let value = mutable_pointer.unwrap();
+    if value.is_null() && optional{
+        return json.to_string();
+    }
     if !value.is_string() {
         return String::new();
     }

--- a/components/resources/wallet_strings.grdp
+++ b/components/resources/wallet_strings.grdp
@@ -337,6 +337,7 @@
   <message name="IDS_BRAVE_WALLET_TRANSACTION_STATUS_SUBMITTED" desc="Status label for submitted transaction">Submitted</message>
   <message name="IDS_BRAVE_WALLET_TRANSACTION_STATUS_CONFIRMED" desc="Status label for confirmed transaction">Confirmed</message>
   <message name="IDS_BRAVE_WALLET_TRANSACTION_STATUS_ERROR" desc="Status label for error transaction">Error</message>
+  <message name="IDS_BRAVE_WALLET_TRANSACTION_STATUS_DROPPED" desc="Status label for dropped transaction">Dropped</message>
   <message name="IDS_BRAVE_WALLET_RECENT_TRANSACTIONS" desc="Transactions panel title">Recent transactions</message>
   <message name="IDS_BRAVE_WALLET_TRANSACTION_DETAILS" desc="Transaction details panel title">Transaction details</message>
   <message name="IDS_BRAVE_WALLET_TRANSACTION_DETAIL_DATE" desc="Transaction Detail Panel Date of transactions">Date</message>


### PR DESCRIPTION
<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/22227
Resolves https://github.com/brave/brave-browser/issues/22142

It's easier to review by each commit.
The first commit is implementing `getBlockHeight` RPC which will be used later to check against if a blockhash stored in a transaction is still valid.
The second commit is updating `getLatestBlockhash` RPC to have `last_valid_block_height` info associated with each latest blockhash we retrieved.
The third commit has several things, please see the commit message.
The fourth commit is adding the logic to drop Solana tx when we get null signature status from remote and it's blockhash is not valid anymore. Also adding Dropped status to TransactionStatus, and related UI handling.

Reference reading if interested: https://solanacookbook.com/guides/retrying-transactions.html#retrying-transactions

<img width="1246" alt="Screen Shot 2022-04-11 at 2 27 15 PM" src="https://user-images.githubusercontent.com/4730197/162836286-1b0e5321-604f-4062-8a05-eae58db84d25.png">

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
1. Try sending out SOL on Solana mainnet-beta using https://api.mainnet-beta.solana.com which cannot be found on the remote explorer after a few minutes.
2. After a few minutes, check if the transaction status is shown as `Dropped` in that sending account's transaction list.
Note that it could take some time to reach the point where it will be dropped because blockhash might be still valid for a few minutes sometimes.
