### PR TITLE
[Android] news crash and orientation issue fixed (uplift to 1.38.x)

### DIFF
--- a/android/java/org/chromium/chrome/browser/ntp/BraveNewTabPageLayout.java
+++ b/android/java/org/chromium/chrome/browser/ntp/BraveNewTabPageLayout.java
@@ -742,7 +742,7 @@ public class BraveNewTabPageLayout extends NewTabPageLayout implements Connectio
 
     private void keepPosition(int prevScrollPosition, int prevRecyclerViewPosition,
             int prevRecyclerViewItemPosition) {
-        if ((mIsNewsOn != mIsShowNewsOn) || (mIsNewsOn && mIsShowOptin)) {
+        if (!mIsNewsOn || !mIsShowNewsOn || (mIsNewsOn && mIsShowOptin)) {
             return;
         }
         processFeed();
@@ -1190,25 +1190,28 @@ public class BraveNewTabPageLayout extends NewTabPageLayout implements Connectio
                         int scrollY = mParentScrollView.getScrollY();
 
                         if (BraveActivity.getBraveActivity() != null
-                                && BraveActivity.getBraveActivity().getActivityTab() != null) {
+                                && BraveActivity.getBraveActivity().getActivityTab() != null
+                                && mRecyclerView.getChildCount() > 0) {
                             View firstChild = mRecyclerView.getChildAt(0);
-                            int firstVisiblePosition =
-                                    mRecyclerView.getChildAdapterPosition(firstChild);
-                            int verticalOffset = firstChild.getTop();
+                            if (firstChild != null) {
+                                int firstVisiblePosition =
+                                        mRecyclerView.getChildAdapterPosition(firstChild);
+                                int verticalOffset = firstChild.getTop();
 
-                            SharedPreferencesManager.getInstance().writeInt(
-                                    BRAVE_RECYCLERVIEW_OFFSET_POSITION
-                                            + BraveActivity.getBraveActivity()
-                                                      .getActivityTab()
-                                                      .getId(),
-                                    verticalOffset);
+                                SharedPreferencesManager.getInstance().writeInt(
+                                        BRAVE_RECYCLERVIEW_OFFSET_POSITION
+                                                + BraveActivity.getBraveActivity()
+                                                          .getActivityTab()
+                                                          .getId(),
+                                        verticalOffset);
 
-                            SharedPreferencesManager.getInstance().writeInt(
-                                    BRAVE_RECYCLERVIEW_POSITION
-                                            + BraveActivity.getBraveActivity()
-                                                      .getActivityTab()
-                                                      .getId(),
-                                    firstVisiblePosition);
+                                SharedPreferencesManager.getInstance().writeInt(
+                                        BRAVE_RECYCLERVIEW_POSITION
+                                                + BraveActivity.getBraveActivity()
+                                                          .getActivityTab()
+                                                          .getId(),
+                                        firstVisiblePosition);
+                            }
                         }
                         mFeedHash = SharedPreferencesManager.getInstance().readString(
                                 BravePreferenceKeys.BRAVE_NEWS_FEED_HASH, "");


### PR DESCRIPTION
Uplift of #13297
Resolves https://github.com/brave/brave-browser/issues/22777

Pre-approval checklist: 
- [ ] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [ ] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [ ] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [ ] The associated issue milestone is set to the smallest version that the changes is landed on.