### PR TITLE
Split tunnel follow up

### DIFF
--- a/android/java/org/chromium/chrome/browser/settings/BraveVpnPreferences.java
+++ b/android/java/org/chromium/chrome/browser/settings/BraveVpnPreferences.java
@@ -208,6 +208,12 @@ public class BraveVpnPreferences extends BravePreferenceFragment implements Brav
             BraveVpnUtils.showProgressDialog(
                     getActivity(), getResources().getString(R.string.vpn_connect_text));
             verifyPurchase(false);
+        } else if (BraveVpnUtils.mUpdateProfileAfterSplitTunnel) {
+            BraveVpnUtils.mUpdateProfileAfterSplitTunnel = false;
+            BraveVpnUtils.showProgressDialog(
+                    getActivity(), getResources().getString(R.string.updating_vpn_profile));
+            BraveVpnUtils.updateProfileConfiguration(getActivity());
+            new Handler().post(() -> updateSummaries());
         } else {
             BraveVpnUtils.dismissProgressDialog();
         }

--- a/android/java/org/chromium/chrome/browser/vpn/split_tunnel/SplitTunnelActivity.java
+++ b/android/java/org/chromium/chrome/browser/vpn/split_tunnel/SplitTunnelActivity.java
@@ -119,11 +119,7 @@ public class SplitTunnelActivity extends AsyncInitializationActivity
             if (mRecyclerViewAdapterExcludedApps != null) {
                 BraveVpnPrefUtils.setExcludedPackages(
                         mRecyclerViewAdapterExcludedApps.getApplicationPackages());
-                BraveVpnNativeWorker.getInstance().invalidateCredentials(
-                        BraveVpnPrefUtils.getHostname(), BraveVpnPrefUtils.getClientId(),
-                        BraveVpnPrefUtils.getSubscriberCredential(),
-                        BraveVpnPrefUtils.getApiAuthToken());
-                BraveVpnUtils.resetProfileConfiguration(SplitTunnelActivity.this);
+                BraveVpnUtils.mUpdateProfileAfterSplitTunnel = true;
                 finish();
                 return true;
             }

--- a/android/java/org/chromium/chrome/browser/vpn/utils/BraveVpnUtils.java
+++ b/android/java/org/chromium/chrome/browser/vpn/utils/BraveVpnUtils.java
@@ -17,6 +17,8 @@ import android.util.Pair;
 
 import androidx.fragment.app.FragmentActivity;
 
