### PR TITLE
Enable P2A json reporting

### DIFF
--- a/components/p3a/brave_p3a_new_uploader.cc
+++ b/components/p3a/brave_p3a_new_uploader.cc
@@ -85,8 +85,6 @@ void BraveP3ANewUploader::UploadLog(const std::string& compressed_log_data,
   if (upload_type == "p2a") {
     resource_request->url = p2a_endpoint_;
     resource_request->headers.SetHeader("X-Brave-P2A", "?1");
-    // TODO(issues/20478): Re-enable once backend is ready.
-    return;
   } else if (upload_type == "p3a") {
     resource_request->url = p3a_endpoint_;
     resource_request->headers.SetHeader("X-Brave-P3A", "?1");

--- a/components/p3a/brave_p3a_service.cc
+++ b/components/p3a/brave_p3a_service.cc
@@ -167,20 +167,20 @@ void BraveP3AService::Init(
   }
 
   // Init other components.
-  uploader_.reset(new BraveP3AUploader(
+  uploader_ = std::make_unique<BraveP3AUploader>(
       url_loader_factory, upload_server_url_, GURL(kP2AServerUrl),
-      base::BindRepeating(&BraveP3AService::OnLogUploadComplete, this)));
+      base::BindRepeating(&BraveP3AService::OnLogUploadComplete, this));
 
-  new_uploader_.reset(new BraveP3ANewUploader(
-      url_loader_factory, GURL(kP3AJsonServerUrl), GURL(kP2AJsonServerUrl)));
+  new_uploader_ = std::make_unique<BraveP3ANewUploader>(
+      url_loader_factory, GURL(kP3AJsonServerUrl), GURL(kP2AJsonServerUrl));
 
-  upload_scheduler_.reset(new BraveP3AScheduler(
+  upload_scheduler_ = std::make_unique<BraveP3AScheduler>(
       base::BindRepeating(&BraveP3AService::StartScheduledUpload, this),
       (randomize_upload_interval_
            ? base::BindRepeating(GetRandomizedUploadInterval,
                                  average_upload_interval_)
            : base::BindRepeating([](base::TimeDelta x) { return x; },
-                                 average_upload_interval_))));
+                                 average_upload_interval_)));
 
   upload_scheduler_->Start();
   if (!rotation_timer_.IsRunning()) {


### PR DESCRIPTION
Now that the https://p2a-json.brave.com/ endpoint is available, start sending P2A reports to it.

We continue to send protobuf-encoded reports to the old endpoint in parallel. That can be dropped in https://github.com/brave/brave-browser/issues/23146.

<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves brave/brave-browser#22079

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

- Start browser with a network proxy for traffic inspection
- Enable rewards
- Open new tabs, or otherwise interact with the browser until several ads have been shown.
- Confirm at least one `Brave.P2A.*` key appears in brave://local-state
- If this is a fresh profile, wait 10-20 minutes for measurements to be sent. If it's a recently-used profile, it may be necessary to set the clock ahead by a week to trigger sending reports.
- Confirm `Brave.P2A.*` reports are sent to the p2a-json.brave.com address, in json format, as well as to the original p2a.brave.com address in binary form.