### PR TITLE
Fixed redundant creation of Default profile

### DIFF
--- a/browser/brave_shields/ad_block_subscription_download_manager_getter.cc
+++ b/browser/brave_shields/ad_block_subscription_download_manager_getter.cc
@@ -10,6 +10,7 @@
 
 #include "base/bind.h"
 #include "base/callback.h"
+#include "base/memory/raw_ptr.h"
 #include "base/memory/singleton.h"
 #include "base/task/task_traits.h"
 #include "base/task/thread_pool.h"
@@ -90,7 +91,8 @@ class AdBlockSubscriptionDownloadManagerGetterImpl
   explicit AdBlockSubscriptionDownloadManagerGetterImpl(
       base::OnceCallback<void(AdBlockSubscriptionDownloadManager*)> callback)
       : callback_(std::move(callback)) {
-    g_browser_process->profile_manager()->AddObserver(this);
+    profile_manager_ = g_browser_process->profile_manager();
+    profile_manager_->AddObserver(this);
   }
 
  private:
@@ -102,10 +104,11 @@ class AdBlockSubscriptionDownloadManagerGetterImpl
   }
 
   void OnProfileManagerDestroying() override {
-    g_browser_process->profile_manager()->RemoveObserver(this);
+    profile_manager_->RemoveObserver(this);
     delete this;
   }
 
+  raw_ptr<ProfileManager> profile_manager_;
   base::OnceCallback<void(AdBlockSubscriptionDownloadManager*)> callback_;
 };
 

--- a/browser/brave_stats/brave_stats_updater.cc
+++ b/browser/brave_stats/brave_stats_updater.cc
@@ -121,7 +121,7 @@ BraveStatsUpdater::BraveStatsUpdater(PrefService* pref_service)
 BraveStatsUpdater::~BraveStatsUpdater() = default;
 
 void BraveStatsUpdater::OnProfileAdded(Profile* profile) {
-  if (profile == ProfileManager::GetLastUsedProfile()) {
+  if (profile == ProfileManager::GetLastUsedProfileIfLoaded()) {
     g_browser_process->profile_manager()->RemoveObserver(this);
     Start();
   }
@@ -191,8 +191,10 @@ PrefService* BraveStatsUpdater::GetProfilePrefs() {
   if (testing_profile_prefs_ != nullptr) {
     return testing_profile_prefs_;
   }
-
-  return ProfileManager::GetLastUsedProfile()->GetPrefs();
+  auto* profile = ProfileManager::GetLastUsedProfileIfLoaded();
+  if (!profile)
+    return nullptr;
+  return profile->GetPrefs();
 }
 
 // static
@@ -322,7 +324,8 @@ bool BraveStatsUpdater::IsReferralInitialized() {
 }
 
 bool BraveStatsUpdater::IsAdsEnabled() {
-  return GetProfilePrefs()->GetBoolean(ads::prefs::kEnabled);
+  return GetProfilePrefs() &&
+         GetProfilePrefs()->GetBoolean(ads::prefs::kEnabled);
 }
 
 bool BraveStatsUpdater::HasDoneThresholdPing() {
@@ -400,6 +403,8 @@ void BraveStatsUpdater::SendServerPing() {
   auto resource_request = std::make_unique<network::ResourceRequest>();
 
   auto* profile_pref_service = GetProfilePrefs();
+  if (!profile_pref_service)
+    return;
   auto stats_updater_params =
       std::make_unique<brave_stats::BraveStatsUpdaterParams>(
           pref_service_, profile_pref_service, arch_);

--- a/browser/brave_stats/brave_stats_updater.cc
+++ b/browser/brave_stats/brave_stats_updater.cc
@@ -121,7 +121,7 @@ BraveStatsUpdater::BraveStatsUpdater(PrefService* pref_service)
 BraveStatsUpdater::~BraveStatsUpdater() = default;
 
 void BraveStatsUpdater::OnProfileAdded(Profile* profile) {
-  if (profile == ProfileManager::GetPrimaryUserProfile()) {
+  if (profile == ProfileManager::GetLastUsedProfile()) {
     g_browser_process->profile_manager()->RemoveObserver(this);
     Start();
   }
@@ -191,7 +191,8 @@ PrefService* BraveStatsUpdater::GetProfilePrefs() {
   if (testing_profile_prefs_ != nullptr) {
     return testing_profile_prefs_;
   }
-  return ProfileManager::GetPrimaryUserProfile()->GetPrefs();
+
+  return ProfileManager::GetLastUsedProfile()->GetPrefs();
 }
 
 // static

--- a/components/brave_referrals/browser/brave_referrals_service.cc
+++ b/components/brave_referrals/browser/brave_referrals_service.cc
@@ -213,7 +213,7 @@ BraveReferralsService::BraveReferralsService(PrefService* pref_service,
 BraveReferralsService::~BraveReferralsService() = default;
 
 void BraveReferralsService::OnProfileAdded(Profile* profile) {
-  if (profile == ProfileManager::GetPrimaryUserProfile()) {
+  if (profile == ProfileManager::GetLastUsedProfile()) {
     g_browser_process->profile_manager()->RemoveObserver(this);
     Start();
   }

--- a/components/brave_referrals/browser/brave_referrals_service.cc
+++ b/components/brave_referrals/browser/brave_referrals_service.cc
@@ -213,7 +213,7 @@ BraveReferralsService::BraveReferralsService(PrefService* pref_service,
 BraveReferralsService::~BraveReferralsService() = default;
 
 void BraveReferralsService::OnProfileAdded(Profile* profile) {
-  if (profile == ProfileManager::GetLastUsedProfile()) {
+  if (profile == ProfileManager::GetLastUsedProfileIfLoaded()) {
     g_browser_process->profile_manager()->RemoveObserver(this);
     Start();
   }


### PR DESCRIPTION
<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/4599

Fixed redundant creation of default profile. `GetPrimaryUserProfile` returns `Default` browser profile, but not the profile which is currently used by user. If user has deleted `Default` profile it will be re-created in this case. Better to use LastUsedProfile which returns current profile for the user.

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [x] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [x] New files have MPL-2.0 license header
- [x] Adequate test coverage exists to prevent regressions
- [x] Major classes, functions and non-trivial code blocks are well-commented
- [x] Changes in component dependencies are properly reflected in `gn`
- [x] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [x] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

- Start a clean profile
- Click on people icon and click on Manage people
- Add a new person in Manage people window
- Click on Person 2 window and click on people icon, lists Person 1 in the list
- In manage people window, click on 3 dots of Person 1 and delete it
- Open Person 2 window and click on people icon, still lists Person 1 there. Clicking that will create a new Person 1 window