### PR TITLE
[iOS] Fix ads resource loads & fatal logs not being passed through (uplift to 1.42.x)

### DIFF
--- a/ios/app/brave_core_main.h
+++ b/ios/app/brave_core_main.h
@@ -39,7 +39,14 @@ OBJC_EXPORT const BraveCoreSwitch BraveCoreSwitchVModule;
 /// Expected value: A URL string
 OBJC_EXPORT const BraveCoreSwitch BraveCoreSwitchSyncURL;
 
-typedef bool (^BraveCoreLogHandler)(int severity,
+typedef int BraveCoreLogSeverity NS_TYPED_ENUM;
+OBJC_EXPORT const BraveCoreLogSeverity BraveCoreLogSeverityFatal;
+OBJC_EXPORT const BraveCoreLogSeverity BraveCoreLogSeverityError;
+OBJC_EXPORT const BraveCoreLogSeverity BraveCoreLogSeverityWarning;
+OBJC_EXPORT const BraveCoreLogSeverity BraveCoreLogSeverityInfo;
+OBJC_EXPORT const BraveCoreLogSeverity BraveCoreLogSeverityVerbose;
+
+typedef bool (^BraveCoreLogHandler)(BraveCoreLogSeverity severity,
                                     NSString* file,
                                     int line,
                                     size_t messageStart,
@@ -58,6 +65,11 @@ OBJC_EXPORT
 
 @property(nonatomic, readonly) BravePasswordAPI* passwordAPI;
 
+/// Sets the global log handler for Chromium & BraveCore logs.
+///
+/// When a custom log handler is set, it is the responsibility of the client
+/// to handle fatal logs from CHECK (and DCHECK on debug builds) by checking
+/// the `serverity` passed in.
 + (void)setLogHandler:(nullable BraveCoreLogHandler)logHandler;
 
 - (instancetype)init NS_UNAVAILABLE;

--- a/ios/app/brave_core_main.mm
+++ b/ios/app/brave_core_main.mm
@@ -70,6 +70,14 @@ const BraveCoreSwitch BraveCoreSwitchVModule =
 const BraveCoreSwitch BraveCoreSwitchSyncURL =
     base::SysUTF8ToNSString(syncer::kSyncServiceURL);
 
+const BraveCoreLogSeverity BraveCoreLogSeverityFatal = logging::LOGGING_FATAL;
+const BraveCoreLogSeverity BraveCoreLogSeverityError = logging::LOGGING_ERROR;
+const BraveCoreLogSeverity BraveCoreLogSeverityWarning =
+    logging::LOGGING_WARNING;
+const BraveCoreLogSeverity BraveCoreLogSeverityInfo = logging::LOGGING_INFO;
+const BraveCoreLogSeverity BraveCoreLogSeverityVerbose =
+    logging::LOGGING_VERBOSE;
+
 @interface BraveCoreMain () {
   std::unique_ptr<BraveWebClient> _webClient;
   std::unique_ptr<BraveMainDelegate> _delegate;
@@ -242,7 +250,7 @@ static bool CustomLogHandler(int severity,
     return false;
   }
   const int vlog_level = logging::GetVlogLevelHelper(file, strlen(file));
-  if (severity <= vlog_level) {
+  if (severity <= vlog_level || severity == logging::LOGGING_FATAL) {
     return _logHandler(severity, base::SysUTF8ToNSString(file), line,
                        message_start, base::SysUTF8ToNSString(str));
   }

--- a/ios/browser/api/ads/brave_ads.mm
+++ b/ios/browser/api/ads/brave_ads.mm
@@ -1138,8 +1138,12 @@ BATClassAdsBridge(BOOL, isDebug, setDebug, g_is_debug)
   BLOG(1, @"Loading %@ ads resource descriptor", nsFilePath);
 
   base::FilePath file_path(nsFilePath.UTF8String);
-  base::File file(file_path, base::File::FLAG_OPEN | base::File::FLAG_READ);
-  std::move(callback).Run(std::move(file));
+  base::ThreadPool::PostTaskAndReplyWithResult(
+      FROM_HERE, {base::MayBlock()}, base::BindOnce(^base::File {
+        return base::File(file_path,
+                          base::File::FLAG_OPEN | base::File::FLAG_READ);
+      }),
+      base::BindOnce(std::move(callback)));
 }
 
 - (void)clearScheduledCaptcha {


### PR DESCRIPTION
Uplift of #14303
Resolves https://github.com/brave/brave-browser/issues/24226

Pre-approval checklist: 
- [ ] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.