### PR TITLE
Sync DSE Desktop <=> Android

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -75,8 +75,10 @@ components/brave_wallet/ @brave/crypto-wallets
 components/brave_referrals/browser/brave_referrals_service* @simonhong
 
 # Brave Sync
+browser/sync/ @brave/sync-reviewers
 components/brave_sync/ @brave/sync-reviewers
 components/sync/driver/ @brave/sync-reviewers
+chromium_src/chrome/browser/sync/ @brave/sync-reviewers
 chromium_src/components/sync/ @brave/sync-reviewers
 chromium_src/components/sync_device_info/device_info_sync_bridge.cc @brave/sync-reviewers
 

--- a/android/java/org/chromium/chrome/browser/search_engines/settings/BraveBaseSearchEngineAdapter.java
+++ b/android/java/org/chromium/chrome/browser/search_engines/settings/BraveBaseSearchEngineAdapter.java
@@ -12,9 +12,13 @@ import android.widget.BaseAdapter;
 
 import androidx.annotation.StringRes;
 
+import org.chromium.base.BraveReflectionUtil;
+import org.chromium.chrome.browser.search_engines.TemplateUrlServiceFactory;
 import org.chromium.chrome.browser.search_engines.settings.SearchEngineAdapter;
 import org.chromium.components.search_engines.TemplateUrl;
+import org.chromium.components.search_engines.TemplateUrlService;
 
+import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
@@ -81,5 +85,60 @@ public class BraveBaseSearchEngineAdapter extends BaseAdapter {
         } else {
             return SearchEngineAdapter.TemplateUrlSourceType.RECENT;
         }
+    }
+
+    public boolean didSearchEnginesChange(List<TemplateUrl> templateUrls) {
+        boolean chromiumDidSearchEnginesChange =
+                (boolean) BraveReflectionUtil.InvokeMethod(SearchEngineAdapter.class, this,
+                        "didSearchEnginesChange", java.util.List.class, templateUrls);
+
+        if (chromiumDidSearchEnginesChange) {
+            return true;
+        }
+
+        // The original SearchEngineAdapter.didSearchEnginesChange method does
+        // not give true when the set of engines wasn't
+        // changed, but was changed the selected default search engine.
+        // This happens because Chromium does not sync the DSE.
+        // The code below is in fact part of SearchEngineAdapter.refreshData
+        // which detects new mSelectedSearchEnginePosition.
+        // We use it to detect the change of the selected DSE.
+
+        List<TemplateUrl> mPrepopulatedSearchEngines =
+                (List<TemplateUrl>) BraveReflectionUtil.getField(
+                        SearchEngineAdapter.class, "mPrepopulatedSearchEngines", this);
+        List<TemplateUrl> mRecentSearchEngines = (List<TemplateUrl>) BraveReflectionUtil.getField(
+                SearchEngineAdapter.class, "mRecentSearchEngines", this);
+        int mSelectedSearchEnginePosition = (int) BraveReflectionUtil.getField(
+                SearchEngineAdapter.class, "mSelectedSearchEnginePosition", this);
+
+        if (mSelectedSearchEnginePosition == -1) {
+            return false;
+        }
+
+        TemplateUrlService templateUrlService = TemplateUrlServiceFactory.get();
+        assert templateUrlService.isLoaded();
+        TemplateUrl defaultSearchEngineTemplateUrl =
+                templateUrlService.getDefaultSearchEngineTemplateUrl();
+
+        // Convert the TemplateUrl index into an index of mSearchEngines.
+        int selectedSearchEnginePosition = -1;
+        for (int i = 0; i < mPrepopulatedSearchEngines.size(); ++i) {
+            if (mPrepopulatedSearchEngines.get(i).equals(defaultSearchEngineTemplateUrl)) {
+                selectedSearchEnginePosition = i;
+            }
+        }
+
+        for (int i = 0; i < mRecentSearchEngines.size(); ++i) {
+            if (mRecentSearchEngines.get(i).equals(defaultSearchEngineTemplateUrl)) {
+                // Add one to offset the title for the recent search engine list.
+                int chromiumStartIndexForRecentSearchEngines =
+                        (int) BraveReflectionUtil.InvokeMethod(SearchEngineAdapter.class, this,
+                                "computeStartIndexForRecentSearchEngines");
+                selectedSearchEnginePosition = i + chromiumStartIndexForRecentSearchEngines;
+            }
+        }
+
+        return selectedSearchEnginePosition != mSelectedSearchEnginePosition;
     }
 }

