### PR TITLE
block sync from recreating balanced content settings

### DIFF
--- a/components/brave_shields/common/brave_shield_utils.cc
+++ b/components/brave_shields/common/brave_shield_utils.cc
@@ -20,6 +20,9 @@ ContentSetting GetBraveFPContentSettingFromRules(
     const GURL& primary_url) {
   ContentSettingPatternSource fp_rule;
   for (const auto& rule : fp_rules) {
+    if (rule.secondary_pattern ==
+        ContentSettingsPattern::FromString("https://balanced"))
+      continue;
     if (rule.primary_pattern.Matches(primary_url)) {
       return rule.GetContentSetting();
     }

--- a/components/content_settings/core/browser/brave_content_settings_pref_provider.h
+++ b/components/content_settings/core/browser/brave_content_settings_pref_provider.h
@@ -47,6 +47,13 @@ class BravePrefProvider : public PrefProvider,
       ContentSettingsType content_type,
       bool incognito) const override;
 
+  // calls superclass directly
+  bool SetWebsiteSettingForTest(const ContentSettingsPattern& primary_pattern,
+                                const ContentSettingsPattern& secondary_pattern,
+                                ContentSettingsType content_type,
+                                base::Value&& value,
+                                const ContentSettingConstraints& constraints);
+
  private:
   friend class BravePrefProviderTest;
   FRIEND_TEST_ALL_PREFIXES(BravePrefProviderTest, TestShieldsSettingsMigration);
@@ -74,7 +81,8 @@ class BravePrefProvider : public PrefProvider,
   void MigrateShieldsSettingsV1ToV2ForOneType(ContentSettingsType content_type);
   void MigrateShieldsSettingsV2ToV3();
   void MigrateShieldsSettingsV3ToV4(int start_version);
-  void MigrateFPShieldsSettings();
+  void MigrateFingerprintingSettings();
+  void MigrateFingerprintingSetingsToOriginScoped();
   void UpdateCookieRules(ContentSettingsType content_type, bool incognito);
   void OnCookieSettingsChanged(ContentSettingsType content_type);
   void NotifyChanges(const std::vector<Rule>& rules, bool incognito);

--- a/components/content_settings/core/browser/brave_content_settings_pref_provider_unittest.cc
+++ b/components/content_settings/core/browser/brave_content_settings_pref_provider_unittest.cc
@@ -23,7 +23,6 @@
 #include "components/content_settings/core/test/content_settings_test_utils.h"
 #include "components/prefs/pref_service.h"
 #include "content/public/test/browser_task_environment.h"
-#include "gtest/gtest.h"
 #include "services/preferences/public/cpp/dictionary_value_update.h"
 #include "services/preferences/public/cpp/scoped_pref_update.h"
 #include "testing/gtest/include/gtest/gtest.h"


### PR DESCRIPTION
Resolves https://github.com/brave/brave-browser/issues/25280

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [x] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [x] New files have MPL-2.0 license header
- [x] Adequate test coverage exists to prevent regressions
- [x] Major classes, functions and non-trivial code blocks are well-commented
- [x] Changes in component dependencies are properly reflected in `gn`
- [x] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [x] Test plan is specified in PR before merging

## After-merge Checklist:

- [x] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [x] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

Start with 1.45.26 or earlier on desktop and android
Add an override for aggressive fingerprinting on desktop for youtube.com
Sync to android
Upgrade desktop
Verify the setting is still aggressive for youtube.com
