### PR TITLE
[CodeHealth] Removing uses of PrefService::Get

### DIFF
--- a/browser/ui/omnibox/brave_omnibox_client_impl.cc
+++ b/browser/ui/omnibox/brave_omnibox_client_impl.cc
@@ -62,9 +62,9 @@ BraveOmniboxClientImpl::BraveOmniboxClientImpl(
       profile_(profile),
       scheme_classifier_(profile) {
   // Record initial search count p3a value.
-  const base::Value* search_p3a =
-      profile_->GetPrefs()->GetList(kSearchCountPrefName);
-  if (search_p3a->GetList().size() == 0) {
+  const base::Value::List& search_p3a =
+      profile_->GetPrefs()->GetValueList(kSearchCountPrefName);
+  if (search_p3a.size() == 0) {
     RecordSearchEventP3A(0);
   }
 }

--- a/components/ntp_background_images/browser/ntp_background_images_service.h
+++ b/components/ntp_background_images/browser/ntp_background_images_service.h
@@ -135,7 +135,7 @@ class NTPBackgroundImagesService {
 
   std::string GetReferralPromoCode() const;
   bool IsValidSuperReferralComponentInfo(
-      const base::Value& component_info) const;
+      const base::Value::Dict& component_info) const;
 
   void CheckImagesComponentUpdate(const std::string& component_id);
 
@@ -175,7 +175,7 @@ class NTPBackgroundImagesService {
   // is done is important for super referral. If this is SR install, we should
   // not show SI images until user chooses Brave default images. So, we should
   // know the exact timing whether SR assets is ready to use or not.
-  base::Value initial_sr_component_info_;
+  absl::optional<base::Value::Dict> initial_sr_component_info_;
   base::WeakPtrFactory<NTPBackgroundImagesService> weak_factory_;
 };
 

--- a/components/ntp_background_images/browser/ntp_background_images_service_unittest.cc
+++ b/components/ntp_background_images/browser/ntp_background_images_service_unittest.cc
@@ -660,8 +660,9 @@ TEST_F(NTPBackgroundImagesServiceTest, WithSuperReferralCodeTest) {
   EXPECT_TRUE(service_->mapping_table_requested_);
   EXPECT_FALSE(service_->marked_this_install_is_not_super_referral_forever_);
 
-  EXPECT_FALSE(service_->IsValidSuperReferralComponentInfo(*pref_service_.Get(
-      prefs::kNewTabPageCachedSuperReferralComponentInfo)));
+  EXPECT_FALSE(
+      service_->IsValidSuperReferralComponentInfo(pref_service_.GetValueDict(
+          prefs::kNewTabPageCachedSuperReferralComponentInfo)));
   service_->OnGetMappingTableData(kTestMappingTable);
   EXPECT_TRUE(pref_service_.GetBoolean(
       prefs::kNewTabPageGetInitialSRComponentInProgress));
@@ -679,8 +680,9 @@ TEST_F(NTPBackgroundImagesServiceTest, WithSuperReferralCodeTest) {
   EXPECT_FALSE(pref_service_.GetBoolean(
       prefs::kNewTabPageGetInitialSRComponentInProgress));
   auto* data = service_->GetBrandedImagesData(true);
-  EXPECT_TRUE(service_->IsValidSuperReferralComponentInfo(*pref_service_.Get(
-      prefs::kNewTabPageCachedSuperReferralComponentInfo)));
+  EXPECT_TRUE(
+      service_->IsValidSuperReferralComponentInfo(pref_service_.GetValueDict(
+          prefs::kNewTabPageCachedSuperReferralComponentInfo)));
   EXPECT_TRUE(data->IsSuperReferral());
   EXPECT_FALSE(pref_service_.GetString(
                    prefs::kNewTabPageCachedSuperReferralComponentData).empty());
@@ -690,8 +692,9 @@ TEST_F(NTPBackgroundImagesServiceTest, WithSuperReferralCodeTest) {
   EXPECT_TRUE(observer.on_super_referral_ended_);
   EXPECT_TRUE(pref_service_.GetString(
       prefs::kNewTabPageCachedSuperReferralCode).empty());
-  EXPECT_FALSE(service_->IsValidSuperReferralComponentInfo(*pref_service_.Get(
-      prefs::kNewTabPageCachedSuperReferralComponentInfo)));
+  EXPECT_FALSE(
+      service_->IsValidSuperReferralComponentInfo(pref_service_.GetValueDict(
+          prefs::kNewTabPageCachedSuperReferralComponentInfo)));
   EXPECT_TRUE(pref_service_.GetString(
                   prefs::kNewTabPageCachedSuperReferralComponentData).empty());
   EXPECT_TRUE(service_->marked_this_install_is_not_super_referral_forever_);


### PR DESCRIPTION
Due to the ongoing base::Value modernisations going on upstream, PrefServices::Get has been deleted already on the main branch, in favour of type specific versions, like PrefService::GetValueDict.

This change removes all uses of PrefService::Get that are possible to be removed for now, to reduce the disruptions in upcoming version upgrades.

<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/25364

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [x] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [x] New files have MPL-2.0 license header
- [x] Adequate test coverage exists to prevent regressions
- [x] Major classes, functions and non-trivial code blocks are well-commented
- [x] Changes in component dependencies are properly reflected in `gn`
- [x] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [x] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

