### PR TITLE
[Android] Brave news re-enable optin card (uplift to 1.38.x)

### DIFF
--- a/android/java/org/chromium/chrome/browser/ntp/BraveNewTabPageLayout.java
+++ b/android/java/org/chromium/chrome/browser/ntp/BraveNewTabPageLayout.java
@@ -681,14 +681,9 @@ public class BraveNewTabPageLayout
                 mIsShowOptin =
                         sharedPreferences.getBoolean(BraveNewsPreferences.PREF_SHOW_OPTIN, false);
                 mIsShowNewsOn = BravePrefServiceBridge.getInstance().getShowNews();
-                if ((!mIsNewsOn && mIsShowOptin) || (mIsNewsOn && !mIsShowOptin)) {
-                    SharedPreferences.Editor sharedPreferencesEditor = sharedPreferences.edit();
-                    sharedPreferencesEditor.putBoolean(BraveNewsPreferences.PREF_SHOW_OPTIN, true);
-                    sharedPreferencesEditor.apply();
-                    mOptinLayout.setVisibility(View.VISIBLE);
-                    mRecyclerView.setVisibility(View.GONE);
-                    initNews();
-                }
+                mOptinLayout.setVisibility(View.GONE);
+                mRecyclerView.setVisibility(View.VISIBLE);
+                initNews();
             }
         };
     }
@@ -1068,7 +1063,7 @@ public class BraveNewTabPageLayout
         SharedPreferences sharedPreferences = ContextUtils.getAppSharedPreferences();
 
         mIsNewsOn = BravePrefServiceBridge.getInstance().getNewsOptIn();
-        mIsShowOptin = sharedPreferences.getBoolean(BraveNewsPreferences.PREF_SHOW_OPTIN, false);
+        mIsShowOptin = sharedPreferences.getBoolean(BraveNewsPreferences.PREF_SHOW_OPTIN, true);
         mIsShowNewsOn = BravePrefServiceBridge.getInstance().getShowNews();
 
         if ((!mIsNewsOn && mIsShowOptin) || (mIsNewsOn && mIsShowOptin)) {
@@ -1508,6 +1503,8 @@ public class BraveNewTabPageLayout
                     SharedPreferences.Editor sharedPreferencesEditor = sharedPreferences.edit();
                     sharedPreferencesEditor.putBoolean(BraveNewsPreferences.PREF_SHOW_OPTIN, false);
                     sharedPreferencesEditor.apply();
+                    BravePrefServiceBridge.getInstance().setNewsOptIn(true);
+                    BravePrefServiceBridge.getInstance().setShowNews(false);
                     correctPosition(false);
                     mParentScrollView.fullScroll(ScrollView.FOCUS_UP);
                     mImageCreditLayout.setAlpha(1.0f);

--- a/android/java/org/chromium/chrome/browser/settings/BraveNewsPreferences.java
+++ b/android/java/org/chromium/chrome/browser/settings/BraveNewsPreferences.java
@@ -196,29 +196,43 @@ public class BraveNewsPreferences extends BravePreferenceFragment
             mAddSource.setText("");
         }
 
-        // Ensure the shownews pref is false when it's unchechecked
-        if (!mShowNews.isChecked()) {
-            BravePrefServiceBridge.getInstance().setShowNews(false);
+        boolean isNewsOn = BravePrefServiceBridge.getInstance().getNewsOptIn();
+        boolean isShowNewsOn = BravePrefServiceBridge.getInstance().getShowNews();
+        if (isNewsOn) {
+            mTurnOnNews.setVisible(false);
+            mShowNews.setVisible(true);
+            if (isShowNewsOn) {
+                mShowNews.setChecked(true);
+            }
+            setSourcesVisibility(isShowNewsOn);
+        } else {
+            mTurnOnNews.setChecked(false);
+            mShowNews.setVisible(false);
+            setSourcesVisibility(isNewsOn);
         }
-        mTurnOnNews.setVisible(false);
-        setSourcesVisibility(BravePrefServiceBridge.getInstance().getShowNews());
     }
 
     @Override
     public boolean onPreferenceChange(Preference preference, Object newValue) {
         String key = preference.getKey();
         if (PREF_TURN_ON_NEWS.equals(key)) {
-            // Unused for now as we temporarly remove the Enable switch
-            BravePrefServiceBridge.getInstance().setShowNews(false);
+            if ((boolean) newValue) {
+                mTurnOnNews.setVisible(false);
+                mShowNews.setVisible(true);
+                mShowNews.setChecked(true);
+                BravePrefServiceBridge.getInstance().setNewsOptIn(true);
+                BravePrefServiceBridge.getInstance().setShowNews(true);
+                SharedPreferences.Editor sharedPreferencesEditor =
+                        ContextUtils.getAppSharedPreferences().edit();
+                sharedPreferencesEditor.putBoolean(BraveNewsPreferences.PREF_SHOW_OPTIN, false);
+                sharedPreferencesEditor.apply();
+            }
         } else if (PREF_SHOW_NEWS.equals(key)) {
             SharedPreferences.Editor sharedPreferencesEditor =
                     ContextUtils.getAppSharedPreferences().edit();
             sharedPreferencesEditor.putBoolean(BraveNewsPreferences.PREF_SHOW_OPTIN, false);
             sharedPreferencesEditor.apply();
             BravePrefServiceBridge.getInstance().setShowNews((boolean) newValue);
-            // Sets Enable switch to the same value to keep the conditions in BraveNewTabLayout.java
-            // valid
-            BravePrefServiceBridge.getInstance().setNewsOptIn((boolean) newValue);
 
         } else if (PREF_RSS_SOURCES.equals(key)) {
             if (((String) newValue).equals("")) {


### PR DESCRIPTION
Uplift of https://github.com/brave/brave-core/pull/13017
Resolves https://github.com/brave/brave-browser/issues/22135

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.