### PR TITLE
Revert "Skip license checking for temp dirs created during the sync"

### DIFF
--- a/script/brave_license_helper.py
+++ b/script/brave_license_helper.py
@@ -161,11 +161,6 @@ def AddBraveCredits(prune_paths, special_cases, prune_dirs, additional_paths):
 
 
 def CheckBraveMissingLicense(target_os, path, error):
-    # Skip chekcing for temp dirs from gclient.
-    # This is workaround fix. Temp dir should not be existed in vendor dir.
-    if path.replace('\\', '/').startswith('brave/vendor/_gclient'):
-        return
-
     if path.startswith('brave'):
         if target_os == 'android':
             if path in DESKTOP_ONLY_PATHS:


### PR DESCRIPTION
Reverts brave/brave-core#13585

fix https://github.com/brave/brave-browser/issues/23226

As @goodov mentioned at https://github.com/brave/brave-browser/issues/23226#issuecomment-1170068413, we can revert this.