### PR TITLE
NotificationHelperWin::CanShowNativeNotifications cannot be const

### DIFF
--- a/browser/brave_ads/notification_helper/notification_helper.cc
+++ b/browser/brave_ads/notification_helper/notification_helper.cc
@@ -15,7 +15,7 @@ NotificationHelper::NotificationHelper() = default;
 
 NotificationHelper::~NotificationHelper() = default;
 
-bool NotificationHelper::CanShowNativeNotifications() const {
+bool NotificationHelper::CanShowNativeNotifications() {
   return true;
 }
 

--- a/browser/brave_ads/notification_helper/notification_helper.h
+++ b/browser/brave_ads/notification_helper/notification_helper.h
@@ -16,7 +16,7 @@ class NotificationHelper {
 
   static NotificationHelper* GetInstance();
 
-  virtual bool CanShowNativeNotifications() const;
+  virtual bool CanShowNativeNotifications();
   virtual bool CanShowNativeNotificationsWhileBrowserIsBackgrounded() const;
 
   virtual bool ShowOnboardingNotification();

--- a/browser/brave_ads/notification_helper/notification_helper_android.cc
+++ b/browser/brave_ads/notification_helper/notification_helper_android.cc
@@ -61,7 +61,7 @@ NotificationHelperAndroid::NotificationHelperAndroid() = default;
 
 NotificationHelperAndroid::~NotificationHelperAndroid() = default;
 
-bool NotificationHelperAndroid::CanShowNativeNotifications() const {
+bool NotificationHelperAndroid::CanShowNativeNotifications() {
   JNIEnv* env = base::android::AttachCurrentThread();
   const int status =
       Java_NotificationSystemStatusUtil_getAppNotificationStatus(env);

--- a/browser/brave_ads/notification_helper/notification_helper_android.h
+++ b/browser/brave_ads/notification_helper/notification_helper_android.h
@@ -27,7 +27,7 @@ class NotificationHelperAndroid
 
  private:
   // NotificationHelper:
-  bool CanShowNativeNotifications() const override;
+  bool CanShowNativeNotifications() override;
   bool CanShowNativeNotificationsWhileBrowserIsBackgrounded() const override;
 
   bool ShowOnboardingNotification() override;

--- a/browser/brave_ads/notification_helper/notification_helper_linux.cc
+++ b/browser/brave_ads/notification_helper/notification_helper_linux.cc
@@ -15,7 +15,7 @@ NotificationHelperLinux::NotificationHelperLinux() = default;
 
 NotificationHelperLinux::~NotificationHelperLinux() = default;
 
-bool NotificationHelperLinux::CanShowNativeNotifications() const {
+bool NotificationHelperLinux::CanShowNativeNotifications() {
   // TODO(https://github.com/brave/brave-browser/issues/5542): Investigate how
   // to detect if notifications are enabled within the Linux operating system
 

--- a/browser/brave_ads/notification_helper/notification_helper_linux.h
+++ b/browser/brave_ads/notification_helper/notification_helper_linux.h
@@ -26,7 +26,7 @@ class NotificationHelperLinux
 
  private:
   // NotificationHelper:
-  bool CanShowNativeNotifications() const override;
+  bool CanShowNativeNotifications() override;
   bool CanShowNativeNotificationsWhileBrowserIsBackgrounded() const override;
 
   bool ShowOnboardingNotification() override;

--- a/browser/brave_ads/notification_helper/notification_helper_mac.h
+++ b/browser/brave_ads/notification_helper/notification_helper_mac.h
@@ -26,7 +26,7 @@ class NotificationHelperMac
 
  private:
   // NotificationHelper:
-  bool CanShowNativeNotifications() const override;
+  bool CanShowNativeNotifications() override;
   bool CanShowNativeNotificationsWhileBrowserIsBackgrounded() const override;
 
   bool ShowOnboardingNotification() override;

--- a/browser/brave_ads/notification_helper/notification_helper_mac.mm
+++ b/browser/brave_ads/notification_helper/notification_helper_mac.mm
@@ -152,7 +152,7 @@ NotificationHelperMac::NotificationHelperMac() = default;
 
 NotificationHelperMac::~NotificationHelperMac() = default;
 
-bool NotificationHelperMac::CanShowNativeNotifications() const {
+bool NotificationHelperMac::CanShowNativeNotifications() {
   if (!base::FeatureList::IsEnabled(::features::kNativeNotifications)) {
     LOG(WARNING) << "Native notifications feature is disabled";
     return false;

--- a/browser/brave_ads/notification_helper/notification_helper_mock.h
+++ b/browser/brave_ads/notification_helper/notification_helper_mock.h
@@ -18,7 +18,7 @@ class NotificationHelperMock : public NotificationHelper {
   NotificationHelperMock& operator=(const NotificationHelperMock&) = delete;
   ~NotificationHelperMock() override;
 
-  MOCK_CONST_METHOD0(CanShowNativeNotifications, bool());
+  MOCK_METHOD0(CanShowNativeNotifications, bool());
   MOCK_CONST_METHOD0(CanShowNativeNotificationsWhileBrowserIsBackgrounded,
                      bool());
 

--- a/browser/brave_ads/notification_helper/notification_helper_win.cc
+++ b/browser/brave_ads/notification_helper/notification_helper_win.cc
@@ -62,7 +62,7 @@ NotificationHelperWin::NotificationHelperWin() = default;
 
 NotificationHelperWin::~NotificationHelperWin() = default;
 
-bool NotificationHelperWin::CanShowNativeNotifications() const {
+bool NotificationHelperWin::CanShowNativeNotifications() {
   if (!base::FeatureList::IsEnabled(::features::kNativeNotifications)) {
     LOG(WARNING) << "Native notifications feature is disabled";
     return false;

--- a/browser/brave_ads/notification_helper/notification_helper_win.h
+++ b/browser/brave_ads/notification_helper/notification_helper_win.h
@@ -44,7 +44,7 @@ class NotificationHelperWin
       notifier_;
 
   // NotificationHelper:
-  bool CanShowNativeNotifications() const override;
+  bool CanShowNativeNotifications() override;
   bool CanShowNativeNotificationsWhileBrowserIsBackgrounded() const override;
 
   bool ShowOnboardingNotification() override;


### PR DESCRIPTION
Fixes: https://github.com/brave/brave-browser/issues/24176

# Cherry-pick of https://github.com/brave/brave-core/commit/a00cc7e93331c854b3fcec9b8c004399b3a3f5c6

It calls IsNotificationEnabled which is not const (and cannot be const
because it calls InitializeToastNotifier which modifies member var).

Rolling back the change to const introduced in
https://github.com/brave/brave-core/pull/14207

Windows error:

../../brave/browser/brave_ads/notification_helper/notification_helper_win.cc(164,16): error: 'this' argument to member function 'InitializeToastNotifier' has type 'const brave_ads::NotificationHelperWin', but function is not marked const
  HRESULT hr = InitializeToastNotifier();
               ^~~~~~~~~~~~~~~~~~~~~~~
../..\brave/browser/brave_ads/notification_helper/notification_helper_win.h(37,11): note: 'InitializeToastNotifier' declared here
  HRESULT InitializeToastNotifier();
          ^
1 error generated.

<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves 

## Submitter Checklist:

- [ ] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [x] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [x] New files have MPL-2.0 license header
- [x] Adequate test coverage exists to prevent regressions
- [x] Major classes, functions and non-trivial code blocks are well-commented
- [x] Changes in component dependencies are properly reflected in `gn`
- [x] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [x] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

