### PR TITLE
Fix wrongly computed insufficient funds errors

### DIFF
--- a/components/brave_wallet_ui/common/hooks/transaction-parser.ts
+++ b/components/brave_wallet_ui/common/hooks/transaction-parser.ts
@@ -422,10 +422,8 @@ export function useTransactionParser (
           ? nativeAsset
           : fillTokens[0]
         const sellAmountWeiBN = new Amount(sellAmountArg || value)
-        const sellAmountBN = sellAmountWeiBN
-          .divideByDecimals(sellToken.decimals)
         const sellAmountFiat = computeFiatAmount(
-          sellAmountBN.format(),
+          sellAmountWeiBN.format(),
           sellToken.symbol,
           sellToken.decimals
         )
@@ -442,8 +440,11 @@ export function useTransactionParser (
 
         const insufficientNativeFunds = new Amount(gasFee)
           .gt(accountNativeBalance)
-        const insufficientTokenFunds = sellAmountBN
+        const insufficientTokenFunds = sellAmountWeiBN
           .gt(getBalance(account, token))
+
+        const sellAmountBN = sellAmountWeiBN
+          .divideByDecimals(sellToken.decimals)
 
         return {
           hash: transactionInfo.txHash,

--- a/components/brave_wallet_ui/common/hooks/transaction-parser.ts
+++ b/components/brave_wallet_ui/common/hooks/transaction-parser.ts
@@ -54,8 +54,8 @@ export interface ParsedTransaction extends ParsedTransactionFees {
   valueExact: string
   symbol: string
   decimals: number
-  insufficientFundsForGasError: boolean
-  insufficientFundsError: boolean
+  insufficientFundsForGasError?: boolean
+  insufficientFundsError?: boolean
   contractAddressError?: string
   sameAddressError?: string
   erc721BlockchainToken?: BraveWallet.BlockchainToken
@@ -237,10 +237,12 @@ export function useTransactionParser (
         const totalAmountFiat = new Amount(gasFeeFiat)
           .plus(sendAmountFiat)
 
-        const insufficientNativeFunds = new Amount(gasFee)
-          .gt(accountNativeBalance)
-        const insufficientTokenFunds = new Amount(amount)
-          .gt(accountTokenBalance)
+        const insufficientNativeFunds = accountNativeBalance !== ''
+          ? new Amount(gasFee).gt(accountNativeBalance)
+          : undefined
+        const insufficientTokenFunds = accountTokenBalance !== ''
+          ? new Amount(amount).gt(accountTokenBalance)
+          : undefined
 
         return {
           hash: transactionInfo.txHash,
@@ -285,8 +287,9 @@ export function useTransactionParser (
         const { gasFeeFiat, gasFee } = feeDetails
         const totalAmountFiat = gasFeeFiat
 
-        const insufficientNativeFunds = new Amount(gasFee)
-          .gt(accountNativeBalance)
+        const insufficientNativeFunds = accountNativeBalance !== ''
+          ? new Amount(gasFee).gt(accountNativeBalance)
+          : undefined
 
         return {
           hash: transactionInfo.txHash,
@@ -322,8 +325,9 @@ export function useTransactionParser (
         const feeDetails = parseTransactionFees(transactionInfo)
         const { gasFeeFiat, gasFee } = feeDetails
         const totalAmountFiat = new Amount(gasFeeFiat)
-        const insufficientNativeFunds = new Amount(gasFee)
-          .gt(accountNativeBalance)
+        const insufficientNativeFunds = accountNativeBalance !== ''
+          ? new Amount(gasFee).gt(accountNativeBalance)
+          : undefined
 
         const amountWrapped = new Amount(amount)
 
@@ -370,10 +374,12 @@ export function useTransactionParser (
         const totalAmountFiat = new Amount(gasFeeFiat)
           .plus(sendAmountFiat)
 
-        const insufficientNativeFunds = new Amount(gasFee)
-          .gt(accountNativeBalance)
-        const insufficientTokenFunds = new Amount(value)
-          .gt(accountTokenBalance)
+        const insufficientNativeFunds = accountNativeBalance !== ''
+          ? new Amount(gasFee).gt(accountNativeBalance)
+          : undefined
+        const insufficientTokenFunds = accountTokenBalance !== ''
+          ? new Amount(value).gt(accountTokenBalance)
+          : undefined
 
         return {
           hash: transactionInfo.txHash,
@@ -438,10 +444,14 @@ export function useTransactionParser (
         const totalAmountFiat = new Amount(gasFeeFiat)
           .plus(sellAmountFiat)
 
-        const insufficientNativeFunds = new Amount(gasFee)
-          .gt(accountNativeBalance)
-        const insufficientTokenFunds = sellAmountWeiBN
-          .gt(getBalance(account, token))
+        const insufficientNativeFunds = accountNativeBalance !== ''
+          ? new Amount(gasFee).gt(accountNativeBalance)
+          : undefined
+
+        const tokenBalance = getBalance(account, token)
+        const insufficientTokenFunds = tokenBalance !== ''
+          ? sellAmountWeiBN.gt(tokenBalance)
+          : undefined
 
         const sellAmountBN = sellAmountWeiBN
           .divideByDecimals(sellToken.decimals)
@@ -513,11 +523,14 @@ export function useTransactionParser (
             .format(),
           symbol: selectedNetwork.symbol,
           decimals: selectedNetwork?.decimals ?? 18,
-          insufficientFundsError: new Amount(value)
-            .plus(gasFee)
-            .gt(accountNativeBalance),
-          insufficientFundsForGasError: new Amount(gasFee)
-            .gt(accountNativeBalance),
+          insufficientFundsError: accountNativeBalance !== ''
+            ? new Amount(value)
+              .plus(gasFee)
+              .gt(accountNativeBalance)
+            : undefined,
+          insufficientFundsForGasError: accountNativeBalance !== ''
+            ? new Amount(gasFee).gt(accountNativeBalance)
+            : undefined,
           isSwap: to.toLowerCase() === SwapExchangeProxy,
           ...feeDetails
         } as ParsedTransaction

--- a/components/brave_wallet_ui/common/hooks/use-pending-transaction.ts
+++ b/components/brave_wallet_ui/common/hooks/use-pending-transaction.ts
@@ -148,6 +148,7 @@ export const usePendingTransactions = () => {
     return (
       !!transactionDetails?.sameAddressError ||
       !!transactionDetails?.contractAddressError ||
+      transactionDetails?.insufficientFundsForGasError ||
       transactionDetails?.insufficientFundsError ||
       !!transactionDetails?.missingGasLimitError
     )

--- a/components/brave_wallet_ui/common/hooks/use-pending-transaction.ts
+++ b/components/brave_wallet_ui/common/hooks/use-pending-transaction.ts
@@ -145,9 +145,15 @@ export const usePendingTransactions = () => {
     , [transactionDetails])
 
   const isConfirmButtonDisabled = React.useMemo(() => {
+    if (!transactionDetails) {
+      return true
+    }
+
     return (
       !!transactionDetails?.sameAddressError ||
       !!transactionDetails?.contractAddressError ||
+      transactionDetails?.insufficientFundsForGasError === undefined ||
+      transactionDetails?.insufficientFundsError === undefined ||
       transactionDetails?.insufficientFundsForGasError ||
       transactionDetails?.insufficientFundsError ||
       !!transactionDetails?.missingGasLimitError

--- a/components/brave_wallet_ui/components/extension/confirm-transaction-panel/erc-twenty-transaction-info.tsx
+++ b/components/brave_wallet_ui/components/extension/confirm-transaction-panel/erc-twenty-transaction-info.tsx
@@ -55,7 +55,7 @@ export const Erc20ApproveTransactionInfo = ({ onToggleEditGas }: Erc20Transactio
       </TransactionText>
     }
 
-    {!transactionDetails.insufficientFundsForGasError &&
+    {transactionDetails.insufficientFundsForGasError === false &&
       transactionDetails.insufficientFundsError &&
         <TransactionText hasError={true}>
           {getLocale('braveWalletSwapInsufficientBalance')}

--- a/components/brave_wallet_ui/components/extension/confirm-transaction-panel/erc-twenty-transaction-info.tsx
+++ b/components/brave_wallet_ui/components/extension/confirm-transaction-panel/erc-twenty-transaction-info.tsx
@@ -44,13 +44,23 @@ export const Erc20ApproveTransactionInfo = ({ onToggleEditGas }: Erc20Transactio
         .formatAsAsset(6, selectedNetwork.symbol)}
     </TransactionTypeText>
 
-    <TransactionText
-      hasError={transactionDetails.insufficientFundsError}
-    >
-      {transactionDetails.insufficientFundsError ? `${getLocale('braveWalletSwapInsufficientBalance')} ` : ''}
+    <TransactionText hasError={false}>
       {new Amount(transactionDetails.gasFeeFiat)
         .formatAsFiat(defaultCurrencies.fiat)}
     </TransactionText>
+
+    {transactionDetails.insufficientFundsForGasError &&
+      <TransactionText hasError={true}>
+        {getLocale('braveWalletSwapInsufficientFundsForGas')}
+      </TransactionText>
+    }
+
+    {!transactionDetails.insufficientFundsForGasError &&
+      transactionDetails.insufficientFundsError &&
+        <TransactionText hasError={true}>
+          {getLocale('braveWalletSwapInsufficientBalance')}
+        </TransactionText>
+    }
 
     <Divider />
 

--- a/components/brave_wallet_ui/components/extension/confirm-transaction-panel/transaction-info.tsx
+++ b/components/brave_wallet_ui/components/extension/confirm-transaction-panel/transaction-info.tsx
@@ -122,7 +122,7 @@ export const TransactionInfo = ({
       </TransactionText>
     }
 
-    {!transactionDetails.insufficientFundsForGasError &&
+    {transactionDetails.insufficientFundsForGasError === false &&
       transactionDetails.insufficientFundsError &&
         <TransactionText hasError={true}>
           {getLocale('braveWalletSwapInsufficientBalance')}

--- a/components/brave_wallet_ui/components/extension/confirm-transaction-panel/transaction-info.tsx
+++ b/components/brave_wallet_ui/components/extension/confirm-transaction-panel/transaction-info.tsx
@@ -112,14 +112,21 @@ export const TransactionInfo = ({
         .formatAsAsset(6, transactionsNetwork.symbol)}
     </TransactionTypeText>
 
-    <TransactionText
-      hasError={transactionDetails.insufficientFundsError}
-    >
-      {transactionDetails.insufficientFundsError
-        ? `${getLocale('braveWalletSwapInsufficientBalance')} `
-        : ''}
-      {transactionDetails.fiatTotal
-        .formatAsFiat(defaultCurrencies.fiat)}
+    <TransactionText hasError={false}>
+      {transactionDetails.fiatTotal.formatAsFiat(defaultCurrencies.fiat)}
     </TransactionText>
+
+    {transactionDetails.insufficientFundsForGasError &&
+      <TransactionText hasError={true}>
+        {getLocale('braveWalletSwapInsufficientFundsForGas')}
+      </TransactionText>
+    }
+
+    {!transactionDetails.insufficientFundsForGasError &&
+      transactionDetails.insufficientFundsError &&
+        <TransactionText hasError={true}>
+          {getLocale('braveWalletSwapInsufficientBalance')}
+        </TransactionText>
+    }
   </>
 }

--- a/components/brave_wallet_ui/utils/amount.test.ts
+++ b/components/brave_wallet_ui/utils/amount.test.ts
@@ -175,8 +175,8 @@ describe('Amount class', () => {
       expect(Amount.empty().gt('3')).toBeFalsy()
 
       // Compare with undefined amount
-      // OK: 3 > undefined == true
-      expect(new Amount('3').gt(Amount.empty())).toBeTruthy()
+      // OK: 3 > undefined == false
+      expect(new Amount('3').gt(Amount.empty())).toBeFalsy()
     })
 
     it('should return correct comparison for .gte()', () => {
@@ -206,11 +206,11 @@ describe('Amount class', () => {
       expect(new Amount('0x2').lt(new Amount('0x3'))).toBeTruthy()
 
       // Compare with undefined amount
-      // OK: undefined < 3 == true
-      expect(Amount.empty().lt('3')).toBeTruthy()
+      // OK: undefined < 3 == false
+      expect(Amount.empty().lt('3')).toBeFalsy()
 
       // Compare with undefined amount
-      // OK: 3 < undefined == true
+      // OK: 3 < undefined == false
       expect(new Amount('3').lt(Amount.empty())).toBeFalsy()
     })
 

--- a/components/brave_wallet_ui/utils/amount.ts
+++ b/components/brave_wallet_ui/utils/amount.ts
@@ -96,7 +96,7 @@ export default class Amount {
     }
 
     if (amount === '') {
-      return true
+      return false
     }
 
     return this.value.gt(amount)
@@ -116,7 +116,7 @@ export default class Amount {
     }
 
     if (this.value === undefined) {
-      return true
+      return false
     }
 
     return this.value.lt(amount)


### PR DESCRIPTION
This PR fixes multiple issues with insufficient funds checks in the transaction confirmation panel.

1. **`ETHSwap`** transactions had wrong computation of fiat amounts. 92587af51ab70dd46974f2c19428bd9f38c772e0
2. Prevent intermittent "insufficient funds" errors in the panel. It is possible these errors do not go away after balance is fetched. 70ed1b7f5ce4374abe67c58208eed2fe3c1cb132 and 89ac58d65fd995ba3e4c71b50c204739f7aa645b
3. Differentiate between insufficient funds due to token balance vs gas fees.  ffc835ff3c97edb6acb44de136e19a18e9c4323b
4. Guarantee disable of the Confirm button in txn confirmation screen when balances are being fetched.  51f47c6f5325eb03c60608e1b05adf723d18cbca

Resolves https://github.com/brave/brave-browser/issues/22877.

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Demo:

### Before

#### Wrong fiat amounts

1. fiat amount of 0.00616164 ETH is too low
5. insufficient balance $18.30 does not reflect send amount + gas fees.

<img width="318" alt="Screenshot 2022-05-16 at 21 17 40" src="https://user-images.githubusercontent.com/3684187/168666116-4f45f6c4-453e-447d-b37e-841e1e45a202.png">

#### Disappearing "Insufficient funds error" text

cc: @srirambv I believe you had logged this at some point, but I can't find the issue.

https://user-images.githubusercontent.com/3684187/168665680-a42201fe-3c9b-4a60-8bac-4178a09d1561.mov

### After

#### No disappearing error text, and correct computation of fiat amount

https://user-images.githubusercontent.com/3684187/168664884-aee4784a-cc78-4c6a-abf8-a360c94ceb23.mov

#### Confirm button is disabled on page load while balances are being fetched

https://user-images.githubusercontent.com/3684187/168674959-da2aae36-5643-481c-a632-4502af385d7c.mov

**Note:** This is not entirely new behaviour, but ensures that Confirm button is not disabled due to `insufficientFundsError` being false for redux state not being ready.