### PR TITLE
[De-AMP] Check for canonical link tag in subsequent chunks as well

### DIFF
--- a/components/body_sniffer/body_sniffer_url_loader.cc
+++ b/components/body_sniffer/body_sniffer_url_loader.cc
@@ -249,25 +249,30 @@ void BodySnifferURLLoader::SendBufferedBodyToClient() {
   // Send the buffered data first.
   DCHECK_GT(bytes_remaining_in_buffer_, 0u);
   size_t start_position = buffered_body_.size() - bytes_remaining_in_buffer_;
+  std::cerr << "in SendBufferedBodyToClient, start_position " << start_position << "\n";
   uint32_t bytes_sent = bytes_remaining_in_buffer_;
   MojoResult result =
       body_producer_handle_->WriteData(buffered_body_.data() + start_position,
                                        &bytes_sent, MOJO_WRITE_DATA_FLAG_NONE);
   switch (result) {
     case MOJO_RESULT_OK:
+      std::cerr << "in SendBufferedBodyToClient, bytes sent successfully " << "\n";
       break;
     case MOJO_RESULT_FAILED_PRECONDITION:
       // The pipe is closed unexpectedly. |this| should be deleted once
       // URLLoaderPtr on the destination is released.
+      std::cerr << "in SendBufferedBodyToClient, FAILURE, bytes NOT sent successfully " << "\n";
       Abort();
       return;
     case MOJO_RESULT_SHOULD_WAIT:
+      std::cerr << "in SendBufferedBodyToClient, SHOULD WAIT " << "\n";
       body_producer_watcher_.ArmOrNotify();
       return;
     default:
       NOTREACHED();
       return;
   }
+  std::cerr << "in SendBufferedBodyToClient, bytes sent: " << bytes_sent << "\n";
   bytes_remaining_in_buffer_ -= bytes_sent;
   body_producer_watcher_.ArmOrNotify();
 }

--- a/components/body_sniffer/body_sniffer_url_loader.cc
+++ b/components/body_sniffer/body_sniffer_url_loader.cc
@@ -5,7 +5,6 @@
 
 #include "brave/components/body_sniffer/body_sniffer_url_loader.h"
 
-#include <iostream>
 #include <utility>
 
 #include "base/bind.h"
