### PR TITLE
Refactor playlist core

### DIFF
--- a/browser/playlist/playlist_service_factory.cc
+++ b/browser/playlist/playlist_service_factory.cc
@@ -6,11 +6,14 @@
 #include "brave/browser/playlist/playlist_service_factory.h"
 
 #include <memory>
+#include <string>
+#include <utility>
 
 #include "base/feature_list.h"
 #include "brave/browser/profiles/profile_util.h"
 #include "brave/components/playlist/features.h"
 #include "brave/components/playlist/media_detector_component_manager.h"
+#include "brave/components/playlist/playlist_constants.h"
 #include "brave/components/playlist/playlist_download_request_manager.h"
 #include "brave/components/playlist/playlist_service.h"
 #include "brave/components/playlist/pref_names.h"
@@ -46,7 +49,15 @@ bool PlaylistServiceFactory::IsPlaylistEnabled(
 
 void PlaylistServiceFactory::RegisterProfilePrefs(
     user_prefs::PrefRegistrySyncable* registry) {
-  registry->RegisterDictionaryPref(kPlaylistItems);
+  base::Value::Dict default_playlist;
+  default_playlist.Set(kPlaylistIDKey, std::string());
+  default_playlist.Set(kPlaylistNameKey, std::string());
+  default_playlist.Set(kPlaylistItemsKey, base::Value::List());
+
+  base::Value::List list;
+  list.Append(std::move(default_playlist));
+  registry->RegisterListPref(kPlaylistListsPref, base::Value(std::move(list)));
+  registry->RegisterDictionaryPref(kPlaylistItemsPref);
 }
 
 PlaylistServiceFactory::PlaylistServiceFactory()

--- a/components/playlist/media_detector_component_manager.cc
+++ b/components/playlist/media_detector_component_manager.cc
@@ -70,4 +70,127 @@ void MediaDetectorComponentManager::OnGetScript(const std::string& script) {
     observer.OnScriptReady(script_);
 }
 
+void MediaDetectorComponentManager::SetUseLocalScriptForTesting() {
+  register_requested_ = true;
+  // This script is modified version of
+  // https://github.com/brave/brave-ios/blob/development/Client/Frontend/UserContent/UserScripts/Playlist.js
+  static const std::string kScript = R"-(
+(function() {
+  function getNodeSource(node, src, mimeType, thumbnail) {
+    var name = node.title;
+    if (name == null || typeof name == 'undefined' || name == "") {
+      name = document.title;
+    }
+
+    if (mimeType == null || typeof mimeType == 'undefined' || mimeType == "") {
+      if (node.constructor.name == 'HTMLVideoElement') {
+        mimeType = 'video';
+      }
+
+      if (node.constructor.name == 'HTMLAudioElement') {
+        mimeType = 'audio';
+      }
+
+      if (node.constructor.name == 'HTMLSourceElement') {
+        videoNode = node.closest('video');
+        if (videoNode != null && typeof videoNode != 'undefined') {
+          mimeType = 'video'
+        } else {
+          mimeType = 'audio'
+        }
+      }
+    }
+
+    if (src && src !== "") {
+      // tagNode(node);
+      return {
+        "name": name,
+        "src": src,
+        "pageSrc": window.location.href,
+        "pageTitle": document.title,
+        "mimeType": mimeType,
+        //"duration": clamp_duration(node.duration),
+        "detected": true,
+        "tagId": node.tagUUID,
+        thumbnail
+      };
+    } else {
+      var target = node;
+      document.querySelectorAll('source').forEach(function(node) {
+        if (node.src !== "") {
+          if (node.closest('video') === target) {
+            // tagNode(target);
+            return {
+              "name": name,
+              "src": node.src,
+              "pageSrc": window.location.href,
+              "pageTitle": document.title,
+              "mimeType": mimeType,
+              //"duration": clamp_duration(target.duration),
+              "detected": true,
+              "tagId": target.tagUUID,
+              thumbnail
+            };
+          }
+
+          if (node.closest('audio') === target) {
+            tagNode(target);
+            return {
+              "name": name,
+              "src": node.src,
+              "pageSrc": window.location.href,
+              "pageTitle": document.title,
+              "mimeType": mimeType,
+              //"duration": clamp_duration(target.duration),
+              "detected": true,
+              "tagId": target.tagUUID,
+              thumbnail
+            };
+          }
+        }
+      });
+    }
+  }
+
+  function getNodeData(node, thumbnail) {
+    return getNodeSource(node, node.src, node.type, thumbnail);
+  }
+
+  function getAllVideoElements() {
+    return document.querySelectorAll('video');
+  }
+
+  function getAllAudioElements() {
+    return document.querySelectorAll('audio');
+  }
+
+  function getOGTagImage() {
+    return document.querySelector('meta[property="og:image"]')?.content
+  }
+
+  let videoElements = getAllVideoElements();
+  let audioElements = getAllAudioElements();
+  if (!videoElements) {
+    videoElements = [];
+  }
+
+  if (!audioElements) {
+    audioElements = [];
+  }
+  
+
+  const thumbnail = getOGTagImage();
+  let medias = [...videoElements].map(e => getNodeData(e, thumbnail));
+  medias = medias.concat([...audioElements].map(e => getNodeData(e, thumbnail)));
+  if (medias.length)
+    return medias;
+
+  return videoElements;
+
+})();
+  )-";
+
+  OnGetScript(kScript);
+}
+
 }  // namespace playlist

