### PR TITLE
Set focus back to wallet panel after Trezor popup

### DIFF
--- a/browser/ui/webui/brave_wallet/panel_handler/wallet_panel_handler.cc
+++ b/browser/ui/webui/brave_wallet/panel_handler/wallet_panel_handler.cc
@@ -9,6 +9,7 @@
 
 #include "base/callback.h"
 #include "brave/components/permissions/contexts/brave_wallet_permission_context.h"
+#include "content/public/browser/web_contents.h"
 
 // It's safe to bind the active webcontents when panel is created because
 // the panel will not be shared across tabs.
@@ -53,4 +54,7 @@ void WalletPanelHandler::CancelConnectToSite() {
 void WalletPanelHandler::SetCloseOnDeactivate(bool close) {
   if (close_on_deactivation_)
     close_on_deactivation_.Run(close);
+}
+void WalletPanelHandler::Focus() {
+  webui_controller_->web_ui()->GetWebContents()->Focus();
 }

--- a/browser/ui/webui/brave_wallet/panel_handler/wallet_panel_handler.h
+++ b/browser/ui/webui/brave_wallet/panel_handler/wallet_panel_handler.h
@@ -37,6 +37,7 @@ class WalletPanelHandler : public brave_wallet::mojom::PanelHandler {
   void SetCloseOnDeactivate(bool close) override;
   void ConnectToSite(const std::vector<std::string>& accounts) override;
   void CancelConnectToSite() override;
+  void Focus() override;
 
  private:
   mojo::Receiver<brave_wallet::mojom::PanelHandler> receiver_;

--- a/components/brave_wallet/common/brave_wallet.mojom
+++ b/components/brave_wallet/common/brave_wallet.mojom
@@ -235,6 +235,7 @@ interface PanelHandler {
   ConnectToSite(array<string> accounts);
   CancelConnectToSite();
   SetCloseOnDeactivate(bool close);
+  Focus();
 };
 
 // Browser-side handler for requests from WebUI page.

--- a/components/brave_wallet_ui/panel/async/wallet_panel_async_handler.ts
+++ b/components/brave_wallet_ui/panel/async/wallet_panel_async_handler.ts
@@ -293,6 +293,15 @@ handler.on(PanelActions.approveHardwareTransaction.getType(), async (store: Stor
       await store.dispatch(PanelActions.setSelectedTransaction(txInfo))
       await store.dispatch(PanelActions.navigateTo('transactionDetails'))
       apiProxy.panelHandler.setCloseOnDeactivate(true)
+      // By default the focus is moved to the browser window automatically when
+      // Trezor popup closed which triggers an OnDeactivate event that would
+      // close the wallet panel because of the above API call. However, there
+      // could be times that the above call happens after OnDeactivate event, so
+      // the wallet panel would stay open after Trezor popup closed.
+      // As a workaround, we manually set the focus back to wallet panel here so
+      // it would trigger another OnDeactivate event when user clicks outside
+      // of the wallet panel.
+      apiProxy.panelHandler.focus()
       return
     }
 


### PR DESCRIPTION
<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/22780

By default the focus is moved to the browser window automatically when Trezor popup closed. We set it back to the panel manually.

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

- Send transaction using Trezor account.
- Click to the browser window right after the Trezor popup is closed.
- Check the wallet panel is closed automatically.

