### PR TITLE
Warmup Filecoin Ledger account before transaction

### DIFF
--- a/components/brave_wallet_ui/common/hardware/ledgerjs/filecoin_ledger_keyring.ts
+++ b/components/brave_wallet_ui/common/hardware/ledgerjs/filecoin_ledger_keyring.ts
@@ -122,6 +122,10 @@ export default class FilecoinLedgerKeyring implements LedgerFilecoinKeyring {
         Method: parsed.Method,
         Params: parsed.Params
       }
+
+      // Accounts must be warmed up before signing.
+      await this.provider?.getAccounts()
+
       const signed: SignedLotusMessage = await this.provider?.sign(parsed.From, lotusMessage)
       return { success: true, payload: signed }
     } catch (e) {

--- a/components/brave_wallet_ui/components/extension/connect-hardware-wallet-panel/index.tsx
+++ b/components/brave_wallet_ui/components/extension/connect-hardware-wallet-panel/index.tsx
@@ -40,6 +40,17 @@ export interface Props {
   onClickInstructions: () => void
 }
 
+function getAppName (coinType: BraveWallet.CoinType): string {
+  switch (coinType) {
+    case BraveWallet.CoinType.SOL:
+      return 'Solana'
+    case BraveWallet.CoinType.FIL:
+      return 'Filecoin'
+    default:
+      return 'Ethereum'
+  }
+}
+
 export const ConnectHardwareWalletPanel = ({
   onCancel,
   walletName,
@@ -60,7 +71,7 @@ export const ConnectHardwareWalletPanel = ({
     }
 
     if (hardwareWalletCode === 'openLedgerApp') {
-      let network = (coinType === BraveWallet.CoinType.SOL) ? 'Solana' : 'Ethereum'
+      let network = getAppName(coinType)
       return getLocale('braveWalletConnectHardwarePanelOpenApp')
         .replace('$1', network)
         .replace('$2', walletName)


### PR DESCRIPTION
Fixes https://github.com/brave/brave-browser/issues/24824

Otherwise there is an error "Must call getAccounts with to derive this from address before signing with it" or "Must call getAccounts with to derive this from address before signing with it"

Submitter Checklist:

## Test Plan:
Test filecoin transaction from HW addr for mainnet and testnet
