### PR TITLE
Move send_options directly to SolanaTransaction::SendOptions::FromValue (uplift to 1.44.x)

### DIFF
--- a/components/brave_wallet/browser/solana_provider_impl.cc
+++ b/components/brave_wallet/browser/solana_provider_impl.cc
@@ -392,7 +392,7 @@ void SolanaProviderImpl::SignAndSendTransaction(
       SolanaTransaction(std::move(msg_pair->first), std::move(param));
   tx.set_tx_type(mojom::TransactionType::SolanaDappSignAndSendTransaction);
   tx.set_send_options(
-      SolanaTransaction::SendOptions::FromValue(std::move(*send_options)));
+      SolanaTransaction::SendOptions::FromValue(std::move(send_options)));
 
   tx_service_->AddUnapprovedTransaction(
       mojom::TxDataUnion::NewSolanaTxData(tx.ToSolanaTxData()),


### PR DESCRIPTION
Uplift of #15083
Resolves https://github.com/brave/brave-browser/issues/25374

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.