### PR TITLE
Support uintN; 0 < N <=256, N%8 == 0 for typed data (uplift to 1.38.x)

### DIFF
--- a/components/brave_wallet/common/brave_wallet_types.cc
+++ b/components/brave_wallet/common/brave_wallet_types.cc
@@ -94,4 +94,48 @@ absl::optional<SolanaSignatureStatus> SolanaSignatureStatus::FromValue(
   return status;
 }
 
+bool ValidSolidityBits(size_t bits) {
+  return bits != 0 && bits % 8 == 0 && bits <= 256;
+}
+
+absl::optional<uint256_t> MaxSolidityUint(size_t bits) {
+  if (!ValidSolidityBits(bits))
+    return absl::nullopt;
+  // Max hex for intN value is 0x[ff]... for num bytes
+  uint256_t value = 0;
+  const size_t num_bytes = bits / 8;
+  for (size_t i = 0; i < num_bytes; i++) {
+    value <<= 8;
+    value += 0xff;
+  }
+  return value;
+}
+
+absl::optional<int256_t> MaxSolidityInt(size_t bits) {
+  if (!ValidSolidityBits(bits))
+    return absl::nullopt;
+  // Max hex for intN value is 0x7f[ff]... for num bytes - 1
+  int256_t value = 0x7f;
+  const size_t num_bytes = bits / 8;
+  for (size_t i = 0; i < num_bytes - 1; i++) {
+    value <<= 8;
+    value += 0xff;
+  }
+  return value;
+}
+
+absl::optional<int256_t> MinSolidityInt(size_t bits) {
+  if (!ValidSolidityBits(bits))
+    return absl::nullopt;
+  // Min hex for intN value is 0x80[00]... for num bytes - 1
+  // A simple bit shift doesn't work quite right because of
+  // using boost's int256_t type.
+  int256_t value = 0x80 * -1;
+  const size_t num_bytes = bits / 8;
+  for (size_t i = 0; i < num_bytes - 1; i++) {
+    value *= 256;
+  }
+  return value;
+}
+
 }  // namespace brave_wallet

--- a/components/brave_wallet/common/brave_wallet_types.h
+++ b/components/brave_wallet/common/brave_wallet_types.h
@@ -40,6 +40,17 @@ constexpr int128_t kMin128BitInt = std::numeric_limits<int128_t>::min() >> 1;
 
 constexpr uint64_t kMaxSafeIntegerUint64 = 9007199254740991;  // 2^53-1
 
+// Determines the min/max value for Solidity types such as uint56
+// uintN where 0 < N <= 256; N % 8 == 0
+// Note that you shouldn't use uint256_t and int256_t in general
+// for passing around values that need to be capped in those ranges.
+// This is being used for sign typed data where values are not passed
+// around.
+bool ValidSolidityBits(size_t bits);
+absl::optional<uint256_t> MaxSolidityUint(size_t bits);
+absl::optional<int256_t> MaxSolidityInt(size_t bits);
+absl::optional<int256_t> MinSolidityInt(size_t bits);
+
 struct TransactionReceipt {
   TransactionReceipt();
   ~TransactionReceipt();

--- a/components/brave_wallet/common/brave_wallet_types_unittest.cc
+++ b/components/brave_wallet/common/brave_wallet_types_unittest.cc
@@ -88,4 +88,43 @@ TEST(BraveWalletTypesTest, SolanaSignatureStatusToValue) {
   EXPECT_EQ(*status_from_value, status);
 }
 
+TEST(BraveWalletTypesTest, ValidSolidityBits) {
+  for (size_t i = 8; i <= 256; i += 8) {
+    EXPECT_TRUE(ValidSolidityBits(i));
+  }
+  std::vector<size_t> invalid_num_bits = {0, 7, 257};
+  for (size_t i : invalid_num_bits) {
+    EXPECT_FALSE(ValidSolidityBits(i));
+    EXPECT_EQ(MaxSolidityUint(i), absl::nullopt);
+    EXPECT_EQ(MaxSolidityInt(i), absl::nullopt);
+    EXPECT_EQ(MinSolidityInt(i), absl::nullopt);
+  }
+}
+
+TEST(BraveWalletTypesTest, MaxSolidityUint) {
+  EXPECT_EQ(MaxSolidityUint(8), uint256_t(255));
+  EXPECT_EQ(MaxSolidityUint(16), uint256_t(65535));
+  EXPECT_EQ(MaxSolidityUint(24), uint256_t(16777215));
+  EXPECT_EQ(MaxSolidityUint(128),
+            uint256_t(std::numeric_limits<uint128_t>::max()));
+  EXPECT_EQ(MaxSolidityUint(256),
+            uint256_t(std::numeric_limits<uint256_t>::max()));
+}
+
+TEST(BraveWalletTypesTest, MaxSolidityInt) {
+  EXPECT_EQ(MaxSolidityInt(8), int256_t(127));
+  EXPECT_EQ(MaxSolidityInt(16), int256_t(32767));
+  EXPECT_EQ(MaxSolidityInt(24), int256_t(8388607));
+  EXPECT_EQ(MaxSolidityInt(128), int256_t(kMax128BitInt));
+  EXPECT_EQ(MaxSolidityInt(256), int256_t(kMax256BitInt));
+}
+
+TEST(BraveWalletTypesTest, MinSolidityInt) {
+  EXPECT_EQ(MinSolidityInt(8), int256_t(-128));
+  EXPECT_EQ(MinSolidityInt(16), int256_t(-32768));
+  EXPECT_EQ(MinSolidityInt(24), int256_t(-8388608));
+  EXPECT_EQ(MinSolidityInt(128), int256_t(kMin128BitInt));
+  EXPECT_EQ(MinSolidityInt(256), int256_t(kMin256BitInt));
+}
+
 }  // namespace brave_wallet

