### PR TITLE
Asset discovery

### DIFF
--- a/components/brave_wallet/browser/BUILD.gn
+++ b/components/brave_wallet/browser/BUILD.gn
@@ -53,6 +53,8 @@ static_library("browser") {
     "eth_requests.h",
     "eth_response_parser.cc",
     "eth_response_parser.h",
+    "eth_topics_builder.cc",
+    "eth_topics_builder.h",
     "eth_tx_manager.cc",
     "eth_tx_manager.h",
     "eth_tx_meta.cc",

--- a/components/brave_wallet/browser/blockchain_list_parser.cc
+++ b/components/brave_wallet/browser/blockchain_list_parser.cc
@@ -71,7 +71,7 @@ bool ParseTokenList(const std::string& json,
       base::JSONReader::Read(json, base::JSON_PARSE_CHROMIUM_EXTENSIONS |
                                        base::JSONParserOptions::JSON_PARSE_RFC);
   if (!records_v || !records_v->is_dict()) {
-    LOG(ERROR) << "Invalid response, could not parse JSON, JSON is: " << json;
+    VLOG(1) << "Invalid response, could not parse JSON, JSON is: " << json;
     return false;
   }
 

--- a/components/brave_wallet/browser/blockchain_registry.cc
+++ b/components/brave_wallet/browser/blockchain_registry.cc
@@ -38,6 +38,12 @@ void BlockchainRegistry::UpdateTokenList(TokenListMap token_list_map) {
   token_list_map_ = std::move(token_list_map);
 }
 
+void BlockchainRegistry::UpdateTokenList(
+    const std::string key,
+    std::vector<mojom::BlockchainTokenPtr> list) {
+  token_list_map_[key] = std::move(list);
+}
+
 void BlockchainRegistry::UpdateChainList(ChainList chains) {
   chain_list_ = std::move(chains);
 }

--- a/components/brave_wallet/browser/blockchain_registry.h
+++ b/components/brave_wallet/browser/blockchain_registry.h
@@ -30,6 +30,8 @@ class BlockchainRegistry : public mojom::BlockchainRegistry {
   void Bind(mojo::PendingReceiver<mojom::BlockchainRegistry> receiver);
 
   void UpdateTokenList(TokenListMap tokens);
+  void UpdateTokenList(const std::string key,
+                       std::vector<mojom::BlockchainTokenPtr> list);
   void UpdateChainList(ChainList chains);
 
   mojom::BlockchainTokenPtr GetTokenByAddress(const std::string& chain_id,

--- a/components/brave_wallet/browser/brave_wallet_service.h
+++ b/components/brave_wallet/browser/brave_wallet_service.h
@@ -80,6 +80,11 @@ class BraveWalletService : public KeyedService,
   static void MigrateMultichainUserAssets(PrefService* prefs);
   static void MigrateUserAssetsAddPreloadingNetworks(PrefService* prefs);
 
+  static bool AddUserAsset(mojom::BlockchainTokenPtr token, PrefService* prefs);
+  static std::vector<mojom::BlockchainTokenPtr> GetUserAssets(
+      const std::string& chain_id,
+      mojom::CoinType coin,
+      PrefService* prefs);
   static base::Value::Dict GetDefaultEthereumAssets();
   static base::Value::Dict GetDefaultSolanaAssets();
   static base::Value::Dict GetDefaultFilecoinAssets();

--- a/components/brave_wallet/browser/brave_wallet_utils.cc
+++ b/components/brave_wallet/browser/brave_wallet_utils.cc
@@ -485,18 +485,6 @@ const base::flat_map<std::string, std::string>
 constexpr const char kEnsRegistryContractAddress[] =
     "0x00000000000C2E074eC69A0dFb2997BA6C7d2e1e";
 
-GURL GetInfuraURLForKnownChainId(const std::string& chain_id) {
-  auto endpoint = brave_wallet::GetInfuraEndpointForKnownChainId(chain_id);
-  if (!endpoint.empty())
-    return GURL(endpoint);
-
-  auto subdomain = brave_wallet::GetInfuraSubdomainForKnownChainId(chain_id);
-  if (subdomain.empty())
-    return GURL();
-  return GURL(
-      base::StringPrintf("https://%s-infura.brave.com/", subdomain.c_str()));
-}
-
 const base::Value::List* GetCustomNetworksList(PrefService* prefs,
                                                mojom::CoinType coin) {
   const base::Value* custom_networks =
@@ -623,6 +611,18 @@ mojom::NetworkInfoPtr GetChain(PrefService* prefs,
   }
 
   return nullptr;
+}
+
+GURL GetInfuraURLForKnownChainId(const std::string& chain_id) {
+  auto endpoint = brave_wallet::GetInfuraEndpointForKnownChainId(chain_id);
+  if (!endpoint.empty())
+    return GURL(endpoint);
+
+  auto subdomain = brave_wallet::GetInfuraSubdomainForKnownChainId(chain_id);
+  if (subdomain.empty())
+    return GURL();
+  return GURL(
+      base::StringPrintf("https://%s-infura.brave.com/", subdomain.c_str()));
 }
 
 std::string GetInfuraEndpointForKnownChainId(const std::string& chain_id) {

--- a/components/brave_wallet/browser/brave_wallet_utils.h
+++ b/components/brave_wallet/browser/brave_wallet_utils.h
@@ -81,8 +81,9 @@ std::vector<mojom::NetworkInfoPtr> GetAllChains(PrefService* prefs,
 GURL GetNetworkURL(PrefService* prefs,
                    const std::string& chain_id,
                    mojom::CoinType coin);
-std::string GetInfuraSubdomainForKnownChainId(const std::string& chain_id);
+GURL GetInfuraURLForKnownChainId(const std::string& chain_id);
 std::string GetInfuraEndpointForKnownChainId(const std::string& chain_id);
+std::string GetInfuraSubdomainForKnownChainId(const std::string& chain_id);
 GURL AddInfuraProjectId(const GURL& url);
 GURL MaybeAddInfuraProjectId(const GURL& url);
 mojom::NetworkInfoPtr GetKnownChain(PrefService* prefs,

--- a/components/brave_wallet/browser/eth_requests.cc
+++ b/components/brave_wallet/browser/eth_requests.cc
@@ -338,12 +338,19 @@ std::string eth_getFilterLogs(const std::string& filter_id) {
 
 std::string eth_getLogs(const std::string& from_block_quantity_tag,
                         const std::string& to_block_quantity_tag,
-                        const std::string& address,
+                        base::Value::List addresses,
                         base::Value::List topics,
                         const std::string& block_hash) {
   base::Value::List params;
   base::Value::Dict filter_options;
-  AddKeyIfNotEmpty(&filter_options, "address", address);
+  // The `address` filter option accepts either a single address, or a list of
+  // addresses (See spec:
+  // https://ethereum.org/en/developers/docs/apis/json-rpc/#eth_getlogs). At
+  // time of writing Infura's documentation suggests they only support a single
+  // address, however we have verified they also support a list.
+  if (!addresses.empty()) {
+    filter_options.Set("address", std::move(addresses));
+  }
   AddKeyIfNotEmpty(&filter_options, "fromBlock", from_block_quantity_tag);
   AddKeyIfNotEmpty(&filter_options, "toBlock", to_block_quantity_tag);
   if (!topics.empty()) {

--- a/components/brave_wallet/browser/eth_requests.h
+++ b/components/brave_wallet/browser/eth_requests.h
@@ -192,7 +192,7 @@ std::string eth_getFilterLogs(const std::string& filter_id);
 // Returns an array of all logs matching a given filter object.
 std::string eth_getLogs(const std::string& from_block_quantity_tag,
                         const std::string& to_block_quantity_tag,
-                        const std::string& address,
+                        base::Value::List addresses,
                         base::Value::List topics,
                         const std::string& block_hash);
 // Returns the hash of the current block, the seedHash, and the boundary

--- a/components/brave_wallet/browser/eth_requests_unittest.cc
+++ b/components/brave_wallet/browser/eth_requests_unittest.cc
@@ -334,12 +334,14 @@ TEST(EthRequestUnitTest, eth_getLogs) {
   sub_topics.Append(
       "0x0000000000000000000000000aff3454fce5edbc8cca8697c15331677e6ebccc");
   topics.Append(std::move(sub_topics));
+
+  base::Value::List addresses;
+  addresses.Append(base::Value("0x8888f1f195afa192cfee860698584c030f4c9db1"));
   ASSERT_EQ(
       eth_getLogs(
-          "0x1", "0x2", "0x8888f1f195afa192cfee860698584c030f4c9db1",
-          std::move(topics),
+          "0x1", "0x2", std::move(addresses), std::move(topics),
           "0xb903239f8543d04b5dc1ba6579132b143087c68db1b2168786408fcbce568238"),
-      R"({"id":1,"jsonrpc":"2.0","method":"eth_getLogs","params":[{"address":"0x8888f1f195afa192cfee860698584c030f4c9db1","blockhash":"0xb903239f8543d04b5dc1ba6579132b143087c68db1b2168786408fcbce568238","fromBlock":"0x1","toBlock":"0x2","topics":["0x000000000000000000000000a94f5374fce5edbc8e2a8697c15331677e6ebf0b",["0x000000000000000000000000a94f5374fce5edbc8e2a8697c15331677e6ebf0b","0x0000000000000000000000000aff3454fce5edbc8cca8697c15331677e6ebccc"]]}]})");  // NOLINT
+      R"({"id":1,"jsonrpc":"2.0","method":"eth_getLogs","params":[{"address":["0x8888f1f195afa192cfee860698584c030f4c9db1"],"blockhash":"0xb903239f8543d04b5dc1ba6579132b143087c68db1b2168786408fcbce568238","fromBlock":"0x1","toBlock":"0x2","topics":["0x000000000000000000000000a94f5374fce5edbc8e2a8697c15331677e6ebf0b",["0x000000000000000000000000a94f5374fce5edbc8e2a8697c15331677e6ebf0b","0x0000000000000000000000000aff3454fce5edbc8cca8697c15331677e6ebccc"]]}]})");  // NOLINT
 }
 
 }  // namespace eth

--- a/components/brave_wallet/browser/eth_response_parser.h
+++ b/components/brave_wallet/browser/eth_response_parser.h
@@ -37,6 +37,7 @@ absl::optional<std::vector<std::string>> DecodeEthCallResponse(
     const std::vector<std::string>& abi_types);
 bool ParseEthEstimateGas(const std::string& json, std::string* result);
 bool ParseEthGasPrice(const std::string& json, std::string* result);
+bool ParseEthGetLogs(const std::string& json, std::vector<Log>* logs);
 
 bool ParseEnsResolverContentHash(const std::string& json,
                                  std::vector<uint8_t>* content_hash);

--- a/components/brave_wallet/browser/eth_topics_builder.cc
+++ b/components/brave_wallet/browser/eth_topics_builder.cc
@@ -1,0 +1,39 @@
+/* Copyright (c) 2022 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "brave/components/brave_wallet/browser/eth_topics_builder.h"
+
+#include <utility>
+
+#include "brave/components/brave_wallet/browser/brave_wallet_utils.h"
+#include "brave/components/brave_wallet/common/hash_utils.h"
+#include "brave/components/brave_wallet/common/hex_utils.h"
+
+namespace brave_wallet {
+
+bool MakeAssetDiscoveryTopics(
+    const std::vector<std::string>& to_account_addresses,
+    base::Value::List* topics) {
+  // First topic matches full keccak hash of the erc20::Transfer event signature
+  topics->Append(brave_wallet::KeccakHash("Transfer(address,address,uint256)"));
+
+  // Second topic matches everything (any from_address)
+  topics->Append(base::Value());
+
+  // Third topic matches any of the to_addresses
+  base::Value::List to_address_topic;
+  for (const auto& account_address : to_account_addresses) {
+    std::string padded_address;
+    if (!brave_wallet::PadHexEncodedParameter(account_address,
+                                              &padded_address)) {
+      return false;
+    }
+    to_address_topic.Append(padded_address);
+  }
+  topics->Append(std::move(to_address_topic));
+  return true;
+}
+
+}  // namespace brave_wallet

--- a/components/brave_wallet/browser/eth_topics_builder.h
+++ b/components/brave_wallet/browser/eth_topics_builder.h
@@ -1,0 +1,23 @@
+/* Copyright (c) 2022 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_COMPONENTS_BRAVE_WALLET_BROWSER_ETH_TOPICS_BUILDER_H_
+#define BRAVE_COMPONENTS_BRAVE_WALLET_BROWSER_ETH_TOPICS_BUILDER_H_
+
+#include <string>
+#include <vector>
+#include "base/values.h"
+
+namespace brave_wallet {
+
+// Returns topics that match all ERC20 transfer event logs for the given
+// to_account_addresses
+bool MakeAssetDiscoveryTopics(
+    const std::vector<std::string>& to_account_addresses,
+    base::Value::List* topics);
+
+}  // namespace brave_wallet
+
+#endif  // BRAVE_COMPONENTS_BRAVE_WALLET_BROWSER_ETH_TOPICS_BUILDER_H_

--- a/components/brave_wallet/browser/eth_topics_builder_unittest.cc
+++ b/components/brave_wallet/browser/eth_topics_builder_unittest.cc
@@ -1,0 +1,31 @@
+/* Copyright (c) 2022 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "brave/components/brave_wallet/browser/eth_topics_builder.h"
+
+#include "brave/components/brave_wallet/common/hex_utils.h"
+#include "testing/gtest/include/gtest/gtest.h"
+
+namespace brave_wallet {
+
+TEST(EthGetLogsTopicBuilderTest, MakeAssetDiscoveryTopics) {
+  // Invalid address
+  base::Value::List topics;
+  EXPECT_FALSE(MakeAssetDiscoveryTopics({"invalid address"}, &topics));
+
+  // Valid
+  topics.clear();
+  ASSERT_TRUE(MakeAssetDiscoveryTopics(
+      {"0x16e4476c8fDDc552e3b1C4b8b56261d85977fE52"}, &topics));
+  EXPECT_EQ(topics[0], base::Value("0xddf252ad1be2c89b69c2b068fc378daa952ba7f16"
+                                   "3c4a11628f55a4df523b3ef"));
+  EXPECT_EQ(topics[1], base::Value());
+  base::Value::List to_address_topic;
+  to_address_topic.Append(base::Value(
+      "0x00000000000000000000000016e4476c8fDDc552e3b1C4b8b56261d85977fE52"));
+  EXPECT_EQ(topics[2], to_address_topic);
+}
+
+}  // namespace brave_wallet

--- a/components/brave_wallet/browser/json_rpc_response_parser.cc
+++ b/components/brave_wallet/browser/json_rpc_response_parser.cc
@@ -75,6 +75,14 @@ absl::optional<base::Value::Dict> ParseResultDict(const std::string& json) {
   return std::move(result->GetDict());
 }
 
+absl::optional<base::Value::List> ParseResultList(const std::string& json) {
+  auto result = ParseResultValue(json);
+  if (!result || !result->is_list())
+    return absl::nullopt;
+
+  return std::move(result->GetList());
+}
+
 bool ParseBoolResult(const std::string& json, bool* value) {
   DCHECK(value);
 

--- a/components/brave_wallet/browser/json_rpc_response_parser.h
+++ b/components/brave_wallet/browser/json_rpc_response_parser.h
@@ -62,6 +62,7 @@ void ParseErrorResult(const std::string& json,
 }
 
 absl::optional<base::Value::Dict> ParseResultDict(const std::string& json);
+absl::optional<base::Value::List> ParseResultList(const std::string& json);
 bool ParseBoolResult(const std::string& json, bool* value);
 
 absl::optional<std::string> ConvertInt64ToString(const std::string& path,

--- a/components/brave_wallet/browser/json_rpc_service.cc
+++ b/components/brave_wallet/browser/json_rpc_service.cc
@@ -6,6 +6,7 @@
 #include "brave/components/brave_wallet/browser/json_rpc_service.h"
 
 #include <memory>
+#include <unordered_set>
 #include <utility>
 
 #include "base/base64.h"
@@ -14,13 +15,17 @@
 #include "base/json/json_writer.h"
 #include "base/no_destructor.h"
 #include "base/notreached.h"
+#include "base/strings/string_util.h"
 #include "base/strings/utf_string_conversions.h"
+#include "brave/components/brave_wallet/browser/blockchain_registry.h"
 #include "brave/components/brave_wallet/browser/brave_wallet_prefs.h"
+#include "brave/components/brave_wallet/browser/brave_wallet_service.h"
 #include "brave/components/brave_wallet/browser/brave_wallet_utils.h"
 #include "brave/components/brave_wallet/browser/ens_resolver_task.h"
 #include "brave/components/brave_wallet/browser/eth_data_builder.h"
 #include "brave/components/brave_wallet/browser/eth_requests.h"
 #include "brave/components/brave_wallet/browser/eth_response_parser.h"
+#include "brave/components/brave_wallet/browser/eth_topics_builder.h"
 #include "brave/components/brave_wallet/browser/fil_requests.h"
 #include "brave/components/brave_wallet/browser/fil_response_parser.h"
 #include "brave/components/brave_wallet/browser/json_rpc_requests_helper.h"
@@ -2090,6 +2095,191 @@ void JsonRpcService::GetERC1155TokenBalance(
   RequestInternal(
       eth::eth_call("", contract_address, "", "", "", data, "latest"), true,
       network_url, std::move(internal_callback));
+}
+
+// Called by KeyringService::CreateWallet, KeyringService::RestoreWallet,
+// KeyringService::AddAccount, KeyringService::ImportAccountForKeyring,
+// and KeyringService::AddHardwareAccounts
+void JsonRpcService::DiscoverAssets(
+    const std::string& chain_id,
+    mojom::CoinType coin,
+    const std::vector<std::string>& account_addresses) {
+  auto callback = base::BindOnce(&JsonRpcService::OnDiscoverAssetsCompleted,
+                                 weak_ptr_factory_.GetWeakPtr());
+  DiscoverAssetsInternal(chain_id, coin, account_addresses,
+                         std::move(callback));
+}
+
+void JsonRpcService::OnDiscoverAssetsCompleted(
+    const std::vector<mojom::BlockchainTokenPtr> discovered_assets,
+    mojom::ProviderError error,
+    const std::string& error_message) {
+  if (error != mojom::ProviderError::kSuccess) {
+    VLOG(1) << __func__ << "Encountered error during asset discovery "
+            << error_message;
+  }
+}
+
+void JsonRpcService::DiscoverAssetsInternal(
+    const std::string& chain_id,
+    mojom::CoinType coin,
+    const std::vector<std::string>& account_addresses,
+    DiscoverAssetsCallback callback) {
+  if (coin != mojom::CoinType::ETH || chain_id != mojom::kMainnetChainId) {
+    std::move(callback).Run(
+        std::vector<mojom::BlockchainTokenPtr>(),
+        mojom::ProviderError::kMethodNotSupported,
+        l10n_util::GetStringUTF8(IDS_WALLET_METHOD_NOT_SUPPORTED_ERROR));
+    return;
+  }
+
+  // Asset discovery only supported when using Infura proxy
+  GURL infura_url = GetInfuraURLForKnownChainId(chain_id);
+  GURL active_url = GetNetworkURL(prefs_, chain_id, coin);
+  if (infura_url.host() != active_url.host()) {
+    std::move(callback).Run(
+        std::vector<mojom::BlockchainTokenPtr>(),
+        mojom::ProviderError::kMethodNotSupported,
+        l10n_util::GetStringUTF8(IDS_WALLET_METHOD_NOT_SUPPORTED_ERROR));
+    return;
+  }
+
+  if (account_addresses.empty()) {
+    std::move(callback).Run(
+        std::vector<mojom::BlockchainTokenPtr>(),
+        mojom::ProviderError::kInvalidParams,
+        l10n_util::GetStringUTF8(IDS_WALLET_INVALID_PARAMETERS));
+    return;
+  }
+
+  for (const auto& account_address : account_addresses) {
+    if (!EthAddress::IsValidAddress(account_address)) {
+      std::move(callback).Run(
+          std::vector<mojom::BlockchainTokenPtr>(),
+          mojom::ProviderError::kInvalidParams,
+          l10n_util::GetStringUTF8(IDS_WALLET_INVALID_PARAMETERS));
+      return;
+    }
+  }
+
+  std::vector<mojom::BlockchainTokenPtr> user_assets =
+      BraveWalletService::GetUserAssets(chain_id, mojom::CoinType::ETH, prefs_);
+  auto internal_callback = base::BindOnce(
+      &JsonRpcService::OnGetAllTokensDiscoverAssets,
+      weak_ptr_factory_.GetWeakPtr(), chain_id, account_addresses,
+      std::move(user_assets), std::move(callback));
+
+  BlockchainRegistry::GetInstance()->GetAllTokens(
+      chain_id, mojom::CoinType::ETH, std::move(internal_callback));
+}
+
+void JsonRpcService::OnGetAllTokensDiscoverAssets(
+    const std::string& chain_id,
+    const std::vector<std::string>& account_addresses,
+    std::vector<mojom::BlockchainTokenPtr> user_assets,
+    DiscoverAssetsCallback callback,
+    std::vector<mojom::BlockchainTokenPtr> token_registry) {
+  auto network_url = GetNetworkURL(prefs_, chain_id, mojom::CoinType::ETH);
+  if (!network_url.is_valid()) {
+    std::move(callback).Run(
+        std::vector<mojom::BlockchainTokenPtr>(),
+        mojom::ProviderError::kInvalidParams,
+        l10n_util::GetStringUTF8(IDS_WALLET_INVALID_PARAMETERS));
+    return;
+  }
+
+  base::Value::List topics;
+  if (!MakeAssetDiscoveryTopics(account_addresses, &topics)) {
+    std::move(callback).Run(
+        std::vector<mojom::BlockchainTokenPtr>(),
+        mojom::ProviderError::kInvalidParams,
+        l10n_util::GetStringUTF8(IDS_WALLET_INVALID_PARAMETERS));
+    return;
+  }
+
+  // Create set of contract addresses the user already has for easy lookups
+  base::flat_set<std::string> user_asset_contract_addresses;
+  for (const auto& user_asset : user_assets) {
+    user_asset_contract_addresses.insert(user_asset->contract_address);
+  }
+
+  // Create a list of contract addresses to search by removing
+  // all erc20s and assets the user has already added.
+  base::Value::List contract_addresses_to_search;
+  // Also create a map for addresses to blockchain tokens for easy lookup
+  // for blockchain tokens in OnGetTransferLogs
+  base::flat_map<std::string, mojom::BlockchainTokenPtr> tokens_to_search;
+  for (auto& registry_token : token_registry) {
+    if (registry_token->is_erc20 && !registry_token->contract_address.empty() &&
+        !user_asset_contract_addresses.contains(
+            registry_token->contract_address)) {
+      // Use lowercase representation of hex address for comparisons
+      // because providers may return all lowercase addresses.
+      const std::string lower_case_contract_address =
+          base::ToLowerASCII(registry_token->contract_address);
+      contract_addresses_to_search.Append(lower_case_contract_address);
+      tokens_to_search[lower_case_contract_address] = std::move(registry_token);
+    }
+  }
+
+  if (contract_addresses_to_search.size() == 0) {
+    std::move(callback).Run(std::vector<mojom::BlockchainTokenPtr>(),
+                            mojom::ProviderError::kSuccess, "");
+    return;
+  }
+
+  auto internal_callback = base::BindOnce(
+      &JsonRpcService::OnGetTransferLogs, weak_ptr_factory_.GetWeakPtr(),
+      std::move(callback), base::OwnedRef(std::move(tokens_to_search)));
+
+  RequestInternal(eth::eth_getLogs("earliest", "latest",
+                                   std::move(contract_addresses_to_search),
+                                   std::move(topics), ""),
+                  true, network_url, std::move(internal_callback));
+}
+
+void JsonRpcService::OnGetTransferLogs(
+    DiscoverAssetsCallback callback,
+    base::flat_map<std::string, mojom::BlockchainTokenPtr>& tokens_to_search,
+    APIRequestResult api_request_result) {
+  if (!api_request_result.Is2XXResponseCode()) {
+    std::move(callback).Run(
+        std::vector<mojom::BlockchainTokenPtr>(),
+        mojom::ProviderError::kInternalError,
+        l10n_util::GetStringUTF8(IDS_WALLET_INTERNAL_ERROR));
+    return;
+  }
+
+  std::vector<Log> logs;
+  if (!eth::ParseEthGetLogs(api_request_result.body(), &logs)) {
+    std::move(callback).Run(std::vector<mojom::BlockchainTokenPtr>(),
+                            mojom::ProviderError::kParsingError,
+                            l10n_util::GetStringUTF8(IDS_WALLET_PARSING_ERROR));
+    return;
+  }
+
+  // Create unique list of addresses that matched eth_getLogs query
+  base::flat_set<std::string> matching_contract_addresses;
+  for (const auto& log : logs) {
+    matching_contract_addresses.insert(base::ToLowerASCII(log.address));
+  }
+  std::vector<mojom::BlockchainTokenPtr> discovered_assets;
+
+  for (const auto& contract_address : matching_contract_addresses) {
+    if (!tokens_to_search.contains(contract_address)) {
+      continue;
+    }
+    mojom::BlockchainTokenPtr token =
+        std::move(tokens_to_search.at(contract_address));
+
+    if (!BraveWalletService::AddUserAsset(token.Clone(), prefs_)) {
+      continue;
+    }
+    discovered_assets.push_back(std::move(token));
+  }
+
+  std::move(callback).Run(std::move(discovered_assets),
+                          mojom::ProviderError::kSuccess, "");
 }
 
 void JsonRpcService::GetSupportsInterface(

--- a/components/brave_wallet/browser/json_rpc_service.h
+++ b/components/brave_wallet/browser/json_rpc_service.h
@@ -307,6 +307,36 @@ class JsonRpcService : public KeyedService, public mojom::JsonRpcService {
                           const std::string& chain_id,
                           GetTokenMetadataCallback callback) override;
 
+  using DiscoverAssetsCallback = base::OnceCallback<void(
+      const std::vector<mojom::BlockchainTokenPtr> discovered_assets,
+      mojom::ProviderError error,
+      const std::string& error_message)>;
+  void DiscoverAssets(const std::string& chain_id,
+                      mojom::CoinType coin,
+                      const std::vector<std::string>& account_addresses);
+
+  void DiscoverAssetsInternal(const std::string& chain_id,
+                              mojom::CoinType coin,
+                              const std::vector<std::string>& account_addresses,
+                              DiscoverAssetsCallback callback);
+
+  void OnGetAllTokensDiscoverAssets(
+      const std::string& chain_id,
+      const std::vector<std::string>& account_addresses,
+      std::vector<mojom::BlockchainTokenPtr> user_assets,
+      DiscoverAssetsCallback callback,
+      std::vector<mojom::BlockchainTokenPtr> token_list);
+
+  void OnGetTransferLogs(
+      DiscoverAssetsCallback callback,
+      base::flat_map<std::string, mojom::BlockchainTokenPtr>& user_assets_map,
+      APIRequestResult api_request_result);
+
+  void OnDiscoverAssetsCompleted(
+      std::vector<mojom::BlockchainTokenPtr> discovered_assets,
+      mojom::ProviderError error,
+      const std::string& error_message);
+
   // Resets things back to the original state of BraveWalletService.
   // To be used when the Wallet is reset / erased
   void Reset();

--- a/components/brave_wallet/browser/json_rpc_service_unittest.cc
+++ b/components/brave_wallet/browser/json_rpc_service_unittest.cc
@@ -22,6 +22,7 @@
 #include "base/test/scoped_feature_list.h"
 #include "base/test/task_environment.h"
 #include "base/values.h"
+#include "brave/components/brave_wallet/browser/blockchain_registry.h"
 #include "brave/components/brave_wallet/browser/brave_wallet_constants.h"
 #include "brave/components/brave_wallet/browser/brave_wallet_prefs.h"
 #include "brave/components/brave_wallet/browser/brave_wallet_utils.h"
@@ -775,6 +776,34 @@ class JsonRpcServiceUnitTest : public testing::Test {
           EXPECT_EQ(error_message, expected_error_message);
           run_loop.Quit();
         }));
+    run_loop.Run();
+  }
+
+  void TestDiscoverAssetsInternal(
+      const std::string& chain_id,
+      mojom::CoinType coin,
+      const std::vector<std::string>& account_addresses,
+      const std::vector<std::string>& expected_token_contract_addresses,
+      mojom::ProviderError expected_error,
+      const std::string& expected_error_message) {
+    base::RunLoop run_loop;
+    std::vector<mojom::BlockchainTokenPtr> expected_tokens;
+    json_rpc_service_->DiscoverAssetsInternal(
+        chain_id, mojom::CoinType::ETH, account_addresses,
+        base::BindLambdaForTesting(
+            [&](const std::vector<mojom::BlockchainTokenPtr> tokens,
+                mojom::ProviderError error, const std::string& error_message) {
+              ASSERT_EQ(tokens.size(),
+                        expected_token_contract_addresses.size());
+              for (size_t i = 0; i < expected_token_contract_addresses.size();
+                   i++) {
+                EXPECT_EQ(tokens[i]->contract_address,
+                          expected_token_contract_addresses[i]);
+              }
+              EXPECT_EQ(error, expected_error);
+              EXPECT_EQ(error_message, expected_error_message);
+              run_loop.Quit();
+            }));
     run_loop.Run();
   }
 
@@ -1982,7 +2011,7 @@ TEST_F(JsonRpcServiceUnitTest, GetERC20TokenBalance) {
       "}");
 
   json_rpc_service_->GetERC20TokenBalance(
-      "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
+      "0x0D8775F648430679A709E98d2b0Cb6250d2887EF",
       "0x4e02f254184E904300e0775E4b8eeCB1", mojom::kMainnetChainId,
       base::BindOnce(&OnStringResponse, &callback_called,
                      mojom::ProviderError::kSuccess, "",
@@ -1993,7 +2022,7 @@ TEST_F(JsonRpcServiceUnitTest, GetERC20TokenBalance) {
   callback_called = false;
   SetHTTPRequestTimeoutInterceptor();
   json_rpc_service_->GetERC20TokenBalance(
-      "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
+      "0x0D8775F648430679A709E98d2b0Cb6250d2887EF",
       "0x4e02f254184E904300e0775E4b8eeCB1", mojom::kMainnetChainId,
       base::BindOnce(&OnStringResponse, &callback_called,
                      mojom::ProviderError::kInternalError,
@@ -3242,7 +3271,6 @@ TEST_F(JsonRpcServiceUnitTest, GetSupportsInterface) {
   EXPECT_TRUE(callback_called);
 
   // Invalid result, should be in hex form
-  // todo can remove this one if we have checks for parsing errors
   callback_called = false;
   SetInterceptor(GetNetwork(mojom::kMainnetChainId, mojom::CoinType::ETH),
                  "eth_call", "",
@@ -3291,6 +3319,204 @@ TEST_F(JsonRpcServiceUnitTest, GetSupportsInterface) {
                      "Request exceeds defined limit", false));
   base::RunLoop().RunUntilIdle();
   EXPECT_TRUE(callback_called);
+}
+
+TEST_F(JsonRpcServiceUnitTest, DiscoverAssets) {
+  auto* blockchain_registry = BlockchainRegistry::GetInstance();
+  TokenListMap token_list_map;
+
+  std::string response;
+
+  // Unsupported chainId is not supported
+  TestDiscoverAssetsInternal(
+      mojom::kPolygonMainnetChainId, mojom::CoinType::ETH,
+      {"0xB4B2802129071b2B9eBb8cBB01EA1E4D14B34961"}, {},
+      mojom::ProviderError::kMethodNotSupported,
+      l10n_util::GetStringUTF8(IDS_WALLET_METHOD_NOT_SUPPORTED_ERROR));
+
+  // Empty address is invalid
+  TestDiscoverAssetsInternal(
+      mojom::kMainnetChainId, mojom::CoinType::ETH, {}, {},
+      mojom::ProviderError::kInvalidParams,
+      l10n_util::GetStringUTF8(IDS_WALLET_INVALID_PARAMETERS));
+
+  // Invalid address is invalid
+  TestDiscoverAssetsInternal(
+      mojom::kMainnetChainId, mojom::CoinType::ETH, {"0xinvalid"}, {},
+      mojom::ProviderError::kInvalidParams,
+      l10n_util::GetStringUTF8(IDS_WALLET_INVALID_PARAMETERS));
+
+  // Invalid RPC response json response triggers parsing error
+  auto expected_network =
+      GetNetwork(mojom::kMainnetChainId, mojom::CoinType::ETH);
+  std::string token_list_json = R"({
+     "0x0d8775f648430679a709e98d2b0cb6250d2887ef": {
+       "name": "Basic Attention Token",
+       "logo": "bat.svg",
+       "erc20": true,
+       "symbol": "BAT",
+       "decimals": 18
+     }
+    })";
+  ASSERT_TRUE(
+      ParseTokenList(token_list_json, &token_list_map, mojom::CoinType::ETH));
+  blockchain_registry->UpdateTokenList(std::move(token_list_map));
+  SetInterceptor(expected_network, "eth_getLogs", "",
+                 "invalid eth_getLogs response");
+  TestDiscoverAssetsInternal(
+      mojom::kMainnetChainId, mojom::CoinType::ETH,
+      {"0xB4B2802129071b2B9eBb8cBB01EA1E4D14B34961"}, {},
+      mojom::ProviderError::kParsingError,
+      l10n_util::GetStringUTF8(IDS_WALLET_PARSING_ERROR));
+
+  // Invalid limit exceeded response triggers parsing error
+  SetLimitExceededJsonErrorResponse();
+  TestDiscoverAssetsInternal(
+      mojom::kMainnetChainId, mojom::CoinType::ETH,
+      {"0xB4B2802129071b2B9eBb8cBB01EA1E4D14B34961"}, {},
+      mojom::ProviderError::kParsingError,
+      l10n_util::GetStringUTF8(IDS_WALLET_PARSING_ERROR));
+
+  // Invalid logs (missing addresses) triggers parsing error
+  response = R"({
+    "jsonrpc": "2.0",
+    "id": 1,
+    "result": [
+      {
+        "blockHash": "0xaefb023131aa58e533c09c0eae29c280460d3976f5235a1ff53159ef37f73073",
+        "blockNumber": "0xa72603",
+        "data": "0x000000000000000000000000000000000000000000000006e83695ab1f893c00",
+        "logIndex": "0x14",
+        "removed": false,
+        "topics": [
+          "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef",
+          "0x000000000000000000000000897bb1e945f5aa7ed7f81646e7991eaba63aa4b0",
+          "0x000000000000000000000000b4b2802129071b2b9ebb8cbb01ea1e4d14b34961"
+        ],
+        "transactionHash": "0x5c655301d386f45af116a4aef418491ee27b71ac30be70a593ccffa3754797d4",
+        "transactionIndex": "0xa"
+      },
+    ]
+  })";
+  SetInterceptor(expected_network, "eth_getLogs", "", response);
+  TestDiscoverAssetsInternal(
+      mojom::kMainnetChainId, mojom::CoinType::ETH,
+      {"0xB4B2802129071b2B9eBb8cBB01EA1E4D14B34961"}, {},
+      mojom::ProviderError::kParsingError,
+      l10n_util::GetStringUTF8(IDS_WALLET_PARSING_ERROR));
+
+  // Valid registry token DAI is discovered and added.
+  // Valid registry token WETH is discovered and added (tests insensitivity to
+  // lower case addresses in provider logs response).
+  // Valid BAT is not added because it is already a user asset.
+  // Invalid LilNoun is not added because it is an ERC721.
+  token_list_json = R"(
+     {
+      "0x0d8775f648430679a709e98d2b0cb6250d2887ef": {
+        "name": "Basic Attention Token",
+        "logo": "bat.svg",
+        "erc20": true,
+        "symbol": "BAT",
+        "decimals": 18
+      },
+      "0x6B175474E89094C44Da98b954EedeAC495271d0F": {
+        "name": "Dai Stablecoin",
+        "logo": "dai.svg",
+        "erc20": true,
+        "symbol": "DAI",
+        "decimals": 18
+      },
+      "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2": {
+        "name": "Wrapped Eth",
+        "logo": "weth.svg",
+        "erc20": true,
+        "symbol": "WETH",
+        "decimals": 18,
+        "chainId": "0x1"
+      },
+      "0x4b10701Bfd7BFEdc47d50562b76b436fbB5BdB3B": {
+        "name": "Lil Nouns",
+        "logo": "lilnouns.svg",
+        "erc20": false,
+        "erc721": true,
+        "symbol": "LilNouns",
+        "chainId": "0x1"
+      }
+     })";
+  ASSERT_TRUE(
+      ParseTokenList(token_list_json, &token_list_map, mojom::CoinType::ETH));
+  blockchain_registry->UpdateTokenList(std::move(token_list_map));
+
+  // Note: the matching transfer log for WETH uses an all lowercase address
+  // while the token registry uses checksum address (contains uppercase)
+  response = R"({
+    "jsonrpc":"2.0",
+    "id":1,
+    "result":[
+      {
+        "address":"0x6B175474E89094C44Da98b954EedeAC495271d0F",
+        "blockHash":"0x2961ceb6c16bab72a55f79e394a35f2bf1c62b30446e3537280f7c22c3115e6e",
+        "blockNumber":"0xd6464c",
+        "data":"0x00000000000000000000000000000000000000000000000555aff1f0fae8c000",
+        "logIndex":"0x159",
+        "removed":false,
+        "topics":[
+          "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef",
+          "0x000000000000000000000000503828976d22510aad0201ac7ec88293211d23da",
+          "0x000000000000000000000000b4b2802129071b2b9ebb8cbb01ea1e4d14b34961"
+        ],
+        "transactionHash":"0x2e652b70966c6a05f4b3e68f20d6540b7a5ab712385464a7ccf62774d39b7066",
+        "transactionIndex":"0x9f"
+      },
+      {
+        "address":"0x4b10701Bfd7BFEdc47d50562b76b436fbB5BdB3B",
+        "blockHash":"0x2961ceb6c16bab72a55f79e394a35f2bf1c62b30446e3537280f7c22c3115e6e",
+        "blockNumber":"0xd6464c",
+        "data":"0x00000000000000000000000000000000000000000000000555aff1f0fae8c000",
+        "logIndex":"0x159",
+        "removed":false,
+        "topics":[
+          "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef",
+          "0x000000000000000000000000503828976d22510aad0201ac7ec88293211d23da",
+          "0x000000000000000000000000b4b2802129071b2b9ebb8cbb01ea1e4d14b34961"
+        ],
+        "transactionHash":"0x2e652b70966c6a05f4b3e68f20d6540b7a5ab712385464a7ccf62774d39b7066",
+        "transactionIndex":"0x9f"
+      },
+      {
+        "address":"0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+        "blockHash":"0x2961ceb6c16bab72a55f79e394a35f2bf1c62b30446e3537280f7c22c3115e6e",
+        "blockNumber":"0xd6464c",
+        "data":"0x00000000000000000000000000000000000000000000000555aff1f0fae8c000",
+        "logIndex":"0x159",
+        "removed":false,
+        "topics":[
+          "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef",
+          "0x000000000000000000000000503828976d22510aad0201ac7ec88293211d23da",
+          "0x000000000000000000000000b4b2802129071b2b9ebb8cbb01ea1e4d14b34961"
+        ],
+        "transactionHash":"0x2e652b70966c6a05f4b3e68f20d6540b7a5ab712385464a7ccf62774d39b7066",
+        "transactionIndex":"0x9f"
+      }
+    ]
+  })";
+  SetInterceptor(expected_network, "eth_getLogs", "", response);
+  TestDiscoverAssetsInternal(mojom::kMainnetChainId, mojom::CoinType::ETH,
+                             {"0xB4B2802129071b2B9eBb8cBB01EA1E4D14B34961"},
+                             {"0x6B175474E89094C44Da98b954EedeAC495271d0F",
+                              "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2"},
+                             mojom::ProviderError::kSuccess, "");
+
+  // Discover assets should not run unless using Infura proxy
+  std::vector<base::Value::Dict> values;
+  mojom::NetworkInfo chain = GetTestNetworkInfo1("0x1");
+  values.push_back(brave_wallet::NetworkInfoToValue(chain));
+  UpdateCustomNetworks(prefs(), &values);
+  TestDiscoverAssetsInternal(
+      mojom::kMainnetChainId, mojom::CoinType::ETH,
+      {"0xB4B2802129071b2B9eBb8cBB01EA1E4D14B34961"}, {},
+      mojom::ProviderError::kMethodNotSupported,
+      l10n_util::GetStringUTF8(IDS_WALLET_METHOD_NOT_SUPPORTED_ERROR));
 }
 
 TEST_F(JsonRpcServiceUnitTest, Reset) {

--- a/components/brave_wallet/browser/keyring_service.h
+++ b/components/brave_wallet/browser/keyring_service.h
@@ -297,6 +297,7 @@ class KeyringService : public KeyedService, public mojom::KeyringService {
   FRIEND_TEST_ALL_PREFIXES(KeyringServiceUnitTest, DefaultSolanaAccountCreated);
   FRIEND_TEST_ALL_PREFIXES(KeyringServiceUnitTest,
                            DefaultSolanaAccountRestored);
+  FRIEND_TEST_ALL_PREFIXES(KeyringServiceUnitTest, DiscoverAssets);
 
   FRIEND_TEST_ALL_PREFIXES(KeyringServiceAccountDiscoveryUnitTest,
                            AccountDiscovery);

--- a/components/brave_wallet/browser/test/BUILD.gn
+++ b/components/brave_wallet/browser/test/BUILD.gn
@@ -25,6 +25,7 @@ source_set("brave_wallet_unit_tests") {
     "//brave/components/brave_wallet/browser/eth_nonce_tracker_unittest.cc",
     "//brave/components/brave_wallet/browser/eth_requests_unittest.cc",
     "//brave/components/brave_wallet/browser/eth_response_parser_unittest.cc",
+    "//brave/components/brave_wallet/browser/eth_topics_builder_unittest.cc",
     "//brave/components/brave_wallet/browser/eth_transaction_unittest.cc",
     "//brave/components/brave_wallet/browser/eth_tx_manager_unittest.cc",
     "//brave/components/brave_wallet/browser/eth_tx_meta_unittest.cc",

--- a/components/brave_wallet/common/brave_wallet_types.cc
+++ b/components/brave_wallet/common/brave_wallet_types.cc
@@ -9,6 +9,22 @@
 
 namespace brave_wallet {
 
+Log::Log() = default;
+Log::~Log() = default;
+Log::Log(const Log&) = default;
+
+bool Log::operator==(const Log& log) const {
+  return address == log.address && block_hash == log.block_hash &&
+         block_number == log.block_number && data == log.data &&
+         log_index == log.log_index && removed == log.removed &&
+         topics == log.topics && transaction_hash == log.transaction_hash &&
+         transaction_index == log.transaction_index;
+}
+
+bool Log::operator!=(const Log& log) const {
+  return !operator==(log);
+}
+
 TransactionReceipt::TransactionReceipt() = default;
 TransactionReceipt::~TransactionReceipt() = default;
 TransactionReceipt::TransactionReceipt(const TransactionReceipt&) = default;
@@ -23,7 +39,8 @@ bool TransactionReceipt::operator==(
          cumulative_gas_used == tx_receipt.cumulative_gas_used &&
          gas_used == tx_receipt.gas_used &&
          contract_address == tx_receipt.contract_address &&
-         logs_bloom == tx_receipt.logs_bloom && status == tx_receipt.status;
+         logs_bloom == tx_receipt.logs_bloom && status == tx_receipt.status &&
+         logs == tx_receipt.logs;
 }
 
 bool TransactionReceipt::operator!=(

--- a/components/brave_wallet/common/brave_wallet_types.h
+++ b/components/brave_wallet/common/brave_wallet_types.h
@@ -44,6 +44,24 @@ absl::optional<uint256_t> MaxSolidityUint(size_t bits);
 absl::optional<int256_t> MaxSolidityInt(size_t bits);
 absl::optional<int256_t> MinSolidityInt(size_t bits);
 
+struct Log {
+  Log();
+  ~Log();
+  Log(const Log&);
+  bool operator==(const Log&) const;
+  bool operator!=(const Log&) const;
+
+  std::string address;
+  std::string block_hash;
+  uint256_t block_number;
+  std::string data;
+  uint32_t log_index;
+  bool removed;
+  std::vector<std::string> topics;
+  std::string transaction_hash;
+  uint32_t transaction_index;
+};
+
 struct TransactionReceipt {
   TransactionReceipt();
   ~TransactionReceipt();
@@ -60,7 +78,7 @@ struct TransactionReceipt {
   uint256_t cumulative_gas_used;
   uint256_t gas_used;
   std::string contract_address;
-  std::vector<std::string> logs;
+  std::vector<Log> logs;
   std::string logs_bloom;
   bool status;
 };


### PR DESCRIPTION
Resolves https://github.com/brave/brave-browser/issues/19746.
Security Review https://github.com/brave/security/issues/1003

This adds logic that automatically detect and add ERC20 tokens on Mainnet Ethereum to the the list of user assets when new accounts are added.

## How it works
We make an eth_getLogs RPC request that returns all events that
* Were created between the "earliest" and "latest" blocks (all blocks). Note: scanning all blocks is intensive and requires the RPC provider to have an efficient eth_getLogs implementation like [Infura](https://blog.infura.io/post/faster-logs-and-events-e43e2fa13773).
* Match the ERC20 Transfer event signature
* Match the user's account address for the "to address" of the event
* Are emitted by ERC20 token contracts whose addresses are in our blockchain registry.

Each distinct address in the returned logs is an ERC20 contract of a token the user held at some point in the past. 

## Implementation (out of date, to be updated)
* Modify KeyringService to emit a AccountsAdded to be consumed by KeyringServiceObservers
* Add new AssetDiscoveryService class that implements KeyringServiceObserver::AccountsAdded which 
   * Filters out any added account that is not CoinType::ETH
   * Calls JsonRpcService::DiscoverAssets
* Add JsonRpcService::DiscoverAssets which 
    * Creates a list of contract_addresses to look for transfer events for by
        * Fetching all supported mainnet Ethereum tokens from the BlockchainRegistry
        * Removing any tokens that the user has already added
        * Removing any non ERC20 tokens
    * Creates a list of topics for the eth_getLogs call that will match all ERC20 transfer events to or from the any of the added accounts that were emitted by token contract addresses from the registry (eth_topics_builder.cc)
    * Makes the eth_getLogs RPC call, parses the returned logs, dedupes the list of contract addresses associated with discovered assets and returns the list of assets
* Adds the discovered assets by calling BraveWalletService::AddUserAsset for each
## Submitter Checklist:

- [ ] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
Set up an account on Ethereum mainnet that has received an ERC20 transfer from an asset that is in our token registry, but are not added as visible assets.  Add this account using each of these methods, and verify the asset is now a visible asset:
* Create wallet
* Restore wallet
* Add account (standard way)
* Import private key
* Import hardware account

Some of these methods only work if the account that received the transfer is the first account derived.