### PR TITLE
Disables kSignedHTTPExchange feature. (uplift to 1.42.x)

### DIFF
--- a/app/brave_main_delegate_browsertest.cc
+++ b/app/brave_main_delegate_browsertest.cc
@@ -123,6 +123,7 @@ IN_PROC_BROWSER_TEST_F(BraveMainDelegateBrowserTest, DisabledFeatures) {
     &features::kPrivacySandboxAdsAPIsOverride,
     &features::kSCTAuditing,
     &features::kSignedExchangeSubresourcePrefetch,
+    &features::kSignedHTTPExchange,
     &features::kSubresourceWebBundles,
 #if !BUILDFLAG(IS_ANDROID)
     &features::kTrustSafetySentimentSurvey,

--- a/browser/net/brave_accept_header_browsertest.cc
+++ b/browser/net/brave_accept_header_browsertest.cc
@@ -1,0 +1,77 @@
+/* Copyright (c) 2022 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "base/containers/contains.h"
+#include "brave/components/constants/network_constants.h"
+#include "chrome/browser/ui/browser.h"
+#include "chrome/test/base/in_process_browser_test.h"
+#include "chrome/test/base/ui_test_utils.h"
+#include "content/public/test/browser_test.h"
+#include "content/public/test/browser_test_utils.h"
+#include "content/public/test/content_mock_cert_verifier.h"
+#include "content/public/test/test_utils.h"
+#include "net/dns/mock_host_resolver.h"
+#include "net/http/http_request_headers.h"
+#include "net/test/embedded_test_server/http_request.h"
+
+class BraveAcceptHeaderBrowserTest : public InProcessBrowserTest {
+ public:
+  BraveAcceptHeaderBrowserTest()
+      : https_server_(net::EmbeddedTestServer::TYPE_HTTPS) {}
+
+  void SetUpOnMainThread() override {
+    InProcessBrowserTest::SetUpOnMainThread();
+    mock_cert_verifier_.mock_cert_verifier()->set_default_result(net::OK);
+    host_resolver()->AddRule("*", "127.0.0.1");
+
+    https_server_.RegisterRequestMonitor(base::BindRepeating(
+        &BraveAcceptHeaderBrowserTest::HandleRequest, base::Unretained(this)));
+
+    ASSERT_TRUE(https_server_.Start());
+  }
+
+  void HandleRequest(const net::test_server::HttpRequest& request) {
+    base::AutoLock auto_lock(header_result_lock_);
+    auto it = request.headers.find(net::HttpRequestHeaders::kAccept);
+    ASSERT_TRUE(it != request.headers.end());
+    header_result_ =
+        it->second.find("application/signed-exchange") == std::string::npos;
+  }
+
+  void SetUpCommandLine(base::CommandLine* command_line) override {
+    InProcessBrowserTest::SetUpCommandLine(command_line);
+    mock_cert_verifier_.SetUpCommandLine(command_line);
+  }
+
+  void SetUpInProcessBrowserTestFixture() override {
+    InProcessBrowserTest::SetUpInProcessBrowserTestFixture();
+    mock_cert_verifier_.SetUpInProcessBrowserTestFixture();
+  }
+
+  void TearDownInProcessBrowserTestFixture() override {
+    mock_cert_verifier_.TearDownInProcessBrowserTestFixture();
+    InProcessBrowserTest::TearDownInProcessBrowserTestFixture();
+  }
+
+  const net::EmbeddedTestServer& https_server() { return https_server_; }
+
+  bool header_result() {
+    base::AutoLock auto_lock(header_result_lock_);
+    return header_result_;
+  }
+
+ private:
+  content::ContentMockCertVerifier mock_cert_verifier_;
+  net::test_server::EmbeddedTestServer https_server_;
+  mutable base::Lock header_result_lock_;
+  bool header_result_ = false;
+};
+
+IN_PROC_BROWSER_TEST_F(BraveAcceptHeaderBrowserTest,
+                       NotIncludesSignedExachange) {
+  GURL target = https_server().GetURL("a.com", "/index.html");
+  ASSERT_TRUE(ui_test_utils::NavigateToURL(browser(), target));
+  EXPECT_TRUE(header_result());
+}

--- a/chromium_src/content/public/common/content_features.cc
+++ b/chromium_src/content/public/common/content_features.cc
@@ -20,6 +20,7 @@ OVERRIDE_FEATURE_DEFAULT_STATES({{
     {kNotificationTriggers, base::FEATURE_DISABLED_BY_DEFAULT},
     {kPrivacySandboxAdsAPIsOverride, base::FEATURE_DISABLED_BY_DEFAULT},
     {kSignedExchangeSubresourcePrefetch, base::FEATURE_DISABLED_BY_DEFAULT},
+    {kSignedHTTPExchange, base::FEATURE_DISABLED_BY_DEFAULT},
     {kSubresourceWebBundles, base::FEATURE_DISABLED_BY_DEFAULT},
 #if BUILDFLAG(IS_ANDROID)
     {kWebNfc, base::FEATURE_DISABLED_BY_DEFAULT},

--- a/test/BUILD.gn
+++ b/test/BUILD.gn
@@ -672,6 +672,7 @@ if (!is_android) {
       "//brave/browser/extensions/brave_theme_event_router_browsertest.cc",
       "//brave/browser/extensions/extension_urls_browsertest.cc",
       "//brave/browser/favicon/favicon_database_browsertest.cc",
+      "//brave/browser/net/brave_accept_header_browsertest.cc",
       "//brave/browser/net/brave_network_delegate_browsertest.cc",
       "//brave/browser/net/brave_network_delegate_hsts_fingerprinting_browsertest.cc",
       "//brave/browser/net/brave_service_key_network_delegate_helper_browsertest.cc",

--- a/test/filters/browser_tests.filter
+++ b/test/filters/browser_tests.filter
@@ -145,6 +145,7 @@
 -CaptureHandleBrowserTestPrerender.*
 -CertificateReportingServiceBrowserTest.*
 -CertificateTransparencyPolicyTest.CertificateTransparencyEnforcementDisabledForUrls
+-ChromeAcceptHeaderTest.Check
 -ChromeBackForwardCacheBrowserTest.*
 -ChromeBrowsingDataLifetimeManagerShutdownTest.*
 -ChromeFileSystemAccessPermissionContextPrerenderingBrowserTest.*
@@ -665,7 +666,10 @@
 -SharedClipboardBrowserTest.*
 -SharedClipboardUIFeatureDisabledBrowserTest.*
 -SharedHighlightingBrowserTest.*
+-SignedExchangePolicyBrowserTest.BlockList
 -SignedExchangePolicyTest.*
+-SignedExchangeSecurityStateTest.SecurityLevelIsSecure/*
+-SignedExchangeSecurityStateTest.SecurityLevelIsSecureAfterPrefetch/*
 -SigninInterceptFirstRunExperienceDialogBrowserTest.*
 -SigninReauthViewControllerBrowserTest.*
 -SigninReauthViewControllerFencedFrameBrowserTest.*


### PR DESCRIPTION
Fixes https://github.com/brave/brave-browser/issues/24227
Uplift of #14304

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.