### PR TITLE
Propagate that authorization is needed to UI for ETH hardware signing (uplift to 1.45.x)

### DIFF
--- a/components/brave_wallet_ui/panel/async/wallet_panel_async_handler.ts
+++ b/components/brave_wallet_ui/panel/async/wallet_panel_async_handler.ts
@@ -521,6 +521,10 @@ handler.on(PanelActions.signMessageHardware.getType(), async (store, messageData
   const info = hardwareAccount.hardware
   const signed = await signMessageWithHardwareKeyring(info.vendor as HardwareVendor, info.path, messageData)
   if (!signed.success && signed.code) {
+    if (signed.code === 'unauthorized') {
+      await store.dispatch(PanelActions.setHardwareWalletInteractionError(signed.code))
+      return
+    }
     const deviceError = (info.vendor === BraveWallet.TREZOR_HARDWARE_VENDOR)
       ? dialogErrorFromTrezorErrorCode(signed.code) : dialogErrorFromLedgerErrorCode(signed.code)
     if (deviceError !== 'transactionRejected') {


### PR DESCRIPTION
Uplift of #15222
Resolves https://github.com/brave/brave-browser/issues/25623

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.