### PR TITLE
Port "--keep-old-history'' flag switch from ungoogled-chromium to disable local history purging that is older than 90 days.

### DIFF
--- a/chromium_src/components/history/core/browser/history_backend.cc
+++ b/chromium_src/components/history/core/browser/history_backend.cc
@@ -1,0 +1,16 @@
+/* Copyright (c) 2022 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "base/command_line.h"
+#include "brave/components/constants/brave_switches.h"
+
+namespace {
+bool KeepOldHistory()
+  return base::CommandLine::ForCurrentProcess()->HasSwitch(
+      switches::kKeepOldHistory);
+}
+
+}  // namespace
+#include "src/components/history/core/browser/history_backend.cc"

--- a/components/constants/brave_switches.cc
+++ b/components/constants/brave_switches.cc
@@ -37,6 +37,9 @@ const char kDisableMachineId[] = "disable-machine-id";
 // what you are doing.
 const char kDisableEncryptionWin[] = "disable-encryption-win";
 
+// Keeps old history that is older than 90 days.
+const char kKeepOldHistory[] = "keep-old-history";
+    
 // Use custom update interval in sec
 const char kComponentUpdateIntervalInSec[] = "component-update-interval-in-sec";
 

--- a/components/constants/brave_switches.h
+++ b/components/constants/brave_switches.h
@@ -27,6 +27,8 @@ extern const char kDarkMode[];
 extern const char kDisableMachineId[];
 
 extern const char kDisableEncryptionWin[];
+  
+extern const char kKeepOldHistory[];
 
 extern const char kComponentUpdateIntervalInSec[];
 

--- a/patches/components-history-core-browser-history_backend.cc
+++ b/patches/components-history-core-browser-history_backend.cc
@@ -1,0 +1,13 @@
+--- a/components/history/core/browser/history_backend.cc	2022-06-12 05:25:32.361826400 +0700
++++ b/components/history/core/browser/history_backend.cc	2022-06-12 05:27:20.721826000 +0700
+@@ -1008,7 +1008,9 @@
+   db_->GetStartDate(&first_recorded_time_);
+ 
+   // Start expiring old stuff.
+-  expirer_.StartExpiringOldStuff(base::Days(kExpireDaysThreshold));
++  if (!KeepOldHistory()) {
++    expirer_.StartExpiringOldStuff(base::Days(kExpireDaysThreshold));
++  }
+ 
+   LOCAL_HISTOGRAM_TIMES("History.InitTime", TimeTicks::Now() - beginning_time);
+ }


### PR DESCRIPTION
<!-- Add brave-browser issue bellow that this PR will resolve -->
This is a [port](https://github.com/ungoogled-software/ungoogled-chromium/blob/master/patches/extra/ungoogled-chromium/add-flag-to-disable-local-history-expiration.patch) of ungoogled-chromium's [--keep-old-history](https://github.com/ungoogled-software/ungoogled-chromium/blob/master/docs/flags.md#:~:text=for%20more%20details.-,--keep-old-history,-Disables%20deletion%20of) that will disable automatic purging of local history beyond 90 days old. 
Closes https://github.com/brave/brave-browser/issues/2783

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

