### PR TITLE
Uplift 1.38.x - #12903 from brave/toolbar-button-panels-close

### DIFF
--- a/browser/ui/views/brave_actions/brave_shields_action_view.cc
+++ b/browser/ui/views/brave_actions/brave_shields_action_view.cc
@@ -77,6 +77,16 @@ BraveShieldsActionView::BraveShieldsActionView(Profile* profile,
   SetHorizontalAlignment(gfx::ALIGN_CENTER);
   ink_drop->SetVisibleOpacity(kToolbarInkDropVisibleOpacity);
   tab_strip_model_->AddObserver(this);
+
+  // The MenuButtonController makes sure the panel closes when clicked if the
+  // panel is already open.
+  auto menu_button_controller = std::make_unique<views::MenuButtonController>(
+      this,
+      base::BindRepeating(&BraveShieldsActionView::ButtonPressed,
+                          base::Unretained(this)),
+      std::make_unique<views::Button::DefaultButtonControllerDelegate>(this));
+  menu_button_controller_ = menu_button_controller.get();
+  SetButtonController(std::move(menu_button_controller));
 }
 
 BraveShieldsActionView::~BraveShieldsActionView() {

--- a/browser/ui/views/brave_actions/brave_shields_action_view.h
+++ b/browser/ui/views/brave_actions/brave_shields_action_view.h
@@ -13,6 +13,7 @@
 #include "chrome/browser/ui/tabs/tab_strip_model_observer.h"
 #include "chrome/browser/ui/views/bubble/webui_bubble_manager.h"
 #include "ui/views/controls/button/label_button.h"
+#include "ui/views/controls/button/menu_button_controller.h"
 
 class TabStripModel;
 class IconWithBadgeImageSource;
@@ -50,6 +51,7 @@ class BraveShieldsActionView
       const TabStripModelChange& change,
       const TabStripSelectionChange& selection) override;
 
+  raw_ptr<views::MenuButtonController> menu_button_controller_ = nullptr;
   Profile* profile_ = nullptr;
   TabStripModel* tab_strip_model_ = nullptr;
   std::unique_ptr<WebUIBubbleManagerT<ShieldsPanelUI>> webui_bubble_manager_;

--- a/browser/ui/views/toolbar/brave_vpn_button.cc
+++ b/browser/ui/views/toolbar/brave_vpn_button.cc
@@ -109,7 +109,9 @@ BraveVPNButton::BraveVPNButton(Browser* browser)
     : ToolbarButton(base::BindRepeating(&BraveVPNButton::OnButtonPressed,
                                         base::Unretained(this)),
                     std::make_unique<VPNButtonMenuModel>(browser),
-                    nullptr),
+                    nullptr,
+                    false),  // Long-pressing is not intended for something that
+                             // already shows a panel on click
       browser_(browser),
       service_(BraveVpnServiceFactory::GetForProfile(browser_->profile())) {
   DCHECK(service_);
@@ -119,6 +121,16 @@ BraveVPNButton::BraveVPNButton(Browser* browser)
   views::HighlightPathGenerator::Install(
       this, std::make_unique<BraveVPNButtonHighlightPathGenerator>(
                 GetToolbarInkDropInsets(this)));
+
+  // The MenuButtonController makes sure the panel closes when clicked if the
+  // panel is already open.
+  auto menu_button_controller = std::make_unique<views::MenuButtonController>(
+      this,
+      base::BindRepeating(&BraveVPNButton::OnButtonPressed,
+                          base::Unretained(this)),
+      std::make_unique<views::Button::DefaultButtonControllerDelegate>(this));
+  menu_button_controller_ = menu_button_controller.get();
+  SetButtonController(std::move(menu_button_controller));
 
   label()->SetText(brave_l10n::GetLocalizedResourceUTF16String(
       IDS_BRAVE_VPN_TOOLBAR_BUTTON_TEXT));

--- a/browser/ui/views/toolbar/brave_vpn_button.h
+++ b/browser/ui/views/toolbar/brave_vpn_button.h
@@ -9,6 +9,7 @@
 #include "brave/components/brave_vpn/brave_vpn_service_observer.h"
 #include "chrome/browser/ui/views/toolbar/toolbar_button.h"
 #include "ui/base/metadata/metadata_header_macros.h"
+#include "ui/views/controls/button/menu_button_controller.h"
 
 class BraveVpnServiceDesktop;
 class Browser;
@@ -38,6 +39,7 @@ class BraveVPNButton : public ToolbarButton, public BraveVPNServiceObserver {
 
   Browser* browser_ = nullptr;
   BraveVpnServiceDesktop* service_ = nullptr;
+  raw_ptr<views::MenuButtonController> menu_button_controller_ = nullptr;
 };
 
 #endif  // BRAVE_BROWSER_UI_VIEWS_TOOLBAR_BRAVE_VPN_BUTTON_H_

--- a/browser/ui/views/toolbar/wallet_button.cc
+++ b/browser/ui/views/toolbar/wallet_button.cc
@@ -73,7 +73,9 @@ WalletButton::WalletButton(View* backup_anchor_view, PrefService* prefs)
     : ToolbarButton(base::BindRepeating(&WalletButton::OnWalletPressed,
                                         base::Unretained(this)),
                     std::make_unique<WalletButtonMenuModel>(prefs),
-                    nullptr),
+                    nullptr,
+                    false),  // Long-pressing is not intended for something that
+                             // already shows a panel on click
       prefs_(prefs),
       backup_anchor_view_(backup_anchor_view) {
   pref_change_registrar_.Init(prefs_);
@@ -81,6 +83,17 @@ WalletButton::WalletButton(View* backup_anchor_view, PrefService* prefs)
       kShowWalletIconOnToolbar,
       base::BindRepeating(&WalletButton::OnPreferenceChanged,
                           base::Unretained(this)));
+
+  // The MenuButtonController makes sure the panel closes when clicked if the
+  // panel is already open.
+  auto menu_button_controller = std::make_unique<views::MenuButtonController>(
+      this,
+      base::BindRepeating(&WalletButton::OnWalletPressed,
+                          base::Unretained(this)),
+      std::make_unique<views::Button::DefaultButtonControllerDelegate>(this));
+  menu_button_controller_ = menu_button_controller.get();
+  SetButtonController(std::move(menu_button_controller));
+
   UpdateVisibility();
 }
 

--- a/browser/ui/views/toolbar/wallet_button.h
+++ b/browser/ui/views/toolbar/wallet_button.h
@@ -13,6 +13,7 @@
 #include "chrome/browser/ui/views/toolbar/toolbar_button.h"
 #include "components/prefs/pref_change_registrar.h"
 #include "ui/base/metadata/metadata_header_macros.h"
+#include "ui/views/controls/button/menu_button_controller.h"
 
 class PrefService;
 
@@ -42,6 +43,7 @@ class WalletButton : public ToolbarButton {
   void OnWalletPressed(const ui::Event& event);
 
   raw_ptr<PrefService> prefs_ = nullptr;
+  raw_ptr<views::MenuButtonController> menu_button_controller_ = nullptr;
   raw_ptr<views::View> backup_anchor_view_ = nullptr;
   PrefChangeRegistrar pref_change_registrar_;
 };


### PR DESCRIPTION
Uplift https://github.com/brave/brave-browser/issues/22026 via #12903. 
Ensure panels opened via toolbar buttons get closed when clicked again (shields, vpn, wallet).