+import com.wireguard.config.Config;
+
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -49,6 +51,7 @@ public class BraveVpnUtils {
     public static final String VERIFY_CREDENTIALS_FAILED = "verify_credentials_failed";
 
     public static boolean mIsServerLocationChanged;
+    public static boolean mUpdateProfileAfterSplitTunnel;
     public static String selectedServerRegion;
     private static ProgressDialog mProgressDialog;
 
@@ -221,6 +224,21 @@ public class BraveVpnUtils {
         BraveVpnPrefUtils.setHostnameDisplay("");
         BraveVpnPrefUtils.setServerRegion(BraveVpnPrefUtils.PREF_BRAVE_VPN_AUTOMATIC);
         BraveVpnPrefUtils.setResetConfiguration(true);
+        dismissProgressDialog();
+    }
+
+    public static void updateProfileConfiguration(Activity activity) {
+        try {
+            Config existingConfig = WireguardConfigUtils.loadConfig(activity);
+            WireguardConfigUtils.deleteConfig(activity);
+            WireguardConfigUtils.createConfig(activity, existingConfig);
+        } catch (Exception ex) {
+            Log.e(TAG, "updateProfileConfiguration : " + ex.getMessage());
+        }
+        if (BraveVpnProfileUtils.getInstance().isBraveVPNConnected(activity)) {
+            BraveVpnProfileUtils.getInstance().stopVpn(activity);
+            BraveVpnProfileUtils.getInstance().startVpn(activity);
+        }
         dismissProgressDialog();
     }
 

--- a/android/java/org/chromium/chrome/browser/vpn/wireguard/WireguardConfigUtils.java
+++ b/android/java/org/chromium/chrome/browser/vpn/wireguard/WireguardConfigUtils.java
@@ -39,6 +39,21 @@ public class WireguardConfigUtils {
         return config;
     }
 
+    public static Config createConfig(Context context, Config existingConfig)
+            throws IOException, BadConfigException {
+        File file = fileForConfig(context);
+        if (!file.createNewFile()) {
+            throw new IOException("Configuration file already exists");
+        }
+        FileOutputStream fileOutputStream = new FileOutputStream(file, false);
+        Config config = new Config.Builder()
+                                .setInterface(getInterface(existingConfig.getInterface()))
+                                .addPeers(existingConfig.getPeers())
+                                .build();
+        fileOutputStream.write(config.toWgQuickString().getBytes(StandardCharsets.UTF_8));
+        return config;
+    }
+
     public static void deleteConfig(Context context) throws Exception {
         File file = fileForConfig(context);
         if (!file.delete()) {

--- a/android/java/org/chromium/chrome/browser/vpn/wireguard/WireguardUtils.java
+++ b/android/java/org/chromium/chrome/browser/vpn/wireguard/WireguardUtils.java
@@ -33,6 +33,16 @@ public class WireguardUtils {
         return builder.build();
     }
 
+    public static Interface getInterface(Interface existingInterface) throws BadConfigException {
+        Interface.Builder builder = new Interface.Builder();
+        builder.addAddresses(existingInterface.getAddresses());
+        builder.parseDnsServers("1.1.1.1, 1.0.0.1");
+        builder.parseListenPort("51821");
+        builder.parsePrivateKey(existingInterface.getKeyPair().getPrivateKey().toBase64());
+        builder.excludeApplications(BraveVpnPrefUtils.getExcludedPackages());
+        return builder.build();
+    }
+
     public static List<Peer> getPeers(String host, String serverPublicKey)
             throws BadConfigException {
         List<Peer> peers = new ArrayList<>();

--- a/android/java/res/layout/activity_split_tunnel.xml
+++ b/android/java/res/layout/activity_split_tunnel.xml
@@ -1,10 +1,18 @@
 <?xml version="1.0" encoding="utf-8"?>
-<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     tools:ignore="MergeRootFrame"
     android:layout_width="match_parent"
-    android:layout_height="match_parent">
+    android:layout_height="match_parent"
+    android:orientation="vertical">
+
+    <androidx.appcompat.widget.Toolbar
+        android:id="@+id/toolbar"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:theme="@style/BraveVpnToolbar"
+        android:minHeight="?attr/actionBarSize"/>
 
     <ProgressBar
         android:id="@+id/progressbar"
@@ -25,13 +33,6 @@
             android:layout_height="match_parent"
             android:orientation="vertical"
             tools:context=".SplitTunnelActivity">
-
-            <androidx.appcompat.widget.Toolbar
-                android:id="@+id/toolbar"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:theme="@style/BraveVpnToolbar"
-                android:minHeight="?attr/actionBarSize"/>
 
             <TextView
                 android:layout_width="match_parent"
@@ -100,4 +101,4 @@
 
     </androidx.core.widget.NestedScrollView>
 
-</FrameLayout>
+</LinearLayout>

--- a/android/java/res/layout/activity_split_tunnel.xml
+++ b/android/java/res/layout/activity_split_tunnel.xml
@@ -1,31 +1,40 @@
 <?xml version="1.0" encoding="utf-8"?>
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.constraintlayout.widget.ConstraintLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
-    tools:ignore="MergeRootFrame"
     android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    android:orientation="vertical">
+    android:layout_height="match_parent">
 
     <androidx.appcompat.widget.Toolbar
         android:id="@+id/toolbar"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:theme="@style/BraveVpnToolbar"
-        android:minHeight="?attr/actionBarSize"/>
+        android:minHeight="?attr/actionBarSize"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintRight_toRightOf="parent"
+        app:layout_constraintLeft_toLeftOf="parent"/>
 
     <ProgressBar
         android:id="@+id/progressbar"
         android:layout_width="50dp"
         android:layout_height="50dp"
         android:indeterminate="true"
-        android:layout_gravity="center"
+        app:layout_constraintLeft_toLeftOf="parent"
+        app:layout_constraintRight_toRightOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintBottom_toBottomOf="parent"
         android:visibility="gone" />
 
     <androidx.core.widget.NestedScrollView
         android:id="@+id/apps_layout"
-        android:layout_width="match_parent"
-        android:layout_height="match_parent"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        app:layout_constraintTop_toBottomOf="@+id/toolbar"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintLeft_toLeftOf="parent"
+        app:layout_constraintRight_toRightOf="parent"
         android:visibility="gone">
 
         <LinearLayout
@@ -101,4 +110,4 @@
 
     </androidx.core.widget.NestedScrollView>
 
-</LinearLayout>
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/browser/ui/android/strings/android_brave_strings.grd
+++ b/browser/ui/android/strings/android_brave_strings.grd
@@ -3095,6 +3095,9 @@ If you don't accept this request, VPN will not reconnect and your internet conne
     <message name="IDS_BRAVE_WALLET_CONFIRM_TRANSACTION_ACCOUNT_CREATION_FEE" desc="Confirm transaction panel account creation fee warning">
       The associated token account does not exist yet. A small amount of SOL will be spent to create and fund it. <ph name="CLICK_START">%1$s</ph>Learn more<ph name="CLICK_END">%2$s</ph>
     </message>
+    <message name="IDS_UPDATING_VPN_PROFILE" desc="Message to indicate profile is being update after split tunnel update.">
+      Updating VPN Profile ...
+    </message>
   </messages>
   </release>
 </grit>


### PR DESCRIPTION
<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/24576

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [x] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [x] New files have MPL-2.0 license header
- [x] Adequate test coverage exists to prevent regressions
- [x] Major classes, functions and non-trivial code blocks are well-commented
- [x] Changes in component dependencies are properly reflected in `gn`
- [x] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [x] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

General points for split tunnel :
1. `Split tunnel` should not be shown if user doesn't have any vpn profile.
2. if vpn is enabled and user tries to exclude the app and press `save`, VPN should be connected automatically with updated profile with out user interaction. 
3. if vpn is disabled and user tries to exclude the app and press `save`, profile should be updated in the background. When user tries to connect to the vpn, vpn should be connected with new profile. 

Plan :
Follow the same test plan from : https://github.com/brave/brave-browser/issues/24576