### PR TITLE
Adds `WalletStatus` change events for bitFlyer and Gemini.

### DIFF
--- a/vendor/bat-native-ledger/src/bat/ledger/internal/gemini/gemini.cc
+++ b/vendor/bat-native-ledger/src/bat/ledger/internal/gemini/gemini.cc
@@ -23,6 +23,7 @@
 #include "bat/ledger/internal/wallet/wallet_util.h"
 #include "brave_base/random.h"
 
+using ledger::wallet::OnWalletStatusChange;
 using std::placeholders::_1;
 using std::placeholders::_2;
 using std::placeholders::_3;
@@ -166,15 +167,16 @@ void Gemini::DisconnectWallet(const bool manual) {
   }
 
   BLOG(1, "Disconnecting wallet");
-  ledger_->database()->SaveEventLog(log::kWalletDisconnected,
-                                    std::string(constant::kWalletGemini) +
-                                        (!wallet->address.empty() ? "/" : "") +
-                                        wallet->address.substr(0, 5));
+  const std::string wallet_address = wallet->address;
 
-  wallet = ::ledger::wallet::ResetWallet(std::move(wallet));
+  const auto from = wallet->status;
+  wallet = ledger::wallet::ResetWallet(std::move(wallet));
   if (manual) {
     wallet->status = type::WalletStatus::NOT_CONNECTED;
   }
+  const auto to = wallet->status;
+
+  OnWalletStatusChange(ledger_, from, to);
 
   const bool shutting_down = ledger_->IsShuttingDown();
 
@@ -183,11 +185,16 @@ void Gemini::DisconnectWallet(const bool manual) {
         ledger::notifications::kWalletDisconnected, {}, [](type::Result) {});
   }
 
-  SetWallet(wallet->Clone());
+  SetWallet(std::move(wallet));
 
   if (!shutting_down) {
     ledger_->ledger_client()->WalletDisconnected(constant::kWalletGemini);
   }
+
+  ledger_->database()->SaveEventLog(log::kWalletDisconnected,
+                                    std::string(constant::kWalletGemini) +
+                                        (!wallet_address.empty() ? "/" : "") +
+                                        wallet_address.substr(0, 5));
 }
 
 void Gemini::SaveTransferFee(const std::string& contribution_id,

--- a/vendor/bat-native-ledger/src/bat/ledger/internal/gemini/gemini_authorization.cc
+++ b/vendor/bat-native-ledger/src/bat/ledger/internal/gemini/gemini_authorization.cc
@@ -15,8 +15,10 @@
 #include "bat/ledger/internal/logging/event_log_keys.h"
 #include "bat/ledger/internal/logging/event_log_util.h"
 #include "bat/ledger/internal/notifications/notification_keys.h"
+#include "bat/ledger/internal/wallet/wallet_util.h"
 #include "crypto/sha2.h"
 
+using ledger::wallet::OnWalletStatusChange;
 using std::placeholders::_1;
 using std::placeholders::_2;
 using std::placeholders::_3;
@@ -236,19 +238,19 @@ void GeminiAuthorization::OnClaimWallet(
       }
   }
 
+  const auto from = wallet_ptr->status;
+  const auto to = wallet_ptr->status = type::WalletStatus::VERIFIED;
   wallet_ptr->address = recipient_id;
 
-  switch (wallet_ptr->status) {
-    case type::WalletStatus::NOT_CONNECTED:
-    case type::WalletStatus::DISCONNECTED_NOT_VERIFIED:
-    case type::WalletStatus::DISCONNECTED_VERIFIED:
-      wallet_ptr->status = type::WalletStatus::VERIFIED;
-      break;
-    default:
-      break;
+  if (!ledger_->gemini()->SetWallet(std::move(wallet_ptr))) {
+    BLOG(0, "Unable to set Gemini wallet!");
+    return callback(type::Result::LEDGER_ERROR, {});
   }
 
-  ledger_->gemini()->SetWallet(std::move(wallet_ptr));
+  OnWalletStatusChange(ledger_, from, to);
+  ledger_->database()->SaveEventLog(
+      log::kWalletVerified,
+      constant::kWalletGemini + std::string("/") + recipient_id.substr(0, 5));
   callback(type::Result::LEDGER_OK, {});
 }
 

--- a/vendor/bat-native-ledger/src/bat/ledger/internal/uphold/uphold.cc
+++ b/vendor/bat-native-ledger/src/bat/ledger/internal/uphold/uphold.cc
@@ -25,6 +25,7 @@
 #include "bat/ledger/internal/wallet/wallet_util.h"
 #include "brave_base/random.h"
 
+using ledger::wallet::OnWalletStatusChange;
 using std::placeholders::_1;
 using std::placeholders::_2;
 using std::placeholders::_3;
@@ -184,7 +185,7 @@ void Uphold::DisconnectWallet(const absl::optional<std::string>& notification) {
   }
 
   BLOG(1, "Disconnecting wallet");
-  const std::string uphold_wallet_address = wallet->address;
+  const std::string wallet_address = wallet->address;
 
   const bool manual = !notification.has_value();
 
@@ -211,11 +212,10 @@ void Uphold::DisconnectWallet(const absl::optional<std::string>& notification) {
     ledger_->ledger_client()->WalletDisconnected(constant::kWalletUphold);
   }
 
