### PR TITLE
Add address, makes eTLD+1 in bold and change places for account name and eTLD+1 on decrypt screen on Android (uplift to 1.41.x)

### DIFF
--- a/android/java/org/chromium/chrome/browser/crypto_wallet/fragments/dapps/EncryptionKeyFragment.java
+++ b/android/java/org/chromium/chrome/browser/crypto_wallet/fragments/dapps/EncryptionKeyFragment.java
@@ -119,7 +119,8 @@ public class EncryptionKeyFragment extends Fragment implements View.OnClickListe
                     getViewLifecycleOwner(), accountInfo -> {
                         Utils.setBlockiesBitmapResource(
                                 mExecutor, mHandler, mAccountImage, accountInfo.address, true);
-                        mAccountName.setText(accountInfo.name);
+                        String accountText = accountInfo.name + "\n" + accountInfo.address;
+                        mAccountName.setText(accountText);
                     });
 
             if (mActivityType

--- a/android/java/res/layout/fragment_encryption_key.xml
+++ b/android/java/res/layout/fragment_encryption_key.xml
@@ -57,6 +57,21 @@
     </com.google.android.material.card.MaterialCardView>
 
     <TextView
+        android:id="@+id/fragment_encryption_msg_tv_eTldPlusOne"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="4dp"
+        android:layout_marginBottom="12dp"
+        android:gravity="center"
+        android:textColor="@color/brave_wallet_dapp_text_color"
+        android:textSize="15sp"
+        android:visibility="gone"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/fragment_encryption_msg_cv_account_image_container"
+        tools:text="brave.com" />
+
+    <TextView
         android:id="@+id/fragment_encryption_msg_tv_account_name"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
@@ -68,25 +83,8 @@
         android:textStyle="bold"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/fragment_encryption_msg_cv_account_image_container"
+        app:layout_constraintTop_toBottomOf="@id/fragment_encryption_msg_tv_eTldPlusOne"
         tools:text="Ledger Nano" />
-
-    <TextView
-        android:id="@+id/fragment_encryption_msg_tv_eTldPlusOne"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_marginTop="6dp"
-        android:layout_marginBottom="12dp"
-        android:gravity="center"
-        android:textColor="@color/brave_wallet_dapp_text_color"
-        android:textSize="14sp"
-        android:textStyle="bold"
-        android:visibility="gone"
-        app:layout_constraintBottom_toTopOf="@+id/fragment_encryption_msg_tv_message"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/fragment_encryption_msg_tv_account_name"
-        tools:text="brave.com" />
 
     <TextView
         android:id="@+id/fragment_encryption_msg_tv_message"
@@ -101,7 +99,7 @@
         app:layout_constraintBottom_toTopOf="@+id/fragment_encryption_msg_title"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/fragment_encryption_msg_tv_eTldPlusOne" />
+        app:layout_constraintTop_toBottomOf="@+id/fragment_encryption_msg_tv_account_name" />
 
     <TextView
         android:id="@+id/fragment_encryption_msg_title"


### PR DESCRIPTION
Uplift of #13936
Resolves https://github.com/brave/brave-browser/issues/23651

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.