### PR TITLE
Make it easy to know where to modify when updating Sidebar item

### DIFF
--- a/browser/ui/sidebar/sidebar_model.cc
+++ b/browser/ui/sidebar/sidebar_model.cc
@@ -193,7 +193,7 @@ const std::vector<SidebarItem>& SidebarModel::GetAllSidebarItems() const {
   return GetSidebarService(profile_)->items();
 }
 
-bool SidebarModel::IsSidebarHasAllBuiltiInItems() const {
+bool SidebarModel::IsSidebarHasAllBuiltInItems() const {
   return GetSidebarService(profile_)->GetHiddenDefaultSidebarItems().empty();
 }
 

--- a/browser/ui/sidebar/sidebar_model.h
+++ b/browser/ui/sidebar/sidebar_model.h
@@ -79,7 +79,7 @@ class SidebarModel : public SidebarService::Observer,
   // |false| is used in unit test.
   void SetActiveIndex(int index, bool load = true);
   // Returns true if webcontents of item at |index| already loaded url.
-  bool IsSidebarHasAllBuiltiInItems() const;
+  bool IsSidebarHasAllBuiltInItems() const;
   int GetIndexOf(const SidebarItem& item) const;
 
   // Don't cache item list. list can be changed during the runtime.

--- a/browser/ui/sidebar/sidebar_unittest.cc
+++ b/browser/ui/sidebar/sidebar_unittest.cc
@@ -79,9 +79,8 @@ class SidebarModelTest : public testing::Test {
 };
 
 TEST_F(SidebarModelTest, ItemsChangedTest) {
-  auto built_in_items_size =
-      std::size(SidebarService::kDefaultBuiltInItemTypes);
-  EXPECT_EQ(built_in_items_size, service()->items().size());
+  auto built_in_items_size = service()->items().size();
+
   model()->Init(nullptr);
 
   EXPECT_EQ(-1, model()->active_index());

--- a/browser/ui/views/sidebar/sidebar_control_view.cc
+++ b/browser/ui/views/sidebar/sidebar_control_view.cc
@@ -227,7 +227,7 @@ void SidebarControlView::UpdateItemAddButtonState() {
   DCHECK(sidebar_item_add_view_);
   // Determine add button enabled state.
   bool should_enable = true;
-  if (browser_->sidebar_controller()->model()->IsSidebarHasAllBuiltiInItems() &&
+  if (browser_->sidebar_controller()->model()->IsSidebarHasAllBuiltInItems() &&
       !sidebar::CanAddCurrentActiveTabToSidebar(browser_)) {
     should_enable = false;
   }

--- a/browser/ui/views/sidebar/sidebar_items_contents_view.cc
+++ b/browser/ui/views/sidebar/sidebar_items_contents_view.cc
@@ -484,7 +484,9 @@ gfx::ImageSkia SidebarItemsContentsView::GetImageForBuiltInItems(
       focused_image_resource = IDR_SIDEBAR_HISTORY_FOCUSED;
       normal_image_icon = &kSidebarHistoryIcon;
       break;
-    default:
+    case sidebar::SidebarItem::BuiltInItemType::kPlaylist:
+      return gfx::ImageSkia();
+    case sidebar::SidebarItem::BuiltInItemType::kNone:
       NOTREACHED();
       return gfx::ImageSkia();
   }

--- a/browser/ui/views/sidebar/sidebar_side_panel_utils.cc
+++ b/browser/ui/views/sidebar/sidebar_side_panel_utils.cc
@@ -20,7 +20,16 @@ SidePanelEntry::Id SidePanelIdFromSideBarItem(const SidebarItem& item) {
       return SidePanelEntry::Id::kReadingList;
     case BuiltInItemType::kBookmarks:
       return SidePanelEntry::Id::kBookmarks;
-    default:
+    case BuiltInItemType::kPlaylist:
+      NOTIMPLEMENTED();
+      return SidePanelEntry::Id::kReadingList;
+    case BuiltInItemType::kWallet:
+      [[fallthrough]];
+    case BuiltInItemType::kBraveTalk:
+      [[fallthrough]];
+    case BuiltInItemType::kHistory:
+      [[fallthrough]];
+    case BuiltInItemType::kNone:
       // Add a new case for any new types which we want to support.
       NOTREACHED() << "Asked for a panel Id from a sidebar item which should "
                       "not have a panel Id, sending Reading List instead.";

--- a/components/sidebar/sidebar_item.h
+++ b/components/sidebar/sidebar_item.h
@@ -16,6 +16,8 @@ struct SidebarItem {
     kTypeWeb,
   };
 
+  // Do not reorder or remove items, as underlying values are used as id of
+  // items.
   enum class BuiltInItemType {
     kNone = 0,
     kBraveTalk,
@@ -23,6 +25,9 @@ struct SidebarItem {
     kBookmarks,
     kReadingList,
     kHistory,
+    kPlaylist,
+    // When adding new item, dont' forget to update kBuiltInItemLast.
+    kBuiltInItemLast = kPlaylist,
   };
 
   static SidebarItem Create(const std::u16string& title,
@@ -42,11 +47,11 @@ struct SidebarItem {
   bool operator==(const SidebarItem& item) const;
 
   GURL url;
-  Type type;
-  BuiltInItemType built_in_item_type;
+  Type type = Type::kTypeBuiltIn;
+  BuiltInItemType built_in_item_type = BuiltInItemType::kNone;
   std::u16string title;
   // Set false to open this item in new tab.
-  bool open_in_panel;
+  bool open_in_panel = false;
 };
 
 bool IsBuiltInType(const SidebarItem& item);

--- a/components/sidebar/sidebar_service.cc
+++ b/components/sidebar/sidebar_service.cc
@@ -48,19 +48,20 @@ SidebarItem GetBuiltInItemForType(SidebarItem::BuiltInItemType type) {
                                      IDS_SIDEBAR_BRAVE_TALK_ITEM_TITLE),
                                  SidebarItem::Type::kTypeBuiltIn,
                                  SidebarItem::BuiltInItemType::kBraveTalk,
-                                 false);
+                                 /* open_in_panel = */ false);
     case SidebarItem::BuiltInItemType::kWallet:
       return SidebarItem::Create(GURL("chrome://wallet/"),
                                  brave_l10n::GetLocalizedResourceUTF16String(
                                      IDS_SIDEBAR_WALLET_ITEM_TITLE),
                                  SidebarItem::Type::kTypeBuiltIn,
-                                 SidebarItem::BuiltInItemType::kWallet, false);
+                                 SidebarItem::BuiltInItemType::kWallet,
+                                 /* open_in_panel = */ false);
     case SidebarItem::BuiltInItemType::kBookmarks:
       return SidebarItem::Create(brave_l10n::GetLocalizedResourceUTF16String(
                                      IDS_SIDEBAR_BOOKMARKS_ITEM_TITLE),
                                  SidebarItem::Type::kTypeBuiltIn,
                                  SidebarItem::BuiltInItemType::kBookmarks,
-                                 true);
+                                 /* open_in_panel = */ true);
     case SidebarItem::BuiltInItemType::kReadingList:
       return SidebarItem::Create(
           // TODO(petemill): Have these items created under brave/browser
@@ -68,15 +69,27 @@ SidebarItem GetBuiltInItemForType(SidebarItem::BuiltInItemType type) {
           brave_l10n::GetLocalizedResourceUTF16String(
               IDS_SIDEBAR_READING_LIST_ITEM_TITLE),
           SidebarItem::Type::kTypeBuiltIn,
-          SidebarItem::BuiltInItemType::kReadingList, true);
-    case SidebarItem::BuiltInItemType::kHistory:
-      return SidebarItem::Create(GURL("chrome://history/"),
-                                 brave_l10n::GetLocalizedResourceUTF16String(
-                                     IDS_SIDEBAR_HISTORY_ITEM_TITLE),
-                                 SidebarItem::Type::kTypeBuiltIn,
-                                 SidebarItem::BuiltInItemType::kHistory, true);
-    default:
+          SidebarItem::BuiltInItemType::kReadingList,
+          /* open_in_panel = */ true);
+    case SidebarItem::BuiltInItemType::kHistory: {
+      // TODO(sko) When should we show history item?
+      constexpr bool kShowHistoryButton = false;
+      if constexpr (kShowHistoryButton) {
+        return SidebarItem::Create(GURL("chrome://history/"),
+                                   brave_l10n::GetLocalizedResourceUTF16String(
+                                       IDS_SIDEBAR_HISTORY_ITEM_TITLE),
+                                   SidebarItem::Type::kTypeBuiltIn,
+                                   SidebarItem::BuiltInItemType::kHistory,
+                                   /* open_in_panel = */ true);
+      } else {
+        return SidebarItem();
+      }
+    }
+    case SidebarItem::BuiltInItemType::kPlaylist:
+      return SidebarItem();
+    case SidebarItem::BuiltInItemType::kNone:
       NOTREACHED();
+      break;
   }
   return SidebarItem();
 }
@@ -106,7 +119,10 @@ SidebarItem::BuiltInItemType GetBuiltInItemTypeForLegacyURL(
 std::vector<SidebarItem> GetDefaultSidebarItems() {
   std::vector<SidebarItem> items;
   for (const auto& item_type : SidebarService::kDefaultBuiltInItemTypes) {
-    items.push_back(GetBuiltInItemForType(item_type));
+    if (auto item = GetBuiltInItemForType(item_type);
+        item.built_in_item_type != SidebarItem::BuiltInItemType::kNone) {
+      items.push_back(item);
+    }
   }
   return items;
 }

--- a/components/sidebar/sidebar_service.h
+++ b/components/sidebar/sidebar_service.h
@@ -46,7 +46,16 @@ class SidebarService : public KeyedService {
       SidebarItem::BuiltInItemType::kBraveTalk,
       SidebarItem::BuiltInItemType::kWallet,
       SidebarItem::BuiltInItemType::kBookmarks,
-      SidebarItem::BuiltInItemType::kReadingList};
+      SidebarItem::BuiltInItemType::kReadingList,
+      SidebarItem::BuiltInItemType::kHistory,
+      SidebarItem::BuiltInItemType::kPlaylist};
+  static_assert(
+      std::size(kDefaultBuiltInItemTypes) ==
+          static_cast<size_t>(SidebarItem::BuiltInItemType::kBuiltInItemLast),
+      "A built-in item in this visual order is missing or you might forget to "
+      "update kBuiltInItemItemLast value. If you want to add a "
+      "new item while keeping that hidden, please visit "
+      "GetBuiltInItemForType() in sidebar_service.cc");
 
   class Observer : public base::CheckedObserver {
    public:

--- a/components/sidebar/sidebar_service_unittest.cc
+++ b/components/sidebar/sidebar_service_unittest.cc
@@ -527,7 +527,9 @@ TEST_F(SidebarServiceTest, MigratePrefSidebarBuiltInItemsNoType) {
   // included in the pref, above), minus the obsolete items (history), plus any
   // new default items, plus the custom item.
   EXPECT_EQ(service_->items().size(),
-            std::size(SidebarService::kDefaultBuiltInItemTypes) + 1);
+            std::size(SidebarService::kDefaultBuiltInItemTypes) -
+                2 /* for history and playlist: invisible built-in itmes */
+                + 1 /*for custom item added above*/);
 }
 
 TEST_F(SidebarServiceTest, HidesBuiltInItemsViaPref) {


### PR DESCRIPTION
There are several places to visit when adding a new Sidebar built-in item. This patch makes it easy to know where to modify when updating Sidebar item by checking preconditions at compile time. Also this PR adds kPlaylist type.

<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/25306

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [x] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [x] New files have MPL-2.0 license header
- [x] Adequate test coverage exists to prevent regressions
- [x] Major classes, functions and non-trivial code blocks are well-commented
- [x] Changes in component dependencies are properly reflected in `gn`
- [x] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [x] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

