### PR TITLE
Remove Jumplist when deleting browser history

### DIFF
--- a/chromium_src/chrome/browser/ui/webui/settings/settings_clear_browsing_data_handler.cc
+++ b/chromium_src/chrome/browser/ui/webui/settings/settings_clear_browsing_data_handler.cc
@@ -1,0 +1,31 @@
+/* Copyright (c) 2022 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "chrome/browser/browsing_data/browsing_data_important_sites_util.h"
+#include "chrome/browser/profiles/profile.h"
+
+#if BUILDFLAG(IS_WIN)
+#include "chrome/browser/shell_integration_win.h"
+#include "chrome/browser/win/jumplist.h"
+#include "chrome/browser/win/jumplist_updater.h"
+
+void BraveRemoveJumplist(Profile* profile) {
+  if (!JumpList::Enabled() || !profile)
+    return;
+  auto app_id =
+      shell_integration::win::GetAppUserModelIdForBrowser(profile->GetPath());
+  JumpListUpdater::DeleteJumpList(app_id);
+}
+
+#define browsing_data_important_sites_util                             \
+  if (remove_mask & chrome_browsing_data_remover::DATA_TYPE_HISTORY) { \
+    BraveRemoveJumplist(profile_);                                     \
+  }                                                                    \
+  browsing_data_important_sites_util
+#endif
+#include "src/chrome/browser/ui/webui/settings/settings_clear_browsing_data_handler.cc"
+#if BUILDFLAG(IS_WIN)
+#undef browsing_data_important_sites_util
+#endif


### PR DESCRIPTION
<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/9820

Jumplist is live for a long time after deleting browsing history, forced it to be removed, it will be recreated automatically after some time.

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [x] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [x] New files have MPL-2.0 license header
- [x] Adequate test coverage exists to prevent regressions
- [x] Major classes, functions and non-trivial code blocks are well-commented
- [x] Changes in component dependencies are properly reflected in `gn`
- [x] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [x] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

1. Launch Brave and browse around various websites to establish a history
2. Close a few tabs so you have some recently closed tabs
3. Pin Brave to the task bar
4. Verify history items show in jump list
    - right click the icon in system taskbar when it's open
    - close Brave and right click the pinned icon
6. You should see entries for `Most visited` and `Recently closed`
7. Re-launch Brave and visit brave://settings/clearBrowserData
8. Pick `All Time` for `Time Range`, select all the items, and then click `Clear data`
9. Verify items from Jump List are cleared
    - Right click Brave icon in task bar
    - You should NOT see `Most visted` and `Recently closed`
    - Close Brave and then right click the pinned icon in system taskbar
    - You should NOT see `Most visted` and `Recently closed`