### PR TITLE
Fixed shields icon state is not updated in inactive window

### DIFF
--- a/browser/ui/brave_shields_data_controller.cc
+++ b/browser/ui/brave_shields_data_controller.cc
@@ -13,11 +13,23 @@
 #include "chrome/browser/browser_process.h"
 #include "chrome/browser/content_settings/host_content_settings_map_factory.h"
 #include "chrome/browser/profiles/profile.h"
+#include "components/content_settings/core/common/content_settings_pattern.h"
 #include "components/favicon/content/content_favicon_driver.h"
 #include "content/public/browser/navigation_handle.h"
+#include "content/public/browser/web_contents.h"
 #include "net/base/url_util.h"
 
 using net::AppendQueryParameter;
+
+namespace {
+
+HostContentSettingsMap* GetHostContentSettingsMap(
+    content::WebContents* web_contents) {
+  return HostContentSettingsMapFactory::GetForProfile(
+      web_contents->GetBrowserContext());
+}
+
+}  // namespace
 
 namespace brave_shields {
 
@@ -29,6 +41,7 @@ BraveShieldsDataController::BraveShieldsDataController(
       content::WebContentsUserData<BraveShieldsDataController>(*web_contents) {
   favicon::ContentFaviconDriver::FromWebContents(web_contents)
       ->AddObserver(this);
+  observation_.Observe(GetHostContentSettingsMap(web_contents));
 }
 
 void BraveShieldsDataController::DidFinishNavigation(
@@ -42,6 +55,18 @@ void BraveShieldsDataController::DidFinishNavigation(
 void BraveShieldsDataController::WebContentsDestroyed() {
   favicon::ContentFaviconDriver::FromWebContents(web_contents())
       ->RemoveObserver(this);
+  observation_.Reset();
+}
+
+void BraveShieldsDataController::OnContentSettingChanged(
+    const ContentSettingsPattern& primary_pattern,
+    const ContentSettingsPattern& secondary_pattern,
+    ContentSettingsTypeSet content_type_set) {
+  if (content_type_set.GetType() == ContentSettingsType::BRAVE_SHIELDS &&
+      primary_pattern.Matches(GetCurrentSiteURL())) {
+    for (Observer& obs : observer_list_)
+      obs.OnShieldsEnabledChanged();
+  }
 }
 
 void BraveShieldsDataController::OnFaviconUpdated(
@@ -119,16 +144,14 @@ std::vector<GURL> BraveShieldsDataController::GetFingerprintsList() {
 }
 
 bool BraveShieldsDataController::GetBraveShieldsEnabled() {
-  auto* map = HostContentSettingsMapFactory::GetForProfile(
-      web_contents()->GetBrowserContext());
-  return brave_shields::GetBraveShieldsEnabled(map, GetCurrentSiteURL());
+  return brave_shields::GetBraveShieldsEnabled(
+      GetHostContentSettingsMap(web_contents()), GetCurrentSiteURL());
 }
 
 void BraveShieldsDataController::SetBraveShieldsEnabled(bool is_enabled) {
-  auto* map = HostContentSettingsMapFactory::GetForProfile(
-      web_contents()->GetBrowserContext());
-
-  brave_shields::SetBraveShieldsEnabled(map, is_enabled, GetCurrentSiteURL());
+  brave_shields::SetBraveShieldsEnabled(
+      GetHostContentSettingsMap(web_contents()), is_enabled,
+      GetCurrentSiteURL());
   ReloadWebContents();
 }
 
@@ -153,8 +176,7 @@ GURL BraveShieldsDataController::GetFaviconURL(bool refresh) {
 }
 
 AdBlockMode BraveShieldsDataController::GetAdBlockMode() {
-  auto* map = HostContentSettingsMapFactory::GetForProfile(
-      web_contents()->GetBrowserContext());
+  auto* map = GetHostContentSettingsMap(web_contents());
 
   ControlType control_type_ad =
       brave_shields::GetAdControlType(map, GetCurrentSiteURL());
@@ -174,11 +196,8 @@ AdBlockMode BraveShieldsDataController::GetAdBlockMode() {
 }
 
 FingerprintMode BraveShieldsDataController::GetFingerprintMode() {
-  auto* map = HostContentSettingsMapFactory::GetForProfile(
-      web_contents()->GetBrowserContext());
-
-  ControlType control_type =
-      brave_shields::GetFingerprintingControlType(map, GetCurrentSiteURL());
+  ControlType control_type = brave_shields::GetFingerprintingControlType(
+      GetHostContentSettingsMap(web_contents()), GetCurrentSiteURL());
 
   if (control_type == ControlType::ALLOW) {
     return FingerprintMode::ALLOW;
@@ -190,11 +209,8 @@ FingerprintMode BraveShieldsDataController::GetFingerprintMode() {
 }
 
 CookieBlockMode BraveShieldsDataController::GetCookieBlockMode() {
-  auto* map = HostContentSettingsMapFactory::GetForProfile(
-      web_contents()->GetBrowserContext());
-
-  ControlType control_type =
-      brave_shields::GetCookieControlType(map, GetCurrentSiteURL());
+  ControlType control_type = brave_shields::GetCookieControlType(
+      GetHostContentSettingsMap(web_contents()), GetCurrentSiteURL());
 
   if (control_type == ControlType::ALLOW) {
     return CookieBlockMode::ALLOW;
@@ -206,16 +222,13 @@ CookieBlockMode BraveShieldsDataController::GetCookieBlockMode() {
 }
 
 bool BraveShieldsDataController::GetHTTPSEverywhereEnabled() {
-  auto* map = HostContentSettingsMapFactory::GetForProfile(
-      web_contents()->GetBrowserContext());
-  return brave_shields::GetHTTPSEverywhereEnabled(map, GetCurrentSiteURL());
+  return brave_shields::GetHTTPSEverywhereEnabled(
+      GetHostContentSettingsMap(web_contents()), GetCurrentSiteURL());
 }
 
 bool BraveShieldsDataController::GetNoScriptEnabled() {
-  auto* map = HostContentSettingsMapFactory::GetForProfile(
-      web_contents()->GetBrowserContext());
-  ControlType control_type =
-      brave_shields::GetNoScriptControlType(map, GetCurrentSiteURL());
+  ControlType control_type = brave_shields::GetNoScriptControlType(
+      GetHostContentSettingsMap(web_contents()), GetCurrentSiteURL());
 
   if (control_type == ControlType::ALLOW) {
     return false;
@@ -225,8 +238,7 @@ bool BraveShieldsDataController::GetNoScriptEnabled() {
 }
 
 void BraveShieldsDataController::SetAdBlockMode(AdBlockMode mode) {
-  auto* map = HostContentSettingsMapFactory::GetForProfile(
-      web_contents()->GetBrowserContext());
+  auto* map = GetHostContentSettingsMap(web_contents());
 
   ControlType control_type_ad;
   ControlType control_type_cosmetic;
@@ -259,9 +271,6 @@ void BraveShieldsDataController::SetAdBlockMode(AdBlockMode mode) {
 }
 
 void BraveShieldsDataController::SetFingerprintMode(FingerprintMode mode) {
-  auto* map = HostContentSettingsMapFactory::GetForProfile(
-      web_contents()->GetBrowserContext());
-
   ControlType control_type;
 
   if (mode == FingerprintMode::ALLOW) {
@@ -276,16 +285,13 @@ void BraveShieldsDataController::SetFingerprintMode(FingerprintMode mode) {
       Profile::FromBrowserContext(web_contents()->GetBrowserContext())
           ->GetPrefs();
   brave_shields::SetFingerprintingControlType(
-      map, control_type, GetCurrentSiteURL(), g_browser_process->local_state(),
-      profile_prefs);
+      GetHostContentSettingsMap(web_contents()), control_type,
+      GetCurrentSiteURL(), g_browser_process->local_state(), profile_prefs);
 
   ReloadWebContents();
 }
 
 void BraveShieldsDataController::SetCookieBlockMode(CookieBlockMode mode) {
-  auto* map = HostContentSettingsMapFactory::GetForProfile(
-      web_contents()->GetBrowserContext());
-
   ControlType control_type;
 
   if (mode == CookieBlockMode::ALLOW) {
@@ -296,16 +302,14 @@ void BraveShieldsDataController::SetCookieBlockMode(CookieBlockMode mode) {
     control_type = ControlType::BLOCK;  // STANDARD
   }
 
-  brave_shields::SetCookieControlType(map, control_type, GetCurrentSiteURL(),
+  brave_shields::SetCookieControlType(GetHostContentSettingsMap(web_contents()),
+                                      control_type, GetCurrentSiteURL(),
                                       g_browser_process->local_state());
 
   ReloadWebContents();
 }
 
 void BraveShieldsDataController::SetIsNoScriptEnabled(bool is_enabled) {
-  auto* map = HostContentSettingsMapFactory::GetForProfile(
-      web_contents()->GetBrowserContext());
-
   ControlType control_type;
 
   if (!is_enabled) {
@@ -314,18 +318,17 @@ void BraveShieldsDataController::SetIsNoScriptEnabled(bool is_enabled) {
     control_type = ControlType::BLOCK;
   }
 
-  brave_shields::SetNoScriptControlType(map, control_type, GetCurrentSiteURL(),
-                                        g_browser_process->local_state());
+  brave_shields::SetNoScriptControlType(
+      GetHostContentSettingsMap(web_contents()), control_type,
+      GetCurrentSiteURL(), g_browser_process->local_state());
 
   ReloadWebContents();
 }
 
 void BraveShieldsDataController::SetIsHTTPSEverywhereEnabled(bool is_enabled) {
-  auto* map = HostContentSettingsMapFactory::GetForProfile(
-      web_contents()->GetBrowserContext());
-
-  brave_shields::SetHTTPSEverywhereEnabled(map, is_enabled, GetCurrentSiteURL(),
-                                           g_browser_process->local_state());
+  brave_shields::SetHTTPSEverywhereEnabled(
+      GetHostContentSettingsMap(web_contents()), is_enabled,
+      GetCurrentSiteURL(), g_browser_process->local_state());
 
   ReloadWebContents();
 }

--- a/browser/ui/brave_shields_data_controller_unittest.cc
+++ b/browser/ui/brave_shields_data_controller_unittest.cc
@@ -22,6 +22,7 @@
 #include "content/public/test/browser_task_environment.h"
 #include "content/public/test/test_renderer_host.h"
 #include "content/public/test/web_contents_tester.h"
+#include "testing/gmock/include/gmock/gmock.h"
 #include "testing/gtest/include/gtest/gtest.h"
 
 using brave_shields::BraveShieldsDataController;
@@ -30,6 +31,12 @@ using brave_shields::mojom::AdBlockMode;
 
 namespace {
 constexpr char kTestProfileName[] = "TestProfile";
+
+class MockObserver : public BraveShieldsDataController::Observer {
+ public:
+  MOCK_METHOD(void, OnResourcesChanged, (), (override));
+  MOCK_METHOD(void, OnShieldsEnabledChanged, (), (override));
+};
 }  // namespace
 
 class BraveShieldsDataControllerTest : public testing::Test {
@@ -325,4 +332,48 @@ TEST_F(BraveShieldsDataControllerTest, GetAdBlockMode_ForOrigin) {
   SetContentSettingFor(ContentSettingsType::BRAVE_COSMETIC_FILTERING,
                        CONTENT_SETTING_BLOCK, GURL("https://firstParty/"));
   EXPECT_EQ(controller->GetAdBlockMode(), AdBlockMode::AGGRESSIVE);
+}
+
+TEST_F(BraveShieldsDataControllerTest, Observer_OnShieldsEnabledChangedTest) {
+  // Set url for default web contents.
+  SetLastCommittedUrl(GURL("http://brave.com"));
+
+  // Create another web contents for testing whether its
+  // OnShieldsEnabledChanged() callback is called when shields enabled is
+  // changed by another web contents when both loaded same url.
+  MockObserver observer_2;
+  EXPECT_CALL(observer_2, OnShieldsEnabledChanged).Times(1);
+  auto web_contents_2 =
+      content::WebContentsTester::CreateTestWebContents(profile(), nullptr);
+  favicon::ContentFaviconDriver::CreateForWebContents(web_contents_2.get(),
+                                                      nullptr);
+  BraveShieldsDataController::CreateForWebContents(web_contents_2.get());
+  auto* ctrl_2 =
+      BraveShieldsDataController::FromWebContents(web_contents_2.get());
+  ctrl_2->AddObserver(&observer_2);
+  content::WebContentsTester::For(web_contents_2.get())
+      ->SetLastCommittedURL(GURL("http://brave.com"));
+
+  // Create another web contents for testing whether its
+  // OnShieldsEnabledChanged() callback is *not* called when shields enabled is
+  // changed by another web contents when both loaded *different* url.
+  MockObserver observer_3;
+  EXPECT_CALL(observer_3, OnShieldsEnabledChanged).Times(0);
+  auto web_contents_3 =
+      content::WebContentsTester::CreateTestWebContents(profile(), nullptr);
+  favicon::ContentFaviconDriver::CreateForWebContents(web_contents_3.get(),
+                                                      nullptr);
+  BraveShieldsDataController::CreateForWebContents(web_contents_3.get());
+  auto* ctrl_3 =
+      BraveShieldsDataController::FromWebContents(web_contents_3.get());
+  ctrl_3->AddObserver(&observer_3);
+  content::WebContentsTester::For(web_contents_3.get())
+      ->SetLastCommittedURL(GURL("http://github.com"));
+
+  // Change default web contents' shields enabled setting.
+  // And this changes will affect |web_contents_2| as both loaded same url.
+  GetShieldsDataController()->SetBraveShieldsEnabled(false);
+
+  ctrl_2->RemoveObserver(&observer_2);
+  ctrl_3->RemoveObserver(&observer_3);
 }

--- a/browser/ui/views/brave_actions/brave_shields_action_view.cc
+++ b/browser/ui/views/brave_actions/brave_shields_action_view.cc
@@ -235,6 +235,10 @@ void BraveShieldsActionView::OnResourcesChanged() {
   UpdateIconState();
 }
 
+void BraveShieldsActionView::OnShieldsEnabledChanged() {
+  UpdateIconState();
+}
+
 void BraveShieldsActionView::OnTabStripModelChanged(
     TabStripModel* tab_strip_model,
     const TabStripModelChange& change,

--- a/browser/ui/views/brave_actions/brave_shields_action_view.h
+++ b/browser/ui/views/brave_actions/brave_shields_action_view.h
@@ -45,6 +45,7 @@ class BraveShieldsActionView
   std::unique_ptr<IconWithBadgeImageSource> GetImageSource();
   // brave_shields::BraveShieldsDataController
   void OnResourcesChanged() override;
+  void OnShieldsEnabledChanged() override;
   // TabStripModelObserver
   void OnTabStripModelChanged(
       TabStripModel* tab_strip_model,


### PR DESCRIPTION
fix https://github.com/brave/brave-browser/issues/22359

When shields is down by window's tab, another inactive window's shields icon
state was not changed when inactive window's active tab loaded same site.
Fixed by observing HostContentSettingsMap from BraveShieldsDataController,
and notified to its observers when it's changed.

<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves 

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

See the linked issue