### PR TITLE
fix(wallet): Submitting Duplicate Transactions

### DIFF
--- a/components/brave_wallet_ui/common/hooks/send.ts
+++ b/components/brave_wallet_ui/common/hooks/send.ts
@@ -298,6 +298,8 @@ export default function useSend () {
           .multiplyByDecimals(selectedSendAsset.decimals).toNumber().toString(),
         coin: selectedAccount.coin
       } as SendFilTransactionParams))
+      setToAddressOrUrl('')
+      setSendAmount('')
       return
     }
     if (selectedSendAsset.isErc721 || selectedSendAsset.isErc20) { return }

--- a/components/brave_wallet_ui/components/extension/confirm-transaction-panel/index.tsx
+++ b/components/brave_wallet_ui/components/extension/confirm-transaction-panel/index.tsx
@@ -47,7 +47,10 @@ import {
   QueueStepRow,
   QueueStepButton,
   ErrorText,
-  WarningIcon
+  WarningIcon,
+  ConfirmingButton,
+  LoadIcon,
+  ConfirmingButtonText
 } from './style'
 import { Skeleton } from '../../shared/loading-skeleton/styles'
 
@@ -122,8 +125,30 @@ function ConfirmTransactionPanel ({
   const [isEditingAllowance, setIsEditingAllowance] = React.useState<boolean>(false)
   const [showAdvancedTransactionSettings, setShowAdvancedTransactionSettings] = React.useState<boolean>(false)
   const [maxPriorityPanel, setMaxPriorityPanel] = React.useState<MaxPriorityPanels>(MaxPriorityPanels.setSuggested)
+  const [transactionConfirmed, setTranactionConfirmed] = React.useState<boolean>(false)
+  const [queueLength, setQueueLength] = React.useState<number | undefined>(undefined)
+
+  React.useEffect(() => {
+    // This will update the transactionConfirmed state back to false
+    // if there are more than 1 transactions in the queue.
+    if (queueLength !== transactionsQueueLength || queueLength === undefined) {
+      setTranactionConfirmed(false)
+    }
+  }, [queueLength, transactionsQueueLength])
 
   // methods
+  const onClickConfirmTransaction = React.useCallback(() => {
+    // Checks to see if there are multiple transactions in the queue,
+    // if there is we keep track of the length of the last confirmed transaction.
+    if (transactionsQueueLength > 1) {
+      setQueueLength(transactionsQueueLength)
+    }
+    // Sets transactionConfirmed state to disable the send button to prevent
+    // being clicked again and submitting the same transaction.
+    setTranactionConfirmed(true)
+    onConfirm()
+  }, [transactionsQueueLength, onConfirm])
+
   const onSelectTab = (tab: confirmPanelTabs) => () => setSelectedTab(tab)
 
   const onToggleEditGas = () => setIsEditing(!isEditing)
@@ -378,13 +403,24 @@ function ConfirmTransactionPanel ({
           buttonType='reject'
           text={getLocale('braveWalletAllowSpendRejectButton')}
           onSubmit={onReject}
+          disabled={transactionConfirmed}
         />
-        <NavButton
-          buttonType='confirm'
-          text={getLocale('braveWalletAllowSpendConfirmButton')}
-          onSubmit={onConfirm}
-          disabled={isConfirmButtonDisabled}
-        />
+        {transactionConfirmed ? (
+          <ConfirmingButton>
+            <ConfirmingButtonText>
+              {getLocale('braveWalletAllowSpendConfirmButton')}
+            </ConfirmingButtonText>
+            <LoadIcon />
+          </ConfirmingButton>
+        ) : (
+          <NavButton
+            buttonType='confirm'
+            text={getLocale('braveWalletAllowSpendConfirmButton')}
+            onSubmit={onClickConfirmTransaction}
+            disabled={isConfirmButtonDisabled}
+          />
+        )}
+
       </ButtonRow>
     </StyledWrapper>
   )

--- a/components/brave_wallet_ui/components/extension/confirm-transaction-panel/style.ts
+++ b/components/brave_wallet_ui/components/extension/confirm-transaction-panel/style.ts
@@ -1,6 +1,5 @@
 import styled from 'styled-components'
-import { ArrowRightIcon } from 'brave-ui/components/icons'
-
+import { ArrowRightIcon, LoaderIcon } from 'brave-ui/components/icons'
 import { WarningBoxIcon } from '../shared-panel-styles'
 
 import {
@@ -271,4 +270,37 @@ export const WarningIcon = styled(WarningBoxIcon)`
   width: 14px;
   height: 14px;
   margin-right: 6px;
+`
+
+export const ConfirmingButton = styled(WalletButton)`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: default;
+  border-radius: 40px;
+  padding: 8px 16px;
+  outline: none;
+  margin: 0px;
+  background-color: ${(p) => p.theme.color.disabled};
+  border: none;
+`
+
+export const ConfirmingButtonText = styled.span`
+  font-style: normal;
+  font-weight: 600;
+  font-size: 13px;
+  line-height: 20px;
+  text-align: center;
+  color: ${(p) => p.theme.color.interactive07};
+  flex: none;
+  order: 1;
+  flex-grow: 0;
+  margin: 0px 8px;
+`
+
+export const LoadIcon = styled(LoaderIcon)`
+  color: ${p => p.theme.color.interactive08};
+  height: 25px;
+  width: 24px;
+  opacity: .4;
 `


### PR DESCRIPTION
## Description 
Fixes a bug where you were able to click the `Confirm` button multiple times on the `Confirm Transaction` panel causing the same transaction to be submitted duplicate times.

<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves <https://github.com/brave/brave-browser/issues/23451>

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [x] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [x] New files have MPL-2.0 license header
- [x] Adequate test coverage exists to prevent regressions
- [x] Major classes, functions and non-trivial code blocks are well-commented
- [x] Changes in component dependencies are properly reflected in `gn`
- [x] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [x] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

1. Submit a `Filecoin` transaction and then click `Confirm` in the Confirm Transaction` Panel
2. Both `Reject` and `Confirm` buttons should then be disabled while transaction is being confirmed.

https://user-images.githubusercontent.com/40611140/173705536-1d0ebaaf-87f8-4f01-a1be-d7710b0b3a7b.mov



