### PR TITLE
fix brave news feed doesn't show when enabled through settings android (uplift to 1.44.x)

### DIFF
--- a/android/java/org/chromium/chrome/browser/ntp/BraveNewTabPageLayout.java
+++ b/android/java/org/chromium/chrome/browser/ntp/BraveNewTabPageLayout.java
@@ -957,6 +957,11 @@ public class BraveNewTabPageLayout
         }
 
         if (mIsDisplayNews) {
+            if (mIsDisplayNewsOptin) {
+                mIsDisplayNewsOptin = false;
+                mNtpAdapter.removeNewsOptin();
+                mNtpAdapter.setImageCreditAlpha(1f);
+            }
             mNtpAdapter.setDisplayNews(mIsDisplayNews);
             getFeed(false);
         }


### PR DESCRIPTION
Uplift of #15153
Resolves https://github.com/brave/brave-browser/issues/25500

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.