### PR TITLE
Added wallet bubble focus observer

### DIFF
--- a/browser/ui/BUILD.gn
+++ b/browser/ui/BUILD.gn
@@ -591,6 +591,8 @@ source_set("ui") {
       "views/permission_bubble/brave_wallet_permission_prompt_impl.h",
       "views/toolbar/wallet_button.cc",
       "views/toolbar/wallet_button.h",
+      "views/wallet_bubble_focus_observer.cc",
+      "views/wallet_bubble_focus_observer.h",
       "wallet_bubble_manager_delegate_impl.cc",
       "wallet_bubble_manager_delegate_impl.h",
       "webui/brave_untrusted_web_ui_controller_factory.cc",

--- a/browser/ui/views/wallet_bubble_focus_observer.cc
+++ b/browser/ui/views/wallet_bubble_focus_observer.cc
@@ -1,0 +1,128 @@
+/* Copyright (c) 2022 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "brave/browser/ui/views/wallet_bubble_focus_observer.h"
+
+#include "chrome/browser/ui/views/bubble/webui_bubble_dialog_view.h"
+#include "chrome/browser/ui/views/frame/browser_view.h"
+#include "ui/views/controls/webview/webview.h"
+
+WalletBubbleFocusObserver::WalletBubbleFocusObserver(
+    WebUIBubbleDialogView* web_ui_bubble_view,
+    views::FocusManager* focus_manager)
+    : web_ui_bubble_view_(web_ui_bubble_view), focus_manager_(focus_manager) {
+  Subscribe();
+}
+
+WalletBubbleFocusObserver::~WalletBubbleFocusObserver() {
+  Unsubscribe();
+}
+
+void WalletBubbleFocusObserver::Subscribe() {
+  if (!web_ui_bubble_view_ || !focus_manager_ ||
+      !web_ui_bubble_view_->web_view())
+    return;
+  web_ui_bubble_view_->web_view()->AddObserver(this);
+  focus_manager_->AddFocusChangeListener(this);
+}
+
+void WalletBubbleFocusObserver::Unsubscribe() {
+  if (web_ui_bubble_view_ && web_ui_bubble_view_->web_view())
+    web_ui_bubble_view_->web_view()->RemoveObserver(this);
+  if (focus_manager_)
+    focus_manager_->RemoveFocusChangeListener(this);
+}
+
+bool WalletBubbleFocusObserver::IsBubbleLocked() const {
+  return close_on_deactivate_.has_value();
+}
+
+void WalletBubbleFocusObserver::Lock(bool close_on_deactivate) {
+  DCHECK(!IsBubbleLocked());
+  // Save state to restore it when lock released.
+  close_on_deactivate_ = close_on_deactivate;
+  // Lock the bubble
+  SetBubbleDeactivationState(false);
+}
+
+void WalletBubbleFocusObserver::ReleaseLock(bool close_on_deactivate) {
+  DCHECK(IsBubbleLocked());
+  SetBubbleDeactivationState(close_on_deactivate);
+  close_on_deactivate_.reset();
+}
+
+// Update saved state to restore with new values.
+void WalletBubbleFocusObserver::UpdateBubbleDeactivationState(bool state) {
+  if (!IsBubbleLocked())
+    return;
+
+  close_on_deactivate_ = state;
+}
+
+void WalletBubbleFocusObserver::SetBubbleDeactivationState(
+    bool close_on_deactivate) {
+  if (!web_ui_bubble_view_)
+    return;
+  web_ui_bubble_view_->set_close_on_deactivate(close_on_deactivate);
+}
+
+bool WalletBubbleFocusObserver::GetCurrentBubbleDeactivationState() {
+  return web_ui_bubble_view_->close_on_deactivate();
+}
+
+void WalletBubbleFocusObserver::CloseBubble() {
+  if (!web_ui_bubble_view_)
+    return;
+  web_ui_bubble_view_->CloseUI();
+}
+
+// Called when the bubble webview captured focus.
+// Set actual flag state back.
+void WalletBubbleFocusObserver::OnViewFocused(views::View* observed_view) {
+  if (!IsBubbleLocked())
+    return;
+
+  ReleaseLock(close_on_deactivate_.value());
+}
+
+// Set lock for closing until we get focus notification from the browser window.
+void WalletBubbleFocusObserver::OnViewBlurred(views::View* observed_view) {
+  Lock(GetCurrentBubbleDeactivationState());
+}
+
+// The focus is in the browser window now.
+void WalletBubbleFocusObserver::OnWillChangeFocus(views::View* focused_before,
+                                                  views::View* focused_now) {
+  if (!IsBubbleLocked() || !focused_now)
+    return;
+
+  if (close_on_deactivate_.value()) {
+    // Close the bubble since it has lost focus already.
+    CloseBubble();
+  }
+
+  ReleaseLock(close_on_deactivate_.value());
+}
+
+void WalletBubbleFocusObserver::OnDidChangeFocus(views::View* focused_before,
+                                                 views::View* focused_now) {}
+
+// static
+std::unique_ptr<WalletBubbleFocusObserver>
+WalletBubbleFocusObserver::CreateForView(
+    WebUIBubbleDialogView* web_ui_bubble_view,
+    Browser* browser) {
+  if (!browser || !web_ui_bubble_view)
+    return nullptr;
+  auto* browser_view = BrowserView::GetBrowserViewForBrowser(browser);
+  if (!browser_view)
+    return nullptr;
+
+  if (!browser_view->GetFocusManager())
+    return nullptr;
+
+  return std::make_unique<WalletBubbleFocusObserver>(
+      web_ui_bubble_view, browser_view->GetFocusManager());
+}

--- a/browser/ui/views/wallet_bubble_focus_observer.h
+++ b/browser/ui/views/wallet_bubble_focus_observer.h
@@ -1,0 +1,77 @@
+/* Copyright (c) 2022 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_BROWSER_UI_VIEWS_WALLET_BUBBLE_FOCUS_OBSERVER_H_
+#define BRAVE_BROWSER_UI_VIEWS_WALLET_BUBBLE_FOCUS_OBSERVER_H_
+
+#include <memory>
+
+#include "third_party/abseil-cpp/absl/types/optional.h"
+#include "ui/views/focus/focus_manager.h"
+#include "ui/views/view_observer.h"
+
+namespace views {
+class View;
+}  // namespace views
+
+class Browser;
+class WebUIBubbleDialogView;
+
+class WalletBubbleFocusObserver : public views::ViewObserver,
+                                  public views::FocusChangeListener {
+ public:
+  static std::unique_ptr<WalletBubbleFocusObserver> CreateForView(
+      WebUIBubbleDialogView* web_ui_bubble_view,
+      Browser* browser);
+
+  explicit WalletBubbleFocusObserver(WebUIBubbleDialogView* web_ui_bubble_view,
+                                     views::FocusManager* focus_manager);
+
+  void UpdateBubbleDeactivationState(bool state);
+  ~WalletBubbleFocusObserver() override;
+
+  WalletBubbleFocusObserver(const WalletBubbleFocusObserver&) = delete;
+  WalletBubbleFocusObserver& operator=(const WalletBubbleFocusObserver&) =
+      delete;
+
+ protected:
+  FRIEND_TEST_ALL_PREFIXES(WalletBubbleFocusObserverUnitTest,
+                           FocusOutFromWindowAndBackToPanel);
+  FRIEND_TEST_ALL_PREFIXES(WalletBubbleFocusObserverUnitTest,
+                           ClosePanelWhenFocusOutAndBackToBrowserWindow);
+  FRIEND_TEST_ALL_PREFIXES(WalletBubbleFocusObserverUnitTest,
+                           UpdatePanelStateWhenUnfocused);
+
+  void ReleaseLock(bool close_on_deactivate);
+  void Lock(bool close_on_deactivate);
+  bool IsBubbleLocked() const;
+
+  // Methods are virtual for testing purposes.
+  virtual void Subscribe();
+  virtual void Unsubscribe();
+  virtual void SetBubbleDeactivationState(bool close_on_deactivate);
+  virtual bool GetCurrentBubbleDeactivationState();
+  virtual void CloseBubble();
+
+  absl::optional<bool> close_on_deactivate() { return close_on_deactivate_; }
+  // views::ViewObserver
+  // Listening Bubble's WebView focus events
+  void OnViewFocused(views::View* observed_view) override;
+  void OnViewBlurred(views::View* observed_view) override;
+
+  // views::FocusChangeListener
+  // Listening Bubble's anchor browser focus events
+  void OnWillChangeFocus(views::View* focused_before,
+                         views::View* focused_now) override;
+  void OnDidChangeFocus(views::View* focused_before,
+                        views::View* focused_now) override;
+
+ private:
+  raw_ptr<WebUIBubbleDialogView> const web_ui_bubble_view_;
+  raw_ptr<views::FocusManager> const focus_manager_;
+  absl::optional<bool> close_on_deactivate_;
+};
+
+#endif  // BRAVE_BROWSER_UI_VIEWS_WALLET_BUBBLE_FOCUS_OBSERVER_H_

--- a/browser/ui/views/wallet_bubble_focus_observer_unittest.cc
+++ b/browser/ui/views/wallet_bubble_focus_observer_unittest.cc
@@ -1,0 +1,117 @@
+/* Copyright (c) 2022 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "brave/browser/ui/views/wallet_bubble_focus_observer.h"
+
+#include "chrome/browser/ui/views/bubble/webui_bubble_dialog_view.h"
+#include "testing/gtest/include/gtest/gtest.h"
+#include "third_party/abseil-cpp/absl/types/optional.h"
+#include "ui/views/focus/focus_manager.h"
+#include "ui/views/view_observer.h"
+
+class WebUIBubbleDialogView;
+
+class TestWalletBubbleFocusObserver : public WalletBubbleFocusObserver {
+ public:
+  TestWalletBubbleFocusObserver(WebUIBubbleDialogView* web_ui_bubble_view,
+                                views::FocusManager* focus_manager)
+      : WalletBubbleFocusObserver(web_ui_bubble_view, focus_manager) {
+    Subscribe();
+  }
+
+  ~TestWalletBubbleFocusObserver() override {}
+
+  void Subscribe() override { subscribed_ = true; }
+  void Unsubscribe() override { subscribed_ = false; }
+  void SetBubbleDeactivationState(bool close_on_deactivate) override {
+    bubble_deactivation_state_ = close_on_deactivate;
+  }
+  bool GetCurrentBubbleDeactivationState() override {
+    return bubble_deactivation_state_;
+  }
+  void CloseBubble() override { close_buble_called_ = true; }
+
+  bool subscribed() { return subscribed_; }
+  bool locked() { return locked_; }
+  bool saved_deactivation_flag() { return saved_deactivation_flag_; }
+  bool bubble_deactivation_state() { return bubble_deactivation_state_; }
+  bool close_buble_called() { return close_buble_called_; }
+
+ private:
+  bool bubble_deactivation_state_ = true;
+  bool close_buble_called_ = false;
+  bool subscribed_ = false;
+  bool locked_ = false;
+  bool saved_deactivation_flag_ = false;
+};
+
+TEST(WalletBubbleFocusObserverUnitTest, FocusOutFromWindowAndBackToPanel) {
+  TestWalletBubbleFocusObserver observer(nullptr, nullptr);
+  ASSERT_TRUE(observer.subscribed());
+  ASSERT_FALSE(observer.IsBubbleLocked());
+  EXPECT_EQ(observer.close_on_deactivate(), absl::nullopt);
+  ASSERT_TRUE(observer.bubble_deactivation_state());
+  // Focus out of view.
+  observer.OnViewBlurred(nullptr);
+  ASSERT_FALSE(observer.bubble_deactivation_state());
+  ASSERT_TRUE(observer.close_on_deactivate());
+
+  // Focus returned back to bubble view.
+  observer.OnViewFocused(nullptr);
+  ASSERT_TRUE(observer.bubble_deactivation_state());
+  EXPECT_EQ(observer.close_on_deactivate(), absl::nullopt);
+}
+
+TEST(WalletBubbleFocusObserverUnitTest,
+     ClosePanelWhenFocusOutAndBackToBrowserWindow) {
+  TestWalletBubbleFocusObserver observer(nullptr, nullptr);
+  ASSERT_TRUE(observer.subscribed());
+  ASSERT_FALSE(observer.IsBubbleLocked());
+  EXPECT_EQ(observer.close_on_deactivate(), absl::nullopt);
+  ASSERT_TRUE(observer.bubble_deactivation_state());
+  ASSERT_FALSE(observer.close_buble_called());
+  // Focus out of view.
+  observer.OnViewBlurred(nullptr);
+  ASSERT_FALSE(observer.bubble_deactivation_state());
+  ASSERT_TRUE(observer.close_on_deactivate());
+  ASSERT_FALSE(observer.close_buble_called());
+  // Focus returned back to bubble view.
+  views::View view;
+  observer.OnWillChangeFocus(nullptr, &view);
+  ASSERT_TRUE(observer.bubble_deactivation_state());
+  EXPECT_EQ(observer.close_on_deactivate(), absl::nullopt);
+  ASSERT_TRUE(observer.close_buble_called());
+}
+
+TEST(WalletBubbleFocusObserverUnitTest, UpdatePanelStateWhenUnfocused) {
+  TestWalletBubbleFocusObserver observer(nullptr, nullptr);
+  ASSERT_TRUE(observer.subscribed());
+  ASSERT_FALSE(observer.IsBubbleLocked());
+  EXPECT_EQ(observer.close_on_deactivate(), absl::nullopt);
+  ASSERT_TRUE(observer.bubble_deactivation_state());
+  ASSERT_FALSE(observer.close_buble_called());
+  // Focus out of view.
+  observer.OnViewBlurred(nullptr);
+  ASSERT_FALSE(observer.bubble_deactivation_state());
+  ASSERT_TRUE(observer.close_on_deactivate());
+  ASSERT_FALSE(observer.close_buble_called());
+
+  // Some API call blocked the bubble form closing while
+  // user was in another window.
+  observer.UpdateBubbleDeactivationState(false);
+
+  // Focus returned back to bubble view.
+  views::View view;
+  observer.OnWillChangeFocus(nullptr, &view);
+  ASSERT_FALSE(observer.bubble_deactivation_state());
+  EXPECT_EQ(observer.close_on_deactivate(), absl::nullopt);
+  // We should not close the bubble if user interacts with the browser window
+  ASSERT_FALSE(observer.close_buble_called());
+
+  // Focus returned back to bubble view.
+  observer.OnViewFocused(nullptr);
+  ASSERT_FALSE(observer.bubble_deactivation_state());
+  EXPECT_EQ(observer.close_on_deactivate(), absl::nullopt);
+}

--- a/test/BUILD.gn
+++ b/test/BUILD.gn
@@ -314,6 +314,7 @@ test("brave_unit_tests") {
       "//brave/browser/themes/brave_theme_service_unittest.cc",
       "//brave/browser/ui/toolbar/brave_location_bar_model_delegate_unittest.cc",
       "//brave/browser/ui/views/accelerator_table_unittest.cc",
+      "//brave/browser/ui/views/wallet_bubble_focus_observer_unittest.cc",
       "//brave/browser/ui/webui/brave_wallet/wallet_common_ui_unittest.cc",
       "//brave/browser/ui/webui/ipfs_dom_handler_unittest.cc",
       "//brave/browser/ui/webui/settings/brave_wallet_handler_unittest.cc",


### PR DESCRIPTION
<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/22516

Implemented observer to keep the wallet bubble opened if user tabbed away from browser window. It closes bubble if user then clicked into the browser window and restores state if it was changed by parallel api calls.

https://user-images.githubusercontent.com/2965009/165538266-a7b13454-20a7-48d0-81f4-29ecb8733c69.mp4


## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

- Open brave wallet popup and try to copy paste password from password manager, the popup should be opened when you interacting with other windows
- Open brave wallet popup, move focus to another window and click back to the browser(not by the popup), the popup should be closed
- Open brave wallet popup, move focus to another window and click back to the popup, the popup should be opened