### PR TITLE
The content on brave://settings/braveHelpTips disappears upon reload and direct access via the address bar (uplift to 1.42.x)

### DIFF
--- a/browser/resources/settings/BUILD.gn
+++ b/browser/resources/settings/BUILD.gn
@@ -147,7 +147,7 @@ preprocess_if_expr("preprocess_generated") {
     "brave_ipfs_page/add_ipfs_peer_dialog.js",
     "brave_default_extensions_page/brave_default_extensions_browser_proxy.m.js",
     "brave_default_extensions_page/brave_default_extensions_page.m.js",
-    "brave_help_tips_page/brave_help_tips_page.m.js",
+    "brave_help_tips_page/brave_help_tips_page.js",
     "brave_icons.m.js",
     "brave_new_tab_page/brave_new_tab_browser_proxy.m.js",
     "brave_new_tab_page/brave_new_tab_page.m.js",

--- a/browser/resources/settings/brave_help_tips_page/BUILD.gn
+++ b/browser/resources/settings/brave_help_tips_page/BUILD.gn
@@ -3,21 +3,17 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this file,
 # you can obtain one at http://mozilla.org/MPL/2.0/.
 
+import("//tools/polymer/html_to_js.gni")
 import("//tools/polymer/polymer.gni")
+import("//ui/webui/resources/tools/js_modulizer.gni")
 import("../settings.gni")
 
 # ES Module conversion from HTML Imports code
 
 group("web_modules") {
-  public_deps = [
-    ":brave_help_tips_page_module",
-  ]
+  public_deps = [ ":templatize" ]
 }
 
-polymer_modulizer("brave_help_tips_page") {
-  js_file = "brave_help_tips_page.js"
-  html_file = "brave_help_tips_page.html"
-  html_type = "dom-module"
-  auto_imports = settings_auto_imports
-  namespace_rewrites = settings_namespace_rewrites
+html_to_js("templatize") {
+  js_files = [ "brave_help_tips_page.js" ]
 }

--- a/browser/resources/settings/brave_help_tips_page/brave_help_tips_page.html
+++ b/browser/resources/settings/brave_help_tips_page/brave_help_tips_page.html
@@ -1,28 +1,18 @@
-<link rel="import" href="chrome://resources/html/polymer.html">
 
-<link rel="import" href="chrome://resources/html/i18n_behavior.html">
-<link rel="import" href="chrome://resources/cr_elements/md_select_css.html">
-<script type="module" src="../settings_shared_css.js"></script>
-<script type="module" src="../settings_vars_css.js"></script>
+<if expr="enable_brave_wayback_machine">
+  <settings-toggle-button class="cr-row"
+                          pref="{{prefs.brave.wayback_machine_enabled}}"
+                          label="$i18n{braveHelpTipsWaybackMachineLabel}">
+  </settings-toggle-button>
+</if>
+  <settings-toggle-button class="cr-row"
+                          pref="{{prefs.brave.enable_window_closing_confirm}}"
+                          label="$i18n{braveHelpTipsWarnBeforeClosingWindow}">
+  </settings-toggle-button>
+<if expr="is_macosx">
+  <settings-toggle-button class="cr-row"
+                          pref="{{prefs.browser.confirm_to_quit}}"
+                          label="$i18n{warnBeforeQuitting}">
+  </settings-toggle-button>
+</if>
 
-<dom-module id="settings-brave-help-tips-page">
-  <template>
-  <if expr="enable_brave_wayback_machine">
-    <settings-toggle-button class="cr-row"
-                            pref="{{prefs.brave.wayback_machine_enabled}}"
-                            label="$i18n{braveHelpTipsWaybackMachineLabel}">
-    </settings-toggle-button>
-  </if>
-    <settings-toggle-button class="cr-row"
-                            pref="{{prefs.brave.enable_window_closing_confirm}}"
-                            label="$i18n{braveHelpTipsWarnBeforeClosingWindow}">
-    </settings-toggle-button>
-  <if expr="is_macosx">
-    <settings-toggle-button class="cr-row"
-                            pref="{{prefs.browser.confirm_to_quit}}"
-                            label="$i18n{warnBeforeQuitting}">
-    </settings-toggle-button>
-  </if>
-  </template>
-  <script src="brave_help_tips_page.js"></script>
-</dom-module>

--- a/browser/resources/settings/brave_help_tips_page/brave_help_tips_page.js
+++ b/browser/resources/settings/brave_help_tips_page/brave_help_tips_page.js
@@ -2,15 +2,23 @@
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
+ 
+ import {html, PolymerElement} from 'chrome://resources/polymer/v3_0/polymer/polymer_bundled.min.js';
+ import {WebUIListenerMixin} from 'chrome://resources/js/web_ui_listener_mixin.js';
+ import {PrefsMixin} from '../prefs/prefs_mixin.js';
+ 
+ const SettingBraveHelpTipsPageElementBase = WebUIListenerMixin(PrefsMixin(PolymerElement))
 
-(function() {
-  'use strict';
 
-  /**
-   * 'settings-brave-help-tips-page' is the settings page containing
-   * brave's help tips features.
-   */
-  Polymer({
-    is: 'settings-brave-help-tips-page'
-  });
-})();
+class SettingsBraveHelpTipsPageElement extends SettingBraveHelpTipsPageElementBase {
+  static get is() {
+    return 'settings-brave-help-tips-page'
+  }
+
+  static get template() {
+    return html`{__html_template__}`
+  }
+}
+
+customElements.define(
+  SettingsBraveHelpTipsPageElement.is, SettingsBraveHelpTipsPageElement)

--- a/browser/resources/settings/brave_overrides/basic_page.js
+++ b/browser/resources/settings/brave_overrides/basic_page.js
@@ -7,7 +7,7 @@ import {html, RegisterPolymerTemplateModifications, RegisterStyleOverride} from 
 import {loadTimeData} from '../i18n_setup.js'
 
 import '../brave_default_extensions_page/brave_default_extensions_page.m.js'
-import '../brave_help_tips_page/brave_help_tips_page.m.js'
+import '../brave_help_tips_page/brave_help_tips_page.js'
 import '../brave_ipfs_page/brave_ipfs_page.js'
 import '../brave_new_tab_page/brave_new_tab_page.m.js'
 import '../brave_rewards_page/brave_rewards_page.js'

--- a/browser/resources/settings/brave_routes.js
+++ b/browser/resources/settings/brave_routes.js
@@ -41,7 +41,7 @@ export default function addBraveRoutes(r) {
     r.BRAVE_WALLET_NETWORKS = r.BRAVE_WALLET.createChild('/wallet/networks');
   }
 
-  r.BRAVE_HELP_TIPS = r.BASIC.createSection('/braveHelpTips', 'braveHelpTips')
+  r.BRAVE_HELP_TIPS = r.ADVANCED.createSection('/braveHelpTips', 'braveHelpTips')
   r.BRAVE_NEW_TAB = r.BASIC.createSection('/newTab', 'newTab')
   if (r.SITE_SETTINGS) {
     r.SITE_SETTINGS_AUTOPLAY = r.SITE_SETTINGS.createChild('autoplay')

--- a/browser/resources/settings/sources.gni
+++ b/browser/resources/settings/sources.gni
@@ -13,7 +13,7 @@ brave_deps_chrome_browser_resources_settings_in_files = [
   "brave_clear_browsing_data_dialog/brave_clear_browsing_data_on_exit_page.js",
   "brave_default_extensions_page/brave_default_extensions_browser_proxy.m.js",
   "brave_default_extensions_page/brave_default_extensions_page.m.js",
-  "brave_help_tips_page/brave_help_tips_page.m.js",
+  "brave_help_tips_page/brave_help_tips_page.js",
   "brave_icons.m.js",
   "brave_ipfs_page/brave_ipfs_browser_proxy.m.js",
   "brave_ipfs_page/brave_ipfs_page.js",


### PR DESCRIPTION
Uplift of #14118
Resolves https://github.com/brave/brave-browser/issues/22736

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.