### PR TITLE
Don't inherit privacy-sensitive content settings in incognito.

### DIFF
--- a/browser/about_flags.cc
+++ b/browser/about_flags.cc
@@ -29,6 +29,7 @@
 #include "brave/components/speedreader/common/buildflags.h"
 #include "brave/components/translate/core/common/brave_translate_features.h"
 #include "brave/components/translate/core/common/buildflags.h"
+#include "components/content_settings/core/common/features.h"
 #include "components/translate/core/browser/translate_prefs.h"
 #include "net/base/features.h"
 #include "third_party/blink/public/common/features.h"
@@ -326,6 +327,13 @@ constexpr char kBraveFederatedDescription[] =
     "Starts local collection for notification ad timing data. This data "
     "is stored locally and automatically erased after one month. No data "
     "leaves the client.";
+
+constexpr char kAllowIncognitoPermissionInheritanceName[] =
+    "Allow permission inheritance in incognito profiles";
+constexpr char kAllowIncognitoPermissionInheritanceDescription[] =
+    "When enabled, most permissions set in a normal profile will be inherited "
+    "in incognito profile if they are less permissive, for ex. Geolocation "
+    "BLOCK will be automatically set to BLOCK in incognito.";
 
 // Blink features.
 constexpr char kFileSystemAccessAPIName[] = "File System Access API";
@@ -636,6 +644,11 @@ constexpr char kAllowCertainClientHintsDescription[] =
       flag_descriptions::kRestrictWebSocketsPoolName,                       \
       flag_descriptions::kRestrictWebSocketsPoolDescription, kOsAll,        \
       FEATURE_VALUE_TYPE(blink::features::kRestrictWebSocketsPool)},        \
+    {"allow-incognito-permission-inheritance",                              \
+      flag_descriptions::kAllowIncognitoPermissionInheritanceName,          \
+      flag_descriptions::kAllowIncognitoPermissionInheritanceDescription,   \
+      kOsAll, FEATURE_VALUE_TYPE(                                           \
+          content_settings::kAllowIncognitoPermissionInheritance)},         \
     BRAVE_IPFS_FEATURE_ENTRIES                                              \
     BRAVE_NATIVE_WALLET_FEATURE_ENTRIES                                     \
     BRAVE_NEWS_FEATURE_ENTRIES                                              \

