### PR TITLE
Remove trezor-connect js library imports outside of untrusted frame

### DIFF
--- a/components/brave_wallet_ui/common/async/hardware.test.ts
+++ b/components/brave_wallet_ui/common/async/hardware.test.ts
@@ -5,7 +5,7 @@
 import { TextEncoder, TextDecoder } from 'util'
 global.TextDecoder = TextDecoder
 global.TextEncoder = TextEncoder
-import { EthereumSignedTx } from 'trezor-connect/lib/typescript'
+import { EthereumSignedTx } from '../hardware/trezor/trezor-connect-types'
 import {
   BraveWallet,
   GetNonceForHardwareTransactionReturnInfo,

--- a/components/brave_wallet_ui/common/async/hardware.ts
+++ b/components/brave_wallet_ui/common/async/hardware.ts
@@ -26,7 +26,7 @@ import LedgerBridgeKeyring from '../hardware/ledgerjs/eth_ledger_bridge_keyring'
 import SolanaLedgerBridgeKeyring from '../hardware/ledgerjs/sol_ledger_bridge_keyring'
 import { BraveWallet } from '../../constants/types'
 import { LedgerEthereumKeyring, LedgerFilecoinKeyring, LedgerSolanaKeyring } from '../hardware/interfaces'
-import { EthereumSignedTx } from 'trezor-connect'
+import { EthereumSignedTx } from '../hardware/trezor/trezor-connect-types'
 import { SignedLotusMessage } from '@glif/filecoin-message'
 
 export function dialogErrorFromLedgerErrorCode (code: string | number): HardwareWalletResponseCodeType {

--- a/components/brave_wallet_ui/common/hardware/trezor/trezor-connect-types.ts
+++ b/components/brave_wallet_ui/common/hardware/trezor/trezor-connect-types.ts
@@ -1,0 +1,94 @@
+export interface Unsuccessful {
+  success: false
+  payload: { error: string, code?: string }
+}
+
+export interface Success<T> {
+  success: true
+  id: number
+  payload: T
+}
+
+export interface EthereumSignTransaction {
+  path: string | number[]
+  transaction: EthereumTransaction | EthereumTransactionEIP1559
+}
+
+export interface EthereumTransaction {
+  to: string
+  value: string
+  gasPrice: string
+  gasLimit: string
+  maxFeePerGas?: typeof undefined
+  maxPriorityFeePerGas?: typeof undefined
+  nonce: string
+  data?: string
+  chainId: number
+  txType?: number
+}
+
+export type EthereumTransactionEIP1559 = {
+  to: string
+  value: string
+  gasLimit: string
+  gasPrice?: typeof undefined
+  nonce: string
+  data?: string
+  chainId: number
+  maxFeePerGas: string
+  maxPriorityFeePerGas: string
+  accessList?: EthereumAccessList[]
+}
+
+export type EthereumAccessList = {
+  address: string
+  storageKeys: string[]
+}
+
+export interface CommonParams {
+  device?: {
+    path: string
+    state?: string
+    instance?: number
+  }
+  useEmptyPassphrase?: boolean
+  allowSeedlessDevice?: boolean
+  keepSession?: boolean
+  skipFinalReload?: boolean
+  useCardanoDerivation?: boolean
+}
+
+export interface HDNodeResponse {
+  path: number[]
+  serializedPath: string
+  childNum: number
+  xpub: string
+  xpubSegwit?: string
+  chainCode: string
+  publicKey: string
+  fingerprint: number
+  depth: number
+}
+
+export interface EthereumSignedTx {
+  v: string
+  r: string
+  s: string
+}
+
+export interface EthereumSignMessage {
+  path: string | number[]
+  message: string
+  hex?: boolean
+}
+
+export interface EthereumSignTypedHash {
+  path: string | number[]
+  domain_separator_hash: string
+  message_hash: string
+}
+
+export type MessageSignature = {
+  address: string
+  signature: string
+}

--- a/components/brave_wallet_ui/common/hardware/trezor/trezor-messages.ts
+++ b/components/brave_wallet_ui/common/hardware/trezor/trezor-messages.ts
@@ -3,9 +3,16 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this file,
 // you can obtain one at http://mozilla.org/MPL/2.0/.
 import { loadTimeData } from '../../../../common/loadTimeData'
-import { Unsuccessful, EthereumSignTransaction, CommonParams, Success } from 'trezor-connect'
-import { HDNodeResponse } from 'trezor-connect/lib/typescript'
-import { EthereumSignedTx, EthereumSignMessage, EthereumSignTypedHash } from 'trezor-connect/lib/typescript/networks/ethereum'
+import {
+  Unsuccessful,
+  EthereumSignTransaction,
+  CommonParams,
+  Success,
+  HDNodeResponse,
+  EthereumSignedTx,
+  EthereumSignMessage,
+  EthereumSignTypedHash
+} from './trezor-connect-types'
 import { MessageSignature } from 'trezor-connect/lib/typescript/trezor/protobuf'
 export const kTrezorBridgeUrl = loadTimeData.getString('braveWalletTrezorBridgeUrl')
 

--- a/components/brave_wallet_ui/common/hardware/trezor/trezor_bridge_keyring.test.ts
+++ b/components/brave_wallet_ui/common/hardware/trezor/trezor_bridge_keyring.test.ts
@@ -25,7 +25,7 @@ import { TrezorBridgeTransport } from './trezor-bridge-transport'
 import { TrezorCommandHandler } from './trezor-command-handler'
 import { getMockedTransactionInfo } from '../../constants/mocks'
 import { HardwareOperationResult, SignHardwareOperationResult } from '../../hardware_operations'
-import { Unsuccessful } from 'trezor-connect'
+import { Unsuccessful } from './trezor-connect-types'
 import { SignHardwareMessageOperationResult, TrezorDerivationPaths } from '../types'
 
 let uuid = 0

--- a/components/brave_wallet_ui/common/hardware/trezor/trezor_bridge_keyring.ts
+++ b/components/brave_wallet_ui/common/hardware/trezor/trezor_bridge_keyring.ts
@@ -31,7 +31,7 @@ import {
   SignHardwareOperationResult,
   TrezorDerivationPaths
 } from '../types'
-import { Unsuccessful } from 'trezor-connect'
+import { Unsuccessful } from './trezor-connect-types'
 import { TrezorKeyring } from '../interfaces'
 import { HardwareVendor } from '../../api/hardware_keyrings'
 

--- a/components/brave_wallet_ui/common/hardware/types.ts
+++ b/components/brave_wallet_ui/common/hardware/types.ts
@@ -1,4 +1,4 @@
-import { EthereumSignedTx } from 'trezor-connect/lib/typescript'
+import { EthereumSignedTx } from './trezor/trezor-connect-types'
 import { BraveWallet } from '../../constants/types'
 import { SignedLotusMessage } from '@glif/filecoin-message'
 import { LedgerError } from './ledgerjs/ledger-messages'

--- a/components/brave_wallet_ui/trezor/trezor.ts
+++ b/components/brave_wallet_ui/trezor/trezor.ts
@@ -3,7 +3,8 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this file,
 // you can obtain one at http://mozilla.org/MPL/2.0/.
 
-import TrezorConnect, { Unsuccessful, Success } from 'trezor-connect'
+import TrezorConnect from 'trezor-connect'
+import { Unsuccessful, Success } from '../common/hardware/trezor/trezor-connect-types'
 import { EthereumSignedTx } from 'trezor-connect/lib/typescript/networks/ethereum'
 import {
   TrezorCommand,


### PR DESCRIPTION
Resolves https://github.com/brave/brave-browser/issues/24549
Instead of importing types from the 'trezor-connect' library
outside the chrome-untrused://trezor-bridge, manually define the types in
trezor-connect-types.ts and import from there.

Types were copied from
https://github.com/trezor/connect.git@57d589e159c6784f9c3b45d564f6eb01f7085c81
(version 8.2.6).

<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves 

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

