### PR TITLE
Default wallet setting to "Brave Wallet" causes some webcompat issues

### DIFF
--- a/browser/brave_wallet/send_transaction_browsertest.cc
+++ b/browser/brave_wallet/send_transaction_browsertest.cc
@@ -822,4 +822,17 @@ IN_PROC_BROWSER_TEST_F(SendTransactionBrowserTest,
             true);
 }
 
+IN_PROC_BROWSER_TEST_F(SendTransactionBrowserTest,
+                       EnsurePropertiesCantBeDeletedNoOverwrite) {
+  brave_wallet_service_->SetDefaultWallet(mojom::DefaultWallet::BraveWallet);
+  GURL url =
+      https_server_for_files()->GetURL("a.com", "/send_transaction.html");
+  ASSERT_TRUE(ui_test_utils::NavigateToURL(browser(), url));
+  EXPECT_TRUE(WaitForLoadStop(web_contents()));
+  ASSERT_EQ(EvalJs(web_contents(), "ensurePropertiesCantBeDeleted()",
+                   content::EXECUTE_SCRIPT_USE_MANUAL_REPLY)
+                .ExtractBool(),
+            true);
+}
+
 }  // namespace brave_wallet

--- a/components/brave_wallet/renderer/js_ethereum_provider.cc
+++ b/components/brave_wallet/renderer/js_ethereum_provider.cc
@@ -158,17 +158,31 @@ void JSEthereumProvider::CreateEthereumObject(
   v8::Local<v8::Object> ethereum_obj;
   v8::Local<v8::Object> metamask_obj;
   v8::Local<v8::Value> ethereum_value;
+  v8::Local<v8::Proxy> ethereum_proxy;
+  v8::Local<v8::Object> ethereum_proxy_handler_obj;
   if (!global->Get(context, gin::StringToV8(isolate, "ethereum"))
            .ToLocal(&ethereum_value) ||
       !ethereum_value->IsObject()) {
+    ethereum_proxy_handler_obj = v8::Object::New(isolate);
+    BindFunctionToObject(
+        isolate, ethereum_proxy_handler_obj, "deleteProperty",
+        base::BindRepeating(&JSEthereumProvider::ProxyDeletePropertyHandler,
+                            base::Unretained(this)));
+
     ethereum_obj = v8::Object::New(isolate);
+    if (!v8::Proxy::New(context, ethereum_obj, ethereum_proxy_handler_obj)
+             .ToLocal(&ethereum_proxy)) {
+      return;
+    }
+
     metamask_obj = v8::Object::New(isolate);
     if (!allow_overwrite_window_ethereum) {
-      SetProviderNonWritable(context, global, ethereum_obj,
+      SetProviderNonWritable(context, global, ethereum_proxy,
                              gin::StringToV8(isolate, "ethereum"), true);
     } else {
       global
-          ->Set(context, gin::StringToSymbol(isolate, "ethereum"), ethereum_obj)
+          ->Set(context, gin::StringToSymbol(isolate, "ethereum"),
+                ethereum_proxy)
           .Check();
     }
     ethereum_obj
@@ -385,6 +399,10 @@ v8::Local<v8::Promise> JSEthereumProvider::Send(gin::Arguments* args) {
                      nullptr, std::move(promise_resolver), isolate, true));
 
   return resolver.ToLocalChecked()->GetPromise();
+}
+
+bool JSEthereumProvider::ProxyDeletePropertyHandler(gin::Arguments* args) {
+  return true;
 }
 
 void JSEthereumProvider::SendAsync(gin::Arguments* args) {

--- a/components/brave_wallet/renderer/js_ethereum_provider.h
+++ b/components/brave_wallet/renderer/js_ethereum_provider.h
@@ -70,6 +70,7 @@ class JSEthereumProvider : public mojom::EventsListener {
   v8::Local<v8::Promise> IsUnlocked();
   v8::Local<v8::Promise> Send(gin::Arguments* args);
   void SendAsync(gin::Arguments* args);
+  bool ProxyDeletePropertyHandler(gin::Arguments* args);
 
   void OnRequestOrSendAsync(v8::Global<v8::Context> global_context,
                             std::unique_ptr<v8::Global<v8::Function>> callback,

--- a/components/brave_wallet/resources/ethereum_provider.js
+++ b/components/brave_wallet/resources/ethereum_provider.js
@@ -36,23 +36,6 @@
     }
   })
 
-  Object.defineProperty(window, 'ethereum', {
-    value: new Proxy(window.ethereum, {
-      get: (...args) => {
-        return Reflect.get(...args)
-      },
-      set: (...args) => {
-        return Reflect.set(...args)
-      },
-      deleteProperty: (target, prop) => {
-        return true
-      }
-    }),
-    enumerable: true,
-    configurable: true,
-    writable: true,
-  })
-
   var alreadyLogged = false
   var logweb3Warning = () => {
     if (!alreadyLogged) {


### PR DESCRIPTION
The problem is that the ethereum object was set to non writable too early.
This moves the code to create the needed proxy to the native side.

Recall that code for deleting a property returns true was needed because of this:
https://github.com/brave/brave-core/commit/819279a8016264f2299085632d91d4c2b3912a2b

<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/23546

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

- Try to login / connect with release channel (1.39) it will fail https://wallet.polygon.technology/
- Try the same steps with the fixed version, it will ask you to sign then log you in.