### PR TITLE
[Android] Disabled `Add to Home screen` IPH (uplift to 1.43.x)

### DIFF
--- a/chromium_src/chrome/browser/flags/android/chrome_feature_list.cc
+++ b/chromium_src/chrome/browser/flags/android/chrome_feature_list.cc
@@ -3,6 +3,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+#include "base/feature_override.h"
 #include "brave/components/brave_rewards/common/features.h"
 #include "brave/components/brave_search_conversion/features.h"
 #include "brave/components/brave_today/common/features.h"
@@ -20,3 +21,13 @@
 
 #include "src/chrome/browser/flags/android/chrome_feature_list.cc"
 #undef kForceWebContentsDarkMode
+
+namespace chrome {
+namespace android {
+
+OVERRIDE_FEATURE_DEFAULT_STATES({{
+    {kAddToHomescreenIPH, base::FEATURE_DISABLED_BY_DEFAULT},
+}});
+
+}  // namespace android
+}  // namespace chrome


### PR DESCRIPTION
Uplift of #14930
Resolves https://github.com/brave/brave-browser/issues/25118

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.