### PR TITLE
fix(wallet): Don't set the global Selected Account from Accounts Tab

### DIFF
--- a/components/brave_wallet_ui/components/desktop/views/accounts/account.tsx
+++ b/components/brave_wallet_ui/components/desktop/views/accounts/account.tsx
@@ -54,7 +54,6 @@ import {
 import { useBalance } from '../../../../common/hooks'
 
 // Actions
-import { WalletActions } from '../../../../common/actions'
 import { WalletPageActions } from '../../../../page/actions'
 
 export interface Props {
@@ -171,13 +170,6 @@ export const Account = (props: Props) => {
     }
     dispatch(WalletPageActions.removeImportedAccount({ address, coin }))
   }, [])
-
-  // effects
-  React.useEffect(() => {
-    if (selectedAccount) {
-      dispatch(WalletActions.selectAccount(selectedAccount))
-    }
-  }, [selectedAccount])
 
   // redirect (asset not found)
   if (!selectedAccount) {


### PR DESCRIPTION
## Description 
- Fixes a bug where selecting an account in the `Accounts` tab set the global `Selected Account`
- Fixes a bug that was causing an endless refresh loop when selecting a `Filecoin` account.

<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves <https://github.com/brave/brave-browser/issues/23289>

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [x] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [x] New files have MPL-2.0 license header
- [x] Adequate test coverage exists to prevent regressions
- [x] Major classes, functions and non-trivial code blocks are well-commented
- [x] Changes in component dependencies are properly reflected in `gn`
- [x] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [x] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

1. In the `Buy/Send/Swap` widget change your selected account to an `Ethereum` account.
2. Go the `Accounts` tab and click on your `Solana` account, the `SelectedAccount` account in the `Buy/Send/Swap` widget should not change.
3. Go back to the `Accounts` tab and click on your `Filecoin` account, the assets should not refresh over and over.

Before:

https://user-images.githubusercontent.com/40611140/172702976-00b9a123-8510-4520-8f9c-24e3573d0e20.mov

After:

https://user-images.githubusercontent.com/40611140/172703001-6d2bbbbf-ad85-44d2-bbc4-57819bed601b.mov
