### PR TITLE
Bug 23170: anti-fingerprinting: hide screen size and window position

### DIFF
--- a/browser/about_flags.cc
+++ b/browser/about_flags.cc
@@ -159,6 +159,12 @@ constexpr char kBraveNTPBrandedWallpaperDemoDescription[] =
     "View rate and user opt-in conditionals will still be followed to decide "
     "when to display the Branded Wallpaper.";
 
+constexpr char kBraveBlockScreenFingerprintingName[] =
+    "Block screen fingerprinting";
+constexpr char kBraveBlockScreenFingerprintingDescription[] =
+    "Prevents JavaScript and CSS from learning the user's screen dimensions "
+    "or window position.";
+
 constexpr char kBraveSpeedreaderName[] = "Enable SpeedReader";
 constexpr char kBraveSpeedreaderDescription[] =
     "Enables faster loading of simplified article-style web pages.";
@@ -565,6 +571,11 @@ const flags_ui::FeatureEntry::Choice kBraveSkusEnvChoices[] = {
       flag_descriptions::kRestrictWebSocketsPoolName,                       \
       flag_descriptions::kRestrictWebSocketsPoolDescription, kOsAll,        \
       FEATURE_VALUE_TYPE(blink::features::kRestrictWebSocketsPool)},        \
+    {"brave-block-screen-fingerprinting",                                   \
+      flag_descriptions::kBraveBlockScreenFingerprintingName,               \
+      flag_descriptions::kBraveBlockScreenFingerprintingDescription,        \
+      kOsAll, FEATURE_VALUE_TYPE(                                           \
+          blink::features::kBraveBlockScreenFingerprinting)},               \
     BRAVE_IPFS_FEATURE_ENTRIES                                              \
     BRAVE_NATIVE_WALLET_FEATURE_ENTRIES                                     \
     BRAVE_NEWS_FEATURE_ENTRIES                                              \
