### PR TITLE
Fix EA login on origin.com

### DIFF
--- a/chromium_src/components/content_settings/core/common/cookie_settings_base.cc
+++ b/chromium_src/components/content_settings/core/common/cookie_settings_base.cc
@@ -25,6 +25,8 @@ namespace {
 
 constexpr char kWp[] = "https://[*.]wp.com/*";
 constexpr char kWordpress[] = "https://[*.]wordpress.com/*";
+constexpr char kOrigin[] = "https://[*.]origin.com/*";
+constexpr char kEA[] = "https://[*.]ea.com/*";
 
 bool BraveIsAllowedThirdParty(const GURL& url,
                               const GURL& first_party_url,
@@ -35,7 +37,9 @@ bool BraveIsAllowedThirdParty(const GURL& url,
       entity_list({{ContentSettingsPattern::FromString(kWp),
                     ContentSettingsPattern::FromString(kWordpress)},
                    {ContentSettingsPattern::FromString(kWordpress),
-                    ContentSettingsPattern::FromString(kWp)}});
+                    ContentSettingsPattern::FromString(kWp)},
+                   {ContentSettingsPattern::FromString(kEA),
+                    ContentSettingsPattern::FromString(kOrigin)}});
 
   if (net::registry_controlled_domains::GetDomainAndRegistry(
           url, net::registry_controlled_domains::INCLUDE_PRIVATE_REGISTRIES) ==


### PR DESCRIPTION
<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/12022  (Previous old PR; https://github.com/brave/brave-core/pull/6798)

Was removed previously due to cleanup. This will allow EA logins on Origin.com, allow the user to login.



