### PR TITLE
Fix incorrect CAPTCHA drag image on scaled Linux display (uplift to 1.38.x)

### DIFF
--- a/components/brave_rewards/resources/rewards_panel/components/grant_captcha_challenge.tsx
+++ b/components/brave_rewards/resources/rewards_panel/components/grant_captcha_challenge.tsx
@@ -39,6 +39,16 @@ export function GrantCaptchaChallenge (props: Props) {
       x: (rect.width / 2) - (event.clientX - rect.left),
       y: (rect.height / 2) - (event.clientY - rect.top)
     })
+
+    // Work around Linux-specific upstream bug by explicitly setting the drag
+    // image offset when initiating the drag
+    // See https://bugs.chromium.org/p/chromium/issues/detail?id=1297990
+    if (window.navigator.userAgent.includes('Linux') && devicePixelRatio > 1) {
+      event.dataTransfer.setDragImage(
+        target,
+        event.clientX - rect.left,
+        event.clientY - rect.top)
+    }
   }
 
   function onDragOver (event: React.DragEvent) {


### PR DESCRIPTION
Uplift of #13072
Resolves https://github.com/brave/brave-browser/issues/22180

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.