### PR TITLE
Update notification permission retaionale dialog behaviour

### DIFF
--- a/android/java/org/chromium/chrome/browser/app/BraveActivity.java
+++ b/android/java/org/chromium/chrome/browser/app/BraveActivity.java
@@ -114,6 +114,8 @@ import org.chromium.chrome.browser.dependency_injection.ChromeActivityComponent;
 import org.chromium.chrome.browser.flags.ChromeSwitches;
 import org.chromium.chrome.browser.fullscreen.BrowserControlsManager;
 import org.chromium.chrome.browser.informers.BraveAndroidSyncDisabledInformer;
+import org.chromium.chrome.browser.notifications.permissions.NotificationPermissionController;
+import org.chromium.chrome.browser.notifications.permissions.NotificationPermissionRationaleDialogController;
 import org.chromium.chrome.browser.notifications.retention.RetentionNotificationUtil;
 import org.chromium.chrome.browser.ntp.NewTabPageManager;
 import org.chromium.chrome.browser.ntp_background_images.util.NewTabPageListener;
@@ -245,6 +247,7 @@ public abstract class BraveActivity<C extends ChromeActivityComponent> extends C
     private int mLastTabId;
     private boolean mNativeInitialized;
     private NewTabPageManager mNewTabPageManager;
+    private NotificationPermissionController mNotificationPermissionController;
 
     @SuppressLint("VisibleForTests")
     public BraveActivity() {
@@ -369,6 +372,10 @@ public abstract class BraveActivity<C extends ChromeActivityComponent> extends C
 
     @Override
     protected void onDestroyInternal() {
+        if (mNotificationPermissionController != null) {
+            NotificationPermissionController.detach(mNotificationPermissionController);
+            mNotificationPermissionController = null;
+        }
         super.onDestroyInternal();
         cleanUpNativeServices();
     }
@@ -978,6 +985,7 @@ public abstract class BraveActivity<C extends ChromeActivityComponent> extends C
                                 if (viewGroup != null && highlightView != null) {
                                     viewGroup.removeView(highlightView);
                                 }
+                                maybeShowNotificationPermissionRetionale();
                             })
                             .modal(true)
                             .contentView(R.layout.brave_onboarding_searchbox)
@@ -994,6 +1002,16 @@ public abstract class BraveActivity<C extends ChromeActivityComponent> extends C
             highlightView.setHighlightItem(item);
             popupWindowTooltip.show();
         }, 500);
+    }
+
+    private void maybeShowNotificationPermissionRetionale() {
+        NotificationPermissionController mNotificationPermissionController =
+                new NotificationPermissionController(getWindowAndroid(),
+                        new NotificationPermissionRationaleDialogController(
+                                this, getModalDialogManager()));
+        NotificationPermissionController.attach(
+                getWindowAndroid(), mNotificationPermissionController);
+        mNotificationPermissionController.requestPermissionIfNeeded(false /* contextual */);
     }
 
     public void setDormantUsersPrefs() {

--- a/patches/chrome-android-java-src-org-chromium-chrome-browser-ChromeTabbedActivity.java.patch
+++ b/patches/chrome-android-java-src-org-chromium-chrome-browser-ChromeTabbedActivity.java.patch
@@ -1,0 +1,13 @@
+diff --git a/chrome/android/java/src/org/chromium/chrome/browser/ChromeTabbedActivity.java b/chrome/android/java/src/org/chromium/chrome/browser/ChromeTabbedActivity.java
+index 419cbde4e1cdf431d3035b3c6ba2bbde955350cc..0122db0889699c77d85183313c39df95e367fec8 100644
+--- a/chrome/android/java/src/org/chromium/chrome/browser/ChromeTabbedActivity.java
++++ b/chrome/android/java/src/org/chromium/chrome/browser/ChromeTabbedActivity.java
+@@ -1041,7 +1041,7 @@ public class ChromeTabbedActivity extends ChromeActivity<ChromeActivityComponent
+                                     this, getModalDialogManager()));
+             NotificationPermissionController.attach(
+                     getWindowAndroid(), mNotificationPermissionController);
+-            mNotificationPermissionController.requestPermissionIfNeeded(false /* contextual */);
++            if(false) mNotificationPermissionController.requestPermissionIfNeeded(false /* contextual */);
+             if (BackPressManager.isEnabled()) initializeBackPressHandlers();
+         }
+     }


### PR DESCRIPTION
<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/25610

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
Notification permission dialog should be shown once user is done with the onboarding. 
