### PR TITLE
Do not allow wildcard content settings entries for "shields enabled" (uplift to 1.41.x)

### DIFF
--- a/components/brave_shields/browser/brave_shields_util.cc
+++ b/components/brave_shields/browser/brave_shields_util.cc
@@ -7,7 +7,9 @@
 
 #include <memory>
 
+#include "base/debug/dump_without_crashing.h"
 #include "base/feature_list.h"
+#include "base/logging.h"
 #include "base/strings/string_number_conversions.h"
 #include "brave/components/brave_shields/browser/brave_shields_p3a.h"
 #include "brave/components/brave_shields/common/brave_shield_constants.h"
@@ -110,12 +112,30 @@ void SetBraveShieldsEnabled(HostContentSettingsMap* map,
   if (url.is_valid() && !url.SchemeIsHTTPOrHTTPS())
     return;
 
-  DCHECK(!url.is_empty()) << "url for shields setting cannot be blank";
+  if (url.is_empty()) {
+    LOG(ERROR) << "url for shields setting cannot be blank";
+    return;
+  }
 
   auto primary_pattern = GetPatternFromURL(url);
 
-  if (!primary_pattern.IsValid())
+  if (primary_pattern.MatchesAllHosts()) {
+    LOG(ERROR) << "Url for shields setting cannot be blank or result in a "
+                  "wildcard content setting.";
+
+#if DCHECK_IS_ON()
+    DCHECK(false);
+#else
+    base::debug::DumpWithoutCrashing();
+#endif
     return;
+  }
+
+  if (!primary_pattern.IsValid()) {
+    DLOG(ERROR) << "Invalid primary pattern for Url: "
+                << url.possibly_invalid_spec();
+    return;
+  }
 
   map->SetContentSettingCustomScope(
       primary_pattern, ContentSettingsPattern::Wildcard(),

--- a/components/content_settings/core/browser/brave_content_settings_pref_provider.h
+++ b/components/content_settings/core/browser/brave_content_settings_pref_provider.h
@@ -55,7 +55,9 @@ class BravePrefProvider : public PrefProvider,
                            TestShieldsSettingsMigrationFromResourceIDs);
   FRIEND_TEST_ALL_PREFIXES(BravePrefProviderTest,
                            TestShieldsSettingsMigrationFromUnknownSettings);
+  FRIEND_TEST_ALL_PREFIXES(BravePrefProviderTest, EnsureNoWildcardEntries);
   void MigrateShieldsSettings(bool incognito);
+  void EnsureNoWildcardEntries();
   void MigrateShieldsSettingsFromResourceIds();
   void MigrateShieldsSettingsFromResourceIdsForOneType(
       const std::string& preference_path,

--- a/components/content_settings/core/browser/brave_content_settings_pref_provider_unittest.cc
+++ b/components/content_settings/core/browser/brave_content_settings_pref_provider_unittest.cc
@@ -13,6 +13,7 @@
 #include "brave/components/content_settings/core/browser/brave_content_settings_pref_provider.h"
 #include "brave/components/content_settings/core/browser/brave_content_settings_utils.h"
 #include "chrome/test/base/testing_profile.h"
+#include "components/content_settings/core/browser/content_settings_pref.h"
 #include "components/content_settings/core/browser/content_settings_registry.h"
 #include "components/content_settings/core/common/content_settings.h"
 #include "components/content_settings/core/common/content_settings_pattern.h"
@@ -522,6 +523,27 @@ TEST_F(BravePrefProviderTest, TestShieldsSettingsMigrationFromUnknownSettings) {
     EXPECT_TRUE(brave_shields_dict->DictEmpty());
   }
 
+  provider.ShutdownOnUIThread();
+}
+
+TEST_F(BravePrefProviderTest, EnsureNoWildcardEntries) {
+  BravePrefProvider provider(
+      testing_profile()->GetPrefs(), false /* incognito */,
+      true /* store_last_modified */, false /* restore_session */);
+  ShieldsEnabledSetting shields_enabled_settings(&provider);
+  GURL example_url("https://example.com");
+  shields_enabled_settings.CheckSettingsAreDefault(example_url);
+  // Set wildcard entry
+  auto pattern = ContentSettingsPattern::Wildcard();
+  provider.SetWebsiteSetting(pattern, pattern,
+                             ContentSettingsType::BRAVE_SHIELDS,
+                             base::Value(CONTENT_SETTING_ALLOW), {});
+  // Verify global has changed
+  shields_enabled_settings.CheckSettingsWouldAllow(example_url);
+  // Remove wildcards
+  provider.EnsureNoWildcardEntries();
+  // Verify global has reset
+  shields_enabled_settings.CheckSettingsAreDefault(example_url);
   provider.ShutdownOnUIThread();
 }
 


### PR DESCRIPTION
Uplift of #14031
Resolves https://github.com/brave/brave-browser/issues/23214

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.