### PR TITLE
Check isBraveWallet before updating properties as mitigation before gin::Wrappable migration.

### DIFF
--- a/components/brave_wallet/renderer/js_ethereum_provider.cc
+++ b/components/brave_wallet/renderer/js_ethereum_provider.cc
@@ -188,7 +188,8 @@ void JSEthereumProvider::CreateEthereumObject(
                             v8::True(isolate))
         .Check();
     ethereum_obj
-        ->Set(context, gin::StringToSymbol(isolate, "_metamask"), metamask_obj)
+        ->DefineOwnProperty(context, gin::StringToSymbol(isolate, "_metamask"),
+                            metamask_obj, v8::ReadOnly)
         .Check();
     BindFunctionsToObject(isolate, context, ethereum_obj, metamask_obj);
     UpdateAndBindJSProperties(isolate, context, ethereum_obj);
@@ -243,8 +244,8 @@ void JSEthereumProvider::UpdateAndBindJSProperties(
   }
 
   ethereum_obj
-      ->Set(context, gin::StringToSymbol(isolate, "chainId"),
-            gin::StringToV8(isolate, chain_id_))
+      ->DefineOwnProperty(context, gin::StringToSymbol(isolate, "chainId"),
+                          gin::StringToV8(isolate, chain_id_), v8::ReadOnly)
       .Check();
 
   // We have no easy way to convert a uin256 to a decimal number string yet
@@ -255,13 +256,16 @@ void JSEthereumProvider::UpdateAndBindJSProperties(
       chain_id_uint256 <= (uint256_t)std::numeric_limits<uint64_t>::max()) {
     uint64_t networkVersion = (uint64_t)chain_id_uint256;
     ethereum_obj
-        ->Set(context, gin::StringToSymbol(isolate, "networkVersion"),
-              gin::StringToV8(isolate, std::to_string(networkVersion)))
+        ->DefineOwnProperty(
+            context, gin::StringToSymbol(isolate, "networkVersion"),
+            gin::StringToV8(isolate, std::to_string(networkVersion)),
+            v8::ReadOnly)
         .Check();
   } else {
     ethereum_obj
-        ->Set(context, gin::StringToSymbol(isolate, "networkVersion"),
-              undefined)
+        ->DefineOwnProperty(context,
+                            gin::StringToSymbol(isolate, "networkVersion"),
+                            undefined, v8::ReadOnly)
         .Check();
   }
 
@@ -269,13 +273,15 @@ void JSEthereumProvider::UpdateAndBindJSProperties(
   // first connected account that was given permissions.
   if (first_allowed_account_.empty()) {
     ethereum_obj
-        ->Set(context, gin::StringToSymbol(isolate, "selectedAddress"),
-              undefined)
+        ->DefineOwnProperty(context,
+                            gin::StringToSymbol(isolate, "selectedAddress"),
+                            undefined, v8::ReadOnly)
         .Check();
   } else {
     ethereum_obj
-        ->Set(context, gin::StringToSymbol(isolate, "selectedAddress"),
-              gin::StringToV8(isolate, first_allowed_account_))
+        ->DefineOwnProperty(
+            context, gin::StringToSymbol(isolate, "selectedAddress"),
+            gin::StringToV8(isolate, first_allowed_account_), v8::ReadOnly)
         .Check();
   }
 }

--- a/components/brave_wallet/resources/ethereum_provider.js
+++ b/components/brave_wallet/resources/ethereum_provider.js
@@ -25,14 +25,6 @@
     removeAllListeners: {
       value: BraveWeb3ProviderEventEmitter.removeAllListeners,
       writable: false
-    },
-    isMetaMask: {
-      value: true,
-      writable: true // https://github.com/brave/brave-browser/issues/22213
-    },
-    isBraveWallet: {
-      value: true,
-      writable: false
     }
   })
 

