### PR TITLE
[iOS] Add empty SessionStorage WebState and Default URL for Navigation Proxy

### DIFF
--- a/ios/browser/api/opentabs/BUILD.gn
+++ b/ios/browser/api/opentabs/BUILD.gn
@@ -41,11 +41,12 @@ source_set("opentabs") {
     "//ios/chrome/browser/tabs",
     "//ios/chrome/browser/ui/recent_tabs:synced_sessions",
     "//ios/chrome/browser/web_state_list",
+    "//ios/web/common:user_agent",
+    "//ios/web/public/session:session",
     "//ios/web/public/thread",
     "//ios/web/web_state",
     "//ios/web/web_state:web_state_impl_header",
     "//ios/web/web_state/ui:crw_web_view_navigation_proxy",
-    "//net",
     "//ui/base",
     "//url",
   ]

--- a/ios/browser/api/opentabs/brave_tabgenerator_api.mm
+++ b/ios/browser/api/opentabs/brave_tabgenerator_api.mm
@@ -17,7 +17,6 @@
 #include "ios/chrome/browser/web_state_list/web_state_list.h"
 #include "ios/chrome/browser/web_state_list/web_state_opener.h"
 
-#include "ios/web/common/user_agent.h"
 #include "ios/web/public/session/crw_navigation_item_storage.h"
 #include "ios/web/public/session/crw_session_storage.h"
 #include "ios/web/public/thread/web_thread.h"


### PR DESCRIPTION

<!-- Add brave-browser issue bellow that this PR will resolve -->
Fixes https://github.com/brave/brave-browser/issues/25316 

Adding blank URL to proxy navigation for backforward list and adding empty session storage for webstate.

```
`web::WebState::CreateWithStorageSession` method requires a `SessionStorage` even the object has item storages empty.

`NavigationProxy` should have `url::kAboutBlankURL` for empty proxy constructing which will be used for backforwardlist.
```

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [x] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [x] New files have MPL-2.0 license header
- [x] Adequate test coverage exists to prevent regressions
- [x] Major classes, functions and non-trivial code blocks are well-commented
- [x] Changes in component dependencies are properly reflected in `gn`
- [x] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [x] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A
