### PR TITLE
Add Brave Ads status header to search.brave.com calls.

### DIFF
--- a/components/brave_ads/browser/BUILD.gn
+++ b/components/brave_ads/browser/BUILD.gn
@@ -8,6 +8,8 @@ source_set("browser") {
     "ads_service.cc",
     "ads_service.h",
     "ads_service_observer.h",
+    "ads_status_header_throttle.cc",
+    "ads_status_header_throttle.h",
     "ads_storage_cleanup.cc",
     "ads_storage_cleanup.h",
     "component_updater/component_info.cc",
@@ -36,6 +38,7 @@ source_set("browser") {
     "//components/prefs",
     "//components/sessions",
     "//sql",
+    "//third_party/blink/public/common",
     "//url",
   ]
 

--- a/components/brave_ads/browser/DEPS
+++ b/components/brave_ads/browser/DEPS
@@ -6,6 +6,7 @@ include_rules = [
   "+brave/components/constants",
   "+content/public/browser",
   "+services/network/public",
+  "+third_party/blink/public",
   "+ui/base",
   "+ui/message_center/public",
 ]

--- a/components/brave_ads/browser/ads_status_header_throttle.cc
+++ b/components/brave_ads/browser/ads_status_header_throttle.cc
@@ -1,0 +1,51 @@
+/* Copyright 2022 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "brave/components/brave_ads/browser/ads_status_header_throttle.h"
+
+#include "brave/components/brave_ads/browser/ads_service.h"
+#include "brave/components/brave_search/common/brave_search_utils.h"
+#include "services/network/public/cpp/resource_request.h"
+#include "third_party/blink/public/mojom/loader/resource_load_info.mojom-shared.h"
+
+namespace {
+
+constexpr char kAdsStatusHeader[] = "X-Brave-Ads-Enabled";
+constexpr char kAdsEnabledStatusValue[] = "1";
+
+}  // namespace
+
+namespace brave_ads {
+
+// static
+std::unique_ptr<blink::URLLoaderThrottle>
+AdsStatusHeaderThrottle::MaybeCreateThrottle(
+    const AdsService* ads_service,
+    const network::ResourceRequest& request) {
+  DCHECK_EQ(request.resource_type,
+            static_cast<int>(blink::mojom::ResourceType::kMainFrame));
+  if (!ads_service || !ads_service->IsEnabled() ||
+      !request.is_outermost_main_frame ||
+      !brave_search::IsAllowedHost(request.url)) {
+    return nullptr;
+  }
+
+  return std::make_unique<AdsStatusHeaderThrottle>();
+}
+
+AdsStatusHeaderThrottle::AdsStatusHeaderThrottle() = default;
+
+AdsStatusHeaderThrottle::~AdsStatusHeaderThrottle() = default;
+
+void AdsStatusHeaderThrottle::WillStartRequest(
+    network::ResourceRequest* request,
+    bool* /* defer */) {
+  DCHECK(request);
+  DCHECK(brave_search::IsAllowedHost(request->url));
+
+  request->headers.SetHeader(kAdsStatusHeader, kAdsEnabledStatusValue);
+}
+
+}  // namespace brave_ads

