### PR TITLE
Remove window.ethereum.* (non function properties) protection

### DIFF
--- a/components/brave_wallet/renderer/js_ethereum_provider.cc
+++ b/components/brave_wallet/renderer/js_ethereum_provider.cc
@@ -177,8 +177,7 @@ void JSEthereumProvider::CreateEthereumObject(
           .Check();
     }
     ethereum_obj
-        ->DefineOwnProperty(context, gin::StringToSymbol(isolate, "_metamask"),
-                            metamask_obj, v8::ReadOnly)
+        ->Set(context, gin::StringToSymbol(isolate, "_metamask"), metamask_obj)
         .Check();
     BindFunctionsToObject(isolate, context, ethereum_obj, metamask_obj);
     UpdateAndBindJSProperties(isolate, context, ethereum_obj);
@@ -220,8 +219,8 @@ void JSEthereumProvider::UpdateAndBindJSProperties(
     v8::Local<v8::Object> ethereum_obj) {
   v8::Local<v8::Primitive> undefined(v8::Undefined(isolate));
   ethereum_obj
-      ->DefineOwnProperty(context, gin::StringToSymbol(isolate, "chainId"),
-                          gin::StringToV8(isolate, chain_id_), v8::ReadOnly)
+      ->Set(context, gin::StringToSymbol(isolate, "chainId"),
+            gin::StringToV8(isolate, chain_id_))
       .Check();
 
   // We have no easy way to convert a uin256 to a decimal number string yet
@@ -232,16 +231,13 @@ void JSEthereumProvider::UpdateAndBindJSProperties(
       chain_id_uint256 <= (uint256_t)std::numeric_limits<uint64_t>::max()) {
     uint64_t networkVersion = (uint64_t)chain_id_uint256;
     ethereum_obj
-        ->DefineOwnProperty(
-            context, gin::StringToSymbol(isolate, "networkVersion"),
-            gin::StringToV8(isolate, std::to_string(networkVersion)),
-            v8::ReadOnly)
+        ->Set(context, gin::StringToSymbol(isolate, "networkVersion"),
+              gin::StringToV8(isolate, std::to_string(networkVersion)))
         .Check();
   } else {
     ethereum_obj
-        ->DefineOwnProperty(context,
-                            gin::StringToSymbol(isolate, "networkVersion"),
-                            undefined, v8::ReadOnly)
+        ->Set(context, gin::StringToSymbol(isolate, "networkVersion"),
+              undefined)
         .Check();
   }
 
@@ -249,15 +245,13 @@ void JSEthereumProvider::UpdateAndBindJSProperties(
   // first connected account that was given permissions.
   if (first_allowed_account_.empty()) {
     ethereum_obj
-        ->DefineOwnProperty(context,
-                            gin::StringToSymbol(isolate, "selectedAddress"),
-                            undefined, v8::ReadOnly)
+        ->Set(context, gin::StringToSymbol(isolate, "selectedAddress"),
+              undefined)
         .Check();
   } else {
     ethereum_obj
-        ->DefineOwnProperty(
-            context, gin::StringToSymbol(isolate, "selectedAddress"),
-            gin::StringToV8(isolate, first_allowed_account_), v8::ReadOnly)
+        ->Set(context, gin::StringToSymbol(isolate, "selectedAddress"),
+              gin::StringToV8(isolate, first_allowed_account_))
         .Check();
   }
 }

--- a/renderer/test/js_ethereum_provider_browsertest.cc
+++ b/renderer/test/js_ethereum_provider_browsertest.cc
@@ -23,15 +23,6 @@
 #include "url/gurl.h"
 
 namespace {
-std::string NonWriteableScriptProperty(const std::string& property) {
-  return base::StringPrintf(
-      R"(window.ethereum.%s = "brave"
-         if (window.ethereum.%s === "brave")
-           window.domAutomationController.send(false)
-         else
-           window.domAutomationController.send(true))",
-      property.c_str(), property.c_str());
-}
 std::string NonWriteableScriptMethod(const std::string& provider,
                                      const std::string& method) {
   return base::StringPrintf(
@@ -163,15 +154,6 @@ IN_PROC_BROWSER_TEST_F(JSEthereumProviderBrowserTest,
 IN_PROC_BROWSER_TEST_F(JSEthereumProviderBrowserTest, NonWritable) {
   const GURL url = https_server_.GetURL("/simple.html");
   ASSERT_TRUE(ui_test_utils::NavigateToURL(browser(), url));
-
-  // window.ethereum.* (properties)
-  for (const std::string& property :
-       {"_metamask", "chainId", "networkVersion", "selectedAddress"}) {
-    SCOPED_TRACE(property);
-    auto result = EvalJs(web_contents(), NonWriteableScriptProperty(property),
-                         content::EXECUTE_SCRIPT_USE_MANUAL_REPLY);
-    EXPECT_EQ(base::Value(true), result.value) << result.error;
-  }
 
   // window.ethereum.* (methods)
   for (const std::string& method :


### PR DESCRIPTION
<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/24456

Currently we define `window.ethereum.*` (non function properties) as read only, then we have to redefine it in order to update the value.
If we redefine it as read only, other extensions like MetaMask won't be able to update the value.
If it is redefined as writable, then we lose the protection.

The reason that above scenario is happening is because we can't tell the `window.ethereum` is own by us or external extensions, we will update the value blindly.
So rewriting Ethereum provider as `gin::Wrappable` like Solana provider is the only way that can make these properties read only to our own provider object and be able to update it.
https://github.com/brave/brave-browser/issues/19909#issuecomment-1206014978

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
1. Install and setup MetaMask
2. Setup Brave Wallet and set default wallet setting to "Prefer extensions"
3. Navigate to any sites
4. Open console and we shouldn't see errors
5. Open any google doc/sheet link which should be loaded successfully.
