### PR TITLE
Brave News: use a larger IntersectionObserver viewport for pagination

### DIFF
--- a/components/brave_new_tab_ui/components/default/braveToday/content.tsx
+++ b/components/brave_new_tab_ui/components/default/braveToday/content.tsx
@@ -35,9 +35,16 @@ export default function BraveTodayContent (props: Props) {
     if (!element) {
       return
     }
+    // Trigger when it's 900px from viewport bottom so it's more seamless
+    const intersectionOptions: IntersectionObserverInit = {
+      rootMargin: '0px 0px 900px 0px'
+    }
     const endOfCurrentArticlesListObserver = new IntersectionObserver((entries) => {
-      console.debug('Brave Today content Intersection Observer triggered')
-      if (entries.some(entry => entry.intersectionRatio > 0)) {
+      console.debug('Brave Today content Intersection Observer triggered', entries)
+      const hasReachedPaginationPoint = entries.some(
+        entry => entry.intersectionRatio > 0 ||
+                  entry.boundingClientRect.top < 0)
+      if (hasReachedPaginationPoint) {
         console.debug('Brave Today content Intersection Observer determined need new page.')
         if (!pageRequestPending) {
           pageRequestPending = true
@@ -47,7 +54,7 @@ export default function BraveTodayContent (props: Props) {
           })
         }
       }
-    })
+    }, intersectionOptions)
     // Load up more posts (infinite scroll)
     endOfCurrentArticlesListObserver.observe(element)
   }, [previousYAxis])
@@ -219,7 +226,7 @@ export default function BraveTodayContent (props: Props) {
             width: '1px',
             height: '1px',
             position: 'absolute',
-            bottom: '900px'
+            bottom: '0'
           }}
         />
       </>


### PR DESCRIPTION
To lessen risk that the trigger element would be "skipped" over the viewport when scrolling down fast. Previously, this easily exposed the situation where further content would not be loaded since the hidden pagination trigger element had jumped from below the viewport to above the viewport, avoiding being in the viewport and triggering intersection.

This occurred for both the first "page" of content or any subsequent "pages".

 Trigger position is the same (900px from the bottom of the viewport), as previously the trigger element used 900px absolute bottom position.

<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/13761

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
- Open NTP
- Opt in to Brave News
- Open another NTP
- Scroll down immediately and very fast
- Content is loaded (i.e. more than 1 card is shown)
- Use the mouse to move the scrollbar immediately to the bottom.
- Verify that another page of content is loaded.
- Repeat and verify some more times. On previous versions, this easily exposed the situation where further content would not be loaded since the hidden pagination trigger element had jumped from below the viewport to above the viewport, avoiding being in the viewport and triggering intersection.
