### PR TITLE
Bug 23170: anti-fingerprinting: hide screen size and window position

### DIFF
--- a/browser/about_flags.cc
+++ b/browser/about_flags.cc
@@ -171,6 +171,12 @@ constexpr char kBraveNTPBrandedWallpaperDemoDescription[] =
     "View rate and user opt-in conditionals will still be followed to decide "
     "when to display the Branded Wallpaper.";
 
+constexpr char kBraveBlockScreenFingerprintingName[] =
+    "Block screen fingerprinting";
+constexpr char kBraveBlockScreenFingerprintingDescription[] =
+    "Prevents JavaScript and CSS from learning the user's screen dimensions "
+    "or window position.";
+
 constexpr char kBraveSpeedreaderName[] = "Enable SpeedReader";
 constexpr char kBraveSpeedreaderDescription[] =
     "Enables faster loading of simplified article-style web pages.";
@@ -603,6 +609,11 @@ constexpr char kPlaylistDescription[] = "Enables Playlist";
       flag_descriptions::kRestrictWebSocketsPoolName,                       \
       flag_descriptions::kRestrictWebSocketsPoolDescription, kOsAll,        \
       FEATURE_VALUE_TYPE(blink::features::kRestrictWebSocketsPool)},        \
+    {"brave-block-screen-fingerprinting",                                   \
+      flag_descriptions::kBraveBlockScreenFingerprintingName,               \
+      flag_descriptions::kBraveBlockScreenFingerprintingDescription,        \
+      kOsAll, FEATURE_VALUE_TYPE(                                           \
+          blink::features::kBraveBlockScreenFingerprinting)},               \
     BRAVE_IPFS_FEATURE_ENTRIES                                              \
     BRAVE_NATIVE_WALLET_FEATURE_ENTRIES                                     \
     BRAVE_NEWS_FEATURE_ENTRIES                                              \

