### PR TITLE
Return encoded hex when export filecoin private key (uplift to 1.40.x)

### DIFF
--- a/browser/brave_wallet/keyring_service_unittest.cc
+++ b/browser/brave_wallet/keyring_service_unittest.cc
@@ -2814,11 +2814,11 @@ TEST_F(KeyringServiceUnitTest, ImportFilecoinAccounts) {
       EXPECT_TRUE(service.IsKeyringCreated(mojom::kFilecoinKeyringId));
     }
 
-    std::string private_key;
+    std::string payload;
     EXPECT_TRUE(
         GetPrivateKeyForImportedAccount(&service, imported_accounts[i].address,
-                                        mojom::CoinType::FIL, &private_key));
-    EXPECT_EQ(imported_accounts[i].private_key, private_key);
+                                        mojom::CoinType::FIL, &payload));
+    EXPECT_EQ(imported_accounts[i].import_payload, payload);
   }
   // filecoin keyring will be lazily created in first FIL import
   auto* filecoin_keyring =
@@ -2902,10 +2902,10 @@ TEST_F(KeyringServiceUnitTest, ImportFilecoinAccounts) {
             amount - 1);
   // private key should also be available now
   private_key.clear();
-  EXPECT_TRUE(
-      GetPrivateKeyForImportedAccount(&service, imported_accounts[0].address,
-                                      mojom::CoinType::FIL, &private_key));
-  EXPECT_EQ(imported_accounts[0].private_key, private_key);
+  std::string payload;
+  EXPECT_TRUE(GetPrivateKeyForImportedAccount(
+      &service, imported_accounts[0].address, mojom::CoinType::FIL, &payload));
+  EXPECT_EQ(imported_accounts[0].import_payload, payload);
 
   auto* default_keyring =
       service.GetHDKeyringById(brave_wallet::mojom::kDefaultKeyringId);

