### PR TITLE
Make window.ethereum.send writable

### DIFF
--- a/components/brave_wallet/renderer/js_ethereum_provider.cc
+++ b/components/brave_wallet/renderer/js_ethereum_provider.cc
@@ -186,7 +186,7 @@ void JSEthereumProvider::CreateEthereumObject(
                             gin::StringToSymbol(isolate, kIsBraveWallet),
                             v8::True(isolate), v8::ReadOnly)
         .Check();
-    // isMetaMask shuld be writable because of
+    // isMetaMask should be writable because of
     // https://github.com/brave/brave-browser/issues/22213
     ethereum_obj
         ->DefineOwnProperty(context, gin::StringToSymbol(isolate, "isMetaMask"),
@@ -198,8 +198,10 @@ void JSEthereumProvider::CreateEthereumObject(
         .Check();
     BindFunctionsToObject(isolate, context, ethereum_obj, metamask_obj);
     UpdateAndBindJSProperties(isolate, context, ethereum_obj);
+    // send should be writable because of
+    // https://github.com/brave/brave-browser/issues/25078
     for (const std::string& method :
-         {"request", "isConnected", "enable", "sendAsync", "send"}) {
+         {"request", "isConnected", "enable", "sendAsync"}) {
       SetOwnPropertyNonWritable(context, ethereum_obj,
                                 gin::StringToV8(isolate, method));
     }

--- a/renderer/test/js_ethereum_provider_browsertest.cc
+++ b/renderer/test/js_ethereum_provider_browsertest.cc
@@ -184,9 +184,11 @@ IN_PROC_BROWSER_TEST_F(JSEthereumProviderBrowserTest, NonWritable) {
     EXPECT_EQ(base::Value(true), result.value) << result.error;
   }
   // window.ethereum.* (methods)
+  // send should be writable because of
+  // https://github.com/brave/brave-browser/issues/25078
   for (const std::string& method :
        {"on", "emit", "removeListener", "removeAllListeners", "request",
-        "isConnected", "enable", "sendAsync", "send"}) {
+        "isConnected", "enable", "sendAsync"}) {
     SCOPED_TRACE(method);
     auto result =
         EvalJs(web_contents(), NonWriteableScriptMethod("ethereum", method),


### PR DESCRIPTION
<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/25078

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
1. Load https://wallet.polygon.technology/
2. Open dev console
3. There should not be error like `Uncaught TypeError: Cannot assign to read only property 'send' of object '#<Object>'`
4. Load https://www.mycryptoheroes.net/
5. Try step 1 - 3 again
