### PR TITLE
Fix arm64 mac symbols generation

### DIFF
--- a/app/mac/BUILD.gn
+++ b/app/mac/BUILD.gn
@@ -32,6 +32,9 @@ group("symbol_dist_resources") {
 }
 
 action("generate_breakpad_symbols") {
+  # host_toolchain must be used for cross-compilation case.
+  # See chrome/updater/mac:syms
+  dump_syms = "//third_party/breakpad:dump_syms($host_toolchain)"
   symbols_dir = "$brave_dist_dir/$brave_product_name.breakpad.syms"
   outputs = [ symbols_dir ]
 
@@ -49,6 +52,8 @@ action("generate_breakpad_symbols") {
     "--build-dir=" + rebase_path(root_out_dir),
     "--binary=$binaries",
     "--libchromiumcontent-dir=" + rebase_path("//"),
+    "--dump-syms-bin=" + rebase_path(get_label_info(dump_syms, "root_out_dir") +
+                                     "/" + get_label_info(dump_syms, "name")),
     "--clear",
   ]
 
@@ -57,7 +62,7 @@ action("generate_breakpad_symbols") {
     "//chrome:chrome_dump_syms",
     "//chrome:chrome_framework",
     "//chrome:chrome_helper_app_default",
-    "//third_party/breakpad:dump_syms",
     "//third_party/crashpad/crashpad/handler:crashpad_handler",
+    dump_syms,
   ]
 }


### PR DESCRIPTION
<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/23696

The main problem: arm64 `dump_syms` was used on intel mac.
Fixed the same way as chromium does https://github.com/chromium/chromium/blob/main/chrome/BUILD.gn#L1298

Also Chromium already have scripts to generate breakpad symbols and we call it (yep, double symbols generation).
I've created [an issue](https://github.com/brave/brave-browser/issues/24125) to reuse them, brave scripts like `generate_breakpad_symbols.py` should be retired.

P.S. I have to format/change some lines to make `pylint` happy.

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [x] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [x] New files have MPL-2.0 license header
- [x] Adequate test coverage exists to prevent regressions
- [x] Major classes, functions and non-trivial code blocks are well-commented
- [x] Changes in component dependencies are properly reflected in `gn`
- [x] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [x] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

