### PR TITLE
Only run set-milestone when PR is merged (uplift to 1.42.x)

### DIFF
--- a/.github/workflows/set-milestone-from-base-branch.yml
+++ b/.github/workflows/set-milestone-from-base-branch.yml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   set-pr-milestone:
+    if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     steps:
       - env:
@@ -26,6 +27,7 @@ jobs:
           gh pr edit "$PR_NUMBER" -R "$REPO_NAME" -m "$milestone"
 
   set-brave-browser-issues-milestone:
+    if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     needs: set-pr-milestone
     steps:


### PR DESCRIPTION
Uplift of #14296

Pre-approval checklist: 
- [ ] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [ ] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [ ] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [ ] The associated issue milestone is set to the smallest version that the changes is landed on.