### PR TITLE
Disable reduce language feature by default (uplift to 1.40.x)

### DIFF
--- a/browser/farbling/brave_navigator_languages_farbling_browsertest.cc
+++ b/browser/farbling/brave_navigator_languages_farbling_browsertest.cc
@@ -37,6 +37,7 @@
 #include "third_party/blink/renderer/core/frame/navigator_language.h"
 
 using brave_shields::ControlType;
+using brave_shields::features::kBraveReduceLanguage;
 using content::TitleWatcher;
 
 namespace {
@@ -48,6 +49,7 @@ class BraveNavigatorLanguagesFarblingBrowserTest : public InProcessBrowserTest {
  public:
   BraveNavigatorLanguagesFarblingBrowserTest()
       : https_server_(net::EmbeddedTestServer::TYPE_HTTPS) {
+    feature_list_.InitAndEnableFeature(kBraveReduceLanguage);
     brave::RegisterPathProvider();
     base::FilePath test_data_dir;
     base::PathService::Get(brave::DIR_TEST_DATA, &test_data_dir);

--- a/components/brave_shields/common/features.cc
+++ b/components/brave_shields/common/features.cc
@@ -53,7 +53,7 @@ const base::Feature kBraveExtensionNetworkBlocking{
     "BraveExtensionNetworkBlocking", base::FEATURE_DISABLED_BY_DEFAULT};
 // When enabled, language headers and APIs may be altered by Brave Shields.
 const base::Feature kBraveReduceLanguage{"BraveReduceLanguage",
-                                         base::FEATURE_ENABLED_BY_DEFAULT};
+                                         base::FEATURE_DISABLED_BY_DEFAULT};
 // When enabled, Brave will always report Light in Fingerprinting: Strict mode
 const base::Feature kBraveDarkModeBlock{"BraveDarkModeBlock",
                                         base::FEATURE_ENABLED_BY_DEFAULT};


### PR DESCRIPTION
Uplift of #13905
Resolves https://github.com/brave/brave-browser/issues/23610

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.