### PR TITLE
Clear window.name on cross-origin navigation (uplift to 1.41.x)

### DIFF
--- a/chromium_src/third_party/blink/renderer/core/page/frame_tree.cc
+++ b/chromium_src/third_party/blink/renderer/core/page/frame_tree.cc
@@ -5,18 +5,17 @@
 
 #include "third_party/blink/renderer/core/page/frame_tree.h"
 
-#define CrossSiteCrossBrowsingContextGroupSetNulledName \
-  CrossSiteCrossBrowsingContextGroupSetNulledName_ChromiumImpl
+#define ExperimentalSetNulledName ExperimentalSetNulledName_ChromiumImpl
 
 #include "src/third_party/blink/renderer/core/page/frame_tree.cc"
 
-#undef CrossSiteCrossBrowsingContextGroupSetNulledName
+#undef ExperimentalSetNulledName
 
 namespace blink {
 
-void FrameTree::CrossSiteCrossBrowsingContextGroupSetNulledName() {
+void FrameTree::ExperimentalSetNulledName() {
   SetName(g_null_atom, kReplicate);
-  CrossSiteCrossBrowsingContextGroupSetNulledName_ChromiumImpl();
+  ExperimentalSetNulledName_ChromiumImpl();
 }
 
 }  // namespace blink

--- a/chromium_src/third_party/blink/renderer/core/page/frame_tree.h
+++ b/chromium_src/third_party/blink/renderer/core/page/frame_tree.h
@@ -6,12 +6,12 @@
 #ifndef BRAVE_CHROMIUM_SRC_THIRD_PARTY_BLINK_RENDERER_CORE_PAGE_FRAME_TREE_H_
 #define BRAVE_CHROMIUM_SRC_THIRD_PARTY_BLINK_RENDERER_CORE_PAGE_FRAME_TREE_H_
 
-#define CrossSiteCrossBrowsingContextGroupSetNulledName           \
-  CrossSiteCrossBrowsingContextGroupSetNulledName_ChromiumImpl(); \
-  void CrossSiteCrossBrowsingContextGroupSetNulledName
+#define ExperimentalSetNulledName           \
+  ExperimentalSetNulledName_ChromiumImpl(); \
+  void ExperimentalSetNulledName
 
 #include "src/third_party/blink/renderer/core/page/frame_tree.h"
 
-#undef CrossSiteCrossBrowsingContextGroupSetNulledName
+#undef ExperimentalSetNulledName
 
 #endif  // BRAVE_CHROMIUM_SRC_THIRD_PARTY_BLINK_RENDERER_CORE_PAGE_FRAME_TREE_H_

--- a/test/data/window_name/set_window_name_same_origin.html
+++ b/test/data/window_name/set_window_name_same_origin.html
@@ -4,9 +4,9 @@
         <meta charset="utf-8">
         <script>
          window.name = "foo";
+         window.location.href = "get_window_name.html";
         </script>
     </head>
     <body>
-        <a id="clickme" href="">Click me</a>
     </body>
 </html>


### PR DESCRIPTION
Uplift of #14024
Resolves https://github.com/brave/brave-browser/issues/23798

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.