### PR TITLE
fix(wallet): use hex-encoded blockCount param for eth_feeHistory

### DIFF
--- a/components/brave_wallet/browser/eth_requests.cc
+++ b/components/brave_wallet/browser/eth_requests.cc
@@ -70,7 +70,7 @@ std::string eth_blockNumber() {
   return GetJsonRpcNoParams("eth_blockNumber");
 }
 
-std::string eth_feeHistory(int num_blocks,
+std::string eth_feeHistory(const std::string& num_blocks,
                            const std::string& head,
                            const std::vector<double>& reward_percentiles) {
   base::Value percentile_values(base::Value::Type::LIST);

--- a/components/brave_wallet/browser/eth_requests.h
+++ b/components/brave_wallet/browser/eth_requests.h
@@ -45,7 +45,7 @@ std::string eth_accounts();
 // Returns the number of most recent block.
 std::string eth_blockNumber();
 // Returns the fee history.
-std::string eth_feeHistory(int num_blocks,
+std::string eth_feeHistory(const std::string& num_blocks,
                            const std::string& head,
                            const std::vector<double>& reward_percentiles);
 // Returns the balance of the account of given address.

--- a/components/brave_wallet/browser/eth_requests_unittest.cc
+++ b/components/brave_wallet/browser/eth_requests_unittest.cc
@@ -85,8 +85,8 @@ TEST(EthRequestUnitTest, eth_blockNumber) {
 
 TEST(EthRequestUnitTest, eth_feeHistory) {
   ASSERT_EQ(
-      eth_feeHistory(40, "latest", std::vector<double>{20, 50, 80}),
-      R"({"id":1,"jsonrpc":"2.0","method":"eth_feeHistory","params":[40,"latest",[20.0,50.0,80.0]]})");
+      eth_feeHistory("0x28", "latest", std::vector<double>{20, 50, 80}),
+      R"({"id":1,"jsonrpc":"2.0","method":"eth_feeHistory","params":["0x28","latest",[20.0,50.0,80.0]]})");
 }
 
 TEST(EthRequestUnitTest, eth_getBalance) {

--- a/components/brave_wallet/browser/json_rpc_service.cc
+++ b/components/brave_wallet/browser/json_rpc_service.cc
@@ -611,8 +611,9 @@ void JsonRpcService::GetFeeHistory(GetFeeHistoryCallback callback) {
                      weak_ptr_factory_.GetWeakPtr(), std::move(callback));
 
   RequestInternal(
-      eth::eth_feeHistory(40, "latest", std::vector<double>{20, 50, 80}), true,
-      network_urls_[mojom::CoinType::ETH], std::move(internal_callback));
+      eth::eth_feeHistory("0x28",  // blockCount = 40
+                          "latest", std::vector<double>{20, 50, 80}),
+      true, network_urls_[mojom::CoinType::ETH], std::move(internal_callback));
 }
 
 void JsonRpcService::OnGetFeeHistory(


### PR DESCRIPTION
Resolves https://github.com/brave/brave-browser/issues/23529

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

Checking known RPC endpoints to see if they support hex-encoded `blockCount` param to `eth_feeHistory` RPC method:
```
curl -s <url> -X POST -H "Content-Type: application/json" -d '{"id":1,"jsonrpc":"2.0","method":"eth_feeHistory","params":["0x28", "latest", [20,50,80]]}' | jq
```

| RPC Name | RPC Endpoint | Supports hex `blockCount` |
-|-|:-:
| Ethereum (Brave) | https://mainnet-infura.brave.com | ✅ |
| Polygon (public) | https://polygon-rpc.com | ✅ |
| Polygon (Brave) | https://mainnet-polygon.brave.com | ✅ |
| Avalanche C-Chain (public) | https://api.avax.network/ext/bc/C/rpc | ✅ |
| Fantom (public) | https://rpc.ftm.tools | ✅ |
| Moonbeam (public) | https://rpc.ankr.com/moonbeam | ✅ |

Optimism, Celo, BSC, and Aurora (NEAR) not included in the above table, since they do not support EIP-1559.

Please see linked issue for steps to reproduce for Moonbeam.