### PR TITLE
[Sync] Force set sync decryption passphrase

### DIFF
--- a/components/sync/driver/BUILD.gn
+++ b/components/sync/driver/BUILD.gn
@@ -30,6 +30,7 @@ source_set("unit_tests") {
     "//components/sync:test_support_engine",
     "//components/sync/driver:driver",
     "//components/sync/driver:test_support",
+    "//components/sync/engine",
     "//content/test:test_support",
     "//services/network:test_support",
     "//services/network/public/cpp:cpp",

--- a/components/sync/driver/brave_sync_service_impl.cc
+++ b/components/sync/driver/brave_sync_service_impl.cc
@@ -154,6 +154,7 @@ void BraveSyncServiceImpl::OnEngineInitialized(
 
   syncer::SyncUserSettings* sync_user_settings = GetUserSettings();
   if (!sync_user_settings->IsFirstSetupComplete()) {
+    // If first setup has not been complete, we don't need to force
     return;
   }
 
@@ -170,6 +171,10 @@ void BraveSyncServiceImpl::OnEngineInitialized(
     VLOG(1) << "Forced set decryption passphrase result is "
             << set_passphrase_result;
   }
+}
+
+SyncServiceCrypto* BraveSyncServiceImpl::GetCryptoForTests() {
+  return &crypto_;
 }
 
 }  // namespace syncer

--- a/components/sync/driver/brave_sync_service_impl.cc
+++ b/components/sync/driver/brave_sync_service_impl.cc
@@ -142,4 +142,34 @@ void BraveSyncServiceImpl::ResumeDeviceObserver() {
   sync_service_impl_delegate_->ResumeDeviceObserver();
 }
 
+void BraveSyncServiceImpl::OnEngineInitialized(
+    const WeakHandle<DataTypeDebugInfoListener>& debug_info_listener,
+    bool success,
+    bool is_first_time_sync_configure) {
+  SyncServiceImpl::OnEngineInitialized(debug_info_listener, success,
+                                       is_first_time_sync_configure);
+  if (!IsEngineInitialized()) {
+    return;
+  }
+
+  syncer::SyncUserSettings* sync_user_settings = GetUserSettings();
+  if (!sync_user_settings->IsFirstSetupComplete()) {
+    return;
+  }
+
+  bool failed_to_decrypt = false;
+  std::string passphrase = brave_sync_prefs_.GetSeed(&failed_to_decrypt);
+  DCHECK(!failed_to_decrypt);
+  if (passphrase.empty()) {
+    return;
+  }
+
+  if (sync_user_settings->IsPassphraseRequired()) {
+    bool set_passphrase_result =
+        sync_user_settings->SetDecryptionPassphrase(passphrase);
+    VLOG(1) << "Forced set decryption passphrase result is "
+            << set_passphrase_result;
+  }
+}
+
 }  // namespace syncer

--- a/components/sync/driver/brave_sync_service_impl.h
+++ b/components/sync/driver/brave_sync_service_impl.h
@@ -20,6 +20,7 @@ namespace syncer {
 
 class BraveSyncAuthManager;
 class SyncServiceImplDelegate;
+class SyncServiceCrypto;
 
 class BraveSyncServiceImpl : public SyncServiceImpl {
  public:
@@ -54,7 +55,11 @@ class BraveSyncServiceImpl : public SyncServiceImpl {
   void Initialize() override;
 
  private:
+  friend class BraveSyncServiceImplTest;
+  FRIEND_TEST_ALL_PREFIXES(BraveSyncServiceImplTest,
+                           ForcedSetDecryptionPassphrase);
   BraveSyncAuthManager* GetBraveSyncAuthManager();
+  SyncServiceCrypto* GetCryptoForTests();
 
   void OnBraveSyncPrefsChanged(const std::string& path);
 

--- a/components/sync/driver/brave_sync_service_impl.h
+++ b/components/sync/driver/brave_sync_service_impl.h
@@ -32,6 +32,12 @@ class BraveSyncServiceImpl : public SyncServiceImpl {
   bool IsSetupInProgress() const override;
   void StopAndClear() override;
 
+  // SyncEngineHost override.
+  void OnEngineInitialized(
+      const WeakHandle<DataTypeDebugInfoListener>& debug_info_listener,
+      bool success,
+      bool is_first_time_sync_configure) override;
+
   std::string GetOrCreateSyncCode();
   bool SetSyncCode(const std::string& sync_code);
 


### PR DESCRIPTION
When sync decryption passphrase is not set during sync setup, then sync goes into error state with bunch of `GenerateCryptoErrorForTypes` errors. This PR does set decryption passphrase for such cases.

<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/22898

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket #22898](https://github.com/brave/brave-browser/issues/22898) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
See the issue https://github.com/brave/brave-browser/issues/22898, `Steps to reproduce if you can't run local sync server:` section.

