### PR TITLE
Return chain_id for known chains not having infura subdomains in GetKnownEthNetworkId (uplift to 1.40.x)

### DIFF
--- a/components/brave_wallet/browser/brave_wallet_utils.cc
+++ b/components/brave_wallet/browser/brave_wallet_utils.cc
@@ -889,14 +889,15 @@ std::string GetKnownEthNetworkId(const std::string& chain_id) {
   if (!subdomain.empty())
     return subdomain;
 
-  // Separate check for localhost in known networks as it is predefined but
-  // does not have infura subdomain.
-  if (chain_id == mojom::kLocalhostChainId) {
-    for (const auto& network : kKnownEthNetworks) {
-      if (network.chain_id == chain_id) {
-        return GURL(network.rpc_urls.front()).spec();
-      }
-    }
+  // For known networks not in kInfuraSubdomains:
+  //   localhost: Use the first RPC URL.
+  //   other: Use chain ID like other custom networks.
+  for (const auto& network : kKnownEthNetworks) {
+    if (network.chain_id != chain_id)
+      continue;
+    if (chain_id == mojom::kLocalhostChainId)
+      return GURL(network.rpc_urls.front()).spec();
+    return chain_id;
   }
 
   return "";

--- a/components/brave_wallet/browser/brave_wallet_utils_unittest.cc
+++ b/components/brave_wallet/browser/brave_wallet_utils_unittest.cc
@@ -879,9 +879,15 @@ TEST(BraveWalletUtilsUnitTest, GetChain) {
 }
 
 TEST(BraveWalletUtilsUnitTest, GetAllKnownEthNetworkIds) {
-  EXPECT_EQ(GetAllKnownEthNetworkIds(),
-            std::vector<std::string>({"mainnet", "rinkeby", "ropsten", "goerli",
-                                      "kovan", "http://localhost:7545/"}));
+  const std::vector<std::string> expected_network_ids(
+      {"mainnet", mojom::kPolygonMainnetChainId,
+       mojom::kBinanceSmartChainMainnetChainId, mojom::kCeloMainnetChainId,
+       mojom::kAvalancheMainnetChainId, mojom::kFantomMainnetChainId,
+       mojom::kOptimismMainnetChainId, "rinkeby", "ropsten", "goerli", "kovan",
+       "http://localhost:7545/"});
+  ASSERT_EQ(GetAllKnownNetworksForTesting().size(),
+            expected_network_ids.size());
+  EXPECT_EQ(GetAllKnownEthNetworkIds(), expected_network_ids);
 }
 
 TEST(BraveWalletUtilsUnitTest, GetKnownEthNetworkId) {
@@ -940,6 +946,12 @@ TEST(BraveWalletUtilsUnitTest, GetNetworkId) {
   EXPECT_EQ(GetNetworkId(&prefs, mojom::CoinType::ETH, "chain_id"), "chain_id");
   EXPECT_EQ(GetNetworkId(&prefs, mojom::CoinType::ETH, "chain_id2"),
             "chain_id2");
+  EXPECT_EQ(
+      GetNetworkId(&prefs, mojom::CoinType::ETH, mojom::kPolygonMainnetChainId),
+      mojom::kPolygonMainnetChainId);
+  EXPECT_EQ(GetNetworkId(&prefs, mojom::CoinType::ETH,
+                         mojom::kBinanceSmartChainMainnetChainId),
+            mojom::kBinanceSmartChainMainnetChainId);
 
   EXPECT_EQ(GetNetworkId(&prefs, mojom::CoinType::SOL, mojom::kSolanaMainnet),
             "mainnet");


### PR DESCRIPTION
Uplift of #13705
Resolves https://github.com/brave/brave-browser/issues/23346
Resolves https://github.com/brave/brave-browser/issues/23360

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.