### PR TITLE
Fix compilation

### DIFF
--- a/browser/brave_shields/ad_block_service_browsertest.cc
+++ b/browser/brave_shields/ad_block_service_browsertest.cc
@@ -167,6 +167,10 @@ void AdBlockServiceTest::AssertTagExists(const std::string& tag,
       g_brave_browser_process->ad_block_service()->TagExistsForTest(tag);
   ASSERT_EQ(exists_default, expected_exists);
 
+  base::AutoLock lock(g_brave_browser_process->ad_block_service()
+                          ->regional_service_manager()
+                          ->regional_services_lock_);
+
   for (const auto& regional_service :
        g_brave_browser_process->ad_block_service()
            ->regional_service_manager()
@@ -268,6 +272,9 @@ bool AdBlockServiceTest::InstallRegionalAdBlockExtension(
     g_brave_browser_process->ad_block_service()
         ->regional_service_manager()
         ->EnableFilterList(uuid, true);
+    base::AutoLock lock(g_brave_browser_process->ad_block_service()
+                            ->regional_service_manager()
+                            ->regional_services_lock_);
     EXPECT_EQ(g_brave_browser_process->ad_block_service()
                   ->regional_service_manager()
                   ->regional_services_.size(),


### PR DESCRIPTION
Introduced in https://github.com/brave/brave-core/pull/13610/files
```
12:49:40  ../../brave/browser/brave_shields/ad_block_service_browsertest.cc(170,37): error: reading variable 'regional_services_' requires holding mutex 'g_brave_browser_process->ad_block_service().regional_service_manager().regional_services_lock_' [-Werror,-Wthread-safety-analysis]
12:49:40    for (const auto& regional_service :
12:49:40                                      ^
12:49:40  ../../brave/browser/brave_shields/ad_block_service_browsertest.cc(170,37): error: reading variable 'regional_services_' requires holding mutex 'g_brave_browser_process->ad_block_service().regional_service_manager().regional_services_lock_' [-Werror,-Wthread-safety-analysis]
12:49:40  ../../brave/browser/brave_shields/ad_block_service_browsertest.cc(273,21): error: reading variable 'regional_services_' requires holding mutex 'g_brave_browser_process->ad_block_service().regional_service_manager().regional_services_lock_' [-Werror,-Wthread-safety-analysis]
12:49:40                    ->regional_services_.size(),
12:49:40                      ^
12:49:40  ../../brave/browser/brave_shields/ad_block_service_browsertest.cc(278,34): error: reading variable 'regional_services_' requires holding mutex 'g_brave_browser_process->ad_block_service().regional_service_manager().regional_services_lock_' [-Werror,-Wthread-safety-analysis]
12:49:40                                 ->regional_services_.find(uuid);
12:49:40        


```
