### PR TITLE
Adjust translate initialization timeouts (uplift to 1.42.x)

### DIFF
--- a/browser/translate/brave_translate_prefs_migration.cc
+++ b/browser/translate/brave_translate_prefs_migration.cc
@@ -29,6 +29,9 @@ void MigrateBraveProfilePrefs(PrefService* prefs) {
     return;  // Already migrated
 
   prefs->SetBoolean(prefs::kMigratedToInternalTranslation, true);
+
+  // TODO(matuchin): make kOfferTranslateEnabled syncable again when the
+  // migration is finished.
   prefs->ClearPref(prefs::kOfferTranslateEnabled);
 }
 

--- a/patches/chrome-browser-ui-browser_ui_prefs.cc.patch
+++ b/patches/chrome-browser-ui-browser_ui_prefs.cc.patch
@@ -1,0 +1,13 @@
+diff --git a/chrome/browser/ui/browser_ui_prefs.cc b/chrome/browser/ui/browser_ui_prefs.cc
+index d70f76650ce3d2c380e81751f0fa039ec2894ad9..a2f87acfa34cfa6b59c2150baeb7a85af1048021 100644
+--- a/chrome/browser/ui/browser_ui_prefs.cc
++++ b/chrome/browser/ui/browser_ui_prefs.cc
+@@ -78,7 +78,7 @@ void RegisterBrowserUserPrefs(user_prefs::PrefRegistrySyncable* registry) {
+   registry->RegisterBooleanPref(prefs::kWebAppCreateInQuickLaunchBar, true);
+   registry->RegisterBooleanPref(
+       translate::prefs::kOfferTranslateEnabled, true,
+-      user_prefs::PrefRegistrySyncable::SYNCABLE_PREF);
++      user_prefs::PrefRegistrySyncable::NO_REGISTRATION_FLAGS);
+   registry->RegisterStringPref(prefs::kCloudPrintEmail, std::string());
+   registry->RegisterBooleanPref(prefs::kCloudPrintProxyEnabled, true);
+   registry->RegisterBooleanPref(prefs::kCloudPrintSubmitEnabled, true);

--- a/patches/components-translate-content-renderer-per_frame_translate_agent.cc.patch
+++ b/patches/components-translate-content-renderer-per_frame_translate_agent.cc.patch
@@ -1,0 +1,13 @@
+diff --git a/components/translate/content/renderer/per_frame_translate_agent.cc b/components/translate/content/renderer/per_frame_translate_agent.cc
+index 34974e0bf54b5210faf8b16fc764657f9b55221e..5455604f53bb44f88e357797078e4b59e1d42362 100644
+--- a/components/translate/content/renderer/per_frame_translate_agent.cc
++++ b/components/translate/content/renderer/per_frame_translate_agent.cc
+@@ -49,7 +49,7 @@ const int kTranslateInitCheckDelayMs = 150;
+ 
+ // The maximum number of times we'll check to see if the translate library
+ // injected in the page is ready.
+-const int kMaxTranslateInitCheckAttempts = 5;
++const int kMaxTranslateInitCheckAttempts = 8;
+ 
+ // The delay we wait in milliseconds before checking whether the translation has
+ // finished.

--- a/patches/components-translate-content-renderer-translate_agent.cc.patch
+++ b/patches/components-translate-content-renderer-translate_agent.cc.patch
@@ -1,0 +1,13 @@
+diff --git a/components/translate/content/renderer/translate_agent.cc b/components/translate/content/renderer/translate_agent.cc
+index ef6beefc0b9c9907a899ccc3016c4e5a2f801d1e..697545d62c9fbe321f3d49e2bc6b2fd5157c537b 100644
+--- a/components/translate/content/renderer/translate_agent.cc
++++ b/components/translate/content/renderer/translate_agent.cc
+@@ -56,7 +56,7 @@ const int kTranslateInitCheckDelayMs = 150;
+ 
+ // The maximum number of times we'll check to see if the translate library
+ // injected in the page is ready.
+-const int kMaxTranslateInitCheckAttempts = 5;
++const int kMaxTranslateInitCheckAttempts = 8;
+ 
+ // The delay we wait in milliseconds before checking whether the translation has
+ // finished.


### PR DESCRIPTION
Uplift of #14181 + one commit https://github.com/brave/brave-core/pull/14047/commits/ffeec90ff89d94b2a14ee90d948600adfe3610fc

These things are needed to launch translate in 1.42.x. The uplift itself is safe to merge because all the changes are related the case when the new flag is enabled. 
Resolves https://github.com/brave/brave-browser/issues/24075

Pre-approval checklist: 
- [ ] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [ ] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [ ] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [ ] The associated issue milestone is set to the smallest version that the changes is landed on.