### PR TITLE
fix(wallet): Show Asset Info While Loading Balances

### DIFF
--- a/components/brave_wallet_ui/components/desktop/portfolio-asset-item/index.tsx
+++ b/components/brave_wallet_ui/components/desktop/portfolio-asset-item/index.tsx
@@ -114,7 +114,7 @@ const PortfolioAssetItem = (props: Props) => {
         <StyledWrapper disabled={token.isErc721 || isLoading} onClick={action}>
           <NameAndIcon>
             <IconsWrapper>
-              {isLoading
+              {!token.logo
                 ? <LoadingSkeleton
                   circle={true}
                   width={40}
@@ -131,7 +131,7 @@ const PortfolioAssetItem = (props: Props) => {
               }
             </IconsWrapper>
             <NameColumn>
-              {isLoading
+              {!token.name && !token.symbol
                 ? <>
                   <LoadingSkeleton width={assetNameSkeletonWidth} height={18} />
                   <Spacer />
@@ -155,17 +155,24 @@ const PortfolioAssetItem = (props: Props) => {
               size='small'
               hideBalances={hideBalances ?? false}
             >
-              {isLoading
-                ? <>
-                  <LoadingSkeleton width={100} height={20} />
-                </>
-                : <>
-                  {!token.isErc721 &&
+
+              {!token.isErc721 &&
+                <>
+                  {formattedFiatBalance ? (
                     <FiatBalanceText>{formattedFiatBalance}</FiatBalanceText>
-                  }
-                  <AssetBalanceText>{formattedAssetBalance}</AssetBalanceText>
+                  ) : (
+                    <>
+                      <LoadingSkeleton width={60} height={18} />
+                      <Spacer />
+                    </>
+                  )}
                 </>
               }
+              {formattedAssetBalance ? (
+                <AssetBalanceText>{formattedAssetBalance}</AssetBalanceText>
+              ) : (
+                <LoadingSkeleton width={60} height={18} />
+              )}
             </WithHideBalancePlaceholder>
           </BalanceColumn>
         </StyledWrapper>


### PR DESCRIPTION
## Description 
Will now show `Asset` information while loading `Asset` balances.

<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves <https://github.com/brave/brave-browser/issues/23436>

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [x] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [x] New files have MPL-2.0 license header
- [x] Adequate test coverage exists to prevent regressions
- [x] Major classes, functions and non-trivial code blocks are well-commented
- [x] Changes in component dependencies are properly reflected in `gn`
- [x] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [x] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

1. On the `Portfolio` page, refresh the page and make sure the assets `Icon, Name and Symbol` are displayed while balances are being loaded.

Before:

https://user-images.githubusercontent.com/40611140/173494411-a4559450-e23d-4b22-86f9-0906e868fcb1.mov

After:

https://user-images.githubusercontent.com/40611140/173492055-7414328a-4913-4b33-8642-5a7f6ca9b9ab.mov
