### PR TITLE
Don't enable 1PES everywhere when global SESSION_ONLY mode is enabled. (uplift to 1.39.x)

### DIFF
--- a/chromium_src/components/content_settings/core/common/cookie_settings_base.cc
+++ b/chromium_src/components/content_settings/core/common/cookie_settings_base.cc
@@ -60,6 +60,12 @@ bool IsFirstPartyAccessAllowed(
   return cookie_settings->IsAllowed(setting);
 }
 
+bool IsSessionOnlyExplicit(
+    const CookieSettingWithBraveMetadata& setting_with_brave_metadata) {
+  return setting_with_brave_metadata.setting == CONTENT_SETTING_SESSION_ONLY &&
+         setting_with_brave_metadata.IsExplicitSetting();
+}
+
 }  // namespace
 
 CookieSettingsBase::CookieSettingsBase() = default;
@@ -77,6 +83,11 @@ CookieSettingWithBraveMetadata& CookieSettingWithBraveMetadata::operator=(
     CookieSettingWithBraveMetadata&&) = default;
 CookieSettingWithBraveMetadata::~CookieSettingWithBraveMetadata() = default;
 
+bool CookieSettingWithBraveMetadata::IsExplicitSetting() const {
+  return !primary_pattern_matches_all_hosts ||
+         !secondary_pattern_matches_all_hosts;
+}
+
 bool CookieSettingsBase::ShouldUseEphemeralStorage(
     const GURL& url,
     const net::SiteForCookies& site_for_cookies,
@@ -92,10 +103,14 @@ bool CookieSettingsBase::ShouldUseEphemeralStorage(
 
   // Enable ephemeral storage for a first party URL if SESSION_ONLY cookie
   // setting is set and the feature is enabled.
+  absl::optional<CookieSettingWithBraveMetadata> first_party_setting;
   if (base::FeatureList::IsEnabled(
-          net::features::kBraveFirstPartyEphemeralStorage) &&
-      IsCookieSessionOnly(first_party_url)) {
-    return true;
+          net::features::kBraveFirstPartyEphemeralStorage)) {
+    first_party_setting =
+        GetCookieSettingWithBraveMetadata(first_party_url, first_party_url);
+    if (IsSessionOnlyExplicit(*first_party_setting)) {
+      return true;
+    }
   }
 
   if (net::registry_controlled_domains::SameDomainOrHost(
@@ -105,7 +120,9 @@ bool CookieSettingsBase::ShouldUseEphemeralStorage(
 
   bool allow_3p =
       IsCookieAccessAllowedImpl(url, site_for_cookies, top_frame_origin);
-  bool allow_1p = IsFirstPartyAccessAllowed(first_party_url, this);
+  bool allow_1p = first_party_setting
+                      ? IsAllowed(first_party_setting->setting)
+                      : IsFirstPartyAccessAllowed(first_party_url, this);
 
   // only use ephemeral storage for block 3p
   return allow_1p && !allow_3p;
@@ -180,7 +197,8 @@ bool CookieSettingsBase::IsCookieAccessAllowedImpl(
     CookieSettingWithBraveMetadata setting_with_brave_metadata =
         GetCookieSettingWithBraveMetadata(first_party_url, first_party_url);
 
-    if (setting_with_brave_metadata.setting == CONTENT_SETTING_SESSION_ONLY) {
+    // Ephemeral mode for the main frame can be enabled only via explicit rule.
+    if (IsSessionOnlyExplicit(setting_with_brave_metadata)) {
       main_frame_mode = MainFrameMode::kEphemeral;
     } else {
       // Disabled shields mode allows everything in nested frames. To properly

--- a/chromium_src/components/content_settings/core/common/cookie_settings_base.h
+++ b/chromium_src/components/content_settings/core/common/cookie_settings_base.h
@@ -22,6 +22,10 @@ struct CookieSettingWithBraveMetadata {
   CookieSettingWithBraveMetadata& operator=(CookieSettingWithBraveMetadata&&);
   ~CookieSettingWithBraveMetadata();
 
+  // Return true if any of the patterns is not "*", similar to
+  // content_settings::IsExplicitSetting().
+  bool IsExplicitSetting() const;
+
   ContentSetting setting = CONTENT_SETTING_DEFAULT;
   bool primary_pattern_matches_all_hosts = false;
   bool secondary_pattern_matches_all_hosts = false;


### PR DESCRIPTION
Uplift of #13127
Resolves https://github.com/brave/brave-browser/issues/22493

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.