### PR TITLE
Fix P3A submission delay

### DIFF
--- a/components/p3a/brave_p3a_new_uploader.h
+++ b/components/p3a/brave_p3a_new_uploader.h
@@ -9,6 +9,7 @@
 #include <memory>
 #include <string>
 
+#include "base/callback.h"
 #include "base/memory/ref_counted.h"
 #include "url/gurl.h"
 
@@ -25,10 +26,13 @@ namespace brave {
 // testing the new endpoint).
 class BraveP3ANewUploader {
  public:
+  using UploadCallback = base::RepeatingCallback<void(int, int, bool)>;
+
   BraveP3ANewUploader(
       scoped_refptr<network::SharedURLLoaderFactory> url_loader_factory,
       const GURL& p3a_endpoint,
-      const GURL& p2a_endpoint);
+      const GURL& p2a_endpoint,
+      const UploadCallback& on_upload_complete);
 
   BraveP3ANewUploader(const BraveP3ANewUploader&) = delete;
   BraveP3ANewUploader& operator=(const BraveP3ANewUploader&) = delete;
@@ -45,6 +49,7 @@ class BraveP3ANewUploader {
   scoped_refptr<network::SharedURLLoaderFactory> url_loader_factory_;
   const GURL p3a_endpoint_;
   const GURL p2a_endpoint_;
+  const UploadCallback on_upload_complete_;
   std::unique_ptr<network::SimpleURLLoader> url_loader_;
 };
 

--- a/components/p3a/brave_p3a_service.cc
+++ b/components/p3a/brave_p3a_service.cc
@@ -167,11 +167,11 @@ void BraveP3AService::Init(
 
   // Init other components.
   uploader_ = std::make_unique<BraveP3AUploader>(
-      url_loader_factory, upload_server_url_, GURL(kP2AServerUrl),
-      base::BindRepeating(&BraveP3AService::OnLogUploadComplete, this));
+      url_loader_factory, upload_server_url_, GURL(kP2AServerUrl));
 
   new_uploader_ = std::make_unique<BraveP3ANewUploader>(
-      url_loader_factory, GURL(kP3AJsonServerUrl), GURL(kP2AJsonServerUrl));
+      url_loader_factory, GURL(kP3AJsonServerUrl), GURL(kP2AJsonServerUrl),
+      base::BindRepeating(&BraveP3AService::OnLogUploadComplete, this));
 
   upload_scheduler_ = std::make_unique<BraveP3AScheduler>(
       base::BindRepeating(&BraveP3AService::StartScheduledUpload, this),

--- a/components/p3a/brave_p3a_uploader.cc
+++ b/components/p3a/brave_p3a_uploader.cc
@@ -88,6 +88,8 @@ void BraveP3AUploader::UploadLog(const std::string& compressed_log_data,
   } else if (upload_type == "p3a") {
     resource_request->url = p3a_endpoint_;
     resource_request->headers.SetHeader("X-Brave-P3A", "?1");
+    // Don't actually send the older format.
+    return;
   } else {
     NOTREACHED();
   }

--- a/components/p3a/brave_p3a_uploader.cc
+++ b/components/p3a/brave_p3a_uploader.cc
@@ -90,8 +90,6 @@ void BraveP3AUploader::UploadLog(const std::string& compressed_log_data,
   } else if (upload_type == "p3a") {
     resource_request->url = p3a_endpoint_;
     resource_request->headers.SetHeader("X-Brave-P3A", "?1");
-    // Don't actually send the older format.
-    return;
   } else {
     NOTREACHED();
   }

--- a/components/p3a/brave_p3a_uploader.cc
+++ b/components/p3a/brave_p3a_uploader.cc
@@ -72,12 +72,10 @@ net::NetworkTrafficAnnotationTag GetNetworkTrafficAnnotation(
 BraveP3AUploader::BraveP3AUploader(
     scoped_refptr<network::SharedURLLoaderFactory> url_loader_factory,
     const GURL& p3a_endpoint,
-    const GURL& p2a_endpoint,
-    const UploadCallback& on_upload_complete)
+    const GURL& p2a_endpoint)
     : url_loader_factory_(url_loader_factory),
       p3a_endpoint_(p3a_endpoint),
-      p2a_endpoint_(p2a_endpoint),
-      on_upload_complete_(on_upload_complete) {}
+      p2a_endpoint_(p2a_endpoint) {}
 
 BraveP3AUploader::~BraveP3AUploader() = default;
 
@@ -112,15 +110,7 @@ void BraveP3AUploader::UploadLog(const std::string& compressed_log_data,
 
 void BraveP3AUploader::OnUploadComplete(
     std::unique_ptr<std::string> response_body) {
-  int response_code = -1;
-  if (url_loader_->ResponseInfo() && url_loader_->ResponseInfo()->headers)
-    response_code = url_loader_->ResponseInfo()->headers->response_code();
-
-  int error_code = url_loader_->NetError();
-
-  bool was_https = url_loader_->GetFinalURL().SchemeIs(url::kHttpsScheme);
   url_loader_.reset();
-  on_upload_complete_.Run(response_code, error_code, was_https);
 }
 
 }  // namespace brave

--- a/components/p3a/brave_p3a_uploader.h
+++ b/components/p3a/brave_p3a_uploader.h
@@ -9,7 +9,6 @@
 #include <memory>
 #include <string>
 
-#include "base/callback.h"
 #include "base/memory/ref_counted.h"
 #include "url/gurl.h"
 
@@ -22,13 +21,10 @@ namespace brave {
 
 class BraveP3AUploader {
  public:
-  using UploadCallback = base::RepeatingCallback<void(int, int, bool)>;
-
   BraveP3AUploader(
       scoped_refptr<network::SharedURLLoaderFactory> url_loader_factory,
       const GURL& p3a_endpoint,
-      const GURL& p2a_endpoint,
-      const UploadCallback& on_upload_complete);
+      const GURL& p2a_endpoint);
 
   BraveP3AUploader(const BraveP3AUploader&) = delete;
   BraveP3AUploader& operator=(const BraveP3AUploader&) = delete;
@@ -45,7 +41,6 @@ class BraveP3AUploader {
   scoped_refptr<network::SharedURLLoaderFactory> url_loader_factory_;
   const GURL p3a_endpoint_;
   const GURL p2a_endpoint_;
-  const UploadCallback on_upload_complete_;
   std::unique_ptr<network::SimpleURLLoader> url_loader_;
 };
 


### PR DESCRIPTION
In https://github.com/brave/brave-browser/issues/23147 we disabled P3A protobuf submission by returning early before submitting the network request in the old BraveP3AUploader. This meant that the completion callback was never called, triggering submission backoff.

This moves the completion callback logic to the new uploader, so a measurement is considered submitted if the json version has been delivered successfully, instead of the old protobuf version. Protobuf submission can then be disabled without issue.

We intend to remove the old protobuf uploader code entirely, but this is still blocked on confirmation that the p2a-json endpoint is working. Hopefully only a week or two away, but I wanted to address this before next week's migration date.

<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/23754

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [x] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [x] New files have MPL-2.0 license header
- [x] Adequate test coverage exists to prevent regressions
- [x] Major classes, functions and non-trivial code blocks are well-commented
- [x] Changes in component dependencies are properly reflected in `gn`
- [x] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [x] Test plan is specified in PR before merging

## After-merge Checklist:

- [x] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [x] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

Same as https://github.com/brave/brave-core/pull/13539 but confirm P2A submission too, to be safe.