### PR TITLE
Move Ethereum Ledger integration in untrusted iframe

### DIFF
--- a/components/brave_wallet_ui/common/api/hardware_keyrings.ts
+++ b/components/brave_wallet_ui/common/api/hardware_keyrings.ts
@@ -5,13 +5,13 @@
 
 import { assert } from 'chrome://resources/js/assert.m.js'
 import { BraveWallet } from '../../constants/types'
-import LedgerBridgeKeyring from '../../common/hardware/ledgerjs/eth_ledger_bridge_keyring'
+import EthereumLedgerBridgeKeyring from '../../common/hardware/ledgerjs/eth_ledger_bridge_keyring'
 import TrezorBridgeKeyring from '../../common/hardware/trezor/trezor_bridge_keyring'
 import * as HWInterfaces from '../hardware/interfaces'
 import FilecoinLedgerKeyring from '../hardware/ledgerjs/filecoin_ledger_keyring'
 import SolanaLedgerBridgeKeyring from '../../common/hardware/ledgerjs/sol_ledger_bridge_keyring'
 
-export type HardwareKeyring = LedgerBridgeKeyring | TrezorBridgeKeyring | SolanaLedgerBridgeKeyring
+export type HardwareKeyring = HWInterfaces.LedgerEthereumKeyring | HWInterfaces.TrezorKeyring | HWInterfaces.LedgerFilecoinKeyring | HWInterfaces.LedgerSolanaKeyring
 
 export function getCoinName (coin: BraveWallet.CoinType) {
   switch (coin) {
@@ -30,7 +30,7 @@ const VendorTypes = [
 export type HardwareVendor = typeof VendorTypes[number]
 
 // Lazy instances for keyrings
-let ethereumHardwareKeyring: LedgerBridgeKeyring
+let ethereumHardwareKeyring: EthereumLedgerBridgeKeyring
 let filecoinHardwareKeyring: FilecoinLedgerKeyring
 let solanaHardwareKeyring: SolanaLedgerBridgeKeyring
 let trezorHardwareKeyring: TrezorBridgeKeyring
@@ -48,10 +48,10 @@ export function getHardwareKeyring (
   type: HardwareVendor,
   coin: BraveWallet.CoinType = BraveWallet.CoinType.ETH,
   onAuthorized?: () => void
-): LedgerBridgeKeyring | HWInterfaces.TrezorKeyring | FilecoinLedgerKeyring | SolanaLedgerBridgeKeyring {
+): EthereumLedgerBridgeKeyring | HWInterfaces.TrezorKeyring | FilecoinLedgerKeyring | SolanaLedgerBridgeKeyring {
   if (type === BraveWallet.LEDGER_HARDWARE_VENDOR) {
     if (coin === BraveWallet.CoinType.ETH) {
-      return getLedgerEthereumHardwareKeyring()
+      return getLedgerEthereumHardwareKeyring(onAuthorized)
     } else if (coin === BraveWallet.CoinType.FIL) {
       return getLedgerFilecoinHardwareKeyring()
     } else if (coin === BraveWallet.CoinType.SOL) {
@@ -64,9 +64,9 @@ export function getHardwareKeyring (
   return trezorKeyring
 }
 
-export function getLedgerEthereumHardwareKeyring (): LedgerBridgeKeyring {
+export function getLedgerEthereumHardwareKeyring (onAuthorized?: () => void): EthereumLedgerBridgeKeyring {
   if (!ethereumHardwareKeyring) {
-    ethereumHardwareKeyring = new LedgerBridgeKeyring()
+    ethereumHardwareKeyring = new EthereumLedgerBridgeKeyring(onAuthorized)
   }
   return ethereumHardwareKeyring
 }

--- a/components/brave_wallet_ui/common/async/hardware.ts
+++ b/components/brave_wallet_ui/common/async/hardware.ts
@@ -22,7 +22,7 @@ import {
 import { TrezorErrorsCodes } from '../hardware/trezor/trezor-messages'
 import FilecoinLedgerKeyring from '../hardware/ledgerjs/filecoin_ledger_keyring'
 import TrezorBridgeKeyring from '../hardware/trezor/trezor_bridge_keyring'
-import LedgerBridgeKeyring from '../hardware/ledgerjs/eth_ledger_bridge_keyring'
+import EthereumLedgerBridgeKeyring from '../hardware/ledgerjs/eth_ledger_bridge_keyring'
 import SolanaLedgerBridgeKeyring from '../hardware/ledgerjs/sol_ledger_bridge_keyring'
 import { BraveWallet } from '../../constants/types'
 import { LedgerEthereumKeyring, LedgerFilecoinKeyring, LedgerSolanaKeyring } from '../hardware/interfaces'
@@ -109,9 +109,6 @@ export async function signLedgerEthereumTransaction (
   if (!signed || !signed.success || !signed.payload) {
     const error = signed?.error ?? getLocale('braveWalletSignOnDeviceError')
     const code = signed?.code ?? ''
-    if (code === 'DisconnectedDeviceDuringOperation') {
-      await deviceKeyring.makeApp()
-    }
     return { success: false, error: error, code: code }
   }
   const { v, r, s } = signed.payload as EthereumSignedTx
@@ -185,7 +182,7 @@ export async function signLedgerSolanaTransaction (
 
 export async function signMessageWithHardwareKeyring (vendor: HardwareVendor, path: string, messageData: BraveWallet.SignMessageRequest): Promise<SignHardwareOperationResult> {
   const deviceKeyring = getHardwareKeyring(vendor, messageData.coin)
-  if (deviceKeyring instanceof LedgerBridgeKeyring) {
+  if (deviceKeyring instanceof EthereumLedgerBridgeKeyring) {
     if (messageData.isEip712) {
       if (!messageData.domainHash || !messageData.primaryHash) {
         return { success: false, error: getLocale('braveWalletUnknownInternalError') }
@@ -213,7 +210,7 @@ export async function signRawTransactionWithHardwareKeyring (vendor: HardwareVen
 
   if (deviceKeyring instanceof SolanaLedgerBridgeKeyring && message.bytes) {
     return deviceKeyring.signTransaction(path, Buffer.from(message.bytes))
-  } else if (deviceKeyring instanceof TrezorBridgeKeyring || deviceKeyring instanceof LedgerBridgeKeyring || deviceKeyring instanceof FilecoinLedgerKeyring) {
+  } else if (deviceKeyring instanceof TrezorBridgeKeyring || deviceKeyring instanceof EthereumLedgerBridgeKeyring || deviceKeyring instanceof FilecoinLedgerKeyring) {
     return { success: false, error: getLocale('braveWalletHardwareOperationUnsupportedError') }
   }
 
@@ -222,7 +219,7 @@ export async function signRawTransactionWithHardwareKeyring (vendor: HardwareVen
 
 export async function cancelHardwareOperation (vendor: HardwareVendor, coin: BraveWallet.CoinType) {
   const deviceKeyring = getHardwareKeyring(vendor, coin)
-  if (deviceKeyring instanceof LedgerBridgeKeyring || deviceKeyring instanceof TrezorBridgeKeyring || deviceKeyring instanceof SolanaLedgerBridgeKeyring) {
+  if (deviceKeyring instanceof EthereumLedgerBridgeKeyring || deviceKeyring instanceof TrezorBridgeKeyring || deviceKeyring instanceof SolanaLedgerBridgeKeyring) {
     return deviceKeyring.cancelOperation()
   }
 }

--- a/components/brave_wallet_ui/common/async/lib.ts
+++ b/components/brave_wallet_ui/common/async/lib.ts
@@ -34,7 +34,7 @@ import getAPIProxy from './bridge'
 import { Dispatch, State, Store } from './types'
 import { getHardwareKeyring } from '../api/hardware_keyrings'
 import { GetAccountsHardwareOperationResult } from '../hardware/types'
-import LedgerBridgeKeyring from '../hardware/ledgerjs/eth_ledger_bridge_keyring'
+import EthereumLedgerBridgeKeyring from '../hardware/ledgerjs/eth_ledger_bridge_keyring'
 import TrezorBridgeKeyring from '../hardware/trezor/trezor_bridge_keyring'
 import { AllNetworksOption } from '../../options/network-filter-options'
 import FilecoinLedgerKeyring from '../hardware/ledgerjs/filecoin_ledger_keyring'
@@ -64,7 +64,7 @@ export const getERC20Allowance = (
 export const onConnectHardwareWallet = (opts: HardwareWalletConnectOpts): Promise<BraveWallet.HardwareWalletAccount[]> => {
   return new Promise(async (resolve, reject) => {
     const keyring = getHardwareKeyring(opts.hardware, opts.coin, opts.onAuthorized)
-    if ((keyring instanceof LedgerBridgeKeyring || keyring instanceof TrezorBridgeKeyring) && opts.scheme) {
+    if ((keyring instanceof EthereumLedgerBridgeKeyring || keyring instanceof TrezorBridgeKeyring) && opts.scheme) {
       keyring.getAccounts(opts.startIndex, opts.stopIndex, opts.scheme)
         .then((result: GetAccountsHardwareOperationResult) => {
           if (result.payload) {

--- a/components/brave_wallet_ui/common/hardware/interfaces.ts
+++ b/components/brave_wallet_ui/common/hardware/interfaces.ts
@@ -30,7 +30,6 @@ export abstract class LedgerEthereumKeyring extends HardwareKeyring {
   abstract signPersonalMessage (path: string, address: string, message: string): Promise<SignHardwareOperationResult>
   abstract signTransaction (path: string, rawTxHex: string): Promise<SignHardwareOperationResult>
   abstract signEip712Message (path: string, domainSeparatorHex: string, hashStructMessageHex: string): Promise<SignHardwareOperationResult>
-  abstract makeApp (): Promise<void>
 }
 
 export abstract class LedgerFilecoinKeyring extends HardwareKeyring {

--- a/components/brave_wallet_ui/common/hardware/ledgerjs/eth-ledger-messages.ts
+++ b/components/brave_wallet_ui/common/hardware/ledgerjs/eth-ledger-messages.ts
@@ -1,0 +1,79 @@
+/* Copyright (c) 2022 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import type {
+  CommandMessage,
+  LedgerCommand,
+  LedgerError,
+  LedgerResponsePayload
+} from './ledger-messages'
+
+// GetAccounts command
+export type EthGetAccountResponsePayload = LedgerResponsePayload & {
+  publicKey: string
+  address: string
+  chainCode?: string
+}
+
+export type EthGetAccountResponse = CommandMessage & {
+  payload: EthGetAccountResponsePayload | LedgerError
+}
+
+export type EthGetAccountCommand = CommandMessage & {
+  command: LedgerCommand.GetAccount
+  path: string
+}
+
+// SignTransaction command
+export type EthereumSignedTx = {
+  v: string
+  r: string
+  s: string
+}
+export type EthSignTransactionResponsePayload = LedgerResponsePayload & EthereumSignedTx
+
+export type EthSignTransactionResponse = CommandMessage & {
+  payload: EthSignTransactionResponsePayload | LedgerError
+}
+
+export type EthSignTransactionCommand = CommandMessage & {
+  command: LedgerCommand.SignTransaction
+  path: string
+  rawTxHex: string
+}
+
+// SignPersonalMessage command
+export type EthSignPersonalMessageResponsePayload = LedgerResponsePayload & {
+  v: number
+  r: string
+  s: string
+}
+
+export type EthSignPersonalMessageResponse = CommandMessage & {
+  payload: EthSignPersonalMessageResponsePayload | LedgerError
+}
+
+export type EthSignPersonalMessageCommand = CommandMessage & {
+  command: LedgerCommand.SignPersonalMessage
+  path: string
+  messageHex: string
+}
+
+// SignEip712Message command
+export type EthSignEip712MessageResponsePayload = EthSignPersonalMessageResponsePayload
+
+export type EthSignEip712MessageResponse = CommandMessage & {
+  payload: EthSignEip712MessageResponsePayload | LedgerError
+}
+
+export type EthSignEip712MessageCommand = CommandMessage & {
+  command: LedgerCommand.SignEip712Message
+  path: string
+  domainSeparatorHex: string
+  hashStructMessageHex: string
+}
+
+export type EthLedgerFrameCommand = EthGetAccountCommand | EthSignTransactionCommand | EthSignPersonalMessageCommand | EthSignEip712MessageCommand
+export type EthLedgerFrameResponse = EthGetAccountResponse | EthSignTransactionResponse | EthSignPersonalMessageResponse | EthSignEip712MessageResponse

--- a/components/brave_wallet_ui/common/hardware/ledgerjs/eth-ledger-untrusted-transport.ts
+++ b/components/brave_wallet_ui/common/hardware/ledgerjs/eth-ledger-untrusted-transport.ts
@@ -1,0 +1,162 @@
+/* Copyright (c) 2022 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import TransportWebHID from '@ledgerhq/hw-transport-webhid'
+import Eth from '@ledgerhq/hw-app-eth'
+import {
+  LedgerCommand,
+  UnlockResponse
+} from './ledger-messages'
+import {
+  EthGetAccountCommand,
+  EthGetAccountResponse,
+  EthGetAccountResponsePayload,
+  EthSignTransactionCommand,
+  EthSignTransactionResponsePayload,
+  EthSignTransactionResponse,
+  EthSignPersonalMessageCommand,
+  EthSignPersonalMessageResponsePayload,
+  EthSignPersonalMessageResponse,
+  EthSignEip712MessageCommand,
+  EthSignEip712MessageResponsePayload,
+  EthSignEip712MessageResponse
+} from './eth-ledger-messages'
+import { LedgerUntrustedMessagingTransport } from './ledger-untrusted-transport'
+
+// EthereumLedgerUntrustedMessagingTransport makes calls to the Ethereum app on a Ledger device
+export class EthereumLedgerUntrustedMessagingTransport extends LedgerUntrustedMessagingTransport {
+  constructor (targetWindow: Window, targetUrl: string) {
+    super(targetWindow, targetUrl)
+    this.addCommandHandler<UnlockResponse>(LedgerCommand.Unlock, this.handleUnlock)
+    this.addCommandHandler<EthGetAccountResponse>(LedgerCommand.GetAccount, this.handleGetAccount)
+    this.addCommandHandler<EthSignTransactionResponse>(LedgerCommand.SignTransaction, this.handleSignTransaction)
+    this.addCommandHandler<EthSignPersonalMessageResponse>(LedgerCommand.SignPersonalMessage, this.handleSignPersonalMessage)
+    this.addCommandHandler<EthSignEip712MessageResponse>(LedgerCommand.SignEip712Message, this.handleSignEip712Message)
+  }
+
+  private handleGetAccount = async (command: EthGetAccountCommand): Promise<EthGetAccountResponse> => {
+    const transport = await TransportWebHID.create()
+    const app = new Eth(transport)
+    try {
+      const result = await app.getAddress(command.path)
+      const getAccountResponsePayload: EthGetAccountResponsePayload = {
+        success: true,
+        publicKey: result.publicKey,
+        address: result.address,
+        chainCode: result.chainCode
+      }
+      const response: EthGetAccountResponse = {
+        id: command.id,
+        command: command.command,
+        payload: getAccountResponsePayload,
+        origin: command.origin
+      }
+      return response
+    } catch (error) {
+      const response: EthGetAccountResponse = {
+        id: command.id,
+        command: command.command,
+        payload: error,
+        origin: command.origin
+      }
+      return response
+    } finally {
+      await transport.close()
+    }
+  }
+
+  private handleSignTransaction = async (command: EthSignTransactionCommand): Promise<EthSignTransactionResponse> => {
+    const transport = await TransportWebHID.create()
+    const app = new Eth(transport)
+    try {
+      const result = await app.signTransaction(command.path, command.rawTxHex)
+      const signTransactionResponsePayload: EthSignTransactionResponsePayload = {
+        success: true,
+        v: result.v,
+        r: result.r,
+        s: result.s
+      }
+      const response: EthSignTransactionResponse = {
+        id: command.id,
+        command: command.command,
+        payload: signTransactionResponsePayload,
+        origin: command.origin
+      }
+      return response
+    } catch (error) {
+      const response: EthSignTransactionResponse = {
+        id: command.id,
+        command: command.command,
+        payload: error,
+        origin: command.origin
+      }
+      return response
+    } finally {
+      await transport.close()
+    }
+  }
+
+  private handleSignPersonalMessage = async (command: EthSignPersonalMessageCommand): Promise<EthSignPersonalMessageResponse> => {
+    const transport = await TransportWebHID.create()
+    const app = new Eth(transport)
+    try {
+      const result = await app.signPersonalMessage(command.path, command.messageHex)
+      const signPersonalMessageResponsePayload: EthSignPersonalMessageResponsePayload = {
+        success: true,
+        v: result.v,
+        r: result.r,
+        s: result.s
+      }
+      const response: EthSignPersonalMessageResponse = {
+        id: command.id,
+        command: command.command,
+        payload: signPersonalMessageResponsePayload,
+        origin: command.origin
+      }
+      return response
+    } catch (error) {
+      const response: EthSignPersonalMessageResponse = {
+        id: command.id,
+        command: command.command,
+        payload: error,
+        origin: command.origin
+      }
+      return response
+    } finally {
+      await transport.close()
+    }
+  }
+
+  private handleSignEip712Message = async (command: EthSignEip712MessageCommand): Promise<EthSignEip712MessageResponse> => {
+    const transport = await TransportWebHID.create()
+    const app = new Eth(transport)
+    try {
+      const result = await app.signEIP712HashedMessage(command.path, command.domainSeparatorHex, command.hashStructMessageHex)
+      const signEip712MessageResponsePayload: EthSignEip712MessageResponsePayload = {
+        success: true,
+        v: result.v,
+        r: result.r,
+        s: result.s
+      }
+      const response: EthSignEip712MessageResponse = {
+        id: command.id,
+        command: command.command,
+        payload: signEip712MessageResponsePayload,
+        origin: command.origin
+      }
+      return response
+    } catch (error) {
+      const response: EthSignEip712MessageResponse = {
+        id: command.id,
+        command: command.command,
+        payload: error,
+        origin: command.origin
+      }
+      return response
+    } finally {
+      await transport.close()
+    }
+  }
+}

--- a/components/brave_wallet_ui/common/hardware/ledgerjs/eth_ledger_bridge_keyring.test.ts
+++ b/components/brave_wallet_ui/common/hardware/ledgerjs/eth_ledger_bridge_keyring.test.ts
@@ -1,229 +1,430 @@
-/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+/* Copyright (c) 2022 The Brave Authors. All rights reserved.
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+import EthereumLedgerBridgeKeyring from './eth_ledger_bridge_keyring'
+import { MockLedgerTransport } from './ledger_bridge_keyring.test'
+import { LedgerDerivationPaths, GetAccountsHardwareOperationResult, SignHardwareOperationResult } from '../types'
 import { BraveWallet } from '../../../constants/types'
-import LedgerBridgeKeyring from './eth_ledger_bridge_keyring'
-import { SignatureVRS } from '../../hardware_operations'
-import { LedgerDerivationPaths } from '../types'
+import { LedgerCommand, LedgerError, UnlockResponse } from './ledger-messages'
+import {
+  EthGetAccountResponsePayload,
+  EthSignTransactionResponse,
+  EthereumSignedTx,
+  EthSignPersonalMessageResponse,
+  EthSignEip712MessageResponse
+} from './eth-ledger-messages'
 
-class MockApp {
-  signature: SignatureVRS
-
-  async getAddress (path: string) {
-    return { address: `address for ${path}` }
-  }
-
-  async signPersonalMessage (path: string, message: Buffer) {
-    return Promise.resolve(this.signature)
-  }
-
-  async signEIP712HashedMessage (path: string, domainSeparatorHex: string, hashStructMessageHex: string) {
-    return Promise.resolve(this.signature)
-  }
+// To use the MockLedgerTransport, we must overwrite
+// the protected `transport` attribute, which yields a typescript
+// error unless we use bracket notation, i.e. keyring['transport']
+// instead of keyring.transport. As a result we silence the dot-notation
+// tslint rule for the file.
+//
+/* eslint-disable @typescript-eslint/dot-notation */
+const createKeyring = (): EthereumLedgerBridgeKeyring => {
+  let keyring = new EthereumLedgerBridgeKeyring()
+  const transport = new MockLedgerTransport(window, window.origin)
+  keyring['transport'] = transport
+  const iframe = document.createElement('iframe')
+  document.body.appendChild(iframe)
+  keyring['bridge'] = iframe
+  return keyring
+}
+const unlockSuccessResponse: UnlockResponse = {
+  id: LedgerCommand.Unlock,
+  origin: window.origin,
+  command: LedgerCommand.Unlock,
+  payload: { success: true }
 }
 
-const createLedgerKeyring = (app: MockApp = new MockApp()) => {
-  const ledgerHardwareKeyring = new LedgerBridgeKeyring()
-  ledgerHardwareKeyring.unlock = async () => {
-    ledgerHardwareKeyring.app = app
-    ledgerHardwareKeyring.deviceId = 'device1'
-    return { success: true }
+const unlockErrorResponse: UnlockResponse = {
+  id: LedgerCommand.Unlock,
+  origin: window.origin,
+  command: LedgerCommand.Unlock,
+  payload: {
+    success: false,
+    message: 'LedgerError',
+    statusCode: 101
   }
-  return ledgerHardwareKeyring
 }
-
-const unlockedLedgerKeyring = () => {
-  const ledgerHardwareKeyring = new LedgerBridgeKeyring()
-  ledgerHardwareKeyring.app = new MockApp()
-  ledgerHardwareKeyring.deviceId = 'device1'
-  return ledgerHardwareKeyring
-}
-
-test('Extracting accounts from device', () => {
-  return expect(createLedgerKeyring().getAccounts(-2, 1, LedgerDerivationPaths.LedgerLive))
-    .resolves.toStrictEqual({
-      payload: [
-        {
-          'address': 'address for m/44\'/60\'/0\'/0/0',
-          'derivationPath': 'm/44\'/60\'/0\'/0/0',
-          'hardwareVendor': 'Ledger',
-          'name': 'Ledger',
-          'deviceId': 'device1',
-          'coin': BraveWallet.CoinType.ETH,
-          'network': undefined
-        },
-        {
-          'address': 'address for m/44\'/60\'/1\'/0/0',
-          'derivationPath': 'm/44\'/60\'/1\'/0/0',
-          'hardwareVendor': 'Ledger',
-          'name': 'Ledger',
-          'deviceId': 'device1',
-          'coin': BraveWallet.CoinType.ETH,
-          'network': undefined
-        }],
-      success: true
-    }
-    )
-})
-
-test('Extracting accounts from legacy device', () => {
-  return expect(createLedgerKeyring().getAccounts(-2, 1, LedgerDerivationPaths.Legacy))
-    .resolves.toStrictEqual({
-      payload: [
-        {
-          'address': 'address for m/44\'/60\'/0\'/0',
-          'derivationPath': 'm/44\'/60\'/0\'/0',
-          'hardwareVendor': 'Ledger',
-          'name': 'Ledger',
-          'deviceId': 'device1',
-          'coin': BraveWallet.CoinType.ETH,
-          'network': undefined
-        },
-        {
-          'address': 'address for m/44\'/60\'/0\'/1',
-          'derivationPath': 'm/44\'/60\'/0\'/1',
-          'hardwareVendor': 'Ledger',
-          'name': 'Ledger',
-          'deviceId': 'device1',
-          'coin': BraveWallet.CoinType.ETH,
-          'network': undefined
-        }],
-      success: true
-    }
-    )
-})
-
-test('Extracting accounts with deprecated derivation paths', () => {
-  return expect(createLedgerKeyring().getAccounts(-2, 1, LedgerDerivationPaths.Deprecated))
-    .resolves.toStrictEqual({
-      payload: [
-        {
-          'address': 'address for m/44\'/60\'/0\'/0',
-          'derivationPath': 'm/44\'/60\'/0\'/0',
-          'hardwareVendor': 'Ledger',
-          'name': 'Ledger',
-          'deviceId': 'device1',
-          'coin': BraveWallet.CoinType.ETH,
-          'network': undefined
-        },
-        {
-          'address': 'address for m/44\'/60\'/1\'/0',
-          'derivationPath': 'm/44\'/60\'/1\'/0',
-          'hardwareVendor': 'Ledger',
-          'name': 'Ledger',
-          'deviceId': 'device1',
-          'coin': BraveWallet.CoinType.ETH,
-          'network': undefined
-        }],
-      success: true
-    }
-    )
-})
 
 test('Check ledger bridge type', () => {
-  const ledgerHardwareKeyring = new LedgerBridgeKeyring()
-  return expect(ledgerHardwareKeyring.type()).toStrictEqual(BraveWallet.LEDGER_HARDWARE_VENDOR)
+  const keyring = createKeyring()
+  return expect(keyring.type()).toStrictEqual(BraveWallet.LEDGER_HARDWARE_VENDOR)
 })
 
-test('Check locks for device app only', () => {
-  const ledgerHardwareKeyring = new LedgerBridgeKeyring()
-  expect(ledgerHardwareKeyring.isUnlocked()).toStrictEqual(false)
-  ledgerHardwareKeyring.app = new MockApp()
-  expect(ledgerHardwareKeyring.isUnlocked()).toStrictEqual(false)
+test('getAccounts unlock error', async () => {
+  const keyring: EthereumLedgerBridgeKeyring = createKeyring()
+  if (!keyring['transport']) { fail('transport should be defined') }
+  keyring['transport']['addSendCommandResponse'](unlockErrorResponse)
+  const result: GetAccountsHardwareOperationResult = await keyring.getAccounts(-2, 1, LedgerDerivationPaths.LedgerLive)
+  const expectedResult: GetAccountsHardwareOperationResult = unlockErrorResponse.payload
+  expect(result).toEqual(expectedResult)
 })
 
-test('Check locks for device app and device id', () => {
-  const ledgerHardwareKeyring = new LedgerBridgeKeyring()
-  expect(ledgerHardwareKeyring.isUnlocked()).toStrictEqual(false)
-  ledgerHardwareKeyring.app = new MockApp()
-  ledgerHardwareKeyring.deviceId = 'test'
-  expect(ledgerHardwareKeyring.isUnlocked()).toStrictEqual(true)
-})
-
-test('Extract accounts from locked device', () => {
-  const ledgerHardwareKeyring = new LedgerBridgeKeyring()
-  ledgerHardwareKeyring.unlock = async function () {
-    return { success: false, error: 'braveWalletUnlockError' }
+test('getAccounts ledger live derivation path success', async () => {
+  const keyring = createKeyring()
+  if (!keyring['transport']) { fail('transport should be defined') }
+  keyring['transport']['addSendCommandResponse'](unlockSuccessResponse)
+  const getAccountsResponsePayload1: EthGetAccountResponsePayload = {
+    success: true,
+    publicKey: 'publicKey',
+    address: 'address'
   }
-  return expect(ledgerHardwareKeyring.getAccounts(-2, 1, LedgerDerivationPaths.LedgerLive))
-    .resolves.toStrictEqual({ error: 'braveWalletUnlockError', success: false })
-})
-
-test('Extract accounts from unknown device', () => {
-  const ledgerHardwareKeyring = unlockedLedgerKeyring()
-  return expect(ledgerHardwareKeyring.getAccounts(-2, 1, 'unknown'))
-    .rejects.toThrow()
-})
-
-test('Sign personal message successfully with padding v<27', () => {
-  const ledgerHardwareKeyring = unlockedLedgerKeyring()
-  ledgerHardwareKeyring.app.signature = { v: 0, r: 'b68983', s: 'r68983' }
-  return expect(ledgerHardwareKeyring.signPersonalMessage(
-    'm/44\'/60\'/0\'/0/0', 'message'))
-    .resolves.toStrictEqual({ payload: '0xb68983r6898300', success: true })
-})
-
-test('Sign personal message successfully with padding v>=27', () => {
-  const ledgerHardwareKeyring = unlockedLedgerKeyring()
-  ledgerHardwareKeyring.app.signature = { v: 28, r: 'b68983', s: 'r68983' }
-  return expect(ledgerHardwareKeyring.signPersonalMessage(
-    'm/44\'/60\'/0\'/0/0', 'message'))
-    .resolves.toStrictEqual({ payload: '0xb68983r6898301', success: true })
-})
-
-test('Sign personal message successfully without padding v>=27', () => {
-  const ledgerHardwareKeyring = unlockedLedgerKeyring()
-  ledgerHardwareKeyring.app.signature = { v: 44, r: 'b68983', s: 'r68983' }
-  return expect(ledgerHardwareKeyring.signPersonalMessage(
-    'm/44\'/60\'/0\'/0/0', 'message'))
-    .resolves.toStrictEqual({ payload: '0xb68983r6898311', success: true })
-})
-
-test('Sign personal message successfully without padding v<27', () => {
-  const ledgerHardwareKeyring = unlockedLedgerKeyring()
-  ledgerHardwareKeyring.app.signature = { v: 17, r: 'b68983', s: 'r68983' }
-  return expect(ledgerHardwareKeyring.signPersonalMessage(
-    'm/44\'/60\'/0\'/0/0', 'message'))
-    .resolves.toStrictEqual({ payload: '0xb68983r6898311', success: true })
-})
-
-test('Sign personal message failed', () => {
-  const ledgerHardwareKeyring = createLedgerKeyring()
-  return expect(ledgerHardwareKeyring.signPersonalMessage(
-    'm/44\'/60\'/0\'/0/0', 'message'))
-    .resolves.toMatchObject({ success: false })
-})
-
-test('Sign typed message success', () => {
-  const app = new MockApp()
-  app.signature = { v: 28, r: 'b68983', s: 'r68983' }
-  const ledgerHardwareKeyring = createLedgerKeyring(app)
-  return expect(ledgerHardwareKeyring.signEip712Message(
-    'm/44\'/60\'/0\'/0/0', 'domainSeparatorHex', 'hashStructMessageHex'))
-    .resolves.toStrictEqual({ payload: '0xb68983r6898301', success: true })
-})
-
-test('Sign typed message locked', () => {
-  const ledgerHardwareKeyring = new LedgerBridgeKeyring()
-  ledgerHardwareKeyring.unlock = async () => {
-    return { success: false }
+  keyring['transport']['addSendCommandResponse']({ payload: getAccountsResponsePayload1 })
+  const getAccountsResponsePayload2: EthGetAccountResponsePayload = {
+    success: true,
+    publicKey: 'publicKey 2',
+    address: 'address 2'
   }
-  return expect(ledgerHardwareKeyring.signEip712Message(
-    'm/44\'/60\'/0\'/0/0', 'domainSeparatorHex', 'hashStructMessageHex'))
-    .resolves.toStrictEqual({ success: false })
+  keyring['transport']['addSendCommandResponse']({ payload: getAccountsResponsePayload2 })
+
+  const result = await keyring.getAccounts(-2, 1, LedgerDerivationPaths.LedgerLive)
+  expect(result).toEqual({
+    success: true,
+    payload: [
+      {
+        address: 'address',
+        derivationPath: "m/44'/60'/0'/0/0",
+        name: 'Ledger',
+        hardwareVendor: 'Ledger',
+        deviceId: 'd80c9bf910f144738ef983724bc04bd6bd3f17c5c83ed57bedee1b1b9278e811',
+        coin: BraveWallet.CoinType.ETH,
+        network: undefined
+      },
+      {
+        address: 'address 2',
+        derivationPath: "m/44'/60'/1'/0/0",
+        name: 'Ledger',
+        hardwareVendor: 'Ledger',
+        deviceId: 'd80c9bf910f144738ef983724bc04bd6bd3f17c5c83ed57bedee1b1b9278e811',
+        coin: BraveWallet.CoinType.ETH,
+        network: undefined
+      }
+    ]
+  })
 })
 
-test('Sign typed message error', () => {
-  const app = new MockApp()
-  app.signEIP712HashedMessage = async (path: string,
-    domainSeparatorHex: string,
-    hashStructMessageHex: string) => {
-      throw Error('some error')
+test('getAccounts legacy derivation path success', async () => {
+  const keyring = createKeyring()
+  if (!keyring['transport']) { fail('transport should be defined') }
+  keyring['transport']['addSendCommandResponse'](unlockSuccessResponse)
+  const getAccountsResponsePayload1: EthGetAccountResponsePayload = {
+    success: true,
+    publicKey: 'publicKey',
+    address: 'address'
   }
-  const ledgerHardwareKeyring = createLedgerKeyring(app)
-  return expect(ledgerHardwareKeyring.signEip712Message(
-    'm/44\'/60\'/0\'/0/0', 'domainSeparatorHex', 'hashStructMessageHex'))
-    .resolves.toStrictEqual({ success: false, error: 'some error', code: 'Error' })
+  keyring['transport']['addSendCommandResponse']({ payload: getAccountsResponsePayload1 })
+  const getAccountsResponsePayload2: EthGetAccountResponsePayload = {
+    success: true,
+    publicKey: 'publicKey 2',
+    address: 'address 2'
+  }
+  keyring['transport']['addSendCommandResponse']({ payload: getAccountsResponsePayload2 })
+
+  const result = await keyring.getAccounts(-2, 1, LedgerDerivationPaths.Legacy)
+  expect(result).toEqual({
+    success: true,
+    payload: [
+      {
+        address: 'address',
+        derivationPath: "m/44'/60'/0'/0",
+        name: 'Ledger',
+        hardwareVendor: 'Ledger',
+        deviceId: 'd80c9bf910f144738ef983724bc04bd6bd3f17c5c83ed57bedee1b1b9278e811',
+        coin: BraveWallet.CoinType.ETH,
+        network: undefined
+      },
+      {
+        address: 'address 2',
+        derivationPath: "m/44'/60'/0'/1",
+        name: 'Ledger',
+        hardwareVendor: 'Ledger',
+        deviceId: 'd80c9bf910f144738ef983724bc04bd6bd3f17c5c83ed57bedee1b1b9278e811',
+        coin: BraveWallet.CoinType.ETH,
+        network: undefined
+      }
+    ]
+  })
+})
+
+test('getAccounts deprecated derivation path success', async () => {
+  const keyring = createKeyring()
+  if (!keyring['transport']) { fail('transport should be defined') }
+  keyring['transport']['addSendCommandResponse'](unlockSuccessResponse)
+
+  const getAccountsResponsePayload1: EthGetAccountResponsePayload = {
+    success: true,
+    publicKey: 'publicKey',
+    address: 'address'
+  }
+  keyring['transport']['addSendCommandResponse']({ payload: getAccountsResponsePayload1 })
+  const getAccountsResponsePayload2: EthGetAccountResponsePayload = {
+    success: true,
+    publicKey: 'publicKey 2',
+    address: 'address 2'
+  }
+  keyring['transport']['addSendCommandResponse']({ payload: getAccountsResponsePayload2 })
+
+  const result = await keyring.getAccounts(-2, 1, LedgerDerivationPaths.Deprecated)
+  expect(result).toEqual({
+    success: true,
+    payload: [
+      {
+        address: 'address',
+        derivationPath: "m/44'/60'/0'/0",
+        name: 'Ledger',
+        hardwareVendor: 'Ledger',
+        deviceId: 'd80c9bf910f144738ef983724bc04bd6bd3f17c5c83ed57bedee1b1b9278e811',
+        coin: BraveWallet.CoinType.ETH,
+        network: undefined
+      },
+      {
+        address: 'address 2',
+        derivationPath: "m/44'/60'/1'/0",
+        name: 'Ledger',
+        hardwareVendor: 'Ledger',
+        deviceId: 'd80c9bf910f144738ef983724bc04bd6bd3f17c5c83ed57bedee1b1b9278e811',
+        coin: BraveWallet.CoinType.ETH,
+        network: undefined
+      }
+    ]
+  })
+})
+
+test('getAccounts ledger error after successful unlock', async () => {
+  const keyring = createKeyring()
+  if (!keyring['transport']) { fail('transport should be defined') }
+  keyring['transport']['addSendCommandResponse'](unlockSuccessResponse)
+  const getAccountResponseLedgerError: LedgerError = {
+    success: false,
+    message: 'LedgerError',
+    statusCode: 101
+  }
+
+  keyring['transport']['addSendCommandResponse']({ payload: getAccountResponseLedgerError })
+  const result: GetAccountsHardwareOperationResult = await keyring.getAccounts(-2, 1, LedgerDerivationPaths.LedgerLive)
+
+  expect(result).toEqual({
+    success: false,
+    error: { message: 'LedgerError', statusCode: 101, success: false },
+    code: 101
+  })
+})
+
+test('signTransaction unlock error', async () => {
+  const keyring = createKeyring()
+  if (!keyring['transport']) { fail('transport should be defined') }
+  keyring['transport']['addSendCommandResponse'](unlockErrorResponse)
+  const result = await keyring.signTransaction("m/44'/60'/0'/0/0", 'transaction')
+  const expectedResult: SignHardwareOperationResult = unlockErrorResponse.payload
+  expect(result).toEqual(expectedResult)
+})
+
+test('signTransaction success', async () => {
+  const keyring = createKeyring()
+  if (!keyring['transport']) { fail('transport should be defined') }
+  keyring['transport']['addSendCommandResponse'](unlockSuccessResponse)
+  const signTransactionResponse: EthSignTransactionResponse = {
+    id: LedgerCommand.SignTransaction,
+    origin: window.origin,
+    command: LedgerCommand.SignTransaction,
+    payload: {
+      success: true,
+      v: 'v',
+      r: 'r',
+      s: 's'
+    }
+  }
+
+  keyring['transport']['addSendCommandResponse'](signTransactionResponse)
+  const result: SignHardwareOperationResult = await keyring.signTransaction(
+    '44\'/501\'/1\'/0\'', 'transaction'
+  )
+
+  const expectedResult: SignHardwareOperationResult = {
+    success: true,
+    payload: {
+      v: 'v',
+      r: 'r',
+      s: 's'
+    } as EthereumSignedTx
+  }
+  expect(result).toEqual(expectedResult)
+})
+
+test('signTransaction ledger error after successful unlock', async () => {
+  const keyring = createKeyring()
+  if (!keyring['transport']) { fail('transport should be defined') }
+  keyring['transport']['addSendCommandResponse'](unlockSuccessResponse)
+  const ledgerError: LedgerError = {
+    success: false,
+    message: 'LedgerError',
+    statusCode: 101
+  }
+
+  const signTransactionResponse: EthSignTransactionResponse = {
+    id: LedgerCommand.SignTransaction,
+    origin: window.origin,
+    command: LedgerCommand.SignTransaction,
+    payload: ledgerError
+  }
+  keyring['transport']['addSendCommandResponse'](signTransactionResponse)
+  const result: SignHardwareOperationResult = await keyring.signTransaction(
+    "m/44'/60'/0'/0/0",
+    'transaction'
+  )
+
+  const expectedResult: SignHardwareOperationResult = {
+    success: false,
+    error: 'LedgerError',
+    code: 101
+  }
+  expect(result).toEqual(expectedResult)
+})
+
+test('signPersonalMessage unlock error', async () => {
+  const keyring = createKeyring()
+  if (!keyring['transport']) { fail('transport should be defined') }
+  keyring['transport']['addSendCommandResponse'](unlockErrorResponse)
+  const result = await keyring.signPersonalMessage(
+    "m/44'/60'/0'/0/0",
+    'message'
+  )
+  const expectedResult: SignHardwareOperationResult = unlockErrorResponse.payload
+  expect(result).toEqual(expectedResult)
+})
+
+test('signPersonalMessage success with padding v<27', async () => {
+  const keyring = createKeyring()
+  if (!keyring['transport']) { fail('transport should be defined') }
+  keyring['transport']['addSendCommandResponse'](unlockSuccessResponse)
+  const responsePayload: EthSignPersonalMessageResponse = {
+    id: LedgerCommand.SignPersonalMessage,
+    origin: window.origin,
+    command: LedgerCommand.SignPersonalMessage,
+    payload: { success: true, v: 0, r: 'b68983', s: 'r68983' }
+  }
+  keyring['transport']['addSendCommandResponse'](responsePayload)
+  const result: SignHardwareOperationResult = await keyring.signPersonalMessage(
+    "m/44'/60'/0'/0/0",
+    'message'
+  )
+
+  const expectedResult = { payload: '0xb68983r6898300', success: true }
+  expect(result).toEqual(expectedResult)
+})
+
+test('signPersonalMessage success with padding v>=27', async () => {
+  const keyring = createKeyring()
+  if (!keyring['transport']) { fail('transport should be defined') }
+  keyring['transport']['addSendCommandResponse'](unlockSuccessResponse)
+  const responsePayload: EthSignPersonalMessageResponse = {
+    id: LedgerCommand.SignPersonalMessage,
+    origin: window.origin,
+    command: LedgerCommand.SignPersonalMessage,
+    payload: { success: true, v: 28, r: 'b68983', s: 'r68983' }
+  }
+  keyring['transport']['addSendCommandResponse'](responsePayload)
+  const result: SignHardwareOperationResult = await keyring.signPersonalMessage(
+    "m/44'/60'/0'/0/0",
+    'message'
+  )
+
+  const expectedResult = { payload: '0xb68983r6898301', success: true }
+  expect(result).toEqual(expectedResult)
+})
+
+test('signPersonalMessage failure after successful unlock', async () => {
+  const keyring = createKeyring()
+  if (!keyring['transport']) { fail('transport should be defined') }
+  keyring['transport']['addSendCommandResponse'](unlockSuccessResponse)
+  const ledgerError: LedgerError = {
+    success: false,
+    message: 'LedgerError',
+    statusCode: 101
+  }
+
+  const signPersonalMessageResponse: EthSignTransactionResponse = {
+    id: LedgerCommand.SignTransaction,
+    origin: window.origin,
+    command: LedgerCommand.SignTransaction,
+    payload: ledgerError
+  }
+  keyring['transport']['addSendCommandResponse'](signPersonalMessageResponse)
+  const result: SignHardwareOperationResult = await keyring.signPersonalMessage(
+    "m/44'/60'/0'/0/0",
+    'message'
+  )
+  const expectedResult: SignHardwareOperationResult = {
+    success: false,
+    error: 'LedgerError',
+    code: 101
+  }
+  expect(result).toEqual(expectedResult)
+})
+
+test('signEip712Message unlock error', async () => {
+  const keyring = createKeyring()
+  if (!keyring['transport']) { fail('transport should be defined') }
+  keyring['transport']['addSendCommandResponse'](unlockErrorResponse)
+  const result = await keyring.signEip712Message(
+    "m/44'/60'/0'/0/0",
+    'domainSeparatorHex',
+    'hashStructMessageHex'
+  )
+  const expectedResult: SignHardwareOperationResult = unlockErrorResponse.payload
+  expect(result).toEqual(expectedResult)
+})
+
+test('signEip712Message success', async () => {
+  const keyring = createKeyring()
+  if (!keyring['transport']) { fail('transport should be defined') }
+  keyring['transport']['addSendCommandResponse'](unlockSuccessResponse)
+  const responsePayload: EthSignEip712MessageResponse = {
+    id: LedgerCommand.SignEip712Message,
+    origin: window.origin,
+    command: LedgerCommand.SignEip712Message,
+    payload: { success: true, v: 28, r: 'b68983', s: 'r68983' }
+  }
+  keyring['transport']['addSendCommandResponse'](responsePayload)
+  const result: SignHardwareOperationResult = await keyring.signEip712Message(
+    "m/44'/60'/0'/0/0",
+    'domainSeparatorHex',
+    'hashStructMessageHex'
+  )
+
+  const expectedResult = { payload: '0xb68983r6898301', success: true }
+  expect(result).toEqual(expectedResult)
+})
+
+test('signEip712Message failure after successful unlock', async () => {
+  const keyring = createKeyring()
+  if (!keyring['transport']) { fail('transport should be defined') }
+  keyring['transport']['addSendCommandResponse'](unlockSuccessResponse)
+  const ledgerError: LedgerError = {
+    success: false,
+    message: 'LedgerError',
+    statusCode: 101
+  }
+  const signEip712MessageResponse: EthSignTransactionResponse = {
+    id: LedgerCommand.SignTransaction,
+    origin: window.origin,
+    command: LedgerCommand.SignTransaction,
+    payload: ledgerError
+  }
+  keyring['transport']['addSendCommandResponse'](signEip712MessageResponse)
+  const result: SignHardwareOperationResult = await keyring.signEip712Message(
+    "m/44'/60'/0'/0/0",
+    'domainSeparatorHex',
+    'hashStructMessageHex'
+  )
+  const expectedResult: SignHardwareOperationResult = {
+    success: false,
+    error: 'LedgerError',
+    code: 101
+  }
+  expect(result).toEqual(expectedResult)
 })

--- a/components/brave_wallet_ui/common/hardware/ledgerjs/eth_ledger_bridge_keyring.ts
+++ b/components/brave_wallet_ui/common/hardware/ledgerjs/eth_ledger_bridge_keyring.ts
@@ -1,152 +1,151 @@
-/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+/* Copyright (c) 2022 The Brave Authors. All rights reserved.
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import { assert } from 'chrome://resources/js/assert.m.js'
-import TransportWebHID from '@ledgerhq/hw-transport-webhid'
-import Eth from '@ledgerhq/hw-app-eth'
 import { BraveWallet } from '../../../constants/types'
 import { getLocale } from '../../../../common/locale'
-import { hardwareDeviceIdFromAddress } from '../hardwareDeviceIdFromAddress'
+import { LedgerEthereumKeyring } from '../interfaces'
 import {
   GetAccountsHardwareOperationResult,
-  SignatureVRS,
   SignHardwareOperationResult,
-  HardwareOperationResult, LedgerDerivationPaths
+  LedgerDerivationPaths
 } from '../types'
-import { LedgerEthereumKeyring } from '../interfaces'
-import { HardwareVendor } from '../../api/hardware_keyrings'
+import {
+  LedgerCommand,
+  LedgerBridgeErrorCodes,
+  LedgerError
+} from './ledger-messages'
+import {
+  EthGetAccountResponse,
+  EthGetAccountResponsePayload,
+  EthSignTransactionResponse,
+  EthSignTransactionResponsePayload,
+  EthSignPersonalMessageResponse,
+  EthSignPersonalMessageResponsePayload,
+  EthSignEip712MessageResponse,
+  EthSignEip712MessageResponsePayload
+} from './eth-ledger-messages'
 
-export enum LedgerErrorsCodes {
-  TransportLocked = 'TransportLocked'
-}
-export default class LedgerBridgeKeyring extends LedgerEthereumKeyring {
-  constructor () {
-    super()
+import { hardwareDeviceIdFromAddress } from '../hardwareDeviceIdFromAddress'
+import LedgerBridgeKeyring from './ledger_bridge_keyring'
+
+export default class EthereumLedgerBridgeKeyring extends LedgerBridgeKeyring implements LedgerEthereumKeyring {
+  constructor (onAuthorized?: () => void) {
+    super(onAuthorized)
   }
-
-  private app?: Eth
-  private deviceId: string
 
   coin = (): BraveWallet.CoinType => {
     return BraveWallet.CoinType.ETH
   }
 
-  type = (): HardwareVendor => {
-    return BraveWallet.LEDGER_HARDWARE_VENDOR
-  }
-
   getAccounts = async (from: number, to: number, scheme: string): Promise<GetAccountsHardwareOperationResult> => {
-    const unlocked = await this.unlock()
-    if (!unlocked.success || !this.app) {
-      return unlocked
+    const result = await this.unlock()
+    if (!result.success) {
+      return result
     }
-    from = (from < 0) ? 0 : from
-    const eth: Eth = this.app
-    const accounts = []
+    from = (from >= 0) ? from : 0
+    const paths = []
+    const addZeroPath = (from > 0 || to < 0)
+    if (addZeroPath) {
+      // Add zero address to calculate device id.
+      paths.push(this.getPathForIndex(0, scheme))
+    }
     for (let i = from; i <= to; i++) {
-      const path = this.getPathForIndex(i, scheme)
-      const address = await eth.getAddress(path)
-      accounts.push({
-        address: address.address,
-        derivationPath: path,
-        name: this.type(),
-        hardwareVendor: this.type(),
-        deviceId: this.deviceId,
-        coin: this.coin(),
-        network: undefined
-      })
+      paths.push(this.getPathForIndex(i, scheme))
     }
-    return { success: true, payload: [...accounts] }
-  }
-
-  isUnlocked = (): boolean => {
-    return this.app !== undefined && this.deviceId !== undefined
-  }
-
-  makeApp = async () => {
-    this.app = new Eth(await TransportWebHID.create())
-  }
-
-  unlock = async (): Promise<HardwareOperationResult> => {
-    if (this.isUnlocked()) {
-      return { success: true }
-    }
-
-    if (!this.app) {
-      await this.makeApp()
-    }
-    if (this.app && !this.deviceId) {
-      const eth: Eth = this.app
-      eth.transport.on('disconnect', this.onDisconnected)
-      const zeroPath = this.getPathForIndex(0, LedgerDerivationPaths.LedgerLive)
-      const address = (await eth.getAddress(zeroPath)).address
-      this.deviceId = await hardwareDeviceIdFromAddress(address)
-    }
-    return { success: this.isUnlocked() }
+    return this.getAccountsFromDevice(paths, addZeroPath, scheme)
   }
 
   signTransaction = async (path: string, rawTxHex: string): Promise<SignHardwareOperationResult> => {
-    try {
-      const unlocked = await this.unlock()
-      if (!unlocked.success || !this.app) {
-        return unlocked
-      }
-      const eth: Eth = this.app
-      const signed = await eth.signTransaction(path, rawTxHex)
-      return { success: true, payload: signed }
-    } catch (e) {
-      return { success: false, error: e.message, code: e.statusCode || e.id || e.name }
+    const result = await this.unlock()
+    if (!result.success) {
+      return result
     }
-  }
+    const data = await this.sendCommand<EthSignTransactionResponse>({
+      command: LedgerCommand.SignTransaction,
+      id: LedgerCommand.SignTransaction,
+      path: path,
+      rawTxHex: rawTxHex,
+      origin: window.origin
+    })
+    if (data === LedgerBridgeErrorCodes.BridgeNotReady ||
+        data === LedgerBridgeErrorCodes.CommandInProgress) {
+      return this.createErrorFromCode(data)
+    }
+    if (!data.payload.success) {
+      const ledgerError = data.payload as LedgerError
+      return { success: false, error: ledgerError.message, code: ledgerError.statusCode }
+    }
 
-  signEip712Message = async (path: string, domainSeparatorHex: string, hashStructMessageHex: string): Promise<SignHardwareOperationResult> => {
-    try {
-      const unlocked = await this.unlock()
-      if (!unlocked.success || !this.app) {
-        return unlocked
-      }
-      const eth: Eth = this.app
-      const data = await eth.signEIP712HashedMessage(path, domainSeparatorHex, hashStructMessageHex)
-      const signature = this.createMessageSignature(data)
-      return { success: true, payload: signature }
-    } catch (e) {
-      return { success: false, error: e.message, code: e.statusCode || e.id || e.name }
-    }
+    const responsePayload = data.payload as EthSignTransactionResponsePayload
+    return { success: true, payload: { v: responsePayload.v, r: responsePayload.r, s: responsePayload.s } }
   }
 
   signPersonalMessage = async (path: string, message: string): Promise<SignHardwareOperationResult> => {
-    try {
-      const unlocked = await this.unlock()
-      if (!unlocked.success || !this.app) {
-        return unlocked
-      }
-      const eth: Eth = this.app
-      const messageHex = Buffer.from(message).toString('hex')
-      const data = await eth.signPersonalMessage(path, messageHex)
-      const signature = this.createMessageSignature(data)
-      if (!signature) {
-        return { success: false, error: getLocale('braveWalletLedgerValidationError') }
-      }
-      return { success: true, payload: signature }
-    } catch (e) {
-      return { success: false, error: e.message, code: e.statusCode || e.id || e.name }
+    const result = await this.unlock()
+    if (!result.success) {
+      return result
     }
-  }
-
-  cancelOperation = async () => {
-    this.app?.transport.close()
-  }
-
-  private onDisconnected = (e: any) => {
-    if (e.name !== 'DisconnectedDevice') {
-      return
+    const messageHex = Buffer.from(message).toString('hex')
+    const data = await this.sendCommand<EthSignPersonalMessageResponse>({
+      command: LedgerCommand.SignPersonalMessage,
+      id: LedgerCommand.SignPersonalMessage,
+      path: path,
+      origin: window.origin,
+      messageHex: messageHex
+    })
+    if (data === LedgerBridgeErrorCodes.BridgeNotReady ||
+        data === LedgerBridgeErrorCodes.CommandInProgress) {
+      return this.createErrorFromCode(data)
     }
-    this.app = undefined
+    if (!data.payload.success) {
+      const ledgerError = data.payload as LedgerError
+      return { success: false, error: ledgerError.message, code: ledgerError.statusCode }
+    }
+
+    const responsePayload = data.payload as EthSignPersonalMessageResponsePayload
+    const signature = this.createMessageSignature(responsePayload)
+    if (!signature) {
+      return { success: false, error: getLocale('braveWalletLedgerValidationError') }
+    }
+
+    return { success: true, payload: signature }
   }
 
-  private readonly createMessageSignature = (result: SignatureVRS) => {
+  signEip712Message = async (path: string, domainSeparatorHex: string, hashStructMessageHex: string): Promise<SignHardwareOperationResult> => {
+    const result = await this.unlock()
+    if (!result.success) {
+      return result
+    }
+    const data = await this.sendCommand<EthSignEip712MessageResponse>({
+      command: LedgerCommand.SignEip712Message,
+      id: LedgerCommand.SignEip712Message,
+      path: path,
+      origin: window.origin,
+      domainSeparatorHex: domainSeparatorHex,
+      hashStructMessageHex: hashStructMessageHex
+    })
+    if (data === LedgerBridgeErrorCodes.BridgeNotReady ||
+        data === LedgerBridgeErrorCodes.CommandInProgress) {
+      return this.createErrorFromCode(data)
+    }
+    if (!data.payload.success) {
+      const ledgerError = data.payload as LedgerError
+      return { success: false, error: ledgerError.message, code: ledgerError.statusCode }
+    }
+
+    const responsePayload = data.payload as EthSignEip712MessageResponsePayload
+    const signature = this.createMessageSignature(responsePayload)
+    if (!signature) {
+      return { success: false, error: getLocale('braveWalletLedgerValidationError') }
+    }
+
+    return { success: true, payload: signature }
+  }
+
+  private readonly createMessageSignature = (result: EthSignPersonalMessageResponsePayload | EthSignPersonalMessageResponsePayload) => {
     // Convert the recovery identifier to standard ECDSA if using bitcoin secp256k1 convention.
     let v = result.v < 27
       ? result.v.toString(16)
@@ -158,6 +157,50 @@ export default class LedgerBridgeKeyring extends LedgerEthereumKeyring {
     }
     const signature = `0x${result.r}${result.s}${v}`
     return signature
+  }
+
+  private readonly getAccountsFromDevice = async (paths: string[], skipZeroPath: boolean, scheme: string): Promise<GetAccountsHardwareOperationResult> => {
+    let accounts = []
+    const zeroPath = this.getPathForIndex(0, scheme)
+    for (const path of paths) {
+      const data = await this.sendCommand<EthGetAccountResponse>({
+        command: LedgerCommand.GetAccount,
+        id: LedgerCommand.GetAccount,
+        path: path,
+        origin: window.origin
+      })
+      if (data === LedgerBridgeErrorCodes.BridgeNotReady ||
+          data === LedgerBridgeErrorCodes.CommandInProgress) {
+        return this.createErrorFromCode(data)
+      }
+
+      if (!data.payload.success) {
+        const ledgerError = data.payload as LedgerError
+        return { success: false, error: ledgerError, code: ledgerError.statusCode }
+      }
+      const responsePayload = data.payload as EthGetAccountResponsePayload
+
+      if (path === zeroPath) {
+        this.deviceId = await hardwareDeviceIdFromAddress(responsePayload.address)
+        if (skipZeroPath) {
+          // If requested addresses do not have zero indexed adress we add it
+          // intentionally to calculate device id and should not add it to
+          // returned accounts
+          continue
+        }
+      }
+
+      accounts.push({
+        address: responsePayload.address,
+        derivationPath: path,
+        name: this.type(),
+        hardwareVendor: this.type(),
+        deviceId: this.deviceId,
+        coin: this.coin(),
+        network: undefined
+      })
+    }
+    return { success: true, payload: accounts }
   }
 
   private readonly getPathForIndex = (index: number, scheme: string): string => {

--- a/components/brave_wallet_ui/common/hardware/ledgerjs/ledger-messages.ts
+++ b/components/brave_wallet_ui/common/hardware/ledgerjs/ledger-messages.ts
@@ -4,18 +4,32 @@
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import { loadTimeData } from '../../../../common/loadTimeData'
+import type {
+  SolLedgerFrameCommand,
+  SolLedgerFrameResponse
+} from './sol-ledger-messages'
+import type {
+  EthLedgerFrameCommand,
+  EthLedgerFrameResponse
+} from './eth-ledger-messages'
 
-export const LEDGER_BRIDGE_URL = loadTimeData.getString('braveWalletLedgerBridgeUrl').slice(0, -1) // Strip off trailing '/' in URL
-
+const braveWalletLedgerBridgeUrl = loadTimeData.getString('braveWalletLedgerBridgeUrl')
+export const LEDGER_BRIDGE_URL = braveWalletLedgerBridgeUrl.charAt(braveWalletLedgerBridgeUrl.length - 1) === '/'
+                                 ? braveWalletLedgerBridgeUrl.slice(0, -1) // Strip off trailing '/' in URL
+                                 : braveWalletLedgerBridgeUrl
 export enum LedgerCommand {
   Unlock = 'ledger-unlock',
   GetAccount = 'ledger-get-accounts',
   SignTransaction = 'ledger-sign-transaction',
+  SignPersonalMessage = 'ledger-sign-personal-message',
+  SignEip712Message = 'ledger-sign-eip-712-message',
   AuthorizationRequired = 'authorization-required', // Sent by the frame to the parent context
   AuthorizationSuccess = 'authorization-success' // Sent by the frame to the parent context
 }
 
-export enum LedgerErrorsCodes {
+// LedgerBrigeErrorCodes are errors related to the configuring
+// and running of postMessages between window objects
+export enum LedgerBridgeErrorCodes {
   BridgeNotReady = 0,
   CommandInProgress = 1
 }
@@ -49,31 +63,6 @@ export type UnlockCommand = CommandMessage & {
   command: LedgerCommand.Unlock
 }
 
-// GetAccounts command
-export type GetAccountResponsePayload = LedgerResponsePayload & {
-  address: Buffer
-}
-export type GetAccountResponse = CommandMessage & {
-  payload: GetAccountResponsePayload | LedgerError
-}
-export type GetAccountCommand = CommandMessage & {
-  command: LedgerCommand.GetAccount
-  path: string
-}
-
-// SignTransaction command
-export type SignTransactionResponsePayload = LedgerResponsePayload & {
-  signature: Buffer
-}
-export type SignTransactionResponse= CommandMessage & {
-  payload: SignTransactionResponsePayload | LedgerError
-}
-export type SignTransactionCommand = CommandMessage & {
-  command: LedgerCommand.SignTransaction
-  path: string
-  rawTxBytes: Buffer
-}
-
 // AuthorizationRequired command
 export type AuthorizationRequiredCommand = CommandMessage & {
   command: LedgerCommand.AuthorizationRequired
@@ -85,8 +74,8 @@ export type AuthorizationSuccessCommand = CommandMessage & {
   command: LedgerCommand.AuthorizationSuccess
 }
 
-export type LedgerFrameCommand = UnlockCommand | GetAccountCommand | SignTransactionCommand | AuthorizationRequiredCommand | AuthorizationSuccessCommand
-export type LedgerFrameResponse = UnlockResponse| GetAccountResponse| SignTransactionResponse
+export type LedgerFrameCommand = UnlockCommand | AuthorizationRequiredCommand | AuthorizationSuccessCommand | SolLedgerFrameCommand | EthLedgerFrameCommand
+export type LedgerFrameResponse = UnlockResponse | SolLedgerFrameResponse | EthLedgerFrameResponse
 
 type LedgerCommandHandler <T>= ((command: LedgerFrameCommand) => Promise<T>)
 type LedgerCommandResponseHandler <T>= ((response: T) => void)

--- a/components/brave_wallet_ui/common/hardware/ledgerjs/ledger-messaging-transport.test.ts
+++ b/components/brave_wallet_ui/common/hardware/ledgerjs/ledger-messaging-transport.test.ts
@@ -6,19 +6,33 @@
 import { LedgerMessagingTransport } from './ledger-messaging-transport'
 import {
   LedgerCommand,
-  LedgerErrorsCodes
+  LedgerBridgeErrorCodes,
+  UnlockCommand
 } from './ledger-messages'
+
+// We must read and write to protected class attributes in the tests.
+// That yields a typescript error unless we use bracket notation, e.g. `transport['handlers']`
+// instead of `transport.handlers`. As a result we silence the dot-notation
+// tslint rule for the file.
+//
+/* eslint-disable @typescript-eslint/dot-notation */
 
 const createTransport = (targetUrl: string = 'chrome-untrusted://ledger-bridge'): LedgerMessagingTransport => {
   const iframe = document.createElement('iframe')
   document.body.appendChild(iframe)
-  iframe.contentWindow.origin = targetUrl
+  if (!iframe.contentWindow) { fail('transport should be defined') }
+  // Use Object.defineProperty in order to assign to
+  // window.crypto because standard assignment results in
+  // assignment error because window.origin is read-only
+  Object.defineProperty(iframe.contentWindow, 'origin', {
+    value: targetUrl
+  })
   const targetWindow = iframe.contentWindow
   const transport = new LedgerMessagingTransport(
     targetWindow,
     targetWindow.origin
   )
-  transport.senderWindow = window // Shorthand for testing
+  transport['senderWindow'] = window // Shorthand for testing
   return transport
 }
 
@@ -28,38 +42,38 @@ test('constructor', () => {
     window.origin
   )
 
-  expect(transport.targetWindow).toEqual(window)
-  expect(transport.targetUrl).toEqual(window.origin)
-  expect(transport.handlers.size).toEqual(0)
+  expect(transport['targetWindow']).toEqual(window)
+  expect(transport['targetUrl']).toEqual(window.origin)
+  expect(transport['handlers'].size).toEqual(0)
 })
 
 test('sendCommand configures handler for the response message ', async () => {
   const transport = createTransport()
-  const sendEvent = {
+  const sendEvent: UnlockCommand = {
     id: LedgerCommand.Unlock,
-    origin: transport.senderWindow.origin,
+    origin: transport['senderWindow']['origin'],
     command: LedgerCommand.Unlock
   }
-  const initialHandlersCount = transport.handlers.size
-  transport.targetWindow.postMessage = (eventData) => {
+  const initialHandlersCount = transport['handlers'].size
+  transport['targetWindow'].postMessage = (eventData) => {
     // Sender should have created a handler to handle the reply
-    expect(transport.handlers.size).toEqual(initialHandlersCount + 1)
+    expect(transport['handlers'].size).toEqual(initialHandlersCount + 1)
   }
   transport.sendCommand(sendEvent)
 })
 
 test('sendCommand returns CommandInProgress if response handler already exists', async () => {
   const transport = createTransport()
-  const sendEvent = {
+  const sendEvent: UnlockCommand = {
     id: LedgerCommand.Unlock,
-    origin: transport.senderWindow.origin,
+    origin: transport['senderWindow'].origin,
     command: LedgerCommand.Unlock
   }
 
-  transport.targetWindow.postMessage = (eventData) => {
+  transport['targetWindow'].postMessage = (eventData) => {
     // Sending a second message before the first is replied to should result in CommandInProgress
     transport.sendCommand(sendEvent).then((inflightResponse) => {
-      expect(inflightResponse).toEqual(LedgerErrorsCodes.CommandInProgress)
+      expect(inflightResponse).toEqual(LedgerBridgeErrorCodes.CommandInProgress)
     })
   }
   transport.sendCommand(sendEvent) // Send the message
@@ -67,25 +81,25 @@ test('sendCommand returns CommandInProgress if response handler already exists',
 
 test('sendCommand removes command handler for the response when its resolved', async () => {
   const transport = createTransport()
-  const sendEvent = {
+  const sendEvent: UnlockCommand = {
     id: LedgerCommand.Unlock,
-    origin: transport.senderWindow.origin,
+    origin: transport['senderWindow']['origin'],
     command: LedgerCommand.Unlock
   }
 
-  transport.targetWindow.postMessage = (eventData) => {
+  transport['targetWindow'].postMessage = (eventData) => {
     const replyEvent: MessageEvent = new MessageEvent('message', {
       data: eventData,
-      origin: transport.targetWindow.origin,
-      source: transport.targetWindow
+      origin: transport['targetWindow'].origin,
+      source: transport['targetWindow']
     })
-    transport.senderWindow.dispatchEvent(replyEvent)
+    transport['senderWindow'].dispatchEvent(replyEvent)
   }
 
   await transport.sendCommand(sendEvent)
 
   // Reply handler should be removed when sendCommand resolves
-  expect(transport.handlers.size).toEqual(0)
+  expect(transport['handlers'].size).toEqual(0)
 })
 
 test('onMessageReceived ignores messages not from the targetUrl', () => {
@@ -100,20 +114,20 @@ test('onMessageReceived ignores messages not from the targetUrl', () => {
   // Events nott from the targetUrl should not be handled
   const invalidEvent: MessageEvent = new MessageEvent('message', {
     data: eventData,
-    origin: transport.senderWindow.origin,
-    source: transport.senderWindow
+    origin: transport['senderWindow']['origin'],
+    source: transport['senderWindow']
   })
-  transport.addCommandHandler(testId, () => callbackCalled = true)
-  transport.senderWindow.dispatchEvent(invalidEvent)
+  transport['addCommandHandler'](testId, () => callbackCalled = true)
+  transport['senderWindow'].dispatchEvent(invalidEvent)
   expect(callbackCalled).toEqual(false)
 
   // Events from the targetUrl should be handled
   const validEvent: MessageEvent = new MessageEvent('message', {
     data: eventData,
-    origin: transport.targetWindow.origin,
-    source: transport.targetWindow
+    origin: transport['targetWindow'].origin,
+    source: transport['targetWindow']
   })
-  transport.senderWindow.dispatchEvent(validEvent)
+  transport['senderWindow'].dispatchEvent(validEvent)
   expect(callbackCalled).toEqual(true)
 })
 
@@ -122,24 +136,24 @@ test('onMessageReceived invokes handler and replies with response', () => {
   const testId = 'test'
   const eventData = {
     id: testId,
-    origin: transport.targetWindow.origin,
+    origin: transport['targetWindow'].origin,
     command: testId
   }
   const event: MessageEvent = new MessageEvent('message', {
     data: eventData,
     origin: eventData.origin, // event.origin === event.data.origin when a response is expected
-    source: transport.targetWindow
+    source: transport['targetWindow']
   })
 
   const expectedResponse = 123
-  transport.addCommandHandler(testId, () => {
+  transport['addCommandHandler'](testId, () => {
     return expectedResponse
   })
 
-  transport.targetWindow.postMessage = (event) => {
+  transport['targetWindow'].postMessage = (event) => {
     expect(event).toEqual(expectedResponse)
   }
-  transport.senderWindow.dispatchEvent(event)
+  transport['senderWindow'].dispatchEvent(event)
 })
 
 test('onMessageReceived does not reply with response if the receiving message is already response', () => {
@@ -147,18 +161,18 @@ test('onMessageReceived does not reply with response if the receiving message is
   const testId = 'test'
   const eventData = {
     id: testId,
-    origin: transport.targetWindow.origin,
+    origin: transport['targetWindow'].origin,
     command: testId
   }
   let callbackCalled = false
   const event: MessageEvent = new MessageEvent('message', {
     data: eventData,
-    origin: transport.senderWindow.origin, // event.origin !== event.data.origin when it is a reponse to a sendCommand
-    source: transport.targetWindow
+    origin: transport['senderWindow']['origin'], // event.origin !== event.data.origin when it is a reponse to a sendCommand
+    source: transport['targetWindow']
   })
-  transport.addCommandHandler(testId, () => {
+  transport['addCommandHandler'](testId, () => {
     callbackCalled = true
   })
-  transport.senderWindow.dispatchEvent(event)
+  transport['senderWindow'].dispatchEvent(event)
   expect(callbackCalled).toEqual(false)
 })

--- a/components/brave_wallet_ui/common/hardware/ledgerjs/ledger-messaging-transport.ts
+++ b/components/brave_wallet_ui/common/hardware/ledgerjs/ledger-messaging-transport.ts
@@ -4,7 +4,7 @@
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import {
-  LedgerErrorsCodes,
+  LedgerBridgeErrorCodes,
   LedgerFrameCommand,
   LedgerFrameResponse,
   LedgerCommandHandlerUnion
@@ -15,7 +15,7 @@ import {
 // to a window object at a targetUrl and subscribing of responses, and (2)
 // the definition of handlers to be run when a different LedgerMessagingTransport
 // instance at a different Window sends messages to it.
-export abstract class LedgerMessagingTransport {
+export class LedgerMessagingTransport {
   protected targetWindow: Window
   protected targetUrl: string
   protected handlers: Map<string, Function>
@@ -27,13 +27,13 @@ export abstract class LedgerMessagingTransport {
   }
 
   // T is response type, e.g. GetAccountResponse
-  sendCommand = <T> (command: LedgerFrameCommand): Promise<T | LedgerErrorsCodes> => {
-    return new Promise<T | LedgerErrorsCodes>(async (resolve) => {
+  sendCommand = <T> (command: LedgerFrameCommand): Promise<T | LedgerBridgeErrorCodes> => {
+    return new Promise<T | LedgerBridgeErrorCodes>(async (resolve) => {
       // Set handler for the response by passing the resolve function to be run
       // when targetWindow responds using the same command.id.
       // This allows us to simply `await` the sendCommand response
       if (!this.addCommandHandler<T>(command.id, resolve)) {
-        resolve(LedgerErrorsCodes.CommandInProgress)
+        resolve(LedgerBridgeErrorCodes.CommandInProgress)
         return
       }
       this.targetWindow.postMessage(command, this.targetUrl)

--- a/components/brave_wallet_ui/common/hardware/ledgerjs/ledger-trusted-transport.test.ts
+++ b/components/brave_wallet_ui/common/hardware/ledgerjs/ledger-trusted-transport.test.ts
@@ -9,10 +9,23 @@ import {
   AuthorizationSuccessCommand
 } from './ledger-messages'
 
+// We must read and write to protected class attributes in the tests.
+// That yields a typescript error unless we use bracket notation, e.g. `transport['handlers']`
+// instead of `transport.handlers`. As a result we silence the dot-notation
+// tslint rule for the file.
+//
+/* eslint-disable @typescript-eslint/dot-notation */
+
 const createWindow = (): Window => {
   let iframe = document.createElement('iframe')
   document.body.appendChild(iframe)
-  iframe.contentWindow.origin = 'chrome-untrusted://ledger-bridge'
+  if (!iframe.contentWindow) { fail('transport should be defined') }
+  // Use Object.defineProperty in order to assign to
+  // window.crypto because standard assignment results in
+  // assignment error because window.origin is read-only
+  Object.defineProperty(iframe.contentWindow, 'origin', {
+    value: 'chrome-untrusted://ledger-bridge'
+  })
   return iframe.contentWindow
 }
 
@@ -27,13 +40,13 @@ test('handleAuthorizationSuccess calls onAuthorize callback', async () => {
 
   const command: AuthorizationSuccessCommand = {
     id: LedgerCommand.AuthorizationSuccess,
-    origin: trustedTransport.targetWindow.origin,
+    origin: trustedTransport['targetWindow'].origin,
     command: LedgerCommand.AuthorizationSuccess
   }
   const event: MessageEvent = new MessageEvent('message', {
     data: command,
-    origin: trustedTransport.targetWindow.origin,
-    source: trustedTransport.targetWindow
+    origin: trustedTransport['targetWindow'].origin,
+    source: trustedTransport['targetWindow']
   })
   window.dispatchEvent(event)
   expect(callbackCalled).toEqual(true)

--- a/components/brave_wallet_ui/common/hardware/ledgerjs/ledger-untrusted-transport.test.ts
+++ b/components/brave_wallet_ui/common/hardware/ledgerjs/ledger-untrusted-transport.test.ts
@@ -5,10 +5,20 @@
 
 import { LedgerUntrustedMessagingTransport } from './ledger-untrusted-transport'
 
+// To use the LedgerUntrustedMessagingTransport, we must read
+// the protected `handlers` attribute, which yields a typescript
+// error unless we use bracket notation. As a result we must
+// silence the dot-notation tslint rule for the file.
+//
+/* eslint-disable @typescript-eslint/dot-notation */
+
 const createWindow = (): Window => {
   let iframe = document.createElement('iframe')
   document.body.appendChild(iframe)
-  iframe.contentWindow.origin = 'chrome-untrusted://ledger-bridge'
+  Object.defineProperty(iframe.contentWindow, 'origin', {
+    value: 'chrome-untrusted://ledger-bridge'
+  })
+  if (!iframe.contentWindow) { fail('transport should be defined') }
   return iframe.contentWindow
 }
 
@@ -18,9 +28,5 @@ test('constructor', async () => {
     targetWindow,
     targetWindow.origin
   )
-  expect(untrustedTransport.handlers.size).toEqual(3)
+  expect(untrustedTransport['handlers'].size).toEqual(0)
 })
-
-// test('handleUnlock', async () => { })
-// test('handleGetAccount', async () => { })
-// test('handleSignTransaction', async () => { })

--- a/components/brave_wallet_ui/common/hardware/ledgerjs/ledger_bridge_keyring.test.ts
+++ b/components/brave_wallet_ui/common/hardware/ledgerjs/ledger_bridge_keyring.test.ts
@@ -1,0 +1,147 @@
+/* Copyright (c) 2022 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { getLocale } from '../../../../common/locale'
+import LedgerBridgeKeyring from './ledger_bridge_keyring'
+import {
+  LedgerBridgeErrorCodes,
+  LedgerFrameCommand,
+  LedgerFrameResponse,
+  LedgerCommand,
+  LedgerError,
+  UnlockResponse
+} from './ledger-messages'
+import { HardwareOperationResult } from '../types'
+import { LedgerTrustedMessagingTransport } from './ledger-trusted-transport'
+import { randomFillSync, randomUUID } from 'crypto'
+
+// Use Object.defineProperty in order to assign to
+// window.crypto because standard assignment results in
+// assignment error because window.crypto is read-only
+Object.defineProperty(window, 'crypto', {
+  value: {
+    getRandomValues: (buffer: any) => randomFillSync(buffer),
+    randomUUID
+  }
+})
+
+export class MockLedgerTransport extends LedgerTrustedMessagingTransport {
+  sendCommandResponses: any [] // queue
+
+  constructor (targetWindow: Window, targetUrl: string, onAuthorized?: () => void) {
+    super(targetWindow, targetUrl)
+    this.sendCommandResponses = []
+  }
+
+ addSendCommandResponse = (response: LedgerFrameResponse) => {
+    this.sendCommandResponses.unshift(response) // appends to the left of the list
+  }
+
+  sendCommand = <T> (command: LedgerFrameCommand): Promise<T | LedgerBridgeErrorCodes> => {
+    if (this.sendCommandResponses.length === 0) {
+      throw new Error('No mock ledger transport responses remaining. More sendCommand calls were made than mocked responses added.')
+    }
+    const response = this.sendCommandResponses.pop()
+    return response
+  }
+}
+
+// To use the MockLedgerTransport, we must overwrite
+// the protected `transport` attribute, which yields a typescript
+// error unless we use bracket notation, i.e. keyring['transport']
+// instead of keyring.transport. As a result we silence the dot-notation
+// tslint rule for the file.
+//
+/* eslint-disable @typescript-eslint/dot-notation */
+
+const createKeyring = () => {
+  const keyring = new LedgerBridgeKeyring()
+  const transport = new MockLedgerTransport(window, window.origin)
+  keyring['transport'] = transport
+  const iframe = document.createElement('iframe')
+  document.body.appendChild(iframe)
+  keyring['bridge'] = iframe
+
+  return keyring
+}
+
+test('unlock successful', async () => {
+  const keyring = createKeyring()
+  if (!keyring['transport']) { fail('transport should be defined') }
+  const unlockResponse: UnlockResponse = {
+    id: LedgerCommand.Unlock,
+    origin: window.origin,
+    command: LedgerCommand.Unlock,
+    payload: {
+      success: false,
+      message: 'LedgerError',
+      statusCode: 101
+    }
+  }
+  keyring['transport']['addSendCommandResponse'](unlockResponse)
+  const result: HardwareOperationResult = await keyring.unlock()
+  const expectedResult: HardwareOperationResult = unlockResponse.payload
+  expect(result).toEqual(expectedResult)
+})
+
+test('unlock ledger error', async () => {
+  const keyring = createKeyring()
+  if (!keyring['transport']) { fail('transport should be defined') }
+  const unlockResponse: UnlockResponse = {
+    id: LedgerCommand.Unlock,
+    origin: window.origin,
+    command: LedgerCommand.Unlock,
+    payload: {
+      success: false,
+      message: 'LedgerError',
+      statusCode: 101
+    }
+  }
+  keyring['transport']['addSendCommandResponse'](unlockResponse)
+  const result: HardwareOperationResult = await keyring.unlock()
+  const expectedResult: HardwareOperationResult = unlockResponse.payload
+  expect(result).toEqual(expectedResult)
+})
+
+test('unlock unauthorized error', async () => {
+  const keyring = createKeyring()
+  if (!keyring['transport']) { fail('transport should be defined') }
+  const sendCommandResponse: UnlockResponse = {
+    id: LedgerCommand.Unlock,
+    origin: window.origin,
+    command: LedgerCommand.Unlock,
+    payload: {
+      success: false,
+      error: 'unauthorized',
+      code: undefined
+    } as LedgerError
+  }
+  keyring['transport']['addSendCommandResponse'](sendCommandResponse)
+  const result: HardwareOperationResult = await keyring.unlock()
+  const expectedResult: HardwareOperationResult = sendCommandResponse.payload
+  expect(result).toEqual(expectedResult)
+})
+
+test('unlock bridge error', async () => {
+  const keyring = createKeyring()
+  if (!keyring['transport']) { fail('transport should be defined') }
+  keyring['transport']['addSendCommandResponse'](LedgerBridgeErrorCodes.BridgeNotReady)
+  let result: HardwareOperationResult = await keyring.unlock()
+  let expectedResult: HardwareOperationResult = {
+    success: false,
+    error: getLocale('braveWalletBridgeNotReady'),
+    code: 0
+  }
+  expect(result).toEqual(expectedResult)
+
+  keyring['transport']['addSendCommandResponse'](LedgerBridgeErrorCodes.CommandInProgress)
+  result = await keyring.unlock()
+  expectedResult = {
+    success: false,
+    error: getLocale('braveWalletBridgeCommandInProgress'),
+    code: 1
+  }
+  expect(result).toEqual(expectedResult)
+})

--- a/components/brave_wallet_ui/common/hardware/ledgerjs/ledger_bridge_keyring.ts
+++ b/components/brave_wallet_ui/common/hardware/ledgerjs/ledger_bridge_keyring.ts
@@ -1,0 +1,109 @@
+/* Copyright (c) 2022 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { LEDGER_HARDWARE_VENDOR } from 'gen/brave/components/brave_wallet/common/brave_wallet.mojom.m.js'
+import { BraveWallet } from '../../../constants/types'
+import { getLocale } from '../../../../common/locale'
+import { HardwareVendor } from '../../api/hardware_keyrings'
+import {
+  HardwareOperationResult
+} from '../types'
+import {
+  LEDGER_BRIDGE_URL,
+  LedgerCommand,
+  UnlockResponse,
+  LedgerFrameCommand,
+  LedgerBridgeErrorCodes
+} from './ledger-messages'
+import { LedgerTrustedMessagingTransport } from './ledger-trusted-transport'
+
+// storybook compiler thinks `randomUUID` doesn't exist
+const randomUUID = () => (window.crypto as Crypto & { randomUUID: () => string }).randomUUID()
+
+// LedgerBridgeKeyring is the parent class for the various BridgeKeyrings, e.g.
+// SolanaLedgerBridgeKeyring
+export default class LedgerBridgeKeyring {
+  protected deviceId: string
+  protected onAuthorized?: () => void
+  protected transport?: LedgerTrustedMessagingTransport
+  protected bridge?: HTMLIFrameElement
+  protected readonly frameId: string
+
+  constructor (onAuthorized?: () => void) {
+    this.onAuthorized = onAuthorized
+    this.frameId = randomUUID()
+  }
+
+  coin = (): BraveWallet.CoinType => {
+    throw new Error('Unimplemented.')
+  }
+
+  type = (): HardwareVendor => {
+    return LEDGER_HARDWARE_VENDOR
+  }
+
+  unlock = async (): Promise<HardwareOperationResult> => {
+    const data = await this.sendCommand<UnlockResponse>({
+      id: LedgerCommand.Unlock,
+      origin: window.origin,
+      command: LedgerCommand.Unlock
+    })
+
+    if (data === LedgerBridgeErrorCodes.BridgeNotReady ||
+        data === LedgerBridgeErrorCodes.CommandInProgress) {
+      return this.createErrorFromCode(data)
+    }
+
+    return data.payload
+  }
+
+  sendCommand = async <T> (command: LedgerFrameCommand): Promise<T | LedgerBridgeErrorCodes > => {
+    if (!this.bridge && !this.hasBridgeCreated()) {
+      this.bridge = await this.createBridge(LEDGER_BRIDGE_URL)
+    }
+    if (!this.bridge || !this.bridge.contentWindow) {
+      return LedgerBridgeErrorCodes.BridgeNotReady
+    }
+    if (!this.transport) {
+      this.transport = new LedgerTrustedMessagingTransport(
+        this.bridge.contentWindow,
+        LEDGER_BRIDGE_URL,
+        this.onAuthorized
+      )
+    }
+    return this.transport.sendCommand(command)
+  }
+
+  cancelOperation = async () => { }
+
+  protected readonly createBridge = (targetUrl: string) => {
+    return new Promise<HTMLIFrameElement>((resolve) => {
+      const element = document.createElement('iframe')
+      element.id = this.frameId
+      element.src = (new URL(targetUrl)).origin + `?targetUrl=${encodeURIComponent(window.origin)}` + '&coinType=' + this.coin()
+      element.style.display = 'none'
+      element.allow = 'hid'
+      element.setAttribute('sandbox', 'allow-scripts allow-same-origin')
+      element.onload = () => {
+        this.bridge = element
+        resolve(element)
+      }
+      document.body.appendChild(element)
+    })
+  }
+
+  protected readonly createErrorFromCode = (code: LedgerBridgeErrorCodes): HardwareOperationResult => {
+    switch (code) {
+      case LedgerBridgeErrorCodes.BridgeNotReady:
+        return { success: false, error: getLocale('braveWalletBridgeNotReady'), code: code }
+      case LedgerBridgeErrorCodes.CommandInProgress:
+        return { success: false, error: getLocale('braveWalletBridgeCommandInProgress'), code: code }
+    }
+  }
+
+  protected readonly hasBridgeCreated = (): boolean => {
+    return document.getElementById(this.frameId) !== null
+  }
+}

--- a/components/brave_wallet_ui/common/hardware/ledgerjs/sol-ledger-messages.ts
+++ b/components/brave_wallet_ui/common/hardware/ledgerjs/sol-ledger-messages.ts
@@ -1,0 +1,39 @@
+/* Copyright (c) 2022 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import type {
+  CommandMessage,
+  LedgerCommand,
+  LedgerError,
+  LedgerResponsePayload
+} from './ledger-messages'
+
+// GetAccounts command
+export type SolGetAccountResponsePayload = LedgerResponsePayload & {
+  address: Buffer
+}
+export type SolGetAccountResponse = CommandMessage & {
+  payload: SolGetAccountResponsePayload | LedgerError
+}
+export type SolGetAccountCommand = CommandMessage & {
+  command: LedgerCommand.GetAccount
+  path: string
+}
+
+// SignTransaction command
+export type SolSignTransactionResponsePayload = LedgerResponsePayload & {
+  signature: Buffer
+}
+export type SolSignTransactionResponse = CommandMessage & {
+  payload: SolSignTransactionResponsePayload | LedgerError
+}
+export type SolSignTransactionCommand = CommandMessage & {
+  command: LedgerCommand.SignTransaction
+  path: string
+  rawTxBytes: Buffer
+}
+
+export type SolLedgerFrameCommand = SolGetAccountCommand | SolSignTransactionCommand
+export type SolLedgerFrameResponse = SolGetAccountResponse | SolSignTransactionResponse

--- a/components/brave_wallet_ui/common/hardware/ledgerjs/sol-ledger-untrusted-transport.ts
+++ b/components/brave_wallet_ui/common/hardware/ledgerjs/sol-ledger-untrusted-transport.ts
@@ -1,0 +1,88 @@
+/* Copyright (c) 2022 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import TransportWebHID from '@ledgerhq/hw-transport-webhid'
+import Sol from '@ledgerhq/hw-app-solana'
+import {
+  LedgerCommand,
+  UnlockResponse
+} from './ledger-messages'
+import {
+  SolGetAccountCommand,
+  SolGetAccountResponse,
+  SolGetAccountResponsePayload,
+  SolSignTransactionCommand,
+  SolSignTransactionResponsePayload,
+  SolSignTransactionResponse
+} from './sol-ledger-messages'
+import { LedgerUntrustedMessagingTransport } from './ledger-untrusted-transport'
+
+// SolanaLedgerUntrustedMessagingTransport makes calls to the Solana app on a Ledger device
+export class SolanaLedgerUntrustedMessagingTransport extends LedgerUntrustedMessagingTransport {
+  constructor (targetWindow: Window, targetUrl: string) {
+    super(targetWindow, targetUrl)
+    this.addCommandHandler<UnlockResponse>(LedgerCommand.Unlock, this.handleUnlock)
+    this.addCommandHandler<SolGetAccountResponse>(LedgerCommand.GetAccount, this.handleGetAccount)
+    this.addCommandHandler<SolSignTransactionResponse>(LedgerCommand.SignTransaction, this.handleSignTransaction)
+  }
+
+  private handleGetAccount = async (command: SolGetAccountCommand): Promise<SolGetAccountResponse> => {
+    const transport = await TransportWebHID.create()
+    const app = new Sol(transport)
+    try {
+      const result = await app.getAddress(command.path)
+      const getAccountResponsePayload: SolGetAccountResponsePayload = {
+        success: true,
+        address: result.address
+      }
+      const response: SolGetAccountResponse = {
+        id: command.id,
+        command: command.command,
+        payload: getAccountResponsePayload,
+        origin: command.origin
+      }
+      return response
+    } catch (error) {
+      const response: SolGetAccountResponse = {
+        id: command.id,
+        command: command.command,
+        payload: error,
+        origin: command.origin
+      }
+      return response
+    } finally {
+      await transport.close()
+    }
+  }
+
+  private handleSignTransaction = async (command: SolSignTransactionCommand): Promise<SolSignTransactionResponse> => {
+    const transport = await TransportWebHID.create()
+    const app = new Sol(transport)
+    try {
+      const result = await app.signTransaction(command.path, Buffer.from(command.rawTxBytes))
+      const signTransactionResponsePayload: SolSignTransactionResponsePayload = {
+        success: true,
+        signature: result.signature
+      }
+      const response: SolSignTransactionResponse = {
+        id: command.id,
+        command: command.command,
+        payload: signTransactionResponsePayload,
+        origin: command.origin
+      }
+      return response
+    } catch (error) {
+      const response: SolSignTransactionResponse = {
+        id: command.id,
+        command: command.command,
+        payload: error,
+        origin: command.origin
+      }
+      return response
+    } finally {
+      await transport.close()
+    }
+  }
+}

--- a/components/brave_wallet_ui/common/hardware/ledgerjs/sol_ledger_bridge_keyring.ts
+++ b/components/brave_wallet_ui/common/hardware/ledgerjs/sol_ledger_bridge_keyring.ts
@@ -3,66 +3,34 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { LEDGER_HARDWARE_VENDOR } from 'gen/brave/components/brave_wallet/common/brave_wallet.mojom.m.js'
 import { BraveWallet } from '../../../constants/types'
-import { getLocale } from '../../../../common/locale'
 import { LedgerSolanaKeyring } from '../interfaces'
-import { HardwareVendor } from '../../api/hardware_keyrings'
 import {
   GetAccountsHardwareOperationResult,
-  HardwareOperationResult,
   SignHardwareOperationResult
 } from '../types'
 import {
-  LEDGER_BRIDGE_URL,
   LedgerCommand,
-  UnlockResponse,
-  LedgerFrameCommand,
-  GetAccountResponse,
-  GetAccountResponsePayload,
-  SignTransactionResponse,
-  SignTransactionResponsePayload,
-  LedgerErrorsCodes,
+  LedgerBridgeErrorCodes,
   LedgerError
 } from './ledger-messages'
-import { LedgerTrustedMessagingTransport } from './ledger-trusted-transport'
+import {
+  SolGetAccountResponse,
+  SolGetAccountResponsePayload,
+  SolSignTransactionResponse,
+  SolSignTransactionResponsePayload
+} from './sol-ledger-messages'
+
 import { hardwareDeviceIdFromAddress } from '../hardwareDeviceIdFromAddress'
+import LedgerBridgeKeyring from './ledger_bridge_keyring'
 
-// storybook compiler thinks `randomUUID` doesn't exist
-const randomUUID = () => (window.crypto as Crypto & { randomUUID: () => string }).randomUUID()
-export default class SolanaLedgerBridgeKeyring implements LedgerSolanaKeyring {
-  private deviceId: string
-  private onAuthorized?: () => void
-  private transport?: LedgerTrustedMessagingTransport
-  private bridge?: HTMLIFrameElement
-  private readonly frameId: string
-
+export default class SolanaLedgerBridgeKeyring extends LedgerBridgeKeyring implements LedgerSolanaKeyring {
   constructor (onAuthorized?: () => void) {
-    this.onAuthorized = onAuthorized
-    this.frameId = randomUUID()
+    super(onAuthorized)
   }
 
   coin = (): BraveWallet.CoinType => {
     return BraveWallet.CoinType.SOL
-  }
-
-  type = (): HardwareVendor => {
-    return LEDGER_HARDWARE_VENDOR
-  }
-
-  unlock = async (): Promise<HardwareOperationResult> => {
-    const data = await this.sendCommand<UnlockResponse>({
-      id: LedgerCommand.Unlock,
-      origin: window.origin,
-      command: LedgerCommand.Unlock
-    })
-
-    if (data === LedgerErrorsCodes.BridgeNotReady ||
-        data === LedgerErrorsCodes.CommandInProgress) {
-      return this.createErrorFromCode(data)
-    }
-
-    return data.payload
   }
 
   getAccounts = async (from: number, to: number): Promise<GetAccountsHardwareOperationResult> => {
@@ -89,15 +57,15 @@ export default class SolanaLedgerBridgeKeyring implements LedgerSolanaKeyring {
       return result
     }
 
-    const data = await this.sendCommand<SignTransactionResponse>({
+    const data = await this.sendCommand<SolSignTransactionResponse>({
       command: LedgerCommand.SignTransaction,
       id: LedgerCommand.SignTransaction,
       path: path,
       rawTxBytes: rawTxBytes,
       origin: window.origin
     })
-    if (data === LedgerErrorsCodes.BridgeNotReady ||
-        data === LedgerErrorsCodes.CommandInProgress) {
+    if (data === LedgerBridgeErrorCodes.BridgeNotReady ||
+        data === LedgerBridgeErrorCodes.CommandInProgress) {
       return this.createErrorFromCode(data)
     }
     if (!data.payload.success) {
@@ -108,37 +76,22 @@ export default class SolanaLedgerBridgeKeyring implements LedgerSolanaKeyring {
       const ledgerError = data.payload as LedgerError
       return { success: false, error: ledgerError.message, code: ledgerError.statusCode }
     }
-    const responsePayload = data.payload as SignTransactionResponsePayload
+    const responsePayload = data.payload as SolSignTransactionResponsePayload
     return { success: true, payload: responsePayload.signature }
-  }
-
-  private readonly createBridge = (targetUrl: string) => {
-    return new Promise<HTMLIFrameElement>((resolve) => {
-      const element = document.createElement('iframe')
-      element.id = this.frameId
-      element.src = (new URL(targetUrl)).origin + `?targetUrl=${encodeURIComponent(window.origin)}`
-      element.style.display = 'none'
-      element.allow = 'hid'
-      element.onload = () => {
-        this.bridge = element
-        resolve(element)
-      }
-      document.body.appendChild(element)
-    })
   }
 
   private readonly getAccountsFromDevice = async (paths: string[], skipZeroPath: boolean): Promise<GetAccountsHardwareOperationResult> => {
     let accounts = []
     const zeroPath = this.getPathForIndex(0)
     for (const path of paths) {
-      const data = await this.sendCommand<GetAccountResponse>({
+      const data = await this.sendCommand<SolGetAccountResponse>({
         command: LedgerCommand.GetAccount,
         id: LedgerCommand.GetAccount,
         path: path,
         origin: window.origin
       })
-      if (data === LedgerErrorsCodes.BridgeNotReady ||
-          data === LedgerErrorsCodes.CommandInProgress) {
+      if (data === LedgerBridgeErrorCodes.BridgeNotReady ||
+          data === LedgerBridgeErrorCodes.CommandInProgress) {
         return this.createErrorFromCode(data)
       }
 
@@ -146,7 +99,7 @@ export default class SolanaLedgerBridgeKeyring implements LedgerSolanaKeyring {
         const ledgerError = data.payload as LedgerError
         return { success: false, error: ledgerError, code: ledgerError.statusCode }
       }
-      const responsePayload = data.payload as GetAccountResponsePayload
+      const responsePayload = data.payload as SolGetAccountResponsePayload
 
       if (path === zeroPath) {
         this.deviceId = await hardwareDeviceIdFromAddress(responsePayload.address)
@@ -172,39 +125,7 @@ export default class SolanaLedgerBridgeKeyring implements LedgerSolanaKeyring {
     return { success: true, payload: accounts }
   }
 
-  sendCommand = async <T> (command: LedgerFrameCommand): Promise<T | LedgerErrorsCodes > => {
-    if (!this.bridge && !this.hasBridgeCreated()) {
-      this.bridge = await this.createBridge(LEDGER_BRIDGE_URL)
-    }
-    if (!this.bridge || !this.bridge.contentWindow) {
-      return LedgerErrorsCodes.BridgeNotReady
-    }
-    if (!this.transport) {
-      this.transport = new LedgerTrustedMessagingTransport(
-        this.bridge.contentWindow,
-        LEDGER_BRIDGE_URL,
-        this.onAuthorized
-      )
-    }
-    return this.transport.sendCommand(command)
-  }
-
-  cancelOperation = async () => { }
-
-  private readonly createErrorFromCode = (code: LedgerErrorsCodes): HardwareOperationResult => {
-    switch (code) {
-      case LedgerErrorsCodes.BridgeNotReady:
-        return { success: false, error: getLocale('braveWalletBridgeNotReady'), code: code }
-      case LedgerErrorsCodes.CommandInProgress:
-        return { success: false, error: getLocale('braveWalletBridgeCommandInProgress'), code: code }
-    }
-  }
-
   private readonly getPathForIndex = (index: number): string => {
     return `44'/501'/${index}'/0'`
-  }
-
-  private readonly hasBridgeCreated = (): boolean => {
-    return document.getElementById(this.frameId) !== null
   }
 }

--- a/components/brave_wallet_ui/common/hardware/types.ts
+++ b/components/brave_wallet_ui/common/hardware/types.ts
@@ -1,7 +1,7 @@
-import { EthereumSignedTx } from './trezor/trezor-connect-types'
 import { BraveWallet } from '../../constants/types'
 import { SignedLotusMessage } from '@glif/filecoin-message'
 import { LedgerError } from './ledgerjs/ledger-messages'
+import { EthereumSignedTx } from './ledgerjs/eth-ledger-messages'
 
 export const FilecoinNetworkTypes = [
   BraveWallet.FILECOIN_MAINNET, BraveWallet.FILECOIN_TESTNET
@@ -34,16 +34,6 @@ export type HardwareOperationResult = {
 
 export type SignHardwareOperationResult = HardwareOperationResult & {
   payload?: EthereumSignedTx | SignedLotusMessage | Buffer | string
-}
-
-export type GetAccountOperationResult = HardwareOperationResult & {
-  payload?: Buffer
-}
-
-export interface TrezorBridgeAccountsPayload {
-  success: boolean
-  accounts: BraveWallet.HardwareWalletAccount[]
-  error?: string
 }
 
 export enum LedgerDerivationPaths {

--- a/components/brave_wallet_ui/components/desktop/popup-modals/add-account-modal/hardware-wallet-connect/index.tsx
+++ b/components/brave_wallet_ui/components/desktop/popup-modals/add-account-modal/hardware-wallet-connect/index.tsx
@@ -237,7 +237,7 @@ export const HardwareWalletConnect = ({ onSuccess, selectedAccountType }: Props)
             </DisclaimerText>
           </HardwareInfoColumn>
         </HardwareInfoRow>
-        <AuthorizeHardwareDeviceIFrame />
+        <AuthorizeHardwareDeviceIFrame coinType={selectedAccountType.coin} />
       </>
     )
   }

--- a/components/brave_wallet_ui/components/extension/connect-hardware-wallet-panel/index.tsx
+++ b/components/brave_wallet_ui/components/extension/connect-hardware-wallet-panel/index.tsx
@@ -95,7 +95,7 @@ export const ConnectHardwareWalletPanel = ({
       <PageIcon />
       {
         hardwareWalletCode !== 'deviceBusy' && (hardwareWalletCode === 'unauthorized'
-          ? <AuthorizeHardwareDeviceIFrame />
+          ? <AuthorizeHardwareDeviceIFrame coinType={coinType}/>
           : <ButtonWrapper>
               <NavButton
                 buttonType='secondary'

--- a/components/brave_wallet_ui/components/shared/authorize-hardware-device/authorize-hardware-device.tsx
+++ b/components/brave_wallet_ui/components/shared/authorize-hardware-device/authorize-hardware-device.tsx
@@ -6,11 +6,17 @@
 import * as React from 'react'
 import { StyledIFrame } from './style'
 import { LEDGER_BRIDGE_URL } from '../../../common/hardware/ledgerjs/ledger-messages'
+import { BraveWallet } from '../../../constants/types'
 
-export const AuthorizeHardwareDeviceIFrame = () => {
-  const src = LEDGER_BRIDGE_URL + `?targetUrl=${encodeURIComponent(window.origin)}`
+export interface Props {
+  coinType: BraveWallet.CoinType
+}
+
+export const AuthorizeHardwareDeviceIFrame = (props: Props) => {
+  const { coinType } = props
+  const src = LEDGER_BRIDGE_URL + `?targetUrl=${encodeURIComponent(window.origin)}` + '&coinType=' + coinType
   return (
-    <StyledIFrame src={src} allow="hid" frameBorder="0"/>
+    <StyledIFrame src={src} allow="hid" frameBorder="0" sandbox="allow-scripts allow-same-origin"/>
   )
 }
 

--- a/components/brave_wallet_ui/ledger/ledger.ts
+++ b/components/brave_wallet_ui/ledger/ledger.ts
@@ -3,11 +3,14 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+import { BraveWallet } from '../constants/types'
 import { LedgerCommand, LEDGER_BRIDGE_URL } from '../common/hardware/ledgerjs/ledger-messages'
 import { LedgerUntrustedMessagingTransport } from '../common/hardware/ledgerjs/ledger-untrusted-transport'
+import { SolanaLedgerUntrustedMessagingTransport } from '../common/hardware/ledgerjs/sol-ledger-untrusted-transport'
+import { EthereumLedgerUntrustedMessagingTransport } from '../common/hardware/ledgerjs/eth-ledger-untrusted-transport'
 
-const setUpAuthorizeButtonListner = (targetUrl: string) => {
-  const untrustedMessagingTransport = new LedgerUntrustedMessagingTransport(window.parent, targetUrl)
+const setUpAuthorizeButtonListener = (targetUrl: string, coinType: BraveWallet.CoinType) => {
+  const untrustedMessagingTransport = getUntrustedMessagingTransport(coinType, targetUrl)
   window.addEventListener('DOMContentLoaded', (event) => {
     const authorizeBtn = document.getElementById('authorize')
     if (authorizeBtn) {
@@ -24,7 +27,20 @@ const setUpAuthorizeButtonListner = (targetUrl: string) => {
   })
 }
 
-const targetUrl = new URLSearchParams(window.location.search).get('targetUrl')
-if (targetUrl) {
-  setUpAuthorizeButtonListner(targetUrl)
+const getUntrustedMessagingTransport = (coinType: BraveWallet.CoinType, targetUrl: string): LedgerUntrustedMessagingTransport => {
+  switch (coinType) {
+    case BraveWallet.CoinType.SOL:
+      return new SolanaLedgerUntrustedMessagingTransport(window.parent, targetUrl)
+    case BraveWallet.CoinType.ETH:
+      return new EthereumLedgerUntrustedMessagingTransport(window.parent, targetUrl)
+    default:
+      throw new Error('Invalid coinType.')
+  }
+}
+
+const params = new URLSearchParams(window.location.search)
+const targetUrl = params.get('targetUrl')
+const coinType = Number(params.get('coinType'))
+if (targetUrl && coinType) {
+  setUpAuthorizeButtonListener(targetUrl, coinType)
 }


### PR DESCRIPTION
Resolves https://github.com/brave/brave-browser/issues/24275

Security Review: https://github.com/brave/security/issues/969

This changes isolates the js libraries required to interact with the Ethereum app on Ledger devices to an iFrame in a chrome untrusted context. This uses the same framework used in the Solana hardware as https://github.com/brave/brave-core/pull/14096, but generalizes some code such that it can be reused for both Solana and Ethereum.  For example:
* Shared logic in SolanaLedgerBridgeKeyring class was moved to a new parent class that LedgerBridgeKeyring that both SolanaLedgerBridgeKeyring and EthereumLedgerBridgeKeyring inherit from
* Solana specific logic was moved from LedgerUntrustedMessagingTransport to a new child class SolanaLedgerUntrustedMessagingTransport.  Similarly, Ethereum specific logic is now in a child class EthereumLedgerUntrustedMessagingTransport.
* Common message types were kept in ledger-messages.ts, but Solana and Ethereum specific message types were separated into their own sol-ledger-messages.ts and eth-ledger-messages.ts module.

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [x] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [x] New files have MPL-2.0 license header
- [x] Adequate test coverage exists to prevent regressions
- [x] Major classes, functions and non-trivial code blocks are well-commented
- [x] Changes in component dependencies are properly reflected in `gn`
- [x] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [x] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
The test plan is very similar to the test plan for the parallel Solana untrusted [refactor](https://github.com/brave/brave-core/pull/14096), except instead of testing Solana Ledger functions, we test the Ethereum ones.
1. Test import accounts flow (chrome://wallet)
   1. Connect ledger device and enter password
   1. Run `(await navigator.hid.getDevices()).forEach((d) => d.forget())` in the js console to forget devices which have already been granted permissions, then refresh the page
   1. Click 'Import from hardware wallet' -> 'Connect' for Ethereum, Select 'Ledger', click 'Connect'
   1. Verify 'Grant Brave access to your Ledger device.' is displayed, hit 'Authorize'
   1. You should be prompted with the permissions screen, select device, hit 'Connect'
   1. Verify you are returned to 'Connect your Ledger wallet directly to your computer' screen, hit 'Connect'
   1. Verify your accounts are listed for import for import. Verify you can load 'Load more' accounts
   1. Verify you can load different accounts by switching derivation paths
   1. Select an account and hit 'Add checked accounts', verify it is added
   1. Repeat the same flow without forgetting the device first and verify no 'Authorize' screen is displayed or permission screen prompted.
1. Test signing flows (chrome://wallet-panel) for (a) sign transaction, (b) sign personal, (c) sign typed data
   1. Connect ledger device and enter password
   1. Create a Ethereum hardware account with a test net balance if you don't have one already
   1. Navigate to chrome://inspect > Other
   1. Open wallet panel, and click 'inspect' on the chrome://inspect page under the 'chrome://wallet-panel.top-chrome' item that pops up.  This is the js console for the panel
   1. Run `(await navigator.hid.getDevices()).forEach((d) => d.forget())` to forget any device which already has permissions on the panel (need to be quick since this closes not long after the panel closes)
   1. Do one of
       1. Create a standard transaction in the panel sending funds to yourself (sign transaction)
       1. Go to OpenSea and like any NFT (I'm partial to [lil nouns](https://opensea.io/assets/ethereum/0x4b10701bfd7bfedc47d50562b76b436fbb5bdb3b/3935)) by clicking the heart (sign personal)
       1. Go to https://metamask.github.io/test-dapp/, connect wallet, and sign + verify 'Sign Typed Data V3' and 'Sign Typed Data V4'
   1. Hit sign / confirm
   1. You should be shown an 'Authorize' button on the panel that says the device is disconnect, click the 'Authorize' button
   1. You should be prompted with the permissions screen, select device, hit 'Connect'
   1. Verify you are returned to the 'Hardware wallet requires Ethereum App opened on Ledger' (it may take a second)
   1. On your ledger device, you should see the the transacition / sign request you entered, confirm.
   1. Verify the post transaction / signing stuff happens: you are shown the details, get a notification when transaction is confirmed, the 'like' is registered by OpenSea, etc
   1. Repeat all steps until all of sign transaction, sign personal, and sign typed data have been completed successfully