### PR TITLE
Remove Brave Ads creative instance per hour frequency cap for New Tab Page ads - 1.43.x

### DIFF
--- a/vendor/bat-native-ads/src/bat/ads/internal/ads/serving/eligible_ads/exclusion_rules/exclusion_rules_base.cc
+++ b/vendor/bat-native-ads/src/bat/ads/internal/ads/serving/eligible_ads/exclusion_rules/exclusion_rules_base.cc
@@ -14,7 +14,6 @@
 #include "bat/ads/internal/ads/serving/eligible_ads/exclusion_rules/marked_as_inappropriate_exclusion_rule.h"
 #include "bat/ads/internal/ads/serving/eligible_ads/exclusion_rules/marked_to_no_longer_receive_exclusion_rule.h"
 #include "bat/ads/internal/ads/serving/eligible_ads/exclusion_rules/per_day_exclusion_rule.h"
-#include "bat/ads/internal/ads/serving/eligible_ads/exclusion_rules/per_hour_exclusion_rule.h"
 #include "bat/ads/internal/ads/serving/eligible_ads/exclusion_rules/per_month_exclusion_rule.h"
 #include "bat/ads/internal/ads/serving/eligible_ads/exclusion_rules/per_week_exclusion_rule.h"
 #include "bat/ads/internal/ads/serving/eligible_ads/exclusion_rules/split_test_exclusion_rule.h"
@@ -87,9 +86,6 @@ ExclusionRulesBase::ExclusionRulesBase(
 
   daypart_exclusion_rule_ = std::make_unique<DaypartExclusionRule>();
   exclusion_rules_.push_back(daypart_exclusion_rule_.get());
-
-  per_hour_exclusion_rule_ = std::make_unique<PerHourExclusionRule>(ad_events);
-  exclusion_rules_.push_back(per_hour_exclusion_rule_.get());
 }
 
 ExclusionRulesBase::~ExclusionRulesBase() = default;

--- a/vendor/bat-native-ads/src/bat/ads/internal/ads/serving/eligible_ads/exclusion_rules/exclusion_rules_base.h
+++ b/vendor/bat-native-ads/src/bat/ads/internal/ads/serving/eligible_ads/exclusion_rules/exclusion_rules_base.h
@@ -33,7 +33,6 @@ class DislikeExclusionRule;
 class MarkedAsInappropriateExclusionRule;
 class MarkedToNoLongerReceiveExclusionRule;
 class PerDayExclusionRule;
-class PerHourExclusionRule;
 class PerMonthExclusionRule;
 class PerWeekExclusionRule;
 class SplitTestExclusionRule;
