### PR TITLE
fix(wallet): Swap Panel Crash

### DIFF
--- a/components/brave_wallet_ui/common/hooks/swap.ts
+++ b/components/brave_wallet_ui/common/hooks/swap.ts
@@ -251,7 +251,7 @@ export default function useSwap ({ fromAsset: fromAssetProp, toAsset: toAssetPro
     if (token) {
       makeTokenVisible(token)
     }
-  }, [])
+  }, [makeTokenVisible])
 
   const fetchSwapQuote = React.useCallback(async (payload: SwapParamsPayloadType) => {
     if (!isMounted) {
@@ -504,7 +504,7 @@ export default function useSwap ({ fromAsset: fromAssetProp, toAsset: toAssetPro
       overrides: { toOrFrom: 'from', fromAsset: toAsset, toAsset: fromAsset },
       state: { fromAmount, toAmount }
     })
-  }, [toAsset, fromAsset, fromAmount, toAmount, onSwapParamsChange])
+  }, [toAsset, fromAsset, fromAmount, toAmount, onSwapParamsChange, setToAssetAndMakeVisible])
 
   const onSetFromAmount = React.useCallback(async (value: string) => {
     setFromAmount(value)
@@ -612,7 +612,7 @@ export default function useSwap ({ fromAsset: fromAssetProp, toAsset: toAssetPro
       state: { fromAmount, toAmount: '0' }
     })
     setIsLoading(false)
-  }, [onSwapParamsChange, fromAmount])
+  }, [onSwapParamsChange, setToAssetAndMakeVisible, fromAmount])
 
   const onSwapInputChange = React.useCallback((value: string, name: 'to' | 'from' | 'rate') => {
     if (name === 'to') {


### PR DESCRIPTION
## Description 
Fixes a bug where the `Swap` panel crashes when changing assets
Regressed in https://github.com/brave/brave-core/pull/12509 for missing dependancies.

<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves <https://github.com/brave/brave-browser/issues/22680>

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/handbook/blob/master/development/security.md#when-is-a-security-review-needed), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/handbook/blob/master/development/security.md#when-is-a-security-review-needed), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

Before:

https://user-images.githubusercontent.com/40611140/166615246-52055a4b-8721-4111-9643-971edbf5920a.mov

After:

https://user-images.githubusercontent.com/40611140/166615263-1d8f9476-c7b4-40c9-aab4-91ec703f158a.mov
