### PR TITLE
Avoid flash of white when opening NTP

### DIFF
--- a/browser/ui/color/brave_color_mixer.cc
+++ b/browser/ui/color/brave_color_mixer.cc
@@ -43,6 +43,8 @@ void AddBraveLightThemeColorMixer(ui::ColorProvider* provider,
 
   mixer[kColorToolbarButtonIconInactive] = {
       color_utils::AlphaBlend(kLightToolbarIcon, kLightToolbar, 0.3f)};
+
+  mixer[kColorNewTabPageBackground] = {kBraveNewTabBackgroundLight};
 }
 
 void AddBraveDarkThemeColorMixer(ui::ColorProvider* provider,
@@ -78,6 +80,8 @@ void AddBraveDarkThemeColorMixer(ui::ColorProvider* provider,
 
   mixer[kColorToolbarButtonIconInactive] = {
       color_utils::AlphaBlend(kDarkToolbarIcon, kDarkToolbar, 0.3f)};
+
+  mixer[kColorNewTabPageBackground] = {kBraveNewTabBackgroundDark};
 }
 
 void AddBravePrivateThemeColorMixer(ui::ColorProvider* provider,
@@ -110,6 +114,8 @@ void AddBravePrivateThemeColorMixer(ui::ColorProvider* provider,
   mixer[kColorToolbarButtonIcon] = {kDarkToolbarIcon};
   mixer[kColorToolbarButtonIconInactive] = {
       color_utils::AlphaBlend(kDarkToolbarIcon, kPrivateToolbar, 0.3f)};
+
+  mixer[kColorNewTabPageBackground] = {kPrivateFrame};
 }
 
 void AddBraveTorThemeColorMixer(ui::ColorProvider* provider,
@@ -134,4 +140,6 @@ void AddBraveTorThemeColorMixer(ui::ColorProvider* provider,
 
   mixer[kColorToolbarButtonIconInactive] = {
       color_utils::AlphaBlend(kDarkToolbarIcon, kPrivateTorToolbar, 0.3f)};
+
+  mixer[kColorNewTabPageBackground] = {kPrivateTorFrame};
 }

--- a/browser/ui/color/color_palette.h
+++ b/browser/ui/color/color_palette.h
@@ -24,5 +24,7 @@ constexpr SkColor kPrivateFrame = SkColorSetRGB(0x19, 0x16, 0x2F);
 constexpr SkColor kPrivateToolbar = SkColorSetRGB(0x32, 0x25, 0x60);
 constexpr SkColor kPrivateTorFrame = SkColorSetRGB(0x19, 0x0E, 0x2A);
 constexpr SkColor kPrivateTorToolbar = SkColorSetRGB(0x49, 0x2D, 0x58);
+constexpr SkColor kBraveNewTabBackgroundDark = SkColorSetRGB(0x33, 0x36, 0x39);
+constexpr SkColor kBraveNewTabBackgroundLight = SkColorSetRGB(0x6B, 0x70, 0x84);
 
 #endif  // BRAVE_BROWSER_UI_COLOR_COLOR_PALETTE_H_

--- a/browser/ui/webui/brave_webui_source.h
+++ b/browser/ui/webui/brave_webui_source.h
@@ -8,7 +8,10 @@
 
 #include <string>
 
+#include "build/build_config.h"
+
 namespace content {
+class WebContents;
 class WebUI;
 class WebUIDataSource;
 }  // namespace content
@@ -25,5 +28,14 @@ content::WebUIDataSource* CreateAndAddWebUIDataSource(
     size_t resouece_map_size,
     int html_resource_id,
     bool disable_trusted_types_csp = false);
+
+#if !BUILDFLAG(IS_ANDROID)
+
+// Provide html with background color so we can avoid flash of
+// different colors as the page loads, especially for New Tab Pages.
+void AddBackgroundColorToSource(content::WebUIDataSource* source,
+                                content::WebContents* contents);
+
+#endif  // !BUILDFLAG(IS_ANDROID)
 
 #endif  // BRAVE_BROWSER_UI_WEBUI_BRAVE_WEBUI_SOURCE_H_

--- a/browser/ui/webui/new_tab_page/brave_new_tab_ui.cc
+++ b/browser/ui/webui/new_tab_page/brave_new_tab_ui.cc
@@ -43,6 +43,7 @@ BraveNewTabUI::BraveNewTabUI(content::WebUI* web_ui, const std::string& name)
     content::WebUIDataSource* source =
         content::WebUIDataSource::Create(name);
     source->SetDefaultResource(IDR_BRAVE_BLANK_NEW_TAB_HTML);
+    AddBackgroundColorToSource(source, web_ui->GetWebContents());
     content::WebUIDataSource::Add(profile, source);
     return;
   }
@@ -51,6 +52,9 @@ BraveNewTabUI::BraveNewTabUI(content::WebUI* web_ui, const std::string& name)
   content::WebUIDataSource* source = CreateAndAddWebUIDataSource(
       web_ui, name, kBraveNewTabGenerated, kBraveNewTabGeneratedSize,
       IDR_BRAVE_NEW_TAB_HTML);
+
+  AddBackgroundColorToSource(source, web_ui->GetWebContents());
+
   source->AddBoolean("featureCustomBackgroundEnabled",
                      !profile->GetPrefs()->IsManagedPreference(
                          prefs::kNtpCustomBackgroundDict));

--- a/browser/ui/webui/private_new_tab_page/brave_private_new_tab_ui.cc
+++ b/browser/ui/webui/private_new_tab_page/brave_private_new_tab_ui.cc
@@ -34,6 +34,8 @@ BravePrivateNewTabUI::BravePrivateNewTabUI(content::WebUI* web_ui,
   }
 
   source->AddBoolean("isWindowTor", profile->IsTor());
+
+  AddBackgroundColorToSource(source, web_ui->GetWebContents());
 }
 
 BravePrivateNewTabUI::~BravePrivateNewTabUI() = default;

--- a/components/brave_blank_page/resources/brave_blank_new_tab.html
+++ b/components/brave_blank_page/resources/brave_blank_new_tab.html
@@ -3,8 +3,8 @@
 <head>
   <title>New Tab</title>
   <style>
-    @media (prefers-color-scheme: dark) {
-      body { background-color: #17171F; }
+    body {
+      background: $i18n{backgroundColor};
     }
   </style>
 </head>

--- a/components/brave_new_tab_ui/brave_new_tab.html
+++ b/components/brave_new_tab_ui/brave_new_tab.html
@@ -13,16 +13,10 @@
 <script src="/strings.js"></script>
 <script src="/brave_new_tab.bundle.js"></script>
 <style>
-  #root { height: 100%; }
   body {
-    --default-bg-color: white;
-    background-color: var(--default-bg-color)
+    background: $i18n{backgroundColor};
   }
-  @media (prefers-color-scheme: dark) {
-    body {
-      --default-bg-color: #333639;
-    }
-  }
+  #root { height: 100%; }
 </style>
 </head>
 <body>

--- a/components/brave_private_new_tab_ui/resources/page/private_new_tab.html
+++ b/components/brave_private_new_tab_ui/resources/page/private_new_tab.html
@@ -12,7 +12,7 @@
 <style>
   #mountPoint { height: 100%; }
   body {
-    background: #333639;
+    background: $i18n{backgroundColor};
   }
 </style>
 </head>


### PR DESCRIPTION
Use consistent tab initial background color and NTP html background color to avoid flashes

These colors have been chosen by the design team in figma.

Demo:

https://user-images.githubusercontent.com/741836/176328807-ad2ede7c-f64f-4e21-8d6e-da47aabab3c2.mov



<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/16078 in so far as the flash isn't white anymore

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

