### PR TITLE
Fixed wrong background color of default browser prompt dialog

### DIFF
--- a/browser/ui/views/brave_default_browser_dialog_view.cc
+++ b/browser/ui/views/brave_default_browser_dialog_view.cc
@@ -131,8 +131,8 @@ BraveDefaultBrowserDialogView::CreateNonClientFrameView(views::Widget* widget) {
   const views::BubbleBorder::Shadow kShadow =
       views::BubbleBorder::DIALOG_SHADOW;
   std::unique_ptr<views::BubbleBorder> border =
-      std::make_unique<views::BubbleBorder>(views::BubbleBorder::FLOAT, kShadow,
-                                            gfx::kPlaceholderColor);
+      std::make_unique<views::BubbleBorder>(views::BubbleBorder::FLOAT,
+                                            kShadow);
   if (GetParams().round_corners)
     border->SetCornerRadius(GetCornerRadius());
   frame->SetFootnoteView(DisownFootnoteView());


### PR DESCRIPTION
fix https://github.com/brave/brave-browser/issues/23422

Fixed by specifying color from BubbleBorder ctor.
By default, kColorDialogBackground will be picked.

This is regression from below upstream change. 

https://chromium-review.googlesource.com/c/chromium/src/+/3600776
`Make BubbleBorder prefer themed colors to SkColors.`

<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves 

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [x] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [x] New files have MPL-2.0 license header
- [x] Adequate test coverage exists to prevent regressions
- [x] Major classes, functions and non-trivial code blocks are well-commented
- [x] Changes in component dependencies are properly reflected in `gn`
- [x] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [x] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

See the test plan of https://github.com/brave/brave-core/pull/8150 and check background color