### PR TITLE
Fix ExternalWalletsImporter::GetMnemonic would often not being called when importing from Crypto Wallets

### DIFF
--- a/browser/brave_wallet/brave_wallet_service_delegate_impl.cc
+++ b/browser/brave_wallet/brave_wallet_service_delegate_impl.cc
@@ -63,27 +63,28 @@ void BraveWalletServiceDelegateImpl::IsExternalWalletInstalled(
 void BraveWalletServiceDelegateImpl::IsExternalWalletInitialized(
     mojom::ExternalWalletType type,
     IsExternalWalletInitializedCallback callback) {
-  std::unique_ptr<ExternalWalletsImporter> importer =
-      std::make_unique<ExternalWalletsImporter>(type, context_);
+  importers_[type] = std::make_unique<ExternalWalletsImporter>(type, context_);
   // Do not try to init the importer when external wallet is not installed
-  if (!importer->IsExternalWalletInstalled()) {
+  if (!importers_[type]->IsExternalWalletInstalled()) {
     std::move(callback).Run(false);
     return;
   }
-  ExternalWalletsImporter* importer_ptr = importer.get();
-  importer_ptr->Initialize(base::BindOnce(
-      &BraveWalletServiceDelegateImpl::ContinueIsExternalWalletInitialized,
-      weak_ptr_factory_.GetWeakPtr(), std::move(importer),
-      std::move(callback)));
+  if (importers_[type]->IsInitialized()) {
+    ContinueIsExternalWalletInitialized(type, std::move(callback), true);
+  } else {
+    importers_[type]->Initialize(base::BindOnce(
+        &BraveWalletServiceDelegateImpl::ContinueIsExternalWalletInitialized,
+        weak_ptr_factory_.GetWeakPtr(), type, std::move(callback)));
+  }
 }
 
 void BraveWalletServiceDelegateImpl::ContinueIsExternalWalletInitialized(
-    std::unique_ptr<ExternalWalletsImporter> importer,
+    mojom::ExternalWalletType type,
     IsExternalWalletInitializedCallback callback,
     bool init_success) {
-  DCHECK(importer);
+  DCHECK(importers_[type]);
   if (init_success) {
-    std::move(callback).Run(importer->IsExternalWalletInitialized());
+    std::move(callback).Run(importers_[type]->IsExternalWalletInitialized());
   } else {
     std::move(callback).Run(false);
   }
@@ -93,24 +94,29 @@ void BraveWalletServiceDelegateImpl::GetImportInfoFromExternalWallet(
     mojom::ExternalWalletType type,
     const std::string& password,
     GetImportInfoCallback callback) {
-  std::unique_ptr<ExternalWalletsImporter> importer =
-      std::make_unique<ExternalWalletsImporter>(type, context_);
-  ExternalWalletsImporter* importer_ptr = importer.get();
-  importer_ptr->Initialize(base::BindOnce(
-      &BraveWalletServiceDelegateImpl::ContinueGetImportInfoFromExternalWallet,
-      weak_ptr_factory_.GetWeakPtr(), std::move(importer), password,
-      std::move(callback)));
+  if (!importers_[type])
+    importers_[type] =
+        std::make_unique<ExternalWalletsImporter>(type, context_);
+  if (importers_[type]->IsInitialized()) {
+    ContinueGetImportInfoFromExternalWallet(type, password, std::move(callback),
+                                            true);
+  } else {
+    importers_[type]->Initialize(base::BindOnce(
+        &BraveWalletServiceDelegateImpl::
+            ContinueGetImportInfoFromExternalWallet,
+        weak_ptr_factory_.GetWeakPtr(), type, password, std::move(callback)));
+  }
 }
 
 void BraveWalletServiceDelegateImpl::ContinueGetImportInfoFromExternalWallet(
-    std::unique_ptr<ExternalWalletsImporter> importer,
+    mojom::ExternalWalletType type,
     const std::string& password,
     GetImportInfoCallback callback,
     bool init_success) {
-  DCHECK(importer);
+  DCHECK(importers_[type]);
   if (init_success) {
-    DCHECK(importer->IsInitialized());
-    importer->GetImportInfo(password, std::move(callback));
+    DCHECK(importers_[type]->IsInitialized());
+    importers_[type]->GetImportInfo(password, std::move(callback));
   } else {
     std::move(callback).Run(false, ImportInfo(), ImportError::kInternalError);
   }

--- a/browser/brave_wallet/brave_wallet_service_delegate_impl.h
+++ b/browser/brave_wallet/brave_wallet_service_delegate_impl.h
@@ -9,6 +9,7 @@
 #include <memory>
 #include <string>
 
+#include "base/containers/flat_map.h"
 #include "base/memory/raw_ptr.h"
 #include "base/memory/weak_ptr.h"
 #include "base/observer_list.h"
@@ -25,8 +26,6 @@ class BrowserContext;
 }
 
 namespace brave_wallet {
-
-class ExternalWalletsImporter;
 
 class BraveWalletServiceDelegateImpl : public BraveWalletServiceDelegate,
                                        public TabStripModelObserver,
@@ -84,20 +83,22 @@ class BraveWalletServiceDelegateImpl : public BraveWalletServiceDelegate,
  private:
   friend class BraveWalletServiceDelegateImplUnitTest;
 
-  void ContinueIsExternalWalletInitialized(
-      std::unique_ptr<ExternalWalletsImporter> importer,
-      IsExternalWalletInitializedCallback,
-      bool init_success);
-  void ContinueGetImportInfoFromExternalWallet(
-      std::unique_ptr<ExternalWalletsImporter> importer,
-      const std::string& password,
-      GetImportInfoCallback callback,
-      bool init_success);
+  void ContinueIsExternalWalletInitialized(mojom::ExternalWalletType type,
+                                           IsExternalWalletInitializedCallback,
+                                           bool init_success);
+  void ContinueGetImportInfoFromExternalWallet(mojom::ExternalWalletType type,
+                                               const std::string& password,
+                                               GetImportInfoCallback callback,
+                                               bool init_success);
 
   url::Origin GetActiveOriginInternal();
   void FireActiveOriginChanged();
 
   raw_ptr<content::BrowserContext> context_ = nullptr;
+  base::flat_map<mojom::ExternalWalletType,
+                 std::unique_ptr<ExternalWalletsImporter>>
+      importers_;
+
   BrowserTabStripTracker browser_tab_strip_tracker_;
   base::ObserverList<BraveWalletServiceDelegate::Observer> observer_list_;
 


### PR DESCRIPTION
<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/25612

1. Before the fix, `ExternalWalletsImporter` instance would often get out of scope and destroyed hence  `ExternalWalletsImporter::GetMnemonic` would never be called.
2. Storing importers to enhance the importing performance because we don't need to Initialize(loading storage data) every time for sequence like checking `IsExternalWalletInitialized` and then `GetImportInfoFromExternalWallet`
3. `IsExternalWalletInitialized` would always create new `ExternalWalletsImporter` to ensure we get updated extension info.

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

1. Steps in original issue
2. Import 12 words from Crypto Wallets should work
4. Import from MetaMask should work