--- a/renderer/test/BUILD.gn
+++ b/renderer/test/BUILD.gn
@@ -21,6 +21,7 @@ source_set("browser_tests") {
 
   deps = [
     "//base/test:test_support",
+    "//brave/browser/brave_wallet",
     "//brave/common",
     "//brave/components/brave_wallet/browser",
     "//brave/components/brave_wallet/browser:utils",

--- a/renderer/test/js_ethereum_provider_browsertest.cc
+++ b/renderer/test/js_ethereum_provider_browsertest.cc
@@ -5,7 +5,9 @@
 
 #include "base/path_service.h"
 #include "base/strings/stringprintf.h"
+#include "brave/browser/brave_wallet/json_rpc_service_factory.h"
 #include "brave/components/brave_wallet/browser/brave_wallet_utils.h"
+#include "brave/components/brave_wallet/browser/json_rpc_service.h"
 #include "brave/components/constants/brave_paths.h"
 #include "build/build_config.h"
 #include "chrome/browser/ui/browser.h"
@@ -35,6 +37,9 @@ std::string NonWriteableScriptMethod(const std::string& provider,
 }
 }  // namespace
 
+// TODO(darkdh): Move this browser test to //brave/browser/brave_wallet/ because
+// it has layer violation (//chrome/browser,
+// //brave/components/brave_wallet/browser and //brave/browser)
 class JSEthereumProviderBrowserTest : public InProcessBrowserTest {
  public:
   JSEthereumProviderBrowserTest()
@@ -84,6 +89,11 @@ class JSEthereumProviderBrowserTest : public InProcessBrowserTest {
   void ReloadAndWaitForLoadStop() {
     chrome::Reload(browser(), WindowOpenDisposition::CURRENT_TAB);
     ASSERT_TRUE(content::WaitForLoadStop(web_contents()));
+  }
+
+  brave_wallet::JsonRpcService* GetJsonRpcService() {
+    return brave_wallet::JsonRpcServiceFactory::GetInstance()
+        ->GetServiceForContext(browser()->profile());
   }
 
  protected:
@@ -200,6 +210,41 @@ IN_PROC_BROWSER_TEST_F(JSEthereumProviderBrowserTest, NonConfigurable) {
        typeof window.ethereum === 'object'
     )";
   EXPECT_TRUE(content::EvalJs(main_frame(), overwrite).ExtractBool());
+}
+
+IN_PROC_BROWSER_TEST_F(JSEthereumProviderBrowserTest, OnlyWriteOwnProperty) {
+  brave_wallet::SetDefaultEthereumWallet(
+      browser()->profile()->GetPrefs(),
+      brave_wallet::mojom::DefaultWallet::BraveWallet);
+  const GURL url = https_server_.GetURL("/simple.html");
+  ASSERT_TRUE(ui_test_utils::NavigateToURL(browser(), url));
+
+  const std::string get_chain_id = "window.ethereum.chainId";
+
+  ASSERT_EQ(content::EvalJs(main_frame(), get_chain_id).ExtractString(), "0x1");
+
+  GetJsonRpcService()->SetNetwork("0x3", brave_wallet::mojom::CoinType::ETH,
+                                  false);
+  // Needed so ChainChangedEvent observers run
+  base::RunLoop().RunUntilIdle();
+  EXPECT_EQ(content::EvalJs(main_frame(), get_chain_id).ExtractString(), "0x3");
+
+  brave_wallet::SetDefaultEthereumWallet(
+      browser()->profile()->GetPrefs(),
+      brave_wallet::mojom::DefaultWallet::BraveWalletPreferExtension);
+  ReloadAndWaitForLoadStop();
+  ASSERT_EQ(content::EvalJs(
+                main_frame(),
+                "window.ethereum = {chainId: '0x89'}; window.ethereum.chainId")
+                .ExtractString(),
+            "0x89");
+
+  GetJsonRpcService()->SetNetwork("0x4", brave_wallet::mojom::CoinType::ETH,
+                                  false);
+  // Needed so ChainChangedEvent observers run
+  base::RunLoop().RunUntilIdle();
+  EXPECT_EQ(content::EvalJs(main_frame(), get_chain_id).ExtractString(),
+            "0x89");
 }
 
 IN_PROC_BROWSER_TEST_F(JSEthereumProviderBrowserTest, Iframe3P) {


### PR DESCRIPTION
<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/24531

1. This is a temporary mitigation before https://github.com/brave/brave-browser/issues/19909 landed.
2. Current `JSEthereumProviderBrowserTest` browser test is already having layer violation, disregarding it for easier uplift.
3. Bring back window.ethereum.* (non function properties) protection which is not the root cause of https://github.com/brave/brave-browser/issues/24456

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

STR in the https://github.com/brave/brave-browser/issues/24531

### STR for regression checking
1. Install and setup MetaMask
2. Setup Brave Wallet and set default wallet setting to "Prefer extensions"
4. Navigate to any sites
5. Open console and we shouldn't see errors
6. Open any google doc/sheet link which should be loaded successfully.