### PR TITLE
Don't enable 1PES everywhere when global SESSION_ONLY mode is enabled. (uplift to 1.38.x)

### DIFF
--- a/chromium_src/components/content_settings/core/common/cookie_settings_base.h
+++ b/chromium_src/components/content_settings/core/common/cookie_settings_base.h
@@ -25,6 +25,10 @@ struct CookieSettingWithBraveMetadata {
   CookieSettingWithBraveMetadata& operator=(CookieSettingWithBraveMetadata&&);
   ~CookieSettingWithBraveMetadata();
 
+  // Return true if any of the patterns is not "*", similar to
+  // content_settings::IsExplicitSetting().
+  bool IsExplicitSetting() const;
+
   ContentSetting setting = CONTENT_SETTING_DEFAULT;
   bool primary_pattern_matches_all_hosts = false;
   bool secondary_pattern_matches_all_hosts = false;


### PR DESCRIPTION
Uplift of #13127
Resolves https://github.com/brave/brave-browser/issues/22493

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.