### PR TITLE
Update notification permission retaionale dialog behaviour (uplift to 1.45.x)

### DIFF
--- a/android/java/org/chromium/chrome/browser/app/BraveActivity.java
+++ b/android/java/org/chromium/chrome/browser/app/BraveActivity.java
@@ -114,6 +114,8 @@ import org.chromium.chrome.browser.dependency_injection.ChromeActivityComponent;
 import org.chromium.chrome.browser.flags.ChromeSwitches;
 import org.chromium.chrome.browser.fullscreen.BrowserControlsManager;
 import org.chromium.chrome.browser.informers.BraveAndroidSyncDisabledInformer;
+import org.chromium.chrome.browser.notifications.permissions.NotificationPermissionController;
+import org.chromium.chrome.browser.notifications.permissions.NotificationPermissionRationaleDialogController;
 import org.chromium.chrome.browser.notifications.retention.RetentionNotificationUtil;
 import org.chromium.chrome.browser.ntp.NewTabPageManager;
 import org.chromium.chrome.browser.ntp_background_images.util.NewTabPageListener;
@@ -245,6 +247,7 @@ public abstract class BraveActivity<C extends ChromeActivityComponent> extends C
     private int mLastTabId;
     private boolean mNativeInitialized;
     private NewTabPageManager mNewTabPageManager;
+    private NotificationPermissionController mNotificationPermissionController;
 
     @SuppressLint("VisibleForTests")
     public BraveActivity() {
@@ -369,6 +372,10 @@ public abstract class BraveActivity<C extends ChromeActivityComponent> extends C
 
     @Override
     protected void onDestroyInternal() {
+        if (mNotificationPermissionController != null) {
+            NotificationPermissionController.detach(mNotificationPermissionController);
+            mNotificationPermissionController = null;
+        }
         super.onDestroyInternal();
         cleanUpNativeServices();
     }
@@ -978,6 +985,7 @@ public abstract class BraveActivity<C extends ChromeActivityComponent> extends C
                                 if (viewGroup != null && highlightView != null) {
                                     viewGroup.removeView(highlightView);
                                 }
+                                maybeShowNotificationPermissionRetionale();
                             })
                             .modal(true)
                             .contentView(R.layout.brave_onboarding_searchbox)
@@ -994,6 +1002,16 @@ public abstract class BraveActivity<C extends ChromeActivityComponent> extends C
             highlightView.setHighlightItem(item);
             popupWindowTooltip.show();
         }, 500);
+    }
+
+    private void maybeShowNotificationPermissionRetionale() {
+        NotificationPermissionController mNotificationPermissionController =
+                new NotificationPermissionController(getWindowAndroid(),
+                        new NotificationPermissionRationaleDialogController(
+                                this, getModalDialogManager()));
+        NotificationPermissionController.attach(
+                getWindowAndroid(), mNotificationPermissionController);
+        mNotificationPermissionController.requestPermissionIfNeeded(false /* contextual */);
     }
 
     public void setDormantUsersPrefs() {

--- a/patches/chrome-android-java-src-org-chromium-chrome-browser-ChromeTabbedActivity.java.patch
+++ b/patches/chrome-android-java-src-org-chromium-chrome-browser-ChromeTabbedActivity.java.patch
@@ -1,0 +1,13 @@
+diff --git a/chrome/android/java/src/org/chromium/chrome/browser/ChromeTabbedActivity.java b/chrome/android/java/src/org/chromium/chrome/browser/ChromeTabbedActivity.java
+index 419cbde4e1cdf431d3035b3c6ba2bbde955350cc..0122db0889699c77d85183313c39df95e367fec8 100644
+--- a/chrome/android/java/src/org/chromium/chrome/browser/ChromeTabbedActivity.java
++++ b/chrome/android/java/src/org/chromium/chrome/browser/ChromeTabbedActivity.java
+@@ -1041,7 +1041,7 @@ public class ChromeTabbedActivity extends ChromeActivity<ChromeActivityComponent
+                                     this, getModalDialogManager()));
+             NotificationPermissionController.attach(
+                     getWindowAndroid(), mNotificationPermissionController);
+-            mNotificationPermissionController.requestPermissionIfNeeded(false /* contextual */);
++            if(false) mNotificationPermissionController.requestPermissionIfNeeded(false /* contextual */);
+             if (BackPressManager.isEnabled()) initializeBackPressHandlers();
+         }
+     }


### PR DESCRIPTION
Uplift of #15214
Resolves https://github.com/brave/brave-browser/issues/25610

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.