### PR TITLE
BraveActionAPI use-after-move fix and modernisation

### DIFF
--- a/browser/brave_rewards/rewards_panel/rewards_panel_extension_handler.cc
+++ b/browser/brave_rewards/rewards_panel/rewards_panel_extension_handler.cc
@@ -78,10 +78,11 @@ void RewardsPanelExtensionHandler::OnRewardsPanelRequested(
       extension_service->component_loader())
       ->AddRewardsExtension();
 
-  std::string error;
-  extensions::BraveActionAPI::ShowActionUI(
-      browser_, brave_rewards_extension_id,
-      std::make_unique<std::string>(GetExtensionPath(args)), &error);
+  auto result = extensions::BraveActionAPI::ShowActionUI(
+      browser_, brave_rewards_extension_id, GetExtensionPath(args));
+  if (!result.has_value()) {
+    LOG(ERROR) << "Failure to show Action UI. error=" << result.error();
+  }
 }
 
 }  // namespace brave_rewards

--- a/browser/extensions/api/brave_action_api.h
+++ b/browser/extensions/api/brave_action_api.h
@@ -6,13 +6,14 @@
 #ifndef BRAVE_BROWSER_EXTENSIONS_API_BRAVE_ACTION_API_H_
 #define BRAVE_BROWSER_EXTENSIONS_API_BRAVE_ACTION_API_H_
 
-#include <memory>
 #include <string>
 
 #include "base/observer_list.h"
+#include "base/types/expected.h"
 #include "components/keyed_service/core/keyed_service.h"
 #include "extensions/browser/extension_function.h"
 #include "extensions/common/extension.h"
+#include "third_party/abseil-cpp/absl/types/optional.h"
 
 class Browser;
 
@@ -23,25 +24,23 @@ class BraveActionAPI : public KeyedService {
    public:
     Observer();
     virtual void OnBraveActionShouldTrigger(
-      const std::string& extension_id,
-      std::unique_ptr<std::string> ui_relative_path) = 0;
+        const std::string& extension_id,
+        const absl::optional<std::string>& ui_relative_path) = 0;
 
    protected:
     virtual ~Observer();
   };
 
   static BraveActionAPI* Get(Browser* context);
-  static bool ShowActionUI(
-        ExtensionFunction* extension_function,
-        const std::string& extension_id,
-        std::unique_ptr<int> window_id,
-        std::unique_ptr<std::string> ui_relative_path,
-        std::string* error);
-  static bool ShowActionUI(
-        Browser* browser,
-        const std::string& extension_id,
-        std::unique_ptr<std::string> ui_relative_path,
-        std::string* error);
+  static base::expected<bool, std::string> ShowActionUI(
+      ExtensionFunction* extension_function,
+      const std::string& extension_id,
+      absl::optional<int> window_id,
+      absl::optional<std::string> ui_relative_path);
+  static base::expected<bool, std::string> ShowActionUI(
+      Browser* browser,
+      const std::string& extension_id,
+      absl::optional<std::string> ui_relative_path);
   BraveActionAPI();
   BraveActionAPI(const BraveActionAPI&) = delete;
   BraveActionAPI& operator=(const BraveActionAPI&) = delete;
@@ -53,7 +52,7 @@ class BraveActionAPI : public KeyedService {
 
  protected:
   bool NotifyObservers(const std::string& extension_id,
-      std::unique_ptr<std::string> ui_relative_path_param);
+                       absl::optional<std::string> ui_relative_path_param);
 
  private:
   base::ObserverList<Observer>::Unchecked observers_;

--- a/browser/ui/views/brave_actions/brave_actions_container.cc
+++ b/browser/ui/views/brave_actions/brave_actions_container.cc
@@ -444,7 +444,7 @@ void BraveActionsContainer::OnExtensionActionUpdated(
 // BraveActionAPI::Observer
 void BraveActionsContainer::OnBraveActionShouldTrigger(
     const std::string& extension_id,
-    std::unique_ptr<std::string> ui_relative_path) {
+    const absl::optional<std::string>& ui_relative_path) {
   if (!IsContainerAction(extension_id)) {
     return;
   }

--- a/browser/ui/views/brave_actions/brave_actions_container.h
+++ b/browser/ui/views/brave_actions/brave_actions_container.h
@@ -177,7 +177,7 @@ class BraveActionsContainer : public views::View,
   // BraveActionAPI::Observer
   void OnBraveActionShouldTrigger(
       const std::string& extension_id,
-      std::unique_ptr<std::string> ui_relative_path) override;
+      const absl::optional<std::string>& ui_relative_path) override;
 
   bool should_hide_ = false;
 


### PR DESCRIPTION
This change corrects a use-after-move in
BraveActionAPI::NotifyObservers, when notifying more than one observer.
At the same time, all unecessary uses of std::unique_ptr<T> have been
removed in favour of stack-based wrapper types.

<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/25066

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [x] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [x] New files have MPL-2.0 license header
- [x] Adequate test coverage exists to prevent regressions
- [x] Major classes, functions and non-trivial code blocks are well-commented
- [x] Changes in component dependencies are properly reflected in `gn`
- [x] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [x] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

