### PR TITLE
Add checks to prevent De-AMP loops

### DIFF
--- a/components/de_amp/browser/de_amp_throttle.cc
+++ b/components/de_amp/browser/de_amp_throttle.cc
@@ -129,9 +129,8 @@ bool DeAmpThrottle::OpenCanonicalURL(const GURL& new_url,
 
   params.initiator_origin = request_.request_initiator;
   params.user_gesture = request_.has_user_gesture;
-
   auto redirect_chain = request_.navigation_redirect_chain;
-  DCHECK(redirect_chain.size());
+  redirect_chain.pop_back();
   params.redirect_chain = std::move(redirect_chain);
   params.extra_headers += base::StringPrintf("%s: true\r\n", kDeAmpHeaderName);
 

--- a/components/de_amp/browser/de_amp_throttle.h
+++ b/components/de_amp/browser/de_amp_throttle.h
@@ -39,7 +39,7 @@ class DeAmpThrottle : public body_sniffer::BodySnifferThrottle {
                            network::mojom::URLResponseHead* response_head,
                            bool* defer) override;
 
-  void Redirect(const GURL& new_url, const GURL& response_url);
+  bool OpenCanonicalURL(const GURL& new_url, const GURL& response_url);
 
  private:
   scoped_refptr<base::SequencedTaskRunner> task_runner_;

--- a/components/de_amp/browser/de_amp_throttle.h
+++ b/components/de_amp/browser/de_amp_throttle.h
@@ -35,6 +35,8 @@ class DeAmpThrottle : public body_sniffer::BodySnifferThrottle {
       const content::WebContents::Getter& wc_getter);
 
   // Implements blink::URLLoaderThrottle.
+  void WillStartRequest(network::ResourceRequest* request,
+                        bool* defer) override;
   void WillProcessResponse(const GURL& response_url,
                            network::mojom::URLResponseHead* response_head,
                            bool* defer) override;
@@ -44,6 +46,7 @@ class DeAmpThrottle : public body_sniffer::BodySnifferThrottle {
  private:
   scoped_refptr<base::SequencedTaskRunner> task_runner_;
   network::ResourceRequest request_;
+  bool is_amp_redirect_;
   content::WebContents::Getter wc_getter_;
   base::WeakPtrFactory<DeAmpThrottle> weak_factory_{this};
 };

--- a/components/de_amp/browser/de_amp_url_loader.cc
+++ b/components/de_amp/browser/de_amp_url_loader.cc
@@ -89,8 +89,11 @@ bool DeAmpURLLoader::MaybeRedirectToCanonicalLink() {
       return false;
     }
     VLOG(2) << __func__ << " de-amping and loading " << canonical_url;
+    if (!de_amp_throttle_->OpenCanonicalURL(canonical_url, response_url_)) {
+      return false;
+    }
+    // Only abort if we know we're successfully going to the canonical URL
     Abort();
-    de_amp_throttle_->Redirect(canonical_url, response_url_);
     return true;
   } else {
     // Did not find AMP page and/or canonical link, load original


### PR DESCRIPTION
<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/22610

1. Set a header called "X-Brave-De-AMP" that we check for before De-AMPing.
2. If canonical/target URL is the same as the current pending URL, don't De-AMP.

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
1. https://shivankaul.com/brave/de-amp/test-redirect-loop-1.html and https://shivankaul.com/brave/de-amp/test-redirect-loop-2.html are 2 AMP pages that point to each other. Visiting one should not cause a redirect loop.
2. https://www.airlive.net/new-footage-shows-an-ukrainian-mig-29-taking-off-from-mykolaiv-seconds-before-the-runway-is-shelled-by-the-russians/ should not cause constant reloading of the page.