### PR TITLE
Provides stub implementation for RouteObserverMixIn

### DIFF
--- a/browser/resources/settings/brave_tor_page/brave_tor_subpage.js
+++ b/browser/resources/settings/brave_tor_page/brave_tor_subpage.js
@@ -300,6 +300,10 @@ class SettingsBraveTorPageElement extends SettingBraveTorPageElementBase {
     this.showRequestBridgesDialog_ = false
     this.requestedBridges_ = event.currentTarget.bridges_.join('\n')
   }
+
+  currentRouteChanged() {
+    // This is intentional. currentRouteChanged() should be overridden.
+  }
 }
 
 customElements.define(


### PR DESCRIPTION
RouteObserverMixin's currentRoutChanged should be overridden. Seems to be regressed from https://github.com/brave/brave-core/pull/13290

```
shared.rollup.js:424 Uncaught Error: Assertion failed: Unreachable code hit
    at assert (shared.rollup.js:424:147)
    at assertNotReached (shared.rollup.js:424:403)
    at SettingsBraveTorPageElement.currentRouteChanged (shared.rollup.js:425:4875)
    at shared.rollup.js:425:1844
    at Set.forEach (<anonymous>)
    at Router.setCurrentRoute (shared.rollup.js:425:1815)
    at Router.navigateTo (shared.rollup.js:425:3177)
    at SettingsMenuElement.onSelectorActivate_ (settings.js:5314:1147)
    at i.<anonymous> (polymer_bundled.min.js:1:23231)
    at i.fire (polymer_bundled.min.js:1:84941)
```

https://github.com/chromium/chromium/blob/646d3dcc08ed74d1b9522f15270251318bab15ae/chrome/browser/resources/settings/router.js#L434

<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/24510

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

