### PR TITLE
Check purchased state when service is launched

### DIFF
--- a/components/brave_vpn/brave_vpn_service.cc
+++ b/components/brave_vpn/brave_vpn_service.cc
@@ -136,6 +136,18 @@ BraveVpnService::BraveVpnService(
   observed_.Observe(GetBraveVPNConnectionAPI());
 
   GetBraveVPNConnectionAPI()->set_target_vpn_entry_name(kBraveVPNEntryName);
+
+  // To get proper connection state, we need to load purchased state.
+  // Connection state will be checked after we confirm that this profile
+  // is purchased user.
+  // However, purchased state loading makes additional network request.
+  // We should not make this network request for fresh user.
+  // To prevent this, we load purchased state at startup only
+  // when profile has cached region list because region list is fetched
+  // and cached only when user purchased at least once.
+  auto* preference = prefs_->FindPreference(prefs::kBraveVPNRegionList);
+  if (preference && !preference->IsDefaultValue())
+    LoadPurchasedState();
 }
 #endif
 
@@ -198,6 +210,11 @@ void BraveVpnService::UpdateAndNotifyConnectionStateChange(
     bool force) {
   // this is a simple state machine for handling connection state
   DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
+  // Ignore connection state change request for non purchased user.
+  // This can be happened when user controls vpn via os settings.
+  if (!is_purchased_user())
+    return;
+
   if (connection_state_ == state)
     return;
 

--- a/components/brave_vpn/brave_vpn_unittest.cc
+++ b/components/brave_vpn/brave_vpn_unittest.cc
@@ -48,8 +48,13 @@ class BraveVPNServiceTest : public testing::Test {
         base::MakeRefCounted<network::TestSharedURLLoaderFactory>();
     skus_service_ = std::make_unique<skus::SkusServiceImpl>(&pref_service_,
                                                             url_loader_factory);
+    ResetVpnService();
+  }
+
+  void ResetVpnService() {
     service_ = std::make_unique<BraveVpnService>(
-        url_loader_factory, &pref_service_,
+        base::MakeRefCounted<network::TestSharedURLLoaderFactory>(),
+        &pref_service_,
         base::BindRepeating(&BraveVPNServiceTest::GetSkusService,
                             base::Unretained(this)));
   }
@@ -80,6 +85,10 @@ class BraveVPNServiceTest : public testing::Test {
 
   void OnCredentialSummary(const std::string& summary) {
     service_->OnCredentialSummary(summary);
+  }
+
+  void UpdateAndNotifyConnectionStateChange(mojom::ConnectionState state) {
+    service_->UpdateAndNotifyConnectionStateChange(state);
   }
 
   std::vector<mojom::Region>& regions() const { return service_->regions_; }
@@ -419,6 +428,9 @@ TEST_F(BraveVPNServiceTest, LoadPurchasedStateTest) {
 }
 
 TEST_F(BraveVPNServiceTest, CancelConnectingTest) {
+  // Connection state can be changed with purchased.
+  purchased_state() = PurchasedState::PURCHASED;
+
   cancel_connecting() = true;
   connection_state() = ConnectionState::CONNECTING;
   OnCreated();
@@ -465,6 +477,29 @@ TEST_F(BraveVPNServiceTest, CancelConnectingTest) {
   EXPECT_EQ(ConnectionState::DISCONNECTED, connection_state());
 }
 
+TEST_F(BraveVPNServiceTest, ConnectionStateUpdateWithPurchasedStateTest) {
+  purchased_state() = PurchasedState::PURCHASED;
+  connection_state() = ConnectionState::CONNECTING;
+  UpdateAndNotifyConnectionStateChange(ConnectionState::CONNECTED);
+  EXPECT_EQ(ConnectionState::CONNECTED, connection_state());
+
+  purchased_state() = PurchasedState::NOT_PURCHASED;
+  connection_state() = ConnectionState::CONNECTING;
+  UpdateAndNotifyConnectionStateChange(ConnectionState::CONNECTED);
+  EXPECT_NE(ConnectionState::CONNECTED, connection_state());
+}
+
+TEST_F(BraveVPNServiceTest, CheckInitialPurchasedStateTest) {
+  // Purchased state is not checked for fresh user.
+  EXPECT_EQ(PurchasedState::NOT_PURCHASED, purchased_state());
+
+  // Dirty region list prefs to pretend it's already cached.
+  pref_service_.Set(prefs::kBraveVPNRegionList,
+                    base::Value(base::Value::Type::LIST));
+  ResetVpnService();
+  EXPECT_EQ(PurchasedState::LOADING, purchased_state());
+}
+
 TEST_F(BraveVPNServiceTest, ConnectionInfoTest) {
   // Having skus_credential is pre-requisite before try connecting.
   skus_credential() = "test_credentials";
@@ -487,6 +522,9 @@ TEST_F(BraveVPNServiceTest, ConnectionInfoTest) {
 }
 
 TEST_F(BraveVPNServiceTest, NeedsConnectTest) {
+  // Connection state can be changed with purchased.
+  purchased_state() = PurchasedState::PURCHASED;
+
   // Check ignore Connect() request while connecting or disconnecting is
   // in-progress.
   SetDeviceRegion("eu-es");


### PR DESCRIPTION
Connection state is queried when purchased state is loaded and
it's purchased user.

fix https://github.com/brave/brave-browser/issues/22677
fix https://github.com/brave/brave-browser/issues/22726
fix https://github.com/brave/brave-browser/issues/23080

<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves 

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

See linked issues.