### PR TITLE
Reverts Chromium's [Clipboard API] Remove user gesture requirement fo…

### DIFF
--- a/chromium_src/third_party/blink/renderer/modules/clipboard/clipboard_promise.cc
+++ b/chromium_src/third_party/blink/renderer/modules/clipboard/clipboard_promise.cc
@@ -1,0 +1,13 @@
+/* Copyright (c) 2022 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "third_party/blink/renderer/modules/clipboard/clipboard_promise.h"
+
+#define BRAVE_CLIPBOARD_PROMISE_REQUEST_PERMISSION \
+  false);                                          \
+  if (
+
+#include "src/third_party/blink/renderer/modules/clipboard/clipboard_promise.cc"
+#undef BRAVE_CLIPBOARD_PROMISE_REQUEST_PERMISSION

--- a/patches/third_party-blink-renderer-modules-clipboard-clipboard_promise.cc.patch
+++ b/patches/third_party-blink-renderer-modules-clipboard-clipboard_promise.cc.patch
@@ -1,0 +1,12 @@
+diff --git a/third_party/blink/renderer/modules/clipboard/clipboard_promise.cc b/third_party/blink/renderer/modules/clipboard/clipboard_promise.cc
+index 232be5f18146d7e54aa41c34fb2f1d4da97c261a..5d678d5c4d57faedf507543939b958bd5ca4c6b4 100644
+--- a/third_party/blink/renderer/modules/clipboard/clipboard_promise.cc
++++ b/third_party/blink/renderer/modules/clipboard/clipboard_promise.cc
+@@ -550,6 +550,7 @@ void ClipboardPromise::RequestPermission(
+   // Currently NTP relies on readText & writeText to be called without any user
+   // gesture.
+   if (allow_without_sanitization &&
++      BRAVE_CLIPBOARD_PROMISE_REQUEST_PERMISSION
+       RuntimeEnabledFeatures::ClipboardCustomFormatsEnabled() &&
+       !has_transient_user_activation) {
+     script_promise_resolver_->Reject(MakeGarbageCollected<DOMException>(


### PR DESCRIPTION
…r read/writeText.

We should not relax the gesture requirement.

Chromium change:

https://chromium.googlesource.com/chromium/src/+/4d7b74b051abfe5945f418601fdc2ffc8ce3072c

commit 4d7b74b051abfe5945f418601fdc2ffc8ce3072c
Author: Anupam Snigdha <snianu@microsoft.com>
Date:   Tue Jun 7 16:36:28 2022 +0000

    [Clipboard API] Remove user gesture requirement for read/writeText.

    Adding user gesture requirement for readText and writeText APIs
    breaks NTP doodle sharing. We are relaxing this check for now, but
    we should fix this for sites to not rely on these APIs to be called
    without a user gesture.
    See NewTabPageDoodleShareDialogFocusTest.All test for more details.

    Bug: 106449, 1334203

<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves [brave/brave-brwoser#16890](https://github.com/brave/brave-browser/issues/16890)
(It doesn't strictly address the original issue, because Chromium's initial implementation before the above change does require a gesture already.)

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [x] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [x] New files have MPL-2.0 license header
- [x] Adequate test coverage exists to prevent regressions
- [x] Major classes, functions and non-trivial code blocks are well-commented
- [x] Changes in component dependencies are properly reflected in `gn`
- [x] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [x] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
1. Visit https://shivankaul.com/brave/clipboard-paste.html
2. You should see a message like:
    ```
    This page will attempt to write text to your clipboard without a permission prompt or user interaction.
    SecurityError: Must be handling a user gesture to use custom clipboard
    ```
3. Reload the page a few times
4. Verify you still don't see a success message
