### PR TITLE
Replace usage of SUCCEED and FAIL in Rewards browser tests (uplift to 1.39.x)

### DIFF
--- a/components/brave_rewards/browser/test/rewards_notification_browsertest.cc
+++ b/components/brave_rewards/browser/test/rewards_notification_browsertest.cc
@@ -319,13 +319,10 @@ IN_PROC_BROWSER_TEST_F(
   WaitForInsufficientFundsNotification();
   const auto& notifications = rewards_service_->GetAllNotifications();
 
-  if (notifications.empty()) {
-    SUCCEED();
-    return;
-  }
-
-  bool is_showing_notification = IsShowingNotificationForType(
-      RewardsNotificationType::REWARDS_NOTIFICATION_INSUFFICIENT_FUNDS);
+  bool is_showing_notification =
+      !notifications.empty() &&
+      IsShowingNotificationForType(
+          RewardsNotificationType::REWARDS_NOTIFICATION_INSUFFICIENT_FUNDS);
 
   EXPECT_FALSE(is_showing_notification);
 }
@@ -353,13 +350,10 @@ IN_PROC_BROWSER_TEST_F(
   WaitForInsufficientFundsNotification();
   const auto& notifications = rewards_service_->GetAllNotifications();
 
-  if (notifications.empty()) {
-    SUCCEED();
-    return;
-  }
-
-  bool is_showing_notification = IsShowingNotificationForType(
-      RewardsNotificationType::REWARDS_NOTIFICATION_INSUFFICIENT_FUNDS);
+  bool is_showing_notification =
+      !notifications.empty() &&
+      IsShowingNotificationForType(
+          RewardsNotificationType::REWARDS_NOTIFICATION_INSUFFICIENT_FUNDS);
 
   EXPECT_FALSE(is_showing_notification);
 }
@@ -387,13 +381,10 @@ IN_PROC_BROWSER_TEST_F(
   WaitForInsufficientFundsNotification();
   const auto& notifications = rewards_service_->GetAllNotifications();
 
-  if (notifications.empty()) {
-    SUCCEED();
-    return;
-  }
-
-  bool is_showing_notification = IsShowingNotificationForType(
-      RewardsNotificationType::REWARDS_NOTIFICATION_INSUFFICIENT_FUNDS);
+  bool is_showing_notification =
+      !notifications.empty() &&
+      IsShowingNotificationForType(
+          RewardsNotificationType::REWARDS_NOTIFICATION_INSUFFICIENT_FUNDS);
 
   EXPECT_FALSE(is_showing_notification);
 }
@@ -421,13 +412,10 @@ IN_PROC_BROWSER_TEST_F(
   WaitForInsufficientFundsNotification();
   const auto& notifications = rewards_service_->GetAllNotifications();
 
-  if (notifications.empty()) {
-    FAIL() << "Should see Insufficient Funds notification";
-    return;
-  }
-
-  bool is_showing_notification = IsShowingNotificationForType(
-      RewardsNotificationType::REWARDS_NOTIFICATION_INSUFFICIENT_FUNDS);
+  bool is_showing_notification =
+      !notifications.empty() &&
+      IsShowingNotificationForType(
+          RewardsNotificationType::REWARDS_NOTIFICATION_INSUFFICIENT_FUNDS);
 
   EXPECT_TRUE(is_showing_notification);
 }


### PR DESCRIPTION
Uplift of #13174
Resolves https://github.com/brave/brave-browser/issues/22545

Pre-approval checklist: 
- [ ] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.