### PR TITLE
Fix possible empty redirect chain crash in Brave Ads. Follow up to 24849 - 1.44.x

### DIFF
--- a/browser/brave_ads/ads_tab_helper.cc
+++ b/browser/brave_ads/ads_tab_helper.cc
@@ -59,7 +59,7 @@ AdsTabHelper::~AdsTabHelper() {
 }
 
 void AdsTabHelper::TabUpdated() {
-  if (!ads_service_ || redirect_chain_.empty()) {
+  if (!ads_service_) {
     return;
   }
 

--- a/vendor/bat-native-ads/src/bat/ads/internal/conversions/conversions.cc
+++ b/vendor/bat-native-ads/src/bat/ads/internal/conversions/conversions.cc
@@ -229,10 +229,12 @@ void Conversions::MaybeConvert(
     const std::vector<GURL>& redirect_chain,
     const std::string& html,
     const ConversionIdPatternMap& conversion_id_patterns) {
-  DCHECK(!redirect_chain.empty());
-
   if (!ShouldAllow()) {
     BLOG(1, "Conversions are not allowed");
+    return;
+  }
+
+  if (redirect_chain.empty()) {
     return;
   }
 

--- a/vendor/bat-native-ads/src/bat/ads/internal/processors/behavioral/purchase_intent/purchase_intent_processor.cc
+++ b/vendor/bat-native-ads/src/bat/ads/internal/processors/behavioral/purchase_intent/purchase_intent_processor.cc
@@ -227,7 +227,9 @@ void PurchaseIntent::OnTextContentDidChange(
     const int32_t tab_id,
     const std::vector<GURL>& redirect_chain,
     const std::string& content) {
-  DCHECK(!redirect_chain.empty());
+  if (redirect_chain.empty()) {
+    return;
+  }
 
   const GURL& url = redirect_chain.back();
 
@@ -243,7 +245,10 @@ void PurchaseIntent::OnTextContentDidChange(
     return;
   }
 
-  DCHECK(!last_visible_tab->redirect_chain.empty());
+  if (last_visible_tab->redirect_chain.empty()) {
+    return;
+  }
+
   if (SameDomainOrHost(url, last_visible_tab->redirect_chain.back())) {
     return;
   }

--- a/vendor/bat-native-ads/src/bat/ads/internal/processors/contextual/text_classification/text_classification_processor.cc
+++ b/vendor/bat-native-ads/src/bat/ads/internal/processors/contextual/text_classification/text_classification_processor.cc
@@ -97,7 +97,9 @@ void TextClassification::OnTextContentDidChange(
     const int32_t tab_id,
     const std::vector<GURL>& redirect_chain,
     const std::string& content) {
-  DCHECK(!redirect_chain.empty());
+  if (redirect_chain.empty()) {
+    return;
+  }
 
   const GURL& url = redirect_chain.back();
 

--- a/vendor/bat-native-ads/src/bat/ads/internal/transfer/transfer.cc
+++ b/vendor/bat-native-ads/src/bat/ads/internal/transfer/transfer.cc
@@ -102,7 +102,15 @@ void Transfer::OnTransferAd(const int32_t tab_id,
     return;
   }
 
-  DCHECK(!tab->redirect_chain.empty());
+  if (tab->redirect_chain.empty()) {
+    // TODO(https://github.com/brave/brave-browser/issues/24970): Decouple
+    // |BrowserListObserver| from |AdsTabHelper| because right now,
+    // |OnTabUpdated| is also called when the browser becomes active or
+    // inactive, which can have an empty redirect chain if the navigation for a
+    // tab did not complete before calling |OnTabUpdated|, which caused a crash.
+    return;
+  }
+
   if (!DomainOrHostExists(redirect_chain, tab->redirect_chain.back())) {
     FailedToTransferAd(ad);
     return;
@@ -172,6 +180,15 @@ void Transfer::NotifyFailedToTransferAd(const AdInfo& ad) const {
 }
 
 void Transfer::OnTabDidChange(const TabInfo& tab) {
+  if (tab.redirect_chain.empty()) {
+    // TODO(https://github.com/brave/brave-browser/issues/24970): Decouple
+    // |BrowserListObserver| from |AdsTabHelper| because right now,
+    // |OnTabUpdated| is also called when the browser becomes active or
+    // inactive, which can have an empty redirect chain if the navigation for a
+    // tab did not complete before calling |OnTabUpdated|, which caused a crash.
+    return;
+  }
+
   MaybeTransferAd(tab.id, tab.redirect_chain);
 }
 


### PR DESCRIPTION
Uplift of https://github.com/brave/brave-core/pull/14812
Resolves https://github.com/brave/brave-browser/issues/24955

- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR.
- [x] You have tested your change on Nightly. 
- [x] The PR milestones match the branch they are landing to. 

After you merge: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.