### PR TITLE
Debounce Brave Ads clicked events

### DIFF
--- a/vendor/bat-native-ads/src/bat/ads/internal/ad_events/ad_event_info.h
+++ b/vendor/bat-native-ads/src/bat/ads/internal/ad_events/ad_event_info.h
@@ -21,7 +21,7 @@ struct AdEventInfo final {
 
   AdType type = AdType::kUndefined;
   ConfirmationType confirmation_type = ConfirmationType::kUndefined;
-  std::string uuid;
+  std::string placement_id;
   std::string campaign_id;
   std::string creative_set_id;
   std::string creative_instance_id;

--- a/vendor/bat-native-ads/src/bat/ads/internal/ad_events/ad_event_unittest_util.cc
+++ b/vendor/bat-native-ads/src/bat/ads/internal/ad_events/ad_event_unittest_util.cc
@@ -30,7 +30,7 @@ AdEventInfo BuildAdEvent(const CreativeAdInfo& creative_ad,
   AdEventInfo ad_event;
   ad_event.type = ad_type;
   ad_event.confirmation_type = confirmation_type;
-  ad_event.uuid = base::GUID::GenerateRandomV4().AsLowercaseString();
+  ad_event.placement_id = base::GUID::GenerateRandomV4().AsLowercaseString();
   ad_event.campaign_id = creative_ad.campaign_id;
   ad_event.creative_set_id = creative_ad.creative_set_id;
   ad_event.creative_instance_id = creative_ad.creative_instance_id;
@@ -53,7 +53,7 @@ AdEventInfo BuildAdEvent(const AdInfo& ad,
   AdEventInfo ad_event;
   ad_event.type = ad_type;
   ad_event.confirmation_type = confirmation_type;
-  ad_event.uuid = base::GUID::GenerateRandomV4().AsLowercaseString();
+  ad_event.placement_id = base::GUID::GenerateRandomV4().AsLowercaseString();
   ad_event.campaign_id = ad.campaign_id;
   ad_event.creative_set_id = ad.creative_set_id;
   ad_event.creative_instance_id = ad.creative_instance_id;
@@ -69,14 +69,14 @@ AdEventInfo BuildAdEvent(const AdInfo& ad,
   return BuildAdEvent(ad, ad_type, confirmation_type, Now());
 }
 
-AdEventInfo BuildAdEvent(const std::string& uuid,
+AdEventInfo BuildAdEvent(const std::string& placement_id,
                          const std::string& creative_set_id,
                          const ConfirmationType& confirmation_type) {
   AdEventInfo ad_event;
 
   ad_event.type = AdType::kAdNotification;
   ad_event.confirmation_type = confirmation_type;
-  ad_event.uuid = uuid;
+  ad_event.placement_id = placement_id;
   ad_event.campaign_id = "604df73f-bc6e-4583-a56d-ce4e243c8537";
   ad_event.creative_set_id = creative_set_id;
   ad_event.creative_instance_id = "7a3b6d9f-d0b7-4da6-8988-8d5b8938c94f";

--- a/vendor/bat-native-ads/src/bat/ads/internal/ad_events/ad_event_unittest_util.h
+++ b/vendor/bat-native-ads/src/bat/ads/internal/ad_events/ad_event_unittest_util.h
@@ -32,7 +32,7 @@ AdEventInfo BuildAdEvent(const AdInfo& ad,
                          const ConfirmationType& confirmation_type,
                          const base::Time created_at);
 
-AdEventInfo BuildAdEvent(const std::string& uuid,
+AdEventInfo BuildAdEvent(const std::string& placement_id,
                          const std::string& creative_set_id,
                          const ConfirmationType& confirmation_type);
 AdEventInfo BuildAdEvent(const std::string& creative_set_id,

--- a/vendor/bat-native-ads/src/bat/ads/internal/ad_events/ad_event_util.cc
+++ b/vendor/bat-native-ads/src/bat/ads/internal/ad_events/ad_event_util.cc
@@ -9,18 +9,22 @@
 
 #include "base/time/time.h"
 #include "bat/ads/ad_info.h"
+#include "bat/ads/confirmation_type.h"
 #include "bat/ads/internal/ad_events/ad_event_info.h"
 #include "bat/ads/internal/ad_server/catalog/bundle/creative_ad_info.h"
 #include "third_party/abseil-cpp/absl/types/optional.h"
 
 namespace ads {
 
-bool HasFiredAdViewedEvent(const AdInfo& ad, const AdEventList& ad_events) {
-  const auto iter = std::find_if(
-      ad_events.cbegin(), ad_events.cend(), [&ad](const AdEventInfo& ad_event) {
-        return ad_event.confirmation_type == ConfirmationType::kViewed &&
-               ad_event.uuid == ad.placement_id;
-      });
+bool HasFiredAdEvent(const AdInfo& ad,
+                     const AdEventList& ad_events,
+                     const ConfirmationType& confirmation_type) {
+  const auto iter =
+      std::find_if(ad_events.cbegin(), ad_events.cend(),
+                   [&ad, &confirmation_type](const AdEventInfo& ad_event) {
+                     return ad_event.placement_id == ad.placement_id &&
+                            ad_event.confirmation_type == confirmation_type;
+                   });
 
   if (iter == ad_events.end()) {
     return false;

--- a/vendor/bat-native-ads/src/bat/ads/internal/ad_events/ad_event_util.h
+++ b/vendor/bat-native-ads/src/bat/ads/internal/ad_events/ad_event_util.h
@@ -19,10 +19,13 @@ class Time;
 
 namespace ads {
 
+class ConfirmationType;
 struct AdInfo;
 struct CreativeAdInfo;
 
-bool HasFiredAdViewedEvent(const AdInfo& ad, const AdEventList& ad_events);
+bool HasFiredAdEvent(const AdInfo& ad,
+                     const AdEventList& ad_events,
+                     const ConfirmationType& confirmation_type);
 
 absl::optional<base::Time> GetLastSeenAdTime(const AdEventList& ad_events,
                                              const CreativeAdInfo& creative_ad);

--- a/vendor/bat-native-ads/src/bat/ads/internal/ad_events/ad_events.cc
+++ b/vendor/bat-native-ads/src/bat/ads/internal/ad_events/ad_events.cc
@@ -23,9 +23,9 @@ void LogAdEvent(const AdInfo& ad,
                 const ConfirmationType& confirmation_type,
                 AdEventCallback callback) {
   AdEventInfo ad_event;
-  ad_event.uuid = ad.placement_id;
   ad_event.type = ad.type;
   ad_event.confirmation_type = confirmation_type;
+  ad_event.placement_id = ad.placement_id;
   ad_event.campaign_id = ad.campaign_id;
   ad_event.creative_set_id = ad.creative_set_id;
   ad_event.creative_instance_id = ad.creative_instance_id;

--- a/vendor/bat-native-ads/src/bat/ads/internal/ad_events/ad_events_database_table.cc
+++ b/vendor/bat-native-ads/src/bat/ads/internal/ad_events/ad_events_database_table.cc
@@ -31,7 +31,7 @@ int BindParameters(mojom::DBCommand* command, const AdEventList& ad_events) {
 
   int index = 0;
   for (const auto& ad_event : ad_events) {
-    BindString(command, index++, ad_event.uuid);
+    BindString(command, index++, ad_event.placement_id);
     BindString(command, index++, ad_event.type.ToString());
     BindString(command, index++, ad_event.confirmation_type.ToString());
     BindString(command, index++, ad_event.campaign_id);
@@ -51,7 +51,7 @@ AdEventInfo GetFromRecord(mojom::DBRecord* record) {
 
   AdEventInfo ad_event;
 
-  ad_event.uuid = ColumnString(record, 0);
+  ad_event.placement_id = ColumnString(record, 0);
   ad_event.type = AdType(ColumnString(record, 1));
   ad_event.confirmation_type = ConfirmationType(ColumnString(record, 2));
   ad_event.campaign_id = ColumnString(record, 3);

--- a/vendor/bat-native-ads/src/bat/ads/internal/creatives/inline_content_ads/inline_content_ad_unittest.cc
+++ b/vendor/bat-native-ads/src/bat/ads/internal/creatives/inline_content_ads/inline_content_ad_unittest.cc
@@ -120,6 +120,21 @@ TEST_F(BatAdsInlineContentAdTest, FireViewedEvent) {
   ExpectAdEventCountEquals(ConfirmationType::kViewed, 1);
 }
 
+TEST_F(BatAdsInlineContentAdTest, DoNotFireViewedEventIfAlreadyFired) {
+  // Arrange
+  const CreativeInlineContentAdInfo& creative_ad = BuildAndSaveCreativeAd();
+
+  inline_content_ad_->FireEvent(kPlacementId, creative_ad.creative_instance_id,
+                                mojom::InlineContentAdEventType::kViewed);
+
+  // Act
+  inline_content_ad_->FireEvent(kPlacementId, creative_ad.creative_instance_id,
+                                mojom::InlineContentAdEventType::kViewed);
+
+  // Assert
+  ExpectAdEventCountEquals(ConfirmationType::kViewed, 1);
+}
+
 TEST_F(BatAdsInlineContentAdTest, FireClickedEvent) {
   // Arrange
   const CreativeInlineContentAdInfo& creative_ad = BuildAndSaveCreativeAd();
@@ -140,19 +155,19 @@ TEST_F(BatAdsInlineContentAdTest, FireClickedEvent) {
   ExpectAdEventCountEquals(ConfirmationType::kClicked, 1);
 }
 
-TEST_F(BatAdsInlineContentAdTest, DoNotFireViewedEventIfAlreadyFired) {
+TEST_F(BatAdsInlineContentAdTest, DoNotFireClickedEventIfAlreadyFired) {
   // Arrange
   const CreativeInlineContentAdInfo& creative_ad = BuildAndSaveCreativeAd();
 
   inline_content_ad_->FireEvent(kPlacementId, creative_ad.creative_instance_id,
-                                mojom::InlineContentAdEventType::kViewed);
+                                mojom::InlineContentAdEventType::kClicked);
 
   // Act
   inline_content_ad_->FireEvent(kPlacementId, creative_ad.creative_instance_id,
-                                mojom::InlineContentAdEventType::kViewed);
+                                mojom::InlineContentAdEventType::kClicked);
 
   // Assert
-  ExpectAdEventCountEquals(ConfirmationType::kViewed, 1);
+  ExpectAdEventCountEquals(ConfirmationType::kClicked, 1);
 }
 
 TEST_F(BatAdsInlineContentAdTest, DoNotFireEventWithInvalidUuid) {

--- a/vendor/bat-native-ads/src/bat/ads/internal/creatives/new_tab_page_ads/new_tab_page_ad_unittest.cc
+++ b/vendor/bat-native-ads/src/bat/ads/internal/creatives/new_tab_page_ads/new_tab_page_ad_unittest.cc
@@ -124,6 +124,23 @@ TEST_F(BatAdsNewTabPageAdTest, FireViewedEvent) {
   ExpectAdEventCountEquals(ConfirmationType::kViewed, 1);
 }
 
+TEST_F(BatAdsNewTabPageAdTest, DoNotFireViewedEventIfAlreadyFired) {
+  // Arrange
+  ForcePermissionRules();
+
+  const CreativeNewTabPageAdInfo& creative_ad = BuildAndSaveCreativeAd();
+
+  new_tab_page_ad_->FireEvent(kPlacementId, creative_ad.creative_instance_id,
+                              mojom::NewTabPageAdEventType::kViewed);
+
+  // Act
+  new_tab_page_ad_->FireEvent(kPlacementId, creative_ad.creative_instance_id,
+                              mojom::NewTabPageAdEventType::kViewed);
+
+  // Assert
+  ExpectAdEventCountEquals(ConfirmationType::kViewed, 1);
+}
+
 TEST_F(BatAdsNewTabPageAdTest, FireClickedEvent) {
   // Arrange
   ForcePermissionRules();
@@ -146,21 +163,21 @@ TEST_F(BatAdsNewTabPageAdTest, FireClickedEvent) {
   ExpectAdEventCountEquals(ConfirmationType::kClicked, 1);
 }
 
-TEST_F(BatAdsNewTabPageAdTest, DoNotFireViewedEventIfAlreadyFired) {
+TEST_F(BatAdsNewTabPageAdTest, DoNotFireClickedEventIfAlreadyFired) {
   // Arrange
   ForcePermissionRules();
 
   const CreativeNewTabPageAdInfo& creative_ad = BuildAndSaveCreativeAd();
 
   new_tab_page_ad_->FireEvent(kPlacementId, creative_ad.creative_instance_id,
-                              mojom::NewTabPageAdEventType::kViewed);
+                              mojom::NewTabPageAdEventType::kClicked);
 
   // Act
   new_tab_page_ad_->FireEvent(kPlacementId, creative_ad.creative_instance_id,
-                              mojom::NewTabPageAdEventType::kViewed);
+                              mojom::NewTabPageAdEventType::kClicked);
 
   // Assert
-  ExpectAdEventCountEquals(ConfirmationType::kViewed, 1);
+  ExpectAdEventCountEquals(ConfirmationType::kClicked, 1);
 }
 
 TEST_F(BatAdsNewTabPageAdTest, DoNotFireEventWithInvalidUuid) {

--- a/vendor/bat-native-ads/src/bat/ads/internal/creatives/promoted_content_ads/promoted_content_ad.cc
+++ b/vendor/bat-native-ads/src/bat/ads/internal/creatives/promoted_content_ads/promoted_content_ad.cc
@@ -19,6 +19,25 @@
 
 namespace ads {
 
+namespace {
+
+bool ShouldDebounceAdEvent(
+    const AdInfo& ad,
+    const AdEventList& ad_events,
+    const mojom::PromotedContentAdEventType& event_type) {
+  if (event_type == mojom::PromotedContentAdEventType::kViewed &&
+      HasFiredAdEvent(ad, ad_events, ConfirmationType::kViewed)) {
+    return true;
+  } else if (event_type == mojom::PromotedContentAdEventType::kClicked &&
+             HasFiredAdEvent(ad, ad_events, ConfirmationType::kClicked)) {
+    return true;
+  }
+
+  return false;
+}
+
+}  // namespace
+
 PromotedContentAd::PromotedContentAd() = default;
 
 PromotedContentAd::~PromotedContentAd() = default;
@@ -103,12 +122,10 @@ void PromotedContentAd::FireEvent(
           return;
         }
 
-        if (event_type == mojom::PromotedContentAdEventType::kViewed &&
-            HasFiredAdViewedEvent(ad, ad_events)) {
-          BLOG(1,
-               "Promoted content ad: Not allowed as already fired a viewed "
-               "event for this placement id "
-                   << placement_id);
+        if (ShouldDebounceAdEvent(ad, ad_events, event_type)) {
+          BLOG(1, "Promoted content ad: Not allowed as already fired "
+                      << event_type << " event for this placement id "
+                      << placement_id);
           NotifyPromotedContentAdEventFailed(placement_id, creative_instance_id,
                                              event_type);
           return;

--- a/vendor/bat-native-ads/src/bat/ads/internal/creatives/promoted_content_ads/promoted_content_ad_unittest.cc
+++ b/vendor/bat-native-ads/src/bat/ads/internal/creatives/promoted_content_ads/promoted_content_ad_unittest.cc
@@ -125,6 +125,25 @@ TEST_F(BatAdsPromotedContentAdTest, FireViewedEvent) {
   ExpectAdEventCountEquals(ConfirmationType::kViewed, 1);
 }
 
+TEST_F(BatAdsPromotedContentAdTest, DoNotFireViewedEventIfAlreadyFired) {
+  // Arrange
+  ForcePermissionRules();
+
+  const CreativePromotedContentAdInfo& creative_ad = BuildAndSaveCreativeAd();
+
+  promoted_content_ad_->FireEvent(kPlacementId,
+                                  creative_ad.creative_instance_id,
+                                  mojom::PromotedContentAdEventType::kViewed);
+
+  // Act
+  promoted_content_ad_->FireEvent(kPlacementId,
+                                  creative_ad.creative_instance_id,
+                                  mojom::PromotedContentAdEventType::kViewed);
+
+  // Assert
+  ExpectAdEventCountEquals(ConfirmationType::kViewed, 1);
+}
+
 TEST_F(BatAdsPromotedContentAdTest, FireClickedEvent) {
   // Arrange
   ForcePermissionRules();
@@ -148,7 +167,7 @@ TEST_F(BatAdsPromotedContentAdTest, FireClickedEvent) {
   ExpectAdEventCountEquals(ConfirmationType::kClicked, 1);
 }
 
-TEST_F(BatAdsPromotedContentAdTest, DoNotFireViewedEventIfAlreadyFired) {
+TEST_F(BatAdsPromotedContentAdTest, DoNotFireClickedEventIfAlreadyFired) {
   // Arrange
   ForcePermissionRules();
 
@@ -156,15 +175,15 @@ TEST_F(BatAdsPromotedContentAdTest, DoNotFireViewedEventIfAlreadyFired) {
 
   promoted_content_ad_->FireEvent(kPlacementId,
                                   creative_ad.creative_instance_id,
-                                  mojom::PromotedContentAdEventType::kViewed);
+                                  mojom::PromotedContentAdEventType::kClicked);
 
   // Act
   promoted_content_ad_->FireEvent(kPlacementId,
                                   creative_ad.creative_instance_id,
-                                  mojom::PromotedContentAdEventType::kViewed);
+                                  mojom::PromotedContentAdEventType::kClicked);
 
   // Assert
-  ExpectAdEventCountEquals(ConfirmationType::kViewed, 1);
+  ExpectAdEventCountEquals(ConfirmationType::kClicked, 1);
 }
 
 TEST_F(BatAdsPromotedContentAdTest, DoNotFireEventWithInvalidUuid) {

--- a/vendor/bat-native-ads/src/bat/ads/internal/creatives/search_result_ads/search_result_ad.h
+++ b/vendor/bat-native-ads/src/bat/ads/internal/creatives/search_result_ads/search_result_ad.h
@@ -33,6 +33,8 @@ class SearchResultAd final : public SearchResultAdObserver {
                  TriggerSearchResultAdEventCallback callback) const;
   void FireViewedEvent(const mojom::SearchResultAdPtr& ad_mojom,
                        TriggerSearchResultAdEventCallback callback) const;
+  void FireClickedEvent(const SearchResultAdInfo& ad,
+                        TriggerSearchResultAdEventCallback callback) const;
 
   void NotifySearchResultAdEvent(
       const SearchResultAdInfo& ad,

--- a/vendor/bat-native-ads/src/bat/ads/internal/creatives/search_result_ads/search_result_ad_unittest.cc
+++ b/vendor/bat-native-ads/src/bat/ads/internal/creatives/search_result_ads/search_result_ad_unittest.cc
@@ -198,6 +198,24 @@ TEST_F(BatAdsSearchResultAdTest, FireViewedEventWithConversion) {
   ExpectConversionCountEquals(1);
 }
 
+TEST_F(BatAdsSearchResultAdTest, DoNotFireViewedEventIfAlreadyFired) {
+  // Arrange
+  ForcePermissionRules();
+
+  const mojom::SearchResultAdPtr ad_mojom =
+      BuildAd(kPlacementId, kCreativeInstanceId);
+
+  FireEvent(ad_mojom, mojom::SearchResultAdEventType::kViewed);
+
+  // Act
+  FireEvent(ad_mojom, mojom::SearchResultAdEventType::kViewed);
+
+  // Assert
+  ExpectAdEventCountEquals(ConfirmationType::kViewed, 1);
+  ExpectDepositExistsForCreativeInstanceId(kCreativeInstanceId);
+  ExpectConversionCountEquals(0);
+}
+
 TEST_F(BatAdsSearchResultAdTest, FireClickedEvent) {
   // Arrange
   ForcePermissionRules();
@@ -219,22 +237,20 @@ TEST_F(BatAdsSearchResultAdTest, FireClickedEvent) {
   ExpectAdEventCountEquals(ConfirmationType::kClicked, 1);
 }
 
-TEST_F(BatAdsSearchResultAdTest, DoNotFireViewedEventIfAlreadyFired) {
+TEST_F(BatAdsSearchResultAdTest, DoNotFireClickedEventIfAlreadyFired) {
   // Arrange
   ForcePermissionRules();
 
   const mojom::SearchResultAdPtr ad_mojom =
       BuildAd(kPlacementId, kCreativeInstanceId);
 
-  FireEvent(ad_mojom, mojom::SearchResultAdEventType::kViewed);
+  FireEvent(ad_mojom, mojom::SearchResultAdEventType::kClicked);
 
   // Act
-  FireEvent(ad_mojom, mojom::SearchResultAdEventType::kViewed);
+  FireEvent(ad_mojom, mojom::SearchResultAdEventType::kClicked);
 
   // Assert
-  ExpectAdEventCountEquals(ConfirmationType::kViewed, 1);
-  ExpectDepositExistsForCreativeInstanceId(kCreativeInstanceId);
-  ExpectConversionCountEquals(0);
+  ExpectAdEventCountEquals(ConfirmationType::kClicked, 1);
 }
 
 TEST_F(BatAdsSearchResultAdTest, DoNotFireEventWithInvalidPlacementId) {


### PR DESCRIPTION
<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/22936

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

Confirm `Not allowed as already fired` appears for duplicate viewed/clicked events for each creative unit type