### PR TITLE
Updated sidebar add bubble hide logic

### DIFF
--- a/app/brave_generated_resources.grd
+++ b/app/brave_generated_resources.grd
@@ -689,6 +689,9 @@ Or change later at <ph name="SETTINGS_EXTENIONS_LINK">$2<ex>brave://settings/ext
         <message name="IDS_SIDEBAR_ITEMS_SCROLL_DOWN_BUTTON_ACCESSIBLE_NAME" desc="Text to be spoken when scroll down button is shown">
           Scroll down
         </message>
+        <message name="IDS_SIDEBAR_ADD_ITEM_BUTTON_TOOLTIP" desc="Text of sidebar add item button tooltip">
+          Add to Sidebar
+        </message>
       </if>
 
       <!-- Speedreader -->

--- a/browser/ui/views/sidebar/sidebar_item_add_button.cc
+++ b/browser/ui/views/sidebar/sidebar_item_add_button.cc
@@ -38,6 +38,8 @@ void SidebarItemAddButton::OnButtonPressed() {
   if (timer_.IsRunning())
     timer_.Stop();
 
+  add_item_bubble_shown_by_click_ = true;
+
   DoShowBubble();
 }
 
@@ -50,6 +52,11 @@ void SidebarItemAddButton::OnMouseExited(const ui::MouseEvent& event) {
   SidebarButtonView::OnMouseExited(event);
   // Don't show bubble if user goes outo from add item quickly.
   timer_.Stop();
+
+  if (!add_item_bubble_shown_by_click_ && IsBubbleVisible()) {
+    DCHECK(add_item_bubble_widget_);
+    add_item_bubble_widget_->Close();
+  }
 }
 
 void SidebarItemAddButton::OnGestureEvent(ui::GestureEvent* event) {
@@ -71,12 +78,17 @@ void SidebarItemAddButton::AddedToWidget() {
 }
 
 void SidebarItemAddButton::OnWidgetDestroying(views::Widget* widget) {
+  DCHECK_EQ(add_item_bubble_widget_, widget);
+  add_item_bubble_widget_ = nullptr;
+  add_item_bubble_shown_by_click_ = false;
   observation_.Reset();
 }
 
 void SidebarItemAddButton::ShowBubbleWithDelay() {
   if (IsBubbleVisible())
     return;
+
+  DCHECK(!add_item_bubble_shown_by_click_);
 
   if (timer_.IsRunning())
     timer_.Stop();
@@ -87,10 +99,11 @@ void SidebarItemAddButton::ShowBubbleWithDelay() {
 }
 
 void SidebarItemAddButton::DoShowBubble() {
-  auto* bubble = views::BubbleDialogDelegateView::CreateBubble(
+  DCHECK(!add_item_bubble_widget_);
+  add_item_bubble_widget_ = views::BubbleDialogDelegateView::CreateBubble(
       new SidebarAddItemBubbleDelegateView(browser_, this));
-  observation_.Observe(bubble);
-  bubble->Show();
+  observation_.Observe(add_item_bubble_widget_);
+  add_item_bubble_widget_->Show();
 }
 
 bool SidebarItemAddButton::IsBubbleVisible() const {

--- a/browser/ui/views/sidebar/sidebar_item_add_button.cc
+++ b/browser/ui/views/sidebar/sidebar_item_add_button.cc
@@ -5,15 +5,21 @@
 
 #include "brave/browser/ui/views/sidebar/sidebar_item_add_button.h"
 
+#include <memory>
+#include <utility>
+
 #include "base/bind.h"
 #include "base/time/time.h"
 #include "brave/app/vector_icons/vector_icons.h"
 #include "brave/browser/ui/color/brave_color_id.h"
 #include "brave/browser/ui/views/sidebar/sidebar_add_item_bubble_delegate_view.h"
+#include "brave/components/l10n/common/locale_util.h"
+#include "brave/grit/brave_generated_resources.h"
 #include "brave/grit/brave_theme_resources.h"
 #include "ui/base/metadata/metadata_impl_macros.h"
 #include "ui/base/resource/resource_bundle.h"
 #include "ui/gfx/paint_vector_icon.h"
+#include "ui/views/controls/button/menu_button_controller.h"
 
 SidebarItemAddButton::SidebarItemAddButton(
     BraveBrowser* browser,
@@ -25,8 +31,16 @@ SidebarItemAddButton::SidebarItemAddButton(
       AddEnabledChangedCallback(base::BindRepeating(
           &SidebarItemAddButton::UpdateButtonImages, base::Unretained(this)));
 
-  SetCallback(base::BindRepeating(&SidebarItemAddButton::OnButtonPressed,
-                                  base::Unretained(this)));
+  // The MenuButtonController makes sure the bubble closes when clicked if the
+  // bubble is already open.
+  auto menu_button_controller = std::make_unique<views::MenuButtonController>(
+      this,
+      base::BindRepeating(&SidebarItemAddButton::OnButtonPressed,
+                          base::Unretained(this)),
+      std::make_unique<views::Button::DefaultButtonControllerDelegate>(this));
+  SetButtonController(std::move(menu_button_controller));
+  SetTooltipText(brave_l10n::GetLocalizedResourceUTF16String(
+      IDS_SIDEBAR_ADD_ITEM_BUTTON_TOOLTIP));
 }
 
 SidebarItemAddButton::~SidebarItemAddButton() = default;
@@ -35,36 +49,7 @@ void SidebarItemAddButton::OnButtonPressed() {
   if (IsBubbleVisible())
     return;
 
-  if (timer_.IsRunning())
-    timer_.Stop();
-
-  add_item_bubble_shown_by_click_ = true;
-
-  DoShowBubble();
-}
-
-void SidebarItemAddButton::OnMouseEntered(const ui::MouseEvent& event) {
-  SidebarButtonView::OnMouseEntered(event);
-  ShowBubbleWithDelay();
-}
-
-void SidebarItemAddButton::OnMouseExited(const ui::MouseEvent& event) {
-  SidebarButtonView::OnMouseExited(event);
-  // Don't show bubble if user goes outo from add item quickly.
-  timer_.Stop();
-
-  if (!add_item_bubble_shown_by_click_ && IsBubbleVisible()) {
-    DCHECK(add_item_bubble_widget_);
-    add_item_bubble_widget_->Close();
-  }
-}
-
-void SidebarItemAddButton::OnGestureEvent(ui::GestureEvent* event) {
-  SidebarButtonView::OnGestureEvent(event);
-  if (event->type() == ui::ET_GESTURE_TAP) {
-    // Show bubble immediately after tapping.
-    DoShowBubble();
-  }
+  ShowBubble();
 }
 
 void SidebarItemAddButton::OnThemeChanged() {
@@ -78,32 +63,14 @@ void SidebarItemAddButton::AddedToWidget() {
 }
 
 void SidebarItemAddButton::OnWidgetDestroying(views::Widget* widget) {
-  DCHECK_EQ(add_item_bubble_widget_, widget);
-  add_item_bubble_widget_ = nullptr;
-  add_item_bubble_shown_by_click_ = false;
   observation_.Reset();
 }
 
-void SidebarItemAddButton::ShowBubbleWithDelay() {
-  if (IsBubbleVisible())
-    return;
-
-  DCHECK(!add_item_bubble_shown_by_click_);
-
-  if (timer_.IsRunning())
-    timer_.Stop();
-
-  constexpr int kBubbleLaunchDelayInMS = 200;
-  timer_.Start(FROM_HERE, base::Milliseconds(kBubbleLaunchDelayInMS), this,
-               &SidebarItemAddButton::DoShowBubble);
-}
-
-void SidebarItemAddButton::DoShowBubble() {
-  DCHECK(!add_item_bubble_widget_);
-  add_item_bubble_widget_ = views::BubbleDialogDelegateView::CreateBubble(
+void SidebarItemAddButton::ShowBubble() {
+  auto* bubble = views::BubbleDialogDelegateView::CreateBubble(
       new SidebarAddItemBubbleDelegateView(browser_, this));
-  observation_.Observe(add_item_bubble_widget_);
-  add_item_bubble_widget_->Show();
+  observation_.Observe(bubble);
+  bubble->Show();
 }
 
 bool SidebarItemAddButton::IsBubbleVisible() const {

--- a/browser/ui/views/sidebar/sidebar_item_add_button.h
+++ b/browser/ui/views/sidebar/sidebar_item_add_button.h
@@ -10,7 +10,6 @@
 
 #include "base/memory/raw_ptr.h"
 #include "base/scoped_observation.h"
-#include "base/timer/timer.h"
 #include "brave/browser/ui/views/sidebar/sidebar_button_view.h"
 #include "ui/views/widget/widget.h"
 #include "ui/views/widget/widget_observer.h"
@@ -29,9 +28,6 @@ class SidebarItemAddButton : public SidebarButtonView,
   SidebarItemAddButton& operator=(const SidebarItemAddButton&) = delete;
 
   // SidebarButtonView overrides:
-  void OnMouseEntered(const ui::MouseEvent& event) override;
-  void OnMouseExited(const ui::MouseEvent& event) override;
-  void OnGestureEvent(ui::GestureEvent* event) override;
   void AddedToWidget() override;
   void OnThemeChanged() override;
 
@@ -41,17 +37,12 @@ class SidebarItemAddButton : public SidebarButtonView,
   bool IsBubbleVisible() const;
 
  private:
-  void ShowBubbleWithDelay();
-  void DoShowBubble();
+  void ShowBubble();
 
   void UpdateButtonImages();
   void OnButtonPressed();
 
   raw_ptr<BraveBrowser> browser_ = nullptr;
-  raw_ptr<views::Widget> add_item_bubble_widget_ = nullptr;
-  // true when bubble is shown by add item button press. Otherwise, false.
-  bool add_item_bubble_shown_by_click_ = false;
-  base::OneShotTimer timer_;
   base::CallbackListSubscription on_enabled_changed_subscription_;
   base::ScopedObservation<views::Widget, views::WidgetObserver> observation_{
       this};

--- a/browser/ui/views/sidebar/sidebar_item_add_button.h
+++ b/browser/ui/views/sidebar/sidebar_item_add_button.h
@@ -48,6 +48,9 @@ class SidebarItemAddButton : public SidebarButtonView,
   void OnButtonPressed();
 
   raw_ptr<BraveBrowser> browser_ = nullptr;
+  raw_ptr<views::Widget> add_item_bubble_widget_ = nullptr;
+  // true when bubble is shown by add item button press. Otherwise, false.
+  bool add_item_bubble_shown_by_click_ = false;
   base::OneShotTimer timer_;
   base::CallbackListSubscription on_enabled_changed_subscription_;
   base::ScopedObservation<views::Widget, views::WidgetObserver> observation_{


### PR DESCRIPTION
fix https://github.com/brave/brave-browser/issues/21156

Changed to show text tooltip on hovered over add item button.
Previously, add bubble is launched on hovered. But, bubble will
be launched only on click.

<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves 

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [x] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [x] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [x] Major classes, functions and non-trivial code blocks are well-commented
- [x] Changes in component dependencies are properly reflected in `gn`
- [x] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [x] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

1. Launch browser
2. Hover over the sidebar item add button
3. Check text tooltip is visible
4. Click add item button and check bubble is launched.