### PR TITLE
Fix crash with new tab page when Brave News is disabled via brave://flags (uplift to 1.43.x)

### DIFF
--- a/browser/brave_profile_prefs.cc
+++ b/browser/brave_profile_prefs.cc
@@ -201,9 +201,7 @@ void RegisterProfilePrefs(user_prefs::PrefRegistrySyncable* registry) {
   brave_vpn::prefs::RegisterProfilePrefs(registry);
 #endif
 
-  if (base::FeatureList::IsEnabled(brave_today::features::kBraveNewsFeature)) {
-    brave_news::BraveNewsController::RegisterProfilePrefs(registry);
-  }
+  brave_news::BraveNewsController::RegisterProfilePrefs(registry);
 
   // TODO(shong): Migrate this to local state also and guard in ENABLE_WIDEVINE.
   // We don't need to display "don't ask widevine prompt option" in settings


### PR DESCRIPTION
Uplift of #15025
Fixes https://github.com/brave/brave-browser/issues/25182

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.