### PR TITLE
Try trigger NTPSI ad on each NTP refresh.

### DIFF
--- a/components/brave_ads/browser/ads_service.h
+++ b/components/brave_ads/browser/ads_service.h
@@ -157,6 +157,9 @@ class AdsService : public KeyedService {
       const ads::mojom::SearchResultAdEventType event_type,
       TriggerSearchResultAdEventCallback callback) = 0;
 
+  // Called to prefetch the next new tab page ad.
+  virtual void PrefetchNewTabPageAd() = 0;
+
   virtual absl::optional<ads::NewTabPageAdInfo> GetPrefetchedNewTabPageAd() = 0;
 
   virtual void PurgeOrphanedAdEventsForType(

--- a/components/brave_ads/browser/ads_service_impl.h
+++ b/components/brave_ads/browser/ads_service_impl.h
@@ -279,7 +279,7 @@ class AdsServiceImpl : public AdsService,
 
   void RegisterResourceComponentsForLocale(const std::string& locale);
 
-  void PrefetchNewTabPageAd();
+  void PrefetchNewTabPageAd() override;
   void OnPrefetchNewTabPageAd(bool success, const std::string& json);
 
   void OnURLRequestStarted(
@@ -519,7 +519,8 @@ class AdsServiceImpl : public AdsService,
   std::unique_ptr<ads::Database> database_;
 
   absl::optional<ads::NewTabPageAdInfo> prefetched_new_tab_page_ad_info_;
-  absl::optional<base::Time> purge_orphaned_new_tab_page_ad_events_time_;
+  bool need_purge_orphaned_new_tab_page_ad_events_ = false;
+  bool prefetch_new_tab_page_ad_on_first_run_ = false;
 
   ui::IdleState last_idle_state_;
   int last_idle_time_;

--- a/components/brave_ads/browser/mock_ads_service.h
+++ b/components/brave_ads/browser/mock_ads_service.h
@@ -98,6 +98,8 @@ class MockAdsService : public AdsService {
                     const ads::mojom::SearchResultAdEventType,
                     TriggerSearchResultAdEventCallback));
 
+  MOCK_METHOD0(PrefetchNewTabPageAd, void());
+
   MOCK_METHOD0(GetPrefetchedNewTabPageAd,
                absl::optional<ads::NewTabPageAdInfo>());
 

--- a/components/ntp_background_images/browser/ntp_sponsored_images_data.cc
+++ b/components/ntp_background_images/browser/ntp_sponsored_images_data.cc
@@ -347,7 +347,7 @@ base::Value NTPSponsoredImagesData::GetBackgroundByAdInfo(
     }
   }
   if (campaign_index == campaigns.size()) {
-    VLOG(0) << "Ad campaign wasn't found in NTP sposored images data: "
+    VLOG(0) << "The ad campaign wasn't found in the NTP sponsored images data: "
             << ad_info.campaign_id;
     return base::Value();
   }

