### PR TITLE
Add delay before reconnect to network service in IpfsDnsResolverImpl.

### DIFF
--- a/browser/ipfs/ipfs_dns_resolver_impl.h
+++ b/browser/ipfs/ipfs_dns_resolver_impl.h
@@ -34,6 +34,7 @@ class IpfsDnsResolverImpl
   absl::optional<std::string> GetFirstDnsOverHttpsServer() override;
 
  private:
+  FRIEND_TEST_ALL_PREFIXES(IpfsDnsResolverImplUnitTest, ReconnectOnMojoError);
   void SetupDnsConfigChangeNotifications();
 
   mojo::Remote<network::mojom::DnsConfigChangeManager>
@@ -41,6 +42,8 @@ class IpfsDnsResolverImpl
   mojo::Receiver<network::mojom::DnsConfigChangeManagerClient> receiver_{this};
 
   SEQUENCE_CHECKER(sequence_checker_);
+
+  base::WeakPtrFactory<IpfsDnsResolverImpl> weak_ptr_factory_;
 };
 
 }  // namespace ipfs

--- a/browser/ipfs/test/BUILD.gn
+++ b/browser/ipfs/test/BUILD.gn
@@ -13,6 +13,7 @@ source_set("unittests") {
     "//brave/browser/ipfs/ipfs_blob_context_getter_factory_unittest.cc",
     "//brave/browser/ipfs/ipfs_host_resolver_unittest.cc",
     "//brave/browser/ipfs/ipfs_tab_helper_unittest.cc",
+    "//brave/browser/ipfs/test/ipfs_dns_resolver_impl_unittest.cc",
     "//brave/browser/ipfs/test/ipfs_navigation_throttle_unittest.cc",
     "//brave/browser/ipfs/test/ipfs_network_utils_unittest.cc",
     "//brave/browser/net/ipfs_redirect_network_delegate_helper_unittest.cc",

--- a/browser/ipfs/test/ipfs_dns_resolver_impl_unittest.cc
+++ b/browser/ipfs/test/ipfs_dns_resolver_impl_unittest.cc
@@ -1,0 +1,45 @@
+/* Copyright (c) 2022 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "brave/browser/ipfs/ipfs_dns_resolver_impl.h"
+
+#include <memory>
+#include <utility>
+
+#include "content/public/browser/network_service_instance.h"
+#include "content/public/test/browser_task_environment.h"
+#include "testing/gtest/include/gtest/gtest.h"
+
+namespace ipfs {
+
+class IpfsDnsResolverImplUnitTest : public testing::Test {
+ public:
+  IpfsDnsResolverImplUnitTest() = default;
+  IpfsDnsResolverImplUnitTest(const IpfsDnsResolverImplUnitTest&) = delete;
+  IpfsDnsResolverImplUnitTest& operator=(const IpfsDnsResolverImplUnitTest&) =
+      delete;
+  ~IpfsDnsResolverImplUnitTest() override = default;
+
+  void SetUp() override {}
+
+  void TearDown() override {}
+  content::BrowserTaskEnvironment task_environment_;
+};
+
+TEST_F(IpfsDnsResolverImplUnitTest, ReconnectOnMojoError) {
+  std::unique_ptr<IpfsDnsResolverImpl> ipfs_dns_resolver_impl_ =
+      std::make_unique<IpfsDnsResolverImpl>();
+  ipfs_dns_resolver_impl_->receiver_.reset();
+  ipfs_dns_resolver_impl_->OnDnsConfigChangeManagerConnectionError();
+  EXPECT_FALSE(ipfs_dns_resolver_impl_->receiver_.is_bound());
+  {
+    base::RunLoop loop;
+    while (!ipfs_dns_resolver_impl_->receiver_.is_bound()) {
+      loop.RunUntilIdle();
+    }
+  }
+}
+
+}  // namespace ipfs


### PR DESCRIPTION
Resolves https://github.com/brave/brave-browser/issues/24461
This should lower CPU usage in case the network service fails to start.


## Test Plan:

Check that IPFS DNS override works after kill network service process. (you can find it by "--utility-sub-type=network.mojom.NetworkService" flag):
Kill network service process, go to DNS settings, select something like Cloudflare option, load ipfs:// url, Check that IPFS daemon uses Cloudflare requests.
