### PR TITLE
Disable tests which fails with TIMED OUT on Windows x86

### DIFF
--- a/browser/themes/brave_theme_service_browsertest.cc
+++ b/browser/themes/brave_theme_service_browsertest.cc
@@ -188,13 +188,20 @@ IN_PROC_BROWSER_TEST_F(BraveThemeServiceTest, OmniboxColorTest) {
       tp->GetColor(ThemeProperties::COLOR_OMNIBOX_RESULTS_BG));
 }
 
+// Some tests are failing for Windows x86 CI,
+// See https://github.com/brave/brave-browser/issues/22767
+#if BUILDFLAG(IS_WIN) && defined(ARCH_CPU_X86)
+#define MAYBE_DarkModeChangeByRegTest DISABLED_DarkModeChangeByRegTest
+#else
+#define MAYBE_DarkModeChangeByRegTest DarkModeChangeByRegTest
+#endif
 #if BUILDFLAG(IS_WIN)
-// Test native theme notification is called properly by changing reg value.
-// This simulates dark mode setting from Windows settings.
-// And Toggle it twice from initial value to go back to initial value  because
-// reg value changes system value. Otherwise, dark mode config could be changed
-// after running this test.
-IN_PROC_BROWSER_TEST_F(BraveThemeServiceTest, DarkModeChangeByRegTest) {
+IN_PROC_BROWSER_TEST_F(BraveThemeServiceTest, MAYBE_DarkModeChangeByRegTest) {
+  // Test native theme notification is called properly by changing reg value.
+  // This simulates dark mode setting from Windows settings.
+  // And Toggle it twice from initial value to go back to initial value  because
+  // reg value changes system value. Otherwise, dark mode config could be
+  // changed after running this test.
   if (!ui::NativeTheme::GetInstanceForNativeUi()->SystemDarkModeSupported())
     return;
 

--- a/components/brave_sync/brave_sync_prefs_unittest.cc
+++ b/components/brave_sync/brave_sync_prefs_unittest.cc
@@ -99,7 +99,15 @@ TEST_F(BraveSyncPrefsTest, FailedToDecryptBraveSeedValue) {
 }
 
 using BraveSyncPrefsDeathTest = BraveSyncPrefsTest;
-TEST_F(BraveSyncPrefsDeathTest, GetSeedOutNullptrCHECK) {
+
+// Some tests are failing for Windows x86 CI,
+// See https://github.com/brave/brave-browser/issues/22767
+#if BUILDFLAG(IS_WIN) && defined(ARCH_CPU_X86)
+#define MAYBE_GetSeedOutNullptrCHECK DISABLED_GetSeedOutNullptrCHECK
+#else
+#define MAYBE_GetSeedOutNullptrCHECK GetSeedOutNullptrCHECK
+#endif
+TEST_F(BraveSyncPrefsDeathTest, MAYBE_GetSeedOutNullptrCHECK) {
   EXPECT_CHECK_DEATH(brave_sync_prefs()->GetSeed(nullptr));
 }
 

--- a/components/child_process_monitor/child_process_monitor_unittest.cc
+++ b/components/child_process_monitor/child_process_monitor_unittest.cc
@@ -125,7 +125,14 @@ MULTIPROCESS_TEST_MAIN(SleepyCrashChildProcess) {
   return 1;
 }
 
-TEST_F(ChildProcessMonitorTest, ChildCrash) {
+// Some tests are failing for Windows x86 CI,
+// See https://github.com/brave/brave-browser/issues/22767
+#if BUILDFLAG(IS_WIN) && defined(ARCH_CPU_X86)
+#define MAYBE_ChildCrash DISABLED_ChildCrash
+#else
+#define MAYBE_ChildCrash ChildCrash
+#endif
+TEST_F(ChildProcessMonitorTest, MAYBE_ChildCrash) {
   std::unique_ptr<ChildProcessMonitor> monitor =
       std::make_unique<ChildProcessMonitor>();
 

--- a/components/sync/driver/brave_sync_service_impl_unittest.cc
+++ b/components/sync/driver/brave_sync_service_impl_unittest.cc
@@ -168,7 +168,15 @@ TEST_F(BraveSyncServiceImplTest, ValidPassphraseLeadingTrailingWhitespace) {
 // for test suite
 using BraveSyncServiceImplDeathTest = BraveSyncServiceImplTest;
 
-TEST_F(BraveSyncServiceImplDeathTest, EmulateGetOrCreateSyncCodeCHECK) {
+// Some tests are failing for Windows x86 CI,
+// See https://github.com/brave/brave-browser/issues/22767
+#if BUILDFLAG(IS_WIN) && defined(ARCH_CPU_X86)
+#define MAYBE_EmulateGetOrCreateSyncCodeCHECK \
+  DISABLED_EmulateGetOrCreateSyncCodeCHECK
+#else
+#define MAYBE_EmulateGetOrCreateSyncCodeCHECK EmulateGetOrCreateSyncCodeCHECK
+#endif
+TEST_F(BraveSyncServiceImplDeathTest, MAYBE_EmulateGetOrCreateSyncCodeCHECK) {
   OSCryptMocker::SetUp();
 
   CreateSyncService(SyncServiceImpl::MANUAL_START);


### PR DESCRIPTION
This PR disables these tests in Windows x86:
- BraveThemeServiceTest.DarkModeChangeByRegTest
- BraveSyncPrefsDeathTest.GetSeedOutNullptrCHECK
- BraveSyncServiceImplDeathTest.EmulateGetOrCreateSyncCodeCHECK
- ChildProcessMonitorTest.ChildCrash
because they fail with TIMED OUT status in CI servers without obvious reason.

This PR should be reverted ASAP once the real reason will be found.

<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/22767

## Submitter Checklist:

- [ ] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

