### PR TITLE
Separated imported Filecoin accounts

### DIFF
--- a/components/brave_wallet/browser/keyring_service.cc
+++ b/components/brave_wallet/browser/keyring_service.cc
@@ -69,17 +69,46 @@
  *         }
  *     },
  *     "selected_account": "t1....ac",
- *     "imported_accounts": [
- *       {
+ *     "imported_accounts": {
+ *       "f": [
+ *         {
+ *           "account_address": "f3abc....ugdaa",
+ *           "account_name": "Filecoin",
+ *           "encrypted_private_key": "1X/E...V5AS",
+ *           "coin_type": 461 // Enum mojom::CoinType
+ *         }
+ *       ],
+ *       "t":[
+ *         {
  *           "account_address": "t3vmv....ughsa",
  *           "account_name": "Filecoin",
  *           "encrypted_private_key": "9/Xb...X4IL",
  *           "coin_type": 461 // Enum mojom::CoinType
- *       }
- *     ],
- *     "hardware":  {
- *        ...
- *     }
+ *         }
+ *       ]
+ *     },
+ *     "hardware": {
+ *       "t": {
+ *          "device1": {
+ *             "t1h3n....jvg33q": {
+ *                 "account_name": "name 1",
+ *                 "coin_type": 461,
+ *                 "derivation_path": "m/44'/461'/0'/0/0",
+ *                 "hardware_vendor": "Ledger"
+ *            }
+ *          },
+ *        },
+ *        "f": {
+ *           "device2": {
+ *             "f3h4n....vg33q": {
+ *                 "account_name": "filecoin 1",
+ *                 "coin_type": 461,
+ *                 "derivation_path": "m/44'/461'/0'/0/0",
+ *                 "hardware_vendor": "Ledger"
+ *             },
+ *           },
+ *        },
+ *     },
  *     "password_encryptor_nonce": "xxx"
  * },
  * "default":
@@ -358,6 +387,82 @@ void KeyringService::MigrateObsoleteProfilePrefs(PrefService* prefs) {
                       mojom::kDefaultKeyringId);
     update->RemovePath(kHardwareAccounts);
   }
