### PR TITLE
Brave Ads failed confirmations should not backoff if payment tokens are not created or not ready - 1.40.x

### DIFF
--- a/vendor/bat-native-ads/src/bat/ads/internal/account/confirmations/confirmations.cc
+++ b/vendor/bat-native-ads/src/bat/ads/internal/account/confirmations/confirmations.cc
@@ -274,7 +274,8 @@ void Confirmations::OnDidRedeemUnblindedToken(
   if (ConfirmationsState::Get()->get_unblinded_payment_tokens()->TokenExists(
           unblinded_payment_token)) {
     BLOG(1, "Unblinded payment token is a duplicate");
-    OnFailedToRedeemUnblindedToken(confirmation, /* should_retry */ false);
+    OnFailedToRedeemUnblindedToken(confirmation, /* should_retry */ false,
+                                   /* should_backoff */ false);
     return;
   }
 
@@ -309,7 +310,8 @@ void Confirmations::OnDidRedeemUnblindedToken(
 
 void Confirmations::OnFailedToRedeemUnblindedToken(
     const ConfirmationInfo& confirmation,
-    const bool should_retry) {
+    const bool should_retry,
+    const bool should_backoff) {
   BLOG(1, "Failed to redeem unblinded token for "
               << confirmation.ad_type << " with confirmation id "
               << confirmation.id << ", transaction id "
@@ -327,6 +329,10 @@ void Confirmations::OnFailedToRedeemUnblindedToken(
 
   if (delegate_) {
     delegate_->OnFailedToConfirm(confirmation);
+  }
+
+  if (!should_backoff) {
+    StopRetrying();
   }
 
   ProcessRetryQueue();

--- a/vendor/bat-native-ads/src/bat/ads/internal/account/confirmations/confirmations.h
+++ b/vendor/bat-native-ads/src/bat/ads/internal/account/confirmations/confirmations.h
@@ -70,7 +70,8 @@ class Confirmations final : public RedeemUnblindedTokenDelegate {
                                  const privacy::UnblindedPaymentTokenInfo&
                                      unblinded_payment_token) override;
   void OnFailedToRedeemUnblindedToken(const ConfirmationInfo& confirmation,
-                                      const bool should_retry) override;
+                                      const bool should_retry,
+                                      const bool should_backoff) override;
 
   raw_ptr<ConfirmationsDelegate> delegate_ = nullptr;
 

--- a/vendor/bat-native-ads/src/bat/ads/internal/account/utility/redeem_unblinded_token/redeem_unblinded_token.h
+++ b/vendor/bat-native-ads/src/bat/ads/internal/account/utility/redeem_unblinded_token/redeem_unblinded_token.h
@@ -50,7 +50,8 @@ class RedeemUnblindedToken final {
       const ConfirmationInfo& confirmation,
       const privacy::UnblindedPaymentTokenInfo& unblinded_payment_token);
   void OnFailedToRedeemUnblindedToken(const ConfirmationInfo& confirmation,
-                                      const bool should_retry);
+                                      const bool should_retry,
+                                      const bool should_backoff);
 
   raw_ptr<RedeemUnblindedTokenDelegate> delegate_ = nullptr;
 };

--- a/vendor/bat-native-ads/src/bat/ads/internal/account/utility/redeem_unblinded_token/redeem_unblinded_token_delegate.h
+++ b/vendor/bat-native-ads/src/bat/ads/internal/account/utility/redeem_unblinded_token/redeem_unblinded_token_delegate.h
@@ -32,10 +32,12 @@ class RedeemUnblindedTokenDelegate {
       const privacy::UnblindedPaymentTokenInfo& unblinded_payment_token) {}
 
   // Invoked to tell the delegate unblinded token redemption failed for the
-  // corresponding |confirmation| and whether we should retry
+  // corresponding |confirmation| and whether we should retry and backoff for
+  // subsequent failures
   virtual void OnFailedToRedeemUnblindedToken(
       const ConfirmationInfo& confirmation,
-      const bool should_retry) {}
+      const bool should_retry,
+      const bool should_backoff) {}
 };
 
 }  // namespace ads

--- a/vendor/bat-native-ads/src/bat/ads/internal/account/utility/redeem_unblinded_token/redeem_unblinded_token_delegate_mock.h
+++ b/vendor/bat-native-ads/src/bat/ads/internal/account/utility/redeem_unblinded_token/redeem_unblinded_token_delegate_mock.h
@@ -37,7 +37,9 @@ class RedeemUnblindedTokenDelegateMock : public RedeemUnblindedTokenDelegate {
 
   MOCK_METHOD(void,
               OnFailedToRedeemUnblindedToken,
-              (const ConfirmationInfo& confirmation, const bool should_retry));
+              (const ConfirmationInfo& confirmation,
+               const bool should_retry,
+               const bool should_backoff));
 };
 
 }  // namespace ads


### PR DESCRIPTION
Uplift of https://github.com/brave/brave-core/pull/13824
Resolves https://github.com/brave/brave-browser/issues/23516

- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR.
- [x] You have tested your change on Nightly. 
- [x] The PR milestones match the branch they are landing to. 

After you merge: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.