--- a/browser/farbling/BUILD.gn
+++ b/browser/farbling/BUILD.gn
@@ -20,6 +20,7 @@ if (!is_android) {
       "brave_navigator_plugins_farbling_browsertest.cc",
       "brave_navigator_useragent_farbling_browsertest.cc",
       "brave_offscreencanvas_farbling_browsertest.cc",
+      "brave_screen_farbling_browsertest.cc",
       "brave_speech_synthesis_farbling_browsertest.cc",
       "brave_webaudio_farbling_browsertest.cc",
       "brave_webgl_farbling_browsertest.cc",

--- a/browser/farbling/brave_screen_farbling_browsertest.cc
+++ b/browser/farbling/brave_screen_farbling_browsertest.cc
@@ -1,0 +1,298 @@
+/* Copyright (c) 2022 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include <algorithm>
+
+#include "base/path_service.h"
+#include "base/run_loop.h"
+#include "base/test/scoped_feature_list.h"
+#include "brave/browser/brave_content_browser_client.h"
+#include "brave/components/brave_shields/browser/brave_shields_util.h"
+#include "brave/components/constants/brave_paths.h"
+#include "chrome/browser/content_settings/host_content_settings_map_factory.h"
+#include "chrome/browser/extensions/extension_browsertest.h"
+#include "chrome/browser/profiles/profile.h"
+#include "chrome/browser/ui/browser_window.h"
+#include "chrome/common/chrome_content_client.h"
+#include "chrome/test/base/ui_test_utils.h"
+#include "content/public/test/browser_test.h"
+#include "net/dns/mock_host_resolver.h"
+#include "net/test/embedded_test_server/embedded_test_server.h"
+#include "net/test/embedded_test_server/http_request.h"
+#include "third_party/blink/public/common/features.h"
+
+using brave_shields::ControlType;
+
+namespace {
+
+const gfx::Rect kTestWindowBounds[] = {
+    gfx::Rect(200, 100, 200, 100), gfx::Rect(50, 50, 100, 100),
+    gfx::Rect(50, 50, 100, 0), gfx::Rect(0, 0, 0, 0)};
+
+}  // namespace
+
+class BraveScreenFarblingBrowserTest : public InProcessBrowserTest {
+ public:
+  void SetUpOnMainThread() override {
+    InProcessBrowserTest::SetUpOnMainThread();
+
+    content_client_.reset(new ChromeContentClient);
+    content::SetContentClient(content_client_.get());
+    browser_content_client_.reset(new BraveContentBrowserClient());
+    content::SetBrowserClientForTesting(browser_content_client_.get());
+
+    host_resolver()->AddRule("*", "127.0.0.1");
+    content::SetupCrossSiteRedirector(embedded_test_server());
+
+    brave::RegisterPathProvider();
+    base::FilePath test_data_dir;
+    base::PathService::Get(brave::DIR_TEST_DATA, &test_data_dir);
+    embedded_test_server()->ServeFilesFromDirectory(test_data_dir);
+
+    ASSERT_TRUE(embedded_test_server()->Start());
+
+    top_level_page_url_ = embedded_test_server()->GetURL("a.com", "/");
+    farbling_url_ = embedded_test_server()->GetURL("a.com", "/simple.html");
+  }
+
+  void TearDown() override {
+    browser_content_client_.reset();
+    content_client_.reset();
+  }
+
+  HostContentSettingsMap* ContentSettings() {
+    return HostContentSettingsMapFactory::GetForProfile(browser()->profile());
+  }
+
+  void SetFingerprintingSetting(bool allow) {
+    brave_shields::SetFingerprintingControlType(
+        ContentSettings(), allow ? ControlType::ALLOW : ControlType::DEFAULT,
+        top_level_page_url_);
+  }
+
+  content::WebContents* Contents() const {
+    return browser()->tab_strip_model()->GetActiveWebContents();
+  }
+
+  bool NavigateToURLUntilLoadStop(const GURL& url) {
+    EXPECT_TRUE(ui_test_utils::NavigateToURL(browser(), url));
+    return WaitForLoadStop(Contents());
+  }
+
+  Browser* OpenPopup(const std::string& script) const {
+    content::ExecuteScriptAsync(Contents(), script);
+    Browser* popup = ui_test_utils::WaitForBrowserToOpen();
+    EXPECT_NE(popup, browser());
+    auto* popup_contents = popup->tab_strip_model()->GetActiveWebContents();
+    EXPECT_TRUE(WaitForRenderFrameReady(popup_contents->GetMainFrame()));
+    return popup;
+  }
+
+  virtual bool IsFlagDisabled() const = 0;
+
+  const GURL& FarblingUrl() { return farbling_url_; }
+
+  void SetBounds(const gfx::Rect& bounds) {
+    browser()->window()->SetBounds(bounds);
+  }
+
+  void FarbleScreenSize() {
+    const char* test_screen_size_scripts[] = {
+        "window.outerWidth - window.innerWidth",
+        "window.outerHeight - window.innerHeight",
+        "window.screen.availWidth - window.innerWidth",
+        "window.screen.availHeight - window.innerHeight",
+        "window.screen.width - window.innerWidth",
+        "window.screen.height - window.innerHeight",
+    };
+    for (int j = 0; j < static_cast<int>(std::size(kTestWindowBounds)); ++j) {
+      SetBounds(kTestWindowBounds[j]);
+      for (bool allow_fingerprinting : {false, true}) {
+        SetFingerprintingSetting(allow_fingerprinting);
+        NavigateToURLUntilLoadStop(FarblingUrl());
+        for (int i = 0;
+             i < static_cast<int>(std::size(test_screen_size_scripts)); ++i) {
+          std::string test_screen_size_scripts_abs =
+              std::string("Math.abs(") + test_screen_size_scripts[i] + ")";
+          if (!allow_fingerprinting && !IsFlagDisabled()) {
+            EXPECT_GE(8, EvalJs(Contents(), test_screen_size_scripts_abs));
+          } else {
+            EXPECT_LT(8, EvalJs(Contents(), test_screen_size_scripts_abs));
+          }
+        }
+      }
+    }
+  }
+
+#define PREPARE_TEST_EVENT                                   \
+  "let fakeScreenX = 100, fakeScreenY = 200; "               \
+  "let fakeClientX = 300, fakeClientY = 400; "               \
+  "let testEvent = document.createEvent('MouseEvent'); "     \
+  "testEvent.initMouseEvent('click', true, true, window, 1," \
+  "fakeScreenX + devicePixelRatio * fakeClientX,"            \
+  "fakeScreenY + devicePixelRatio * fakeClientY,"            \
+  "fakeClientX, fakeClientY, false, false, false, false, 0, null); "
+
+  void FarbleWindowPosition() {
+    for (bool allow_fingerprinting : {false, true}) {
+      SetFingerprintingSetting(allow_fingerprinting);
+      for (int i = 0; i < static_cast<int>(std::size(kTestWindowBounds)); ++i) {
+        SetBounds(kTestWindowBounds[i]);
+        NavigateToURLUntilLoadStop(FarblingUrl());
+        if (!allow_fingerprinting && !IsFlagDisabled()) {
+          EXPECT_GE(8, EvalJs(Contents(), "window.screenX"));
+          EXPECT_GE(8, EvalJs(Contents(), "window.screenY"));
+          EXPECT_GE(8, EvalJs(Contents(), "window.screen.availLeft"));
+          EXPECT_GE(8, EvalJs(Contents(), "window.screen.availTop"));
+          EXPECT_GE(
+              8,
+              EvalJs(
+                  Contents(), PREPARE_TEST_EVENT
+                  "testEvent.screenX - devicePixelRatio * testEvent.clientX"));
+          EXPECT_GE(
+              8,
+              EvalJs(
+                  Contents(), PREPARE_TEST_EVENT
+                  "testEvent.screenY - devicePixelRatio * testEvent.clientY"));
+        } else {
+          EXPECT_LE(kTestWindowBounds[i].x(),
+                    EvalJs(Contents(), "window.screenX"));
+          EXPECT_LE(kTestWindowBounds[i].y(),
+                    EvalJs(Contents(), "window.screenY"));
+        }
+      }
+    }
+  }
+
+  void FarbleScreenMediaQuery() {
+    for (int j = 0; j < static_cast<int>(std::size(kTestWindowBounds)); ++j) {
+      SetBounds(kTestWindowBounds[j]);
+      for (bool allow_fingerprinting : {false, true}) {
+        SetFingerprintingSetting(allow_fingerprinting);
+        NavigateToURLUntilLoadStop(FarblingUrl());
+        EXPECT_EQ(
+            !allow_fingerprinting && !IsFlagDisabled(),
+            EvalJs(Contents(),
+                   "matchMedia(`(max-device-width: ${innerWidth + 8}px) and "
+                   "(min-device-width: ${innerWidth}px)`).matches"));
+        EXPECT_EQ(
+            !allow_fingerprinting && !IsFlagDisabled(),
+            EvalJs(Contents(),
+                   "matchMedia(`(max-device-height: ${innerHeight + 8}px) and "
+                   "(min-device-height: ${innerHeight}px)`).matches"));
+      }
+    }
+  }
+
+  void FarbleScreenPopupPosition() {
+    for (int j = 0; j < static_cast<int>(std::size(kTestWindowBounds)); ++j) {
+      SetBounds(kTestWindowBounds[j]);
+      for (bool allow_fingerprinting : {false, true}) {
+        SetFingerprintingSetting(allow_fingerprinting);
+        NavigateToURLUntilLoadStop(FarblingUrl());
+        gfx::Rect parent_bounds = browser()->window()->GetBounds();
+        const char* script =
+            "open('http://d.test/', '', `"
+            "left=${screen.availLeft + 10},"
+            "top=${screen.availTop + 10},"
+            "width=${outerWidth + 200},"
+            "height=${outerHeight + 200}"
+            "`);";
+        Browser* popup = OpenPopup(script);
+        gfx::Rect child_bounds = popup->window()->GetBounds();
+        auto* parent_contents = Contents();
+        auto* popup_contents = popup->tab_strip_model()->GetActiveWebContents();
+        const int popup_inner_width =
+            EvalJs(popup_contents, "innerWidth").value.GetInt();
+        const int popup_inner_height =
+            EvalJs(popup_contents, "innerHeight").value.GetInt();
+        if (!allow_fingerprinting && !IsFlagDisabled()) {
+          EXPECT_GE(child_bounds.x(), 10 + parent_bounds.x());
+          EXPECT_GE(child_bounds.y(), 10 + parent_bounds.y());
+          EXPECT_LE(popup_inner_width,
+                    EvalJs(parent_contents, "innerWidth + 8"));
+          EXPECT_LE(popup_inner_height,
+                    EvalJs(parent_contents, "Math.max(100, innerHeight + 8)"));
+        } else {
+          EXPECT_LE(child_bounds.x(), std::max(80, 10 + parent_bounds.x()));
+          EXPECT_LE(child_bounds.y(), std::max(80, 10 + parent_bounds.y()));
+          EXPECT_GE(popup_inner_width, EvalJs(parent_contents, "innerWidth"));
+          EXPECT_GE(popup_inner_height, EvalJs(parent_contents, "innerHeight"));
+        }
+      }
+    }
+  }
+
+ protected:
+  base::test::ScopedFeatureList feature_list_;
+
+ private:
+  GURL top_level_page_url_;
+  GURL farbling_url_;
+  std::unique_ptr<ChromeContentClient> content_client_;
+  std::unique_ptr<BraveContentBrowserClient> browser_content_client_;
+};
+
+class BraveScreenFarblingBrowserTest_EnableFlag
+    : public BraveScreenFarblingBrowserTest {
+ public:
+  BraveScreenFarblingBrowserTest_EnableFlag() {
+    feature_list_.InitAndEnableFeature(
+        blink::features::kBraveBlockScreenFingerprinting);
+  }
+
+  bool IsFlagDisabled() const override { return false; }
+};
+
+class BraveScreenFarblingBrowserTest_DisableFlag
+    : public BraveScreenFarblingBrowserTest {
+ public:
+  BraveScreenFarblingBrowserTest_DisableFlag() {
+    feature_list_.InitAndDisableFeature(
+        blink::features::kBraveBlockScreenFingerprinting);
+  }
+
+  bool IsFlagDisabled() const override { return true; }
+};
+
+IN_PROC_BROWSER_TEST_F(BraveScreenFarblingBrowserTest_EnableFlag,
+                       FarbleScreenSize_EnableFlag) {
+  FarbleScreenSize();
+}
+
+IN_PROC_BROWSER_TEST_F(BraveScreenFarblingBrowserTest_DisableFlag,
+                       FarbleScreenSize_DisableFlag) {
+  FarbleScreenSize();
+}
+
+IN_PROC_BROWSER_TEST_F(BraveScreenFarblingBrowserTest_EnableFlag,
+                       FarbleWindowPosition_EnableFlag) {
+  FarbleWindowPosition();
+}
+
+IN_PROC_BROWSER_TEST_F(BraveScreenFarblingBrowserTest_DisableFlag,
+                       FarbleWindowPosition_DisableFlag) {
+  FarbleWindowPosition();
+}
+
+IN_PROC_BROWSER_TEST_F(BraveScreenFarblingBrowserTest_EnableFlag,
+                       FarbleScreenMediaQuery_EnableFlag) {
+  FarbleScreenMediaQuery();
+}
+
+IN_PROC_BROWSER_TEST_F(BraveScreenFarblingBrowserTest_DisableFlag,
+                       FarbleScreenMediaQuery_DisableFlag) {
+  FarbleScreenMediaQuery();
+}
+
+IN_PROC_BROWSER_TEST_F(BraveScreenFarblingBrowserTest_EnableFlag,
+                       FarbleScreenPopupPosition_EnableFlag) {
+  FarbleScreenPopupPosition();
+}
+
+IN_PROC_BROWSER_TEST_F(BraveScreenFarblingBrowserTest_DisableFlag,
+                       FarbleScreenPopupPosition_DisableFlag) {
+  FarbleScreenPopupPosition();
+}

--- a/chromium_src/third_party/blink/common/features.cc
+++ b/chromium_src/third_party/blink/common/features.cc
@@ -48,5 +48,9 @@ const base::Feature kPartitionBlinkMemoryCache{
 const base::Feature kRestrictWebSocketsPool{"RestrictWebSocketsPool",
                                             base::FEATURE_ENABLED_BY_DEFAULT};
 
+// Disable protection against fingerprinting on screen dimensions by default.
+const base::Feature kBraveBlockScreenFingerprinting{
+    "kBraveBlockScreenFingerprinting", base::FEATURE_DISABLED_BY_DEFAULT};
+
 }  // namespace features
 }  // namespace blink

--- a/chromium_src/third_party/blink/public/common/features.h
+++ b/chromium_src/third_party/blink/public/common/features.h
@@ -15,6 +15,7 @@ BLINK_COMMON_EXPORT extern const base::Feature kFileSystemAccessAPI;
 BLINK_COMMON_EXPORT extern const base::Feature kNavigatorConnectionAttribute;
 BLINK_COMMON_EXPORT extern const base::Feature kPartitionBlinkMemoryCache;
 BLINK_COMMON_EXPORT extern const base::Feature kRestrictWebSocketsPool;
+BLINK_COMMON_EXPORT extern const base::Feature kBraveBlockScreenFingerprinting;
 
 }  // namespace features
 }  // namespace blink

--- a/chromium_src/third_party/blink/renderer/core/DEPS
+++ b/chromium_src/third_party/blink/renderer/core/DEPS
@@ -1,3 +1,5 @@
 include_rules = [
   "+brave/third_party/blink/renderer",
+  "+ui/display",
+  "+ui/gfx/geometry",
 ]

--- a/chromium_src/third_party/blink/renderer/core/core_initializer.cc
+++ b/chromium_src/third_party/blink/renderer/core/core_initializer.cc
@@ -3,8 +3,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+#include "brave/third_party/blink/renderer/core/farbling/brave_session_cache.h"
 #include "third_party/blink/renderer/bindings/core/v8/binding_security.h"
-#include "third_party/blink/renderer/core/execution_context/execution_context.h"
 
 #define BindingSecurity             \
   brave::BraveSessionCache::Init(); \

--- a/chromium_src/third_party/blink/renderer/core/css/local_font_face_source.cc
+++ b/chromium_src/third_party/blink/renderer/core/css/local_font_face_source.cc
@@ -5,7 +5,7 @@
 
 #include "third_party/blink/renderer/core/css/local_font_face_source.h"
 
-#include "third_party/blink/renderer/core/execution_context/execution_context.h"
+#include "brave/third_party/blink/renderer/core/farbling/brave_session_cache.h"
 
 #define IsLocalFontAvailable IsLocalFontAvailable_ChromiumImpl
 

--- a/chromium_src/third_party/blink/renderer/core/css/media_values.cc
+++ b/chromium_src/third_party/blink/renderer/core/css/media_values.cc
@@ -1,0 +1,34 @@
+/* Copyright (c) 2022 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "third_party/blink/renderer/core/css/media_values.h"
+
+#include "brave/third_party/blink/renderer/core/farbling/brave_session_cache.h"
+#include "third_party/blink/renderer/core/frame/local_dom_window.h"
+#include "third_party/blink/renderer/core/frame/screen.h"
+
+#define CalculateDeviceWidth                                                   \
+  CalculateDeviceWidth(LocalFrame* frame) {                                    \
+    return MaybeFarbleScreenInteger(frame->DomWindow()->GetExecutionContext(), \
+                                    brave::FarbleKey::kWindowInnerWidth,       \
+                                    frame->DomWindow()->innerWidth(), 0, 8,    \
+                                    CalculateDeviceWidth_ChromiumImpl(frame)); \
+  }                                                                            \
+  int MediaValues::CalculateDeviceWidth_ChromiumImpl
+
+#define CalculateDeviceHeight                       \
+  CalculateDeviceHeight(LocalFrame* frame) {        \
+    return MaybeFarbleScreenInteger(                \
+        frame->DomWindow()->GetExecutionContext(),  \
+        brave::FarbleKey::kWindowInnerHeight,       \
+        frame->DomWindow()->innerHeight(), 0, 8,    \
+        CalculateDeviceHeight_ChromiumImpl(frame)); \
+  }                                                 \
+  int MediaValues::CalculateDeviceHeight_ChromiumImpl
+
+#include "src/third_party/blink/renderer/core/css/media_values.cc"
+
+#undef CalculateDeviceWidth
+#undef CalculateDeviceHeight

--- a/chromium_src/third_party/blink/renderer/core/css/media_values.h
+++ b/chromium_src/third_party/blink/renderer/core/css/media_values.h
@@ -1,0 +1,22 @@
+/* Copyright (c) 2022 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_CHROMIUM_SRC_THIRD_PARTY_BLINK_RENDERER_CORE_CSS_MEDIA_VALUES_H_
+#define BRAVE_CHROMIUM_SRC_THIRD_PARTY_BLINK_RENDERER_CORE_CSS_MEDIA_VALUES_H_
+
+#define CalculateDeviceWidth                      \
+  CalculateDeviceWidth_ChromiumImpl(LocalFrame*); \
+  static int CalculateDeviceWidth
+
+#define CalculateDeviceHeight                      \
+  CalculateDeviceHeight_ChromiumImpl(LocalFrame*); \
+  static int CalculateDeviceHeight
+
+#include "src/third_party/blink/renderer/core/css/media_values.h"
+
+#undef CalculateDeviceWidth
+#undef CalculateDeviceHeight
+
+#endif  // BRAVE_CHROMIUM_SRC_THIRD_PARTY_BLINK_RENDERER_CORE_CSS_MEDIA_VALUES_H_

--- a/chromium_src/third_party/blink/renderer/core/events/mouse_event.h
+++ b/chromium_src/third_party/blink/renderer/core/events/mouse_event.h
@@ -1,0 +1,32 @@
+/* Copyright (c) 2022 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_CHROMIUM_SRC_THIRD_PARTY_BLINK_RENDERER_CORE_EVENTS_MOUSE_EVENT_H_
+#define BRAVE_CHROMIUM_SRC_THIRD_PARTY_BLINK_RENDERER_CORE_EVENTS_MOUSE_EVENT_H_
+
+#include "brave/third_party/blink/renderer/core/farbling/brave_session_cache.h"
+
+#define screenX                                               \
+  screenX() const {                                           \
+    return brave::FarbledPointerScreenCoordinate(             \
+        view(), brave::FarbleKey::kPointerScreenX, clientX(), \
+        screenX_ChromiumImpl());                              \
+  }                                                           \
+  virtual double screenX_ChromiumImpl
+
+#define screenY                                               \
+  screenY() const {                                           \
+    return brave::FarbledPointerScreenCoordinate(             \
+        view(), brave::FarbleKey::kPointerScreenY, clientY(), \
+        screenY_ChromiumImpl());                              \
+  }                                                           \
+  virtual double screenY_ChromiumImpl
+
+#include "src/third_party/blink/renderer/core/events/mouse_event.h"
+
+#undef screenX
+#undef screenY
+
+#endif  // BRAVE_CHROMIUM_SRC_THIRD_PARTY_BLINK_RENDERER_CORE_EVENTS_MOUSE_EVENT_H_

--- a/chromium_src/third_party/blink/renderer/core/events/pointer_event.h
+++ b/chromium_src/third_party/blink/renderer/core/events/pointer_event.h
@@ -1,0 +1,25 @@
+/* Copyright (c) 2022 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_CHROMIUM_SRC_THIRD_PARTY_BLINK_RENDERER_CORE_EVENTS_POINTER_EVENT_H_
+#define BRAVE_CHROMIUM_SRC_THIRD_PARTY_BLINK_RENDERER_CORE_EVENTS_POINTER_EVENT_H_
+
+#include "brave/third_party/blink/renderer/core/farbling/brave_session_cache.h"
+#include "third_party/blink/renderer/core/events/mouse_event.h"
+
+#define screen_x_                        \
+  brave::FarbledPointerScreenCoordinate( \
+      view(), brave::FarbleKey::kPointerScreenX, client_x_, screen_x_);
+
+#define screen_y_                        \
+  brave::FarbledPointerScreenCoordinate( \
+      view(), brave::FarbleKey::kPointerScreenY, client_y_, screen_y_);
+
+#include "src/third_party/blink/renderer/core/events/pointer_event.h"
+
+#undef screen_x_
+#undef screen_y_
+
+#endif  // BRAVE_CHROMIUM_SRC_THIRD_PARTY_BLINK_RENDERER_CORE_EVENTS_POINTER_EVENT_H_

--- a/chromium_src/third_party/blink/renderer/core/execution_context/navigator_base.cc
+++ b/chromium_src/third_party/blink/renderer/core/execution_context/navigator_base.cc
@@ -7,6 +7,7 @@
 
 #include "base/compiler_specific.h"
 #include "base/system/sys_info.h"
+#include "brave/third_party/blink/renderer/core/farbling/brave_session_cache.h"
 #include "third_party/abseil-cpp/absl/random/random.h"
 #include "third_party/blink/public/platform/web_content_settings_client.h"
 #include "third_party/blink/renderer/core/execution_context/execution_context.h"

--- a/chromium_src/third_party/blink/renderer/core/fileapi/public_url_manager.cc
+++ b/chromium_src/third_party/blink/renderer/core/fileapi/public_url_manager.cc
@@ -3,11 +3,11 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+#include "brave/third_party/blink/renderer/core/farbling/brave_session_cache.h"
 #include "net/base/features.h"
 #include "third_party/blink/public/mojom/blob/blob_registry.mojom-blink.h"
 #include "third_party/blink/public/platform/web_content_settings_client.h"
 #include "third_party/blink/public/platform/web_security_origin.h"
-#include "third_party/blink/renderer/core/execution_context/execution_context.h"
 
 namespace blink {
 namespace {

--- a/chromium_src/third_party/blink/renderer/core/frame/local_dom_window.cc
+++ b/chromium_src/third_party/blink/renderer/core/frame/local_dom_window.cc
@@ -4,10 +4,28 @@
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 #include "third_party/blink/renderer/core/frame/local_dom_window.h"
+#include "brave/third_party/blink/renderer/core/farbling/brave_session_cache.h"
+// Include mouse_event.h, pointer_event.h here to avoid re-defining
+// tokens named screenX, screenY:
+#include "third_party/blink/renderer/core/events/mouse_event.h"
+#include "third_party/blink/renderer/core/events/pointer_event.h"
+
+#define outerHeight outerHeight_ChromiumImpl
+#define outerWidth outerWidth_ChromiumImpl
+#define screenX screenX_ChromiumImpl
+#define screenY screenY_ChromiumImpl
 
 #include "src/third_party/blink/renderer/core/frame/local_dom_window.cc"
 
+#undef outerHeight
+#undef outerWidth
+#undef screenX
+#undef screenY
+
 namespace blink {
+
+using brave::FarbleKey;
+using brave::MaybeFarbleScreenInteger;
 
 void LocalDOMWindow::SetEphemeralStorageOrigin(
     const SecurityOrigin* ephemeral_storage_origin) {
@@ -31,6 +49,36 @@ LocalDOMWindow::GetEphemeralStorageOriginOrSecurityOrigin() const {
   return ephemeral_storage_key_
              ? ephemeral_storage_key_->GetSecurityOrigin().get()
              : GetSecurityOrigin();
+}
+
+int LocalDOMWindow::outerHeight() const {
+  // Prevent fingerprinter use of outerHeight by returning a farbled value near
+  // innerHeight instead:
+  return MaybeFarbleScreenInteger(
+      GetExecutionContext(), brave::FarbleKey::kWindowInnerHeight,
+      innerHeight(), 0, 8, outerHeight_ChromiumImpl());
+}
+
+int LocalDOMWindow::outerWidth() const {
+  // Prevent fingerprinter use of outerWidth by returning a farbled value near
+  // innerWidth instead:
+  return MaybeFarbleScreenInteger(
+      GetExecutionContext(), brave::FarbleKey::kWindowInnerWidth, innerWidth(),
+      0, 8, outerWidth_ChromiumImpl());
+}
+
+int LocalDOMWindow::screenX() const {
+  // Prevent fingerprinter use of screenX, screenLeft by returning value near 0:
+  return MaybeFarbleScreenInteger(GetExecutionContext(),
+                                  brave::FarbleKey::kWindowScreenX, 0, 0, 8,
+                                  screenX_ChromiumImpl());
+}
+
+int LocalDOMWindow::screenY() const {
+  // Prevent fingerprinter use of screenY, screenTop by returning value near 0:
+  return MaybeFarbleScreenInteger(GetExecutionContext(),
+                                  brave::FarbleKey::kWindowScreenY, 0, 0, 8,
+                                  screenY_ChromiumImpl());
 }
 
 }  // namespace blink

--- a/chromium_src/third_party/blink/renderer/core/frame/local_dom_window.h
+++ b/chromium_src/third_party/blink/renderer/core/frame/local_dom_window.h
@@ -20,8 +20,28 @@
  public:                                                                     \
   void SetStorageKey
 
+#define outerHeight                 \
+  outerHeight_ChromiumImpl() const; \
+  int outerHeight
+
+#define outerWidth                 \
+  outerWidth_ChromiumImpl() const; \
+  int outerWidth
+
+#define screenLeft              \
+  screenX_ChromiumImpl() const; \
+  int screenLeft
+
+#define screenTop               \
+  screenY_ChromiumImpl() const; \
+  int screenTop
+
 #include "src/third_party/blink/renderer/core/frame/local_dom_window.h"
 
 #undef SetStorageKey
+#undef outerHeight
+#undef outerWidth
+#undef screenLeft
+#undef screenTop
 
 #endif  // BRAVE_CHROMIUM_SRC_THIRD_PARTY_BLINK_RENDERER_CORE_FRAME_LOCAL_DOM_WINDOW_H_

--- a/chromium_src/third_party/blink/renderer/core/frame/navigator_device_memory.cc
+++ b/chromium_src/third_party/blink/renderer/core/frame/navigator_device_memory.cc
@@ -6,9 +6,9 @@
 #include "third_party/abseil-cpp/absl/random/random.h"
 
 #include "brave/third_party/blink/renderer/brave_farbling_constants.h"
+#include "brave/third_party/blink/renderer/core/farbling/brave_session_cache.h"
 #include "third_party/blink/public/common/device_memory/approximated_device_memory.h"
 #include "third_party/blink/public/platform/web_content_settings_client.h"
-#include "third_party/blink/renderer/core/execution_context/execution_context.h"
 #include "third_party/blink/renderer/core/frame/navigator_device_memory.h"
 
 namespace brave {

--- a/chromium_src/third_party/blink/renderer/core/frame/navigator_language.cc
+++ b/chromium_src/third_party/blink/renderer/core/frame/navigator_language.cc
@@ -5,6 +5,7 @@
 
 #include "third_party/blink/renderer/core/frame/navigator_language.h"
 
+#include "brave/third_party/blink/renderer/core/farbling/brave_session_cache.h"
 #include "third_party/blink/public/platform/web_content_settings_client.h"
 
 #define NavigatorLanguage NavigatorLanguage_ChromiumImpl

--- a/chromium_src/third_party/blink/renderer/core/frame/screen.cc
+++ b/chromium_src/third_party/blink/renderer/core/frame/screen.cc
@@ -1,0 +1,12 @@
+/* Copyright (c) 2022 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "third_party/blink/renderer/core/page/chrome_client.h"
+
+#define GetScreenInfos BraveGetScreenInfos
+
+#include "src/third_party/blink/renderer/core/frame/screen.cc"
+
+#undef BraveGetScreenInfos

--- a/chromium_src/third_party/blink/renderer/core/frame/screen.h
+++ b/chromium_src/third_party/blink/renderer/core/frame/screen.h
@@ -1,0 +1,20 @@
+/* Copyright (c) 2022 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_CHROMIUM_SRC_THIRD_PARTY_BLINK_RENDERER_CORE_FRAME_SCREEN_H_
+#define BRAVE_CHROMIUM_SRC_THIRD_PARTY_BLINK_RENDERER_CORE_FRAME_SCREEN_H_
+
+#include "ui/display/screen_info.h"
+
+#define GetScreenInfo                             \
+  GetScreenInfo() const;                          \
+  mutable display::ScreenInfo brave_screen_info_; \
+  void dummy
+
+#include "src/third_party/blink/renderer/core/frame/screen.h"
+
+#undef GetScreenInfo
+
+#endif  // BRAVE_CHROMIUM_SRC_THIRD_PARTY_BLINK_RENDERER_CORE_FRAME_SCREEN_H_

--- a/chromium_src/third_party/blink/renderer/core/html/canvas/canvas_async_blob_creator.cc
+++ b/chromium_src/third_party/blink/renderer/core/html/canvas/canvas_async_blob_creator.cc
@@ -3,8 +3,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+#include "brave/third_party/blink/renderer/core/farbling/brave_session_cache.h"
 #include "third_party/blink/public/platform/web_content_settings_client.h"
-#include "third_party/blink/renderer/core/execution_context/execution_context.h"
 
 #define BRAVE_CANVAS_ASYNC_BLOB_CREATOR                                \
   if (WebContentSettingsClient* settings =                             \

--- a/chromium_src/third_party/blink/renderer/core/html/canvas/html_canvas_element.cc
+++ b/chromium_src/third_party/blink/renderer/core/html/canvas/html_canvas_element.cc
@@ -4,8 +4,8 @@
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 #include "base/auto_reset.h"
+#include "brave/third_party/blink/renderer/core/farbling/brave_session_cache.h"
 #include "third_party/blink/public/platform/web_content_settings_client.h"
-#include "third_party/blink/renderer/core/execution_context/execution_context.h"
 
 #define BRAVE_TO_DATA_URL_INTERNAL                                     \
   {                                                                    \

--- a/chromium_src/third_party/blink/renderer/core/input/touch.h
+++ b/chromium_src/third_party/blink/renderer/core/input/touch.h
@@ -1,0 +1,32 @@
+/* Copyright (c) 2022 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_CHROMIUM_SRC_THIRD_PARTY_BLINK_RENDERER_CORE_INPUT_TOUCH_H_
+#define BRAVE_CHROMIUM_SRC_THIRD_PARTY_BLINK_RENDERER_CORE_INPUT_TOUCH_H_
+
+#include "brave/third_party/blink/renderer/core/farbling/brave_session_cache.h"
+
+#define screenX                                                                \
+  screenX() const {                                                            \
+    return brave::FarbledPointerScreenCoordinate(                              \
+        target()->ToDOMWindow(), brave::FarbleKey::kPointerScreenX, clientX(), \
+        screenX_ChromiumImpl());                                               \
+  }                                                                            \
+  double screenX_ChromiumImpl
+
+#define screenY                                                                \
+  screenY() const {                                                            \
+    return brave::FarbledPointerScreenCoordinate(                              \
+        target()->ToDOMWindow(), brave::FarbleKey::kPointerScreenY, clientY(), \
+        screenY_ChromiumImpl());                                               \
+  }                                                                            \
+  double screenY_ChromiumImpl
+
+#include "src/third_party/blink/renderer/core/input/touch.h"
+
+#undef screenX
+#undef screenY
+
+#endif  // BRAVE_CHROMIUM_SRC_THIRD_PARTY_BLINK_RENDERER_CORE_INPUT_TOUCH_H_

--- a/chromium_src/third_party/blink/renderer/core/page/chrome_client.cc
+++ b/chromium_src/third_party/blink/renderer/core/page/chrome_client.cc
@@ -1,0 +1,15 @@
+/* Copyright (c) 2022 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "src/third_party/blink/renderer/core/page/chrome_client.cc"
+
+namespace blink {
+
+const display::ScreenInfos& ChromeClient::BraveGetScreenInfos(
+    LocalFrame& frame) const {
+  return this->GetScreenInfos(frame);
+}
+
+}  // namespace blink

--- a/chromium_src/third_party/blink/renderer/core/page/chrome_client.h
+++ b/chromium_src/third_party/blink/renderer/core/page/chrome_client.h
@@ -1,0 +1,17 @@
+/* Copyright (c) 2022 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_CHROMIUM_SRC_THIRD_PARTY_BLINK_RENDERER_CORE_PAGE_CHROME_CLIENT_H_
+#define BRAVE_CHROMIUM_SRC_THIRD_PARTY_BLINK_RENDERER_CORE_PAGE_CHROME_CLIENT_H_
+
+#define GetScreenInfos                          \
+  BraveGetScreenInfos(LocalFrame& frame) const; \
+  virtual const display::ScreenInfos& GetScreenInfos
+
+#include "src/third_party/blink/renderer/core/page/chrome_client.h"
+
+#undef GetScreenInfos
+
+#endif  // BRAVE_CHROMIUM_SRC_THIRD_PARTY_BLINK_RENDERER_CORE_PAGE_CHROME_CLIENT_H_

--- a/chromium_src/third_party/blink/renderer/core/page/chrome_client_impl.cc
+++ b/chromium_src/third_party/blink/renderer/core/page/chrome_client_impl.cc
@@ -1,0 +1,41 @@
+/* Copyright (c) 2022 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "src/third_party/blink/renderer/core/page/chrome_client_impl.cc"
+
+#include "brave/third_party/blink/renderer/core/farbling/brave_session_cache.h"
+#include "third_party/blink/renderer/core/execution_context/execution_context.h"
+#include "third_party/blink/renderer/core/frame/local_dom_window.h"
+#include "third_party/blink/renderer/core/frame/local_frame.h"
+#include "third_party/blink/renderer/core/frame/screen.h"
+#include "ui/display/screen_info.h"
+#include "ui/display/screen_infos.h"
+#include "ui/gfx/geometry/rect.h"
+
+namespace blink {
+
+const display::ScreenInfos& ChromeClientImpl::BraveGetScreenInfos(
+    LocalFrame& frame) const {
+  display::ScreenInfo screen_info = GetScreenInfo(frame);
+  LocalDOMWindow* dom_window = frame.DomWindow();
+  if (!dom_window) {
+    return GetScreenInfos(frame);
+  }
+  ExecutionContext* context = dom_window->GetExecutionContext();
+  if (!brave::BlockScreenFingerprinting(context)) {
+    return GetScreenInfos(frame);
+  }
+  gfx::Rect farbled_screen_rect(dom_window->screenX(), dom_window->screenY(),
+                                dom_window->outerWidth(),
+                                dom_window->outerHeight());
+  screen_info.rect = farbled_screen_rect;
+  screen_info.available_rect = farbled_screen_rect;
+  screen_info.is_extended = false;
+  screen_info.is_primary = false;
+  screen_infos_ = display::ScreenInfos(screen_info);
+  return screen_infos_;
+}
+
+}  // namespace blink

--- a/chromium_src/third_party/blink/renderer/core/page/chrome_client_impl.h
+++ b/chromium_src/third_party/blink/renderer/core/page/chrome_client_impl.h
@@ -1,0 +1,25 @@
+/* Copyright (c) 2022 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_CHROMIUM_SRC_THIRD_PARTY_BLINK_RENDERER_CORE_PAGE_CHROME_CLIENT_IMPL_H_
+#define BRAVE_CHROMIUM_SRC_THIRD_PARTY_BLINK_RENDERER_CORE_PAGE_CHROME_CLIENT_IMPL_H_
+
+#include "third_party/blink/renderer/core/page/chrome_client.h"
+#include "ui/display/screen_infos.h"
+
+#define GetScreenInfos                             \
+  BraveGetScreenInfos(LocalFrame&) const override; \
+  const display::ScreenInfos& GetScreenInfos
+
+#define cursor_overridden_ \
+  cursor_overridden_;      \
+  mutable display::ScreenInfos screen_infos_;
+
+#include "src/third_party/blink/renderer/core/page/chrome_client_impl.h"
+
+#undef cursor_overridden_
+#undef GetScreenInfos
+
+#endif  // BRAVE_CHROMIUM_SRC_THIRD_PARTY_BLINK_RENDERER_CORE_PAGE_CHROME_CLIENT_IMPL_H_

--- a/chromium_src/third_party/blink/renderer/core/page/create_window.cc
+++ b/chromium_src/third_party/blink/renderer/core/page/create_window.cc
@@ -1,0 +1,63 @@
+/* Copyright (c) 2022 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "third_party/blink/renderer/core/page/create_window.h"
+
+#include "brave/third_party/blink/renderer/core/farbling/brave_session_cache.h"
+#include "third_party/blink/public/web/web_window_features.h"
+#include "third_party/blink/renderer/core/execution_context/execution_context.h"
+#include "third_party/blink/renderer/core/frame/local_dom_window.h"
+#include "third_party/blink/renderer/core/frame/screen.h"
+#include "third_party/blink/renderer/platform/wtf/text/wtf_string.h"
+
+// Because we are spoofing screenX and screenY, we need to offset the position
+// when a page script opens a new window in screen coordinates. And because
+// we are spoofing screen width and height, we should artificially limit the
+// window size to that width and height as well, so that window.open can't
+// be used to probe the screen size.
+
+namespace {
+
+blink::WebWindowFeatures MaybeFarbleWindowFeatures(
+    const String& feature_string,
+    blink::LocalDOMWindow* dom_window) {
+  blink::WebWindowFeatures window_features =
+      GetWindowFeaturesFromString_ChromiumImpl(feature_string, dom_window);
+  blink::ExecutionContext* context = dom_window->GetExecutionContext();
+  if (brave::BlockScreenFingerprinting(context)) {
+    if (window_features.x_set) {
+      window_features.x += dom_window->screenX_ChromiumImpl();
+    }
+    if (window_features.y_set) {
+      window_features.y += dom_window->screenY_ChromiumImpl();
+    }
+    if (window_features.width_set) {
+      int max_width = dom_window->screen()->width();
+      if (window_features.width > max_width) {
+        window_features.width = max_width;
+      }
+    }
+    if (window_features.height_set) {
+      int max_height = dom_window->screen()->height();
+      if (window_features.height > max_height) {
+        window_features.height = max_height;
+      }
+    }
+  }
+  return window_features;
+}
+
+}  // namespace
+
+#define GetWindowFeaturesFromString                               \
+  GetWindowFeaturesFromString(const String& feature_string,       \
+                              LocalDOMWindow* dom_window) {       \
+    return MaybeFarbleWindowFeatures(feature_string, dom_window); \
+  }                                                               \
+  WebWindowFeatures GetWindowFeaturesFromString_ChromiumImpl
+
+#include "src/third_party/blink/renderer/core/page/create_window.cc"
+
+#undef GetWindowFeaturesFromString

--- a/chromium_src/third_party/blink/renderer/core/page/create_window.h
+++ b/chromium_src/third_party/blink/renderer/core/page/create_window.h
@@ -1,0 +1,22 @@
+/* Copyright (c) 2022 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_CHROMIUM_SRC_THIRD_PARTY_BLINK_RENDERER_CORE_PAGE_CREATE_WINDOW_H_
+#define BRAVE_CHROMIUM_SRC_THIRD_PARTY_BLINK_RENDERER_CORE_PAGE_CREATE_WINDOW_H_
+
+#include "third_party/blink/public/web/web_window_features.h"
+#include "third_party/blink/renderer/core/frame/local_dom_window.h"
+#include "third_party/blink/renderer/platform/wtf/text/wtf_string.h"
+
+#define GetWindowFeaturesFromString                                      \
+  GetWindowFeaturesFromString_ChromiumImpl(const String& feature_string, \
+                                           LocalDOMWindow* dom_window);  \
+  CORE_EXPORT WebWindowFeatures GetWindowFeaturesFromString
+
+#include "src/third_party/blink/renderer/core/page/create_window.h"
+
+#undef GetWindowFeaturesFromString
+
+#endif  // BRAVE_CHROMIUM_SRC_THIRD_PARTY_BLINK_RENDERER_CORE_PAGE_CREATE_WINDOW_H_

--- a/chromium_src/third_party/blink/renderer/modules/canvas/canvas2d/base_rendering_context_2d.cc
+++ b/chromium_src/third_party/blink/renderer/modules/canvas/canvas2d/base_rendering_context_2d.cc
@@ -6,8 +6,8 @@
 #include "third_party/blink/renderer/modules/canvas/canvas2d/base_rendering_context_2d.h"
 
 #include "base/notreached.h"
+#include "brave/third_party/blink/renderer/core/farbling/brave_session_cache.h"
 #include "third_party/blink/public/platform/web_content_settings_client.h"
-#include "third_party/blink/renderer/core/execution_context/execution_context.h"
 #include "third_party/blink/renderer/platform/graphics/image_data_buffer.h"
 
 #define BRAVE_GET_IMAGE_DATA                                              \

--- a/chromium_src/third_party/blink/renderer/modules/canvas/canvas2d/canvas_rendering_context_2d.cc
+++ b/chromium_src/third_party/blink/renderer/modules/canvas/canvas2d/canvas_rendering_context_2d.cc
@@ -5,7 +5,7 @@
 
 #include "third_party/blink/renderer/modules/canvas/canvas2d/canvas_rendering_context_2d.h"
 
-#include "third_party/blink/renderer/core/execution_context/execution_context.h"
+#include "brave/third_party/blink/renderer/core/farbling/brave_session_cache.h"
 
 #define BRAVE_CANVAS_RENDERING_CONTEXT_2D_MEASURE_TEXT    \
   if (!brave::AllowFingerprinting(GetExecutionContext())) \

--- a/chromium_src/third_party/blink/renderer/modules/keyboard/navigator_keyboard.cc
+++ b/chromium_src/third_party/blink/renderer/modules/keyboard/navigator_keyboard.cc
@@ -6,8 +6,8 @@
 #include "third_party/blink/renderer/modules/keyboard/navigator_keyboard.h"
 
 #include "brave/third_party/blink/renderer/brave_farbling_constants.h"
+#include "brave/third_party/blink/renderer/core/farbling/brave_session_cache.h"
 #include "third_party/blink/public/platform/web_content_settings_client.h"
-#include "third_party/blink/renderer/core/execution_context/execution_context.h"
 
 #define keyboard keyboard_ChromiumImpl
 #include "src/third_party/blink/renderer/modules/keyboard/navigator_keyboard.cc"

--- a/chromium_src/third_party/blink/renderer/modules/mediastream/media_devices.cc
+++ b/chromium_src/third_party/blink/renderer/modules/mediastream/media_devices.cc
@@ -3,8 +3,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+#include "brave/third_party/blink/renderer/core/farbling/brave_session_cache.h"
 #include "third_party/abseil-cpp/absl/random/random.h"
-#include "third_party/blink/renderer/core/execution_context/execution_context.h"
 #include "third_party/blink/renderer/modules/mediastream/media_device_info.h"
 
 using blink::ExecutionContext;

--- a/chromium_src/third_party/blink/renderer/modules/plugins/dom_plugin_array.cc
+++ b/chromium_src/third_party/blink/renderer/modules/plugins/dom_plugin_array.cc
@@ -5,8 +5,8 @@
 
 #include "third_party/blink/renderer/modules/plugins/dom_plugin_array.h"
 #include "base/compiler_specific.h"
+#include "brave/third_party/blink/renderer/core/farbling/brave_session_cache.h"
 #include "third_party/abseil-cpp/absl/random/random.h"
-#include "third_party/blink/renderer/core/execution_context/execution_context.h"
 #include "third_party/blink/renderer/core/frame/local_dom_window.h"
 #include "third_party/blink/renderer/core/frame/local_frame.h"
 #include "third_party/blink/renderer/core/page/plugin_data.h"

--- a/chromium_src/third_party/blink/renderer/modules/speech/speech_synthesis.cc
+++ b/chromium_src/third_party/blink/renderer/modules/speech/speech_synthesis.cc
@@ -5,9 +5,9 @@
 
 #include "third_party/blink/renderer/modules/speech/speech_synthesis.h"
 #include "brave/third_party/blink/renderer/brave_farbling_constants.h"
+#include "brave/third_party/blink/renderer/core/farbling/brave_session_cache.h"
 #include "third_party/abseil-cpp/absl/random/random.h"
 #include "third_party/blink/public/platform/web_content_settings_client.h"
-#include "third_party/blink/renderer/core/execution_context/execution_context.h"
 
 #define OnSetVoiceList OnSetVoiceList_ChromiumImpl
 #include "src/third_party/blink/renderer/modules/speech/speech_synthesis.cc"

--- a/chromium_src/third_party/blink/renderer/modules/webaudio/analyser_handler.cc
+++ b/chromium_src/third_party/blink/renderer/modules/webaudio/analyser_handler.cc
@@ -3,9 +3,9 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+#include "brave/third_party/blink/renderer/core/farbling/brave_session_cache.h"
 #include "third_party/blink/public/platform/web_content_settings_client.h"
 #include "third_party/blink/renderer/core/dom/document.h"
-#include "third_party/blink/renderer/core/execution_context/execution_context.h"
 #include "third_party/blink/renderer/core/frame/local_dom_window.h"
 #include "third_party/blink/renderer/core/frame/local_frame.h"
 #include "third_party/blink/renderer/core/workers/worker_global_scope.h"

--- a/chromium_src/third_party/blink/renderer/modules/webaudio/audio_buffer.cc
+++ b/chromium_src/third_party/blink/renderer/modules/webaudio/audio_buffer.cc
@@ -5,9 +5,9 @@
 
 #include "base/callback.h"
 #include "brave/third_party/blink/renderer/brave_farbling_constants.h"
+#include "brave/third_party/blink/renderer/core/farbling/brave_session_cache.h"
 #include "third_party/blink/public/platform/web_content_settings_client.h"
 #include "third_party/blink/renderer/core/dom/document.h"
-#include "third_party/blink/renderer/core/execution_context/execution_context.h"
 #include "third_party/blink/renderer/core/frame/local_dom_window.h"
 #include "third_party/blink/renderer/core/frame/local_frame.h"
 #include "third_party/blink/renderer/core/workers/worker_global_scope.h"

--- a/chromium_src/third_party/blink/renderer/modules/webgl/webgl2_rendering_context_base.cc
+++ b/chromium_src/third_party/blink/renderer/modules/webgl/webgl2_rendering_context_base.cc
@@ -4,11 +4,12 @@
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 #include "third_party/blink/renderer/modules/webgl/webgl2_rendering_context_base.h"
+#include "brave/third_party/blink/renderer/core/farbling/brave_session_cache.h"
 #include "third_party/blink/renderer/bindings/modules/v8/webgl_any.h"
-#include "third_party/blink/renderer/core/execution_context/execution_context.h"
 
 #include <algorithm>
 
+using blink::ExecutionContext;
 using blink::ScriptState;
 using blink::ScriptValue;
 using blink::WebGL2RenderingContextBase;

--- a/chromium_src/third_party/blink/renderer/modules/webgl/webgl_rendering_context_base.cc
+++ b/chromium_src/third_party/blink/renderer/modules/webgl/webgl_rendering_context_base.cc
@@ -4,9 +4,10 @@
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 #include "third_party/blink/renderer/modules/webgl/webgl_rendering_context_base.h"
+
+#include "brave/third_party/blink/renderer/core/farbling/brave_session_cache.h"
 #include "third_party/blink/public/platform/web_content_settings_client.h"
 #include "third_party/blink/renderer/core/dom/document.h"
-#include "third_party/blink/renderer/core/execution_context/execution_context.h"
 #include "third_party/blink/renderer/core/frame/local_dom_window.h"
 #include "third_party/blink/renderer/core/frame/local_frame.h"
 #include "third_party/blink/renderer/core/html/canvas/canvas_rendering_context_host.h"

--- a/chromium_src/third_party/blink/renderer/modules/websockets/websocket_channel_impl.cc
+++ b/chromium_src/third_party/blink/renderer/modules/websockets/websocket_channel_impl.cc
@@ -5,6 +5,7 @@
 
 #include "third_party/blink/renderer/modules/websockets/websocket_channel_impl.h"
 
+#include "brave/third_party/blink/renderer/core/farbling/brave_session_cache.h"
 #include "third_party/blink/public/common/features.h"
 #include "third_party/blink/public/common/scheme_registry.h"
 #include "third_party/blink/public/platform/web_content_settings_client.h"

--- a/test/filters/browser_tests-linux.filter
+++ b/test/filters/browser_tests-linux.filter
@@ -9,6 +9,9 @@
 -ExternalProtocolHandlerSandboxBrowserTest.*
 -IndividualNetworkContextsPrefetchProxyBrowserTest.*
 -LayoutInstabilityTest.*
+-MultiscreenWindowPlacementPermissionContextTest.IsExtendedCrossOriginAllow
+-MultiscreenWindowPlacementPermissionContextTest.IsExtendedCrossOriginDeny
+-MultiscreenWindowPlacementPermissionContextTest.IsExtendedSameOriginAllow
 -NewTabUIBrowserTest.*
 -NewTabUIProcessPerTabTest.*
 -OzonePlatformTest.*

--- a/third_party/blink/renderer/core/farbling/DEPS
+++ b/third_party/blink/renderer/core/farbling/DEPS
@@ -1,0 +1,6 @@
+include_rules = [
+  "+third_party/abseil-cpp/absl/random",
+  "+third_party/blink/public/platform",
+  "+third_party/blink/public/common",
+  "+third_party/blink/renderer/execution_context",
+]

--- a/third_party/blink/renderer/core/farbling/brave_session_cache.cc
+++ b/third_party/blink/renderer/core/farbling/brave_session_cache.cc
@@ -1,18 +1,23 @@
+
 /* Copyright (c) 2020 The Brave Authors. All rights reserved.
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-#include "third_party/blink/renderer/core/execution_context/execution_context.h"
+#include "brave/third_party/blink/renderer/core/farbling/brave_session_cache.h"
 
 #include "base/command_line.h"
+#include "base/feature_list.h"
 #include "base/sequence_checker.h"
 #include "base/strings/string_number_conversions.h"
 #include "brave/third_party/blink/renderer/brave_farbling_constants.h"
 #include "brave/third_party/blink/renderer/brave_font_whitelist.h"
+#include "build/build_config.h"
 #include "crypto/hmac.h"
+#include "third_party/blink/public/common/features.h"
 #include "third_party/blink/public/platform/web_content_settings_client.h"
 #include "third_party/blink/renderer/core/dom/document.h"
+#include "third_party/blink/renderer/core/execution_context/execution_context.h"
 #include "third_party/blink/renderer/core/frame/local_dom_window.h"
 #include "third_party/blink/renderer/core/frame/local_frame.h"
 #include "third_party/blink/renderer/core/workers/worker_global_scope.h"
@@ -25,11 +30,16 @@
 #include "third_party/blink/renderer/platform/language.h"
 #include "third_party/blink/renderer/platform/network/network_utils.h"
 #include "third_party/blink/renderer/platform/supplementable.h"
+#include "third_party/blink/renderer/platform/weborigin/security_origin.h"
+#include "third_party/blink/renderer/platform/wtf/casting.h"
 #include "third_party/blink/renderer/platform/wtf/text/string_builder.h"
+#include "third_party/blink/renderer/platform/wtf/text/wtf_string.h"
+#include "url/url_constants.h"
 
 namespace {
 
-const uint64_t zero = 0;
+constexpr uint64_t zero = 0;
+constexpr double maxUInt64AsDouble = static_cast<double>(UINT64_MAX);
 
 inline uint64_t lfsr_next(uint64_t v) {
   return ((v >> 1) | (((v << 62) ^ (v << 61)) & (~(~zero << 63) << 62)));
@@ -45,7 +55,6 @@ float ConstantMultiplier(double fudge_factor, float value, size_t index) {
 
 float PseudoRandomSequence(uint64_t seed, float value, size_t index) {
   static uint64_t v;
-  const double maxUInt64AsDouble = UINT64_MAX;
   if (index == 0) {
     // start of loop, reset to initial seed which was passed in and is based on
     // the domain key
@@ -76,6 +85,12 @@ blink::WebContentSettingsClient* GetContentSettingsClientFor(
   blink::WebContentSettingsClient* settings = nullptr;
   if (!context)
     return settings;
+  // Avoid blocking fingerprinting in WebUI pages.
+  const String protocol = context->GetSecurityOrigin()->Protocol();
+  if (protocol == url::kAboutScheme || protocol == "chrome" ||
+      protocol == "brave") {
+    return settings;
+  }
   if (auto* window = blink::DynamicTo<blink::LocalDOMWindow>(context)) {
     auto* frame = window->GetFrame();
     if (!frame)
@@ -122,6 +137,44 @@ bool AllowFontFamily(ExecutionContext* context,
     return false;
 
   return true;
+}
+
+int MaybeFarbleScreenInteger(ExecutionContext* context,
+                             brave::FarbleKey key,
+                             int spoof_value,
+                             int min_value,
+                             int max_value,
+                             int default_value) {
+  if (!brave::BlockScreenFingerprinting(context)) {
+    return default_value;
+  }
+  BraveSessionCache& cache = BraveSessionCache::From(*context);
+  return cache.FarbledInteger(key, spoof_value, min_value, max_value);
+}
+
+bool BlockScreenFingerprinting(ExecutionContext* context) {
+  if (!base::FeatureList::IsEnabled(
+          blink::features::kBraveBlockScreenFingerprinting)) {
+    return false;
+  }
+  BraveFarblingLevel level =
+      GetBraveFarblingLevelFor(context, BraveFarblingLevel::OFF);
+  return level != BraveFarblingLevel::OFF;
+}
+
+int FarbledPointerScreenCoordinate(const DOMWindow* view,
+                                   FarbleKey key,
+                                   int client_coordinate,
+                                   int true_screen_coordinate) {
+  const blink::LocalDOMWindow* local_dom_window =
+      blink::DynamicTo<blink::LocalDOMWindow>(view);
+  if (!local_dom_window) {
+    return true_screen_coordinate;
+  }
+  ExecutionContext* context = local_dom_window->GetExecutionContext();
+  double zoom_factor = local_dom_window->GetFrame()->PageZoomFactor();
+  return MaybeFarbleScreenInteger(context, key, zoom_factor * client_coordinate,
+                                  0, 8, true_screen_coordinate);
 }
 
 BraveSessionCache::BraveSessionCache(ExecutionContext& context)
@@ -190,7 +243,6 @@ AudioFarblingCallback BraveSessionCache::GetAudioFarblingCallback(
       }
       case BraveFarblingLevel::BALANCED: {
         const uint64_t* fudge = reinterpret_cast<const uint64_t*>(domain_key_);
-        const double maxUInt64AsDouble = UINT64_MAX;
         double fudge_factor = 0.99 + ((*fudge / maxUInt64AsDouble) / 100);
         VLOG(1) << "audio fudge factor (based on session token) = "
                 << fudge_factor;
@@ -296,6 +348,19 @@ WTF::String BraveSessionCache::FarbledUserAgent(WTF::String real_user_agent) {
   return result.ToString();
 }
 
+int BraveSessionCache::FarbledInteger(FarbleKey key,
+                                      int spoof_value,
+                                      int min_random_offset,
+                                      int max_random_offset) {
+  if (farbled_integers_.count(key) == 0) {
+    FarblingPRNG prng = MakePseudoRandomGenerator(key);
+    farbled_integers_[key] =
+        prng() % (1 + max_random_offset - min_random_offset) +
+        min_random_offset;
+  }
+  return farbled_integers_[key] + spoof_value;
+}
+
 bool BraveSessionCache::AllowFontFamily(
     blink::WebContentSettingsClient* settings,
     const AtomicString& family_name) {
@@ -325,11 +390,10 @@ bool BraveSessionCache::AllowFontFamily(
   return true;
 }
 
-FarblingPRNG BraveSessionCache::MakePseudoRandomGenerator() {
-  uint64_t seed = *reinterpret_cast<uint64_t*>(domain_key_);
+FarblingPRNG BraveSessionCache::MakePseudoRandomGenerator(FarbleKey key) {
+  uint64_t seed =
+      *reinterpret_cast<uint64_t*>(domain_key_) ^ static_cast<uint64_t>(key);
   return FarblingPRNG(seed);
 }
 
 }  // namespace brave
-
-#include "src/third_party/blink/renderer/core/execution_context/execution_context.cc"

--- a/third_party/blink/renderer/core/farbling/brave_session_cache.h
+++ b/third_party/blink/renderer/core/farbling/brave_session_cache.h
@@ -3,26 +3,42 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-#ifndef BRAVE_CHROMIUM_SRC_THIRD_PARTY_BLINK_RENDERER_CORE_EXECUTION_CONTEXT_EXECUTION_CONTEXT_H_
-#define BRAVE_CHROMIUM_SRC_THIRD_PARTY_BLINK_RENDERER_CORE_EXECUTION_CONTEXT_EXECUTION_CONTEXT_H_
+#ifndef BRAVE_THIRD_PARTY_BLINK_RENDERER_CORE_FARBLING_BRAVE_SESSION_CACHE_H_
+#define BRAVE_THIRD_PARTY_BLINK_RENDERER_CORE_FARBLING_BRAVE_SESSION_CACHE_H_
+
+#include <map>
+#include <string>
 
 #include "base/callback.h"
 #include "brave/third_party/blink/renderer/brave_farbling_constants.h"
-#include "src/third_party/blink/renderer/core/execution_context/execution_context.h"
 #include "third_party/abseil-cpp/absl/random/random.h"
 #include "third_party/blink/renderer/core/core_export.h"
+#include "third_party/blink/renderer/core/execution_context/execution_context.h"
+#include "third_party/blink/renderer/core/frame/dom_window.h"
 #include "third_party/blink/renderer/platform/wtf/text/atomic_string.h"
 
 namespace blink {
 class WebContentSettingsClient;
 }  // namespace blink
 
+namespace brave {
+
+using blink::DOMWindow;
 using blink::ExecutionContext;
 using blink::GarbageCollected;
 using blink::MakeGarbageCollected;
 using blink::Supplement;
 
-namespace brave {
+enum FarbleKey : uint64_t {
+  kNone,
+  kWindowInnerWidth,
+  kWindowInnerHeight,
+  kWindowScreenX,
+  kWindowScreenY,
+  kPointerScreenX,
+  kPointerScreenY,
+  kKeyCount
+};
 
 typedef absl::randen_engine<uint64_t> FarblingPRNG;
 typedef base::RepeatingCallback<float(float, size_t)> AudioFarblingCallback;
@@ -35,6 +51,17 @@ GetBraveFarblingLevelFor(ExecutionContext* context,
 CORE_EXPORT bool AllowFingerprinting(ExecutionContext* context);
 CORE_EXPORT bool AllowFontFamily(ExecutionContext* context,
                                  const AtomicString& family_name);
+CORE_EXPORT int MaybeFarbleScreenInteger(ExecutionContext* context,
+                                         brave::FarbleKey key,
+                                         int spoof_value,
+                                         int min_value,
+                                         int max_value,
+                                         int default_value);
+CORE_EXPORT bool BlockScreenFingerprinting(ExecutionContext* context);
+CORE_EXPORT int FarbledPointerScreenCoordinate(const DOMWindow* view,
+                                               FarbleKey key,
+                                               int client_coordinate,
+                                               int true_screen_coordinate);
 
 class CORE_EXPORT BraveSessionCache final
     : public GarbageCollected<BraveSessionCache>,
@@ -55,17 +82,23 @@ class CORE_EXPORT BraveSessionCache final
                      size_t size);
   WTF::String GenerateRandomString(std::string seed, wtf_size_t length);
   WTF::String FarbledUserAgent(WTF::String real_user_agent);
+  int FarbledInteger(FarbleKey key,
+                     int spoof_value,
+                     int min_random_offset,
+                     int max_random_offset);
   bool AllowFontFamily(blink::WebContentSettingsClient* settings,
                        const AtomicString& family_name);
-  FarblingPRNG MakePseudoRandomGenerator();
+  FarblingPRNG MakePseudoRandomGenerator(FarbleKey key = FarbleKey::kNone);
 
  private:
   bool farbling_enabled_;
   uint64_t session_key_;
   uint8_t domain_key_[32];
+  std::map<FarbleKey, int> farbled_integers_;
 
   void PerturbPixelsInternal(const unsigned char* data, size_t size);
 };
+
 }  // namespace brave
 
-#endif  // BRAVE_CHROMIUM_SRC_THIRD_PARTY_BLINK_RENDERER_CORE_EXECUTION_CONTEXT_EXECUTION_CONTEXT_H_
+#endif  // BRAVE_THIRD_PARTY_BLINK_RENDERER_CORE_FARBLING_BRAVE_SESSION_CACHE_H_

--- a/third_party/blink/renderer/includes.gni
+++ b/third_party/blink/renderer/includes.gni
@@ -6,6 +6,8 @@ brave_blink_renderer_core_visibility =
 brave_blink_renderer_core_public_deps = [ "//brave/third_party/blink/renderer" ]
 
 brave_blink_renderer_core_sources = [
+  "//brave/third_party/blink/renderer/core/farbling/brave_session_cache.cc",
+  "//brave/third_party/blink/renderer/core/farbling/brave_session_cache.h",
   "//brave/third_party/blink/renderer/core/resource_pool_limiter/resource_pool_limiter.cc",
   "//brave/third_party/blink/renderer/core/resource_pool_limiter/resource_pool_limiter.h",
 ]


### PR DESCRIPTION
On by default, behind the kBraveBlockScreenFingerprinting flag.

When farbling is active, modify API behavior in 4 categories:

1. window.outer{Width,Height}, window.screen{X,Y},
   window.screen.{width,height,avail{Width,Height,Left,Top}}

R = random number between 0 and 8, seeded by session+domain

window.screen{X,Y} -> R
window.outer{Width,Height} -> window.inner{Width, Height} + R
window.screen.{width, height} -> window.inner{Width, Height} + R
window.screen.avail{Width, Height} => window.inner{Width, Height} + R
window.screen.avail{Top, Left} -> R
window.screen.isExtended -> false

2. {mouse,drag,pointer,touch}Event.screen{X,Y}

Rewrite Event screen coordinates such that
event.screenX -> event.screenX_ChromiumImpl +
                 window.innerWidth - window.outerWidth_ChromiumImpl +
		 window.screenX - window.screenX_ChromiumImpl

etc.

3. device-{width,height} in media queries

When farbling is enabled, media query for device-width
matches the same value as window.screen.width (also farbled).
Same for device-height.

4: make window.open play nice with spoofed screen coords

When a web page opens a child window, the position of the child window
should be relative to the spoofed screen coordinates, not relative
to the real screen coordinates.

Also:

* Factor out brave_session_cache.{cc,h} to speed up incremental builds.
* Unit tests

<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/23170

## Submitter Checklist:

- [x] I have requested a security/privacy review: https://github.com/brave/security/issues/929
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

