### PR TITLE
[Android] Fixes news settings bar disappears when switching tabs (uplift to 1.39.x) 

### DIFF
--- a/android/java/org/chromium/chrome/browser/ntp/BraveNewTabPageLayout.java
+++ b/android/java/org/chromium/chrome/browser/ntp/BraveNewTabPageLayout.java
@@ -893,6 +893,10 @@ public class BraveNewTabPageLayout extends NewTabPageLayout implements Connectio
                     mActivity = BraveActivity.getBraveActivity();
                 }
 
+                if (mSettingsBar != null && prevRecyclerViewItemPosition > 0) {
+                    mSettingsBar.setVisibility(View.VISIBLE);
+                    mSettingsBar.setAlpha(0f);
+                }
                 keepPosition(
                         prevScrollPosition, prevRecyclerViewPosition, prevRecyclerViewItemPosition);
             }
@@ -1328,7 +1332,6 @@ public class BraveNewTabPageLayout extends NewTabPageLayout implements Connectio
                         mTouchScroll = true;
                         mFirstVisibleCard = linearLayoutManager.findFirstVisibleItemPosition();
                         mParentScrollView.scrollBy(0, offset + 2);
-
                     } catch (Exception e) {
                         Log.e("bn", "Exception onScrolled:" + e);
                     }
@@ -1646,8 +1649,9 @@ public class BraveNewTabPageLayout extends NewTabPageLayout implements Connectio
                                                                       .getActivityTab()
                                                                       .getId(),
                                                     0);
-                                    if (compositorView.getChildAt(2).getId()
-                                            == R.id.news_settings_bar) {
+                                    if (mSettingsBar == null
+                                            && compositorView.getChildAt(2).getId()
+                                                    == R.id.news_settings_bar) {
                                         mSettingsBar = (LinearLayout) compositorView.getChildAt(2);
                                         mSettingsBar.setVisibility(View.INVISIBLE);
                                         mSettingsBar.setAlpha(0f);


### PR DESCRIPTION
Uplift of #13372
Resolves https://github.com/brave/brave-browser/issues/22878

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.