### PR TITLE
Implement eth_coinbase handling for MM compat

### DIFF
--- a/components/brave_wallet/browser/ethereum_provider_impl.cc
+++ b/components/brave_wallet/browser/ethereum_provider_impl.cc
@@ -979,7 +979,7 @@ void EthereumProviderImpl::CommonRequestOrSendAsync(base::ValueView input_value,
     return;
   }
 
-  if (method == kEthAccounts) {
+  if (method == kEthAccounts || method == kEthCoinbase) {
     GetAllowedAccounts(
         false,
         base::BindOnce(&EthereumProviderImpl::OnContinueGetAllowedAccounts,
@@ -1361,6 +1361,13 @@ void EthereumProviderImpl::OnContinueGetAllowedAccounts(
       list.Append(account);
     }
     formed_response = base::Value(std::move(list));
+    update_bindings = false;
+  } else if (method == kEthCoinbase) {
+    if (accounts.empty()) {
+      formed_response = base::Value();
+    } else {
+      formed_response = base::Value(accounts[0]);
+    }
     update_bindings = false;
   } else {
     formed_response =

--- a/components/brave_wallet/browser/ethereum_provider_impl.h
+++ b/components/brave_wallet/browser/ethereum_provider_impl.h
@@ -156,6 +156,7 @@ class EthereumProviderImpl final
                            RequestEthereumPermissionsNoWallet);
   FRIEND_TEST_ALL_PREFIXES(EthereumProviderImplUnitTest,
                            RequestEthereumPermissionsLocked);
+  FRIEND_TEST_ALL_PREFIXES(EthereumProviderImplUnitTest, RequestEthCoinbase);
   FRIEND_TEST_ALL_PREFIXES(EthereumProviderImplUnitTest,
                            RequestEthereumPermissionsWithAccounts);
   friend class EthereumProviderImplUnitTest;

--- a/components/brave_wallet/common/web3_provider_constants.h
+++ b/components/brave_wallet/common/web3_provider_constants.h
@@ -29,6 +29,7 @@ constexpr char kSignMessage[] = "signMessage";
 }  // namespace solana
 
 constexpr char kEthAccounts[] = "eth_accounts";
+constexpr char kEthCoinbase[] = "eth_coinbase";
 constexpr char kEthRequestAccounts[] = "eth_requestAccounts";
 constexpr char kEthSendTransaction[] = "eth_sendTransaction";
 constexpr char kEthGetBlockByNumber[] = "eth_getBlockByNumber";


### PR DESCRIPTION
This returns the same information as `eth_accounts`. No extra information
is leaked (e.g. with regards to potential fingerprinting data).

The main difference is that it returns only 1 string account or null, instead of
an array with 0 or 1 item.  This is needed for webcompat reasons for
sites like bsc.cryptoz.cards which use `eth_coinbase` instead of
`eth_accounts`.

Before this PR we would pass this to Infura and it would return an error.

<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/23571

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [x] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [x] New files have MPL-2.0 license header
- [x] Adequate test coverage exists to prevent regressions
- [x] Major classes, functions and non-trivial code blocks are well-commented
- [x] Changes in component dependencies are properly reflected in `gn`
- [x] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [x] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