--- a/components/brave_wallet/common/eth_sign_typed_data_helper_unittest.cc
+++ b/components/brave_wallet/common/eth_sign_typed_data_helper_unittest.cc
@@ -405,6 +405,7 @@ TEST(EthSignedTypedDataHelperUnitTest, EncodeField) {
   EXPECT_FALSE(helper->EncodeField("uint1", base::Value(1)));
   EXPECT_FALSE(helper->EncodeField("uint9", base::Value(1)));
   EXPECT_FALSE(helper->EncodeField("uint264", base::Value(1)));
+  EXPECT_FALSE(helper->EncodeField("uint55", base::Value(1)));
   // exceeds 8 bits maximum
   EXPECT_FALSE(helper->EncodeField("uint8", base::Value(256)));
   // exceeds Number.MAX_SAFE_INTEGER
@@ -421,6 +422,13 @@ TEST(EthSignedTypedDataHelperUnitTest, EncodeField) {
     EXPECT_EQ(
         base::ToLowerASCII(base::HexEncode(*encoded_field)),
         "0000000000000000000000000000000000000000000000000000000000001000");
+
+    encoded_field = helper->EncodeField("uint56", base::Value(4096));
+    ASSERT_TRUE(encoded_field);
+    EXPECT_EQ(
+        base::ToLowerASCII(base::HexEncode(*encoded_field)),
+        "0000000000000000000000000000000000000000000000000000000000001000");
+
     encoded_field = helper->EncodeField("uint256", base::Value(65536));
     ASSERT_TRUE(encoded_field);
     EXPECT_EQ(
@@ -436,6 +444,11 @@ TEST(EthSignedTypedDataHelperUnitTest, EncodeField) {
         base::ToLowerASCII(base::HexEncode(*encoded_field)),
         "00000000000000000000000000000000000000000000000000000000000000ff");
     encoded_field = helper->EncodeField("uint32", base::Value("4096"));
+    ASSERT_TRUE(encoded_field);
+    EXPECT_EQ(
+        base::ToLowerASCII(base::HexEncode(*encoded_field)),
+        "0000000000000000000000000000000000000000000000000000000000001000");
+    encoded_field = helper->EncodeField("uint56", base::Value("4096"));
     ASSERT_TRUE(encoded_field);
     EXPECT_EQ(
         base::ToLowerASCII(base::HexEncode(*encoded_field)),
@@ -468,6 +481,8 @@ TEST(EthSignedTypedDataHelperUnitTest, EncodeField) {
     EXPECT_FALSE(helper->EncodeField("uint16", base::Value("0x10000")));
     EXPECT_FALSE(helper->EncodeField("uint32", base::Value("4294967296")));
     EXPECT_FALSE(helper->EncodeField("uint32", base::Value("0x100000000")));
+    EXPECT_FALSE(
+        helper->EncodeField("uint56", base::Value("0x100000000000000")));
     EXPECT_FALSE(
         helper->EncodeField("uint64", base::Value("18446744073709551616")));
     EXPECT_FALSE(
@@ -511,6 +526,7 @@ TEST(EthSignedTypedDataHelperUnitTest, EncodeField) {
   EXPECT_FALSE(helper->EncodeField("int1", base::Value(1)));
   EXPECT_FALSE(helper->EncodeField("int9", base::Value(1)));
   EXPECT_FALSE(helper->EncodeField("int264", base::Value(1)));
+  EXPECT_FALSE(helper->EncodeField("int55", base::Value(1)));
   // exceeds 8 bits maximum
   EXPECT_FALSE(helper->EncodeField("int8", base::Value(128)));
   // exceeds Number.MAX_SAFE_INTEGER
@@ -577,6 +593,10 @@ TEST(EthSignedTypedDataHelperUnitTest, EncodeField) {
     EXPECT_FALSE(helper->EncodeField("int32", base::Value("-2147483649")));
     EXPECT_FALSE(helper->EncodeField("int32", base::Value("0x100000000")));
     EXPECT_FALSE(
+        helper->EncodeField("int56", base::Value("72057594037927935")));
+    EXPECT_FALSE(
+        helper->EncodeField("int56", base::Value("-72057594037927936")));
+    EXPECT_FALSE(
         helper->EncodeField("int64", base::Value("9223372036854775808")));
     EXPECT_FALSE(
         helper->EncodeField("int64", base::Value("-9223372036854775809")));
@@ -629,6 +649,11 @@ TEST(EthSignedTypedDataHelperUnitTest, EncodeField) {
         base::ToLowerASCII(base::HexEncode(*encoded_field)),
         "000000000000000000000000000000000000000000000000000000000000007f");
     encoded_field = helper->EncodeField("int32", base::Value("4096"));
+    ASSERT_TRUE(encoded_field);
+    EXPECT_EQ(
+        base::ToLowerASCII(base::HexEncode(*encoded_field)),
+        "0000000000000000000000000000000000000000000000000000000000001000");
+    encoded_field = helper->EncodeField("int56", base::Value("4096"));
     ASSERT_TRUE(encoded_field);
     EXPECT_EQ(
         base::ToLowerASCII(base::HexEncode(*encoded_field)),


### PR DESCRIPTION
Important for Dapp compatibility for loopring.io l2 activation

Uplift of https://github.com/brave/brave-core/pull/12958
Resolves https://github.com/brave/brave-browser/issues/22070

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 

Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.