### PR TITLE
Downloads playlist from background web contents w/o ads

### DIFF
--- a/browser/playlist/playlist_service_factory.cc
+++ b/browser/playlist/playlist_service_factory.cc
@@ -18,6 +18,7 @@
 #include "brave/components/playlist/playlist_service.h"
 #include "brave/components/playlist/pref_names.h"
 #include "chrome/browser/browser_process.h"
+#include "chrome/browser/content_settings/host_content_settings_map_factory.h"
 #include "chrome/common/chrome_isolated_world_ids.h"
 #include "components/keyed_service/content/browser_context_dependency_manager.h"
 #include "components/pref_registry/pref_registry_syncable.h"
@@ -69,6 +70,7 @@ PlaylistServiceFactory::PlaylistServiceFactory()
     : BrowserContextKeyedServiceFactory(
           "PlaylistService",
           BrowserContextDependencyManager::GetInstance()) {
+  DependsOn(HostContentSettingsMapFactory::GetInstance());
   PlaylistDownloadRequestManager::SetPlaylistJavaScriptWorldId(
       ISOLATED_WORLD_ID_CHROME_INTERNAL);
 }
@@ -78,7 +80,9 @@ PlaylistServiceFactory::~PlaylistServiceFactory() = default;
 KeyedService* PlaylistServiceFactory::BuildServiceInstanceFor(
     content::BrowserContext* context) const {
   DCHECK(media_detector_component_manager_);
-  return new PlaylistService(context, media_detector_component_manager_.get());
+  return new PlaylistService(
+      context, HostContentSettingsMapFactory::GetForProfile(context),
+      media_detector_component_manager_.get());
 }
 
 void PlaylistServiceFactory::PrepareMediaDetectorComponentManager() {

--- a/browser/playlist/test/BUILD.gn
+++ b/browser/playlist/test/BUILD.gn
@@ -24,6 +24,7 @@ source_set("browser_tests") {
     "//chrome/browser/profiles:profile",
     "//chrome/browser/ui",
     "//chrome/test:test_support",
+    "//components/content_settings/browser",
     "//components/network_session_configurator/common",
     "//content/test:test_support",
     "//net",

--- a/components/playlist/BUILD.gn
+++ b/components/playlist/BUILD.gn
@@ -52,6 +52,7 @@ source_set("playlist") {
     "//brave/components/api_request_helper:api_request_helper",
     "//brave/components/brave_component_updater/browser",
     "//components/component_updater",
+    "//components/content_settings/browser",
     "//components/keyed_service/core",
     "//components/prefs",
     "//components/user_prefs",

--- a/components/playlist/playlist_download_request_manager.h
+++ b/components/playlist/playlist_download_request_manager.h
@@ -29,6 +29,9 @@ namespace content {
 class BrowserContext;
 }  // namespace content
 
+class HostContentSettingsMap;
+class PlaylistDownloadRequestManagerBrowserTest;
+
 namespace playlist {
 
 // This class finds media files and their thumbnails and title from a page
@@ -56,6 +59,7 @@ class PlaylistDownloadRequestManager
   static void SetPlaylistJavaScriptWorldId(const int32_t id);
 
   PlaylistDownloadRequestManager(content::BrowserContext* context,
+                                 HostContentSettingsMap* map,
                                  MediaDetectorComponentManager* manager);
   ~PlaylistDownloadRequestManager() override;
   PlaylistDownloadRequestManager(const PlaylistDownloadRequestManager&) =
@@ -67,6 +71,8 @@ class PlaylistDownloadRequestManager
   void GetMediaFilesFromPage(Request request);
 
  private:
+  friend class ::PlaylistDownloadRequestManagerBrowserTest;
+
   // Calling this will trigger loading |url| on a web contents,
   // and we'll inject javascript on the contents to get a list of
   // media files on the page.
@@ -110,9 +116,11 @@ class PlaylistDownloadRequestManager
   Request::Callback callback_for_current_request_ = base::NullCallback();
 
   std::string media_detector_script_;
-  raw_ptr<content::BrowserContext> context_;
+  raw_ptr<content::BrowserContext> context_ = nullptr;
+  raw_ptr<HostContentSettingsMap> map_ = nullptr;
 
-  raw_ptr<MediaDetectorComponentManager> media_detector_component_manager_;
+  raw_ptr<MediaDetectorComponentManager> media_detector_component_manager_ =
+      nullptr;
   base::ScopedObservation<MediaDetectorComponentManager,
                           MediaDetectorComponentManager::Observer>
       observed_{this};

--- a/components/playlist/playlist_service.cc
+++ b/components/playlist/playlist_service.cc
@@ -53,6 +53,7 @@ std::vector<base::FilePath> GetOrphanedPaths(
 }  // namespace
 
 PlaylistService::PlaylistService(content::BrowserContext* context,
+                                 HostContentSettingsMap* map,
                                  MediaDetectorComponentManager* manager)
     : base_dir_(context->GetPath().Append(kBaseDirName)),
       prefs_(user_prefs::UserPrefs::Get(context)) {
@@ -64,7 +65,7 @@ PlaylistService::PlaylistService(content::BrowserContext* context,
   thumbnail_downloader_ =
       std::make_unique<PlaylistThumbnailDownloader>(context, this);
   download_request_manager_ =
-      std::make_unique<PlaylistDownloadRequestManager>(context, manager);
+      std::make_unique<PlaylistDownloadRequestManager>(context, map, manager);
 
   // This is for cleaning up malformed items during development. Once we
   // release Playlist feature officially, we should migrate items

--- a/components/playlist/playlist_service.h
+++ b/components/playlist/playlist_service.h
@@ -30,6 +30,7 @@ class BrowserContext;
 class WebContents;
 }  // namespace content
 
+class HostContentSettingsMap;
 class PrefService;
 
 namespace playlist {
@@ -66,6 +67,7 @@ class PlaylistService : public KeyedService,
                         public PlaylistThumbnailDownloader::Delegate {
  public:
   PlaylistService(content::BrowserContext* context,
+                  HostContentSettingsMap* map,
                   MediaDetectorComponentManager* manager);
   ~PlaylistService() override;
   PlaylistService(const PlaylistService&) = delete;


### PR DESCRIPTION
fix https://github.com/brave/brave-browser/issues/25062

To make `CosmeticFiltersJsRenderFrameObserver` works,
`PageSpecificContentSettings` should be attached to background WebContents.

<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves 

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

1. Launch brave and load chrome-untrusted://playlist
2. Copy any youtube url to URL input box in chrome-untrusted://playlist
3. Click `Click here to download` button and check media contents are downloaded always when shields is on for youtube

`npm run test brave_browser_tests -- --filter=PlaylistDownloadRequestManagerBrowserTest.BackgroundWebContents`