### PR TITLE
Fixed bookmarks bar inst text is not visible with custom theme and dark mode

### DIFF
--- a/browser/themes/theme_properties.cc
+++ b/browser/themes/theme_properties.cc
@@ -37,7 +37,6 @@ absl::optional<SkColor> MaybeGetDefaultColorForBraveLightUi(int id) {
       return kLightToolbar;
     case ThemeProperties::COLOR_TAB_FOREGROUND_ACTIVE_FRAME_ACTIVE:
     case ThemeProperties::COLOR_BOOKMARK_TEXT:
-    case BraveThemeProperties::COLOR_BOOKMARK_BAR_INSTRUCTIONS_TEXT:
     case ThemeProperties::COLOR_TAB_FOREGROUND_INACTIVE_FRAME_ACTIVE:
     case ThemeProperties::COLOR_TOOLBAR_BUTTON_ICON:
       return kLightToolbarIcon;
@@ -154,7 +153,6 @@ absl::optional<SkColor> MaybeGetDefaultColorForBraveDarkUi(int id) {
     case ThemeProperties::COLOR_TAB_FOREGROUND_ACTIVE_FRAME_ACTIVE:
       return SkColorSetRGB(0xF3, 0xF3, 0xF3);
     case ThemeProperties::COLOR_BOOKMARK_TEXT:
-    case BraveThemeProperties::COLOR_BOOKMARK_BAR_INSTRUCTIONS_TEXT:
     case ThemeProperties::COLOR_TAB_FOREGROUND_INACTIVE_FRAME_ACTIVE:
       return SkColorSetRGB(0xFF, 0xFF, 0xFF);
     case ThemeProperties::COLOR_TOOLBAR_BUTTON_ICON:

--- a/browser/ui/views/bookmarks/bookmark_bar_instructions_view.h
+++ b/browser/ui/views/bookmarks/bookmark_bar_instructions_view.h
@@ -37,8 +37,6 @@ class BookmarkBarInstructionsView : public views::View,
   void Layout() override;
   const char* GetClassName() const override;
   void OnThemeChanged() override;
-  void ViewHierarchyChanged(
-      const views::ViewHierarchyChangedDetails& details) override;
   void GetAccessibleNodeData(ui::AXNodeData* node_data) override;
 
   // views::ContextMenuController:
@@ -48,13 +46,11 @@ class BookmarkBarInstructionsView : public views::View,
 
   void UpdateColors();
   void LinkClicked();
+  SkColor GetInstructionsTextColor();
 
   raw_ptr<views::Label> instructions_ = nullptr;
   raw_ptr<views::Link> import_link_ = nullptr;
 
-  // Have the colors of the child views been updated? This is initially false
-  // and set to true once we have a valid ThemeProvider.
-  bool updated_colors_;
   raw_ptr<Browser> browser_ = nullptr;
 };
 


### PR DESCRIPTION
fix https://github.com/brave/brave-browser/issues/24110

Pick proper text color based on bookmarks bar bg colors for regular profile.
Custom theme is not applied to private(including tor and guest) profile.
<img width="660" alt="Screen Shot 2022-07-20 at 11 58 43 AM" src="https://user-images.githubusercontent.com/6786187/179887152-a1b5680f-39f8-46b2-abd8-459742becd39.png">
<img width="573" alt="Screen Shot 2022-07-20 at 12 04 19 PM" src="https://user-images.githubusercontent.com/6786187/179887296-56536cde-e825-480a-b5b7-4d829371908e.png">


<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves 

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

See the linked issue