--- a/android/java/org/chromium/chrome/browser/search_engines/settings/BraveSearchEngineAdapter.java
+++ b/android/java/org/chromium/chrome/browser/search_engines/settings/BraveSearchEngineAdapter.java
@@ -23,17 +23,20 @@ public class BraveSearchEngineAdapter extends SearchEngineAdapter {
     private static final String TAG = "BraveSearchEngineAdapter";
 
     public static final String PRIVATE_DSE_SHORTNAME = "private_dse_shortname";
-    public static final String STANDARD_DSE_SHORTNAME = "standard_dse_shortname";
 
     private boolean mIsPrivate;
 
     static public void setDSEPrefs(TemplateUrl templateUrl, boolean isPrivate) {
-        SharedPreferences.Editor sharedPreferencesEditor =
-                ContextUtils.getAppSharedPreferences().edit();
-        sharedPreferencesEditor.putString(
-                isPrivate ? PRIVATE_DSE_SHORTNAME : STANDARD_DSE_SHORTNAME,
-                templateUrl.getShortName());
-        sharedPreferencesEditor.apply();
+        if (isPrivate) {
+            SharedPreferences.Editor sharedPreferencesEditor =
+                    ContextUtils.getAppSharedPreferences().edit();
+            sharedPreferencesEditor.putString(PRIVATE_DSE_SHORTNAME, templateUrl.getShortName());
+            sharedPreferencesEditor.apply();
+        } else {
+            // For the regular tab we save DSE in native code
+            String keyword = templateUrl.getKeyword();
+            TemplateUrlServiceFactory.get().setSearchEngine(keyword);
+        }
     }
 
     static public void updateActiveDSE(boolean isPrivate) {
@@ -72,8 +75,7 @@ public class BraveSearchEngineAdapter extends SearchEngineAdapter {
         }
 
         return ContextUtils.getAppSharedPreferences().getString(
-                isPrivate ? PRIVATE_DSE_SHORTNAME : STANDARD_DSE_SHORTNAME,
-                defaultSearchEngineName);
+                PRIVATE_DSE_SHORTNAME, defaultSearchEngineName);
     }
 
     static public TemplateUrl getTemplateUrlByShortName(String name) {

--- a/android/java/org/chromium/chrome/browser/search_engines/settings/BraveSearchEngineAdapter.java
+++ b/android/java/org/chromium/chrome/browser/search_engines/settings/BraveSearchEngineAdapter.java
@@ -37,6 +37,12 @@ public class BraveSearchEngineAdapter extends SearchEngineAdapter {
     }
 
     static public void updateActiveDSE(boolean isPrivate) {
+        // For the regular tab, trust the native Chromium's TemplateUrlService and
+        // don't overwrite with our value to make sync work
+        if (isPrivate == false) {
+            return;
+        }
+
         TemplateUrl templateUrl = getTemplateUrlByShortName(getDSEShortName(isPrivate));
         if (templateUrl == null) {
             return;
@@ -50,6 +56,12 @@ public class BraveSearchEngineAdapter extends SearchEngineAdapter {
         TemplateUrl dseTemplateUrl =
                 TemplateUrlServiceFactory.get().getDefaultSearchEngineTemplateUrl();
         if (dseTemplateUrl != null) defaultSearchEngineName = dseTemplateUrl.getShortName();
+
+        if (isPrivate == false) {
+            // For the regular tab, rely on the value from the native Chromium's
+            // TemplateUrlService to make sync work
+            return defaultSearchEngineName;
+        }
 
         // TODO(sergz): A check, do we need to fetch a default SE from native and avoid
         // overwrite.

--- a/android/java/org/chromium/chrome/browser/settings/BraveSearchEngineUtils.java
+++ b/android/java/org/chromium/chrome/browser/settings/BraveSearchEngineUtils.java
@@ -36,18 +36,17 @@ public class BraveSearchEngineUtils {
     }
 
     static private void initializeDSEPrefs() {
-        // At first run, we should set initial default prefs to each standard/private DSE prefs.
-        // Those pref values will be used until user change DES options explicitly.
+        // At first run, we should set initial default prefs to private DSE pref.
+        // Those pref values will be used until user change DSE options explicitly.
+        // DSE for normal tab will be managed by native code, TemplateUrlService.
         final String notInitialized = "notInitialized";
         if (notInitialized.equals(ContextUtils.getAppSharedPreferences().getString(
-                    BraveSearchEngineAdapter.STANDARD_DSE_SHORTNAME, notInitialized))) {
+                    BraveSearchEngineAdapter.PRIVATE_DSE_SHORTNAME, notInitialized))) {
             TemplateUrl templateUrl =
                     TemplateUrlServiceFactory.get().getDefaultSearchEngineTemplateUrl();
 
             SharedPreferences.Editor sharedPreferencesEditor =
                     ContextUtils.getAppSharedPreferences().edit();
-            sharedPreferencesEditor.putString(
-                    BraveSearchEngineAdapter.STANDARD_DSE_SHORTNAME, templateUrl.getShortName());
             sharedPreferencesEditor.putString(
                     BraveSearchEngineAdapter.PRIVATE_DSE_SHORTNAME, templateUrl.getShortName());
             sharedPreferencesEditor.apply();

--- a/android/java/org/chromium/chrome/browser/settings/BraveSearchEnginesPreferences.java
+++ b/android/java/org/chromium/chrome/browser/settings/BraveSearchEnginesPreferences.java
@@ -12,9 +12,12 @@ import androidx.preference.Preference;
 
 import org.chromium.chrome.R;
 import org.chromium.chrome.browser.privacy.settings.PrivacySettings;
+import org.chromium.chrome.browser.search_engines.TemplateUrlServiceFactory;
 import org.chromium.components.browser_ui.settings.SettingsUtils;
+import org.chromium.components.search_engines.TemplateUrlService;
 
-public class BraveSearchEnginesPreferences extends BravePreferenceFragment {
+public class BraveSearchEnginesPreferences
+        extends BravePreferenceFragment implements TemplateUrlService.TemplateUrlServiceObserver {
     private static final String PREF_STANDARD_SEARCH_ENGINE = "standard_search_engine";
     private static final String PREF_PRIVATE_SEARCH_ENGINE = "private_search_engine";
 
@@ -23,6 +26,13 @@ public class BraveSearchEnginesPreferences extends BravePreferenceFragment {
         super.onCreate(savedInstanceState);
         getActivity().setTitle(R.string.brave_search_engines);
         SettingsUtils.addPreferencesFromResource(this, R.xml.brave_search_engines_preferences);
+        TemplateUrlServiceFactory.get().addObserver(this);
+    }
+
+    @Override
+    public void onDestroy() {
+        super.onDestroy();
+        TemplateUrlServiceFactory.get().removeObserver(this);
     }
 
     @Override
@@ -39,5 +49,10 @@ public class BraveSearchEnginesPreferences extends BravePreferenceFragment {
         searchEnginePreference = findPreference(PREF_PRIVATE_SEARCH_ENGINE);
         searchEnginePreference.setEnabled(true);
         searchEnginePreference.setSummary(BraveSearchEngineUtils.getDSEShortName(true));
+    }
+
+    @Override
+    public void onTemplateURLServiceChanged() {
+        new Handler().post(() -> updateSearchEnginePreference());
     }
 }

--- a/android/java/proguard.flags
+++ b/android/java/proguard.flags
@@ -18,6 +18,14 @@
     *** getProcessorForSuggestion(...);
 }
 
+-keep class org.chromium.chrome.browser.search_engines.settings.SearchEngineAdapter {
+    *** didSearchEnginesChange(...);
+    *** computeStartIndexForRecentSearchEngines(...);
+    *** mPrepopulatedSearchEngines;
+    *** mRecentSearchEngines;
+    *** mSelectedSearchEnginePosition;
+}
+
 -keep class org.chromium.components.browser_ui.site_settings.ContentSettingsResources {
     *** getResourceItem(...);
 }

--- a/android/javatests/org/chromium/chrome/browser/BytecodeTest.java
+++ b/android/javatests/org/chromium/chrome/browser/BytecodeTest.java
@@ -453,6 +453,12 @@ public class BytecodeTest {
         Assert.assertTrue(methodExists("org/chromium/components/browser_ui/site_settings/Website",
                 "setContentSetting", true, void.class, BrowserContextHandle.class, int.class,
                 int.class));
+        Assert.assertTrue(methodExists(
+                "org/chromium/chrome/browser/search_engines/settings/SearchEngineAdapter",
+                "didSearchEnginesChange", true, boolean.class, List.class));
+        Assert.assertTrue(methodExists(
+                "org/chromium/chrome/browser/search_engines/settings/SearchEngineAdapter",
+                "computeStartIndexForRecentSearchEngines", true, int.class));
         // NOTE: Add new checks above. For each new check in this method add proguard exception in
         // `brave/android/java/proguard.flags` file under `Add methods for invocation below`
         // section. Both test and regular apks should have the same exceptions.
@@ -771,12 +777,23 @@ public class BytecodeTest {
                 "org/chromium/chrome/browser/ntp/NewTabPageLayout", "mMvTilesContainerLayout"));
         Assert.assertTrue(
                 fieldExists("org/chromium/chrome/browser/dom_distiller/ReaderModeManager", "mTab"));
+
         Assert.assertTrue(fieldExists(
                 "org/chromium/chrome/browser/omnibox/suggestions/DropdownItemViewInfoListBuilder",
                 "mDropdownHeight"));
         Assert.assertTrue(fieldExists(
                 "org/chromium/chrome/browser/omnibox/suggestions/DropdownItemViewInfoListBuilder",
                 "mPriorityOrderedSuggestionProcessors"));
+
+        Assert.assertTrue(fieldExists(
+                "org/chromium/chrome/browser/search_engines/settings/SearchEngineAdapter",
+                "mPrepopulatedSearchEngines"));
+        Assert.assertTrue(fieldExists(
+                "org/chromium/chrome/browser/search_engines/settings/SearchEngineAdapter",
+                "mRecentSearchEngines"));
+        Assert.assertTrue(fieldExists(
+                "org/chromium/chrome/browser/search_engines/settings/SearchEngineAdapter",
+                "mSelectedSearchEnginePosition"));
     }
 
     @Test

--- a/browser/net/brave_ad_block_tp_network_delegate_helper_unittest.cc
+++ b/browser/net/brave_ad_block_tp_network_delegate_helper_unittest.cc
@@ -34,50 +34,6 @@
 using brave::ResponseCallback;
 using brave_shields::TestFiltersProvider;
 
-namespace {
-
-// Note: extract a common impl if needed for other tests, do not copy.
-
-// TODO(iefremov): This is only needed to provide a task runner to the adblock
-// service. We can drop this stub once the service doesn't need an
-// "external" runner.
-class TestingBraveComponentUpdaterDelegate : public BraveComponent::Delegate {
- public:
-  explicit TestingBraveComponentUpdaterDelegate(PrefService* local_state)
-      : local_state_(local_state) {}
-  ~TestingBraveComponentUpdaterDelegate() override = default;
-
-  TestingBraveComponentUpdaterDelegate(TestingBraveComponentUpdaterDelegate&) =
-      delete;
-  TestingBraveComponentUpdaterDelegate& operator=(
-      TestingBraveComponentUpdaterDelegate&) = delete;
-
-  using ComponentObserver = update_client::UpdateClient::Observer;
-
-  // brave_component_updater::BraveComponent::Delegate implementation
-  void Register(const std::string& component_name,
-                const std::string& component_base64_public_key,
-                base::OnceClosure registered_callback,
-                BraveComponent::ReadyCallback ready_callback) override {}
-  bool Unregister(const std::string& component_id) override { return true; }
-  void OnDemandUpdate(const std::string& component_id) override {}
-
-  void AddObserver(ComponentObserver* observer) override {}
-  void RemoveObserver(ComponentObserver* observer) override {}
-
-  scoped_refptr<base::SequencedTaskRunner> GetTaskRunner() override {
-    return base::ThreadTaskRunnerHandle::Get();
-  }
-
-  const std::string locale() const override { return "en"; }
-  PrefService* local_state() override { return local_state_; }
-
- private:
-  raw_ptr<PrefService> local_state_ = nullptr;
-};
-
-}  // namespace
-
 void FakeAdBlockSubscriptionDownloadManagerGetter(
     base::OnceCallback<
         void(brave_shields::AdBlockSubscriptionDownloadManager*)>) {
@@ -90,19 +46,12 @@ class BraveAdBlockTPNetworkDelegateHelperTest : public testing::Test {
     local_state_ = std::make_unique<ScopedTestingLocalState>(
         TestingBrowserProcess::GetGlobal());
 
-    brave_component_updater_delegate_ =
-        std::make_unique<TestingBraveComponentUpdaterDelegate>(
-            local_state_->Get());
-
     base::FilePath user_data_dir;
     DCHECK(base::PathService::Get(chrome::DIR_USER_DATA, &user_data_dir));
     auto adblock_service = std::make_unique<brave_shields::AdBlockService>(
-        brave_component_updater_delegate_->local_state(),
-        brave_component_updater_delegate_->locale(), nullptr,
-        brave_component_updater_delegate_->GetTaskRunner(),
+        local_state_->Get(), "en", nullptr, base::ThreadTaskRunnerHandle::Get(),
         std::make_unique<brave_shields::AdBlockSubscriptionServiceManager>(
-            brave_component_updater_delegate_->local_state(),
-            brave_component_updater_delegate_->GetTaskRunner(),
+            local_state_->Get(), base::ThreadTaskRunnerHandle::Get(),
             base::BindOnce(&FakeAdBlockSubscriptionDownloadManagerGetter),
             user_data_dir));
 
@@ -149,9 +98,6 @@ class BraveAdBlockTPNetworkDelegateHelperTest : public testing::Test {
   }
 
   std::unique_ptr<ScopedTestingLocalState> local_state_;
-
-  std::unique_ptr<TestingBraveComponentUpdaterDelegate>
-      brave_component_updater_delegate_;
 
   content::BrowserTaskEnvironment task_environment_;
 

--- a/browser/sync/BUILD.gn
+++ b/browser/sync/BUILD.gn
@@ -10,3 +10,24 @@ source_set("sync") {
     "//components/sync_device_info",
   ]
 }
+
+source_set("unit_tests") {
+  testonly = true
+
+  sources = []
+  deps = []
+
+  # Chromium/iOS shouldn't use anything in //chrome, so disable these tests
+  # for iOS
+  if (!is_ios) {
+    sources += [ "brave_sync_client_unittest.cc" ]
+    deps += [
+      "//brave/components/brave_component_updater/browser",
+      "//brave/components/brave_shields/browser",
+      "//chrome/browser",
+      "//chrome/browser/profiles:profile",
+      "//chrome/test:test_support",
+      "//testing/gtest",
+    ]
+  }
+}

--- a/browser/sync/brave_sync_client_unittest.cc
+++ b/browser/sync/brave_sync_client_unittest.cc
@@ -1,0 +1,134 @@
+/* Copyright (c) 2022 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include <algorithm>
+
+#include "base/files/scoped_temp_dir.h"
+#include "base/path_service.h"
+#include "base/ranges/algorithm.h"
+#include "brave/components/brave_component_updater/browser/brave_component.h"
+#include "brave/components/brave_shields/browser/ad_block_subscription_service_manager.h"
+#include "brave/test/base/testing_brave_browser_process.h"
+#include "chrome/browser/prefs/browser_prefs.h"
+#include "chrome/browser/profiles/profile.h"
+#include "chrome/browser/sync/chrome_sync_client.h"
+#include "chrome/browser/sync/sync_service_factory.h"
+#include "chrome/common/chrome_paths.h"
+#include "chrome/test/base/scoped_testing_local_state.h"
+#include "chrome/test/base/testing_browser_process.h"
+#include "chrome/test/base/testing_profile.h"
+#include "chrome/test/base/testing_profile_manager.h"
+#include "components/search_engines/search_engines_pref_names.h"
+#include "components/sync/driver/test_sync_service.h"
+#include "components/sync_preferences/pref_service_mock_factory.h"
+#include "components/sync_preferences/testing_pref_service_syncable.h"
+#include "content/public/test/browser_task_environment.h"
+#include "testing/gtest/include/gtest/gtest.h"
+
+namespace {
+
+std::unique_ptr<Profile> CreateProfile(const base::FilePath& path) {
+  SyncServiceFactory::GetInstance();
+
+  sync_preferences::PrefServiceMockFactory factory;
+  auto registry = base::MakeRefCounted<user_prefs::PrefRegistrySyncable>();
+  std::unique_ptr<sync_preferences::PrefServiceSyncable> prefs(
+      factory.CreateSyncable(registry.get()));
+  RegisterUserProfilePrefs(registry.get());
+
+  TestingProfile::Builder profile_builder;
+  profile_builder.SetPrefService(std::move(prefs));
+  profile_builder.SetPath(path);
+  return profile_builder.Build();
+}
+
+void FakeAdBlockSubscriptionDownloadManagerGetter(
+    base::OnceCallback<
+        void(brave_shields::AdBlockSubscriptionDownloadManager*)>) {
+  // no-op, subscription services are not currently used in unit tests
+}
+
+}  // namespace
+
+namespace browser_sync {
+
+class BraveSyncClientTest : public testing::Test {
+ public:
+  BraveSyncClientTest() {}
+  ~BraveSyncClientTest() override {}
+
+ protected:
+  void SetUp() override {
+    EXPECT_TRUE(temp_dir_.CreateUniqueTempDir());
+    profile_ = CreateProfile(temp_dir_.GetPath());
+    EXPECT_TRUE(profile_.get() != NULL);
+
+    SetupAdblockServiceForBraveBrowserProcess();
+  }
+
+  Profile* profile() { return profile_.get(); }
+
+ private:
+  void SetupAdblockServiceForBraveBrowserProcess();
+
+  // Need this as a very first member to run tests in UI thread
+  // When this is set, class should not install any other MessageLoops, like
+  // base::test::ScopedTaskEnvironment
+  content::BrowserTaskEnvironment task_environment_;
+  std::unique_ptr<Profile> profile_;
+  base::ScopedTempDir temp_dir_;
+
+  std::unique_ptr<ScopedTestingLocalState> local_state_;
+};
+
+// We need this because otherwise we'll get crash on uninitialized
+// ad_block_service_ at
+//    component_factory_->CreateCommonDataTypeControllers() =>
+//    CreateAdBlockSubscriptionDownloadClient() =>
+//    g_brave_browser_process->ad_block_service()
+void BraveSyncClientTest::SetupAdblockServiceForBraveBrowserProcess() {
+  local_state_ = std::make_unique<ScopedTestingLocalState>(
+      TestingBrowserProcess::GetGlobal());
+
+  base::FilePath user_data_dir;
+  DCHECK(base::PathService::Get(chrome::DIR_USER_DATA, &user_data_dir));
+  auto adblock_service = std::make_unique<brave_shields::AdBlockService>(
+      local_state_->Get(), "en", nullptr, base::ThreadTaskRunnerHandle::Get(),
+      std::make_unique<brave_shields::AdBlockSubscriptionServiceManager>(
+          local_state_->Get(), base::ThreadTaskRunnerHandle::Get(),
+          base::BindOnce(&FakeAdBlockSubscriptionDownloadManagerGetter),
+          user_data_dir));
+
+  TestingBraveBrowserProcess::GetGlobal()->SetAdBlockService(
+      std::move(adblock_service));
+}
+
+TEST_F(BraveSyncClientTest, CreateDataTypeControllersSearchEngines) {
+  auto sync_client =
+      std::make_unique<browser_sync::ChromeSyncClient>(profile());
+
+  syncer::TestSyncService service;
+  const syncer::DataTypeController::TypeVector controllers =
+      sync_client->CreateDataTypeControllers(&service);
+
+  EXPECT_TRUE(base::ranges::any_of(
+      controllers,
+      [](const std::unique_ptr<syncer::DataTypeController>& controller) {
+        return controller->type() == syncer::SEARCH_ENGINES;
+      }));
+}
+
+TEST_F(BraveSyncClientTest, PrefSyncedDefaultSearchProviderGUIDIsSyncable) {
+  // This test supposed to be near
+  // components/search_engines/template_url_service.cc
+  // But we have it here because we have profile here and both these tests are
+  // related by the final purpose
+  const PrefService::Preference* pref = profile()->GetPrefs()->FindPreference(
+      prefs::kSyncedDefaultSearchProviderGUID);
+  EXPECT_TRUE(pref->registration_flags() &
+              user_prefs::PrefRegistrySyncable::SYNCABLE_PREF);
+}
+
+}  // namespace browser_sync

--- a/build/android/bytecode/java/org/brave/bytecode/BraveSearchEngineAdapterClassAdapter.java
+++ b/build/android/bytecode/java/org/brave/bytecode/BraveSearchEngineAdapterClassAdapter.java
@@ -41,5 +41,8 @@ public class BraveSearchEngineAdapterClassAdapter extends BraveClassVisitor {
         makePublicMethod(sSearchEngineSettingsClassName, "createAdapterIfNecessary");
         addMethodAnnotation(sBraveSearchEnginePreferenceClassName, "createAdapterIfNecessary",
                 "Ljava/lang/Override;");
+
+        changeMethodOwner(sSearchEngineAdapterClassName, "didSearchEnginesChange",
+                sBraveSearchEngineAdapterBaseClassName);
     }
 }

--- a/chromium_src/chrome/browser/sync/chrome_sync_client.cc
+++ b/chromium_src/chrome/browser/sync/chrome_sync_client.cc
@@ -3,6 +3,9 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+#include "chrome/browser/sync/chrome_sync_client.h"
+
+#include "build/build_config.h"
 #include "build/buildflag.h"
 #include "extensions/buildflags/buildflags.h"
 
@@ -13,4 +16,33 @@
 
 #endif  // !BUILDFLAG(ENABLE_EXTENSIONS)
 
+#define CreateDataTypeControllers CreateDataTypeControllers_ChromiumImpl
+
 #include "src/chrome/browser/sync/chrome_sync_client.cc"
+
+#undef CreateDataTypeControllers
+
+namespace browser_sync {
+
+syncer::DataTypeController::TypeVector
+ChromeSyncClient::CreateDataTypeControllers(syncer::SyncService* sync_service) {
+  syncer::DataTypeController::TypeVector controllers =
+      CreateDataTypeControllers_ChromiumImpl(sync_service);
+
+#if BUILDFLAG(IS_ANDROID)
+  const base::RepeatingClosure dump_stack = GetDumpStackClosure();
+
+  syncer::RepeatingModelTypeStoreFactory model_type_store_factory =
+      GetModelTypeStoreService()->GetStoreFactory();
+
+  controllers.push_back(
+      std::make_unique<syncer::SyncableServiceBasedModelTypeController>(
+          syncer::SEARCH_ENGINES, model_type_store_factory,
+          GetSyncableServiceForType(syncer::SEARCH_ENGINES),
+          std::move(dump_stack)));
+#endif
+
+  return controllers;
+}
+
+}  // namespace browser_sync

--- a/chromium_src/chrome/browser/sync/chrome_sync_client.h
+++ b/chromium_src/chrome/browser/sync/chrome_sync_client.h
@@ -1,0 +1,21 @@
+/* Copyright (c) 2022 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_CHROMIUM_SRC_CHROME_BROWSER_SYNC_CHROME_SYNC_CLIENT_H_
+#define BRAVE_CHROMIUM_SRC_CHROME_BROWSER_SYNC_CHROME_SYNC_CLIENT_H_
+
+// Forward include to avoid redefine CreateDataTypeControllers at
+// BrowserSyncClient
+#include "components/browser_sync/browser_sync_client.h"
+
+#define CreateDataTypeControllers                                            \
+  CreateDataTypeControllers_ChromiumImpl(syncer::SyncService* sync_service); \
+  syncer::DataTypeController::TypeVector CreateDataTypeControllers
+
+#include "src/chrome/browser/sync/chrome_sync_client.h"
+
+#undef CreateDataTypeControllers
+
+#endif  // BRAVE_CHROMIUM_SRC_CHROME_BROWSER_SYNC_CHROME_SYNC_CLIENT_H_

--- a/chromium_src/components/search_engines/template_url_service.cc
+++ b/chromium_src/components/search_engines/template_url_service.cc
@@ -1,0 +1,29 @@
+/* Copyright (c) 2022 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include <utility>
+
+#include "build/build_config.h"
+
+#if BUILDFLAG(IS_ANDROID)
+// Forward include these headers to:
+// 1. Avoid potential re-defining NO_REGISTRATION_FLAGS in other includes;
+// 2. Perform static_asserts below to ensure the trick with define works as we
+// expect.
+#include "components/pref_registry/pref_registry_syncable.h"
+#include "components/prefs/pref_registry.h"
+
+static_assert(PrefRegistry::NO_REGISTRATION_FLAGS == 0);
+static_assert(user_prefs::PrefRegistrySyncable::SYNCABLE_PREF == 1);
+
+#define NO_REGISTRATION_FLAGS \
+  NO_REGISTRATION_FLAGS + user_prefs::PrefRegistrySyncable::SYNCABLE_PREF
+#endif  // BUILDFLAG(IS_ANDROID)
+
+#include "src/components/search_engines/template_url_service.cc"
+
+#if BUILDFLAG(IS_ANDROID)
+#undef NO_REGISTRATION_FLAGS
+#endif

--- a/test/BUILD.gn
+++ b/test/BUILD.gn
@@ -179,6 +179,7 @@ test("brave_unit_tests") {
     "//brave/browser/profiles:profiles",
     "//brave/browser/safebrowsing",
     "//brave/browser/search:unit_tests",
+    "//brave/browser/sync:unit_tests",
     "//brave/browser/themes",
     "//brave/browser/tor:unit_tests",
     "//brave/browser/ui",
@@ -432,6 +433,7 @@ test("brave_unit_tests") {
       "//brave:brave_pak_assets",
       "//chrome:chrome_android_core",
       "//chrome/android:chrome_apk_paks",
+      "//chrome/android:delegate_public_impl_java",
       "//chrome/test/android:chrome_java_test_support",
       "//components/gcm_driver/instance_id/android:instance_id_driver_test_support_java",
     ]


### PR DESCRIPTION
<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/10760

This PR enables syncing of default search engine (DSE) between Android and Desktop for normal tab/window.
DSE for the private window/tab is still not synced.

Main points of PR:
- makes pref `kSyncedDefaultSearchProviderGUID` to be syncable on Android;
- adds the datatype controller for `SEARCH_ENGINES` type on Android;
- DSE on Android is saved to native prefs, removed logic which saved that into `SharePref` of `STANDARD_DSE_SHORTNAME`;
- DSE state observers to reflect change in Android Settings UI on-fly;
- unit tests.

Video:

https://user-images.githubusercontent.com/24739341/183759627-c9896ac4-916b-48fb-9cba-3c266abcd5e5.mp4



## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [x] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [x] New files have MPL-2.0 license header
- [x] Adequate test coverage exists to prevent regressions
- [x] Major classes, functions and non-trivial code blocks are well-commented
- [x] Changes in component dependencies are properly reflected in `gn`
- [x] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [x] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
1. Enable sync on Desktop, turn on the `Settings` type;
2. Join Android device to the chain, also turn on the `Settings` type;
3. On Desktop go to brave://settings/search settings page;
4. On Desktop change Normal Window DSE to `DuckDuckGo`
5. On Android open `Settings` => `Search Engines`
Expected to see `Standard Tab`=>`DuckDuckGo`
6. On Android open `Settings` => `Search Engines` => `Standard Tab`, change from `DuckDuckGo` to `Brave`
Expected on Desktop also to have the DSE changed to `Brave`
7. On Desktop change DSE from `Brave` to `Qwant`
8. Expected on Android at the settings screen with search engine radio-boxes also to have it changed to `Qwant` on-fly
9. On Android open new tab and search something in address bar, expected Qwant wite to be opened.






