### PR TITLE
Brave search omnibox & default engine promo P3A

### DIFF
--- a/browser/brave_local_state_prefs.cc
+++ b/browser/brave_local_state_prefs.cc
@@ -11,6 +11,7 @@
 #include "brave/browser/metrics/metrics_reporting_util.h"
 #include "brave/browser/themes/brave_dark_mode_utils.h"
 #include "brave/components/brave_referrals/buildflags/buildflags.h"
+#include "brave/components/brave_search_conversion/p3a.h"
 #include "brave/components/brave_shields/browser/ad_block_service.h"
 #include "brave/components/brave_shields/browser/brave_shields_p3a.h"
 #include "brave/components/constants/pref_names.h"
@@ -107,6 +108,8 @@ void RegisterLocalStatePrefs(PrefRegistrySimple* registry) {
   decentralized_dns::RegisterLocalStatePrefs(registry);
 
   RegisterLocalStatePrefsForMigration(registry);
+
+  brave_search_conversion::p3a::RegisterLocalStatePrefs(registry);
 }
 
 }  // namespace brave

--- a/browser/search_engines/search_engine_tracker.h
+++ b/browser/search_engines/search_engine_tracker.h
@@ -77,7 +77,8 @@ class SearchEngineTracker : public KeyedService,
                             public TemplateURLServiceObserver {
  public:
   SearchEngineTracker(TemplateURLService* template_url_service,
-                      PrefService* user_prefs);
+                      PrefService* profile_prefs,
+                      PrefService* local_state);
   ~SearchEngineTracker() override;
 
   SearchEngineTracker(const SearchEngineTracker&) = delete;
@@ -96,6 +97,8 @@ class SearchEngineTracker : public KeyedService,
   GURL default_search_url_;
   GURL previous_search_url_;
   WeeklyEventStorage switch_record_;
+
+  raw_ptr<PrefService> local_state_;
 
   raw_ptr<TemplateURLService> template_url_service_ = nullptr;
 };

--- a/browser/ui/omnibox/brave_omnibox_client_impl.cc
+++ b/browser/ui/omnibox/brave_omnibox_client_impl.cc
@@ -99,23 +99,12 @@ void BraveOmniboxClientImpl::OnInputAccepted(const AutocompleteMatch& match) {
   }
 }
 
-void BraveOmniboxClientImpl::OnTextChanged(
-    const AutocompleteMatch& current_match,
-    bool user_input_in_progress,
-    const std::u16string& user_text,
-    const AutocompleteResult& result,
-    bool has_focus) {
-  // Cache current input for checking whether current match is search promotion
-  // match or not when current input is accepted.
-  user_text_ = user_text;
-}
-
 void BraveOmniboxClientImpl::OnURLOpenedFromOmnibox(OmniboxLog* log) {
-  if (log->selected_index > 0 &&
-      IsBraveSearchPromotionMatch(log->result.match_at(log->selected_index),
-                                  user_text_)) {
+  if (log->selected_index <= 0)
+    return;
+  const auto match = log->result.match_at(log->selected_index);
+  if (IsBraveSearchPromotionMatch(match)) {
     brave_search_conversion::p3a::RecordOmniboxPromoTrigger(
-        g_browser_process->local_state(),
-        brave_search_conversion::GetConversionType());
+        g_browser_process->local_state(), GetConversionTypeFromMatch(match));
   }
 }

--- a/browser/ui/omnibox/brave_omnibox_client_impl.h
+++ b/browser/ui/omnibox/brave_omnibox_client_impl.h
@@ -34,6 +34,7 @@ class BraveOmniboxClientImpl : public ChromeOmniboxClient {
                      const std::u16string& user_text,
                      const AutocompleteResult& result,
                      bool has_focus) override;
+  void OnURLOpenedFromOmnibox(OmniboxLog* log) override;
 
  private:
   std::u16string user_text_;

--- a/browser/ui/omnibox/brave_omnibox_client_impl.h
+++ b/browser/ui/omnibox/brave_omnibox_client_impl.h
@@ -6,8 +6,6 @@
 #ifndef BRAVE_BROWSER_UI_OMNIBOX_BRAVE_OMNIBOX_CLIENT_IMPL_H_
 #define BRAVE_BROWSER_UI_OMNIBOX_BRAVE_OMNIBOX_CLIENT_IMPL_H_
 
