### PR TITLE
Disabled flaky SuggestPermissionIfWidevineDetected on Windows only (uplift to 1.38.x)

### DIFF
--- a/browser/widevine/widevine_permission_request_browsertest.cc
+++ b/browser/widevine/widevine_permission_request_browsertest.cc
@@ -258,8 +258,15 @@ class ScriptTriggerWidevinePermissionRequestBrowserTest
   net::EmbeddedTestServer https_server_;
 };
 
+#if defined(OFFICIAL_BUILD) && BUILDFLAG(IS_WIN)
+#define MAYBE_SuggestPermissionIfWidevineDetected \
+  DISABLED_SuggestPermissionIfWidevineDetected
+#else
+#define MAYBE_SuggestPermissionIfWidevineDetected \
+  SuggestPermissionIfWidevineDetected
+#endif
 IN_PROC_BROWSER_TEST_F(ScriptTriggerWidevinePermissionRequestBrowserTest,
-                       SuggestPermissionIfWidevineDetected) {
+                       MAYBE_SuggestPermissionIfWidevineDetected) {
   // In this test, we just want to know whether permission bubble is shown.
   GURL url = https_server_.GetURL("a.com", "/simple.html");
   ASSERT_TRUE(ui_test_utils::NavigateToURL(browser(), url));


### PR DESCRIPTION
Uplift of #13103
fix https://github.com/brave/brave-browser/issues/22386

Pre-approval checklist: 
- [ ] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.