### PR TITLE
Support 3p APIs in chrome.identity without Google API keys

### DIFF
--- a/chromium_src/chrome/browser/extensions/api/identity/identity_get_auth_token_function.cc
+++ b/chromium_src/chrome/browser/extensions/api/identity/identity_get_auth_token_function.cc
@@ -1,0 +1,13 @@
+/* Copyright (c) 2022 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "base/time/time.h"
+
+#define FromSeconds \
+  Max().is_max() ? base::Seconds(time_to_live_seconds) : base::Seconds
+#define FALLTHROUGH [[fallthrough]]
+#include "src/chrome/browser/extensions/api/identity/identity_get_auth_token_function.cc"
+#undef FALLTHROUGH
+#undef FromSeconds

--- a/patches/chrome-browser-extensions-api-identity-identity_get_auth_token_function.cc.patch
+++ b/patches/chrome-browser-extensions-api-identity-identity_get_auth_token_function.cc.patch
@@ -1,0 +1,214 @@
+diff --git a/chrome/browser/extensions/api/identity/identity_get_auth_token_function.cc b/chrome/browser/extensions/api/identity/identity_get_auth_token_function.cc
+index 9f9e9eb07044c5ed1a9655a25b365c4cd7c21f43..84a2c30b089d1529c66d3463dfb9d00f4af664ae 100644
+--- a/chrome/browser/extensions/api/identity/identity_get_auth_token_function.cc
++++ b/chrome/browser/extensions/api/identity/identity_get_auth_token_function.cc
+@@ -4,6 +4,8 @@
+ 
+ #include "chrome/browser/extensions/api/identity/identity_get_auth_token_function.h"
+ 
++#include <algorithm>
++
+ #include <set>
+ #include <vector>
+ 
+@@ -46,6 +48,13 @@
+ #include "google_apis/gaia/gaia_urls.h"
+ #include "services/network/public/cpp/shared_url_loader_factory.h"
+ 
++#include "base/compiler_specific.h"
++#include "base/strings/string_split.h"
++#include "base/strings/string_util.h"
++#include "google_apis/google_api_keys.h"
++#include "net/base/url_util.h"
++
++
+ #if BUILDFLAG(IS_CHROMEOS_ASH)
+ #include "chrome/browser/app_mode/app_mode_utils.h"
+ #include "chrome/browser/ash/login/session/user_session_manager.h"
+@@ -174,6 +183,14 @@ ExtensionFunction::ResponseAction IdentityGetAuthTokenFunction::Run() {
+   // From here on out, results must be returned asynchronously.
+   StartAsyncRun();
+ 
++  // Use the embedded Google OAuth flow only if Google Chrome API key is used.
++  // Otherwise, fallback to the web OAuth flow.
++  if (!google_apis::IsGoogleChromeAPIKeyUsed()) {
++    // Start mint token flow with an empty account id.
++    StartMintTokenFlow(IdentityMintRequestQueue::MINT_TYPE_NONINTERACTIVE);
++    return RespondLater();
++  }
++
+   if (gaia_id.empty() || IsPrimaryAccountOnly()) {
+     // Try the primary account.
+     // TODO(https://crbug.com/932400): collapse the asynchronicity
+@@ -407,11 +424,17 @@ void IdentityGetAuthTokenFunction::StartSigninFlow() {
+ 
+ void IdentityGetAuthTokenFunction::StartMintTokenFlow(
+     IdentityMintRequestQueue::MintType type) {
++// ChromeOS in kiosk mode may start the mint token flow without account.
+ #if !BUILDFLAG(IS_CHROMEOS_ASH)
+-  // ChromeOS in kiosk mode may start the mint token flow without account.
+-  DCHECK(!token_key_.account_info.IsEmpty());
+-  DCHECK(IdentityManagerFactory::GetForProfile(GetProfile())
+-             ->HasAccountWithRefreshToken(token_key_.account_info.account_id));
++  if (!google_apis::IsGoogleChromeAPIKeyUsed()) {
++    // Web Auth flow doesn't use an account.
++    DCHECK(token_key_.account_info.IsEmpty());
++  } else {
++    DCHECK(!token_key_.account_info.IsEmpty());
++    DCHECK(
++        IdentityManagerFactory::GetForProfile(GetProfile())
++            ->HasAccountWithRefreshToken(token_key_.account_info.account_id));
++  }
+ #endif
+   TRACE_EVENT_NESTABLE_ASYNC_BEGIN1("identity", "MintTokenFlow", this, "type",
+                                     type);
+@@ -497,6 +520,14 @@ void IdentityGetAuthTokenFunction::StartMintToken(
+         }
+ #endif
+ 
++        if (!google_apis::IsGoogleChromeAPIKeyUsed()) {
++          // Fallback to the web OAuth flow that can only be completed in
++          // interactive mode.
++          CompleteMintTokenFlow();
++          StartMintTokenFlow(IdentityMintRequestQueue::MINT_TYPE_INTERACTIVE);
++          return;
++        }
++
+         if (oauth2_info.auto_approve && *oauth2_info.auto_approve) {
+           // oauth2_info.auto_approve is protected by an allowlist in
+           // _manifest_features.json hence only selected extensions take
+@@ -539,6 +570,11 @@ void IdentityGetAuthTokenFunction::StartMintToken(
+                                    cache_entry.granted_scopes());
+         break;
+       case IdentityTokenCacheValue::CACHE_STATUS_NOTFOUND:
++        if (!google_apis::IsGoogleChromeAPIKeyUsed()) {
++          StartWebAuthFlow();
++          return;
++        }
++        FALLTHROUGH;
+       case IdentityTokenCacheValue::CACHE_STATUS_REMOTE_CONSENT:
+         ShowRemoteConsentDialog(resolution_data_);
+         break;
+@@ -613,6 +649,33 @@ void IdentityGetAuthTokenFunction::OnRemoteConsentSuccess(
+   StartMintTokenFlow(IdentityMintRequestQueue::MINT_TYPE_INTERACTIVE);
+ }
+ 
++void IdentityGetAuthTokenFunction::StartWebAuthFlow() {
++  // Compute the reverse DNS notation of the client ID and use it as a custom
++  // URI scheme.
++  std::vector<std::string> client_id_components = base::SplitString(
++      oauth2_client_id_, ".", base::TRIM_WHITESPACE, base::SPLIT_WANT_NONEMPTY);
++  std::reverse(client_id_components.begin(), client_id_components.end());
++  GURL redirect_url = GURL(base::JoinString(client_id_components, ".") + ":/");
++  redirect_scheme_ = redirect_url.scheme();
++  GURL google_oauth_url = GURL("https://accounts.google.com/o/oauth2/v2/auth");
++  google_oauth_url = net::AppendQueryParameter(google_oauth_url, "client_id",
++                                               oauth2_client_id_);
++  google_oauth_url = net::AppendQueryParameter(google_oauth_url, "redirect_uri",
++                                               redirect_url.spec());
++  google_oauth_url =
++      net::AppendQueryParameter(google_oauth_url, "response_type", "token");
++  google_oauth_url = net::AppendQueryParameter(
++      google_oauth_url, "scope",
++      base::JoinString(std::vector<std::string>(token_key_.scopes.begin(),
++                                                token_key_.scopes.end()),
++                       " "));
++  web_auth_flow_ = std::make_unique<WebAuthFlow>(
++      this, GetProfile(), google_oauth_url,
++      interactive_ ? WebAuthFlow::INTERACTIVE : WebAuthFlow::SILENT,
++      WebAuthFlow::LAUNCH_WEB_AUTH_FLOW);
++  web_auth_flow_->Start();
++}
++
+ void IdentityGetAuthTokenFunction::OnRefreshTokenUpdatedForAccount(
+     const CoreAccountInfo& account_info) {
+   if (account_listening_mode_ != AccountListeningMode::kListeningTokens)
+@@ -762,6 +825,88 @@ void IdentityGetAuthTokenFunction::OnGaiaRemoteConsentFlowApproved(
+   StartMintTokenFlow(IdentityMintRequestQueue::MINT_TYPE_NONINTERACTIVE);
+ }
+ 
++void IdentityGetAuthTokenFunction::OnAuthFlowFailure(
++    WebAuthFlow::Failure failure) {
++  IdentityGetAuthTokenError error;
++  switch (failure) {
++    case WebAuthFlow::WINDOW_CLOSED:
++      error = IdentityGetAuthTokenError(
++          IdentityGetAuthTokenError::State::kRemoteConsentFlowRejected);
++      break;
++    case WebAuthFlow::INTERACTION_REQUIRED:
++      error = IdentityGetAuthTokenError(
++          IdentityGetAuthTokenError::State::kGaiaConsentInteractionRequired);
++      break;
++    case WebAuthFlow::LOAD_FAILED:
++      error = IdentityGetAuthTokenError(
++          IdentityGetAuthTokenError::State::kRemoteConsentPageLoadFailure);
++      break;
++    default:
++      NOTREACHED() << "Unexpected error from web auth flow: " << failure;
++      break;
++  }
++  if (web_auth_flow_)
++    web_auth_flow_.release()->DetachDelegateAndDelete();
++  CompleteMintTokenFlow();
++  CompleteFunctionWithError(error);
++}
++
++void IdentityGetAuthTokenFunction::OnAuthFlowURLChange(
++    const GURL& redirect_url) {
++  if (!redirect_url.SchemeIs(redirect_scheme_))
++    return;
++
++  if (web_auth_flow_)
++    web_auth_flow_.release()->DetachDelegateAndDelete();
++
++  CompleteMintTokenFlow();
++
++  base::StringPairs response_pairs;
++  if (!base::SplitStringIntoKeyValuePairs(redirect_url.ref(), '=', '&',
++                                          &response_pairs)) {
++    CompleteFunctionWithError(
++        IdentityGetAuthTokenError(IdentityGetAuthTokenError::State::kNoGrant));
++    return;
++  }
++
++  auto access_token_it =
++      std::find_if(response_pairs.begin(), response_pairs.end(),
++                   [](const auto& key_value_pair) {
++                     return key_value_pair.first == "access_token";
++                   });
++  if (access_token_it == response_pairs.end()) {
++    CompleteFunctionWithError(
++        IdentityGetAuthTokenError(IdentityGetAuthTokenError::State::kNoGrant));
++    return;
++  }
++  std::string access_token = access_token_it->second;
++
++  auto expires_in_it =
++      std::find_if(response_pairs.begin(), response_pairs.end(),
++                   [](const auto& key_value_pair) {
++                     return key_value_pair.first == "expires_in";
++                   });
++  int time_to_live_seconds;
++  if (expires_in_it == response_pairs.end() ||
++      !base::StringToInt(expires_in_it->second, &time_to_live_seconds)) {
++    CompleteFunctionWithError(
++        IdentityGetAuthTokenError(IdentityGetAuthTokenError::State::kNoGrant));
++    return;
++  }
++
++  // `token_key_` doesn't have information about the account being used, so only
++  // the last used token will be cached.
++  IdentityTokenCacheValue token = IdentityTokenCacheValue::CreateToken(
++      access_token, token_key_.scopes,
++      base::TimeDelta::FromSeconds(time_to_live_seconds));
++  IdentityAPI::GetFactoryInstance()
++      ->Get(GetProfile())
++      ->token_cache()
++      ->SetToken(token_key_, token);
++
++  CompleteFunctionWithResult(access_token, token_key_.scopes);
++}
++
+ void IdentityGetAuthTokenFunction::OnGetAccessTokenComplete(
+     const absl::optional<std::string>& access_token,
+     base::Time expiration_time,

--- a/patches/chrome-browser-extensions-api-identity-identity_get_auth_token_function.h.patch
+++ b/patches/chrome-browser-extensions-api-identity-identity_get_auth_token_function.h.patch
@@ -1,0 +1,45 @@
+diff --git a/chrome/browser/extensions/api/identity/identity_get_auth_token_function.h b/chrome/browser/extensions/api/identity/identity_get_auth_token_function.h
+index dc9259349ea3ddde10a6bee547f3f030061fdaa0..a8456d6ae2c06a62486f6c092526baa38ac573e9 100644
+--- a/chrome/browser/extensions/api/identity/identity_get_auth_token_function.h
++++ b/chrome/browser/extensions/api/identity/identity_get_auth_token_function.h
+@@ -50,6 +50,7 @@ class IdentityGetAuthTokenError;
+ // successfully, getAuthToken proceeds to the non-interactive flow.
+ class IdentityGetAuthTokenFunction : public ExtensionFunction,
+                                      public GaiaRemoteConsentFlow::Delegate,
++                                     public WebAuthFlow::Delegate,
+                                      public IdentityMintRequestQueue::Request,
+                                      public signin::IdentityManager::Observer,
+ #if BUILDFLAG(IS_CHROMEOS_ASH)
+@@ -77,6 +78,11 @@ class IdentityGetAuthTokenFunction : public ExtensionFunction,
+   void OnGaiaRemoteConsentFlowApproved(const std::string& consent_result,
+                                        const std::string& gaia_id) override;
+ 
++  // Used only if Google API keys aren't set up.
++  // WebAuthFlow::Delegate implementation:
++  void OnAuthFlowFailure(WebAuthFlow::Failure failure) override;
++  void OnAuthFlowURLChange(const GURL& redirect_url) override;
++
+   // Starts a login access token request.
+   virtual void StartTokenKeyAccountAccessTokenRequest();
+ 
+@@ -193,6 +199,9 @@ class IdentityGetAuthTokenFunction : public ExtensionFunction,
+   void OnRemoteConsentSuccess(
+       const RemoteConsentResolutionData& resolution_data) override;
+ 
++  // Used only if Google API keys aren't set up.
++  void StartWebAuthFlow();
++
+ #if BUILDFLAG(IS_CHROMEOS_ASH)
+   // Starts a login access token request for device robot account. This method
+   // will be called only in Chrome OS for:
+@@ -241,6 +250,10 @@ class IdentityGetAuthTokenFunction : public ExtensionFunction,
+   // Added for debugging https://crbug.com/1091423.
+   bool remote_consent_approved_ = false;
+ 
++  // Used only if Google API keys aren't set up.
++  std::unique_ptr<WebAuthFlow> web_auth_flow_;
++  std::string redirect_scheme_;
++
+   // Invoked when IdentityAPI is shut down.
+   base::CallbackListSubscription identity_api_shutdown_subscription_;
+ 


### PR DESCRIPTION
<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/15754

This patch replaces the chrome.identity API, which relies on 1p APIs,
with a version that relies on 3p APIs, necessary for some extensions
to work Brave after chrome.identity changed to only support 1p APIs.

Applying upstream patch as-is https://crrev.com/c/2704571

Security / privacy review https://github.com/brave/security/issues/947

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [x] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [x] New files have MPL-2.0 license header
- [x] Adequate test coverage exists to prevent regressions
- [x] Major classes, functions and non-trivial code blocks are well-commented
- [x] Changes in component dependencies are properly reflected in `gn`
- [x] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [x] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
- Download/ install an extension with 3p authorization; @spylogsster used https://chrome.google.com/webstore/detail/drive-sample/jpabeekbjicamajjcfejnochhmlbpgjh/related?pli=1
- Login to extension using Google login and verify you can login
