### PR TITLE
Window closing confirm dialog

### DIFF
--- a/app/brave_generated_resources.grd
+++ b/app/brave_generated_resources.grd
@@ -549,6 +549,25 @@ Or change later at <ph name="SETTINGS_EXTENIONS_LINK">$2<ex>brave://settings/ext
         <message name="IDS_CRASH_REPORT_PERMISSION_ASK_DIALOG_FOOTNOTE_TEXT_SETTING_PART" desc="This is used for replacing SETTING_TEXT from above FOOTNOTE_TEXT.">
           this setting
         </message>
+        <!-- Closing confirm dialog -->
+        <message name="IDS_WINDOW_CLOSING_CONFIRM_DLG_OK_BUTTON_LABEL" desc="The text for ok button in the dialog">
+          Close all
+        </message>
+        <message name="IDS_WINDOW_CLOSING_CONFIRM_DLG_CANCEL_BUTTON_LABEL" desc="The text for cancel button in the dialog">
+          Cancel
+        </message>
+        <message name="IDS_WINDOW_CLOSING_CONFIRM_DLG_HEADER_LABEL" desc="The text for header part in the dialog">
+          Close all tabs?
+        </message>
+        <message name="IDS_WINDOW_CLOSING_CONFIRM_DLG_CONTENTS_LABEL" desc="The text for content part in the dialog">
+          You have <ph name="NUMBER_OF_TABS">$1<ex>2</ex></ph> tabs open in this browser window.
+        </message>
+        <message name="IDS_WINDOW_CLOSING_CONFIRM_DLG_CONTENTS_LABEL_TAB_NUM_PART" desc="This is used for finding 'n tabs' part in above DLG_CONTENTS_LABEL. So both should have same translation.">
+          <ph name="NUMBER_OF_TABS">$1<ex>2</ex></ph> tabs
+        </message>
+        <message name="IDS_WINDOW_CLOSING_CONFIRM_DLG_DONT_ASK_AGAIN_LABEL" desc="The text for checkbox in the dialog">
+          Don't ask me again
+        </message>
       </if>
 
       <!-- Brave Ads -->

--- a/app/brave_settings_strings.grdp
+++ b/app/brave_settings_strings.grdp
@@ -877,6 +877,9 @@
   <message name="IDS_SETTINGS_HELP_TIPS_SHOW_BRAVE_WAYBACK_MACHINE_PROMPT" desc="The label describing the 'wayback machine' toggle option">
     Show Wayback Machine prompt on 404 pages
   </message>
+  <message name="IDS_SETTINGS_WINDOW_CLOSING_CONFIRM_OPTION_LABEL" desc="The text for settings option">
+    Warn me before closing window with multiple tabs
+  </message>
 
   <!-- Avatars. Generated via zsh and node:
         declare -i a=56

