### PR TITLE
Enables Android DApps support by default (uplift to 1.40.x)

### DIFF
--- a/browser/profiles/brave_renderer_updater.cc
+++ b/browser/profiles/brave_renderer_updater.cc
@@ -15,7 +15,6 @@
 #include "brave/components/brave_wallet/common/brave_wallet.mojom.h"
 #include "brave/components/de_amp/browser/de_amp_util.h"
 #include "brave/components/de_amp/common/pref_names.h"
-#include "build/build_config.h"
 #include "chrome/browser/profiles/profile.h"
 #include "chrome/common/pref_names.h"
 #include "components/prefs/pref_service.h"

--- a/components/brave_wallet/common/features.cc
+++ b/components/brave_wallet/common/features.cc
@@ -32,14 +32,8 @@ const base::Feature kBraveWalletSolanaFeature{
 const base::Feature kBraveWalletSolanaProviderFeature{
     "BraveWalletSolanaProvider", base::FEATURE_DISABLED_BY_DEFAULT};
 
-const base::Feature kBraveWalletDappsSupportFeature {
-  "BraveWalletDappsSupport",
-#if BUILDFLAG(IS_ANDROID)
-      base::FEATURE_DISABLED_BY_DEFAULT
-#else
-      base::FEATURE_ENABLED_BY_DEFAULT
-#endif
-};
+const base::Feature kBraveWalletDappsSupportFeature{
+    "BraveWalletDappsSupport", base::FEATURE_ENABLED_BY_DEFAULT};
 
 const base::FeatureParam<bool> kFilecoinTestnetEnabled = {
     &kBraveWalletFilecoinFeature, "filecoin_testnet_enabled", false};


### PR DESCRIPTION
Uplift of #13547
Resolves https://github.com/brave/brave-browser/issues/23159

Pre-approval checklist: 
- [ ] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.