@@ -77,7 +76,6 @@ class ExclusionRulesBase {
   std::unique_ptr<MarkedToNoLongerReceiveExclusionRule>
       marked_to_no_longer_receive_exclusion_rule_;
   std::unique_ptr<PerDayExclusionRule> per_day_exclusion_rule_;
-  std::unique_ptr<PerHourExclusionRule> per_hour_exclusion_rule_;
   std::unique_ptr<PerMonthExclusionRule> per_month_exclusion_rule_;
   std::unique_ptr<PerWeekExclusionRule> per_week_exclusion_rule_;
   std::unique_ptr<SplitTestExclusionRule> split_test_exclusion_rule_;

--- a/vendor/bat-native-ads/src/bat/ads/internal/ads/serving/eligible_ads/exclusion_rules/inline_content_ads/inline_content_ad_exclusion_rules.cc
+++ b/vendor/bat-native-ads/src/bat/ads/internal/ads/serving/eligible_ads/exclusion_rules/inline_content_ads/inline_content_ad_exclusion_rules.cc
@@ -5,6 +5,7 @@
 
 #include "bat/ads/internal/ads/serving/eligible_ads/exclusion_rules/inline_content_ads/inline_content_ad_exclusion_rules.h"
 
+#include "bat/ads/internal/ads/serving/eligible_ads/exclusion_rules/per_hour_exclusion_rule.h"
 #include "bat/ads/internal/geographic/subdivision/subdivision_targeting.h"
 #include "bat/ads/internal/resources/behavioral/anti_targeting/anti_targeting_resource.h"
 
@@ -19,7 +20,10 @@ ExclusionRules::ExclusionRules(
     : ExclusionRulesBase(ad_events,
                          subdivision_targeting,
                          anti_targeting_resource,
-                         browsing_history) {}
+                         browsing_history) {
+  per_hour_exclusion_rule_ = std::make_unique<PerHourExclusionRule>(ad_events);
+  exclusion_rules_.push_back(per_hour_exclusion_rule_.get());
+}
 
 ExclusionRules::~ExclusionRules() = default;
 

--- a/vendor/bat-native-ads/src/bat/ads/internal/ads/serving/eligible_ads/exclusion_rules/inline_content_ads/inline_content_ad_exclusion_rules.h
+++ b/vendor/bat-native-ads/src/bat/ads/internal/ads/serving/eligible_ads/exclusion_rules/inline_content_ads/inline_content_ad_exclusion_rules.h
@@ -6,6 +6,8 @@
 #ifndef BRAVE_VENDOR_BAT_NATIVE_ADS_SRC_BAT_ADS_INTERNAL_ADS_SERVING_ELIGIBLE_ADS_EXCLUSION_RULES_INLINE_CONTENT_ADS_INLINE_CONTENT_AD_EXCLUSION_RULES_H_
 #define BRAVE_VENDOR_BAT_NATIVE_ADS_SRC_BAT_ADS_INTERNAL_ADS_SERVING_ELIGIBLE_ADS_EXCLUSION_RULES_INLINE_CONTENT_ADS_INLINE_CONTENT_AD_EXCLUSION_RULES_H_
 
+#include <memory>
+
 #include "bat/ads/internal/ads/serving/eligible_ads/exclusion_rules/exclusion_rules_base.h"
 
 namespace ads {
@@ -17,6 +19,8 @@ class SubdivisionTargeting;
 namespace resource {
 class AntiTargeting;
 }  // namespace resource
+
+class PerHourExclusionRule;
 
 namespace inline_content_ads {
 
@@ -31,6 +35,8 @@ class ExclusionRules final : public ExclusionRulesBase {
  private:
   ExclusionRules(const ExclusionRules&) = delete;
   ExclusionRules& operator=(const ExclusionRules&) = delete;
+
+  std::unique_ptr<PerHourExclusionRule> per_hour_exclusion_rule_;
 };
 
 }  // namespace inline_content_ads

--- a/vendor/bat-native-ads/src/bat/ads/internal/ads/serving/eligible_ads/exclusion_rules/notification_ads/notification_ad_exclusion_rules.cc
+++ b/vendor/bat-native-ads/src/bat/ads/internal/ads/serving/eligible_ads/exclusion_rules/notification_ads/notification_ad_exclusion_rules.cc
@@ -6,6 +6,7 @@
 #include "bat/ads/internal/ads/serving/eligible_ads/exclusion_rules/notification_ads/notification_ad_exclusion_rules.h"
 
 #include "bat/ads/internal/ads/serving/eligible_ads/exclusion_rules/dismissed_exclusion_rule.h"
+#include "bat/ads/internal/ads/serving/eligible_ads/exclusion_rules/per_hour_exclusion_rule.h"
 #include "bat/ads/internal/geographic/subdivision/subdivision_targeting.h"
 #include "bat/ads/internal/resources/behavioral/anti_targeting/anti_targeting_resource.h"
 
@@ -24,6 +25,9 @@ ExclusionRules::ExclusionRules(
   dismissed_exclusion_rule_ =
       std::make_unique<DismissedExclusionRule>(ad_events);
   exclusion_rules_.push_back(dismissed_exclusion_rule_.get());
+
+  per_hour_exclusion_rule_ = std::make_unique<PerHourExclusionRule>(ad_events);
+  exclusion_rules_.push_back(per_hour_exclusion_rule_.get());
 }
 
 ExclusionRules::~ExclusionRules() = default;

--- a/vendor/bat-native-ads/src/bat/ads/internal/ads/serving/eligible_ads/exclusion_rules/notification_ads/notification_ad_exclusion_rules.h
+++ b/vendor/bat-native-ads/src/bat/ads/internal/ads/serving/eligible_ads/exclusion_rules/notification_ads/notification_ad_exclusion_rules.h
@@ -21,6 +21,7 @@ class AntiTargeting;
 }  // namespace resource
 
 class DismissedExclusionRule;
+class PerHourExclusionRule;
 
 namespace notification_ads {
 
@@ -37,6 +38,7 @@ class ExclusionRules final : public ExclusionRulesBase {
   ExclusionRules& operator=(const ExclusionRules&) = delete;
 
   std::unique_ptr<DismissedExclusionRule> dismissed_exclusion_rule_;
+  std::unique_ptr<PerHourExclusionRule> per_hour_exclusion_rule_;
 };
 
 }  // namespace notification_ads


### PR DESCRIPTION
Uplift of https://github.com/brave/brave-core/pull/14726
Resolves https://github.com/brave/brave-browser/issues/24820

- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR.
- [x] You have tested your change on Nightly. 
- [x] The PR milestones match the branch they are landing to. 

After you merge: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.