### PR TITLE
Make Dapp addresses lowercase to be compatible with MM

### DIFF
--- a/browser/brave_wallet/ethereum_provider_impl_unittest.cc
+++ b/browser/brave_wallet/ethereum_provider_impl_unittest.cc
@@ -5,6 +5,7 @@
 
 #include "brave/components/brave_wallet/browser/ethereum_provider_impl.h"
 
+#include <algorithm>
 #include <memory>
 #include <utility>
 #include <vector>
@@ -134,7 +135,10 @@ class TestEventsListener : public brave_wallet::mojom::EventsListener {
   }
 
   void AccountsChangedEvent(const std::vector<std::string>& accounts) override {
-    accounts_ = accounts;
+    lowercase_accounts_.resize(accounts.size());
+    std::transform(accounts.cbegin(), accounts.cend(),
+                   lowercase_accounts_.begin(),
+                   [](auto&& account) { return base::ToLowerASCII(account); });
     accounts_changed_fired_ = true;
   }
 
@@ -153,9 +157,9 @@ class TestEventsListener : public brave_wallet::mojom::EventsListener {
     return chain_id_;
   }
 
-  std::vector<std::string> GetAccounts() const {
+  std::vector<std::string> GetLowercaseAccounts() const {
     base::RunLoop().RunUntilIdle();
-    return accounts_;
+    return lowercase_accounts_;
   }
 
   mojo::PendingRemote<brave_wallet::mojom::EventsListener> GetReceiver() {
@@ -164,7 +168,7 @@ class TestEventsListener : public brave_wallet::mojom::EventsListener {
 
   void Reset() {
     chain_id_.clear();
-    accounts_.clear();
+    lowercase_accounts_.clear();
     chain_changed_fired_ = false;
     accounts_changed_fired_ = false;
     EXPECT_FALSE(ChainChangedFired());
@@ -173,7 +177,7 @@ class TestEventsListener : public brave_wallet::mojom::EventsListener {
 
   bool chain_changed_fired_ = false;
   bool accounts_changed_fired_ = false;
-  std::vector<std::string> accounts_;
+  std::vector<std::string> lowercase_accounts_;
   std::string chain_id_;
 
  private:
@@ -383,6 +387,9 @@ class EthereumProviderImplUnitTest : public testing::Test {
     return keyring_service()
         ->GetHDKeyringById(brave_wallet::mojom::kDefaultKeyringId)
         ->GetAddress(from_index);
+  }
+  std::string from_lower(size_t from_index = 0) {
+    return base::ToLowerASCII(from(from_index));
   }
 
   content::BrowserContext* browser_context() { return &profile_; }
@@ -1369,7 +1376,8 @@ TEST_F(EthereumProviderImplUnitTest, RequestEthereumPermissionNotNewSetup) {
   Navigate(url);
   AddEthereumPermission(GetOrigin());
   base::RunLoop run_loop;
-  EXPECT_EQ(RequestEthereumPermissions(), std::vector<std::string>{from(0)});
+  EXPECT_EQ(RequestEthereumPermissions(),
+            std::vector<std::string>{from_lower(0)});
   // Make sure even with a delay the new setup callback is not called.
   browser_task_environment_.RunUntilIdle();
   EXPECT_FALSE(new_setup_callback_called);
@@ -1455,26 +1463,30 @@ TEST_F(EthereumProviderImplUnitTest, RequestEthereumPermissionsWithAccounts) {
 
   // Allowing 1 account should return that account for allowed accounts
   AddEthereumPermission(GetOrigin(), 0);
-  EXPECT_EQ(RequestEthereumPermissions(), std::vector<std::string>{from(0)});
+  EXPECT_EQ(RequestEthereumPermissions(),
+            std::vector<std::string>{from_lower(0)});
 
   // Multiple accounts can be returned
   AddEthereumPermission(GetOrigin(), 1);
   EXPECT_EQ(RequestEthereumPermissions(),
-            (std::vector<std::string>{from(0), from(1)}));
+            (std::vector<std::string>{from_lower(0), from_lower(1)}));
 
   // Resetting permissions should return the remaining allowed account
   ResetEthereumPermission(GetOrigin(), 1);
-  EXPECT_EQ(RequestEthereumPermissions(), std::vector<std::string>{from(0)});
+  EXPECT_EQ(RequestEthereumPermissions(),
+            std::vector<std::string>{from_lower(0)});
 
   // Selected account should filter the accounts returned
   AddEthereumPermission(GetOrigin(), 1);
   SetSelectedAccount(from(0), mojom::CoinType::ETH);
-  EXPECT_EQ(RequestEthereumPermissions(), std::vector<std::string>{from(0)});
+  EXPECT_EQ(RequestEthereumPermissions(),
+            std::vector<std::string>{from_lower(0)});
   SetSelectedAccount(from(1), mojom::CoinType::ETH);
-  EXPECT_EQ(RequestEthereumPermissions(), std::vector<std::string>{from(1)});
+  EXPECT_EQ(RequestEthereumPermissions(),
+            std::vector<std::string>{from_lower(1)});
   SetSelectedAccount(from(2), mojom::CoinType::ETH);
   EXPECT_EQ(RequestEthereumPermissions(),
-            (std::vector<std::string>{from(0), from(1)}));
+            (std::vector<std::string>{from_lower(0), from_lower(1)}));
 
   // CONTENT_SETTING_BLOCK will rule out previous granted permission.
   host_content_settings_map()->SetContentSettingDefaultScope(
@@ -1501,7 +1513,7 @@ TEST_F(EthereumProviderImplUnitTest, RequestEthereumPermissionsWithAccounts) {
   host_content_settings_map()->SetContentSettingDefaultScope(
       url, url, ContentSettingsType::BRAVE_ETHEREUM, CONTENT_SETTING_DEFAULT);
   EXPECT_EQ(RequestEthereumPermissions(),
-            (std::vector<std::string>{from(0), from(1)}));
+            (std::vector<std::string>{from_lower(0), from_lower(1)}));
 }
 
 TEST_F(EthereumProviderImplUnitTest, RequestEthereumPermissionsLocked) {
@@ -1510,7 +1522,7 @@ TEST_F(EthereumProviderImplUnitTest, RequestEthereumPermissionsLocked) {
   GURL url("https://brave.com");
   Navigate(url);
 
-  std::string account0 = from(0);
+  std::string account0 = from_lower(0);
 
   // Allowing 1 account should return that account for allowed accounts
   AddEthereumPermission(GetOrigin(), 0);
@@ -1920,19 +1932,21 @@ TEST_F(EthereumProviderImplUnitTest, AccountsChangedEvent) {
   EXPECT_FALSE(observer_->AccountsChangedFired());
   AddEthereumPermission(GetOrigin());
   EXPECT_TRUE(observer_->AccountsChangedFired());
-  EXPECT_EQ(std::vector<std::string>{from()}, observer_->GetAccounts());
+  EXPECT_EQ(std::vector<std::string>{from_lower()},
+            observer_->GetLowercaseAccounts());
   observer_->Reset();
 
   // Locking the account fires an event change with no accounts
   Lock();
   EXPECT_TRUE(observer_->AccountsChangedFired());
-  EXPECT_EQ(std::vector<std::string>(), observer_->GetAccounts());
+  EXPECT_EQ(std::vector<std::string>(), observer_->GetLowercaseAccounts());
   observer_->Reset();
 
   // Unlocking also fires an event wit the same account list as before
   Unlock();
   EXPECT_TRUE(observer_->AccountsChangedFired());
-  EXPECT_EQ(std::vector<std::string>{from()}, observer_->GetAccounts());
+  EXPECT_EQ(std::vector<std::string>{from_lower()},
+            observer_->GetLowercaseAccounts());
   observer_->Reset();
 
   // Does not fire for a different origin that has no permissions
@@ -1971,33 +1985,36 @@ TEST_F(EthereumProviderImplUnitTest, AccountsChangedEventSelectedAccount) {
   // BraveWalletProviderDelegateImpl::GetAllowedAccounts
   base::RunLoop().RunUntilIdle();
   EXPECT_TRUE(observer_->AccountsChangedFired());
-  EXPECT_EQ((std::vector<std::string>{from(0), from(1)}),
-            observer_->GetAccounts());
+  EXPECT_EQ((std::vector<std::string>{from_lower(0), from_lower(1)}),
+            observer_->GetLowercaseAccounts());
   observer_->Reset();
 
   // Changing the selected account only returns that account
   SetSelectedAccount(from(0), mojom::CoinType::ETH);
   EXPECT_TRUE(observer_->AccountsChangedFired());
-  EXPECT_EQ((std::vector<std::string>{from(0)}), observer_->GetAccounts());
+  EXPECT_EQ((std::vector<std::string>{from_lower(0)}),
+            observer_->GetLowercaseAccounts());
   observer_->Reset();
 
   // Changing to a different allowed account only returns that account
   SetSelectedAccount(from(1), mojom::CoinType::ETH);
   EXPECT_TRUE(observer_->AccountsChangedFired());
-  EXPECT_EQ((std::vector<std::string>{from(1)}), observer_->GetAccounts());
+  EXPECT_EQ((std::vector<std::string>{from_lower(1)}),
+            observer_->GetLowercaseAccounts());
   observer_->Reset();
 
   // Changing gto a not allowed account returns all allowed accounts
   SetSelectedAccount(from(2), mojom::CoinType::ETH);
   EXPECT_TRUE(observer_->AccountsChangedFired());
-  EXPECT_EQ((std::vector<std::string>{from(0), from(1)}),
-            observer_->GetAccounts());
+  EXPECT_EQ((std::vector<std::string>{from_lower(0), from_lower(1)}),
+            observer_->GetLowercaseAccounts());
   observer_->Reset();
 
   // Resetting with multiple accounts works
   ResetEthereumPermission(GetOrigin(), 1);
   EXPECT_TRUE(observer_->AccountsChangedFired());
-  EXPECT_EQ((std::vector<std::string>{from(0)}), observer_->GetAccounts());
+  EXPECT_EQ((std::vector<std::string>{from_lower(0)}),
+            observer_->GetLowercaseAccounts());
   observer_->Reset();
 }
 
@@ -2008,8 +2025,8 @@ TEST_F(EthereumProviderImplUnitTest, GetAllowedAccounts) {
   GURL url("https://brave.com");
   Navigate(url);
 
-  std::string account0 = from(0);
-  std::string account1 = from(1);
+  std::string account0 = from_lower(0);
+  std::string account1 = from_lower(1);
 
   // When nothing is allowed, empty array should be returned
   EXPECT_EQ(GetAllowedAccounts(false), std::vector<std::string>());
@@ -2392,7 +2409,7 @@ TEST_F(EthereumProviderImplUnitTest, RequestEthCoinbase) {
 
   CreateWallet();
   AddAccount();
-  std::string account0 = from(0);
+  std::string account0 = from_lower(0);
   GURL url("https://brave.com");
   Navigate(url);
 

--- a/browser/brave_wallet/send_transaction_browsertest.cc
+++ b/browser/brave_wallet/send_transaction_browsertest.cc
@@ -278,10 +278,10 @@ class SendTransactionBrowserTest : public InProcessBrowserTest {
 
   std::string from(size_t index = 0) {
     if (index == 0) {
-      return "0x084DCb94038af1715963F149079cE011C4B22961";
+      return "0x084dcb94038af1715963f149079ce011c4b22961";
     }
     if (index == 1) {
-      return "0xE60A2209372AF1049C4848B1bF0136258c35f268";
+      return "0xe60a2209372af1049c4848b1bf0136258c35f268";
     }
     return "";
   }

--- a/components/brave_wallet/browser/ethereum_provider_impl.cc
+++ b/components/brave_wallet/browser/ethereum_provider_impl.cc
@@ -1260,7 +1260,7 @@ void EthereumProviderImpl::OnRequestEthereumPermissions(
 
   std::string first_allowed_account;
   if (accounts.size() > 0) {
-    first_allowed_account = accounts[0];
+    first_allowed_account = base::ToLowerASCII(accounts[0]);
   }
   if (success && accounts.empty()) {
     formed_response = GetProviderErrorDictionary(
@@ -1287,7 +1287,7 @@ void EthereumProviderImpl::OnRequestEthereumPermissions(
   } else {
     base::Value::List list;
     for (const auto& account : accounts) {
-      list.Append(account);
+      list.Append(base::ToLowerASCII(account));
     }
     formed_response = base::Value(std::move(list));
   }
@@ -1313,7 +1313,7 @@ void EthereumProviderImpl::ContinueGetAllowedAccounts(
     brave_wallet::mojom::KeyringInfoPtr keyring_info) {
   std::vector<std::string> addresses;
   for (const auto& account_info : keyring_info->account_infos) {
-    addresses.push_back(account_info->address);
+    addresses.push_back(base::ToLowerASCII(account_info->address));
   }
 
   DCHECK(delegate_);
@@ -1361,7 +1361,7 @@ void EthereumProviderImpl::OnContinueGetAllowedAccounts(
   } else if (method == kEthAccounts) {
     base::Value::List list;
     for (const auto& account : accounts) {
-      list.Append(account);
+      list.Append(base::ToLowerASCII(account));
     }
     formed_response = base::Value(std::move(list));
     update_bindings = false;
@@ -1369,7 +1369,7 @@ void EthereumProviderImpl::OnContinueGetAllowedAccounts(
     if (accounts.empty()) {
       formed_response = base::Value();
     } else {
-      formed_response = base::Value(accounts[0]);
+      formed_response = base::Value(base::ToLowerASCII(accounts[0]));
     }
     update_bindings = false;
   } else {

--- a/components/brave_wallet/common/value_conversion_utils.cc
+++ b/components/brave_wallet/common/value_conversion_utils.cc
@@ -323,7 +323,7 @@ base::Value::List PermissionRequestResponseToValue(
   caveats_obj2.Set("type", "filterResponse");
   base::Value::List filter_response_list;
   for (auto account : accounts) {
-    filter_response_list.Append(account);
+    filter_response_list.Append(base::ToLowerASCII(account));
   }
   caveats_obj2.Set("value", std::move(filter_response_list));
   caveats_list.Append(std::move(caveats_obj2));

--- a/components/brave_wallet/common/value_conversion_utils_unittest.cc
+++ b/components/brave_wallet/common/value_conversion_utils_unittest.cc
@@ -356,7 +356,7 @@ TEST(ValueConversionUtilsUnitTest, PermissionRequestResponseToValue) {
   ASSERT_NE(exposed_accounts, nullptr);
   ASSERT_EQ(exposed_accounts->size(), 1UL);
   EXPECT_EQ((*exposed_accounts)[0],
-            base::Value("0xA99D71De40D67394eBe68e4D0265cA6C9D421029"));
+            base::Value("0xa99d71de40d67394ebe68e4d0265ca6c9d421029"));
 
   auto* context = param0.FindList("context");
   ASSERT_NE(context, nullptr);


### PR DESCRIPTION
Fix https://github.com/brave/brave-browser/issues/25039

Adobe connect MetaMask feature doesn't work for this URL: https://connected-accounts.adobe.com/

This turns out to be because the accounts we return EIP-55 checksumed addresses to Dapps instead of lowercase like MetaMask.

On this particular Adobe site, the connected account is sent up in a JSON structure to Adobe with a POST HTTPS request to https://connected-accounts.adobe.com/api/connection/metamask. If that address is not lowercase, the server responds with an HTTP status code of 400. The Adobe site uses the address that is given from the `eth_requestAccounts` call they make.

MM has lowercase addresses for return info via these functions: `eth_requestAccounts`, `eth_accounts`, `eth_coinbase`, `wallet_requestPermissions`, and `wallet_getPermissions` For the best possible webcompat we need to unfortunately follow their standard in the wild. This pull requests makes the return values to Dapps lowercase.

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [x] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [x] New files have MPL-2.0 license header
- [x] Adequate test coverage exists to prevent regressions
- [x] Major classes, functions and non-trivial code blocks are well-commented
- [x] Changes in component dependencies are properly reflected in `gn`
- [x] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [x] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

