### PR TITLE
Sync - on nigory folder error wait 3 sec instead of 30 sec

### DIFF
--- a/chromium_src/components/sync/engine/cycle/model_neutral_state.h
+++ b/chromium_src/components/sync/engine/cycle/model_neutral_state.h
@@ -1,0 +1,18 @@
+/* Copyright (c) 2022 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_CHROMIUM_SRC_COMPONENTS_SYNC_ENGINE_CYCLE_MODEL_NEUTRAL_STATE_H_
+#define BRAVE_CHROMIUM_SRC_COMPONENTS_SYNC_ENGINE_CYCLE_MODEL_NEUTRAL_STATE_H_
+
+#define last_download_updates_result     \
+  unused;                                \
+  std::string last_server_error_message; \
+  SyncerError last_download_updates_result
+
+#include "src/components/sync/engine/cycle/model_neutral_state.h"
+
+#undef last_download_updates_result
+
+#endif  // BRAVE_CHROMIUM_SRC_COMPONENTS_SYNC_ENGINE_CYCLE_MODEL_NEUTRAL_STATE_H_

--- a/chromium_src/components/sync/engine/cycle/status_controller.cc
+++ b/chromium_src/components/sync/engine/cycle/status_controller.cc
@@ -7,13 +7,13 @@
 
 namespace syncer {
 
-std::string StatusController::get_last_server_error_message() const {
-  return last_server_error_message_;
+const std::string& StatusController::get_last_server_error_message() const {
+  return model_neutral_.last_server_error_message;
 }
 
 void StatusController::set_last_server_error_message(
     const std::string& message) {
-  last_server_error_message_ = message;
+  model_neutral_.last_server_error_message = message;
 }
 
 }  // namespace syncer

--- a/chromium_src/components/sync/engine/cycle/status_controller.cc
+++ b/chromium_src/components/sync/engine/cycle/status_controller.cc
@@ -1,0 +1,19 @@
+/* Copyright (c) 2022 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "src/components/sync/engine/cycle/status_controller.cc"
+
+namespace syncer {
+
+std::string StatusController::get_last_server_error_message() const {
+  return last_server_error_message_;
+}
+
+void StatusController::set_last_server_error_message(
+    const std::string& message) {
+  last_server_error_message_ = message;
+}
+
+}  // namespace syncer

--- a/chromium_src/components/sync/engine/cycle/status_controller.h
+++ b/chromium_src/components/sync/engine/cycle/status_controller.h
@@ -1,0 +1,23 @@
+/* Copyright (c) 2022 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_CHROMIUM_SRC_COMPONENTS_SYNC_ENGINE_CYCLE_STATUS_CONTROLLER_H_
+#define BRAVE_CHROMIUM_SRC_COMPONENTS_SYNC_ENGINE_CYCLE_STATUS_CONTROLLER_H_
+
+#define set_commit_result                                    \
+  set_last_server_error_message(const std::string& message); \
+                                                             \
+ private:                                                    \
+  std::string last_server_error_message_;                    \
+                                                             \
+ public:                                                     \
+  std::string get_last_server_error_message() const;         \
+  void set_commit_result
+
+#include "src/components/sync/engine/cycle/status_controller.h"
+
+#undef set_commit_result
+
+#endif  // BRAVE_CHROMIUM_SRC_COMPONENTS_SYNC_ENGINE_CYCLE_STATUS_CONTROLLER_H_

--- a/chromium_src/components/sync/engine/cycle/status_controller.h
+++ b/chromium_src/components/sync/engine/cycle/status_controller.h
@@ -9,11 +9,8 @@
 #define set_commit_result                                    \
   set_last_server_error_message(const std::string& message); \
                                                              \
- private:                                                    \
-  std::string last_server_error_message_;                    \
-                                                             \
  public:                                                     \
-  std::string get_last_server_error_message() const;         \
+  const std::string& get_last_server_error_message() const;  \
   void set_commit_result
 
 #include "src/components/sync/engine/cycle/status_controller.h"

--- a/chromium_src/components/sync/engine/sync_scheduler_impl.cc
+++ b/chromium_src/components/sync/engine/sync_scheduler_impl.cc
@@ -1,0 +1,33 @@
+/* Copyright (c) 2022 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#define BRAVE_HANDLE_CONFIGURATION_FAILURE \
+  HandleBraveConfigurationFailure(cycle.status_controller());
+
+#include "src/components/sync/engine/sync_scheduler_impl.cc"
+
+#undef BRAVE_HANDLE_CONFIGURATION_FAILURE
+
+namespace syncer {
+
+namespace {
+
+const char kNigoriFolderNotReadyError[] =
+    "nigori root folder entity is not ready yet";
+
+}  // namespace
+
+void SyncSchedulerImpl::HandleBraveConfigurationFailure(
+    const StatusController& status_controller) {
+  if (status_controller.get_last_server_error_message() ==
+      kNigoriFolderNotReadyError) {
+    VLOG(1) << "Got nigori root folder error from sync server. Override wait "
+               "interval to 3 sec";
+    wait_interval_ = std::make_unique<WaitInterval>(
+        WaitInterval::BlockingMode::kThrottled, base::Seconds(3));
+  }
+}
+
+}  // namespace syncer

--- a/chromium_src/components/sync/engine/sync_scheduler_impl.cc
+++ b/chromium_src/components/sync/engine/sync_scheduler_impl.cc
@@ -3,12 +3,12 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-#define BRAVE_HANDLE_CONFIGURATION_FAILURE \
-  HandleBraveConfigurationFailure(cycle.status_controller());
+#define BRAVE_SYNC_SCHEDULER_IMPL_HANDLE_FAILURE \
+  HandleBraveConfigurationFailure(model_neutral_state);
 
 #include "src/components/sync/engine/sync_scheduler_impl.cc"
 
-#undef BRAVE_HANDLE_CONFIGURATION_FAILURE
+#undef BRAVE_SYNC_SCHEDULER_IMPL_HANDLE_FAILURE
 
 namespace syncer {
 
@@ -16,8 +16,8 @@ const char kNigoriFolderNotReadyError[] =
     "nigori root folder entity is not ready yet";
 
 void SyncSchedulerImpl::HandleBraveConfigurationFailure(
-    const StatusController& status_controller) {
-  if (status_controller.get_last_server_error_message() ==
+    const ModelNeutralState& model_neutral_state) {
+  if (model_neutral_state.last_server_error_message ==
       kNigoriFolderNotReadyError) {
     VLOG(1) << "Got nigori root folder error from sync server. Override wait "
                "interval to 3 sec";

--- a/chromium_src/components/sync/engine/sync_scheduler_impl.cc
+++ b/chromium_src/components/sync/engine/sync_scheduler_impl.cc
@@ -12,12 +12,8 @@
 
 namespace syncer {
 
-namespace {
-
 const char kNigoriFolderNotReadyError[] =
     "nigori root folder entity is not ready yet";
-
-}  // namespace
 
 void SyncSchedulerImpl::HandleBraveConfigurationFailure(
     const StatusController& status_controller) {

--- a/chromium_src/components/sync/engine/sync_scheduler_impl.h
+++ b/chromium_src/components/sync/engine/sync_scheduler_impl.h
@@ -12,8 +12,9 @@ extern const char kNigoriFolderNotReadyError[];
 
 }  // namespace syncer
 
-#define DoPollSyncCycleJob                                                    \
-  HandleBraveConfigurationFailure(const StatusController& status_controller); \
+#define DoPollSyncCycleJob                           \
+  HandleBraveConfigurationFailure(                   \
+      const ModelNeutralState& model_neutral_state); \
   void DoPollSyncCycleJob
 
 #include "src/components/sync/engine/sync_scheduler_impl.h"

--- a/chromium_src/components/sync/engine/sync_scheduler_impl.h
+++ b/chromium_src/components/sync/engine/sync_scheduler_impl.h
@@ -1,0 +1,17 @@
+/* Copyright (c) 2022 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_CHROMIUM_SRC_COMPONENTS_SYNC_ENGINE_SYNC_SCHEDULER_IMPL_H_
+#define BRAVE_CHROMIUM_SRC_COMPONENTS_SYNC_ENGINE_SYNC_SCHEDULER_IMPL_H_
+
+#define DoPollSyncCycleJob                                                    \
+  HandleBraveConfigurationFailure(const StatusController& status_controller); \
+  void DoPollSyncCycleJob
+
+#include "src/components/sync/engine/sync_scheduler_impl.h"
+
+#undef DoPollSyncCycleJob
+
+#endif  // BRAVE_CHROMIUM_SRC_COMPONENTS_SYNC_ENGINE_SYNC_SCHEDULER_IMPL_H_

--- a/chromium_src/components/sync/engine/sync_scheduler_impl.h
+++ b/chromium_src/components/sync/engine/sync_scheduler_impl.h
@@ -6,6 +6,12 @@
 #ifndef BRAVE_CHROMIUM_SRC_COMPONENTS_SYNC_ENGINE_SYNC_SCHEDULER_IMPL_H_
 #define BRAVE_CHROMIUM_SRC_COMPONENTS_SYNC_ENGINE_SYNC_SCHEDULER_IMPL_H_
 
+namespace syncer {
+
+extern const char kNigoriFolderNotReadyError[];
+
+}  // namespace syncer
+
 #define DoPollSyncCycleJob                                                    \
   HandleBraveConfigurationFailure(const StatusController& status_controller); \
   void DoPollSyncCycleJob

--- a/chromium_src/components/sync/engine/sync_scheduler_impl_unittest.cc
+++ b/chromium_src/components/sync/engine/sync_scheduler_impl_unittest.cc
@@ -1,0 +1,52 @@
+/* Copyright (c) 2022 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "src/components/sync/engine/sync_scheduler_impl_unittest.cc"
+
+namespace syncer {
+
+namespace {
+
+void SimulatePollFailedRegularTransientError(ModelTypeSet requested_types,
+                                             SyncCycle* cycle) {
+  cycle->mutable_status_controller()->set_last_download_updates_result(
+      SyncerError(SyncerError::SERVER_RETURN_TRANSIENT_ERROR));
+}
+
+void SimulatePollFailedNigoryNotReady(ModelTypeSet requested_types,
+                                      SyncCycle* cycle) {
+  cycle->mutable_status_controller()->set_last_download_updates_result(
+      SyncerError(SyncerError::SERVER_RETURN_TRANSIENT_ERROR));
+
+  cycle->mutable_status_controller()->set_last_server_error_message(
+      kNigoriFolderNotReadyError);
+}
+
+}  // namespace
+
+TEST_F(SyncSchedulerImplTest, BraveNoBackoffOnNigoriError) {
+  scheduler()->OnReceivedPollIntervalUpdate(base::Milliseconds(10));
+  UseMockDelayProvider();  // Will cause test failure if backoff is initiated.
+  EXPECT_CALL(*delay(), GetDelay).WillRepeatedly(Return(base::Milliseconds(0)));
+
+  SyncShareTimes times;
+  EXPECT_CALL(*syncer(), PollSyncShare)
+      .WillOnce(DoAll(Invoke(SimulatePollFailedNigoryNotReady),
+                      RecordSyncShare(&times, false)))
+      .WillOnce(DoAll(Invoke(SimulatePollFailedRegularTransientError),
+                      RecordSyncShare(&times, false)));
+
+  StartSyncScheduler(base::Time());
+
+  // Nigory folder error should not trigger backoff.
+  RunLoop();
+  EXPECT_FALSE(scheduler()->IsGlobalBackoff());
+
+  // Regular transient error should trigger backoff.
+  RunLoop();
+  EXPECT_TRUE(scheduler()->IsGlobalBackoff());
+}
+
+}  // namespace syncer

--- a/chromium_src/components/sync/engine/syncer_proto_util.cc
+++ b/chromium_src/components/sync/engine/syncer_proto_util.cc
@@ -3,12 +3,12 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-#define BRAVE_POST_CLIENT_TO_SERVER_MESSAGE \
+#define BRAVE_SYNCER_PROTO_UTIL_POST_CLIENT_TO_SERVER_MESSAGE \
   SaveServerErrorMessage(*response, cycle->mutable_status_controller());
 
 #include "src/components/sync/engine/syncer_proto_util.cc"
 
-#undef BRAVE_POST_CLIENT_TO_SERVER_MESSAGE
+#undef BRAVE_SYNCER_PROTO_UTIL_POST_CLIENT_TO_SERVER_MESSAGE
 
 namespace syncer {
 
@@ -17,8 +17,7 @@ void SyncerProtoUtil::SaveServerErrorMessage(
     const sync_pb::ClientToServerResponse& response,
     StatusController* status_controller) {
   if (response.has_error_message()) {
-    std::string error_description = response.error_message();
-    status_controller->set_last_server_error_message(error_description);
+    status_controller->set_last_server_error_message(response.error_message());
   } else {
     status_controller->set_last_server_error_message(std::string());
   }

--- a/chromium_src/components/sync/engine/syncer_proto_util.cc
+++ b/chromium_src/components/sync/engine/syncer_proto_util.cc
@@ -1,0 +1,27 @@
+/* Copyright (c) 2022 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#define BRAVE_POST_CLIENT_TO_SERVER_MESSAGE \
+  SaveServerErrorMessage(*response, cycle->mutable_status_controller());
+
+#include "src/components/sync/engine/syncer_proto_util.cc"
+
+#undef BRAVE_POST_CLIENT_TO_SERVER_MESSAGE
+
+namespace syncer {
+
+// static
+void SyncerProtoUtil::SaveServerErrorMessage(
+    const sync_pb::ClientToServerResponse& response,
+    StatusController* status_controller) {
+  if (response.has_error_message()) {
+    std::string error_description = response.error_message();
+    status_controller->set_last_server_error_message(error_description);
+  } else {
+    status_controller->set_last_server_error_message(std::string());
+  }
+}
+
+}  // namespace syncer

--- a/chromium_src/components/sync/engine/syncer_proto_util.h
+++ b/chromium_src/components/sync/engine/syncer_proto_util.h
@@ -1,0 +1,18 @@
+/* Copyright (c) 2022 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_CHROMIUM_SRC_COMPONENTS_SYNC_ENGINE_SYNCER_PROTO_UTIL_H_
+#define BRAVE_CHROMIUM_SRC_COMPONENTS_SYNC_ENGINE_SYNCER_PROTO_UTIL_H_
+
+#define SetProtocolVersion                                                \
+  SaveServerErrorMessage(const sync_pb::ClientToServerResponse& response, \
+                         StatusController* status_controller);            \
+  static void SetProtocolVersion
+
+#include "src/components/sync/engine/syncer_proto_util.h"
+
+#undef SetProtocolVersion
+
+#endif  // BRAVE_CHROMIUM_SRC_COMPONENTS_SYNC_ENGINE_SYNCER_PROTO_UTIL_H_

--- a/patches/components-sync-engine-sync_scheduler_impl.cc.patch
+++ b/patches/components-sync-engine-sync_scheduler_impl.cc.patch
@@ -1,28 +1,12 @@
 diff --git a/components/sync/engine/sync_scheduler_impl.cc b/components/sync/engine/sync_scheduler_impl.cc
-index d1291a21684f65dc7904d42e06718d852c088f08..8503eca3984b454728c09da4d6530433635631b3 100644
+index d1291a21684f65dc7904d42e06718d852c088f08..f4e0e972c8f13d437b4e7eaf798c2b3cb54d1214 100644
 --- a/components/sync/engine/sync_scheduler_impl.cc
 +++ b/components/sync/engine/sync_scheduler_impl.cc
-@@ -445,6 +445,7 @@ void SyncSchedulerImpl::DoNudgeSyncCycleJob(JobPriority priority) {
-     }
-   } else {
-     HandleFailure(cycle.status_controller().model_neutral_state());
-+    BRAVE_HANDLE_CONFIGURATION_FAILURE
+@@ -507,6 +507,7 @@ void SyncSchedulerImpl::HandleFailure(
+     SDVLOG(2) << "Sync cycle failed.  Will back off for "
+               << wait_interval_->length.InMilliseconds() << "ms.";
    }
++  BRAVE_SYNC_SCHEDULER_IMPL_HANDLE_FAILURE
  }
  
-@@ -480,6 +481,7 @@ void SyncSchedulerImpl::DoConfigurationSyncCycleJob(JobPriority priority) {
-     HandleFailure(cycle.status_controller().model_neutral_state());
-     // Sync cycle might receive response from server that causes scheduler to
-     // stop and draws pending_configure_params_ invalid.
-+    BRAVE_HANDLE_CONFIGURATION_FAILURE
-   }
- }
- 
-@@ -522,6 +524,7 @@ void SyncSchedulerImpl::DoPollSyncCycleJob() {
-     HandleSuccess();
-   } else {
-     HandleFailure(cycle.status_controller().model_neutral_state());
-+    BRAVE_HANDLE_CONFIGURATION_FAILURE
-   }
- }
- 
+ void SyncSchedulerImpl::DoPollSyncCycleJob() {

--- a/patches/components-sync-engine-sync_scheduler_impl.cc.patch
+++ b/patches/components-sync-engine-sync_scheduler_impl.cc.patch
@@ -1,0 +1,28 @@
+diff --git a/components/sync/engine/sync_scheduler_impl.cc b/components/sync/engine/sync_scheduler_impl.cc
+index d1291a21684f65dc7904d42e06718d852c088f08..8503eca3984b454728c09da4d6530433635631b3 100644
+--- a/components/sync/engine/sync_scheduler_impl.cc
++++ b/components/sync/engine/sync_scheduler_impl.cc
+@@ -445,6 +445,7 @@ void SyncSchedulerImpl::DoNudgeSyncCycleJob(JobPriority priority) {
+     }
+   } else {
+     HandleFailure(cycle.status_controller().model_neutral_state());
++    BRAVE_HANDLE_CONFIGURATION_FAILURE
+   }
+ }
+ 
+@@ -480,6 +481,7 @@ void SyncSchedulerImpl::DoConfigurationSyncCycleJob(JobPriority priority) {
+     HandleFailure(cycle.status_controller().model_neutral_state());
+     // Sync cycle might receive response from server that causes scheduler to
+     // stop and draws pending_configure_params_ invalid.
++    BRAVE_HANDLE_CONFIGURATION_FAILURE
+   }
+ }
+ 
+@@ -522,6 +524,7 @@ void SyncSchedulerImpl::DoPollSyncCycleJob() {
+     HandleSuccess();
+   } else {
+     HandleFailure(cycle.status_controller().model_neutral_state());
++    BRAVE_HANDLE_CONFIGURATION_FAILURE
+   }
+ }
+ 

--- a/patches/components-sync-engine-syncer_proto_util.cc.patch
+++ b/patches/components-sync-engine-syncer_proto_util.cc.patch
@@ -1,0 +1,12 @@
+diff --git a/components/sync/engine/syncer_proto_util.cc b/components/sync/engine/syncer_proto_util.cc
+index dfc4a2d32a81aab75ef4cf083a133029105a057e..f4b34d14ea69167d2952e50fab3f3d2c605f529e 100644
+--- a/components/sync/engine/syncer_proto_util.cc
++++ b/components/sync/engine/syncer_proto_util.cc
+@@ -440,6 +440,7 @@ SyncerError SyncerProtoUtil::PostClientToServerMessage(
+ 
+   SyncProtocolError sync_protocol_error =
+       GetProtocolErrorFromResponse(*response, cycle->context());
++  BRAVE_POST_CLIENT_TO_SERVER_MESSAGE
+ 
+   // Inform the delegate of the error we got.
+   cycle->delegate()->OnSyncProtocolError(sync_protocol_error);

--- a/patches/components-sync-engine-syncer_proto_util.cc.patch
+++ b/patches/components-sync-engine-syncer_proto_util.cc.patch
@@ -1,12 +1,12 @@
 diff --git a/components/sync/engine/syncer_proto_util.cc b/components/sync/engine/syncer_proto_util.cc
-index dfc4a2d32a81aab75ef4cf083a133029105a057e..f4b34d14ea69167d2952e50fab3f3d2c605f529e 100644
+index dfc4a2d32a81aab75ef4cf083a133029105a057e..186d123dd931ba03e7edaca14c44ad341821737f 100644
 --- a/components/sync/engine/syncer_proto_util.cc
 +++ b/components/sync/engine/syncer_proto_util.cc
 @@ -440,6 +440,7 @@ SyncerError SyncerProtoUtil::PostClientToServerMessage(
  
    SyncProtocolError sync_protocol_error =
        GetProtocolErrorFromResponse(*response, cycle->context());
-+  BRAVE_POST_CLIENT_TO_SERVER_MESSAGE
++  BRAVE_SYNCER_PROTO_UTIL_POST_CLIENT_TO_SERVER_MESSAGE
  
    // Inform the delegate of the error we got.
    cycle->delegate()->OnSyncProtocolError(sync_protocol_error);

--- a/test/BUILD.gn
+++ b/test/BUILD.gn
@@ -146,6 +146,7 @@ test("brave_unit_tests") {
     "//components/bookmarks/browser/bookmark_model_unittest.cc",
     "//components/sync/base/model_type_unittest.cc",
     "//components/sync/driver/sync_auth_manager_unittest.cc",
+    "//components/sync/engine/sync_scheduler_impl_unittest.cc",
     "//components/sync_device_info/device_info_sync_bridge_unittest.cc",
   ]
 


### PR DESCRIPTION
<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/22577

This PR adds the code, which handles `nigori root folder entity is not ready yet` server error more gently, by doing the next poll attempt in 3 sec instead of 30. 

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

