### PR TITLE
Add De-AMP setting for Android, enable by default (uplift to 1.38.x)

### DIFF
--- a/android/java/org/chromium/chrome/browser/preferences/BravePrefServiceBridge.java
+++ b/android/java/org/chromium/chrome/browser/preferences/BravePrefServiceBridge.java
@@ -36,6 +36,13 @@ public class BravePrefServiceBridge {
     }
 
     /**
+     * @param whether De-AMP should be enabled.
+     */
+    public void setDeAmpEnabled(boolean enabled) {
+        BravePrefServiceBridgeJni.get().setDeAmpEnabled(enabled);
+    }
+
+    /**
      * @param whether the IPFS gateway should be enabled.
      */
     public void setIpfsGatewayEnabled(boolean enabled) {
@@ -295,6 +302,7 @@ public class BravePrefServiceBridge {
         String getNoScriptControlType();
 
         void setHTTPSEEnabled(boolean enabled);
+        void setDeAmpEnabled(boolean enabled);
         void setIpfsGatewayEnabled(boolean enabled);
         void setAdBlockEnabled(boolean enabled);
 

--- a/android/java/org/chromium/chrome/browser/privacy/settings/BravePrivacySettings.java
+++ b/android/java/org/chromium/chrome/browser/privacy/settings/BravePrivacySettings.java
@@ -61,6 +61,7 @@ public class BravePrivacySettings extends PrivacySettings {
             "other_privacy_settings_section";
 
     private static final String PREF_HTTPSE = "httpse";
+    private static final String PREF_DE_AMP = "de_amp";
     private static final String PREF_IPFS_GATEWAY = "ipfs_gateway";
     private static final String PREF_AD_BLOCK = "ad_block";
     private static final String PREF_BLOCK_SCRIPTS = "scripts_block";
@@ -92,8 +93,9 @@ public class BravePrivacySettings extends PrivacySettings {
 
     private static final String[] NEW_PRIVACY_PREFERENCE_ORDER = {
             PREF_BRAVE_SHIELDS_GLOBALS_SECTION, //  shields globals  section
-            PREF_SHIELDS_SUMMARY, PREF_BLOCK_TRACKERS_ADS, PREF_HTTPSE, PREF_HTTPS_FIRST_MODE,
-            PREF_BLOCK_SCRIPTS, PREF_BLOCK_CROSS_SITE_COOKIES, PREF_FINGERPRINTING_PROTECTION,
+            PREF_SHIELDS_SUMMARY, PREF_BLOCK_TRACKERS_ADS, PREF_DE_AMP, PREF_HTTPSE,
+            PREF_HTTPS_FIRST_MODE, PREF_BLOCK_SCRIPTS, PREF_BLOCK_CROSS_SITE_COOKIES,
+            PREF_FINGERPRINTING_PROTECTION,
             PREF_CLEAR_DATA_SECTION, //  clear data automatically  section
             PREF_CLEAR_ON_EXIT, PREF_CLEAR_BROWSING_DATA,
             PREF_BRAVE_SOCIAL_BLOCKING_SECTION, // social blocking section
@@ -125,6 +127,7 @@ public class BravePrivacySettings extends PrivacySettings {
     private ChromeSwitchPreference mAutocompleteTopSites;
     private ChromeSwitchPreference mAutocompleteBraveSuggestedSites;
     private ChromeSwitchPreference mHttpsePref;
+    private ChromeSwitchPreference mDeAmpPref;
     private ChromeSwitchPreference mHttpsFirstModePref;
     private BraveDialogPreference mFingerprintingProtectionPref;
     private ChromeSwitchPreference mBlockScriptsPref;
@@ -154,6 +157,9 @@ public class BravePrivacySettings extends PrivacySettings {
 
         mHttpsePref = (ChromeSwitchPreference) findPreference(PREF_HTTPSE);
         mHttpsePref.setOnPreferenceChangeListener(this);
+
+        mDeAmpPref = (ChromeSwitchPreference) findPreference(PREF_DE_AMP);
+        mDeAmpPref.setOnPreferenceChangeListener(this);
 
         mHttpsFirstModePref = (ChromeSwitchPreference) findPreference(PREF_HTTPS_FIRST_MODE);
         mHttpsFirstModePref.setVisible(mHttpsePref.isChecked());
@@ -277,6 +283,9 @@ public class BravePrivacySettings extends PrivacySettings {
                 UserPrefs.get(Profile.getLastUsedRegularProfile())
                         .setBoolean(Pref.HTTPS_ONLY_MODE_ENABLED, newValueBool);
             }
+        } else if (PREF_DE_AMP.equals(key)) {
+            BravePrefServiceBridge.getInstance().setDeAmpEnabled((boolean) newValue);
+
         } else if (PREF_IPFS_GATEWAY.equals(key)) {
             BravePrefServiceBridge.getInstance().setIpfsGatewayEnabled((boolean) newValue);
         } else if (PREF_FINGERPRINTING_PROTECTION.equals(key)) {

--- a/android/java/res/xml/brave_privacy_preferences.xml
+++ b/android/java/res/xml/brave_privacy_preferences.xml
@@ -46,7 +46,11 @@
             app:dialog_subtitle="@string/block_fingerprinting_text"
             app:dialog_entries="@array/blockFingerprintingTexts"
             app:dialog_default_index="1" />
-
+        <org.chromium.components.browser_ui.settings.ChromeSwitchPreference
+            android:key="de_amp"
+            android:title="@string/de_amp_switch"
+            android:summary="@string/de_amp_summary"
+            android:defaultValue="true" />
 
     <PreferenceCategory
         android:key="clear_data_section"

--- a/android/javatests/org/chromium/chrome/browser/privacy/settings/BravePrivacySettingsTest.java
+++ b/android/javatests/org/chromium/chrome/browser/privacy/settings/BravePrivacySettingsTest.java
@@ -46,7 +46,7 @@ public class BravePrivacySettingsTest {
     private static final String PREF_INCOGNITO_LOCK = "incognito_lock";
     private static final String PREF_PHONE_AS_A_SECURITY_KEY = "phone_as_a_security_key";
 
-    private static int BRAVE_PRIVACY_SETTINGS_NUMBER_OF_ITEMS = 21;
+    private static int BRAVE_PRIVACY_SETTINGS_NUMBER_OF_ITEMS = 22;
 
     private int mItemsLeft;
 

--- a/browser/android/preferences/brave_pref_service_bridge.cc
+++ b/browser/android/preferences/brave_pref_service_bridge.cc
@@ -14,6 +14,7 @@
 #include "brave/components/brave_shields/common/pref_names.h"
 #include "brave/components/brave_sync/brave_sync_prefs.h"
 #include "brave/components/brave_today/common/pref_names.h"
+#include "brave/components/de_amp/common/pref_names.h"
 #include "brave/components/decentralized_dns/buildflags/buildflags.h"
 #include "brave/components/ipfs/buildflags/buildflags.h"
 #include "brave/components/p3a/buildflags.h"
@@ -95,6 +96,11 @@ void JNI_BravePrefServiceBridge_SetHTTPSEEnabled(
       enabled,
       GURL(),
       g_browser_process->local_state());
+}
+
+void JNI_BravePrefServiceBridge_SetDeAmpEnabled(JNIEnv* env, jboolean enabled) {
+  GetOriginalProfile()->GetPrefs()->SetBoolean(de_amp::kDeAmpPrefEnabled,
+                                               enabled);
 }
 
 void JNI_BravePrefServiceBridge_SetIpfsGatewayEnabled(JNIEnv* env,

--- a/browser/ui/android/strings/android_brave_strings.grd
+++ b/browser/ui/android/strings/android_brave_strings.grd
@@ -151,6 +151,12 @@ This file contains all "about" strings.  It is set to NOT be translated, in tran
       <message name="IDS_BRAVE_SHIELDS_HTTPS_EVERYWHERE_SWITCH_SUMMARY" desc="Summary for HTTPS Everywhere.">
         Opens some sites using a secure HTTPS connection instead of plain HTTP.
       </message>
+      <message name="IDS_DE_AMP_SWITCH" desc="Switch to activate De-AMP feature">
+        Auto-redirect AMP pages
+      </message>
+      <message name="IDS_DE_AMP_SUMMARY" desc="Summary for De-AMP feature">
+        Always visit original (non-AMP) page URLs, instead of Google's Accelerated Mobile Page versions
+      </message>
       <message name="IDS_BRAVE_SHIELDS_BLOCKS_SCRIPTS_SWITCH" desc="Switch for Block Scripts.">
         Block Scripts
       </message>

--- a/components/de_amp/common/features.cc
+++ b/components/de_amp/common/features.cc
@@ -13,14 +13,7 @@ namespace features {
 
 // When enabled, Brave will try to de-AMP a page i.e. load the canonical,
 // non-AMP version if the page is an AMP page.
-const base::Feature kBraveDeAMP {
-  "BraveDeAMP",
-#if BUILDFLAG(IS_ANDROID)
-      base::FEATURE_DISABLED_BY_DEFAULT
-#else
-      base::FEATURE_ENABLED_BY_DEFAULT
-#endif
-};
+const base::Feature kBraveDeAMP{"BraveDeAMP", base::FEATURE_ENABLED_BY_DEFAULT};
 
 }  // namespace features
 }  // namespace de_amp


### PR DESCRIPTION
Uplift of #13001
Resolves https://github.com/brave/brave-browser/issues/21643

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.