### PR TITLE
Hide private search provider options when extension's provider is used

### DIFF
--- a/browser/resources/settings/brave_search_engines_page/brave_search_engines_page.html
+++ b/browser/resources/settings/brave_search_engines_page/brave_search_engines_page.html
@@ -1,5 +1,6 @@
 <style include="settings-shared iron-flex"></style>
-<template is="dom-if" if="[[shouldShowPrivateSearchProvider_]]">
+<template is="dom-if" if="[[shouldShowPrivateSearchProvider_(
+    prefs.default_search_provider_data.template_url_data)]]">
   <div class="settings-box">
     <div class="label flex">$i18n{privateSearchExplanation}</div>
     <settings-dropdown-menu

--- a/browser/resources/settings/brave_search_engines_page/brave_search_engines_page.js
+++ b/browser/resources/settings/brave_search_engines_page/brave_search_engines_page.js
@@ -24,12 +24,6 @@ class BraveSearchEnginesPage extends BraveSearchEnginesPageBase {
 
   static get properties() {
     return {
-      shouldShowPrivateSearchProvider_: {
-        readOnly: true,
-        type: Boolean,
-        value: !loadTimeData.getBoolean('isGuest')
-      },
-
       privateSearchEngines_: {
         readOnly: false,
         type: Array
@@ -48,6 +42,17 @@ class BraveSearchEnginesPage extends BraveSearchEnginesPageBase {
 
     this.browserProxy_.getPrivateSearchEnginesList().then(updatePrivateSearchEngines)
     this.addWebUIListener('private-search-engines-changed', updatePrivateSearchEngines)
+  }
+
+  shouldShowPrivateSearchProvider_(prefs) {
+    // When default search engine is enforced, configured provider is not used.
+    // If we install search provider extension, that extension will be used on normal and
+    // private(tor) window. So, just hide this option.
+    return !loadTimeData.getBoolean('isGuest') && !this.isDefaultSearchEngineEnforced_(prefs)
+  }
+
+  isDefaultSearchEngineEnforced_(prefs) {
+    return prefs.enforcement === chrome.settingsPrivate.Enforcement.ENFORCED;
   }
 }
 


### PR DESCRIPTION
fix https://github.com/brave/brave-browser/issues/23592

When search provider extension is enabled, all profiles(normal, private and tor)
uses that provider.
Option for private search provider doesn't have any meaning in this condition.

When search provider extension is not configured, both options are visible.
<img width="727" alt="Screen Shot 2022-06-22 at 5 19 40 PM" src="https://user-images.githubusercontent.com/6786187/174980181-e6670a22-5abf-4bfe-8ed8-0c9d72fecd0d.png">

When search provider extensionis enabled, only normal window option is visible.
<img width="719" alt="Screen Shot 2022-06-22 at 5 19 30 PM" src="https://user-images.githubusercontent.com/6786187/174980273-ded2f149-f155-44d3-9bc5-8eef9a62272c.png">

<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves 

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

1. Launch browser and load brave://settings/search
2. Install qwant extension from webstore - https://chrome.google.com/webstore/detail/qwant-viprivacy/hnlkiofnhhoahaiimdicppgemmmomijo
3. Check private search provider is hidden
4. Disable qwant extension from brave://extensions/ and check both search provider options are visible