### PR TITLE
Fix encode type for array types (Open Sea and Evmos governance site were affected)

### DIFF
--- a/components/brave_wallet/common/eth_sign_typed_data_helper.cc
+++ b/components/brave_wallet/common/eth_sign_typed_data_helper.cc
@@ -62,8 +62,16 @@ void EthSignTypedDataHelper::FindAllDependencyTypes(
 
   for (const auto& field : anchor_type->GetList()) {
     const std::string* type = field.FindStringKey("type");
-    if (type && !known_types->contains(*type)) {
-      FindAllDependencyTypes(known_types, *type);
+    if (type) {
+      auto type_split = base::SplitString(*type, "[", base::KEEP_WHITESPACE,
+                                          base::SPLIT_WANT_ALL);
+      std::string lookup_type = *type;
+      if (type_split.size() == 2)
+        lookup_type = type_split[0];
+
+      if (!known_types->contains(lookup_type)) {
+        FindAllDependencyTypes(known_types, lookup_type);
+      }
     }
   }
 }

--- a/components/brave_wallet/common/eth_sign_typed_data_helper.h
+++ b/components/brave_wallet/common/eth_sign_typed_data_helper.h
@@ -50,7 +50,8 @@ class EthSignTypedDataHelper {
       const base::Value& domain_separator) const;
 
  private:
-  FRIEND_TEST_ALL_PREFIXES(EthSignedTypedDataHelperUnitTest, Types);
+  FRIEND_TEST_ALL_PREFIXES(EthSignedTypedDataHelperUnitTest, EncodeTypes);
+  FRIEND_TEST_ALL_PREFIXES(EthSignedTypedDataHelperUnitTest, EncodeTypesArrays);
   FRIEND_TEST_ALL_PREFIXES(EthSignedTypedDataHelperUnitTest, EncodeField);
 
   explicit EthSignTypedDataHelper(const base::Value& types, Version version);


### PR DESCRIPTION
Resolves https://github.com/brave/brave-browser/issues/23889
Resolves https://github.com/brave/brave-browser/issues/22650
Resolves https://github.com/brave/brave-browser/issues/23298


Basically we were getting a type hash of:
`Mail(Person[] to)`

instead of
`Mail(Person[] to)Person(string name,address wallet)`

But only if there was no other `Person` type (like in the `from` field)
So if there was only an array and not another instance of the `Person` it would reproduce

So basically data type like this would reproduce:
```js
    "Mail": [
        {"name": "to", "type": "Person[]"},
    ],
    "Person": [
        {"name": "name", "type": "string"},
        {"name": "wallet", "type": "address"}
    ]})");
```

but one like this would NOT reproduce:

```js
    "Mail": [
        {"name": "to", "type": "Person[]"},
        {"name": "from", "type": "Person"},
    ],
    "Person": [
        {"name": "name", "type": "string"},
        {"name": "wallet", "type": "address"}
    ]})");
```

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [x] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [x] New files have MPL-2.0 license header
- [x] Adequate test coverage exists to prevent regressions
- [x] Major classes, functions and non-trivial code blocks are well-commented
- [x] Changes in component dependencies are properly reflected in `gn`
- [x] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [x] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

Try listing an NFT on OpenSea and make sure it doesn't give the invalid signature order error like it used to.