### PR TITLE
Removed static size setting to try button in promotion view

### DIFF
--- a/browser/ui/views/omnibox/brave_search_conversion_promotion_view.cc
+++ b/browser/ui/views/omnibox/brave_search_conversion_promotion_view.cc
@@ -544,7 +544,6 @@ void BraveSearchConversionPromotionView::ConfigureForBannerType() {
       std::make_unique<TryButton>(views::Button::PressedCallback(
           base::BindRepeating(&BraveSearchConversionPromotionView::OpenMatch,
                               base::Unretained(this)))));
-  try_button->SetPreferredSize(gfx::Size(151, 32));
   try_button->SetProperty(
       views::kFlexBehaviorKey,
       views::FlexSpecification(views::MinimumFlexSizeRule::kScaleToZero,


### PR DESCRIPTION
fix https://github.com/brave/brave-browser/issues/24005

Deleted accidently added size setting code.
<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves 

<img width="637" alt="Screen Shot 2022-07-13 at 9 51 16 PM" src="https://user-images.githubusercontent.com/6786187/178738547-339ac1f1-bf25-45b7-a55e-0ee0f4dd7703.png">
<img width="644" alt="image" src="https://user-images.githubusercontent.com/6786187/178859922-2b76a212-c39c-4c0a-b14a-d6083f1450b7.png">

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [x] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [x] New files have MPL-2.0 license header
- [x] Adequate test coverage exists to prevent regressions
- [x] Major classes, functions and non-trivial code blocks are well-commented
- [x] Changes in component dependencies are properly reflected in `gn`
- [x] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [x] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

See the linked issue