### PR TITLE
Sidebar ASAN fix erasing past the end

### DIFF
--- a/browser/ui/sidebar/sidebar_unittest.cc
+++ b/browser/ui/sidebar/sidebar_unittest.cc
@@ -65,7 +65,7 @@ class SidebarModelTest : public testing::Test, public SidebarModel::Observer {
 
 TEST_F(SidebarModelTest, ItemsChangedTest) {
   auto built_in_items_size =
-      SidebarService::GetDefaultBuiltInItemTypes_ForTesting().size();
+      std::size(SidebarService::kDefaultBuiltInItemTypes);
   EXPECT_EQ(built_in_items_size, service()->items().size());
   model()->Init(nullptr);
 

--- a/components/sidebar/sidebar_service.h
+++ b/components/sidebar/sidebar_service.h
@@ -33,6 +33,13 @@ class SidebarService : public KeyedService {
     kShowNever,
   };
 
+  // This is the default display order
+  static constexpr SidebarItem::BuiltInItemType kDefaultBuiltInItemTypes[] = {
+      SidebarItem::BuiltInItemType::kBraveTalk,
+      SidebarItem::BuiltInItemType::kWallet,
+      SidebarItem::BuiltInItemType::kBookmarks,
+      SidebarItem::BuiltInItemType::kReadingList};
+
   class Observer : public base::CheckedObserver {
    public:
     virtual void OnItemAdded(const SidebarItem& item, int index) {}
@@ -74,12 +81,10 @@ class SidebarService : public KeyedService {
   FRIEND_TEST_ALL_PREFIXES(SidebarServiceTest, AddRemoveItems);
   FRIEND_TEST_ALL_PREFIXES(SidebarServiceTest, NewDefaultItemAdded);
 
-  static std::vector<SidebarItem::BuiltInItemType>
-  GetDefaultBuiltInItemTypes_ForTesting();
-
   void LoadSidebarItems();
   void UpdateSidebarItemsToPrefStore();
-  std::vector<SidebarItem> GetDefaultSidebarItemsFromCurrentItems() const;
+  std::vector<SidebarItem::BuiltInItemType> GetCurrentlyPresentBuiltInTypes()
+      const;
   void OnPreferenceChanged(const std::string& pref_name);
   void MigrateSidebarShowOptions();
   void MigratePrefSidebarBuiltInItemsToHidden();

--- a/components/sidebar/sidebar_service_unittest.cc
+++ b/components/sidebar/sidebar_service_unittest.cc
@@ -116,7 +116,7 @@ TEST_F(SidebarServiceTest, AddRemoveItems) {
   EXPECT_EQ(4, item_index_on_called_);
   EXPECT_EQ(5UL, service_->items().size());
   // Default item count is not changed.
-  EXPECT_EQ(4UL, service_->GetDefaultSidebarItemsFromCurrentItems().size());
+  EXPECT_EQ(4UL, service_->GetCurrentlyPresentBuiltInTypes().size());
 }
 
 TEST_F(SidebarServiceTest, MoveItem) {
@@ -253,8 +253,7 @@ TEST_F(SidebarServiceTest, NewDefaultItemAdded) {
   };
   // Get expected indexes (the custom item will replace the index of the removed
   // built-in).
-  auto all_default_item_types =
-      SidebarService::GetDefaultBuiltInItemTypes_ForTesting();
+  const auto& all_default_item_types = SidebarService::kDefaultBuiltInItemTypes;
   // There should also be the custom item we added
   EXPECT_EQ(remaining_default_items.size() + 1, service_->items().size());
   for (auto built_in_type : remaining_default_items) {
@@ -264,9 +263,8 @@ TEST_F(SidebarServiceTest, NewDefaultItemAdded) {
         });
     EXPECT_NE(iter, items.end());
     auto expected_index =
-        std::find(all_default_item_types.begin(), all_default_item_types.end(),
-                  built_in_type) -
-        all_default_item_types.begin();
+        base::ranges::find(all_default_item_types, built_in_type) -
+        std::begin(all_default_item_types);
     auto index = iter - items.begin();
     EXPECT_EQ(expected_index, index)
         << "New item with ID " << static_cast<int>(built_in_type)


### PR DESCRIPTION
This change corrects the signaled asan failure erasing past the end of
the vector. It also simplifies the code around, and removes the use of
no-destructor statics for constexpr arrays.

<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves https://github.com/brave/internal/issues/899
Resolves https://github.com/brave/internal/issues/900
Resolves https://github.com/brave/internal/issues/901

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [x] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [x] New files have MPL-2.0 license header
- [x] Adequate test coverage exists to prevent regressions
- [x] Major classes, functions and non-trivial code blocks are well-commented
- [x] Changes in component dependencies are properly reflected in `gn`
- [x] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [x] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

