### PR TITLE
Display "open hardware app" messaging when  hardwareWalletErrorCode undefined

### DIFF
--- a/components/brave_wallet_ui/components/extension/connect-hardware-wallet-panel/index.tsx
+++ b/components/brave_wallet_ui/components/extension/connect-hardware-wallet-panel/index.tsx
@@ -75,7 +75,7 @@ export const ConnectHardwareWalletPanel = ({
       return getLocale('braveWalletConnectHardwarePanelConnect').replace('$1', walletName)
     }
 
-    let network = getAppName(coinType)
+    const network = getAppName(coinType)
     return getLocale('braveWalletConnectHardwarePanelOpenApp')
       .replace('$1', network)
       .replace('$2', walletName)

--- a/components/brave_wallet_ui/components/extension/connect-hardware-wallet-panel/index.tsx
+++ b/components/brave_wallet_ui/components/extension/connect-hardware-wallet-panel/index.tsx
@@ -70,14 +70,15 @@ export const ConnectHardwareWalletPanel = ({
       return getLocale('braveWalletConnectHardwarePanelConfirmation')
     }
 
-    if (hardwareWalletCode === 'openLedgerApp') {
-      let network = getAppName(coinType)
-      return getLocale('braveWalletConnectHardwarePanelOpenApp')
-        .replace('$1', network)
-        .replace('$2', walletName)
+    // Not connected
+    if (hardwareWalletCode === 'deviceNotConnected' || hardwareWalletCode === 'unauthorized') {
+      return getLocale('braveWalletConnectHardwarePanelConnect').replace('$1', walletName)
     }
 
-    return getLocale('braveWalletConnectHardwarePanelConnect').replace('$1', walletName)
+    let network = getAppName(coinType)
+    return getLocale('braveWalletConnectHardwarePanelOpenApp')
+      .replace('$1', network)
+      .replace('$2', walletName)
   }, [hardwareWalletCode])
 
   // custom hooks


### PR DESCRIPTION
Resolves https://github.com/brave/brave-browser/issues/24429.

Previously, if the hardwareWalletCode was undefined, the code assumed a device was not connected.  As a result, we are displaying "Connect your Ledger" messaging, when there is a device connected.

This pull request makes the change that if hardwareWalletCode is undefined, we assume (1) the device is connected (this should be the case, otherwise we would get the 'unauthorized' error if no devices were found) and (2) that the user just needs to complete signing (this may not always be true, there could be other errors we aren't handling - see https://github.com/brave/brave-browser/issues/24443).

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
Send a transaction with a Ledger and verify 'Connect your Ledger' is not displayed when it's already connected and instead it says "Hardware wallet requires Solana App opened on Ledger".