-  ledger_->database()->SaveEventLog(
-      log::kWalletDisconnected,
-      std::string(constant::kWalletUphold) +
-          (!uphold_wallet_address.empty() ? "/" : "") +
-          uphold_wallet_address.substr(0, 5));
+  ledger_->database()->SaveEventLog(log::kWalletDisconnected,
+                                    std::string(constant::kWalletUphold) +
+                                        (!wallet_address.empty() ? "/" : "") +
+                                        wallet_address.substr(0, 5));
 }
 
 void Uphold::GetUser(GetUserCallback callback) {

--- a/vendor/bat-native-ledger/src/bat/ledger/internal/uphold/uphold_authorization.cc
+++ b/vendor/bat-native-ledger/src/bat/ledger/internal/uphold/uphold_authorization.cc
@@ -12,7 +12,9 @@
 #include "bat/ledger/internal/ledger_impl.h"
 #include "bat/ledger/internal/logging/event_log_keys.h"
 #include "bat/ledger/internal/uphold/uphold_util.h"
+#include "bat/ledger/internal/wallet/wallet_util.h"
 
+using ledger::wallet::OnWalletStatusChange;
 using std::placeholders::_1;
 using std::placeholders::_2;
 

--- a/vendor/bat-native-ledger/src/bat/ledger/internal/uphold/uphold_util.cc
+++ b/vendor/bat-native-ledger/src/bat/ledger/internal/uphold/uphold_util.cc
@@ -13,8 +13,6 @@
 #include "base/strings/stringprintf.h"
 #include "bat/ledger/buildflags.h"
 #include "bat/ledger/global_constants.h"
-#include "bat/ledger/internal/ledger_impl.h"
-#include "bat/ledger/internal/logging/event_log_keys.h"
 #include "bat/ledger/internal/state/state_keys.h"
 #include "bat/ledger/internal/uphold/uphold_util.h"
 #include "crypto/random.h"
@@ -130,37 +128,6 @@ type::ExternalWalletPtr GenerateLinks(type::ExternalWalletPtr wallet) {
   wallet->activity_url = GetActivityUrl(wallet->address);
 
   return wallet;
-}
-
-template <typename T, typename... Ts>
-bool one_of(T&& t, Ts&&... ts) {
-  bool match = false;
-
-  static_cast<void>(std::initializer_list<bool>{
-      (match = match || std::forward<T>(t) == std::forward<Ts>(ts))...});
-
-  return match;
-}
-
-void OnWalletStatusChange(LedgerImpl* ledger,
-                          absl::optional<type::WalletStatus> from,
-                          type::WalletStatus to) {
-  DCHECK(ledger);
-  DCHECK(!from ||
-         one_of(*from, type::WalletStatus::NOT_CONNECTED,
-                type::WalletStatus::DISCONNECTED_VERIFIED,
-                type::WalletStatus::PENDING, type::WalletStatus::VERIFIED));
-  DCHECK(one_of(to, type::WalletStatus::NOT_CONNECTED,
-                type::WalletStatus::DISCONNECTED_VERIFIED,
-                type::WalletStatus::PENDING, type::WalletStatus::VERIFIED));
-
-  std::ostringstream oss{};
-  if (from) {
-    oss << *from << ' ';
-  }
-  oss << "==> " << to;
-
-  ledger->database()->SaveEventLog(log::kWalletStatusChange, oss.str());
 }
 
 void CheckWalletState(const type::ExternalWallet* wallet) {

--- a/vendor/bat-native-ledger/src/bat/ledger/internal/uphold/uphold_util.h
+++ b/vendor/bat-native-ledger/src/bat/ledger/internal/uphold/uphold_util.h
@@ -41,10 +41,6 @@ std::string GetActivityUrl(const std::string& address);
 
 type::ExternalWalletPtr GenerateLinks(type::ExternalWalletPtr wallet);
 
-void OnWalletStatusChange(LedgerImpl* ledger,
-                          absl::optional<type::WalletStatus> from,
-                          type::WalletStatus to);
-
 void CheckWalletState(const type::ExternalWallet* wallet);
 
 }  // namespace uphold

--- a/vendor/bat-native-ledger/src/bat/ledger/internal/uphold/uphold_wallet.cc
+++ b/vendor/bat-native-ledger/src/bat/ledger/internal/uphold/uphold_wallet.cc
@@ -15,8 +15,10 @@
 #include "bat/ledger/internal/logging/event_log_util.h"
 #include "bat/ledger/internal/notifications/notification_keys.h"
 #include "bat/ledger/internal/uphold/uphold_util.h"
+#include "bat/ledger/internal/wallet/wallet_util.h"
 
 using ledger::uphold::Capabilities;
+using ledger::wallet::OnWalletStatusChange;
 
 namespace ledger {
 namespace uphold {

--- a/vendor/bat-native-ledger/src/bat/ledger/internal/wallet/wallet_util.h
+++ b/vendor/bat-native-ledger/src/bat/ledger/internal/wallet/wallet_util.h
@@ -29,6 +29,10 @@ bool SetWallet(LedgerImpl* ledger,
 
 type::ExternalWalletPtr ResetWallet(type::ExternalWalletPtr wallet);
 
+void OnWalletStatusChange(LedgerImpl* ledger,
+                          absl::optional<type::WalletStatus> from,
+                          type::WalletStatus to);
+
 }  // namespace wallet
 }  // namespace ledger
 


### PR DESCRIPTION
<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/24112.

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

`WalletStatus` transitions are now shown for all custodians in `brave://rewards-internals` `==>` `Event logs`.