--- a/browser/content_settings/brave_content_settings_browsertest.cc
+++ b/browser/content_settings/brave_content_settings_browsertest.cc
@@ -1,0 +1,132 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "base/strings/stringprintf.h"
+#include "chrome/browser/content_settings/host_content_settings_map_factory.h"
+#include "chrome/browser/profiles/profile.h"
+#include "chrome/browser/ui/browser.h"
+#include "chrome/test/base/in_process_browser_test.h"
+#include "chrome/test/base/ui_test_utils.h"
+#include "components/content_settings/core/browser/content_settings_registry.h"
+#include "components/content_settings/core/browser/host_content_settings_map.h"
+#include "components/content_settings/core/common/content_settings.h"
+#include "components/content_settings/core/common/content_settings_types.h"
+#include "content/public/test/browser_test.h"
+#include "net/dns/mock_host_resolver.h"
+#include "net/test/embedded_test_server/embedded_test_server.h"
+#include "services/network/public/cpp/network_switches.h"
+#include "url/gurl.h"
+
+class BraveContentSettingsBrowserTest : public InProcessBrowserTest {
+ public:
+  BraveContentSettingsBrowserTest()
+      : https_server_(net::EmbeddedTestServer::TYPE_HTTPS) {
+    https_server_.SetSSLConfig(net::EmbeddedTestServer::CERT_TEST_NAMES);
+    https_server_.ServeFilesFromSourceDirectory(GetChromeTestDataDir());
+    EXPECT_TRUE(https_server_.Start());
+  }
+
+  ~BraveContentSettingsBrowserTest() override = default;
+
+  void SetUpCommandLine(base::CommandLine* command_line) override {
+    InProcessBrowserTest::SetUpCommandLine(command_line);
+    command_line->AppendSwitchASCII(
+        network::switches::kHostResolverRules,
+        base::StringPrintf("MAP *:443 127.0.0.1:%d", https_server_.port()));
+  }
+
+  void SetUpOnMainThread() override {
+    InProcessBrowserTest::SetUpOnMainThread();
+    host_resolver()->AddRule("*", "127.0.0.1");
+  }
+
+  static ContentSetting GetIncognitoAwareDefaultSetting(
+      ContentSettingsType content_type,
+      ContentSetting incognito_default_setting) {
+    // NOTIFICATIONS is auto-blocked in incognito after a random timeout, it
+    // requires special handling.
+    if (content_type == ContentSettingsType::NOTIFICATIONS) {
+      return CONTENT_SETTING_BLOCK;
+    }
+    return incognito_default_setting;
+  }
+
+ protected:
+  net::test_server::EmbeddedTestServer https_server_;
+};
+
+IN_PROC_BROWSER_TEST_F(BraveContentSettingsBrowserTest,
+                       ContentSettingsInheritanceInIncognito) {
+  const GURL url("https://a.test/");
+
+  Browser* incognito_browser = CreateIncognitoBrowser();
+  auto* normal_host_content_settings =
+      HostContentSettingsMapFactory::GetForProfile(browser()->profile());
+  auto* incognito_host_content_settings =
+      HostContentSettingsMapFactory::GetForProfile(
+          incognito_browser->profile());
+  ASSERT_NE(normal_host_content_settings, incognito_host_content_settings);
+
+  for (const content_settings::ContentSettingsInfo* info :
+       *content_settings::ContentSettingsRegistry::GetInstance()) {
+    const ContentSettingsType type = info->website_settings_info()->type();
+    SCOPED_TRACE(testing::Message()
+                 << "ContentSettingsType=" << static_cast<int>(type));
+    // Ignore unusual settings and settings that use CONTENT_SETTING_DEFAULT as
+    // a default value (DCHECKs as invalid default value).
+    if (!info->IsSettingValid(CONTENT_SETTING_BLOCK) ||
+        info->website_settings_info()->initial_default_value().GetInt() == 0) {
+      continue;
+    }
+
+    if (info->GetInitialDefaultSetting() == CONTENT_SETTING_BLOCK) {
+      // Not interested in already blocked permissions.
+      continue;
+    }
+
+    // Make sure defaults are equal in normal and incognito profiles.
+    const ContentSetting normal_default_setting =
+        normal_host_content_settings->GetDefaultContentSetting(type, nullptr);
+    const ContentSetting incognito_default_setting =
+        incognito_host_content_settings->GetDefaultContentSetting(type,
+                                                                  nullptr);
+    EXPECT_EQ(normal_default_setting, incognito_default_setting);
+    // Make sure the current value in normal profile is default.
+    EXPECT_EQ(normal_host_content_settings->GetContentSetting(url, url, type),
+              normal_default_setting);
+    // Make sure the current value in inconito profile is default.
+    EXPECT_EQ(
+        incognito_host_content_settings->GetContentSetting(url, url, type),
+        incognito_default_setting);
+
+    // Set non-default value in normal profile.
+    normal_host_content_settings->SetContentSettingDefaultScope(
+        url, url, type, CONTENT_SETTING_BLOCK);
+    // Make sure the value is properly applied in normal profile.
+    EXPECT_EQ(normal_host_content_settings->GetContentSetting(url, url, type),
+              CONTENT_SETTING_BLOCK);
+
+    // Check incognito value inheritance.
+    const bool should_ignore_inheritance_for_privacy =
+        info->incognito_behavior() ==
+        content_settings::ContentSettingsInfo::INHERIT_IF_LESS_PERMISSIVE;
+    EXPECT_EQ(
+        incognito_host_content_settings->GetContentSetting(url, url, type),
+        should_ignore_inheritance_for_privacy
+            ? GetIncognitoAwareDefaultSetting(type, incognito_default_setting)
+            : CONTENT_SETTING_BLOCK);
+
+    incognito_host_content_settings->SetContentSettingDefaultScope(
+        url, url, type, CONTENT_SETTING_BLOCK);
+    // Make sure the value is properly applied in incognito profile.
+    EXPECT_EQ(
+        incognito_host_content_settings->GetContentSetting(url, url, type),
+        CONTENT_SETTING_BLOCK);
+  }
+
+  const GURL url_to_navigate(url.Resolve("/empty.html"));
+  EXPECT_TRUE(ui_test_utils::NavigateToURL(browser(), url_to_navigate));
+  EXPECT_TRUE(ui_test_utils::NavigateToURL(incognito_browser, url_to_navigate));
+}

--- a/browser/content_settings/brave_content_settings_browsertest.cc
+++ b/browser/content_settings/brave_content_settings_browsertest.cc
@@ -115,7 +115,14 @@ IN_PROC_BROWSER_TEST_F(BraveContentSettingsBrowserTest,
       EXPECT_EQ(
           info->incognito_behavior(),
           content_settings::ContentSettingsInfo::INHERIT_IF_LESS_PERMISSIVE)
-          << "Unexpected inheritance setting found. Please review this test.";
+          << "Unexpected inheritance setting found. Most likely you should "
+             "make adjustments to the logic to handle it properly.";
+
+      EXPECT_NE(info->GetInitialDefaultSetting(), CONTENT_SETTING_ALLOW)
+          << "INHERIT_IF_LESS_PERMISSIVE setting should not default to ALLOW, "
+             "otherwise it's a privacy issue. Please review this setting and "
+             "most likely add an exception for it to always use upstream "
+             "IsMorePermissive() call.";
     }
 
     // Set ALLOW value in normal profile.

