### PR TITLE
Fixes a crash on Solana icon on Android 6 and 7 (uplift to 1.42.x)

### DIFF
--- a/android/java/org/chromium/chrome/browser/crypto_wallet/util/Utils.java
+++ b/android/java/org/chromium/chrome/browser/crypto_wallet/util/Utils.java
@@ -47,6 +47,7 @@ import androidx.annotation.StringRes;
 import androidx.annotation.VisibleForTesting;
 import androidx.appcompat.app.AlertDialog;
 import androidx.appcompat.app.AppCompatActivity;
+import androidx.appcompat.content.res.AppCompatResources;
 import androidx.core.hardware.fingerprint.FingerprintManagerCompat;
 import androidx.recyclerview.widget.LinearLayoutManager;
 import androidx.recyclerview.widget.RecyclerView;
@@ -751,8 +752,7 @@ public class Utils {
             } catch (Exception exc) {
                 org.chromium.base.Log.e("Utils", exc.getMessage());
                 if (textView != null) {
-                    Drawable iconDrawable =
-                            ApiCompatibilityUtils.getDrawable(context.getResources(), iconId);
+                    Drawable iconDrawable = AppCompatResources.getDrawable(context, iconId);
                     Bitmap bitmap = Bitmap.createBitmap(iconDrawable.getIntrinsicWidth(),
                             iconDrawable.getIntrinsicHeight(), Bitmap.Config.ARGB_8888);
                     Canvas canvas = new Canvas(bitmap);


### PR DESCRIPTION
Uplift of #14577
Resolves https://github.com/brave/brave-browser/issues/24566

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.