### PR TITLE
Fix thread-safety issues in CookieSettings when NavigationThreadingOptimizations is enabled.

### DIFF
--- a/chromium_src/components/content_settings/core/browser/cookie_settings.cc
+++ b/chromium_src/components/content_settings/core/browser/cookie_settings.cc
@@ -40,7 +40,10 @@ namespace content_settings {
 
 void CookieSettings::ShutdownOnUIThread() {
   ShutdownOnUIThread_ChromiumImpl();
-  ephemeral_storage_origins_.clear();
+  {
+    base::AutoLock auto_lock(lock_);
+    ephemeral_storage_origins_.clear();
+  }
 }
 
 bool CookieSettings::ShouldUseEphemeralStorage(
@@ -57,6 +60,7 @@ bool CookieSettings::ShouldUseEphemeralStorage(
   const std::string ephemeral_storage_domain =
       net::URLToEphemeralStorageDomain(top_frame_origin->GetURL());
 
+  base::AutoLock auto_lock(lock_);
   auto ephemeral_storage_origins_it =
       ephemeral_storage_origins_.find(ephemeral_storage_domain);
   if (ephemeral_storage_origins_it != ephemeral_storage_origins_.end()) {
@@ -83,6 +87,7 @@ bool CookieSettings::ShouldUseEphemeralStorage(
 std::vector<url::Origin> CookieSettings::TakeEphemeralStorageOpaqueOrigins(
     const std::string& ephemeral_storage_domain) {
   std::vector<url::Origin> result;
+  base::AutoLock auto_lock(lock_);
   auto ephemeral_storage_origins_it =
       ephemeral_storage_origins_.find(ephemeral_storage_domain);
   if (ephemeral_storage_origins_it != ephemeral_storage_origins_.end()) {

--- a/chromium_src/components/content_settings/core/browser/cookie_settings.h
+++ b/chromium_src/components/content_settings/core/browser/cookie_settings.h
@@ -28,7 +28,7 @@
   /* Ephemeral storage domain to non_opaque->opaque origins map. */           \
   using EphemeralStorageOrigins =                                             \
       base::flat_map<std::string, base::flat_map<url::Origin, url::Origin>>;  \
-  EphemeralStorageOrigins ephemeral_storage_origins_;                         \
+  EphemeralStorageOrigins ephemeral_storage_origins_ GUARDED_BY(lock_);       \
                                                                               \
  public:                                                                      \
   void ShutdownOnUIThread

--- a/chromium_src/components/content_settings/core/common/cookie_settings_base.h
+++ b/chromium_src/components/content_settings/core/common/cookie_settings_base.h
@@ -6,13 +6,10 @@
 #ifndef BRAVE_CHROMIUM_SRC_COMPONENTS_CONTENT_SETTINGS_CORE_COMMON_COOKIE_SETTINGS_BASE_H_
 #define BRAVE_CHROMIUM_SRC_COMPONENTS_CONTENT_SETTINGS_CORE_COMMON_COOKIE_SETTINGS_BASE_H_
 
-#include "base/auto_reset.h"
+#include "base/threading/thread_local.h"
 #include "components/content_settings/core/common/content_settings.h"
 
 namespace content_settings {
-
-// Helper to allow patchless ephemeral storage access in Chromium code.
-using ScopedEphemeralStorageAwareness = base::AutoReset<bool>;
 
 // Contains some useful settings metadata which is not accessible via default
 // accessors.
@@ -36,8 +33,6 @@ struct CookieSettingWithBraveMetadata {
   ShouldUseEphemeralStorage(                                                   \
       const GURL& url, const net::SiteForCookies& site_for_cookies,            \
       const absl::optional<url::Origin>& top_frame_origin) const;              \
-  ScopedEphemeralStorageAwareness CreateScopedEphemeralStorageAwareness()      \
-      const;                                                                   \
   bool IsEphemeralCookieAccessAllowed(const GURL& url,                         \
                                       const GURL& first_party_url) const;      \
   bool IsEphemeralCookieAccessAllowed(                                         \
@@ -54,7 +49,7 @@ struct CookieSettingWithBraveMetadata {
   CookieSettingWithBraveMetadata GetCookieSettingWithBraveMetadata(            \
       const GURL& url, const GURL& first_party_url) const;                     \
   CookieSettingWithBraveMetadata* cookie_setting_with_brave_metadata() const { \
-    return cookie_setting_with_brave_metadata_;                                \
+    return cookie_setting_with_brave_metadata_.Get();                          \
   }                                                                            \
                                                                                \
  private:                                                                      \
@@ -62,9 +57,8 @@ struct CookieSettingWithBraveMetadata {
       const GURL& url, const net::SiteForCookies& site_for_cookies,            \
       const absl::optional<url::Origin>& top_frame_origin) const;              \
                                                                                \
-  mutable bool ephemeral_storage_aware_ = false;                               \
-  mutable CookieSettingWithBraveMetadata*                                      \
-      cookie_setting_with_brave_metadata_ = nullptr;                           \
+  mutable base::ThreadLocalPointer<CookieSettingWithBraveMetadata>             \
+      cookie_setting_with_brave_metadata_;                                     \
                                                                                \
  public:                                                                       \
   bool IsCookieSessionOnly

--- a/patches/components-content_settings-core-common-cookie_settings_base.h.patch
+++ b/patches/components-content_settings-core-common-cookie_settings_base.h.patch
@@ -1,0 +1,19 @@
+diff --git a/components/content_settings/core/common/cookie_settings_base.h b/components/content_settings/core/common/cookie_settings_base.h
+index 01786694a1be87448964db3b75448244d0bf0fd1..dc707cf0af0901914d68b7dc75e3038f720f81a2 100644
+--- a/components/content_settings/core/common/cookie_settings_base.h
++++ b/components/content_settings/core/common/cookie_settings_base.h
+@@ -66,12 +66,12 @@ namespace content_settings {
+ // |top_frame_origin|. This is done inconsistently and needs to be fixed.
+ class CookieSettingsBase {
+  public:
+-  CookieSettingsBase() = default;
++  CookieSettingsBase();
+ 
+   CookieSettingsBase(const CookieSettingsBase&) = delete;
+   CookieSettingsBase& operator=(const CookieSettingsBase&) = delete;
+ 
+-  virtual ~CookieSettingsBase() = default;
++  virtual ~CookieSettingsBase();
+ 
+   // Returns true if the cookie associated with |domain| should be deleted
+   // on exit.


### PR DESCRIPTION
<!-- Add brave-browser issue bellow that this PR will resolve -->
`CookieSettings::GetCookieSettingInternal` can be called from multiple threads. Fix our additions to be also thread-safe.

`ContentSettingsManagerImpl` handles mojo calls on a worker thread when `NavigationThreadingOptimizations` feature is [enabled](https://github.com/chromium/chromium/blob/102.0.4987.1/components/content_settings/browser/content_settings_manager_impl.cc#L141-L151). This feature is disabled currently via Griffin, that's why we don't see these issues in production. I've also ran some tests to ensure all calls in this area are made from UI thread when `NavigationThreadingOptimizations` is disabled.

Resolves https://github.com/brave/internal/issues/868

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

