### PR TITLE
Update alert indicator when active state changes

### DIFF
--- a/chromium_src/chrome/browser/ui/views/tabs/tab.cc
+++ b/chromium_src/chrome/browser/ui/views/tabs/tab.cc
@@ -21,7 +21,9 @@
 
 #define GetWidthOfLargestSelectableRegion \
   GetWidthOfLargestSelectableRegion_ChromiumImpl
+#define ActiveStateChanged ActiveStateChanged_ChromiumImpl
 #include "src/chrome/browser/ui/views/tabs/tab.cc"
+#undef ActiveStateChanged
 #undef GetWidthOfLargestSelectableRegion
 #undef BRAVE_UI_VIEWS_TABS_TAB_UPDATE_ICON_VISIBILITY
 #undef BRAVE_UI_VIEWS_TABS_TAB_ALERT_INDICATOR_POSITION
@@ -42,4 +44,12 @@ int Tab::GetWidthOfLargestSelectableRegion() const {
     selectable_width -= close_button_->width();
 
   return std::max(0, selectable_width);
+}
+
+void Tab::ActiveStateChanged() {
+  ActiveStateChanged_ChromiumImpl();
+  // This should be called whenever acitve state changes
+  // see comment on UpdateEnabledForMuteToggle();
+  // https://github.com/brave/brave-browser/issues/23476/
+  alert_indicator_button_->UpdateEnabledForMuteToggle();
 }

--- a/chromium_src/chrome/browser/ui/views/tabs/tab.h
+++ b/chromium_src/chrome/browser/ui/views/tabs/tab.h
@@ -13,7 +13,11 @@
 #define GetWidthOfLargestSelectableRegion    \
   GetWidthOfLargestSelectableRegion() const; \
   int GetWidthOfLargestSelectableRegion_ChromiumImpl
+#define ActiveStateChanged           \
+  ActiveStateChanged_ChromiumImpl(); \
+  void ActiveStateChanged
 #include "src/chrome/browser/ui/views/tabs/tab.h"
+#undef ActiveStateChanged
 #undef GetWidthOfLargestSelectableRegion
 #undef kMinimumContentsWidthForCloseButtons
 


### PR DESCRIPTION
We should update 'enabled' state for the indicator button so that
it can be clicked by users after activated.

Upstream has the same issue but they seem not to notice this.

Resolves https://github.com/brave/brave-browser/issues/23476

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
Manual: original issue has steps to reproduce.

