### PR TITLE
Make window.ethereum.send writable (uplift to 1.44.x)

### DIFF
--- a/components/brave_wallet/renderer/js_ethereum_provider.cc
+++ b/components/brave_wallet/renderer/js_ethereum_provider.cc
@@ -181,7 +181,7 @@ void JSEthereumProvider::CreateEthereumObject(
                             gin::StringToSymbol(isolate, "isBraveWallet"),
                             v8::True(isolate), v8::ReadOnly)
         .Check();
-    // isMetaMask shuld be writable because of
+    // isMetaMask should be writable because of
     // https://github.com/brave/brave-browser/issues/22213
     ethereum_obj
         ->DefineOwnProperty(context, gin::StringToSymbol(isolate, "isMetaMask"),
@@ -193,8 +193,10 @@ void JSEthereumProvider::CreateEthereumObject(
         .Check();
     BindFunctionsToObject(isolate, context, ethereum_obj, metamask_obj);
     UpdateAndBindJSProperties(isolate, context, ethereum_obj);
+    // send should be writable because of
+    // https://github.com/brave/brave-browser/issues/25078
     for (const std::string& method :
-         {"request", "isConnected", "enable", "sendAsync", "send"}) {
+         {"request", "isConnected", "enable", "sendAsync"}) {
       SetOwnPropertyNonWritable(context, ethereum_obj,
                                 gin::StringToV8(isolate, method));
     }

--- a/renderer/test/js_ethereum_provider_browsertest.cc
+++ b/renderer/test/js_ethereum_provider_browsertest.cc
@@ -184,9 +184,11 @@ IN_PROC_BROWSER_TEST_F(JSEthereumProviderBrowserTest, NonWritable) {
     EXPECT_EQ(base::Value(true), result.value) << result.error;
   }
   // window.ethereum.* (methods)
+  // send should be writable because of
+  // https://github.com/brave/brave-browser/issues/25078
   for (const std::string& method :
        {"on", "emit", "removeListener", "removeAllListeners", "request",
-        "isConnected", "enable", "sendAsync", "send"}) {
+        "isConnected", "enable", "sendAsync"}) {
     SCOPED_TRACE(method);
     auto result =
         EvalJs(web_contents(), NonWriteableScriptMethod("ethereum", method),


### PR DESCRIPTION
Uplift of #14895
Resolves https://github.com/brave/brave-browser/issues/25078

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.