### PR TITLE
Show focus on password visibility toggle

### DIFF
--- a/components/brave_wallet_ui/components/shared/password-input/index.tsx
+++ b/components/brave_wallet_ui/components/shared/password-input/index.tsx
@@ -4,6 +4,7 @@ import {
   StyledWrapper,
   InputWrapper,
   ToggleVisibilityButton,
+  ToggleVisibilityIcon,
   Input,
   ErrorText,
   ErrorRow,
@@ -47,10 +48,9 @@ function PasswordInput (props: Props) {
           autoComplete='off'
         />
         {showToggleButton &&
-          <ToggleVisibilityButton
-            showPassword={showPassword}
-            onClick={onTogglePasswordVisibility}
-          />
+          <ToggleVisibilityButton onClick={onTogglePasswordVisibility}>
+            <ToggleVisibilityIcon showPassword={showPassword} />
+          </ToggleVisibilityButton>
         }
       </InputWrapper>
       {hasError &&

--- a/components/brave_wallet_ui/components/shared/password-input/style.ts
+++ b/components/brave_wallet_ui/components/shared/password-input/style.ts
@@ -105,6 +105,11 @@ export const ToggleVisibilityButton = styled(WalletButton)<Partial<StyleProps>>`
   padding: 0px;
   width: 18px;
   height: 18px;
+`
+
+export const ToggleVisibilityIcon = styled.div<Partial<StyleProps>>`
+  width: 18px;
+  height: 18px;
   background-color: ${(p) => p.theme.color.text02};
   -webkit-mask-image: url(${(p) => p.showPassword ? EyeOffIcon : EyeOnIcon});
   mask-image: url(${(p) => p.showPassword ? EyeOffIcon : EyeOnIcon});

--- a/components/brave_wallet_ui/components/shared/password-input/style.ts
+++ b/components/brave_wallet_ui/components/shared/password-input/style.ts
@@ -91,7 +91,7 @@ export const WarningIcon = styled.div`
   background: url(${WarningCircle});
 `
 
-export const ToggleVisibilityButton = styled(WalletButton)<Partial<StyleProps>>`
+export const ToggleVisibilityButton = styled(WalletButton)`
   display: flex;
   align-items: center;
   justify-content: center;


### PR DESCRIPTION

https://user-images.githubusercontent.com/168356/167611163-acc0cd91-bffd-4722-ba75-5a37c205f516.mp4



<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/21845

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

"Eye" button on password fields show be focusable