+  // Moving Filecoin imported and hardware accounts under network layer.
+  if (IsFilecoinEnabled()) {
+    auto* keyring_pref = update->FindDictKey(mojom::kFilecoinKeyringId);
+    if (keyring_pref) {
+      MigrateObosoleteFilecoinImportedPrefs(keyring_pref);
+      MigrateObosoleteFilecoinHardwarePrefs(keyring_pref);
+    }
+  }
+}
+
+// Migrate hardware accounts.
+// static
+void KeyringService::MigrateObosoleteFilecoinHardwarePrefs(
+    base::Value* keyring_pref) {
+  auto* obsolete_hardware_accounts =
+      keyring_pref->FindDictKey(kHardwareAccounts);
+  if (!obsolete_hardware_accounts)
+    return;
+  base::Value new_hardware_accounts(base::Value::Type::DICT);
+  for (const auto [device, value] : obsolete_hardware_accounts->GetDict()) {
+    base::Value f_meta(base::Value::Type::DICT);
+    base::Value t_meta(base::Value::Type::DICT);
+
+    for (const auto [address, meta] : value.GetDict()) {
+      auto network = FilAddress::FromAddress(address).network();
+      if (network == mojom::kFilecoinMainnet) {
+        f_meta.SetKey(address, std::move(meta));
+      } else {
+        t_meta.SetKey(address, std::move(meta));
+      }
+    }
+    if (!f_meta.DictEmpty()) {
+      base::Value f_network(base::Value::Type::DICT);
+      f_network.SetKey(device, std::move(f_meta));
+      new_hardware_accounts.SetKey(mojom::kFilecoinMainnet,
+                                   std::move(f_network));
+    }
+    if (!t_meta.DictEmpty()) {
+      base::Value t_network(base::Value::Type::DICT);
+      t_network.SetKey(device, std::move(t_meta));
+      new_hardware_accounts.SetKey(mojom::kFilecoinTestnet,
+                                   std::move(t_network));
+    }
+  }
+  if (!new_hardware_accounts.DictEmpty()) {
+    keyring_pref->SetKey(kHardwareAccounts, std::move(new_hardware_accounts));
+  }
+}
+
+// Migrate imported accounts.
+// static
+void KeyringService::MigrateObosoleteFilecoinImportedPrefs(
+    base::Value* keyring_pref) {
+  DCHECK(keyring_pref);
+  auto* obsolete_imported_accounts =
+      keyring_pref->FindListKey(kImportedAccounts);
+  if (!obsolete_imported_accounts)
+    return;
+  base::Value f_list(base::Value::Type::LIST);
+  base::Value t_list(base::Value::Type::LIST);
+  for (const auto& account : obsolete_imported_accounts->GetList()) {
+    auto* account_address = account.FindStringKey(kAccountAddress);
+    if (!account_address)
+      continue;
+    auto network = FilAddress::FromAddress(*account_address).network();
+    if (network == mojom::kFilecoinMainnet) {
+      f_list.Append(account.Clone());
+    } else {
+      t_list.Append(account.Clone());
+    }
+  }
+  keyring_pref->RemovePath(kImportedAccounts);
+  base::Value new_imported_accounts(base::Value::Type::DICTIONARY);
+  new_imported_accounts.SetKey(mojom::kFilecoinMainnet, std::move(f_list));
+  new_imported_accounts.SetKey(mojom::kFilecoinTestnet, std::move(t_list));
+  keyring_pref->SetKey(kImportedAccounts, std::move(new_imported_accounts));
 }
 
 // static
@@ -379,6 +484,36 @@ std::vector<std::string> KeyringService::GetAvailableKeyringsFromPrefs(
     keyrings.push_back(it.first);
   }
   return keyrings;
+}
+
+// static
+const base::Value* KeyringService::GetImportedAccountsPrefForKeyring(
+    PrefService* prefs,
+    const std::string& id) {
+  const base::Value* imported_accounts =
+      GetPrefForKeyring(prefs, kImportedAccounts, id);
+  if (!imported_accounts)
+    return nullptr;
+  if (id == mojom::kFilecoinKeyringId) {
+    auto prefix = GetCurrentFilecoinNetworkPrefix(prefs);
+    return imported_accounts->FindKey(prefix);
+  }
+  return imported_accounts;
+}
+
+// static
+const base::Value* KeyringService::GetHardwareAccountsPrefForKeyring(
+    PrefService* prefs,
+    const std::string& id) {
+  const base::Value* hardware_accounts =
+      GetPrefForKeyring(prefs, kHardwareAccounts, id);
+  if (!hardware_accounts)
+    return nullptr;
+  if (id == mojom::kFilecoinKeyringId) {
+    auto prefix = GetCurrentFilecoinNetworkPrefix(prefs);
+    return hardware_accounts->FindKey(prefix);
+  }
+  return hardware_accounts;
 }
 
 // static
