### PR TITLE
[Android] fixes orientation issue after turning news on

### DIFF
--- a/android/java/org/chromium/chrome/browser/ntp/BraveNewTabPageLayout.java
+++ b/android/java/org/chromium/chrome/browser/ntp/BraveNewTabPageLayout.java
@@ -738,7 +738,7 @@ public class BraveNewTabPageLayout extends NewTabPageLayout implements Connectio
 
     private void keepPosition(int prevScrollPosition, int prevRecyclerViewPosition,
             int prevRecyclerViewItemPosition) {
-        if (!mIsNewsOn || !mIsShowNewsOn || (mIsNewsOn && mIsShowOptin)) {
+        if (!mIsNewsOn || !mIsShowNewsOn || (mIsNewsOn && mIsShowOptin && !mIsShowNewsOn)) {
             return;
         }
         processFeed();
@@ -1366,6 +1366,8 @@ public class BraveNewTabPageLayout extends NewTabPageLayout implements Connectio
                     sharedPreferencesEditor.apply();
                     BravePrefServiceBridge.getInstance().setNewsOptIn(true);
                     BravePrefServiceBridge.getInstance().setShowNews(true);
+                    mIsNewsOn = BravePrefServiceBridge.getInstance().getNewsOptIn();
+                    mIsShowNewsOn = BravePrefServiceBridge.getInstance().getShowNews();
                     if (BraveActivity.getBraveActivity() != null) {
                         BraveActivity.getBraveActivity().inflateNewsSettingsBar();
                         mSettingsBar =


### PR DESCRIPTION
<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/23060

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
Best visible on tablet, but occurs on phones too.
1. Turn news on and stay in the same tab
2. Scroll a bit in portrait mode then rotate to landscape
3. Scroll some more on landscape too then rotate back to portrait
4. Before, at this point all the cards would have been "squished" together, now it should look normal

Might be useful to do a sanity check for possible regressions like : 
- rotations with optin card on
- rotations after hitting the 'x' to close the optin card
- going to tab tray and back, going between tabs
- disabling news and rotating
I tested for these scenarios but...
