### PR TITLE
[iOS] Fix selector mismatch for FilterListCatalogEntry initializer (uplift to 1.45.x)

### DIFF
--- a/ios/browser/api/brave_shields/adblock_filter_list_catalog_entry+private.h
+++ b/ios/browser/api/brave_shields/adblock_filter_list_catalog_entry+private.h
@@ -16,7 +16,8 @@ class FilterListCatalogEntry;
 NS_ASSUME_NONNULL_BEGIN
 
 @interface AdblockFilterListCatalogEntry (Private)
-- (instancetype)initWithFilterList:(brave_shields::FilterListCatalogEntry)entry;
+- (instancetype)initWithFilterListCatalogEntry:
+    (brave_shields::FilterListCatalogEntry)entry;
 - (brave_shields::FilterListCatalogEntry)entry;
 @end
 

--- a/ios/browser/api/brave_shields/adblock_service.mm
+++ b/ios/browser/api/brave_shields/adblock_service.mm
@@ -63,7 +63,7 @@
         for (const auto& entry : catalog) {
           [lists
               addObject:[[AdblockFilterListCatalogEntry alloc]
-                            initWithFilterList:
+                            initWithFilterListCatalogEntry:
                                 brave_shields::FilterListCatalogEntry(entry)]];
         }
         strongSelf.regionalFilterLists = lists;


### PR DESCRIPTION
Uplift of #15185
Resolves https://github.com/brave/brave-browser/issues/25567

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.