@@ -414,6 +549,43 @@ base::Value* KeyringService::GetPrefForKeyringUpdate(PrefService* prefs,
     pref =
         keyring_dict->SetKey(key, base::Value(base::Value::Type::DICTIONARY));
   return pref;
+}
+
+// static
+base::Value* KeyringService::GetHardwareAccountsPrefForKeyringUpdate(
+    PrefService* prefs,
+    const std::string& id) {
+  base::Value* hardware_accounts =
+      GetPrefForKeyringUpdate(prefs, kHardwareAccounts, id);
+  if (!hardware_accounts) {
+    hardware_accounts = hardware_accounts->SetKey(
+        kHardwareAccounts, base::Value(base::Value::Type::DICTIONARY));
+  }
+  if (id == mojom::kFilecoinKeyringId) {
+    std::string prefix = GetCurrentFilecoinNetworkPrefix(prefs);
+    if (!hardware_accounts->FindKey(prefix))
+      return hardware_accounts->SetKey(
+          prefix, base::Value(base::Value::Type::DICTIONARY));
+    return hardware_accounts->FindKey(prefix);
+  }
+  return hardware_accounts;
+}
+
+// static
+void KeyringService::SetImportedAccountsPrefForKeyring(PrefService* prefs,
+                                                       base::Value value,
+                                                       const std::string& id) {
+  if (id == mojom::kFilecoinKeyringId) {
+    base::Value* imported_accounts =
+        GetPrefForKeyringUpdate(prefs, kImportedAccounts, id);
+    if (!imported_accounts)
+      return;
+
+    std::string prefix = GetCurrentFilecoinNetworkPrefix(prefs);
+    imported_accounts->SetKey(prefix, std::move(value));
+    return;
+  }
+  SetPrefForKeyring(prefs, kImportedAccounts, std::move(value), id);
 }
 
 // static
@@ -539,12 +711,12 @@ void KeyringService::SetImportedAccountForKeyring(
   imported_account.SetIntKey(kCoinType, static_cast<int>(info.coin));
 
   base::Value imported_accounts(base::Value::Type::LIST);
-  const base::Value* value = GetPrefForKeyring(prefs, kImportedAccounts, id);
+  const base::Value* value = GetImportedAccountsPrefForKeyring(prefs, id);
+
   if (value)
     imported_accounts = value->Clone();
   imported_accounts.Append(std::move(imported_account));
-
-  SetPrefForKeyring(prefs, kImportedAccounts, std::move(imported_accounts), id);
+  SetImportedAccountsPrefForKeyring(prefs, std::move(imported_accounts), id);
 }
 
 // static
