### PR TITLE
Turned on playlist buildflag

### DIFF
--- a/browser/about_flags.cc
+++ b/browser/about_flags.cc
@@ -47,8 +47,6 @@
 
 #if BUILDFLAG(ENABLE_PLAYLIST)
 #include "brave/components/playlist/features.h"
-#include "chrome/common/channel_info.h"
-#include "components/version_info/version_info.h"
 #endif
 
 using brave_shields::features::kBraveAdblockCnameUncloaking;
@@ -471,22 +469,11 @@ constexpr char kPlaylistDescription[] = "Enables Playlist";
 #endif  // BUILDFLAG(ENABLE_BRAVE_TRANSLATE_GO)
 
 #if BUILDFLAG(ENABLE_PLAYLIST)
-uint16_t AllowForDevVersion(uint16_t os) {
-  if (auto channel = chrome::GetChannel();
-      channel == version_info::Channel::STABLE ||
-      channel == version_info::Channel::BETA) {
-    return 0;
-  }
-
-  return os;
-}
-
 #define PLAYLIST_FEATURE_ENTRIES                                           \
-     {"playlist",                                                          \
+     {kPlaylistFeatureInternalName,                                        \
      flag_descriptions::kPlaylistName,                                     \
      flag_descriptions::kPlaylistDescription,                              \
-     AllowForDevVersion(                                                   \
-        flags_ui::kOsMac | flags_ui::kOsWin | flags_ui::kOsLinux),         \
+     flags_ui::kOsMac | flags_ui::kOsWin | flags_ui::kOsLinux,             \
      FEATURE_VALUE_TYPE(playlist::features::kPlaylist)},
 #else
 #define PLAYLIST_FEATURE_ENTRIES

--- a/browser/brave_features_internal_names.h
+++ b/browser/brave_features_internal_names.h
@@ -7,5 +7,6 @@
 #define BRAVE_BROWSER_BRAVE_FEATURES_INTERNAL_NAMES_H_
 
 constexpr char kBraveVPNFeatureInternalName[] = "brave-vpn";
+constexpr char kPlaylistFeatureInternalName[] = "playlist";
 
 #endif  // BRAVE_BROWSER_BRAVE_FEATURES_INTERNAL_NAMES_H_

--- a/chromium_src/chrome/browser/DEPS
+++ b/chromium_src/chrome/browser/DEPS
@@ -25,6 +25,7 @@ include_rules = [
   "+brave/components/ntp_tiles",
   "+brave/components/omnibox",
   "+brave/components/permissions",
+  "+brave/components/playlist",
   "+brave/components/privacy_sandbox",
   "+brave/components/sidebar",
   "+brave/components/sync",

--- a/chromium_src/chrome/browser/sources.gni
+++ b/chromium_src/chrome/browser/sources.gni
@@ -9,6 +9,7 @@ import("//brave/components/sidebar/buildflags/buildflags.gni")
 brave_chromium_src_chrome_browser_deps = [
   "//base",
   "//brave/components/brave_vpn/buildflags",
+  "//brave/components/playlist/buildflags",
   "//brave/components/sidebar/buildflags",
   "//chrome/common:channel_info",
   "//components/version_info",

--- a/chromium_src/chrome/browser/unexpire_flags.cc
+++ b/chromium_src/chrome/browser/unexpire_flags.cc
@@ -6,6 +6,7 @@
 #include "base/strings/string_util.h"
 #include "brave/browser/brave_features_internal_names.h"
 #include "brave/components/brave_vpn/buildflags/buildflags.h"
+#include "brave/components/playlist/buildflags/buildflags.h"
 #include "chrome/common/channel_info.h"
 #include "components/version_info/version_info.h"
 
@@ -17,12 +18,25 @@ namespace flags {
 
 bool IsFlagExpired(const flags_ui::FlagsStorage* storage,
                    const char* internal_name) {
-#if BUILDFLAG(ENABLE_BRAVE_VPN)
+#if BUILDFLAG(ENABLE_BRAVE_VPN) || BUILDFLAG(ENABLE_PLAYLIST)
   version_info::Channel channel = chrome::GetChannel();
-  // Enable VPN feature only for nightly/development.
+#endif
+
+#if BUILDFLAG(ENABLE_BRAVE_VPN)
+  // Enable VPN feature except stable.
   if (base::EqualsCaseInsensitiveASCII(kBraveVPNFeatureInternalName,
                                        internal_name) &&
       channel == version_info::Channel::STABLE) {
+    return true;
+  }
+#endif
+
+#if BUILDFLAG(ENABLE_PLAYLIST)
+  // Enable playlist feature only for nightly/development.
+  if (base::EqualsCaseInsensitiveASCII(kPlaylistFeatureInternalName,
+                                       internal_name) &&
+      (channel == version_info::Channel::STABLE ||
+       channel == version_info::Channel::BETA)) {
     return true;
   }
 #endif

--- a/components/playlist/buildflags/buildflags.gni
+++ b/components/playlist/buildflags/buildflags.gni
@@ -4,5 +4,5 @@
 # You can obtain one at http://mozilla.org/MPL/2.0/.
 
 declare_args() {
-  enable_playlist = false
+  enable_playlist = is_win || is_mac || is_linux
 }


### PR DESCRIPTION
fix https://github.com/brave/brave-browser/issues/24205

Querying channel info caused crash at startup because channel info
is not set on Windows official build for unittest.
Do filtering playlist feature via unexpire_flags.cc instead.

Crash happened by null `payload_`.
```
  std::wstring channel() const {
    return std::wstring(payload_->channel, payload_->channel_length);
  }
```

callstack
```
>	brave_unit_tests.exe!install_static::InstallDetails::channel() Line 164	C++
 	[Inline Frame] brave_unit_tests.exe!install_static::GetChromeChannelName(bool with_extended_stable) Line 651	C++
 	brave_unit_tests.exe!install_static::GetChromeChannel() Line 42	C++
 	[Inline Frame] brave_unit_tests.exe!AllowForDevVersion(unsigned short os) Line 475	C++
 	brave_unit_tests.exe!about_flags::`anonymous namespace'::`dynamic initializer for 'kFeatureEntries'() Line 0	C++

```
PR Builder doesn't catch this because it's unofficial build by defauilt.
Unofficial build uses `version_info::Channel::UNKNOWN` always.
```
version_info::Channel GetChromeChannel() {
#if defined(OFFICIAL_BUILD)
  std::wstring channel_name(
      GetChromeChannelName(/*with_extended_stable=*/false));
  if (channel_name == L"nightly")
    return version_info::Channel::CANARY;
  return GetChromeChannel_ChromiumImpl();
#endif

  return version_info::Channel::UNKNOWN;
}
```

<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves 

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
Check there is no crash from ` npm run test brave_unit_tests Release`