### PR TITLE
Implement signMessage and publicKey getter for Solana dApp

### DIFF
--- a/browser/brave_content_browser_client.cc
+++ b/browser/brave_content_browser_client.cc
@@ -311,11 +311,18 @@ void MaybeBindSolanaProvider(
           frame_host->GetBrowserContext());
   if (!keyring_service)
     return;
+
+  auto* brave_wallet_service =
+      brave_wallet::BraveWalletServiceFactory::GetServiceForContext(
+          frame_host->GetBrowserContext());
+  if (!brave_wallet_service)
+    return;
+
   content::WebContents* web_contents =
       content::WebContents::FromRenderFrameHost(frame_host);
   mojo::MakeSelfOwnedReceiver(
       std::make_unique<brave_wallet::SolanaProviderImpl>(
-          keyring_service,
+          keyring_service, brave_wallet_service,
           std::make_unique<brave_wallet::BraveWalletProviderDelegateImpl>(
               web_contents, frame_host)),
       std::move(receiver));

--- a/browser/brave_wallet/brave_wallet_service_unittest.cc
+++ b/browser/brave_wallet/brave_wallet_service_unittest.cc
@@ -1668,7 +1668,7 @@ TEST_F(BraveWalletServiceUnitTest, SignMessageHardware) {
   auto request1 = mojom::SignMessageRequest::New(
       origin_info.Clone(), 1, address,
       std::string(message.begin(), message.end()), false, absl::nullopt,
-      absl::nullopt);
+      absl::nullopt, mojom::CoinType::ETH);
   bool callback_is_called = false;
   service_->AddSignMessageRequest(
       std::move(request1), base::BindLambdaForTesting(
@@ -1692,7 +1692,7 @@ TEST_F(BraveWalletServiceUnitTest, SignMessageHardware) {
   auto request2 = mojom::SignMessageRequest::New(
       origin_info.Clone(), 2, address,
       std::string(message.begin(), message.end()), false, absl::nullopt,
-      absl::nullopt);
+      absl::nullopt, mojom::CoinType::ETH);
   service_->AddSignMessageRequest(
       std::move(request2), base::BindLambdaForTesting(
                                [&](bool approved, const std::string& signature,
@@ -1718,7 +1718,7 @@ TEST_F(BraveWalletServiceUnitTest, SignMessage) {
   auto request1 = mojom::SignMessageRequest::New(
       origin_info.Clone(), 1, address,
       std::string(message.begin(), message.end()), false, absl::nullopt,
-      absl::nullopt);
+      absl::nullopt, mojom::CoinType::ETH);
   bool callback_is_called = false;
   service_->AddSignMessageRequest(
       std::move(request1), base::BindLambdaForTesting(
@@ -1738,7 +1738,7 @@ TEST_F(BraveWalletServiceUnitTest, SignMessage) {
   auto request2 = mojom::SignMessageRequest::New(
       origin_info.Clone(), 2, address,
       std::string(message.begin(), message.end()), false, absl::nullopt,
-      absl::nullopt);
+      absl::nullopt, mojom::CoinType::ETH);
   service_->AddSignMessageRequest(
       std::move(request2), base::BindLambdaForTesting(
                                [&](bool approved, const std::string& signature,
@@ -1943,7 +1943,7 @@ TEST_F(BraveWalletServiceUnitTest, Reset) {
   auto request1 = mojom::SignMessageRequest::New(
       origin_info.Clone(), 1, address,
       std::string(message.begin(), message.end()), false, absl::nullopt,
-      absl::nullopt);
+      absl::nullopt, mojom::CoinType::ETH);
   service_->AddSignMessageRequest(
       std::move(request1),
       base::BindLambdaForTesting(

--- a/browser/brave_wallet/ethereum_provider_impl_unittest.cc
+++ b/browser/brave_wallet/ethereum_provider_impl_unittest.cc
@@ -455,8 +455,8 @@ class EthereumProviderImplUnitTest : public testing::Test {
     // Wait for EthereumProviderImpl::ContinueSignMessage
     browser_task_environment_.RunUntilIdle();
     brave_wallet_service_->NotifySignMessageHardwareRequestProcessed(
-        user_approved, provider()->sign_message_id_ - 1, hardware_signature,
-        error_in);
+        user_approved, brave_wallet_service_->sign_message_id_ - 1,
+        hardware_signature, error_in);
     run_loop.Run();
   }
 
@@ -489,7 +489,7 @@ class EthereumProviderImplUnitTest : public testing::Test {
     browser_task_environment_.RunUntilIdle();
     if (user_approved)
       brave_wallet_service_->NotifySignMessageRequestProcessed(
-          *user_approved, provider()->sign_message_id_ - 1);
+          *user_approved, brave_wallet_service_->sign_message_id_ - 1);
     run_loop.Run();
   }
 
@@ -552,7 +552,7 @@ class EthereumProviderImplUnitTest : public testing::Test {
     browser_task_environment_.RunUntilIdle();
     if (user_approved)
       brave_wallet_service_->NotifySignMessageRequestProcessed(
-          *user_approved, provider()->sign_message_id_ - 1);
+          *user_approved, brave_wallet_service_->sign_message_id_ - 1);
     run_loop.Run();
   }
 
@@ -561,7 +561,7 @@ class EthereumProviderImplUnitTest : public testing::Test {
                          const std::string& message) {
     provider()->SignMessage(address, message, base::DoNothing(), base::Value());
     base::RunLoop().RunUntilIdle();
-    return provider()->sign_message_id_ - 1;
+    return brave_wallet_service_->sign_message_id_ - 1;
   }
 
   size_t GetSignMessageQueueSize() const {

--- a/browser/brave_wallet/solana_provider_browsertest.cc
+++ b/browser/brave_wallet/solana_provider_browsertest.cc
@@ -249,17 +249,11 @@ IN_PROC_BROWSER_TEST_F(SolanaProviderTest, SignMessage) {
   GURL url = https_server()->GetURL("a.test", "/solana_provider.html");
   ASSERT_TRUE(ui_test_utils::NavigateToURL(browser(), url));
 
-  // Disconnected state will be rejcted.
-  constexpr char message[] = "bravey baby!";
-  CallSolanaSignMessage(message, "utf8");
-  WaitForResultReady();
-  EXPECT_EQ(GetSignMessageResult(),
-            l10n_util::GetStringUTF8(IDS_WALLET_NOT_AUTHED));
-
   CallSolanaConnect();
   UserGrantPermission(true);
   ASSERT_TRUE(IsSolanaConnected());
 
+  constexpr char message[] = "bravey baby!";
   size_t request_index = 0;
   CallSolanaSignMessage(message, "utf8");
   EXPECT_TRUE(

--- a/browser/brave_wallet/solana_provider_impl_unittest.cc
+++ b/browser/brave_wallet/solana_provider_impl_unittest.cc
@@ -89,7 +89,7 @@ class SolanaProviderImplUnitTest : public testing::Test {
         brave_wallet::BraveWalletServiceFactory::GetServiceForContext(
             browser_context());
     provider_ = std::make_unique<SolanaProviderImpl>(
-        keyring_service_,
+        keyring_service_, brave_wallet_service_,
         std::make_unique<brave_wallet::BraveWalletProviderDelegateImpl>(
             web_contents(), web_contents()->GetMainFrame()));
     observer_.reset(new TestEventsListener());

--- a/browser/brave_wallet/solana_provider_impl_unittest.cc
+++ b/browser/brave_wallet/solana_provider_impl_unittest.cc
@@ -104,6 +104,21 @@ class SolanaProviderImplUnitTest : public testing::Test {
     return web_contents()->GetMainFrame()->GetLastCommittedOrigin();
   }
 
+  std::vector<mojom::SignMessageRequestPtr> GetPendingSignMessageRequests()
+      const {
+    base::RunLoop run_loop;
+    std::vector<mojom::SignMessageRequestPtr> requests_out;
+    brave_wallet_service_->GetPendingSignMessageRequests(
+        base::BindLambdaForTesting(
+            [&](std::vector<mojom::SignMessageRequestPtr> requests) {
+              for (const auto& request : requests)
+                requests_out.push_back(request.Clone());
+              run_loop.Quit();
+            }));
+    run_loop.Run();
+    return requests_out;
+  }
+
   void CreateWallet() {
     base::RunLoop run_loop;
     keyring_service_->CreateWallet(
@@ -174,6 +189,31 @@ class SolanaProviderImplUnitTest : public testing::Test {
         }));
     run_loop.Run();
     return account;
+  }
+
+  std::string SignMessage(const std::vector<uint8_t>& blob_msg,
+                          const absl::optional<std::string>& display_encoding,
+                          mojom::SolanaProviderError* error_out,
+                          std::string* error_message_out) {
+    std::string signature_out;
+    base::RunLoop run_loop;
+    provider_->SignMessage(
+        blob_msg, display_encoding,
+        base::BindLambdaForTesting([&](mojom::SolanaProviderError error,
+                                       const std::string& error_message,
+                                       base::Value result) {
+          if (error_out)
+            *error_out = error;
+          if (error_message_out)
+            *error_message_out = error_message;
+          const std::string* signature =
+              result.GetDict().FindString("signature");
+          if (signature)
+            signature_out = *signature;
+          run_loop.Quit();
+        }));
+    run_loop.Run();
+    return signature_out;
   }
 
   bool IsConnected() {
@@ -319,6 +359,7 @@ TEST_F(SolanaProviderImplUnitTest, NoSelectedAccount) {
   std::string account = Connect(absl::nullopt, &error, &error_message);
   EXPECT_TRUE(account.empty());
   EXPECT_EQ(error, mojom::SolanaProviderError::kInternalError);
+  EXPECT_EQ(error_message, l10n_util::GetStringUTF8(IDS_WALLET_INTERNAL_ERROR));
   EXPECT_FALSE(IsConnected());
 
   base::Value dict(base::Value::Type::DICT);
@@ -327,7 +368,54 @@ TEST_F(SolanaProviderImplUnitTest, NoSelectedAccount) {
   account = Connect(dict.Clone(), &error, &error_message);
   EXPECT_TRUE(account.empty());
   EXPECT_EQ(error, mojom::SolanaProviderError::kInternalError);
+  EXPECT_EQ(error_message, l10n_util::GetStringUTF8(IDS_WALLET_INTERNAL_ERROR));
   EXPECT_FALSE(IsConnected());
+
+  // sign message
+  const std::string signature =
+      SignMessage({1, 2, 3, 4}, absl::nullopt, &error, &error_message);
+  EXPECT_TRUE(signature.empty());
+  EXPECT_EQ(error, mojom::SolanaProviderError::kInternalError);
+  EXPECT_EQ(error_message, l10n_util::GetStringUTF8(IDS_WALLET_INTERNAL_ERROR));
+}
+
+TEST_F(SolanaProviderImplUnitTest, SignMessage) {
+  CreateWallet();
+  AddAccount();
+  std::string address = GetAddressByIndex(0);
+  SetSelectedAccount(address, mojom::CoinType::SOL);
+  Navigate(GURL("https://brave.com"));
+
+  mojom::SolanaProviderError error;
+  std::string error_message;
+
+  // Disconnected state will be rejcted.
+  ASSERT_FALSE(IsConnected());
+  const std::string signature =
+      SignMessage({1, 2, 3, 4}, absl::nullopt, &error, &error_message);
+  EXPECT_TRUE(signature.empty());
+  EXPECT_EQ(error, mojom::SolanaProviderError::kUnauthorized);
+  EXPECT_EQ(error_message, l10n_util::GetStringUTF8(IDS_WALLET_NOT_AUTHED));
+
+  AddSolanaPermission(GetOrigin(), address);
+  Connect(absl::nullopt, &error, &error_message);
+  ASSERT_TRUE(IsConnected());
+  // test encoding, sign message requests won't be processed so callbacks will
+  // not run
+  const std::vector<uint8_t> message = {66, 82, 65, 86, 69};
+  provider_->SignMessage(message, absl::nullopt, base::DoNothing());
+  provider_->SignMessage(message, "utf8", base::DoNothing());
+  provider_->SignMessage(message, "hex", base::DoNothing());
+  provider_->SignMessage(message, "invalid", base::DoNothing());
+
+  // wait for requests getting added
+  base::RunLoop().RunUntilIdle();
+  auto requests = GetPendingSignMessageRequests();
+  ASSERT_EQ(requests.size(), 4u);
+  EXPECT_EQ(requests[0]->message, "BRAVE");
+  EXPECT_EQ(requests[1]->message, "BRAVE");
+  EXPECT_EQ(requests[2]->message, "0x4252415645");
+  EXPECT_EQ(requests[3]->message, "BRAVE");
 }
 
 }  // namespace brave_wallet

--- a/browser/brave_wallet/solana_provider_impl_unittest.cc
+++ b/browser/brave_wallet/solana_provider_impl_unittest.cc
@@ -391,8 +391,26 @@ TEST_F(SolanaProviderImplUnitTest, SignMessage) {
 
   // Disconnected state will be rejcted.
   ASSERT_FALSE(IsConnected());
-  const std::string signature =
+  std::string signature =
       SignMessage({1, 2, 3, 4}, absl::nullopt, &error, &error_message);
+  EXPECT_TRUE(signature.empty());
+  EXPECT_EQ(error, mojom::SolanaProviderError::kUnauthorized);
+  EXPECT_EQ(error_message, l10n_util::GetStringUTF8(IDS_WALLET_NOT_AUTHED));
+
+  // transaction payload message will be rejected
+  signature = SignMessage(
+      {1,   0,   1,   3,   161, 51,  89,  91,  115, 210, 217, 212, 76,  159,
+       171, 200, 40,  150, 157, 70,  197, 71,  24,  44,  209, 108, 143, 4,
+       58,  251, 215, 62,  201, 172, 159, 197, 255, 224, 228, 245, 94,  238,
+       23,  132, 206, 40,  82,  249, 219, 203, 103, 158, 110, 219, 93,  249,
+       143, 134, 207, 172, 179, 76,  67,  6,   169, 164, 149, 38,  0,   0,
+       0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,
+       0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,
+       0,   0,   131, 191, 83,  201, 108, 193, 222, 255, 176, 67,  136, 209,
+       219, 42,  6,   169, 240, 137, 142, 185, 169, 6,   17,  87,  123, 6,
+       42,  55,  162, 64,  120, 91,  1,   2,   2,   0,   1,   12,  2,   0,
+       0,   0,   128, 150, 152, 0,   0,   0,   0,   0},
+      absl::nullopt, &error, &error_message);
   EXPECT_TRUE(signature.empty());
   EXPECT_EQ(error, mojom::SolanaProviderError::kUnauthorized);
   EXPECT_EQ(error_message, l10n_util::GetStringUTF8(IDS_WALLET_NOT_AUTHED));

--- a/browser/brave_wallet/solana_provider_renderer_browsertest.cc
+++ b/browser/brave_wallet/solana_provider_renderer_browsertest.cc
@@ -888,20 +888,25 @@ IN_PROC_BROWSER_TEST_F(SolanaProviderRendererTest, SignMessage) {
 
   // not Uint8Array
   const std::string msg4 = base::StrCat({"([", msg_str, "])"});
-  auto result4 =
-      EvalJs(web_contents(browser()), SignAndSendTransactionScript(msg4),
-             content::EXECUTE_SCRIPT_USE_MANUAL_REPLY);
+  auto result4 = EvalJs(web_contents(browser()), SignMessageScript(msg4),
+                        content::EXECUTE_SCRIPT_USE_MANUAL_REPLY);
   EXPECT_EQ(
       base::Value(l10n_util::GetStringUTF8(IDS_WALLET_INVALID_PARAMETERS)),
       result4.value);
 
   // no arg
-  auto result5 =
-      EvalJs(web_contents(browser()), SignAndSendTransactionScript("()"),
-             content::EXECUTE_SCRIPT_USE_MANUAL_REPLY);
+  auto result5 = EvalJs(web_contents(browser()), SignMessageScript("()"),
+                        content::EXECUTE_SCRIPT_USE_MANUAL_REPLY);
   EXPECT_EQ(
       base::Value(l10n_util::GetStringUTF8(IDS_WALLET_INVALID_PARAMETERS)),
       result5.value);
+
+  // display is not string, use default utf8 encoding
+  const std::string msg6 =
+      base::StrCat({"(new Uint8Array([", msg_str, "], 12345))"});
+  auto result6 = EvalJs(web_contents(browser()), SignMessageScript(msg6),
+                        content::EXECUTE_SCRIPT_USE_MANUAL_REPLY);
+  EXPECT_EQ(base::Value(true), result6.value);
 
   TestSolanaProvider* provider = test_content_browser_client_.GetProvider(
       web_contents(browser())->GetMainFrame());
@@ -909,13 +914,13 @@ IN_PROC_BROWSER_TEST_F(SolanaProviderRendererTest, SignMessage) {
 
   provider->SetError(SolanaProviderError::kUserRejectedRequest, kErrorMessage);
 
-  auto result6 = EvalJs(web_contents(browser()), SignMessageScript(msg),
+  auto result7 = EvalJs(web_contents(browser()), SignMessageScript(msg),
                         content::EXECUTE_SCRIPT_USE_MANUAL_REPLY);
   // check error message + error code
   EXPECT_EQ(base::Value(kErrorMessage +
                         base::NumberToString(static_cast<int>(
                             SolanaProviderError::kUserRejectedRequest))),
-            result6.value);
+            result7.value);
 }
 
 // Request test here won't be testing params object, renderer just convert the

--- a/browser/brave_wallet/solana_provider_renderer_browsertest.cc
+++ b/browser/brave_wallet/solana_provider_renderer_browsertest.cc
@@ -321,10 +321,10 @@ class TestSolanaProvider final : public brave_wallet::mojom::SolanaProvider {
       ClearError();
     }
   }
-  void SignMessage(const std::string& encoded_msg,
+  void SignMessage(const std::vector<uint8_t>& blob_msg,
                    const absl::optional<std::string>& display_encoding,
                    SignMessageCallback callback) override {
-    EXPECT_EQ(encoded_msg, brave_wallet::Base58Encode(kMessageToSign));
+    EXPECT_EQ(blob_msg, kMessageToSign);
     base::Value result(base::Value::Type::DICTIONARY);
     if (error_ == SolanaProviderError::kSuccess) {
       result.SetStringKey("publicKey", kTestPublicKey);

--- a/components/brave_wallet/browser/brave_wallet_service.cc
+++ b/components/brave_wallet/browser/brave_wallet_service.cc
@@ -926,6 +926,9 @@ void BraveWalletService::OnGetImportInfo(
 void BraveWalletService::AddSignMessageRequest(
     mojom::SignMessageRequestPtr request,
     SignMessageRequestCallback callback) {
+  if (request->id < 0) {
+    request->id = sign_message_id_++;
+  }
   sign_message_requests_.push_back(std::move(request));
   sign_message_callbacks_.push_back(std::move(callback));
 }

--- a/components/brave_wallet/browser/brave_wallet_service.h
+++ b/components/brave_wallet/browser/brave_wallet_service.h
@@ -223,6 +223,7 @@ class BraveWalletService : public KeyedService,
   void CancelAllGetEncryptionPublicKeyCallbacks();
   void CancelAllDecryptCallbacks();
 
+  int sign_message_id_ = 0;
   base::circular_deque<mojom::SignMessageRequestPtr> sign_message_requests_;
   base::circular_deque<SignMessageRequestCallback> sign_message_callbacks_;
   base::flat_map<std::string, mojom::EthereumProvider::RequestCallback>

--- a/components/brave_wallet/browser/ethereum_provider_impl.cc
+++ b/components/brave_wallet/browser/ethereum_provider_impl.cc
@@ -827,8 +827,8 @@ void EthereumProviderImpl::ContinueSignMessage(
   }
 
   auto request = mojom::SignMessageRequest::New(
-      MakeOriginInfo(origin), sign_message_id_++, address, message, is_eip712,
-      domain_hash, primary_hash, mojom::CoinType::ETH);
+      MakeOriginInfo(origin), -1, address, message, is_eip712, domain_hash,
+      primary_hash, mojom::CoinType::ETH);
 
   if (keyring_service_->IsHardwareAccount(address)) {
     brave_wallet_service_->AddSignMessageRequest(

--- a/components/brave_wallet/browser/ethereum_provider_impl.cc
+++ b/components/brave_wallet/browser/ethereum_provider_impl.cc
@@ -828,7 +828,7 @@ void EthereumProviderImpl::ContinueSignMessage(
 
   auto request = mojom::SignMessageRequest::New(
       MakeOriginInfo(origin), sign_message_id_++, address, message, is_eip712,
-      domain_hash, primary_hash);
+      domain_hash, primary_hash, mojom::CoinType::ETH);
 
   if (keyring_service_->IsHardwareAccount(address)) {
     brave_wallet_service_->AddSignMessageRequest(

--- a/components/brave_wallet/browser/ethereum_provider_impl.h
+++ b/components/brave_wallet/browser/ethereum_provider_impl.h
@@ -348,7 +348,6 @@ class EthereumProviderImpl final
       RequestPermissionsError error,
       const absl::optional<std::vector<std::string>>& allowed_accounts);
 
-  int sign_message_id_ = 0;
   raw_ptr<HostContentSettingsMap> host_content_settings_map_ = nullptr;
   std::unique_ptr<BraveWalletProviderDelegate> delegate_;
   mojo::Remote<mojom::EventsListener> events_listener_;

--- a/components/brave_wallet/browser/solana_provider_impl.cc
+++ b/components/brave_wallet/browser/solana_provider_impl.cc
@@ -125,7 +125,7 @@ void SolanaProviderImpl::SignAndSendTransaction(
 }
 
 void SolanaProviderImpl::SignMessage(
-    const std::string& encoded_msg,
+    const std::vector<uint8_t>& blob_msg,
     const absl::optional<std::string>& display_encoding,
     SignMessageCallback callback) {
   base::Value result(base::Value::Type::DICTIONARY);

--- a/components/brave_wallet/browser/solana_provider_impl.cc
+++ b/components/brave_wallet/browser/solana_provider_impl.cc
@@ -9,9 +9,13 @@
 #include <vector>
 
 #include "base/notreached.h"
+#include "base/strings/strcat.h"
 #include "base/values.h"
 #include "brave/components/brave_wallet/browser/brave_wallet_provider_delegate.h"
+#include "brave/components/brave_wallet/browser/brave_wallet_service.h"
+#include "brave/components/brave_wallet/browser/brave_wallet_utils.h"
 #include "brave/components/brave_wallet/browser/keyring_service.h"
+#include "brave/components/brave_wallet/common/solana_utils.h"
 #include "components/grit/brave_components_strings.h"
 #include "ui/base/l10n/l10n_util.h"
 
@@ -27,8 +31,10 @@ constexpr char kOnlyIfTrustedOption[] = "onlyIfTrusted";
 
 SolanaProviderImpl::SolanaProviderImpl(
     KeyringService* keyring_service,
+    BraveWalletService* brave_wallet_service,
     std::unique_ptr<BraveWalletProviderDelegate> delegate)
     : keyring_service_(keyring_service),
+      brave_wallet_service_(brave_wallet_service),
       delegate_(std::move(delegate)),
       weak_factory_(this) {
   DCHECK(keyring_service_);
@@ -128,10 +134,35 @@ void SolanaProviderImpl::SignMessage(
     const std::vector<uint8_t>& blob_msg,
     const absl::optional<std::string>& display_encoding,
     SignMessageCallback callback) {
-  base::Value result(base::Value::Type::DICTIONARY);
-  NOTIMPLEMENTED();
-  std::move(callback).Run(mojom::SolanaProviderError::kInternalError, "",
-                          std::move(result));
+  absl::optional<std::string> account =
+      keyring_service_->GetSelectedAccount(mojom::CoinType::SOL);
+  if (!account) {
+    std::move(callback).Run(mojom::SolanaProviderError::kInternalError,
+                            l10n_util::GetStringUTF8(IDS_WALLET_INTERNAL_ERROR),
+                            base::Value(base::Value::Type::DICTIONARY));
+    return;
+  }
+  if (!connected_set_.contains(*account)) {
+    std::move(callback).Run(mojom::SolanaProviderError::kUnauthorized,
+                            l10n_util::GetStringUTF8(IDS_WALLET_NOT_AUTHED),
+                            base::Value(base::Value::Type::DICTIONARY));
+    return;
+  }
+  std::string message;
+  if (display_encoding && *display_encoding == "hex")
+    message = base::StrCat({"0x", base::HexEncode(blob_msg)});
+  else
+    message = std::string(blob_msg.begin(), blob_msg.end());
+  auto request = mojom::SignMessageRequest::New(
+      MakeOriginInfo(delegate_->GetOrigin()), sign_message_id_++, *account,
+      message, false, absl::nullopt, absl::nullopt);
+
+  brave_wallet_service_->AddSignMessageRequest(
+      std::move(request),
+      base::BindOnce(&SolanaProviderImpl::OnSignMessageRequestProcessed,
+                     weak_factory_.GetWeakPtr(), blob_msg, *account,
+                     std::move(callback)));
+  delegate_->ShowPanel();
 }
 
 void SolanaProviderImpl::Request(base::Value arg, RequestCallback callback) {
@@ -188,6 +219,30 @@ void SolanaProviderImpl::OnConnect(
     }
   } else {
     NOTREACHED();
+  }
+}
+
+void SolanaProviderImpl::OnSignMessageRequestProcessed(
+    const std::vector<uint8_t>& blob_msg,
+    const std::string& account,
+    SignMessageCallback callback,
+    bool approved,
+    const std::string& signature_not_used,
+    const std::string& error_not_used) {
+  base::Value result(base::Value::Type::DICTIONARY);
+  if (!approved) {
+    std::move(callback).Run(
+        mojom::SolanaProviderError::kUserRejectedRequest,
+        l10n_util::GetStringUTF8(IDS_WALLET_USER_REJECTED_REQUEST),
+        std::move(result));
+  } else {
+    auto signature = keyring_service_->SignMessage(mojom::kSolanaKeyringId,
+                                                   account, blob_msg);
+    result.GetDict().Set("publicKey", account);
+    result.GetDict().Set("signature", Base58Encode(signature));
+
+    std::move(callback).Run(mojom::SolanaProviderError::kSuccess, "",
+                            std::move(result));
   }
 }
 

--- a/components/brave_wallet/browser/solana_provider_impl.cc
+++ b/components/brave_wallet/browser/solana_provider_impl.cc
@@ -162,8 +162,8 @@ void SolanaProviderImpl::SignMessage(
   else
     message = std::string(blob_msg.begin(), blob_msg.end());
   auto request = mojom::SignMessageRequest::New(
-      MakeOriginInfo(delegate_->GetOrigin()), sign_message_id_++, *account,
-      message, false, absl::nullopt, absl::nullopt, mojom::CoinType::SOL);
+      MakeOriginInfo(delegate_->GetOrigin()), -1, *account, message, false,
+      absl::nullopt, absl::nullopt, mojom::CoinType::SOL);
 
   brave_wallet_service_->AddSignMessageRequest(
       std::move(request),

--- a/components/brave_wallet/browser/solana_provider_impl.cc
+++ b/components/brave_wallet/browser/solana_provider_impl.cc
@@ -163,7 +163,7 @@ void SolanaProviderImpl::SignMessage(
     message = std::string(blob_msg.begin(), blob_msg.end());
   auto request = mojom::SignMessageRequest::New(
       MakeOriginInfo(delegate_->GetOrigin()), sign_message_id_++, *account,
-      message, false, absl::nullopt, absl::nullopt);
+      message, false, absl::nullopt, absl::nullopt, mojom::CoinType::SOL);
 
   brave_wallet_service_->AddSignMessageRequest(
       std::move(request),

--- a/components/brave_wallet/browser/solana_provider_impl.cc
+++ b/components/brave_wallet/browser/solana_provider_impl.cc
@@ -15,6 +15,7 @@
 #include "brave/components/brave_wallet/browser/brave_wallet_service.h"
 #include "brave/components/brave_wallet/browser/brave_wallet_utils.h"
 #include "brave/components/brave_wallet/browser/keyring_service.h"
+#include "brave/components/brave_wallet/browser/solana_message.h"
 #include "brave/components/brave_wallet/common/solana_utils.h"
 #include "components/grit/brave_components_strings.h"
 #include "ui/base/l10n/l10n_util.h"
@@ -151,6 +152,13 @@ void SolanaProviderImpl::SignMessage(
     return;
   }
   if (!IsAccountConnected(*account)) {
+    std::move(callback).Run(mojom::SolanaProviderError::kUnauthorized,
+                            l10n_util::GetStringUTF8(IDS_WALLET_NOT_AUTHED),
+                            base::Value(base::Value::Type::DICTIONARY));
+    return;
+  }
+  // Prevent transaction payload from being signed
+  if (SolanaMessage::Deserialize(blob_msg)) {
     std::move(callback).Run(mojom::SolanaProviderError::kUnauthorized,
                             l10n_util::GetStringUTF8(IDS_WALLET_NOT_AUTHED),
                             base::Value(base::Value::Type::DICTIONARY));

--- a/components/brave_wallet/browser/solana_provider_impl.h
+++ b/components/brave_wallet/browser/solana_provider_impl.h
@@ -47,7 +47,7 @@ class SolanaProviderImpl final : public mojom::SolanaProvider,
       SignAllTransactionsCallback callback) override;
   void SignAndSendTransaction(const std::string& encoded_serialized_msg,
                               SignAndSendTransactionCallback callback) override;
-  void SignMessage(const std::string& encoded_msg,
+  void SignMessage(const std::vector<uint8_t>& blob_msg,
                    const absl::optional<std::string>& display_encoding,
                    SignMessageCallback callback) override;
   void Request(base::Value arg, RequestCallback callback) override;

--- a/components/brave_wallet/browser/solana_provider_impl.h
+++ b/components/brave_wallet/browser/solana_provider_impl.h
@@ -55,6 +55,7 @@ class SolanaProviderImpl final : public mojom::SolanaProvider,
   void Request(base::Value arg, RequestCallback callback) override;
 
  private:
+  bool IsAccountConnected(const std::string& account);
   void ContinueConnect(bool is_eagerly_connect,
                        const std::string& selected_account,
                        ConnectCallback callback,

--- a/components/brave_wallet/browser/solana_provider_impl.h
+++ b/components/brave_wallet/browser/solana_provider_impl.h
@@ -93,7 +93,6 @@ class SolanaProviderImpl final : public mojom::SolanaProvider,
   // will be saved and future connect from the same site will not ask user for
   // permission again until the permission is removed.
   base::flat_set<std::string> connected_set_;
-  int sign_message_id_ = 0;
   mojo::Remote<mojom::SolanaEventsListener> events_listener_;
   raw_ptr<KeyringService> keyring_service_ = nullptr;
   raw_ptr<BraveWalletService> brave_wallet_service_ = nullptr;

--- a/components/brave_wallet/common/brave_wallet.mojom
+++ b/components/brave_wallet/common/brave_wallet.mojom
@@ -173,12 +173,12 @@ interface SolanaProvider {
   SignAndSendTransaction(string encoded_serialized_msg)
     => (SolanaProviderError error, string error_message,
         mojo_base.mojom.DeprecatedDictionaryValue result);
-  // It takes a base58 encoded message and an optional display encoding for
+  // It takes a byte array and an optional display encoding for
   // users and returns an object as
   // { publicKey: <base58 encoded string>,
   //   signature:  <base58 encoded string>
   // }
-  SignMessage(string encoded_msg, string? display_encoding)
+  SignMessage(array<uint8> blob_msg, string? display_encoding)
     => (SolanaProviderError error, string error_message,
         mojo_base.mojom.DeprecatedDictionaryValue result);
 

--- a/components/brave_wallet/common/brave_wallet.mojom
+++ b/components/brave_wallet/common/brave_wallet.mojom
@@ -972,6 +972,7 @@ struct SignMessageRequest {
   // Should be used only if is_eip712 is true
   string? domain_hash;
   string? primary_hash;
+  CoinType coin;
 };
 
 enum ExternalWalletType {

--- a/components/brave_wallet/renderer/js_solana_provider.cc
+++ b/components/brave_wallet/renderer/js_solana_provider.cc
@@ -54,7 +54,7 @@ JSSolanaProvider::~JSSolanaProvider() {
 
 gin::WrapperInfo JSSolanaProvider::kWrapperInfo = {gin::kEmbedderNativeGin};
 
-// Convert Uint8Array to base58 encoded string
+// Convert Uint8Array to blob base::Value
 bool JSSolanaProvider::V8ConverterStrategy::FromV8ArrayBuffer(
     v8::Local<v8::Object> value,
     std::unique_ptr<base::Value>* out,
@@ -74,7 +74,7 @@ bool JSSolanaProvider::V8ConverterStrategy::FromV8ArrayBuffer(
   if (!bytes.size())
     return false;
   std::unique_ptr<base::Value> new_value =
-      std::make_unique<base::Value>(Base58Encode(bytes));
+      std::make_unique<base::Value>(bytes);
   *out = std::move(new_value);
 
   return true;
@@ -321,9 +321,10 @@ v8::Local<v8::Promise> JSSolanaProvider::SignMessage(
         l10n_util::GetStringUTF8(IDS_WALLET_INVALID_PARAMETERS));
     return v8::Local<v8::Promise>();
   }
-  std::unique_ptr<base::Value> encoded_msg =
+
+  std::unique_ptr<base::Value> blob_msg =
       v8_value_converter_->FromV8Value(message, isolate->GetCurrentContext());
-  if (!encoded_msg->is_string()) {
+  if (!blob_msg->is_blob()) {
     arguments->ThrowTypeError(
         l10n_util::GetStringUTF8(IDS_WALLET_INVALID_PARAMETERS));
     return v8::Local<v8::Promise>();
@@ -343,7 +344,7 @@ v8::Local<v8::Promise> JSSolanaProvider::SignMessage(
   auto promise_resolver(
       v8::Global<v8::Promise::Resolver>(isolate, resolver.ToLocalChecked()));
   solana_provider_->SignMessage(
-      encoded_msg->GetString(), display_str,
+      blob_msg->GetBlob(), display_str,
       base::BindOnce(&JSSolanaProvider::OnSignMessage,
                      weak_ptr_factory_.GetWeakPtr(), std::move(global_context),
                      std::move(promise_resolver), isolate));
@@ -726,14 +727,12 @@ absl::optional<std::string> JSSolanaProvider::GetSerializedMessage(
       std::vector<v8::Local<v8::Value>>());
   if (serialized_msg.IsEmpty())
     return absl::nullopt;
-  // base58 encode Uint8Array which is defined in
-  // V8ConverterStrategy::FromV8ArrayBuffer
-  std::unique_ptr<base::Value> encoded_msg = v8_value_converter_->FromV8Value(
+  std::unique_ptr<base::Value> blob_value = v8_value_converter_->FromV8Value(
       serialized_msg.ToLocalChecked(), isolate->GetCurrentContext());
-  if (!encoded_msg->is_string())
+  if (!blob_value->is_blob())
     return absl::nullopt;
 
-  return encoded_msg->GetString();
+  return Base58Encode(blob_value->GetBlob());
 }
 
 v8::Local<v8::Value> JSSolanaProvider::CreatePublicKey(

--- a/components/brave_wallet/renderer/js_solana_provider.cc
+++ b/components/brave_wallet/renderer/js_solana_provider.cc
@@ -73,8 +73,7 @@ bool JSSolanaProvider::V8ConverterStrategy::FromV8ArrayBuffer(
   }
   if (!bytes.size())
     return false;
-  std::unique_ptr<base::Value> new_value =
-      std::make_unique<base::Value>(bytes);
+  std::unique_ptr<base::Value> new_value = std::make_unique<base::Value>(bytes);
   *out = std::move(new_value);
 
   return true;

--- a/components/brave_wallet_ui/components/extension/sign-panel/index.tsx
+++ b/components/brave_wallet_ui/components/extension/sign-panel/index.tsx
@@ -5,7 +5,6 @@ import { BraveWallet, WalletAccountType } from '../../../constants/types'
 import { SignMessagePayload } from '../../../panel/constants/action_types'
 
 // Utils
-import { reduceAccountDisplayName } from '../../../utils/reduce-account-name'
 import { getLocale } from '../../../../common/locale'
 
 // Components
@@ -45,8 +44,9 @@ import {
 
 export interface Props {
   accounts: WalletAccountType[]
+  defaultNetworks: BraveWallet.NetworkInfo[]
   selectedNetwork: BraveWallet.NetworkInfo
-  signMessageData: SignMessagePayload[]
+  signMessageData: BraveWallet.SignMessageRequest[]
   onSign: () => void
   onCancel: () => void
   showWarning: boolean
@@ -60,6 +60,7 @@ enum SignDataSteps {
 function SignPanel (props: Props) {
   const {
     accounts,
+    defaultNetworks,
     selectedNetwork,
     signMessageData,
     onSign,
@@ -116,10 +117,14 @@ function SignPanel (props: Props) {
     , [signMessageData, selectedQueueData]
   )
 
+  const network = React.useMemo(() => {
+    return defaultNetworks.find((n) => n.coin === signMessageData[0].coin) ?? selectedNetwork
+  }, [defaultNetworks, selectedNetwork, signMessageData])
+
   return (
     <StyledWrapper>
       <TopRow>
-        <NetworkText>{selectedNetwork.chainName}</NetworkText>
+        <NetworkText>{network.chainName}</NetworkText>
         {signMessageQueueInfo.queueLength > 1 &&
           <QueueStepRow>
             <QueueStepText>{signMessageQueueInfo.queueNumber} {getLocale('braveWalletQueueOf')} {signMessageQueueInfo.queueLength}</QueueStepText>
@@ -141,7 +146,7 @@ function SignPanel (props: Props) {
           eTldPlusOne={selectedQueueData.originInfo.eTldPlusOne}
         />
       </URLText>
-      <AccountNameText>{reduceAccountDisplayName(findAccountName(selectedQueueData.address) ?? '', 14)}</AccountNameText>
+      <AccountNameText>{findAccountName(selectedQueueData.address) ?? ''}</AccountNameText>
       <PanelTitle>{getLocale('braveWalletSignTransactionTitle')}</PanelTitle>
       {signStep === SignDataSteps.SignRisk &&
         <WarningBox warningType='danger'>

--- a/components/brave_wallet_ui/components/extension/sign-panel/style.ts
+++ b/components/brave_wallet_ui/components/extension/sign-panel/style.ts
@@ -42,6 +42,9 @@ export const AccountNameText = styled.span`
   line-height: 20px;
   color: ${(p) => p.theme.color.text02};
   margin-bottom: 2px;
+  max-width: 80%;
+  word-break: break-word;
+  text-align: center;
 `
 
 export const NetworkText = styled.span`

--- a/components/brave_wallet_ui/panel/container.tsx
+++ b/components/brave_wallet_ui/panel/container.tsx
@@ -108,7 +108,8 @@ function Container (props: Props) {
     defaultCurrencies,
     transactions,
     userVisibleTokensInfo,
-    defaultAccounts
+    defaultAccounts,
+    defaultNetworks
   } = props.wallet
 
   const {
@@ -651,6 +652,7 @@ function Container (props: Props) {
             onCancel={onCancelSigning}
             onSign={onSignData}
             selectedNetwork={getNetworkInfo(selectedNetwork.chainId, selectedNetwork.coin, networkList)}
+            defaultNetworks={defaultNetworks}
             // Pass a boolean here if the signing method is risky
             showWarning={false}
           />

--- a/components/brave_wallet_ui/panel/reducers/panel_reducer.ts
+++ b/components/brave_wallet_ui/panel/reducers/panel_reducer.ts
@@ -59,7 +59,8 @@ const defaultState: PanelState = {
     message: '',
     isEip712: false,
     domainHash: '',
-    primaryHash: ''
+    primaryHash: '',
+    coin: BraveWallet.CoinType.ETH
   }],
   getEncryptionPublicKeyRequest: {
     originInfo: defaultOriginInfo,

--- a/components/brave_wallet_ui/panel/reducers/panel_reducer.ts
+++ b/components/brave_wallet_ui/panel/reducers/panel_reducer.ts
@@ -135,13 +135,6 @@ export const createPanelReducer = (initialState: PanelState) => {
     }
   })
 
-  reducer.on(PanelActions.signMessage, (state: any, payload: SignMessagePayload[]) => {
-    return {
-      ...state,
-      signMessageData: payload
-    }
-  })
-
   reducer.on(PanelActions.setHardwareWalletInteractionError, (state: any, payload?: HardwareWalletResponseCodeType) => {
     return {
       ...state,

--- a/components/brave_wallet_ui/stories/wallet-extension-panels.tsx
+++ b/components/brave_wallet_ui/stories/wallet-extension-panels.tsx
@@ -455,13 +455,18 @@ export const _SignData = () => {
     id: 0,
     address: '0x3f29A1da97149722eB09c526E4eAd698895b426',
     message: 'To avoid digital cat burglars, sign below to authenticate with CryptoKitties.',
-    originInfo: mockOriginInfo
+    originInfo: mockOriginInfo,
+    coin: BraveWallet.CoinType.ETH,
+    isEip712: true,
+    domainHash: '',
+    primaryHash: ''
   }]
 
   return (
     <StyledExtensionWrapperLonger>
       <SignPanel
         signMessageData={signMessageDataPayload}
+        defaultNetworks={mockNetworks}
         accounts={mockAccounts}
         selectedNetwork={mockNetworks[0]}
         onCancel={onCancel}

--- a/components/resources/wallet_strings.grdp
+++ b/components/resources/wallet_strings.grdp
@@ -37,6 +37,7 @@
   <message name="IDS_WALLET_ETH_SEND_TRANSACTION_FROM_EMPTY" desc="Transaction data is not validated">Transaction data 'from' must be specified</message>
   <message name="IDS_WALLET_GET_NONCE_ERROR" desc="Failed to get nonce">Failed to get next nonce value</message>
   <message name="IDS_WALLET_SEND_TRANSACTION_TO_INVALID" desc="Transaction data is not validated">Transaction data 'to' must be a valid address when specified</message>
+  <message name="IDS_WALLET_NOT_AUTHED" desc="Method or account not authorized">The requested method and/or account has not been authorized by the user.</message>
   <message name="IDS_BRAVE_WALLET_DEFI_CATEGORY" desc="Defi apps title">Defi apps</message>
   <message name="IDS_BRAVE_WALLET_NFT_CATEGORY" desc="NFT marketplace title">NFT marketplaces</message>
   <message name="IDS_BRAVE_WALLET_SEARCH_CATEGORY" desc="Filter apps placeholder">Search results</message>

--- a/ios/app/brave_core_main.mm
+++ b/ios/app/brave_core_main.mm
@@ -375,8 +375,14 @@ static bool CustomLogHandler(int severity,
     return nil;
   }
 
+  auto* brave_wallet_service =
+      brave_wallet::BraveWalletServiceFactory::GetServiceForState(browserState);
+  if (!brave_wallet_service) {
+    return nil;
+  }
+
   auto* provider = new brave_wallet::SolanaProviderImpl(
-      keyring_service,
+      keyring_service, brave_wallet_service,
       std::make_unique<brave_wallet::BraveWalletProviderDelegateBridge>(
           delegate));
   return

--- a/test/data/brave-wallet/solana_provider.html
+++ b/test/data/brave-wallet/solana_provider.html
@@ -2,6 +2,7 @@
 
 <script>
   var connectedAccount = ''
+  var signMessageResult = ''
 
   function solanaConnect() {
     window.solana.connect().then(result => {
@@ -25,6 +26,22 @@
 
   function isSolanaConnected() {
     window.domAutomationController.send(window.solana.isConnected)
+  }
+
+  function solanaSignMessage(message, encoding) {
+    const encodedMessage = new TextEncoder().encode(message)
+    window.solana.signMessage(encodedMessage, encoding)
+      .then(result => {
+        signMessageResult = result.signature.join()
+        window.domAutomationController.send('result ready')
+      }).catch(error => {
+        signMessageResult = error.message
+        window.domAutomationController.send('result ready')
+      })
+  }
+
+  function getSignMessageResult() {
+    window.domAutomationController.send(signMessageResult)
   }
 
 </script>


### PR DESCRIPTION
<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/21767

security review: https://github.com/brave/security/issues/872

1. `solana.signMessage()`where message input must be Uint8Array and optional display encoding(utf8, hex), if encoding is not specified or invalid, it would be default be utf8
2. `solana.publicKey` will return null when disconnected and return selected account address otherwise.

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

