### PR TITLE
Removed redundant json sanitizing from BraveVPNService

### DIFF
--- a/components/brave_vpn/BUILD.gn
+++ b/components/brave_vpn/BUILD.gn
@@ -35,7 +35,6 @@ static_library("brave_vpn") {
     "//components/prefs",
     "//components/version_info",
     "//net",
-    "//services/data_decoder/public/cpp",
     "//services/network/public/cpp",
     "//third_party/abseil-cpp:absl",
     "//ui/base",

--- a/components/brave_vpn/brave_vpn_service.cc
+++ b/components/brave_vpn/brave_vpn_service.cc
@@ -1202,41 +1202,11 @@ void BraveVpnService::OnGetResponse(
     int status,
     const std::string& body,
     const base::flat_map<std::string, std::string>& headers) {
-  std::string json_response;
-  bool success = status == 200;
-  if (success) {
-    // Give sanitized json response on success.
-    json_response = body;
-    data_decoder::JsonSanitizer::Sanitize(
-        json_response,
-        base::BindOnce(&BraveVpnService::OnGetSanitizedJsonResponse,
-                       weak_ptr_factory_.GetWeakPtr(), std::move(callback)));
-  } else {
-    // Give empty response on failure.
-    std::move(callback).Run(json_response, success);
-  }
-}
-
-void BraveVpnService::OnGetSanitizedJsonResponse(
-    ResponseCallback callback,
-    data_decoder::JsonSanitizer::Result sanitized_json_response) {
-  DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
-
-  std::string json_response;
-  bool success = true;
-  if (sanitized_json_response.error) {
-    VLOG(1) << "Response validation error: " << *sanitized_json_response.error;
-    success = false;
-  }
-
-  if (success && !sanitized_json_response.value.has_value()) {
-    VLOG(1) << "Empty response";
-    success = false;
-  }
-
-  if (success)
-    json_response = sanitized_json_response.value.value();
-  std::move(callback).Run(json_response, success);
+  // NOTE: |api_request_helper_| uses JsonSanitizer to sanitize input made with
+  // requests. |body| will be empty when the response from service is invalid
+  // json.
+  const bool success = status == 200;
+  std::move(callback).Run(body, success);
 }
 
 void BraveVpnService::GetSubscriberCredential(

--- a/components/brave_vpn/brave_vpn_service.h
+++ b/components/brave_vpn/brave_vpn_service.h
@@ -22,7 +22,6 @@
 #include "components/keyed_service/core/keyed_service.h"
 #include "mojo/public/cpp/bindings/pending_remote.h"
 #include "mojo/public/cpp/bindings/remote_set.h"
-#include "services/data_decoder/public/cpp/json_sanitizer.h"
 #include "services/network/public/cpp/shared_url_loader_factory.h"
 #include "third_party/abseil-cpp/absl/types/optional.h"
 #include "url/gurl.h"
@@ -234,9 +233,6 @@ class BraveVpnService :
                      int status,
                      const std::string& body,
                      const base::flat_map<std::string, std::string>& headers);
-  void OnGetSanitizedJsonResponse(
-      ResponseCallback callback,
-      data_decoder::JsonSanitizer::Result sanitized_json_response);
 
   void OnGetSubscriberCredential(
       ResponseCallback callback,

--- a/components/brave_vpn/brave_vpn_unittest.cc
+++ b/components/brave_vpn/brave_vpn_unittest.cc
@@ -511,6 +511,21 @@ TEST(BraveVPNFeatureTest, FeatureTest) {
   EXPECT_FALSE(IsBraveVPNEnabled());
 }
 
+TEST_F(BraveVPNServiceTest, ResponseSanitizingTest) {
+  // Give invalid json data as a server response and check sanitized(empty
+  // string) result is returned.
+  SetInterceptorResponse("{'a':'b',}");
+  base::RunLoop loop;
+  service_->GetAllServerRegions(base::BindOnce(
+      [](base::OnceClosure callback, const std::string& region_list,
+         bool success) {
+        EXPECT_TRUE(region_list.empty());
+        std::move(callback).Run();
+      },
+      loop.QuitClosure()));
+  loop.Run();
+}
+
 #if !BUILDFLAG(IS_ANDROID)
 TEST_F(BraveVPNServiceTest, RegionDataTest) {
   // Test invalid region data.


### PR DESCRIPTION
fix https://github.com/brave/brave-browser/issues/23726

As BraveVPNService gets json via APIRequestHelper,
doing json sanitizing from it is redundant.
APIRequestHelper already does it for client.

<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves 

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

`npm run test brave_unit_tests -- --filter=*ResponseSanitizingTest`