-#include <string>
-
 #include "base/memory/raw_ptr.h"
 #include "brave/browser/autocomplete/brave_autocomplete_scheme_classifier.h"
 #include "chrome/browser/ui/omnibox/chrome_omnibox_client.h"
@@ -29,15 +27,9 @@ class BraveOmniboxClientImpl : public ChromeOmniboxClient {
   bool IsAutocompleteEnabled() const override;
 
   void OnInputAccepted(const AutocompleteMatch& match) override;
-  void OnTextChanged(const AutocompleteMatch& current_match,
-                     bool user_input_in_progress,
-                     const std::u16string& user_text,
-                     const AutocompleteResult& result,
-                     bool has_focus) override;
   void OnURLOpenedFromOmnibox(OmniboxLog* log) override;
 
  private:
-  std::u16string user_text_;
   raw_ptr<Profile> profile_ = nullptr;
   BraveAutocompleteSchemeClassifier scheme_classifier_;
 };

--- a/browser/ui/omnibox/brave_omnibox_client_impl.h
+++ b/browser/ui/omnibox/brave_omnibox_client_impl.h
@@ -6,6 +6,8 @@
 #ifndef BRAVE_BROWSER_UI_OMNIBOX_BRAVE_OMNIBOX_CLIENT_IMPL_H_
 #define BRAVE_BROWSER_UI_OMNIBOX_BRAVE_OMNIBOX_CLIENT_IMPL_H_
 
+#include <string>
+
 #include "base/memory/raw_ptr.h"
 #include "brave/browser/autocomplete/brave_autocomplete_scheme_classifier.h"
 #include "chrome/browser/ui/omnibox/chrome_omnibox_client.h"
@@ -27,8 +29,14 @@ class BraveOmniboxClientImpl : public ChromeOmniboxClient {
   bool IsAutocompleteEnabled() const override;
 
   void OnInputAccepted(const AutocompleteMatch& match) override;
+  void OnTextChanged(const AutocompleteMatch& current_match,
+                     bool user_input_in_progress,
+                     const std::u16string& user_text,
+                     const AutocompleteResult& result,
+                     bool has_focus) override;
 
  private:
+  std::u16string user_text_;
   raw_ptr<Profile> profile_ = nullptr;
   BraveAutocompleteSchemeClassifier scheme_classifier_;
 };

--- a/browser/ui/views/omnibox/brave_omnibox_result_view.cc
+++ b/browser/ui/views/omnibox/brave_omnibox_result_view.cc
@@ -12,6 +12,7 @@
 #include "brave/components/brave_search_conversion/types.h"
 #include "brave/components/brave_search_conversion/utils.h"
 #include "brave/components/omnibox/browser/promotion_utils.h"
+#include "chrome/browser/browser_process.h"
 #include "chrome/browser/ui/views/omnibox/omnibox_popup_contents_view.h"
 #include "chrome/browser/ui/views/omnibox/omnibox_suggestion_button_row_view.h"
 #include "components/omnibox/browser/autocomplete_controller.h"
