### PR TITLE
Improve license check error message

### DIFF
--- a/script/brave_license_helper.py
+++ b/script/brave_license_helper.py
@@ -168,4 +168,9 @@ def CheckBraveMissingLicense(target_os, path, error):
         else:
             if path in ANDROID_ONLY_PATHS:
                 return  # Android failures are not relevant on desktop.
+        print('\nERROR: missing license information in %s\n'
+              "If this is code you added, then you'll have to add the required "
+              "metadata.\nIf the path that's mentioned isn't something you "
+              "added, then you probably just need to remove that obsolete path "
+              "from your local checkout.\n" % path)
         raise error


### PR DESCRIPTION
<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves brave/brave-browser#25261.

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [x] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [x] New files have MPL-2.0 license header
- [x] Adequate test coverage exists to prevent regressions
- [x] Major classes, functions and non-trivial code blocks are well-commented
- [x] Changes in component dependencies are properly reflected in `gn`
- [x] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [x] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
1. Create a leftover directory: `mkdir -p src/brave/third_party/boost`
2. Attempt to build: `npm run build`
3. Look for the new error message:
```
[228/40646] ACTION //components/resources:ab...t_credits(//build/toolchain/linux:clang_x64)
FAILED: gen/components/resources/about_credits.html 
python3 ../../tools/licenses.py --target-os=linux --depfile gen/components/resources/about_credits.d credits gen/components/resources/about_credits.html

ERROR: missing license information in brave/third_party/boost
If this is code you added, then you'll have to add the required metadata.
If the path that's mentioned isn't something you added, then you probably just need to remove that obsolete path from your local checkout.

Traceback (most recent call last):
  File "../../tools/licenses.py", line 903, in <module>
    sys.exit(main())
  File "../../tools/licenses.py", line 885, in main
    if not GenerateCredits(args.file_template, args.entry_template,
  File "../../tools/licenses.py", line 752, in GenerateCredits
    CheckBraveMissingLicense(target_os, path, e)
  File "/home/francois/devel/brave-browser/src/brave/script/brave_license_helper.py", line 175, in CheckBraveMissingLicense
    raise error
  File "../../tools/licenses.py", line 750, in GenerateCredits
    metadata = ParseDir(path, _REPOSITORY_ROOT)
  File "../../tools/licenses.py", line 458, in ParseDir
    raise LicenseError("missing README.chromium or licenses.py "
__main__.LicenseError: missing README.chromium or licenses.py SPECIAL_CASES entry in brave/third_party/boost

[347/40646] CXX obj/base/base/scoped_thread_priority.o
```