### PR TITLE
Fixes a from value reset on swap when To asset is changed on Android (uplift to 1.41.x)

### DIFF
--- a/android/java/org/chromium/chrome/browser/crypto_wallet/activities/BuySendSwapActivity.java
+++ b/android/java/org/chromium/chrome/browser/crypto_wallet/activities/BuySendSwapActivity.java
@@ -1419,7 +1419,6 @@ public class BuySendSwapActivity extends BraveWalletBaseActivity
             mFromValueBlock.setVisibility(View.GONE);
         } else {
             mFromValueBlock.setVisibility(View.VISIBLE);
-            mFromValueText.setText("");
         }
         if (buySend && mActivityType == ActivityType.SWAP || !buySend) {
             enableDisableSwapButton();


### PR DESCRIPTION
Uplift of #13952
Resolves https://github.com/brave/brave-browser/issues/23631

Pre-approval checklist: 
- [ ] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [ ] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [ ] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [ ] The associated issue milestone is set to the smallest version that the changes is landed on.