### PR TITLE
Add NTP search promo P3A question

### DIFF
--- a/browser/ui/omnibox/brave_omnibox_client_impl.cc
+++ b/browser/ui/omnibox/brave_omnibox_client_impl.cc
@@ -100,7 +100,7 @@ void BraveOmniboxClientImpl::OnURLOpenedFromOmnibox(OmniboxLog* log) {
     return;
   const auto match = log->result.match_at(log->selected_index);
   if (IsBraveSearchPromotionMatch(match)) {
-    brave_search_conversion::p3a::RecordOmniboxPromoTrigger(
+    brave_search_conversion::p3a::RecordPromoTrigger(
         g_browser_process->local_state(), GetConversionTypeFromMatch(match));
   }
 }

--- a/browser/ui/views/omnibox/brave_search_conversion_promotion_view.cc
+++ b/browser/ui/views/omnibox/brave_search_conversion_promotion_view.cc
@@ -289,7 +289,7 @@ void BraveSearchConversionPromotionView::SetTypeAndInput(
 
   UpdateState();
 
-  brave_search_conversion::p3a::RecordOmniboxPromoShown(local_state_, type);
+  brave_search_conversion::p3a::RecordPromoShown(local_state_, type);
 }
 
 void BraveSearchConversionPromotionView::OnSelectionStateChanged(
@@ -307,7 +307,7 @@ void BraveSearchConversionPromotionView::UpdateState() {
 }
 
 void BraveSearchConversionPromotionView::OpenMatch() {
-  brave_search_conversion::p3a::RecordOmniboxPromoTrigger(local_state_, type_);
+  brave_search_conversion::p3a::RecordPromoTrigger(local_state_, type_);
   result_view_->OpenMatch();
 }
 

--- a/browser/ui/webui/new_tab_page/brave_new_tab_page_handler.cc
+++ b/browser/ui/webui/new_tab_page/brave_new_tab_page_handler.cc
@@ -14,11 +14,14 @@
 #include "base/memory/ref_counted_memory.h"
 #include "base/task/thread_pool.h"
 #include "brave/browser/ntp_background_images/constants.h"
+#include "brave/components/brave_search_conversion/p3a.h"
 #include "brave/components/brave_search_conversion/pref_names.h"
+#include "brave/components/brave_search_conversion/types.h"
 #include "brave/components/brave_search_conversion/utils.h"
 #include "brave/components/constants/pref_names.h"
 #include "brave/components/l10n/common/locale_util.h"
 #include "brave/components/ntp_background_images/browser/url_constants.h"
+#include "chrome/browser/browser_process.h"
 #include "chrome/browser/image_fetcher/image_decoder_impl.h"
 #include "chrome/browser/profiles/profile.h"
 #include "chrome/browser/search_engines/template_url_service_factory.h"
@@ -83,6 +86,10 @@ void BraveNewTabPageHandler::InitForSearchPromotion() {
                           base::Unretained(this)));
   template_url_service_observation_.Observe(
       TemplateURLServiceFactory::GetForProfile(profile_));
+
+  brave_search_conversion::p3a::RecordPromoShown(
+      g_browser_process->local_state(),
+      brave_search_conversion::ConversionType::kNTP);
 }
 
 void BraveNewTabPageHandler::ChooseLocalCustomBackground() {
@@ -126,6 +133,10 @@ void BraveNewTabPageHandler::TryBraveSearchPromotion(const std::string& input,
   web_contents_->OpenURL(content::OpenURLParams(
       promo_url, content::Referrer(), window_open_disposition,
       ui::PageTransition::PAGE_TRANSITION_FORM_SUBMIT, false));
+
+  brave_search_conversion::p3a::RecordPromoTrigger(
+      g_browser_process->local_state(),
+      brave_search_conversion::ConversionType::kNTP);
 }
 
 void BraveNewTabPageHandler::DismissBraveSearchPromotion() {

--- a/components/brave_search_conversion/p3a.cc
+++ b/components/brave_search_conversion/p3a.cc
@@ -17,24 +17,28 @@ namespace p3a {
 
 namespace {
 
-const char* GetOmniboxShownPrefName(ConversionType type) {
+const char* GetPromoShownPrefName(ConversionType type) {
   switch (type) {
     case ConversionType::kBanner:
       return prefs::kP3ABannerShown;
     case ConversionType::kButton:
       return prefs::kP3AButtonShown;
+    case ConversionType::kNTP:
+      return prefs::kP3ANTPShown;
     default:
       NOTREACHED();
       return nullptr;
   }
 }
 
-const char* GetOmniboxTriggeredPrefName(ConversionType type) {
+const char* GetPromoTriggeredPrefName(ConversionType type) {
   switch (type) {
     case ConversionType::kBanner:
       return prefs::kP3ABannerTriggered;
     case ConversionType::kButton:
       return prefs::kP3AButtonTriggered;
+    case ConversionType::kNTP:
+      return prefs::kP3ANTPTriggered;
     default:
       NOTREACHED();
       return nullptr;
@@ -47,6 +51,8 @@ const char* GetPromoTypeHistogramName(ConversionType type) {
       return kSearchPromoBannerHistogramName;
     case ConversionType::kButton:
       return kSearchPromoButtonHistogramName;
+    case ConversionType::kNTP:
+      return kSearchPromoNTPHistogramName;
     default:
       NOTREACHED();
       return nullptr;
@@ -54,16 +60,16 @@ const char* GetPromoTypeHistogramName(ConversionType type) {
 }
 
 void UpdateHistograms(PrefService* prefs) {
-  const ConversionType types[] = {ConversionType::kBanner,
-                                  ConversionType::kButton};
+  const ConversionType types[] = {
+      ConversionType::kBanner, ConversionType::kButton, ConversionType::kNTP};
 
   VLOG(1) << "SearchConversionP3A: updating histograms";
 
   const bool default_engine_triggered =
       prefs->GetBoolean(prefs::kP3ADefaultEngineChanged);
   for (const auto type : types) {
-    const char* shown_pref_name = GetOmniboxShownPrefName(type);
-    const char* triggered_pref_name = GetOmniboxTriggeredPrefName(type);
+    const char* shown_pref_name = GetPromoShownPrefName(type);
+    const char* triggered_pref_name = GetPromoTriggeredPrefName(type);
     const char* histogram_name = GetPromoTypeHistogramName(type);
     DCHECK(shown_pref_name);
     DCHECK(triggered_pref_name);
@@ -93,16 +99,20 @@ void UpdateHistograms(PrefService* prefs) {
 void RegisterLocalStatePrefs(PrefRegistrySimple* registry) {
   registry->RegisterBooleanPref(prefs::kP3AButtonShown, false);
   registry->RegisterBooleanPref(prefs::kP3ABannerShown, false);
+  registry->RegisterBooleanPref(prefs::kP3ANTPShown, false);
+
   registry->RegisterBooleanPref(prefs::kP3ABannerTriggered, false);
   registry->RegisterBooleanPref(prefs::kP3AButtonTriggered, false);
+  registry->RegisterBooleanPref(prefs::kP3ANTPTriggered, false);
+
   registry->RegisterBooleanPref(prefs::kP3ADefaultEngineChanged, false);
 }
 
-void RecordOmniboxPromoShown(PrefService* prefs, ConversionType type) {
-  const char* pref_name = GetOmniboxShownPrefName(type);
+void RecordPromoShown(PrefService* prefs, ConversionType type) {
+  const char* pref_name = GetPromoShownPrefName(type);
   DCHECK(pref_name);
 
-  VLOG(1) << "SearchConversionP3A: omnibox promo shown, pref = " << pref_name;
+  VLOG(1) << "SearchConversionP3A: promo shown, pref = " << pref_name;
 
   const bool prev_setting = prefs->GetBoolean(pref_name);
   if (prev_setting) {
@@ -112,12 +122,11 @@ void RecordOmniboxPromoShown(PrefService* prefs, ConversionType type) {
   UpdateHistograms(prefs);
 }
 
-void RecordOmniboxPromoTrigger(PrefService* prefs, ConversionType type) {
-  const char* pref_name = GetOmniboxTriggeredPrefName(type);
+void RecordPromoTrigger(PrefService* prefs, ConversionType type) {
+  const char* pref_name = GetPromoTriggeredPrefName(type);
   DCHECK(pref_name);
 
-  VLOG(1) << "SearchConversionP3A: omnibox promo triggered, pref = "
-          << pref_name;
+  VLOG(1) << "SearchConversionP3A: promo triggered, pref = " << pref_name;
 
   const bool prev_setting = prefs->GetBoolean(pref_name);
   if (prev_setting) {

--- a/components/brave_search_conversion/p3a.h
+++ b/components/brave_search_conversion/p3a.h
@@ -16,10 +16,11 @@ namespace p3a {
 
 constexpr char kSearchPromoButtonHistogramName[] = "Brave.Search.Promo.Button";
 constexpr char kSearchPromoBannerHistogramName[] = "Brave.Search.Promo.Banner";
+constexpr char kSearchPromoNTPHistogramName[] = "Brave.Search.Promo.NewTabPage";
 
 void RegisterLocalStatePrefs(PrefRegistrySimple* registry);
-void RecordOmniboxPromoShown(PrefService* prefs, ConversionType type);
-void RecordOmniboxPromoTrigger(PrefService* prefs, ConversionType type);
+void RecordPromoShown(PrefService* prefs, ConversionType type);
+void RecordPromoTrigger(PrefService* prefs, ConversionType type);
 void RecordDefaultEngineChange(PrefService* prefs);
 
 }  // namespace p3a

--- a/components/brave_search_conversion/p3a_unittest.cc
+++ b/components/brave_search_conversion/p3a_unittest.cc
@@ -27,7 +27,10 @@ const ConversionTypeInfo type_infos[] = {
         .type = ConversionType::kButton,
         .histogram_name = kSearchPromoButtonHistogramName,
     },
-};
+    {
+        .type = ConversionType::kNTP,
+        .histogram_name = kSearchPromoNTPHistogramName,
+    }};
 
 class BraveSearchConversionP3ATest : public testing::Test {
  protected:
@@ -50,21 +53,21 @@ TEST_F(BraveSearchConversionP3ATest, TestOmniboxTriggerAndDefaultEngine) {
 
     histogram_tester_.ExpectTotalCount(type_info.histogram_name, 0);
 
-    RecordOmniboxPromoShown(GetPrefs(), type_info.type);
+    RecordPromoShown(GetPrefs(), type_info.type);
 
     histogram_tester_.ExpectTotalCount(type_info.histogram_name, 1);
     histogram_tester_.ExpectBucketCount(type_info.histogram_name, 0, 1);
 
-    RecordOmniboxPromoShown(GetPrefs(), type_info.type);
+    RecordPromoShown(GetPrefs(), type_info.type);
 
     // Should not record twice
     histogram_tester_.ExpectTotalCount(type_info.histogram_name, 1);
 
-    RecordOmniboxPromoTrigger(GetPrefs(), type_info.type);
+    RecordPromoTrigger(GetPrefs(), type_info.type);
     histogram_tester_.ExpectTotalCount(type_info.histogram_name, 2);
     histogram_tester_.ExpectBucketCount(type_info.histogram_name, 1, 1);
 
-    RecordOmniboxPromoTrigger(GetPrefs(), type_info.type);
+    RecordPromoTrigger(GetPrefs(), type_info.type);
 
     // Also should not record twice
     histogram_tester_.ExpectTotalCount(type_info.histogram_name, 2);
@@ -82,12 +85,12 @@ TEST_F(BraveSearchConversionP3ATest, TestOmniboxShownAndDefaultEngine) {
 
     histogram_tester_.ExpectTotalCount(type_info.histogram_name, 0);
 
-    RecordOmniboxPromoShown(GetPrefs(), type_info.type);
+    RecordPromoShown(GetPrefs(), type_info.type);
 
     histogram_tester_.ExpectTotalCount(type_info.histogram_name, 1);
     histogram_tester_.ExpectBucketCount(type_info.histogram_name, 0, 1);
 
-    RecordOmniboxPromoShown(GetPrefs(), type_info.type);
+    RecordPromoShown(GetPrefs(), type_info.type);
 
     // Should not record twice
     histogram_tester_.ExpectTotalCount(type_info.histogram_name, 1);

--- a/components/brave_search_conversion/pref_names.h
+++ b/components/brave_search_conversion/pref_names.h
@@ -15,10 +15,15 @@ constexpr char kDismissed[] = "brave.brave_search_conversion.dismissed";
 
 constexpr char kP3ABannerShown[] = "brave.brave_search_conversion.banner_shown";
 constexpr char kP3AButtonShown[] = "brave.brave_search_conversion.button_shown";
+constexpr char kP3ANTPShown[] = "brave.brave_search_conversion.ntp_shown";
+
 constexpr char kP3ABannerTriggered[] =
     "brave.brave_search_conversion.banner_triggered";
 constexpr char kP3AButtonTriggered[] =
     "brave.brave_search_conversion.button_triggered";
+constexpr char kP3ANTPTriggered[] =
+    "brave.brave_search_conversion.ntp_triggered";
+
 constexpr char kP3ADefaultEngineChanged[] =
     "brave.brave_search_conversion.default_changed";
 

--- a/components/brave_search_conversion/types.h
+++ b/components/brave_search_conversion/types.h
@@ -12,6 +12,7 @@ enum class ConversionType {
   kNone = 0,
   kButton,
   kBanner,
+  kNTP,
 };
 
 }  // namespace brave_search_conversion

--- a/components/p3a/metric_names.h
+++ b/components/p3a/metric_names.h
@@ -49,6 +49,7 @@ constexpr inline auto kCollectedHistograms =
     "Brave.Search.DefaultEngine.4",
     "Brave.Search.Promo.Banner",
     "Brave.Search.Promo.Button",
+    "Brave.Search.Promo.NewTabPage",
     "Brave.Search.SwitchEngine",
     "Brave.Shields.AdBlockSetting",
     "Brave.Shields.DomainAdsSettingsAboveGlobal",


### PR DESCRIPTION
<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves brave/brave-browser#24065

## Submitter Checklist:

- [ ] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

Regression testing of brave/brave-browser#23191 recommended.

1. Launch browser using `--enable-features="BraveSearchNTP"` switch, with fresh profile.
2. Access `brave://local-state`, ensure `Brave.Search.Promo.NewTabPage` does not exist.
3. Access `brave://settings/search`, change search engine to something other than Brave.
4. Ensure sponsored images are disabled and access new tab page, ensure promo appears.
5. Check local state, the metric should now exist, and should be set to 0.
6. Make search query via NTP promo.
7. Metric should have a value of 1.
8. Change the default search engine to Brave by either clicking on the prompt that appears on the search engine results page, or via `brave://settings/search` (may be good to test both).
9. Relevant metric should have a value of 3.
10. Start over with a fresh profile, see promo but do not perform a search.
11. Change search engine to Brave via one of the methods in step 8. (Accessing https://search.brave.com/search?q=test&action=makeDefault directly will force the SERP prompt to show up.)
12. Relevant metric should have a value of 2.