### PR TITLE
Fix weekly total card views histogram name in p3a metric name list (uplift to 1.39.x)

### DIFF
--- a/components/p3a/brave_p3a_service.cc
+++ b/components/p3a/brave_p3a_service.cc
@@ -100,7 +100,7 @@ constexpr const char* kCollectedHistograms[] = {
     "Brave.SpeedReader.ToggleCount",
     "Brave.Today.DirectFeedsTotal",
     "Brave.Today.HasEverInteracted",
-    "Brave.Today.TotalCardViewsCount",
+    "Brave.Today.WeeklyTotalCardViews",
     "Brave.Today.WeeklyDisplayAdsViewedCount",
     "Brave.Today.WeeklyMaxCardViewsCount",
     "Brave.Today.WeeklyMaxCardVisitsCount",


### PR DESCRIPTION
Related to brave/brave-browser#22222