### PR TITLE
Respect CONTENT_SETTING_BLOCK for wallet permissions

### DIFF
--- a/browser/brave_wallet/brave_wallet_provider_delegate_impl.cc
+++ b/browser/brave_wallet/brave_wallet_provider_delegate_impl.cc
@@ -182,8 +182,16 @@ bool BraveWalletProviderDelegateImpl::IsPermissionDenied(mojom::CoinType type) {
     return false;
   }
 
+  auto* rfh = content::RenderFrameHost::FromID(host_id_);
+  if (!rfh) {
+    return false;
+  }
+
+  auto* web_contents = content::WebContents::FromRenderFrameHost(rfh);
+
   return permissions::BraveWalletPermissionContext::IsPermissionDenied(
-      *permission, content::RenderFrameHost::FromID(host_id_));
+      *permission, web_contents->GetBrowserContext(),
+      url::Origin::Create(rfh->GetLastCommittedURL()));
 }
 
 void BraveWalletProviderDelegateImpl::AddSolanaConnectedAccount(

--- a/browser/brave_wallet/brave_wallet_provider_delegate_impl.cc
+++ b/browser/brave_wallet/brave_wallet_provider_delegate_impl.cc
@@ -117,6 +117,10 @@ void BraveWalletProviderDelegateImpl::GetAllowedAccounts(
     mojom::CoinType type,
     const std::vector<std::string>& accounts,
     GetAllowedAccountsCallback callback) {
+  if (IsPermissionDenied(type)) {
+    std::move(callback).Run(true, std::vector<std::string>());
+    return;
+  }
   auto permission = CoinTypeToPermissionType(type);
   if (!permission) {
     std::move(callback).Run(false, std::vector<std::string>());
@@ -170,6 +174,16 @@ void BraveWalletProviderDelegateImpl::IsAccountAllowed(
   permissions::BraveWalletPermissionContext::GetAllowedAccounts(
       *permission, content::RenderFrameHost::FromID(host_id_), {account},
       base::BindOnce(&OnIsAccountAllowed, account, std::move(callback)));
+}
+
+bool BraveWalletProviderDelegateImpl::IsPermissionDenied(mojom::CoinType type) {
+  auto permission = CoinTypeToPermissionType(type);
+  if (!permission) {
+    return false;
+  }
+
+  return permissions::BraveWalletPermissionContext::IsPermissionDenied(
+      *permission, content::RenderFrameHost::FromID(host_id_));
 }
 
 void BraveWalletProviderDelegateImpl::AddSolanaConnectedAccount(

--- a/browser/brave_wallet/brave_wallet_provider_delegate_impl.h
+++ b/browser/brave_wallet/brave_wallet_provider_delegate_impl.h
@@ -50,6 +50,7 @@ class BraveWalletProviderDelegateImpl : public BraveWalletProviderDelegate,
   void IsAccountAllowed(mojom::CoinType type,
                         const std::string& account,
                         IsAccountAllowedCallback callback) override;
+  bool IsPermissionDenied(mojom::CoinType type) override;
   void AddSolanaConnectedAccount(const std::string& account) override;
   void RemoveSolanaConnectedAccount(const std::string& account) override;
   bool IsSolanaAccountConnected(const std::string& account) override;

--- a/browser/brave_wallet/brave_wallet_service_delegate_impl.cc
+++ b/browser/brave_wallet/brave_wallet_service_delegate_impl.cc
@@ -160,6 +160,20 @@ void BraveWalletServiceDelegateImpl::ResetPermission(
   std::move(callback).Run(success);
 }
 
+void BraveWalletServiceDelegateImpl::IsPermissionDenied(
+    mojom::CoinType coin,
+    const url::Origin& origin,
+    IsPermissionDeniedCallback callback) {
+  auto type = CoinTypeToPermissionType(coin);
+  if (!type) {
+    std::move(callback).Run(false);
+    return;
+  }
+  std::move(callback).Run(
+      permissions::BraveWalletPermissionContext::IsPermissionDenied(
+          *type, context_, origin));
+}
+
 void BraveWalletServiceDelegateImpl::OnTabStripModelChanged(
     TabStripModel* tab_strip_model,
     const TabStripModelChange& change,

--- a/browser/brave_wallet/brave_wallet_service_delegate_impl.h
+++ b/browser/brave_wallet/brave_wallet_service_delegate_impl.h
@@ -60,6 +60,9 @@ class BraveWalletServiceDelegateImpl : public BraveWalletServiceDelegate,
                        const url::Origin& origin,
                        const std::string& account,
                        ResetPermissionCallback callback) override;
+  void IsPermissionDenied(mojom::CoinType coin,
+                          const url::Origin& origin,
+                          IsPermissionDeniedCallback callback) override;
 
   void GetActiveOrigin(GetActiveOriginCallback callback) override;
 

--- a/browser/brave_wallet/brave_wallet_service_delegate_impl_android.cc
+++ b/browser/brave_wallet/brave_wallet_service_delegate_impl_android.cc
@@ -70,6 +70,20 @@ void BraveWalletServiceDelegateImpl::ResetPermission(
   std::move(callback).Run(success);
 }
 
+void BraveWalletServiceDelegateImpl::IsPermissionDenied(
+    mojom::CoinType coin,
+    const url::Origin& origin,
+    IsPermissionDeniedCallback callback) {
+  auto type = CoinTypeToPermissionType(coin);
+  if (!type) {
+    std::move(callback).Run(false);
+    return;
+  }
+  std::move(callback).Run(
+      permissions::BraveWalletPermissionContext::IsPermissionDenied(
+          *type, context_, origin));
+}
+
 void BraveWalletServiceDelegateImpl::GetWebSitesWithPermission(
     mojom::CoinType coin,
     GetWebSitesWithPermissionCallback callback) {

--- a/browser/brave_wallet/brave_wallet_service_delegate_impl_android.h
+++ b/browser/brave_wallet/brave_wallet_service_delegate_impl_android.h
@@ -45,6 +45,9 @@ class BraveWalletServiceDelegateImpl : public BraveWalletServiceDelegate {
                        const url::Origin& origin,
                        const std::string& account,
                        ResetPermissionCallback callback) override;
+  void IsPermissionDenied(mojom::CoinType coin,
+                          const url::Origin& origin,
+                          IsPermissionDeniedCallback callback) override;
   void GetWebSitesWithPermission(
       mojom::CoinType coin,
       GetWebSitesWithPermissionCallback callback) override;

--- a/browser/brave_wallet/solana_provider_impl_unittest.cc
+++ b/browser/brave_wallet/solana_provider_impl_unittest.cc
@@ -24,7 +24,9 @@
 #include "brave/components/brave_wallet/common/brave_wallet_constants.h"
 #include "brave/components/brave_wallet/common/features.h"
 #include "brave/components/brave_wallet/common/solana_utils.h"
+#include "chrome/browser/content_settings/host_content_settings_map_factory.h"
 #include "chrome/test/base/testing_profile.h"
+#include "components/content_settings/core/browser/host_content_settings_map.h"
 #include "components/grit/brave_components_strings.h"
 #include "components/permissions/permission_request_manager.h"
 #include "content/public/test/browser_task_environment.h"
@@ -394,7 +396,8 @@ TEST_F(SolanaProviderImplUnitTest, Connect) {
   EXPECT_EQ(error, mojom::SolanaProviderError::kInternalError);
   EXPECT_FALSE(IsConnected());
 
-  Navigate(GURL("https://brave.com"));
+  GURL url("https://brave.com");
+  Navigate(url);
   AddSolanaPermission(GetOrigin(), address);
   account = Connect(absl::nullopt, &error, &error_message);
   EXPECT_EQ(account, address);
@@ -436,6 +439,26 @@ TEST_F(SolanaProviderImplUnitTest, Connect) {
   EXPECT_EQ(pending_error, mojom::SolanaProviderError::kSuccess);
   EXPECT_TRUE(pending_error_message.empty());
   EXPECT_TRUE(IsConnected());
+
+  // CONTENT_SETTING_BLOCK will rule out previous granted permission.
+  scoped_refptr<HostContentSettingsMap> map =
+      HostContentSettingsMapFactory::GetForProfile(browser_context());
+  ASSERT_TRUE(map);
+  map->SetContentSettingDefaultScope(
+      url, url, ContentSettingsType::BRAVE_SOLANA, CONTENT_SETTING_BLOCK);
+  account = Connect(absl::nullopt, &error, &error_message);
+  EXPECT_TRUE(account.empty());
+  EXPECT_EQ(error, mojom::SolanaProviderError::kUserRejectedRequest);
+  EXPECT_EQ(error_message,
+            l10n_util::GetStringUTF8(IDS_WALLET_USER_REJECTED_REQUEST));
+  // When CONTENT_SETTING_BLOCK is removed, previously granted permission works
+  // again.
+  map->SetContentSettingDefaultScope(
+      url, url, ContentSettingsType::BRAVE_SOLANA, CONTENT_SETTING_DEFAULT);
+  account = Connect(absl::nullopt, &error, &error_message);
+  EXPECT_EQ(account, address);
+  EXPECT_EQ(error, mojom::SolanaProviderError::kSuccess);
+  EXPECT_TRUE(error_message.empty());
 }
 
 TEST_F(SolanaProviderImplUnitTest, EagerlyConnect) {

--- a/components/brave_wallet/browser/brave_wallet_provider_delegate.h
+++ b/components/brave_wallet/browser/brave_wallet_provider_delegate.h
@@ -45,6 +45,7 @@ class BraveWalletProviderDelegate {
   virtual void GetAllowedAccounts(mojom::CoinType type,
                                   const std::vector<std::string>& accounts,
                                   GetAllowedAccountsCallback callback) = 0;
+  virtual bool IsPermissionDenied(mojom::CoinType type) = 0;
   virtual void AddSolanaConnectedAccount(const std::string& account) {}
   virtual void RemoveSolanaConnectedAccount(const std::string& account) {}
   virtual bool IsSolanaAccountConnected(const std::string& account);

--- a/components/brave_wallet/browser/brave_wallet_service.cc
+++ b/components/brave_wallet/browser/brave_wallet_service.cc
@@ -611,6 +611,16 @@ void BraveWalletService::ResetPermission(mojom::CoinType coin,
     std::move(callback).Run(false);
 }
 
+void BraveWalletService::IsPermissionDenied(
+    mojom::CoinType coin,
+    const url::Origin& origin,
+    IsPermissionDeniedCallback callback) {
+  if (delegate_)
+    delegate_->IsPermissionDenied(coin, origin, std::move(callback));
+  else
+    std::move(callback).Run(false);
+}
+
 void BraveWalletService::GetWebSitesWithPermission(
     mojom::CoinType coin,
     GetWebSitesWithPermissionCallback callback) {

--- a/components/brave_wallet/browser/brave_wallet_service.h
+++ b/components/brave_wallet/browser/brave_wallet_service.h
@@ -124,6 +124,9 @@ class BraveWalletService : public KeyedService,
                        const url::Origin& origin,
                        const std::string& account,
                        ResetPermissionCallback callback) override;
+  void IsPermissionDenied(mojom::CoinType coin,
+                          const url::Origin& origin,
+                          IsPermissionDeniedCallback callback) override;
   void GetWebSitesWithPermission(
       mojom::CoinType coin,
       GetWebSitesWithPermissionCallback callback) override;

--- a/components/brave_wallet/browser/brave_wallet_service_delegate.cc
+++ b/components/brave_wallet/browser/brave_wallet_service_delegate.cc
@@ -53,6 +53,13 @@ void BraveWalletServiceDelegate::ResetPermission(
   std::move(callback).Run(false);
 }
 
+void BraveWalletServiceDelegate::IsPermissionDenied(
+    mojom::CoinType coin,
+    const url::Origin& origin,
+    IsPermissionDeniedCallback callback) {
+  std::move(callback).Run(false);
+}
+
 void BraveWalletServiceDelegate::GetActiveOrigin(
     GetActiveOriginCallback callback) {
   std::move(callback).Run(MakeOriginInfo(url::Origin()));

--- a/components/brave_wallet/browser/brave_wallet_service_delegate.h
+++ b/components/brave_wallet/browser/brave_wallet_service_delegate.h
@@ -34,6 +34,8 @@ class BraveWalletServiceDelegate {
       mojom::BraveWalletService::HasPermissionCallback;
   using ResetPermissionCallback =
       mojom::BraveWalletService::ResetPermissionCallback;
+  using IsPermissionDeniedCallback =
+      mojom::BraveWalletService::IsPermissionDeniedCallback;
   using GetActiveOriginCallback =
       mojom::BraveWalletService::GetActiveOriginCallback;
   using GetWebSitesWithPermissionCallback =
@@ -74,6 +76,9 @@ class BraveWalletServiceDelegate {
                                const url::Origin& origin,
                                const std::string& account,
                                ResetPermissionCallback callback);
+  virtual void IsPermissionDenied(mojom::CoinType coin,
+                                  const url::Origin& origin,
+                                  IsPermissionDeniedCallback callback);
   virtual void GetWebSitesWithPermission(
       mojom::CoinType coin,
       GetWebSitesWithPermissionCallback callback);

--- a/components/brave_wallet/browser/ethereum_provider_impl.cc
+++ b/components/brave_wallet/browser/ethereum_provider_impl.cc
@@ -1180,6 +1180,12 @@ void EthereumProviderImpl::RequestEthereumPermissions(
     const std::string& method,
     const url::Origin& origin) {
   DCHECK(delegate_);
+  if (delegate_->IsPermissionDenied(mojom::CoinType::ETH)) {
+    OnRequestEthereumPermissions(std::move(callback), std::move(id), method,
+                                 origin, RequestPermissionsError::kNone,
+                                 std::vector<std::string>());
+    return;
+  }
   keyring_service_->GetKeyringInfo(
       brave_wallet::mojom::kDefaultKeyringId,
       base::BindOnce(

--- a/components/brave_wallet/browser/ethereum_provider_impl.h
+++ b/components/brave_wallet/browser/ethereum_provider_impl.h
@@ -156,6 +156,8 @@ class EthereumProviderImpl final
                            RequestEthereumPermissionsNoWallet);
   FRIEND_TEST_ALL_PREFIXES(EthereumProviderImplUnitTest,
                            RequestEthereumPermissionsLocked);
+  FRIEND_TEST_ALL_PREFIXES(EthereumProviderImplUnitTest,
+                           RequestEthereumPermissionsWithAccounts);
   friend class EthereumProviderImplUnitTest;
 
   // mojom::BraveWalletProvider:

--- a/components/brave_wallet/browser/solana_provider_impl.cc
+++ b/components/brave_wallet/browser/solana_provider_impl.cc
@@ -68,6 +68,12 @@ void SolanaProviderImpl::Init(
 void SolanaProviderImpl::Connect(absl::optional<base::Value> arg,
                                  ConnectCallback callback) {
   DCHECK(delegate_);
+  if (delegate_->IsPermissionDenied(mojom::CoinType::SOL)) {
+    std::move(callback).Run(
+        mojom::SolanaProviderError::kUserRejectedRequest,
+        l10n_util::GetStringUTF8(IDS_WALLET_USER_REJECTED_REQUEST), "");
+    return;
+  }
   absl::optional<std::string> account =
       keyring_service_->GetSelectedAccount(mojom::CoinType::SOL);
   if (!account) {

--- a/components/brave_wallet/common/brave_wallet.mojom
+++ b/components/brave_wallet/common/brave_wallet.mojom
@@ -1129,6 +1129,9 @@ interface BraveWalletService {
   ResetPermission(CoinType coin, url.mojom.Origin origin, string account)
     => (bool success);
 
+  // Check if permission is denied for the origin
+  IsPermissionDenied(CoinType coin, url.mojom.Origin origin) => (bool denied);
+
   // Obtains the active origin info.
   GetActiveOrigin() => (OriginInfo origin_info);
 

--- a/components/permissions/contexts/brave_wallet_permission_context.cc
+++ b/components/permissions/contexts/brave_wallet_permission_context.cc
@@ -242,6 +242,33 @@ void BraveWalletPermissionContext::GetAllowedAccounts(
 }
 
 // static
+bool BraveWalletPermissionContext::IsPermissionDenied(
+    blink::PermissionType permission,
+    content::RenderFrameHost* rfh) {
+  if (!rfh) {
+    return false;
+  }
+
+  // Fail if there is no last committed URL yet
+  auto* web_contents = content::WebContents::FromRenderFrameHost(rfh);
+  if (web_contents->GetMainFrame()->GetLastCommittedURL().is_empty()) {
+    return false;
+  }
+
+  auto* permission_manager = static_cast<permissions::BravePermissionManager*>(
+      permissions::PermissionsClient::Get()->GetPermissionManager(
+          web_contents->GetBrowserContext()));
+  if (!permission_manager) {
+    return false;
+  }
+
+  url::Origin origin = url::Origin::Create(rfh->GetLastCommittedURL());
+  return permission_manager->GetPermissionStatusForOrigin(permission, rfh,
+                                                          origin.GetURL()) ==
+         blink::mojom::PermissionStatus::DENIED;
+}
+
+// static
 bool BraveWalletPermissionContext::AddPermission(
     blink::PermissionType permission,
     content::BrowserContext* context,
@@ -285,6 +312,12 @@ bool BraveWalletPermissionContext::HasPermission(
       permissions::PermissionsClient::Get()->GetPermissionManager(context));
   if (!permission_manager)
     return false;
+
+  if (permission_manager->GetPermissionStatus(permission, origin.GetURL(),
+                                              origin.GetURL()) ==
+      blink::mojom::PermissionStatus::DENIED) {
+    return true;
+  }
 
   const ContentSettingsType content_settings_type =
       PermissionUtil::PermissionTypeToContentSettingSafe(permission);

--- a/components/permissions/contexts/brave_wallet_permission_context.h
+++ b/components/permissions/contexts/brave_wallet_permission_context.h
@@ -70,6 +70,11 @@ class BraveWalletPermissionContext : public PermissionContextBase {
       const std::vector<std::string>& addresses,
       base::OnceCallback<void(bool, const std::vector<std::string>&)> callback);
 
+  // We will only check global setting and setting per origin since we won't
+  // write block rule per address on an origin.
+  static bool IsPermissionDenied(blink::PermissionType permission,
+                                 content::RenderFrameHost* rfh);
+
   static bool AddPermission(blink::PermissionType permission,
                             content::BrowserContext* context,
                             const url::Origin& origin,

--- a/components/permissions/contexts/brave_wallet_permission_context.h
+++ b/components/permissions/contexts/brave_wallet_permission_context.h
@@ -73,7 +73,8 @@ class BraveWalletPermissionContext : public PermissionContextBase {
   // We will only check global setting and setting per origin since we won't
   // write block rule per address on an origin.
   static bool IsPermissionDenied(blink::PermissionType permission,
-                                 content::RenderFrameHost* rfh);
+                                 content::BrowserContext* context,
+                                 const url::Origin& origin);
 
   static bool AddPermission(blink::PermissionType permission,
                             content::BrowserContext* context,

--- a/ios/browser/api/brave_wallet/brave_wallet_provider_delegate_ios+private.h
+++ b/ios/browser/api/brave_wallet/brave_wallet_provider_delegate_ios+private.h
@@ -39,6 +39,7 @@ class BraveWalletProviderDelegateBridge
   void GetAllowedAccounts(mojom::CoinType type,
                           const std::vector<std::string>& accounts,
                           GetAllowedAccountsCallback callback) override;
+  bool IsPermissionDenied(mojom::CoinType type) override;
 };
 
 }  // namespace brave_wallet

--- a/ios/browser/api/brave_wallet/brave_wallet_provider_delegate_ios.h
+++ b/ios/browser/api/brave_wallet/brave_wallet_provider_delegate_ios.h
@@ -38,6 +38,7 @@ OBJC_EXPORT
 - (void)getAllowedAccounts:(BraveWalletCoinType)type
                   accounts:(NSArray<NSString*>*)accounts
                 completion:(GetAllowedAccountsCallback)completion;
+- (bool)isPermissionDenied:(BraveWalletCoinType)type;
 @end
 
 NS_ASSUME_NONNULL_END

--- a/ios/browser/api/brave_wallet/brave_wallet_provider_delegate_ios.mm
+++ b/ios/browser/api/brave_wallet/brave_wallet_provider_delegate_ios.mm
@@ -98,4 +98,9 @@ void BraveWalletProviderDelegateBridge::GetAllowedAccounts(
                    completion:completion];
 }
 
+bool BraveWalletProviderDelegateBridge::IsPermissionDenied(
+    mojom::CoinType type) {
+  return [bridge_ isPermissionDenied:static_cast<BraveWalletCoinType>(type)];
+}
+
 }  // namespace brave_wallet


### PR DESCRIPTION
<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/22471

1. Check if permission is blocked before requesting permission, if it is blocked then request will be rejected.
2. When a wallet permission is blocked, `HasPermission` will return false.
3. Expose `IsPermissionDenied` so front end can use it to differentiate between no permission and permission denied.
   - https://github.com/brave/brave-browser/issues/24022

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
### Ethereum
1. Visit any page, https://example.com/ will be used in the following plan
2. Open console and type `ethereum.enable()` and approve permission
3. Navigate to `brave://settings/content/ethereum` and turn top toggle off (It will show `Block sites from accessing the Ethereum provider API`)
4. Go back to the tab and type `ethereum.enable()` again, it would be rejected
5. Revert step 3 and navigate to `brave://settings/content/siteDetails?site=https%3A%2F%2Fexample.com` (this can also be  opened through lock icon on omnibox)
6. Find Ethereum and set it to block and check `brave://settings/content/ethereum` has the block rule.
7. Go back to the tab and type `ethereum.enable()` again, it would be rejected.
8. Revert step 6 and go back to the tab and type `ethereum.enable()` which shouldn't be rejected.

### Solana
1. Visit any page, https://example.com/ will be used in the following plan
2. Open console and type `solana.connect()` and approve permission
3. Navigate to `brave://settings/content/solana` and turn top toggle off (It will show `Block sites from accessing the Solana provider API`)
4. Go back to the tab and type `solana.connect()` again, it would be rejected
5. Revert step 3 and navigate to `brave://settings/content/siteDetails?site=https%3A%2F%2Fexample.com` (this can also be  opened through lock icon on omnibox)
6. Find Solana and set it to block and check `brave://settings/content/solana` has the block rule.
7. Go back to the tab and type `solana.connect()` again, it would be rejected.
8. Revert step 6 and go back to the tab and type `solana.connect()` which shouldn't be rejected.

### Panel
We will test panel status in https://github.com/brave/brave-browser/issues/24022