### PR TITLE
Add allow-header into Autoplay settings

### DIFF
--- a/browser/resources/settings/brave_overrides/privacy_page.js
+++ b/browser/resources/settings/brave_overrides/privacy_page.js
@@ -31,7 +31,8 @@ RegisterPolymerTemplateModifications({
             </category-default-setting>
             <category-setting-exceptions
                 category="[[contentSettingsTypesEnum_.AUTOPLAY]]"
-                block-header="${I18nBehavior.i18n('siteSettingsBlock')}">
+                block-header="${I18nBehavior.i18n('siteSettingsBlock')}"
+                allow-header="${I18nBehavior.i18n('siteSettingsAllow')}">
             </category-setting-exceptions>
           </settings-subpage>
         </template>


### PR DESCRIPTION
<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/20018

The missing Autoplay Allow text was because we forgot to add the `allow-header` attribute.

Before:
![image](https://user-images.githubusercontent.com/7678024/180345599-80a436f4-d1b8-4581-a989-07bc2aab43a0.png)


After:
![image](https://user-images.githubusercontent.com/7678024/180345546-a81e1896-cd0b-4dcf-b268-a4175c92c294.png)

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [x] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [x] New files have MPL-2.0 license header
- [x] Adequate test coverage exists to prevent regressions
- [x] Major classes, functions and non-trivial code blocks are well-commented
- [x] Changes in component dependencies are properly reflected in `gn`
- [x] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [x] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

1. Navigate to `brave://settings/content/autoplay`
2. Check that the text `Allow` is visible above the sites allowed to autoplay