### PR TITLE
Use Locale in formatting fiat amounts

### DIFF
--- a/components/brave_wallet_ui/components/desktop/views/portfolio/portfolio-asset.tsx
+++ b/components/brave_wallet_ui/components/desktop/views/portfolio/portfolio-asset.tsx
@@ -17,7 +17,6 @@ import {
   SupportedTestNetworks,
   WalletRoutes
 } from '../../../../constants/types'
-import { CurrencySymbols } from '../../../../utils/currency-symbols'
 
 // Utils
 import Amount from '../../../../utils/amount'
@@ -281,8 +280,8 @@ export const PortfolioAsset = () => {
   ])
 
   const onUpdateBalance = React.useCallback((value: number | undefined) => {
-    setHoverPrice(value ? new Amount(value).formatAsFiat() : undefined)
-  }, [])
+    setHoverPrice(value ? new Amount(value).formatAsFiat(defaultCurrencies.fiat) : undefined)
+  }, [defaultCurrencies])
 
   const onToggleHideBalances = React.useCallback(() => {
     setHideBalances(prevHideBalances => !prevHideBalances)
@@ -344,7 +343,7 @@ export const PortfolioAsset = () => {
           </AssetRow>
 
           <PriceRow>
-            <PriceText>{CurrencySymbols[defaultCurrencies.fiat]}{hoverPrice || (selectedAssetFiatPrice ? new Amount(selectedAssetFiatPrice.price).formatAsFiat() : 0.00)}</PriceText>
+            <PriceText>{hoverPrice || (selectedAssetFiatPrice ? new Amount(selectedAssetFiatPrice.price).formatAsFiat(defaultCurrencies.fiat) : 0.00)}</PriceText>
             <PercentBubble isDown={selectedAssetFiatPrice ? Number(selectedAssetFiatPrice.assetTimeframeChange) < 0 : false}>
               <ArrowIcon isDown={selectedAssetFiatPrice ? Number(selectedAssetFiatPrice.assetTimeframeChange) < 0 : false} />
               <PercentText>{selectedAssetFiatPrice ? Number(selectedAssetFiatPrice.assetTimeframeChange).toFixed(2) : 0.00}%</PercentText>

--- a/components/brave_wallet_ui/components/desktop/views/portfolio/portfolio-overview.tsx
+++ b/components/brave_wallet_ui/components/desktop/views/portfolio/portfolio-overview.tsx
@@ -17,7 +17,6 @@ import {
   WalletRoutes
 } from '../../../../constants/types'
 import { getLocale } from '../../../../../common/locale'
-import { CurrencySymbols } from '../../../../utils/currency-symbols'
 
 // Utils
 import { getTokensCoinType } from '../../../../utils/network-utils'
@@ -143,7 +142,7 @@ export const PortfolioOverview = () => {
     const grandTotal = visibleAssetFiatBalances.reduce(function (a, b) {
       return a.plus(b)
     })
-    return grandTotal.formatAsFiat()
+    return grandTotal.formatAsFiat(defaultCurrencies.fiat)
   }, [userAssetList, computeFiatAmount])
 
   const priceHistory = React.useMemo(() => {
@@ -174,8 +173,8 @@ export const PortfolioOverview = () => {
   }, [selectedTimeline])
 
   const onUpdateBalance = React.useCallback((value: number | undefined) => {
-    setHoverBalance(value ? new Amount(value).formatAsFiat() : undefined)
-  }, [])
+    setHoverBalance(value ? new Amount(value).formatAsFiat(defaultCurrencies.fiat) : undefined)
+  }, [defaultCurrencies])
 
   const onToggleHideBalances = React.useCallback(() => {
     setHideBalances(!hideBalances)
@@ -216,7 +215,7 @@ export const PortfolioOverview = () => {
       >
         <BalanceText>
           {fullPortfolioFiatBalance !== ''
-            ? `${CurrencySymbols[defaultCurrencies.fiat]}${hoverBalance || fullPortfolioFiatBalance}`
+            ? `${hoverBalance || fullPortfolioFiatBalance}`
             : <LoadingSkeleton width={150} height={32} />
           }
         </BalanceText>

--- a/components/brave_wallet_ui/utils/amount.test.ts
+++ b/components/brave_wallet_ui/utils/amount.test.ts
@@ -1,5 +1,12 @@
 import Amount from './amount'
 
+let languageGetter
+
+beforeEach(() => {
+  languageGetter = jest.spyOn(window.navigator, 'language', 'get')
+  languageGetter.mockReturnValue('en-GB')
+})
+
 describe('Amount class', () => {
   describe('instantiation tests', () => {
     it('should create Amount object using empty value', () => {

--- a/components/brave_wallet_ui/utils/amount.ts
+++ b/components/brave_wallet_ui/utils/amount.ts
@@ -235,34 +235,34 @@ export default class Amount {
   }
 
   formatAsFiat (currency?: string): string {
-    const fmt = {
-      decimalSeparator: '.',
-      groupSeparator: ',',
-      groupSize: 3
-    } as BigNumber.Format
+    let decimals
+    let value
 
-    let result
     if (this.value === undefined || this.value.isNaN()) {
-      result = ''
-    } else if (this.value.isZero()) {
-      result = '0.00'
-    } else if (this.value.decimalPlaces() < 2) {
-      result = this.value.toFormat(2, BigNumber.ROUND_UP, fmt)
-    } else if (this.value.isGreaterThanOrEqualTo(10)) {
-      result = this.value.toFormat(2, BigNumber.ROUND_UP, fmt)
-    } else if (this.value.isGreaterThanOrEqualTo(1)) {
-      result = this.value.toFormat(3, BigNumber.ROUND_UP, fmt)
-    } else {
-      result = this.format(4, true)
-    }
-
-    if (!result) {
       return ''
+    } else if (this.value.decimalPlaces() < 2 || this.value.isGreaterThanOrEqualTo(10)) {
+      decimals = 2
+      value = this.value.toNumber()
+    } else if (this.value.isGreaterThanOrEqualTo(1)) {
+      decimals = 3
+      value = this.value.toNumber()
+    } else {
+      value = new BigNumber(this.format(4)).toNumber()
     }
 
-    return currency !== undefined
-      ? `${CurrencySymbols[currency]}${result}`
-      : result
+    const options: Intl.NumberFormatOptions = {
+      style: 'decimal',
+      minimumFractionDigits: decimals || 0,
+      maximumFractionDigits: decimals || 20
+    }
+
+    if (currency && CurrencySymbols[currency]) {
+      options.style = 'currency'
+      options.currency = currency
+      options.currencyDisplay = 'narrowSymbol'
+    }
+
+    return Intl.NumberFormat(navigator.language, options).format(value)
   }
 
   toHex (): string {


### PR DESCRIPTION
<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/22815

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

### Before:

https://user-images.githubusercontent.com/48117473/175321554-7e538572-ccba-4e6b-96dc-90926d21c2c0.mov

### After:

https://user-images.githubusercontent.com/48117473/175319967-8a5f136b-5402-411b-ae13-cec4a34c6f24.mov
