### PR TITLE
Strip mkt_tok query parameter conditionally

### DIFF
--- a/browser/net/brave_site_hacks_network_delegate_helper.cc
+++ b/browser/net/brave_site_hacks_network_delegate_helper.cc
@@ -9,9 +9,11 @@
 #include <string>
 #include <vector>
 
-#include "base/lazy_instance.h"
+#include "base/containers/fixed_flat_map.h"
+#include "base/containers/fixed_flat_set.h"
 #include "base/metrics/histogram_macros.h"
-#include "base/no_destructor.h"
+#include "base/strings/string_piece.h"
+#include "base/strings/string_split.h"
 #include "base/strings/string_util.h"
 #include "brave/components/brave_shields/browser/brave_shields_util.h"
 #include "brave/components/constants/url_constants.h"
@@ -26,75 +28,82 @@ namespace brave {
 
 namespace {
 
-const std::string& GetQueryStringTrackers() {
-  static const base::NoDestructor<std::string> trackers(base::JoinString(
-      std::vector<std::string>(
-          {// https://github.com/brave/brave-browser/issues/4239
-           "fbclid", "gclid", "msclkid", "mc_eid",
-           // https://github.com/brave/brave-browser/issues/9879
-           "dclid",
-           // https://github.com/brave/brave-browser/issues/13644
-           "oly_anon_id", "oly_enc_id",
-           // https://github.com/brave/brave-browser/issues/11579
-           "_openstat",
-           // https://github.com/brave/brave-browser/issues/11817
-           "vero_conv", "vero_id",
-           // https://github.com/brave/brave-browser/issues/13647
-           "wickedid",
-           // https://github.com/brave/brave-browser/issues/11578
-           "yclid",
-           // https://github.com/brave/brave-browser/issues/8975
-           "__s",
-           // https://github.com/brave/brave-browser/issues/17451
-           "rb_clickid",
-           // https://github.com/brave/brave-browser/issues/17452
-           "s_cid",
-           // https://github.com/brave/brave-browser/issues/17507
-           "ml_subscriber", "ml_subscriber_hash",
-           // https://github.com/brave/brave-browser/issues/18020
-           "twclid",
-           // https://github.com/brave/brave-browser/issues/18758
-           "gbraid", "wbraid",
-           // https://github.com/brave/brave-browser/issues/9019
-           "_hsenc", "__hssc", "__hstc", "__hsfp", "hsCtaTracking",
-           // https://github.com/brave/brave-browser/issues/22082
-           "oft_id", "oft_k", "oft_lk", "oft_d", "oft_c", "oft_ck", "oft_ids",
-           "oft_sk",
-           // https://github.com/brave/brave-browser/issues/11580
-           "igshid"}),
-      "|"));
-  return *trackers;
+static constexpr auto kSimpleQueryStringTrackers =
+    base::MakeFixedFlatSet<base::StringPiece>(
+        {// https://github.com/brave/brave-browser/issues/4239
+         "fbclid", "gclid", "msclkid", "mc_eid",
+         // https://github.com/brave/brave-browser/issues/9879
+         "dclid",
+         // https://github.com/brave/brave-browser/issues/13644
+         "oly_anon_id", "oly_enc_id",
+         // https://github.com/brave/brave-browser/issues/11579
+         "_openstat",
+         // https://github.com/brave/brave-browser/issues/11817
+         "vero_conv", "vero_id",
+         // https://github.com/brave/brave-browser/issues/13647
+         "wickedid",
+         // https://github.com/brave/brave-browser/issues/11578
+         "yclid",
+         // https://github.com/brave/brave-browser/issues/8975
+         "__s",
+         // https://github.com/brave/brave-browser/issues/17451
+         "rb_clickid",
+         // https://github.com/brave/brave-browser/issues/17452
+         "s_cid",
+         // https://github.com/brave/brave-browser/issues/17507
+         "ml_subscriber", "ml_subscriber_hash",
+         // https://github.com/brave/brave-browser/issues/18020
+         "twclid",
+         // https://github.com/brave/brave-browser/issues/18758
+         "gbraid", "wbraid",
+         // https://github.com/brave/brave-browser/issues/9019
+         "_hsenc", "__hssc", "__hstc", "__hsfp", "hsCtaTracking",
+         // https://github.com/brave/brave-browser/issues/22082
+         "oft_id", "oft_k", "oft_lk", "oft_d", "oft_c", "oft_ck", "oft_ids",
+         "oft_sk",
+         // https://github.com/brave/brave-browser/issues/11580
+         "igshid"});
+
+static constexpr auto kConditionalQueryStringTrackers =
+    base::MakeFixedFlatMap<base::StringPiece, base::StringPiece>(
+        {// https://github.com/brave/brave-browser/issues/9018
+         {"mkt_tok", "[uU]nsubscribe"}});
+
+// Remove tracking query parameters from a GURL, leaving all
+// other parts untouched.
+std::string StripQueryParameter(const std::string& query,
+                                const std::string& spec) {
+  // We are using custom query string parsing code here. See
+  // https://github.com/brave/brave-core/pull/13726#discussion_r897712350
+  // for more information on why this approach was selected.
+  //
+  // Split query string by ampersands, remove tracking parameters,
+  // then join the remaining query parameters, untouched, back into
+  // a single query string.
+  const std::vector<std::string> input_kv_strings =
+      SplitString(query, "&", base::KEEP_WHITESPACE, base::SPLIT_WANT_ALL);
+  std::vector<std::string> output_kv_strings;
+  int disallowed_count = 0;
+  for (const std::string& kv_string : input_kv_strings) {
+    const std::vector<std::string> pieces = SplitString(
+        kv_string, "=", base::KEEP_WHITESPACE, base::SPLIT_WANT_NONEMPTY);
+    const std::string& key = pieces.empty() ? "" : pieces[0];
+    if (pieces.size() >= 2 &&
+        (kSimpleQueryStringTrackers.count(key) == 1 ||
+         (kConditionalQueryStringTrackers.count(key) == 1 &&
+          !re2::RE2::PartialMatch(
+              spec, kConditionalQueryStringTrackers.at(key).data())))) {
+      ++disallowed_count;
+    } else {
+      output_kv_strings.push_back(kv_string);
+    }
+  }
+  if (disallowed_count > 0) {
+    return base::JoinString(output_kv_strings, "&");
+  } else {
+    return query;
+  }
 }
-
-// From src/components/autofill/content/renderer/page_passwords_analyser.cc
-// and password_form_conversion_utils.cc:
-#define DECLARE_LAZY_MATCHER(NAME, PATTERN)                                   \
-  struct LabelPatternLazyInstanceTraits_##NAME                                \
-      : public base::internal::DestructorAtExitLazyInstanceTraits<re2::RE2> { \
-    static re2::RE2* New(void* instance) {                                    \
-      re2::RE2::Options options;                                              \
-      options.set_case_sensitive(false);                                      \
-      re2::RE2* matcher = new (instance) re2::RE2(PATTERN, options);          \
-      DCHECK(matcher->ok());                                                  \
-      return matcher;                                                         \
-    }                                                                         \
-  };                                                                          \
-  base::LazyInstance<re2::RE2, LabelPatternLazyInstanceTraits_##NAME> NAME =  \
-      LAZY_INSTANCE_INITIALIZER
-
-// e.g. "?fbclid=1234"
-DECLARE_LAZY_MATCHER(tracker_only_matcher,
-                     "^(" + GetQueryStringTrackers() + ")=[^&]+$");
-
-// e.g. "?fbclid=1234&foo=1"
-DECLARE_LAZY_MATCHER(tracker_first_matcher,
-                     "^(" + GetQueryStringTrackers() + ")=[^&]+&");
-
-// e.g. "?foo=1&fbclid=1234" or "?foo=1&fbclid=1234&bar=2"
-DECLARE_LAZY_MATCHER(tracker_appended_matcher,
-                     "&(" + GetQueryStringTrackers() + ")=[^&]+");
-
-#undef DECLARE_LAZY_MATCHER
 
 void ApplyPotentialQueryStringFilter(std::shared_ptr<BraveRequestInfo> ctx) {
   SCOPED_UMA_HISTOGRAM_TIMER("Brave.SiteHacks.QueryFilter");
@@ -125,25 +134,15 @@ void ApplyPotentialQueryStringFilter(std::shared_ptr<BraveRequestInfo> ctx) {
     return;
   }
 
-  // Regular expressions are dirty and error-prone, but unfortunately
-  // there is no right way to parse a query string, other than one
-  // generated by a URL-encoded HTML form submission. See
-  // https://github.com/brave/brave-core/pull/3239#issuecomment-524073918
-  // for more information on why this approach was selected.
-
-  std::string new_query = ctx->request_url.query();
-  // Note: the ordering of these replacements is important.
-  const int replacement_count =
-      re2::RE2::GlobalReplace(&new_query, tracker_appended_matcher.Get(), "") +
-      re2::RE2::GlobalReplace(&new_query, tracker_first_matcher.Get(), "") +
-      re2::RE2::GlobalReplace(&new_query, tracker_only_matcher.Get(), "");
-
-  if (replacement_count > 0) {
+  const std::string query = ctx->request_url.query();
+  const std::string spec = ctx->request_url.spec();
+  const std::string clean_query = StripQueryParameter(query, spec);
+  if (clean_query.length() < query.length()) {
     GURL::Replacements replacements;
-    if (new_query.empty()) {
+    if (clean_query.empty()) {
       replacements.ClearQuery();
     } else {
-      replacements.SetQueryStr(new_query);
+      replacements.SetQueryStr(clean_query);
     }
     ctx->new_url_spec = ctx->request_url.ReplaceComponents(replacements).spec();
   }

--- a/browser/net/brave_site_hacks_network_delegate_helper_browsertest.cc
+++ b/browser/net/brave_site_hacks_network_delegate_helper_browsertest.cc
@@ -222,9 +222,13 @@ class BraveSiteHacksNetworkDelegateBrowserTest : public InProcessBrowserTest {
 
 IN_PROC_BROWSER_TEST_F(BraveSiteHacksNetworkDelegateBrowserTest,
                        QueryStringFilterCrossSite) {
-  const std::string inputs[] = {
-      "", "foo=bar", "fbclid=1", "fbclid=2&key=value", "key=value&fbclid=3",
-  };
+  const std::string inputs[] = {"",
+                                "foo=bar",
+                                "fbclid=1",
+                                "fbclid=2&key=value",
+                                "key=value&fbclid=3",
+                                "mkt_tok=xyz&foo=bar",
+                                "mkt_tok=xyz&foo=bar&mkt_unsubscribe=1"};
   const std::string outputs[] = {
       // URLs without trackers should be untouched.
       "",
@@ -233,6 +237,10 @@ IN_PROC_BROWSER_TEST_F(BraveSiteHacksNetworkDelegateBrowserTest,
       "",
       "key=value",
       "key=value",
+      // URLs with conditional trackers should have those removed
+      // only at the right time.
+      "foo=bar",
+      "mkt_tok=xyz&foo=bar&mkt_unsubscribe=1",
   };
 
   constexpr size_t input_count = std::size(inputs);

--- a/browser/net/brave_site_hacks_network_delegate_helper_unittest.cc
+++ b/browser/net/brave_site_hacks_network_delegate_helper_unittest.cc
@@ -120,25 +120,27 @@ TEST(BraveSiteHacksNetworkDelegateHelperTest, OnionReferrerStripped) {
 }
 
 TEST(BraveSiteHacksNetworkDelegateHelperTest, QueryStringUntouched) {
-  const std::vector<const std::string> urls({
-      "https://example.com/",
-      "https://example.com/?",
-      "https://example.com/?+%20",
-      "https://user:pass@example.com/path/file.html?foo=1#fragment",
-      "http://user:pass@example.com/path/file.html?foo=1&bar=2#fragment",
-      "https://example.com/?file=https%3A%2F%2Fexample.com%2Ftest.pdf",
-      "https://example.com/?title=1+2&caption=1%202",
-      "https://example.com/?foo=1&&bar=2#fragment",
-      "https://example.com/?foo&bar=&#fragment",
-      "https://example.com/?foo=1&fbcid=no&gcid=no&mc_cid=no&bar=&#frag",
-      "https://example.com/?fbclid=&gclid&=mc_eid&msclkid=",
-      "https://example.com/?value=fbclid=1&not-gclid=2&foo+mc_eid=3",
-      "https://example.com/?+fbclid=1",
-      "https://example.com/?%20fbclid=1",
-      "https://example.com/#fbclid=1",
-      "https://example.com/1;k=v;&a=b&c=d&gclid=1234;%3fhttp://ad.co/?e=f&g=1",
-      "https://example.com/?__ss=1234-abcd",
-  });
+  const std::vector<const std::string> urls(
+      {"https://example.com/",
+       "https://example.com/?",
+       "https://example.com/?+%20",
+       "https://user:pass@example.com/path/file.html?foo=1#fragment",
+       "http://user:pass@example.com/path/file.html?foo=1&bar=2#fragment",
+       "https://example.com/?file=https%3A%2F%2Fexample.com%2Ftest.pdf",
+       "https://example.com/?title=1+2&caption=1%202",
+       "https://example.com/?foo=1&&bar=2#fragment",
+       "https://example.com/?foo&bar=&#fragment",
+       "https://example.com/?foo=1&fbcid=no&gcid=no&mc_cid=no&bar=&#frag",
+       "https://example.com/?fbclid=&gclid&=mc_eid&msclkid=",
+       "https://example.com/?value=fbclid=1&not-gclid=2&foo+mc_eid=3",
+       "https://example.com/?+fbclid=1",
+       "https://example.com/?%20fbclid=1",
+       "https://example.com/#fbclid=1",
+       "https://example.com/1;k=v;&a=b&c=d&gclid=1234;%3fhttp://ad.co/?e=f&g=1",
+       "https://example.com/?__ss=1234-abcd",
+       "https://example.com/?mkt_tok=123&mkt_unsubscribe=1",
+       "https://example.com/?mkt_unsubscribe=1&fake_param=abc&mkt_tok=123",
+       "https://example.com/Unsubscribe.html?fake_param=abc&mkt_tok=123"});
   for (const auto& url : urls) {
     auto brave_request_info =
         std::make_shared<brave::BraveRequestInfo>(GURL(url));
@@ -205,31 +207,32 @@ TEST(BraveSiteHacksNetworkDelegateHelperTest, QueryStringExempted) {
 
 TEST(BraveSiteHacksNetworkDelegateHelperTest, QueryStringFiltered) {
   const std::vector<const std::pair<const std::string, const std::string>> urls(
-      {
-          // { original url, expected url after filtering }
-          {"https://example.com/?fbclid=1234", "https://example.com/"},
-          {"https://example.com/?fbclid=1234&", "https://example.com/"},
-          {"https://example.com/?&fbclid=1234", "https://example.com/"},
-          {"https://example.com/?gclid=1234", "https://example.com/"},
-          {"https://example.com/?fbclid=0&gclid=1&msclkid=a&mc_eid=a1",
-           "https://example.com/"},
-          {"https://example.com/?fbclid=&foo=1&bar=2&gclid=abc",
-           "https://example.com/?fbclid=&foo=1&bar=2"},
-          {"https://example.com/?fbclid=&foo=1&gclid=1234&bar=2",
-           "https://example.com/?fbclid=&foo=1&bar=2"},
-          {"http://u:p@example.com/path/file.html?foo=1&fbclid=abcd#fragment",
-           "http://u:p@example.com/path/file.html?foo=1#fragment"},
-          {"https://example.com/?__s=1234-abcd", "https://example.com/"},
-          // Obscure edge cases that break most parsers:
-          {"https://example.com/?fbclid&foo&&gclid=2&bar=&%20",
-           "https://example.com/?fbclid&foo&&bar=&%20"},
-          {"https://example.com/?fbclid=1&1==2&=msclkid&foo=bar&&a=b=c&",
-           "https://example.com/?1==2&=msclkid&foo=bar&&a=b=c&"},
-          {"https://example.com/?fbclid=1&=2&?foo=yes&bar=2+",
-           "https://example.com/?=2&?foo=yes&bar=2+"},
-          {"https://example.com/?fbclid=1&a+b+c=some%20thing&1%202=3+4",
-           "https://example.com/?a+b+c=some%20thing&1%202=3+4"},
-      });
+      {// { original url, expected url after filtering }
+       {"https://example.com/?fbclid=1234", "https://example.com/"},
+       {"https://example.com/?fbclid=1234&", "https://example.com/"},
+       {"https://example.com/?&fbclid=1234", "https://example.com/"},
+       {"https://example.com/?gclid=1234", "https://example.com/"},
+       {"https://example.com/?fbclid=0&gclid=1&msclkid=a&mc_eid=a1",
+        "https://example.com/"},
+       {"https://example.com/?fbclid=&foo=1&bar=2&gclid=abc",
+        "https://example.com/?fbclid=&foo=1&bar=2"},
+       {"https://example.com/?fbclid=&foo=1&gclid=1234&bar=2",
+        "https://example.com/?fbclid=&foo=1&bar=2"},
+       {"http://u:p@example.com/path/file.html?foo=1&fbclid=abcd#fragment",
+        "http://u:p@example.com/path/file.html?foo=1#fragment"},
+       {"https://example.com/?__s=1234-abcd", "https://example.com/"},
+       // Obscure edge cases that break most parsers:
+       {"https://example.com/?fbclid&foo&&gclid=2&bar=&%20",
+        "https://example.com/?fbclid&foo&&bar=&%20"},
+       {"https://example.com/?fbclid=1&1==2&=msclkid&foo=bar&&a=b=c&",
+        "https://example.com/?1==2&=msclkid&foo=bar&&a=b=c&"},
+       {"https://example.com/?fbclid=1&=2&?foo=yes&bar=2+",
+        "https://example.com/?=2&?foo=yes&bar=2+"},
+       {"https://example.com/?fbclid=1&a+b+c=some%20thing&1%202=3+4",
+        "https://example.com/?a+b+c=some%20thing&1%202=3+4"},
+       // Conditional query parameter stripping
+       {"https://example.com/?mkt_tok=123&foo=bar",
+        "https://example.com/?foo=bar"}});
   for (const auto& pair : urls) {
     auto brave_request_info =
         std::make_shared<brave::BraveRequestInfo>(GURL(pair.first));


### PR DESCRIPTION
1. Change query parameter stripping approach to use split and join to
make it possible to do conditional query parameter stripping.

2. Ensure that existing tests for query parameter stripping all still pass.

3. Strip mkt_tok except when `mkt_unsubscribe=1` is present in the URL.

4. Add new unit tests to ensure that mk_tok is correctly stripped
under the right conditions.
<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/9018

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [x] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [x] New files have MPL-2.0 license header
- [x] Adequate test coverage exists to prevent regressions
- [x] Major classes, functions and non-trivial code blocks are well-commented
- [x] Changes in component dependencies are properly reflected in `gn`
- [x] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [x] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

