### PR TITLE
Implement Brave Ads browser manager observers

### DIFF
--- a/browser/brave_ads/ads_service_impl.cc
+++ b/browser/brave_ads/ads_service_impl.cc
@@ -2364,20 +2364,20 @@ bool AdsServiceImpl::HasPrefPath(const std::string& path) const {
 
 ///////////////////////////////////////////////////////////////////////////////
 
-void AdsServiceImpl::OnBackground() {
+void AdsServiceImpl::OnBrowserDidEnterForeground() {
   if (!connected()) {
     return;
   }
 
-  bat_ads_->OnBackground();
+  bat_ads_->OnBrowserDidEnterForeground();
 }
 
-void AdsServiceImpl::OnForeground() {
+void AdsServiceImpl::OnBrowserDidEnterBackground() {
   if (!connected()) {
     return;
   }
 
-  bat_ads_->OnForeground();
+  bat_ads_->OnBrowserDidEnterBackground();
 }
 
 }  // namespace brave_ads

--- a/browser/brave_ads/ads_service_impl.h
+++ b/browser/brave_ads/ads_service_impl.h
@@ -475,8 +475,8 @@ class AdsServiceImpl : public AdsService,
   bool HasPrefPath(const std::string& path) const override;
 
   // BackgroundHelper::Observer implementation
-  void OnBackground() override;
-  void OnForeground() override;
+  void OnBrowserDidEnterForeground() override;
+  void OnBrowserDidEnterBackground() override;
 
   raw_ptr<Profile> profile_ = nullptr;  // NOT OWNED
 

--- a/browser/brave_ads/background_helper/background_helper.cc
+++ b/browser/brave_ads/background_helper/background_helper.cc
@@ -27,15 +27,15 @@ void BackgroundHelper::RemoveObserver(Observer* observer) {
   observers_.RemoveObserver(observer);
 }
 
-void BackgroundHelper::TriggerOnBackground() {
+void BackgroundHelper::TriggerOnForeground() {
   for (auto& observer : observers_) {
-    observer.OnBackground();
+    observer.OnBrowserDidEnterForeground();
   }
 }
 
-void BackgroundHelper::TriggerOnForeground() {
+void BackgroundHelper::TriggerOnBackground() {
   for (auto& observer : observers_) {
-    observer.OnForeground();
+    observer.OnBrowserDidEnterBackground();
   }
 }
 

--- a/browser/brave_ads/background_helper/background_helper.h
+++ b/browser/brave_ads/background_helper/background_helper.h
@@ -18,8 +18,8 @@ class BackgroundHelper {
    public:
     virtual ~Observer() = default;
 
-    virtual void OnBackground() = 0;
-    virtual void OnForeground() = 0;
+    virtual void OnBrowserDidEnterForeground() = 0;
+    virtual void OnBrowserDidEnterBackground() = 0;
   };
 
   virtual ~BackgroundHelper();
@@ -32,8 +32,8 @@ class BackgroundHelper {
   void AddObserver(Observer* observer);
   void RemoveObserver(Observer* observer);
 
-  void TriggerOnBackground();
   void TriggerOnForeground();
+  void TriggerOnBackground();
 
   virtual bool IsForeground() const;
 

--- a/components/services/bat_ads/bat_ads_impl.cc
+++ b/components/services/bat_ads/bat_ads_impl.cc
@@ -92,12 +92,12 @@ void BatAdsImpl::OnIdle() {
   ads_->OnIdle();
 }
 
-void BatAdsImpl::OnForeground() {
-  ads_->OnForeground();
+void BatAdsImpl::OnBrowserDidEnterForeground() {
+  ads_->OnBrowserDidEnterForeground();
 }
 
-void BatAdsImpl::OnBackground() {
-  ads_->OnBackground();
+void BatAdsImpl::OnBrowserDidEnterBackground() {
+  ads_->OnBrowserDidEnterBackground();
 }
 
 void BatAdsImpl::OnMediaPlaying(

--- a/components/services/bat_ads/bat_ads_impl.h
+++ b/components/services/bat_ads/bat_ads_impl.h
@@ -61,8 +61,8 @@ class BatAdsImpl :
   void OnUnIdle(const int idle_time, const bool was_locked) override;
   void OnIdle() override;
 
-  void OnForeground() override;
-  void OnBackground() override;
+  void OnBrowserDidEnterForeground() override;
+  void OnBrowserDidEnterBackground() override;
 
   void OnMediaPlaying(
       const int32_t tab_id) override;

--- a/components/services/bat_ads/public/interfaces/bat_ads.mojom
+++ b/components/services/bat_ads/public/interfaces/bat_ads.mojom
@@ -85,8 +85,8 @@ interface BatAds {
   OnUserGesture(int32 page_transition_type);
   OnUnIdle(int32 idle_time, bool was_locked);
   OnIdle();
-  OnForeground();
-  OnBackground();
+  OnBrowserDidEnterForeground();
+  OnBrowserDidEnterBackground();
   OnMediaPlaying(int32 tab_id);
   OnMediaStopped(int32 tab_id);
   OnTabUpdated(int32 tab_id, string url, bool is_active, bool is_browser_active, bool is_incognito);

--- a/ios/browser/api/ads/brave_ads.mm
+++ b/ios/browser/api/ads/brave_ads.mm
@@ -477,14 +477,14 @@ BATClassAdsBridge(BOOL, isDebug, setDebug, g_is_debug)
   if (![self isAdsServiceRunning]) {
     return;
   }
-  ads->OnForeground();
+  ads->OnBrowserDidEnterForeground();
 }
 
 - (void)applicationDidBackground {
   if (![self isAdsServiceRunning]) {
     return;
   }
-  ads->OnBackground();
+  ads->OnBrowserDidEnterBackground();
 }
 
 #pragma mark - History

--- a/vendor/bat-native-ads/BUILD.gn
+++ b/vendor/bat-native-ads/BUILD.gn
@@ -466,6 +466,7 @@ source_set("ads") {
     "src/bat/ads/internal/base64_util.h",
     "src/bat/ads/internal/browser_manager/browser_manager.cc",
     "src/bat/ads/internal/browser_manager/browser_manager.h",
+    "src/bat/ads/internal/browser_manager/browser_manager_observer.h",
     "src/bat/ads/internal/bundle/bundle.cc",
     "src/bat/ads/internal/bundle/bundle.h",
     "src/bat/ads/internal/bundle/bundle_info.cc",

--- a/vendor/bat-native-ads/include/bat/ads/ads.h
+++ b/vendor/bat-native-ads/include/bat/ads/ads.h
@@ -99,11 +99,11 @@ class ADS_EXPORT Ads {
   // |prefs::kIdleTimeThreshold|. This should not be called on mobile devices.
   virtual void OnIdle() = 0;
 
-  // Called when the browser becomes active.
-  virtual void OnForeground() = 0;
+  // Called when the browser did enter the foreground.
+  virtual void OnBrowserDidEnterForeground() = 0;
 
-  // Called when the browser enters the background.
-  virtual void OnBackground() = 0;
+  // Called when the browser did enter the background.
+  virtual void OnBrowserDidEnterBackground() = 0;
 
   // Called when media starts playing on a browser tab for the specified
   // |tab_id|.

--- a/vendor/bat-native-ads/src/bat/ads/internal/ads_impl.cc
+++ b/vendor/bat-native-ads/src/bat/ads/internal/ads_impl.cc
@@ -269,16 +269,16 @@ void AdsImpl::OnUnIdle(const int idle_time, const bool was_locked) {
   MaybeServeAdNotification();
 }
 
-void AdsImpl::OnForeground() {
-  BrowserManager::Get()->OnForegrounded();
+void AdsImpl::OnBrowserDidEnterForeground() {
+  BrowserManager::Get()->OnDidEnterForeground();
 
   MaybeUpdateCatalog();
 
   MaybeServeAdNotificationsAtRegularIntervals();
 }
 
-void AdsImpl::OnBackground() {
-  BrowserManager::Get()->OnBackgrounded();
+void AdsImpl::OnBrowserDidEnterBackground() {
+  BrowserManager::Get()->OnDidEnterBackground();
 
   MaybeServeAdNotificationsAtRegularIntervals();
 }
@@ -309,9 +309,9 @@ void AdsImpl::OnTabUpdated(const int32_t tab_id,
   }
 
   if (is_browser_active) {
-    BrowserManager::Get()->OnActive();
+    BrowserManager::Get()->OnDidBecomeActive();
   } else {
-    BrowserManager::Get()->OnInactive();
+    BrowserManager::Get()->OnDidResignActive();
   }
 
   const bool is_visible = is_active && is_browser_active;
@@ -619,7 +619,7 @@ void AdsImpl::set(privacy::TokenGeneratorInterface* token_generator) {
 void AdsImpl::InitializeBrowserManager() {
   const bool is_browser_active = AdsClientHelper::Get()->IsBrowserActive();
 
-  BrowserManager::Get()->SetForegrounded(is_browser_active);
+  BrowserManager::Get()->SetForeground(is_browser_active);
   BrowserManager::Get()->SetActive(is_browser_active);
 }
 

--- a/vendor/bat-native-ads/src/bat/ads/internal/ads_impl.h
+++ b/vendor/bat-native-ads/src/bat/ads/internal/ads_impl.h
@@ -149,8 +149,8 @@ class AdsImpl final : public Ads,
   void OnIdle() override;
   void OnUnIdle(const int idle_time, const bool was_locked) override;
 
-  void OnForeground() override;
-  void OnBackground() override;
+  void OnBrowserDidEnterForeground() override;
+  void OnBrowserDidEnterBackground() override;
 
   void OnMediaPlaying(const int32_t tab_id) override;
   void OnMediaStopped(const int32_t tab_id) override;

--- a/vendor/bat-native-ads/src/bat/ads/internal/browser_manager/browser_manager.h
+++ b/vendor/bat-native-ads/src/bat/ads/internal/browser_manager/browser_manager.h
@@ -6,6 +6,9 @@
 #ifndef BRAVE_VENDOR_BAT_NATIVE_ADS_SRC_BAT_ADS_INTERNAL_BROWSER_MANAGER_BROWSER_MANAGER_H_
 #define BRAVE_VENDOR_BAT_NATIVE_ADS_SRC_BAT_ADS_INTERNAL_BROWSER_MANAGER_BROWSER_MANAGER_H_
 
+#include "base/observer_list.h"
+#include "bat/ads/internal/browser_manager/browser_manager_observer.h"
+
 namespace ads {
 
 class BrowserManager final {
@@ -20,20 +23,36 @@ class BrowserManager final {
 
   static bool HasInstance();
 
-  void SetActive(const bool is_active);
-  bool IsActive() const;
-  void OnActive();
-  void OnInactive();
+  void AddObserver(BrowserManagerObserver* observer);
+  void RemoveObserver(BrowserManagerObserver* observer);
 
-  void SetForegrounded(const bool is_foregrounded);
-  bool IsForegrounded() const;
-  void OnForegrounded();
-  void OnBackgrounded();
+  void OnDidBecomeActive();
+  void OnDidResignActive();
+
+  void OnDidEnterForeground();
+  void OnDidEnterBackground();
+
+  void SetActive(const bool is_active) { is_active_ = is_active; }
+
+  bool IsActive() const { return is_active_ && is_foreground_; }
+
+  void SetForeground(const bool is_foreground) {
+    is_foreground_ = is_foreground;
+  }
+
+  bool IsForeground() const { return is_foreground_; }
 
  private:
+  void NotifyBrowserDidBecomeActive() const;
+  void NotifyBrowserDidResignActive() const;
+  void NotifyBrowserDidEnterForeground() const;
+  void NotifyBrowserDidEnterBackground() const;
+
+  base::ObserverList<BrowserManagerObserver> observers_;
+
   bool is_active_ = false;
 
-  bool is_foregrounded_ = false;
+  bool is_foreground_ = false;
 };
 
 }  // namespace ads

--- a/vendor/bat-native-ads/src/bat/ads/internal/browser_manager/browser_manager_observer.h
+++ b/vendor/bat-native-ads/src/bat/ads/internal/browser_manager/browser_manager_observer.h
@@ -1,0 +1,33 @@
+/* Copyright (c) 2022 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_VENDOR_BAT_NATIVE_ADS_SRC_BAT_ADS_INTERNAL_BROWSER_MANAGER_BROWSER_MANAGER_OBSERVER_H_
+#define BRAVE_VENDOR_BAT_NATIVE_ADS_SRC_BAT_ADS_INTERNAL_BROWSER_MANAGER_BROWSER_MANAGER_OBSERVER_H_
+
+#include "base/observer_list_types.h"
+
+namespace ads {
+
+class BrowserManagerObserver : public base::CheckedObserver {
+ public:
+  // Tells the delegate that the browser has become active.
+  virtual void OnBrowserDidBecomeActive() {}
+
+  // Tells the delegate that the browser did become inactive.
+  virtual void OnBrowserDidResignActive() {}
+
+  // Tells the delegate that the browser is now in the background.
+  virtual void OnBrowserDidEnterForeground() {}
+
+  // Tells the delegate that the browser is now in the foreground.
+  virtual void OnBrowserDidEnterBackground() {}
+
+ protected:
+  ~BrowserManagerObserver() override = default;
+};
+
+}  // namespace ads
+
+#endif  // BRAVE_VENDOR_BAT_NATIVE_ADS_SRC_BAT_ADS_INTERNAL_BROWSER_MANAGER_BROWSER_MANAGER_OBSERVER_H_

--- a/vendor/bat-native-ads/src/bat/ads/internal/federated/covariate_logs.cc
+++ b/vendor/bat-native-ads/src/bat/ads/internal/federated/covariate_logs.cc
@@ -41,12 +41,12 @@ GetUserActivityEventToCovariateTypesMapping() {
              kNumberOfBrowserDidBecomeActiveEvents,
          brave_federated::mojom::CovariateType::
              kTimeSinceLastBrowserDidBecomeActiveEvent}},
-       {UserActivityEventType::kBrowserWindowIsActive,
+       {UserActivityEventType::kBrowserDidBecomeActive,
         {brave_federated::mojom::CovariateType::
              kNumberOfBrowserWindowIsActiveEvents,
          brave_federated::mojom::CovariateType::
              kTimeSinceLastBrowserWindowIsActiveEvent}},
-       {UserActivityEventType::kBrowserWindowIsInactive,
+       {UserActivityEventType::kBrowserDidResignActive,
         {brave_federated::mojom::CovariateType::
              kNumberOfBrowserWindowIsInactiveEvents,
          brave_federated::mojom::CovariateType::

--- a/vendor/bat-native-ads/src/bat/ads/internal/federated/covariate_logs_unittest.cc
+++ b/vendor/bat-native-ads/src/bat/ads/internal/federated/covariate_logs_unittest.cc
@@ -28,7 +28,7 @@ TEST_F(BatAdsCovariateLogsTest, GetTrainingInstance) {
       CovariateLogs::Get()->GetTrainingInstance();
 
   // Assert
-  EXPECT_EQ(32U, training_covariates->covariates.size());
+  EXPECT_EQ(30U, training_covariates->covariates.size());
 }
 
 TEST_F(BatAdsCovariateLogsTest, GetTrainingInstanceWithSetters) {
@@ -41,7 +41,7 @@ TEST_F(BatAdsCovariateLogsTest, GetTrainingInstanceWithSetters) {
       CovariateLogs::Get()->GetTrainingInstance();
 
   // Assert
-  EXPECT_EQ(34U, training_covariates->covariates.size());
+  EXPECT_EQ(32U, training_covariates->covariates.size());
 }
 
 }  // namespace ads

--- a/vendor/bat-native-ads/src/bat/ads/internal/federated/log_entries/number_of_user_activity_events_unittest.cc
+++ b/vendor/bat-native-ads/src/bat/ads/internal/federated/log_entries/number_of_user_activity_events_unittest.cc
@@ -61,7 +61,7 @@ TEST_F(BatAdsFederatedLogEntriesNumberOfUserActivityEventsTest, GetValue) {
 
   UserActivity::Get()->RecordEvent(UserActivityEventType::kOpenedNewTab);
   UserActivity::Get()->RecordEvent(
-      UserActivityEventType::kBrowserWindowIsInactive);
+      UserActivityEventType::kBrowserDidResignActive);
 
   AdvanceClock(base::Minutes(31));
 

--- a/vendor/bat-native-ads/src/bat/ads/internal/frequency_capping/permission_rules/browser_is_active_permission_rule_unittest.cc
+++ b/vendor/bat-native-ads/src/bat/ads/internal/frequency_capping/permission_rules/browser_is_active_permission_rule_unittest.cc
@@ -29,8 +29,8 @@ TEST_F(BatAdsBrowserIsActivePermissionRuleTest, AllowAd) {
   MockPlatformHelper(platform_helper_mock_, PlatformType::kWindows);
 
   // Act
-  BrowserManager::Get()->OnActive();
-  BrowserManager::Get()->OnForegrounded();
+  BrowserManager::Get()->OnDidBecomeActive();
+  BrowserManager::Get()->OnDidEnterForeground();
 
   // Assert
   BrowserIsActivePermissionRule permission_rule;
@@ -43,8 +43,8 @@ TEST_F(BatAdsBrowserIsActivePermissionRuleTest, AlwaysAllowAdForAndroid) {
   MockPlatformHelper(platform_helper_mock_, PlatformType::kAndroid);
 
   // Act
-  BrowserManager::Get()->OnInactive();
-  BrowserManager::Get()->OnBackgrounded();
+  BrowserManager::Get()->OnDidResignActive();
+  BrowserManager::Get()->OnDidEnterBackground();
 
   // Assert
   BrowserIsActivePermissionRule permission_rule;
@@ -57,8 +57,8 @@ TEST_F(BatAdsBrowserIsActivePermissionRuleTest, DoNotAllowAd) {
   MockPlatformHelper(platform_helper_mock_, PlatformType::kWindows);
 
   // Act
-  BrowserManager::Get()->OnInactive();
-  BrowserManager::Get()->OnBackgrounded();
+  BrowserManager::Get()->OnDidResignActive();
+  BrowserManager::Get()->OnDidEnterBackground();
 
   // Assert
   BrowserIsActivePermissionRule permission_rule;
@@ -84,8 +84,8 @@ TEST_F(BatAdsBrowserIsActivePermissionRuleTest,
   MockPlatformHelper(platform_helper_mock_, PlatformType::kWindows);
 
   // Act
-  BrowserManager::Get()->OnInactive();
-  BrowserManager::Get()->OnBackgrounded();
+  BrowserManager::Get()->OnDidResignActive();
+  BrowserManager::Get()->OnDidEnterBackground();
 
   // Assert
   BrowserIsActivePermissionRule permission_rule;
@@ -99,8 +99,8 @@ TEST_F(BatAdsBrowserIsActivePermissionRuleTest,
   MockPlatformHelper(platform_helper_mock_, PlatformType::kWindows);
 
   // Act
-  BrowserManager::Get()->OnActive();
-  BrowserManager::Get()->OnBackgrounded();
+  BrowserManager::Get()->OnDidBecomeActive();
+  BrowserManager::Get()->OnDidEnterBackground();
 
   // Assert
   BrowserIsActivePermissionRule permission_rule;
@@ -114,8 +114,8 @@ TEST_F(BatAdsBrowserIsActivePermissionRuleTest,
   MockPlatformHelper(platform_helper_mock_, PlatformType::kWindows);
 
   // Act
-  BrowserManager::Get()->OnInactive();
-  BrowserManager::Get()->OnForegrounded();
+  BrowserManager::Get()->OnDidResignActive();
+  BrowserManager::Get()->OnDidEnterForeground();
 
   // Assert
   BrowserIsActivePermissionRule permission_rule;

--- a/vendor/bat-native-ads/src/bat/ads/internal/frequency_capping/permission_rules/do_not_disturb_permission_rule_unittest.cc
+++ b/vendor/bat-native-ads/src/bat/ads/internal/frequency_capping/permission_rules/do_not_disturb_permission_rule_unittest.cc
@@ -25,8 +25,8 @@ TEST_F(BatAdsDoNotDisturbPermissionRuleTest,
   // Arrange
   MockPlatformHelper(platform_helper_mock_, PlatformType::kAndroid);
 
-  BrowserManager::Get()->OnInactive();
-  BrowserManager::Get()->OnBackgrounded();
+  BrowserManager::Get()->OnDidResignActive();
+  BrowserManager::Get()->OnDidEnterBackground();
 
   AdvanceClockToMidnightUTC();
 
@@ -77,8 +77,8 @@ TEST_F(BatAdsDoNotDisturbPermissionRuleTest,
   // Arrange
   MockPlatformHelper(platform_helper_mock_, PlatformType::kAndroid);
 
-  BrowserManager::Get()->OnActive();
-  BrowserManager::Get()->OnForegrounded();
+  BrowserManager::Get()->OnDidBecomeActive();
+  BrowserManager::Get()->OnDidEnterForeground();
 
   AdvanceClock(Now().LocalMidnight() + base::Days(1) - Now());
 
@@ -128,8 +128,8 @@ TEST_F(BatAdsDoNotDisturbPermissionRuleTest, AlwaysAllowAdForIOS) {
   // Arrange
   MockPlatformHelper(platform_helper_mock_, PlatformType::kIOS);
 
-  BrowserManager::Get()->OnActive();
-  BrowserManager::Get()->OnForegrounded();
+  BrowserManager::Get()->OnDidBecomeActive();
+  BrowserManager::Get()->OnDidEnterForeground();
 
   AdvanceClock(Now().LocalMidnight() + base::Days(1) - Now());
 
@@ -158,8 +158,8 @@ TEST_F(BatAdsDoNotDisturbPermissionRuleTest, AlwaysAllowAdForMacOS) {
   // Arrange
   MockPlatformHelper(platform_helper_mock_, PlatformType::kWindows);
 
-  BrowserManager::Get()->OnActive();
-  BrowserManager::Get()->OnForegrounded();
+  BrowserManager::Get()->OnDidBecomeActive();
+  BrowserManager::Get()->OnDidEnterForeground();
 
   AdvanceClock(Now().LocalMidnight() + base::Days(1) - Now());
 
@@ -188,8 +188,8 @@ TEST_F(BatAdsDoNotDisturbPermissionRuleTest, AlwaysAllowAdForWindows) {
   // Arrange
   MockPlatformHelper(platform_helper_mock_, PlatformType::kWindows);
 
-  BrowserManager::Get()->OnActive();
-  BrowserManager::Get()->OnForegrounded();
+  BrowserManager::Get()->OnDidBecomeActive();
+  BrowserManager::Get()->OnDidEnterForeground();
 
   AdvanceClock(Now().LocalMidnight() + base::Days(1) - Now());
 
@@ -218,8 +218,8 @@ TEST_F(BatAdsDoNotDisturbPermissionRuleTest, AlwaysAllowAdForLinux) {
   // Arrange
   MockPlatformHelper(platform_helper_mock_, PlatformType::kLinux);
 
-  BrowserManager::Get()->OnActive();
-  BrowserManager::Get()->OnForegrounded();
+  BrowserManager::Get()->OnDidBecomeActive();
+  BrowserManager::Get()->OnDidEnterForeground();
 
   AdvanceClock(Now().LocalMidnight() + base::Days(1) - Now());
 

--- a/vendor/bat-native-ads/src/bat/ads/internal/user_activity/user_activity.cc
+++ b/vendor/bat-native-ads/src/bat/ads/internal/user_activity/user_activity.cc
@@ -10,6 +10,7 @@
 #include "base/check_op.h"
 #include "base/strings/string_number_conversions.h"
 #include "base/time/time.h"
+#include "bat/ads/internal/browser_manager/browser_manager.h"
 #include "bat/ads/internal/logging.h"
 #include "bat/ads/internal/user_activity/page_transition_util.h"
 #include "bat/ads/internal/user_activity/user_activity_features.h"
@@ -49,9 +50,13 @@ void LogEvent(const UserActivityEventType event_type) {
 UserActivity::UserActivity() {
   DCHECK_EQ(g_user_activity, nullptr);
   g_user_activity = this;
+
+  BrowserManager::Get()->AddObserver(this);
 }
 
 UserActivity::~UserActivity() {
+  BrowserManager::Get()->RemoveObserver(this);
+
   DCHECK(g_user_activity);
   g_user_activity = nullptr;
 }
@@ -133,6 +138,22 @@ UserActivityEventList UserActivity::GetHistoryForTimeWindow(
   filtered_history.erase(iter, filtered_history.end());
 
   return filtered_history;
+}
+
+void UserActivity::OnBrowserDidBecomeActive() {
+  RecordEvent(UserActivityEventType::kBrowserDidBecomeActive);
+}
+
+void UserActivity::OnBrowserDidResignActive() {
+  RecordEvent(UserActivityEventType::kBrowserDidResignActive);
+}
+
+void UserActivity::OnBrowserDidEnterForeground() {
+  RecordEvent(UserActivityEventType::kBrowserDidEnterForeground);
+}
+
+void UserActivity::OnBrowserDidEnterBackground() {
+  RecordEvent(UserActivityEventType::kBrowserDidEnterBackground);
 }
 
 }  // namespace ads

--- a/vendor/bat-native-ads/src/bat/ads/internal/user_activity/user_activity.h
+++ b/vendor/bat-native-ads/src/bat/ads/internal/user_activity/user_activity.h
@@ -8,6 +8,7 @@
 
 #include <cstdint>
 
+#include "bat/ads/internal/browser_manager/browser_manager_observer.h"
 #include "bat/ads/internal/user_activity/user_activity_event_info_aliases.h"
 #include "bat/ads/internal/user_activity/user_activity_event_types.h"
 #include "bat/ads/page_transition_types.h"
@@ -20,10 +21,10 @@ namespace ads {
 
 const int kMaximumHistoryEntries = 3600;
 
-class UserActivity final {
+class UserActivity final : public BrowserManagerObserver {
  public:
   UserActivity();
-  ~UserActivity();
+  ~UserActivity() override;
 
   UserActivity(const UserActivity&) = delete;
   UserActivity& operator=(const UserActivity&) = delete;
@@ -40,6 +41,12 @@ class UserActivity final {
       const base::TimeDelta time_window) const;
 
  private:
+  // BrowserManagerObserver:
+  void OnBrowserDidBecomeActive() override;
+  void OnBrowserDidResignActive() override;
+  void OnBrowserDidEnterForeground() override;
+  void OnBrowserDidEnterBackground() override;
+
   UserActivityEventList history_;
 };
 

--- a/vendor/bat-native-ads/src/bat/ads/internal/user_activity/user_activity_event_types.h
+++ b/vendor/bat-native-ads/src/bat/ads/internal/user_activity/user_activity_event_types.h
@@ -15,7 +15,7 @@ namespace ads {
 
 enum class UserActivityEventType : int8_t {
   /* 00 */ kInitializedAds = 0,
-  /* 01 */ kBrowserDidBecomeActive,
+  /* 01 */ kBrowserDidEnterForeground,
   /* 02 */ kBrowserDidEnterBackground,
   /* 03 */ kClickedBackOrForwardNavigationButtons,
   /* 04 */ kClickedBookmark,
@@ -36,8 +36,8 @@ enum class UserActivityEventType : int8_t {
   /* 13 */ kTypedKeywordOtherThanDefaultSearchProvider,
   /* 14 */ kTypedUrl,
   /* 15 */ kUsedAddressBar,
-  /* 16 */ kBrowserWindowIsActive,
-  /* 17 */ kBrowserWindowIsInactive
+  /* 16 */ kBrowserDidBecomeActive,
+  /* 17 */ kBrowserDidResignActive
 };
 
 }  // namespace ads

--- a/vendor/bat-native-ads/src/bat/ads/internal/user_activity/user_activity_unittest.cc
+++ b/vendor/bat-native-ads/src/bat/ads/internal/user_activity/user_activity_unittest.cc
@@ -31,7 +31,7 @@ TEST_F(BatAdsUserActivityTest, HasInstance) {
   EXPECT_TRUE(has_instance);
 }
 
-TEST_F(BatAdsUserActivityTest, RecordLaunchedBrowserEvent) {
+TEST_F(BatAdsUserActivityTest, RecordInitializedAdsEvent) {
   // Arrange
   const UserActivityEventType event_type =
       UserActivityEventType::kInitializedAds;
@@ -52,10 +52,10 @@ TEST_F(BatAdsUserActivityTest, RecordLaunchedBrowserEvent) {
   EXPECT_TRUE(IsEqualContainers(expected_events, events));
 }
 
-TEST_F(BatAdsUserActivityTest, RecordBrowserDidBecomeActiveEvent) {
+TEST_F(BatAdsUserActivityTest, RecordBrowserDidEnterForegroundEvent) {
   // Arrange
   const UserActivityEventType event_type =
-      UserActivityEventType::kBrowserDidBecomeActive;
+      UserActivityEventType::kBrowserDidEnterForeground;
 
   // Act
   UserActivity::Get()->RecordEvent(event_type);
@@ -472,6 +472,48 @@ TEST_F(BatAdsUserActivityTest, RecordUsedAddressBarEvent) {
   // Arrange
   const UserActivityEventType event_type =
       UserActivityEventType::kUsedAddressBar;
+
+  // Act
+  UserActivity::Get()->RecordEvent(event_type);
+
+  const UserActivityEventList events =
+      UserActivity::Get()->GetHistoryForTimeWindow(base::Hours(1));
+
+  // Assert
+  UserActivityEventList expected_events;
+  UserActivityEventInfo event;
+  event.type = event_type;
+  event.created_at = Now();
+  expected_events.push_back(event);
+
+  EXPECT_TRUE(IsEqualContainers(expected_events, events));
+}
+
+TEST_F(BatAdsUserActivityTest, RecordBrowserDidBecomeActiveEvent) {
+  // Arrange
+  const UserActivityEventType event_type =
+      UserActivityEventType::kBrowserDidBecomeActive;
+
+  // Act
+  UserActivity::Get()->RecordEvent(event_type);
+
+  const UserActivityEventList events =
+      UserActivity::Get()->GetHistoryForTimeWindow(base::Hours(1));
+
+  // Assert
+  UserActivityEventList expected_events;
+  UserActivityEventInfo event;
+  event.type = event_type;
+  event.created_at = Now();
+  expected_events.push_back(event);
+
+  EXPECT_TRUE(IsEqualContainers(expected_events, events));
+}
+
+TEST_F(BatAdsUserActivityTest, RecordBrowserDidResignActiveEvent) {
+  // Arrange
+  const UserActivityEventType event_type =
+      UserActivityEventType::kBrowserDidResignActive;
 
   // Act
   UserActivity::Get()->RecordEvent(event_type);


### PR DESCRIPTION
<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/14758

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

Confirm `Browser did enter background` appears in the log when the browser enters the background
Confirm `Browser did enter foreground` appears in the log when the browser enters the foreground
Confirm `Browser did become active` appears in the log when the browser window gains focus (i.e selecting between multiple active user profiles)
Confirm `Browser did resign active` appears in the log when the browser window loses focus (i.e selecting between multiple active user profiles)