### PR TITLE
Fix linux official builds: generate_breakpad_symbols.py (uplift to 1.42.x)

### DIFF
--- a/app/linux/BUILD.gn
+++ b/app/linux/BUILD.gn
@@ -2,6 +2,9 @@ import("//brave/build/config.gni")
 
 if (should_generate_breakpad_symbols) {
   action("generate_breakpad_symbols") {
+    # host_toolchain must be used for cross-compilation case.
+    # See chrome/updater/mac:syms
+    dump_syms = "//third_party/breakpad:dump_syms($host_toolchain)"
     symbols_dir = "$brave_dist_dir/$brave_product_name.breakpad.syms"
     outputs = [ symbols_dir ]
 
@@ -14,12 +17,15 @@ if (should_generate_breakpad_symbols) {
       "--build-dir=" + rebase_path(root_out_dir),
       "--binary=$start",
       "--libchromiumcontent-dir=" + rebase_path("//"),
+      "--dump-syms-bin=" +
+          rebase_path(get_label_info(dump_syms, "root_out_dir") + "/" +
+                      get_label_info(dump_syms, "name")),
       "--clear",
     ]
 
     deps = [
       "//chrome",  # To be sure brave executable is ready now
-      "//third_party/breakpad:dump_syms",
+      dump_syms,
     ]
   }
 } else {


### PR DESCRIPTION
Uplift of #14281
The details in slack: https://bravesoftware.slack.com/archives/CHGKGMHDJ/p1658737943905799?thread_ts=1658430185.399099&cid=CHGKGMHDJ

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.