### PR TITLE
fix(wallet): correctly handle extra calldata bytes

### DIFF
--- a/components/brave_wallet/browser/eth_abi_decoder.cc
+++ b/components/brave_wallet/browser/eth_abi_decoder.cc
@@ -242,14 +242,14 @@ absl::optional<std::vector<std::string>> UniswapEncodedPathDecode(
   return path;
 }
 
-absl::optional<std::tuple<std::vector<std::string>,   // tx_params
-                          std::vector<std::string>>>  // tx_args
+absl::optional<std::tuple<std::vector<std::string>,   // params
+                          std::vector<std::string>>>  // args
 ABIDecode(const std::vector<std::string>& types,
           const std::vector<uint8_t>& data) {
   size_t offset = 0;
   size_t calldata_tail = 0;
-  std::vector<std::string> tx_params;
-  std::vector<std::string> tx_args;
+  std::vector<std::string> params;
+  std::vector<std::string> args;
 
   for (const auto& type : types) {
     absl::optional<std::string> value;
@@ -285,15 +285,13 @@ ABIDecode(const std::vector<std::string>& types,
 
     offset += 32;
 
-    tx_args.push_back(*value);
-    tx_params.push_back(type);
+    args.push_back(*value);
+    params.push_back(type);
   }
 
-  // Extraneous calldata, unless in the tail section, is considered invalid.
-  if (offset != calldata_tail && offset < data.size())
-    return absl::nullopt;
+  // Extra calldata bytes are ignored.
 
-  return std::make_tuple(tx_params, tx_args);
+  return std::make_tuple(params, args);
 }
 
 }  // namespace brave_wallet

