### PR TITLE
Fixed tab group border thickness in light theme

### DIFF
--- a/browser/ui/color/BUILD.gn
+++ b/browser/ui/color/BUILD.gn
@@ -1,0 +1,16 @@
+# Copyright (c) 2022 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at http://mozilla.org/MPL/2.0/.
+
+source_set("unit_tests") {
+  testonly = true
+  sources = [ "color_palette_unittest.cc" ]
+
+  deps = [
+    "//brave/browser/ui",
+    "//chrome/browser/ui/color:mixers",
+    "//testing/gtest",
+    "//ui/gfx",
+  ]
+}

--- a/browser/ui/color/color_palette_unittest.cc
+++ b/browser/ui/color/color_palette_unittest.cc
@@ -1,0 +1,16 @@
+/* Copyright (c) 2022 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "brave/browser/ui/color/color_palette.h"
+#include "brave/browser/ui/views/tabs/brave_tab_strip.h"
+#include "testing/gtest/include/gtest/gtest.h"
+#include "ui/gfx/color_utils.h"
+
+TEST(ColorPaletteTest, LightThemeMinimumContrast) {
+  // Re-visit kBraveMinimumContrastRatioForOutlines when contrast ratio between
+  // kLightToolbar and kLightFrame has lowered.
+  EXPECT_GT(color_utils::GetContrastRatio(kLightToolbar, kLightFrame),
+            BraveTabStrip::kBraveMinimumContrastRatioForOutlines);
+}

--- a/browser/ui/views/tabs/brave_tab_strip.h
+++ b/browser/ui/views/tabs/brave_tab_strip.h
@@ -16,8 +16,14 @@ class BraveTabStrip : public TabStrip {
   BraveTabStrip& operator=(const BraveTabStrip&) = delete;
 
  private:
+  FRIEND_TEST_ALL_PREFIXES(ColorPaletteTest, LightThemeMinimumContrast);
+
   // TabStrip overrides:
   SkColor GetTabSeparatorColor() const override;
+  bool ShouldDrawStrokes() const override;
+
+  // Exposed for testing.
+  static constexpr float kBraveMinimumContrastRatioForOutlines = 1.2797f;
 };
 
 #endif  // BRAVE_BROWSER_UI_VIEWS_TABS_BRAVE_TAB_STRIP_H_

--- a/chromium_src/chrome/browser/ui/views/tabs/tab_strip.h
+++ b/chromium_src/chrome/browser/ui/views/tabs/tab_strip.h
@@ -1,0 +1,18 @@
+/* Copyright (c) 2022 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_CHROMIUM_SRC_CHROME_BROWSER_UI_VIEWS_TABS_TAB_STRIP_H_
+#define BRAVE_CHROMIUM_SRC_CHROME_BROWSER_UI_VIEWS_TABS_TAB_STRIP_H_
+
+#define ShouldDrawStrokes     \
+  UnUsed() { return true; }   \
+  friend class BraveTabStrip; \
+  virtual bool ShouldDrawStrokes
+
+#include "src/chrome/browser/ui/views/tabs/tab_strip.h"
+
+#undef ShouldDrawStrokes
+
+#endif  // BRAVE_CHROMIUM_SRC_CHROME_BROWSER_UI_VIEWS_TABS_TAB_STRIP_H_

--- a/test/BUILD.gn
+++ b/test/BUILD.gn
@@ -363,6 +363,7 @@ test("brave_unit_tests") {
     ]
     deps += [
       "//brave/app:brave_generated_resources_grit",
+      "//brave/browser/ui/color:unit_tests",
       "//brave/browser/ui/toolbar:brave_app_menu_unit_test",
       "//brave/components/brave_shields/common:mojom",
       "//brave/components/brave_wallet/browser:pref_names",


### PR DESCRIPTION
fix https://github.com/brave/brave-browser/issues/24095

<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves 
<img width="553" alt="Screen Shot 2022-07-18 at 10 44 00 AM" src="https://user-images.githubusercontent.com/6786187/179434429-31ec64c6-f994-4cff-be15-848f21ed93d4.png">
<img width="461" alt="Screen Shot 2022-07-18 at 10 44 06 AM" src="https://user-images.githubusercontent.com/6786187/179434431-7e6b9a8f-8fa9-41be-8195-87eeddfe8d8e.png">

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

`npm run test -- --filter=ColorPaletteTest.LightThemeMinimumContrast`

See the linked issue for STR.