### PR TITLE
Fixes Brave Ads issuers fail to update on iOS - 1.44.x

### DIFF
--- a/vendor/bat-native-ads/src/bat/ads/internal/account/issuers/issuers_util.cc
+++ b/vendor/bat-native-ads/src/bat/ads/internal/account/issuers/issuers_util.cc
@@ -87,14 +87,10 @@ bool HasIssuers() {
 bool HasIssuersChanged(const IssuersInfo& issuers) {
   const absl::optional<IssuersInfo> last_issuers = GetIssuers();
   if (!last_issuers) {
-    return false;
+    return true;
   }
 
-  if (issuers == *last_issuers) {
-    return false;
-  }
-
-  return true;
+  return issuers != *last_issuers;
 }
 
 bool IssuerExistsForType(const IssuerType issuer_type) {

--- a/vendor/bat-native-ads/src/bat/ads/internal/account/issuers/issuers_util_unittest.cc
+++ b/vendor/bat-native-ads/src/bat/ads/internal/account/issuers/issuers_util_unittest.cc
@@ -8,6 +8,7 @@
 #include "bat/ads/internal/account/issuers/issuers_info.h"
 #include "bat/ads/internal/account/issuers/issuers_unittest_util.h"
 #include "bat/ads/internal/base/unittest/unittest_base.h"
+#include "bat/ads/pref_names.h"
 
 // npm run test -- brave_unit_tests --filter=BatAds*
 
@@ -27,6 +28,24 @@ TEST_F(BatAdsIssuersUtilTest, HasIssuersChanged) {
   // Act
   const IssuersInfo issuers =
       BuildIssuers(3600000,
+                   {{"Nj2NZ6nJUsK5MJ9ga9tfyctxzpT+GlvENF2TRHU4kBg=", 0.0},
+                    {"TFQCiRJocOh0A8+qHQvdu3V/lDpGsZHJOnZzqny6rFg=", 0.0}},
+                   {{"PmXS59VTEVIPZckOqGdpjisDidUbhLGbhAhN5tmfhhs=", 0.1},
+                    {"Bgk5gT+b96iSr3nD5nuTM/yGQ5klrIe6VC6DDdM6sFs=", 0.0}});
+
+  const bool has_changed = HasIssuersChanged(issuers);
+
+  // Assert
+  EXPECT_TRUE(has_changed);
+}
+
+TEST_F(BatAdsIssuersUtilTest, HasIssuersChangedOnInitialFetch) {
+  // Arrange
+  AdsClientHelper::GetInstance()->ClearPref(prefs::kIssuers);
+
+  // Act
+  const IssuersInfo issuers =
+      BuildIssuers(3'600'000,
                    {{"Nj2NZ6nJUsK5MJ9ga9tfyctxzpT+GlvENF2TRHU4kBg=", 0.0},
                     {"TFQCiRJocOh0A8+qHQvdu3V/lDpGsZHJOnZzqny6rFg=", 0.0}},
                    {{"PmXS59VTEVIPZckOqGdpjisDidUbhLGbhAhN5tmfhhs=", 0.1},

--- a/vendor/bat-native-ads/src/bat/ads/internal/base/unittest/unittest_mock_util.cc
+++ b/vendor/bat-native-ads/src/bat/ads/internal/base/unittest/unittest_mock_util.cc
@@ -510,7 +510,10 @@ void MockGetDictPref(const std::unique_ptr<AdsClientMock>& mock) {
             const std::string& json = Prefs()[uuid];
             const absl::optional<base::Value> root =
                 base::JSONReader::Read(json);
-            CHECK(root);
+            if (!root) {
+              return absl::nullopt;
+            }
+
             const base::Value::Dict* dict = root->GetIfDict();
             CHECK(dict);
             return dict->Clone();
@@ -536,7 +539,10 @@ void MockGetListPref(const std::unique_ptr<AdsClientMock>& mock) {
             const std::string& json = Prefs()[uuid];
             const absl::optional<base::Value> root =
                 base::JSONReader::Read(json);
-            DCHECK(root);
+            if (!root) {
+              return absl::nullopt;
+            }
+
             const base::Value::List* list = root->GetIfList();
             CHECK(list);
             return list->Clone();


### PR DESCRIPTION
Uplift of https://github.com/brave/brave-core/pull/15032
Resolves https://github.com/brave/brave-browser/issues/25266
Resolves https://github.com/brave/brave-ios/issues/6001

- [ ] You have checked CI and the builds, lint, and tests all pass or are not related to your PR.
- [x] You have tested your change on Nightly. 
- [x] The PR milestones match the branch they are landing to. 

After you merge: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.