### PR TITLE
Move P3A metric list to a separate file

### DIFF
--- a/components/p3a/BUILD.gn
+++ b/components/p3a/BUILD.gn
@@ -24,6 +24,7 @@ static_library("p3a") {
     "brave_p3a_utils.h",
     "histograms_braveizer.cc",
     "histograms_braveizer.h",
+    "metric_names.h",
     "p3a_message.cc",
     "p3a_message.h",
     "pref_names.cc",

--- a/components/p3a/brave_p3a_service.cc
+++ b/components/p3a/brave_p3a_service.cc
@@ -20,6 +20,7 @@
 #include "base/no_destructor.h"
 #include "base/rand_util.h"
 #include "base/strings/string_number_conversions.h"
+#include "base/strings/string_piece_forward.h"
 #include "base/task/post_task.h"
 #include "base/trace_event/trace_event.h"
 #include "brave/components/brave_prochlo/prochlo_message.pb.h"
@@ -31,6 +32,7 @@
 #include "brave/components/p3a/brave_p3a_scheduler.h"
 #include "brave/components/p3a/brave_p3a_switches.h"
 #include "brave/components/p3a/brave_p3a_uploader.h"
+#include "brave/components/p3a/metric_names.h"
 #include "brave/components/p3a/pref_names.h"
 #include "brave/components/version_info/version_info.h"
 #include "brave/vendor/brave_base/random.h"
@@ -59,134 +61,6 @@ constexpr char kP3AJsonServerUrl[] = "https://p3a-json.brave.com/";
 constexpr char kP2AJsonServerUrl[] = "https://p2a-json.brave.com/";
 
 constexpr uint64_t kDefaultUploadIntervalSeconds = 60;  // 1 minute.
-
-// TODO(iefremov): Provide moar histograms!
-// Whitelist for histograms that we collect. Will be replaced with something
-// updating on the fly.
-// clang-format off
-constexpr const char* kCollectedHistograms[] = {
-    "Brave.Core.BookmarksCountOnProfileLoad.2",
-    "Brave.Core.CrashReportsEnabled",
-    "Brave.Core.IsDefault",
-    "Brave.Core.LastTimeIncognitoUsed",
-    "Brave.Core.NumberOfExtensions",
-    "Brave.Core.TabCount",
-    "Brave.Core.TorEverUsed",
-    "Brave.Core.WindowCount.2",
-    "Brave.Importer.ImporterSource",
-    "Brave.NTP.CustomizeUsageStatus",
-    "Brave.NTP.NewTabsCreated",
-    "Brave.NTP.SponsoredImagesEnabled",
-    "Brave.NTP.SponsoredNewTabsCreated",
-    "Brave.Omnibox.SearchCount",
-    "Brave.P3A.SentAnswersCount",
-    "Brave.Rewards.AdsState.2",
-    "Brave.Rewards.AutoContributionsState.2",
-    "Brave.Rewards.TipsState.2",
-    "Brave.Rewards.AdsEnabledDuration",
-    "Brave.Rewards.WalletBalance.3",
-    "Brave.Rewards.WalletState",
-    "Brave.Savings.BandwidthSavingsMB",
-    "Brave.Search.DefaultEngine.4",
-    "Brave.Search.SwitchEngine",
-    "Brave.Shields.AdBlockSetting",
-    "Brave.Shields.DomainAdsSettingsAboveGlobal",
-    "Brave.Shields.DomainAdsSettingsBelowGlobal",
-    "Brave.Shields.DomainFingerprintSettingsAboveGlobal",
-    "Brave.Shields.DomainFingerprintSettingsBelowGlobal",
-    "Brave.Shields.FingerprintBlockSetting",
-    "Brave.Shields.UsageStatus",
-    "Brave.SpeedReader.Enabled",
-    "Brave.SpeedReader.ToggleCount",
-    "Brave.Today.DirectFeedsTotal",
-    "Brave.Today.HasEverInteracted",
-    "Brave.Today.TotalCardViewsCount",
-    "Brave.Today.WeeklyDisplayAdsViewedCount",
-    "Brave.Today.WeeklyMaxCardViewsCount",
-    "Brave.Today.WeeklyMaxCardVisitsCount",
-    "Brave.Today.WeeklySessionCount",
-    "Brave.Today.WeeklyAddedDirectFeedsCount",
-    "Brave.Sync.Status.2",
-    "Brave.Sync.ProgressTokenEverReset",
-    "Brave.Uptime.BrowserOpenMinutes",
-    "Brave.Wallet.DefaultWalletSetting",
-    "Brave.Wallet.KeyringCreated",
-    "Brave.Wallet.UsageDaysInWeek",
-    "Brave.Wallet.UsageMonthly.2",
-    "Brave.Welcome.InteractionStatus",
-
-    // IPFS
-    "Brave.IPFS.IPFSCompanionInstalled",
-    "Brave.IPFS.DetectionPromptCount",
-    "Brave.IPFS.GatewaySetting",
-    "Brave.IPFS.DaemonRunTime",
-    "Brave.IPFS.LocalNodeRetention",
-
-    // P2A
-    // Ad Opportunities
-    "Brave.P2A.TotalAdOpportunities",
-    "Brave.P2A.AdOpportunitiesPerSegment.architecture",
-    "Brave.P2A.AdOpportunitiesPerSegment.artsentertainment",
-    "Brave.P2A.AdOpportunitiesPerSegment.automotive",
-    "Brave.P2A.AdOpportunitiesPerSegment.business",
-    "Brave.P2A.AdOpportunitiesPerSegment.careers",
-    "Brave.P2A.AdOpportunitiesPerSegment.cellphones",
-    "Brave.P2A.AdOpportunitiesPerSegment.crypto",
-    "Brave.P2A.AdOpportunitiesPerSegment.education",
-    "Brave.P2A.AdOpportunitiesPerSegment.familyparenting",
-    "Brave.P2A.AdOpportunitiesPerSegment.fashion",
-    "Brave.P2A.AdOpportunitiesPerSegment.folklore",
-    "Brave.P2A.AdOpportunitiesPerSegment.fooddrink",
-    "Brave.P2A.AdOpportunitiesPerSegment.gaming",
-    "Brave.P2A.AdOpportunitiesPerSegment.healthfitness",
-    "Brave.P2A.AdOpportunitiesPerSegment.history",
-    "Brave.P2A.AdOpportunitiesPerSegment.hobbiesinterests",
-    "Brave.P2A.AdOpportunitiesPerSegment.home",
-    "Brave.P2A.AdOpportunitiesPerSegment.law",
-    "Brave.P2A.AdOpportunitiesPerSegment.military",
-    "Brave.P2A.AdOpportunitiesPerSegment.other",
-    "Brave.P2A.AdOpportunitiesPerSegment.personalfinance",
-    "Brave.P2A.AdOpportunitiesPerSegment.pets",
-    "Brave.P2A.AdOpportunitiesPerSegment.realestate",
-    "Brave.P2A.AdOpportunitiesPerSegment.science",
-    "Brave.P2A.AdOpportunitiesPerSegment.sports",
-    "Brave.P2A.AdOpportunitiesPerSegment.technologycomputing",
-    "Brave.P2A.AdOpportunitiesPerSegment.travel",
-    "Brave.P2A.AdOpportunitiesPerSegment.weather",
-    "Brave.P2A.AdOpportunitiesPerSegment.untargeted",
-    // Ad Impressions
-    "Brave.P2A.TotalAdImpressions",
-    "Brave.P2A.AdImpressionsPerSegment.architecture",
-    "Brave.P2A.AdImpressionsPerSegment.artsentertainment",
-    "Brave.P2A.AdImpressionsPerSegment.automotive",
-    "Brave.P2A.AdImpressionsPerSegment.business",
-    "Brave.P2A.AdImpressionsPerSegment.careers",
-    "Brave.P2A.AdImpressionsPerSegment.cellphones",
-    "Brave.P2A.AdImpressionsPerSegment.crypto",
-    "Brave.P2A.AdImpressionsPerSegment.education",
-    "Brave.P2A.AdImpressionsPerSegment.familyparenting",
-    "Brave.P2A.AdImpressionsPerSegment.fashion",
-    "Brave.P2A.AdImpressionsPerSegment.folklore",
-    "Brave.P2A.AdImpressionsPerSegment.fooddrink",
-    "Brave.P2A.AdImpressionsPerSegment.gaming",
-    "Brave.P2A.AdImpressionsPerSegment.healthfitness",
-    "Brave.P2A.AdImpressionsPerSegment.history",
-    "Brave.P2A.AdImpressionsPerSegment.hobbiesinterests",
-    "Brave.P2A.AdImpressionsPerSegment.home",
-    "Brave.P2A.AdImpressionsPerSegment.law",
-    "Brave.P2A.AdImpressionsPerSegment.military",
-    "Brave.P2A.AdImpressionsPerSegment.other",
-    "Brave.P2A.AdImpressionsPerSegment.personalfinance",
-    "Brave.P2A.AdImpressionsPerSegment.pets",
-    "Brave.P2A.AdImpressionsPerSegment.realestate",
-    "Brave.P2A.AdImpressionsPerSegment.science",
-    "Brave.P2A.AdImpressionsPerSegment.sports",
-    "Brave.P2A.AdImpressionsPerSegment.technologycomputing",
-    "Brave.P2A.AdImpressionsPerSegment.travel",
-    "Brave.P2A.AdImpressionsPerSegment.weather",
-    "Brave.P2A.AdImpressionsPerSegment.untargeted"
-};
-// clang-format on
 
 bool IsSuspendedMetric(base::StringPiece metric_name,
                        uint64_t value_or_bucket) {
@@ -240,11 +114,11 @@ void BraveP3AService::RegisterPrefs(PrefRegistrySimple* registry,
 }
 
 void BraveP3AService::InitCallbacks() {
-  for (const char* histogram_name : kCollectedHistograms) {
+  for (base::StringPiece histogram_name : p3a::kCollectedHistograms) {
     histogram_sample_callbacks_.push_back(
         std::make_unique<
             base::StatisticsRecorder::ScopedHistogramSampleObserver>(
-            histogram_name,
+            std::string(histogram_name),
             base::BindRepeating(&BraveP3AService::OnHistogramChanged, this)));
   }
 }
@@ -339,10 +213,7 @@ BraveP3ALogStore::LogForJsonMigration BraveP3AService::Serialize(
 
 bool
 BraveP3AService::IsActualMetric(base::StringPiece histogram_name) const {
-  static const base::NoDestructor<base::flat_set<base::StringPiece>>
-      metric_names {std::begin(kCollectedHistograms),
-                    std::end(kCollectedHistograms)};
-  return metric_names->contains(histogram_name);
+  return p3a::kCollectedHistograms.contains(histogram_name);
 }
 
 void BraveP3AService::MaybeOverrideSettingsFromCommandLine() {

--- a/components/p3a/brave_p3a_service.h
+++ b/components/p3a/brave_p3a_service.h
@@ -14,6 +14,7 @@
 #include "base/memory/ref_counted.h"
 #include "base/metrics/histogram_base.h"
 #include "base/metrics/statistics_recorder.h"
+#include "base/strings/string_piece_forward.h"
 #include "base/timer/wall_clock_timer.h"
 #include "brave/components/p3a/brave_p3a_log_store.h"
 #include "brave/components/p3a/p3a_message.h"

--- a/components/p3a/metric_names.h
+++ b/components/p3a/metric_names.h
@@ -1,0 +1,152 @@
+/* Copyright 2022 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_COMPONENTS_P3A_METRIC_NAMES_H_
+#define BRAVE_COMPONENTS_P3A_METRIC_NAMES_H_
+
+#include "base/containers/fixed_flat_set.h"
+#include "base/strings/string_piece.h"
+
+namespace brave::p3a {
+
+// Allowlist for histograms that we collect.
+// A metric must be listed here to be reported.
+//
+// Please keep them properly sorted within their categories.
+//
+// Could be replaced with something built dynamically,
+// although so far we've found it a useful review point.
+//
+// TODO(iefremov) Clean up obsolete metrics.
+//
+// clang-format off
+constexpr inline auto kCollectedHistograms =
+  base::MakeFixedFlatSet<base::StringPiece>({
+    "Brave.Core.BookmarksCountOnProfileLoad.2",
+    "Brave.Core.CrashReportsEnabled",
+    "Brave.Core.IsDefault",
+    "Brave.Core.LastTimeIncognitoUsed",
+    "Brave.Core.NumberOfExtensions",
+    "Brave.Core.TabCount",
+    "Brave.Core.TorEverUsed",
+    "Brave.Core.WindowCount.2",
+    "Brave.Importer.ImporterSource",
+    "Brave.NTP.CustomizeUsageStatus",
+    "Brave.NTP.NewTabsCreated",
+    "Brave.NTP.SponsoredImagesEnabled",
+    "Brave.NTP.SponsoredNewTabsCreated",
+    "Brave.Omnibox.SearchCount",
+    "Brave.P3A.SentAnswersCount",
+    "Brave.Rewards.AdsState.2",
+    "Brave.Rewards.AutoContributionsState.2",
+    "Brave.Rewards.TipsState.2",
+    "Brave.Rewards.AdsEnabledDuration",
+    "Brave.Rewards.WalletBalance.3",
+    "Brave.Rewards.WalletState",
+    "Brave.Savings.BandwidthSavingsMB",
+    "Brave.Search.DefaultEngine.4",
+    "Brave.Search.SwitchEngine",
+    "Brave.Shields.AdBlockSetting",
+    "Brave.Shields.DomainAdsSettingsAboveGlobal",
+    "Brave.Shields.DomainAdsSettingsBelowGlobal",
+    "Brave.Shields.DomainFingerprintSettingsAboveGlobal",
+    "Brave.Shields.DomainFingerprintSettingsBelowGlobal",
+    "Brave.Shields.FingerprintBlockSetting",
+    "Brave.Shields.UsageStatus",
+    "Brave.SpeedReader.Enabled",
+    "Brave.SpeedReader.ToggleCount",
+    "Brave.Today.DirectFeedsTotal",
+    "Brave.Today.HasEverInteracted",
+    "Brave.Today.TotalCardViewsCount",
+    "Brave.Today.WeeklyDisplayAdsViewedCount",
+    "Brave.Today.WeeklyMaxCardViewsCount",
+    "Brave.Today.WeeklyMaxCardVisitsCount",
+    "Brave.Today.WeeklySessionCount",
+    "Brave.Today.WeeklyAddedDirectFeedsCount",
+    "Brave.Sync.Status.2",
+    "Brave.Sync.ProgressTokenEverReset",
+    "Brave.Uptime.BrowserOpenMinutes",
+    "Brave.Wallet.DefaultWalletSetting",
+    "Brave.Wallet.KeyringCreated",
+    "Brave.Wallet.UsageDaysInWeek",
+    "Brave.Wallet.UsageMonthly.2",
+    "Brave.Welcome.InteractionStatus",
+
+    // IPFS
+    "Brave.IPFS.IPFSCompanionInstalled",
+    "Brave.IPFS.DetectionPromptCount",
+    "Brave.IPFS.GatewaySetting",
+    "Brave.IPFS.DaemonRunTime",
+    "Brave.IPFS.LocalNodeRetention",
+
+    // P2A
+    // Ad Opportunities
+    "Brave.P2A.TotalAdOpportunities",
+    "Brave.P2A.AdOpportunitiesPerSegment.architecture",
+    "Brave.P2A.AdOpportunitiesPerSegment.artsentertainment",
+    "Brave.P2A.AdOpportunitiesPerSegment.automotive",
+    "Brave.P2A.AdOpportunitiesPerSegment.business",
+    "Brave.P2A.AdOpportunitiesPerSegment.careers",
+    "Brave.P2A.AdOpportunitiesPerSegment.cellphones",
+    "Brave.P2A.AdOpportunitiesPerSegment.crypto",
+    "Brave.P2A.AdOpportunitiesPerSegment.education",
+    "Brave.P2A.AdOpportunitiesPerSegment.familyparenting",
+    "Brave.P2A.AdOpportunitiesPerSegment.fashion",
+    "Brave.P2A.AdOpportunitiesPerSegment.folklore",
+    "Brave.P2A.AdOpportunitiesPerSegment.fooddrink",
+    "Brave.P2A.AdOpportunitiesPerSegment.gaming",
+    "Brave.P2A.AdOpportunitiesPerSegment.healthfitness",
+    "Brave.P2A.AdOpportunitiesPerSegment.history",
+    "Brave.P2A.AdOpportunitiesPerSegment.hobbiesinterests",
+    "Brave.P2A.AdOpportunitiesPerSegment.home",
+    "Brave.P2A.AdOpportunitiesPerSegment.law",
+    "Brave.P2A.AdOpportunitiesPerSegment.military",
+    "Brave.P2A.AdOpportunitiesPerSegment.other",
+    "Brave.P2A.AdOpportunitiesPerSegment.personalfinance",
+    "Brave.P2A.AdOpportunitiesPerSegment.pets",
+    "Brave.P2A.AdOpportunitiesPerSegment.realestate",
+    "Brave.P2A.AdOpportunitiesPerSegment.science",
+    "Brave.P2A.AdOpportunitiesPerSegment.sports",
+    "Brave.P2A.AdOpportunitiesPerSegment.technologycomputing",
+    "Brave.P2A.AdOpportunitiesPerSegment.travel",
+    "Brave.P2A.AdOpportunitiesPerSegment.weather",
+    "Brave.P2A.AdOpportunitiesPerSegment.untargeted",
+    // Ad Impressions
+    "Brave.P2A.TotalAdImpressions",
+    "Brave.P2A.AdImpressionsPerSegment.architecture",
+    "Brave.P2A.AdImpressionsPerSegment.artsentertainment",
+    "Brave.P2A.AdImpressionsPerSegment.automotive",
+    "Brave.P2A.AdImpressionsPerSegment.business",
+    "Brave.P2A.AdImpressionsPerSegment.careers",
+    "Brave.P2A.AdImpressionsPerSegment.cellphones",
+    "Brave.P2A.AdImpressionsPerSegment.crypto",
+    "Brave.P2A.AdImpressionsPerSegment.education",
+    "Brave.P2A.AdImpressionsPerSegment.familyparenting",
+    "Brave.P2A.AdImpressionsPerSegment.fashion",
+    "Brave.P2A.AdImpressionsPerSegment.folklore",
+    "Brave.P2A.AdImpressionsPerSegment.fooddrink",
+    "Brave.P2A.AdImpressionsPerSegment.gaming",
+    "Brave.P2A.AdImpressionsPerSegment.healthfitness",
+    "Brave.P2A.AdImpressionsPerSegment.history",
+    "Brave.P2A.AdImpressionsPerSegment.hobbiesinterests",
+    "Brave.P2A.AdImpressionsPerSegment.home",
+    "Brave.P2A.AdImpressionsPerSegment.law",
+    "Brave.P2A.AdImpressionsPerSegment.military",
+    "Brave.P2A.AdImpressionsPerSegment.other",
+    "Brave.P2A.AdImpressionsPerSegment.personalfinance",
+    "Brave.P2A.AdImpressionsPerSegment.pets",
+    "Brave.P2A.AdImpressionsPerSegment.realestate",
+    "Brave.P2A.AdImpressionsPerSegment.science",
+    "Brave.P2A.AdImpressionsPerSegment.sports",
+    "Brave.P2A.AdImpressionsPerSegment.technologycomputing",
+    "Brave.P2A.AdImpressionsPerSegment.travel",
+    "Brave.P2A.AdImpressionsPerSegment.weather",
+    "Brave.P2A.AdImpressionsPerSegment.untargeted"
+});
+// clang-format on
+
+}  // namespace brave::p3a
+
+#endif  // BRAVE_COMPONENTS_P3A_METRIC_NAMES_H_

--- a/components/p3a/metric_names_unittest.cc
+++ b/components/p3a/metric_names_unittest.cc
@@ -1,0 +1,51 @@
+// Copyright (c) 2022 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// you can obtain one at http://mozilla.org/MPL/2.0/.
+
+#include <string>
+
+#include "base/logging.h"
+#include "brave/components/p3a/metric_names.h"
+#include "testing/gtest/include/gtest/gtest.h"
+
+// npm run test -- brave_unit_tests --filter=P3AMetrics*
+
+namespace brave::p3a {
+
+TEST(P3AMetrics, Searchable) {
+  // Check that some expected elements made it into the set.
+  // This set was chosen as likely to be long-lived; it will need
+  // to be updated if any of them are retired.
+  EXPECT_TRUE(kCollectedHistograms.contains("Brave.Core.IsDefault"));
+  EXPECT_TRUE(kCollectedHistograms.contains("Brave.P3A.SentAnswersCount"));
+  EXPECT_TRUE(kCollectedHistograms.contains("Brave.P2A.TotalAdOpportunities"));
+  // Verify set membership testing isn't returning true unconditionally.
+  EXPECT_FALSE(kCollectedHistograms.contains("Not.A.Brave.Metric"));
+  EXPECT_FALSE(kCollectedHistograms.contains("antimetric"));
+}
+
+TEST(P3AMetrics, Enumerable) {
+  const size_t size = kCollectedHistograms.size();
+  size_t count = 0;
+  std::string last = {};
+
+  // Check that we can loop through the set members.
+  DLOG(INFO) << "Set of collected metrics has " << size << " members:";
+  for (auto item : kCollectedHistograms) {
+    DLOG(INFO) << "  " << item;
+    // Each item should be a set member.
+    EXPECT_TRUE(kCollectedHistograms.contains(item));
+    // Each item should be different from the previous one.
+    EXPECT_NE(item, last);
+    last = std::string(item);
+    // Count the number of items.
+    count++;
+  }
+
+  // Verify we saw all of the members.
+  EXPECT_EQ(count, size);
+  EXPECT_EQ(size, kCollectedHistograms.size());
+}
+
+}  // namespace brave::p3a

--- a/test/BUILD.gn
+++ b/test/BUILD.gn
@@ -134,6 +134,7 @@ test("brave_unit_tests") {
     "//brave/components/ntp_widget_utils/browser/ntp_widget_utils_oauth_unittest.cc",
     "//brave/components/ntp_widget_utils/browser/ntp_widget_utils_region_unittest.cc",
     "//brave/components/p3a/brave_p2a_protocols_unittest.cc",
+    "//brave/components/p3a/metric_names_unittest.cc",
     "//brave/components/weekly_storage/daily_storage_unittest.cc",
     "//brave/components/weekly_storage/weekly_event_storage_unittest.cc",
     "//brave/components/weekly_storage/weekly_storage_unittest.cc",


### PR DESCRIPTION
Adding a new P3A probe requires updating the list of allowed metrics so the new measurement can be reported. This is a lower review bar than changing the reporting code itself, so we'd like to have it in a different place so we can have a separate list of code owners for it.

The definition is in a header so for-each iteration still works on the fixed-length array without having to explicitly declare the length. Now that we're building as C++17, declaring it `inline` should take care of de-duplication if it ends up included in another translation unit.

<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/22263

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

- Launch browser on a fresh profile
- Observe network traffic for ~10 minutes
- Confirm P3A report messages are sent as before