@@ -89,8 +90,9 @@ void BraveOmniboxResultView::UpdateForBraveSearchConversion() {
   button_row_->SetVisible(false);
 
   if (!brave_search_promotion_view_) {
-    brave_search_promotion_view_ = AddChildView(
-        std::make_unique<BraveSearchConversionPromotionView>(this));
+    brave_search_promotion_view_ =
+        AddChildView(std::make_unique<BraveSearchConversionPromotionView>(
+            this, g_browser_process->local_state()));
   }
 
   brave_search_promotion_view_->SetVisible(true);

--- a/browser/ui/views/omnibox/brave_search_conversion_promotion_view.cc
+++ b/browser/ui/views/omnibox/brave_search_conversion_promotion_view.cc
@@ -295,10 +295,6 @@ void BraveSearchConversionPromotionView::SetTypeAndInput(
 void BraveSearchConversionPromotionView::OnSelectionStateChanged(
     bool selected) {
   selected_ = selected;
-  if (selected) {
-    brave_search_conversion::p3a::RecordOmniboxPromoTrigger(local_state_,
-                                                            type_);
-  }
   UpdateState();
 }
 

--- a/browser/ui/views/omnibox/brave_search_conversion_promotion_view.cc
+++ b/browser/ui/views/omnibox/brave_search_conversion_promotion_view.cc
@@ -10,6 +10,7 @@
 #include "base/logging.h"
 #include "brave/browser/themes/theme_properties.h"
 #include "brave/browser/ui/views/omnibox/brave_omnibox_result_view.h"
+#include "brave/components/brave_search_conversion/p3a.h"
 #include "brave/components/l10n/common/locale_util.h"
 #include "brave/grit/brave_generated_resources.h"
 #include "brave/grit/brave_theme_resources.h"
@@ -17,6 +18,7 @@
 #include "chrome/browser/ui/layout_constants.h"
 #include "chrome/browser/ui/omnibox/omnibox_theme.h"
 #include "chrome/browser/ui/views/chrome_typography.h"
+#include "components/prefs/pref_service.h"
 #include "components/strings/grit/components_strings.h"
 #include "components/vector_icons/vector_icons.h"
 #include "third_party/skia/include/core/SkPath.h"
@@ -245,11 +247,13 @@ END_METADATA
 }  // namespace
 
 BraveSearchConversionPromotionView::BraveSearchConversionPromotionView(
-    BraveOmniboxResultView* result_view)
+    BraveOmniboxResultView* result_view,
+    PrefService* local_state)
     : result_view_(result_view),
       mouse_enter_exit_handler_(base::BindRepeating(
           &BraveSearchConversionPromotionView::UpdateHoverState,
-          base::Unretained(this))) {
+          base::Unretained(this))),
+      local_state_(local_state) {
   SetLayoutManager(std::make_unique<views::FlexLayout>());
   mouse_enter_exit_handler_.ObserveMouseEnterExitOn(this);
 }
@@ -284,11 +288,17 @@ void BraveSearchConversionPromotionView::SetTypeAndInput(
   }
 
   UpdateState();
+
+  brave_search_conversion::p3a::RecordOmniboxPromoShown(local_state_, type);
 }
 
 void BraveSearchConversionPromotionView::OnSelectionStateChanged(
     bool selected) {
   selected_ = selected;
+  if (selected) {
+    brave_search_conversion::p3a::RecordOmniboxPromoTrigger(local_state_,
+                                                            type_);
+  }
   UpdateState();
 }
 
@@ -301,6 +311,7 @@ void BraveSearchConversionPromotionView::UpdateState() {
 }
 
 void BraveSearchConversionPromotionView::OpenMatch() {
+  brave_search_conversion::p3a::RecordOmniboxPromoTrigger(local_state_, type_);
   result_view_->OpenMatch();
 }
 

--- a/browser/ui/views/omnibox/brave_search_conversion_promotion_view.h
+++ b/browser/ui/views/omnibox/brave_search_conversion_promotion_view.h
@@ -16,6 +16,7 @@
 #include "ui/views/view.h"
 
 class BraveOmniboxResultView;
