### PR TITLE
Fix chromium tools/git/move_source_file.py

### DIFF
--- a/build/commands/lib/util.js
+++ b/build/commands/lib/util.js
@@ -634,6 +634,11 @@ const util = {
     util.run('vpython', [path.join(config.braveCoreDir, 'build', 'commands', 'scripts', 'format.py'), options.full ? '--full' : ''], cmd_options)
   },
 
+  massRename: (options = {}) => {
+    let cmd_options = config.defaultOptions
+    cmd_options.cwd = config.braveCoreDir
+    util.run('vpython3', [path.join(config.srcDir, 'tools', 'git', 'mass-rename.py')], cmd_options)
+  },
 
   shouldUpdateChromium: (chromiumRef = config.getProjectRef('chrome')) => {
     const headSHA = util.runGit(config.srcDir, ['rev-parse', 'HEAD'], true)

--- a/build/commands/lib/util.js
+++ b/build/commands/lib/util.js
@@ -637,7 +637,7 @@ const util = {
   massRename: (options = {}) => {
     let cmd_options = config.defaultOptions
     cmd_options.cwd = config.braveCoreDir
-    util.run('vpython3', [path.join(config.srcDir, 'tools', 'git', 'mass-rename.py')], cmd_options)
+    util.run('python3', [path.join(config.srcDir, 'tools', 'git', 'mass-rename.py')], cmd_options)
   },
 
   shouldUpdateChromium: (chromiumRef = config.getProjectRef('chrome')) => {

--- a/build/commands/scripts/commands.js
+++ b/build/commands/scripts/commands.js
@@ -261,4 +261,8 @@ program
   .action(util.format)
 
 program
+  .command('mass-rename')
+  .action(util.massRename)
+
+program
   .parse(process.argv)

--- a/build/commands/scripts/commands.js
+++ b/build/commands/scripts/commands.js
@@ -261,7 +261,7 @@ program
   .action(util.format)
 
 program
-  .command('mass-rename')
+  .command('mass_rename')
   .action(util.massRename)
 
 program

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "chromium_rebase_l10n": "node ./build/commands/scripts/commands.js chromium_rebase_l10n",
     "lint": "node ./build/commands/scripts/commands.js lint",
     "format": "node ./build/commands/scripts/commands.js format",
+    "mass-rename": "node ./build/commands/scripts/commands.js mass-rename",
     "test": "node ./build/commands/scripts/commands.js test",
     "test:scripts": "jest build/commands/lib build/commands/scripts",
     "test-security": "npm run check_security && npm run audit_deps && npm run network-audit",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "chromium_rebase_l10n": "node ./build/commands/scripts/commands.js chromium_rebase_l10n",
     "lint": "node ./build/commands/scripts/commands.js lint",
     "format": "node ./build/commands/scripts/commands.js format",
-    "mass-rename": "node ./build/commands/scripts/commands.js mass-rename",
+    "mass_rename": "node ./build/commands/scripts/commands.js mass_rename",
     "test": "node ./build/commands/scripts/commands.js test",
     "test:scripts": "jest build/commands/lib build/commands/scripts",
     "test-security": "npm run check_security && npm run audit_deps && npm run network-audit",

--- a/patches/tools-git-move_source_file.py.patch
+++ b/patches/tools-git-move_source_file.py.patch
@@ -1,8 +1,16 @@
 diff --git a/tools/git/move_source_file.py b/tools/git/move_source_file.py
-index ab57ae721179f77bb92b808e65dfe1ced8cf605f..affc0ac8142d6575176675b413d0920a1c2139ec 100755
+index ab57ae721179f77bb92b808e65dfe1ced8cf605f..ef3fb8f06b312609cf86e0c088e7c4804c9eef8e 100755
 --- a/tools/git/move_source_file.py
 +++ b/tools/git/move_source_file.py
-@@ -115,6 +115,7 @@ def UpdatePostMove(from_path, to_path):
+@@ -91,6 +91,7 @@ def UpdatePostMove(from_path, to_path):
+   to update references in .gyp(i) files using a heuristic.
+   """
+   # Include paths always use forward slashes.
++  from move_source_fille_utils import to_src_relative_path; from_path, to_path = to_src_relative_path(from_path, to_path)
+   from_path = from_path.replace('\\', '/')
+   to_path = to_path.replace('\\', '/')
+   extension = os.path.splitext(from_path)[1]
+@@ -115,6 +116,7 @@ def UpdatePostMove(from_path, to_path):
    mffr.MultiFileFindReplace(
        r'(//.*)%s' % re.escape(from_path),
        r'\1%s' % to_path,
@@ -10,27 +18,19 @@ index ab57ae721179f77bb92b808e65dfe1ced8cf605f..affc0ac8142d6575176675b413d0920a
        ['*.cc', '*.h', '*.m', '*.mm', '*.cpp'])
  
    # Update references in GYP and BUILD.gn files.
-@@ -152,6 +153,7 @@ def UpdatePostMove(from_path, to_path):
+@@ -150,6 +152,7 @@ def UpdatePostMove(from_path, to_path):
+       return (parts[0], '')
+ 
    visiting_directory = ''
++  from move_source_fille_utils import to_cwd_relative_path; from_path, to_path = to_cwd_relative_path(from_path, to_path)
    from_rest = from_path
    to_rest = to_path
-+  from move_source_fille_utils import to_cwd_relative_path; from_rest, to_rest = to_cwd_relative_path(from_rest), to_cwd_relative_path(to_rest)
    while True:
-     files_with_changed_sources = mffr.MultiFileFindReplace(
-         r'([\'"])%s([\'"])' % from_rest,
-@@ -186,6 +188,7 @@ def UpdateIncludeGuard(old_path, new_path):
+@@ -186,6 +189,7 @@ def UpdateIncludeGuard(old_path, new_path):
    old_guard = MakeIncludeGuardName(old_path)
    new_guard = MakeIncludeGuardName(new_path)
  
-+  from move_source_fille_utils import to_cwd_relative_path; old_path, new_path = to_cwd_relative_path(old_path), to_cwd_relative_path(new_path)
++  from move_source_fille_utils import to_cwd_relative_path; [new_path] = to_cwd_relative_path(new_path)
    with open(new_path) as f:
      contents = f.read()
- 
-@@ -244,6 +247,7 @@ def main():
-     to_path = MakeDestinationPath(from_path, orig_to_path)
-     if not opts.already_moved:
-       MoveFile(from_path, to_path)
-+    from move_source_fille_utils import to_src_relative_path; from_path, to_path = to_src_relative_path(from_path), to_src_relative_path(to_path)
-     UpdatePostMove(from_path, to_path)
-   return 0
  

--- a/patches/tools-git-move_source_file.py.patch
+++ b/patches/tools-git-move_source_file.py.patch
@@ -1,30 +1,42 @@
 diff --git a/tools/git/move_source_file.py b/tools/git/move_source_file.py
-index ab57ae721179f77bb92b808e65dfe1ced8cf605f..4536e3c8d8def51553be568f4332802a936f30e7 100755
+index ab57ae721179f77bb92b808e65dfe1ced8cf605f..ba5bea39efb977398649ebe5c60e6952cd798705 100755
 --- a/tools/git/move_source_file.py
 +++ b/tools/git/move_source_file.py
-@@ -30,7 +30,9 @@ if __name__ == '__main__':
-   # Need to add the directory containing sort_sources.py to the Python
-   # classpath.
-   sys.path.append(os.path.abspath(os.path.join(sys.path[0], '..')))
-+  sys.path.append(os.path.join(os.path.dirname(__file__), os.pardir, os.pardir, 'brave', 'script'))
- import sort_sources
-+from move_source_fille_utils import to_src_relative_path, to_cwd_relative_path
+@@ -115,6 +115,7 @@ def UpdatePostMove(from_path, to_path):
+   mffr.MultiFileFindReplace(
+       r'(//.*)%s' % re.escape(from_path),
+       r'\1%s' % to_path,
++      ['*.gni'] + # Brave uses sources.gni to add files to original targets
+       ['*.cc', '*.h', '*.m', '*.mm', '*.cpp'])
  
- 
- HANDLED_EXTENSIONS = ['.cc', '.mm', '.h', '.hh', '.cpp', '.mojom']
-@@ -186,6 +188,7 @@ def UpdateIncludeGuard(old_path, new_path):
+   # Update references in GYP and BUILD.gn files.
+@@ -152,11 +153,13 @@ def UpdatePostMove(from_path, to_path):
+   visiting_directory = ''
+   from_rest = from_path
+   to_rest = to_path
++  from move_source_fille_utils import to_cwd_relative_path; from_rest, to_rest = to_cwd_relative_path(from_rest), to_cwd_relative_path(to_rest)
+   while True:
+     files_with_changed_sources = mffr.MultiFileFindReplace(
+         r'([\'"])%s([\'"])' % from_rest,
+         r'\1%s\2' % to_rest,
+         [os.path.join(visiting_directory, 'BUILD.gn'),
++         os.path.join(visiting_directory, 'sources.gni'),
+          os.path.join(visiting_directory, '*.gyp*')])
+     for changed_file in files_with_changed_sources:
+       sort_sources.ProcessFile(changed_file, should_confirm=False)
+@@ -186,6 +189,7 @@ def UpdateIncludeGuard(old_path, new_path):
    old_guard = MakeIncludeGuardName(old_path)
    new_guard = MakeIncludeGuardName(new_path)
  
-+  old_path, new_path = to_cwd_relative_path(old_path), to_cwd_relative_path(new_path)
++  from move_source_fille_utils import to_cwd_relative_path; old_path, new_path = to_cwd_relative_path(old_path), to_cwd_relative_path(new_path)
    with open(new_path) as f:
      contents = f.read()
  
-@@ -244,6 +247,7 @@ def main():
+@@ -244,6 +248,7 @@ def main():
      to_path = MakeDestinationPath(from_path, orig_to_path)
      if not opts.already_moved:
        MoveFile(from_path, to_path)
-+    from_path, to_path = to_src_relative_path(from_path), to_src_relative_path(to_path)
++    from move_source_fille_utils import to_src_relative_path; from_path, to_path = to_src_relative_path(from_path), to_src_relative_path(to_path)
      UpdatePostMove(from_path, to_path)
    return 0
  

--- a/patches/tools-git-move_source_file.py.patch
+++ b/patches/tools-git-move_source_file.py.patch
@@ -1,16 +1,16 @@
 diff --git a/tools/git/move_source_file.py b/tools/git/move_source_file.py
-index ab57ae721179f77bb92b808e65dfe1ced8cf605f..ba5bea39efb977398649ebe5c60e6952cd798705 100755
+index ab57ae721179f77bb92b808e65dfe1ced8cf605f..affc0ac8142d6575176675b413d0920a1c2139ec 100755
 --- a/tools/git/move_source_file.py
 +++ b/tools/git/move_source_file.py
 @@ -115,6 +115,7 @@ def UpdatePostMove(from_path, to_path):
    mffr.MultiFileFindReplace(
        r'(//.*)%s' % re.escape(from_path),
        r'\1%s' % to_path,
-+      ['*.gni'] + # Brave uses sources.gni to add files to original targets
++      ['*.gni', '*.gn'] + # Brave uses full paths (start with //) to add files
        ['*.cc', '*.h', '*.m', '*.mm', '*.cpp'])
  
    # Update references in GYP and BUILD.gn files.
-@@ -152,11 +153,13 @@ def UpdatePostMove(from_path, to_path):
+@@ -152,6 +153,7 @@ def UpdatePostMove(from_path, to_path):
    visiting_directory = ''
    from_rest = from_path
    to_rest = to_path
@@ -18,13 +18,7 @@ index ab57ae721179f77bb92b808e65dfe1ced8cf605f..ba5bea39efb977398649ebe5c60e6952
    while True:
      files_with_changed_sources = mffr.MultiFileFindReplace(
          r'([\'"])%s([\'"])' % from_rest,
-         r'\1%s\2' % to_rest,
-         [os.path.join(visiting_directory, 'BUILD.gn'),
-+         os.path.join(visiting_directory, 'sources.gni'),
-          os.path.join(visiting_directory, '*.gyp*')])
-     for changed_file in files_with_changed_sources:
-       sort_sources.ProcessFile(changed_file, should_confirm=False)
-@@ -186,6 +189,7 @@ def UpdateIncludeGuard(old_path, new_path):
+@@ -186,6 +188,7 @@ def UpdateIncludeGuard(old_path, new_path):
    old_guard = MakeIncludeGuardName(old_path)
    new_guard = MakeIncludeGuardName(new_path)
  
@@ -32,7 +26,7 @@ index ab57ae721179f77bb92b808e65dfe1ced8cf605f..ba5bea39efb977398649ebe5c60e6952
    with open(new_path) as f:
      contents = f.read()
  
-@@ -244,6 +248,7 @@ def main():
+@@ -244,6 +247,7 @@ def main():
      to_path = MakeDestinationPath(from_path, orig_to_path)
      if not opts.already_moved:
        MoveFile(from_path, to_path)

--- a/patches/tools-git-move_source_file.py.patch
+++ b/patches/tools-git-move_source_file.py.patch
@@ -1,0 +1,30 @@
+diff --git a/tools/git/move_source_file.py b/tools/git/move_source_file.py
+index ab57ae721179f77bb92b808e65dfe1ced8cf605f..4536e3c8d8def51553be568f4332802a936f30e7 100755
+--- a/tools/git/move_source_file.py
++++ b/tools/git/move_source_file.py
+@@ -30,7 +30,9 @@ if __name__ == '__main__':
+   # Need to add the directory containing sort_sources.py to the Python
+   # classpath.
+   sys.path.append(os.path.abspath(os.path.join(sys.path[0], '..')))
++  sys.path.append(os.path.join(os.path.dirname(__file__), os.pardir, os.pardir, 'brave', 'script'))
+ import sort_sources
++from move_source_fille_utils import to_src_relative_path, to_cwd_relative_path
+ 
+ 
+ HANDLED_EXTENSIONS = ['.cc', '.mm', '.h', '.hh', '.cpp', '.mojom']
+@@ -186,6 +188,7 @@ def UpdateIncludeGuard(old_path, new_path):
+   old_guard = MakeIncludeGuardName(old_path)
+   new_guard = MakeIncludeGuardName(new_path)
+ 
++  old_path, new_path = to_cwd_relative_path(old_path), to_cwd_relative_path(new_path)
+   with open(new_path) as f:
+     contents = f.read()
+ 
+@@ -244,6 +247,7 @@ def main():
+     to_path = MakeDestinationPath(from_path, orig_to_path)
+     if not opts.already_moved:
+       MoveFile(from_path, to_path)
++    from_path, to_path = to_src_relative_path(from_path), to_src_relative_path(to_path)
+     UpdatePostMove(from_path, to_path)
+   return 0
+ 

--- a/script/move_source_fille_utils.py
+++ b/script/move_source_fille_utils.py
@@ -9,18 +9,17 @@ import os
 
 BRAVE_DIR_NAME = 'brave'
 
-def is_in_brave_dir():
-  _, tail = os.path.split(os.getcwd())
-  return tail == BRAVE_DIR_NAME
+def _is_in_brave_dir():
+  return BRAVE_DIR_NAME == os.path.basename(os.getcwd())
 
 
-def to_src_relative_path(dir):
-  if is_in_brave_dir():
-    return os.path.join(BRAVE_DIR_NAME, dir)
-  return dir
+def to_src_relative_path(*args):
+  if _is_in_brave_dir():
+    return tuple(os.path.join(BRAVE_DIR_NAME, d) for d in args)
+  return args
 
 
-def to_cwd_relative_path(dir):
-  if is_in_brave_dir():
-    return os.path.relpath(dir, BRAVE_DIR_NAME)
-  return dir
+def to_cwd_relative_path(*args):
+  if _is_in_brave_dir():
+    return tuple(os.path.relpath(d, BRAVE_DIR_NAME) for d in args)
+  return args

--- a/script/move_source_fille_utils.py
+++ b/script/move_source_fille_utils.py
@@ -1,0 +1,24 @@
+# Copyright (c) 2022 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import os
+
+BRAVE_DIR_NAME = 'brave'
+
+def is_in_brave_dir():
+  _, tail = os.path.split(os.getcwd())
+  return tail == BRAVE_DIR_NAME
+
+
+def to_src_relative_path(dir):
+  if is_in_brave_dir():
+    return os.path.join(BRAVE_DIR_NAME, dir)
+  return dir
+
+
+def to_cwd_relative_path(dir):
+  if is_in_brave_dir():
+    return os.path.normpath(os.path.join(os.pardir, dir))
+  return dir

--- a/script/move_source_fille_utils.py
+++ b/script/move_source_fille_utils.py
@@ -20,5 +20,5 @@ def to_src_relative_path(dir):
 
 def to_cwd_relative_path(dir):
   if is_in_brave_dir():
-    return os.path.normpath(os.path.join(os.pardir, dir))
+    return os.path.relpath(dir, BRAVE_DIR_NAME)
   return dir

--- a/script/move_source_fille_utils.py
+++ b/script/move_source_fille_utils.py
@@ -3,6 +3,8 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this file,
 # You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+"""This utils is used in chromium tools/git/move_source_file.py."""
+
 import os
 
 BRAVE_DIR_NAME = 'brave'


### PR DESCRIPTION
<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/23233

This patch fixes chromium extremely useful tools : `mass-rename.py` & `move_single_file.py`.
The tools helps then you move some files. They: 
1. Change includes & include guards;
2. Chang gn files;
After launching `git cl format` you will get the well formatted diff. 

The PR adds/removes `brave` in paths when it necessary. The script should be launched from `src\brave` to work correctly

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [x] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [x] New files have MPL-2.0 license header
- [x] Adequate test coverage exists to prevent regressions
- [x] Major classes, functions and non-trivial code blocks are well-commented
- [x] Changes in component dependencies are properly reflected in `gn`
- [x] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [x] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

