### PR TITLE
Add restamp attribute to Restart buttons to avoid misstyling them when hiding/showing

### DIFF
--- a/browser/resources/settings/brave_rewards_page/brave_rewards_page.html
+++ b/browser/resources/settings/brave_rewards_page/brave_rewards_page.html
@@ -122,7 +122,7 @@
   <settings-toggle-button
     label="$i18n{braveRewardsInlineTipRedditLabel}"
     pref="{{prefs.brave.rewards.inline_tip.reddit}}">
-    <template is="dom-if" if="[[shouldShowRestartButtonForReddit_(prefs.brave.rewards.inline_tip.reddit.value)]]">
+    <template is="dom-if" if="[[shouldShowRestartButtonForReddit_(prefs.brave.rewards.inline_tip.reddit.value)]]" restamp>
       <cr-button on-click="restartBrowser_" slot="more-actions">
         $i18n{restart}
       </cr-button>
@@ -131,7 +131,7 @@
   <settings-toggle-button
     label="$i18n{braveRewardsInlineTipTwitterLabel}"
     pref="{{prefs.brave.rewards.inline_tip.twitter}}">
-    <template is="dom-if" if="[[shouldShowRestartButtonForTwitter_(prefs.brave.rewards.inline_tip.twitter.value)]]">
+    <template is="dom-if" if="[[shouldShowRestartButtonForTwitter_(prefs.brave.rewards.inline_tip.twitter.value)]]" restamp>
       <cr-button on-click="restartBrowser_" slot="more-actions">
         $i18n{restart}
       </cr-button>
@@ -140,7 +140,7 @@
   <settings-toggle-button
     label="$i18n{braveRewardsInlineTipGithubLabel}"
     pref="{{prefs.brave.rewards.inline_tip.github}}">
-    <template is="dom-if" if="[[shouldShowRestartButtonForGithub_(prefs.brave.rewards.inline_tip.github.value)]]">
+    <template is="dom-if" if="[[shouldShowRestartButtonForGithub_(prefs.brave.rewards.inline_tip.github.value)]]" restamp>
       <cr-button on-click="restartBrowser_" slot="more-actions">
         $i18n{restart}
       </cr-button>


### PR DESCRIPTION
<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/19675

Adds `restamp` attribute so that the tip-related relaunch buttons are recreated in the DOM vs. being hidden/shown, as that will ensure that the correct styling is applied.

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [x] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [x] New files have MPL-2.0 license header
- [x] Adequate test coverage exists to prevent regressions
- [x] Major classes, functions and non-trivial code blocks are well-commented
- [x] Changes in component dependencies are properly reflected in `gn`
- [x] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [x] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

See STR in original issue