### PR TITLE
Android: Disable chrome Translate feature by default

### DIFF
--- a/browser/about_flags.cc
+++ b/browser/about_flags.cc
@@ -28,6 +28,7 @@
 #include "brave/components/speedreader/common/buildflags.h"
 #include "brave/components/translate/core/common/brave_translate_features.h"
 #include "brave/components/translate/core/common/buildflags.h"
+#include "components/translate/core/browser/translate_prefs.h"
 #include "net/base/features.h"
 #include "third_party/blink/public/common/features.h"
 
@@ -291,9 +292,14 @@ constexpr char kUseDevUpdaterUrlDescription[] =
 constexpr char kBraveTranslateGoName[] =
     "Enable internal translate engine (brave-translate-go)";
 constexpr char kBraveTranslateGoDescription[] =
-    "Enable internal translate engine, which are build on top of client engine "
+    "For Android also enable `translate` flag. Enable internal translate engine, which are build on top of client engine "
     "and brave translation backed. Also disables suggestions to install google "
     "translate extension.";
+
+constexpr char kTranslateName[] =
+    "Enable Chromium Translate feature";
+constexpr char kTranslateDescription[] =
+    "Should be used with brave-translate-go, see the description here.";
 
 constexpr char kBraveFederatedName[] =
     "Enables local data collection for notification ad timing "
@@ -444,7 +450,12 @@ constexpr char kRestrictWebSocketsPoolDescription[] =
      flag_descriptions::kBraveTranslateGoName,                       \
      flag_descriptions::kBraveTranslateGoDescription,                \
      kOsDesktop | kOsAndroid,                                        \
-     FEATURE_VALUE_TYPE(translate::features::kUseBraveTranslateGo)},
+     FEATURE_VALUE_TYPE(translate::features::kUseBraveTranslateGo)}, \
+    {"translate",                                                    \
+     flag_descriptions::kTranslateName,                              \
+     flag_descriptions::kTranslateDescription,                       \
+     kOsAndroid,                                                     \
+     FEATURE_VALUE_TYPE(translate::kTranslate)},
 #else
 #define BRAVE_TRANSLATE_GO_FEATURE_ENTRIES
 #endif  // BUILDFLAG(ENABLE_BRAVE_TRANSLATE_GO)

--- a/browser/about_flags.cc
+++ b/browser/about_flags.cc
@@ -292,12 +292,12 @@ constexpr char kUseDevUpdaterUrlDescription[] =
 constexpr char kBraveTranslateGoName[] =
     "Enable internal translate engine (brave-translate-go)";
 constexpr char kBraveTranslateGoDescription[] =
-    "For Android also enable `translate` flag. Enable internal translate engine, which are build on top of client engine "
+    "For Android also enable `translate` flag. Enable internal translate "
+    "engine, which are build on top of client engine "
     "and brave translation backed. Also disables suggestions to install google "
     "translate extension.";
 
-constexpr char kTranslateName[] =
-    "Enable Chromium Translate feature";
+constexpr char kTranslateName[] = "Enable Chromium Translate feature";
 constexpr char kTranslateDescription[] =
     "Should be used with brave-translate-go, see the description here.";
 

--- a/chromium_src/components/translate/core/browser/translate_manager.cc
+++ b/chromium_src/components/translate/core/browser/translate_manager.cc
@@ -5,10 +5,8 @@
 
 #include "components/translate/core/browser/translate_manager.h"
 
-#include "brave/components/translate/core/common/brave_translate_features.h"
 #include "brave/components/translate/core/common/brave_translate_language_filter.h"
 #include "brave/components/translate/core/common/buildflags.h"
-#include "build/build_config.h"
 #include "components/translate/core/browser/translate_download_manager.h"
 #include "components/translate/core/browser/translate_prefs.h"
 
@@ -48,18 +46,6 @@ void TranslateManager::FilterIsTranslatePossible(
   ChromiumTranslateManager::FilterIsTranslatePossible(
       decision, translate_prefs, page_language_code, target_lang);
 #if BUILDFLAG(ENABLE_BRAVE_TRANSLATE_GO)
-#if BUILDFLAG(IS_ANDROID)
-  // Disable translate completely if brave translate feature is disabled.
-  // The code is Android only because desktops use TranslateManager to show
-  // Google translate extension bubble.
-  if (!IsBraveTranslateGoAvailable()) {
-    decision->PreventAllTriggering();
-    decision->initiation_statuses.push_back(
-        TranslateBrowserMetrics::INITIATION_STATUS_DISABLED_BY_SWITCH);
-    GetActiveTranslateMetricsLogger()->LogTriggerDecision(
-        TriggerDecision::kDisabledTranslationFeatureDisabled);
-  }
-#endif
   // The source language is not supported by Brave backend. Currently we allow a
   // user to trigger a manual translation to have a chance to change the
   // incorrectly recognized source language to the correct one.

--- a/chromium_src/components/translate/core/browser/translate_prefs.cc
+++ b/chromium_src/components/translate/core/browser/translate_prefs.cc
@@ -7,6 +7,20 @@
 // chromium_src/chrome/browser/prefs/browser_prefs.cc
 #include "components/translate/core/browser/translate_prefs.h"
 
+#include "build/build_config.h"
+
 #define MigrateObsoleteProfilePrefs MigrateObsoleteProfilePrefs_ChromiumImpl
 #include "src/components/translate/core/browser/translate_prefs.cc"
 #undef MigrateObsoleteProfilePrefs
+
+#include "base/feature_override.h"
+
+namespace translate {
+
+OVERRIDE_FEATURE_DEFAULT_STATES({{
+#if BUILDFLAG(IS_ANDROID)
+    {kTranslate, base::FEATURE_DISABLED_BY_DEFAULT},
+#endif
+}});
+
+}  // namespace translate


### PR DESCRIPTION
<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/24076

Now it results in some side effects like unready UI menu element.
To enable translate for Android two features should be enabled (after merging this PR).
<img width="803" alt="image" src="https://user-images.githubusercontent.com/45488748/178997982-3566fe5b-81e4-4d18-a615-367ca8819b35.png">

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

