### PR TITLE
Fix WebTorrent first load of magnet links

### DIFF
--- a/components/brave_webtorrent/extension/actions/tab_actions.ts
+++ b/components/brave_webtorrent/extension/actions/tab_actions.ts
@@ -8,7 +8,7 @@ import { action } from 'typesafe-actions'
 import { types } from '../constants/tab_types'
 
 export const tabUpdated = (tabId: number,
-    changeInfo: chrome.webNavigation.WebNavigationFramedCallbackDetails) =>
+    changeInfo: { url: string }) =>
   action(types.TAB_UPDATED, {
     tabId, changeInfo
   })

--- a/components/brave_webtorrent/extension/background/events/tabsEvents.ts
+++ b/components/brave_webtorrent/extension/background/events/tabsEvents.ts
@@ -4,6 +4,16 @@
 
 import tabActions from '../actions/tabActions'
 
+// On initialization, make sure we tell WebTorrent about all existing tabs. This
+// fixes a bug where WebTorrent wouldn't load for the first click of magnet
+// links (as the background page would not be running on that first load).
+// Note: Empty query for {} returns all tabs this extension is interested in.
+chrome.tabs.query({}, tabs => {
+  for (const tab of tabs) {
+    tabActions.tabUpdated(tab.id!, { url: tab.url ?? '' })
+  }
+})
+
 chrome.webNavigation.onCommitted.addListener(
   (details: chrome.webNavigation.WebNavigationFramedCallbackDetails) => {
     tabActions.tabUpdated(details.tabId, details)

--- a/components/brave_webtorrent/extension/background/reducers/webtorrent_reducer.ts
+++ b/components/brave_webtorrent/extension/background/reducers/webtorrent_reducer.ts
@@ -227,7 +227,7 @@ export const webtorrentReducer = (state: TorrentsState = defaultState, action: a
   switch (action.type) {
     case tabTypes.types.TAB_UPDATED:
       if (payload.changeInfo.url) {
-        state = tabUpdated(payload.changeInfo.tabId, payload.changeInfo.url, state)
+        state = tabUpdated(payload.tabId, payload.changeInfo.url, state)
       }
       break
     case tabTypes.types.TAB_REMOVED:


### PR DESCRIPTION
<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/24552

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

- Create a new Browser profile
- Open https://webtorrent.io/free-torrents
- Click one of the magnet links

If the page loads, the fix has worked. **Note:** This bug only shows up if this is the first launch of WebTorrent in a profile **AND** the first launch is via a magnet link.