+class PrefService;
 
 namespace views {
 class Background;
@@ -27,7 +28,8 @@ class BraveSearchConversionPromotionView : public views::View {
   METADATA_HEADER(BraveSearchConversionPromotionView);
 
   explicit BraveSearchConversionPromotionView(
-      BraveOmniboxResultView* result_view);
+      BraveOmniboxResultView* result_view,
+      PrefService* local_state);
   BraveSearchConversionPromotionView(
       const BraveSearchConversionPromotionView&) = delete;
   BraveSearchConversionPromotionView& operator=(
@@ -84,6 +86,8 @@ class BraveSearchConversionPromotionView : public views::View {
 
   // Keeps track of mouse-enter and mouse-exit events of child Views.
   OmniboxMouseEnterExitHandler mouse_enter_exit_handler_;
+
+  raw_ptr<PrefService> local_state_;
 };
 
 #endif  // BRAVE_BROWSER_UI_VIEWS_OMNIBOX_BRAVE_SEARCH_CONVERSION_PROMOTION_VIEW_H_

--- a/browser/ui/views/omnibox/brave_search_conversion_promotion_view.h
+++ b/browser/ui/views/omnibox/brave_search_conversion_promotion_view.h
@@ -27,9 +27,8 @@ class BraveSearchConversionPromotionView : public views::View {
  public:
   METADATA_HEADER(BraveSearchConversionPromotionView);
 
-  explicit BraveSearchConversionPromotionView(
-      BraveOmniboxResultView* result_view,
-      PrefService* local_state);
+  BraveSearchConversionPromotionView(BraveOmniboxResultView* result_view,
+                                     PrefService* local_state);
   BraveSearchConversionPromotionView(
       const BraveSearchConversionPromotionView&) = delete;
   BraveSearchConversionPromotionView& operator=(

--- a/components/brave_search_conversion/BUILD.gn
+++ b/components/brave_search_conversion/BUILD.gn
@@ -8,6 +8,8 @@ static_library("brave_search_conversion") {
     "constants.h",
     "features.cc",
     "features.h",
+    "p3a.cc",
+    "p3a.h",
     "pref_names.h",
     "types.h",
     "utils.cc",
@@ -28,7 +30,10 @@ static_library("brave_search_conversion") {
 source_set("unit_tests") {
   testonly = true
 
-  sources = [ "brave_search_conversion_unittest.cc" ]
+  sources = [
+    "brave_search_conversion_unittest.cc",
+    "p3a_unittest.cc",
+  ]
 
   deps = [
     ":brave_search_conversion",

--- a/components/brave_search_conversion/p3a.cc
+++ b/components/brave_search_conversion/p3a.cc
@@ -1,0 +1,130 @@
+// Copyright (c) 2022 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// you can obtain one at http://mozilla.org/MPL/2.0/.
+
+#include "brave/components/brave_search_conversion/p3a.h"
+
+#include "base/logging.h"
+#include "base/metrics/histogram_functions.h"
+#include "brave/components/brave_search_conversion/pref_names.h"
+#include "components/prefs/pref_registry_simple.h"
+#include "components/prefs/pref_service.h"
+
+namespace brave_search_conversion {
+namespace p3a {
+
+namespace {
+
+const char* GetOmniboxShownPrefName(ConversionType type) {
+  switch (type) {
+    case ConversionType::kBanner:
+      return prefs::kP3ABannerShown;
+    case ConversionType::kButton:
+      return prefs::kP3AButtonShown;
+    default:
+      return nullptr;
+  }
+}
+
+const char* GetOmniboxTriggeredPrefName(ConversionType type) {
+  switch (type) {
+    case ConversionType::kBanner:
+      return prefs::kP3ABannerTriggered;
+    case ConversionType::kButton:
+      return prefs::kP3AButtonTriggered;
+    default:
+      return nullptr;
+  }
+}
+
+const char* GetPromoTypeHistogramName(ConversionType type) {
+  switch (type) {
+    case ConversionType::kBanner:
+      return kSearchPromoBannerHistogramName;
+    case ConversionType::kButton:
+      return kSearchPromoButtonHistogramName;
+    default:
+      return nullptr;
+  }
+}
+
+void UpdateHistograms(PrefService* prefs) {
+  const ConversionType types[] = {ConversionType::kBanner,
+                                  ConversionType::kButton};
+  const bool default_engine_triggered =
+      prefs->GetBoolean(prefs::kP3ADefaultEngineChanged);
+  for (const auto type : types) {
+    const char* shown_pref_name = GetOmniboxShownPrefName(type);
+    const char* triggered_pref_name = GetOmniboxTriggeredPrefName(type);
+    const char* histogram_name = GetPromoTypeHistogramName(type);
+    DCHECK(shown_pref_name);
+    DCHECK(triggered_pref_name);
+    DCHECK(histogram_name);
+    if (!prefs->GetBoolean(shown_pref_name)) {
+      // Do not report to P3A if promo was never shown.
+      continue;
+    }
+    const bool promo_triggered = prefs->GetBoolean(triggered_pref_name);
+
+    // 0 = have not triggered promo, have not made Brave default via SERP
+    // 1 = have triggered promo, have not made Brave default via SERP
+    int answer = promo_triggered;
+
+    if (default_engine_triggered) {
+      // 2 = have not triggered promo, have made Brave default via SERP
+      // 3 = have triggered promo, have made Brave default via SERP
+      answer += 2;
+    }
+
+    base::UmaHistogramExactLinear(histogram_name, answer, 4);
+  }
+}
+
+}  // namespace
+
+void RegisterLocalStatePrefs(PrefRegistrySimple* registry) {
+  registry->RegisterBooleanPref(prefs::kP3AButtonShown, false);
+  registry->RegisterBooleanPref(prefs::kP3ABannerShown, false);
+  registry->RegisterBooleanPref(prefs::kP3ABannerTriggered, false);
+  registry->RegisterBooleanPref(prefs::kP3AButtonTriggered, false);
+  registry->RegisterBooleanPref(prefs::kP3ADefaultEngineChanged, false);
+}
+
+void RecordOmniboxPromoShown(PrefService* prefs, ConversionType type) {
+  const char* pref_name = GetOmniboxShownPrefName(type);
+  DCHECK(pref_name);
+
+  const bool prev_setting = prefs->GetBoolean(pref_name);
+  if (prev_setting) {
+    return;
+  }
+
+  VLOG(1) << "SearchConversionP3A: omnibox promo shown, pref = " << pref_name;
+  prefs->SetBoolean(pref_name, true);
+  UpdateHistograms(prefs);
+}
+
+void RecordOmniboxPromoTrigger(PrefService* prefs, ConversionType type) {
+  const char* pref_name = GetOmniboxTriggeredPrefName(type);
+  DCHECK(pref_name);
+
+  const bool prev_setting = prefs->GetBoolean(pref_name);
+  if (prev_setting) {
+    return;
+  }
+
+  VLOG(1) << "SearchConversionP3A: omnibox promo triggered, pref = "
+          << pref_name;
+  prefs->SetBoolean(pref_name, true);
+  UpdateHistograms(prefs);
+}
+
+void RecordDefaultEngineChange(PrefService* prefs) {
+  VLOG(1) << "SearchConversionP3A: default engine changed";
+  prefs->SetBoolean(prefs::kP3ADefaultEngineChanged, true);
+  UpdateHistograms(prefs);
+}
+
+}  // namespace p3a
+}  // namespace brave_search_conversion

--- a/components/brave_search_conversion/p3a.cc
+++ b/components/brave_search_conversion/p3a.cc
@@ -7,6 +7,7 @@
 
 #include "base/logging.h"
 #include "base/metrics/histogram_functions.h"
+#include "base/notreached.h"
 #include "brave/components/brave_search_conversion/pref_names.h"
 #include "components/prefs/pref_registry_simple.h"
 #include "components/prefs/pref_service.h"
@@ -23,6 +24,7 @@ const char* GetOmniboxShownPrefName(ConversionType type) {
     case ConversionType::kButton:
       return prefs::kP3AButtonShown;
     default:
+      NOTREACHED();
       return nullptr;
   }
 }
@@ -34,6 +36,7 @@ const char* GetOmniboxTriggeredPrefName(ConversionType type) {
     case ConversionType::kButton:
       return prefs::kP3AButtonTriggered;
     default:
+      NOTREACHED();
       return nullptr;
   }
 }
@@ -45,6 +48,7 @@ const char* GetPromoTypeHistogramName(ConversionType type) {
     case ConversionType::kButton:
       return kSearchPromoButtonHistogramName;
     default:
+      NOTREACHED();
       return nullptr;
   }
 }
@@ -52,6 +56,9 @@ const char* GetPromoTypeHistogramName(ConversionType type) {
 void UpdateHistograms(PrefService* prefs) {
   const ConversionType types[] = {ConversionType::kBanner,
                                   ConversionType::kButton};
+
+  VLOG(1) << "SearchConversionP3A: updating histograms";
+
   const bool default_engine_triggered =
       prefs->GetBoolean(prefs::kP3ADefaultEngineChanged);
   for (const auto type : types) {
@@ -95,12 +102,12 @@ void RecordOmniboxPromoShown(PrefService* prefs, ConversionType type) {
   const char* pref_name = GetOmniboxShownPrefName(type);
   DCHECK(pref_name);
 
+  VLOG(1) << "SearchConversionP3A: omnibox promo shown, pref = " << pref_name;
+
   const bool prev_setting = prefs->GetBoolean(pref_name);
   if (prev_setting) {
     return;
   }
-
-  VLOG(1) << "SearchConversionP3A: omnibox promo shown, pref = " << pref_name;
   prefs->SetBoolean(pref_name, true);
   UpdateHistograms(prefs);
 }
@@ -109,13 +116,13 @@ void RecordOmniboxPromoTrigger(PrefService* prefs, ConversionType type) {
   const char* pref_name = GetOmniboxTriggeredPrefName(type);
   DCHECK(pref_name);
 
+  VLOG(1) << "SearchConversionP3A: omnibox promo triggered, pref = "
+          << pref_name;
+
   const bool prev_setting = prefs->GetBoolean(pref_name);
   if (prev_setting) {
     return;
   }
-
-  VLOG(1) << "SearchConversionP3A: omnibox promo triggered, pref = "
-          << pref_name;
   prefs->SetBoolean(pref_name, true);
   UpdateHistograms(prefs);
 }

--- a/components/brave_search_conversion/p3a.h
+++ b/components/brave_search_conversion/p3a.h
@@ -1,0 +1,28 @@
+// Copyright (c) 2022 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// you can obtain one at http://mozilla.org/MPL/2.0/.
+
+#ifndef BRAVE_COMPONENTS_BRAVE_SEARCH_CONVERSION_P3A_H_
+#define BRAVE_COMPONENTS_BRAVE_SEARCH_CONVERSION_P3A_H_
+
+#include "brave/components/brave_search_conversion/types.h"
+
+class PrefRegistrySimple;
+class PrefService;
+
+namespace brave_search_conversion {
+namespace p3a {
+
+constexpr char kSearchPromoButtonHistogramName[] = "Brave.Search.Promo.Button";
+constexpr char kSearchPromoBannerHistogramName[] = "Brave.Search.Promo.Banner";
+
+void RegisterLocalStatePrefs(PrefRegistrySimple* registry);
+void RecordOmniboxPromoShown(PrefService* prefs, ConversionType type);
+void RecordOmniboxPromoTrigger(PrefService* prefs, ConversionType type);
+void RecordDefaultEngineChange(PrefService* prefs);
+
+}  // namespace p3a
+}  // namespace brave_search_conversion
+
+#endif  // BRAVE_COMPONENTS_BRAVE_SEARCH_CONVERSION_P3A_H_

--- a/components/brave_search_conversion/p3a_unittest.cc
+++ b/components/brave_search_conversion/p3a_unittest.cc
@@ -1,0 +1,103 @@
+// Copyright (c) 2022 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// you can obtain one at http://mozilla.org/MPL/2.0/.
+
+#include "brave/components/brave_search_conversion/p3a.h"
+
+#include "base/test/metrics/histogram_tester.h"
+#include "brave/components/brave_search_conversion/pref_names.h"
+#include "components/prefs/testing_pref_service.h"
+#include "testing/gtest/include/gtest/gtest.h"
+
+namespace brave_search_conversion {
+namespace p3a {
+
+struct ConversionTypeInfo {
+  ConversionType type;
+  const char* histogram_name;
+};
+
+const ConversionTypeInfo type_infos[] = {
+    {
+        .type = ConversionType::kBanner,
+        .histogram_name = kSearchPromoBannerHistogramName,
+    },
+    {
+        .type = ConversionType::kButton,
+        .histogram_name = kSearchPromoButtonHistogramName,
+    },
+};
+
+class BraveSearchConversionP3ATest : public testing::Test {
+ protected:
+  void SetUp() override {
+    PrefRegistrySimple* registry = pref_service_.registry();
+    RegisterLocalStatePrefs(registry);
+  }
+
+  PrefService* GetPrefs() { return &pref_service_; }
+
+  base::HistogramTester histogram_tester_;
+
+ private:
+  TestingPrefServiceSimple pref_service_;
+};
+
+TEST_F(BraveSearchConversionP3ATest, TestOmniboxTriggerAndDefaultEngine) {
+  for (auto& type_info : type_infos) {
+    GetPrefs()->ClearPrefsWithPrefixSilently("brave.brave_search_conversion");
+
+    histogram_tester_.ExpectTotalCount(type_info.histogram_name, 0);
+
+    RecordOmniboxPromoShown(GetPrefs(), type_info.type);
+
+    histogram_tester_.ExpectTotalCount(type_info.histogram_name, 1);
+    histogram_tester_.ExpectBucketCount(type_info.histogram_name, 0, 1);
+
+    RecordOmniboxPromoShown(GetPrefs(), type_info.type);
+
+    // Should not record twice
+    histogram_tester_.ExpectTotalCount(type_info.histogram_name, 1);
+
+    RecordOmniboxPromoTrigger(GetPrefs(), type_info.type);
+    histogram_tester_.ExpectTotalCount(type_info.histogram_name, 2);
+    histogram_tester_.ExpectBucketCount(type_info.histogram_name, 1, 1);
+
+    RecordOmniboxPromoTrigger(GetPrefs(), type_info.type);
+
+    // Also should not record twice
+    histogram_tester_.ExpectTotalCount(type_info.histogram_name, 2);
+
+    RecordDefaultEngineChange(GetPrefs());
+
+    histogram_tester_.ExpectTotalCount(type_info.histogram_name, 3);
+    histogram_tester_.ExpectBucketCount(type_info.histogram_name, 3, 1);
+  }
+}
+
+TEST_F(BraveSearchConversionP3ATest, TestOmniboxShownAndDefaultEngine) {
+  for (auto& type_info : type_infos) {
+    GetPrefs()->ClearPrefsWithPrefixSilently("brave.brave_search_conversion");
+
+    histogram_tester_.ExpectTotalCount(type_info.histogram_name, 0);
+
+    RecordOmniboxPromoShown(GetPrefs(), type_info.type);
+
+    histogram_tester_.ExpectTotalCount(type_info.histogram_name, 1);
+    histogram_tester_.ExpectBucketCount(type_info.histogram_name, 0, 1);
+
+    RecordOmniboxPromoShown(GetPrefs(), type_info.type);
+
+    // Should not record twice
+    histogram_tester_.ExpectTotalCount(type_info.histogram_name, 1);
+
+    RecordDefaultEngineChange(GetPrefs());
+
+    histogram_tester_.ExpectTotalCount(type_info.histogram_name, 2);
+    histogram_tester_.ExpectBucketCount(type_info.histogram_name, 2, 1);
+  }
+}
+
+}  // namespace p3a
+}  // namespace brave_search_conversion

--- a/components/brave_search_conversion/pref_names.h
+++ b/components/brave_search_conversion/pref_names.h
@@ -13,6 +13,15 @@ namespace prefs {
 
 constexpr char kDismissed[] = "brave.brave_search_conversion.dismissed";
 
+constexpr char kP3ABannerShown[] = "brave.brave_search_conversion.banner_shown";
+constexpr char kP3AButtonShown[] = "brave.brave_search_conversion.button_shown";
+constexpr char kP3ABannerTriggered[] =
+    "brave.brave_search_conversion.banner_triggered";
+constexpr char kP3AButtonTriggered[] =
+    "brave.brave_search_conversion.button_triggered";
+constexpr char kP3ADefaultEngineChanged[] =
+    "brave.brave_search_conversion.default_changed";
+
 }  // namespace prefs
 }  // namespace brave_search_conversion
 

--- a/components/p3a/metric_names.h
+++ b/components/p3a/metric_names.h
@@ -47,6 +47,8 @@ constexpr inline auto kCollectedHistograms =
     "Brave.Rewards.WalletState",
     "Brave.Savings.BandwidthSavingsMB",
     "Brave.Search.DefaultEngine.4",
+    "Brave.Search.Promo.Banner",
+    "Brave.Search.Promo.Button",
     "Brave.Search.SwitchEngine",
     "Brave.Shields.AdBlockSetting",
     "Brave.Shields.DomainAdsSettingsAboveGlobal",


### PR DESCRIPTION
<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves brave/brave-browser#23191

Using @simonhong 's branch since his PR is not merged yet. If his PR merges before this one, I'll change the base branch of this PR to master.

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

Follow test plan for both the button (group A) and banner (group B).

1. Launch browser using `--enable-features="BraveSearchOmniboxButton"` or `--enable-features="BraveSearchOmniboxBanner"` switch, with fresh profile.
2. Access `brave://local-state`, ensure `Brave.Search.Promo.Button` or `Brave.Search.Promo.Banner` do not exist in the p3a object.
3. Access `brave://settings/search`, change search engine to something other than Brave.
4. Type some random text into the omnibox, ensure promo appears in suggestions.
5. Check local state, the button or banner metric should now exist, and should be set to 0.
6. Enter random text in omnibox again, click on promo.
7. Relevant metric should have a value of 1.
8. Change the default search engine to Brave by either clicking on the prompt that appears on the search engine results page, or via `brave://settings/search` (may be good to test both).
9. Relevant metric should have a value of 3.
10. Start over with a fresh profile, type random text in omnibox, see promo but do not click on it.
11. Change search engine to Brave via one of the methods in step 8.
12. Relevant metric should have a value of 2.