### PR TITLE
Checks for a wallet badge only when native init is done and a wallet icon is visible on Android (uplift to 1.40.x)

### DIFF
--- a/android/java/org/chromium/chrome/browser/app/BraveActivity.java
+++ b/android/java/org/chromium/chrome/browser/app/BraveActivity.java
@@ -234,6 +234,7 @@ public abstract class BraveActivity<C extends ChromeActivityComponent> extends C
     public CopyOnWriteArrayList<FeedItemsCard> mNewsItemsFeedCards;
     private boolean isProcessingPendingDappsTxRequest;
     private int mLastTabId;
+    private boolean mNativeInitialized;
 
     @SuppressLint("VisibleForTests")
     public BraveActivity() {
@@ -248,6 +249,16 @@ public abstract class BraveActivity<C extends ChromeActivityComponent> extends C
         if (BraveVpnUtils.isBraveVpnFeatureEnable()) {
             InAppPurchaseWrapper.getInstance().startBillingServiceConnection(BraveActivity.this);
             BraveVpnNativeWorker.getInstance().addObserver(this);
+        }
+        // The check on mNativeInitialized is mostly to ensure that mojo
+        // services for wallet are initialized.
+        // TODO(sergz): verify do we need it in that phase or not.
+        if (mNativeInitialized) {
+            BraveToolbarLayoutImpl layout = getBraveToolbarLayout();
+            if (layout == null || !layout.isWalletIconVisible()) {
+                return;
+            }
+            updateWalletBadgeVisibility();
         }
     }
 
@@ -677,7 +688,6 @@ public abstract class BraveActivity<C extends ChromeActivityComponent> extends C
         // If active tab is private, set private DSE as an active DSE.
         BraveSearchEngineUtils.updateActiveDSE(tab.isIncognito());
         BraveStatsUtil.removeShareStatsFile();
-        updateWalletBadgeVisibility();
     }
 
     @Override
@@ -889,6 +899,7 @@ public abstract class BraveActivity<C extends ChromeActivityComponent> extends C
             }
         }
         initNativeServices();
+        mNativeInitialized = true;
     }
 
     public void setDormantUsersPrefs() {

--- a/android/java/org/chromium/chrome/browser/toolbar/top/BraveToolbarLayoutImpl.java
+++ b/android/java/org/chromium/chrome/browser/toolbar/top/BraveToolbarLayoutImpl.java
@@ -874,6 +874,13 @@ public abstract class BraveToolbarLayoutImpl extends ToolbarLayout
         }.executeOnExecutor(AsyncTask.THREAD_POOL_EXECUTOR);
     }
 
+    public boolean isWalletIconVisible() {
+        if (mWalletLayout == null) {
+            return false;
+        }
+        return mWalletLayout.getVisibility() == View.VISIBLE;
+    }
+
     public void showWalletIcon(boolean show) {
         assert mWalletLayout != null;
         if (mWalletLayout == null) {


### PR DESCRIPTION
Uplift of https://github.com/brave/brave-core/pull/13896
Resolves https://github.com/brave/brave-browser/issues/23604