@@ -553,7 +725,7 @@ KeyringService::GetImportedAccountsForKeyring(PrefService* prefs,
                                               const std::string& id) {
   std::vector<ImportedAccountInfo> result;
   const base::Value* imported_accounts =
-      GetPrefForKeyring(prefs, kImportedAccounts, id);
+      GetImportedAccountsPrefForKeyring(prefs, id);
   if (!imported_accounts)
     return result;
   for (const auto& imported_account : imported_accounts->GetList()) {
@@ -583,7 +755,7 @@ void KeyringService::RemoveImportedAccountForKeyring(PrefService* prefs,
                                                      const std::string& address,
                                                      const std::string& id) {
   base::Value imported_accounts(base::Value::Type::LIST);
-  const base::Value* value = GetPrefForKeyring(prefs, kImportedAccounts, id);
+  const base::Value* value = GetImportedAccountsPrefForKeyring(prefs, id);
   if (!value)
     return;
   imported_accounts = value->Clone();
@@ -597,7 +769,7 @@ void KeyringService::RemoveImportedAccountForKeyring(PrefService* prefs,
     }
   }
 
-  SetPrefForKeyring(prefs, kImportedAccounts, std::move(imported_accounts), id);
+  SetImportedAccountsPrefForKeyring(prefs, std::move(imported_accounts), id);
 }
 
 HDKeyring* KeyringService::CreateKeyring(const std::string& keyring_id,
@@ -1266,13 +1438,11 @@ std::vector<mojom::AccountInfoPtr> KeyringService::GetAccountInfosForKeyring(
 std::vector<mojom::AccountInfoPtr> KeyringService::GetHardwareAccountsSync(
     const std::string& keyring_id) const {
   std::vector<mojom::AccountInfoPtr> accounts;
-  base::Value hardware_keyrings(base::Value::Type::DICTIONARY);
   const base::Value* value =
-      GetPrefForKeyringUpdate(prefs_, kHardwareAccounts, keyring_id);
+      GetHardwareAccountsPrefForKeyring(prefs_, keyring_id);
   if (!value) {
     return {};
   }
-
   for (const auto hw_keyring : value->DictItems()) {
     std::string device_id = hw_keyring.first;
     const base::Value* account_value = hw_keyring.second.FindKey(kAccountMetas);
@@ -1304,7 +1474,7 @@ void KeyringService::AddHardwareAccounts(
     auto keyring_id = GetKeyringIdForCoin(info->coin);
 
     base::Value* hardware_keyrings =
-        GetPrefForKeyringUpdate(prefs_, kHardwareAccounts, keyring_id);
+        GetHardwareAccountsPrefForKeyringUpdate(prefs_, keyring_id);
     base::Value* device_value = hardware_keyrings->FindKey(device_id);
     if (!device_value) {
       device_value = hardware_keyrings->SetKey(
@@ -1327,7 +1497,7 @@ void KeyringService::RemoveHardwareAccount(const std::string& address,
                                            mojom::CoinType coin) {
   auto keyring_id = GetKeyringIdForCoin(coin);
   base::Value* hardware_keyrings =
-      GetPrefForKeyringUpdate(prefs_, kHardwareAccounts, keyring_id);
+      GetHardwareAccountsPrefForKeyringUpdate(prefs_, keyring_id);
   for (auto devices : hardware_keyrings->DictItems()) {
     base::Value* account_metas = devices.second.FindKey(kAccountMetas);
     if (!account_metas)
@@ -1791,7 +1961,7 @@ bool KeyringService::UpdateNameForHardwareAccountSync(
     mojom::CoinType coin) {
   auto keyring_id = GetKeyringIdForCoin(coin);
   base::Value* hardware_keyrings =
-      GetPrefForKeyringUpdate(prefs_, kHardwareAccounts, keyring_id);
+      GetHardwareAccountsPrefForKeyringUpdate(prefs_, keyring_id);
   for (auto devices : hardware_keyrings->DictItems()) {
     base::Value* account_metas = devices.second.FindKey(kAccountMetas);
     if (!account_metas)
@@ -1833,7 +2003,7 @@ void KeyringService::SetKeyringImportedAccountName(
 
   base::Value imported_accounts(base::Value::Type::LIST);
   const base::Value* value =
-      GetPrefForKeyring(prefs_, kImportedAccounts, keyring_id);
+      GetImportedAccountsPrefForKeyring(prefs_, keyring_id);
   if (!value) {
     std::move(callback).Run(false);
     return;
@@ -1848,8 +2018,8 @@ void KeyringService::SetKeyringImportedAccountName(
         imported_accounts_list[i].FindStringKey(kAccountAddress);
     if (account_address && *account_address == address) {
       imported_accounts_list[i].SetStringKey(kAccountName, name);
-      SetPrefForKeyring(prefs_, kImportedAccounts, std::move(imported_accounts),
-                        keyring_id);
+      SetImportedAccountsPrefForKeyring(prefs_, std::move(imported_accounts),
+                                        keyring_id);
       NotifyAccountsChanged();
       name_updated = true;
       break;

--- a/components/brave_wallet/browser/keyring_service.h
+++ b/components/brave_wallet/browser/keyring_service.h
@@ -56,6 +56,13 @@ class KeyringService : public KeyedService, public mojom::KeyringService {
   static const base::Value* GetPrefForKeyring(PrefService* prefs,
                                               const std::string& key,
                                               const std::string& id);
+  static const base::Value* GetImportedAccountsPrefForKeyring(
+      PrefService* prefs,
+      const std::string& id);
+  static void SetImportedAccountsPrefForKeyring(PrefService* prefs,
+                                                base::Value value,
+                                                const std::string& id);
+
   static base::Value* GetPrefForKeyringUpdate(PrefService* prefs,
                                               const std::string& key,
                                               const std::string& id);
@@ -107,10 +114,18 @@ class KeyringService : public KeyedService, public mojom::KeyringService {
   static std::vector<ImportedAccountInfo> GetImportedAccountsForKeyring(
       PrefService* prefs,
       const std::string& id);
+  static const base::Value* GetHardwareAccountsPrefForKeyring(
+      PrefService* prefs,
+      const std::string& id);
   static void RemoveImportedAccountForKeyring(PrefService* prefs,
                                               const std::string& address,
                                               const std::string& id);
+  static base::Value* GetHardwareAccountsPrefForKeyringUpdate(
+      PrefService* prefs,
+      const std::string& id);
 
+  static void MigrateObosoleteFilecoinImportedPrefs(base::Value* keyring_pref);
+  static void MigrateObosoleteFilecoinHardwarePrefs(base::Value* keyring_pref);
   mojo::PendingRemote<mojom::KeyringService> MakeRemote();
   void Bind(mojo::PendingReceiver<mojom::KeyringService> receiver);
 

--- a/components/brave_wallet_ui/common/hardware/types.ts
+++ b/components/brave_wallet_ui/common/hardware/types.ts
@@ -61,13 +61,5 @@ export type GetAccountsHardwareOperationResult = HardwareOperationResult & {
   payload?: BraveWallet.HardwareWalletAccount[]
 }
 
-// Did not create a string for these yet since it is
-// likely these names will be returned from another service
-// that will be localized.
-export const FilecoinNetworkLocaleMapping = {
-  [BraveWallet.FILECOIN_MAINNET]: 'Filecoin Mainnet',
-  [BraveWallet.FILECOIN_TESTNET]: 'Filecoin Testnet'
-}
-
 // Batch size of accounts imported from the device in one step.
 export const DerivationBatchSize = 4

--- a/components/brave_wallet_ui/components/desktop/popup-modals/add-account-modal/add-imported-account-modal.tsx
+++ b/components/brave_wallet_ui/components/desktop/popup-modals/add-account-modal/add-imported-account-modal.tsx
@@ -16,7 +16,7 @@ import { CreateAccountOptions } from '../../../../options/create-account-options
 
 // types
 import { BraveWallet, CreateAccountOptionsType, PageState, WalletRoutes, WalletState } from '../../../../constants/types'
-import { FilecoinNetworkTypes, FilecoinNetworkLocaleMapping, FilecoinNetwork } from '../../../../common/hardware/types'
+import { FilecoinNetwork } from '../../../../common/hardware/types'
 
 // actions
 import { WalletPageActions } from '../../../../page/actions'
@@ -74,8 +74,12 @@ export const ImportAccountModal = () => {
   }, [accountTypeName, isFilecoinEnabled, isSolanaEnabled])
 
   // state
+  const selectedFilecoinNetwork = useSelector(({ wallet }: { wallet: WalletState }) => {
+    return wallet.defaultNetworks.find((network) => { return network.coin === BraveWallet.CoinType.FIL })
+})
   const [accountName, setAccountName] = React.useState<string>('')
-  const [filecoinNetwork, setFilecoinNetwork] = React.useState<FilecoinNetwork>('f')
+  const networkSymbol = selectedFilecoinNetwork?.chainId === BraveWallet.FILECOIN_MAINNET ? BraveWallet.FILECOIN_MAINNET : BraveWallet.FILECOIN_TESTNET
+  const [filecoinNetwork] = React.useState<FilecoinNetwork>(networkSymbol)
   const [importOption, setImportOption] = React.useState<string>('key')
   const [privateKey, setPrivateKey] = React.useState<string>('')
   const [file, setFile] = React.useState<HTMLInputElement['files']>()
@@ -111,10 +115,6 @@ export const ImportAccountModal = () => {
     setAccountName(event.target.value)
     setImportError(false)
   }, [setImportError])
-
-  const onChangeFilecoinNetwork = React.useCallback((network: FilecoinNetwork) => {
-    setFilecoinNetwork(network)
-  }, [])
 
   const handlePrivateKeyChanged = React.useCallback((event: React.ChangeEvent<HTMLInputElement>) => {
     setPrivateKey(event.target.value)
@@ -207,23 +207,6 @@ export const ImportAccountModal = () => {
           <ImportDisclaimer>
             <DisclaimerText>{getLocale('braveWalletImportAccountDisclaimer')}</DisclaimerText>
           </ImportDisclaimer>
-
-          {selectedAccountType?.coin === BraveWallet.CoinType.FIL &&
-            <>
-              <SelectWrapper>
-                <Select value={filecoinNetwork} onChange={onChangeFilecoinNetwork}>
-                  {FilecoinNetworkTypes.map((network, index) => {
-                    const networkLocale = FilecoinNetworkLocaleMapping[network]
-                    return (
-                      <div data-value={network} key={index}>
-                        {networkLocale}
-                      </div>
-                    )
-                  })}
-                </Select>
-              </SelectWrapper>
-            </>
-          }
 
           {selectedAccountType?.coin === BraveWallet.CoinType.ETH &&
             <SelectWrapper>

--- a/components/brave_wallet_ui/components/desktop/popup-modals/add-account-modal/add-imported-account-modal.tsx
+++ b/components/brave_wallet_ui/components/desktop/popup-modals/add-account-modal/add-imported-account-modal.tsx
@@ -16,7 +16,6 @@ import { CreateAccountOptions } from '../../../../options/create-account-options
 
 // types
 import { BraveWallet, CreateAccountOptionsType, PageState, WalletRoutes, WalletState } from '../../../../constants/types'
-import { FilecoinNetwork } from '../../../../common/hardware/types'
 
 // actions
 import { WalletPageActions } from '../../../../page/actions'
@@ -78,8 +77,7 @@ export const ImportAccountModal = () => {
     return wallet.defaultNetworks.find((network) => { return network.coin === BraveWallet.CoinType.FIL })
 })
   const [accountName, setAccountName] = React.useState<string>('')
-  const networkSymbol = selectedFilecoinNetwork?.chainId === BraveWallet.FILECOIN_MAINNET ? BraveWallet.FILECOIN_MAINNET : BraveWallet.FILECOIN_TESTNET
-  const [filecoinNetwork] = React.useState<FilecoinNetwork>(networkSymbol)
+  const networkSymbol = selectedFilecoinNetwork?.chainId.toLowerCase() === BraveWallet.FILECOIN_MAINNET.toLowerCase() ? BraveWallet.FILECOIN_MAINNET : BraveWallet.FILECOIN_TESTNET
   const [importOption, setImportOption] = React.useState<string>('key')
   const [privateKey, setPrivateKey] = React.useState<string>('')
   const [file, setFile] = React.useState<HTMLInputElement['files']>()
@@ -141,7 +139,7 @@ export const ImportAccountModal = () => {
   const onClickCreateAccount = React.useCallback(() => {
     if (importOption === 'key') {
       if (selectedAccountType?.coin === BraveWallet.CoinType.FIL) {
-        importFilecoinAccount(accountName, privateKey, filecoinNetwork)
+        importFilecoinAccount(accountName, privateKey, networkSymbol)
       } else {
         importAccount(accountName, privateKey, selectedAccountType?.coin || BraveWallet.CoinType.ETH)
       }

--- a/components/brave_wallet_ui/components/desktop/popup-modals/add-account-modal/hardware-wallet-connect/accounts-list.tsx
+++ b/components/brave_wallet_ui/components/desktop/popup-modals/add-account-modal/hardware-wallet-connect/accounts-list.tsx
@@ -20,9 +20,7 @@ import {
   HardwareWalletDerivationPathsMapping
 } from './types'
 import {
-  FilecoinNetwork,
-  FilecoinNetworkTypes,
-  FilecoinNetworkLocaleMapping
+  FilecoinNetwork
 } from '../../../../../common/hardware/types'
 import { BraveWallet, WalletAccountType, CreateAccountOptionsType } from '../../../../../constants/types'
 import { getLocale } from '../../../../../../common/locale'
@@ -47,7 +45,6 @@ interface Props {
   onAddAccounts: () => void
   getBalance: (address: string, coin: BraveWallet.CoinType) => Promise<string>
   filecoinNetwork: FilecoinNetwork
-  onChangeFilecoinNetwork: (network: FilecoinNetwork) => void
   selectedAccountType: CreateAccountOptionsType
 }
 
@@ -64,8 +61,6 @@ export default function (props: Props) {
     onLoadMore,
     onAddAccounts,
     getBalance,
-    filecoinNetwork,
-    onChangeFilecoinNetwork,
     selectedAccountType
   } = props
   const [filteredAccountList, setFilteredAccountList] = React.useState<BraveWallet.HardwareWalletAccount[]>([])
@@ -115,7 +110,7 @@ export default function (props: Props) {
     <>
       <SelectRow>
         <SelectWrapper>
-          {selectedAccountType.coin !== BraveWallet.CoinType.FIL ? (
+          {selectedAccountType.coin !== BraveWallet.CoinType.FIL && (
             <Select value={selectedDerivationScheme} onChange={setSelectedDerivationScheme}>
               {Object.keys(derivationPathsEnum).map((path, index) => {
                 const pathValue = derivationPathsEnum[path]
@@ -123,17 +118,6 @@ export default function (props: Props) {
                 return (
                   <div data-value={pathValue} key={index}>
                     {pathLocale}
-                  </div>
-                )
-              })}
-            </Select>
-          ) : (
-            <Select value={filecoinNetwork} onChange={onChangeFilecoinNetwork}>
-              {FilecoinNetworkTypes.map((network, index) => {
-                const networkLocale = FilecoinNetworkLocaleMapping[network]
-                return (
-                  <div data-value={network} key={index}>
-                    {networkLocale}
                   </div>
                 )
               })}

--- a/components/brave_wallet_ui/components/desktop/popup-modals/add-account-modal/hardware-wallet-connect/index.tsx
+++ b/components/brave_wallet_ui/components/desktop/popup-modals/add-account-modal/hardware-wallet-connect/index.tsx
@@ -84,7 +84,7 @@ export const HardwareWalletConnect = ({ onSuccess, selectedAccountType }: Props)
   )
 
   const [showAccountsList, setShowAccountsList] = React.useState<boolean>(false)
-  const filecoinNetwork = selectedFilecoinNetwork?.chainId === BraveWallet.FILECOIN_MAINNET ? BraveWallet.FILECOIN_MAINNET : BraveWallet.FILECOIN_TESTNET
+  const filecoinNetwork = selectedFilecoinNetwork?.chainId.toLowerCase() === BraveWallet.FILECOIN_MAINNET.toLowerCase() ? BraveWallet.FILECOIN_MAINNET : BraveWallet.FILECOIN_TESTNET
 
   // methods
   const onAddHardwareAccounts = React.useCallback((selected: BraveWallet.HardwareWalletAccount[]) => {

--- a/components/brave_wallet_ui/components/desktop/popup-modals/add-account-modal/hardware-wallet-connect/index.tsx
+++ b/components/brave_wallet_ui/components/desktop/popup-modals/add-account-modal/hardware-wallet-connect/index.tsx
@@ -32,7 +32,7 @@ import {
 
 // Custom types
 import { ErrorMessage, HardwareWalletDerivationPathsMapping } from './types'
-import { HardwareDerivationScheme, LedgerDerivationPaths, FilecoinNetwork, DerivationBatchSize } from '../../../../../common/hardware/types'
+import { HardwareDerivationScheme, LedgerDerivationPaths, DerivationBatchSize } from '../../../../../common/hardware/types'
 import { HardwareVendor } from '../../../../../common/api/hardware_keyrings'
 import { WalletPageActions } from '../../../../../page/actions'
 import { BraveWallet, CreateAccountOptionsType, WalletState } from '../../../../../constants/types'
@@ -68,6 +68,9 @@ export const HardwareWalletConnect = ({ onSuccess, selectedAccountType }: Props)
   // redux
   const dispatch = useDispatch()
   const selectedNetwork = useSelector(({ wallet }: { wallet: WalletState }) => wallet.selectedNetwork)
+  const selectedFilecoinNetwork = useSelector(({ wallet }: { wallet: WalletState }) => {
+    return wallet.defaultNetworks.find((network) => { return network.coin === BraveWallet.CoinType.FIL })
+})
   const savedAccounts = useSelector(({ wallet }: { wallet: WalletState }) => wallet.accounts)
 
   // state
@@ -79,28 +82,11 @@ export const HardwareWalletConnect = ({ onSuccess, selectedAccountType }: Props)
   const [selectedDerivationScheme, setSelectedDerivationScheme] = React.useState<HardwareDerivationScheme>(
     LedgerDerivationPaths.LedgerLive
   )
+
   const [showAccountsList, setShowAccountsList] = React.useState<boolean>(false)
-  const [filecoinNetwork, setFilecoinNetwork] = React.useState<FilecoinNetwork>('f')
+  const filecoinNetwork = selectedFilecoinNetwork?.chainId === BraveWallet.FILECOIN_MAINNET ? BraveWallet.FILECOIN_MAINNET : BraveWallet.FILECOIN_TESTNET
 
   // methods
-  const onFilecoinNetworkChanged = React.useCallback((network: FilecoinNetwork) => {
-    setFilecoinNetwork(network)
-    onConnectHardwareWallet({
-      hardware: BraveWallet.LEDGER_HARDWARE_VENDOR,
-      startIndex: 0,
-      stopIndex: DerivationBatchSize,
-      network: network,
-      coin: BraveWallet.CoinType.FIL
-    }).then((result) => {
-      setAccounts(result)
-    }).catch((error) => {
-      setConnectionError(getErrorMessage(error, selectedAccountType.name))
-      setShowAccountsList(false)
-    }).finally(
-      () => setIsConnecting(false)
-    )
-  }, [onConnectHardwareWallet, selectedAccountType])
-
   const onAddHardwareAccounts = React.useCallback((selected: BraveWallet.HardwareWalletAccount[]) => {
     dispatch(WalletPageActions.addHardwareAccounts(selected))
     onSuccess()
@@ -215,7 +201,6 @@ export const HardwareWalletConnect = ({ onSuccess, selectedAccountType }: Props)
         getBalance={getBalance}
         selectedNetwork={selectedNetwork}
         filecoinNetwork={filecoinNetwork}
-        onChangeFilecoinNetwork={onFilecoinNetworkChanged}
         selectedAccountType={selectedAccountType}
       />
     )


### PR DESCRIPTION
<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/23078

Previously we separated Mainnet and Testnet Filecoin accounts to be filtered by currently used network. Here we are separating imported accounts same way.

- Removed network selectors when importing Filecoin accounts
- Saving imported accounts for Filecoin under network layer same as usual accounts.
- Added migration for old imported accounts to new locations

https://user-images.githubusercontent.com/2965009/171609412-67b77cd7-2be3-4aa3-b653-fbc6b834deaa.mp4

<img width="629" alt="image" src="https://user-images.githubusercontent.com/2965009/171609035-20868530-c0db-417b-bada-5225a8f62e67.png">

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

- Select Mainnet and import FIlecoin accounts both ways: from `lotus wallet export` and from hardware device
- Should be imported f-addresses only
- Do same for Testnet/Localhost nets, should be imported t-addresses only
- When switching networks addresses which are not related to the selected network should disappear.
 