### PR TITLE
Add hook for subscribing/updating NTP Prefs

### DIFF
--- a/components/brave_new_tab_ui/api/preferences.ts
+++ b/components/brave_new_tab_ui/api/preferences.ts
@@ -18,7 +18,7 @@ export function getPreferences (): Promise<NewTab.Preferences> {
   return sendWithPromise('getNewTabPagePreferences')
 }
 
-function sendSavePref (key: string, value: any) {
+export function sendSavePref (key: string, value: any) {
   chrome.send('saveNewTabPagePref', [key, value])
 }
 

--- a/components/brave_new_tab_ui/containers/app.tsx
+++ b/components/brave_new_tab_ui/containers/app.tsx
@@ -52,7 +52,6 @@ function DefaultPage (props: Props) {
         ftx={props.ftx}
         actions={actions}
         saveShowBackgroundImage={PreferencesAPI.saveShowBackgroundImage}
-        saveShowStats={PreferencesAPI.saveShowStats}
         saveShowToday={PreferencesAPI.saveShowToday}
         saveShowBraveNewsButton={PreferencesAPI.saveShowBraveNewsButton}
         saveShowRewards={PreferencesAPI.saveShowRewards}

--- a/components/brave_new_tab_ui/containers/newTab/index.tsx
+++ b/components/brave_new_tab_ui/containers/newTab/index.tsx
@@ -53,6 +53,7 @@ import { FTXState } from '../../widgets/ftx/ftx_state'
 // NTP features
 import Settings, { TabType as SettingsTabType } from './settings'
 import { MAX_GRID_SIZE } from '../../constants/new_tab_ui'
+import { saveShowStats } from '../../api/preferences'
 
 interface Props {
   newTabData: NewTab.State
@@ -62,7 +63,6 @@ interface Props {
   actions: NewTabActions
   getBraveNewsDisplayAd: GetDisplayAdContent
   saveShowBackgroundImage: (value: boolean) => void
-  saveShowStats: (value: boolean) => void
   saveShowToday: (value: boolean) => any
   saveShowBraveNewsButton: (value: boolean) => any
   saveShowRewards: (value: boolean) => void
@@ -289,12 +289,6 @@ class NewTabPage extends React.Component<Props, State> {
     this.props.actions.clockWidgetUpdated(
       this.props.newTabData.showClock,
       newFormat)
-  }
-
-  toggleShowStats = () => {
-    this.props.saveShowStats(
-      !this.props.newTabData.showStats
-    )
   }
 
   toggleShowToday = () => {
@@ -1207,7 +1201,7 @@ class NewTabPage extends React.Component<Props, State> {
               widgetTitle={getLocale('statsTitle')}
               textDirection={newTabData.textDirection}
               stats={newTabData.stats}
-              hideWidget={this.toggleShowStats}
+              hideWidget={() => saveShowStats(false)}
               menuPosition={'right'}
             />
           </Page.GridItemStats>
@@ -1325,7 +1319,6 @@ class NewTabPage extends React.Component<Props, State> {
           onClearTodayPrefs={this.props.actions.today.resetTodayPrefsToDefault}
           toggleShowBackgroundImage={this.toggleShowBackgroundImage}
           toggleShowClock={this.toggleShowClock}
-          toggleShowStats={this.toggleShowStats}
           toggleShowToday={this.toggleShowToday}
           toggleShowBraveNewsButton={this.toggleShowBraveNewsButton}
           toggleShowTopSites={this.toggleShowTopSites}
@@ -1335,7 +1328,6 @@ class NewTabPage extends React.Component<Props, State> {
           showBackgroundImage={newTabData.showBackgroundImage}
           showClock={newTabData.showClock}
           clockFormat={newTabData.clockFormat}
-          showStats={newTabData.showStats}
           showToday={newTabData.showToday}
           showBraveNewsButton={newTabData.showBraveNewsButton}
           showTopSites={newTabData.showTopSites}

--- a/components/brave_new_tab_ui/containers/newTab/settings.tsx
+++ b/components/brave_new_tab_ui/containers/newTab/settings.tsx
@@ -54,7 +54,6 @@ export interface Props {
   onClearTodayPrefs: () => any
   toggleShowBackgroundImage: () => void
   toggleShowClock: () => void
-  toggleShowStats: () => void
   toggleShowToday: () => any
   toggleShowBraveNewsButton: () => any
   toggleShowTopSites: () => void
@@ -69,7 +68,6 @@ export interface Props {
   toggleCards: (show: boolean) => void
   useCustomBackgroundImage: (useCustom: boolean) => void
   showBackgroundImage: boolean
-  showStats: boolean
   showToday: boolean
   showBraveNewsButton: boolean
   showClock: boolean
@@ -259,7 +257,6 @@ export default class Settings extends React.PureComponent<Props, State> {
       textDirection,
       showSettingsMenu,
       toggleShowClock,
-      toggleShowStats,
       toggleShowTopSites,
       setMostVisitedSettings,
       toggleShowRewards,
@@ -267,7 +264,6 @@ export default class Settings extends React.PureComponent<Props, State> {
       toggleBrandedWallpaperOptIn,
       showBackgroundImage,
       featureCustomBackgroundEnabled,
-      showStats,
       showClock,
       clockFormat,
       showTopSites,
@@ -359,8 +355,6 @@ export default class Settings extends React.PureComponent<Props, State> {
                 activeTab === TabType.BraveStats
                   ? (
                     <BraveStatsSettings
-                      toggleShowStats={toggleShowStats}
-                      showStats={showStats}
                     />
                   ) : null
               }

--- a/components/brave_new_tab_ui/containers/newTab/settings/braveStats.tsx
+++ b/components/brave_new_tab_ui/containers/newTab/settings/braveStats.tsx
@@ -12,29 +12,18 @@ import {
 import { Toggle } from '../../../components/toggle'
 
 import { getLocale } from '../../../../common/locale'
+import { useNewTabPref } from '../../../hooks/usePref'
 
-interface Props {
-  toggleShowStats: () => void
-  showStats: boolean
+export default function BraveStatsSettings () {
+  const [showStats, setShowStats] = useNewTabPref('showStats')
+  return <div>
+    <SettingsRow>
+      <SettingsText>{getLocale('showBraveStats')}</SettingsText>
+      <Toggle
+        onChange={() => setShowStats(!showStats)}
+        checked={showStats}
+        size='large'
+      />
+    </SettingsRow>
+  </div>
 }
-
-class BraveStatsSettings extends React.PureComponent<Props, {}> {
-  render () {
-    const { toggleShowStats, showStats } = this.props
-
-    return (
-      <div>
-        <SettingsRow>
-          <SettingsText>{getLocale('showBraveStats')}</SettingsText>
-          <Toggle
-            onChange={toggleShowStats}
-            checked={showStats}
-            size='large'
-          />
-        </SettingsRow>
-      </div>
-    )
-  }
-}
-
-export default BraveStatsSettings

--- a/components/brave_new_tab_ui/hooks/PrefHookManager.ts
+++ b/components/brave_new_tab_ui/hooks/PrefHookManager.ts
@@ -1,0 +1,104 @@
+import { useCallback, useEffect, useState } from 'react'
+
+export type PrefListener<OnType, KeyType extends keyof OnType> = (name: KeyType, newValue: OnType[KeyType], oldValue?: OnType[KeyType]) => void
+
+/**
+ * A class to help wrapping mojom pref access in a React hook.
+ */
+export class PrefHookManager<T> {
+    #listeners: Map<keyof T, Array<PrefListener<T, keyof T>>> = new Map()
+    #lastValue?: T
+    #savePref: (key: keyof T, value: T[keyof T]) => void
+
+    /**
+     * 
+     * @param getInitialValue A function for triggering an initial get of the prefs this manager is responsible for. This function will be invoked when the |PrefHookManager| is constructed.
+     * @param savePref A function for saving a single pref and it's value.
+     * @param addListener A function allowing the |PrefHookManager| to subscribe to updates.
+     */
+    constructor(getInitialValue: () => Promise<T>, savePref: (key: keyof T, value: T[keyof T]) => void, addListener: (listener: (prefs: T) => void) => void) {
+        this.#savePref = savePref
+
+        addListener((prefs: T) => {
+            const oldPrefs = this.#lastValue ?? {} as Partial<T>
+            this.#lastValue = prefs
+
+            for (const [pref, listeners] of this.#listeners.entries()) {
+                const newValue = prefs[pref]
+                const oldValue = oldPrefs[pref]
+                if (newValue === oldValue) continue
+
+                for (const listener of listeners) { listener(pref, newValue, oldValue) }
+            }
+        })
+        getInitialValue().then(v => this.#lastValue = v)
+    }
+
+    /**
+     * Save a pref.
+     * @param prefName The name of the pref being saved.
+     * @param value The new value for the pref.
+     */
+    savePref<KeyType extends keyof T>(prefName: KeyType, value: T[KeyType]) {
+        this.#savePref(prefName, value)
+    }
+
+    /**
+     * Get the current value of a pref.
+     * @param prefName The name of the pref to get.
+     * @returns The pref value, or undefined, if the PrefHookManager has not received an initial value.
+     */
+    getPref<KeyType extends keyof T>(prefName: KeyType) {
+        return this.#lastValue?.[prefName]
+    }
+
+    /**
+     * Subscribe to changes in a pref value.
+     * @param prefName The name of the pref to listen to.
+     * @param listener A function to be invoked whenever the pref value changes.
+     */
+    addPrefListener<KeyType extends keyof T>(prefName: KeyType, listener: PrefListener<T, KeyType>) {
+        if (!this.#listeners.has(prefName)) { this.#listeners.set(prefName, []) }
+        this.#listeners.get(prefName)!.push(listener)
+    }
+
+    /**
+     * Unsubscribe from changes to a pref value.
+     * @param prefName The name of the pref to remove the listener from.
+     * @param listener The listener to remove.
+     * @returns Whether or not a listener was removed.
+     */
+    removePrefListener<KeyType extends keyof T>(prefName: KeyType, listener: PrefListener<T, KeyType>) {
+        const prefListeners = this.#listeners.get(prefName)
+        if (!prefListeners) return false
+
+        const index = prefListeners.indexOf(listener)
+        prefListeners.splice(index, 1)
+        return index !== -1
+    }
+}
+
+/**
+ * A hook for subscribing and updating prefs. This hook exposes a similar API
+ * to |React.useState|.
+ * @param prefManager The pref manager for this set of prefs.
+ * @param pref The pref to subscribe to.
+ * @returns An array with two items. The first is the current value of the pref,
+ * the second is a function for setting the pref.
+ */
+export const usePref = <OnType, PrefType extends keyof OnType>(prefManager: PrefHookManager<OnType>, pref: PrefType) => {
+    const [value, setValue] = useState(prefManager.getPref(pref))
+    const setPref = useCallback((value: OnType[PrefType]) => prefManager.savePref(pref, value), [prefManager, pref])
+    useEffect(() => {
+        const handler: PrefListener<OnType, PrefType> = (_, newValue) => setValue(newValue as typeof value)
+        prefManager.addPrefListener(pref, handler)
+        return () => {
+            prefManager.removePrefListener(pref, handler)
+        }
+    }, [prefManager, pref])
+
+    return [
+        value,
+        setPref
+    ] as const
+}

--- a/components/brave_new_tab_ui/hooks/PrefHookManager.ts
+++ b/components/brave_new_tab_ui/hooks/PrefHookManager.ts
@@ -2,7 +2,7 @@ import { useCallback, useEffect, useState } from 'react'
 
 export type PrefListener<OnType, KeyType extends keyof OnType> = (name: KeyType, newValue: OnType[KeyType], oldValue?: OnType[KeyType]) => void
 
-type Updater<T> = <K extends keyof T>(key: K, value: T[K]) => void;
+type Updater<T> = <K extends keyof T>(key: K, value: T[K]) => void
 
 /**
  * A class to help wrapping mojom pref access in a React hook.
@@ -13,31 +13,31 @@ export class PrefHookManager<T> {
     #savePref: Updater<T>
 
     /**
-     * 
+     *
      * @param getInitialValue A function for triggering an initial get of the prefs this manager is responsible for. This function will be invoked when the |PrefHookManager| is constructed.
      * @param savePref A function for saving a single pref and it's value.
      * @param addListener A function allowing the |PrefHookManager| to subscribe to updates.
      */
-    constructor(getInitialValue: () => Promise<T>, savePref: Updater<T>, addListener: (listener: (prefs: T) => void) => void) {
+    constructor (getInitialValue: () => Promise<T>, savePref: Updater<T>, addListener: (listener: (prefs: T) => void) => void) {
         this.#savePref = savePref
-
-        const notifyListeners = (prefs: T) => {
-            const oldPrefs = this.#lastValue ?? {} as Partial<T>
-            this.#lastValue = prefs
-
-            for (const [pref, listeners] of this.#listeners.entries()) {
-                const newValue = prefs[pref]
-                const oldValue = oldPrefs[pref]
-                if (newValue === oldValue) continue
-
-                for (const listener of listeners) listener(pref, newValue, oldValue)
-            }
-        }
 
         // Subscribe to all changes in the prefs, and notify individual pref
         // listeners when the value they're interested in has changed.
-        addListener(notifyListeners)
-        getInitialValue().then(notifyListeners)
+        addListener(this.notifyListeners)
+        getInitialValue().then(this.notifyListeners)
+    }
+
+    notifyListeners (prefs: T) {
+        const oldPrefs = this.#lastValue ?? {} as Partial<T>
+        this.#lastValue = prefs
+
+        for (const [pref, listeners] of this.#listeners.entries()) {
+            const newValue = prefs[pref]
+            const oldValue = oldPrefs[pref]
+            if (newValue === oldValue) continue
+
+            for (const listener of listeners) listener(pref, newValue, oldValue)
+        }
     }
 
     /**
@@ -100,7 +100,7 @@ export class PrefHookManager<T> {
  * @returns A hook which can be used to subscribe to and update prefs managed by
  * |prefManager|.
  */
-export function createPrefsHook<OnType>(prefManager: PrefHookManager<OnType>) {
+export function createPrefsHook<OnType> (prefManager: PrefHookManager<OnType>) {
     return <PrefType extends keyof OnType>(pref: PrefType) => {
         const [value, setValue] = useState(prefManager.getPref(pref))
         const setPref = useCallback((value: OnType[PrefType]) => prefManager.savePref(pref, value), [prefManager, pref])
@@ -108,7 +108,7 @@ export function createPrefsHook<OnType>(prefManager: PrefHookManager<OnType>) {
             // Update the value here - the value could have been updated between
             // the hook being created and getting mounted (triggering the
             // useEffect).
-            setValue(prefManager.getPref(pref));
+            setValue(prefManager.getPref(pref))
 
             const handler: PrefListener<OnType, PrefType> = (_, newValue) => {
                 setValue(newValue as typeof value)

--- a/components/brave_new_tab_ui/hooks/usePref.ts
+++ b/components/brave_new_tab_ui/hooks/usePref.ts
@@ -1,0 +1,12 @@
+import { addChangeListener, getPreferences, sendSavePref } from '../api/preferences'
+import { PrefHookManager, usePref } from './PrefHookManager'
+
+const prefManager = new PrefHookManager(getPreferences, sendSavePref, addChangeListener)
+
+/**
+ * A hook for subscribing to and updating |NewTab.Preferences|.
+ * @param pref The name of the pref.
+ * @returns An array with two items, the current value of the pref, and a function
+ * for updating the pref.
+ */
+export const useNewTabPref = <T extends keyof NewTab.Preferences>(pref: T) => usePref(prefManager, pref)

--- a/components/brave_new_tab_ui/hooks/usePref.ts
+++ b/components/brave_new_tab_ui/hooks/usePref.ts
@@ -1,5 +1,5 @@
 import { addChangeListener, getPreferences, sendSavePref } from '../api/preferences'
-import { PrefHookManager, usePref } from './PrefHookManager'
+import { PrefHookManager, createPrefsHook } from './PrefHookManager'
 
 const prefManager = new PrefHookManager(getPreferences, sendSavePref, addChangeListener)
 
@@ -9,4 +9,4 @@ const prefManager = new PrefHookManager(getPreferences, sendSavePref, addChangeL
  * @returns An array with two items, the current value of the pref, and a function
  * for updating the pref.
  */
-export const useNewTabPref = <T extends keyof NewTab.Preferences>(pref: T) => usePref(prefManager, pref)
+export const useNewTabPref = createPrefsHook(prefManager);

--- a/components/brave_new_tab_ui/hooks/usePref.ts
+++ b/components/brave_new_tab_ui/hooks/usePref.ts
@@ -1,7 +1,10 @@
 import { addChangeListener, getPreferences, sendSavePref } from '../api/preferences'
 import { PrefHookManager, createPrefsHook } from './PrefHookManager'
 
-const prefManager = new PrefHookManager(getPreferences, sendSavePref, addChangeListener)
+/**
+ * The pref manager. Exported for use from stories.
+ */
+export const newTabPrefManager = new PrefHookManager(getPreferences, sendSavePref, addChangeListener)
 
 /**
  * A hook for subscribing to and updating |NewTab.Preferences|.
@@ -9,4 +12,4 @@ const prefManager = new PrefHookManager(getPreferences, sendSavePref, addChangeL
  * @returns An array with two items, the current value of the pref, and a function
  * for updating the pref.
  */
-export const useNewTabPref = createPrefsHook(prefManager);
+export const useNewTabPref = createPrefsHook(newTabPrefManager)

--- a/components/brave_new_tab_ui/stories/default/data/storybookState.ts
+++ b/components/brave_new_tab_ui/stories/default/data/storybookState.ts
@@ -1,10 +1,15 @@
-import { select, boolean, number } from '@storybook/addon-knobs'
+import { select, boolean, number, CHANGE } from '@storybook/addon-knobs'
+import { addons } from '@storybook/addons'
 import { images } from '../../../data/backgrounds'
 import { defaultTopSitesData } from '../../../data/defaultTopSites'
 import { defaultState } from '../../../storage/new_tab_storage'
 import { initialGridSitesState } from '../../../storage/grid_sites_storage'
 import { TabType as SettingsTabType } from '../../../containers/newTab/settings'
 import dummyBrandedWallpaper from './brandedWallpaper'
+import { newTabPrefManager } from '../../../hooks/usePref'
+import { useEffect } from 'react'
+
+const addonsChannel = addons.getChannel()
 
 function generateStaticImages (images: NewTab.BackgroundWallpaper[]) {
   const staticImages = { SpaceX: undefined }
@@ -55,51 +60,100 @@ function getWidgetStackOrder (firstWidget: string): NewTab.StackWidget[] {
   }
 }
 
-export const getNewTabData = (state: NewTab.State = defaultState): NewTab.State => ({
-  ...state,
-  brandedWallpaper: shouldShowBrandedWallpaperData(
-    boolean('Show branded background image?', true)
-  ),
-  backgroundWallpaper: select(
-    'Background image',
-    generateStaticImages(images),
-    generateStaticImages(images).SpaceX
-  ),
-  customLinksEnabled: boolean('CustomLinks Enabled?', false),
-  featureFlagBraveNewsEnabled: true,
-  featureFlagBraveNewsPromptEnabled: true,
-  searchPromotionEnabled: false,
-  forceSettingsTab: select('Open settings tab?', [undefined, ...Object.keys(SettingsTabType)], undefined),
-  showBackgroundImage: boolean('Show background image?', true),
-  showStats: boolean('Show stats?', true),
-  showToday: boolean('Show Brave News?', true),
-  showClock: boolean('Show clock?', true),
-  showTopSites: boolean('Show top sites?', true),
-  showRewards: boolean('Show rewards?', true),
-  showBraveTalk: boolean('Show Brave Talk?', true),
-  braveTalkSupported: boolean('Brave Talk supported?', true),
-  braveTalkPromptDismissed: !boolean('Brave Talk prompt?', false),
-  geminiSupported: boolean('Gemini Supported?', true),
-  cryptoDotComSupported: boolean('Crypto.com supported?', true),
-  ftxSupported: boolean('FTX supported?', true),
-  showFTX: boolean('Show FTX?', true),
-  showBinance: boolean('Show Binance?', true),
-  hideAllWidgets: boolean('Hide all widgets?', false),
-  isBraveTodayOptedIn: boolean('Brave Today opted-in?', false),
-  textDirection: select('Text direction', { ltr: 'ltr', rtl: 'rtl' }, 'ltr'),
-  stats: {
-    ...state.stats,
-    adsBlockedStat: number('Number of blocked items', 1337),
-    httpsUpgradesStat: number('Number of HTTPS upgrades', 1337)
-  },
-  // TODO(petemill): Support binance state when binance can be included without chrome.* APIs
-  // binanceState: {
-  //   ...state.binanceState,
-  //   binanceSupported: boolean('Binance supported?', true)
-  // },
-  initialDataLoaded: true,
-  widgetStackOrder: getWidgetStackOrder(select('First widget', ['braveTalk', 'rewards'], 'rewards'))
-})
+/**
+ * Guesses what the label for a settings key is. This is only accurate for the
+ * case where the settings key is exactly a camelCased version of a
+ * Sentence cased label ending with a '?'
+ * i.e.
+ * 'showStats' ==> 'Show stats?'
+ *
+ * A title case label or acronyms will break this, however, this isn't used
+ * much at the moment.
+ * @param key The key to guess the label for.
+ * @returns The guessed label. Not guaranteed to be accurate, sorry :'(
+ */
+const guessLabelForKey = (key: string) => key
+  .replace(/([A-Z])/g, (match) => ` ${match.toLowerCase()}`)
+  .replace(/^./, (match) => match.toUpperCase())
+  .trim() + '?'
+
+export const useNewTabData = (state: NewTab.State = defaultState) => {
+  const result: NewTab.State = {
+    ...state,
+    brandedWallpaper: shouldShowBrandedWallpaperData(
+      boolean('Show branded background image?', true)
+    ),
+    backgroundWallpaper: select(
+      'Background image',
+      generateStaticImages(images),
+      generateStaticImages(images).SpaceX
+    ),
+    customLinksEnabled: boolean('CustomLinks Enabled?', false),
+    featureFlagBraveNewsEnabled: true,
+    featureFlagBraveNewsPromptEnabled: true,
+    searchPromotionEnabled: false,
+    forceSettingsTab: select('Open settings tab?', [undefined, ...Object.keys(SettingsTabType)], undefined),
+    showBackgroundImage: boolean('Show background image?', true),
+    showStats: boolean('Show stats?', true),
+    showToday: boolean('Show Brave News?', true),
+    showClock: boolean('Show clock?', true),
+    showTopSites: boolean('Show top sites?', true),
+    showRewards: boolean('Show rewards?', true),
+    showBraveTalk: boolean('Show Brave Talk?', true),
+    braveTalkSupported: boolean('Brave Talk supported?', true),
+    braveTalkPromptDismissed: !boolean('Brave Talk prompt?', false),
+    geminiSupported: boolean('Gemini Supported?', true),
+    cryptoDotComSupported: boolean('Crypto.com supported?', true),
+    ftxSupported: boolean('FTX supported?', true),
+    showFTX: boolean('Show FTX?', true),
+    showBinance: boolean('Show Binance?', true),
+    hideAllWidgets: boolean('Hide all widgets?', false),
+    isBraveTodayOptedIn: boolean('Brave Today opted-in?', false),
+    textDirection: select('Text direction', { ltr: 'ltr', rtl: 'rtl' }, 'ltr'),
+    stats: {
+      ...state.stats,
+      adsBlockedStat: number('Number of blocked items', 1337),
+      httpsUpgradesStat: number('Number of HTTPS upgrades', 1337)
+    },
+    // TODO(petemill): Support binance state when binance can be included without chrome.* APIs
+    // binanceState: {
+    //   ...state.binanceState,
+    //   binanceSupported: boolean('Binance supported?', true)
+    // },
+    initialDataLoaded: true,
+    widgetStackOrder: getWidgetStackOrder(select('First widget', ['braveTalk', 'rewards'], 'rewards'))
+  }
+
+  // On all updates, notify that the prefs might've changed. Listeners are
+  // only notified when the setting they're interested in updates anyway.
+  useEffect(() => {
+    newTabPrefManager.notifyListeners(result)
+  })
+
+  // In Storybook, we aren't wired up to the settings backend. This effect
+  // **VERY** hackily overrides the savePref function to emit a knob change
+  // event, guessing what the correct knob label is.
+
+  // This is unfortunate, but the `addon-knob` library is deprecated and does
+  // not offer any better way of setting knob values.
+
+  // See https://github.com/storybookjs/storybook/issues/3855#issuecomment-624164453
+  // for discussion of this issue.
+  useEffect(() => {
+    const originalSavePref = newTabPrefManager.savePref
+    newTabPrefManager.savePref = (key, value) => {
+      addonsChannel.emit(CHANGE, {
+        name: guessLabelForKey(key),
+        value: value
+      })
+    }
+    return () => {
+      newTabPrefManager.savePref = originalSavePref
+    }
+  }, [])
+
+  return result
+}
 
 export const getGridSitesData = (
   state: NewTab.GridSitesState = initialGridSitesState

--- a/components/brave_new_tab_ui/stories/regular.tsx
+++ b/components/brave_new_tab_ui/stories/regular.tsx
@@ -9,7 +9,7 @@ import { Provider as ReduxProvider } from 'react-redux'
 import NewTabPage from '../containers/newTab'
 import { getActionsForDispatch } from '../api/getActions'
 import store from '../store'
-import { getNewTabData, getGridSitesData } from './default/data/storybookState'
+import { useNewTabData, getGridSitesData } from './default/data/storybookState'
 import getTodayState from './default/data/todayStorybookState'
 import getBraveNewsDisplayAd from './default/data/getBraveNewsDisplayAd'
 import { getDataUrl, getUnpaddedAsDataUrl } from '../../common/privateCDN'
@@ -51,9 +51,10 @@ export default {
 export const Regular = () => {
   const doNothing = (value: boolean) => value
   const state = store.getState()
-  const newTabData = getNewTabData(state.newTabData)
+  const newTabData = useNewTabData(state.newTabData)
   const gridSitesData = getGridSitesData(state.gridSitesData)
   const todayState = getTodayState()
+
   return (
     <NewTabPage
       ftx={getFTXStorybookState()}

--- a/components/brave_new_tab_ui/stories/regular.tsx
+++ b/components/brave_new_tab_ui/stories/regular.tsx
@@ -62,7 +62,6 @@ export const Regular = () => {
       gridSitesData={gridSitesData}
       actions={getActions()}
       saveShowBackgroundImage={doNothing}
-      saveShowStats={doNothing}
       saveShowToday={doNothing}
       saveShowBraveNewsButton={doNothing}
       saveShowRewards={doNothing}


### PR DESCRIPTION
<!-- Add brave-browser issue bellow that this PR will resolve -->

This PR offers a solution to the current prop drilling on the NTP. It provides the following API for accessing and updating prefs

```ts
// Correct types are inferred, assuming NewTab.Preferences has a property 'myPref'
const [myPref, setMyPref] = useNewTabPref('myPref');
```

It works by maintaining a list of hooks interested in pref state, and notifying them of any relevant changes. Because the `PrefHookManager` is subscribed via the mojom, it will be notified of all updates, including those originating via the existing system and will automatically remain in sync.

As a proof of concept, I have migrated the `showStats` pref to this system. If the PR is accepted, I'd like to migrate the various other prefs on the settings page to this API.

**Note:** as `components/brave_new_tab_ui/containers/newTab/index.tsx` is a class component we can't use hooks from within it, which is why I'm not using the new hook there. As part of the migration to this hooks API, I would like to manually convert it, and other class components to functional components.

## Submitter Checklist:

- [ ] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

