### PR TITLE
Keep playlist web contents alive even when side panel closes

### DIFF
--- a/browser/ui/views/side_panel/playlist/playlist_side_panel_coordinator.h
+++ b/browser/ui/views/side_panel/playlist/playlist_side_panel_coordinator.h
@@ -9,13 +9,18 @@
 #include <memory>
 
 #include "chrome/browser/ui/browser_user_data.h"
+#include "chrome/browser/ui/views/bubble/bubble_contents_wrapper.h"
 
-class Browser;
-class SidePanelRegistry;
+namespace playlist {
+class PlaylistUI;
+}  // namespace playlist
 
 namespace views {
 class View;
 }  // namespace views
+
+class Browser;
+class SidePanelRegistry;
 
 class PlaylistSidePanelCoordinator
     : public BrowserUserData<PlaylistSidePanelCoordinator> {
@@ -32,6 +37,9 @@ class PlaylistSidePanelCoordinator
   friend class BrowserUserData<PlaylistSidePanelCoordinator>;
 
   std::unique_ptr<views::View> CreateWebView();
+
+  std::unique_ptr<BubbleContentsWrapperT<playlist::PlaylistUI>>
+      contents_wrapper_;
 
   BROWSER_USER_DATA_KEY_DECL();
 };

--- a/browser/ui/views/side_panel/playlist/playlist_side_panel_coordinator.h
+++ b/browser/ui/views/side_panel/playlist/playlist_side_panel_coordinator.h
@@ -8,22 +8,22 @@
 
 #include <memory>
 
+#include "base/scoped_observation.h"
 #include "chrome/browser/ui/browser_user_data.h"
 #include "chrome/browser/ui/views/bubble/bubble_contents_wrapper.h"
+#include "ui/views/view.h"
+#include "ui/views/view_observer.h"
 
 namespace playlist {
 class PlaylistUI;
 }  // namespace playlist
 
-namespace views {
-class View;
-}  // namespace views
-
 class Browser;
 class SidePanelRegistry;
 
 class PlaylistSidePanelCoordinator
-    : public BrowserUserData<PlaylistSidePanelCoordinator> {
+    : public BrowserUserData<PlaylistSidePanelCoordinator>,
+      public views::ViewObserver {
  public:
   explicit PlaylistSidePanelCoordinator(Browser* browser);
   PlaylistSidePanelCoordinator(const PlaylistSidePanelCoordinator&) = delete;
@@ -33,13 +33,21 @@ class PlaylistSidePanelCoordinator
 
   void CreateAndRegisterEntry(SidePanelRegistry* global_registry);
 
+  // views::ViewObserver:
+  void OnViewIsDeleting(views::View* view) override;
+
  private:
   friend class BrowserUserData<PlaylistSidePanelCoordinator>;
+
+  void DestroyWebContentsIfNeeded();
 
   std::unique_ptr<views::View> CreateWebView();
 
   std::unique_ptr<BubbleContentsWrapperT<playlist::PlaylistUI>>
       contents_wrapper_;
+
+  base::ScopedObservation<views::View, views::ViewObserver> view_observation_{
+      this};
 
   BROWSER_USER_DATA_KEY_DECL();
 };

--- a/browser/ui/views/side_panel/playlist/playlist_side_panel_web_view.cc
+++ b/browser/ui/views/side_panel/playlist/playlist_side_panel_web_view.cc
@@ -5,24 +5,13 @@
 
 #include "brave/browser/ui/views/side_panel/playlist/playlist_side_panel_web_view.h"
 
-#include <memory>
-
-#include "brave/components/constants/webui_url_constants.h"
-#include "chrome/browser/profiles/profile.h"
-#include "chrome/browser/ui/browser.h"
-#include "chrome/browser/ui/views/bubble/bubble_contents_wrapper.h"
-
 PlaylistSidePanelWebView::PlaylistSidePanelWebView(
     Browser* browser,
-    base::RepeatingClosure close_cb)
-    : SidePanelWebUIViewT(
+    base::RepeatingClosure close_cb,
+    BubbleContentsWrapper* contents_wrapper)
+    : SidePanelWebUIView(
           /* on_show_cb = */ base::RepeatingClosure(),
           close_cb,
-          std::make_unique<BubbleContentsWrapperT<playlist::PlaylistUI>>(
-              GURL(kPlaylistURL),
-              browser->profile(),
-              0,
-              /*webui_resizes_host=*/false,
-              /*esc_closes_ui=*/false)) {}
+          contents_wrapper) {}
 
 PlaylistSidePanelWebView::~PlaylistSidePanelWebView() = default;

--- a/browser/ui/views/side_panel/playlist/playlist_side_panel_web_view.h
+++ b/browser/ui/views/side_panel/playlist/playlist_side_panel_web_view.h
@@ -7,15 +7,17 @@
 #define BRAVE_BROWSER_UI_VIEWS_SIDE_PANEL_PLAYLIST_PLAYLIST_SIDE_PANEL_WEB_VIEW_H_
 
 class Browser;
+class BubbleContentsWrapper;
 
 #include "base/callback_forward.h"
 #include "brave/browser/ui/webui/playlist_ui.h"
 #include "chrome/browser/ui/views/side_panel/side_panel_web_ui_view.h"
 
-class PlaylistSidePanelWebView
-    : public SidePanelWebUIViewT<playlist::PlaylistUI> {
+class PlaylistSidePanelWebView : public SidePanelWebUIView {
  public:
-  PlaylistSidePanelWebView(Browser* browser, base::RepeatingClosure close_cb);
+  PlaylistSidePanelWebView(Browser* browser,
+                           base::RepeatingClosure close_cb,
+                           BubbleContentsWrapper* contents_wrapper);
   PlaylistSidePanelWebView(const PlaylistSidePanelWebView&) = delete;
   PlaylistSidePanelWebView& operator=(const PlaylistSidePanelWebView&) = delete;
   ~PlaylistSidePanelWebView() override;


### PR DESCRIPTION
Resolves https://github.com/brave/brave-browser/issues/25639

DEMO:

https://user-images.githubusercontent.com/5474642/192519404-828e8dd2-1a7e-41ad-b867-bdcbcb53668d.mov



We should playlist keep alive so that user can play media on the background. Currently the web contents is owned by BubbleContentsWrapper. So we should keep BubbleContentsWrapper to PlaylistSidePanelCoordinator whose lifecycle is bound to a browser.

<!-- Add brave-browser issue bellow that this PR will resolve -->

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
### Manual
* open playlist
* play a video
* close sidepanel
* see if video is still playing
* open sidepanel again
* see if the page isn't reloaded and reused
