### PR TITLE
fix(wallet): use hex-encoded blockCount param for eth_feeHistory (uplift to 1.42.x)

### DIFF
--- a/components/brave_wallet/browser/eth_requests.cc
+++ b/components/brave_wallet/browser/eth_requests.cc
@@ -70,7 +70,7 @@ std::string eth_blockNumber() {
   return GetJsonRpcNoParams("eth_blockNumber");
 }
 
-std::string eth_feeHistory(int num_blocks,
+std::string eth_feeHistory(const std::string& num_blocks,
                            const std::string& head,
                            const std::vector<double>& reward_percentiles) {
   base::Value percentile_values(base::Value::Type::LIST);

--- a/components/brave_wallet/browser/eth_requests.h
+++ b/components/brave_wallet/browser/eth_requests.h
@@ -45,7 +45,7 @@ std::string eth_accounts();
 // Returns the number of most recent block.
 std::string eth_blockNumber();
 // Returns the fee history.
-std::string eth_feeHistory(int num_blocks,
+std::string eth_feeHistory(const std::string& num_blocks,
                            const std::string& head,
                            const std::vector<double>& reward_percentiles);
 // Returns the balance of the account of given address.

--- a/components/brave_wallet/browser/eth_requests_unittest.cc
+++ b/components/brave_wallet/browser/eth_requests_unittest.cc
@@ -85,8 +85,8 @@ TEST(EthRequestUnitTest, eth_blockNumber) {
 
 TEST(EthRequestUnitTest, eth_feeHistory) {
   ASSERT_EQ(
-      eth_feeHistory(40, "latest", std::vector<double>{20, 50, 80}),
-      R"({"id":1,"jsonrpc":"2.0","method":"eth_feeHistory","params":[40,"latest",[20.0,50.0,80.0]]})");
+      eth_feeHistory("0x28", "latest", std::vector<double>{20, 50, 80}),
+      R"({"id":1,"jsonrpc":"2.0","method":"eth_feeHistory","params":["0x28","latest",[20.0,50.0,80.0]]})");
 }
 
 TEST(EthRequestUnitTest, eth_getBalance) {

--- a/components/brave_wallet/browser/json_rpc_service.cc
+++ b/components/brave_wallet/browser/json_rpc_service.cc
@@ -611,8 +611,9 @@ void JsonRpcService::GetFeeHistory(GetFeeHistoryCallback callback) {
                      weak_ptr_factory_.GetWeakPtr(), std::move(callback));
 
   RequestInternal(
-      eth::eth_feeHistory(40, "latest", std::vector<double>{20, 50, 80}), true,
-      network_urls_[mojom::CoinType::ETH], std::move(internal_callback));
+      eth::eth_feeHistory("0x28",  // blockCount = 40
+                          "latest", std::vector<double>{20, 50, 80}),
+      true, network_urls_[mojom::CoinType::ETH], std::move(internal_callback));
 }
 
 void JsonRpcService::OnGetFeeHistory(


### PR DESCRIPTION
Uplift of #14088
Resolves https://github.com/brave/brave-browser/issues/23529

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.