### PR TITLE
Conditionally disable the `brave://crash/` schema browser test (uplift to 1.39.x)

### DIFF
--- a/browser/brave_scheme_load_browsertest.cc
+++ b/browser/brave_scheme_load_browsertest.cc
@@ -205,7 +205,18 @@ IN_PROC_BROWSER_TEST_F(BraveSchemeLoadBrowserTest,
 }
 
 // Check renderer crash happened by observing related notification.
-IN_PROC_BROWSER_TEST_F(BraveSchemeLoadBrowserTest, CrashURLTest) {
+// Some tests are failing for Windows x86 CI,
+// See https://github.com/brave/brave-browser/issues/22767
+#if BUILDFLAG(IS_WIN) && defined(ARCH_CPU_X86)
+#define MAYBE_CrashURLTest DISABLED_CrashURLTest
+#else
+#define MAYBE_CrashURLTest CrashURLTest
+#endif
+// NOTE: the actual crash functionality is covered upstream in
+// chrome/browser/crash_recovery_browsertest.cc
+// This test is for the brave:// scheme. This is a regression test added with:
+// https://github.com/brave/brave-core/pull/2229)
+IN_PROC_BROWSER_TEST_F(BraveSchemeLoadBrowserTest, MAYBE_CrashURLTest) {
   content::RenderProcessHostWatcher crash_observer(
       browser()->tab_strip_model()->GetActiveWebContents(),
       content::RenderProcessHostWatcher::WATCH_FOR_PROCESS_EXIT);


### PR DESCRIPTION
Uplift of #13631
Fixes https://github.com/brave/brave-browser/issues/23264

Pre-approval checklist: 
- [ ] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.