### PR TITLE
Revert "Pin once for existing users who set brave as a default browser"

### DIFF
--- a/browser/brave_browser_process_impl.cc
+++ b/browser/brave_browser_process_impl.cc
@@ -79,10 +79,6 @@
 #include "brave/components/speedreader/speedreader_rewriter_service.h"
 #endif
 
-#if BUILDFLAG(IS_WIN)
-#include "brave/browser/brave_shell_integration_win.h"
-#endif
-
 #if BUILDFLAG(IS_ANDROID)
 #include "chrome/browser/flags/android/chrome_feature_list.h"
 #else
@@ -157,10 +153,6 @@ void BraveBrowserProcessImpl::Init() {
 #endif
 
   InitSystemRequestHandlerCallback();
-
-#if BUILDFLAG(IS_WIN)
-  shell_integration::win::PinDefaultShortcutForExistingUsers();
-#endif
 }
 
 brave_component_updater::BraveComponent::Delegate*

--- a/browser/brave_local_state_prefs.cc
+++ b/browser/brave_local_state_prefs.cc
@@ -110,10 +110,6 @@ void RegisterLocalStatePrefs(PrefRegistrySimple* registry) {
   RegisterWidevineLocalstatePrefs(registry);
 #endif
 
-#if BUILDFLAG(IS_WIN)
-  registry->RegisterBooleanPref(kTryToPinForExistingUsers, true);
-#endif
-
   decentralized_dns::RegisterLocalStatePrefs(registry);
 
   RegisterLocalStatePrefsForMigration(registry);

--- a/browser/brave_shell_integration_win.cc
+++ b/browser/brave_shell_integration_win.cc
@@ -22,18 +22,14 @@
 #include "base/task/thread_pool.h"
 #include "base/win/shortcut.h"
 #include "base/win/windows_version.h"
-#include "brave/components/constants/pref_names.h"
 #include "chrome/browser/browser_process.h"
-#include "chrome/browser/first_run/first_run.h"
 #include "chrome/browser/profiles/profile.h"
 #include "chrome/browser/profiles/profile_attributes_entry.h"
 #include "chrome/browser/profiles/profile_manager.h"
 #include "chrome/browser/profiles/profile_shortcut_manager_win.h"
-#include "chrome/browser/shell_integration.h"
 #include "chrome/browser/shell_integration_win.h"
 #include "chrome/installer/util/install_util.h"
 #include "chrome/installer/util/shell_util.h"
-#include "components/prefs/pref_service.h"
 #include "content/public/browser/browser_thread.h"
 #include "third_party/abseil-cpp/absl/types/optional.h"
 
@@ -369,33 +365,6 @@ void PinToTaskbar(Profile* profile) {
               },
               profile));
   return;
-}
-
-void PinDefaultShortcutForExistingUsers() {
-  // TODO(simonhong): Support win7/8
-  // Below win::PinToTaskbar() doesn't work for win7/8.
-  if (base::win::GetVersion() < base::win::Version::WIN10_RS5)
-    return;
-
-  if (first_run::IsChromeFirstRun())
-    return;
-
-  auto* local_prefs = g_browser_process->local_state();
-  if (!local_prefs->GetBoolean(kTryToPinForExistingUsers))
-    return;
-
-  // Do this only once.
-  local_prefs->SetBoolean(kTryToPinForExistingUsers, false);
-
-  // Try to pin default shortcut when existing user already set Brave as a
-  // default browser.
-  auto set_browser_worker = base::MakeRefCounted<DefaultBrowserWorker>();
-  set_browser_worker->StartCheckIsDefault(
-      base::BindOnce([](shell_integration::DefaultWebClientState state) {
-        if (state == shell_integration::IS_DEFAULT) {
-          win::PinToTaskbar();
-        }
-      }));
 }
 
 }  // namespace shell_integration::win

--- a/browser/brave_shell_integration_win.h
+++ b/browser/brave_shell_integration_win.h
@@ -12,7 +12,6 @@ namespace shell_integration::win {
 
 // Pin profile-specific shortcut when |profile| is non-null.
 void PinToTaskbar(Profile* profile = nullptr);
-void PinDefaultShortcutForExistingUsers();
 
 }  // namespace shell_integration::win
 

--- a/components/constants/pref_names.cc
+++ b/components/constants/pref_names.cc
@@ -98,12 +98,6 @@ const char kEnableWindowClosingConfirm[] =
 const char kEnableClosingLastTab[] = "brave.enable_closing_last_tab";
 #endif
 
-#if BUILDFLAG(IS_WIN)
-// For existing users, we'll try once to pin when Brave is set as a default
-// browser.
-const char kTryToPinForExistingUsers[] = "brave.try_to_pin_for_existing_users";
-#endif
-
 const char kDefaultBrowserLaunchingCount[] =
     "brave.default_browser.launching_count";
 

--- a/components/constants/pref_names.h
+++ b/components/constants/pref_names.h
@@ -79,10 +79,6 @@ extern const char kSafetynetCheckFailed[];
 extern const char kSafetynetStatus[];
 #endif
 
-#if BUILDFLAG(IS_WIN)
-extern const char kTryToPinForExistingUsers[];
-#endif
-
 #if !BUILDFLAG(IS_ANDROID)
 extern const char kEnableWindowClosingConfirm[];
 extern const char kEnableClosingLastTab[];


### PR DESCRIPTION
Reverts brave/brave-core#14692

We decided to have checkbox to ask the user to pin or not.
So, this implicit pinning logic should be deleted.