### PR TITLE
Fixes First Run dialog on MacOS not wrapping text. (uplift to 1.42.x)

### DIFF
--- a/chromium_src/chrome/browser/ui/cocoa/first_run_dialog_controller.mm
+++ b/chromium_src/chrome/browser/ui/cocoa/first_run_dialog_controller.mm
@@ -73,6 +73,7 @@
   [headerLabel setFont:[NSFont systemFontOfSize:16.0
                                          weight:NSFontWeightSemibold]];
   [headerLabel sizeToFit];
+  [headerLabel setLineBreakMode:NSLineBreakByWordWrapping];
   int defaultHeight = NSHeight(headerLabel.frame);
   int numOfLines =
       static_cast<int>(NSWidth(headerLabel.frame)) / contentsWidth + 1;
@@ -87,6 +88,7 @@
   [contentsLabel setFont:[NSFont systemFontOfSize:15.0
                                            weight:NSFontWeightRegular]];
   [contentsLabel sizeToFit];
+  [contentsLabel setLineBreakMode:NSLineBreakByWordWrapping];
   defaultHeight = NSHeight(contentsLabel.frame);
   numOfLines =
       static_cast<int>(NSWidth(contentsLabel.frame)) / contentsWidth + 1;


### PR DESCRIPTION
Fixes https://github.com/brave/brave-browser/issues/24297
Uplift of #14374

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.