### PR TITLE
Fix weekly total card views histogram name in p3a metric name list

### DIFF
--- a/components/p3a/metric_names.h
+++ b/components/p3a/metric_names.h
@@ -59,7 +59,7 @@ constexpr inline auto kCollectedHistograms =
     "Brave.SpeedReader.ToggleCount",
     "Brave.Today.DirectFeedsTotal",
     "Brave.Today.HasEverInteracted",
-    "Brave.Today.TotalCardViewsCount",
+    "Brave.Today.WeeklyTotalCardViews",
     "Brave.Today.WeeklyDisplayAdsViewedCount",
     "Brave.Today.WeeklyMaxCardViewsCount",
     "Brave.Today.WeeklyMaxCardVisitsCount",


### PR DESCRIPTION
Resolves brave/brave-browser#22222