--- a/components/brave_wallet/browser/eth_abi_decoder_unittest.cc
+++ b/components/brave_wallet/browser/eth_abi_decoder_unittest.cc
@@ -39,68 +39,78 @@ TEST(EthABIDecoderTest, ABIDecodeAddress) {
 TEST(EthABIDecoderTest, ABIDecodeUint256) {
   std::vector<std::string> tx_params;
   std::vector<std::string> tx_args;
-
   std::vector<uint8_t> data;
+
+  // OK: 32-bytes well-formed uint256
   ASSERT_TRUE(PrefixedHexStringToBytes(
       "0x00000000000000000000000000000000000000000000000000000000000000ff",
       &data));
   auto decoded = ABIDecode({"uint256"}, data);
   ASSERT_NE(decoded, absl::nullopt);
   std::tie(tx_params, tx_args) = *decoded;
-
   ASSERT_EQ(tx_params.size(), 1UL);
   EXPECT_EQ(tx_params[0], "uint256");
   EXPECT_EQ(tx_args[0], "0xff");
 
-  // Insufficient uint256 length
+  // KO: insufficient uint256 length
   ASSERT_TRUE(PrefixedHexStringToBytes("0xff", &data));
   ASSERT_FALSE(ABIDecode({"uint256"}, data));
 
-  // Extra uint256 length
+  // OK: extra uint256 length
   ASSERT_TRUE(PrefixedHexStringToBytes(
       "0x00000000000000000000000000000000000000000000000000000000000000ff"
       "ff",
       &data));
-  ASSERT_FALSE(ABIDecode({"uint256"}, data));
+  decoded = ABIDecode({"uint256"}, data);
+  ASSERT_NE(decoded, absl::nullopt);
+  std::tie(tx_params, tx_args) = *decoded;
+  ASSERT_EQ(tx_params.size(), 1UL);
+  EXPECT_EQ(tx_params[0], "uint256");
+  EXPECT_EQ(tx_args[0], "0xff");
 }
 
 TEST(EthABIDecoderTest, ABIDecodeBool) {
   std::vector<std::string> tx_params;
   std::vector<std::string> tx_args;
-
   std::vector<uint8_t> data;
+
+  // OK: false
   ASSERT_TRUE(PrefixedHexStringToBytes(
       "0x0000000000000000000000000000000000000000000000000000000000000000",
       &data));
   auto decoded = ABIDecode({"bool"}, data);
   ASSERT_NE(decoded, absl::nullopt);
   std::tie(tx_params, tx_args) = *decoded;
-
   ASSERT_EQ(tx_params.size(), 1UL);
   EXPECT_EQ(tx_params[0], "bool");
   EXPECT_EQ(tx_args[0], "false");
 
+  // OK: true
   ASSERT_TRUE(PrefixedHexStringToBytes(
       "0x0000000000000000000000000000000000000000000000000000000000000001",
       &data));
   decoded = ABIDecode({"bool"}, data);
   ASSERT_NE(decoded, absl::nullopt);
   std::tie(tx_params, tx_args) = *decoded;
-
   ASSERT_EQ(tx_params.size(), 1UL);
   EXPECT_EQ(tx_params[0], "bool");
   EXPECT_EQ(tx_args[0], "true");
 
-  // Insufficient bool length
+  // KO: insufficient bool length
   ASSERT_TRUE(PrefixedHexStringToBytes("0x0", &data));
   ASSERT_FALSE(ABIDecode({"bool"}, data));
 
-  // Extra bool length
+  // OK: extra bool length
   ASSERT_TRUE(PrefixedHexStringToBytes(
       "0x0000000000000000000000000000000000000000000000000000000000000000"
       "00",
       &data));
-  ASSERT_FALSE(ABIDecode({"bool"}, data));
+  decoded = ABIDecode({"bool"}, data);
+  ASSERT_NE(decoded, absl::nullopt);
+  std::tie(tx_params, tx_args) = *decoded;
+  ASSERT_EQ(tx_params.size(), 1UL);
+  EXPECT_EQ(tx_params[0], "bool");
+  EXPECT_EQ(tx_args[0], "false");
 }
 
 TEST(EthABIDecoderTest, ABIDecodeAddressArray) {

--- a/components/brave_wallet/browser/eth_data_parser_unittest.cc
+++ b/components/brave_wallet/browser/eth_data_parser_unittest.cc
@@ -44,8 +44,9 @@ TEST(EthDataParser, GetTransactionInfoFromDataTransfer) {
   mojom::TransactionType tx_type;
   std::vector<std::string> tx_params;
   std::vector<std::string> tx_args;
-
   std::vector<uint8_t> data;
+
+  // OK: well-formed ERC20Transfer
   ASSERT_TRUE(PrefixedHexStringToBytes(
       "0xa9059cbb"
       "000000000000000000000000BFb30a082f650C2A15D0632f0e87bE4F8e64460f"
@@ -54,7 +55,6 @@ TEST(EthDataParser, GetTransactionInfoFromDataTransfer) {
   auto tx_info = GetTransactionInfoFromData(data);
   ASSERT_NE(tx_info, absl::nullopt);
   std::tie(tx_type, tx_params, tx_args) = *tx_info;
-
   ASSERT_EQ(tx_type, mojom::TransactionType::ERC20Transfer);
   ASSERT_EQ(tx_params.size(), 2UL);
   EXPECT_EQ(tx_params[0], "address");
@@ -63,7 +63,7 @@ TEST(EthDataParser, GetTransactionInfoFromDataTransfer) {
   EXPECT_EQ(tx_args[0], "0xbfb30a082f650c2a15d0632f0e87be4f8e64460f");
   EXPECT_EQ(tx_args[1], "0x3fffffffffffffff");
 
-  // Missing a byte for the last param
+  // KO: missing a byte for the last param
   ASSERT_TRUE(PrefixedHexStringToBytes(
       "0xa9059cbb"
       "000000000000000000000000BFb30a082f650C2A15D0632f0e87bE4F8e64460f"
@@ -71,33 +71,43 @@ TEST(EthDataParser, GetTransactionInfoFromDataTransfer) {
       &data));
   EXPECT_FALSE(GetTransactionInfoFromData(data));
 
-  // Missing the entire last param
+  // KO: missing the entire last param
   ASSERT_TRUE(PrefixedHexStringToBytes(
       "0xa9059cbb"
       "000000000000000000000000BFb30a082f650C2A15D0632f0e87bE4F8e64460f",
       &data));
   EXPECT_FALSE(GetTransactionInfoFromData(data));
 
-  // No params
+  // KO: no params
   ASSERT_TRUE(PrefixedHexStringToBytes("0xa9059cbb", &data));
   EXPECT_FALSE(GetTransactionInfoFromData(data));
 
-  // Extra data
+  // OK: extra data
   ASSERT_TRUE(PrefixedHexStringToBytes(
       "0xa9059cbb"
       "000000000000000000000000BFb30a082f650C2A15D0632f0e87bE4F8e64460f"
       "0000000000000000000000000000000000000000000000003fffffffffffffff"
       "00",
       &data));
-  EXPECT_FALSE(GetTransactionInfoFromData(data));
+  tx_info = GetTransactionInfoFromData(data);
+  ASSERT_NE(tx_info, absl::nullopt);
+  std::tie(tx_type, tx_params, tx_args) = *tx_info;
+  ASSERT_EQ(tx_type, mojom::TransactionType::ERC20Transfer);
+  ASSERT_EQ(tx_params.size(), 2UL);
+  EXPECT_EQ(tx_params[0], "address");
+  EXPECT_EQ(tx_params[1], "uint256");
+  ASSERT_EQ(tx_args.size(), 2UL);
+  EXPECT_EQ(tx_args[0], "0xbfb30a082f650c2a15d0632f0e87be4f8e64460f");
+  EXPECT_EQ(tx_args[1], "0x3fffffffffffffff");
 }
 
 TEST(EthDataParser, GetTransactionInfoFromDataApprove) {
   mojom::TransactionType tx_type;
   std::vector<std::string> tx_params;
   std::vector<std::string> tx_args;
-
   std::vector<uint8_t> data;
+
+  // OK: well-formed ERC20Approve
   ASSERT_TRUE(PrefixedHexStringToBytes(
       "0x095ea7b3"
       "000000000000000000000000BFb30a082f650C2A15D0632f0e87bE4F8e64460f"
@@ -106,7 +116,6 @@ TEST(EthDataParser, GetTransactionInfoFromDataApprove) {
   auto tx_info = GetTransactionInfoFromData(data);
   ASSERT_NE(tx_info, absl::nullopt);
   std::tie(tx_type, tx_params, tx_args) = *tx_info;
-
   ASSERT_EQ(tx_type, mojom::TransactionType::ERC20Approve);
   ASSERT_EQ(tx_params.size(), 2UL);
   EXPECT_EQ(tx_params[0], "address");
@@ -115,7 +124,7 @@ TEST(EthDataParser, GetTransactionInfoFromDataApprove) {
   EXPECT_EQ(tx_args[0], "0xbfb30a082f650c2a15d0632f0e87be4f8e64460f");
   EXPECT_EQ(tx_args[1], "0x3fffffffffffffff");
 
-  // Function case doesn't matter
+  // OK: function case doesn't matter
   ASSERT_TRUE(PrefixedHexStringToBytes(
       "0x095EA7b3"
       "000000000000000000000000BFb30a082f650C2A15D0632f0e87bE4F8e64460f"
@@ -124,7 +133,6 @@ TEST(EthDataParser, GetTransactionInfoFromDataApprove) {
   tx_info = GetTransactionInfoFromData(data);
   ASSERT_NE(tx_info, absl::nullopt);
   std::tie(tx_type, tx_params, tx_args) = *tx_info;
-
   ASSERT_EQ(tx_type, mojom::TransactionType::ERC20Approve);
   ASSERT_EQ(tx_params.size(), 2UL);
   EXPECT_EQ(tx_params[0], "address");
@@ -133,7 +141,7 @@ TEST(EthDataParser, GetTransactionInfoFromDataApprove) {
   EXPECT_EQ(tx_args[0], "0xbfb30a082f650c2a15d0632f0e87be4f8e64460f");
   EXPECT_EQ(tx_args[1], "0x3fffffffffffffff");
 
-  // Missing a byte for the last param
+  // KO: missing a byte for the last param
   ASSERT_TRUE(PrefixedHexStringToBytes(
       "0x095ea7b3"
       "000000000000000000000000BFb30a082f650C2A15D0632f0e87bE4F8e64460f"
@@ -141,25 +149,34 @@ TEST(EthDataParser, GetTransactionInfoFromDataApprove) {
       &data));
   EXPECT_FALSE(GetTransactionInfoFromData(data));
 
-  // Missing the entire last param
+  // KO: missing the entire last param
   ASSERT_TRUE(PrefixedHexStringToBytes(
       "0x095ea7b3"
       "000000000000000000000000BFb30a082f650C2A15D0632f0e87bE4F8e64460f",
       &data));
   EXPECT_FALSE(GetTransactionInfoFromData(data));
 
-  // No params
+  // KO: no params
   ASSERT_TRUE(PrefixedHexStringToBytes("0x095ea7b3", &data));
   EXPECT_FALSE(GetTransactionInfoFromData(data));
 
-  // Extra data
+  // OK: extra data
   ASSERT_TRUE(PrefixedHexStringToBytes(
       "0x095ea7b3"
       "000000000000000000000000BFb30a082f650C2A15D0632f0e87bE4F8e64460f"
       "0000000000000000000000000000000000000000000000003fffffffffffffff"
       "00",
       &data));
-  EXPECT_FALSE(GetTransactionInfoFromData(data));
+  tx_info = GetTransactionInfoFromData(data);
+  ASSERT_NE(tx_info, absl::nullopt);
+  std::tie(tx_type, tx_params, tx_args) = *tx_info;
+  ASSERT_EQ(tx_type, mojom::TransactionType::ERC20Approve);
+  ASSERT_EQ(tx_params.size(), 2UL);
+  EXPECT_EQ(tx_params[0], "address");
+  EXPECT_EQ(tx_params[1], "uint256");
+  ASSERT_EQ(tx_args.size(), 2UL);
+  EXPECT_EQ(tx_args[0], "0xbfb30a082f650c2a15d0632f0e87be4f8e64460f");
+  EXPECT_EQ(tx_args[1], "0x3fffffffffffffff");
 }
 
 TEST(EthDataParser, GetTransactionInfoFromDataETHSend) {
@@ -189,8 +206,9 @@ TEST(EthDataParser, GetTransactionInfoFromDataERC721TransferFrom) {
   mojom::TransactionType tx_type;
   std::vector<std::string> tx_params;
   std::vector<std::string> tx_args;
-
   std::vector<uint8_t> data;
+
+  // OK: well-formed ERC721TransferFrom
   ASSERT_TRUE(PrefixedHexStringToBytes(
       "0x23b872dd"
       "000000000000000000000000BFb30a082f650C2A15D0632f0e87bE4F8e64460f"
@@ -200,7 +218,6 @@ TEST(EthDataParser, GetTransactionInfoFromDataERC721TransferFrom) {
   auto tx_info = GetTransactionInfoFromData(data);
   ASSERT_NE(tx_info, absl::nullopt);
   std::tie(tx_type, tx_params, tx_args) = *tx_info;
-
   ASSERT_EQ(tx_type, mojom::TransactionType::ERC721TransferFrom);
   ASSERT_EQ(tx_params.size(), 3UL);
   EXPECT_EQ(tx_params[0], "address");
@@ -211,6 +228,7 @@ TEST(EthDataParser, GetTransactionInfoFromDataERC721TransferFrom) {
   EXPECT_EQ(tx_args[1], "0xbfb30a082f650c2a15d0632f0e87be4f8e64460a");
   EXPECT_EQ(tx_args[2], "0xf");
 
+  // OK: well-formed ERC721SafeTransferFrom
   ASSERT_TRUE(PrefixedHexStringToBytes(
       "0x42842e0e"
       "000000000000000000000000BFb30a082f650C2A15D0632f0e87bE4F8e64460f"
@@ -220,7 +238,6 @@ TEST(EthDataParser, GetTransactionInfoFromDataERC721TransferFrom) {
   tx_info = GetTransactionInfoFromData(data);
   ASSERT_NE(tx_info, absl::nullopt);
   std::tie(tx_type, tx_params, tx_args) = *tx_info;
-
   ASSERT_EQ(tx_type, mojom::TransactionType::ERC721SafeTransferFrom);
   ASSERT_EQ(tx_params.size(), 3UL);
   EXPECT_EQ(tx_params[0], "address");
@@ -231,7 +248,7 @@ TEST(EthDataParser, GetTransactionInfoFromDataERC721TransferFrom) {
   EXPECT_EQ(tx_args[1], "0xbfb30a082f650c2a15d0632f0e87be4f8e64460a");
   EXPECT_EQ(tx_args[2], "0xf");
 
-  // Missing a byte for the last param
+  // KO: missing a byte for the last param
   ASSERT_TRUE(PrefixedHexStringToBytes(
       "0x23b872dd"
       "000000000000000000000000BFb30a082f650C2A15D0632f0e87bE4F8e64460f"
@@ -240,7 +257,7 @@ TEST(EthDataParser, GetTransactionInfoFromDataERC721TransferFrom) {
       &data));
   EXPECT_FALSE(GetTransactionInfoFromData(data));
 
-  // Missing the entire last param
+  // KO: missing the entire last param
   ASSERT_TRUE(PrefixedHexStringToBytes(
       "0x23b872dd"
       "000000000000000000000000BFb30a082f650C2A15D0632f0e87bE4F8e64460f"
@@ -248,11 +265,11 @@ TEST(EthDataParser, GetTransactionInfoFromDataERC721TransferFrom) {
       &data));
   EXPECT_FALSE(GetTransactionInfoFromData(data));
 
-  // No params
+  // KO: no params
   ASSERT_TRUE(PrefixedHexStringToBytes("0x23b872dd", &data));
   EXPECT_FALSE(GetTransactionInfoFromData(data));
 
-  // Extra data
+  // OK: extra data
   ASSERT_TRUE(PrefixedHexStringToBytes(
       "0x23b872dd"
       "000000000000000000000000BFb30a082f650C2A15D0632f0e87bE4F8e64460f"
@@ -260,7 +277,18 @@ TEST(EthDataParser, GetTransactionInfoFromDataERC721TransferFrom) {
       "000000000000000000000000000000000000000000000000000000000000000f"
       "00",
       &data));
-  EXPECT_FALSE(GetTransactionInfoFromData(data));
+  tx_info = GetTransactionInfoFromData(data);
+  ASSERT_NE(tx_info, absl::nullopt);
+  std::tie(tx_type, tx_params, tx_args) = *tx_info;
+  ASSERT_EQ(tx_type, mojom::TransactionType::ERC721TransferFrom);
+  ASSERT_EQ(tx_params.size(), 3UL);
+  EXPECT_EQ(tx_params[0], "address");
+  EXPECT_EQ(tx_params[1], "address");
+  EXPECT_EQ(tx_params[2], "uint256");
+  ASSERT_EQ(tx_args.size(), 3UL);
+  EXPECT_EQ(tx_args[0], "0xbfb30a082f650c2a15d0632f0e87be4f8e64460f");
+  EXPECT_EQ(tx_args[1], "0xbfb30a082f650c2a15d0632f0e87be4f8e64460a");
+  EXPECT_EQ(tx_args[2], "0xf");
 }
 
 TEST(EthDataParser, GetTransactionInfoFromDataERC1155SafeTransferFrom) {

--- a/components/brave_wallet/browser/eth_response_parser.h
+++ b/components/brave_wallet/browser/eth_response_parser.h
@@ -32,6 +32,9 @@ bool ParseEthGetTransactionReceipt(const std::string& json,
                                    TransactionReceipt* receipt);
 bool ParseEthSendRawTransaction(const std::string& json, std::string* tx_hash);
 bool ParseEthCall(const std::string& json, std::string* result);
+absl::optional<std::vector<std::string>> DecodeEthCallResponse(
+    const std::string& data,
+    const std::vector<std::string>& abi_types);
 bool ParseEthEstimateGas(const std::string& json, std::string* result);
 bool ParseEthGasPrice(const std::string& json, std::string* result);
 

--- a/components/brave_wallet/browser/eth_response_parser_unittest.cc
+++ b/components/brave_wallet/browser/eth_response_parser_unittest.cc
@@ -71,6 +71,32 @@ TEST(EthResponseParserUnitTest, ParseEthCall) {
   ASSERT_EQ(result, "0x0");
 }
 
+TEST(EthResponseParserUnitTest, DecodeEthCallResponse) {
+  // OK: 32-byte uint256
+  std::string result =
+      "0x00000000000000000000000000000000000000000000000166e12cfce39a0000";
+  auto args = DecodeEthCallResponse(result, {"uint256"});
+  ASSERT_NE(args, absl::nullopt);
+  ASSERT_EQ(args->size(), 1UL);
+  ASSERT_EQ(args->at(0), "0x166e12cfce39a0000");
+
+  // OK: 32-byte uint256 with extra zero bytes
+  result =
+      "0x0000000000000000000000000000000000000000000000000000000000045d12000000"
+      "000000000000000000000000000000000000000000000000000000000000000000000000"
+      "00000000000000000000000000000000000000000000000000";
+  args = DecodeEthCallResponse(result, {"uint256"});
+  ASSERT_NE(args, absl::nullopt);
+  ASSERT_EQ(args->size(), 1UL);
+  ASSERT_EQ(args->at(0), "0x45d12");
+
+  // KO: insufficient length of response
+  ASSERT_EQ(DecodeEthCallResponse("0x0", {"uint256"}), absl::nullopt);
+
+  // KO: invalid response
+  ASSERT_EQ(DecodeEthCallResponse("foobarbaz", {"uint256"}), absl::nullopt);
+}
+
 TEST(EthResponseParserUnitTest, ParseEthGetTransactionReceipt) {
   std::string json(
       R"({

--- a/components/brave_wallet/browser/json_rpc_service.cc
+++ b/components/brave_wallet/browser/json_rpc_service.cc
@@ -975,7 +975,16 @@ void JsonRpcService::OnGetERC20TokenBalance(
     std::move(callback).Run("", error, error_message);
     return;
   }
-  std::move(callback).Run(result, mojom::ProviderError::kSuccess, "");
+
+  const auto& args = eth::DecodeEthCallResponse(result, {"uint256"});
+  if (args == absl::nullopt) {
+    std::move(callback).Run(
+        "", mojom::ProviderError::kInternalError,
+        l10n_util::GetStringUTF8(IDS_WALLET_INTERNAL_ERROR));
+    return;
+  }
+
+  std::move(callback).Run(args->at(0), mojom::ProviderError::kSuccess, "");
 }
 
 void JsonRpcService::GetERC20TokenAllowance(
@@ -1018,7 +1027,16 @@ void JsonRpcService::OnGetERC20TokenAllowance(
     std::move(callback).Run("", error, error_message);
     return;
   }
-  std::move(callback).Run(result, mojom::ProviderError::kSuccess, "");
+
+  const auto& args = eth::DecodeEthCallResponse(result, {"uint256"});
+  if (args == absl::nullopt) {
+    std::move(callback).Run(
+        "", mojom::ProviderError::kInternalError,
+        l10n_util::GetStringUTF8(IDS_WALLET_INTERNAL_ERROR));
+    return;
+  }
+
+  std::move(callback).Run(args->at(0), mojom::ProviderError::kSuccess, "");
 }
 
 void JsonRpcService::EnsRegistryGetResolver(const std::string& domain,

--- a/components/brave_wallet/browser/json_rpc_service_unittest.cc
+++ b/components/brave_wallet/browser/json_rpc_service_unittest.cc
@@ -1784,8 +1784,7 @@ TEST_F(JsonRpcServiceUnitTest, GetERC20TokenBalance) {
       "0x4e02f254184E904300e0775E4b8eeCB1", mojom::kMainnetChainId,
       base::BindOnce(&OnStringResponse, &callback_called,
                      mojom::ProviderError::kSuccess, "",
-                     "0x00000000000000000000000000000000000000000000000166e12cf"
-                     "ce39a0000"));
+                     "0x166e12cfce39a0000"));
   base::RunLoop().RunUntilIdle();
   EXPECT_TRUE(callback_called);
 
@@ -1860,8 +1859,7 @@ TEST_F(JsonRpcServiceUnitTest, GetERC20TokenAllowance) {
       "0xBFb30a082f650C2A15D0632f0e87bE4F8e64460a",
       base::BindOnce(&OnStringResponse, &callback_called,
                      mojom::ProviderError::kSuccess, "",
-                     "0x00000000000000000000000000000000000000000000000166e12cf"
-                     "ce39a0000"));
+                     "0x166e12cfce39a0000"));
   base::RunLoop().RunUntilIdle();
   EXPECT_TRUE(callback_called);
 


### PR DESCRIPTION
In general, extraneous calldata bytes are ignored by the EVM according to https://ethereum.stackexchange.com/a/66090.
> extra calldata bytes will be ignored, and yes, calldata read past the end of the length is 0s

I confirmed the same by appending bogus bytes to a `balanceOf()` call and verifying that balances are fetched correctly.

This also applies to return value of a contract method invoked using `eth_call`, according to the [Solidity ABI spec](https://docs.soliditylang.org/en/latest/abi-spec.html#argument-encoding).
> This encoding is also used in other places, e.g. the return values and also event arguments are encoded in the same way, without the four bytes specifying the function.

This PR therefore changes the following:
1. Allow calldata to have extra bytes without being considered invalid by `ABIDecode`.
2. Use `ABIDecode` to decode the response of `eth_call` invocations - in our case, calling contract methods `balanceOf` and `allowance`.

Resolves https://github.com/brave/brave-browser/issues/23998

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [x]  Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

### Before

<img src="https://user-images.githubusercontent.com/3684187/178447762-55f8c1fd-2867-498a-8dd5-21427a084b95.png">

### After

<img src="https://user-images.githubusercontent.com/3684187/178447469-62110bad-8269-45f2-9ca4-686d297df6ab.png">

