### PR TITLE
Add delay before reconnect to network service in IpfsDnsResolverImpl. (uplift to 1.43.x)

### DIFF
--- a/browser/ipfs/ipfs_dns_resolver_impl.h
+++ b/browser/ipfs/ipfs_dns_resolver_impl.h
@@ -34,6 +34,7 @@ class IpfsDnsResolverImpl
   absl::optional<std::string> GetFirstDnsOverHttpsServer() override;
 
  private:
+  FRIEND_TEST_ALL_PREFIXES(IpfsDnsResolverImplUnitTest, ReconnectOnMojoError);
   void SetupDnsConfigChangeNotifications();
 
   mojo::Remote<network::mojom::DnsConfigChangeManager>
@@ -41,6 +42,8 @@ class IpfsDnsResolverImpl
   mojo::Receiver<network::mojom::DnsConfigChangeManagerClient> receiver_{this};
 
   SEQUENCE_CHECKER(sequence_checker_);
+
+  base::WeakPtrFactory<IpfsDnsResolverImpl> weak_ptr_factory_;
 };
 
 }  // namespace ipfs

--- a/browser/ipfs/test/BUILD.gn
+++ b/browser/ipfs/test/BUILD.gn
@@ -13,6 +13,7 @@ source_set("unittests") {
     "//brave/browser/ipfs/ipfs_blob_context_getter_factory_unittest.cc",
     "//brave/browser/ipfs/ipfs_host_resolver_unittest.cc",
     "//brave/browser/ipfs/ipfs_tab_helper_unittest.cc",
+    "//brave/browser/ipfs/test/ipfs_dns_resolver_impl_unittest.cc",
     "//brave/browser/ipfs/test/ipfs_navigation_throttle_unittest.cc",
     "//brave/browser/ipfs/test/ipfs_network_utils_unittest.cc",
     "//brave/browser/net/ipfs_redirect_network_delegate_helper_unittest.cc",

--- a/browser/ipfs/test/ipfs_dns_resolver_impl_unittest.cc
+++ b/browser/ipfs/test/ipfs_dns_resolver_impl_unittest.cc
@@ -1,0 +1,45 @@
+/* Copyright (c) 2022 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "brave/browser/ipfs/ipfs_dns_resolver_impl.h"
+
+#include <memory>
+#include <utility>
+
+#include "content/public/browser/network_service_instance.h"
+#include "content/public/test/browser_task_environment.h"
+#include "testing/gtest/include/gtest/gtest.h"
+
+namespace ipfs {
+
+class IpfsDnsResolverImplUnitTest : public testing::Test {
+ public:
+  IpfsDnsResolverImplUnitTest() = default;
+  IpfsDnsResolverImplUnitTest(const IpfsDnsResolverImplUnitTest&) = delete;
+  IpfsDnsResolverImplUnitTest& operator=(const IpfsDnsResolverImplUnitTest&) =
+      delete;
+  ~IpfsDnsResolverImplUnitTest() override = default;
+
+  void SetUp() override {}
+
+  void TearDown() override {}
+  content::BrowserTaskEnvironment task_environment_;
+};
+
+TEST_F(IpfsDnsResolverImplUnitTest, ReconnectOnMojoError) {
+  std::unique_ptr<IpfsDnsResolverImpl> ipfs_dns_resolver_impl_ =
+      std::make_unique<IpfsDnsResolverImpl>();
+  ipfs_dns_resolver_impl_->receiver_.reset();
+  ipfs_dns_resolver_impl_->OnDnsConfigChangeManagerConnectionError();
+  EXPECT_FALSE(ipfs_dns_resolver_impl_->receiver_.is_bound());
+  {
+    base::RunLoop loop;
+    while (!ipfs_dns_resolver_impl_->receiver_.is_bound()) {
+      loop.RunUntilIdle();
+    }
+  }
+}
+
+}  // namespace ipfs


### PR DESCRIPTION
Uplift of #14510
Resolves https://github.com/brave/brave-browser/issues/24461

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.