### PR TITLE
Prevent brave wallet providers from being generated in third party iframe

### DIFF
--- a/renderer/brave_wallet/brave_wallet_render_frame_observer.cc
+++ b/renderer/brave_wallet/brave_wallet_render_frame_observer.cc
@@ -45,6 +45,11 @@ void BraveWalletRenderFrameObserver::DidCreateScriptContext(
     js_ethereum_provider_.reset();
     return;
   }
+  // Wallet provider objects won't be generated for third party iframe
+  if (!render_frame()->IsMainFrame() &&
+      render_frame()->GetWebFrame()->IsCrossOriginToMainFrame()) {
+    return;
+  }
 
   bool is_main_world = world_id == content::ISOLATED_WORLD_ID_GLOBAL;
   if (!js_ethereum_provider_) {

--- a/renderer/test/js_ethereum_provider_browsertest.cc
+++ b/renderer/test/js_ethereum_provider_browsertest.cc
@@ -17,6 +17,7 @@
 #include "content/public/browser/web_contents.h"
 #include "content/public/test/browser_test.h"
 #include "content/public/test/browser_test_utils.h"
+#include "content/public/test/content_mock_cert_verifier.h"
 #include "net/dns/mock_host_resolver.h"
 #include "net/test/embedded_test_server/embedded_test_server.h"
 #include "url/gurl.h"
@@ -41,18 +42,33 @@ class JSEthereumProviderBrowserTest : public InProcessBrowserTest {
     brave::RegisterPathProvider();
     base::FilePath test_data_dir;
     base::PathService::Get(brave::DIR_TEST_DATA, &test_data_dir);
-    https_server_.SetSSLConfig(net::EmbeddedTestServer::CERT_OK);
     https_server_.ServeFilesFromDirectory(test_data_dir);
   }
 
   ~JSEthereumProviderBrowserTest() override = default;
 
+  void SetUpCommandLine(base::CommandLine* command_line) override {
+    InProcessBrowserTest::SetUpCommandLine(command_line);
+    mock_cert_verifier_.SetUpCommandLine(command_line);
+  }
+
+  void SetUpInProcessBrowserTestFixture() override {
+    InProcessBrowserTest::SetUpInProcessBrowserTestFixture();
+    mock_cert_verifier_.SetUpInProcessBrowserTestFixture();
+  }
+
+  void TearDownInProcessBrowserTestFixture() override {
+    mock_cert_verifier_.TearDownInProcessBrowserTestFixture();
+    InProcessBrowserTest::TearDownInProcessBrowserTestFixture();
+  }
+
   void SetUpOnMainThread() override {
     InProcessBrowserTest::SetUpOnMainThread();
 
-    EXPECT_TRUE(https_server_.Start());
+    mock_cert_verifier_.mock_cert_verifier()->set_default_result(net::OK);
     // Map all hosts to localhost.
     host_resolver()->AddRule("*", "127.0.0.1");
+    EXPECT_TRUE(https_server_.Start());
   }
 
   content::WebContents* web_contents() {
@@ -74,6 +90,7 @@ class JSEthereumProviderBrowserTest : public InProcessBrowserTest {
   }
 
  protected:
+  content::ContentMockCertVerifier mock_cert_verifier_;
   net::EmbeddedTestServer https_server_;
 };
 
@@ -81,7 +98,7 @@ IN_PROC_BROWSER_TEST_F(JSEthereumProviderBrowserTest, AttachOnReload) {
   brave_wallet::SetDefaultWallet(browser()->profile()->GetPrefs(),
                                  brave_wallet::mojom::DefaultWallet::None);
   const GURL url = https_server_.GetURL("/simple.html");
-  NavigateToURLAndWaitForLoadStop(url);
+  ASSERT_TRUE(ui_test_utils::NavigateToURL(browser(), url));
 
   std::string command = "window.ethereum.isMetaMask";
   EXPECT_TRUE(content::EvalJs(main_frame(), command)
@@ -112,7 +129,8 @@ IN_PROC_BROWSER_TEST_F(JSEthereumProviderBrowserTest,
                        DoNotAttachToChromePages) {
   brave_wallet::SetDefaultWallet(browser()->profile()->GetPrefs(),
                                  brave_wallet::mojom::DefaultWallet::None);
-  NavigateToURLAndWaitForLoadStop(GURL("chrome://newtab/"));
+  ASSERT_TRUE(
+      ui_test_utils::NavigateToURL(browser(), GURL("chrome://newtab/")));
 
   std::string command = "window.ethereum.isMetaMask";
   EXPECT_TRUE(content::EvalJs(main_frame(), command,
@@ -135,7 +153,7 @@ IN_PROC_BROWSER_TEST_F(JSEthereumProviderBrowserTest,
 
 IN_PROC_BROWSER_TEST_F(JSEthereumProviderBrowserTest, NonWritable) {
   const GURL url = https_server_.GetURL("/simple.html");
-  NavigateToURLAndWaitForLoadStop(url);
+  ASSERT_TRUE(ui_test_utils::NavigateToURL(browser(), url));
 
   // window.ethereum.*
   auto result =
@@ -164,7 +182,7 @@ IN_PROC_BROWSER_TEST_F(JSEthereumProviderBrowserTest, NonWritable) {
 // See https://github.com/brave/brave-browser/issues/22213 for details
 IN_PROC_BROWSER_TEST_F(JSEthereumProviderBrowserTest, IsMetaMaskWritable) {
   const GURL url = https_server_.GetURL("/simple.html");
-  NavigateToURLAndWaitForLoadStop(url);
+  ASSERT_TRUE(ui_test_utils::NavigateToURL(browser(), url));
 
   std::string overwrite =
       "window.ethereum.isMetaMask = false;"
@@ -177,7 +195,7 @@ IN_PROC_BROWSER_TEST_F(JSEthereumProviderBrowserTest, NonConfigurable) {
       browser()->profile()->GetPrefs(),
       brave_wallet::mojom::DefaultWallet::BraveWallet);
   const GURL url = https_server_.GetURL("/simple.html");
-  NavigateToURLAndWaitForLoadStop(url);
+  ASSERT_TRUE(ui_test_utils::NavigateToURL(browser(), url));
   std::string overwrite =
       R"(try {
          Object.defineProperty(window, 'ethereum', {
@@ -188,4 +206,25 @@ IN_PROC_BROWSER_TEST_F(JSEthereumProviderBrowserTest, NonConfigurable) {
        typeof window.ethereum === 'object'
     )";
   EXPECT_TRUE(content::EvalJs(main_frame(), overwrite).ExtractBool());
+}
+
+IN_PROC_BROWSER_TEST_F(JSEthereumProviderBrowserTest, Block3PIframe) {
+  GURL top_url(https_server_.GetURL("a.com", "/iframe.html"));
+  ASSERT_TRUE(ui_test_utils::NavigateToURL(browser(), top_url));
+  // third party
+  GURL iframe_url_3p(https_server_.GetURL("b.com", "/"));
+  EXPECT_TRUE(NavigateIframeToURL(web_contents(), "test", iframe_url_3p));
+
+  constexpr char kEvalEthereum[] = R"(typeof window.ethereum === 'undefined')";
+
+  auto* iframe_rfh = ChildFrameAt(main_frame(), 0);
+  ASSERT_TRUE(iframe_rfh);
+  EXPECT_TRUE(content::EvalJs(iframe_rfh, kEvalEthereum).ExtractBool());
+
+  // same party
+  GURL iframe_url_1p(https_server_.GetURL("a.com", "/"));
+  EXPECT_TRUE(NavigateIframeToURL(web_contents(), "test", iframe_url_1p));
+  iframe_rfh = ChildFrameAt(main_frame(), 0);
+  ASSERT_TRUE(iframe_rfh);
+  EXPECT_FALSE(content::EvalJs(iframe_rfh, kEvalEthereum).ExtractBool());
 }


### PR DESCRIPTION


<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/22686

1. `window.ethereum` and `window.solana` will be unavailable in 3rd party iframe
2. Some browser test cleanup

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

### Same party test
1. Navigate to https://www.w3schools.com/tags/tryit.asp?filename=tryhtml_iframe
2. Add `id="test"` to iframe element and click `Run`
3. Open console and inspect any element at the right panel
4. Select `iframe` result in console like this 
<img width="333" alt="Screen Shot 2022-05-09 at 15 13 50" src="https://user-images.githubusercontent.com/11330831/167507474-22b632b8-5013-4736-8b9e-b0d0a8e29cb1.png">
5. Type these in console

```
  let iframe = document.getElementById('test')
  console.log(iframe.contentWindow.ethereum)
 ```

6.  It should not be undefined
### Third party test
1. Navigate to https://www.w3schools.com/tags/tryit.asp?filename=tryhtml_iframe
2. Add `id="test"` to iframe element and change src to https://metamask.github.io/test-dapp/ and click `Run`
3. Open console and inspect any element at the right panel
4. Select `iframe` result in console like this 
<img width="333" alt="Screen Shot 2022-05-09 at 15 13 50" src="https://user-images.githubusercontent.com/11330831/167507474-22b632b8-5013-4736-8b9e-b0d0a8e29cb1.png">
5. Type these in console

```
  let iframe = document.getElementById('test')
  console.log(iframe.contentWindow.ethereum)
 ```

6.  It should be undefined