### PR TITLE
fix(wallet): ERC20 Approve using Wrong Network

### DIFF
--- a/components/brave_wallet_ui/components/extension/confirm-transaction-panel/erc-twenty-transaction-info.tsx
+++ b/components/brave_wallet_ui/components/extension/confirm-transaction-panel/erc-twenty-transaction-info.tsx
@@ -23,12 +23,12 @@ interface Erc20TransactionInfoProps {
 
 export const Erc20ApproveTransactionInfo = ({ onToggleEditGas }: Erc20TransactionInfoProps) => {
   const {
-    currentTokenAllowance, transactionDetails
+    currentTokenAllowance, transactionDetails, transactionsNetwork
   } = usePendingTransactions()
 
   // redux
   const {
-    selectedNetwork, defaultCurrencies
+    defaultCurrencies
   } = useSelector((state: { wallet: WalletState }) => state.wallet)
 
   // exit early if no details
@@ -45,8 +45,8 @@ export const Erc20ApproveTransactionInfo = ({ onToggleEditGas }: Erc20Transactio
 
     <TransactionTypeText>
       {new Amount(transactionDetails.gasFee)
-        .divideByDecimals(selectedNetwork.decimals)
-        .formatAsAsset(6, selectedNetwork.symbol)}
+        .divideByDecimals(transactionsNetwork.decimals)
+        .formatAsAsset(6, transactionsNetwork.symbol)}
     </TransactionTypeText>
 
     <TransactionText hasError={false}>
@@ -62,9 +62,9 @@ export const Erc20ApproveTransactionInfo = ({ onToggleEditGas }: Erc20Transactio
 
     {transactionDetails.insufficientFundsForGasError === false &&
       transactionDetails.insufficientFundsError &&
-        <TransactionText hasError={true}>
-          {getLocale('braveWalletSwapInsufficientBalance')}
-        </TransactionText>
+      <TransactionText hasError={true}>
+        {getLocale('braveWalletSwapInsufficientBalance')}
+      </TransactionText>
     }
 
     <Divider />


### PR DESCRIPTION
## Description 
Fixes a bug where the `ERC20 Approve` panel was parsing network fees for the wrong network.

<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves <https://github.com/brave/brave-browser/issues/25255>

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [x] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [x] New files have MPL-2.0 license header
- [x] Adequate test coverage exists to prevent regressions
- [x] Major classes, functions and non-trivial code blocks are well-commented
- [x] Changes in component dependencies are properly reflected in `gn`
- [x] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [x] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

1. Go to https://app.uniswap.org/ and connect your `Ethereum` wallet
2. Open the panel and change the network to `Solana Mainnet`
3. Now create an `ERC20 Approve` transactions
4. The network fees should not be parsed for `Solana`

Before:

https://user-images.githubusercontent.com/40611140/188921858-824ed785-a64a-419b-906a-8c2b4ef6dae1.mov

After:

https://user-images.githubusercontent.com/40611140/188921906-ceb9e9dc-73fc-4d73-bfbb-4e2cc98a9c74.mov
