### PR TITLE
Allow callers to call DOMPluginArray::IsPdfViewerAvailable unconditionally even if should_return_fixed_plugin_data_ is false

### DIFF
--- a/browser/farbling/brave_navigator_plugins_farbling_browsertest.cc
+++ b/browser/farbling/brave_navigator_plugins_farbling_browsertest.cc
@@ -27,8 +27,14 @@
 
 using brave_shields::ControlType;
 
+namespace {
+
 const char kPluginsLengthScript[] =
     "domAutomationController.send(navigator.plugins.length);";
+const char kNavigatorPdfViewerEnabledCrashTest[] =
+    "navigator.pdfViewerEnabled == navigator.pdfViewerEnabled";
+
+}  // namespace
 
 class BraveNavigatorPluginsFarblingBrowserTest : public InProcessBrowserTest {
  public:
@@ -109,6 +115,13 @@ class BraveNavigatorPluginsFarblingBrowserTest : public InProcessBrowserTest {
   std::unique_ptr<ChromeContentClient> content_client_;
   std::unique_ptr<BraveContentBrowserClient> browser_content_client_;
 };
+
+// Tests that access to navigator.pdfViewerEnabled attribute does not crash.
+IN_PROC_BROWSER_TEST_F(BraveNavigatorPluginsFarblingBrowserTest,
+                       NavigatorPdfViewerEnabledNoCrash) {
+  NavigateToURLUntilLoadStop(farbling_url());
+  EXPECT_EQ(true, EvalJs(contents(), kNavigatorPdfViewerEnabledCrashTest));
+}
 
 // Tests results of farbling known values
 // https://github.com/brave/brave-browser/issues/9435

--- a/chromium_src/third_party/blink/renderer/modules/plugins/dom_plugin_array.cc
+++ b/chromium_src/third_party/blink/renderer/modules/plugins/dom_plugin_array.cc
@@ -145,6 +145,13 @@ void FarblePlugins(DOMPluginArray* owner,
 
 }  // namespace brave
 
+#define BRAVE_DOM_PLUGINS_IS_PDF_VIEWER_AVAILABLE                \
+  if (auto* data = GetPluginData())                              \
+    for (const Member<MimeClassInfo>& mime_info : data->Mimes()) \
+      if (mime_info->Type() == "application/pdf")                \
+        return true;                                             \
+  return false;
+
 #define BRAVE_DOM_PLUGINS_UPDATE_PLUGIN_DATA__RESET_PLUGIN_DATA \
   if (PluginData* data = GetPluginData())                       \
     data->ResetPluginData();
@@ -154,4 +161,6 @@ void FarblePlugins(DOMPluginArray* owner,
 
 #include "src/third_party/blink/renderer/modules/plugins/dom_plugin_array.cc"
 
-#undef BRAVE_DOM_PLUGIN_ARRAY_GET_PLUGIN_DATA
+#undef BRAVE_DOM_PLUGINS_UPDATE_PLUGIN_DATA__FARBLE_PLUGIN_DATA
+#undef BRAVE_DOM_PLUGINS_UPDATE_PLUGIN_DATA__RESET_PLUGIN_DATA
+#undef BRAVE_DOM_PLUGINS_IS_PDF_VIEWER_AVAILABLE

--- a/chromium_src/third_party/blink/renderer/modules/plugins/dom_plugin_array.cc
+++ b/chromium_src/third_party/blink/renderer/modules/plugins/dom_plugin_array.cc
@@ -145,13 +145,6 @@ void FarblePlugins(DOMPluginArray* owner,
 
 }  // namespace brave
 
-#define BRAVE_DOM_PLUGINS_IS_PDF_VIEWER_AVAILABLE                \
-  if (auto* data = GetPluginData())                              \
-    for (const Member<MimeClassInfo>& mime_info : data->Mimes()) \
-      if (mime_info->Type() == "application/pdf")                \
-        return true;                                             \
-  return false;
-
 #define BRAVE_DOM_PLUGINS_UPDATE_PLUGIN_DATA__RESET_PLUGIN_DATA \
   if (PluginData* data = GetPluginData())                       \
     data->ResetPluginData();
@@ -163,4 +156,3 @@ void FarblePlugins(DOMPluginArray* owner,
 
 #undef BRAVE_DOM_PLUGINS_UPDATE_PLUGIN_DATA__FARBLE_PLUGIN_DATA
 #undef BRAVE_DOM_PLUGINS_UPDATE_PLUGIN_DATA__RESET_PLUGIN_DATA
-#undef BRAVE_DOM_PLUGINS_IS_PDF_VIEWER_AVAILABLE

--- a/patches/third_party-blink-renderer-modules-plugins-dom_plugin_array.cc.patch
+++ b/patches/third_party-blink-renderer-modules-plugins-dom_plugin_array.cc.patch
@@ -1,8 +1,16 @@
 diff --git a/third_party/blink/renderer/modules/plugins/dom_plugin_array.cc b/third_party/blink/renderer/modules/plugins/dom_plugin_array.cc
-index 2bb7e4138da4e9b31734e4ee3b5e26e7399bcffd..98d7ac259179dab1360cb6b6dda26b2bc287d4b8 100644
+index 2bb7e4138da4e9b31734e4ee3b5e26e7399bcffd..ae62755ab4fecab3b037081b17ccbb12a0f128c7 100644
 --- a/third_party/blink/renderer/modules/plugins/dom_plugin_array.cc
 +++ b/third_party/blink/renderer/modules/plugins/dom_plugin_array.cc
-@@ -196,6 +196,7 @@ void DOMPluginArray::UpdatePluginData() {
+@@ -170,6 +170,7 @@ HeapVector<Member<DOMMimeType>> DOMPluginArray::GetFixedMimeTypeArray() {
+ }
+ 
+ bool DOMPluginArray::IsPdfViewerAvailable() {
++  BRAVE_DOM_PLUGINS_IS_PDF_VIEWER_AVAILABLE
+   DCHECK(should_return_fixed_plugin_data_);
+   auto* data = GetPluginData();
+   if (!data)
+@@ -196,6 +197,7 @@ void DOMPluginArray::UpdatePluginData() {
      }
      return;
    }
@@ -10,7 +18,7 @@ index 2bb7e4138da4e9b31734e4ee3b5e26e7399bcffd..98d7ac259179dab1360cb6b6dda26b2b
    PluginData* data = GetPluginData();
    if (!data) {
      dom_plugins_.clear();
-@@ -217,6 +218,7 @@ void DOMPluginArray::UpdatePluginData() {
+@@ -217,6 +219,7 @@ void DOMPluginArray::UpdatePluginData() {
        }
      }
    }

--- a/patches/third_party-blink-renderer-modules-plugins-dom_plugin_array.cc.patch
+++ b/patches/third_party-blink-renderer-modules-plugins-dom_plugin_array.cc.patch
@@ -1,16 +1,16 @@
 diff --git a/third_party/blink/renderer/modules/plugins/dom_plugin_array.cc b/third_party/blink/renderer/modules/plugins/dom_plugin_array.cc
-index 2bb7e4138da4e9b31734e4ee3b5e26e7399bcffd..ae62755ab4fecab3b037081b17ccbb12a0f128c7 100644
+index 2bb7e4138da4e9b31734e4ee3b5e26e7399bcffd..864933cfb0438ec698db71b2b3b753df52ed2b64 100644
 --- a/third_party/blink/renderer/modules/plugins/dom_plugin_array.cc
 +++ b/third_party/blink/renderer/modules/plugins/dom_plugin_array.cc
-@@ -170,6 +170,7 @@ HeapVector<Member<DOMMimeType>> DOMPluginArray::GetFixedMimeTypeArray() {
+@@ -170,7 +170,6 @@ HeapVector<Member<DOMMimeType>> DOMPluginArray::GetFixedMimeTypeArray() {
  }
  
  bool DOMPluginArray::IsPdfViewerAvailable() {
-+  BRAVE_DOM_PLUGINS_IS_PDF_VIEWER_AVAILABLE
-   DCHECK(should_return_fixed_plugin_data_);
+-  DCHECK(should_return_fixed_plugin_data_);
    auto* data = GetPluginData();
    if (!data)
-@@ -196,6 +197,7 @@ void DOMPluginArray::UpdatePluginData() {
+     return false;
+@@ -196,6 +195,7 @@ void DOMPluginArray::UpdatePluginData() {
      }
      return;
    }
@@ -18,7 +18,7 @@ index 2bb7e4138da4e9b31734e4ee3b5e26e7399bcffd..ae62755ab4fecab3b037081b17ccbb12
    PluginData* data = GetPluginData();
    if (!data) {
      dom_plugins_.clear();
-@@ -217,6 +219,7 @@ void DOMPluginArray::UpdatePluginData() {
+@@ -217,6 +217,7 @@ void DOMPluginArray::UpdatePluginData() {
        }
      }
    }


### PR DESCRIPTION
<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/22247

This is really an upstream bug. `DOMPluginArray::IsPdfViewerAvailable` has a `DCHECK` on `should_return_fixed_plugin_data_` and other callers check that that is true before calling, but the new(?) `PdfViewerEnabled` attribute on `navigator` calls it unconditionally. Since upstream always has `should_return_fixed_plugin_data_` true, they didn't notice. We have it false, so we hit this whenever you try to access the `navigator.PdfViewerEnabled` attribute, which can happen from JS but also happens a lot in developer tools, which is annoying.

Also the DCHECK shouldn't exist, because the function runs just fine regardless of the value of `should_return_fixed_plugin_data_`.

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

