### PR TITLE
Add Keep in dock option to first run dialog and settings

### DIFF
--- a/app/BUILD.gn
+++ b/app/BUILD.gn
@@ -1,3 +1,4 @@
+import("//brave/browser/shell_integrations/buildflags/buildflags.gni")
 import("//brave/components/brave_vpn/buildflags/buildflags.gni")
 import("//brave/components/sidebar/buildflags/buildflags.gni")
 import("//brave/components/speedreader/common/buildflags.gni")
@@ -14,6 +15,7 @@ brave_grit("brave_generated_resources_grit") {
     "enable_sidebar=$enable_sidebar",
     "enable_speedreader=$enable_speedreader",
     "enable_brave_vpn=$enable_brave_vpn",
+    "enable_pin_shortcut=$enable_pin_shortcut",
   ]
   source = "brave_generated_resources.grd"
   output_dir = "$root_gen_dir/brave"

--- a/app/brave_generated_resources.grd
+++ b/app/brave_generated_resources.grd
@@ -939,9 +939,16 @@ Or change later at <ph name="SETTINGS_EXTENIONS_LINK">$2<ex>brave://settings/ext
       </message>
 
       <if expr="enable_pin_shortcut">
-        <message name="IDS_FIRSTRUN_DLG_PIN_SHORTCUT_TEXT" desc="Text for pin to taskbar checkbox">
-          Pin to taskbar
-        </message>
+        <if expr="is_win">
+          <message name="IDS_FIRSTRUN_DLG_PIN_SHORTCUT_TEXT" desc="Text for pin to taskbar checkbox">
+            Pin to taskbar
+          </message>
+        </if>
+        <if expr="is_macosx">
+          <message name="IDS_FIRSTRUN_DLG_PIN_SHORTCUT_TEXT" desc="Text for pin to taskbar checkbox">
+            Keep in Dock
+          </message>
+        </if>
       </if>
 
       <!-- Importer -->

--- a/app/brave_generated_resources.grd
+++ b/app/brave_generated_resources.grd
@@ -938,11 +938,12 @@ Or change later at <ph name="SETTINGS_EXTENIONS_LINK">$2<ex>brave://settings/ext
         Maybe later
       </message>
 
-      <if expr="is_win">
+      <if expr="enable_pin_shortcut">
         <message name="IDS_FIRSTRUN_DLG_PIN_SHORTCUT_TEXT" desc="Text for pin to taskbar checkbox">
           Pin to taskbar
         </message>
       </if>
+
       <!-- Importer -->
       <message name="IDS_BRAVE_IMPORT_FROM_EDGE" desc="browser combo box: Microsoft Edge Legacy">
         Microsoft Edge Legacy

--- a/app/brave_settings_strings.grdp
+++ b/app/brave_settings_strings.grdp
@@ -141,7 +141,7 @@
   </message>
 
   <!-- Settings / Pin shortcut-->
-  <if expr="is_win">
+  <if expr="enable_pin_shortcut">
     <message name="IDS_SETTINGS_CAN_PIN_SHORTCUT">
       Pin to taskbar
     </message>

--- a/app/brave_settings_strings.grdp
+++ b/app/brave_settings_strings.grdp
@@ -142,15 +142,28 @@
 
   <!-- Settings / Pin shortcut-->
   <if expr="enable_pin_shortcut">
-    <message name="IDS_SETTINGS_CAN_PIN_SHORTCUT">
-      Pin to taskbar
-    </message>
-    <message name="IDS_SETTINGS_PIN_SHORTCUT">
-      Pin
-    </message>
-    <message name="IDS_SETTINGS_SHORTCUT_PINNED">
-      Brave is already pinned
-    </message>
+    <if expr="is_win">
+      <message name="IDS_SETTINGS_CAN_PIN_SHORTCUT" desc="The label for pin to taskbar settings">
+        Pin to taskbar
+      </message>
+      <message name="IDS_SETTINGS_PIN_SHORTCUT" desc="The label for pin to taskbar button">
+        Pin
+      </message>
+      <message name="IDS_SETTINGS_SHORTCUT_PINNED" desc="The label for pinned state description">
+        Brave is already pinned
+      </message>
+    </if>
+    <if expr="is_macosx">
+      <message name="IDS_SETTINGS_CAN_PIN_SHORTCUT" desc="The label for keep in dock settings">
+        Keep in Dock
+      </message>
+      <message name="IDS_SETTINGS_PIN_SHORTCUT" desc="The label for dock button">
+        Dock
+      </message>
+      <message name="IDS_SETTINGS_SHORTCUT_PINNED" desc="The label for docked state description">
+        Brave is already in Dock
+      </message>
+    </if>
   </if>
 
   <!-- Settings / Shields -->

