### PR TITLE
Removed Adblock item from Browser app menu

### DIFF
--- a/app/brave_command_ids.h
+++ b/app/brave_command_ids.h
@@ -10,8 +10,7 @@
 // Check chrome/app/chrome_command_ids.h when rebase.
 // ID of IDC_BRAVE_COMANDS_START and first brave command should be same.
 #define IDC_BRAVE_COMMANDS_START 56000
-#define IDC_SHOW_BRAVE_REWARDS   56000
-#define IDC_SHOW_BRAVE_ADBLOCK   56001
+#define IDC_SHOW_BRAVE_REWARDS 56000
 #define IDC_NEW_TOR_CONNECTION_FOR_SITE     56002
 #define IDC_NEW_OFFTHERECORD_WINDOW_TOR 56003
 #define IDC_CONTENT_CONTEXT_OPENLINKTOR 56004

--- a/app/brave_generated_resources.grd
+++ b/app/brave_generated_resources.grd
@@ -167,9 +167,6 @@
       <message name="IDS_SHOW_BRAVE_REWARDS" desc="The show Brave Rewards menu in the app menu">
         Brave Rewards
       </message>
-      <message name="IDS_SHOW_BRAVE_ADBLOCK" desc="The show Brave Ad Block menu in the app menu">
-        Brave Ad Block
-      </message>
       <if expr="use_titlecase">
         <message name="IDS_SHOW_BRAVE_WEBCOMPAT_REPORTER" desc="The menu item to report a broken site in the app menu">
           Report a Broken Site

--- a/browser/brave_content_browser_client.cc
+++ b/browser/brave_content_browser_client.cc
@@ -846,6 +846,17 @@ bool BraveContentBrowserClient::HandleURLOverrideRewrite(
     return true;
   }
 
