### PR TITLE
Enables the opt-in card in 1.38.x by reverting the commit which disabled it.

### DIFF
--- a/android/java/org/chromium/chrome/browser/ntp/BraveNewTabPageLayout.java
+++ b/android/java/org/chromium/chrome/browser/ntp/BraveNewTabPageLayout.java
@@ -465,14 +465,9 @@ public class BraveNewTabPageLayout extends NewTabPageLayout implements Connectio
                 mIsShowOptin =
                         sharedPreferences.getBoolean(BraveNewsPreferences.PREF_SHOW_OPTIN, false);
                 mIsShowNewsOn = BravePrefServiceBridge.getInstance().getShowNews();
-                if ((!mIsNewsOn && mIsShowOptin) || (mIsNewsOn && !mIsShowOptin)) {
-                    SharedPreferences.Editor sharedPreferencesEditor = sharedPreferences.edit();
-                    sharedPreferencesEditor.putBoolean(BraveNewsPreferences.PREF_SHOW_OPTIN, true);
-                    sharedPreferencesEditor.apply();
-                    mOptinLayout.setVisibility(View.VISIBLE);
-                    mRecyclerView.setVisibility(View.GONE);
-                    initNews();
-                }
+                mOptinLayout.setVisibility(View.GONE);
+                mRecyclerView.setVisibility(View.VISIBLE);
+                initNews();
             }
         };
     }
@@ -832,7 +827,7 @@ public class BraveNewTabPageLayout extends NewTabPageLayout implements Connectio
         SharedPreferences sharedPreferences = ContextUtils.getAppSharedPreferences();
 
         mIsNewsOn = BravePrefServiceBridge.getInstance().getNewsOptIn();
-        mIsShowOptin = sharedPreferences.getBoolean(BraveNewsPreferences.PREF_SHOW_OPTIN, false);
+        mIsShowOptin = sharedPreferences.getBoolean(BraveNewsPreferences.PREF_SHOW_OPTIN, true);
         mIsShowNewsOn = BravePrefServiceBridge.getInstance().getShowNews();
 
         if ((!mIsNewsOn && mIsShowOptin) || (mIsNewsOn && mIsShowOptin)) {
@@ -1279,6 +1274,8 @@ public class BraveNewTabPageLayout extends NewTabPageLayout implements Connectio
                     SharedPreferences.Editor sharedPreferencesEditor = sharedPreferences.edit();
                     sharedPreferencesEditor.putBoolean(BraveNewsPreferences.PREF_SHOW_OPTIN, false);
                     sharedPreferencesEditor.apply();
+                    BravePrefServiceBridge.getInstance().setNewsOptIn(true);
+                    BravePrefServiceBridge.getInstance().setShowNews(false);
                     correctPosition(false);
                     mParentScrollView.fullScroll(NestedScrollView.FOCUS_UP);
                     mImageCreditLayout.setAlpha(1.0f);

--- a/android/java/org/chromium/chrome/browser/settings/BraveNewsPreferences.java
+++ b/android/java/org/chromium/chrome/browser/settings/BraveNewsPreferences.java
@@ -196,29 +196,43 @@ public class BraveNewsPreferences extends BravePreferenceFragment
             mAddSource.setText("");
         }
 
-        // Ensure the shownews pref is false when it's unchechecked
-        if (!mShowNews.isChecked()) {
-            BravePrefServiceBridge.getInstance().setShowNews(false);
+        boolean isNewsOn = BravePrefServiceBridge.getInstance().getNewsOptIn();
+        boolean isShowNewsOn = BravePrefServiceBridge.getInstance().getShowNews();
+        if (isNewsOn) {
+            mTurnOnNews.setVisible(false);
+            mShowNews.setVisible(true);
+            if (isShowNewsOn) {
+                mShowNews.setChecked(true);
+            }
+            setSourcesVisibility(isShowNewsOn);
+        } else {
+            mTurnOnNews.setChecked(false);
+            mShowNews.setVisible(false);
+            setSourcesVisibility(isNewsOn);
         }
-        mTurnOnNews.setVisible(false);
-        setSourcesVisibility(BravePrefServiceBridge.getInstance().getShowNews());
     }
 
     @Override
     public boolean onPreferenceChange(Preference preference, Object newValue) {
         String key = preference.getKey();
         if (PREF_TURN_ON_NEWS.equals(key)) {
-            // Unused for now as we temporarly remove the Enable switch
-            BravePrefServiceBridge.getInstance().setShowNews(false);
+            if ((boolean) newValue) {
+                mTurnOnNews.setVisible(false);
+                mShowNews.setVisible(true);
+                mShowNews.setChecked(true);
+                BravePrefServiceBridge.getInstance().setNewsOptIn(true);
+                BravePrefServiceBridge.getInstance().setShowNews(true);
+                SharedPreferences.Editor sharedPreferencesEditor =
+                        ContextUtils.getAppSharedPreferences().edit();
+                sharedPreferencesEditor.putBoolean(BraveNewsPreferences.PREF_SHOW_OPTIN, false);
+                sharedPreferencesEditor.apply();
+            }
         } else if (PREF_SHOW_NEWS.equals(key)) {
             SharedPreferences.Editor sharedPreferencesEditor =
                     ContextUtils.getAppSharedPreferences().edit();
             sharedPreferencesEditor.putBoolean(BraveNewsPreferences.PREF_SHOW_OPTIN, false);
             sharedPreferencesEditor.apply();
             BravePrefServiceBridge.getInstance().setShowNews((boolean) newValue);
-            // Sets Enable switch to the same value to keep the conditions in BraveNewTabLayout.java
-            // valid
-            BravePrefServiceBridge.getInstance().setNewsOptIn((boolean) newValue);
 
         } else if (PREF_RSS_SOURCES.equals(key)) {
             if (((String) newValue).equals("")) {


### PR DESCRIPTION
This reverts commit e6317629885064ae09ad9919be82d3fdd57df994.

<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/22778 for 1.38.x only

## Submitter Checklist:

- [ ] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

