### PR TITLE
Warmup Filecoin Ledger account before transaction (uplift to 1.43.x)

### DIFF
--- a/components/brave_wallet_ui/common/hardware/ledgerjs/filecoin_ledger_keyring.test.ts
+++ b/components/brave_wallet_ui/common/hardware/ledgerjs/filecoin_ledger_keyring.test.ts
@@ -92,16 +92,16 @@ test('Check locks for device', () => {
 test('Extract accounts from locked device', () => {
   const ledgerHardwareKeyring = new FilecoinLedgerKeyring()
   ledgerHardwareKeyring.unlock = async function () {
-    return { success: false, error: 'braveWalletUnlockError' }
+    return { success: false, error: 'braveWalletUnlockError', code: 'unlockError' }
   }
   return expect(ledgerHardwareKeyring.getAccounts(-2, 1, CoinType.TEST))
-    .resolves.toStrictEqual({ error: 'braveWalletUnlockError', success: false })
+    .resolves.toStrictEqual({ error: 'braveWalletUnlockError', success: false, code: 'unlockError' })
 })
 
 test('Sign transaction locked device, unlock error', () => {
   const ledgerHardwareKeyring = new FilecoinLedgerKeyring()
   ledgerHardwareKeyring.unlock = async function () {
-    return { success: false, error: 'braveWalletUnlockError' }
+    return { success: false, error: 'braveWalletUnlockError', code: 'unlockError' }
   }
   ledgerHardwareKeyring.provider = new MockApp() as LedgerProvider
   const message = {
@@ -118,7 +118,7 @@ test('Sign transaction locked device, unlock error', () => {
   }
 
   return expect(ledgerHardwareKeyring.signTransaction(JSON.stringify(message)))
-    .resolves.toStrictEqual({ success: false, error: 'braveWalletUnlockError' })
+    .resolves.toStrictEqual({ success: false, error: 'braveWalletUnlockError', code: 'unlockError' })
 })
 
 test('Sign transaction locked device, success', () => {

--- a/components/brave_wallet_ui/common/hardware/ledgerjs/filecoin_ledger_keyring.ts
+++ b/components/brave_wallet_ui/common/hardware/ledgerjs/filecoin_ledger_keyring.ts
@@ -122,6 +122,10 @@ export default class FilecoinLedgerKeyring implements LedgerFilecoinKeyring {
         Method: parsed.Method,
         Params: parsed.Params
       }
+
+      // Accounts must be warmed up before signing.
+      await this.provider?.getAccounts()
+
       const signed: SignedLotusMessage = await this.provider?.sign(parsed.From, lotusMessage)
       return { success: true, payload: signed }
     } catch (e) {

--- a/components/brave_wallet_ui/common/hardware/ledgerjs/filecoin_ledger_keyring.ts
+++ b/components/brave_wallet_ui/common/hardware/ledgerjs/filecoin_ledger_keyring.ts
@@ -35,7 +35,7 @@ export default class FilecoinLedgerKeyring implements LedgerFilecoinKeyring {
   getAccounts = async (from: number, to: number, network: FilecoinNetwork): Promise<GetAccountsHardwareOperationResult> => {
     const unlocked = await this.unlock()
     if (!unlocked.success || !this.provider) {
-      return unlocked
+      return { success: false, error: unlocked.error, code: unlocked.code }
     }
     from = (from < 0) ? 0 : from
     const app: LedgerProvider = this.provider
@@ -89,14 +89,14 @@ export default class FilecoinLedgerKeyring implements LedgerFilecoinKeyring {
     }
     try {
       if (!await this.makeApp() || !this.provider) {
-        return { success: false }
+        return { success: false, code: 'unlockError' }
       }
       const app: LedgerProvider = this.provider
       const address = await app.getAccounts(0, 1, CoinType.TEST)
       this.deviceId = address[0]
       return { success: this.isUnlocked() }
     } catch (e) {
-      return { success: false, error: getLocale('braveWalletLedgerFilecoinUnlockError') }
+      return { success: false, error: getLocale('braveWalletLedgerFilecoinUnlockError'), code: 'unlockError' }
     }
   }
 
@@ -107,7 +107,7 @@ export default class FilecoinLedgerKeyring implements LedgerFilecoinKeyring {
   signTransaction = async (message: string): Promise<SignHardwareOperationResult> => {
     const unlocked = await this.unlock()
     if (!unlocked.success || !this.provider) {
-      return { success: false, error: unlocked.error }
+      return { success: false, error: unlocked.error, code: unlocked.code }
     }
     try {
       const parsed = JSON.parse(message)

--- a/components/brave_wallet_ui/components/extension/connect-hardware-wallet-panel/index.tsx
+++ b/components/brave_wallet_ui/components/extension/connect-hardware-wallet-panel/index.tsx
@@ -27,6 +27,17 @@ export interface Props {
   onClickInstructions: () => void
 }
 
+function getAppName (coinType: BraveWallet.CoinType): string {
+  switch (coinType) {
+    case BraveWallet.CoinType.SOL:
+      return 'Solana'
+    case BraveWallet.CoinType.FIL:
+      return 'Filecoin'
+    default:
+      return 'Ethereum'
+  }
+}
+
 function ConnectHardwareWalletPanel (props: Props) {
   const {
     onCancel,
@@ -48,7 +59,7 @@ function ConnectHardwareWalletPanel (props: Props) {
     }
 
     if (hardwareWalletCode === 'openLedgerApp') {
-      let network = (coinType === BraveWallet.CoinType.SOL) ? 'Solana' : 'Ethereum'
+      let network = getAppName(coinType)
       return getLocale('braveWalletConnectHardwarePanelOpenApp')
         .replace('$1', network)
         .replace('$2', walletName)


### PR DESCRIPTION
Uplift of #14767
Fixes https://github.com/brave/brave-browser/issues/24824
Also fixed showing of error dialogs when sign with filecoin HW acc.

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.

