### PR TITLE
Unconditionally query external wallet state on Rewards page (uplift to 1.44.x)

### DIFF
--- a/components/brave_rewards/resources/page/components/settings.tsx
+++ b/components/brave_rewards/resources/page/components/settings.tsx
@@ -70,6 +70,7 @@ export function Settings () {
     actions.getAutoContributeProperties()
     actions.getBalance()
     actions.fetchPromotions()
+    actions.getExternalWallet()
     actions.getOnboardingStatus()
     actions.getEnabledInlineTippingPlatforms()
 
@@ -87,12 +88,6 @@ export function Settings () {
     actions.getContributeList()
     actions.getReconcileStamp()
   }, [rewardsData.enabledContribute])
-
-  React.useEffect(() => {
-    if (!rewardsData.externalWallet) {
-      actions.getExternalWallet()
-    }
-  }, [rewardsData.externalWallet])
 
   const onTakeTour = () => { setShowRewardsTour(true) }
 


### PR DESCRIPTION
Uplift of #15056
Resolves https://github.com/brave/brave-browser/issues/25311

Pre-approval checklist: 
- [ ] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [ ] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [ ] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [ ] The associated issue milestone is set to the smallest version that the changes is landed on.