@@ -573,5 +584,5 @@ const flags_ui::FeatureEntry::Choice kBraveSkusEnvChoices[] = {
     BRAVE_VPN_FEATURE_ENTRIES                                               \
     BRAVE_SKU_SDK_FEATURE_ENTRIES                                           \
     SPEEDREADER_FEATURE_ENTRIES                                             \
-    BRAVE_SHIELDS_FEATURE_ENTRIES                                        \
+    BRAVE_SHIELDS_FEATURE_ENTRIES                                           \
     BRAVE_TRANSLATE_GO_FEATURE_ENTRIES

--- a/browser/farbling/BUILD.gn
+++ b/browser/farbling/BUILD.gn
@@ -19,6 +19,7 @@ if (!is_android) {
       "brave_navigator_plugins_farbling_browsertest.cc",
       "brave_navigator_useragent_farbling_browsertest.cc",
       "brave_offscreencanvas_farbling_browsertest.cc",
+      "brave_screen_farbling_browsertest.cc",
       "brave_speech_synthesis_farbling_browsertest.cc",
       "brave_webaudio_farbling_browsertest.cc",
       "brave_webgl_farbling_browsertest.cc",

--- a/browser/farbling/brave_screen_farbling_browsertest.cc
+++ b/browser/farbling/brave_screen_farbling_browsertest.cc
@@ -1,0 +1,156 @@
+/* Copyright (c) 2022 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "base/path_service.h"
+#include "brave/browser/brave_content_browser_client.h"
+#include "brave/common/brave_paths.h"
+#include "brave/components/brave_shields/browser/brave_shields_util.h"
+#include "chrome/browser/content_settings/host_content_settings_map_factory.h"
+#include "chrome/browser/extensions/extension_browsertest.h"
+#include "chrome/browser/ui/browser_window.h"
+#include "chrome/common/chrome_content_client.h"
+#include "chrome/test/base/ui_test_utils.h"
+#include "content/public/test/browser_test.h"
+#include "net/dns/mock_host_resolver.h"
+#include "net/test/embedded_test_server/embedded_test_server.h"
+#include "net/test/embedded_test_server/http_request.h"
+
+using brave_shields::ControlType;
+
+class BraveScreenFarblingBrowserTest : public InProcessBrowserTest {
+ public:
+  void SetUpOnMainThread() override {
+    InProcessBrowserTest::SetUpOnMainThread();
+
+    content_client_.reset(new ChromeContentClient);
+    content::SetContentClient(content_client_.get());
+    browser_content_client_.reset(new BraveContentBrowserClient());
+    content::SetBrowserClientForTesting(browser_content_client_.get());
+
+    host_resolver()->AddRule("*", "127.0.0.1");
+    https_server_.reset(new net::EmbeddedTestServer(
+        net::test_server::EmbeddedTestServer::TYPE_HTTPS));
+    content::SetupCrossSiteRedirector(https_server_.get());
+
+    brave::RegisterPathProvider();
+    base::FilePath test_data_dir;
+    base::PathService::Get(brave::DIR_TEST_DATA, &test_data_dir);
+    https_server_->ServeFilesFromDirectory(test_data_dir);
+
+    ASSERT_TRUE(https_server_->Start());
+  }
+
+  void TearDown() override {
+    browser_content_client_.reset();
+    content_client_.reset();
+  }
+
+  HostContentSettingsMap* content_settings() {
+    return HostContentSettingsMapFactory::GetForProfile(browser()->profile());
+  }
+
+  void AllowFingerprinting(std::string domain) {
+    brave_shields::SetFingerprintingControlType(
+        content_settings(), ControlType::ALLOW,
+        https_server()->GetURL(domain, "/"));
+  }
+
+  void SetFingerprintingDefault(std::string domain) {
+    brave_shields::SetFingerprintingControlType(
+        content_settings(), ControlType::DEFAULT,
+        https_server()->GetURL(domain, "/"));
+  }
+
+  content::WebContents* contents() const {
+    return browser()->tab_strip_model()->GetActiveWebContents();
+  }
+
+  bool NavigateToURLUntilLoadStop(const GURL& url) {
+    EXPECT_TRUE(ui_test_utils::NavigateToURL(browser(), url));
+    return WaitForLoadStop(contents());
+  }
+
+  Browser* OpenPopup(const std::string& script) const {
+    content::ExecuteScriptAsync(contents(), script);
+    Browser* popup = ui_test_utils::WaitForBrowserToOpen();
+    EXPECT_NE(popup, browser());
+    auto* popup_contents = popup->tab_strip_model()->GetActiveWebContents();
+    EXPECT_TRUE(WaitForRenderFrameReady(popup_contents->GetMainFrame()));
+    return popup;
+  }
+
+  net::EmbeddedTestServer* https_server() { return https_server_.get(); }
+
+ private:
+  std::unique_ptr<net::EmbeddedTestServer> https_server_;
+  std::unique_ptr<ChromeContentClient> content_client_;
+  std::unique_ptr<BraveContentBrowserClient> browser_content_client_;
+  std::vector<std::string> user_agents_;
+};
+
+const char* testScript[] = {"window.screenX",
+                            "window.screenY",
+                            "window.screen.availLeft",
+                            "window.screen.availTop",
+                            "window.outerWidth - window.innerWidth",
+                            "window.outerHeight - window.innerHeight",
+                            "window.screen.availWidth - window.innerWidth",
+                            "window.screen.availHeight - window.innerHeight",
+                            "window.screen.width - window.innerWidth",
+                            "window.screen.height - window.innerHeight"};
+
+IN_PROC_BROWSER_TEST_F(BraveScreenFarblingBrowserTest, FarbleScreenSize) {
+  std::string domain = "a.test";
+  GURL url = https_server()->GetURL(domain, "/simple.html");
+  AllowFingerprinting(domain);
+  NavigateToURLUntilLoadStop(url);
+  for (int i = 0; i < static_cast<int>(std::size(testScript)); ++i) {
+    EXPECT_LE(0, EvalJs(contents(), testScript[i]));
+  }
+
+  SetFingerprintingDefault(domain);
+  NavigateToURLUntilLoadStop(url);
+  for (int i = 0; i < static_cast<int>(std::size(testScript)); ++i) {
+    EXPECT_GE(8, EvalJs(contents(), testScript[i]));
+  }
+}
+
+const char* mediaQueryTestScripts[] = {
+    "matchMedia(`(max-device-width: ${innerWidth + 8}px) and "
+    "(min-device-width: ${innerWidth}px)`).matches",
+    "matchMedia(`(max-device-height: ${innerHeight + 8}px) and "
+    "(min-device-height: ${innerHeight}px)`).matches"};
+
+IN_PROC_BROWSER_TEST_F(BraveScreenFarblingBrowserTest, FarbleScreenMediaQuery) {
+  std::string domain = "a.test";
+  GURL url = https_server()->GetURL(domain, "/simple.html");
+  SetFingerprintingDefault(domain);
+  NavigateToURLUntilLoadStop(url);
+  for (int i = 0; i < static_cast<int>(std::size(mediaQueryTestScripts)); ++i) {
+    EXPECT_EQ(true, EvalJs(contents(), mediaQueryTestScripts[i]));
+  }
+  AllowFingerprinting(domain);
+  for (int i = 0; i < static_cast<int>(std::size(mediaQueryTestScripts)); ++i) {
+    EXPECT_EQ(false, EvalJs(contents(), mediaQueryTestScripts[i]));
+  }
+}
+
+IN_PROC_BROWSER_TEST_F(BraveScreenFarblingBrowserTest,
+                       FarbleScreenPopupPosition) {
+  std::string domain = "a.test";
+  GURL url = https_server()->GetURL(domain, "/simple.html");
+  SetFingerprintingDefault(domain);
+  NavigateToURLUntilLoadStop(url);
+  gfx::Rect parentBounds = browser()->window()->GetBounds();
+  const char* script =
+      "open('http://d.test/', '', `left=${screen.availLeft + "
+      "50},top=${screen.availTop + 50},width=50,height=50`);";
+  Browser* popup = OpenPopup(script);
+  gfx::Rect childBounds = popup->window()->GetBounds();
+  printf("%d %d %d %d\n", childBounds.x(), parentBounds.x(), childBounds.y(),
+         parentBounds.y());
+  EXPECT_GT(childBounds.x(), 50 + parentBounds.x());
+  EXPECT_GT(childBounds.y(), 50 + parentBounds.y());
+}

--- a/chromium_src/third_party/blink/common/features.cc
+++ b/chromium_src/third_party/blink/common/features.cc
@@ -46,5 +46,9 @@ const base::Feature kPartitionBlinkMemoryCache{
 const base::Feature kRestrictWebSocketsPool{"RestrictWebSocketsPool",
                                             base::FEATURE_ENABLED_BY_DEFAULT};
 
+// Enable protection against fingerprinting on screen dimensions.
+const base::Feature kBraveBlockScreenFingerprinting{
+    "kBraveBlockScreenFingerprinting", base::FEATURE_ENABLED_BY_DEFAULT};
+
 }  // namespace features
 }  // namespace blink

--- a/chromium_src/third_party/blink/public/common/features.h
+++ b/chromium_src/third_party/blink/public/common/features.h
@@ -15,6 +15,7 @@ BLINK_COMMON_EXPORT extern const base::Feature kFileSystemAccessAPI;
 BLINK_COMMON_EXPORT extern const base::Feature kNavigatorConnectionAttribute;
 BLINK_COMMON_EXPORT extern const base::Feature kPartitionBlinkMemoryCache;
 BLINK_COMMON_EXPORT extern const base::Feature kRestrictWebSocketsPool;
+BLINK_COMMON_EXPORT extern const base::Feature kBraveBlockScreenFingerprinting;
 
 }  // namespace features
 }  // namespace blink

--- a/chromium_src/third_party/blink/renderer/core/core_initializer.cc
+++ b/chromium_src/third_party/blink/renderer/core/core_initializer.cc
@@ -3,8 +3,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+#include "brave/third_party/blink/renderer/core/brave_session_cache.h"
 #include "third_party/blink/renderer/bindings/core/v8/binding_security.h"
-#include "third_party/blink/renderer/core/execution_context/execution_context.h"
 
 #define BindingSecurity             \
   brave::BraveSessionCache::Init(); \

--- a/chromium_src/third_party/blink/renderer/core/css/media_values.cc
+++ b/chromium_src/third_party/blink/renderer/core/css/media_values.cc
@@ -1,0 +1,39 @@
+/* Copyright (c) 2022 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_CHROMIUM_SRC_THIRD_PARTY_BLINK_RENDERER_CORE_CSS_MEDIA_VALUES_CC_
+#define BRAVE_CHROMIUM_SRC_THIRD_PARTY_BLINK_RENDERER_CORE_CSS_MEDIA_VALUES_CC_
+
+#include "third_party/blink/renderer/core/css/media_values.h"
+#include "third_party/blink/renderer/core/frame/local_dom_window.h"
+#include "third_party/blink/renderer/core/frame/screen.h"
+
+#include "brave/third_party/blink/renderer/core/brave_session_cache.h"
+
+#define CalculateDeviceWidth                                               \
+  CalculateDeviceWidth(LocalFrame* frame) {                                \
+    ExecutionContext* context = frame->DomWindow()->GetExecutionContext(); \
+    return brave::AllowScreenFingerprinting(context)                       \
+               ? CalculateDeviceWidth_ChromiumImpl(frame)                  \
+               : frame->DomWindow()->screen()->width();                    \
+  }                                                                        \
+  int MediaValues::CalculateDeviceWidth_ChromiumImpl
+
+#define CalculateDeviceHeight                                              \
+  CalculateDeviceHeight(LocalFrame* frame) {                               \
+    ExecutionContext* context = frame->DomWindow()->GetExecutionContext(); \
+    return brave::AllowScreenFingerprinting(context)                       \
+               ? CalculateDeviceHeight_ChromiumImpl(frame)                 \
+               : frame->DomWindow()->screen()->height();                   \
+  }                                                                        \
+  int MediaValues::CalculateDeviceHeight_ChromiumImpl
+
+#include "src/third_party/blink/renderer/core/css/media_values.cc"
+
+#undef CalculateDeviceWidth
+#undef CalculateDeviceHeight
+
+// BRAVE_CHROMIUM_SRC_THIRD_PARTY_BLINK_RENDERER_CORE_CSS_MEDIA_VALUES_CC_
+#endif

--- a/chromium_src/third_party/blink/renderer/core/css/media_values.h
+++ b/chromium_src/third_party/blink/renderer/core/css/media_values.h
@@ -1,0 +1,22 @@
+/* Copyright (c) 2022 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_CHROMIUM_SRC_THIRD_PARTY_BLINK_RENDERER_CORE_CSS_MEDIA_VALUES_H_
+#define BRAVE_CHROMIUM_SRC_THIRD_PARTY_BLINK_RENDERER_CORE_CSS_MEDIA_VALUES_H_
+
+#define CalculateDeviceWidth                      \
+  CalculateDeviceWidth_ChromiumImpl(LocalFrame*); \
+  static int CalculateDeviceWidth
+
+#define CalculateDeviceHeight                      \
+  CalculateDeviceHeight_ChromiumImpl(LocalFrame*); \
+  static int CalculateDeviceHeight
+
+#include "src/third_party/blink/renderer/core/css/media_values.h"
+
+#undef CalculateDeviceWidth
+#undef CalculateDeviceHeight
+
+#endif  // BRAVE_CHROMIUM_SRC_THIRD_PARTY_BLINK_RENDERER_CORE_CSS_MEDIA_VALUES_H_

--- a/chromium_src/third_party/blink/renderer/core/events/mouse_event.h
+++ b/chromium_src/third_party/blink/renderer/core/events/mouse_event.h
@@ -1,0 +1,48 @@
+/* Copyright (c) 2022 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_CHROMIUM_SRC_THIRD_PARTY_BLINK_RENDERER_CORE_EVENTS_MOUSE_EVENT_H_
+#define BRAVE_CHROMIUM_SRC_THIRD_PARTY_BLINK_RENDERER_CORE_EVENTS_MOUSE_EVENT_H_
+
+#include "third_party/blink/renderer/core/frame/local_dom_window.h"
+
+#define screenX                                                            \
+  screenX() const {                                                        \
+    auto* local_dom_window = DynamicTo<LocalDOMWindow>(view());            \
+    int delta_screenX = local_dom_window                                   \
+                            ? local_dom_window->screenX() -                \
+                                  local_dom_window->screenX_ChromiumImpl() \
+                            : 0;                                           \
+    int delta_outerWidth =                                                 \
+        local_dom_window ? local_dom_window->outerWidth() -                \
+                               local_dom_window->outerWidth_ChromiumImpl() \
+                         : 0;                                              \
+    return std::floor(screenX_ChromiumImpl() + delta_screenX +             \
+                      delta_outerWidth);                                   \
+  }                                                                        \
+  virtual double screenX_ChromiumImpl
+
+#define screenY                                                             \
+  screenY() const {                                                         \
+    auto* local_dom_window = DynamicTo<LocalDOMWindow>(view());             \
+    int delta_screenY = local_dom_window                                    \
+                            ? local_dom_window->screenY() -                 \
+                                  local_dom_window->screenY_ChromiumImpl()  \
+                            : 0;                                            \
+    int delta_outerHeight =                                                 \
+        local_dom_window ? local_dom_window->outerHeight() -                \
+                               local_dom_window->outerHeight_ChromiumImpl() \
+                         : 0;                                               \
+    return std::floor(screenY_ChromiumImpl() + delta_screenY +              \
+                      delta_outerHeight);                                   \
+  }                                                                         \
+  virtual double screenY_ChromiumImpl
+
+#include "src/third_party/blink/renderer/core/events/mouse_event.h"
+
+#undef screenX
+#undef screenY
+
+#endif  // BRAVE_CHROMIUM_SRC_THIRD_PARTY_BLINK_RENDERER_CORE_EVENTS_MOUSE_EVENT_H_

--- a/chromium_src/third_party/blink/renderer/core/events/pointer_event.h
+++ b/chromium_src/third_party/blink/renderer/core/events/pointer_event.h
@@ -1,0 +1,20 @@
+/* Copyright (c) 2022 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_CHROMIUM_SRC_THIRD_PARTY_BLINK_RENDERER_CORE_EVENTS_POINTER_EVENT_H_
+#define BRAVE_CHROMIUM_SRC_THIRD_PARTY_BLINK_RENDERER_CORE_EVENTS_POINTER_EVENT_H_
+
+#include "third_party/blink/renderer/core/events/mouse_event.h"
+
+#define screen_x_ MouseEvent::screenX() + screen_x_ - std::floor(screen_x_)
+
+#define screen_y_ MouseEvent::screenY() + screen_y_ - std::floor(screen_y_)
+
+#include "src/third_party/blink/renderer/core/events/pointer_event.h"
+
+#undef screen_x_
+#undef screen_y_
+
+#endif  // BRAVE_CHROMIUM_SRC_THIRD_PARTY_BLINK_RENDERER_CORE_EVENTS_POINTER_EVENT_H_

--- a/chromium_src/third_party/blink/renderer/core/execution_context/navigator_base.cc
+++ b/chromium_src/third_party/blink/renderer/core/execution_context/navigator_base.cc
@@ -5,6 +5,7 @@
 
 #include "third_party/blink/renderer/core/execution_context/navigator_base.h"
 
+#include "brave/third_party/blink/renderer/core/brave_session_cache.h"
 #include "third_party/blink/public/platform/web_content_settings_client.h"
 #include "third_party/blink/renderer/core/frame/local_dom_window.h"
 #include "third_party/blink/renderer/core/frame/local_frame.h"

--- a/chromium_src/third_party/blink/renderer/core/fileapi/public_url_manager.cc
+++ b/chromium_src/third_party/blink/renderer/core/fileapi/public_url_manager.cc
@@ -3,11 +3,11 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+#include "brave/third_party/blink/renderer/core/brave_session_cache.h"
 #include "net/base/features.h"
 #include "third_party/blink/public/mojom/blob/blob_registry.mojom-blink.h"
 #include "third_party/blink/public/platform/web_content_settings_client.h"
 #include "third_party/blink/public/platform/web_security_origin.h"
-#include "third_party/blink/renderer/core/execution_context/execution_context.h"
 
 namespace blink {
 namespace {

--- a/chromium_src/third_party/blink/renderer/core/frame/local_dom_window.cc
+++ b/chromium_src/third_party/blink/renderer/core/frame/local_dom_window.cc
@@ -4,10 +4,37 @@
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 #include "third_party/blink/renderer/core/frame/local_dom_window.h"
+#include "brave/third_party/blink/renderer/core/brave_session_cache.h"
+#include "third_party/blink/renderer/core/events/mouse_event.h"
+#include "third_party/blink/renderer/core/events/pointer_event.h"
+
+#define outerHeight outerHeight_ChromiumImpl
+#define outerWidth outerWidth_ChromiumImpl
+#define screenX screenX_ChromiumImpl
+#define screenY screenY_ChromiumImpl
 
 #include "src/third_party/blink/renderer/core/frame/local_dom_window.cc"
 
+#undef outerHeight
+#undef outerWidth
+#undef screenX
+#undef screenY
+
 namespace blink {
+
+using brave::FarbleKey;
+
+int LocalDOMWindow::MaybeFarbleInteger(brave::FarbleKey key,
+                                       int spoof_value,
+                                       int min_value,
+                                       int max_value,
+                                       int defaultValue) const {
+  ExecutionContext* context = GetExecutionContext();
+  return brave::AllowScreenFingerprinting(context)
+             ? defaultValue
+             : brave::FarbledInteger(context, key, spoof_value, min_value,
+                                     max_value);
+}
 
 void LocalDOMWindow::SetEphemeralStorageOrigin(
     const SecurityOrigin* ephemeral_storage_origin) {
@@ -31,6 +58,32 @@ LocalDOMWindow::GetEphemeralStorageOriginOrSecurityOrigin() const {
   return ephemeral_storage_key_
              ? ephemeral_storage_key_->GetSecurityOrigin().get()
              : GetSecurityOrigin();
+}
+
+int LocalDOMWindow::outerHeight() const {
+  // Prevent fingerprinter use of outerHeight by returning a farbled value near
+  // innerHeight instead:
+  return MaybeFarbleInteger(brave::FarbleKey::WINDOW_INNERHEIGHT, innerHeight(),
+                            0, 8, outerHeight_ChromiumImpl());
+}
+
+int LocalDOMWindow::outerWidth() const {
+  // Prevent fingerprinter use of outerWidth by returning a farbled value near
+  // innerWidth instead:
+  return MaybeFarbleInteger(brave::FarbleKey::WINDOW_INNERWIDTH, innerWidth(),
+                            0, 8, outerWidth_ChromiumImpl());
+}
+
+int LocalDOMWindow::screenX() const {
+  // Prevent fingerprinter use of screenX, screenLeft by returning value near 0:
+  return MaybeFarbleInteger(brave::FarbleKey::WINDOW_SCREENX, 0, 0, 8,
+                            screenX_ChromiumImpl());
+}
+
+int LocalDOMWindow::screenY() const {
+  // Prevent fingerprinter use of screenY, screenTop by returning value near 0:
+  return MaybeFarbleInteger(brave::FarbleKey::WINDOW_SCREENY, 0, 0, 8,
+                            screenY_ChromiumImpl());
 }
 
 }  // namespace blink

--- a/chromium_src/third_party/blink/renderer/core/frame/local_dom_window.h
+++ b/chromium_src/third_party/blink/renderer/core/frame/local_dom_window.h
@@ -8,6 +8,8 @@
 
 #include "third_party/abseil-cpp/absl/types/optional.h"
 
+#include "brave/third_party/blink/renderer/core/brave_session_cache.h"
+
 #define SetStorageKey                                                        \
   SetEphemeralStorageOrigin(const SecurityOrigin* ephemeral_storage_origin); \
   const SecurityOrigin* GetEphemeralStorageOrigin() const;                   \
@@ -20,8 +22,30 @@
  public:                                                                     \
   void SetStorageKey
 
+#define outerHeight                                                        \
+  MaybeFarbleInteger(brave::FarbleKey key, int spoof_value, int min_value, \
+                     int max_value, int defaultValue) const;               \
+  int outerHeight_ChromiumImpl() const;                                    \
+  int outerHeight
+
+#define outerWidth                 \
+  outerWidth_ChromiumImpl() const; \
+  int outerWidth
+
+#define screenLeft              \
+  screenX_ChromiumImpl() const; \
+  int screenLeft
+
+#define screenTop               \
+  screenY_ChromiumImpl() const; \
+  int screenTop
+
 #include "src/third_party/blink/renderer/core/frame/local_dom_window.h"
 
 #undef SetStorageKey
+#undef outerHeight
+#undef outerWidth
+#undef screenLeft
+#undef screenTop
 
 #endif  // BRAVE_CHROMIUM_SRC_THIRD_PARTY_BLINK_RENDERER_CORE_FRAME_LOCAL_DOM_WINDOW_H_

--- a/chromium_src/third_party/blink/renderer/core/frame/navigator_concurrent_hardware.cc
+++ b/chromium_src/third_party/blink/renderer/core/frame/navigator_concurrent_hardware.cc
@@ -4,10 +4,11 @@
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 #include "third_party/blink/renderer/core/frame/navigator_concurrent_hardware.h"
+
 #include "base/compiler_specific.h"
 #include "base/system/sys_info.h"
+#include "brave/third_party/blink/renderer/core/brave_session_cache.h"
 #include "third_party/abseil-cpp/absl/random/random.h"
-#include "third_party/blink/renderer/core/execution_context/execution_context.h"
 
 namespace brave {
 

--- a/chromium_src/third_party/blink/renderer/core/frame/navigator_device_memory.cc
+++ b/chromium_src/third_party/blink/renderer/core/frame/navigator_device_memory.cc
@@ -6,9 +6,9 @@
 #include "third_party/abseil-cpp/absl/random/random.h"
 
 #include "brave/third_party/blink/renderer/brave_farbling_constants.h"
+#include "brave/third_party/blink/renderer/core/brave_session_cache.h"
 #include "third_party/blink/public/common/device_memory/approximated_device_memory.h"
 #include "third_party/blink/public/platform/web_content_settings_client.h"
-#include "third_party/blink/renderer/core/execution_context/execution_context.h"
 #include "third_party/blink/renderer/core/frame/navigator_device_memory.h"
 
 namespace brave {

--- a/chromium_src/third_party/blink/renderer/core/frame/navigator_language.cc
+++ b/chromium_src/third_party/blink/renderer/core/frame/navigator_language.cc
@@ -5,6 +5,7 @@
 
 #include "third_party/blink/renderer/core/frame/navigator_language.h"
 
+#include "brave/third_party/blink/renderer/core/brave_session_cache.h"
 #include "third_party/blink/public/platform/web_content_settings_client.h"
 
 #define NavigatorLanguage NavigatorLanguage_ChromiumImpl

--- a/chromium_src/third_party/blink/renderer/core/frame/screen.cc
+++ b/chromium_src/third_party/blink/renderer/core/frame/screen.cc
@@ -1,0 +1,12 @@
+/* Copyright (c) 2022 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "third_party/blink/renderer/core/page/chrome_client.h"
+
+#define GetScreenInfos BraveGetScreenInfos
+
+#include "src/third_party/blink/renderer/core/frame/screen.cc"
+
+#undef BraveGetScreenInfos

--- a/chromium_src/third_party/blink/renderer/core/frame/screen.h
+++ b/chromium_src/third_party/blink/renderer/core/frame/screen.h
@@ -1,0 +1,26 @@
+/* Copyright (c) 2022 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_CHROMIUM_SRC_THIRD_PARTY_BLINK_RENDERER_CORE_FRAME_SCREEN_H_
+#define BRAVE_CHROMIUM_SRC_THIRD_PARTY_BLINK_RENDERER_CORE_FRAME_SCREEN_H_
+
+#include "third_party/blink/renderer/core/core_export.h"
+#include "third_party/blink/renderer/core/dom/events/event_target.h"
+#include "third_party/blink/renderer/core/execution_context/execution_context_lifecycle_observer.h"
+#include "third_party/blink/renderer/platform/heap/garbage_collected.h"
+#include "third_party/blink/renderer/platform/supplementable.h"
+#include "third_party/blink/renderer/platform/wtf/text/atomic_string.h"
+#include "ui/display/screen_info.h"
+
+#define GetScreenInfo                             \
+  GetScreenInfo() const;                          \
+  mutable display::ScreenInfo brave_screen_info_; \
+  void dummy
+
+#include "src/third_party/blink/renderer/core/frame/screen.h"
+
+#undef GetScreenInfo
+
+#endif  // BRAVE_CHROMIUM_SRC_THIRD_PARTY_BLINK_RENDERER_CORE_FRAME_SCREEN_H_

--- a/chromium_src/third_party/blink/renderer/core/html/canvas/canvas_async_blob_creator.cc
+++ b/chromium_src/third_party/blink/renderer/core/html/canvas/canvas_async_blob_creator.cc
@@ -3,8 +3,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+#include "brave/third_party/blink/renderer/core/brave_session_cache.h"
 #include "third_party/blink/public/platform/web_content_settings_client.h"
-#include "third_party/blink/renderer/core/execution_context/execution_context.h"
 
 #define BRAVE_CANVAS_ASYNC_BLOB_CREATOR                                \
   if (WebContentSettingsClient* settings =                             \

--- a/chromium_src/third_party/blink/renderer/core/html/canvas/html_canvas_element.cc
+++ b/chromium_src/third_party/blink/renderer/core/html/canvas/html_canvas_element.cc
@@ -4,8 +4,8 @@
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 #include "base/auto_reset.h"
+#include "brave/third_party/blink/renderer/core/brave_session_cache.h"
 #include "third_party/blink/public/platform/web_content_settings_client.h"
-#include "third_party/blink/renderer/core/execution_context/execution_context.h"
 
 #define BRAVE_TO_DATA_URL_INTERNAL                                     \
   {                                                                    \

--- a/chromium_src/third_party/blink/renderer/core/input/touch.h
+++ b/chromium_src/third_party/blink/renderer/core/input/touch.h
@@ -1,0 +1,48 @@
+/* Copyright (c) 2022 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_CHROMIUM_SRC_THIRD_PARTY_BLINK_RENDERER_CORE_INPUT_TOUCH_H_
+#define BRAVE_CHROMIUM_SRC_THIRD_PARTY_BLINK_RENDERER_CORE_INPUT_TOUCH_H_
+
+#include "third_party/blink/renderer/core/frame/local_dom_window.h"
+
+#define screenX                                                            \
+  screenX() const {                                                        \
+    auto* local_dom_window = target()->ToLocalDOMWindow();                 \
+    int delta_screenX = local_dom_window                                   \
+                            ? local_dom_window->screenX() -                \
+                                  local_dom_window->screenX_ChromiumImpl() \
+                            : 0;                                           \
+    int delta_outerWidth =                                                 \
+        local_dom_window ? local_dom_window->outerWidth() -                \
+                               local_dom_window->outerWidth_ChromiumImpl() \
+                         : 0;                                              \
+    return std::floor(screenX_ChromiumImpl() + delta_screenX +             \
+                      delta_outerWidth);                                   \
+  }                                                                        \
+  double screenX_ChromiumImpl
+
+#define screenY                                                             \
+  screenY() const {                                                         \
+    auto* local_dom_window = target()->ToLocalDOMWindow();                  \
+    int delta_screenY = local_dom_window                                    \
+                            ? local_dom_window->screenY() -                 \
+                                  local_dom_window->screenY_ChromiumImpl()  \
+                            : 0;                                            \
+    int delta_outerHeight =                                                 \
+        local_dom_window ? local_dom_window->outerHeight() -                \
+                               local_dom_window->outerHeight_ChromiumImpl() \
+                         : 0;                                               \
+    return std::floor(screenY_ChromiumImpl() + delta_screenY +              \
+                      delta_outerHeight);                                   \
+  }                                                                         \
+  double screenY_ChromiumImpl
+
+#include "src/third_party/blink/renderer/core/input/touch.h"
+
+#undef screenX
+#undef screenY
+
+#endif  // BRAVE_CHROMIUM_SRC_THIRD_PARTY_BLINK_RENDERER_CORE_INPUT_TOUCH_H_

--- a/chromium_src/third_party/blink/renderer/core/page/chrome_client.cc
+++ b/chromium_src/third_party/blink/renderer/core/page/chrome_client.cc
@@ -1,0 +1,15 @@
+/* Copyright (c) 2022 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "src/third_party/blink/renderer/core/page/chrome_client.cc"
+
+namespace blink {
+
+const display::ScreenInfos& ChromeClient::BraveGetScreenInfos(
+    LocalFrame& frame) const {
+  return this->GetScreenInfos(frame);
+}
+
+}  // namespace blink

--- a/chromium_src/third_party/blink/renderer/core/page/chrome_client.h
+++ b/chromium_src/third_party/blink/renderer/core/page/chrome_client.h
@@ -1,0 +1,17 @@
+/* Copyright (c) 2022 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_CHROMIUM_SRC_THIRD_PARTY_BLINK_RENDERER_CORE_PAGE_CHROME_CLIENT_H_
+#define BRAVE_CHROMIUM_SRC_THIRD_PARTY_BLINK_RENDERER_CORE_PAGE_CHROME_CLIENT_H_
+
+#define GetScreenInfos                          \
+  BraveGetScreenInfos(LocalFrame& frame) const; \
+  virtual const display::ScreenInfos& GetScreenInfos
+
+#include "src/third_party/blink/renderer/core/page/chrome_client.h"
+
+#undef GetScreenInfos
+
+#endif  // BRAVE_CHROMIUM_SRC_THIRD_PARTY_BLINK_RENDERER_CORE_PAGE_CHROME_CLIENT_H_

--- a/chromium_src/third_party/blink/renderer/core/page/chrome_client_impl.cc
+++ b/chromium_src/third_party/blink/renderer/core/page/chrome_client_impl.cc
@@ -1,0 +1,34 @@
+/* Copyright (c) 2022 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "src/third_party/blink/renderer/core/page/chrome_client_impl.cc"
+
+#include "third_party/blink/public/common/features.h"
+
+namespace blink {
+
+const display::ScreenInfos& ChromeClientImpl::BraveGetScreenInfos(
+    LocalFrame& frame) const {
+  display::ScreenInfo screenInfo = GetScreenInfo(frame);
+  LocalDOMWindow* dom_window = frame.DomWindow();
+  if (!dom_window) {
+    return GetScreenInfos(frame);
+  }
+  ExecutionContext* context = dom_window->GetExecutionContext();
+  if (brave::AllowScreenFingerprinting(context)) {
+    return GetScreenInfos(frame);
+  }
+  gfx::Rect farbledScreenRect(dom_window->screenX(), dom_window->screenY(),
+                              dom_window->outerWidth(),
+                              dom_window->outerHeight());
+  screenInfo.rect = farbledScreenRect;
+  screenInfo.available_rect = farbledScreenRect;
+  screenInfo.is_extended = false;
+  screenInfo.is_primary = false;
+  screen_infos_ = display::ScreenInfos(screenInfo);
+  return screen_infos_;
+}
+
+}  // namespace blink

--- a/chromium_src/third_party/blink/renderer/core/page/chrome_client_impl.h
+++ b/chromium_src/third_party/blink/renderer/core/page/chrome_client_impl.h
@@ -1,0 +1,25 @@
+/* Copyright (c) 2022 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_CHROMIUM_SRC_THIRD_PARTY_BLINK_RENDERER_CORE_PAGE_CHROME_CLIENT_IMPL_H_
+#define BRAVE_CHROMIUM_SRC_THIRD_PARTY_BLINK_RENDERER_CORE_PAGE_CHROME_CLIENT_IMPL_H_
+
+#include "third_party/blink/renderer/core/page/chrome_client.h"
+#include "ui/display/screen_infos.h"
+
+#define GetScreenInfos                             \
+  BraveGetScreenInfos(LocalFrame&) const override; \
+  const display::ScreenInfos& GetScreenInfos
+
+#define cursor_overridden_ \
+  cursor_overridden_;      \
+  mutable display::ScreenInfos screen_infos_;
+
+#include "src/third_party/blink/renderer/core/page/chrome_client_impl.h"
+
+#undef cursor_overridden_
+#undef GetScreenInfos
+
+#endif  // BRAVE_CHROMIUM_SRC_THIRD_PARTY_BLINK_RENDERER_CORE_PAGE_CHROME_CLIENT_IMPL_H_

--- a/chromium_src/third_party/blink/renderer/core/page/create_window.cc
+++ b/chromium_src/third_party/blink/renderer/core/page/create_window.cc
@@ -1,0 +1,48 @@
+/* Copyright (c) 2022 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "third_party/blink/renderer/core/page/create_window.h"
+#include "third_party/blink/renderer/core/frame/screen.h"
+
+#include "brave/third_party/blink/renderer/core/brave_session_cache.h"
+
+// Because we are spoofing screenX and screenY, we need to offset the position
+// when a page script opens a new window in screen coordinates. And because
+// we are spoofing screen width and height, we should artificially limit the
+// window size to that width and height as well, so that window.open can't
+// be used to probe the screen size.
+#define GetWindowFeaturesFromString                                           \
+  GetWindowFeaturesFromString(const String& feature_string,                   \
+                              LocalDOMWindow* dom_window) {                   \
+    WebWindowFeatures window_features =                                       \
+        GetWindowFeaturesFromString_ChromiumImpl(feature_string, dom_window); \
+    ExecutionContext* context = dom_window->GetExecutionContext();            \
+    if (!brave::AllowScreenFingerprinting(context)) {                         \
+      if (window_features.x_set) {                                            \
+        window_features.x += dom_window->screenX_ChromiumImpl();              \
+      }                                                                       \
+      if (window_features.y_set) {                                            \
+        window_features.y += dom_window->screenY_ChromiumImpl();              \
+      }                                                                       \
+      if (window_features.width_set) {                                        \
+        int maxWidth = dom_window->screen()->width();                         \
+        if (window_features.width > maxWidth) {                               \
+          window_features.width = maxWidth;                                   \
+        }                                                                     \
+      }                                                                       \
+      if (window_features.height_set) {                                       \
+        int maxHeight = dom_window->screen()->height();                       \
+        if (window_features.height > maxHeight) {                             \
+          window_features.height = maxHeight;                                 \
+        }                                                                     \
+      }                                                                       \
+    }                                                                         \
+    return window_features;                                                   \
+  }                                                                           \
+  WebWindowFeatures GetWindowFeaturesFromString_ChromiumImpl
+
+#include "src/third_party/blink/renderer/core/page/create_window.cc"
+
+#undef GetWindowFeaturesFromString

--- a/chromium_src/third_party/blink/renderer/core/page/create_window.h
+++ b/chromium_src/third_party/blink/renderer/core/page/create_window.h
@@ -1,0 +1,18 @@
+/* Copyright (c) 2022 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_CHROMIUM_SRC_THIRD_PARTY_BLINK_RENDERER_CORE_PAGE_CREATE_WINDOW_H_
+#define BRAVE_CHROMIUM_SRC_THIRD_PARTY_BLINK_RENDERER_CORE_PAGE_CREATE_WINDOW_H_
+
+#define GetWindowFeaturesFromString                                      \
+  GetWindowFeaturesFromString_ChromiumImpl(const String& feature_string, \
+                                           LocalDOMWindow* dom_window);  \
+  CORE_EXPORT WebWindowFeatures GetWindowFeaturesFromString
+
+#include "src/third_party/blink/renderer/core/page/create_window.h"
+
+#undef GetWindowFeaturesFromString
+
+#endif  // BRAVE_CHROMIUM_SRC_THIRD_PARTY_BLINK_RENDERER_CORE_PAGE_CREATE_WINDOW_H_

--- a/chromium_src/third_party/blink/renderer/modules/canvas/canvas2d/base_rendering_context_2d.cc
+++ b/chromium_src/third_party/blink/renderer/modules/canvas/canvas2d/base_rendering_context_2d.cc
@@ -6,8 +6,8 @@
 #include "third_party/blink/renderer/modules/canvas/canvas2d/base_rendering_context_2d.h"
 
 #include "base/notreached.h"
+#include "brave/third_party/blink/renderer/core/brave_session_cache.h"
 #include "third_party/blink/public/platform/web_content_settings_client.h"
-#include "third_party/blink/renderer/core/execution_context/execution_context.h"
 #include "third_party/blink/renderer/platform/graphics/image_data_buffer.h"
 
 #define BRAVE_GET_IMAGE_DATA                                              \

--- a/chromium_src/third_party/blink/renderer/modules/canvas/canvas2d/canvas_rendering_context_2d.cc
+++ b/chromium_src/third_party/blink/renderer/modules/canvas/canvas2d/canvas_rendering_context_2d.cc
@@ -5,7 +5,7 @@
 
 #include "third_party/blink/renderer/modules/canvas/canvas2d/canvas_rendering_context_2d.h"
 
-#include "third_party/blink/renderer/core/execution_context/execution_context.h"
+#include "brave/third_party/blink/renderer/core/brave_session_cache.h"
 
 #define BRAVE_CANVAS_RENDERING_CONTEXT_2D_MEASURE_TEXT    \
   if (!brave::AllowFingerprinting(GetExecutionContext())) \

--- a/chromium_src/third_party/blink/renderer/modules/keyboard/navigator_keyboard.cc
+++ b/chromium_src/third_party/blink/renderer/modules/keyboard/navigator_keyboard.cc
@@ -6,8 +6,8 @@
 #include "third_party/blink/renderer/modules/keyboard/navigator_keyboard.h"
 
 #include "brave/third_party/blink/renderer/brave_farbling_constants.h"
+#include "brave/third_party/blink/renderer/core/brave_session_cache.h"
 #include "third_party/blink/public/platform/web_content_settings_client.h"
-#include "third_party/blink/renderer/core/execution_context/execution_context.h"
 
 #define keyboard keyboard_ChromiumImpl
 #include "src/third_party/blink/renderer/modules/keyboard/navigator_keyboard.cc"

--- a/chromium_src/third_party/blink/renderer/modules/mediastream/media_devices.cc
+++ b/chromium_src/third_party/blink/renderer/modules/mediastream/media_devices.cc
@@ -3,8 +3,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+#include "brave/third_party/blink/renderer/core/brave_session_cache.h"
 #include "third_party/abseil-cpp/absl/random/random.h"
-#include "third_party/blink/renderer/core/execution_context/execution_context.h"
 #include "third_party/blink/renderer/modules/mediastream/media_device_info.h"
 
 using blink::ExecutionContext;

--- a/chromium_src/third_party/blink/renderer/modules/plugins/dom_plugin_array.cc
+++ b/chromium_src/third_party/blink/renderer/modules/plugins/dom_plugin_array.cc
@@ -5,8 +5,8 @@
 
 #include "third_party/blink/renderer/modules/plugins/dom_plugin_array.h"
 #include "base/compiler_specific.h"
+#include "brave/third_party/blink/renderer/core/brave_session_cache.h"
 #include "third_party/abseil-cpp/absl/random/random.h"
-#include "third_party/blink/renderer/core/execution_context/execution_context.h"
 #include "third_party/blink/renderer/core/frame/local_dom_window.h"
 #include "third_party/blink/renderer/core/frame/local_frame.h"
 #include "third_party/blink/renderer/core/page/plugin_data.h"

--- a/chromium_src/third_party/blink/renderer/modules/speech/speech_synthesis.cc
+++ b/chromium_src/third_party/blink/renderer/modules/speech/speech_synthesis.cc
@@ -5,9 +5,9 @@
 
 #include "third_party/blink/renderer/modules/speech/speech_synthesis.h"
 #include "brave/third_party/blink/renderer/brave_farbling_constants.h"
+#include "brave/third_party/blink/renderer/core/brave_session_cache.h"
 #include "third_party/abseil-cpp/absl/random/random.h"
 #include "third_party/blink/public/platform/web_content_settings_client.h"
-#include "third_party/blink/renderer/core/execution_context/execution_context.h"
 
 #define OnSetVoiceList OnSetVoiceList_ChromiumImpl
 #include "src/third_party/blink/renderer/modules/speech/speech_synthesis.cc"

--- a/chromium_src/third_party/blink/renderer/modules/webaudio/analyser_handler.cc
+++ b/chromium_src/third_party/blink/renderer/modules/webaudio/analyser_handler.cc
@@ -3,9 +3,9 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+#include "brave/third_party/blink/renderer/core/brave_session_cache.h"
 #include "third_party/blink/public/platform/web_content_settings_client.h"
 #include "third_party/blink/renderer/core/dom/document.h"
-#include "third_party/blink/renderer/core/execution_context/execution_context.h"
 #include "third_party/blink/renderer/core/frame/local_dom_window.h"
 #include "third_party/blink/renderer/core/frame/local_frame.h"
 #include "third_party/blink/renderer/core/workers/worker_global_scope.h"

--- a/chromium_src/third_party/blink/renderer/modules/webaudio/audio_buffer.cc
+++ b/chromium_src/third_party/blink/renderer/modules/webaudio/audio_buffer.cc
@@ -5,9 +5,9 @@
 
 #include "base/callback.h"
 #include "brave/third_party/blink/renderer/brave_farbling_constants.h"
+#include "brave/third_party/blink/renderer/core/brave_session_cache.h"
 #include "third_party/blink/public/platform/web_content_settings_client.h"
 #include "third_party/blink/renderer/core/dom/document.h"
-#include "third_party/blink/renderer/core/execution_context/execution_context.h"
 #include "third_party/blink/renderer/core/frame/local_dom_window.h"
 #include "third_party/blink/renderer/core/frame/local_frame.h"
 #include "third_party/blink/renderer/core/workers/worker_global_scope.h"

--- a/chromium_src/third_party/blink/renderer/modules/webgl/webgl2_rendering_context_base.cc
+++ b/chromium_src/third_party/blink/renderer/modules/webgl/webgl2_rendering_context_base.cc
@@ -4,8 +4,8 @@
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 #include "third_party/blink/renderer/modules/webgl/webgl2_rendering_context_base.h"
+#include "brave/third_party/blink/renderer/core/brave_session_cache.h"
 #include "third_party/blink/renderer/bindings/modules/v8/webgl_any.h"
-#include "third_party/blink/renderer/core/execution_context/execution_context.h"
 
 #include <algorithm>
 

--- a/chromium_src/third_party/blink/renderer/modules/webgl/webgl_rendering_context_base.cc
+++ b/chromium_src/third_party/blink/renderer/modules/webgl/webgl_rendering_context_base.cc
@@ -4,9 +4,10 @@
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 #include "third_party/blink/renderer/modules/webgl/webgl_rendering_context_base.h"
+
+#include "brave/third_party/blink/renderer/core/brave_session_cache.h"
 #include "third_party/blink/public/platform/web_content_settings_client.h"
 #include "third_party/blink/renderer/core/dom/document.h"
-#include "third_party/blink/renderer/core/execution_context/execution_context.h"
 #include "third_party/blink/renderer/core/frame/local_dom_window.h"
 #include "third_party/blink/renderer/core/frame/local_frame.h"
 #include "third_party/blink/renderer/core/html/canvas/canvas_rendering_context_host.h"

--- a/chromium_src/third_party/blink/renderer/modules/websockets/websocket_channel_impl.cc
+++ b/chromium_src/third_party/blink/renderer/modules/websockets/websocket_channel_impl.cc
@@ -5,6 +5,7 @@
 
 #include "third_party/blink/renderer/modules/websockets/websocket_channel_impl.h"
 
+#include "brave/third_party/blink/renderer/core/brave_session_cache.h"
 #include "third_party/blink/public/common/features.h"
 #include "third_party/blink/public/common/scheme_registry.h"
 #include "third_party/blink/public/platform/web_content_settings_client.h"

--- a/third_party/blink/renderer/core/DEPS
+++ b/third_party/blink/renderer/core/DEPS
@@ -1,4 +1,5 @@
 include_rules = [
   "+third_party/blink/renderer/core",
+  "+third_party/blink/renderer/execution_context",
   "+third_party/blink/renderer/platform",
 ]

--- a/third_party/blink/renderer/includes.gni
+++ b/third_party/blink/renderer/includes.gni
@@ -6,6 +6,8 @@ brave_blink_renderer_core_visibility =
 brave_blink_renderer_core_public_deps = [ "//brave/third_party/blink/renderer" ]
 
 brave_blink_renderer_core_sources = [
+  "//brave/third_party/blink/renderer/core/brave_session_cache.cc",
+  "//brave/third_party/blink/renderer/core/brave_session_cache.h",
   "//brave/third_party/blink/renderer/core/resource_pool_limiter/resource_pool_limiter.cc",
   "//brave/third_party/blink/renderer/core/resource_pool_limiter/resource_pool_limiter.h",
 ]


### PR DESCRIPTION
Closes 23170

Behind the kBraveBlockScreenFingerprinting flag.

When farbling is active, modify API behavior in 4 categories:

1. window.outer{Width,Height}, window.screen{X,Y},
   window.screen.{width,height,avail{Width,Height,Left,Top}}

R = random number between 0 and 8, seeded by session+domain

window.screen{X,Y} -> R
window.outer{Width,Height} -> window.inner{Width, Height} + R
window.screen.{width, height} -> window.inner{Width, Height} + R
window.screen.avail{Width, Height} => window.inner{Width, Height} + R
window.screen.avail{Top, Left} -> R
window.screen.isExtended -> false

2. {mouse,drag,pointer,touch}Event.screen{X,Y}

Rewrite Event screen coordinates such that
event.screenX -> event.screenX_ChromiumImpl +
                 window.innerWidth - window.outerWidth_ChromiumImpl +
		 window.screenX - window.screenX_ChromiumImpl

etc.

3. device-{width,height} in media queries

When farbling is enabled, media query for device-width
matches the same value as window.screen.width (also farbled).
Same for device-height.

4: make window.open play nice with spoofed screen coords

When a web page opens a child window, the position of the child window
should be relative to the spoofed screen coordinates, not relative
to the real screen coordinates.

Also:

* Factor out brave_session_cache.{cc,h} to speed up incremental builds.
* Unit tests

<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves 

## Submitter Checklist:

- [ ] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues/23170) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

