### PR TITLE
Settings icons fix uplift

### DIFF
--- a/browser/resources/settings/brave_overrides/settings_menu.js
+++ b/browser/resources/settings/brave_overrides/settings_menu.js
@@ -201,7 +201,7 @@ RegisterStyleOverride(
 
 RegisterStyleOverride('iron-icon', html`
  <style>
-    :host svg {
+    :host-context(.cr-nav-menu-item) svg {
       fill: url(#selectedGradient);
     }
  </style>`)


### PR DESCRIPTION
Resolves https://github.com/brave/brave-browser/issues/24872
Resolves https://github.com/brave/brave-browser/issues/24944
Original PR: https://github.com/brave/brave-core/pull/14780

Sorry for the delay, I didn't realise the bug made it into 1.44.x
