### PR TITLE
Add q value to fake accept-language header in max anti-fingerprinting mode (uplift to 1.42.x)

### DIFF
--- a/browser/brave_shields/reduce_language_navigation_throttle.cc
+++ b/browser/brave_shields/reduce_language_navigation_throttle.cc
@@ -86,7 +86,7 @@ void ReduceLanguageNavigationThrottle::UpdateHeaders() {
   // static value regardless of other preferences.
   if (fingerprinting_control_type == ControlType::BLOCK) {
     handle->SetRequestHeader(net::HttpRequestHeaders::kAcceptLanguage,
-                             "en-US,en");
+                             "en-US,en;q=0.9");
     return;
   }
 

--- a/browser/farbling/brave_navigator_languages_farbling_browsertest.cc
+++ b/browser/farbling/brave_navigator_languages_farbling_browsertest.cc
@@ -261,7 +261,7 @@ IN_PROC_BROWSER_TEST_F(BraveNavigatorLanguagesFarblingBrowserTest,
   // Farbling level: maximum
   // HTTP Accept-Language header should be farbled but the same across domains.
   BlockFingerprinting(domain_b);
-  SetExpectedHTTPAcceptLanguage("en-US,en");
+  SetExpectedHTTPAcceptLanguage("en-US,en;q=0.9");
   NavigateToURLUntilLoadStop(url_b);
   BlockFingerprinting(domain_d);
   NavigateToURLUntilLoadStop(url_d);


### PR DESCRIPTION
Uplift of #14235
Resolves https://github.com/brave/brave-browser/issues/24126

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.