### PR TITLE
Only hide sidebar when tab-initiated fullscreen mode

### DIFF
--- a/browser/ui/views/sidebar/sidebar_container_view.cc
+++ b/browser/ui/views/sidebar/sidebar_container_view.cc
@@ -22,6 +22,8 @@
 #include "chrome/browser/profiles/profile.h"
 #include "chrome/browser/ui/browser_window.h"
 #include "chrome/browser/ui/color/chrome_color_id.h"
+#include "chrome/browser/ui/exclusive_access/exclusive_access_manager.h"
+#include "chrome/browser/ui/exclusive_access/fullscreen_controller.h"
 #include "chrome/browser/ui/views/frame/browser_view.h"
 #include "chrome/browser/ui/views/side_panel/side_panel_entry.h"
 #include "chrome/browser/ui/views/toolbar/toolbar_view.h"
@@ -184,7 +186,7 @@ void SidebarContainerView::Layout() {
 
 gfx::Size SidebarContainerView::CalculatePreferredSize() const {
   if (!initialized_ || !sidebar_control_view_->GetVisible() ||
-      browser_->window()->IsFullscreen())
+      IsFullscreenByTab())
     return View::CalculatePreferredSize();
 
   int preferred_width =
@@ -199,6 +201,14 @@ void SidebarContainerView::OnThemeChanged() {
   View::OnThemeChanged();
 
   UpdateBackground();
+}
+
+bool SidebarContainerView::IsFullscreenByTab() const {
+  DCHECK(browser_->exclusive_access_manager() &&
+         browser_->exclusive_access_manager()->fullscreen_controller());
+  return browser_->exclusive_access_manager()
+      ->fullscreen_controller()
+      ->IsWindowFullscreenForTabOrPending();
 }
 
 bool SidebarContainerView::ShouldForceShowSidebar() const {

--- a/browser/ui/views/sidebar/sidebar_container_view.h
+++ b/browser/ui/views/sidebar/sidebar_container_view.h
@@ -109,6 +109,9 @@ class SidebarContainerView
   bool ShouldForceShowSidebar() const;
   void UpdateToolbarButtonVisibility();
 
+  // true when fullscreen is initiated by tab. (Ex, fullscreen mode in youtube)
+  bool IsFullscreenByTab() const;
+
   // On some condition(ex, add item bubble is visible),
   // sidebar should not be hidden even if mouse goes out from sidebar ui.
   // If it's hidden, only bubble ui is visible. Then, weird situation happens.


### PR DESCRIPTION
fix https://github.com/brave/brave-browser/issues/16160

<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves 

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

1. Launch browser and check sidebar is visible
2. Load youtube.com and play anything.
3. Change to youtube fullscreen mode by pressing `f` key
4. Check sidebar is not visible
5. Pressing `esc` to exit fullscreen mode check sidebar is visible again
6. Make browser maximized windows by using window button
7. Check sidebar is still visible