### PR TITLE
Turned on closing window dialog by default (uplift to 1.40.x)

### DIFF
--- a/browser/brave_profile_prefs.cc
+++ b/browser/brave_profile_prefs.cc
@@ -426,7 +426,7 @@ void RegisterProfilePrefs(user_prefs::PrefRegistrySyncable* registry) {
   // We can turn customization mode on when we have add-shortcut feature.
   registry->SetDefaultPrefValue(ntp_prefs::kNtpUseMostVisitedTiles,
                                 base::Value(true));
-  registry->RegisterBooleanPref(kEnableWindowClosingConfirm, false);
+  registry->RegisterBooleanPref(kEnableWindowClosingConfirm, true);
   RegisterDefaultBraveBrowserPromptPrefs(registry);
 #endif
 

--- a/browser/ui/brave_browser.cc
+++ b/browser/ui/brave_browser.cc
@@ -24,6 +24,17 @@
 #include "chrome/browser/ui/tabs/tab_strip_model_observer.h"
 #endif
 
+namespace {
+
+bool g_suppress_dialog_for_testing = false;
+
+}  // namespace
+
+// static
+void BraveBrowser::SuppressBrowserWindowClosingDialogForTesting(bool suppress) {
+  g_suppress_dialog_for_testing = suppress;
+}
+
 BraveBrowser::BraveBrowser(const CreateParams& params) : Browser(params) {
 #if BUILDFLAG(ENABLE_SIDEBAR)
   if (!sidebar::CanUseSidebar(this))
@@ -138,6 +149,9 @@ void BraveBrowser::ResetTryToCloseWindow() {
 }
 
 bool BraveBrowser::ShouldAskForBrowserClosingBeforeHandlers() {
+  if (g_suppress_dialog_for_testing)
+    return false;
+
   // Don't need to ask when application closing is in-progress.
   if (BrowserCloseManager::BrowserClosingStarted())
     return false;

--- a/browser/ui/brave_browser.h
+++ b/browser/ui/brave_browser.h
@@ -63,6 +63,12 @@ class BraveBrowser : public Browser {
   void set_confirmed_to_close(bool close) { confirmed_to_close_ = close; }
 
  private:
+  friend class BraveTestLauncherDelegate;
+  friend class WindowClosingConfirmBrowserTest;
+
+  // static
+  static void SuppressBrowserWindowClosingDialogForTesting(bool suppress);
+
 #if BUILDFLAG(ENABLE_SIDEBAR)
   std::unique_ptr<sidebar::SidebarController> sidebar_controller_;
 #endif

--- a/browser/ui/window_closing_confirm_browsertest.cc
+++ b/browser/ui/window_closing_confirm_browsertest.cc
@@ -53,16 +53,21 @@ void CancelClose() {
 class WindowClosingConfirmBrowserTest : public InProcessBrowserTest {
  public:
   void SetUpOnMainThread() override {
+    BraveBrowser::SuppressBrowserWindowClosingDialogForTesting(false);
+
     InProcessBrowserTest::SetUpOnMainThread();
 
     PrefService* prefs = browser()->profile()->GetPrefs();
-    // Disabled by default.
-    EXPECT_FALSE(prefs->GetBoolean(kEnableWindowClosingConfirm));
-
-    // Enable for testing.
-    prefs->SetBoolean(kEnableWindowClosingConfirm, true);
+    // Enabled by default.
+    EXPECT_TRUE(prefs->GetBoolean(kEnableWindowClosingConfirm));
 
     SetDialogCreationCallback();
+  }
+
+  void TearDownOnMainThread() override {
+    BraveBrowser::SuppressBrowserWindowClosingDialogForTesting(true);
+
+    InProcessBrowserTest::TearDownOnMainThread();
   }
 
   void SetDialogCreationCallback() {

--- a/test/BUILD.gn
+++ b/test/BUILD.gn
@@ -596,7 +596,10 @@ static_library("browser_test_support") {
     "base/brave_test_launcher_delegate.h",
   ]
 
-  deps = [ "//chrome/browser" ]
+  deps = [
+    "//brave/browser/ui",
+    "//chrome/browser",
+  ]
 }
 
 static_library("browser_tests_runner") {

--- a/test/base/brave_test_launcher_delegate.cc
+++ b/test/base/brave_test_launcher_delegate.cc
@@ -6,6 +6,7 @@
 #include "brave/test/base/brave_test_launcher_delegate.h"
 
 #include "brave/app/brave_main_delegate.h"
+#include "brave/browser/ui/brave_browser.h"
 #include "build/build_config.h"
 
 #if BUILDFLAG(IS_MAC) || BUILDFLAG(IS_LINUX)
@@ -20,6 +21,10 @@ BraveTestLauncherDelegate::BraveTestLauncherDelegate(
 #if BUILDFLAG(IS_MAC) || BUILDFLAG(IS_LINUX)
   first_run::internal::ForceFirstRunDialogShownForTesting(false);
 #endif
+
+  // Suppress browser window closing dialog during the test.
+  // It can cause some tests timeout.
+  BraveBrowser::SuppressBrowserWindowClosingDialogForTesting(true);
 }
 
 BraveTestLauncherDelegate::~BraveTestLauncherDelegate() = default;


### PR DESCRIPTION
Uplift of #13502
fix https://github.com/brave/brave-browser/issues/23056

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.