### PR TITLE
Fixed wrong location bar/omnibox colors are used

### DIFF
--- a/browser/themes/brave_theme_helper_utils.cc
+++ b/browser/themes/brave_theme_helper_utils.cc
@@ -1,0 +1,65 @@
+/* Copyright (c) 2022 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "brave/browser/themes/brave_theme_helper_utils.h"
+
+#include "base/numerics/safe_conversions.h"
+#include "chrome/browser/themes/theme_properties.h"
+#include "chrome/browser/ui/omnibox/omnibox_theme.h"
+#include "ui/gfx/color_palette.h"
+#include "ui/gfx/color_utils.h"
+#include "ui/native_theme/native_theme.h"
+
+namespace {
+
+// Location bar colors
+const SkColor kPrivateLocationBarBgBase = SkColorSetRGB(0x0B, 0x07, 0x24);
+const SkColor kDarkLocationBarBgBase = SkColorSetRGB(0x18, 0x1A, 0x21);
+const SkColor kDarkLocationBarHoverBg = SkColorSetRGB(0x23, 0x25, 0x2F);
+
+}  // namespace
+
+SkColor GetLocationBarBackground(bool dark, bool priv, bool hover) {
+  if (priv) {
+    return hover ? color_utils::HSLShift(kPrivateLocationBarBgBase,
+                                         {-1, -1, 0.54})
+                 : kPrivateLocationBarBgBase;
+  }
+
+  if (dark) {
+    return hover ? kDarkLocationBarHoverBg : kDarkLocationBarBgBase;
+  }
+
+  return hover ? color_utils::AlphaBlend(SK_ColorWHITE,
+                                         SkColorSetRGB(0xf3, 0xf3, 0xf3), 0.7f)
+               : SK_ColorWHITE;
+}
+
+// Omnibox result bg colors
+SkColor GetOmniboxResultBackground(int id, bool dark, bool priv) {
+  // For high contrast, selected rows use inverted colors to stand out more.
+  ui::NativeTheme* native_theme = ui::NativeTheme::GetInstanceForNativeUi();
+  bool high_contrast =
+      native_theme && native_theme->UserHasContrastPreference();
+  OmniboxPartState state = OmniboxPartState::NORMAL;
+  if (id == ThemeProperties::COLOR_OMNIBOX_RESULTS_BG_HOVERED) {
+    state = OmniboxPartState::HOVERED;
+  } else if (id == ThemeProperties::COLOR_OMNIBOX_RESULTS_BG_SELECTED) {
+    state = OmniboxPartState::SELECTED;
+  }
+
+  SkColor color;
+  if (priv) {
+    color = high_contrast ? color_utils::HSLShift(kPrivateLocationBarBgBase,
+                                                  {-1, -1, 0.45})
+                          : kPrivateLocationBarBgBase;
+  } else if (dark) {
+    color = high_contrast ? gfx::kGoogleGrey900 : kDarkLocationBarBgBase;
+  } else {
+    color = SK_ColorWHITE;
+  }
+  return color_utils::BlendTowardMaxContrast(
+      color, base::ClampRound(GetOmniboxStateOpacity(state) * 0xff));
+}

--- a/browser/themes/brave_theme_helper_utils.h
+++ b/browser/themes/brave_theme_helper_utils.h
@@ -1,0 +1,14 @@
+/* Copyright (c) 2022 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_BROWSER_THEMES_BRAVE_THEME_HELPER_UTILS_H_
+#define BRAVE_BROWSER_THEMES_BRAVE_THEME_HELPER_UTILS_H_
+
+#include "third_party/skia/include/core/SkColor.h"
+
+SkColor GetLocationBarBackground(bool dark, bool priv, bool hover);
+SkColor GetOmniboxResultBackground(int id, bool dark, bool priv);
+
+#endif  // BRAVE_BROWSER_THEMES_BRAVE_THEME_HELPER_UTILS_H_

--- a/browser/themes/brave_theme_service_browsertest.cc
+++ b/browser/themes/brave_theme_service_browsertest.cc
@@ -4,6 +4,7 @@
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 #include "brave/browser/themes/brave_dark_mode_utils.h"
+#include "brave/browser/themes/brave_theme_helper_utils.h"
 #include "brave/browser/themes/theme_properties.h"
 #include "brave/common/pref_names.h"
 #include "build/build_config.h"
@@ -12,6 +13,8 @@
 #include "chrome/browser/themes/theme_service.h"
 #include "chrome/browser/themes/theme_service_factory.h"
 #include "chrome/browser/ui/browser.h"
+#include "chrome/browser/ui/omnibox/omnibox_theme.h"
+#include "chrome/browser/ui/views/frame/browser_view.h"
 #include "chrome/test/base/in_process_browser_test.h"
 #include "components/prefs/pref_service.h"
 #include "content/public/test/browser_test.h"
@@ -150,6 +153,39 @@ IN_PROC_BROWSER_TEST_F(BraveThemeServiceTest, SystemThemeChangeTest) {
     EXPECT_EQ(initial_mode,
               ui::NativeTheme::GetInstanceForNativeUi()->ShouldUseDarkColors());
   }
+}
+
+IN_PROC_BROWSER_TEST_F(BraveThemeServiceTest, OmniboxColorTest) {
+  auto* browser_view = BrowserView::GetBrowserViewForBrowser(browser());
+  auto* tp = browser_view->GetThemeProvider();
+  const int hovered = false;
+
+  // Change to light.
+  dark_mode::SetBraveDarkModeType(
+      dark_mode::BraveDarkModeType::BRAVE_DARK_MODE_TYPE_LIGHT);
+  bool dark = false;
+  EXPECT_EQ(GetLocationBarBackground(dark, false /* incognito */, hovered),
+            GetOmniboxColor(tp, OmniboxPart::LOCATION_BAR_BACKGROUND));
+  EXPECT_EQ(
+      GetOmniboxResultBackground(ThemeProperties::COLOR_OMNIBOX_RESULTS_BG,
+                                 dark, false /* incognito */),
+      tp->GetColor(ThemeProperties::COLOR_OMNIBOX_RESULTS_BG));
+
+  // Change to dark.
+  dark_mode::SetBraveDarkModeType(
+      dark_mode::BraveDarkModeType::BRAVE_DARK_MODE_TYPE_DARK);
+  dark = true;
+
+  EXPECT_EQ(GetLocationBarBackground(dark, false /* incognito */, hovered),
+            GetOmniboxColor(tp, OmniboxPart::LOCATION_BAR_BACKGROUND));
+  // Check color is different on dark mode and incognito mode.
+  EXPECT_NE(GetLocationBarBackground(dark, true /* incognito */, hovered),
+            GetOmniboxColor(tp, OmniboxPart::LOCATION_BAR_BACKGROUND));
+
+  EXPECT_EQ(
+      GetOmniboxResultBackground(ThemeProperties::COLOR_OMNIBOX_RESULTS_BG,
+                                 dark, false /* incognito */),
+      tp->GetColor(ThemeProperties::COLOR_OMNIBOX_RESULTS_BG));
 }
 
 #if BUILDFLAG(IS_WIN)