--- a/browser/brave_profile_prefs.cc
+++ b/browser/brave_profile_prefs.cc
@@ -419,17 +419,13 @@ void RegisterProfilePrefs(user_prefs::PrefRegistrySyncable* registry) {
 
 #if !BUILDFLAG(IS_ANDROID)
   BraveOmniboxClientImpl::RegisterProfilePrefs(registry);
-#endif
-
-#if !BUILDFLAG(IS_ANDROID)
   brave_ads::RegisterP2APrefs(registry);
-#endif
 
-#if !BUILDFLAG(IS_ANDROID)
   // Turn on most visited mode on NTP by default.
   // We can turn customization mode on when we have add-shortcut feature.
   registry->SetDefaultPrefValue(ntp_prefs::kNtpUseMostVisitedTiles,
                                 base::Value(true));
+  registry->RegisterBooleanPref(kEnableWindowClosingConfirm, false);
   RegisterDefaultBraveBrowserPromptPrefs(registry);
 #endif
 

--- a/browser/extensions/api/settings_private/brave_prefs_util.cc
+++ b/browser/extensions/api/settings_private/brave_prefs_util.cc
@@ -243,6 +243,8 @@ const PrefsUtil::TypedPrefMap& BravePrefsUtil::GetAllowlistedKeys() {
   (*s_brave_allowlist)[kBraveWaybackMachineEnabled] =
       settings_api::PrefType::PREF_TYPE_BOOLEAN;
 #endif
+  (*s_brave_allowlist)[kEnableWindowClosingConfirm] =
+      settings_api::PrefType::PREF_TYPE_BOOLEAN;
   // Hangouts pref
   (*s_brave_allowlist)[kHangoutsEnabled] =
       settings_api::PrefType::PREF_TYPE_BOOLEAN;

--- a/browser/resources/settings/brave_help_tips_page/brave_help_tips_page.html
+++ b/browser/resources/settings/brave_help_tips_page/brave_help_tips_page.html
@@ -13,6 +13,16 @@
                             label="$i18n{braveHelpTipsWaybackMachineLabel}">
     </settings-toggle-button>
   </if>
+    <settings-toggle-button class="cr-row"
+                            pref="{{prefs.brave.enable_window_closing_confirm}}"
+                            label="$i18n{braveHelpTipsWarnBeforeClosingWindow}">
+    </settings-toggle-button>
+  <if expr="is_macosx">
+    <settings-toggle-button class="cr-row"
+                            pref="{{prefs.browser.confirm_to_quit}}"
+                            label="$i18n{warnBeforeQuitting}">
+    </settings-toggle-button>
+  </if>
   </template>
   <script src="brave_help_tips_page.js"></script>
 </dom-module>

--- a/browser/resources/settings/brave_overrides/appearance_page.js
+++ b/browser/resources/settings/brave_overrides/appearance_page.js
@@ -82,6 +82,16 @@ RegisterPolymerTemplateModifications({
       `)
       }
     }
+
+    // <if expr="is_macosx">
+    const confirmToQuit = templateContent.querySelector('[pref="{{prefs.browser.confirm_to_quit}}"]')
+    if (!confirmToQuit) {
+      console.error(`[Brave Settings Overrides] Couldn't find confirm to quit`)
+    } else {
+      confirmToQuit.remove()
+    }
+    // </if>
+
     // Super referral themes prefs
     const pages = templateContent.getElementById('pages')
     if (!pages) {

--- a/browser/ui/BUILD.gn
+++ b/browser/ui/BUILD.gn
@@ -186,6 +186,8 @@ source_set("ui") {
       "views/toolbar/brave_app_menu.h",
       "views/web_discovery_dialog_view.cc",
       "views/web_discovery_dialog_view.h",
+      "views/window_closing_confirm_dialog_view.cc",
+      "views/window_closing_confirm_dialog_view.h",
     ]
 
     if (use_aura) {
@@ -654,12 +656,20 @@ source_set("browser_tests") {
     testonly = true
     defines = [ "HAS_OUT_OF_PROC_TEST_RUNNER" ]
 
-    sources = [ "brave_browser_browsertest.cc" ]
+    sources = [
+      "brave_browser_browsertest.cc",
+      "window_closing_confirm_browsertest.cc",
+    ]
 
     deps = [
       "//brave/browser/ui",
+      "//brave/common:pref_names",
+      "//chrome/browser",
+      "//chrome/browser/profiles:profile",
       "//chrome/browser/ui",
       "//chrome/test:test_support_ui",
+      "//components/javascript_dialogs",
+      "//components/prefs",
       "//content/test:test_support",
     ]
   }

--- a/browser/ui/brave_browser.h
+++ b/browser/ui/brave_browser.h
@@ -39,6 +39,18 @@ class BraveBrowser : public Browser {
       TabStripModel* tab_strip_model,
       const TabStripModelChange& change,
       const TabStripSelectionChange& selection) override;
+  void FinishWarnBeforeClosing(WarnBeforeClosingResult result) override;
+  void BeforeUnloadFired(content::WebContents* source,
+                         bool proceed,
+                         bool* proceed_to_fire_unload) override;
+  bool TryToCloseWindow(
+      bool skip_beforeunload,
+      const base::RepeatingCallback<void(bool)>& on_close_confirmed) override;
+  void ResetTryToCloseWindow() override;
+
+  // Returns true when we should ask browser closing to users before handling
+  // any warning/onbeforeunload handlers.
+  bool ShouldAskForBrowserClosingBeforeHandlers();
 
 #if BUILDFLAG(ENABLE_SIDEBAR)
   sidebar::SidebarController* sidebar_controller() {
@@ -48,10 +60,16 @@ class BraveBrowser : public Browser {
 
   BraveBrowserWindow* brave_window();
 
+  void set_confirmed_to_close(bool close) { confirmed_to_close_ = close; }
+
  private:
 #if BUILDFLAG(ENABLE_SIDEBAR)
   std::unique_ptr<sidebar::SidebarController> sidebar_controller_;
 #endif
+
+  // Set true when user allowed to close browser before starting any
+  // warning or onbeforeunload handlers.
+  bool confirmed_to_close_ = false;
 };
 
 #endif  // BRAVE_BROWSER_UI_BRAVE_BROWSER_H_

--- a/browser/ui/views/window_closing_confirm_dialog_view.cc
+++ b/browser/ui/views/window_closing_confirm_dialog_view.cc
@@ -1,0 +1,210 @@
+/* Copyright (c) 2022 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "brave/browser/ui/views/window_closing_confirm_dialog_view.h"
+
+#include <utility>
+
+#include "base/bind.h"
+#include "base/callback.h"
+#include "base/no_destructor.h"
+#include "base/strings/string_number_conversions.h"
+#include "brave/common/pref_names.h"
+#include "brave/grit/brave_generated_resources.h"
+#include "build/build_config.h"
+#include "chrome/browser/profiles/profile.h"
+#include "chrome/browser/ui/browser.h"
+#include "chrome/browser/ui/browser_window.h"
+#include "chrome/browser/ui/tabs/tab_strip_model.h"
+#include "chrome/browser/ui/views/frame/browser_view.h"
+#include "chrome/grit/chromium_strings.h"
+#include "components/constrained_window/constrained_window_views.h"
+#include "components/prefs/pref_service.h"
+#include "ui/base/l10n/l10n_util.h"
+#include "ui/base/metadata/metadata_impl_macros.h"
+#include "ui/gfx/font_list.h"
+#include "ui/gfx/geometry/insets.h"
+#include "ui/views/controls/button/checkbox.h"
+#include "ui/views/controls/label.h"
+#include "ui/views/controls/styled_label.h"
+#include "ui/views/layout/box_layout.h"
+#include "ui/views/widget/widget.h"
+#include "ui/views/window/dialog_delegate.h"
+
+namespace {
+
+base::RepeatingCallback<void(views::DialogDelegateView*)>&
+GetCreationCallbackForTesting() {
+  static base::NoDestructor<
+      base::RepeatingCallback<void(views::DialogDelegateView*)>>
+      callback;
+  return *callback;
+}
+
+gfx::FontList GetFont(int font_size, gfx::Font::Weight weight) {
+  gfx::FontList font_list;
+  return font_list.DeriveWithSizeDelta(font_size - font_list.GetFontSize())
+      .DeriveWithWeight(weight);
+}
+
+}  // namespace
+
+// Subclass for custom font.
+class DontAskAgainCheckbox : public views::Checkbox {
+ public:
+  METADATA_HEADER(DontAskAgainCheckbox);
+
+  using views::Checkbox::Checkbox;
+  ~DontAskAgainCheckbox() override = default;
+  DontAskAgainCheckbox(const DontAskAgainCheckbox&) = delete;
+  DontAskAgainCheckbox& operator=(const DontAskAgainCheckbox&) = delete;
+
+  void SetFontList(const gfx::FontList& font_list) {
+    label()->SetFontList(font_list);
+  }
+};
+
+BEGIN_METADATA(DontAskAgainCheckbox, views::Checkbox)
+END_METADATA
+
+// static
+void WindowClosingConfirmDialogView::Show(
+    Browser* browser,
+    base::OnceCallback<void(bool)> response_callback) {
+  // The dialog eats mouse events which results in the close button
+  // getting stuck in the hover state. Reset the window controls to
+  // prevent this.
+  BrowserView::GetBrowserViewForBrowser(browser)
+      ->GetWidget()
+      ->non_client_view()
+      ->ResetWindowControls();
+
+  auto* delegate =
+      new WindowClosingConfirmDialogView(browser, std::move(response_callback));
+  constrained_window::CreateBrowserModalDialogViews(
+      delegate, browser->window()->GetNativeWindow())
+      ->Show();
+
+  if (GetCreationCallbackForTesting())
+    GetCreationCallbackForTesting().Run(delegate);
+}
+
+// static
+void WindowClosingConfirmDialogView::SetCreationCallbackForTesting(
+    base::RepeatingCallback<void(views::DialogDelegateView*)>
+        creation_callback) {
+  GetCreationCallbackForTesting() = std::move(creation_callback);
+}
+
+WindowClosingConfirmDialogView::WindowClosingConfirmDialogView(
+    Browser* browser,
+    base::OnceCallback<void(bool)> response_callback)
+    : browser_(browser),
+      response_callback_(std::move(response_callback)),
+      prefs_(browser->profile()->GetPrefs()) {
+  set_should_ignore_snapping(true);
+  SetButtonLabel(ui::DIALOG_BUTTON_OK,
+                 l10n_util::GetStringUTF16(
+                     IDS_WINDOW_CLOSING_CONFIRM_DLG_OK_BUTTON_LABEL));
+  SetButtonLabel(ui::DIALOG_BUTTON_CANCEL,
+                 l10n_util::GetStringUTF16(
+                     IDS_WINDOW_CLOSING_CONFIRM_DLG_CANCEL_BUTTON_LABEL));
+  RegisterWindowClosingCallback(base::BindOnce(
+      &WindowClosingConfirmDialogView::OnClosing, base::Unretained(this)));
+  SetAcceptCallback(base::BindOnce(&WindowClosingConfirmDialogView::OnAccept,
+                                   base::Unretained(this)));
+  SetCancelCallback(base::BindOnce(&WindowClosingConfirmDialogView::OnCancel,
+                                   base::Unretained(this)));
+
+  constexpr int kChildSpacing = 16;
+  constexpr int kPadding = 24;
+  constexpr int kTopPadding = 32;
+  constexpr int kBottomPadding = 26;
+
+  SetLayoutManager(std::make_unique<views::BoxLayout>(
+      views::BoxLayout::Orientation::kVertical,
+      gfx::Insets(kTopPadding, kPadding, kBottomPadding, kPadding),
+      kChildSpacing));
+
+  constexpr int kHeaderFontSize = 15;
+  views::Label::CustomFont header_font = {
+      GetFont(kHeaderFontSize, gfx::Font::Weight::SEMIBOLD)};
+  auto* header_label = AddChildView(std::make_unique<views::Label>(
+      l10n_util::GetStringUTF16(IDS_WINDOW_CLOSING_CONFIRM_DLG_HEADER_LABEL),
+      header_font));
+  header_label->SetHorizontalAlignment(gfx::ALIGN_LEFT);
+
+  const int tab_count = browser_->tab_strip_model()->count();
+  const std::u16string tab_count_part = l10n_util::GetStringFUTF16Int(
+      IDS_WINDOW_CLOSING_CONFIRM_DLG_CONTENTS_LABEL_TAB_NUM_PART, tab_count);
+  size_t offset;
+
+  const std::u16string contents_text =
+      l10n_util::GetStringFUTF16(IDS_WINDOW_CLOSING_CONFIRM_DLG_CONTENTS_LABEL,
+                                 base::NumberToString16(tab_count), &offset);
+
+  auto* contents_label = AddChildView(std::make_unique<views::StyledLabel>());
+  contents_label->SetText(contents_text);
+
+  constexpr int kContentsFontSize = 14;
+  views::StyledLabel::RangeStyleInfo tab_count_style;
+  tab_count_style.custom_font =
+      GetFont(kContentsFontSize, gfx::Font::Weight::SEMIBOLD);
+  contents_label->AddStyleRange(
+      gfx::Range(offset, offset + tab_count_part.length()), tab_count_style);
+
+  views::StyledLabel::RangeStyleInfo default_style;
+  default_style.custom_font =
+      GetFont(kContentsFontSize, gfx::Font::Weight::NORMAL);
+  contents_label->AddStyleRange(
+      gfx::Range(offset + tab_count_part.length(), contents_text.length()),
+      default_style);
+  if (offset != 0)
+    contents_label->AddStyleRange(gfx::Range(0, offset), default_style);
+  constexpr int kMaxWidth = 389;
+  contents_label->SizeToFit(kMaxWidth);
+  contents_label->SetHorizontalAlignment(gfx::ALIGN_LEFT);
+
+  dont_ask_again_checkbox_ = AddChildView(
+      std::make_unique<DontAskAgainCheckbox>(l10n_util::GetStringUTF16(
+          IDS_WINDOW_CLOSING_CONFIRM_DLG_DONT_ASK_AGAIN_LABEL)));
+  dont_ask_again_checkbox_->SetFontList(
+      GetFont(kContentsFontSize, gfx::Font::Weight::NORMAL));
+}
+
+WindowClosingConfirmDialogView::~WindowClosingConfirmDialogView() = default;
+
+ui::ModalType WindowClosingConfirmDialogView::GetModalType() const {
+  return ui::MODAL_TYPE_WINDOW;
+}
+
+bool WindowClosingConfirmDialogView::ShouldShowCloseButton() const {
+  return false;
+}
+
+bool WindowClosingConfirmDialogView::ShouldShowWindowTitle() const {
+  return false;
+}
+
+void WindowClosingConfirmDialogView::OnAccept() {
+  close_window_ = true;
+}
+
+void WindowClosingConfirmDialogView::OnCancel() {
+  close_window_ = false;
+}
+
+void WindowClosingConfirmDialogView::OnClosing() {
+  prefs_->SetBoolean(kEnableWindowClosingConfirm,
+                     !dont_ask_again_checkbox_->GetChecked());
+  // Run callback here instead of by OnAccept() or OnCancel().
+  // This dialog is modal and this callback could launch another modal dialog.
+  // On macOS, new modal dialog seems not launched when this callback is called
+  // more earlier than this closing callback.
+  std::move(response_callback_).Run(close_window_);
+}
+
+BEGIN_METADATA(WindowClosingConfirmDialogView, views::DialogDelegateView)
+END_METADATA

--- a/browser/ui/views/window_closing_confirm_dialog_view.h
+++ b/browser/ui/views/window_closing_confirm_dialog_view.h
@@ -1,0 +1,60 @@
+/* Copyright (c) 2022 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_BROWSER_UI_VIEWS_WINDOW_CLOSING_CONFIRM_DIALOG_VIEW_H_
+#define BRAVE_BROWSER_UI_VIEWS_WINDOW_CLOSING_CONFIRM_DIALOG_VIEW_H_
+
+#include <memory>
+
+#include "base/callback_forward.h"
+#include "base/memory/raw_ptr.h"
+#include "ui/base/metadata/metadata_header_macros.h"
+#include "ui/views/window/dialog_delegate.h"
+
+class Browser;
+class PrefService;
+class DontAskAgainCheckbox;
+
+class WindowClosingConfirmDialogView : public views::DialogDelegateView {
+ public:
+  METADATA_HEADER(WindowClosingConfirmDialogView);
+
+  static void Show(Browser* browser,
+                   base::OnceCallback<void(bool)> response_callback);
+
+  WindowClosingConfirmDialogView(const WindowClosingConfirmDialogView&) =
+      delete;
+  WindowClosingConfirmDialogView& operator=(
+      const WindowClosingConfirmDialogView&) = delete;
+
+ private:
+  friend class WindowClosingConfirmBrowserTest;
+
+  static void SetCreationCallbackForTesting(
+      base::RepeatingCallback<void(views::DialogDelegateView*)>
+          creation_callback);
+
+  explicit WindowClosingConfirmDialogView(
+      Browser* browser,
+      base::OnceCallback<void(bool)> response_callback);
+  ~WindowClosingConfirmDialogView() override;
+
+  void OnAccept();
+  void OnCancel();
+  void OnClosing();
+
+  // views::DialogDelegate overrides:
+  ui::ModalType GetModalType() const override;
+  bool ShouldShowCloseButton() const override;
+  bool ShouldShowWindowTitle() const override;
+
+  bool close_window_ = true;
+  raw_ptr<Browser> browser_ = nullptr;
+  base::OnceCallback<void(bool)> response_callback_;
+  raw_ptr<PrefService> prefs_ = nullptr;
+  raw_ptr<DontAskAgainCheckbox> dont_ask_again_checkbox_ = nullptr;
+};
+
+#endif  // BRAVE_BROWSER_UI_VIEWS_WINDOW_CLOSING_CONFIRM_DIALOG_VIEW_H_

--- a/browser/ui/window_closing_confirm_browsertest.cc
+++ b/browser/ui/window_closing_confirm_browsertest.cc
@@ -1,0 +1,310 @@
+/* Copyright (c) 2022 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "base/bind.h"
+#include "base/run_loop.h"
+#include "brave/browser/ui/brave_browser.h"
+#include "brave/browser/ui/views/frame/brave_browser_view.h"
+#include "brave/browser/ui/views/window_closing_confirm_dialog_view.h"
+#include "brave/common/pref_names.h"
+#include "chrome/browser/download/download_manager_utils.h"
+#include "chrome/browser/download/download_prefs.h"
+#include "chrome/browser/lifetime/application_lifetime.h"
+#include "chrome/browser/profiles/profile.h"
+#include "chrome/browser/ui/browser.h"
+#include "chrome/browser/ui/browser_commands.h"
+#include "chrome/browser/ui/browser_finder.h"
+#include "chrome/browser/ui/browser_list.h"
+#include "chrome/browser/ui/tabs/tab_strip_model.h"
+#include "chrome/browser/ui/webui/profile_helper.h"
+#include "chrome/common/pref_names.h"
+#include "chrome/test/base/in_process_browser_test.h"
+#include "chrome/test/base/ui_test_utils.h"
+#include "components/javascript_dialogs/app_modal_dialog_controller.h"
+#include "components/javascript_dialogs/app_modal_dialog_view.h"
+#include "components/prefs/pref_service.h"
+#include "content/public/browser/download_manager.h"
+#include "content/public/test/browser_test.h"
+#include "content/public/test/download_test_observer.h"
+#include "content/public/test/test_download_http_response.h"
+#include "net/test/embedded_test_server/embedded_test_server.h"
+
+namespace {
+
+javascript_dialogs::AppModalDialogView* GetNextDialog() {
+  javascript_dialogs::AppModalDialogController* dialog =
+      ui_test_utils::WaitForAppModalDialog();
+  CHECK(dialog->view());
+  return dialog->view();
+}
+
+void AcceptClose() {
+  GetNextDialog()->AcceptAppModalDialog();
+}
+
+void CancelClose() {
+  GetNextDialog()->CancelAppModalDialog();
+}
+
+}  // namespace
+
+class WindowClosingConfirmBrowserTest : public InProcessBrowserTest {
+ public:
+  void SetUpOnMainThread() override {
+    InProcessBrowserTest::SetUpOnMainThread();
+
+    PrefService* prefs = browser()->profile()->GetPrefs();
+    // Disabled by default.
+    EXPECT_FALSE(prefs->GetBoolean(kEnableWindowClosingConfirm));
+
+    // Enable for testing.
+    prefs->SetBoolean(kEnableWindowClosingConfirm, true);
+
+    SetDialogCreationCallback();
+  }
+
+  void SetDialogCreationCallback() {
+    WindowClosingConfirmDialogView::SetCreationCallbackForTesting(
+        base::BindRepeating(&WindowClosingConfirmBrowserTest::
+                                OnWindowClosingConfirmDialogCreated,
+                            base::Unretained(this)));
+  }
+
+  void OnWindowClosingConfirmDialogCreated(views::DialogDelegateView* view) {
+    EXPECT_FALSE(closing_confirm_dialog_created_);
+
+    closing_confirm_dialog_created_ = true;
+    allow_to_close_ ? view->AcceptDialog() : view->CancelDialog();
+  }
+
+  void PrepareForBeforeUnloadDialog(content::WebContents* web_contents) {
+    content::PrepContentsForBeforeUnloadTest(web_contents);
+  }
+
+  void PrepareForBeforeUnloadDialog(Browser* browser) {
+    for (int i = 0; i < browser->tab_strip_model()->count(); i++)
+      PrepareForBeforeUnloadDialog(
+          browser->tab_strip_model()->GetWebContentsAt(i));
+  }
+
+  void WaitForAllBrowsersToClose() {
+    while (!BrowserList::GetInstance()->empty())
+      ui_test_utils::WaitForBrowserToClose();
+  }
+
+  void SetClosingBrowserCallbackAndWait() {
+    run_loop_ = std::make_unique<base::RunLoop>();
+    auto subscription =
+        chrome::AddClosingAllBrowsersCallback(base::BindRepeating(
+            &WindowClosingConfirmBrowserTest::OnClosingAllBrowserCallback,
+            base::Unretained(this)));
+    run_loop_->Run();
+    run_loop_.reset();
+  }
+
+  // To detect the timing when BeforeUnloadFired() is called.
+  void OnClosingAllBrowserCallback(bool closing) {
+    if (run_loop_)
+      run_loop_->Quit();
+  }
+
+  // Create a DownloadTestObserverInProgress that will wait for the
+  // specified number of downloads to start.
+  content::DownloadTestObserver* CreateInProgressWaiter(Browser* browser,
+                                                        int num_downloads) {
+    content::DownloadManager* download_manager =
+        DownloadManagerForBrowser(browser);
+    return new content::DownloadTestObserverInProgress(download_manager,
+                                                       num_downloads);
+  }
+
+  content::DownloadManager* DownloadManagerForBrowser(Browser* browser) {
+    return browser->profile()->GetDownloadManager();
+  }
+
+  DownloadPrefs* GetDownloadPrefs(Browser* browser) {
+    return DownloadPrefs::FromDownloadManager(
+        DownloadManagerForBrowser(browser));
+  }
+
+  base::FilePath GetDownloadDirectory(Browser* browser) {
+    return GetDownloadPrefs(browser)->DownloadPath();
+  }
+
+  content::TestDownloadResponseHandler* test_response_handler() {
+    return &test_response_handler_;
+  }
+
+  void SetDownloadConfirmReturn(bool allow) {
+    BraveBrowserView::SetDownloadConfirmReturnForTesting(allow);
+  }
+
+  content::TestDownloadResponseHandler test_response_handler_;
+  bool closing_confirm_dialog_created_ = false;
+  bool allow_to_close_ = false;
+  std::unique_ptr<base::RunLoop> run_loop_;
+};
+
+IN_PROC_BROWSER_TEST_F(WindowClosingConfirmBrowserTest, TestWithTwoNTPTabs) {
+  BraveBrowser* brave_browser = static_cast<BraveBrowser*>(browser());
+  // One tab. Doesn't need to ask.
+  EXPECT_FALSE(brave_browser->ShouldAskForBrowserClosingBeforeHandlers());
+
+  // Two tabs. Need to ask browser closing.
+  ui_test_utils::NavigateToURLWithDisposition(
+      brave_browser, GURL(url::kAboutBlankURL),
+      WindowOpenDisposition::NEW_FOREGROUND_TAB,
+      ui_test_utils::BROWSER_TEST_WAIT_FOR_LOAD_STOP);
+  EXPECT_TRUE(brave_browser->ShouldAskForBrowserClosingBeforeHandlers());
+
+  closing_confirm_dialog_created_ = false;
+  allow_to_close_ = true;
+  chrome::CloseWindow(brave_browser);
+  ui_test_utils::WaitForBrowserToClose(brave_browser);
+  EXPECT_TRUE(closing_confirm_dialog_created_);
+}
+
+IN_PROC_BROWSER_TEST_F(WindowClosingConfirmBrowserTest, TestWithQuit) {
+  BraveBrowser* brave_browser = static_cast<BraveBrowser*>(browser());
+  ui_test_utils::NavigateToURLWithDisposition(
+      brave_browser, GURL(url::kAboutBlankURL),
+      WindowOpenDisposition::NEW_FOREGROUND_TAB,
+      ui_test_utils::BROWSER_TEST_WAIT_FOR_LOAD_STOP);
+  // Should ask closing.
+  EXPECT_TRUE(brave_browser->ShouldAskForBrowserClosingBeforeHandlers());
+
+  // Should not ask for quit command.
+  closing_confirm_dialog_created_ = false;
+  chrome::CloseAllBrowsersAndQuit();
+  WaitForAllBrowsersToClose();
+  EXPECT_FALSE(closing_confirm_dialog_created_);
+}
+
+IN_PROC_BROWSER_TEST_F(WindowClosingConfirmBrowserTest,
+                       TestWithProfileDeletion) {
+  // Make two tabs.
+  ui_test_utils::NavigateToURLWithDisposition(
+      browser(), GURL(url::kAboutBlankURL),
+      WindowOpenDisposition::NEW_FOREGROUND_TAB,
+      ui_test_utils::BROWSER_TEST_WAIT_FOR_LOAD_STOP);
+  // Should ask closing for this browser window as this has more than one tab.
+  EXPECT_TRUE(static_cast<BraveBrowser*>(browser())
+                  ->ShouldAskForBrowserClosingBeforeHandlers());
+
+  // However, should not ask for profile deletion.
+  closing_confirm_dialog_created_ = false;
+  webui::DeleteProfileAtPath(browser()->profile()->GetPath(),
+                             ProfileMetrics::DELETE_PROFILE_SETTINGS);
+  ui_test_utils::WaitForBrowserToClose(browser());
+  EXPECT_FALSE(closing_confirm_dialog_created_);
+}
+
+IN_PROC_BROWSER_TEST_F(WindowClosingConfirmBrowserTest,
+                       TestWithOnBeforeUnload) {
+  ASSERT_TRUE(embedded_test_server()->Start());
+
+  BraveBrowser* brave_browser = static_cast<BraveBrowser*>(browser());
+  ASSERT_NO_FATAL_FAILURE(ASSERT_TRUE(ui_test_utils::NavigateToURL(
+      brave_browser, embedded_test_server()->GetURL("/beforeunload.html"))));
+  ui_test_utils::NavigateToURLWithDisposition(
+      brave_browser, GURL(url::kAboutBlankURL),
+      WindowOpenDisposition::NEW_FOREGROUND_TAB,
+      ui_test_utils::BROWSER_TEST_WAIT_FOR_LOAD_STOP);
+
+  PrepareForBeforeUnloadDialog(brave_browser);
+
+  // Check beforeunload dialog is launched after allowed to close window.
+  allow_to_close_ = true;
+  chrome::CloseWindow(brave_browser);
+  EXPECT_TRUE(closing_confirm_dialog_created_);
+  ASSERT_NO_FATAL_FAILURE(CancelClose());
+  SetClosingBrowserCallbackAndWait();
+  EXPECT_TRUE(brave_browser->ShouldAskForBrowserClosingBeforeHandlers());
+
+  // Check window closing dialog is launched again after cancelling
+  // beforeunlaod handler.
+  closing_confirm_dialog_created_ = false;
+  allow_to_close_ = true;
+  chrome::CloseWindow(brave_browser);
+  EXPECT_TRUE(closing_confirm_dialog_created_);
+
+  // Close browser
+  ASSERT_NO_FATAL_FAILURE(AcceptClose());
+  ui_test_utils::WaitForBrowserToClose(brave_browser);
+}
+
+IN_PROC_BROWSER_TEST_F(WindowClosingConfirmBrowserTest, TestWithDownload) {
+// On macOS, download in-progress warning is not shown for normal profile window
+// closing as it can still continue after window is closed.
+// However, private profile window works like normal window of other platforms.
+// So, test with private profile window on macOS.
+#if BUILDFLAG(IS_MAC)
+  auto* brave_browser = static_cast<BraveBrowser*>(CreateIncognitoBrowser());
+#else
+  auto* brave_browser = static_cast<BraveBrowser*>(browser());
+#endif
+  brave_browser->profile()->GetPrefs()->SetBoolean(prefs::kPromptForDownload,
+                                                   false);
+
+  test_response_handler()->RegisterToTestServer(embedded_test_server());
+  ASSERT_TRUE(embedded_test_server()->Start());
+  GURL url = embedded_test_server()->GetURL("/large_file");
+
+  content::TestDownloadHttpResponse::Parameters parameters;
+  parameters.size = 1024 * 1024 * 32; /* 32MB file. */
+  content::TestDownloadHttpResponse::StartServing(parameters, url);
+
+  // Ensure that we have enough disk space to download the large file.
+  {
+    base::ScopedAllowBlockingForTesting allow_blocking;
+    int64_t free_space = base::SysInfo::AmountOfFreeDiskSpace(
+        GetDownloadDirectory(brave_browser));
+    ASSERT_LE(parameters.size, free_space)
+        << "Not enough disk space to download. Got " << free_space;
+  }
+
+  // Make browser has two tabs.
+  ui_test_utils::NavigateToURLWithDisposition(
+      brave_browser, GURL(url::kAboutBlankURL),
+      WindowOpenDisposition::NEW_FOREGROUND_TAB,
+      ui_test_utils::BROWSER_TEST_WAIT_FOR_LOAD_STOP);
+
+  std::unique_ptr<content::DownloadTestObserver> progress_waiter(
+      CreateInProgressWaiter(brave_browser, 1));
+
+  // Start downloading a file, wait for it to be created.
+  ui_test_utils::NavigateToURLWithDisposition(
+      brave_browser, url, WindowOpenDisposition::CURRENT_TAB,
+      ui_test_utils::BROWSER_TEST_NONE);
+  progress_waiter->WaitForFinished();
+
+  EXPECT_EQ(1u, progress_waiter->NumDownloadsSeenInState(
+                    download::DownloadItem::IN_PROGRESS));
+
+  // Don't allow window closing while downloading.
+  allow_to_close_ = false;
+  closing_confirm_dialog_created_ = false;
+  SetDownloadConfirmReturn(false);
+  chrome::CloseWindow(brave_browser);
+  EXPECT_TRUE(closing_confirm_dialog_created_);
+  EXPECT_TRUE(brave_browser->ShouldAskForBrowserClosingBeforeHandlers());
+
+  // Allow window closing while downloading and don't cancel downloading.
+  // Then, we could ask window closing again.
+  allow_to_close_ = true;
+  closing_confirm_dialog_created_ = false;
+  SetDownloadConfirmReturn(false);
+  chrome::CloseWindow(brave_browser);
+  EXPECT_TRUE(closing_confirm_dialog_created_);
+  SetClosingBrowserCallbackAndWait();
+  EXPECT_TRUE(brave_browser->ShouldAskForBrowserClosingBeforeHandlers());
+
+  // Close window again by cancelling download to terminate test.
+  allow_to_close_ = true;
+  closing_confirm_dialog_created_ = false;
+  SetDownloadConfirmReturn(true);
+  chrome::CloseWindow(brave_browser);
+  EXPECT_TRUE(closing_confirm_dialog_created_);
+}

--- a/chromium_src/chrome/browser/lifetime/browser_close_manager.cc
+++ b/chromium_src/chrome/browser/lifetime/browser_close_manager.cc
@@ -1,0 +1,39 @@
+/* Copyright 2022 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "chrome/browser/lifetime/browser_close_manager.h"
+
+#define StartClosingBrowsers StartClosingBrowsers_ChromiumImpl
+#define CancelBrowserClose CancelBrowserClose_ChromiumImpl
+
+#include "src/chrome/browser/lifetime/browser_close_manager.cc"
+
+#undef CancelBrowserClose
+#undef StartClosingBrowsers
+
+namespace {
+
+// Whether the browser closing is in-progress or not.
+// Introduced this new flag instead of using browser_shutdown::IsTryingToQuit()
+// because it returns true when all browser windows are closed on Windows/Linux.
+// I assume that the reason is background running on Windows/Linux.
+bool g_browser_closing_started = false;
+
+}  // namespace
+
+// static
+bool BrowserCloseManager::BrowserClosingStarted() {
+  return g_browser_closing_started;
+}
+
+void BrowserCloseManager::StartClosingBrowsers() {
+  g_browser_closing_started = true;
+  StartClosingBrowsers_ChromiumImpl();
+}
+
+void BrowserCloseManager::CancelBrowserClose() {
+  g_browser_closing_started = false;
+  CancelBrowserClose_ChromiumImpl();
+}

--- a/chromium_src/chrome/browser/lifetime/browser_close_manager.h
+++ b/chromium_src/chrome/browser/lifetime/browser_close_manager.h
@@ -1,0 +1,23 @@
+/* Copyright 2022 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_CHROMIUM_SRC_CHROME_BROWSER_LIFETIME_BROWSER_CLOSE_MANAGER_H_
+#define BRAVE_CHROMIUM_SRC_CHROME_BROWSER_LIFETIME_BROWSER_CLOSE_MANAGER_H_
+
+#define StartClosingBrowsers           \
+  StartClosingBrowsers();              \
+  static bool BrowserClosingStarted(); \
+  void StartClosingBrowsers_ChromiumImpl
+
+#define CancelBrowserClose \
+  CancelBrowserClose();    \
+  void CancelBrowserClose_ChromiumImpl
+
+#include "src/chrome/browser/lifetime/browser_close_manager.h"
+
+#undef CancelBrowserClose
+#undef StartClosingBrowsers
+
+#endif  // BRAVE_CHROMIUM_SRC_CHROME_BROWSER_LIFETIME_BROWSER_CLOSE_MANAGER_H_

--- a/chromium_src/chrome/browser/ui/browser.h
+++ b/chromium_src/chrome/browser/ui/browser.h
@@ -6,8 +6,13 @@
 #ifndef BRAVE_CHROMIUM_SRC_CHROME_BROWSER_UI_BROWSER_H_
 #define BRAVE_CHROMIUM_SRC_CHROME_BROWSER_UI_BROWSER_H_
 
+#include "chrome/browser/ui/unload_controller.h"
+
+#define FinishWarnBeforeClosing virtual FinishWarnBeforeClosing
 #define ScheduleUIUpdate virtual ScheduleUIUpdate
 #define ShouldDisplayFavicon virtual ShouldDisplayFavicon
+#define TryToCloseWindow virtual TryToCloseWindow
+#define ResetTryToCloseWindow virtual ResetTryToCloseWindow
 #define BRAVE_BROWSER_H              \
  private:                            \
   friend class BookmarkPrefsService; \
@@ -16,7 +21,10 @@
 #include "src/chrome/browser/ui/browser.h"
 
 #undef BRAVE_BROWSER_H
-#undef ScheduleUIUpdate
+#undef ResetTryToCloseWindow
+#undef TryToCloseWindow
 #undef ShouldDisplayFavicon
+#undef ScheduleUIUpdate
+#undef FinishWarnBeforeClosing
 
 #endif  // BRAVE_CHROMIUM_SRC_CHROME_BROWSER_UI_BROWSER_H_

--- a/chromium_src/chrome/browser/ui/webui/settings/settings_localized_strings_provider.cc
+++ b/chromium_src/chrome/browser/ui/webui/settings/settings_localized_strings_provider.cc
@@ -254,6 +254,8 @@ void BraveAddCommonStrings(content::WebUIDataSource* html_source,
     {"braveHelpTips", IDS_SETTINGS_HELP_TIPS},
     {"braveHelpTipsWaybackMachineLabel",
      IDS_SETTINGS_HELP_TIPS_SHOW_BRAVE_WAYBACK_MACHINE_PROMPT},
+    {"braveHelpTipsWarnBeforeClosingWindow",
+     IDS_SETTINGS_WINDOW_CLOSING_CONFIRM_OPTION_LABEL},
     // New Tab Page
     {"braveNewTab", IDS_SETTINGS_NEW_TAB},
     {"braveNewTabBraveRewards", IDS_SETTINGS_NEW_TAB_BRAVE_REWARDS},

--- a/common/pref_names.cc
+++ b/common/pref_names.cc
@@ -110,6 +110,11 @@ const char kSafetynetCheckFailed[] = "safetynetcheck.failed";
 const char kSafetynetStatus[] = "safetynet.status";
 #endif
 
+#if !BUILDFLAG(IS_ANDROID)
+const char kEnableWindowClosingConfirm[] =
+    "brave.enable_window_closing_confirm";
+#endif
+
 const char kDefaultBrowserLaunchingCount[] =
     "brave.default_browser.launching_count";
 

--- a/common/pref_names.h
+++ b/common/pref_names.h
@@ -91,6 +91,10 @@ extern const char kSafetynetCheckFailed[];
 extern const char kSafetynetStatus[];
 #endif
 
+#if !BUILDFLAG(IS_ANDROID)
+extern const char kEnableWindowClosingConfirm[];
+#endif
+
 extern const char kDefaultBrowserLaunchingCount[];
 extern const char kTabsSearchShow[];
 extern const char kDontAskForCrashReporting[];


### PR DESCRIPTION
fix https://github.com/brave/brave-browser/issues/10430

Window closing confirm dialog will be shown when user tries to
close each window. This dialog is shown before any warning/beforeunload
handlers. This confirm dialog is not launched when window is closed by
application quit command. This confirmation is disabled by default.

<img width="500" alt="Screen Shot 2022-04-15 at 12 50 44 PM" src="https://user-images.githubusercontent.com/6786187/163515401-d95342c1-68f4-42a0-9dae-abf3754c6e33.png">

**Windows/Linux**
![image](https://user-images.githubusercontent.com/6786187/164155587-04257423-e84a-49d3-98f9-5c7ff0bfadaf.png)


**macOS** - note: show warning before quit option is also moved to help tips section
<img width="722" alt="Screen Shot 2022-04-20 at 1 49 56 PM" src="https://user-images.githubusercontent.com/6786187/164152789-7b9e6ad6-2564-4de5-b83f-af69ba783701.png">

**macOS** - Appearance section doesn't have warning before quit option.
<img width="750" alt="Screen Shot 2022-04-20 at 1 50 15 PM" src="https://user-images.githubusercontent.com/6786187/164152797-c2dc447d-ca90-45e5-84da-c9e8669c8495.png">


<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves 

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
`npm run test brave_browser_tests -- --filter=WindowClosingConfirmBrowserTest*`

**Basic Test**
1. Launch Brave and check settings option is disabled by default at brave://settings/braveHelpTips
2. Create new window and create more than one NTP tabs
3. Try to close window by clicking close button or window closing shortcut (alt + f4, or cmd+shift+w on macOS)
4. Check window closing dialog is not launched before window is closed.
5. Enable this option at brave://settings/braveHelpTips
6. Repeat step 2,3 
7. Check window closing dialog is launched and checkbox is not selected
8. Select `Cancel`
9. Repeat step 3 and check dialog is launched again
10. Select `Close all` and check window is closed.
11. Repeat step 2,3 and Select `Cancel`  after checking don't ask me again checkbox
12. Repeat step 3 and Check window is closed w/o window closing dialog

**Test with onbeforeunload handler**
1. Launch Browser and set option is enabled
2. Create window and create more than one NTP tabs
3. Load https://www.w3schools.com/jsref/tryit.asp?filename=tryjsref_onbeforeunload in one NTP and click `Click here to go to w3schools.com` and check beforeunload dialog is launched. Then, dismiss it.
4. Try to close window by clicking close button or window closing shortcut (alt + f4, or cmd+shift+w on macOS)
5. Select `Close all` and check beforeunload dialog is launched
6. Cancel beforeunlaod dialog
7. Repeat step 4 and check window closing dialog is shown again
8. Select `Close all` and also `Leave` from beforeunload dialog and check window is closed

**Test with download in-progress handler**
(Note: On macOS, download warning dialog is not shown on normal profile. Private window will have same behavior on macOS with other platform's normal window)
1. Launch Browser and set option is enabled
2. Create window and create more than one NTP tabs
3. Load https://ubuntu.com/download/desktop/thank-you?version=22.04&architecture=amd64 and start download
4. Try to close window by clicking close button or window closing shortcut (alt + f4, or cmd+shift+w on macOS)
5. Select `Close all` from window closing dialog and check `Download in-progress` warning dialog is launched
6. Select `Continue downloading`
7. Repeat step 4 and check window closing dialog is launched again
8. Select `Close all` from window closing dialog and select `Exit` from `Download in-progress` warning dialog
9. Check window is closed.

**Test with onbeforeunload and download in-progress handler**
(Note: On macOS, download warning dialog is not shown on normal profile. Private window will have same behavior on macOS with other platform's normal window)
1. Launch Browser and set option is enabled
2. Create window and create more than one NTP tabs
3. Load https://ubuntu.com/download/desktop/thank-you?version=22.04&architecture=amd64 and start download
4. Load https://www.w3schools.com/jsref/tryit.asp?filename=tryjsref_onbeforeunload in one NTP and click `Click here to go to w3schools.com` and check beforeunload dialog is launched. Then, dismiss it.
5. Try to close window by clicking close button or window closing shortcut (alt + f4, or cmd+shift+w on macOS)
6. Check download warning or beforeunload dialog is launched one by one after selecting `Close all` from window closing dialog

**Test with reboot/restart**
1. Launch Browser and set option is enabled
2. Create window and create more than one NTP tabs
3. Load brave://restart and check window closing dialog is not launched
4. Repeat step 1,2 and load brave://quit and check window closing dialog is not launched

**Test with profile deletion**
1. Launch Browser and set option is enabled
2. Create window with more than one tabs
3. Delete active profile and check window closing confirm dialog is not launched.

**Windows/Linux specific test**
1. Launch Browser and set option is enabled
4. Create window and create more than one NTP tabs
5. Repeat step 2 to recreate another window with multiple tabs
6. Do closing all windows from app icon's context menu at Dock(linux) or at Taskbar(Windows)
7. Check each Windows' closing is done separately like above

**macOS specfic test**
1. Launch Browser and set option is enabled
2. Create window and create more than one NTP tabs
3. Repeat step 2 to recreate another window with multiple tabs
4. Do quit request from app icon's context menu at Dock or using quit shortcut (cmd+Q)
6. Check closing window dialog is not launched for all windows
    (This is `Quit` command not `Closing all windows` So, closing confirm dialog is not used here.)