--- a/components/brave_wallet/browser/brave_wallet_constants.h
+++ b/components/brave_wallet/browser/brave_wallet_constants.h
@@ -271,6 +271,8 @@ constexpr webui::LocalizedString kLocalizedStrings[] = {
     {"braveWalletAddAsset", IDS_BRAVE_WALLET_ADD_ASSET},
     {"braveWalletAccountSettingsDisclaimer",
      IDS_BRAVE_WALLET_ACCOUNT_SETTINGS_DISCLAIMER},
+    {"braveWalletFilExportPrivateKeyFormatDescription",
+     IDS_BRAVE_WALLET_FIL_EXPORT_PRIVATE_KEY_FORMAT_DESCRIPTION},
     {"braveWalletAccountSettingsShowKey",
      IDS_BRAVE_WALLET_ACCOUNT_SETTINGS_SHOW_KEY},
     {"braveWalletAccountSettingsHideKey",

--- a/components/brave_wallet/browser/filecoin_keyring.h
+++ b/components/brave_wallet/browser/filecoin_keyring.h
@@ -36,8 +36,13 @@ class FilecoinKeyring : public HDKeyring {
   void RestoreFilecoinAccount(const std::vector<uint8_t>& input_key,
                               const std::string& address);
   absl::optional<std::string> SignTransaction(const FilTransaction* tx);
+  std::string GetEncodedPrivateKey(const std::string& address) override;
+  static std::string GetExportEncodedJSON(const std::string& private_key,
+                                          const std::string& address);
 
  private:
+  static bool GetProtocolFromAddress(const std::string& address,
+                                     mojom::FilecoinAddressProtocol* protocol);
   std::string GetAddressInternal(HDKeyBase* hd_key_base) const override;
 };
 

--- a/components/brave_wallet/browser/hd_keyring.cc
+++ b/components/brave_wallet/browser/hd_keyring.cc
@@ -61,7 +61,7 @@ void HDKeyring::RemoveAccount() {
 bool HDKeyring::AddImportedAddress(const std::string& address,
                                    std::unique_ptr<HDKeyBase> hd_key) {
   // Account already exists
-  if (imported_accounts_[address])
+  if (imported_accounts_.find(address) != imported_accounts_.end())
     return false;
   // Check if it is duplicate in derived accounts
   for (size_t i = 0; i < accounts_.size(); ++i) {

--- a/components/brave_wallet/browser/hd_keyring.h
+++ b/components/brave_wallet/browser/hd_keyring.h
@@ -48,7 +48,7 @@ class HDKeyring {
   std::string GetDiscoveryAddress(size_t index) const;
   // Find private key by address (it would be hex or base58 depends on
   // underlying hd key
-  std::string GetEncodedPrivateKey(const std::string& address);
+  virtual std::string GetEncodedPrivateKey(const std::string& address);
 
   std::vector<uint8_t> SignMessage(const std::string& address,
                                    const std::vector<uint8_t>& message);

--- a/components/brave_wallet/browser/keyring_service.cc
+++ b/components/brave_wallet/browser/keyring_service.cc
@@ -1024,6 +1024,10 @@ void KeyringService::GetPrivateKeyForImportedAccount(
       encoded_private_key = Base58Encode(private_key);
     } else if (keyring_id == mojom::kFilecoinKeyringId) {
       encoded_private_key = base::Base64Encode(private_key);
+      std::string json =
+          FilecoinKeyring::GetExportEncodedJSON(encoded_private_key, address);
+      std::move(callback).Run(!json.empty(), json);
+      return;
     } else {
       encoded_private_key = base::ToLowerASCII(base::HexEncode(private_key));
     }

--- a/components/brave_wallet_ui/components/desktop/popup-modals/account-settings-modal/index.tsx
+++ b/components/brave_wallet_ui/components/desktop/popup-modals/account-settings-modal/index.tsx
@@ -198,6 +198,11 @@ const AddAccountModal = (props: Props) => {
             <WarningWrapper>
               <WarningText>{getLocale('braveWalletAccountSettingsDisclaimer')}</WarningText>
             </WarningWrapper>
+            {showPrivateKey && account.coin === BraveWallet.CoinType.FIL &&
+            <WarningWrapper>
+               <WarningText>{getLocale('braveWalletFilExportPrivateKeyFormatDescription')}</WarningText>
+            </WarningWrapper>
+            }
             {showPrivateKey &&
               <Tooltip text={getLocale('braveWalletToolTipCopyToClipboard')}>
                 <PrivateKeyBubble onClick={onCopyPrivateKey}>{privateKey}</PrivateKeyBubble>

--- a/components/resources/wallet_strings.grdp
+++ b/components/resources/wallet_strings.grdp
@@ -210,6 +210,7 @@
   <message name="IDS_BRAVE_WALLET_ICON_URL" desc="Visible assets modal Icon URL label">Icon URL</message>
   <message name="IDS_BRAVE_WALLET_ADD_ASSET" desc="Asset Panel add asset button">Add asset</message>
   <message name="IDS_BRAVE_WALLET_ACCOUNT_SETTINGS_DISCLAIMER" desc="Account settings modal warning">WARNING: Never share your recovery phrase. Anyone with this phrase can take your assets forever.</message>
+  <message name="IDS_BRAVE_WALLET_FIL_EXPORT_PRIVATE_KEY_FORMAT_DESCRIPTION" desc="Filecoin private key format description">NOTE: Private key is provided as a hex-encoded JSON that contains private key and protocol information. See https://lotus.filecoin.io/lotus/manage/lotus-cli/#lotus-wallet-import for more info.</message>
   <message name="IDS_BRAVE_WALLET_ACCOUNT_SETTINGS_SHOW_KEY" desc="Account settings modal show key button">Show key</message>
   <message name="IDS_BRAVE_WALLET_ACCOUNT_SETTINGS_HIDE_KEY" desc="Account settings modal hide key button">Hide key</message>
   <message name="IDS_BRAVE_WALLET_ACCOUNT_SETTINGS_UPDATE_ERROR" desc="Account settings modal failed to updated name error">Failed to update account name, please try again.</message>


### PR DESCRIPTION
Uplift of #13784
Resolves https://github.com/brave/brave-browser/issues/23441

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.