### PR TITLE
Updated the bookmrk icon of omnibox autocomplete entry

### DIFF
--- a/vector_icons/components/omnibox/browser/vector_icons/bookmark.icon
+++ b/vector_icons/components/omnibox/browser/vector_icons/bookmark.icon
@@ -1,0 +1,26 @@
+// Copyright 2022 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at http://mozilla.org/MPL/2.0/.
+
+CANVAS_DIMENSIONS, 16,
+R_MOVE_TO, 2.97f, 15.91f,
+R_LINE_TO, 4.88f, -2.77f,
+R_LINE_TO, 4.88f, 2.77f,
+R_CUBIC_TO, 0.43f, 0.25f, 0.96f, -0.07f, 0.96f, -0.58f,
+V_LINE_TO, 0.67f,
+ARC_TO, 0.66f, 0.66f, 0, 0, 0, 13.04f, 0,
+H_LINE_TO, 2.65f,
+ARC_TO, 0.66f, 0.66f, 0, 0, 0, 2, 0.67f,
+R_V_LINE_TO, 14.66f,
+R_CUBIC_TO, 0, 0.51f, 0.53f, 0.83f, 0.97f, 0.58f,
+CLOSE,
+MOVE_TO, 3.3f, 14.2f,
+V_LINE_TO, 1.33f,
+R_H_LINE_TO, 9.09f,
+R_V_LINE_TO, 12.87f,
+LINE_TO, 8.16f, 11.8f,
+R_ARC_TO, 0.62f, 0.62f, 0, 0, 0, -0.63f, 0,
+CLOSE,
+R_MOVE_TO, 0, 0,
+CLOSE


### PR DESCRIPTION
fix https://github.com/brave/brave-browser/issues/24247

Updated icon:
<img width="366" alt="Screen Shot 2022-08-10 at 10 43 25 AM" src="https://user-images.githubusercontent.com/6786187/183792320-d1302e81-ea88-4ac0-80d4-cf1659267d15.png">

Current chromium icon:
<img width="364" alt="Screen Shot 2022-08-10 at 10 46 33 AM" src="https://user-images.githubusercontent.com/6786187/183792430-ae0da75f-e917-4115-849e-3f2a40a2691a.png">

<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves 

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

1. Launch with clean profile
2. Open NTP and add brave bookmark item (https://www.brave.com/) via bookmark bar's `Add page` context menu item
3. Type brave.com in omnibox and check new icon is used