--- a/chromium_src/components/content_settings/core/browser/host_content_settings_map.cc
+++ b/chromium_src/components/content_settings/core/browser/host_content_settings_map.cc
@@ -4,13 +4,36 @@
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 #include "build/build_config.h"
+#include "components/content_settings/core/browser/content_settings_utils.h"
 
-#if BUILDFLAG(IS_IOS)
-#include "src/components/content_settings/core/browser/host_content_settings_map.cc"
-#else
+#if !BUILDFLAG(IS_IOS)
 #include "brave/components/content_settings/core/browser/brave_content_settings_pref_provider.h"
-
 #define PrefProvider BravePrefProvider
+#endif
+
+namespace content_settings {
+namespace {
+
+bool IsMorePermissive_BraveImpl(ContentSettingsType content_type,
+                                ContentSetting a,
+                                ContentSetting b) {
+  // NOTIFICATIONS is auto-blocked in incognito after a random timeout, it
+  // requires special handling.
+  if (content_type == ContentSettingsType::NOTIFICATIONS) {
+    return IsMorePermissive(a, b);
+  }
+  return true;
+}
+
+}  // namespace
+}  // namespace content_settings
+
+#define IsMorePermissive(a, b) IsMorePermissive_BraveImpl(content_type, a, b)
+
 #include "src/components/content_settings/core/browser/host_content_settings_map.cc"
+
+#undef IsMorePermissive
+
+#if !BUILDFLAG(IS_IOS)
 #undef PrefProvider
 #endif

--- a/chromium_src/components/content_settings/core/common/features.cc
+++ b/chromium_src/components/content_settings/core/common/features.cc
@@ -1,0 +1,13 @@
+/* Copyright (c) 2022 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "src/components/content_settings/core/common/features.cc"
+
+namespace content_settings {
+
+const base::Feature kAllowIncognitoPermissionInheritance{
+    "AllowIncognitoPermissionInheritance", base::FEATURE_DISABLED_BY_DEFAULT};
+
+}  // namespace content_settings

--- a/chromium_src/components/content_settings/core/common/features.h
+++ b/chromium_src/components/content_settings/core/common/features.h
@@ -1,0 +1,18 @@
+/* Copyright (c) 2022 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_CHROMIUM_SRC_COMPONENTS_CONTENT_SETTINGS_CORE_COMMON_FEATURES_H_
+#define BRAVE_CHROMIUM_SRC_COMPONENTS_CONTENT_SETTINGS_CORE_COMMON_FEATURES_H_
+
+#include "src/components/content_settings/core/common/features.h"
+
+namespace content_settings {
+
+COMPONENT_EXPORT(CONTENT_SETTINGS_FEATURES)
+extern const base::Feature kAllowIncognitoPermissionInheritance;
+
+}  // namespace content_settings
+
+#endif  // BRAVE_CHROMIUM_SRC_COMPONENTS_CONTENT_SETTINGS_CORE_COMMON_FEATURES_H_

--- a/test/BUILD.gn
+++ b/test/BUILD.gn
@@ -670,6 +670,7 @@ if (!is_android) {
       "//brave/browser/brave_wallet/solana_provider_browsertest.cc",
       "//brave/browser/brave_wallet/solana_provider_renderer_browsertest.cc",
       "//brave/browser/brave_wallet/wallet_watch_asset_browsertest.cc",
+      "//brave/browser/content_settings/brave_content_settings_browsertest.cc",
       "//brave/browser/debounce/debounce_browsertest.cc",
       "//brave/browser/ephemeral_storage/blob_url_browsertest.cc",
       "//brave/browser/ephemeral_storage/ephemeral_storage_1p_browsertest.cc",

--- a/test/filters/unit_tests.filter
+++ b/test/filters/unit_tests.filter
@@ -244,6 +244,7 @@
 -OverlayWindowViewsTest.*
 -PageFreezerTest.*
 -PageInfoBubbleViewTest.*
+-PageInfoTest.IncognitoPermissionsDontShowAsk # Change upstream logic for incognito windows. https://github.com/brave/brave-browser/issues/24720
 -PdfPrinterHandlerGetCapabilityTest.*
 -PdfPrinterHandlerPosixTest.*
 -PeopleHandlerTest.*


### PR DESCRIPTION
<!-- Add brave-browser issue bellow that this PR will resolve -->
Change logic for `INHERIT_IF_LESS_PERMISSIVE` mode to not inherit settings from a normal profile.

Some content settings are aware of incognito profiles [(NOTIFICATIONS for ex.)](https://github.com/chromium/chromium/blob/94646fe0f5cc9eaae2e428006c09836a08129a12/chrome/browser/notifications/notification_permission_context.cc#L152-L158) and use `INHERIT_IF_LESS_PERMISSIVE` mode differently to automatically generate "BLOCK" decision after a random timeout instead of actually inheriting the value from a normal profile.

Sec review: https://github.com/brave/security/issues/1002

Resolves https://github.com/brave/brave-browser/issues/24720

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

