### PR TITLE
[CodeHealth] Broken code flagged by clang-tidy

### DIFF
--- a/browser/brave_wallet/brave_wallet_service_delegate_impl.cc
+++ b/browser/brave_wallet/brave_wallet_service_delegate_impl.cc
@@ -70,7 +70,8 @@ void BraveWalletServiceDelegateImpl::IsExternalWalletInitialized(
     std::move(callback).Run(false);
     return;
   }
-  importer->Initialize(base::BindOnce(
+  ExternalWalletsImporter* importer_ptr = importer.get();
+  importer_ptr->Initialize(base::BindOnce(
       &BraveWalletServiceDelegateImpl::ContinueIsExternalWalletInitialized,
       weak_ptr_factory_.GetWeakPtr(), std::move(importer),
       std::move(callback)));
@@ -94,7 +95,8 @@ void BraveWalletServiceDelegateImpl::GetImportInfoFromExternalWallet(
     GetImportInfoCallback callback) {
   std::unique_ptr<ExternalWalletsImporter> importer =
       std::make_unique<ExternalWalletsImporter>(type, context_);
-  importer->Initialize(base::BindOnce(
+  ExternalWalletsImporter* importer_ptr = importer.get();
+  importer_ptr->Initialize(base::BindOnce(
       &BraveWalletServiceDelegateImpl::ContinueGetImportInfoFromExternalWallet,
       weak_ptr_factory_.GetWeakPtr(), std::move(importer), password,
       std::move(callback)));

--- a/browser/brave_wallet/external_wallets_importer.cc
+++ b/browser/brave_wallet/external_wallets_importer.cc
@@ -428,6 +428,7 @@ void ExternalWalletsImporter::GetMnemonic(bool is_legacy_crypto_wallets,
   if (!mnemonic) {
     VLOG(0) << "Failed to find mnemonic in decrypted keyrings";
     std::move(callback).Run(false, ImportInfo(), ImportError::kJsonError);
+    return;
   }
 
   std::move(callback).Run(

--- a/browser/brave_wallet/keyring_service_unittest.cc
+++ b/browser/brave_wallet/keyring_service_unittest.cc
@@ -10,6 +10,7 @@
 #include "base/base64.h"
 #include "base/callback_helpers.h"
 #include "base/json/json_reader.h"
+#include "base/ranges/algorithm.h"
 #include "base/strings/utf_string_conversions.h"
 #include "base/test/bind.h"
 #include "base/test/scoped_feature_list.h"
@@ -2136,6 +2137,10 @@ TEST_F(KeyringServiceUnitTest, HardwareAccounts) {
       "0xFILTEST", "m/44'/1'/2'/0/0", "filecoin testnet 1", "Ledger", "device2",
       mojom::CoinType::FIL, mojom::kFilecoinTestnet));
 
+  std::vector<mojom::HardwareWalletAccountPtr> accounts;
+  base::ranges::transform(new_accounts, std::back_inserter(accounts),
+                          [](const auto& account) { return account.Clone(); });
+
   EXPECT_FALSE(observer.AccountsChangedFired());
   service.AddHardwareAccounts(std::move(new_accounts));
   EXPECT_TRUE(service.IsHardwareAccount("0x111"));
@@ -2143,7 +2148,7 @@ TEST_F(KeyringServiceUnitTest, HardwareAccounts) {
   base::RunLoop().RunUntilIdle();
   EXPECT_TRUE(observer.AccountsChangedFired());
   observer.Reset();
-  for (const auto& account : new_accounts) {
+  for (const auto& account : accounts) {
     auto keyring_id =
         account->coin == mojom::CoinType::FIL
             ? brave_wallet::GetFilecoinKeyringId(*account->network)

--- a/browser/net/brave_proxying_url_loader_factory.cc
+++ b/browser/net/brave_proxying_url_loader_factory.cc
@@ -376,7 +376,8 @@ void BraveProxyingURLLoaderFactory::InProgressRequest::
         std::make_unique<mojo::DataPipeProducer>(std::move(producer));
 
     base::StringPiece string_piece(write_data->data);
-    write_data->producer->Write(
+    WriteData* write_data_ptr = write_data.get();
+    write_data_ptr->producer->Write(
         std::make_unique<mojo::StringDataSource>(
             string_piece, mojo::StringDataSource::AsyncWritingMode::
                               STRING_STAYS_VALID_UNTIL_COMPLETION),

--- a/browser/ui/views/profiles/brave_incognito_menu_view.cc
+++ b/browser/ui/views/profiles/brave_incognito_menu_view.cc
@@ -74,8 +74,8 @@ void BraveIncognitoMenuView::AddedToWidget() {
       browser()->profile());
   SetProfileIdentityInfo(
       /*profile_name=*/std::u16string(),
-      /*background_color=*/SK_ColorTRANSPARENT,
-      /*edit_button=*/absl::nullopt,
+      /*profile_background_color=*/SK_ColorTRANSPARENT,
+      /*edit_button_params=*/absl::nullopt,
       ui::ImageModel::FromVectorIcon(kIncognitoProfileIcon, icon_color),
       brave_l10n::GetLocalizedResourceUTF16String(
           GetProfileMenuTitleId(browser()->profile())),

--- a/browser/ui/views/profiles/brave_profile_menu_view.cc
+++ b/browser/ui/views/profiles/brave_profile_menu_view.cc
@@ -35,7 +35,7 @@ void BraveProfileMenuView::BuildIdentity() {
   SetProfileIdentityInfo(
       /*profile_name=*/std::u16string(),
       profile_attributes->GetProfileThemeColors().profile_highlight_color,
-      /*edit_button=*/absl::nullopt,
+      /*edit_button_params=*/absl::nullopt,
       ui::ImageModel::FromImage(profile_attributes->GetAvatarIcon()),
       /*title=*/profile_attributes->GetName());
 }

--- a/browser/ui/webui/brave_wallet/common_handler/wallet_handler.cc
+++ b/browser/ui/webui/brave_wallet/common_handler/wallet_handler.cc
@@ -10,6 +10,7 @@
 #include <vector>
 
 #include "base/bind.h"
+#include "base/ranges/algorithm.h"
 #include "brave/browser/brave_wallet/keyring_service_factory.h"
 #include "brave/components/brave_wallet/browser/brave_wallet_constants.h"
 #include "brave/components/brave_wallet/browser/brave_wallet_utils.h"
@@ -93,8 +94,10 @@ void WalletHandler::AddFavoriteApp(
 void WalletHandler::RemoveFavoriteApp(
     brave_wallet::mojom::AppItemPtr app_item) {
   favorite_apps.erase(
-      remove_if(favorite_apps.begin(), favorite_apps.end(),
-                [&app_item](const brave_wallet::mojom::AppItemPtr& it) -> bool {
-                  return it->name == app_item->name;
-                }));
+      base::ranges::remove_if(
+          favorite_apps,
+          [&app_item](const brave_wallet::mojom::AppItemPtr& it) -> bool {
+            return it->name == app_item->name;
+          }),
+      favorite_apps.end());
 }

--- a/chromium_src/components/autofill/core/browser/autofill_experiments_unittest.cc
+++ b/chromium_src/components/autofill/core/browser/autofill_experiments_unittest.cc
@@ -67,9 +67,9 @@ TEST_F(
     AutofillExperimentsTest,
     IsCardUploadEnabled_TransportSyncDoesNotHaveAutofillProfileActiveDataType) {
   scoped_feature_list_.InitWithFeatures(
-      /*enable_features=*/{features::kAutofillUpstream,
-                           features::kAutofillEnableAccountWalletStorage},
-      /*disable_features=*/{});
+      /*enabled_features=*/{features::kAutofillUpstream,
+                            features::kAutofillEnableAccountWalletStorage},
+      /*disabled_features=*/{});
   // When we have no primary account, Sync will start in Transport-only mode
   // (if allowed).
   sync_service_.SetHasSyncConsent(false);

--- a/components/brave_wallet/browser/eth_pending_tx_tracker.cc
+++ b/components/brave_wallet/browser/eth_pending_tx_tracker.cc
@@ -133,9 +133,8 @@ bool EthPendingTxTracker::ShouldTxDropped(const EthTxMeta& meta) {
   const std::string hex_address = meta.from();
   if (network_nonce_map_.find(hex_address) == network_nonce_map_.end()) {
     json_rpc_service_->GetEthTransactionCount(
-        hex_address,
-        base::BindOnce(&EthPendingTxTracker::OnGetNetworkNonce,
-                       weak_factory_.GetWeakPtr(), std::move(hex_address)));
+        hex_address, base::BindOnce(&EthPendingTxTracker::OnGetNetworkNonce,
+                                    weak_factory_.GetWeakPtr(), hex_address));
   } else {
     uint256_t network_nonce = network_nonce_map_[hex_address];
     network_nonce_map_.erase(hex_address);

--- a/components/brave_wallet/browser/fil_tx_manager.cc
+++ b/components/brave_wallet/browser/fil_tx_manager.cc
@@ -309,6 +309,7 @@ void FilTxManager::OnGetNextNonceForHardware(
   auto message = meta->tx()->GetMessageToSign();
   if (!message.has_value()) {
     std::move(callback).Run(nullptr);
+    return;
   }
 
   std::move(callback).Run(mojom::MessageToSignUnion::NewMessageStr(*message));

--- a/components/brave_wallet/browser/json_rpc_service.cc
+++ b/components/brave_wallet/browser/json_rpc_service.cc
@@ -1943,6 +1943,7 @@ void JsonRpcService::GetSupportsInterface(
     std::move(callback).Run(
         false, mojom::ProviderError::kInvalidParams,
         l10n_util::GetStringUTF8(IDS_WALLET_INVALID_PARAMETERS));
+    return;
   }
 
   auto internal_callback =

--- a/components/brave_wallet/browser/solana_tx_manager.cc
+++ b/components/brave_wallet/browser/solana_tx_manager.cc
@@ -148,8 +148,10 @@ void SolanaTxManager::OnGetLatestBlockhashHardware(
   tx_state_manager_->AddOrUpdateTx(*meta);
 
   auto message_signers_pair = meta->tx()->GetSerializedMessage();
-  if (!message_signers_pair)
+  if (!message_signers_pair) {
     std::move(callback).Run(nullptr);
+    return;
+  }
 
   auto& message_bytes = message_signers_pair->first;
   std::move(callback).Run(

--- a/components/brave_wallet/browser/solana_tx_manager_unittest.cc
+++ b/components/brave_wallet/browser/solana_tx_manager_unittest.cc
@@ -663,6 +663,7 @@ TEST_F(SolanaTxManagerUnitTest, MakeTokenProgramTransferTxData) {
       spl_token_mint_address, from_wallet_address, to_wallet_address, 10000000,
       std::move(tx_data), mojom::SolanaProviderError::kSuccess, "");
 
+  account_metas.clear();
   auto solana_account_meta4 =
       mojom::SolanaAccountMeta::New(from_wallet_address, true, true);
   auto solana_account_meta5 =
@@ -684,6 +685,8 @@ TEST_F(SolanaTxManagerUnitTest, MakeTokenProgramTransferTxData) {
   account_metas.push_back(std::move(solana_account_meta8));
   account_metas.push_back(std::move(solana_account_meta9));
   account_metas.push_back(std::move(solana_account_meta10));
+
+  instructions.clear();
   auto mojom_create_associated_account_instruction =
       mojom::SolanaInstruction::New(kSolanaAssociatedTokenProgramId,
                                     std::move(account_metas),

--- a/components/ftx/browser/ftx_service.cc
+++ b/components/ftx/browser/ftx_service.cc
@@ -232,13 +232,10 @@ bool FTXService::AuthenticateFromAuthToken(const std::string& auth_token) {
       std::move(onRequest), true);
 }
 
-bool FTXService::GetConvertQuote(
-    const std::string& from,
-    const std::string& to,
-    const std::string& amount,
-    GetConvertQuoteCallback callback) {
-  auto internal_callback = base::BindOnce(&FTXService::OnGetConvertQuote,
-      base::Unretained(this), std::move(callback));
+bool FTXService::GetConvertQuote(const std::string& from,
+                                 const std::string& to,
+                                 const std::string& amount,
+                                 GetConvertQuoteCallback callback) {
   GURL url = GetOAuthURL(oauth_quote_path);
   base::Value::Dict request_data;
   request_data.Set("fromCoin", from);
@@ -250,8 +247,11 @@ bool FTXService::GetConvertQuote(
     std::move(callback).Run("");
     return false;
   }
-  return NetworkRequest(url, "POST", body, "application/json",
-      std::move(internal_callback), true);
+  return NetworkRequest(
+      url, "POST", body, "application/json",
+      base::BindOnce(&FTXService::OnGetConvertQuote, base::Unretained(this),
+                     std::move(callback)),
+      true);
 }
 
 void FTXService::OnGetConvertQuote(

--- a/components/ipfs/ipfs_service.cc
+++ b/components/ipfs/ipfs_service.cc
@@ -861,9 +861,8 @@ void IpfsService::PreWarmShareableLink(const GURL& url) {
   auto url_loader = CreateURLLoader(url, "HEAD");
   auto iter = url_loaders_.insert(url_loaders_.begin(), std::move(url_loader));
   iter->get()->DownloadToStringOfUnboundedSizeUntilCrashAndDie(
-      url_loader_factory_.get(),
-      base::BindOnce(&IpfsService::OnPreWarmComplete, base::Unretained(this),
-                     std::move(iter)));
+      url_loader_factory_.get(), base::BindOnce(&IpfsService::OnPreWarmComplete,
+                                                base::Unretained(this), iter));
 }
 
 void IpfsService::OnPreWarmComplete(
@@ -885,8 +884,7 @@ void IpfsService::ValidateGateway(const GURL& url, BoolCallback callback) {
   iter->get()->DownloadToStringOfUnboundedSizeUntilCrashAndDie(
       url_loader_factory_.get(),
       base::BindOnce(&IpfsService::OnGatewayValidationComplete,
-                     base::Unretained(this), std::move(iter),
-                     std::move(callback), url));
+                     base::Unretained(this), iter, std::move(callback), url));
 }
 
 void IpfsService::OnGatewayValidationComplete(

--- a/components/tor/tor_control.cc
+++ b/components/tor/tor_control.cc
@@ -148,9 +148,8 @@ void TorControl::OpenControl(int portno, std::vector<uint8_t> cookie) {
       net::IPAddress::IPv4Localhost(), portno);
   socket_ = std::make_unique<net::TCPClientSocket>(
       addrlist, nullptr, nullptr, net::NetLog::Get(), net::NetLogSource());
-  int rv = socket_->Connect(base::BindOnce(&TorControl::Connected,
-                                           weak_ptr_factory_.GetWeakPtr(),
-                                           std::move(cookie)));
+  int rv = socket_->Connect(base::BindOnce(
+      &TorControl::Connected, weak_ptr_factory_.GetWeakPtr(), cookie));
   if (rv == net::ERR_IO_PENDING)
     return;
   Connected(std::move(cookie), rv);

--- a/vendor/bat-native-ledger/src/bat/ledger/internal/endpoint/promotion/post_claim_brave/post_claim_brave.cc
+++ b/vendor/bat-native-ledger/src/bat/ledger/internal/endpoint/promotion/post_claim_brave/post_claim_brave.cc
@@ -84,11 +84,8 @@ type::Result PostClaimBrave::CheckStatusCode(const int status_code) {
   return type::Result::LEDGER_OK;
 }
 
-void PostClaimBrave::Request(
-    const std::string& destination_payment_id,
-    PostClaimBraveCallback callback) {
-  auto url_callback = base::BindOnce(
-      &PostClaimBrave::OnRequest, base::Unretained(this), std::move(callback));
+void PostClaimBrave::Request(const std::string& destination_payment_id,
+                             PostClaimBraveCallback callback) {
   const std::string payload = GeneratePayload(destination_payment_id);
 
   const auto wallet = ledger_->wallet()->GetWallet();
@@ -97,6 +94,9 @@ void PostClaimBrave::Request(
     std::move(callback).Run(type::Result::LEDGER_ERROR);
     return;
   }
+
+  auto url_callback = base::BindOnce(
+      &PostClaimBrave::OnRequest, base::Unretained(this), std::move(callback));
 
   const auto sign_url =  base::StringPrintf(
       "post %s",

--- a/vendor/bat-native-ledger/src/bat/ledger/internal/endpoint/promotion/post_suggestions_claim/post_suggestions_claim.cc
+++ b/vendor/bat-native-ledger/src/bat/ledger/internal/endpoint/promotion/post_suggestions_claim/post_suggestions_claim.cc
@@ -70,13 +70,8 @@ type::Result PostSuggestionsClaim::CheckStatusCode(const int status_code) {
   return type::Result::LEDGER_OK;
 }
 
-void PostSuggestionsClaim::Request(
-    const credential::CredentialsRedeem& redeem,
-    PostSuggestionsClaimCallback callback) {
-  auto url_callback =
-      base::BindOnce(&PostSuggestionsClaim::OnRequest, base::Unretained(this),
-                     std::move(callback));
-
+void PostSuggestionsClaim::Request(const credential::CredentialsRedeem& redeem,
+                                   PostSuggestionsClaimCallback callback) {
   const std::string payload = GeneratePayload(redeem);
 
   auto wallet = ledger_->wallet()->GetWallet();
@@ -85,6 +80,10 @@ void PostSuggestionsClaim::Request(
     std::move(callback).Run(type::Result::LEDGER_ERROR, "");
     return;
   }
+
+  auto url_callback =
+      base::BindOnce(&PostSuggestionsClaim::OnRequest, base::Unretained(this),
+                     std::move(callback));
 
   auto headers = util::BuildSignHeaders(
       "post /v2/suggestions/claim",

--- a/vendor/bat-native-ledger/src/bat/ledger/internal/ledger_impl.cc
+++ b/vendor/bat-native-ledger/src/bat/ledger/internal/ledger_impl.cc
@@ -403,10 +403,10 @@ void LedgerImpl::OnPostData(
   }
 
   if (type == TWITCH_MEDIA_TYPE) {
-    std::vector<base::flat_map<std::string, std::string>> twitchParts;
-    braveledger_media::GetTwitchParts(post_data, &twitchParts);
-    for (auto& twitchPart : twitchParts) {
-      media()->ProcessMedia(twitchPart, type, std::move(visit_data));
+    std::vector<base::flat_map<std::string, std::string>> twitch_parts;
+    braveledger_media::GetTwitchParts(post_data, &twitch_parts);
+    for (auto& twitch_part : twitch_parts) {
+      media()->ProcessMedia(twitch_part, type, visit_data.Clone());
     }
     return;
   }
@@ -416,7 +416,7 @@ void LedgerImpl::OnPostData(
     braveledger_media::GetVimeoParts(post_data, &parts);
 
     for (auto& part : parts) {
-      media()->ProcessMedia(part, type, std::move(visit_data));
+      media()->ProcessMedia(part, type, visit_data.Clone());
     }
     return;
   }


### PR DESCRIPTION
This change is the result of running the following clang-tidy
modernisers:

  bugprone-argument-comment
  bugprone-assert-side-effect
  bugprone-dangling-handle
  bugprone-inaccurate-erase
  bugprone-string-constructor
  bugprone-string-integer-assignment
  bugprone-unused-raii
  bugprone-use-after-move

There are actual UB, and crashes that have been caught specially in the
user-after-move category. One bug was also found on the use of
innaccurate erasure. A similar bug to this one had caused a crash to the
nightly release this week.

<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/24992

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [x] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [x] New files have MPL-2.0 license header
- [x] Adequate test coverage exists to prevent regressions
- [x] Major classes, functions and non-trivial code blocks are well-commented
- [x] Changes in component dependencies are properly reflected in `gn`
- [x] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [x] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

