### PR TITLE
Update whitelist with Apple system pseudo-fonts (uplift to 1.43.x)

### DIFF
--- a/third_party/blink/renderer/brave_font_whitelist.cc
+++ b/third_party/blink/renderer/brave_font_whitelist.cc
@@ -19,6 +19,7 @@ bool kCanRestrictFonts = true;
 // This list covers the fonts installed by default on Mac OS as of Mac OS 12.3.
 base::flat_set<base::StringPiece> kAllowedFontFamilies =
     base::MakeFlatSet<base::StringPiece>(std::vector<base::StringPiece>{
+        "-apple-system",
         "academy engraved let",
         "al bayan",
         "al nile",
@@ -69,6 +70,7 @@ base::flat_set<base::StringPiece> kAllowedFontFamilies =
         "baskerville",
         "beirut",
         "big caslon",
+        "blinkmacsystemfont",
         "bodoni 72",
         "bodoni 72 oldstyle",
         "bodoni 72 smallcaps",
@@ -284,6 +286,7 @@ base::flat_set<base::StringPiece> kAllowedFontFamilies =
         "sukhumvit set",
         "superclarendon",
         "symbol",
+        "system-ui",
         "tahoma",
         "tamil mn",
         "tamil sangam mn",

--- a/third_party/blink/renderer/brave_font_whitelist_unittest.cc
+++ b/third_party/blink/renderer/brave_font_whitelist_unittest.cc
@@ -43,7 +43,7 @@ TEST(BraveFontWhitelistTest, Platforms) {
 
 #if BUILDFLAG(IS_MAC)
   EXPECT_EQ(brave::CanRestrictFontFamiliesOnThisPlatform(), true);
-  EXPECT_EQ(allowed.size(), 282UL);
+  EXPECT_EQ(allowed.size(), 285UL);
 #elif BUILDFLAG(IS_WIN)
   EXPECT_EQ(brave::CanRestrictFontFamiliesOnThisPlatform(), true);
   EXPECT_EQ(allowed.size(), 312UL);
@@ -105,8 +105,11 @@ TEST(BraveFontWhitelistTest, Locales) {
 }
 
 TEST(BraveFontWhitelistTest, KnownFonts) {
-  const std::array<std::tuple<AtomicString, bool>, 7> test_cases = {
+  const std::array<std::tuple<AtomicString, bool>, 10> test_cases = {
 #if BUILDFLAG(IS_MAC)
+    std::make_tuple<>("-apple-system", true),
+    std::make_tuple<>("system-ui", true),
+    std::make_tuple<>("BlinkMacSystemFont", true),
     std::make_tuple<>("Arial Unicode MS", true),
     std::make_tuple<>("Calibri", false),
     std::make_tuple<>("Gill Sans", true),
@@ -115,6 +118,9 @@ TEST(BraveFontWhitelistTest, KnownFonts) {
     std::make_tuple<>("Menlo", true),
     std::make_tuple<>("Franklin Gothic Medium", false),
 #elif BUILDFLAG(IS_WIN)
+    std::make_tuple<>("-apple-system", false),
+    std::make_tuple<>("system-ui", false),
+    std::make_tuple<>("BlinkMacSystemFont", false),
     std::make_tuple<>("Arial Unicode MS", false),
     std::make_tuple<>("Calibri", true),
     std::make_tuple<>("Gill Sans", false),
@@ -123,6 +129,9 @@ TEST(BraveFontWhitelistTest, KnownFonts) {
     std::make_tuple<>("Menlo", false),
     std::make_tuple<>("Franklin Gothic Medium", true),
 #else
+    std::make_tuple<>("-apple-system", false),
+    std::make_tuple<>("system-ui", false),
+    std::make_tuple<>("BlinkMacSystemFont", false),
     std::make_tuple<>("Arial Unicode MS", false),
     std::make_tuple<>("Calibri", false),
     std::make_tuple<>("Gill Sans", false),


### PR DESCRIPTION
Uplift of #14489
Resolves https://github.com/brave/brave-browser/issues/24468

Pre-approval checklist: 
- [ ] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [ ] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [ ] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [ ] The associated issue milestone is set to the smallest version that the changes is landed on.