### PR TITLE
Uplift - Misc fixes for DeAMP (#12999)

### DIFF
--- a/browser/resources/settings/brave_privacy_page/brave_personalization_options.html
+++ b/browser/resources/settings/brave_privacy_page/brave_personalization_options.html
@@ -54,12 +54,6 @@
         sub-label="$i18n{statsUsagePingEnabledDesc}"
         on-settings-boolean-control-change="onStatsUsagePingEnabledChange_">
     </settings-toggle-button>
-    <settings-toggle-button
-        class="cr-row"
-        pref="{{prefs.brave.de_amp.enabled}}"
-        label="$i18n{deAmpSettingLabel}"
-        sub-label="$i18n{deAmpSettingSubLabel}">
-    </settings-toggle-button>
   </template>
   <script src="brave_personalization_options.js"></script>
 </dom-module>

--- a/browser/resources/settings/default_brave_shields_page/default_brave_shields_page.html
+++ b/browser/resources/settings/default_brave_shields_page/default_brave_shields_page.html
@@ -56,6 +56,18 @@
         pref="{{prefs.brave.shields.stats_badge_visible}}"
         label="$i18n{showStatsBlockedBadgeLabel}">
     </settings-toggle-button>
+    <settings-toggle-button
+        class="cr-row"
+        pref="{{prefs.brave.de_amp.enabled}}"
+        label="$i18n{deAmpSettingLabel}"
+        sub-label="$i18n{deAmpSettingSubLabel}">
+    </settings-toggle-button>
+    <settings-toggle-button
+        class="cr-row"
+        pref="{{prefs.brave.reduce_language}}"
+        label="$i18n{reduceLanguageControlLabel}"
+        sub-label="$i18n{reduceLanguageDesc}">
+    </settings-toggle-button>
     <div class="settings-box">
       <div class="start">$i18n{adControlLabel}</div>
       <select id="adControlType" class="md-select"

--- a/browser/resources/settings/default_brave_shields_page/default_brave_shields_page.html
+++ b/browser/resources/settings/default_brave_shields_page/default_brave_shields_page.html
@@ -62,12 +62,6 @@
         label="$i18n{deAmpSettingLabel}"
         sub-label="$i18n{deAmpSettingSubLabel}">
     </settings-toggle-button>
-    <settings-toggle-button
-        class="cr-row"
-        pref="{{prefs.brave.reduce_language}}"
-        label="$i18n{reduceLanguageControlLabel}"
-        sub-label="$i18n{reduceLanguageDesc}">
-    </settings-toggle-button>
     <div class="settings-box">
       <div class="start">$i18n{adControlLabel}</div>
       <select id="adControlType" class="md-select"

--- a/components/de_amp/browser/de_amp_util.cc
+++ b/components/de_amp/browser/de_amp_util.cc
@@ -14,11 +14,12 @@ namespace {
 // Check for "amp" or "⚡" in <html> tag
 // https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml/?format=websites#ampd
 constexpr char kGetHtmlTagPattern[] = "(<\\s*?html\\s.*?>)";
-constexpr char kDetectAmpPattern[] = "(?:<.*\\s.*(amp|⚡)(?:\\s.*>|>|/>))";
+constexpr char kDetectAmpPattern[] =
+    "(?:<.*?\\s.*?(amp|⚡|amp=\"\\s*\"|amp='\\s*')(?:\\s.*?>|>|/>))";
 // Look for canonical link tag and get href
 // https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml/?format=websites#canon
 constexpr char kFindCanonicalLinkTagPattern[] =
-    "(<\\s*link\\s[^>]*rel=(?:\"|')canonical(?:\"|')(?:\\s[^>]*>|>|/>))";
+    "(<\\s*?link\\s[^>]*?rel=(?:\"|')canonical(?:\"|')(?:\\s[^>]*?>|>|/>))";
 constexpr char kFindCanonicalHrefInTagPattern[] = "href=(?:\"|')(.*?)(?:\"|')";
 }  // namespace
 


### PR DESCRIPTION
- Tweak DeAMP regexes to be lazy
- The amp html attribute might have empty value i.e. amp=""
- Move DeAMP (from Security & Privacy section) ~~and ReduceLanguage (from bottom of brave://settings/shields)~~ settings to be near-top of brave://settings/shields so as to separate them from other per-site privacy settings

**NOTE:** this PR differs from https://github.com/brave/brave-core/pull/12999 in 1.39.x in the way that it does not also move ReduceLanguage pref; that feature and pref doesn't exist in 1.38.x, so shouldn't be part of the uplift.

<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/22262
Uplift of https://github.com/brave/brave-core/pull/12999


## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

