### PR TITLE
Re-allow cosmetic filtering to override in-page !important styles after regression (uplift to 1.38.x)

### DIFF
--- a/browser/brave_shields/ad_block_service_browsertest.cc
+++ b/browser/brave_shields/ad_block_service_browsertest.cc
@@ -1905,6 +1905,7 @@ IN_PROC_BROWSER_TEST_F(AdBlockServiceTest, CosmeticFilteringHide1pContent) {
 
 // Test cosmetic filtering on elements added dynamically
 IN_PROC_BROWSER_TEST_F(AdBlockServiceTest, CosmeticFilteringDynamic) {
+  ASSERT_TRUE(InstallDefaultAdBlockExtension());
   UpdateAdBlockInstanceWithRules("##.blockme");
 
   GURL tab_url =
@@ -2156,12 +2157,39 @@ IN_PROC_BROWSER_TEST_F(AdBlockServiceTest, CosmeticFilteringIframeScriptlet) {
 
 // Test cosmetic filtering on an element that already has an `!important`
 // marker on its `display` style.
-// Temporarily disabled by https://github.com/brave/brave-core/pull/12950 due
-// to performance impact of newer injection method.
 IN_PROC_BROWSER_TEST_F(AdBlockServiceTest,
                        DISABLED_CosmeticFilteringOverridesImportant) {
   ASSERT_TRUE(InstallDefaultAdBlockExtension());
   UpdateAdBlockInstanceWithRules("###inline-block-important");
+
+  GURL tab_url =
+      embedded_test_server()->GetURL("b.com", "/cosmetic_filtering.html");
+  ASSERT_TRUE(ui_test_utils::NavigateToURL(browser(), tab_url));
+
+  content::WebContents* contents =
+      browser()->tab_strip_model()->GetActiveWebContents();
+
+  auto result_first = EvalJs(contents,
+                             R"(async function waitCSSSelector() {
+          if (await checkSelector('#inline-block-important', 'display', 'none')) {
+            window.domAutomationController.send(true);
+          } else {
+            console.error('still waiting for css selector');
+            setTimeout(waitCSSSelector, 200);
+          }
+        } waitCSSSelector())",
+                             content::EXECUTE_SCRIPT_USE_MANUAL_REPLY);
+  ASSERT_TRUE(result_first.error.empty());
+  EXPECT_EQ(base::Value(true), result_first.value);
+}
+
+// Test cosmetic filtering on an element that already has an `!important`
+// marker on its `display` style, from an engine without the first-party
+// exception policy.
+IN_PROC_BROWSER_TEST_F(AdBlockServiceTest,
+                       CustomCosmeticFilteringOverridesImportant) {
+  ASSERT_TRUE(InstallDefaultAdBlockExtension());
+  UpdateCustomAdBlockInstanceWithRules("###inline-block-important");
 
   GURL tab_url =
       embedded_test_server()->GetURL("b.com", "/cosmetic_filtering.html");

--- a/components/cosmetic_filters/renderer/cosmetic_filters_js_handler.h
+++ b/components/cosmetic_filters/renderer/cosmetic_filters_js_handler.h
@@ -32,7 +32,7 @@ class CosmeticFiltersJSHandler {
                            const int32_t isolated_world_id);
   ~CosmeticFiltersJSHandler();
 
-  // Adds the "cs_worker" JavaScript object and its functions to the current
+  // Adds the "cf_worker" JavaScript object and its functions to the current
   // render_frame_.
   void AddJavaScriptObjectToFrame(v8::Local<v8::Context> context);
   // Fetches an initial set of resources to inject into the page if cosmetic
@@ -68,7 +68,10 @@ class CosmeticFiltersJSHandler {
   void OnHiddenClassIdSelectors(base::Value result);
   bool OnIsFirstParty(const std::string& url_string);
 
+  void InjectStylesheet(const std::string& stylesheet);
+
   bool generichide_ = false;
+
   raw_ptr<content::RenderFrame> render_frame_ = nullptr;
   mojo::Remote<cosmetic_filters::mojom::CosmeticFiltersResources>
       cosmetic_filters_resources_;


### PR DESCRIPTION
Uplift of #13079
Resolves https://github.com/brave/brave-browser/issues/22264

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.