--- a/components/brave_ads/browser/ads_status_header_throttle.h
+++ b/components/brave_ads/browser/ads_status_header_throttle.h
@@ -1,0 +1,42 @@
+/* Copyright 2022 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_COMPONENTS_BRAVE_ADS_BROWSER_ADS_STATUS_HEADER_THROTTLE_H_
+#define BRAVE_COMPONENTS_BRAVE_ADS_BROWSER_ADS_STATUS_HEADER_THROTTLE_H_
+
+#include <memory>
+
+#include "third_party/blink/public/common/loader/url_loader_throttle.h"
+
+namespace network {
+struct ResourceRequest;
+}  // namespace network
+
+namespace brave_ads {
+
+class AdsService;
+
+class AdsStatusHeaderThrottle : public blink::URLLoaderThrottle {
+ public:
+  static std::unique_ptr<blink::URLLoaderThrottle> MaybeCreateThrottle(
+      const AdsService* ads_service,
+      const network::ResourceRequest& request);
+
+  AdsStatusHeaderThrottle();
+  ~AdsStatusHeaderThrottle() override;
+
+  AdsStatusHeaderThrottle(const AdsStatusHeaderThrottle&) = delete;
+  AdsStatusHeaderThrottle& operator=(const AdsStatusHeaderThrottle&) = delete;
+  AdsStatusHeaderThrottle(AdsStatusHeaderThrottle&&) = delete;
+  AdsStatusHeaderThrottle& operator=(AdsStatusHeaderThrottle&&) = delete;
+
+  // Implements blink::URLLoaderThrottle:
+  void WillStartRequest(network::ResourceRequest* request,
+                        bool* defer) override;
+};
+
+}  // namespace brave_ads
+
+#endif  // BRAVE_COMPONENTS_BRAVE_ADS_BROWSER_ADS_STATUS_HEADER_THROTTLE_H_

--- a/components/brave_ads/browser/ads_status_header_throttle_unittest.cc
+++ b/components/brave_ads/browser/ads_status_header_throttle_unittest.cc
@@ -1,0 +1,97 @@
+/* Copyright (c) 2022 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include <string>
+
+#include "brave/components/brave_ads/browser/ads_service.h"
+#include "brave/components/brave_ads/browser/ads_status_header_throttle.h"
+#include "brave/components/brave_ads/browser/mock_ads_service.h"
+#include "services/network/public/cpp/resource_request.h"
+#include "testing/gtest/include/gtest/gtest.h"
+#include "third_party/blink/public/mojom/loader/resource_load_info.mojom-shared.h"
+
+using ::testing::Return;
+
+namespace {
+
+constexpr char kAdsStatusHeader[] = "X-Brave-Ads-Enabled";
+constexpr char kAdsEnabledStatusValue[] = "1";
+constexpr char kAllowedURL[] = "https://search.brave.com/search";
+constexpr char kNotAllowedURL[] = "https://brave.com/search";
+constexpr char kTestingHeaderName[] = "TestingHeaderName";
+constexpr char kTestingHeaderValue[] = "TestingHeaderValue";
+
+}  // namespace
+
+namespace brave_ads {
+
+class AdsStatusHeaderThrottleTest : public ::testing::Test {
+ public:
+  void SetUp() override {
+    ON_CALL(mock_ads_service_, IsEnabled()).WillByDefault(Return(true));
+  }
+
+  const AdsService* GetAdsService() const { return &mock_ads_service_; }
+
+  network::ResourceRequest BuildRequest() {
+    network::ResourceRequest request;
+    request.url = GURL(kAllowedURL);
+    request.is_outermost_main_frame = true;
+    request.headers.SetHeader("TestingHeaderName", "TestingHeaderValue");
+    return request;
+  }
+
+ private:
+  MockAdsService mock_ads_service_;
+};
+
+TEST_F(AdsStatusHeaderThrottleTest, AdsEnabledForAllowedHost) {
+  network::ResourceRequest request = BuildRequest();
+  auto throttle =
+      AdsStatusHeaderThrottle::MaybeCreateThrottle(GetAdsService(), request);
+  ASSERT_TRUE(throttle);
+  bool defer = false;
+  throttle->WillStartRequest(&request, &defer);
+  EXPECT_FALSE(defer);
+  std::string value;
+  EXPECT_TRUE(request.headers.GetHeader(kAdsStatusHeader, &value));
+  EXPECT_EQ(kAdsEnabledStatusValue, value);
+  EXPECT_TRUE(request.headers.GetHeader(kTestingHeaderName, &value));
+  EXPECT_EQ(kTestingHeaderValue, value);
+}
+
+TEST_F(AdsStatusHeaderThrottleTest, AdsDisabledForAllowedHost) {
+  network::ResourceRequest request = BuildRequest();
+  MockAdsService ads_service;
+  EXPECT_CALL(ads_service, IsEnabled()).WillOnce(Return(false));
+  auto throttle =
+      AdsStatusHeaderThrottle::MaybeCreateThrottle(&ads_service, request);
+  EXPECT_FALSE(throttle);
+}
+
+TEST_F(AdsStatusHeaderThrottleTest, IncognitoModeForAllowedHost) {
+  network::ResourceRequest request = BuildRequest();
+  auto throttle =
+      AdsStatusHeaderThrottle::MaybeCreateThrottle(nullptr, request);
+  EXPECT_FALSE(throttle);
+}
+
+TEST_F(AdsStatusHeaderThrottleTest, AdsEnabledForNotAllowedHost) {
+  network::ResourceRequest request = BuildRequest();
+  request.url = GURL(kNotAllowedURL);
+  auto throttle =
+      AdsStatusHeaderThrottle::MaybeCreateThrottle(GetAdsService(), request);
+  EXPECT_FALSE(throttle);
+}
+
+TEST_F(AdsStatusHeaderThrottleTest, NonOutermostMainFrameNavigation) {
+  network::ResourceRequest request = BuildRequest();
+  request.is_outermost_main_frame = false;
+  auto throttle =
+      AdsStatusHeaderThrottle::MaybeCreateThrottle(GetAdsService(), request);
+  EXPECT_FALSE(throttle);
+}
+
+}  // namespace brave_ads

--- a/test/BUILD.gn
+++ b/test/BUILD.gn
@@ -110,6 +110,7 @@ test("brave_unit_tests") {
     "//brave/chromium_src/services/network/public/cpp/cors/cors_unittest.cc",
     "//brave/common/brave_content_client_unittest.cc",
     "//brave/components/assist_ranker/ranker_model_loader_impl_unittest.cc",
+    "//brave/components/brave_ads/browser/ads_status_header_throttle_unittest.cc",
     "//brave/components/brave_ads/common/search_result_ad_util_unittest.cc",
     "//brave/components/brave_ads/content/browser/search_result_ad/search_result_ad_parsing_unittest.cc",
     "//brave/components/brave_perf_predictor/browser/bandwidth_linreg_unittest.cc",


### PR DESCRIPTION
The PR adds Brave Ads status header `X-Brave-Ads-Enabled: 1` to search.brave.com requests when:
- Brave Ads are enabled
- Browser is not in Private/Tor Window mode

<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/25430

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [x] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [x] New files have MPL-2.0 license header
- [x] Adequate test coverage exists to prevent regressions
- [x] Major classes, functions and non-trivial code blocks are well-commented
- [x] Changes in component dependencies are properly reflected in `gn`
- [x] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [x] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

**Run Brave browser with fresh profile**
* Open https://search.brave.com
* make sure that `X-Brave-Ads-Enabled` header is not set in the request
* type query in the search box and press submit
* make sure that `X-Brave-Ads-Enabled` header is not set in the request
* do a search query from Omnibus
* make sure that `X-Brave-Ads-Enabled` header is not set in the request

**Enable Brave Private Ads**
* Open https://search.brave.com
* make sure that `X-Brave-Ads-Enabled: 1` header is presented in request
* type query in the search box and press submit
* make sure that `X-Brave-Ads-Enabled: 1` header is presented in request
* do a search query from Omnibus
* make sure that `X-Brave-Ads-Enabled: 1` header is presented in request

**Disable Brave Private Ads**
* Open https://search.brave.com
* make sure that `X-Brave-Ads-Enabled` header is not set in the request
* type query in the search box and press submit
* make sure that `X-Brave-Ads-Enabled` header is not set in the request
* do a search query from Omnibus
* make sure that `X-Brave-Ads-Enabled` header is not set in the request

Also need to make sure that this logic is working for dev/staging Brave Search environments. The list of supported hosts is here: [hosts](https://github.com/brave/brave-core/blob/master/components/brave_search/common/brave_search_utils.cc#L22)