--- a/browser/brave_shell_integration.cc
+++ b/browser/brave_shell_integration.cc
@@ -11,11 +11,38 @@
 
 #include <utility>
 
+#include "brave/browser/brave_shell_integration_win.h"
 #include "brave/browser/default_protocol_handler_utils_win.h"
 #include "chrome/installer/util/shell_util.h"
 #endif
 
+#if BUILDFLAG(IS_MAC)
+#include "brave/browser/brave_shell_integration_mac.h"
+#endif
+
 namespace shell_integration {
+
+void PinShortcut(Profile* profile,
+                 base::OnceCallback<void(bool)> result_callback) {
+#if BUILDFLAG(IS_WIN)
+  win::PinToTaskbar(profile, std::move(result_callback));
+#elif BUILDFLAG(IS_MAC)
+  // Mac doesn't support profile specific icon in dock.
+  mac::AddIconToDock(std::move(result_callback));
+#elif BUILDFLAG(IS_LINUX)
+  NOTREACHED() << "Not supported on linux yet.";
+#endif
+}
+
+void IsShortcutPinned(base::OnceCallback<void(bool)> result_callback) {
+#if BUILDFLAG(IS_WIN)
+  win::IsShortcutPinned(std::move(result_callback));
+#elif BUILDFLAG(IS_MAC)
+  mac::IsIconAddedToDock(std::move(result_callback));
+#elif BUILDFLAG(IS_LINUX)
+  NOTREACHED() << "Not supported on linux yet.";
+#endif
+}
 
 BraveDefaultBrowserWorker::BraveDefaultBrowserWorker() = default;
 BraveDefaultBrowserWorker::~BraveDefaultBrowserWorker() = default;

--- a/browser/brave_shell_integration.h
+++ b/browser/brave_shell_integration.h
@@ -6,9 +6,19 @@
 #ifndef BRAVE_BROWSER_BRAVE_SHELL_INTEGRATION_H_
 #define BRAVE_BROWSER_BRAVE_SHELL_INTEGRATION_H_
 
+#include "base/callback.h"
+#include "base/callback_helpers.h"
 #include "chrome/browser/shell_integration.h"
 
+class Profile;
+
 namespace shell_integration {
+
+void PinShortcut(
+    Profile* profile = nullptr,
+    base::OnceCallback<void(bool)> result_callback = base::DoNothing());
+void IsShortcutPinned(
+    base::OnceCallback<void(bool)> result_callback = base::DoNothing());
 
 class BraveDefaultBrowserWorker : public DefaultBrowserWorker {
  public:

--- a/browser/brave_shell_integration_mac.h
+++ b/browser/brave_shell_integration_mac.h
@@ -1,0 +1,20 @@
+/* Copyright (c) 2022 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_BROWSER_BRAVE_SHELL_INTEGRATION_MAC_H_
+#define BRAVE_BROWSER_BRAVE_SHELL_INTEGRATION_MAC_H_
+
+#include "base/callback.h"
+#include "base/callback_helpers.h"
+
+namespace shell_integration::mac {
+
+// No-op if already added.
+void AddIconToDock(
+    base::OnceCallback<void(bool)> result_callback = base::DoNothing());
+void IsIconAddedToDock(base::OnceCallback<void(bool)> result_callback);
+}  // namespace shell_integration::mac
+
+#endif  // BRAVE_BROWSER_BRAVE_SHELL_INTEGRATION_MAC_H_

--- a/browser/brave_shell_integration_mac.mm
+++ b/browser/brave_shell_integration_mac.mm
@@ -1,0 +1,25 @@
+/* Copyright (c) 2022 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "brave/browser/brave_shell_integration_mac.h"
+
+#include "base/mac/bundle_locations.h"
+#include "chrome/browser/mac/dock.h"
+
+namespace shell_integration::mac {
+
+void AddIconToDock(base::OnceCallback<void(bool)> result_callback) {
+  dock::AddIcon([base::mac::MainBundle() bundlePath], nullptr);
+
+  std::move(result_callback)
+      .Run(dock::ChromeIsInTheDock() == dock::ChromeInDockTrue);
+}
+
+void IsIconAddedToDock(base::OnceCallback<void(bool)> result_callback) {
+  std::move(result_callback)
+      .Run(dock::ChromeIsInTheDock() == dock::ChromeInDockTrue);
+}
+
+}  // namespace shell_integration::mac

--- a/browser/resources/settings/BUILD.gn
+++ b/browser/resources/settings/BUILD.gn
@@ -4,6 +4,7 @@
 # you can obtain one at http://mozilla.org/MPL/2.0/.
 
 import("//brave/browser/resources/settings/sources.gni")
+import("//brave/browser/shell_integrations/buildflags/buildflags.gni")
 import("//brave/build/config.gni")
 import("//brave/components/brave_vpn/buildflags/buildflags.gni")
 import("//brave/components/brave_wayback_machine/buildflags/buildflags.gni")
@@ -70,6 +71,7 @@ preprocess_if_expr("preprocess") {
     "enable_brave_wayback_machine=$enable_brave_wayback_machine",
     "enable_brave_vpn=$enable_brave_vpn",
     "enable_extensions=$enable_extensions",
+    "enable_pin_shortcut=$enable_pin_shortcut",
   ]
   in_folder = "./"
   out_folder =

--- a/browser/resources/settings/getting_started_page/getting_started.html
+++ b/browser/resources/settings/getting_started_page/getting_started.html
@@ -6,7 +6,7 @@
 <settings-animated-pages id="pages" section="getStarted">
   <div route-path="default">
     <settings-default-browser-page></settings-default-browser-page>
-<if expr="is_win">
+<if expr="enable_pin_shortcut">
     <settings-pin-shortcut-page></settings-pin-shortcut-page>
 </if>
     <div class="settings-box">$i18n{onStartup}</div>

--- a/browser/resources/settings/getting_started_page/getting_started.ts
+++ b/browser/resources/settings/getting_started_page/getting_started.ts
@@ -11,7 +11,7 @@ import '../default_browser_page/default_browser_page.js'
 import '../on_startup_page/on_startup_page.js'
 import {getTemplate} from './getting_started.html.js'
 
-// <if expr="is_win">
+// <if expr="enable_pin_shortcut">
 import '../pin_shortcut_page/pin_shortcut_page.js'
 // </if>
 

--- a/browser/resources/settings/pin_shortcut_page/pin_shortcut_page.html
+++ b/browser/resources/settings/pin_shortcut_page/pin_shortcut_page.html
@@ -3,7 +3,7 @@ This Source Code Form is subject to the terms of the Mozilla Public
 License, v. 2.0. If a copy of the MPL was not distributed with this file,
 You can obtain one at http://mozilla.org/MPL/2.0/. -->
 
-<if expr="is_win">
+<if expr="enable_pin_shortcut">
 <style include="cr-shared-style settings-shared iron-flex">
 </style>
 <template is="dom-if" if="[[!pinned_]]">

--- a/browser/resources/settings/settings.gni
+++ b/browser/resources/settings/settings.gni
@@ -1,3 +1,4 @@
+import("//brave/browser/shell_integrations/buildflags/buildflags.gni")
 import("//chrome/browser/resources/settings/settings.gni")
 
 settings_namespace_rewrites = [
@@ -15,7 +16,7 @@ settings_namespace_rewrites = [
   "settings.Router|Router",
 ]
 
-if (is_win) {
+if (enable_pin_shortcut) {
   settings_namespace_rewrites += [
     "settings.PinShortcutPageBrowserProxyImpl|PinShortcutPageBrowserProxyImpl",
   ]

--- a/browser/resources/settings/sources.gni
+++ b/browser/resources/settings/sources.gni
@@ -3,6 +3,8 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this file,
 # you can obtain one at http://mozilla.org/MPL/2.0/.
 
+import("//brave/browser/shell_integrations/buildflags/buildflags.gni")
+
 # Provide our file list to chromium's settings page build
 # Since our components start in a different path, we'll do the first step (move them to
 # the generated preprocessed path via preprocess_if_expr, but let chromium handle the rest of the
@@ -44,7 +46,6 @@ brave_settings_web_component_files = [
   "default_brave_shields_page/components/brave_adblock_subscribe_dropdown.ts",
   "default_brave_shields_page/components/brave_adblock_editor.ts",
   "getting_started_page/getting_started.ts",
-  "pin_shortcut_page/pin_shortcut_page.ts",
   "social_blocking_page/social_blocking_page.ts",
 ]
 brave_settings_non_web_component_files = [
@@ -91,9 +92,16 @@ brave_settings_non_web_component_files = [
   "brave_wallet_page/brave_wallet_browser_proxy.ts",
   "default_brave_shields_page/brave_adblock_browser_proxy.ts",
   "default_brave_shields_page/default_brave_shields_browser_proxy.ts",
-  "pin_shortcut_page/pin_shortcut_page_browser_proxy.ts",
   "brave_routes.ts",
 ]
+
+if (enable_pin_shortcut) {
+  brave_settings_web_component_files +=
+      [ "pin_shortcut_page/pin_shortcut_page.ts" ]
+  brave_settings_non_web_component_files +=
+      [ "pin_shortcut_page/pin_shortcut_page_browser_proxy.ts" ]
+}
+
 brave_settings_icons_html_files = [ "brave_icons.html" ]
 brave_settings_ts_definitions = [
   "//brave/components/definitions/chrome_brave_theme.d.ts",

--- a/browser/shell_integrations/buildflags/BUILD.gn
+++ b/browser/shell_integrations/buildflags/BUILD.gn
@@ -1,0 +1,12 @@
+# Copyright (c) 2022 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import("//build/buildflag_header.gni")
+import("buildflags.gni")
+
+buildflag_header("buildflags") {
+  header = "buildflags.h"
+  flags = [ "ENABLE_PIN_SHORTCUT=$enable_pin_shortcut" ]
+}

--- a/browser/shell_integrations/buildflags/buildflags.gni
+++ b/browser/shell_integrations/buildflags/buildflags.gni
@@ -1,0 +1,6 @@
+# Copyright (c) 2022 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at http://mozilla.org/MPL/2.0/.
+
+enable_pin_shortcut = is_win

--- a/browser/shell_integrations/buildflags/buildflags.gni
+++ b/browser/shell_integrations/buildflags/buildflags.gni
@@ -3,4 +3,4 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this file,
 # You can obtain one at http://mozilla.org/MPL/2.0/.
 
-enable_pin_shortcut = is_win
+enable_pin_shortcut = is_win || is_mac

--- a/browser/sources.gni
+++ b/browser/sources.gni
@@ -220,6 +220,8 @@ if (is_mac) {
   brave_chrome_browser_sources += [
     "//brave/browser/brave_browser_main_parts_mac.h",
     "//brave/browser/brave_browser_main_parts_mac.mm",
+    "//brave/browser/brave_shell_integration_mac.h",
+    "//brave/browser/brave_shell_integration_mac.mm",
   ]
 }
 

--- a/browser/ui/BUILD.gn
+++ b/browser/ui/BUILD.gn
@@ -1,4 +1,5 @@
 import("//brave/browser/ethereum_remote_client/buildflags/buildflags.gni")
+import("//brave/browser/shell_integrations/buildflags/buildflags.gni")
 import("//brave/build/config.gni")
 import("//brave/components/brave_vpn/buildflags/buildflags.gni")
 import("//brave/components/brave_wayback_machine/buildflags/buildflags.gni")
@@ -159,7 +160,7 @@ source_set("ui") {
       "webui/speedreader/speedreader_panel_ui.h",
     ]
 
-    if (is_win) {
+    if (enable_pin_shortcut) {
       sources += [
         "webui/settings/pin_shortcut_handler.cc",
         "webui/settings/pin_shortcut_handler.h",
@@ -331,6 +332,7 @@ source_set("ui") {
     # //chrome/browser/ui depends on //brave/browser/ui, add this target here
     # to pull in dependencies needed for the overwrite codes in chromium_src.
     "//brave/browser/resources/federated_internals:resources",
+    "//brave/browser/shell_integrations/buildflags",
     "//brave/browser/ui/brave_ads",
     "//brave/browser/ui/brave_tooltips",
     "//brave/browser/ui/webui/brave_federated:mojo_bindings",

--- a/browser/ui/views/brave_first_run_dialog.cc
+++ b/browser/ui/views/brave_first_run_dialog.cc
@@ -26,10 +26,7 @@
 #include "ui/views/window/dialog_delegate.h"
 
 #if BUILDFLAG(ENABLE_PIN_SHORTCUT)
-#if BUILDFLAG(IS_WIN)
 #include "brave/browser/brave_shell_integration.h"
-#include "brave/browser/brave_shell_integration_win.h"
-#endif
 #else  // BUILDFLAG(ENABLE_PIN_SHORTCUT)
 #include "chrome/browser/shell_integration.h"
 #endif
@@ -166,7 +163,6 @@ bool BraveFirstRunDialog::Accept() {
   GetWidget()->Hide();
 
 #if BUILDFLAG(ENABLE_PIN_SHORTCUT)
-#if BUILDFLAG(IS_WIN)
   base::MakeRefCounted<shell_integration::BraveDefaultBrowserWorker>()
       ->StartSetAsDefault(base::BindOnce(
           [](bool pin_to_shortcut,
@@ -174,11 +170,10 @@ bool BraveFirstRunDialog::Accept() {
             if (pin_to_shortcut &&
                 state == shell_integration::DefaultWebClientState::IS_DEFAULT) {
               // Try to pin to taskbar when Brave is set as a default browser.
-              shell_integration::win::PinToTaskbar();
+              shell_integration::PinShortcut();
             }
           },
           pin_shortcut_checkbox_->GetChecked()));
-#endif
 #else
   shell_integration::SetAsDefaultBrowser();
 #endif

--- a/browser/ui/views/brave_first_run_dialog.cc
+++ b/browser/ui/views/brave_first_run_dialog.cc
@@ -25,10 +25,12 @@
 #include "ui/views/layout/box_layout.h"
 #include "ui/views/window/dialog_delegate.h"
 
+#if BUILDFLAG(ENABLE_PIN_SHORTCUT)
 #if BUILDFLAG(IS_WIN)
 #include "brave/browser/brave_shell_integration.h"
 #include "brave/browser/brave_shell_integration_win.h"
-#else
+#endif
+#else  // BUILDFLAG(ENABLE_PIN_SHORTCUT)
 #include "chrome/browser/shell_integration.h"
 #endif
 
@@ -40,7 +42,7 @@ void ShowBraveFirstRunDialogViews(Profile* profile) {
   run_loop.Run();
 }
 
-#if BUILDFLAG(IS_WIN)
+#if BUILDFLAG(ENABLE_PIN_SHORTCUT)
 class PinShortcutCheckbox : public views::Checkbox {
  public:
   METADATA_HEADER(PinShortcutCheckbox);
@@ -133,7 +135,7 @@ BraveFirstRunDialog::BraveFirstRunDialog(base::RepeatingClosure quit_runloop)
   constexpr int kMaxWidth = 350;
   contents_label->SetMaximumWidth(kMaxWidth);
 
-#if BUILDFLAG(IS_WIN)
+#if BUILDFLAG(ENABLE_PIN_SHORTCUT)
   pin_shortcut_checkbox_ =
       AddChildView(std::make_unique<PinShortcutCheckbox>());
 #endif
@@ -143,7 +145,7 @@ BraveFirstRunDialog::BraveFirstRunDialog(base::RepeatingClosure quit_runloop)
   constexpr int kTopPadding = 20;
   int kBottomPadding = 55;
 
-#if BUILDFLAG(IS_WIN)
+#if BUILDFLAG(ENABLE_PIN_SHORTCUT)
   kBottomPadding -= pin_shortcut_checkbox_->GetPreferredSize().height();
 #endif
 
@@ -163,6 +165,7 @@ void BraveFirstRunDialog::Done() {
 bool BraveFirstRunDialog::Accept() {
   GetWidget()->Hide();
 
+#if BUILDFLAG(ENABLE_PIN_SHORTCUT)
 #if BUILDFLAG(IS_WIN)
   base::MakeRefCounted<shell_integration::BraveDefaultBrowserWorker>()
       ->StartSetAsDefault(base::BindOnce(
@@ -175,6 +178,7 @@ bool BraveFirstRunDialog::Accept() {
             }
           },
           pin_shortcut_checkbox_->GetChecked()));
+#endif
 #else
   shell_integration::SetAsDefaultBrowser();
 #endif

--- a/browser/ui/views/brave_first_run_dialog.h
+++ b/browser/ui/views/brave_first_run_dialog.h
@@ -8,7 +8,7 @@
 
 #include "base/callback.h"
 #include "base/memory/raw_ptr.h"
-#include "build/build_config.h"
+#include "brave/browser/shell_integrations/buildflags/buildflags.h"
 #include "ui/base/metadata/metadata_header_macros.h"
 #include "ui/views/window/dialog_delegate.h"
 
@@ -40,7 +40,7 @@ class BraveFirstRunDialog : public views::DialogDelegateView {
 
   base::RepeatingClosure quit_runloop_;
 
-#if BUILDFLAG(IS_WIN)
+#if BUILDFLAG(ENABLE_PIN_SHORTCUT)
   raw_ptr<views::Checkbox> pin_shortcut_checkbox_ = nullptr;
 #endif
 };

--- a/browser/ui/webui/brave_settings_ui.cc
+++ b/browser/ui/webui/brave_settings_ui.cc
@@ -14,6 +14,7 @@
 #include "brave/browser/ntp_background/view_counter_service_factory.h"
 #include "brave/browser/resources/settings/grit/brave_settings_resources.h"
 #include "brave/browser/resources/settings/grit/brave_settings_resources_map.h"
+#include "brave/browser/shell_integrations/buildflags/buildflags.h"
 #include "brave/browser/ui/webui/navigation_bar_data_provider.h"
 #include "brave/browser/ui/webui/settings/brave_adblock_handler.h"
 #include "brave/browser/ui/webui/settings/brave_appearance_handler.h"
@@ -37,7 +38,7 @@
 #include "content/public/browser/web_ui_data_source.h"
 #include "content/public/common/content_features.h"
 
-#if BUILDFLAG(IS_WIN)
+#if BUILDFLAG(ENABLE_PIN_SHORTCUT)
 #include "brave/browser/ui/webui/settings/pin_shortcut_handler.h"
 #endif
 
@@ -70,7 +71,7 @@ BraveSettingsUI::BraveSettingsUI(content::WebUI* web_ui,
 #if BUILDFLAG(ENABLE_TOR)
   web_ui->AddMessageHandler(std::make_unique<BraveTorHandler>());
 #endif
-#if BUILDFLAG(IS_WIN)
+#if BUILDFLAG(ENABLE_PIN_SHORTCUT)
   web_ui->AddMessageHandler(std::make_unique<PinShortcutHandler>());
 #endif
 }

--- a/browser/ui/webui/settings/brave_settings_localized_strings_provider.cc
+++ b/browser/ui/webui/settings/brave_settings_localized_strings_provider.cc
@@ -7,6 +7,7 @@
 #include <string>
 
 #include "base/strings/utf_string_conversions.h"
+#include "brave/browser/shell_integrations/buildflags/buildflags.h"
 #include "brave/browser/ui/webui/brave_settings_ui.h"
 #include "brave/browser/ui/webui/settings/brave_privacy_handler.h"
 #include "brave/components/brave_vpn/buildflags/buildflags.h"
@@ -275,7 +276,7 @@ void BraveAddCommonStrings(content::WebUIDataSource* html_source,
     {"braveNewTabNewTabCustomizeWidgets",
      IDS_SETTINGS_NEW_TAB_NEW_TAB_CUSTOMIZE_WIDGETS},
   // Pin shortcut page
-#if BUILDFLAG(IS_WIN)
+#if BUILDFLAG(ENABLE_PIN_SHORTCUT)
     {"canPinShortcut", IDS_SETTINGS_CAN_PIN_SHORTCUT},
     {"pinShortcut", IDS_SETTINGS_PIN_SHORTCUT},
     {"shortcutPinned", IDS_SETTINGS_SHORTCUT_PINNED},

--- a/browser/ui/webui/settings/pin_shortcut_handler.cc
+++ b/browser/ui/webui/settings/pin_shortcut_handler.cc
@@ -6,14 +6,10 @@
 #include "brave/browser/ui/webui/settings/pin_shortcut_handler.h"
 
 #include "base/bind.h"
-#include "build/build_config.h"
+#include "brave/browser/brave_shell_integration.h"
 #include "chrome/browser/profiles/profile.h"
 #include "content/public/browser/browser_thread.h"
 #include "content/public/browser/web_ui.h"
-
-#if BUILDFLAG(IS_WIN)
-#include "brave/browser/brave_shell_integration_win.h"
-#endif
 
 PinShortcutHandler::PinShortcutHandler() = default;
 
@@ -32,26 +28,21 @@ void PinShortcutHandler::RegisterMessages() {
 void PinShortcutHandler::HandlePinShortcut(const base::Value::List& args) {
   AllowJavascript();
 
-#if BUILDFLAG(IS_WIN)
-  shell_integration::win::PinToTaskbar(
+  shell_integration::PinShortcut(
       Profile::FromWebUI(web_ui()),
       base::BindOnce(&PinShortcutHandler::OnPinShortcut,
                      weak_factory_.GetWeakPtr()));
-#endif
 }
 
 void PinShortcutHandler::HandleCheckShortcutPinState(
     const base::Value::List& args) {
   AllowJavascript();
 
-#if BUILDFLAG(IS_WIN)
-  shell_integration::win::IsShortcutPinned(
+  shell_integration::IsShortcutPinned(
       base::BindOnce(&PinShortcutHandler::OnCheckShortcutPinState,
                      weak_factory_.GetWeakPtr()));
-#endif
 }
 
-#if BUILDFLAG(IS_WIN)
 void PinShortcutHandler::OnPinShortcut(bool pinned) {
   DCHECK_CURRENTLY_ON(content::BrowserThread::UI);
 
@@ -63,7 +54,6 @@ void PinShortcutHandler::OnCheckShortcutPinState(bool pinned) {
 
   NotifyShortcutPinStateChangeToPage(pinned);
 }
-#endif  // BUILDFLAG(IS_WIN)
 
 void PinShortcutHandler::NotifyShortcutPinStateChangeToPage(bool pinned) {
   if (IsJavascriptAllowed()) {

--- a/browser/ui/webui/settings/pin_shortcut_handler.h
+++ b/browser/ui/webui/settings/pin_shortcut_handler.h
@@ -27,12 +27,10 @@ class PinShortcutHandler : public settings::SettingsPageUIHandler {
   void HandlePinShortcut(const base::Value::List& args);
   void NotifyShortcutPinStateChangeToPage(bool pinned);
 
-#if BUILDFLAG(IS_WIN)
   void OnPinShortcut(bool pinned);
   void OnCheckShortcutPinState(bool pinned);
 
   base::WeakPtrFactory<PinShortcutHandler> weak_factory_{this};
-#endif
 };
 
 #endif  // BRAVE_BROWSER_UI_WEBUI_SETTINGS_PIN_SHORTCUT_HANDLER_H_


### PR DESCRIPTION
fix https://github.com/brave/brave-browser/issues/24055

First run dialog:
<img width="413" alt="Screen Shot 2022-10-28 at 8 54 25 AM" src="https://user-images.githubusercontent.com/6786187/198418748-6307f44c-eea7-4d99-9faa-bef006f3981f.png">


Settings: not added to dock
<img width="728" alt="Screen Shot 2022-10-28 at 8 52 18 AM" src="https://user-images.githubusercontent.com/6786187/198418766-5d9b8003-31fb-424b-a289-fc76012c8f0e.png">

After added to dock
<img width="714" alt="Screen Shot 2022-10-28 at 8 52 26 AM" src="https://user-images.githubusercontent.com/6786187/198418790-1533dec9-f791-4395-8045-dd88be26922a.png">

<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves 

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

See the linked issue