### PR TITLE
[iOS] Add missing BraveWalletProviderDelegate bridging methods (uplift to 1.44.x)

### DIFF
--- a/ios/browser/api/brave_wallet/brave_wallet_provider_delegate_ios+private.h
+++ b/ios/browser/api/brave_wallet/brave_wallet_provider_delegate_ios+private.h
@@ -41,6 +41,9 @@ class BraveWalletProviderDelegateBridge
                           const std::vector<std::string>& accounts,
                           GetAllowedAccountsCallback callback) override;
   bool IsPermissionDenied(mojom::CoinType type) override;
+  void AddSolanaConnectedAccount(const std::string& account) override;
+  void RemoveSolanaConnectedAccount(const std::string& account) override;
+  bool IsSolanaAccountConnected(const std::string& account) override;
 };
 
 }  // namespace brave_wallet

--- a/ios/browser/api/brave_wallet/brave_wallet_provider_delegate_ios.h
+++ b/ios/browser/api/brave_wallet/brave_wallet_provider_delegate_ios.h
@@ -40,6 +40,9 @@ OBJC_EXPORT
                   accounts:(NSArray<NSString*>*)accounts
                 completion:(GetAllowedAccountsCallback)completion;
 - (bool)isPermissionDenied:(BraveWalletCoinType)type;
+- (void)addSolanaConnectedAccount:(NSString*)account;
+- (void)removeSolanaConnectedAccount:(NSString*)account;
+- (bool)isSolanaAccountConnected:(NSString*)account;
 @end
 
 NS_ASSUME_NONNULL_END

--- a/ios/browser/api/brave_wallet/brave_wallet_provider_delegate_ios.mm
+++ b/ios/browser/api/brave_wallet/brave_wallet_provider_delegate_ios.mm
@@ -108,4 +108,19 @@ bool BraveWalletProviderDelegateBridge::IsPermissionDenied(
   return [bridge_ isPermissionDenied:static_cast<BraveWalletCoinType>(type)];
 }
 
+void BraveWalletProviderDelegateBridge::AddSolanaConnectedAccount(
+    const std::string& account) {
+  [bridge_ addSolanaConnectedAccount:base::SysUTF8ToNSString(account)];
+}
+
+void BraveWalletProviderDelegateBridge::RemoveSolanaConnectedAccount(
+    const std::string& account) {
+  [bridge_ removeSolanaConnectedAccount:base::SysUTF8ToNSString(account)];
+}
+
+bool BraveWalletProviderDelegateBridge::IsSolanaAccountConnected(
+    const std::string& account) {
+  return [bridge_ isSolanaAccountConnected:base::SysUTF8ToNSString(account)];
+}
+
 }  // namespace brave_wallet


### PR DESCRIPTION
Uplift of #14776
Resolves https://github.com/brave/brave-browser/issues/24906

Pre-approval checklist: 
- [ ] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.