### PR TITLE
Fix pending tips processing for verified Rewards profiles

### DIFF
--- a/vendor/bat-native-ledger/src/bat/ledger/internal/contribution/contribution_external_wallet.cc
+++ b/vendor/bat-native-ledger/src/bat/ledger/internal/contribution/contribution_external_wallet.cc
@@ -154,15 +154,6 @@ void ContributionExternalWallet::OnServerPublisherInfo(
 
     BLOG(1, "Publisher not verified");
 
-    // TODO(zenparsing): Adding a record to the pending contribution table at
-    // this point can lead to an (async) infinite loop if pending contributions
-    // are currently being flushed. In `unverified.cc`, the pending contribution
-    // processor processes the first available pending record and then sets a
-    // timer to process the next one. If another record is added before that
-    // timer expires, it can cause the flushing operation to continue
-    // indefinitely.
-
-    /*
     auto save_callback =
         std::bind(&ContributionExternalWallet::OnSavePendingContribution,
             this,
@@ -176,10 +167,8 @@ void ContributionExternalWallet::OnServerPublisherInfo(
     type::PendingContributionList list;
     list.push_back(std::move(contribution));
 
-    ledger_->database()->SavePendingContribution(
-        std::move(list),
-        save_callback);
-    */
+    ledger_->database()->SavePendingContribution(std::move(list),
+                                                 save_callback);
 
     callback(type::Result::LEDGER_ERROR);
     return;

--- a/vendor/bat-native-ledger/src/bat/ledger/internal/contribution/unverified.h
+++ b/vendor/bat-native-ledger/src/bat/ledger/internal/contribution/unverified.h
@@ -13,8 +13,10 @@
 #include <string>
 #include <vector>
 
+#include "base/time/time.h"
 #include "base/timer/timer.h"
 #include "bat/ledger/ledger.h"
+#include "third_party/abseil-cpp/absl/types/optional.h"
 
 namespace ledger {
 class LedgerImpl;
@@ -45,6 +47,8 @@ class Unverified {
 
   void OnRemovePendingContribution(type::Result result);
 
+  void ProcessNext();
+
   void OnContributeUnverifiedBalance(
       type::Result result,
       type::BalancePtr properties);
@@ -57,8 +61,11 @@ class Unverified {
       const type::Result result,
       const uint64_t pending_contribution_id);
 
+  void ProcessingCompleted();
+
   LedgerImpl* ledger_;  // NOT OWNED
   base::OneShotTimer unverified_publishers_timer_;
+  absl::optional<base::Time> processing_start_time_;
 };
 
 }  // namespace contribution


### PR DESCRIPTION
<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/20090
Resolves https://github.com/brave/brave-browser/issues/19982

In the current implementation, the pending tips processor will attempt to process records that are added while it is running. This can lead to an infinite (async) loop in the case of external wallet funded contributions. This change implements a minimal solution, where the start time of the process is recorded and compared to the `added_date` value of pending tip entries. Pending tips that are added after the "processor start time" are skipped.

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [x] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [x] New files have MPL-2.0 license header
- [x] Adequate test coverage exists to prevent regressions
- [x] Major classes, functions and non-trivial code blocks are well-commented
- [x] Changes in component dependencies are properly reflected in `gn`
- [x] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [x] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

- Open browser with a new profile in staging.
- Enable Rewards.
- Verify with an external wallet provider (e.g. Uphold).
- Visit a site that is creator-verified in staging with a different wallet provider.
  - For example, if you linked with Uphold, visit `http://github.com/miyayes` (a Gemini-verified creator in staging).
- Make a one-time tip.
- Visit `brave://rewards` and view the list of pending tips.
  - Verify that the one-time tip created above appears in the list of pending tips.
- Trigger pending tips processing.
  - This can be accomplished by visiting the creator site above, opening the panel, and pressing the "Refresh" status button.
- Visit `brave://rewards` and view the list of pending tips.
  - Verify that the one-time tip created above appears in the list of pending tips, and no other tips appear.
- Close the browser.
- Modify the database to simulate a case where the creator has verified with a matching provider.
  - Open `publisher_info_db`.
  - Browse the `pending_contribution` table.
  - In the database row, change the `publisher_id` field value to the publisher ID of a publisher that is verified on a matching external wallet provider.
    - For example, if you linked with Uphold, use `laurenwags.github.io`.
  - Save the changes and close the database.
- Restart the browser.
- Trigger pending tips processing.
  - This can be accomplished by visiting any creator, opening the Rewards panel, and pressing "Refresh".
- Visit `brave://rewards` and verify that the pending tip has been sent.