--- a/components/ntp_background_images/browser/view_counter_service.cc
+++ b/components/ntp_background_images/browser/view_counter_service.cc
@@ -301,6 +301,7 @@ void ViewCounterService::RegisterPageView() {
   // This will be no-op when component is not ready.
   service_->CheckNTPSIComponentUpdateIfNeeded();
   model_.RegisterPageView();
+  MaybePrefetchNewTabPageAd();
 }
 
 void ViewCounterService::BrandedWallpaperLogoClicked(
@@ -372,6 +373,17 @@ std::string ViewCounterService::GetSuperReferralThemeName() const {
 
 std::string ViewCounterService::GetSuperReferralCode() const {
   return service_->GetSuperReferralCode();
+}
+
+void ViewCounterService::MaybePrefetchNewTabPageAd() {
+  NTPSponsoredImagesData* images_data = GetCurrentBrandedWallpaperData();
+  if (!IsBrandedWallpaperActive() || !ads_service_ ||
+      !ads_service_->IsEnabled() || !images_data ||
+      images_data->IsSuperReferral()) {
+    return;
+  }
+
+  ads_service_->PrefetchNewTabPageAd();
 }
 
 void ViewCounterService::UpdateP3AValues() const {

--- a/components/ntp_background_images/browser/view_counter_service.h
+++ b/components/ntp_background_images/browser/view_counter_service.h
@@ -145,6 +145,8 @@ class ViewCounterService : public KeyedService,
 
   void ResetModel();
 
+  void MaybePrefetchNewTabPageAd();
+
   void UpdateP3AValues() const;
 
   raw_ptr<NTPBackgroundImagesService> service_ = nullptr;

--- a/components/ntp_background_images/browser/view_counter_service_unittest.cc
+++ b/components/ntp_background_images/browser/view_counter_service_unittest.cc
@@ -207,10 +207,13 @@ class NTPBackgroundImagesViewCounterTest : public testing::Test {
     return ad_info;
   }
 
+  int GetInitialCountToBrandedWallpaper() const {
+    return ViewCounterModel::kInitialCountToBrandedWallpaper;
+  }
+
   base::Value TryGetFirstSponsoredImageWallpaper() {
     // Loading initial count times.
-    for (int i = 0; i < ViewCounterModel::kInitialCountToBrandedWallpaper;
-         ++i) {
+    for (int i = 0; i < GetInitialCountToBrandedWallpaper(); ++i) {
       base::Value wallpaper = view_counter_->GetCurrentWallpaperForDisplay();
       EXPECT_TRUE(wallpaper.FindBoolKey(ntp_background_images::kIsBackgroundKey)
                       .value_or(false));
@@ -367,7 +370,7 @@ TEST_F(NTPBackgroundImagesViewCounterTest, ModelTest) {
 
   // Initial count is not changed because branded wallpaper is always
   // visible in SR mode.
-  int expected_count = ViewCounterModel::kInitialCountToBrandedWallpaper;
+  int expected_count = GetInitialCountToBrandedWallpaper();
   view_counter_->RegisterPageView();
   view_counter_->RegisterPageView();
   EXPECT_EQ(expected_count, view_counter_->model_.count_to_branded_wallpaper_);
@@ -409,8 +412,9 @@ TEST_F(NTPBackgroundImagesViewCounterTest,
        GetSposoredImageWallpaperAdsServiceDisabled) {
   InitBackgroundAndSponsoredImageWallpapers();
 
-  EXPECT_CALL(ads_service_, IsEnabled()).WillOnce(Return(false));
+  EXPECT_CALL(ads_service_, IsEnabled()).WillRepeatedly(Return(false));
   EXPECT_CALL(ads_service_, GetPrefetchedNewTabPageAd()).Times(0);
+  EXPECT_CALL(ads_service_, PrefetchNewTabPageAd()).Times(0);
 
   base::Value si_wallpaper = TryGetFirstSponsoredImageWallpaper();
   EXPECT_FALSE(si_wallpaper.FindBoolKey(ntp_background_images::kIsBackgroundKey)
@@ -430,9 +434,11 @@ TEST_F(NTPBackgroundImagesViewCounterTest,
 TEST_F(NTPBackgroundImagesViewCounterTest, SponsoredImageAdFrequencyCapped) {
   InitBackgroundAndSponsoredImageWallpapers();
 
-  EXPECT_CALL(ads_service_, IsEnabled()).WillOnce(Return(true));
+  EXPECT_CALL(ads_service_, IsEnabled()).WillRepeatedly(Return(true));
   EXPECT_CALL(ads_service_, GetPrefetchedNewTabPageAd())
       .WillOnce(Return(absl::nullopt));
+  EXPECT_CALL(ads_service_, PrefetchNewTabPageAd())
+      .Times(GetInitialCountToBrandedWallpaper());
   EXPECT_CALL(ads_service_, OnFailedToServeNewTabPageAd(_, _)).Times(0);
 
   base::Value si_wallpaper = TryGetFirstSponsoredImageWallpaper();
@@ -450,9 +456,11 @@ TEST_F(NTPBackgroundImagesViewCounterTest, SponsoredImageAdServed) {
   ads::NewTabPageAdInfo ad_info = CreateNewTabPageAdInfo();
   EXPECT_TRUE(AdInfoMatchesSponsoredImage(ad_info, 0, 1));
 
-  EXPECT_CALL(ads_service_, IsEnabled()).WillOnce(Return(true));
+  EXPECT_CALL(ads_service_, IsEnabled()).WillRepeatedly(Return(true));
   EXPECT_CALL(ads_service_, GetPrefetchedNewTabPageAd())
       .WillOnce(Return(ad_info));
+  EXPECT_CALL(ads_service_, PrefetchNewTabPageAd())
+      .Times(GetInitialCountToBrandedWallpaper());
   EXPECT_CALL(ads_service_, OnFailedToServeNewTabPageAd(_, _)).Times(0);
 
   base::Value si_wallpaper = TryGetFirstSponsoredImageWallpaper();
@@ -477,9 +485,11 @@ TEST_F(NTPBackgroundImagesViewCounterTest, WrongSponsoredImageAdServed) {
   ad_info.creative_instance_id = "wrong_creative_instance_id";
   EXPECT_FALSE(AdInfoMatchesSponsoredImage(ad_info, 0, 1));
 
-  EXPECT_CALL(ads_service_, IsEnabled()).WillOnce(Return(true));
+  EXPECT_CALL(ads_service_, IsEnabled()).WillRepeatedly(Return(true));
   EXPECT_CALL(ads_service_, GetPrefetchedNewTabPageAd())
       .WillOnce(Return(ad_info));
+  EXPECT_CALL(ads_service_, PrefetchNewTabPageAd())
+      .Times(GetInitialCountToBrandedWallpaper());
   EXPECT_CALL(ads_service_, OnFailedToServeNewTabPageAd(_, _));
 
   base::Value si_wallpaper = TryGetFirstSponsoredImageWallpaper();


### PR DESCRIPTION
This is the manual uplift of https://github.com/brave/brave-core/pull/14225. 
Automatic uplift cannot be done due to conflicts.

<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/24107

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [x] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [x] New files have MPL-2.0 license header
- [x] Adequate test coverage exists to prevent regressions
- [x] Major classes, functions and non-trivial code blocks are well-commented
- [x] Changes in component dependencies are properly reflected in `gn`
- [x] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [x] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
Need to check that if there is no prefetched NTP ad, then each NTP refresh/open triggers NTP ad serving attempt.