### PR TITLE
Randomly choose NTP-SI for users both opted-in and out of Brave Ads

### DIFF
--- a/components/ntp_background_images/browser/view_counter_model.cc
+++ b/components/ntp_background_images/browser/view_counter_model.cc
@@ -75,13 +75,13 @@ void ViewCounterModel::RegisterPageViewForBrandedImages() {
   // view of the branded wallpaper.
   count_to_branded_wallpaper_--;
   if (count_to_branded_wallpaper_ < 0) {
-    // Reset count and increse image index for next time.
+    // Reset count and increase image index for next time.
     count_to_branded_wallpaper_ = kRegularCountToBrandedWallpaper;
     campaigns_current_branded_image_index_[current_campaign_index_]++;
     campaigns_current_branded_image_index_[current_campaign_index_] %=
         campaigns_total_branded_image_count_[current_campaign_index_];
 
-    // Increse campaign index for next time.
+    // Increase campaign index for next time.
     current_campaign_index_++;
     current_campaign_index_ %= total_campaign_count_;
     return;

--- a/components/ntp_background_images/browser/view_counter_model_unittest.cc
+++ b/components/ntp_background_images/browser/view_counter_model_unittest.cc
@@ -33,104 +33,28 @@ TEST(ViewCounterModelTest, NTPSponsoredImagesTest) {
     model.RegisterPageView();
   }
 
-  // (campaign index, image index)
-  // Image at index (1, 0) should be displayed now after loading initial count.
-  EXPECT_TRUE(model.ShouldShowBrandedWallpaper());
-  auto current_index = model.GetCurrentBrandedImageIndex();
-  EXPECT_EQ(1UL, std::get<0>(current_index));
-  EXPECT_EQ(0UL, std::get<1>(current_index));
-  model.RegisterPageView();
+  for (int i = 0; i < 30; i++) {
+    // Random image should be displayed now after loading initial count.
+    EXPECT_TRUE(model.ShouldShowBrandedWallpaper());
 
-  // Loading regular-count times.
-  for (int i = 0; i < ViewCounterModel::kRegularCountToBrandedWallpaper; ++i) {
-    EXPECT_FALSE(model.ShouldShowBrandedWallpaper());
+    const std::tuple</*campaign index*/ size_t, /*image index*/ size_t>
+        current_index = model.GetCurrentBrandedImageIndex();
+    const size_t campaign_index = std::get<0>(current_index);
+    const size_t image_index = std::get<1>(current_index);
+
+    EXPECT_TRUE(campaign_index >= 0 &&
+                campaign_index < kTestCampaignsTotalImageCount.size());
+    EXPECT_TRUE(image_index >= 0 &&
+                image_index < kTestCampaignsTotalImageCount.at(campaign_index));
     model.RegisterPageView();
+
+    // Loading regular-count times.
+    for (int i = 0; i < ViewCounterModel::kRegularCountToBrandedWallpaper;
+         ++i) {
+      EXPECT_FALSE(model.ShouldShowBrandedWallpaper());
+      model.RegisterPageView();
+    }
   }
-
-  // Image at index (2, 0) should be displayed now because
-  EXPECT_TRUE(model.ShouldShowBrandedWallpaper());
-  current_index = model.GetCurrentBrandedImageIndex();
-  EXPECT_EQ(2UL, std::get<0>(current_index));
-  EXPECT_EQ(0UL, std::get<1>(current_index));
-  model.RegisterPageView();
-
-  // Loading regular-count times again.
-  for (int i = 0; i < ViewCounterModel::kRegularCountToBrandedWallpaper; ++i) {
-    EXPECT_FALSE(model.ShouldShowBrandedWallpaper());
-    model.RegisterPageView();
-  }
-
-  // Image at index (0, 0) should be displayed now.
-  EXPECT_TRUE(model.ShouldShowBrandedWallpaper());
-  current_index = model.GetCurrentBrandedImageIndex();
-  EXPECT_EQ(0UL, std::get<0>(current_index));
-  EXPECT_EQ(0UL, std::get<1>(current_index));
-  model.RegisterPageView();
-
-  // Loading regular-count times again.
-  for (int i = 0; i < ViewCounterModel::kRegularCountToBrandedWallpaper; ++i) {
-    EXPECT_FALSE(model.ShouldShowBrandedWallpaper());
-    model.RegisterPageView();
-  }
-
-  // Image at index (1, 1) should be displayed now.
-  EXPECT_TRUE(model.ShouldShowBrandedWallpaper());
-  current_index = model.GetCurrentBrandedImageIndex();
-  EXPECT_EQ(1UL, std::get<0>(current_index));
-  EXPECT_EQ(1UL, std::get<1>(current_index));
-  model.RegisterPageView();
-
-  // Loading regular-count times again.
-  for (int i = 0; i < ViewCounterModel::kRegularCountToBrandedWallpaper; ++i) {
-    EXPECT_FALSE(model.ShouldShowBrandedWallpaper());
-    model.RegisterPageView();
-  }
-
-  // Image at index (2, 1) should be displayed now.
-  EXPECT_TRUE(model.ShouldShowBrandedWallpaper());
-  current_index = model.GetCurrentBrandedImageIndex();
-  EXPECT_EQ(2UL, std::get<0>(current_index));
-  EXPECT_EQ(1UL, std::get<1>(current_index));
-  model.RegisterPageView();
-
-  // Loading regular-count times again.
-  for (int i = 0; i < ViewCounterModel::kRegularCountToBrandedWallpaper; ++i) {
-    EXPECT_FALSE(model.ShouldShowBrandedWallpaper());
-    model.RegisterPageView();
-  }
-
-  // Image at index (0, 1) should be displayed now.
-  EXPECT_TRUE(model.ShouldShowBrandedWallpaper());
-  current_index = model.GetCurrentBrandedImageIndex();
-  EXPECT_EQ(0UL, std::get<0>(current_index));
-  EXPECT_EQ(1UL, std::get<1>(current_index));
-  model.RegisterPageView();
-
-  // Loading regular-count times again.
-  for (int i = 0; i < ViewCounterModel::kRegularCountToBrandedWallpaper; ++i) {
-    EXPECT_FALSE(model.ShouldShowBrandedWallpaper());
-    model.RegisterPageView();
-  }
-
-  // Image at index (1, 0) should be displayed now.
-  EXPECT_TRUE(model.ShouldShowBrandedWallpaper());
-  current_index = model.GetCurrentBrandedImageIndex();
-  EXPECT_EQ(1UL, std::get<0>(current_index));
-  EXPECT_EQ(0UL, std::get<1>(current_index));
-  model.RegisterPageView();
-
-  // Loading regular-count times again.
-  for (int i = 0; i < ViewCounterModel::kRegularCountToBrandedWallpaper; ++i) {
-    EXPECT_FALSE(model.ShouldShowBrandedWallpaper());
-    model.RegisterPageView();
-  }
-
-  // Image at index (2, 2) should be displayed now.
-  EXPECT_TRUE(model.ShouldShowBrandedWallpaper());
-  current_index = model.GetCurrentBrandedImageIndex();
-  EXPECT_EQ(2UL, std::get<0>(current_index));
-  EXPECT_EQ(2UL, std::get<1>(current_index));
-  model.RegisterPageView();
 }
 
 TEST(ViewCounterModelTest, NTPBackgroundImagesTest) {

--- a/components/ntp_background_images/browser/view_counter_service.cc
+++ b/components/ntp_background_images/browser/view_counter_service.cc
@@ -287,9 +287,9 @@ void ViewCounterService::ResetModel() {
       campaigns_total_branded_images_count.push_back(
           campaign.backgrounds.size());
     }
+    model_.set_always_show_branded_wallpaper(data->IsSuperReferral());
     model_.SetCampaignsTotalBrandedImageCount(
         campaigns_total_branded_images_count);
-    model_.set_always_show_branded_wallpaper(data->IsSuperReferral());
   }
   // BI
   if (auto* data = GetCurrentWallpaperData()) {

--- a/components/ntp_background_images/browser/view_counter_service_unittest.cc
+++ b/components/ntp_background_images/browser/view_counter_service_unittest.cc
@@ -424,7 +424,7 @@ TEST_F(NTPBackgroundImagesViewCounterTest, GetCurrentWallpaperTest) {
 }
 
 TEST_F(NTPBackgroundImagesViewCounterTest,
-       GetSposoredImageWallpaperAdsServiceDisabled) {
+       GetSponsoredImageWallpaperAdsServiceDisabled) {
   InitBackgroundAndSponsoredImageWallpapers();
 
   EXPECT_CALL(ads_service_, IsEnabled()).WillRepeatedly(Return(false));
@@ -436,9 +436,8 @@ TEST_F(NTPBackgroundImagesViewCounterTest,
                    .value_or(true));
   ASSERT_TRUE(
       si_wallpaper->FindString(ntp_background_images::kCreativeInstanceIDKey));
-  EXPECT_EQ(kFirstCreativeInstanceId,
-            *(si_wallpaper->FindString(
-                ntp_background_images::kCreativeInstanceIDKey)));
+  EXPECT_TRUE(
+      si_wallpaper->FindString(ntp_background_images::kCreativeInstanceIDKey));
   ASSERT_TRUE(si_wallpaper->FindString(ntp_background_images::kWallpaperIDKey));
   EXPECT_FALSE(si_wallpaper->FindString(ntp_background_images::kWallpaperIDKey)
                    ->empty());


### PR DESCRIPTION
<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/25352

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- x[] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [x] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [x] New files have MPL-2.0 license header
- [x] Adequate test coverage exists to prevent regressions
- [x] Major classes, functions and non-trivial code blocks are well-commented
- [x] Changes in component dependencies are properly reflected in `gn`
- [x] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [x] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

Test NTP-SI work as expected for both opted-in and out of Brave Ads. However, campaigns/wallpapers should now be shown in a random order (and not sequentially). Super referrals should be sequential (i.e. same as before this change).