@@ -162,31 +161,22 @@ void BodySnifferURLLoader::ResumeReadingBodyFromNet() {
 // Only returns true if MOJO_RESULT_OK
 bool BodySnifferURLLoader::CheckBufferedBody(uint32_t readBufferSize) {
   size_t start_size = buffered_body_.size();  // Initial size
-  std::cerr << "read bytes before are " << read_bytes_ << "\n";
-  std::cerr << "start size " << start_size << "\n";
   uint32_t read_bytes = readBufferSize;
   buffered_body_.resize(start_size +
                         read_bytes);  // Increase size of the buffer vector
-  std::cerr << "read bytes after are " << read_bytes_ << "\n";
 
   auto result = body_consumer_handle_->ReadData(
       &buffered_body_[0] + start_size, &read_bytes, MOJO_READ_DATA_FLAG_NONE);
   switch (result) {
     case MOJO_RESULT_OK:
-      std::cerr << "OK: buffered body size after reading is "
-                << buffered_body_.size() << "\n";
       read_bytes_ += read_bytes;
       buffered_body_.resize(start_size + read_bytes);
       return true;
     case MOJO_RESULT_FAILED_PRECONDITION:
-      std::cerr << "FAILED: buffered body size after reading is "
-                << buffered_body_.size() << "\n";
       buffered_body_.resize(start_size);
       CompleteLoading(std::move(buffered_body_));
       break;
     case MOJO_RESULT_SHOULD_WAIT:
-      std::cerr << "SHOULD WAIT: buffered body size after reading is "
-                << buffered_body_.size() << "\n";
       body_consumer_watcher_.ArmOrNotify();
       break;
     default:
@@ -197,8 +187,6 @@ bool BodySnifferURLLoader::CheckBufferedBody(uint32_t readBufferSize) {
 }
 
 void BodySnifferURLLoader::CompleteLoading(std::string body) {
-  std::cerr << "In CompleteLoading"
-            << "\n";
   read_bytes_ = 0;
   DCHECK_EQ(State::kLoading, state_);
   state_ = State::kSending;
@@ -219,9 +207,6 @@ void BodySnifferURLLoader::CompleteLoading(std::string body) {
                           base::Unretained(this)));
 
   if (bytes_remaining_in_buffer_) {
-    std::cerr << "in completeloading, there are bytes remainign in buffer, "
-                 "send received body to client"
-              << "\n";
     SendBufferedBodyToClient();
     return;
   }
@@ -251,42 +236,29 @@ void BodySnifferURLLoader::CancelAndResetHandles() {
 }
 
 void BodySnifferURLLoader::SendBufferedBodyToClient() {
-  std::cerr << "in SendBufferedBodyToClient, bytes remaining in buffer "
-            << bytes_remaining_in_buffer_ << "\n";
   DCHECK_EQ(State::kSending, state_);
   // Send the buffered data first.
   DCHECK_GT(bytes_remaining_in_buffer_, 0u);
   size_t start_position = buffered_body_.size() - bytes_remaining_in_buffer_;
-  std::cerr << "in SendBufferedBodyToClient, start_position " << start_position
-            << "\n";
   uint32_t bytes_sent = bytes_remaining_in_buffer_;
   MojoResult result =
       body_producer_handle_->WriteData(buffered_body_.data() + start_position,
                                        &bytes_sent, MOJO_WRITE_DATA_FLAG_NONE);
   switch (result) {
     case MOJO_RESULT_OK:
-      std::cerr << "in SendBufferedBodyToClient, bytes sent successfully "
-                << "\n";
       break;
     case MOJO_RESULT_FAILED_PRECONDITION:
       // The pipe is closed unexpectedly. |this| should be deleted once
       // URLLoaderPtr on the destination is released.
-      std::cerr << "in SendBufferedBodyToClient, FAILURE, bytes NOT sent "
-                   "successfully "
-                << "\n";
       Abort();
       return;
     case MOJO_RESULT_SHOULD_WAIT:
-      std::cerr << "in SendBufferedBodyToClient, SHOULD WAIT "
-                << "\n";
       body_producer_watcher_.ArmOrNotify();
       return;
     default:
       NOTREACHED();
       return;
   }
-  std::cerr << "in SendBufferedBodyToClient, bytes sent: " << bytes_sent
-            << "\n";
   bytes_remaining_in_buffer_ -= bytes_sent;
   body_producer_watcher_.ArmOrNotify();
 }

--- a/components/body_sniffer/body_sniffer_url_loader.cc
+++ b/components/body_sniffer/body_sniffer_url_loader.cc
@@ -160,10 +160,10 @@ void BodySnifferURLLoader::ResumeReadingBodyFromNet() {
 
 // Only returns true if MOJO_RESULT_OK
 bool BodySnifferURLLoader::CheckBufferedBody(uint32_t readBufferSize) {
-  size_t start_size = buffered_body_.size();  // Initial size
+  size_t start_size = buffered_body_.size();  // Where to start reading from
   uint32_t read_bytes = readBufferSize;
-  buffered_body_.resize(start_size +
-                        read_bytes);  // Increase size of the buffer vector
+  // Increase size of the buffer to accommodate new bytes to read
+  buffered_body_.resize(start_size + read_bytes);
 
   auto result = body_consumer_handle_->ReadData(
       &buffered_body_[0] + start_size, &read_bytes, MOJO_READ_DATA_FLAG_NONE);

--- a/components/body_sniffer/body_sniffer_url_loader.h
+++ b/components/body_sniffer/body_sniffer_url_loader.h
@@ -100,7 +100,7 @@ class BodySnifferURLLoader : public network::mojom::URLLoaderClient,
   virtual void CompleteLoading(std::string body);
   void CompleteSending();
   virtual void OnCompleteSending();
-  void SendReceivedBodyToClient();
+  void SendBufferedBodyToClient();
 
   void Abort();
 
@@ -121,6 +121,7 @@ class BodySnifferURLLoader : public network::mojom::URLLoaderClient,
 
   std::string buffered_body_;
   size_t bytes_remaining_in_buffer_;
+  size_t read_bytes_;
 
   mojo::ScopedDataPipeConsumerHandle body_consumer_handle_;
   mojo::ScopedDataPipeProducerHandle body_producer_handle_;

--- a/components/body_sniffer/body_sniffer_url_loader.h
+++ b/components/body_sniffer/body_sniffer_url_loader.h
@@ -121,7 +121,7 @@ class BodySnifferURLLoader : public network::mojom::URLLoaderClient,
 
   std::string buffered_body_;
   size_t bytes_remaining_in_buffer_;
-  size_t read_bytes_;
+  size_t read_bytes_ = 0;
 
   mojo::ScopedDataPipeConsumerHandle body_consumer_handle_;
   mojo::ScopedDataPipeProducerHandle body_producer_handle_;

--- a/components/de_amp/browser/de_amp_url_loader.cc
+++ b/components/de_amp/browser/de_amp_url_loader.cc
@@ -93,8 +93,6 @@ bool DeAmpURLLoader::MaybeRedirectToCanonicalLink() {
     return false;
   }
 
-  // todo make sure that we're getting meaningfully different chunks every time.
-
   // If we are not already on an AMP page, check if this chunk has the AMP HTML
   if (!found_amp_ && !CheckIfAmpPage(buffered_body_)) {
     return false;
@@ -131,10 +129,9 @@ void DeAmpURLLoader::OnBodyWritable(MojoResult r) {
   }
 }
 
-// No buffered data to be sent, read and forward data to producer (renderer)
+// No buffered data to be sent, read and forward data to producer
 void DeAmpURLLoader::ForwardBodyToClient() {
   DCHECK_EQ(0u, bytes_remaining_in_buffer_);
-  // it's loading
   // Send the body from the consumer to the producer.
   const void* buffer;
   uint32_t buffer_size = 0;

--- a/components/de_amp/browser/de_amp_url_loader.cc
+++ b/components/de_amp/browser/de_amp_url_loader.cc
@@ -74,8 +74,8 @@ void DeAmpURLLoader::OnBodyReadable(MojoResult) {
   if (!CheckBufferedBody(kReadBufferSize)) {
     return;
   }
-  bool redirected = MaybeRedirectToCanonicalLink();
-  bool found_amp_but_not_canonical_link = !redirected && found_amp_;
+  const bool redirected = MaybeRedirectToCanonicalLink();
+  const bool found_amp_but_not_canonical_link = !redirected && found_amp_;
 
   // If we were not redirected (navigation is cancelled) and we didn't find AMP,
   // or if we did find AMP previously and we've already read more bytes than

--- a/components/de_amp/browser/de_amp_url_loader.cc
+++ b/components/de_amp/browser/de_amp_url_loader.cc
@@ -19,7 +19,7 @@ namespace {
 
 constexpr uint32_t kReadBufferSize = 65536;  // bytes
 constexpr uint32_t kMaxBytesToCheck =
-    kReadBufferSize * 2;  // Should always be a multiple
+    kReadBufferSize * 3;  // Should always be a multiple
 
 }  // namespace
 

--- a/components/de_amp/browser/de_amp_url_loader.h
+++ b/components/de_amp/browser/de_amp_url_loader.h
@@ -42,16 +42,13 @@ class DeAmpURLLoader : public body_sniffer::BodySnifferURLLoader {
                  mojo::PendingRemote<network::mojom::URLLoaderClient>
                      destination_url_loader_client,
                  scoped_refptr<base::SequencedTaskRunner> task_runner);
-
   void OnBodyReadable(MojoResult) override;
   void OnBodyWritable(MojoResult) override;
-  bool found_amp_ = false;
-
   bool MaybeRedirectToCanonicalLink();
-
   void ForwardBodyToClient();
 
   base::WeakPtr<DeAmpThrottle> de_amp_throttle_;
+  bool found_amp_ = false;
 };
 
 }  // namespace de_amp

--- a/components/de_amp/browser/de_amp_url_loader.h
+++ b/components/de_amp/browser/de_amp_url_loader.h
@@ -47,7 +47,6 @@ class DeAmpURLLoader : public body_sniffer::BodySnifferURLLoader {
   void OnBodyWritable(MojoResult) override;
   bool found_amp_ = false;
 
-
   bool MaybeRedirectToCanonicalLink();
 
   void ForwardBodyToClient();

--- a/components/de_amp/browser/de_amp_url_loader.h
+++ b/components/de_amp/browser/de_amp_url_loader.h
@@ -45,6 +45,8 @@ class DeAmpURLLoader : public body_sniffer::BodySnifferURLLoader {
 
   void OnBodyReadable(MojoResult) override;
   void OnBodyWritable(MojoResult) override;
+  bool found_amp_ = false;
+
 
   bool MaybeRedirectToCanonicalLink();
 

--- a/components/de_amp/browser/de_amp_util.cc
+++ b/components/de_amp/browser/de_amp_util.cc
@@ -7,7 +7,6 @@
 
 #include "base/feature_list.h"
 #include "base/no_destructor.h"
-#include "base/types/expected.h"
 #include "brave/components/de_amp/common/features.h"
 #include "brave/components/de_amp/common/pref_names.h"
 #include "components/prefs/pref_service.h"
@@ -30,7 +29,6 @@ constexpr char kFindCanonicalLinkTagPattern[] =
     "(<\\s*?link\\s[^>]*?rel=(?:\"|')?canonical(?:\"|')?(?:\\s[^>]*?>|>|/>))";
 constexpr char kFindCanonicalHrefInTagPattern[] =
     "href=(?:\"|')?(.*?)(?:\"|')?(?:\\s[^>]*?>|>|/>)";
-}  // namespace
 
 RE2::Options InitRegexOptions() {
   RE2::Options opt;
@@ -38,6 +36,8 @@ RE2::Options InitRegexOptions() {
   opt.set_dot_nl(true);
   return opt;
 }
+
+}  // namespace
 
 bool IsDeAmpEnabled(PrefService* prefs) {
   return base::FeatureList::IsEnabled(features::kBraveDeAMP) &&
@@ -52,7 +52,6 @@ bool VerifyCanonicalAmpUrl(const GURL& canonical_link,
          canonical_link != original_url;
 }
 
-// Run a regex against a string to check if AMP page
 bool CheckIfAmpPage(const std::string& body) {
   auto opt = InitRegexOptions();
   // The order of running these regexes is important:
@@ -74,8 +73,6 @@ bool CheckIfAmpPage(const std::string& body) {
   return true;
 }
 
-// Find canonical link in body or return error
-// NOTE: caller makes sure that body is AMP page
 base::expected<std::string, std::string> FindCanonicalAmpUrl(
     const std::string& body) {
   auto opt = InitRegexOptions();

--- a/components/de_amp/browser/de_amp_util.cc
+++ b/components/de_amp/browser/de_amp_util.cc
@@ -33,6 +33,13 @@ constexpr char kFindCanonicalHrefInTagPattern[] =
     "href=(?:\"|')?(.*?)(?:\"|')?(?:\\s[^>]*?>|>|/>)";
 }  // namespace
 
+RE2::Options InitRegexOptions() {
+  RE2::Options opt;
+  opt.set_case_sensitive(false);
+  opt.set_dot_nl(true);
+  return opt;
+}
+
 bool IsDeAmpEnabled(PrefService* prefs) {
   return base::FeatureList::IsEnabled(features::kBraveDeAMP) &&
          prefs->GetBoolean(de_amp::kDeAmpPrefEnabled);
@@ -46,11 +53,8 @@ bool VerifyCanonicalAmpUrl(const GURL& canonical_link,
          canonical_link != original_url;
 }
 
-
 bool CheckIfAmpPage(const std::string& body) {
-    RE2::Options opt;
-  opt.set_case_sensitive(false);
-  opt.set_dot_nl(true);
+  auto opt = InitRegexOptions();
   // The order of running these regexes is important:
   // we first get the relevant HTML tag and then find the info.
   static const base::NoDestructor<re2::RE2> kGetHtmlTagRegex(kGetHtmlTagPattern,
@@ -59,7 +63,8 @@ bool CheckIfAmpPage(const std::string& body) {
                                                             opt);
   // std::cerr << "body is " << body << "\n";
 
-  std::cerr << "Checking for AMP page" << "\n";
+  std::cerr << "Checking for AMP page"
+            << "\n";
 
   std::string html_tag;
   if (!RE2::PartialMatch(body, *kGetHtmlTagRegex, &html_tag)) {
@@ -74,18 +79,17 @@ bool CheckIfAmpPage(const std::string& body) {
               << "\n";
     return false;
   }
-  std::cerr << "Found AMP page!" << "\n";
+  std::cerr << "Found AMP page!"
+            << "\n";
   return true;
 }
 
 // Find canonical link in body or return error
-// NOTE: caller is responsible for making sure that we are already on an AMP page
-base::expected<std::string, std::string> FindCanonicalAmpUrl(const std::string& body) {
- 
-  RE2::Options opt;
-  opt.set_case_sensitive(false);
-  opt.set_dot_nl(true);
-
+// NOTE: caller is responsible for making sure that we are already on an AMP
+// page
+base::expected<std::string, std::string> FindCanonicalAmpUrl(
+    const std::string& body) {
+  auto opt = InitRegexOptions();
   // The order of running these regexes is important
   static const base::NoDestructor<re2::RE2> kFindCanonicalLinkTagRegex(
       kFindCanonicalLinkTagPattern, opt);
@@ -105,7 +109,8 @@ base::expected<std::string, std::string> FindCanonicalAmpUrl(const std::string& 
   std::string canonical_url;
   // Find href in canonical link tag
   // Check there is only 1 href captured, else fail
-  if (!RE2::PartialMatch(link_tag, *kFindCanonicalHrefInTagRegex, &canonical_url)) {
+  if (!RE2::PartialMatch(link_tag, *kFindCanonicalHrefInTagRegex,
+                         &canonical_url)) {
     // Didn't find canonical link, potentially try again
     std::cerr << "can't find canonical link "
               << "\n";

--- a/components/de_amp/browser/de_amp_util.cc
+++ b/components/de_amp/browser/de_amp_util.cc
@@ -4,7 +4,6 @@
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 #include "brave/components/de_amp/browser/de_amp_util.h"
-#include <iostream>
 
 #include "base/feature_list.h"
 #include "base/no_destructor.h"
@@ -61,26 +60,16 @@ bool CheckIfAmpPage(const std::string& body) {
                                                              opt);
   static const base::NoDestructor<re2::RE2> kDetectAmpRegex(kDetectAmpPattern,
                                                             opt);
-  // std::cerr << "body is " << body << "\n";
-
-  std::cerr << "Checking for AMP page"
-            << "\n";
 
   std::string html_tag;
   if (!RE2::PartialMatch(body, *kGetHtmlTagRegex, &html_tag)) {
     // Early exit if we can't find HTML tag - malformed document (or error)
-    std::cerr << "not HTML "
-              << "\n";
     return false;
   }
   if (!RE2::PartialMatch(html_tag, *kDetectAmpRegex)) {
     // Not AMP
-    std::cerr << "not AMP "
-              << "\n";
     return false;
   }
-  std::cerr << "Found AMP page!"
-            << "\n";
   return true;
 }
 
@@ -96,24 +85,17 @@ base::expected<std::string, std::string> FindCanonicalAmpUrl(
   static const base::NoDestructor<re2::RE2> kFindCanonicalHrefInTagRegex(
       kFindCanonicalHrefInTagPattern, opt);
 
-  // std::cerr << "body is " << body << "\n";
-
   std::string link_tag;
   if (!RE2::PartialMatch(body, *kFindCanonicalLinkTagRegex, &link_tag)) {
     // Can't find link tag, exit
-    std::cerr << "can't find link tag "
-              << "\n";
     return base::unexpected("Couldn't find link tag");
   }
-  std::cerr << "canonical link tag is " << link_tag << "\n";
   std::string canonical_url;
   // Find href in canonical link tag
   // Check there is only 1 href captured, else fail
   if (!RE2::PartialMatch(link_tag, *kFindCanonicalHrefInTagRegex,
                          &canonical_url)) {
     // Didn't find canonical link, potentially try again
-    std::cerr << "can't find canonical link "
-              << "\n";
     return base::unexpected("Couldn't find canonical URL in link tag");
   }
   return canonical_url;

--- a/components/de_amp/browser/de_amp_util.cc
+++ b/components/de_amp/browser/de_amp_util.cc
@@ -52,6 +52,7 @@ bool VerifyCanonicalAmpUrl(const GURL& canonical_link,
          canonical_link != original_url;
 }
 
+// Run a regex against a string to check if AMP page
 bool CheckIfAmpPage(const std::string& body) {
   auto opt = InitRegexOptions();
   // The order of running these regexes is important:
@@ -74,8 +75,7 @@ bool CheckIfAmpPage(const std::string& body) {
 }
 
 // Find canonical link in body or return error
-// NOTE: caller is responsible for making sure that we are already on an AMP
-// page
+// NOTE: caller makes sure that body is AMP page
 base::expected<std::string, std::string> FindCanonicalAmpUrl(
     const std::string& body) {
   auto opt = InitRegexOptions();

--- a/components/de_amp/browser/de_amp_util.cc
+++ b/components/de_amp/browser/de_amp_util.cc
@@ -79,6 +79,7 @@ bool CheckIfAmpPage(const std::string& body) {
 }
 
 // Find canonical link in body or return error
+// NOTE: caller is responsible for making sure that we are already on an AMP page
 base::expected<std::string, std::string> FindCanonicalAmpUrl(const std::string& body) {
  
   RE2::Options opt;

--- a/components/de_amp/browser/de_amp_util.h
+++ b/components/de_amp/browser/de_amp_util.h
@@ -8,14 +8,15 @@
 
 #include <string>
 
+#include "base/types/expected.h"
 #include "components/prefs/pref_service.h"
 #include "url/gurl.h"
-#include "base/types/expected.h"
 
 namespace de_amp {
 bool IsDeAmpEnabled(PrefService* prefs);
 bool CheckIfAmpPage(const std::string& body);
-base::expected<std::string, std::string> FindCanonicalAmpUrl(const std::string& body);
+base::expected<std::string, std::string> FindCanonicalAmpUrl(
+    const std::string& body);
 bool VerifyCanonicalAmpUrl(const GURL& canonical_url, const GURL& original_url);
 }  // namespace de_amp
 

--- a/components/de_amp/browser/de_amp_util.h
+++ b/components/de_amp/browser/de_amp_util.h
@@ -10,11 +10,12 @@
 
 #include "components/prefs/pref_service.h"
 #include "url/gurl.h"
+#include "base/types/expected.h"
 
 namespace de_amp {
 bool IsDeAmpEnabled(PrefService* prefs);
-bool MaybeFindCanonicalAmpUrl(const std::string& body,
-                              std::string* canonical_url);
+bool CheckIfAmpPage(const std::string& body);
+base::expected<std::string, std::string> FindCanonicalAmpUrl(const std::string& body);
 bool VerifyCanonicalAmpUrl(const GURL& canonical_url, const GURL& original_url);
 }  // namespace de_amp
 

--- a/components/de_amp/browser/de_amp_util.h
+++ b/components/de_amp/browser/de_amp_util.h
@@ -13,10 +13,18 @@
 #include "url/gurl.h"
 
 namespace de_amp {
+// Check feature flag and user pref
 bool IsDeAmpEnabled(PrefService* prefs);
+
+// Run a regex against a string to check if AMP page
 bool CheckIfAmpPage(const std::string& body);
+
+// Find canonical link in body or return error
+// Caller makes sure that body is AMP page
 base::expected<std::string, std::string> FindCanonicalAmpUrl(
     const std::string& body);
+
+// Validation check for canonical URL
 bool VerifyCanonicalAmpUrl(const GURL& canonical_url, const GURL& original_url);
 }  // namespace de_amp
 

--- a/components/de_amp/browser/test/de_amp_browsertest.cc
+++ b/components/de_amp/browser/test/de_amp_browsertest.cc
@@ -283,7 +283,7 @@ IN_PROC_BROWSER_TEST_F(DeAmpBrowserTest, CanonicalLinkOutsideChunkOutsideMax) {
   TogglePref(true);
   // Construct page with large <head>
   const std::string large_string = base::StringPrintf(
-      "%s\n%s", std::string(kTestReadBufferSize * 3, 'a').c_str(),
+      "%s\n%s", std::string(kTestReadBufferSize * 4, 'a').c_str(),
       kTestAmpCanonicalLink);
   const std::string amp_body_large =
       base::StringPrintf(kTestAmpBodyScaffolding, large_string.c_str());

--- a/components/de_amp/browser/test/de_amp_browsertest.cc
+++ b/components/de_amp/browser/test/de_amp_browsertest.cc
@@ -3,8 +3,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-#include <string>
 #include <iostream>
+#include <string>
 
 #include "base/bind.h"
 #include "base/strings/stringprintf.h"
@@ -53,10 +53,13 @@ const char kTestAmpBodyScaffolding[] =
     </head>
     </html>
     )";
-constexpr uint32_t kTestReadBufferSize = 65536; // bytes
-const char kTestAmpCanonicalLink[] = "<link rel='canonical' href='https://%s:%s%s'>";
-const std::string kTestAmpBody = base::StringPrintf(kTestAmpBodyScaffolding, kTestAmpCanonicalLink);
-const std::string kTestNonAmpBody = base::StringPrintf(kTestAmpBodyScaffolding, "simple");
+constexpr uint32_t kTestReadBufferSize = 65536;  // bytes
+const char kTestAmpCanonicalLink[] =
+    "<link rel='canonical' href='https://%s:%s%s'>";
+const char kTestAmpBody[] =
+    base::StringPrintf(kTestAmpBodyScaffolding, kTestAmpCanonicalLink).c_str();
+const char kTestNonAmpBody[] =
+    base::StringPrintf(kTestAmpBodyScaffolding, "simple").c_str();
 
 class DeAmpBrowserTest : public InProcessBrowserTest {
  public:
@@ -246,9 +249,12 @@ IN_PROC_BROWSER_TEST_F(DeAmpBrowserTest, SimpleDeAmp) {
 
 IN_PROC_BROWSER_TEST_F(DeAmpBrowserTest, CanonicalLinkOutsideChunkWithinMax) {
   TogglePref(true);
-  // Construct page with large <head> 
-  const std::string large_string = base::StringPrintf("%s\n%s", std::string(kTestReadBufferSize, 'a').c_str(), kTestAmpCanonicalLink);
-  const std::string amp_body_large = base::StringPrintf(kTestAmpBodyScaffolding, large_string.c_str());
+  // Construct page with large <head>
+  const std::string large_string = base::StringPrintf(
+      "%s\n%s", std::string(kTestReadBufferSize, 'a').c_str(),
+      kTestAmpCanonicalLink);
+  const std::string amp_body_large =
+      base::StringPrintf(kTestAmpBodyScaffolding, large_string.c_str());
   https_server_->RegisterRequestHandler(base::BindRepeating(
       HandleRequest, kTestSimpleNonAmpPage, kTestNonAmpBody));
 
@@ -272,10 +278,13 @@ IN_PROC_BROWSER_TEST_F(DeAmpBrowserTest, CanonicalLinkOutsideChunkWithinMax) {
 
 IN_PROC_BROWSER_TEST_F(DeAmpBrowserTest, CanonicalLinkOutsideChunkOutsideMax) {
   TogglePref(true);
-  // Construct page with large <head> 
-  const std::string large_string = base::StringPrintf("%s\n%s", std::string(kTestReadBufferSize * 2, 'a').c_str(), kTestAmpCanonicalLink);
-  const std::string amp_body_large = base::StringPrintf(kTestAmpBodyScaffolding, large_string.c_str());
-  
+  // Construct page with large <head>
+  const std::string large_string = base::StringPrintf(
+      "%s\n%s", std::string(kTestReadBufferSize * 2, 'a').c_str(),
+      kTestAmpCanonicalLink);
+  const std::string amp_body_large =
+      base::StringPrintf(kTestAmpBodyScaffolding, large_string.c_str());
+
   https_server_->RegisterRequestHandler(base::BindRepeating(
       HandleRequest, kTestSimpleNonAmpPage, kTestNonAmpBody));
 

--- a/components/de_amp/browser/test/de_amp_browsertest.cc
+++ b/components/de_amp/browser/test/de_amp_browsertest.cc
@@ -3,7 +3,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-#include <iostream>
 #include <string>
 
 #include "base/bind.h"

--- a/components/de_amp/browser/test/de_amp_util_unittest.cc
+++ b/components/de_amp/browser/test/de_amp_util_unittest.cc
@@ -15,7 +15,8 @@ void CheckFindCanonicalLinkResult(const std::string& expected_link,
                                   const bool expected_find_canonical) {
   const bool actual_detect_amp = CheckIfAmpPage(body);
   EXPECT_EQ(expected_detect_amp, actual_detect_amp);
-  if (expected_detect_amp) { // Only check for canonical link if this is an AMP page
+  if (expected_detect_amp) {  // Only check for canonical link if this is an AMP
+                              // page
     auto canonical_link = FindCanonicalAmpUrl(body);
     EXPECT_EQ(expected_find_canonical, canonical_link.has_value());
     if (expected_find_canonical) {

--- a/components/de_amp/browser/test/de_amp_util_unittest.cc
+++ b/components/de_amp/browser/test/de_amp_util_unittest.cc
@@ -125,7 +125,6 @@ TEST(DeAmpUtilUnitTest, NegativeDetectAmp) {
 }
 
 TEST(DeAmpUtilUnitTest, DetectAmpButNoCanonicalLink) {
-  // Put AMP attribute in a different tag than html
   const std::string body =
       "<html amp xyzzy>"
       "<head>"

--- a/components/de_amp/browser/test/de_amp_util_unittest.cc
+++ b/components/de_amp/browser/test/de_amp_util_unittest.cc
@@ -175,7 +175,7 @@ TEST(DeAmpUtilUnitTest, NoQuotes) {
       "<head><link rel=author href=https://xyz.com/>\n"
       "<link href=https://abc.com rel=canonical>"
       "</head><body></body></html>";
-  CheckFindCanonicalLinkResult("https://abc.com", body, true);
+  CheckFindCanonicalLinkResult("https://abc.com", body, true, true);
 }
 
 TEST(DeAmpUtilUnitTest, NoQuotesEndingWithHref) {
@@ -185,7 +185,7 @@ TEST(DeAmpUtilUnitTest, NoQuotesEndingWithHref) {
       "<head><link rel=author href=https://xyz.com/>\n"
       "<link rel=canonical href=https://abc.com/>"
       "</head><body></body></html>";
-  CheckFindCanonicalLinkResult("https://abc.com", body, true);
+  CheckFindCanonicalLinkResult("https://abc.com", body, true, true);
 }
 
 TEST(DeAmpUtilUnitTest, NoQuotesEndingWithSpaceSlashAngleBracket) {
@@ -195,7 +195,7 @@ TEST(DeAmpUtilUnitTest, NoQuotesEndingWithSpaceSlashAngleBracket) {
       "<head><link rel=author href=https://xyz.com/>\n"
       "<link rel=canonical href=https://abc.com />"
       "</head><body></body></html>";
-  CheckFindCanonicalLinkResult("https://abc.com", body, true);
+  CheckFindCanonicalLinkResult("https://abc.com", body, true, true);
 }
 
 TEST(DeAmpUtilUnitTest, NoQuotesEndingWithAngleBracket) {
@@ -205,7 +205,7 @@ TEST(DeAmpUtilUnitTest, NoQuotesEndingWithAngleBracket) {
       "<head><link rel=author href=https://xyz.com/>\n"
       "<link rel=canonical href=https://abc.com>"
       "</head><body></body></html>";
-  CheckFindCanonicalLinkResult("https://abc.com", body, true);
+  CheckFindCanonicalLinkResult("https://abc.com", body, true, true);
 }
 
 TEST(DeAmpUtilUnitTest, NoQuotesEndingWithSpaceAngleBracket) {
@@ -215,7 +215,7 @@ TEST(DeAmpUtilUnitTest, NoQuotesEndingWithSpaceAngleBracket) {
       "<head>\n<link rel=canonical href=https://abc.com ><link rel=author "
       "href=https://xyz.com/>"
       "</head><body></body></html>";
-  CheckFindCanonicalLinkResult("https://abc.com", body, true);
+  CheckFindCanonicalLinkResult("https://abc.com", body, true, true);
 }
 
 TEST(DeAmpUtilUnitTest, CanonicalLinkMissingScheme) {

--- a/components/speedreader/speedreader_url_loader.cc
+++ b/components/speedreader/speedreader_url_loader.cc
@@ -92,7 +92,7 @@ void SpeedReaderURLLoader::OnBodyReadable(MojoResult) {
 void SpeedReaderURLLoader::OnBodyWritable(MojoResult r) {
   DCHECK_EQ(State::kSending, state_);
   if (bytes_remaining_in_buffer_ > 0) {
-    SendReceivedBodyToClient();
+    SendBufferedBodyToClient();
   } else {
     CompleteSending();
   }


### PR DESCRIPTION
<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/22917

If (and only if) the page is an AMP page as determined by the first chunk (this PR doesn't change this), then check the next few chunks of incoming network data for canonical link if not found in the first one (up to a max number of bytes).

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

https://github.com/brave/brave-browser/issues/22917 has 3 example URLs which fail currently, those should work.
[test-very-big-amp-outside-max-chunk.html](https://shivankaul.com/brave/de-amp/test-very-big-amp-outside-max-chunk.html) should NOT de-amp, i.e. should just load a page with lots of 'a'
[test-very-big-amp-inside-max-chunk.html](https://shivankaul.com/brave/de-amp/test-very-big-amp-inside-max-chunk.html) should de-amp, i.e. should redirect to brave.com