### PR TITLE
Fixes client hints UA to have invariable brand name. (uplift to 1.45.x)

### DIFF
--- a/chromium_src/components/embedder_support/user_agent_utils.cc
+++ b/chromium_src/components/embedder_support/user_agent_utils.cc
@@ -3,7 +3,20 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-#define BRAVE_GET_USER_AGENT_BRAND_LIST brand = version_info::GetProductName();
+namespace {
+
+constexpr char kBraveBrandNameForCHUA[] = "Brave";
+
+}  // namespace
+
+// Chromium uses `version_info::GetProductName()` to get the browser's "brand"
+// name, but on MacOS we use different names for different channels (adding Beta
+// or Nightly, for example). In the UA client hint, though, we want a consistent
+// name regardless of the channel, so we just hard-code it. Note, that we use
+// IDS_PRODUCT_NAME from app/chromium_strings.grd (brave_strings.grd) in
+// constructing the UA in brave/browser/brave_content_browser_client.cc, but we
+// can't use it here in the //components.
+#define BRAVE_GET_USER_AGENT_BRAND_LIST brand = kBraveBrandNameForCHUA;
 
 #include "src/components/embedder_support/user_agent_utils.cc"
 #undef BRAVE_GET_USER_AGENT_BRAND_LIST

--- a/components/embedder_support/BUILD.gn
+++ b/components/embedder_support/BUILD.gn
@@ -1,0 +1,21 @@
+# Copyright (c) 2022 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import("//testing/test.gni")
+
+source_set("unit_tests") {
+  testonly = true
+
+  sources = [ "user_agent_utils_unittest.cc" ]
+
+  deps = [
+    "//components/embedder_support:browser_util",
+    "//components/version_info",
+    "//testing/gtest",
+    "//third_party/blink/public/common",
+  ]
+
+  defines = [ "HAS_OUT_OF_PROC_TEST_RUNNER" ]
+}

--- a/components/embedder_support/user_agent_utils_unittest.cc
+++ b/components/embedder_support/user_agent_utils_unittest.cc
@@ -1,0 +1,36 @@
+/* Copyright (c) 2022 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "components/embedder_support/user_agent_utils.h"
+#include "components/version_info/version_info.h"
+#include "testing/gtest/include/gtest/gtest.h"
+#include "third_party/blink/public/common/user_agent/user_agent_metadata.h"
+
+namespace embedder_support {
+
+namespace {
+
+bool ContainsBrandVersion(const blink::UserAgentBrandList& brand_list,
+                          const blink::UserAgentBrandVersion brand_version) {
+  for (const auto& brand_list_entry : brand_list) {
+    if (brand_list_entry == brand_version)
+      return true;
+  }
+  return false;
+}
+
+}  // namespace
+
+TEST(UserAgentUtilsTest, UserAgentMetadata) {
+  auto metadata = GetUserAgentMetadata();
+
+  const std::string major_version = version_info::GetMajorVersionNumber();
+  const blink::UserAgentBrandVersion product_brand_version = {"Brave",
+                                                              major_version};
+  EXPECT_TRUE(
+      ContainsBrandVersion(metadata.brand_version_list, product_brand_version));
+}
+
+}  // namespace embedder_support

--- a/test/BUILD.gn
+++ b/test/BUILD.gn
@@ -228,6 +228,7 @@ test("brave_unit_tests") {
     "//brave/components/constants",
     "//brave/components/de_amp/browser/test:unit_tests",
     "//brave/components/debounce/browser/test:unit_tests",
+    "//brave/components/embedder_support:unit_tests",
     "//brave/components/ipfs/buildflags",
     "//brave/components/ipfs/test:brave_ipfs_unit_tests",
     "//brave/components/json:brave_json_unit_tests",


### PR DESCRIPTION
https://github.com/brave/brave-browser/issues/25459
Uplift of #15134

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.