### PR TITLE
Adds Android guards for ads_tooltips_delegate_ that prevents a crash (uplift to 1.43.x)

### DIFF
--- a/components/brave_ads/browser/ads_service_impl.cc
+++ b/components/brave_ads/browser/ads_service_impl.cc
@@ -813,7 +813,9 @@ void AdsServiceImpl::OnEnabledPrefChanged() {
 
 #if BUILDFLAG(BRAVE_ADAPTIVE_CAPTCHA_ENABLED)
     adaptive_captcha_service_->ClearScheduledCaptcha();
+#if !BUILDFLAG(IS_ANDROID)
     ads_tooltips_delegate_->CloseCaptchaTooltip();
+#endif
 #endif
   }
 
@@ -1762,6 +1764,9 @@ void AdsServiceImpl::ShowScheduledCaptchaNotification(
       return;
     }
 
+// TODO(sergz): made a guard to prevent a potential crash, but need to
+// check as we could have the guard in the higher level for Android
+#if !BUILDFLAG(IS_ANDROID)
     const int snooze_count = pref_service->GetInteger(
         brave_adaptive_captcha::prefs::kScheduledCaptchaSnoozeCount);
 
@@ -1771,6 +1776,7 @@ void AdsServiceImpl::ShowScheduledCaptchaNotification(
         payment_id, captcha_id, snooze_count == 0,
         base::BindOnce(&AdsServiceImpl::ShowScheduledCaptcha, AsWeakPtr()),
         base::BindOnce(&AdsServiceImpl::SnoozeScheduledCaptcha, AsWeakPtr()));
+#endif
   } else {
     ShowScheduledCaptcha(payment_id, captcha_id);
   }


### PR DESCRIPTION
Uplift of https://github.com/brave/brave-core/pull/14982
Resolves https://github.com/brave/brave-browser/issues/25191