### PR TITLE
Do not skip disconnection message on mac

### DIFF
--- a/components/brave_vpn/brave_vpn_service.cc
+++ b/components/brave_vpn/brave_vpn_service.cc
@@ -214,7 +214,7 @@ void BraveVpnService::UpdateAndNotifyConnectionStateChange(
     VLOG(2) << __func__ << ": Ignore disconnected state while connecting";
     return;
   }
-#endif
+
   // On Windows, we could get disconnected state after connect failed.
   // To make connect failed state as a last state, ignore disconnected state.
   if (!force && connection_state_ == ConnectionState::CONNECT_FAILED &&
@@ -222,7 +222,7 @@ void BraveVpnService::UpdateAndNotifyConnectionStateChange(
     VLOG(2) << __func__ << ": Ignore disconnected state after connect failed";
     return;
   }
-
+#endif  // BUILDFLAG(IS_WIN)
   VLOG(2) << __func__ << " : changing from " << connection_state_ << " to "
           << state;
 

--- a/components/brave_vpn/brave_vpn_service.cc
+++ b/components/brave_vpn/brave_vpn_service.cc
@@ -200,7 +200,7 @@ void BraveVpnService::UpdateAndNotifyConnectionStateChange(
   DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
   if (connection_state_ == state)
     return;
-
+#if BUILDFLAG(IS_WIN)
   // On Windows, we get disconnected status update twice.
   // When user connects to different region while connected,
   // we disconnect current connection and connect to newly selected
@@ -214,7 +214,7 @@ void BraveVpnService::UpdateAndNotifyConnectionStateChange(
     VLOG(2) << __func__ << ": Ignore disconnected state while connecting";
     return;
   }
-
+#endif
   // On Windows, we could get disconnected state after connect failed.
   // To make connect failed state as a last state, ignore disconnected state.
   if (!force && connection_state_ == ConnectionState::CONNECT_FAILED &&


### PR DESCRIPTION
<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/22883

On mac we should not skip disconnection message, seems forgot to wrap code to be win-only. This PR fixes only infinite connection view. Specific error view will be added as requested in https://github.com/brave/brave-browser/issues/22754

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

   1. Enable VPN (see test plan in https://github.com/brave/brave-browser/issues/15804 for more information)
   2. Click VPN button (next to hamburger menu) and connect to a server
   3. Disconnect your network (if plugged in with ethernet unplug, if on WiFi disable)
   4. Click VPN button again - it should be trying to reconnect
   5. It should stop immediately and show disconnection status