+#if !BUILDFLAG(IS_ANDROID)
+  if (url->host() == kAdblockHost) {
+    GURL::Replacements replacements;
+    replacements.SetSchemeStr(content::kChromeUIScheme);
+    replacements.SetHostStr(chrome::kChromeUISettingsHost);
+    replacements.SetPathStr(kContentFiltersPath);
+    *url = url->ReplaceComponents(replacements);
+    return false;
+  }
+#endif
+
   // no special win10 welcome page
   if (url->host() == chrome::kChromeUIWelcomeHost) {
     *url = GURL(chrome::kChromeUIWelcomeURL);

--- a/browser/brave_content_browser_client_browsertest.cc
+++ b/browser/brave_content_browser_client_browsertest.cc
@@ -166,7 +166,7 @@ IN_PROC_BROWSER_TEST_F(BraveContentBrowserClientTest, CanLoadChromeURL) {
 
 IN_PROC_BROWSER_TEST_F(BraveContentBrowserClientTest, CanLoadCustomBravePages) {
   std::vector<std::string> pages{
-      "adblock",
+      "ipfs-internals",
       "rewards",
   };
 
@@ -263,6 +263,31 @@ IN_PROC_BROWSER_TEST_F(BraveContentBrowserClientTest, RewriteChromeSync) {
                      .spec()
                      .c_str(),
                  "chrome://settings/braveSync");
+  }
+}
+
+IN_PROC_BROWSER_TEST_F(BraveContentBrowserClientTest, RewriteAdblock) {
+  std::vector<std::string> schemes{
+      "brave://",
+      "chrome://",
+  };
+
+  for (const std::string& scheme : schemes) {
+    content::WebContents* contents =
+        browser()->tab_strip_model()->GetActiveWebContents();
+    ASSERT_TRUE(
+        ui_test_utils::NavigateToURL(browser(), GURL(scheme + "adblock")));
+    ASSERT_TRUE(WaitForLoadStop(contents));
+
+    EXPECT_STREQ(base::UTF16ToUTF8(
+                     browser()->location_bar_model()->GetFormattedFullURL())
+                     .c_str(),
+                 "brave://settings/shields/content-filters");
+    EXPECT_EQ(browser()->location_bar_model()->GetURL(),
+              GURL("chrome://settings/shields/content-filters"));
+    EXPECT_EQ(
+        contents->GetController().GetLastCommittedEntry()->GetVirtualURL(),
+        GURL("chrome://settings/shields/content-filters"));
   }
 }
 

--- a/browser/ui/brave_browser_command_controller.cc
+++ b/browser/ui/brave_browser_command_controller.cc
@@ -132,7 +132,6 @@ void BraveBrowserCommandController::InitBraveCommandState() {
     if (syncer::IsSyncAllowedByFlag())
       UpdateCommandForBraveSync();
   }
-  UpdateCommandForBraveAdblock();
   UpdateCommandForWebcompatReporter();
 #if BUILDFLAG(ENABLE_TOR)
   UpdateCommandForTor();
@@ -163,10 +162,6 @@ void BraveBrowserCommandController::InitBraveCommandState() {
 
 void BraveBrowserCommandController::UpdateCommandForBraveRewards() {
   UpdateCommandEnabled(IDC_SHOW_BRAVE_REWARDS, true);
-}
-
-void BraveBrowserCommandController::UpdateCommandForBraveAdblock() {
-  UpdateCommandEnabled(IDC_SHOW_BRAVE_ADBLOCK, true);
 }
 
 void BraveBrowserCommandController::UpdateCommandForWebcompatReporter() {
@@ -258,9 +253,6 @@ bool BraveBrowserCommandController::ExecuteBraveCommandWithDisposition(
       break;
     case IDC_SHOW_BRAVE_REWARDS:
       brave::ShowBraveRewards(browser_);
-      break;
-    case IDC_SHOW_BRAVE_ADBLOCK:
-      brave::ShowBraveAdblock(browser_);
       break;
     case IDC_SHOW_BRAVE_WEBCOMPAT_REPORTER:
       brave::ShowWebcompatReporter(browser_);

--- a/browser/ui/brave_browser_command_controller.h
+++ b/browser/ui/brave_browser_command_controller.h
@@ -65,7 +65,6 @@ class BraveBrowserCommandController : public chrome::BrowserCommandController
 
   void InitBraveCommandState();
   void UpdateCommandForBraveRewards();
-  void UpdateCommandForBraveAdblock();
   void UpdateCommandForWebcompatReporter();
   void UpdateCommandForBraveSync();
   void UpdateCommandForBraveWallet();

--- a/browser/ui/brave_browser_command_controller_browsertest.cc
+++ b/browser/ui/brave_browser_command_controller_browsertest.cc
@@ -101,7 +101,6 @@ IN_PROC_BROWSER_TEST_F(BraveBrowserCommandControllerTest,
   // Test normal browser's brave commands status.
   auto* command_controller = browser()->command_controller();
   EXPECT_TRUE(command_controller->IsCommandEnabled(IDC_SHOW_BRAVE_REWARDS));
-  EXPECT_TRUE(command_controller->IsCommandEnabled(IDC_SHOW_BRAVE_ADBLOCK));
 
 #if BUILDFLAG(ENABLE_TOR)
   EXPECT_FALSE(
@@ -138,7 +137,6 @@ IN_PROC_BROWSER_TEST_F(BraveBrowserCommandControllerTest,
   auto* private_browser = CreateIncognitoBrowser();
   auto* command_controller = private_browser->command_controller();
   EXPECT_TRUE(command_controller->IsCommandEnabled(IDC_SHOW_BRAVE_REWARDS));
-  EXPECT_TRUE(command_controller->IsCommandEnabled(IDC_SHOW_BRAVE_ADBLOCK));
 
 #if BUILDFLAG(ENABLE_TOR)
   EXPECT_FALSE(
@@ -172,8 +170,6 @@ IN_PROC_BROWSER_TEST_F(BraveBrowserCommandControllerTest,
   auto* command_controller = guest_browser->command_controller();
   EXPECT_FALSE(command_controller->IsCommandEnabled(IDC_SHOW_BRAVE_REWARDS));
 
-  EXPECT_TRUE(command_controller->IsCommandEnabled(IDC_SHOW_BRAVE_ADBLOCK));
-
 #if BUILDFLAG(ENABLE_TOR)
   EXPECT_FALSE(
       command_controller->IsCommandEnabled(IDC_NEW_TOR_CONNECTION_FOR_SITE));
@@ -202,8 +198,6 @@ IN_PROC_BROWSER_TEST_F(BraveBrowserCommandControllerTest,
   EXPECT_TRUE(tor_browser->profile()->IsTor());
   auto* command_controller = tor_browser->command_controller();
   EXPECT_TRUE(command_controller->IsCommandEnabled(IDC_SHOW_BRAVE_REWARDS));
-
-  EXPECT_TRUE(command_controller->IsCommandEnabled(IDC_SHOW_BRAVE_ADBLOCK));
 
   EXPECT_TRUE(
       command_controller->IsCommandEnabled(IDC_NEW_TOR_CONNECTION_FOR_SITE));

--- a/browser/ui/toolbar/brave_app_menu_model.cc
+++ b/browser/ui/toolbar/brave_app_menu_model.cc
@@ -247,12 +247,6 @@ void BraveAppMenuModel::InsertBraveMenuItems() {
   }
 #endif
 
-  // Insert adblock menu at last. Assumed this is always enabled.
-  DCHECK(IsCommandIdEnabled(IDC_SHOW_BRAVE_ADBLOCK));
-  InsertItemWithStringIdAt(GetIndexOfBraveAdBlockItem(),
-                           IDC_SHOW_BRAVE_ADBLOCK,
-                           IDS_SHOW_BRAVE_ADBLOCK);
-
   // Insert webcompat reporter item.
   InsertItemWithStringIdAt(GetIndexOfCommandId(IDC_ABOUT),
                            IDC_SHOW_BRAVE_WEBCOMPAT_REPORTER,
@@ -282,7 +276,7 @@ void BraveAppMenuModel::InsertBraveMenuItems() {
     }
     int index = IsCommandIdEnabled(IDC_SHOW_BRAVE_SYNC)
                     ? GetIndexOfBraveSyncItem() + 1
-                    : GetIndexOfBraveAdBlockItem();
+                    : GetLastIndexOfSecondSection();
     InsertSubMenuWithStringIdAt(index, IDC_APP_MENU_IPFS, IDS_APP_MENU_IPFS,
                                 &ipfs_submenu_model_);
 
@@ -447,7 +441,7 @@ void BraveAppMenuModel::InsertAlternateProfileItems() {
     InsertSeparatorAt(index, ui::NORMAL_SEPARATOR);
 }
 
-int BraveAppMenuModel::GetIndexOfBraveAdBlockItem() const {
+int BraveAppMenuModel::GetLastIndexOfSecondSection() const {
   // Insert as a last item in second section.
   std::vector<int> commands_to_check = {IDC_SHOW_BRAVE_VPN_PANEL,
                                         IDC_BRAVE_VPN_MENU,

--- a/browser/ui/toolbar/brave_app_menu_model.h
+++ b/browser/ui/toolbar/brave_app_menu_model.h
@@ -47,7 +47,7 @@ class BraveAppMenuModel : public AppMenuModel {
   void InsertBraveMenuItems();
   void InsertAlternateProfileItems();
   int GetIndexOfBraveRewardsItem() const;
-  int GetIndexOfBraveAdBlockItem() const;
+  int GetLastIndexOfSecondSection() const;
   int GetIndexOfBraveSyncItem() const;
   int GetIndexOfBraveVPNItem() const;
 #if BUILDFLAG(ENABLE_SIDEBAR)

--- a/browser/ui/toolbar/brave_app_menu_model_browsertest.cc
+++ b/browser/ui/toolbar/brave_app_menu_model_browsertest.cc
@@ -158,7 +158,6 @@ IN_PROC_BROWSER_TEST_F(BraveAppMenuBrowserTest, MenuOrderTest) {
 #if BUILDFLAG(ENABLE_BRAVE_VPN)
     IDC_SHOW_BRAVE_VPN_PANEL,
 #endif
-    IDC_SHOW_BRAVE_ADBLOCK,
     IDC_ADD_NEW_PROFILE,
     IDC_OPEN_GUEST_PROFILE,
     IDC_SHOW_BRAVE_WEBCOMPAT_REPORTER
@@ -193,7 +192,6 @@ IN_PROC_BROWSER_TEST_F(BraveAppMenuBrowserTest, MenuOrderTest) {
     IDC_SHOW_BRAVE_WALLET,
     IDC_MANAGE_EXTENSIONS,
     IDC_SHOW_BRAVE_SYNC,
-    IDC_SHOW_BRAVE_ADBLOCK,
     IDC_ADD_NEW_PROFILE,
     IDC_OPEN_GUEST_PROFILE,
     IDC_SHOW_BRAVE_WEBCOMPAT_REPORTER
@@ -226,7 +224,7 @@ IN_PROC_BROWSER_TEST_F(BraveAppMenuBrowserTest, MenuOrderTest) {
   DCHECK(guest_browser);
   EXPECT_TRUE(guest_browser->profile()->IsGuestSession());
   std::vector<int> commands_in_order_for_guest_profile = {
-      IDC_NEW_TAB, IDC_NEW_WINDOW, IDC_SHOW_DOWNLOADS, IDC_SHOW_BRAVE_ADBLOCK,
+      IDC_NEW_TAB, IDC_NEW_WINDOW, IDC_SHOW_DOWNLOADS,
       IDC_SHOW_BRAVE_WEBCOMPAT_REPORTER};
   CheckCommandsAreInOrderInMenuModel(guest_browser,
                                      commands_in_order_for_guest_profile);
@@ -267,7 +265,6 @@ IN_PROC_BROWSER_TEST_F(BraveAppMenuBrowserTest, MenuOrderTest) {
       IDC_SHOW_DOWNLOADS,
       IDC_SHOW_BRAVE_WALLET,
       IDC_SHOW_BRAVE_SYNC,
-      IDC_SHOW_BRAVE_ADBLOCK,
       IDC_ADD_NEW_PROFILE,
       IDC_OPEN_GUEST_PROFILE,
       IDC_SHOW_BRAVE_WEBCOMPAT_REPORTER};

--- a/components/brave_shields/resources/panel/components/advanced-controls-content/index.tsx
+++ b/components/brave_shields/resources/panel/components/advanced-controls-content/index.tsx
@@ -28,7 +28,7 @@ const fingerprintModeOptions = [
 
 function GlobalSettings () {
   const onAdBlockListsClick = () => {
-    chrome.tabs.create({ url: 'chrome://adblock', active: true })
+    chrome.tabs.create({ url: 'chrome://settings/shields/content-filters', active: true })
   }
 
   const onSettingsClick = () => {

--- a/components/constants/webui_url_constants.cc
+++ b/components/constants/webui_url_constants.cc
@@ -40,3 +40,4 @@ const char kShieldsPanelHost[] = "brave-shields.top-chrome";
 const char kSidebarBookmarksHost[] = "sidebar-bookmarks.top-chrome";
 const char kFederatedInternalsURL[] = "brave://federated-internals";
 const char kFederatedInternalsHost[] = "federated-internals";
+const char kContentFiltersPath[] = "shields/content-filters";

--- a/components/constants/webui_url_constants.h
+++ b/components/constants/webui_url_constants.h
@@ -42,5 +42,6 @@ extern const char kShieldsPanelHost[];
 extern const char kSidebarBookmarksHost[];
 extern const char kFederatedInternalsURL[];
 extern const char kFederatedInternalsHost[];
+extern const char kContentFiltersPath[];
 
 #endif  // BRAVE_COMPONENTS_CONSTANTS_WEBUI_URL_CONSTANTS_H_


### PR DESCRIPTION
<!-- Add brave-browser issue bellow that this PR will resolve -->

This PR
1. removes "Brave Ad block" item from the browser's app menu
2. replaces the previous Adblock url to the Shields settings content filters url in the new Panel UI
3. Rewrites `brave://adblock` contents to `brave://settings/shields/content-filters` for desktop builds only

Resolves https://github.com/brave/brave-browser/issues/23194

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [x] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [x] New files have MPL-2.0 license header
- [x] Adequate test coverage exists to prevent regressions
- [x] Major classes, functions and non-trivial code blocks are well-commented
- [x] Changes in component dependencies are properly reflected in `gn`
- [x] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [x] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

1. Open Browser app menu to see if "Brave Adblock" item exists
2. Open the new shields panel > advanced controls > click "Filter lists" ensure it's linked to `brave://settings/shields/content-filters`
3. Create a new tab and visit `brave://adblock`> content should be overridden to the new shields content filters settings page (DESKTOP BUILDS ONLY)