### PR TITLE
feat(wallet): only use direct routes for Jupiter quotes

### DIFF
--- a/components/brave_wallet/browser/brave_wallet_constants.h
+++ b/components/brave_wallet/browser/brave_wallet_constants.h
@@ -956,7 +956,7 @@ constexpr char kAffiliateAddress[] =
 constexpr char kSolanaSwapBaseAPIURL[] = "https://quote-api.jup.ag/";
 constexpr char kSolanaBuyTokenFeeBps[] = "85";
 constexpr char kSolanaFeeRecipient[] =
-    "8eekKfUAGSJbq3CdA2TmHb8tKuyzd5gtEas3MYAtXzrT";
+    "3NUW8hWoCnLgJwWCVnwdFo2Dsz8bKwLac9A3VgS2jLUQ";
 
 constexpr int64_t kBlockTrackerDefaultTimeInSeconds = 20;
 

--- a/components/brave_wallet/browser/swap_request_helper_unittest.cc
+++ b/components/brave_wallet/browser/swap_request_helper_unittest.cc
@@ -71,7 +71,7 @@ TEST(SwapRequestHelperUnitTest, EncodeJupiterTransactionParams) {
 
   std::string expected_params(R"(
     {
-      "feeAccount": "6qzJdco58Q4VN76mX4c6rjkRSsvpaBz6wsnJxW4uWswC",
+      "feeAccount": "9ogHW3wZ4unrLhQJNWnRsoggsV27QURAnb6iDptmg46j",
       "route": {
         "inAmount": 10000,
         "outAmount": 261273,

--- a/components/brave_wallet/browser/swap_service.cc
+++ b/components/brave_wallet/browser/swap_service.cc
@@ -108,8 +108,12 @@ GURL AppendJupiterQuoteParams(
   url = net::AppendQueryParameter(url, "feeBps",
                                   brave_wallet::SwapService::GetFee(chain_id));
   url = net::AppendQueryParameter(
-      url, "slippagePercentage",
-      base::StringPrintf("%.6f", params.slippage_percentage));
+      url, "slippage", base::StringPrintf("%.6f", params.slippage_percentage));
+
+  // Indirect routes requires multiple transactions to complete the swap,
+  // which must be confirmed sequentially. We currently use direct routes only
+  // until there's a reliable way to get around this UX issue.
+  url = net::AppendQueryParameter(url, "onlyDirectRoutes", "true");
   return url;
 }
 

--- a/components/brave_wallet/browser/swap_service_unittest.cc
+++ b/components/brave_wallet/browser/swap_service_unittest.cc
@@ -33,7 +33,7 @@ brave_wallet::mojom::JupiterQuoteParamsPtr GetCannedJupiterQuoteParams() {
   params->output_mint = "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v";
   params->input_mint = "So11111111111111111111111111111111111111112";
   params->amount = "10000";
-  params->slippage_percentage = 1;
+  params->slippage_percentage = 0.5;
   return params;
 }
 
@@ -460,7 +460,8 @@ TEST_F(SwapServiceUnitTest, GetJupiterQuoteURL) {
             "outputMint=EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v&"
             "amount=10000&"
             "feeBps=85&"
-            "slippagePercentage=1.000000");
+            "slippage=0.500000&"
+            "onlyDirectRoutes=true");
 }
 
 TEST_F(SwapServiceUnitTest, GetJupiterSwapTransactionsURL) {


### PR DESCRIPTION
This PR contains four different changes:
1. **(primary)** Use direct routes for Jupiter quotes. This avoids having 3 separate transactions for a swap, which can be bad UX if any one of those transactions fails.

    If future, we'll remove this once there's a reliable way to pack the entire swap in one transaction, or if we add a way to sign and broadcast multiple transactions in one go.

2. Update `feeRecipient` address to the one controlled by Brave. I somehow forgot to update this previously.
3. Jupiter API changed `slippagePercentage` to `slippage`, so incorporated this change.

Resolves https://github.com/brave/brave-browser/issues/25570
Maybe resolves https://github.com/brave/brave-browser/issues/25551

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

Also see expected behaviour in linked issue.

https://user-images.githubusercontent.com/3684187/191899303-b0f06e6c-8b4f-4a16-866e-67813874465a.mov
