### PR TITLE
Uplift 1.41.x - (perf) brave extension: remove shields blocking data for closed tabs

### DIFF
--- a/components/brave_extension/extension/brave_extension/actions/tabActions.ts
+++ b/components/brave_extension/extension/brave_extension/actions/tabActions.ts
@@ -28,3 +28,10 @@ export const tabDataChanged: actions.TabDataChanged = (tabId, changeInfo, tab) =
     tab
   }
 }
+
+export function tabRemoved (tabId: number): actions.TabRemovedReturn {
+  return {
+    type: types.TAB_REMOVED,
+    tabId
+  }
+}

--- a/components/brave_extension/extension/brave_extension/background/events/tabsEvents.ts
+++ b/components/brave_extension/extension/brave_extension/background/events/tabsEvents.ts
@@ -15,3 +15,7 @@ chrome.tabs.onCreated.addListener(function (tab: chrome.tabs.Tab) {
 chrome.tabs.onUpdated.addListener(function (tabId: number, changeInfo: chrome.tabs.TabChangeInfo, tab: chrome.tabs.Tab) {
   tabActions.tabDataChanged(tabId, changeInfo, tab)
 })
+
+chrome.tabs.onRemoved.addListener(function (tabId: number) {
+  tabActions.tabRemoved(tabId)
+})

--- a/components/brave_extension/extension/brave_extension/background/reducers/shieldsPanelReducer.ts
+++ b/components/brave_extension/extension/brave_extension/background/reducers/shieldsPanelReducer.ts
@@ -103,6 +103,10 @@ export default function shieldsPanelReducer (
       }
       break
     }
+    case tabTypes.TAB_REMOVED: {
+      delete state.tabs[action.tabId]
+      break
+    }
     case shieldsPanelTypes.SHIELDS_PANEL_DATA_UPDATED: {
       // @ts-expect-error (petemill) - shields Tab / ShieldDetails types are a mess of
       // and used interchangably and all this code will be removed soon.

--- a/components/brave_extension/extension/brave_extension/constants/tabTypes.ts
+++ b/components/brave_extension/extension/brave_extension/constants/tabTypes.ts
@@ -5,3 +5,4 @@
 export const ACTIVE_TAB_CHANGED = 'ACTIVE_TAB_CHANGED'
 export const TAB_DATA_CHANGED = 'TAB_DATA_CHANGED'
 export const TAB_CREATED = 'TAB_CREATED'
+export const TAB_REMOVED = 'TAB_REMOVED'

--- a/components/brave_extension/extension/brave_extension/types/actions/tabActions.ts
+++ b/components/brave_extension/extension/brave_extension/types/actions/tabActions.ts
@@ -19,6 +19,11 @@ interface TabCreatedReturn {
 
 export type TabCreated = (tab: chrome.tabs.Tab) => TabCreatedReturn
 
+export interface TabRemovedReturn {
+  type: types.TAB_REMOVED
+  tabId: number
+}
+
 interface TabDataChangedReturn {
   type: types.TAB_DATA_CHANGED
   tabId: number
@@ -31,4 +36,5 @@ export type TabDataChanged = (tabId: number, changeInfo: chrome.tabs.TabChangeIn
 export type tabActions =
   ActiveTabChangedReturn |
   TabCreatedReturn |
-  TabDataChangedReturn
+  TabDataChangedReturn |
+  TabRemovedReturn

--- a/components/brave_extension/extension/brave_extension/types/constants/tabTypes.ts
+++ b/components/brave_extension/extension/brave_extension/types/constants/tabTypes.ts
@@ -6,4 +6,5 @@ import * as types from '../../constants/tabTypes'
 
 export type ACTIVE_TAB_CHANGED = typeof types.ACTIVE_TAB_CHANGED
 export type TAB_CREATED = typeof types.TAB_CREATED
+export type TAB_REMOVED = typeof types.TAB_REMOVED
 export type TAB_DATA_CHANGED = typeof types.TAB_DATA_CHANGED

--- a/components/test/testData.ts
+++ b/components/test/testData.ts
@@ -202,7 +202,8 @@ export const getMockChrome = () => {
       },
       onActivated: new ChromeEvent(),
       onCreated: new ChromeEvent(),
-      onUpdated: new ChromeEvent()
+      onUpdated: new ChromeEvent(),
+      onRemoved: new ChromeEvent()
     },
     windows: {
       onFocusChanged: new ChromeEvent(),


### PR DESCRIPTION
<!-- Add brave-browser issue bellow that this PR will resolve -->
Uplifts https://github.com/brave/brave-browser/issues/23559 to 1.41.x

(Original PR https://github.com/brave/brave-core/pull/13872)
