### PR TITLE
Add P3A metrics for cookie consent notice blocking

### DIFF
--- a/android/java/org/chromium/chrome/browser/toolbar/top/BraveToolbarLayoutImpl.java
+++ b/android/java/org/chromium/chrome/browser/toolbar/top/BraveToolbarLayoutImpl.java
@@ -665,6 +665,7 @@ public abstract class BraveToolbarLayoutImpl extends ToolbarLayout
             @Override
             public void onClick(View v) {
                 if (mCookieListOptInPageAndroidHandler != null) {
+                    mCookieListOptInPageAndroidHandler.onTooltipYesClicked();
                     mCookieListOptInPageAndroidHandler.enableFilter(true);
                 }
                 mCookieConsentTooltip.dismiss();
@@ -675,6 +676,9 @@ public abstract class BraveToolbarLayoutImpl extends ToolbarLayout
         txtNoThanks.setOnClickListener((new View.OnClickListener() {
             @Override
             public void onClick(View v) {
+                if (mCookieListOptInPageAndroidHandler != null) {
+                    mCookieListOptInPageAndroidHandler.onTooltipNoClicked();
+                }
                 mCookieConsentTooltip.dismiss();
             }
         }));
@@ -683,6 +687,9 @@ public abstract class BraveToolbarLayoutImpl extends ToolbarLayout
             mCookieConsentTooltip.show();
             SharedPreferencesManager.getInstance().writeBoolean(
                     BravePreferenceKeys.SHOULD_SHOW_COOKIE_CONSENT_NOTICE, false);
+            if (mCookieListOptInPageAndroidHandler != null) {
+                mCookieListOptInPageAndroidHandler.onTooltipShown();
+            }
         }
     }
 

--- a/browser/brave_shields/cookie_list_opt_in_service_factory.cc
+++ b/browser/brave_shields/cookie_list_opt_in_service_factory.cc
@@ -9,6 +9,7 @@
 
 #include "brave/browser/brave_browser_process.h"
 #include "brave/components/brave_shields/browser/cookie_list_opt_in_service.h"
+#include "chrome/browser/browser_process.h"
 #include "chrome/browser/profiles/incognito_helpers.h"
 #include "components/keyed_service/content/browser_context_dependency_manager.h"
 
