### PR TITLE
Fix Firebase exceptions in brave_content_settings_pref_provider.cc

### DIFF
--- a/components/content_settings/core/browser/brave_content_settings_pref_provider.cc
+++ b/components/content_settings/core/browser/brave_content_settings_pref_provider.cc
@@ -48,8 +48,9 @@ constexpr char kObsoleteShieldCookies[] =
 constexpr char kBraveShieldsFPSettingsMigration[] =
     "brave.shields_fp_settings_migration";
 
-constexpr char kGoogleAuthPattern[] = "https://accounts.google.com/*";
-constexpr char kFirebasePattern[] = "https://[*.]firebaseapp.com/*";
+constexpr char kGoogleAuthPattern[] =
+    "https://accounts.google.com/o/oauth2/auth/*";
+constexpr char kFirebasePattern[] = "https://[*.]firebaseapp.com/__/auth/*";
 
 const char kExpirationPath[] = "expiration";
 const char kLastModifiedPath[] = "last_modified";


### PR DESCRIPTION
Testing https://www.humblebundle.com/ login.  (new PR, rebased again)

 - Opens this first: 

​`https://hr-humblebundle.firebaseapp.com/__/auth/handler?apiKey=AIzaSyAFKtpUPxUQdd2LlX7wj4ud9w334PHp5wM&appName=%5BDEFAULT%5D&authType=signInViaRedirect&providerId=google.com&customParameters=%7B%22prompt%22%3A%22select_account%20consent%22%7D&scopes=profile%2Cemail&redirectUrl=https%3A%2F%2Fwww.humblebundle.com%2Fsignup%3Fhmb_source%3Dnavbar%26goto%3D%252F&v=7.4.0​​​​​`

- Then redirects too:

`https://accounts.google.com/o/oauth2/auth/oauthchooseaccount?response_type=code&client_id=73712311582-5u2c0q36ftlakq9ut8gao6si5452unki.apps.googleusercontent.com&redirect_uri=https%3A%2F%2Fhr-humblebundle.firebaseapp.com%2F__%2Fauth%2Fhandler&state=AMbdmDnrjqtIEcWAbGUwqrU8Sj_1dZQzTcrvh17b78eI1eHF1dNqkeHKtjw6Qa9e63m0gm1cE6gZAe2whED0AzO4y-bkcGAjQPd7Xq6BRdYHoh258yL0RsLNayCs8weTZdedG5Zk0FqK5csHxutXHcg4Rj4ETnzo_7zq5mEiNOYMMbFgi4jhsN9U2GZhN9TlFU71XEy1arD5FwKcf2_JT811MloKAnW5HlcOTc3tBjprySIfLyLRy1X3Ojh92SxEuM01OmqOPCqCsnOLVAVLhY9OePk_KP3WwhD2aQFdJJVUNC-zyT69iRrDrZo__u4giZZXH-Qz3MtmbQ&scope=openid%20profile%20email&prompt=select_account%20consent&context_uri=https%3A%2F%2Fwww.humblebundle.com&flowName=GeneralOAuthFlow`


