### PR TITLE
Disable tests which fails with TIMED OUT on Windows x86 (uplift to 1.39.x)

### DIFF
--- a/browser/themes/brave_theme_service_browsertest.cc
+++ b/browser/themes/brave_theme_service_browsertest.cc
@@ -188,13 +188,20 @@ IN_PROC_BROWSER_TEST_F(BraveThemeServiceTest, OmniboxColorTest) {
       tp->GetColor(ThemeProperties::COLOR_OMNIBOX_RESULTS_BG));
 }
 
+// Some tests are failing for Windows x86 CI,
+// See https://github.com/brave/brave-browser/issues/22767
+#if BUILDFLAG(IS_WIN) && defined(ARCH_CPU_X86)
+#define MAYBE_DarkModeChangeByRegTest DISABLED_DarkModeChangeByRegTest
+#else
+#define MAYBE_DarkModeChangeByRegTest DarkModeChangeByRegTest
+#endif
 #if BUILDFLAG(IS_WIN)
-// Test native theme notification is called properly by changing reg value.
-// This simulates dark mode setting from Windows settings.
-// And Toggle it twice from initial value to go back to initial value  because
-// reg value changes system value. Otherwise, dark mode config could be changed
-// after running this test.
-IN_PROC_BROWSER_TEST_F(BraveThemeServiceTest, DarkModeChangeByRegTest) {
+IN_PROC_BROWSER_TEST_F(BraveThemeServiceTest, MAYBE_DarkModeChangeByRegTest) {
+  // Test native theme notification is called properly by changing reg value.
+  // This simulates dark mode setting from Windows settings.
+  // And Toggle it twice from initial value to go back to initial value  because
+  // reg value changes system value. Otherwise, dark mode config could be
+  // changed after running this test.
   if (!ui::NativeTheme::GetInstanceForNativeUi()->SystemDarkModeSupported())
     return;
 

--- a/components/brave_sync/brave_sync_prefs_unittest.cc
+++ b/components/brave_sync/brave_sync_prefs_unittest.cc
@@ -99,7 +99,15 @@ TEST_F(BraveSyncPrefsTest, FailedToDecryptBraveSeedValue) {
 }
 
 using BraveSyncPrefsDeathTest = BraveSyncPrefsTest;
-TEST_F(BraveSyncPrefsDeathTest, GetSeedOutNullptrCHECK) {
+
+// Some tests are failing for Windows x86 CI,
+// See https://github.com/brave/brave-browser/issues/22767
+#if BUILDFLAG(IS_WIN) && defined(ARCH_CPU_X86)
+#define MAYBE_GetSeedOutNullptrCHECK DISABLED_GetSeedOutNullptrCHECK
+#else
+#define MAYBE_GetSeedOutNullptrCHECK GetSeedOutNullptrCHECK
+#endif
+TEST_F(BraveSyncPrefsDeathTest, MAYBE_GetSeedOutNullptrCHECK) {
   EXPECT_CHECK_DEATH(brave_sync_prefs()->GetSeed(nullptr));
 }
 

--- a/components/child_process_monitor/child_process_monitor_unittest.cc
+++ b/components/child_process_monitor/child_process_monitor_unittest.cc
@@ -125,7 +125,14 @@ MULTIPROCESS_TEST_MAIN(SleepyCrashChildProcess) {
   return 1;
 }
 
-TEST_F(ChildProcessMonitorTest, ChildCrash) {
+// Some tests are failing for Windows x86 CI,
+// See https://github.com/brave/brave-browser/issues/22767
+#if BUILDFLAG(IS_WIN) && defined(ARCH_CPU_X86)
+#define MAYBE_ChildCrash DISABLED_ChildCrash
+#else
+#define MAYBE_ChildCrash ChildCrash
+#endif
+TEST_F(ChildProcessMonitorTest, MAYBE_ChildCrash) {
   std::unique_ptr<ChildProcessMonitor> monitor =
       std::make_unique<ChildProcessMonitor>();
 

--- a/components/sync/driver/brave_sync_service_impl_unittest.cc
+++ b/components/sync/driver/brave_sync_service_impl_unittest.cc
@@ -168,7 +168,15 @@ TEST_F(BraveSyncServiceImplTest, ValidPassphraseLeadingTrailingWhitespace) {
 // for test suite
 using BraveSyncServiceImplDeathTest = BraveSyncServiceImplTest;
 
-TEST_F(BraveSyncServiceImplDeathTest, EmulateGetOrCreateSyncCodeCHECK) {
+// Some tests are failing for Windows x86 CI,
+// See https://github.com/brave/brave-browser/issues/22767
+#if BUILDFLAG(IS_WIN) && defined(ARCH_CPU_X86)
+#define MAYBE_EmulateGetOrCreateSyncCodeCHECK \
+  DISABLED_EmulateGetOrCreateSyncCodeCHECK
+#else
+#define MAYBE_EmulateGetOrCreateSyncCodeCHECK EmulateGetOrCreateSyncCodeCHECK
+#endif
+TEST_F(BraveSyncServiceImplDeathTest, MAYBE_EmulateGetOrCreateSyncCodeCHECK) {
   OSCryptMocker::SetUp();
 
   CreateSyncService(SyncServiceImpl::MANUAL_START);


### PR DESCRIPTION
Uplift of #13284
Resolves https://github.com/brave/brave-browser/issues/22767

Pre-approval checklist: 
- [ ] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.