@@ -55,7 +56,8 @@ CookieListOptInServiceFactory::~CookieListOptInServiceFactory() = default;
 KeyedService* CookieListOptInServiceFactory::BuildServiceInstanceFor(
     content::BrowserContext* context) const {
   auto* ad_block_service = g_brave_browser_process->ad_block_service();
-  return new CookieListOptInService(ad_block_service);
+  return new CookieListOptInService(ad_block_service,
+                                    g_browser_process->local_state());
 }
 
 content::BrowserContext* CookieListOptInServiceFactory::GetBrowserContextToUse(

--- a/browser/ui/views/brave_shields/cookie_list_opt_in_bubble_host.cc
+++ b/browser/ui/views/brave_shields/cookie_list_opt_in_bubble_host.cc
@@ -8,6 +8,7 @@
 #include <memory>
 
 #include "base/feature_list.h"
+#include "base/metrics/histogram_functions.h"
 #include "brave/browser/brave_browser_process.h"
 #include "brave/browser/ui/webui/brave_shields/cookie_list_opt_in_ui.h"
 #include "brave/components/brave_shields/browser/ad_block_regional_service_manager.h"
@@ -58,6 +59,8 @@ bool ShouldEventuallyShowBubble() {
   if (local_state->GetBoolean(prefs::kAdBlockCookieListOptInShown)) {
     return false;
   }
+
+  base::UmaHistogramExactLinear(kCookieListPromptHistogram, 0, 4);
 
   auto* regional_service_manager =
       g_brave_browser_process->ad_block_service()->regional_service_manager();

--- a/browser/ui/webui/brave_shields/cookie_list_opt_in_page_handler.cc
+++ b/browser/ui/webui/brave_shields/cookie_list_opt_in_page_handler.cc
@@ -7,6 +7,7 @@
 
 #include <utility>
 
+#include "base/metrics/histogram_functions.h"
 #include "brave/browser/brave_browser_process.h"
 #include "brave/components/brave_shields/browser/ad_block_regional_service_manager.h"
 #include "brave/components/brave_shields/browser/ad_block_service.h"
@@ -27,6 +28,8 @@ CookieListOptInPageHandler::CookieListOptInPageHandler(
 CookieListOptInPageHandler::~CookieListOptInPageHandler() = default;
 
 void CookieListOptInPageHandler::ShowUI() {
+  base::UmaHistogramExactLinear(brave_shields::kCookieListPromptHistogram, 1,
+                                4);
   if (embedder_) {
     embedder_->ShowUI();
   }
@@ -42,4 +45,14 @@ void CookieListOptInPageHandler::EnableFilter() {
   g_brave_browser_process->ad_block_service()
       ->regional_service_manager()
       ->EnableFilterList(brave_shields::kCookieListUuid, true);
+}
+
+void CookieListOptInPageHandler::OnUINoClicked() {
+  base::UmaHistogramExactLinear(brave_shields::kCookieListPromptHistogram, 2,
+                                4);
+}
+
+void CookieListOptInPageHandler::OnUIYesClicked() {
+  base::UmaHistogramExactLinear(brave_shields::kCookieListPromptHistogram, 3,
+                                4);
 }

--- a/browser/ui/webui/brave_shields/cookie_list_opt_in_page_handler.h
+++ b/browser/ui/webui/brave_shields/cookie_list_opt_in_page_handler.h
@@ -35,6 +35,9 @@ class CookieListOptInPageHandler
   void CloseUI() override;
   void EnableFilter() override;
 
+  void OnUINoClicked() override;
+  void OnUIYesClicked() override;
+
  private:
   mojo::Receiver<brave_shields::mojom::CookieListOptInPageHandler> receiver_;
   base::WeakPtr<ui::MojoBubbleWebUIController::Embedder> embedder_;

--- a/components/brave_shields/browser/ad_block_regional_service_manager.cc
+++ b/components/brave_shields/browser/ad_block_regional_service_manager.cc
@@ -10,6 +10,7 @@
 #include <vector>
 
 #include "base/feature_list.h"
+#include "base/metrics/histogram_macros.h"
 #include "base/strings/string_util.h"
 #include "base/values.h"
 #include "brave/components/brave_shields/browser/ad_block_engine.h"
@@ -146,6 +147,13 @@ void AdBlockRegionalServiceManager::UpdateFilterListPrefs(
   if (uuid == kCookieListUuid) {
     local_state_->SetBoolean(prefs::kAdBlockCookieListSettingTouched, true);
   }
+
+  RecordP3ACookieListEnabled();
+}
+
+void AdBlockRegionalServiceManager::RecordP3ACookieListEnabled() {
+  UMA_HISTOGRAM_BOOLEAN(kCookieListEnabledHistogram,
+                        IsFilterListEnabled(kCookieListUuid));
 }
 
 bool AdBlockRegionalServiceManager::Start() {
@@ -334,6 +342,7 @@ void AdBlockRegionalServiceManager::SetFilterListCatalog(
     std::vector<FilterListCatalogEntry> catalog) {
   filter_list_catalog_ = std::move(catalog);
   StartRegionalServices();
+  RecordP3ACookieListEnabled();
 }
 
 const std::vector<FilterListCatalogEntry>&

--- a/components/brave_shields/browser/ad_block_regional_service_manager.h
+++ b/components/brave_shields/browser/ad_block_regional_service_manager.h
@@ -91,6 +91,8 @@ class AdBlockRegionalServiceManager
   void StartRegionalServices();
   void UpdateFilterListPrefs(const std::string& uuid, bool enabled);
 
+  void RecordP3ACookieListEnabled();
+
   raw_ptr<PrefService> local_state_;
   std::string locale_;
   bool initialized_;

--- a/components/brave_shields/browser/cookie_list_opt_in_service.cc
+++ b/components/brave_shields/browser/cookie_list_opt_in_service.cc
@@ -8,16 +8,28 @@
 #include <utility>
 
 #include "base/feature_list.h"
+#include "base/metrics/histogram_functions.h"
 #include "brave/components/brave_shields/browser/ad_block_regional_service_manager.h"
 #include "brave/components/brave_shields/browser/ad_block_service.h"
 #include "brave/components/brave_shields/common/brave_shield_constants.h"
 #include "brave/components/brave_shields/common/cookie_list_opt_in.mojom-forward.h"
 #include "brave/components/brave_shields/common/cookie_list_opt_in.mojom-shared.h"
 #include "brave/components/brave_shields/common/features.h"
+#include "brave/components/brave_shields/common/pref_names.h"
+#include "components/prefs/pref_service.h"
 
 namespace brave_shields {
-CookieListOptInService::CookieListOptInService(AdBlockService* ad_block_service)
-    : ad_block_service_(ad_block_service) {}
+
+CookieListOptInService::CookieListOptInService(AdBlockService* ad_block_service,
+                                               PrefService* local_state)
+    : ad_block_service_(ad_block_service), local_state_(local_state) {
+  if (base::FeatureList::IsEnabled(
+          brave_shields::features::kBraveAdblockCookieListOptIn)) {
+    if (!local_state->GetBoolean(prefs::kAdBlockCookieListOptInShown)) {
+      base::UmaHistogramExactLinear(kCookieListPromptHistogram, 0, 4);
+    }
+  }
+}
 
 CookieListOptInService::~CookieListOptInService() = default;
 
@@ -53,6 +65,19 @@ void CookieListOptInService::IsFilterListEnabled(
 void CookieListOptInService::EnableFilter(bool shouldEnableFilter) {
   ad_block_service_->regional_service_manager()->EnableFilterList(
       brave_shields::kCookieListUuid, shouldEnableFilter);
+}
+
+void CookieListOptInService::OnTooltipShown() {
+  local_state_->SetBoolean(prefs::kAdBlockCookieListOptInShown, true);
+  base::UmaHistogramExactLinear(kCookieListPromptHistogram, 1, 4);
+}
+
+void CookieListOptInService::OnTooltipNoClicked() {
+  base::UmaHistogramExactLinear(kCookieListPromptHistogram, 2, 4);
+}
+
+void CookieListOptInService::OnTooltipYesClicked() {
+  base::UmaHistogramExactLinear(kCookieListPromptHistogram, 3, 4);
 }
 
 }  // namespace brave_shields

--- a/components/brave_shields/browser/cookie_list_opt_in_service.h
+++ b/components/brave_shields/browser/cookie_list_opt_in_service.h
@@ -14,6 +14,8 @@
 #include "mojo/public/cpp/bindings/receiver_set.h"
 #include "mojo/public/cpp/bindings/remote_set.h"
 
+class PrefService;
+
 namespace brave_shields {
 class AdBlockService;
 
@@ -21,7 +23,8 @@ class AdBlockService;
 class CookieListOptInService : public KeyedService,
                                public mojom::CookieListOptInPageAndroidHandler {
  public:
-  explicit CookieListOptInService(AdBlockService* ad_block_service);
+  CookieListOptInService(AdBlockService* ad_block_service,
+                         PrefService* local_state);
   ~CookieListOptInService() override;
 
   mojo::PendingRemote<mojom::CookieListOptInPageAndroidHandler> MakeRemote();
@@ -32,8 +35,13 @@ class CookieListOptInService : public KeyedService,
   void IsFilterListEnabled(IsFilterListEnabledCallback callback) override;
   void EnableFilter(bool shouldEnableFilter) override;
 
+  void OnTooltipShown() override;
+  void OnTooltipNoClicked() override;
+  void OnTooltipYesClicked() override;
+
  private:
   raw_ptr<AdBlockService> ad_block_service_ = nullptr;
+  raw_ptr<PrefService> local_state_ = nullptr;
   mojo::ReceiverSet<mojom::CookieListOptInPageAndroidHandler> receivers_;
   base::WeakPtrFactory<CookieListOptInService> discovery_weak_factory_{this};
 

--- a/components/brave_shields/browser/cookie_list_opt_in_service_unittest.cc
+++ b/components/brave_shields/browser/cookie_list_opt_in_service_unittest.cc
@@ -1,0 +1,108 @@
+// Copyright (c) 2022 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// you can obtain one at http://mozilla.org/MPL/2.0/.
+
+#include "brave/components/brave_shields/browser/cookie_list_opt_in_service.h"
+
+#include <memory>
+
+#include "base/feature_list.h"
+#include "base/test/metrics/histogram_tester.h"
+#include "base/test/scoped_feature_list.h"
+#include "brave/components/brave_shields/browser/ad_block_service.h"
+#include "brave/components/brave_shields/common/brave_shield_constants.h"
+#include "brave/components/brave_shields/common/features.h"
+#include "brave/components/brave_shields/common/pref_names.h"
+#include "components/prefs/testing_pref_service.h"
+#include "content/public/test/browser_task_environment.h"
+#include "testing/gtest/include/gtest/gtest.h"
+
+namespace brave_shields {
+
+class CookieListOptInServiceTest : public testing::Test {
+ public:
+  CookieListOptInServiceTest() = default;
+
+ protected:
+  void SetUp() override {
+    auto* registry = pref_service_.registry();
+    RegisterPrefsForAdBlockService(registry);
+    histogram_tester_ = std::make_unique<base::HistogramTester>();
+  }
+
+  PrefService* GetPrefs() { return &pref_service_; }
+
+  base::test::ScopedFeatureList scoped_feature_list_;
+  std::unique_ptr<base::HistogramTester> histogram_tester_;
+  TestingPrefServiceSimple pref_service_;
+};
+
+TEST_F(CookieListOptInServiceTest, FeatureDisabledNoInitHistogram) {
+  scoped_feature_list_.InitWithFeatures({}, {});
+  CookieListOptInService service(nullptr, GetPrefs());
+  // Should not write to histogram if feature is disabled
+  histogram_tester_->ExpectTotalCount(kCookieListPromptHistogram, 0);
+}
+
+TEST_F(CookieListOptInServiceTest, FeatureEnabledInitHistogram) {
+  scoped_feature_list_.InitWithFeatures(
+      {brave_shields::features::kBraveAdblockCookieListOptIn}, {});
+  CookieListOptInService service(nullptr, GetPrefs());
+  // Should write to histogram if feature is enabled
+  histogram_tester_->ExpectTotalCount(kCookieListPromptHistogram, 1);
+  histogram_tester_->ExpectBucketCount(kCookieListPromptHistogram, 0, 1);
+}
+
+TEST_F(CookieListOptInServiceTest, FeatureEnabledShownNoInitHistogram) {
+  scoped_feature_list_.InitWithFeatures(
+      {brave_shields::features::kBraveAdblockCookieListOptIn}, {});
+  GetPrefs()->SetBoolean(prefs::kAdBlockCookieListOptInShown, true);
+  CookieListOptInService service(nullptr, GetPrefs());
+  // Should not write to histogram if tooltip was already shown
+  histogram_tester_->ExpectTotalCount(kCookieListPromptHistogram, 0);
+}
+
+TEST_F(CookieListOptInServiceTest, TooltipShownHistogram) {
+  scoped_feature_list_.InitWithFeatures(
+      {brave_shields::features::kBraveAdblockCookieListOptIn}, {});
+  CookieListOptInService service(nullptr, GetPrefs());
+
+  histogram_tester_->ExpectTotalCount(kCookieListPromptHistogram, 1);
+  histogram_tester_->ExpectBucketCount(kCookieListPromptHistogram, 0, 1);
+
+  service.OnTooltipShown();
+
+  histogram_tester_->ExpectTotalCount(kCookieListPromptHistogram, 2);
+  histogram_tester_->ExpectBucketCount(kCookieListPromptHistogram, 1, 1);
+}
+
+TEST_F(CookieListOptInServiceTest, TooltipNoClickedHistogram) {
+  scoped_feature_list_.InitWithFeatures(
+      {brave_shields::features::kBraveAdblockCookieListOptIn}, {});
+  CookieListOptInService service(nullptr, GetPrefs());
+
+  histogram_tester_->ExpectTotalCount(kCookieListPromptHistogram, 1);
+  histogram_tester_->ExpectBucketCount(kCookieListPromptHistogram, 0, 1);
+
+  service.OnTooltipNoClicked();
+
+  histogram_tester_->ExpectTotalCount(kCookieListPromptHistogram, 2);
+  histogram_tester_->ExpectBucketCount(kCookieListPromptHistogram, 2, 1);
+}
+
+TEST_F(CookieListOptInServiceTest, TooltipYesClickedHistogram) {
+  scoped_feature_list_.InitWithFeatures(
+      {brave_shields::features::kBraveAdblockCookieListOptIn}, {});
+  CookieListOptInService service(nullptr, GetPrefs());
+
+  histogram_tester_->ExpectTotalCount(kCookieListPromptHistogram, 1);
+  histogram_tester_->ExpectBucketCount(kCookieListPromptHistogram, 0, 1);
+
+  service.OnTooltipYesClicked();
+
+  histogram_tester_->ExpectTotalCount(kCookieListPromptHistogram, 2);
+  histogram_tester_->ExpectBucketCount(kCookieListPromptHistogram, 3, 1);
+}
+
+}  // namespace brave_shields

--- a/components/brave_shields/common/brave_shield_constants.h
+++ b/components/brave_shields/common/brave_shield_constants.h
@@ -87,6 +87,9 @@ constexpr webui::LocalizedString kLocalizedStrings[] = {
      IDS_BRAVE_SHIELDS_BLOCKED_SCRIPTS_LABEL},
 };
 
+const char kCookieListEnabledHistogram[] = "Brave.Shields.CookieListEnabled";
+const char kCookieListPromptHistogram[] = "Brave.Shields.CookieListPrompt";
+
 }  // namespace brave_shields
 
 #endif  // BRAVE_COMPONENTS_BRAVE_SHIELDS_COMMON_BRAVE_SHIELD_CONSTANTS_H_

--- a/components/brave_shields/common/cookie_list_opt_in.mojom
+++ b/components/brave_shields/common/cookie_list_opt_in.mojom
@@ -13,10 +13,17 @@ interface CookieListOptInPageHandler {
   ShowUI();
   CloseUI();
   EnableFilter();
+
+  OnUINoClicked();
+  OnUIYesClicked();
 };
 
 interface CookieListOptInPageAndroidHandler {
   ShouldShowDialog() => (bool should_show_dialog);
   IsFilterListEnabled() => (bool is_enabled);
   EnableFilter(bool should_enable_filter);
+
+  OnTooltipShown();
+  OnTooltipNoClicked();
+  OnTooltipYesClicked();
 };

--- a/components/brave_shields/resources/cookie_list_opt_in/cookie_list_opt_in.tsx
+++ b/components/brave_shields/resources/cookie_list_opt_in/cookie_list_opt_in.tsx
@@ -19,7 +19,13 @@ function App () {
     proxy.handler.closeUI()
   }
 
+  const onDecline = () => {
+    proxy.handler.onUINoClicked()
+    closeBubble()
+  }
+
   const onEnable = () => {
+    proxy.handler.onUIYesClicked()
     proxy.handler.enableFilter()
   }
 
@@ -49,7 +55,7 @@ function App () {
       key={openedAt}
       onEnable={onEnable}
       onDismiss={closeBubble}
-      onDecline={closeBubble}
+      onDecline={onDecline}
       onAnimationComplete={closeBubble}
     />
   )

--- a/components/p3a/metric_names.h
+++ b/components/p3a/metric_names.h
@@ -53,6 +53,8 @@ constexpr inline auto kCollectedHistograms =
     "Brave.Search.SwitchEngine",
     "Brave.Search.WebDiscoveryEnabled",
     "Brave.Shields.AdBlockSetting",
+    "Brave.Shields.CookieListEnabled",
+    "Brave.Shields.CookieListPrompt",
     "Brave.Shields.DomainAdsSettingsAboveGlobal",
     "Brave.Shields.DomainAdsSettingsBelowGlobal",
     "Brave.Shields.DomainFingerprintSettingsAboveGlobal",

--- a/test/BUILD.gn
+++ b/test/BUILD.gn
@@ -122,6 +122,7 @@ test("brave_unit_tests") {
     "//brave/components/brave_shields/browser/ad_block_regional_service_unittest.cc",
     "//brave/components/brave_shields/browser/adblock_stub_response_unittest.cc",
     "//brave/components/brave_shields/browser/brave_farbling_service_unittest.cc",
+    "//brave/components/brave_shields/browser/cookie_list_opt_in_service_unittest.cc",
     "//brave/components/brave_shields/browser/cosmetic_merge_unittest.cc",
     "//brave/components/brave_shields/browser/csp_merge_unittest.cc",
     "//brave/components/brave_shields/browser/https_everywhere_recently_used_cache_unittest.cpp",


### PR DESCRIPTION
<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves brave/brave-browser#25568

## Submitter Checklist:

- [ ] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

Start with fresh profile, ensure `Brave.Shields.CookieListPrompt` does not appear on the local state page. Enable "opt-in bubble" flag.

Android setup:
1. On local state page, ensure `Brave.Shields.CookieListPrompt` has a value of 0.
2. Visit https://dev-pages.brave.software/filtering/cookie-banners.html. Refresh the page repeatedly until the notice appears.

Desktop setup:
1. The panel should appear immediately after enabling the flag.

Main test plan:

1. Ignore the notice by tapping on an area outside of the panel. Ensure the metric has a value of 1.
2. Delete profile, repeat initial steps, click "No thanks" on the panel. Ensure the metric has a value of 2.
3. Delete profile, repeat initial steps, click "Block cookie notices" on the panel. Ensure the metric has a value of 3.
4. Ensure `Brave.Shields.CookieListEnabled` has a value of 1.
5. Disable cookie consent notice blocking in the shields settings. Ensure the "enabled" metric has a value of 0.