### PR TITLE
Update back/foreground colors for HelpBubble

### DIFF
--- a/browser/ui/color/brave_color_mixer.cc
+++ b/browser/ui/color/brave_color_mixer.cc
@@ -34,6 +34,15 @@ const SkColor kDarkLocationBarHoverBg = SkColorSetRGB(0x23, 0x25, 0x2F);
 constexpr float kOmniboxOpacityHovered = 0.10f;
 constexpr float kOmniboxOpacitySelected = 0.16f;
 
+SkColor GetToolbarInkDropColor(const ui::ColorMixer& mixer) {
+  // Copied from
+  // chrome/browser/ui/views/toolbar/toolbar_ink_drop_util.h
+  // to use same hover background with toolbar button.
+  constexpr float kToolbarInkDropHighlightVisibleOpacity = 0.08f;
+  return SkColorSetA(mixer.GetResultColor(kColorToolbarInkDrop),
+                     0xFF * kToolbarInkDropHighlightVisibleOpacity);
+}
+
 enum class ProfileType {
   kNormalProfile,
   kPrivateProfile,
@@ -217,13 +226,7 @@ void AddBraveFeaturesColors(const ui::ColorProviderManager::Key& key,
       }
       case BraveThemeProperties::COLOR_SIDEBAR_ARROW_BACKGROUND_HOVERED:
       case BraveThemeProperties::COLOR_SIDEBAR_ITEM_BACKGROUND_HOVERED: {
-        // Copied from
-        // chrome/browser/ui/views/toolbar/toolbar_ink_drop_util.h
-        // to use same hover background with toolbar button.
-        constexpr float kToolbarInkDropHighlightVisibleOpacity = 0.08f;
-        mixer[entry.color_id] = {
-            SkColorSetA(mixer.GetResultColor(kColorToolbarInkDrop),
-                        0xFF * kToolbarInkDropHighlightVisibleOpacity)};
+        mixer[entry.color_id] = {GetToolbarInkDropColor(mixer)};
         break;
       }
 #endif
@@ -334,6 +337,13 @@ void AddBraveLightThemeColorMixer(ui::ColorProvider* provider,
   mixer[ui::kColorToggleButtonTrackOff] = {SkColorSetRGB(0xDA, 0xDC, 0xE8)};
   mixer[ui::kColorToggleButtonTrackOn] = {SkColorSetRGB(0xE1, 0xE2, 0xF6)};
 
+  // Colors for HelpBubble. IDs are defined in
+  // chrome/browser/ui/color/chrome_color_id.h
+  mixer[kColorFeaturePromoBubbleBackground] = {SK_ColorWHITE};
+  mixer[kColorFeaturePromoBubbleForeground] = {SkColorSetRGB(0x42, 0x45, 0x52)};
+  mixer[kColorFeaturePromoBubbleCloseButtonInkDrop] = {
+      GetToolbarInkDropColor(mixer)};
+
   AddBraveFeaturesColors(key, &mixer, ProfileType::kNormalProfile);
 }
 
@@ -371,6 +381,13 @@ void AddBraveDarkThemeColorMixer(ui::ColorProvider* provider,
   mixer[ui::kColorToggleButtonThumbOn] = {SkColorSetRGB(0x44, 0x36, 0xE1)};
   mixer[ui::kColorToggleButtonTrackOff] = {SkColorSetRGB(0x5E, 0x61, 0x75)};
   mixer[ui::kColorToggleButtonTrackOn] = {SkColorSetRGB(0x76, 0x79, 0xB1)};
+
+  // Colors for HelpBubble. IDs are defined in
+  // chrome/browser/ui/color/chrome_color_id.h
+  mixer[kColorFeaturePromoBubbleBackground] = {SkColorSetRGB(0x12, 0x13, 0x16)};
+  mixer[kColorFeaturePromoBubbleForeground] = {SkColorSetRGB(0xC6, 0xC8, 0xD0)};
+  mixer[kColorFeaturePromoBubbleCloseButtonInkDrop] = {
+      GetToolbarInkDropColor(mixer)};
 
   AddBraveFeaturesColors(key, &mixer, ProfileType::kNormalProfile);
 }


### PR DESCRIPTION
Remove GoogleBlue color.

<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/24466

### on dark theme
<img width="439" alt="image" src="https://user-images.githubusercontent.com/5474642/191951706-fc7b4eb2-9cea-4c80-b1a6-2500d333db47.png">

### on light theme
<img width="382" alt="image" src="https://user-images.githubusercontent.com/5474642/191951906-80031cab-505d-498e-8471-3600faaf3bb1.png">


## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [x] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [x] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [x] Major classes, functions and non-trivial code blocks are well-commented
- [x] Changes in component dependencies are properly reflected in `gn`
- [x] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [x] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
* Create a second profile.
* Note message on the new window of second profile is in Chrome blue color, should be Brave-ified.
