### PR TITLE
Turned on closing window dialog by default

### DIFF
--- a/browser/brave_profile_prefs.cc
+++ b/browser/brave_profile_prefs.cc
@@ -431,7 +431,7 @@ void RegisterProfilePrefs(user_prefs::PrefRegistrySyncable* registry) {
   // We can turn customization mode on when we have add-shortcut feature.
   registry->SetDefaultPrefValue(ntp_prefs::kNtpUseMostVisitedTiles,
                                 base::Value(true));
-  registry->RegisterBooleanPref(kEnableWindowClosingConfirm, false);
+  registry->RegisterBooleanPref(kEnableWindowClosingConfirm, true);
   RegisterDefaultBraveBrowserPromptPrefs(registry);
 #endif
 

--- a/browser/ui/brave_browser.cc
+++ b/browser/ui/brave_browser.cc
@@ -24,6 +24,17 @@
 #include "chrome/browser/ui/tabs/tab_strip_model_observer.h"
 #endif
 
+namespace {
+
+bool g_suppress_dialog_for_testing = false;
+
+}  // namespace
+
+// static
+void BraveBrowser::SuppressBrowserWindowClosingDialogForTesting(bool suppress) {
+  g_suppress_dialog_for_testing = suppress;
+}
+
 BraveBrowser::BraveBrowser(const CreateParams& params) : Browser(params) {
 #if BUILDFLAG(ENABLE_SIDEBAR)
   if (!sidebar::CanUseSidebar(this))
@@ -138,6 +149,9 @@ void BraveBrowser::ResetTryToCloseWindow() {
 }
 
 bool BraveBrowser::ShouldAskForBrowserClosingBeforeHandlers() {
+  if (g_suppress_dialog_for_testing)
+    return false;
+
   // Don't need to ask when application closing is in-progress.
   if (BrowserCloseManager::BrowserClosingStarted())
     return false;

--- a/browser/ui/brave_browser.h
+++ b/browser/ui/brave_browser.h
@@ -63,6 +63,12 @@ class BraveBrowser : public Browser {
   void set_confirmed_to_close(bool close) { confirmed_to_close_ = close; }
 
  private:
+  friend class BraveTestLauncherDelegate;
+  friend class WindowClosingConfirmBrowserTest;
+
+  // static
+  static void SuppressBrowserWindowClosingDialogForTesting(bool suppress);
+
 #if BUILDFLAG(ENABLE_SIDEBAR)
   std::unique_ptr<sidebar::SidebarController> sidebar_controller_;
 #endif

--- a/browser/ui/window_closing_confirm_browsertest.cc
+++ b/browser/ui/window_closing_confirm_browsertest.cc
@@ -53,16 +53,21 @@ void CancelClose() {
 class WindowClosingConfirmBrowserTest : public InProcessBrowserTest {
  public:
   void SetUpOnMainThread() override {
+    BraveBrowser::SuppressBrowserWindowClosingDialogForTesting(false);
+
     InProcessBrowserTest::SetUpOnMainThread();
 
     PrefService* prefs = browser()->profile()->GetPrefs();
-    // Disabled by default.
-    EXPECT_FALSE(prefs->GetBoolean(kEnableWindowClosingConfirm));
-
-    // Enable for testing.
-    prefs->SetBoolean(kEnableWindowClosingConfirm, true);
+    // Enabled by default.
+    EXPECT_TRUE(prefs->GetBoolean(kEnableWindowClosingConfirm));
 
     SetDialogCreationCallback();
+  }
+
+  void TearDownOnMainThread() override {
+    BraveBrowser::SuppressBrowserWindowClosingDialogForTesting(true);
+
+    InProcessBrowserTest::TearDownOnMainThread();
   }
 
   void SetDialogCreationCallback() {

--- a/test/BUILD.gn
+++ b/test/BUILD.gn
@@ -593,7 +593,10 @@ static_library("browser_test_support") {
     "base/brave_test_launcher_delegate.h",
   ]
 
-  deps = [ "//chrome/browser" ]
+  deps = [
+    "//brave/browser/ui",
+    "//chrome/browser",
+  ]
 }
 
 static_library("browser_tests_runner") {

--- a/test/base/brave_test_launcher_delegate.cc
+++ b/test/base/brave_test_launcher_delegate.cc
@@ -6,6 +6,7 @@
 #include "brave/test/base/brave_test_launcher_delegate.h"
 
 #include "brave/app/brave_main_delegate.h"
+#include "brave/browser/ui/brave_browser.h"
 #include "build/build_config.h"
 
 #if BUILDFLAG(IS_MAC) || BUILDFLAG(IS_LINUX)
@@ -20,6 +21,10 @@ BraveTestLauncherDelegate::BraveTestLauncherDelegate(
 #if BUILDFLAG(IS_MAC) || BUILDFLAG(IS_LINUX)
   first_run::internal::ForceFirstRunDialogShownForTesting(false);
 #endif
+
+  // Suppress browser window closing dialog during the test.
+  // It can cause some tests timeout.
+  BraveBrowser::SuppressBrowserWindowClosingDialogForTesting(true);
 }
 
 BraveTestLauncherDelegate::~BraveTestLauncherDelegate() = default;


### PR DESCRIPTION
fix https://github.com/brave/brave-browser/issues/23056

<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves 

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

1. Launch brave with clean profile
2. Load brave://settings and go to Help tips section and check `Warn me before closing window with multiple tabs` is enabled by default