### PR TITLE
Reverts Chromium's [Clipboard API] Remove user gesture requirement fo… (uplift to 1.43.x)

### DIFF
--- a/chromium_src/third_party/blink/renderer/modules/clipboard/clipboard_promise.cc
+++ b/chromium_src/third_party/blink/renderer/modules/clipboard/clipboard_promise.cc
@@ -1,0 +1,13 @@
+/* Copyright (c) 2022 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "third_party/blink/renderer/modules/clipboard/clipboard_promise.h"
+
+#define BRAVE_CLIPBOARD_PROMISE_REQUEST_PERMISSION \
+  false);                                          \
+  if (
+
+#include "src/third_party/blink/renderer/modules/clipboard/clipboard_promise.cc"
+#undef BRAVE_CLIPBOARD_PROMISE_REQUEST_PERMISSION

--- a/patches/third_party-blink-renderer-modules-clipboard-clipboard_promise.cc.patch
+++ b/patches/third_party-blink-renderer-modules-clipboard-clipboard_promise.cc.patch
@@ -1,0 +1,12 @@
+diff --git a/third_party/blink/renderer/modules/clipboard/clipboard_promise.cc b/third_party/blink/renderer/modules/clipboard/clipboard_promise.cc
+index 232be5f18146d7e54aa41c34fb2f1d4da97c261a..5d678d5c4d57faedf507543939b958bd5ca4c6b4 100644
+--- a/third_party/blink/renderer/modules/clipboard/clipboard_promise.cc
++++ b/third_party/blink/renderer/modules/clipboard/clipboard_promise.cc
+@@ -550,6 +550,7 @@ void ClipboardPromise::RequestPermission(
+   // Currently NTP relies on readText & writeText to be called without any user
+   // gesture.
+   if (allow_without_sanitization &&
++      BRAVE_CLIPBOARD_PROMISE_REQUEST_PERMISSION
+       RuntimeEnabledFeatures::ClipboardCustomFormatsEnabled() &&
+       !has_transient_user_activation) {
+     script_promise_resolver_->Reject(MakeGarbageCollected<DOMException>(


### PR DESCRIPTION
Resolves https://github.com/brave/brave-browser/issues/16890
Uplift of #14901

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.