### PR TITLE
Reopen sync code dialog when switching desktop <=> mobile

### DIFF
--- a/browser/resources/settings/brave_sync_page/brave_sync_code_dialog.js
+++ b/browser/resources/settings/brave_sync_page/brave_sync_code_dialog.js
@@ -90,11 +90,17 @@ Polymer({
   },
 
   handleChooseMobile_: function() {
-    this.codeType = 'qr'
+    this.codeType = null
+    window.setTimeout(() => {
+      this.codeType = 'qr'
+    }, 0)
   },
 
   handleChooseComputer_: function() {
-    this.codeType = 'words'
+    this.codeType = null
+    window.setTimeout(() => {
+      this.codeType = 'words'
+    }, 0)
   },
 
   handleSyncCodeCopy_: function() {


### PR DESCRIPTION
<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/23262

The behavior which happens in the original issue doesn't leave any traces in console. It acts like click happened not on the `View Sync Code` link, but somewhere outside of the modal dialog, [this line at onPointerdown_(e) {}](https://source.chromium.org/chromium/chromium/src/+/main:ui/webui/resources/cr_elements/cr_dialog/cr_dialog.js;l=318?q=ui%2Fwebui%2Fresources%2Fcr_elements%2Fcr_dialog%2Fcr_dialog.js&ss=chromium%2Fchromium%2Fsrc)

 This PR forces to re-open the dialog when its type is changed. This introduces flickering, but UI is always responsible.

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

Please see https://github.com/brave/brave-browser/issues/23262 
