### PR TITLE
Jest can now follow -common and -components imports (uplift to 1.43.x)

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -67,6 +67,8 @@ module.exports = {
   moduleNameMapper: {
     "\\.(jpg|jpeg|png|gif|eot|otf|svg|ttf|woff|woff2)$": "<rootDir>/components/test/fileMock.ts",
     "\\.(css|less)$": "identity-obj-proxy",
+    "^\\$web-common\\/(.*)": "<rootDir>/components/common/$1",
+    "^\\$web-components\\/(.*)": "<rootDir>/components/web-components/$1",
     "^brave-ui$": "<rootDir>/node_modules/brave-ui/src",
     "^brave-ui\\/(.*)": "<rootDir>/node_modules/brave-ui/src/$1",
     // TODO(petemill): The ordering here can get problematic for devs


### PR DESCRIPTION
Uplift of #14706
Resolves https://github.com/brave/brave-browser/issues/24787

Pre-approval checklist: 
- [ ] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.