### PR TITLE
[CodeHealth] Clang tidy vendor/* with use-equals-default

### DIFF
--- a/vendor/bat-native-ledger/src/bat/ledger/internal/bitflyer/bitflyer_util_unittest.cc
+++ b/vendor/bat-native-ledger/src/bat/ledger/internal/bitflyer/bitflyer_util_unittest.cc
@@ -41,7 +41,7 @@ class BitflyerUtilTest : public testing::Test {
         std::make_unique<ledger::MockLedgerImpl>(mock_ledger_client_.get());
   }
 
-  ~BitflyerUtilTest() override {}
+  ~BitflyerUtilTest() override = default;
 };
 
 TEST_F(BitflyerUtilTest, GetClientId) {

--- a/vendor/bat-native-ledger/src/bat/ledger/internal/database/database_activity_info_unittest.cc
+++ b/vendor/bat-native-ledger/src/bat/ledger/internal/database/database_activity_info_unittest.cc
@@ -42,7 +42,7 @@ class DatabaseActivityInfoTest : public ::testing::Test {
         mock_ledger_impl_.get());
   }
 
-  ~DatabaseActivityInfoTest() override {}
+  ~DatabaseActivityInfoTest() override = default;
 
   void SetUp() override {
     ON_CALL(*mock_ledger_impl_, database())

--- a/vendor/bat-native-ledger/src/bat/ledger/internal/database/database_balance_report_info_unittest.cc
+++ b/vendor/bat-native-ledger/src/bat/ledger/internal/database/database_balance_report_info_unittest.cc
@@ -39,7 +39,7 @@ class DatabaseBalanceReportTest : public ::testing::Test {
         std::make_unique<DatabaseBalanceReport>(mock_ledger_impl_.get());
   }
 
-  ~DatabaseBalanceReportTest() override {}
+  ~DatabaseBalanceReportTest() override = default;
 };
 
 TEST_F(DatabaseBalanceReportTest, InsertOrUpdateOk) {

--- a/vendor/bat-native-ledger/src/bat/ledger/internal/database/database_publisher_prefix_list_unittest.cc
+++ b/vendor/bat-native-ledger/src/bat/ledger/internal/database/database_publisher_prefix_list_unittest.cc
@@ -42,7 +42,7 @@ class DatabasePublisherPrefixListTest : public ::testing::Test {
         mock_ledger_impl_.get());
   }
 
-  ~DatabasePublisherPrefixListTest() override {}
+  ~DatabasePublisherPrefixListTest() override = default;
 
   std::unique_ptr<publisher::PrefixListReader>
   CreateReader(uint32_t prefix_count) {

--- a/vendor/bat-native-ledger/src/bat/ledger/internal/gemini/gemini_util_unittest.cc
+++ b/vendor/bat-native-ledger/src/bat/ledger/internal/gemini/gemini_util_unittest.cc
@@ -39,7 +39,7 @@ class GeminiUtilTest : public testing::Test {
         std::make_unique<ledger::MockLedgerImpl>(mock_ledger_client_.get());
   }
 
-  ~GeminiUtilTest() override {}
+  ~GeminiUtilTest() override = default;
 };
 
 TEST_F(GeminiUtilTest, GetClientId) {

--- a/vendor/bat-native-ledger/src/bat/ledger/internal/legacy/media/github.cc
+++ b/vendor/bat-native-ledger/src/bat/ledger/internal/legacy/media/github.cc
@@ -27,8 +27,7 @@ namespace braveledger_media {
 GitHub::GitHub(ledger::LedgerImpl* ledger) : ledger_(ledger) {
 }
 
-GitHub::~GitHub() {
-}
+GitHub::~GitHub() = default;
 
 // static
 std::string GitHub::GetLinkType(const std::string& url) {

--- a/vendor/bat-native-ledger/src/bat/ledger/internal/legacy/media/media.cc
+++ b/vendor/bat-native-ledger/src/bat/ledger/internal/legacy/media/media.cc
@@ -41,7 +41,7 @@ Media::Media(ledger::LedgerImpl* ledger):
   media_github_(new braveledger_media::GitHub(ledger)) {
 }  // namespace braveledger_media
 
-Media::~Media() {}
+Media::~Media() = default;
 
 // static
 std::string Media::GetLinkType(

--- a/vendor/bat-native-ledger/src/bat/ledger/internal/legacy/media/reddit.cc
+++ b/vendor/bat-native-ledger/src/bat/ledger/internal/legacy/media/reddit.cc
@@ -27,8 +27,7 @@ namespace braveledger_media {
 Reddit::Reddit(ledger::LedgerImpl* ledger): ledger_(ledger) {
 }
 
-Reddit::~Reddit() {
-}
+Reddit::~Reddit() = default;
 
 void Reddit::ProcessActivityFromUrl(
     uint64_t window_id,

--- a/vendor/bat-native-ledger/src/bat/ledger/internal/legacy/media/twitch.cc
+++ b/vendor/bat-native-ledger/src/bat/ledger/internal/legacy/media/twitch.cc
@@ -37,8 +37,7 @@ Twitch::Twitch(ledger::LedgerImpl* ledger):
   ledger_(ledger) {
 }
 
-Twitch::~Twitch() {
-}
+Twitch::~Twitch() = default;
 
 // static
 std::pair<std::string, std::string> Twitch::GetMediaIdFromParts(

--- a/vendor/bat-native-ledger/src/bat/ledger/internal/legacy/media/vimeo.cc
+++ b/vendor/bat-native-ledger/src/bat/ledger/internal/legacy/media/vimeo.cc
@@ -28,8 +28,7 @@ Vimeo::Vimeo(ledger::LedgerImpl* ledger):
   ledger_(ledger) {
 }
 
-Vimeo::~Vimeo() {
-}
+Vimeo::~Vimeo() = default;
 
 // static
 std::string Vimeo::GetLinkType(const std::string& url) {

--- a/vendor/bat-native-ledger/src/bat/ledger/internal/legacy/media/youtube.cc
+++ b/vendor/bat-native-ledger/src/bat/ledger/internal/legacy/media/youtube.cc
@@ -25,8 +25,7 @@ YouTube::YouTube(ledger::LedgerImpl* ledger):
   ledger_(ledger) {
 }
 
-YouTube::~YouTube() {
-}
+YouTube::~YouTube() = default;
 
 // static
 std::string YouTube::GetMediaIdFromParts(

--- a/vendor/bat-native-ledger/src/bat/ledger/internal/uphold/uphold_util_unittest.cc
+++ b/vendor/bat-native-ledger/src/bat/ledger/internal/uphold/uphold_util_unittest.cc
@@ -41,7 +41,7 @@ class UpholdUtilTest : public testing::Test {
         std::make_unique<ledger::MockLedgerImpl>(mock_ledger_client_.get());
   }
 
-  ~UpholdUtilTest() override {}
+  ~UpholdUtilTest() override = default;
 };
 
 TEST_F(UpholdUtilTest, GetClientId) {

--- a/vendor/brave_base/random_unittest.cc
+++ b/vendor/brave_base/random_unittest.cc
@@ -12,11 +12,11 @@
 
 class BraveRandomDeterministicTest : public testing::Test {
  public:
-  BraveRandomDeterministicTest() {}
+  BraveRandomDeterministicTest() = default;
   BraveRandomDeterministicTest(const BraveRandomDeterministicTest&) = delete;
   BraveRandomDeterministicTest& operator=(const BraveRandomDeterministicTest&) =
       delete;
-  ~BraveRandomDeterministicTest() override {}
+  ~BraveRandomDeterministicTest() override = default;
 
  private:
 };


### PR DESCRIPTION
This change applies clang-tidy with modernize-use-equals-default to
files under vendor.

<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/24727

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [x] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [x] New files have MPL-2.0 license header
- [x] Adequate test coverage exists to prevent regressions
- [x] Major classes, functions and non-trivial code blocks are well-commented
- [x] Changes in component dependencies are properly reflected in `gn`
- [x] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [x] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

