### PR TITLE
Enable HTTPS-Only Mode on Private Windows with Tor

### DIFF
--- a/browser/about_flags.cc
+++ b/browser/about_flags.cc
@@ -190,6 +190,12 @@ constexpr char kBraveBlockScreenFingerprintingDescription[] =
     "Prevents JavaScript and CSS from learning the user's screen dimensions "
     "or window position.";
 
+constexpr char kBraveTorWindowsHttpsOnlyName[] =
+    "Use HTTPS-Only Mode in Private Windows with Tor";
+constexpr char kBraveTorWindowsHttpsOnlyDescription[] =
+    "Prevents Private Windows with Tor from making any insecure HTTP "
+    "connections without warning the user first.";
+
 constexpr char kBraveSpeedreaderName[] = "Enable SpeedReader";
 constexpr char kBraveSpeedreaderDescription[] =
     "Enables faster loading of simplified article-style web pages.";
@@ -678,6 +684,11 @@ constexpr char kBraveVerticalTabsDescription[] =
       flag_descriptions::kBraveBlockScreenFingerprintingDescription,        \
       kOsAll, FEATURE_VALUE_TYPE(                                           \
           blink::features::kBraveBlockScreenFingerprinting)},               \
+    {"brave-tor-windows-https-only",                                        \
+      flag_descriptions::kBraveTorWindowsHttpsOnlyName,                     \
+      flag_descriptions::kBraveTorWindowsHttpsOnlyDescription,              \
+      kOsAll, FEATURE_VALUE_TYPE(                                           \
+          blink::features::kBraveTorWindowsHttpsOnly)},                     \
     BRAVE_IPFS_FEATURE_ENTRIES                                              \
     BRAVE_NATIVE_WALLET_FEATURE_ENTRIES                                     \
     BRAVE_NEWS_FEATURE_ENTRIES                                              \

--- a/browser/tor/tor_profile_manager.cc
+++ b/browser/tor/tor_profile_manager.cc
@@ -8,6 +8,7 @@
 #include <algorithm>
 #include <utility>
 
+#include "base/feature_list.h"
 #include "brave/browser/tor/tor_profile_service_factory.h"
 #include "brave/components/brave_webtorrent/browser/buildflags/buildflags.h"
 #include "brave/components/constants/pref_names.h"
@@ -20,6 +21,7 @@
 #include "chrome/common/pref_names.h"
 #include "components/prefs/pref_service.h"
 #include "components/safe_browsing/core/common/safe_browsing_prefs.h"
+#include "third_party/blink/public/common/features.h"
 #include "third_party/blink/public/common/peerconnection/webrtc_ip_handling_policy.h"
 
 #if BUILDFLAG(ENABLE_BRAVE_TRANSLATE_GO)
@@ -120,6 +122,10 @@ void TorProfileManager::InitTorProfileUserPrefs(Profile* profile) {
   pref_service->SetString(prefs::kWebRTCIPHandlingPolicy,
                           blink::kWebRTCIPHandlingDisableNonProxiedUdp);
   pref_service->SetBoolean(prefs::kSafeBrowsingEnabled, false);
+  if (base::FeatureList::IsEnabled(
+          blink::features::kBraveTorWindowsHttpsOnly)) {
+    pref_service->SetBoolean(prefs::kHttpsOnlyModeEnabled, true);
+  }
   // https://blog.torproject.org/bittorrent-over-tor-isnt-good-idea
 #if BUILDFLAG(ENABLE_BRAVE_WEBTORRENT)
   pref_service->SetBoolean(kWebTorrentEnabled, false);

--- a/chromium_src/chrome/browser/ssl/https_only_mode_upgrade_interceptor.cc
+++ b/chromium_src/chrome/browser/ssl/https_only_mode_upgrade_interceptor.cc
@@ -1,0 +1,28 @@
+/* Copyright (c) 2022 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "chrome/browser/ssl/https_only_mode_upgrade_interceptor.h"
+
+#include "net/base/url_util.h"
+
+namespace net {
+namespace {
+
+bool IsOnion(const GURL& url) {
+  return IsSubdomainOf(url.host(), "onion");
+}
+
+bool IsLocalhostOrOnion(const GURL& url) {
+  return IsLocalhost(url) || IsOnion(url);
+}
+
+}  // namespace
+}  // namespace net
+
+#define IsLocalhost(URL) IsLocalhostOrOnion(URL)
+
+#include "src/chrome/browser/ssl/https_only_mode_upgrade_interceptor.cc"
+
+#undef IsLocalHost

--- a/chromium_src/third_party/blink/common/features.cc
+++ b/chromium_src/third_party/blink/common/features.cc
@@ -58,5 +58,9 @@ const base::Feature kRestrictWebSocketsPool{"RestrictWebSocketsPool",
 const base::Feature kBraveBlockScreenFingerprinting{
     "BraveBlockScreenFingerprinting", base::FEATURE_DISABLED_BY_DEFAULT};
 
+// Enable HTTPS-Only Mode in Private Windows with Tor by default.
+const base::Feature kBraveTorWindowsHttpsOnly{"BraveTorWindowsHttpsOnly",
+                                              base::FEATURE_ENABLED_BY_DEFAULT};
+
 }  // namespace features
 }  // namespace blink

--- a/chromium_src/third_party/blink/public/common/features.h
+++ b/chromium_src/third_party/blink/public/common/features.h
@@ -17,6 +17,7 @@ BLINK_COMMON_EXPORT extern const base::Feature kNavigatorConnectionAttribute;
 BLINK_COMMON_EXPORT extern const base::Feature kPartitionBlinkMemoryCache;
 BLINK_COMMON_EXPORT extern const base::Feature kRestrictWebSocketsPool;
 BLINK_COMMON_EXPORT extern const base::Feature kBraveBlockScreenFingerprinting;
+BLINK_COMMON_EXPORT extern const base::Feature kBraveTorWindowsHttpsOnly;
 
 }  // namespace features
 }  // namespace blink


### PR DESCRIPTION
Create a feature flag, BraveTorWindowsHttpsOnly, that enables HTTPS-Only Mode for Private Windows with Tor. Enable that flag by default.

Do not enforce HTTPS-Only for .onion sites: these
are already secure when using http://.

(Users can check "Always use secure connections" to enable HTTPS-Only Mode for other windows if they wish.)

Security review: https://github.com/brave/security/issues/1041

<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/23030

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [x] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

