### PR TITLE
Make the TabSearch icon a Sqircle

### DIFF
--- a/browser/ui/views/tabs/brave_new_tab_button.cc
+++ b/browser/ui/views/tabs/brave_new_tab_button.cc
@@ -10,12 +10,33 @@
 #include "chrome/browser/ui/layout_constants.h"
 #include "chrome/browser/ui/views/tabs/new_tab_button.h"
 #include "chrome/browser/ui/views/tabs/tab_strip.h"
-#include "ui/gfx/geometry/size.h"
 #include "ui/gfx/geometry/skia_conversions.h"
 #include "ui/gfx/scoped_canvas.h"
 
 // static
 const gfx::Size BraveNewTabButton::kButtonSize{24, 24};
+
+// static
+SkPath BraveNewTabButton::GetBorderPath(const gfx::Point& origin,
+                                        float scale,
+                                        bool extend_to_top,
+                                        int corner_radius,
+                                        const gfx::Size& contents_bounds) {
+  // Overriden to use Brave's non-circular shape
+  gfx::PointF scaled_origin(origin);
+  scaled_origin.Scale(scale);
+  const float radius = corner_radius * scale;
+
+  SkPath path;
+  const gfx::Rect path_rect(
+      scaled_origin.x(), extend_to_top ? 0 : scaled_origin.y(),
+      contents_bounds.width() * scale,
+      (extend_to_top ? scaled_origin.y() : 0) +
+          std::min(contents_bounds.width(), contents_bounds.height()) * scale);
+  path.addRoundRect(RectToSkRect(path_rect), radius, radius);
+  path.close();
+  return path;
+}
 
 gfx::Size BraveNewTabButton::CalculatePreferredSize() const {
   // Overriden so that we use Brave's custom button size
@@ -28,21 +49,8 @@ gfx::Size BraveNewTabButton::CalculatePreferredSize() const {
 SkPath BraveNewTabButton::GetBorderPath(const gfx::Point& origin,
                                         float scale,
                                         bool extend_to_top) const {
-  // Overriden to use Brave's non-circular shape
-  gfx::PointF scaled_origin(origin);
-  scaled_origin.Scale(scale);
-  const float radius = GetCornerRadius() * scale;
-
-  SkPath path;
-  const gfx::Rect contents_bounds = GetContentsBounds();
-  const gfx::Rect path_rect(
-      scaled_origin.x(), extend_to_top ? 0 : scaled_origin.y(),
-      contents_bounds.width() * scale,
-      (extend_to_top ? scaled_origin.y() : 0) +
-          std::min(contents_bounds.width(), contents_bounds.height()) * scale);
-  path.addRoundRect(RectToSkRect(path_rect), radius, radius);
-  path.close();
-  return path;
+  return GetBorderPath(origin, scale, extend_to_top, GetCornerRadius(),
+                       GetContentsBounds().size());
 }
 
 void BraveNewTabButton::PaintIcon(gfx::Canvas* canvas) {

--- a/browser/ui/views/tabs/brave_new_tab_button.h
+++ b/browser/ui/views/tabs/brave_new_tab_button.h
@@ -8,6 +8,8 @@
 
 #include "chrome/browser/ui/views/tabs/new_tab_button.h"
 #include "third_party/skia/include/core/SkPath.h"
+#include "ui/gfx/geometry/point.h"
+#include "ui/gfx/geometry/size.h"
 
 class TabStrip;
 namespace views {
@@ -17,6 +19,12 @@ class ButtonListener;
 class BraveNewTabButton : public NewTabButton {
  public:
   static const gfx::Size kButtonSize;
+  static SkPath GetBorderPath(const gfx::Point& origin,
+                              float scale,
+                              bool extend_to_top,
+                              int border_radius,
+                              const gfx::Size& contents_bounds);
+
   using NewTabButton::NewTabButton;
 
   BraveNewTabButton(const BraveNewTabButton&) = delete;

--- a/browser/ui/views/tabs/brave_tab_search_button.cc
+++ b/browser/ui/views/tabs/brave_tab_search_button.cc
@@ -7,14 +7,30 @@
 
 #include <algorithm>
 
+#include "brave/browser/ui/views/tabs/brave_new_tab_button.h"
+#include "chrome/browser/ui/views/chrome_layout_provider.h"
+#include "chrome/browser/ui/views/tabs/new_tab_button.h"
+#include "ui/gfx/geometry/point_f.h"
+#include "ui/gfx/geometry/rect.h"
 #include "ui/gfx/geometry/size.h"
+#include "ui/gfx/geometry/skia_conversions.h"
+#include "ui/views/layout/layout_provider.h"
 
 BraveTabSearchButton::~BraveTabSearchButton() = default;
 
+gfx::Size BraveTabSearchButton::CalculatePreferredSize() const {
+  return BraveNewTabButton::kButtonSize;
+}
+
+SkPath BraveTabSearchButton::GetBorderPath(const gfx::Point& origin,
+                                           float scale,
+                                           bool extend_to_top) const {
+  return BraveNewTabButton::GetBorderPath(origin, scale, extend_to_top,
+                                          GetCornerRadius(),
+                                          GetContentsBounds().size());
+}
+
 int BraveTabSearchButton::GetCornerRadius() const {
-  // Copied from LayoutProvider::GetCornerRadiusMetric() for kMaximum.
-  // We override GetCornerRadiusMetric() by BraveLayoutProvider. However,
-  // TabSearchButton needs original radius value.
-  auto size = GetContentsBounds().size();
-  return std::min(size.width(), size.height()) / 2;
+  return ChromeLayoutProvider::Get()->GetCornerRadiusMetric(
+      views::Emphasis::kMaximum, GetContentsBounds().size());
 }

--- a/browser/ui/views/tabs/brave_tab_search_button.h
+++ b/browser/ui/views/tabs/brave_tab_search_button.h
@@ -7,6 +7,8 @@
 #define BRAVE_BROWSER_UI_VIEWS_TABS_BRAVE_TAB_SEARCH_BUTTON_H_
 
 #include "chrome/browser/ui/views/tabs/tab_search_button.h"
+#include "third_party/skia/include/core/SkPath.h"
+#include "ui/gfx/geometry/size.h"
 
 class BraveTabSearchButton : public TabSearchButton {
  public:
@@ -16,6 +18,10 @@ class BraveTabSearchButton : public TabSearchButton {
   BraveTabSearchButton& operator=(const BraveTabSearchButton&) = delete;
 
   // TabSearchButton overrides:
+  SkPath GetBorderPath(const gfx::Point& origin,
+                       float scale,
+                       bool extend_to_top) const override;
+  gfx::Size CalculatePreferredSize() const override;
   int GetCornerRadius() const override;
 };
 


### PR DESCRIPTION
<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/23767

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [x] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [x] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [x] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

