### PR TITLE
[iOS] Enable adaptive captcha build flag for iOS (uplift to 1.43.x)

### DIFF
--- a/components/brave_adaptive_captcha/buildflags/buildflags.gni
+++ b/components/brave_adaptive_captcha/buildflags/buildflags.gni
@@ -1,3 +1,3 @@
 declare_args() {
-  brave_adaptive_captcha_enabled = is_mac || is_linux || is_win
+  brave_adaptive_captcha_enabled = is_mac || is_linux || is_win || is_ios
 }


### PR DESCRIPTION
Uplift of #14441
Resolves https://github.com/brave/brave-browser/issues/24393

Pre-approval checklist: 
- [ ] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [ ] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [ ] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [ ] The associated issue milestone is set to the smallest version that the changes is landed on.