### PR TITLE
Only hide sidebar when tab-initiated fullscreen mode (uplift to 1.44.x)

### DIFF
--- a/browser/ui/views/sidebar/sidebar_container_view.cc
+++ b/browser/ui/views/sidebar/sidebar_container_view.cc
@@ -22,6 +22,8 @@
 #include "chrome/browser/profiles/profile.h"
 #include "chrome/browser/ui/browser_window.h"
 #include "chrome/browser/ui/color/chrome_color_id.h"
+#include "chrome/browser/ui/exclusive_access/exclusive_access_manager.h"
+#include "chrome/browser/ui/exclusive_access/fullscreen_controller.h"
 #include "chrome/browser/ui/views/frame/browser_view.h"
 #include "chrome/browser/ui/views/side_panel/side_panel_entry.h"
 #include "chrome/browser/ui/views/toolbar/toolbar_view.h"
@@ -184,7 +186,7 @@ void SidebarContainerView::Layout() {
 
 gfx::Size SidebarContainerView::CalculatePreferredSize() const {
   if (!initialized_ || !sidebar_control_view_->GetVisible() ||
-      browser_->window()->IsFullscreen())
+      IsFullscreenByTab())
     return View::CalculatePreferredSize();
 
   int preferred_width =
@@ -199,6 +201,14 @@ void SidebarContainerView::OnThemeChanged() {
   View::OnThemeChanged();
 
   UpdateBackground();
+}
+
+bool SidebarContainerView::IsFullscreenByTab() const {
+  DCHECK(browser_->exclusive_access_manager() &&
+         browser_->exclusive_access_manager()->fullscreen_controller());
+  return browser_->exclusive_access_manager()
+      ->fullscreen_controller()
+      ->IsWindowFullscreenForTabOrPending();
 }
 
 bool SidebarContainerView::ShouldForceShowSidebar() const {

--- a/browser/ui/views/sidebar/sidebar_container_view.h
+++ b/browser/ui/views/sidebar/sidebar_container_view.h
@@ -109,6 +109,9 @@ class SidebarContainerView
   bool ShouldForceShowSidebar() const;
   void UpdateToolbarButtonVisibility();
 
+  // true when fullscreen is initiated by tab. (Ex, fullscreen mode in youtube)
+  bool IsFullscreenByTab() const;
+
   // On some condition(ex, add item bubble is visible),
   // sidebar should not be hidden even if mouse goes out from sidebar ui.
   // If it's hidden, only bubble ui is visible. Then, weird situation happens.


### PR DESCRIPTION
Uplift of #14790
fix https://github.com/brave/brave-browser/issues/16160

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.