### PR TITLE
Fixing GetSubscriberCredentialFromJson fail path (uplift to 1.42.x)

### DIFF
--- a/components/brave_vpn/brave_vpn_service.cc
+++ b/components/brave_vpn/brave_vpn_service.cc
@@ -88,7 +88,7 @@ std::string GetSubscriberCredentialFromJson(const std::string& json) {
           json, base::JSON_PARSE_CHROMIUM_EXTENSIONS |
                     base::JSONParserOptions::JSON_PARSE_RFC);
   absl::optional<base::Value>& records_v = value_with_error.value;
-  if (!records_v && records_v->is_dict()) {
+  if (!records_v || !records_v->is_dict()) {
     VLOG(1) << __func__ << "Invalid response, could not parse JSON.";
     return "";
   }


### PR DESCRIPTION
Uplift of #14049
Resolves https://github.com/brave/brave-browser/issues/23636

Pre-approval checklist: 
- [ ] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.