--- a/components/playlist/media_detector_component_manager.h
+++ b/components/playlist/media_detector_component_manager.h
@@ -45,6 +45,8 @@ class MediaDetectorComponentManager {
 
   std::string script() const { return script_; }
 
+  void SetUseLocalScriptForTesting();
+
  private:
   void OnComponentReady(const base::FilePath& install_path);
   void OnGetScript(const std::string& script);

--- a/components/playlist/playlist_constants.h
+++ b/components/playlist/playlist_constants.h
@@ -8,28 +8,15 @@
 
 namespace playlist {
 
-constexpr char kPlaylistMediaFileUrlKey[] = "mediaFileUrl";
-constexpr char kPlaylistMediaFileTitleKey[] = "mediaFileTitle";
-
-constexpr char kPlaylistPlaylistNameKey[] = "playlistName";
-constexpr char kPlaylistPlaylistThumbnailUrlKey[] = "playlistThumbnailUrl";
-constexpr char kPlaylistVideoMediaFilesKey[] = "videoMediaFiles";
-constexpr char kPlaylistAudioMediaFilesKey[] = "audioMediaFiles";
-
 constexpr char kPlaylistIDKey[] = "id";
-constexpr char kPlaylistThumbnailPathKey[] = "thumbnailPath";
-constexpr char kPlaylistVideoMediaFilePathKey[] = "videoMediaFilePath";
-constexpr char kPlaylistAudioMediaFilePathKey[] = "audioMediaFilePath";
-constexpr char kPlaylistReadyKey[] = "ready";
-constexpr char kPlaylistTitlesKey[] = "titles";
-constexpr char kPlaylistCreateParamsKey[] = "createParams";
+constexpr char kPlaylistNameKey[] = "name";
+constexpr char kPlaylistItemsKey[] = "items";
 
-constexpr char kPlaylistCreateParamsThumbnailUrlPathKey[] =
-    "createParams.playlistThumbnailUrl";
-constexpr char kPlaylistCreateParamsVideoMediaFilesPathKey[] =
-    "createParams.videoMediaFiles";
-constexpr char kPlaylistCreateParamsAudioMediaFilesPathKey[] =
-    "createParams.audioMediaFiles";
+constexpr char kPlaylistItemIDKey[] = "id";
+constexpr char kPlaylistItemThumbnailPathKey[] = "thumbnailPath";
+constexpr char kPlaylistItemMediaFilePathKey[] = "mediaFilePath";
+constexpr char kPlaylistItemReadyKey[] = "ready";
+constexpr char kPlaylistItemTitleKey[] = "title";
 
 }  // namespace playlist
 

--- a/components/playlist/playlist_download_request_manager.cc
+++ b/components/playlist/playlist_download_request_manager.cc
@@ -6,6 +6,7 @@
 #include "brave/components/playlist/playlist_download_request_manager.h"
 
 #include "base/bind.h"
+#include "base/json/json_writer.h"
 #include "base/strings/utf_string_conversions.h"
 #include "base/time/time.h"
 #include "base/timer/timer.h"
@@ -14,6 +15,7 @@
 #include "content/public/browser/render_frame_host.h"
 #include "content/public/browser/web_contents.h"
 #include "content/public/common/isolated_world_ids.h"
+#include "net/base/registry_controlled_domains/registry_controlled_domain.h"
 #include "third_party/re2/src/re2/re2.h"
 
 namespace playlist {
@@ -50,7 +52,11 @@ PlaylistDownloadRequestManager::PlaylistDownloadRequestManager(
       delegate_(delegate),
       media_detector_component_manager_(manager) {
   observed_.Observe(media_detector_component_manager_);
+
   media_detector_script_ = media_detector_component_manager_->script();
+
+  // TODO(sko) This line should be removed when the component is ready.
+  media_detector_component_manager_->SetUseLocalScriptForTesting();
 }
 
 PlaylistDownloadRequestManager::~PlaylistDownloadRequestManager() = default;
@@ -60,22 +66,18 @@ void PlaylistDownloadRequestManager::CreateWebContents() {
     return;
 
   // |web_contents_| is created on demand.
-  constexpr char kYoutubeURL[] = "https://www.youtube.com/";
   content::WebContents::CreateParams create_params(context_, nullptr);
   web_contents_ = content::WebContents::Create(create_params);
-  web_contents_->GetController().LoadURLWithParams(
-      content::NavigationController::LoadURLParams(GURL(kYoutubeURL)));
   Observe(web_contents_.get());
 }
 
-void PlaylistDownloadRequestManager::GeneratePlaylistCreateParamsForYoutubeURL(
+void PlaylistDownloadRequestManager::GetMediaFilesFromPage(
     const std::string& url) {
   web_contents_destroy_timer_.reset();
 
+  CreateWebContents();
   if (!ReadyToRunMediaDetectorScript()) {
-    pending_youtube_urls_.push_back(url);
-
-    CreateWebContents();
+    pending_urls_.push_back(url);
     media_detector_component_manager_->RegisterIfNeeded();
     return;
   }
@@ -87,26 +89,64 @@ void PlaylistDownloadRequestManager::OnScriptReady(const std::string& script) {
   media_detector_script_ = script;
 
   if (ReadyToRunMediaDetectorScript())
-    FetchAllPendingYoutubeURLs();
+    FetchPendingURL();
 }
 
-void PlaylistDownloadRequestManager::FetchAllPendingYoutubeURLs() {
-  if (pending_youtube_urls_.empty())
+void PlaylistDownloadRequestManager::FetchPendingURL() {
+  if (pending_urls_.empty())
     return;
 
-  // Run all pending request.
-  for (const auto& url : pending_youtube_urls_) {
-    RunMediaDetector(url);
-  }
-
-  pending_youtube_urls_.clear();
+  auto url = pending_urls_.front();
+  pending_urls_.pop_front();
+  RunMediaDetector(url);
 }
 
 void PlaylistDownloadRequestManager::RunMediaDetector(const std::string& url) {
   DCHECK(PlaylistJavaScriptWorldIdIsSet());
 
-  DCHECK_GE(in_progress_youtube_urls_count_, 0);
-  in_progress_youtube_urls_count_++;
+  DCHECK_GE(in_progress_urls_count_, 0);
+  in_progress_urls_count_++;
+
+  web_contents_->GetController().LoadURLWithParams(
+      content::NavigationController::LoadURLParams(GURL(url)));
+}
+
+bool PlaylistDownloadRequestManager::ReadyToRunMediaDetectorScript() const {
+  return !media_detector_script_.empty();
+}
+
+void PlaylistDownloadRequestManager::DidFinishNavigation(
+    content::NavigationHandle* navigation_handle) {
+  DCHECK(web_contents_->GetMainFrame());
+
+  // This script is from
+  // https://github.com/brave/brave-ios/blob/development/Client/Frontend/UserContent/UserScripts/PlaylistSwizzler.js
+  static const std::u16string kScriptToHideMediaSourceAPI =
+      uR"-(
+    (function() {
+      // Stub out the MediaSource API so video players do not attempt to use `blob` for streaming
+      if (window.MediaSource || window.WebKitMediaSource || window.HTMLMediaElement && HTMLMediaElement.prototype.webkitSourceAddId) {
+        window.MediaSource = null;
+        window.WebKitMediaSource = null;
+        delete window.MediaSource;
+        delete window.WebKitMediaSource;
+      }
+    })();
+    )-";
+
+  // In order to hide js API from main world, use testing
+  // api temporarily.
+  web_contents_->GetMainFrame()->ExecuteJavaScriptForTests(
+      kScriptToHideMediaSourceAPI, base::NullCallback());
+}
+
+void PlaylistDownloadRequestManager::DidFinishLoad(
+    content::RenderFrameHost* render_frame_host,
+    const GURL& validated_url) {
+  if (in_progress_urls_count_ == 0)
+    return;
+
+  DCHECK(web_contents_->GetMainFrame());
 
   web_contents_->GetMainFrame()->ExecuteJavaScriptInIsolatedWorld(
       base::UTF8ToUTF16(media_detector_script_),
@@ -115,84 +155,69 @@ void PlaylistDownloadRequestManager::RunMediaDetector(const std::string& url) {
       g_playlist_javascript_world_id);
 }
 
-bool PlaylistDownloadRequestManager::ReadyToRunMediaDetectorScript() const {
-  if (!media_detector_script_.empty() && web_contents_ && web_contents_ready_)
-    return true;
-
-  return false;
-}
-
-void PlaylistDownloadRequestManager::DidFinishLoad(
-    content::RenderFrameHost* render_frame_host,
-    const GURL& validated_url) {
-  if (render_frame_host->GetMainFrame()) {
-    // To run youtubedown.js, frame should be ready.
-    // After that, we don't need to observe.
-    web_contents_ready_ = true;
-    Observe(nullptr);
-
-    if (ReadyToRunMediaDetectorScript())
-      FetchAllPendingYoutubeURLs();
-  }
-}
-
 void PlaylistDownloadRequestManager::OnGetMedia(base::Value value) {
-  DCHECK_GT(in_progress_youtube_urls_count_, 0);
-  in_progress_youtube_urls_count_--;
+  auto print_value = [](const base::Value& value) {
+    std::string out;
+    base::JSONWriter::Write(value, &out);
+    LOG(ERROR) << value;
+  };
 
-  if (in_progress_youtube_urls_count_ == 0)
+  DCHECK_GT(in_progress_urls_count_, 0);
+  in_progress_urls_count_--;
+
+  /* Expected output:
+    [
+      {
+        "detected": boolean,
+        "mimeType": "video" | "audio",
+        "name": string,
+        "pageSrc": url,
+        "pageTitle": string
+        "src": url
+        "thumbnail": url | undefined
+      }
+    ]
+  */
+
+  if (in_progress_urls_count_ == 0)
     ScheduleWebContentsDestroying();
 
   if (!value.is_list()) {
     LOG(ERROR) << __func__
-               << " Got invalid value after running media detector script";
+               << " Got invalid value after running media detector script:";
+    print_value(value);
     return;
   }
 
-  CreatePlaylistParams params;
-
-  const auto& list = value.GetList();
-  if (list.empty()) {
-    LOG(ERROR) << __func__
-               << " Got invalid value after running media detector script";
-    return;
-  }
-
-  const bool has_audio = list.size() > 1;
-
-  // Get clean playlist name.
-  // TODO(sko) This routine is set for youtubedown.js. We need to clean this up
-  // with new script.
-  auto* file = list[0].FindStringKey("file");
-  auto* thumb = list[0].FindStringKey("thumb");
-  DCHECK(file);
-  DCHECK(thumb);
-
-  params.playlist_name = *file;
-  RE2::Replace(&params.playlist_name, "\\s\\[.*$", "");
-
-  params.playlist_thumbnail_url = *thumb;
-  if (const std::string* url = list[0].FindStringKey("url")) {
-    params.video_media_files.emplace_back(*url, "");
-  } else {
-    DCHECK(list[0].FindListKey("url"));
-    for (const auto& value : list[0].FindListKey("url")->GetList()) {
-      params.video_media_files.emplace_back(value.GetString(), "");
+  for (const auto& media : value.GetList()) {
+    if (!media.is_dict()) {
+      LOG(ERROR) << __func__
+                 << " Got invalid value after running media detector script";
+      print_value(media);
+      return;
     }
+
+    auto* name = media.FindStringKey("name");
+    auto* page_title = media.FindStringKey("pageTitle");
+    auto* page_source = media.FindStringKey("pageSrc");
+    auto* mime_type = media.FindStringKey("mimeType");
+    auto* src = media.FindStringKey("src");
+    auto* thumbnail = media.FindStringKey("thumbnail");
+    DCHECK(name);
+    DCHECK(page_source);
+    DCHECK(page_title);
+    DCHECK(mime_type);
+    DCHECK(src);
+
+    PlaylistItemInfo info;
+    info.title = *name;
+    if (thumbnail)
+      info.thumbnail_path = *thumbnail;
+    info.media_file_path = *src;
+    delegate_->OnPlaylistCreationParamsReady(info);
   }
 
-  if (has_audio) {
-    if (const std::string* url = list[1].FindStringKey("url")) {
-      params.audio_media_files.emplace_back(*url, "");
-    } else {
-      DCHECK(list[0].FindListKey("url"));
-      for (const auto& value : list[1].FindListKey("url")->GetList()) {
-        params.audio_media_files.emplace_back(value.GetString(), "");
-      }
-    }
-  }
-
-  delegate_->OnPlaylistCreationParamsReady(params);
+  FetchPendingURL();
 }
 
 void PlaylistDownloadRequestManager::ScheduleWebContentsDestroying() {

--- a/components/playlist/playlist_media_file_download_manager.cc
+++ b/components/playlist/playlist_media_file_download_manager.cc
@@ -9,6 +9,7 @@
 
 #include "base/files/file_path.h"
 #include "base/logging.h"
+#include "base/threading/sequenced_task_runner_handle.h"
 #include "base/values.h"
 #include "brave/components/playlist/playlist_constants.h"
 
@@ -21,21 +22,15 @@ PlaylistMediaFileDownloadManager::PlaylistMediaFileDownloadManager(
     : base_dir_(base_dir), delegate_(delegate) {
   // TODO(pilgrim) dynamically set file extensions based on format
   // (may require changes to youtubedown parser)
-  video_media_file_downloader_ = std::make_unique<PlaylistMediaFileDownloader>(
-      this, context, FILE_PATH_LITERAL("video_source_files"),
-      FILE_PATH_LITERAL("video_file.mp4"), kPlaylistVideoMediaFilePathKey,
-      kPlaylistCreateParamsVideoMediaFilesPathKey);
-  audio_media_file_downloader_ = std::make_unique<PlaylistMediaFileDownloader>(
-      this, context, FILE_PATH_LITERAL("audio_source_files"),
-      FILE_PATH_LITERAL("audio_file.m4a"), kPlaylistAudioMediaFilePathKey,
-      kPlaylistCreateParamsAudioMediaFilesPathKey);
+  media_file_downloader_ = std::make_unique<PlaylistMediaFileDownloader>(
+      this, context, FILE_PATH_LITERAL("media_file.mp4"));
 }
 
 PlaylistMediaFileDownloadManager::~PlaylistMediaFileDownloadManager() = default;
 
 void PlaylistMediaFileDownloadManager::GenerateMediaFileForPlaylistItem(
-    const base::Value& playlist_item) {
-  pending_media_file_creation_jobs_.push(playlist_item.Clone());
+    const PlaylistItemInfo& playlist_item) {
+  pending_media_file_creation_jobs_.push(playlist_item);
 
   // If either media file controller is generating a playlist media file,
   // delay the next playlist generation. It will be triggered when the current
@@ -46,6 +41,8 @@ void PlaylistMediaFileDownloadManager::GenerateMediaFileForPlaylistItem(
 
 void PlaylistMediaFileDownloadManager::CancelDownloadRequest(
     const std::string& id) {
+  VLOG(2) << __func__ << " " << id;
+
   // Cancel if currently downloading item is id.
   // Otherwise, GetNextPlaylistItemTarget() will drop canceled one.
   if (GetCurrentDownloadingPlaylistItemID() == id) {
@@ -55,101 +52,84 @@ void PlaylistMediaFileDownloadManager::CancelDownloadRequest(
   }
 }
 
-void PlaylistMediaFileDownloadManager::ResetCurrentPlaylistItemInfo() {
-  current_playlist_item_id_.clear();
-  current_playlist_item_audio_file_path_.clear();
-  current_playlist_item_video_file_path_.clear();
-}
-
 void PlaylistMediaFileDownloadManager::CancelAllDownloadRequests() {
   CancelCurrentDownloadingPlaylistItem();
-  pending_media_file_creation_jobs_ = base::queue<base::Value>();
+  pending_media_file_creation_jobs_ = {};
 }
 
 void PlaylistMediaFileDownloadManager::GenerateMediaFiles() {
-  DCHECK(!IsCurrentDownloadingInProgress());
-  ResetCurrentPlaylistItemInfo();
+  if (IsCurrentDownloadingInProgress())
+    return;
 
   if (pending_media_file_creation_jobs_.empty())
     return;
 
-  base::Value video_value = GetNextPlaylistItemTarget();
-  if (video_value.is_none())
+  current_item_ = GetNextPlaylistItemTarget();
+  if (!current_item_)
     return;
 
-  base::Value audio_value = video_value.Clone();
-  auto* playlist_name = video_value.FindStringKey(kPlaylistPlaylistNameKey);
-  DCHECK(playlist_name);
-  VLOG(2) << __func__ << ": " << *playlist_name;
+  VLOG(2) << __func__ << ": " << current_item_->title;
 
-  video_media_file_downloader_->GenerateSingleMediaFile(std::move(video_value),
-                                                        base_dir_);
-  audio_media_file_downloader_->GenerateSingleMediaFile(std::move(audio_value),
-                                                        base_dir_);
+  media_file_downloader_->DownloadMediaFileForPlaylistItem(*current_item_,
+                                                           base_dir_);
 }
 
-base::Value PlaylistMediaFileDownloadManager::GetNextPlaylistItemTarget() {
+std::unique_ptr<PlaylistItemInfo>
+PlaylistMediaFileDownloadManager::GetNextPlaylistItemTarget() {
   while (!pending_media_file_creation_jobs_.empty()) {
-    base::Value playlist_item(
-        std::move(pending_media_file_creation_jobs_.front()));
+    auto playlist_item(std::move(pending_media_file_creation_jobs_.front()));
     pending_media_file_creation_jobs_.pop();
-    DCHECK(playlist_item.is_dict());
-    const std::string* playlist_id =
-        playlist_item.FindStringKey(kPlaylistIDKey);
-    DCHECK(playlist_id);
-    if (delegate_->IsValidPlaylistItem(*playlist_id)) {
-      current_playlist_item_id_ = *playlist_id;
-      return playlist_item;
-    }
+
+    if (delegate_->IsValidPlaylistItem(playlist_item.id))
+      return std::make_unique<PlaylistItemInfo>(std::move(playlist_item));
   }
 
-  return {};
+  return nullptr;
 }
 
 std::string
 PlaylistMediaFileDownloadManager::GetCurrentDownloadingPlaylistItemID() const {
-  return video_media_file_downloader_->current_playlist_id();
+  if (IsCurrentDownloadingInProgress())
+    return media_file_downloader_->current_playlist_id();
+
+  return {};
 }
 
 void PlaylistMediaFileDownloadManager::CancelCurrentDownloadingPlaylistItem() {
-  video_media_file_downloader_->RequestCancelCurrentPlaylistGeneration();
-  audio_media_file_downloader_->RequestCancelCurrentPlaylistGeneration();
+  media_file_downloader_->RequestCancelCurrentPlaylistGeneration();
 }
 
 bool PlaylistMediaFileDownloadManager::IsCurrentDownloadingInProgress() const {
-  return video_media_file_downloader_->in_progress() ||
-         audio_media_file_downloader_->in_progress();
+  return media_file_downloader_->in_progress();
 }
 
 void PlaylistMediaFileDownloadManager::OnMediaFileReady(
     const std::string& id,
-    const std::string& media_file_path_key,
     const std::string& media_file_path) {
-  if (media_file_path_key == kPlaylistAudioMediaFilePathKey) {
-    current_playlist_item_audio_file_path_ = media_file_path;
-  } else {
-    current_playlist_item_video_file_path_ = media_file_path;
-  }
-  if (IsCurrentDownloadingInProgress())
-    return;
-
   VLOG(2) << __func__ << ": " << id << " is ready.";
 
-  delegate_->OnMediaFileReady(id, current_playlist_item_audio_file_path_,
-                              current_playlist_item_video_file_path_);
+  delegate_->OnMediaFileReady(id, current_item_->media_file_path);
 
-  ResetCurrentPlaylistItemInfo();
-  GenerateMediaFiles();
+  current_item_.reset();
+
+  base::SequencedTaskRunnerHandle::Get()->PostTask(
+      FROM_HERE,
+      base::BindOnce(&PlaylistMediaFileDownloadManager::GenerateMediaFiles,
+                     weak_factory_.GetWeakPtr()));
 }
 
 void PlaylistMediaFileDownloadManager::OnMediaFileGenerationFailed(
     const std::string& id) {
   VLOG(2) << __func__ << ": " << id;
 
-  CancelCurrentDownloadingPlaylistItem();
   delegate_->OnMediaFileGenerationFailed(id);
 
-  GenerateMediaFiles();
+  CancelCurrentDownloadingPlaylistItem();
+
+  base::SequencedTaskRunnerHandle::Get()->PostTask(
+      FROM_HERE,
+      base::BindOnce(&PlaylistMediaFileDownloadManager::GenerateMediaFiles,
+                     weak_factory_.GetWeakPtr()));
 }
 
 }  // namespace playlist

--- a/components/playlist/playlist_media_file_download_manager.h
+++ b/components/playlist/playlist_media_file_download_manager.h
@@ -32,8 +32,7 @@ class PlaylistMediaFileDownloadManager
   class Delegate {
    public:
     virtual void OnMediaFileReady(const std::string& id,
-                                  const std::string& audio_file_path,
-                                  const std::string& video_file_path) = 0;
+                                  const std::string& media_file_path) = 0;
     virtual void OnMediaFileGenerationFailed(const std::string& id) = 0;
     virtual bool IsValidPlaylistItem(const std::string& id) = 0;
 
@@ -51,35 +50,31 @@ class PlaylistMediaFileDownloadManager
   PlaylistMediaFileDownloadManager& operator=(
       const PlaylistMediaFileDownloadManager&) = delete;
 
-  void GenerateMediaFileForPlaylistItem(const base::Value& playlist_item);
+  void GenerateMediaFileForPlaylistItem(const PlaylistItemInfo& playlist_item);
   void CancelDownloadRequest(const std::string& id);
   void CancelAllDownloadRequests();
 
  private:
   // PlaylistMediaFileDownloader::Delegate overrides:
   void OnMediaFileReady(const std::string& id,
-                        const std::string& media_file_path_key,
                         const std::string& media_file_path) override;
   void OnMediaFileGenerationFailed(const std::string& id) override;
 
   void GenerateMediaFiles();
-  base::Value GetNextPlaylistItemTarget();
+  std::unique_ptr<PlaylistItemInfo> GetNextPlaylistItemTarget();
   std::string GetCurrentDownloadingPlaylistItemID() const;
   void CancelCurrentDownloadingPlaylistItem();
   bool IsCurrentDownloadingInProgress() const;
-  void ResetCurrentPlaylistItemInfo();
 
   const base::FilePath base_dir_;
   raw_ptr<Delegate> delegate_;
-  base::queue<base::Value> pending_media_file_creation_jobs_;
-  std::string current_playlist_item_id_;
-  std::string current_playlist_item_audio_file_path_;
-  std::string current_playlist_item_video_file_path_;
+  base::queue<PlaylistItemInfo> pending_media_file_creation_jobs_;
 
-  // TODO(simonhong): Unify these two downloader into one. Using two downloaders
-  // just increase complexity.
-  std::unique_ptr<PlaylistMediaFileDownloader> video_media_file_downloader_;
-  std::unique_ptr<PlaylistMediaFileDownloader> audio_media_file_downloader_;
+  std::unique_ptr<PlaylistItemInfo> current_item_;
+
+  std::unique_ptr<PlaylistMediaFileDownloader> media_file_downloader_;
+
+  base::WeakPtrFactory<PlaylistMediaFileDownloadManager> weak_factory_{this};
 };
 
 }  // namespace playlist

--- a/components/playlist/playlist_media_file_downloader.cc
+++ b/components/playlist/playlist_media_file_downloader.cc
@@ -47,104 +47,12 @@ net::NetworkTrafficAnnotationTag GetNetworkTrafficAnnotationTagForURLLoad() {
       })");
 }
 
-base::FilePath::StringType GetFileNameStringFromIndex(int index) {
-#if BUILDFLAG(IS_WIN)
-  return base::NumberToWString(index);
-#else
-  return base::NumberToString(index);
-#endif
-}
-
-// Return false when source file is not appended properly.
-bool AppendToFileThenDeleteSource(const base::FilePath& source_path,
-                                  base::File* dest_file) {
-  DCHECK(dest_file->IsValid());
-
-  base::File source_file(source_path, base::File::FLAG_OPEN |
-                                          base::File::FLAG_READ |
-                                          base::File::FLAG_DELETE_ON_CLOSE);
-  if (!source_file.IsValid())
-    return false;
-
-  // Read |source_path|'s contents in chunks of read_buffer_size and append
-  // to |destination_file_path|.
-  size_t num_bytes_read = 0;
-  bool got_error = false;
-
-  constexpr size_t kReadBufferSize = 1 << 16;  // 64KiB
-  char read_buffer[kReadBufferSize];
-
-  while ((num_bytes_read =
-              source_file.ReadAtCurrentPos(read_buffer, kReadBufferSize)) > 0) {
-    if (!dest_file->WriteAtCurrentPos(read_buffer, num_bytes_read)) {
-      VLOG(2) << __func__ << " failed to append: " << source_path;
-      got_error = true;
-      break;
-    }
-  }
-
-  return !got_error;
-}
-
-bool DoGenerateSingleMediaFile(
-    const base::FilePath& playlist_dir_path,
-    const base::FilePath::StringType& source_media_files_dir,
-    const base::FilePath::StringType& unified_media_file_name,
-    int num_source_files) {
-  const base::FilePath source_files_dir =
-      playlist_dir_path.Append(base::FilePath::StringType(
-          source_media_files_dir.begin(), source_media_files_dir.end()));
-
-  const base::FilePath unified_media_file_path =
-      playlist_dir_path.Append(base::FilePath::StringType(
-          unified_media_file_name.begin(), unified_media_file_name.end()));
-
-  // Prepare empty target file to append.
-  base::DeleteFile(unified_media_file_path);
-  base::File unified_media_file(
-      unified_media_file_path,
-      base::File::FLAG_CREATE | base::File::FLAG_APPEND);
-  if (!unified_media_file.IsValid())
-    return false;
-
-  bool failed = false;
-  for (int i = 0; i < num_source_files; ++i) {
-    const base::FilePath media_file_source_path =
-        source_files_dir.Append(GetFileNameStringFromIndex(i));
-    if (!base::PathExists(media_file_source_path)) {
-      VLOG(2) << __func__
-              << " file not existed: " << media_file_source_path.value();
-      failed = true;
-      break;
-    }
-
-    if (!AppendToFileThenDeleteSource(media_file_source_path,
-                                      &unified_media_file)) {
-      failed = true;
-      break;
-    }
-  }
-
-  // Delete source files dir.
-  base::DeletePathRecursively(source_files_dir);
-
-  if (failed) {
-    base::DeleteFile(unified_media_file_path);
-    return false;
-  }
-
-  return true;
-}
-
 }  // namespace
 
 PlaylistMediaFileDownloader::PlaylistMediaFileDownloader(
     Delegate* delegate,
     content::BrowserContext* context,
-    base::FilePath::StringType source_media_files_dir,
-    base::FilePath::StringType unified_media_file_name,
-    std::string media_file_path_key,
-    std::string create_params_path_key)
+    base::FilePath::StringType media_file_name)
     : delegate_(delegate),
       url_loader_factory_(
           context->content::BrowserContext::GetDefaultStoragePartition()
@@ -152,95 +60,47 @@ PlaylistMediaFileDownloader::PlaylistMediaFileDownloader(
       request_helper_(std::make_unique<api_request_helper::APIRequestHelper>(
           GetNetworkTrafficAnnotationTagForURLLoad(),
           url_loader_factory_)),
-      source_media_files_dir_(source_media_files_dir),
-      unified_media_file_name_(unified_media_file_name),
-      media_file_path_key_(media_file_path_key),
-      create_params_path_key_(create_params_path_key) {}
+      media_file_name_(media_file_name) {}
 
 PlaylistMediaFileDownloader::~PlaylistMediaFileDownloader() = default;
 
 void PlaylistMediaFileDownloader::NotifyFail(const std::string& id) {
-  ResetDownloadStatus();
+  CHECK(!id.empty());
   delegate_->OnMediaFileGenerationFailed(id);
+  ResetDownloadStatus();
 }
 
 void PlaylistMediaFileDownloader::NotifySucceed(
     const std::string& id,
-    const std::string& media_file_path_key,
     const std::string& media_file_path) {
+  DCHECK(!id.empty());
+  DCHECK(!media_file_path.empty());
+  delegate_->OnMediaFileReady(id, media_file_path);
   ResetDownloadStatus();
-  delegate_->OnMediaFileReady(id, media_file_path_key, media_file_path);
 }
 
-void PlaylistMediaFileDownloader::GenerateSingleMediaFile(
-    base::Value&& playlist_value,
+void PlaylistMediaFileDownloader::DownloadMediaFileForPlaylistItem(
+    const PlaylistItemInfo& item,
     const base::FilePath& base_dir) {
   DCHECK(!in_progress_);
 
   ResetDownloadStatus();
 
   in_progress_ = true;
-  current_playlist_ = std::move(playlist_value);
+  current_item_ = std::make_unique<PlaylistItemInfo>(item);
 
-  auto* id = current_playlist_.FindStringKey(kPlaylistIDKey);
-  DCHECK(id);
-  current_playlist_id_ = *id;
-
-  remained_download_files_ = GetNumberOfMediaFileSources();
-  media_file_source_files_count_ = remained_download_files_;
-  if (media_file_source_files_count_ == 0) {
-    VLOG(2) << __func__ << ": Empty media file source list";
-    // Consider this as normal if youtubedown.js gives empty source list.
-    // Maybe this playlist only has audio or video. not both.
-    NotifySucceed(current_playlist_id_, media_file_path_key_, "");
-    return;
-  }
-
-  playlist_dir_path_ = base_dir.AppendASCII(current_playlist_id_);
-
-  // Create PROFILE_DIR/playlist/ID/source_files dir to store each media files.
-  // Then, downloads them in that directory.
-  CreateSourceFilesDirThenDownloads();
-}
-
-void PlaylistMediaFileDownloader::CreateSourceFilesDirThenDownloads() {
-  const base::FilePath source_files_dir =
-      playlist_dir_path_.Append(source_media_files_dir_);
-  task_runner()->PostTaskAndReplyWithResult(
-      FROM_HERE, base::BindOnce(&base::CreateDirectory, source_files_dir),
-      base::BindOnce(&PlaylistMediaFileDownloader::OnSourceFilesDirCreated,
-                     weak_factory_.GetWeakPtr()));
-}
-
-void PlaylistMediaFileDownloader::OnSourceFilesDirCreated(bool success) {
-  if (!success) {
-    NotifyFail(current_playlist_id_);
-    return;
-  }
-
-  DownloadAllMediaFileSources();
-}
-
-int PlaylistMediaFileDownloader::GetNumberOfMediaFileSources() {
-  DCHECK(in_progress_);
-  base::Value* media_files =
-      current_playlist_.FindPath(create_params_path_key_);
-  return media_files->GetList().size();
-}
-
-void PlaylistMediaFileDownloader::DownloadAllMediaFileSources() {
-  base::Value* media_files =
-      current_playlist_.FindPath(create_params_path_key_);
-  for (int i = 0; i < media_file_source_files_count_; ++i) {
-    const std::string* url =
-        media_files->GetList()[i].FindStringKey(kPlaylistMediaFileUrlKey);
-    if (url) {
-      DownloadMediaFile(GURL(*url), i);
-    } else {
-      NOTREACHED() << "Playlist has empty media file url";
-      NotifyFail(current_playlist_id_);
-      break;
+  if (GURL media_url(current_item_->media_file_path); media_url.is_valid()) {
+    if (media_url.SchemeIsFile()) {
+      VLOG(2) << __func__ << ": media file is already downloaded";
+      NotifySucceed(current_item_->id, current_item_->media_file_path);
+      return;
     }
+
+    playlist_dir_path_ = base_dir.AppendASCII(current_item_->id);
+    DownloadMediaFile(media_url, 0);
+  } else {
+    VLOG(2) << __func__ << ": media file is empty";
+    NotifyFail(current_item_->id);
   }
 }
 
@@ -248,9 +108,7 @@ void PlaylistMediaFileDownloader::DownloadMediaFile(const GURL& url,
                                                     int index) {
   VLOG(2) << __func__ << ": " << url.spec() << " at: " << index;
 
-  const base::FilePath file_path =
-      playlist_dir_path_.Append(source_media_files_dir_)
-          .Append(GetFileNameStringFromIndex(index));
+  const base::FilePath file_path = playlist_dir_path_.Append(media_file_name_);
   request_helper_->Download(
       url, {}, {}, true, file_path,
       base::BindOnce(&PlaylistMediaFileDownloader::OnMediaFileDownloaded,
@@ -261,52 +119,22 @@ void PlaylistMediaFileDownloader::OnMediaFileDownloaded(int index,
                                                         base::FilePath path) {
   VLOG(2) << __func__ << ": downloaded media file at " << path;
 
+  DCHECK(current_item_);
+
   if (path.empty()) {
     // This fail is handled during the generation.
     // See |has_skipped_source_files| in DoGenerateSingleMediaFile().
     // |has_skipped_source_files| will be set to true.
     VLOG(1) << __func__ << ": failed to download media file at " << index;
+    NotifyFail(current_item_->id);
+    return;
   }
 
-  remained_download_files_--;
-
-  // If all source files are downloaded, unify them into one media file.
-  if (IsDownloadFinished())
-    StartSingleMediaFileGeneration();
+  NotifySucceed(current_item_->id, path.AsUTF8Unsafe());
 }
 
 void PlaylistMediaFileDownloader::RequestCancelCurrentPlaylistGeneration() {
   ResetDownloadStatus();
-}
-
-void PlaylistMediaFileDownloader::StartSingleMediaFileGeneration() {
-  task_runner()->PostTaskAndReplyWithResult(
-      FROM_HERE,
-      base::BindOnce(&DoGenerateSingleMediaFile, playlist_dir_path_,
-                     source_media_files_dir_, unified_media_file_name_,
-                     media_file_source_files_count_),
-      base::BindOnce(&PlaylistMediaFileDownloader::OnSingleMediaFileGenerated,
-                     weak_factory_.GetWeakPtr(), current_playlist_id_));
-}
-
-// If some of source files are not fetched properly, it should be treated as
-// fail.
-void PlaylistMediaFileDownloader::OnSingleMediaFileGenerated(
-    const std::string& id,
-    bool success) {
-  // If canceled or canceled and new download is started, |id| will be different
-  // with |current_playlist_id_|.
-  // Just silently end here.
-  if (id != current_playlist_id_)
-    return;
-
-  if (success) {
-    base::FilePath media_file_path =
-        playlist_dir_path_.Append(unified_media_file_name_);
-    NotifySucceed(id, media_file_path_key_, media_file_path.AsUTF8Unsafe());
-  } else {
-    NotifyFail(id);
-  }
 }
 
 base::SequencedTaskRunner* PlaylistMediaFileDownloader::task_runner() {
@@ -320,17 +148,10 @@ base::SequencedTaskRunner* PlaylistMediaFileDownloader::task_runner() {
 
 void PlaylistMediaFileDownloader::ResetDownloadStatus() {
   in_progress_ = false;
-  remained_download_files_ = 0;
-  media_file_source_files_count_ = 0;
-  current_playlist_id_.clear();
-  current_playlist_ = base::Value();
+  current_item_.reset();
   request_helper_ = std::make_unique<api_request_helper::APIRequestHelper>(
       GetNetworkTrafficAnnotationTagForURLLoad(), url_loader_factory_);
   playlist_dir_path_.clear();
-}
-
-bool PlaylistMediaFileDownloader::IsDownloadFinished() {
-  return remained_download_files_ == 0;
 }
 
 }  // namespace playlist

--- a/components/playlist/playlist_media_file_downloader.h
+++ b/components/playlist/playlist_media_file_downloader.h
@@ -14,6 +14,7 @@
 #include "base/files/file_path.h"
 #include "base/memory/weak_ptr.h"
 #include "base/values.h"
+#include "brave/components/playlist/playlist_types.h"
 
 namespace api_request_helper {
 class APIRequestHelper;
@@ -44,7 +45,6 @@ class PlaylistMediaFileDownloader {
    public:
     // Called when target media file generation succeed.
     virtual void OnMediaFileReady(const std::string& id,
-                                  const std::string& media_file_path_key,
                                   const std::string& media_file_path) = 0;
     // Called when target media file generation failed.
     virtual void OnMediaFileGenerationFailed(const std::string& id) = 0;
@@ -53,48 +53,30 @@ class PlaylistMediaFileDownloader {
     virtual ~Delegate() {}
   };
 
-  PlaylistMediaFileDownloader(
-      Delegate* delegate,
-      content::BrowserContext* context,
-      base::FilePath::StringType source_media_files_dir,
-      base::FilePath::StringType unified_media_file_name,
-      std::string media_file_path_key,
-      std::string create_params_path_key);
+  PlaylistMediaFileDownloader(Delegate* delegate,
+                              content::BrowserContext* context,
+                              base::FilePath::StringType media_file_name);
   virtual ~PlaylistMediaFileDownloader();
 
   PlaylistMediaFileDownloader(const PlaylistMediaFileDownloader&) = delete;
   PlaylistMediaFileDownloader& operator=(const PlaylistMediaFileDownloader&) =
       delete;
 
-  void GenerateSingleMediaFile(base::Value&& playlist_value,
-                               const base::FilePath& base_dir);
+  void DownloadMediaFileForPlaylistItem(const PlaylistItemInfo& item,
+                                        const base::FilePath& base_dir);
 
   void RequestCancelCurrentPlaylistGeneration();
 
   bool in_progress() const { return in_progress_; }
-  const std::string& current_playlist_id() const {
-    return current_playlist_id_;
-  }
+  const std::string& current_playlist_id() const { return current_item_->id; }
 
  private:
   void ResetDownloadStatus();
-  void DownloadAllMediaFileSources();
   void DownloadMediaFile(const GURL& url, int index);
-  void CreateSourceFilesDirThenDownloads();
-  void OnSourceFilesDirCreated(bool success);
   void OnMediaFileDownloaded(int index, base::FilePath path);
-  void StartSingleMediaFileGeneration();
-  void OnSingleMediaFileGenerated(const std::string& id, bool success);
-
-  // True when all source media files are downloaded.
-  // If it's true, single media file will be generated.
-  bool IsDownloadFinished();
-  int GetNumberOfMediaFileSources();
 
   void NotifyFail(const std::string& id);
-  void NotifySucceed(const std::string& id,
-                     const std::string& media_file_path_key,
-                     const std::string& media_file_path);
+  void NotifySucceed(const std::string& id, const std::string& media_file_path);
 
   base::SequencedTaskRunner* task_runner();
 
@@ -103,17 +85,11 @@ class PlaylistMediaFileDownloader {
   scoped_refptr<network::SharedURLLoaderFactory> url_loader_factory_;
   std::unique_ptr<api_request_helper::APIRequestHelper> request_helper_;
 
-  const base::FilePath::StringType source_media_files_dir_;
-  const base::FilePath::StringType unified_media_file_name_;
-  const std::string media_file_path_key_;
-  const std::string create_params_path_key_;
+  const base::FilePath::StringType media_file_name_;
 
   // All below variables are only for playlist creation.
   base::FilePath playlist_dir_path_;
-  base::Value current_playlist_;
-  std::string current_playlist_id_;
-  int remained_download_files_ = 0;
-  int media_file_source_files_count_ = 0;
+  std::unique_ptr<PlaylistItemInfo> current_item_;
 
   // true when this class is working for playlist now.
   bool in_progress_ = false;

--- a/components/playlist/playlist_service.cc
+++ b/components/playlist/playlist_service.cc
@@ -38,14 +38,6 @@ constexpr base::FilePath::StringPieceType kBaseDirName =
 constexpr base::FilePath::StringPieceType kThumbnailFileName =
     FILE_PATH_LITERAL("thumbnail");
 
-PlaylistInfo CreatePlaylistInfo(const CreatePlaylistParams& params) {
-  PlaylistInfo p;
-  p.id = base::Token::CreateRandom().ToString();
-  p.playlist_name = params.playlist_name;
-  p.create_params = params;
-  return p;
-}
-
 std::vector<base::FilePath> GetOrphanedPaths(
     const base::FilePath& base_dir,
     const base::flat_set<std::string>& ids) {
@@ -73,7 +65,6 @@ PlaylistService::PlaylistService(content::BrowserContext* context,
       std::make_unique<PlaylistThumbnailDownloader>(context, this);
   download_request_manager_ =
       std::make_unique<PlaylistDownloadRequestManager>(context, this, manager);
-
   CleanUp();
 }
 
@@ -87,19 +78,22 @@ void PlaylistService::Shutdown() {
   task_runner_.reset();
 }
 
-void PlaylistService::RequestDownload(const std::string& url) {
-  download_request_manager_->GeneratePlaylistCreateParamsForYoutubeURL(url);
+void PlaylistService::RequestDownloadMediaFilesFromPage(
+    const std::string& playlist_id,
+    const std::string& url) {
+  // TODO(sko) consider |playlist_id|
+  download_request_manager_->GetMediaFilesFromPage(url);
 }
 
 void PlaylistService::OnPlaylistCreationParamsReady(
-    const CreatePlaylistParams& params) {
+    const PlaylistItemInfo& params) {
   CreatePlaylistItem(params);
 }
 
-void PlaylistService::NotifyPlaylistChanged(
-    const PlaylistChangeParams& params) {
+void PlaylistService::NotifyPlaylistItemChanged(
+    const PlaylistItemChangeParams& params) {
   VLOG(2) << __func__ << ": params="
-          << PlaylistChangeParams::GetPlaylistChangeTypeAsString(
+          << PlaylistItemChangeParams::GetPlaylistChangeTypeAsString(
                  params.change_type);
 
   for (PlaylistServiceObserver& obs : observers_)
@@ -107,22 +101,16 @@ void PlaylistService::NotifyPlaylistChanged(
 }
 
 bool PlaylistService::HasPrefStorePlaylistItem(const std::string& id) const {
-  const base::Value* playlist_info =
-      prefs_->Get(kPlaylistItems)->FindDictKey(id);
+  auto* items = prefs_->Get(kPlaylistItemsPref);
+  DCHECK(items);
+  const base::Value* playlist_info = items->FindDictKey(id);
   return !!playlist_info;
 }
 
-void PlaylistService::GenerateMediafileForPlaylistItem(const std::string& id) {
-  const base::Value* playlist_info =
-      prefs_->Get(kPlaylistItems)->FindDictKey(id);
-  if (!playlist_info) {
-    LOG(ERROR) << __func__ << ": Invalid playlist id for recover: " << id;
-    return;
-  }
-
+void PlaylistService::GenerateMediafileForPlaylistItem(
+    const PlaylistItemInfo& info) {
   VLOG(2) << __func__;
-  media_file_download_manager_->GenerateMediaFileForPlaylistItem(
-      *playlist_info);
+  media_file_download_manager_->GenerateMediaFileForPlaylistItem(info);
 }
 
 base::FilePath PlaylistService::GetPlaylistItemDirPath(
@@ -130,63 +118,58 @@ base::FilePath PlaylistService::GetPlaylistItemDirPath(
   return base_dir_.AppendASCII(id);
 }
 
-void PlaylistService::UpdatePlaylistValue(const std::string& id,
-                                          base::Value value) {
-  prefs::ScopedDictionaryPrefUpdate update(prefs_, kPlaylistItems);
+void PlaylistService::UpdatePlaylistItemValue(const std::string& id,
+                                              base::Value value) {
+  prefs::ScopedDictionaryPrefUpdate update(prefs_, kPlaylistItemsPref);
   auto playlist_items = update.Get();
   playlist_items->Set(id, base::Value::ToUniquePtrValue(std::move(value)));
 }
 
-void PlaylistService::RemovePlaylist(const std::string& id) {
-  prefs::ScopedDictionaryPrefUpdate update(prefs_, kPlaylistItems);
+void PlaylistService::RemovePlaylistItem(const std::string& id) {
+  prefs::ScopedDictionaryPrefUpdate update(prefs_, kPlaylistItemsPref);
   auto playlist_items = update.Get();
   playlist_items->Remove(id);
 }
 
-void PlaylistService::CreatePlaylistItem(const CreatePlaylistParams& params) {
+void PlaylistService::CreatePlaylistItem(const PlaylistItemInfo& params) {
   VLOG(2) << __func__;
-  const PlaylistInfo info = CreatePlaylistInfo(params);
-  UpdatePlaylistValue(info.id, GetValueFromPlaylistInfo(info));
 
-  NotifyPlaylistChanged(
-      {PlaylistChangeParams::ChangeType::kChangeTypeAdded, info.id});
+  PlaylistItemInfo info = params;
+  info.id = base::Token::CreateRandom().ToString();
+
+  UpdatePlaylistItemValue(info.id, GetValueFromPlaylistItemInfo(info));
+
+  NotifyPlaylistItemChanged({PlaylistItemChangeParams::Type::kAdded, info.id});
 
   task_runner()->PostTaskAndReplyWithResult(
       FROM_HERE,
       base::BindOnce(&base::CreateDirectory, GetPlaylistItemDirPath(info.id)),
       base::BindOnce(&PlaylistService::OnPlaylistItemDirCreated,
-                     weak_factory_.GetWeakPtr(), info.id));
+                     weak_factory_.GetWeakPtr(), info));
 }
 
-void PlaylistService::OnPlaylistItemDirCreated(const std::string& id,
+void PlaylistService::OnPlaylistItemDirCreated(const PlaylistItemInfo& info,
                                                bool directory_ready) {
   VLOG(2) << __func__;
   if (!directory_ready) {
-    NotifyPlaylistChanged(
-        {PlaylistChangeParams::ChangeType::kChangeTypeAborted, id});
+    NotifyPlaylistItemChanged(
+        {PlaylistItemChangeParams::Type::kAborted, info.id});
     return;
   }
 
-  DownloadThumbnail(id);
-  GenerateMediafileForPlaylistItem(id);
+  DownloadThumbnail(info);
+  GenerateMediafileForPlaylistItem(info);
 }
 
-void PlaylistService::DownloadThumbnail(const std::string& id) {
-  const base::Value* item_value = prefs_->Get(kPlaylistItems)->FindDictKey(id);
-  DCHECK(item_value);
-  const base::Value* create_params_value =
-      item_value->FindDictKey(kPlaylistCreateParamsKey);
-  DCHECK(create_params_value);
-  const std::string* thumbnail_url =
-      create_params_value->FindStringKey(kPlaylistPlaylistThumbnailUrlKey);
-  if (!thumbnail_url || thumbnail_url->empty()) {
-    VLOG(2) << __func__ << ": thumbnail url is not available.";
-    return;
-  }
+void PlaylistService::DownloadThumbnail(const PlaylistItemInfo& info) {
+  VLOG(2) << __func__ << " " << info.thumbnail_path;
 
-  thumbnail_downloader_->DownloadThumbnail(
-      id, GURL(*thumbnail_url),
-      GetPlaylistItemDirPath(id).Append(kThumbnailFileName));
+  if (GURL thumbnail_url(info.thumbnail_path);
+      thumbnail_url.is_valid() && !thumbnail_url.SchemeIsFile()) {
+    thumbnail_downloader_->DownloadThumbnail(
+        info.id, thumbnail_url,
+        GetPlaylistItemDirPath(info.id).Append(kThumbnailFileName));
+  }
 }
 
 void PlaylistService::OnThumbnailDownloaded(const std::string& id,
@@ -195,52 +178,50 @@ void PlaylistService::OnThumbnailDownloaded(const std::string& id,
 
   if (path.empty()) {
     VLOG(2) << __func__ << ": thumbnail fetching failed for " << id;
-    NotifyPlaylistChanged(
-        {PlaylistChangeParams::ChangeType::kChangeTypeThumbnailFailed, id});
+    NotifyPlaylistItemChanged(
+        {PlaylistItemChangeParams::Type::kThumbnailFailed, id});
     return;
   }
 
-  const base::Value* value = prefs_->Get(kPlaylistItems)->FindDictKey(id);
+  const base::Value* value = prefs_->Get(kPlaylistItemsPref)->FindDictKey(id);
   DCHECK(value);
   if (value) {
     base::Value copied_value = value->Clone();
-    copied_value.SetStringKey(kPlaylistThumbnailPathKey, path.AsUTF8Unsafe());
-    UpdatePlaylistValue(id, std::move(copied_value));
-    NotifyPlaylistChanged(
-        {PlaylistChangeParams::ChangeType::kChangeTypeThumbnailReady, id});
+    copied_value.SetStringKey(kPlaylistItemThumbnailPathKey,
+                              path.AsUTF8Unsafe());
+    UpdatePlaylistItemValue(id, std::move(copied_value));
+    NotifyPlaylistItemChanged(
+        {PlaylistItemChangeParams::Type::kThumbnailReady, id});
   }
 }
 
 base::Value PlaylistService::GetAllPlaylistItems() {
   base::Value playlist(base::Value::Type::LIST);
-  for (const auto it : prefs_->Get(kPlaylistItems)->GetDict()) {
-    base::Value item = it.second.Clone();
-    item.RemoveKey(kPlaylistCreateParamsKey);
-    playlist.Append(std::move(item));
-  }
+  for (const auto it : prefs_->Get(kPlaylistItemsPref)->GetDict())
+    playlist.Append(it.second.Clone());
 
   return playlist;
 }
 
 base::Value PlaylistService::GetPlaylistItem(const std::string& id) {
-  const base::Value* item_value_ptr =
-      prefs_->Get(kPlaylistItems)->FindDictKey(id);
-  if (item_value_ptr) {
-    base::Value item = item_value_ptr->Clone();
-    item.RemoveKey(kPlaylistCreateParamsKey);
-    return item;
+  if (const base::Value* item_value_ptr =
+          prefs_->Get(kPlaylistItemsPref)->FindDictKey(id)) {
+    return item_value_ptr->Clone();
   }
+
   return {};
 }
 
 void PlaylistService::RecoverPlaylistItem(const std::string& id) {
-  const base::Value* playlist_info =
-      prefs_->Get(kPlaylistItems)->FindDictKey(id);
-  if (!playlist_info) {
+  const base::Value* playlist_value =
+      prefs_->Get(kPlaylistItemsPref)->FindDictKey(id);
+  if (!playlist_value) {
     LOG(ERROR) << __func__ << ": Invalid playlist id for recover: " << id;
     return;
   }
-  absl::optional<bool> ready = playlist_info->FindBoolPath(kPlaylistReadyKey);
+
+  absl::optional<bool> ready =
+      playlist_value->FindBoolPath(kPlaylistItemReadyKey);
   if (*ready) {
     VLOG(2) << __func__ << ": This is ready to play(" << id << ")";
     return;
@@ -248,32 +229,37 @@ void PlaylistService::RecoverPlaylistItem(const std::string& id) {
 
   VLOG(2) << __func__ << ": This is in recovering playlist item(" << id << ")";
 
-  const std::string* thumbnail_path_str =
-      playlist_info->FindStringPath(kPlaylistThumbnailPathKey);
-  const bool has_thumbnail =
-      !!thumbnail_path_str && !thumbnail_path_str->empty();
-  if (!has_thumbnail)
-    DownloadThumbnail(id);
+  PlaylistItemInfo info;
+  info.id = *playlist_value->FindStringKey(kPlaylistItemIDKey);
+  info.title = *playlist_value->FindStringKey(kPlaylistItemTitleKey);
 
-  const std::string* video_media_file_path =
-      playlist_info->FindStringPath(kPlaylistVideoMediaFilePathKey);
-  const std::string* audio_media_file_path =
-      playlist_info->FindStringPath(kPlaylistAudioMediaFilePathKey);
-  // Only try to regenerate if partial ready or there is no media file.
-  if (!video_media_file_path || video_media_file_path->empty() ||
-      !audio_media_file_path || audio_media_file_path->empty()) {
+  const std::string* thumbnail_path_str =
+      playlist_value->FindStringPath(kPlaylistItemThumbnailPathKey);
+  if (thumbnail_path_str)
+    info.thumbnail_path = *thumbnail_path_str;
+
+  const std::string* media_file_path =
+      playlist_value->FindStringPath(kPlaylistItemMediaFilePathKey);
+  if (media_file_path)
+    info.media_file_path = *media_file_path;
+
+  if (thumbnail_path_str && !thumbnail_path_str->empty()) {
+    VLOG(2) << __func__ << ": Regenerate thumbnail";
+    DownloadThumbnail(info);
+  }
+
+  if (media_file_path && !media_file_path->empty()) {
     VLOG(2) << __func__ << ": Regenerate media file";
-    GenerateMediafileForPlaylistItem(id);
+    GenerateMediafileForPlaylistItem(info);
   }
 }
 
 void PlaylistService::DeletePlaylistItem(const std::string& id) {
   media_file_download_manager_->CancelDownloadRequest(id);
   thumbnail_downloader_->CancelDownloadRequest(id);
-  RemovePlaylist(id);
+  RemovePlaylistItem(id);
 
-  NotifyPlaylistChanged(
-      {PlaylistChangeParams::ChangeType::kChangeTypeDeleted, id});
+  NotifyPlaylistItemChanged({PlaylistItemChangeParams::Type::kDeleted, id});
 
   // TODO(simonhong): Delete after getting cancel complete message from all
   // downloader.
@@ -290,10 +276,9 @@ void PlaylistService::DeleteAllPlaylistItems() {
   media_file_download_manager_->CancelAllDownloadRequests();
   thumbnail_downloader_->CancelAllDownloadRequests();
 
-  prefs_->ClearPref(kPlaylistItems);
+  prefs_->ClearPref(kPlaylistItemsPref);
 
-  NotifyPlaylistChanged(
-      {PlaylistChangeParams::ChangeType::kChangeTypeAllDeleted, ""});
+  NotifyPlaylistItemChanged({PlaylistItemChangeParams::Type::kAllDeleted, ""});
 
   CleanUp();
 }
@@ -307,22 +292,19 @@ void PlaylistService::RemoveObserver(PlaylistServiceObserver* observer) {
 }
 
 void PlaylistService::OnMediaFileReady(const std::string& id,
-                                       const std::string& audio_file_path,
-                                       const std::string& video_file_path) {
+                                       const std::string& media_file_path) {
   VLOG(2) << __func__ << ": " << id;
   DCHECK(IsValidPlaylistItem(id));
 
   const base::Value* item_value_ptr =
-      prefs_->Get(kPlaylistItems)->FindDictKey(id);
+      prefs_->Get(kPlaylistItemsPref)->FindDictKey(id);
   base::Value item = item_value_ptr->Clone();
 
-  item.SetBoolKey(kPlaylistReadyKey, true);
-  item.SetStringKey(kPlaylistAudioMediaFilePathKey, audio_file_path);
-  item.SetStringKey(kPlaylistVideoMediaFilePathKey, video_file_path);
-  UpdatePlaylistValue(id, std::move(item));
+  item.SetBoolKey(kPlaylistItemReadyKey, true);
+  item.SetStringKey(kPlaylistItemMediaFilePathKey, media_file_path);
+  UpdatePlaylistItemValue(id, std::move(item));
 
-  NotifyPlaylistChanged(
-      {PlaylistChangeParams::ChangeType::kChangeTypePlayReady, id});
+  NotifyPlaylistItemChanged({PlaylistItemChangeParams::Type::kPlayReady, id});
 }
 
 void PlaylistService::OnMediaFileGenerationFailed(const std::string& id) {
@@ -331,18 +313,15 @@ void PlaylistService::OnMediaFileGenerationFailed(const std::string& id) {
   DCHECK(IsValidPlaylistItem(id));
 
   const base::Value* item_value_ptr =
-      prefs_->Get(kPlaylistItems)->FindDictKey(id);
+      prefs_->Get(kPlaylistItemsPref)->FindDictKey(id);
   base::Value item = item_value_ptr->Clone();
 
-  item.SetBoolKey(kPlaylistReadyKey, false);
-  item.SetStringKey(kPlaylistAudioMediaFilePathKey, "");
-  item.SetStringKey(kPlaylistVideoMediaFilePathKey, "");
+  item.SetBoolKey(kPlaylistItemReadyKey, false);
 
-  UpdatePlaylistValue(id, std::move(item));
+  UpdatePlaylistItemValue(id, std::move(item));
 
   thumbnail_downloader_->CancelDownloadRequest(id);
-  NotifyPlaylistChanged(
-      {PlaylistChangeParams::ChangeType::kChangeTypeAborted, id});
+  NotifyPlaylistItemChanged({PlaylistItemChangeParams::Type::kAborted, id});
 }
 
 bool PlaylistService::IsValidPlaylistItem(const std::string& id) {
@@ -368,7 +347,7 @@ void PlaylistService::CleanUp() {
 
   base::flat_set<std::string> ids;
   for (const auto& item : playlist.GetList()) {
-    const std::string* id = item.FindStringKey(kPlaylistIDKey);
+    const std::string* id = item.FindStringKey(kPlaylistItemIDKey);
     DCHECK(id);
     if (id)
       ids.insert(*id);

--- a/components/playlist/playlist_service.h
+++ b/components/playlist/playlist_service.h
@@ -35,7 +35,6 @@ namespace playlist {
 
 class PlaylistServiceObserver;
 class MediaDetectorComponentManager;
-struct CreatePlaylistParams;
 
 // This class is key interace for playlist. Client will ask any playlist related
 // requests to this class.
@@ -52,7 +51,7 @@ struct CreatePlaylistParams;
 // Next, PlaylistService asks downloading audio/video media files and thumbnails
 // to PlaylistMediaFileDownloadManager and PlaylistThumbnailDownloader.
 // When each of data is ready to use it's notified to client.
-// You can see all notification type - PlaylistChangeParams::ChangeType.
+// You can see all notification type - PlaylistItemChangeParams::Type.
 class PlaylistService : public KeyedService,
                         public PlaylistMediaFileDownloadManager::Delegate,
                         public PlaylistThumbnailDownloader::Delegate,
@@ -69,7 +68,8 @@ class PlaylistService : public KeyedService,
   void RecoverPlaylistItem(const std::string& id);
   void DeletePlaylistItem(const std::string& id);
   void DeleteAllPlaylistItems();
-  void RequestDownload(const std::string& url);
+  void RequestDownloadMediaFilesFromPage(const std::string& playlist_id,
+                                         const std::string& url);
 
   void AddObserver(PlaylistServiceObserver* observer);
   void RemoveObserver(PlaylistServiceObserver* observer);
@@ -92,8 +92,7 @@ class PlaylistService : public KeyedService,
   // PlaylistMediaFileDownloadManager::Delegate overrides:
   // Called when all audio/video media file are downloaded.
   void OnMediaFileReady(const std::string& id,
-                        const std::string& audio_file_path,
-                        const std::string& video_file_path) override;
+                        const std::string& media_file_path) override;
   void OnMediaFileGenerationFailed(const std::string& id) override;
   bool IsValidPlaylistItem(const std::string& id) override;
 
@@ -105,14 +104,14 @@ class PlaylistService : public KeyedService,
   // PlaylistDownloadRequestManager::Delegate overrides:
   // Called when meta data is ready. |params| have playlist item's audio/video
   // media files url, thumbnail and title.
-  void OnPlaylistCreationParamsReady(
-      const CreatePlaylistParams& params) override;
+  void OnPlaylistCreationParamsReady(const PlaylistItemInfo& params) override;
 
-  void OnPlaylistItemDirCreated(const std::string& id, bool directory_ready);
+  void OnPlaylistItemDirCreated(const PlaylistItemInfo& info,
+                                bool directory_ready);
 
-  void CreatePlaylistItem(const CreatePlaylistParams& params);
-  void DownloadThumbnail(const std::string& id);
-  void GenerateMediafileForPlaylistItem(const std::string& id);
+  void CreatePlaylistItem(const PlaylistItemInfo& info);
+  void DownloadThumbnail(const PlaylistItemInfo& info);
+  void GenerateMediafileForPlaylistItem(const PlaylistItemInfo& info);
 
   base::SequencedTaskRunner* task_runner();
 
@@ -120,10 +119,10 @@ class PlaylistService : public KeyedService,
   void CleanUp();
   void OnGetOrphanedPaths(const std::vector<base::FilePath> paths);
 
-  void NotifyPlaylistChanged(const PlaylistChangeParams& params);
+  void NotifyPlaylistItemChanged(const PlaylistItemChangeParams& params);
 
-  void UpdatePlaylistValue(const std::string& id, base::Value value);
-  void RemovePlaylist(const std::string& id);
+  void UpdatePlaylistItemValue(const std::string& id, base::Value value);
+  void RemovePlaylistItem(const std::string& id);
 
   bool HasPrefStorePlaylistItem(const std::string& id) const;
 

--- a/components/playlist/playlist_service_helper.cc
+++ b/components/playlist/playlist_service_helper.cc
@@ -13,59 +13,15 @@
 
 namespace playlist {
 
-namespace {
-
-base::Value GetValueFromMediaFile(const MediaFileInfo& info) {
-  base::Value media_file(base::Value::Type::DICTIONARY);
-  media_file.SetStringKey(kPlaylistMediaFileUrlKey, info.media_file_url);
-  media_file.SetStringKey(kPlaylistMediaFileTitleKey, info.media_file_title);
-  return media_file;
-}
-
-base::Value GetValueFromCreateParams(const CreatePlaylistParams& params) {
-  base::Value create_params_value(base::Value::Type::DICTIONARY);
-  create_params_value.SetStringKey(kPlaylistPlaylistThumbnailUrlKey,
-                                   params.playlist_thumbnail_url);
-  create_params_value.SetStringKey(kPlaylistPlaylistNameKey,
-                                   params.playlist_name);
-  create_params_value.SetKey(kPlaylistVideoMediaFilesKey,
-                             GetValueFromMediaFiles(params.video_media_files));
-  create_params_value.SetKey(kPlaylistAudioMediaFilesKey,
-                             GetValueFromMediaFiles(params.audio_media_files));
-  return create_params_value;
-}
-
-base::Value GetTitleValueFromCreateParams(const CreatePlaylistParams& params) {
-  base::Value titles_value(base::Value::Type::LIST);
-  for (const MediaFileInfo& info : params.video_media_files)
-    titles_value.Append(base::Value(info.media_file_title));
-  return titles_value;
-}
-
-}  // namespace
-
-base::Value GetValueFromMediaFiles(
-    const std::vector<MediaFileInfo>& media_files) {
-  base::Value media_files_value(base::Value::Type::LIST);
-  for (const MediaFileInfo& info : media_files)
-    media_files_value.Append(GetValueFromMediaFile(info));
-  return media_files_value;
-}
-
-base::Value GetValueFromPlaylistInfo(const PlaylistInfo& info) {
+base::Value GetValueFromPlaylistItemInfo(const PlaylistItemInfo& info) {
   base::Value playlist_value(base::Value::Type::DICTIONARY);
-  playlist_value.SetStringKey(kPlaylistIDKey, info.id);
-  playlist_value.SetStringKey(kPlaylistPlaylistNameKey, info.playlist_name);
-  playlist_value.SetStringKey(kPlaylistThumbnailPathKey, info.thumbnail_path);
-  playlist_value.SetStringKey(kPlaylistVideoMediaFilePathKey,
-                              info.video_media_file_path);
-  playlist_value.SetStringKey(kPlaylistAudioMediaFilePathKey,
-                              info.audio_media_file_path);
-  playlist_value.SetBoolKey(kPlaylistReadyKey, info.ready);
-  playlist_value.SetKey(kPlaylistTitlesKey,
-                        GetTitleValueFromCreateParams(info.create_params));
-  playlist_value.SetKey(kPlaylistCreateParamsKey,
-                        GetValueFromCreateParams(info.create_params));
+  playlist_value.SetStringKey(kPlaylistItemIDKey, info.id);
+  playlist_value.SetStringKey(kPlaylistItemTitleKey, info.title);
+  playlist_value.SetStringKey(kPlaylistItemThumbnailPathKey,
+                              info.thumbnail_path);
+  playlist_value.SetStringKey(kPlaylistItemMediaFilePathKey,
+                              info.media_file_path);
+  playlist_value.SetBoolKey(kPlaylistItemReadyKey, info.ready);
   return playlist_value;
 }
 

--- a/components/playlist/playlist_service_helper.h
+++ b/components/playlist/playlist_service_helper.h
@@ -14,12 +14,9 @@ class Value;
 
 namespace playlist {
 
-struct PlaylistInfo;
-struct MediaFileInfo;
+struct PlaylistItemInfo;
 
-base::Value GetValueFromMediaFiles(
-    const std::vector<MediaFileInfo>& media_files);
-base::Value GetValueFromPlaylistInfo(const PlaylistInfo& info);
+base::Value GetValueFromPlaylistItemInfo(const PlaylistItemInfo& info);
 
 }  // namespace playlist
 

--- a/components/playlist/playlist_service_observer.h
+++ b/components/playlist/playlist_service_observer.h
@@ -10,12 +10,12 @@
 
 namespace playlist {
 
-struct PlaylistChangeParams;
+struct PlaylistItemChangeParams;
 
 class PlaylistServiceObserver : public base::CheckedObserver {
  public:
   virtual void OnPlaylistItemStatusChanged(
-      const PlaylistChangeParams& params) = 0;
+      const PlaylistItemChangeParams& params) = 0;
 };
 
 }  // namespace playlist

--- a/components/playlist/playlist_thumbnail_downloader.cc
+++ b/components/playlist/playlist_thumbnail_downloader.cc
@@ -51,14 +51,18 @@ void PlaylistThumbnailDownloader::DownloadThumbnail(
     const std::string& id,
     const GURL& thumbnail_url,
     const base::FilePath& target_thumbnail_path) {
+  VLOG(2) << __func__ << " " << id << " : " << thumbnail_url.spec();
+  CancelDownloadRequest(id);
+
   auto ticket = request_helper_->Download(
       thumbnail_url, {}, {}, true, target_thumbnail_path,
       base::BindOnce(&PlaylistThumbnailDownloader::OnThumbnailDownloaded,
                      base::Unretained(this), id));
-  ticket_map_.insert_or_assign(id, ticket);
+  ticket_map_[id] = ticket;
 }
 
 void PlaylistThumbnailDownloader::CancelDownloadRequest(const std::string& id) {
+  VLOG(2) << __func__ << " " << id;
   if (!ticket_map_.count(id))
     return;
 
@@ -67,6 +71,7 @@ void PlaylistThumbnailDownloader::CancelDownloadRequest(const std::string& id) {
 }
 
 void PlaylistThumbnailDownloader::CancelAllDownloadRequests() {
+  VLOG(2) << __func__;
   request_helper_ = std::make_unique<api_request_helper::APIRequestHelper>(
       GetNetworkTrafficAnnotationTagForURLLoad(), url_loader_factory_);
   ticket_map_.clear();
@@ -74,6 +79,7 @@ void PlaylistThumbnailDownloader::CancelAllDownloadRequests() {
 
 void PlaylistThumbnailDownloader::OnThumbnailDownloaded(const std::string& id,
                                                         base::FilePath path) {
+  VLOG(2) << __func__ << " id: " << id;
   DCHECK(!ticket_map_.empty());
   ticket_map_.erase(id);
   delegate_->OnThumbnailDownloaded(id, path);

--- a/components/playlist/playlist_types.cc
+++ b/components/playlist/playlist_types.cc
@@ -10,58 +10,45 @@
 
 namespace playlist {
 
-std::string PlaylistChangeParams::GetPlaylistChangeTypeAsString(
-    PlaylistChangeParams::ChangeType type) {
+std::string PlaylistItemChangeParams::GetPlaylistChangeTypeAsString(
+    PlaylistItemChangeParams::Type type) {
   switch (type) {
-    case PlaylistChangeParams::ChangeType::kChangeTypeAdded:
-      return "added";
-    case PlaylistChangeParams::ChangeType::kChangeTypeDeleted:
-      return "deleted";
-    case PlaylistChangeParams::ChangeType::kChangeTypeAllDeleted:
-      return "all_deleted";
-    case PlaylistChangeParams::ChangeType::kChangeTypeAborted:
-      return "aborted";
-    case PlaylistChangeParams::ChangeType::kChangeTypeThumbnailReady:
-      return "thumbnail_ready";
-    case PlaylistChangeParams::ChangeType::kChangeTypeThumbnailFailed:
-      return "thumbnail_failed";
-    case PlaylistChangeParams::ChangeType::kChangeTypePlayReady:
-      return "play_ready";
-    case PlaylistChangeParams::ChangeType::kChangeTypeNone:
+    case PlaylistItemChangeParams::Type::kAdded:
+      return "item: added";
+    case PlaylistItemChangeParams::Type::kDeleted:
+      return "item: deleted";
+    case PlaylistItemChangeParams::Type::kAborted:
+      return "item: aborted";
+    case PlaylistItemChangeParams::Type::kThumbnailReady:
+      return "item: thumbnail_ready";
+    case PlaylistItemChangeParams::Type::kThumbnailFailed:
+      return "item: thumbnail_failed";
+    case PlaylistItemChangeParams::Type::kPlayReady:
+      return "item: play_ready";
+    case PlaylistItemChangeParams::Type::kAllDeleted:
+      return "item: all deleted";
+    case PlaylistItemChangeParams::Type::kNone:
       [[fallthrough]];
     default:
       NOTREACHED();
-      return "unknown";
+      return "item: unknown";
   }
 }
 
-PlaylistChangeParams::PlaylistChangeParams() = default;
+PlaylistItemChangeParams::PlaylistItemChangeParams() = default;
 
-PlaylistChangeParams::PlaylistChangeParams(ChangeType type,
-                                           const std::string& id)
+PlaylistItemChangeParams::PlaylistItemChangeParams(Type type,
+                                                   const std::string& id)
     : change_type(type), playlist_id(id) {}
-PlaylistChangeParams::~PlaylistChangeParams() = default;
+PlaylistItemChangeParams::~PlaylistItemChangeParams() = default;
 
-MediaFileInfo::MediaFileInfo(const std::string& url, const std::string& title)
-    : media_file_url(url), media_file_title(title) {}
-MediaFileInfo::~MediaFileInfo() {}
-
-CreatePlaylistParams::CreatePlaylistParams() = default;
-CreatePlaylistParams::~CreatePlaylistParams() = default;
-CreatePlaylistParams::CreatePlaylistParams(const CreatePlaylistParams& rhs) =
+PlaylistItemInfo::PlaylistItemInfo() = default;
+PlaylistItemInfo::~PlaylistItemInfo() = default;
+PlaylistItemInfo::PlaylistItemInfo(const PlaylistItemInfo& rhs) = default;
+PlaylistItemInfo& PlaylistItemInfo::operator=(const PlaylistItemInfo& rhs) =
     default;
-CreatePlaylistParams& CreatePlaylistParams::operator=(
-    const CreatePlaylistParams& rhs) = default;
-CreatePlaylistParams::CreatePlaylistParams(
-    CreatePlaylistParams&& rhs) noexcept = default;
-CreatePlaylistParams& CreatePlaylistParams::operator=(
-    CreatePlaylistParams&& rhs) noexcept = default;
-
-PlaylistInfo::PlaylistInfo() = default;
-PlaylistInfo::~PlaylistInfo() = default;
-PlaylistInfo::PlaylistInfo(const PlaylistInfo& rhs) = default;
-PlaylistInfo& PlaylistInfo::operator=(const PlaylistInfo& rhs) = default;
-PlaylistInfo::PlaylistInfo(PlaylistInfo&& rhs) noexcept = default;
-PlaylistInfo& PlaylistInfo::operator=(PlaylistInfo&& rhs) noexcept = default;
+PlaylistItemInfo::PlaylistItemInfo(PlaylistItemInfo&& rhs) noexcept = default;
+PlaylistItemInfo& PlaylistItemInfo::operator=(PlaylistItemInfo&& rhs) noexcept =
+    default;
 
 }  // namespace playlist

--- a/components/playlist/playlist_types.h
+++ b/components/playlist/playlist_types.h
@@ -11,68 +11,42 @@
 
 namespace playlist {
 
-struct PlaylistChangeParams {
-  enum class ChangeType {
-    kChangeTypeNone,
-    kChangeTypeAdded,            // New playlist added but not ready state
-    kChangeTypeThumbnailReady,   // Thumbnail ready to use for playlist
-    kChangeTypeThumbnailFailed,  // Failed to fetch thumbnail
-    kChangeTypePlayReady,        // Playlist ready to play
-    kChangeTypeDeleted,          // A playlist deleted
-    kChangeTypeAllDeleted,       // All playlist are deleted
-    kChangeTypeAborted,          // Aborted during the creation process
+struct PlaylistItemChangeParams {
+  enum class Type {
+    kNone,
+    kAdded,            // New playlist added but not ready state
+    kThumbnailReady,   // Thumbnail ready to use for playlist
+    kThumbnailFailed,  // Failed to fetch thumbnail
+    kPlayReady,        // Playlist ready to play
+    kDeleted,          // A playlist deleted
+    kAborted,          // Aborted during the creation process
+
+    // TODO(sko) This should be event of Playlist, not of PlaylistItem.
+    kAllDeleted,  // All playlist are deleted
   };
-  static std::string GetPlaylistChangeTypeAsString(
-      PlaylistChangeParams::ChangeType type);
+  static std::string GetPlaylistChangeTypeAsString(Type type);
 
-  PlaylistChangeParams();
-  PlaylistChangeParams(ChangeType type, const std::string& id);
-  ~PlaylistChangeParams();
+  PlaylistItemChangeParams();
+  PlaylistItemChangeParams(Type type, const std::string& id);
+  ~PlaylistItemChangeParams();
 
-  ChangeType change_type = ChangeType::kChangeTypeNone;
+  Type change_type = Type::kNone;
   std::string playlist_id;
 };
 
-struct MediaFileInfo {
-  MediaFileInfo(const std::string& url, const std::string& title);
-  ~MediaFileInfo();
-
-  std::string media_file_url;
-  std::string media_file_title;
-};
-
-struct CreatePlaylistParams {
-  CreatePlaylistParams();
-  CreatePlaylistParams(const CreatePlaylistParams& rhs);
-  CreatePlaylistParams& operator=(const CreatePlaylistParams& rhs);
-  CreatePlaylistParams(CreatePlaylistParams&& rhs) noexcept;
-  CreatePlaylistParams& operator=(CreatePlaylistParams&& rhs) noexcept;
-  ~CreatePlaylistParams();
-
-  std::string playlist_thumbnail_url;
-  std::string playlist_name;
-  std::vector<MediaFileInfo> video_media_files;
-  std::vector<MediaFileInfo> audio_media_files;
-};
-
-// TODO(simonhong): Rename to PlaylistItemInfo
-struct PlaylistInfo {
-  PlaylistInfo();
-  PlaylistInfo(const PlaylistInfo& rhs);
-  PlaylistInfo& operator=(const PlaylistInfo& rhs);
-  PlaylistInfo(PlaylistInfo&& rhs) noexcept;
-  PlaylistInfo& operator=(PlaylistInfo&& rhs) noexcept;
-  ~PlaylistInfo();
+struct PlaylistItemInfo {
+  PlaylistItemInfo();
+  PlaylistItemInfo(const PlaylistItemInfo& rhs);
+  PlaylistItemInfo& operator=(const PlaylistItemInfo& rhs);
+  PlaylistItemInfo(PlaylistItemInfo&& rhs) noexcept;
+  PlaylistItemInfo& operator=(PlaylistItemInfo&& rhs) noexcept;
+  ~PlaylistItemInfo();
 
   std::string id;
-  // TODO(simonhong): Delete this. |create_params| has it.
-  std::string playlist_name;
+  std::string title;
   std::string thumbnail_path;
-  std::string video_media_file_path;
-  std::string audio_media_file_path;
+  std::string media_file_path;
   bool ready{false};
-
-  CreatePlaylistParams create_params;
 };
 
 }  // namespace playlist

--- a/components/playlist/pref_names.h
+++ b/components/playlist/pref_names.h
@@ -8,9 +8,16 @@
 
 namespace playlist {
 
+// Lists of playlist items. Each list has ids of it's items
+// so that multiple lists can share same item efficiently
+// e.g. list [{ name: "playlist1", items: [id1, id2, id3] },
+//            { name: "playlist2", items: [id1, id4, id5] }]
+//                                          ^ same item
+constexpr char kPlaylistListsPref[] = "brave.playlist.lists";
+
 // Stores playlist item key-value pairs in a dict. Each item has unique key and
 // it's metadata(such as, title, media file path and etc..).
-constexpr char kPlaylistItems[] = "brave.playlist.items";
+constexpr char kPlaylistItemsPref[] = "brave.playlist.items";
 
 }  // namespace playlist
 


### PR DESCRIPTION
The goal of this refactoring is
* Clean up data structures
  * Distinguish Playlist and PlaylistItem
  * Currently the core assumes that there's only one playlist
  * But our spec require us to support multiple playlists for users
* Make use of new js script to detect media files
  * Now we don't get separated auido/video files. Thus, cleaned up
    code that we don't need anymore.
  * Temporarily, bundle the script in the binary. this should be
    converted to component extensions.
  * also it'd be good to have unittests for this script.

<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/23967

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