--- a/browser/themes/sources.gni
+++ b/browser/themes/sources.gni
@@ -12,6 +12,8 @@ if (!is_android) {
     "//brave/browser/themes/brave_dark_mode_utils.cc",
     "//brave/browser/themes/brave_theme_helper.cc",
     "//brave/browser/themes/brave_theme_helper.h",
+    "//brave/browser/themes/brave_theme_helper_utils.cc",
+    "//brave/browser/themes/brave_theme_helper_utils.h",
     "//brave/browser/themes/brave_theme_service.cc",
     "//brave/browser/themes/brave_theme_service.h",
   ]


### PR DESCRIPTION
fix https://github.com/brave/brave-browser/issues/22479

<img width="603" alt="Screen Shot 2022-04-22 at 12 12 11 PM" src="https://user-images.githubusercontent.com/6786187/164589052-ed4f1a4b-ccae-4bd3-8b7e-5187d49a321f.png">

This regression comes from below upstream changes.
https://chromium-review.googlesource.com/c/chromium/src/+/3472345

Beforer this change, GetOmniboxColor() is called by ThemeHelper::GetColor()
whereas it's called by ThemeHelper::GetDefaultColor() now.
Then, we get incognito's omnibox color due to our below code at
BraveThemeHelper::GetDefaultColor().
```
  // Make sure we fallback to Chrome's dark theme (incognito) for our dark theme
  if (type == dark_mode::BraveDarkModeType::BRAVE_DARK_MODE_TYPE_DARK) {
    incognito = true;
  }

  DCHECK(!is_brave_theme_properties);
  return ThemeHelper::GetDefaultColor(id, incognito, theme_supplier);
```

Fixed by handling omnibox colors before overriding |incognito| var.

<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves 

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
`npm run test brave_browser_tests -- --filter=BraveThemeServiceTest.OmniboxColorTest`
