### PR TITLE
[CodeHealth] Clang tidy browser with use-equals-default V

### DIFF
--- a/browser/renderer_context_menu/brave_mock_render_view_context_menu.cc
+++ b/browser/renderer_context_menu/brave_mock_render_view_context_menu.cc
@@ -29,7 +29,7 @@ BraveMockRenderViewContextMenu::MockMenuItem::MockMenuItem()
 BraveMockRenderViewContextMenu::MockMenuItem::MockMenuItem(
     const MockMenuItem& other) = default;
 
-BraveMockRenderViewContextMenu::MockMenuItem::~MockMenuItem() {}
+BraveMockRenderViewContextMenu::MockMenuItem::~MockMenuItem() = default;
 
 BraveMockRenderViewContextMenu::MockMenuItem&
 BraveMockRenderViewContextMenu::MockMenuItem::operator=(
@@ -64,7 +64,7 @@ void BraveMockRenderViewContextMenu::MockMenuItem::PrintMockMenuItem(
 BraveMockRenderViewContextMenu::BraveMockRenderViewContextMenu(Profile* profile)
     : observer_(nullptr), profile_(profile), enable_print_menu_(false) {}
 
-BraveMockRenderViewContextMenu::~BraveMockRenderViewContextMenu() {}
+BraveMockRenderViewContextMenu::~BraveMockRenderViewContextMenu() = default;
 
 // SimpleMenuModel::Delegate implementation.
 

--- a/browser/renderer_context_menu/brave_spelling_menu_observer_browsertest.cc
+++ b/browser/renderer_context_menu/brave_spelling_menu_observer_browsertest.cc
@@ -75,9 +75,9 @@ class BraveSpellingMenuObserverTest : public InProcessBrowserTest {
   std::unique_ptr<BraveMockRenderViewContextMenu> menu_;
 };
 
-BraveSpellingMenuObserverTest::BraveSpellingMenuObserverTest() {}
+BraveSpellingMenuObserverTest::BraveSpellingMenuObserverTest() = default;
 
-BraveSpellingMenuObserverTest::~BraveSpellingMenuObserverTest() {}
+BraveSpellingMenuObserverTest::~BraveSpellingMenuObserverTest() = default;
 
 }  // namespace
 

--- a/browser/search_engines/search_engine_provider_service_factory.cc
+++ b/browser/search_engines/search_engine_provider_service_factory.cc
@@ -54,7 +54,8 @@ SearchEngineProviderServiceFactory::SearchEngineProviderServiceFactory()
   DependsOn(TemplateURLServiceFactory::GetInstance());
 }
 
-SearchEngineProviderServiceFactory::~SearchEngineProviderServiceFactory() {}
+SearchEngineProviderServiceFactory::~SearchEngineProviderServiceFactory() =
+    default;
 
 KeyedService* SearchEngineProviderServiceFactory::BuildServiceInstanceFor(
     content::BrowserContext* context) const {

--- a/browser/search_engines/search_engine_tracker.cc
+++ b/browser/search_engines/search_engine_tracker.cc
@@ -101,7 +101,7 @@ SearchEngineTrackerFactory::SearchEngineTrackerFactory()
   DependsOn(TemplateURLServiceFactory::GetInstance());
 }
 
-SearchEngineTrackerFactory::~SearchEngineTrackerFactory() {}
+SearchEngineTrackerFactory::~SearchEngineTrackerFactory() = default;
 
 KeyedService* SearchEngineTrackerFactory::BuildServiceInstanceFor(
     content::BrowserContext* context) const {
@@ -152,7 +152,7 @@ SearchEngineTracker::SearchEngineTracker(
   }
 }
 
