### PR TITLE
Add ignore for warning triggered on dev-dependencies (uplift to 1.41.x)

### DIFF
--- a/script/audit_deps.py
+++ b/script/audit_deps.py
@@ -45,7 +45,9 @@ IGNORED_NPM_ADVISORIES = [
     'https://github.com/advisories/GHSA-w5p7-h5w8-2hfq',  # rxdos
     'https://github.com/advisories/GHSA-w8qv-6jwh-64r5',  # rxdos
     'https://github.com/advisories/GHSA-whgm-jr23-g3j9',  # rxdos
-    'https://github.com/advisories/GHSA-ww39-953v-wcq6'   # rxdos
+    'https://github.com/advisories/GHSA-ww39-953v-wcq6',  # rxdos
+    # Only affects dev dependencies (storybook, enzyme for unit test)
+    'https://github.com/advisories/GHSA-cj88-88mr-972w'   # rxdos
 ]
 
 


### PR DESCRIPTION
Uplift of #14242
Fixes https://github.com/brave/brave-browser/issues/24115

Pre-approval checklist: 
- [ ] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.