### PR TITLE
Fix encode type for array types (Open Sea and Evmos governance site were affected) (uplift to 1.42.x)

### DIFF
--- a/components/brave_wallet/common/eth_sign_typed_data_helper.cc
+++ b/components/brave_wallet/common/eth_sign_typed_data_helper.cc
@@ -62,8 +62,16 @@ void EthSignTypedDataHelper::FindAllDependencyTypes(
 
   for (const auto& field : anchor_type->GetList()) {
     const std::string* type = field.FindStringKey("type");
-    if (type && !known_types->contains(*type)) {
-      FindAllDependencyTypes(known_types, *type);
+    if (type) {
+      auto type_split = base::SplitString(*type, "[", base::KEEP_WHITESPACE,
+                                          base::SPLIT_WANT_ALL);
+      std::string lookup_type = *type;
+      if (type_split.size() == 2)
+        lookup_type = type_split[0];
+
+      if (!known_types->contains(lookup_type)) {
+        FindAllDependencyTypes(known_types, lookup_type);
+      }
     }
   }
 }

--- a/components/brave_wallet/common/eth_sign_typed_data_helper.h
+++ b/components/brave_wallet/common/eth_sign_typed_data_helper.h
@@ -50,7 +50,8 @@ class EthSignTypedDataHelper {
       const base::Value& domain_separator) const;
 
  private:
-  FRIEND_TEST_ALL_PREFIXES(EthSignedTypedDataHelperUnitTest, Types);
+  FRIEND_TEST_ALL_PREFIXES(EthSignedTypedDataHelperUnitTest, EncodeTypes);
+  FRIEND_TEST_ALL_PREFIXES(EthSignedTypedDataHelperUnitTest, EncodeTypesArrays);
   FRIEND_TEST_ALL_PREFIXES(EthSignedTypedDataHelperUnitTest, EncodeField);
 
   explicit EthSignTypedDataHelper(const base::Value& types, Version version);


### PR DESCRIPTION
Uplift of #14239
Resolves https://github.com/brave/brave-browser/issues/23889
Resolves https://github.com/brave/brave-browser/issues/22650
Resolves https://github.com/brave/brave-browser/issues/23298

Pre-approval checklist: 
- [ ] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [ ] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [ ] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [ ] The associated issue milestone is set to the smallest version that the changes is landed on.