### PR TITLE
Add check for empty attribute-value for ⚡

### DIFF
--- a/components/de_amp/browser/de_amp_util.cc
+++ b/components/de_amp/browser/de_amp_util.cc
@@ -18,8 +18,11 @@ namespace {
 // Check for "amp" or "⚡" in <html> tag
 // https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml/?format=websites#ampd
 constexpr char kGetHtmlTagPattern[] = "(<\\s*?html\\s.*?>)";
+// To see the expected behaviour of this regex, please see unit tests in
+// de_amp_util_unittest.cc
 constexpr char kDetectAmpPattern[] =
-    "(?:<.*?\\s.*?(amp|⚡|amp=\"\\s*\"|amp='\\s*')(?:\\s.*?>|>|/>))";
+    "(?:<.*?\\s.*?(amp|⚡|⚡=\"\\s*\"|⚡=\'\\s*\'|amp=\"\\s*\"|amp='\\s*')(?:\\s.*"
+    "?>|>|/>))";
 // Look for canonical link tag and get href
 // https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml/?format=websites#canon
 constexpr char kFindCanonicalLinkTagPattern[] =

--- a/components/de_amp/browser/test/de_amp_util_unittest.cc
+++ b/components/de_amp/browser/test/de_amp_util_unittest.cc
@@ -62,6 +62,39 @@ TEST(DeAmpUtilUnitTest, DetectAmpWithWordAmpNotAtEnd) {
   CheckFindCanonicalLinkResult("https://abc.com", body, true);
 }
 
+TEST(DeAmpUtilUnitTest, DetectAmpWithAmpEmptyAttribute) {
+  const std::string body =
+      "<html amp=\"\" xyzzy>"
+      "<head>"
+      "<link rel=\"canonical\" href=\"https://abc.com\"/>"
+      "</head>"
+      "<body></body>"
+      "</html>";
+  CheckFindCanonicalLinkResult("https://abc.com", body, true);
+}
+
+TEST(DeAmpUtilUnitTest, DetectAmpWithEmojiEmptyAttribute) {
+  const std::string body =
+      "<html tomato ⚡=\"\" xyzzy >"
+      "<head>"
+      "<link rel=\"canonical\" href=\"https://abc.com\"/>"
+      "</head>"
+      "<body></body>"
+      "</html>";
+  CheckFindCanonicalLinkResult("https://abc.com", body, true);
+}
+
+TEST(DeAmpUtilUnitTest, DetectAmpWithEmojiEmptyAttributeSingleQuotes) {
+  const std::string body =
+      "<html tomato ⚡='' xyzzy >"
+      "<head>"
+      "<link rel=\"canonical\" href=\"https://abc.com\"/>"
+      "</head>"
+      "<body></body>"
+      "</html>";
+  CheckFindCanonicalLinkResult("https://abc.com", body, true);
+}
+
 TEST(DeAmpUtilUnitTest, DetectAmpMixedCase) {
   const std::string body =
       "<DOCTYPE! html>\n"


### PR DESCRIPTION
<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/22573

Add empty attribute check in regex for ⚡. We already have a check for `amp`. Also add unit tests.

cc @jonathansampson 

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

1. Going to https://shivankaul.com/brave/de-amp/test-amp-lightning-empty-attribute.html should navigate to https://brave.com with the De-AMP pref (in brave://settings/shields) turned on. 
2. If turned off, it should stay on https://shivankaul.com/brave/de-amp/test-amp-lightning-empty-attribute.html.
3. This should happen on both Desktop and Android.

