### PR TITLE
[Android] fixes orientation issue after turning news on (uplift to 1.39.x)

### DIFF
--- a/android/java/org/chromium/chrome/browser/ntp/BraveNewTabPageLayout.java
+++ b/android/java/org/chromium/chrome/browser/ntp/BraveNewTabPageLayout.java
@@ -743,7 +743,7 @@ public class BraveNewTabPageLayout extends NewTabPageLayout implements Connectio
 
     private void keepPosition(int prevScrollPosition, int prevRecyclerViewPosition,
             int prevRecyclerViewItemPosition) {
-        if (!mIsNewsOn || !mIsShowNewsOn || (mIsNewsOn && mIsShowOptin)) {
+        if (!mIsNewsOn || !mIsShowNewsOn || (mIsNewsOn && mIsShowOptin && !mIsShowNewsOn)) {
             return;
         }
         processFeed();
@@ -1373,6 +1373,8 @@ public class BraveNewTabPageLayout extends NewTabPageLayout implements Connectio
                     sharedPreferencesEditor.apply();
                     BravePrefServiceBridge.getInstance().setNewsOptIn(true);
                     BravePrefServiceBridge.getInstance().setShowNews(true);
+                    mIsNewsOn = BravePrefServiceBridge.getInstance().getNewsOptIn();
+                    mIsShowNewsOn = BravePrefServiceBridge.getInstance().getShowNews();
                     if (BraveActivity.getBraveActivity() != null) {
                         BraveActivity.getBraveActivity().inflateNewsSettingsBar();
                         mSettingsBar =


### PR DESCRIPTION
Uplift of #13453
Resolves https://github.com/brave/brave-browser/issues/23060

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.