### PR TITLE
ExternalWalletImporter will now try utf8 encoded mnemonic when string mnemonic is not found. (uplift to 1.39.x)

### DIFF
--- a/browser/brave_wallet/external_wallets_importer_unittest.cc
+++ b/browser/brave_wallet/external_wallets_importer_unittest.cc
@@ -30,6 +30,25 @@ const char* valid_data =
     "\\\",\\\"iv\\\":\\\"fOHBjjQcsi1KmaeQ7xA7Aw==\\\", "
     "\\\"salt\\\":\\\"z1bTZtBY33d2l6CfiFs5V/eRQLS6Qsq5UtAQOIfaIps=\\\"}\"}}}";
 
+const char* valid_data_with_utf8_mnemonic =
+    "{\"data\": {\"KeyringController\": {\"vault\": "
+    "\"{\\\"data\\\":\\\"Q27H35GCkppku8PtVmiPsNJNfe5wjSWgjD5JGa3jtTlmwaTBffWJL+"
+    "cadVr5X8c0JnPToVUwbJXcIdmKxT8vAWZWQqRoeiTXOl6iF9SaoqhhnOIX1+"
+    "FPEPyHV4bu3GUpUVokgdYA1eryw39sQxFm5gLyl44VfF8hmuG+"
+    "2c4nEmPbK7XBDMSwif4Q1jas4CkhHBKGL3j6x7jpyMBtku4FK5LpFC5+G+A/"
+    "OOOUPFQWUpct5JidweZWFoABHz0WIRGnZXWeFE/BoO+/"
+    "JaHN08k9jQH4TMw6TylVODgqxVk1EqsYOvJfVZIRIjP7no0c94ZlyukcUOmtuFWE2N4swndqUB"
+    "TPBobISrSyBIK/SbgMJRcK/VwYlXRAjDCKJ8WIhVezPm8pZap2e6SM/"
+    "cKs0ScKe7Ngjw25UHKRB1QAoVgCbeJiv+"
+    "UqpuGpcFAbrZ1tYcJyqJkguw8fMMWiehtmYubzFx4plXzcz7h4ZHbnkzR7BNHUCemmFhsXxTpe"
+    "UtvH3kcDKtSu4H0JwUMMh7a8gCp/MYZxMxGo2aSKKLBkpW0l/mt/"
+    "IWgChfXq1h7Ch3hCxGdG+mNx/mZ8xkXakzJzPw20MNdejx5gqF/pUp/"
+    "jRGbSaPCaVhkT2a0rXnj8YFjMJbGuPnOn8hmSanIOOK1ETwkQolA+"
+    "jo8qyNXFtmsCmyrbdSPfEFLZGC0MyUD4viNN2aRoIDa8339YF4C8qkg3U0Zh6z0gmbgnNDMAjn"
+    "BmFl5sCGtRolu9pT+EJAE9XGDh5cvSCA7YMeLQTvLrhDn8o8kXc8J92yjw\\\",\\\"iv\\\":"
+    "\\\"mmSwsbEsytQDfdNBP6WwOw==\\\",\\\"salt\\\":"
+    "\\\"ZNDNQqgIaLswCtSH72AwaaymPQqmO6VCgpbfAmAuw5s=\\\"}\"}}}";
+
 const char* valid_legacy_mnemonic =
     "cushion pitch impact album daring marine much annual budget social "
     "clarify "
@@ -201,6 +220,19 @@ TEST_F(ExternalWalletsImporterUnitTest, OnGetImportInfo) {
   ImportInfo info;
   ImportError error;
   SimulateGetImportInfo("brave4ever", valid_data, &result, &info, &error);
+  EXPECT_TRUE(result);
+  EXPECT_EQ(error, ImportError::kNone);
+  EXPECT_EQ(info.mnemonic, valid_mnemonic);
+  EXPECT_FALSE(info.is_legacy_crypto_wallets);
+  EXPECT_EQ(info.number_of_accounts, 1u);
+}
+
+TEST_F(ExternalWalletsImporterUnitTest, OnGetImportInfo_UTF8Mnemonic) {
+  bool result = false;
+  ImportInfo info;
+  ImportError error;
+  SimulateGetImportInfo("brave4ever", valid_data_with_utf8_mnemonic, &result,
+                        &info, &error);
   EXPECT_TRUE(result);
   EXPECT_EQ(error, ImportError::kNone);
   EXPECT_EQ(info.mnemonic, valid_mnemonic);


### PR DESCRIPTION
Uplift of #13125
Resolves https://github.com/brave/brave-browser/issues/22492
Resolves https://github.com/brave/brave-browser/issues/19526

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.