### PR TITLE
Fetch purchased state update in background without redundant notifications in the UI

### DIFF
--- a/components/brave_vpn/BUILD.gn
+++ b/components/brave_vpn/BUILD.gn
@@ -124,6 +124,7 @@ source_set("unit_tests") {
       "//net:test_support",
       "//services/network:test_support",
       "//testing/gtest",
+      "//third_party/abseil-cpp:absl",
     ]
   }
 }

--- a/components/brave_vpn/brave_vpn_service.cc
+++ b/components/brave_vpn/brave_vpn_service.cc
@@ -886,14 +886,13 @@ void BraveVpnService::AddObserver(
 }
 
 mojom::PurchasedState BraveVpnService::GetPurchasedStateSync() const {
-  return purchased_state_.has_value() ? purchased_state_.value()
-                                      : mojom::PurchasedState::NOT_PURCHASED;
+  return purchased_state_.value_or(mojom::PurchasedState::NOT_PURCHASED);
 }
 
 void BraveVpnService::GetPurchasedState(GetPurchasedStateCallback callback) {
   DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
   auto value = GetPurchasedStateSync();
-  VLOG(2) << __func__ << " : " << static_cast<int>(value);
+  VLOG(2) << __func__ << " : " << value;
   std::move(callback).Run(value);
 }
 

--- a/components/brave_vpn/brave_vpn_service.h
+++ b/components/brave_vpn/brave_vpn_service.h
@@ -22,6 +22,7 @@
 #include "mojo/public/cpp/bindings/remote_set.h"
 #include "services/data_decoder/public/cpp/json_sanitizer.h"
 #include "services/network/public/cpp/shared_url_loader_factory.h"
+#include "third_party/abseil-cpp/absl/types/optional.h"
 #include "url/gurl.h"
 
 #if !BUILDFLAG(IS_ANDROID)
@@ -245,7 +246,7 @@ class BraveVpnService :
       int status,
       const std::string& body,
       const base::flat_map<std::string, std::string>& headers);
-
+  mojom::PurchasedState GetPurchasedStateSync() const;
   void SetPurchasedState(mojom::PurchasedState state);
   void EnsureMojoConnected();
   void OnMojoConnectionError();
@@ -278,7 +279,7 @@ class BraveVpnService :
   base::RepeatingCallback<mojo::PendingRemote<skus::mojom::SkusService>()>
       skus_service_getter_;
   mojo::Remote<skus::mojom::SkusService> skus_service_;
-  mojom::PurchasedState purchased_state_ = mojom::PurchasedState::NOT_PURCHASED;
+  absl::optional<mojom::PurchasedState> purchased_state_;
   mojo::RemoteSet<mojom::ServiceObserver> observers_;
   api_request_helper::APIRequestHelper api_request_helper_;
   std::string skus_credential_;

--- a/components/brave_vpn/resources/panel/state/reducer.ts
+++ b/components/brave_vpn/resources/panel/state/reducer.ts
@@ -16,7 +16,7 @@ type RootState = {
   regions?: Region[]
   currentRegion?: Region
   productUrls?: ProductUrls
-  currentView: ViewType | null
+  currentView: ViewType
 }
 
 const defaultState: RootState = {
@@ -25,7 +25,7 @@ const defaultState: RootState = {
   connectionStatus: ConnectionState.DISCONNECTED,
   regions: undefined,
   currentRegion: undefined,
-  currentView: null
+  currentView: ViewType.Loading
 }
 
 const reducer = createReducer<RootState>({}, defaultState)
@@ -85,7 +85,7 @@ reducer.on(Actions.retryConnect, (state): RootState => {
 reducer.on(Actions.purchaseConfirmed, (state): RootState => {
   return {
     ...state,
-    currentView: null
+    currentView: ViewType.Main
   }
 })
 


### PR DESCRIPTION
<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/21754
Resolves https://github.com/brave/brave-browser/issues/23116
Resolves https://github.com/brave/brave-browser/issues/22882

Fetch purchased state update in background without redundant notifications in the UI. The observer is called only if purchased state was actually changed.

https://user-images.githubusercontent.com/2965009/173059814-8ea35951-4035-4ce9-87cf-f9711e5c50dc.mp4

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

- Open vpn popup multiple times, it should not flicker and should show actual status.