### PR TITLE
Return chain_id for known chains not having infura subdomains in GetK…

### DIFF
--- a/components/brave_wallet/browser/brave_wallet_utils.cc
+++ b/components/brave_wallet/browser/brave_wallet_utils.cc
@@ -960,14 +960,15 @@ std::string GetKnownEthNetworkId(const std::string& chain_id) {
   if (!subdomain.empty())
     return subdomain;
 
-  // Separate check for localhost in known networks as it is predefined but
-  // does not have infura subdomain.
-  if (chain_id == mojom::kLocalhostChainId) {
-    for (const auto& network : kKnownEthNetworks) {
-      if (network.chain_id == chain_id) {
-        return GURL(network.rpc_urls.front()).spec();
-      }
-    }
+  // For known networks not in kInfuraSubdomains:
+  //   localhost: Use the first RPC URL.
+  //   other: Use chain ID like other custom networks.
+  for (const auto& network : kKnownEthNetworks) {
+    if (network.chain_id != chain_id)
+      continue;
+    if (chain_id == mojom::kLocalhostChainId)
+      return GURL(network.rpc_urls.front()).spec();
+    return chain_id;
   }
 
   return "";

--- a/components/brave_wallet/browser/brave_wallet_utils_unittest.cc
+++ b/components/brave_wallet/browser/brave_wallet_utils_unittest.cc
@@ -959,9 +959,15 @@ TEST(BraveWalletUtilsUnitTest, GetChain) {
 }
 
 TEST(BraveWalletUtilsUnitTest, GetAllKnownEthNetworkIds) {
-  EXPECT_EQ(GetAllKnownEthNetworkIds(),
-            std::vector<std::string>({"mainnet", "rinkeby", "ropsten", "goerli",
-                                      "kovan", "http://localhost:7545/"}));
+  const std::vector<std::string> expected_network_ids(
+      {"mainnet", mojom::kPolygonMainnetChainId,
+       mojom::kBinanceSmartChainMainnetChainId, mojom::kCeloMainnetChainId,
+       mojom::kAvalancheMainnetChainId, mojom::kFantomMainnetChainId,
+       mojom::kOptimismMainnetChainId, "rinkeby", "ropsten", "goerli", "kovan",
+       "http://localhost:7545/"});
+  ASSERT_EQ(GetAllKnownNetworksForTesting().size(),
+            expected_network_ids.size());
+  EXPECT_EQ(GetAllKnownEthNetworkIds(), expected_network_ids);
 }
 
 TEST(BraveWalletUtilsUnitTest, GetKnownEthNetworkId) {
@@ -1018,6 +1024,12 @@ TEST(BraveWalletUtilsUnitTest, GetNetworkId) {
   EXPECT_EQ(GetNetworkId(&prefs, mojom::CoinType::ETH, "chain_id"), "chain_id");
   EXPECT_EQ(GetNetworkId(&prefs, mojom::CoinType::ETH, "chain_id2"),
             "chain_id2");
+  EXPECT_EQ(
+      GetNetworkId(&prefs, mojom::CoinType::ETH, mojom::kPolygonMainnetChainId),
+      mojom::kPolygonMainnetChainId);
+  EXPECT_EQ(GetNetworkId(&prefs, mojom::CoinType::ETH,
+                         mojom::kBinanceSmartChainMainnetChainId),
+            mojom::kBinanceSmartChainMainnetChainId);
 
   EXPECT_EQ(GetNetworkId(&prefs, mojom::CoinType::SOL, mojom::kSolanaMainnet),
             "mainnet");


### PR DESCRIPTION
…nownEthNetworkId

Fix the bug that currently GetNetworkId might return empty string for preloading networks not in kInfuraSubdomains. It needs to be non-empty for all known networks because we are using it as pref key in multiple places.

<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/23346

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [x] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [x] New files have MPL-2.0 license header
- [x] Adequate test coverage exists to prevent regressions
- [x] Major classes, functions and non-trivial code blocks are well-commented
- [x] Changes in component dependencies are properly reflected in `gn`
- [x] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
covered by auto tests.
