### PR TITLE
Migrate sidebar item pref for built-in items which do not specify built-in-item-type

### DIFF
--- a/components/sidebar/sidebar_service.cc
+++ b/components/sidebar/sidebar_service.cc
@@ -81,6 +81,28 @@ SidebarItem GetBuiltInItemForType(SidebarItem::BuiltInItemType type) {
   return SidebarItem();
 }
 
+SidebarItem::BuiltInItemType GetBuiltInItemTypeForLegacyURL(
+    const std::string& url) {
+  // A previous version of prefs used the URL even for built-in items, and not
+  // the |SidebarItem::BuiltInItemType|. Therefore, this list should not
+  // need to be updated.
+  if (url == "https://together.brave.com/" || url == "https://talk.brave.com/")
+    return SidebarItem::BuiltInItemType::kBraveTalk;
+
+  if (url == "chrome://wallet/")
+    return SidebarItem::BuiltInItemType::kWallet;
+
+  if (url == "chrome://sidebar-bookmarks.top-chrome/" ||
+      url == "chrome://bookmarks/")
+    return SidebarItem::BuiltInItemType::kBookmarks;
+
+  if (url == "chrome://history/")
+    return SidebarItem::BuiltInItemType::kHistory;
+
+  NOTREACHED() << url;
+  return SidebarItem::BuiltInItemType::kNone;
+}
+
 std::vector<SidebarItem> GetDefaultSidebarItems() {
   std::vector<SidebarItem> items;
   for (const auto& item_type : SidebarService::kDefaultBuiltInItemTypes) {
@@ -159,21 +181,30 @@ void SidebarService::MigratePrefSidebarBuiltInItemsToHidden() {
   built_in_items_to_hide.push_back(
       GetBuiltInItemForType(SidebarItem::BuiltInItemType::kBookmarks));
 
+  // We will also correct built-in items which did not specify their type
+  // and instead relied on Url matching to find the built-in type.
+  bool items_are_modified = false;
+  constexpr char kSidebarItemShouldRemoveKey[] = "should_remove";
+
   const auto& items = preference->GetValue()->GetList();
   VLOG(2) << "MigratePrefSidebarBuiltInItemsToHidden: item count is "
           << items.size();
 
-  // Find built-in items in items pref and keep them visible
-  for (const auto& item : items) {
-    DVLOG(2) << "Found an item: " << item.DebugString();
+  // Find built-in items in items pref and keep them visible. Clone so that we
+  // can potentially modify and re-save.
+  auto new_items = items.Clone();
+  for (auto& item_value : new_items) {
+    DVLOG(2) << "Found an item: " << item_value.DebugString();
     // Verify item is valid
-    if (!item.is_dict() || item.GetDict().empty()) {
-      DVLOG(1) << "Item in prefs was not a valid dict: " << item.DebugString();
+    auto* item = item_value.GetIfDict();
+    if (!item || item->empty()) {
+      DVLOG(1) << "Item in prefs was not a valid dict: "
+               << item_value.DebugString();
       continue;
     }
     // Only care about built-in type
     SidebarItem::Type type;
-    const auto type_value = item.FindIntKey(kSidebarItemTypeKey);
+    const auto type_value = item->FindInt(kSidebarItemTypeKey);
     if (!type_value) {
       VLOG(1) << "Item has no type item";
       continue;
@@ -184,11 +215,41 @@ void SidebarService::MigratePrefSidebarBuiltInItemsToHidden() {
       continue;
     }
     // Found a built-in item to keep
-    const auto item_id = item.FindIntKey(kSidebarItemBuiltInItemTypeKey);
+    auto item_id = item->FindInt(kSidebarItemBuiltInItemTypeKey);
     if (!item_id.has_value()) {
-      LOG(ERROR) << "MigratePrefSidebarBuiltInItemsToHidden: A built-in item "
-                    "was found in the older pref format without a valid id.";
-      DVLOG(1) << "Pref list item was: " << item.DebugString();
+      // Attempt to get item_id from the url, which was a legacy method of
+      // storing the built-in type.
+      VLOG(1) << "MigratePrefSidebarBuiltInItemsToHidden: A built-in item "
+                 "was found in the older pref format without a valid id. "
+                 "Attempting to migrate...";
+      DVLOG(1) << "Pref list item was: " << item->DebugString();
+      const auto* url = item->FindString(kSidebarItemURLKey);
+      if (url->empty()) {
+        // This should be impossible (a built-in item without a url or type),
+        // but could happen if someone manually edited the settings file.
+        VLOG(1)
+            << "...could not migrate item, url was empty! Marking for removal.";
+        item->Set(kSidebarItemShouldRemoveKey, true);
+        items_are_modified = true;
+        continue;
+      }
+      const auto item_type = GetBuiltInItemTypeForLegacyURL(*url);
+      if (item_type == SidebarItem::BuiltInItemType::kNone) {
+        // This should be impossible (a built-in item without a url or type),
+        // but could happen if someone manually edited the settings file.
+        VLOG(1)
+            << "...could not migrate item, url was empty! Marking for removal.";
+        item->Set(kSidebarItemShouldRemoveKey, true);
+        items_are_modified = true;
+        continue;
+      }
+      const auto item_id_parsed = static_cast<int>(item_type);
+      // Mark this item to be updated
+      items_are_modified = true;
+      item->Set(kSidebarItemBuiltInItemTypeKey, item_id_parsed);
+      item->Remove(kSidebarItemURLKey);
+      // Proceed with new value
+      item_id = item_id_parsed;
     }
     // Remember not to hide this item
     auto iter = base::ranges::find_if(
@@ -220,6 +281,21 @@ void SidebarService::MigratePrefSidebarBuiltInItemsToHidden() {
     // Always store something so that we know migration is done
     // when pref isn't default value.
     builtin_items_update->ClearList();
+  }
+
+  // Fix items pref, if needed
+  if (items_are_modified) {
+    ListPrefUpdate items_update(prefs_, kSidebarItems);
+    items_update->ClearList();
+    for (const auto& item_value : new_items) {
+      auto* item = item_value.GetIfDict();
+      DCHECK(item);
+      const auto should_ignore = item->FindBool(kSidebarItemShouldRemoveKey);
+      if (should_ignore.value_or(false)) {
+        continue;
+      }
+      items_update->Append(base::Value(item->Clone()));
+    }
   }
 }
 
@@ -379,23 +455,28 @@ void SidebarService::LoadSidebarItems() {
       }
       // Always use latest properties for built-in type item.
       if (type == SidebarItem::Type::kTypeBuiltIn) {
-        if (const auto value =
-                item.FindIntKey(kSidebarItemBuiltInItemTypeKey)) {
-          auto id = static_cast<SidebarItem::BuiltInItemType>(*value);
-          auto iter = std::find_if(
-              default_items_to_add.begin(), default_items_to_add.end(),
-              [id](const auto& default_item) {
-                return default_item.built_in_item_type == id;
-              });
-          // It might be an item which is no longer is offered as built-in
-          if (iter == default_items_to_add.end()) {
-            continue;
-          }
-          // Valid built-in item, add it
-          items_.emplace_back(*std::make_move_iterator(iter));
-          default_items_to_add.erase(iter);
+        const auto built_in_type_value =
+            item.FindIntKey(kSidebarItemBuiltInItemTypeKey);
+        if (!built_in_type_value.has_value()) {
+          VLOG(1) << "built-in item did not have a type: "
+                  << item.DebugString();
           continue;
         }
+        auto id =
+            static_cast<SidebarItem::BuiltInItemType>(*built_in_type_value);
+        auto iter = base::ranges::find_if(
+            default_items_to_add, [id](const auto& default_item) {
+              return default_item.built_in_item_type == id;
+            });
+        // It might be an item which is no longer is offered as built-in
+        if (iter == default_items_to_add.end()) {
+          VLOG(1) << "item not found: " << item.DebugString();
+          continue;
+        }
+        // Valid built-in item, add it
+        items_.emplace_back(*std::make_move_iterator(iter));
+        default_items_to_add.erase(iter);
+        continue;
       }
       // Deserialize custom item
       std::string url;

--- a/components/sidebar/sidebar_service.h
+++ b/components/sidebar/sidebar_service.h
@@ -77,9 +77,7 @@ class SidebarService : public KeyedService {
   SidebarService& operator=(const SidebarService&) = delete;
 
  private:
-  FRIEND_TEST_ALL_PREFIXES(SidebarModelTest, ItemsChangedTest);
   FRIEND_TEST_ALL_PREFIXES(SidebarServiceTest, AddRemoveItems);
-  FRIEND_TEST_ALL_PREFIXES(SidebarServiceTest, NewDefaultItemAdded);
 
   void LoadSidebarItems();
   void UpdateSidebarItemsToPrefStore();


### PR DESCRIPTION
Avoid crash by not trying to load them, but also migrate these items to include the item type key, bringing back the function to find built-in item type from url.

This crash was occuring on Nightly for some users who had modified sidebar preferences close to the time that it was initially released and not modified the preferences since.

<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/24965
Additionally, from https://github.com/brave/brave-core/pull/14800:
Resolves https://github.com/brave/internal/issues/899
Resolves https://github.com/brave/internal/issues/900
Resolves https://github.com/brave/internal/issues/901

## Submitter Checklist:

- [ ] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
On any profile, open the Preferences file in a code editor, and replace the "brave.sidebar" section with the following:
```
    "sidebar": {
      "sidebar_items": [
        {
          "open_in_panel": true,
          "title": "Brave Together",
          "type": 0,
          "url": "https://together.brave.com/"
        },
        {
          "open_in_panel": false,
          "title": "Crypto Wallets",
          "type": 0,
          "url": "chrome://wallet/"
        },
        {
          "open_in_panel": true,
          "title": "Bookmarks",
          "type": 0,
          "url": "chrome://bookmarks/"
        },
        {
          "open_in_panel": true,
          "title": "History",
          "type": 0,
          "url": "chrome://history/"
        },
        {
          "open_in_panel": false,
          "title": "Settings - About Brave",
          "type": 1,
          "url": "chrome://settings/help"
        }
      ]
    },
```
