### PR TITLE
Fix Brave Ads UserActivityManager should be UserActivity for Griffin - 1.41.x

### DIFF
--- a/vendor/bat-native-ads/src/bat/ads/internal/user_interaction/browsing/user_activity_features.cc
+++ b/vendor/bat-native-ads/src/bat/ads/internal/user_interaction/browsing/user_activity_features.cc
@@ -15,7 +15,7 @@ namespace features {
 
 namespace {
 
-constexpr char kFeatureName[] = "UserActivityManager";
+constexpr char kFeatureName[] = "UserActivity";
 
 constexpr char kFieldTrialParameterTriggers[] = "triggers";
 constexpr char kDefaultTriggers[] = "01=.5;02=.5;08=1;09=1;0D=1;0E=1";


### PR DESCRIPTION
Uplift of https://github.com/brave/brave-core/pull/13832
Resolves https://github.com/brave/brave-browser/issues/23528

- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR.
- [x] You have tested your change on Nightly. 
- [x] The PR milestones match the branch they are landing to. 

After you merge: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.