-SearchEngineTracker::~SearchEngineTracker() {}
+SearchEngineTracker::~SearchEngineTracker() = default;
 
 void SearchEngineTracker::OnTemplateURLServiceChanged() {
   const TemplateURL* template_url =

--- a/browser/speedreader/speedreader_browsertest.cc
+++ b/browser/speedreader/speedreader_browsertest.cc
@@ -64,7 +64,7 @@ class SpeedReaderBrowserTest : public InProcessBrowserTest {
   SpeedReaderBrowserTest(const SpeedReaderBrowserTest&) = delete;
   SpeedReaderBrowserTest& operator=(const SpeedReaderBrowserTest&) = delete;
 
-  ~SpeedReaderBrowserTest() override {}
+  ~SpeedReaderBrowserTest() override = default;
 
   void SetUpOnMainThread() override {
     host_resolver()->AddRule("*", "127.0.0.1");

--- a/browser/speedreader/speedreader_service_factory.cc
+++ b/browser/speedreader/speedreader_service_factory.cc
@@ -28,7 +28,7 @@ SpeedreaderServiceFactory::SpeedreaderServiceFactory()
           "SpeedreaderService",
           BrowserContextDependencyManager::GetInstance()) {}
 
-SpeedreaderServiceFactory::~SpeedreaderServiceFactory() {}
+SpeedreaderServiceFactory::~SpeedreaderServiceFactory() = default;
 
 content::BrowserContext*
 SpeedreaderServiceFactory::GetBrowserContextToUse(

--- a/browser/sync/brave_sync_client_unittest.cc
+++ b/browser/sync/brave_sync_client_unittest.cc
@@ -56,8 +56,8 @@ namespace browser_sync {
 
 class BraveSyncClientTest : public testing::Test {
  public:
-  BraveSyncClientTest() {}
-  ~BraveSyncClientTest() override {}
+  BraveSyncClientTest() = default;
+  ~BraveSyncClientTest() override = default;
 
  protected:
   void SetUp() override {

--- a/browser/sync/brave_sync_service_impl_delegate.cc
+++ b/browser/sync/brave_sync_service_impl_delegate.cc
@@ -33,7 +33,7 @@ BraveSyncServiceImplDelegate::BraveSyncServiceImplDelegate(
   device_info_observer_.Observe(device_info_tracker_);
 }
 
-BraveSyncServiceImplDelegate::~BraveSyncServiceImplDelegate() {}
+BraveSyncServiceImplDelegate::~BraveSyncServiceImplDelegate() = default;
 
 void BraveSyncServiceImplDelegate::OnDeviceInfoChange() {
   DCHECK(sync_service_impl_);

--- a/browser/test/disabled_features/disable_client_hints_browsertest.cc
+++ b/browser/test/disabled_features/disable_client_hints_browsertest.cc
@@ -82,7 +82,7 @@ class ClientHintsBrowserTest : public InProcessBrowserTest,
 
   ClientHintsBrowserTest& operator=(const ClientHintsBrowserTest&) = delete;
 
-  ~ClientHintsBrowserTest() override {}
+  ~ClientHintsBrowserTest() override = default;
 
   bool IsClientHintHeaderEnabled() { return GetParam(); }
 

--- a/browser/test/disabled_features/window_name_browsertest.cc
+++ b/browser/test/disabled_features/window_name_browsertest.cc
@@ -43,7 +43,7 @@ class BraveWindowNameBrowserTest : public InProcessBrowserTest {
   BraveWindowNameBrowserTest& operator=(const BraveWindowNameBrowserTest&) =
       delete;
 
-  ~BraveWindowNameBrowserTest() override {}
+  ~BraveWindowNameBrowserTest() override = default;
 
   void SetUpOnMainThread() override {
     InProcessBrowserTest::SetUpOnMainThread();

--- a/browser/themes/brave_theme_service_browsertest.cc
+++ b/browser/themes/brave_theme_service_browsertest.cc
@@ -38,8 +38,8 @@ namespace {
 
 class TestNativeThemeObserver : public ui::NativeThemeObserver {
  public:
-  TestNativeThemeObserver() {}
-  ~TestNativeThemeObserver() override {}
+  TestNativeThemeObserver() = default;
+  ~TestNativeThemeObserver() override = default;
 
   MOCK_METHOD1(OnNativeThemeUpdated, void(ui::NativeTheme*));
 };

--- a/browser/webcompat_reporter/webcompat_reporter_dialog.cc
+++ b/browser/webcompat_reporter/webcompat_reporter_dialog.cc
@@ -57,7 +57,7 @@ WebcompatReporterDialogDelegate::WebcompatReporterDialogDelegate(
     base::Value::Dict params)
     : params_(std::move(params)) {}
 
-WebcompatReporterDialogDelegate::~WebcompatReporterDialogDelegate() {}
+WebcompatReporterDialogDelegate::~WebcompatReporterDialogDelegate() = default;
 
 ui::ModalType WebcompatReporterDialogDelegate::GetDialogModalType() const {
   // Not used, returning dummy value.

--- a/chromium_src/components/autofill/core/browser/autofill_experiments_unittest.cc
+++ b/chromium_src/components/autofill/core/browser/autofill_experiments_unittest.cc
@@ -19,7 +19,7 @@ namespace autofill {
 
 class AutofillExperimentsTest : public testing::Test {
  public:
-  AutofillExperimentsTest() {}
+  AutofillExperimentsTest() = default;
 
  protected:
   void SetUp() override {

--- a/common/brave_channel_info_posix.h
+++ b/common/brave_channel_info_posix.h
@@ -1,9 +1,12 @@
-/* This Source Code Form is subject to the terms of the Mozilla Public
+/* Copyright (c) 2022 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 #ifndef BRAVE_COMMON_BRAVE_CHANNEL_INFO_POSIX_H_
 #define BRAVE_COMMON_BRAVE_CHANNEL_INFO_POSIX_H_
+
+#include <string>
 
 #include "components/version_info/version_info.h"
 

--- a/common/brave_content_client.cc
+++ b/common/brave_content_client.cc
@@ -59,9 +59,9 @@ void CreateDefaultWidevineCdmHintFile() {
 
 }  // namespace
 
-BraveContentClient::BraveContentClient() {}
+BraveContentClient::BraveContentClient() = default;
 
-BraveContentClient::~BraveContentClient() {}
+BraveContentClient::~BraveContentClient() = default;
 
 base::RefCountedMemory* BraveContentClient::GetDataResourceBytes(
     int resource_id) {

--- a/common/extensions/brave_extensions_api_provider.cc
+++ b/common/extensions/brave_extensions_api_provider.cc
@@ -1,4 +1,5 @@
-/* This Source Code Form is subject to the terms of the Mozilla Public
+/* Copyright (c) 2022 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
@@ -10,7 +11,7 @@
 
 namespace extensions {
 
-BraveExtensionsAPIProvider::BraveExtensionsAPIProvider() {}
+BraveExtensionsAPIProvider::BraveExtensionsAPIProvider() = default;
 BraveExtensionsAPIProvider::~BraveExtensionsAPIProvider() = default;
 
 void BraveExtensionsAPIProvider::AddAPIFeatures(FeatureProvider* provider) {

--- a/content/browser/webui/brave_shared_resources_data_source.cc
+++ b/content/browser/webui/brave_shared_resources_data_source.cc
@@ -76,7 +76,7 @@ BraveSharedResourcesDataSource::BraveSharedResourcesDataSource(
     bool is_untrusted)
     : is_untrusted_(is_untrusted) {}
 
-BraveSharedResourcesDataSource::~BraveSharedResourcesDataSource() {}
+BraveSharedResourcesDataSource::~BraveSharedResourcesDataSource() = default;
 
 std::string BraveSharedResourcesDataSource::GetSource() {
   if (is_untrusted_) {

--- a/net/proxy_resolution/proxy_config_service_tor.cc
+++ b/net/proxy_resolution/proxy_config_service_tor.cc
@@ -103,13 +103,13 @@ const int kTorPasswordLength = 16;
 // Default tor circuit life time is 10 minutes
 constexpr base::TimeDelta kTenMins = base::Minutes(10);
 
-ProxyConfigServiceTor::ProxyConfigServiceTor() {}
+ProxyConfigServiceTor::ProxyConfigServiceTor() = default;
 
 ProxyConfigServiceTor::ProxyConfigServiceTor(const std::string& proxy_uri) {
   UpdateProxyURI(proxy_uri);
 }
 
-ProxyConfigServiceTor::~ProxyConfigServiceTor() {}
+ProxyConfigServiceTor::~ProxyConfigServiceTor() = default;
 
 void ProxyConfigServiceTor::UpdateProxyURI(const std::string& uri) {
   ProxyServer proxy_server =

--- a/net/proxy_resolution/proxy_config_service_tor_unittest.cc
+++ b/net/proxy_resolution/proxy_config_service_tor_unittest.cc
@@ -21,11 +21,11 @@ namespace net {
 
 class ProxyConfigServiceTorTest : public TestWithTaskEnvironment {
  public:
-  ProxyConfigServiceTorTest() {}
+  ProxyConfigServiceTorTest() = default;
   ProxyConfigServiceTorTest(const ProxyConfigServiceTorTest&) = delete;
   ProxyConfigServiceTorTest& operator=(const ProxyConfigServiceTorTest&) =
       delete;
-  ~ProxyConfigServiceTorTest() override {}
+  ~ProxyConfigServiceTorTest() override = default;
 
  private:
 };

--- a/renderer/brave_render_thread_observer.cc
+++ b/renderer/brave_render_thread_observer.cc
@@ -20,9 +20,9 @@ brave::mojom::DynamicParams* GetDynamicConfigParams() {
 
 }  // namespace
 
-BraveRenderThreadObserver::BraveRenderThreadObserver() {}
+BraveRenderThreadObserver::BraveRenderThreadObserver() = default;
 
-BraveRenderThreadObserver::~BraveRenderThreadObserver() {}
+BraveRenderThreadObserver::~BraveRenderThreadObserver() = default;
 
 // static
 const brave::mojom::DynamicParams&

--- a/renderer/brave_url_loader_throttle_provider.cc
+++ b/renderer/brave_url_loader_throttle_provider.cc
@@ -24,9 +24,9 @@ BraveURLLoaderThrottleProvider::BraveURLLoaderThrottleProvider(
               type,
               chrome_content_renderer_client)) {}
 
-BraveURLLoaderThrottleProvider::~BraveURLLoaderThrottleProvider() {}
+BraveURLLoaderThrottleProvider::~BraveURLLoaderThrottleProvider() = default;
 
-BraveURLLoaderThrottleProvider::BraveURLLoaderThrottleProvider() {}
+BraveURLLoaderThrottleProvider::BraveURLLoaderThrottleProvider() = default;
 
 std::unique_ptr<blink::URLLoaderThrottleProvider>
 BraveURLLoaderThrottleProvider::Clone() {

--- a/renderer/brave_wallet/brave_wallet_render_frame_observer.cc
+++ b/renderer/brave_wallet/brave_wallet_render_frame_observer.cc
@@ -23,7 +23,7 @@ BraveWalletRenderFrameObserver::BraveWalletRenderFrameObserver(
     : RenderFrameObserver(render_frame),
       get_dynamic_params_callback_(std::move(get_dynamic_params_callback)) {}
 
-BraveWalletRenderFrameObserver::~BraveWalletRenderFrameObserver() {}
+BraveWalletRenderFrameObserver::~BraveWalletRenderFrameObserver() = default;
 
 void BraveWalletRenderFrameObserver::DidStartNavigation(
     const GURL& url,

--- a/services/network/public/cpp/system_request_handler.cc
+++ b/services/network/public/cpp/system_request_handler.cc
@@ -25,8 +25,8 @@ network::ResourceRequest SystemRequestHandler::OnBeforeSystemRequest(
   return on_before_system_request_callback_.Run(url_request);
 }
 
-SystemRequestHandler::SystemRequestHandler() {}
+SystemRequestHandler::SystemRequestHandler() = default;
 
-SystemRequestHandler::~SystemRequestHandler() {}
+SystemRequestHandler::~SystemRequestHandler() = default;
 
 }  // namespace network

--- a/test/base/testing_brave_browser_process.cc
+++ b/test/base/testing_brave_browser_process.cc
@@ -38,9 +38,9 @@ void TestingBraveBrowserProcess::DeleteInstance() {
   delete browser_process;
 }
 
-TestingBraveBrowserProcess::TestingBraveBrowserProcess() {}
+TestingBraveBrowserProcess::TestingBraveBrowserProcess() = default;
 
-TestingBraveBrowserProcess::~TestingBraveBrowserProcess() {}
+TestingBraveBrowserProcess::~TestingBraveBrowserProcess() = default;
 
 void TestingBraveBrowserProcess::StartBraveServices() {}
 

--- a/utility/importer/chrome_importer.cc
+++ b/utility/importer/chrome_importer.cc
@@ -171,9 +171,9 @@ bool PasswordFormToImportedPasswordForm(
 
 }  // namespace
 
-ChromeImporter::ChromeImporter() {}
+ChromeImporter::ChromeImporter() = default;
 
-ChromeImporter::~ChromeImporter() {}
+ChromeImporter::~ChromeImporter() = default;
 
 void ChromeImporter::StartImport(const importer::SourceProfile& source_profile,
                                  uint16_t items,


### PR DESCRIPTION
This change corrects the constructors of several classes under
browser/, using clang-tidy's modernize-use-equals-default. Additionally,
this commit includes a few additional straggler files.

<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/24738

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [x] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [x] New files have MPL-2.0 license header
- [x] Adequate test coverage exists to prevent regressions
- [x] Major classes, functions and non-trivial code blocks are well-commented
- [x] Changes in component dependencies are properly reflected in `gn`
- [x] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [x] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

