### PR TITLE
Fix ExternalWalletsImporter::GetMnemonic would often not being called when importing from Crypto Wallets (uplift to 1.45.x)

### DIFF
--- a/browser/brave_wallet/brave_wallet_service_delegate_impl.cc
+++ b/browser/brave_wallet/brave_wallet_service_delegate_impl.cc
@@ -63,27 +63,28 @@ void BraveWalletServiceDelegateImpl::IsExternalWalletInstalled(
 void BraveWalletServiceDelegateImpl::IsExternalWalletInitialized(
     mojom::ExternalWalletType type,
     IsExternalWalletInitializedCallback callback) {
-  std::unique_ptr<ExternalWalletsImporter> importer =
-      std::make_unique<ExternalWalletsImporter>(type, context_);
+  importers_[type] = std::make_unique<ExternalWalletsImporter>(type, context_);
   // Do not try to init the importer when external wallet is not installed
-  if (!importer->IsExternalWalletInstalled()) {
+  if (!importers_[type]->IsExternalWalletInstalled()) {
     std::move(callback).Run(false);
     return;
   }
-  ExternalWalletsImporter* importer_ptr = importer.get();
-  importer_ptr->Initialize(base::BindOnce(
-      &BraveWalletServiceDelegateImpl::ContinueIsExternalWalletInitialized,
-      weak_ptr_factory_.GetWeakPtr(), std::move(importer),
-      std::move(callback)));
+  if (importers_[type]->IsInitialized()) {
+    ContinueIsExternalWalletInitialized(type, std::move(callback), true);
+  } else {
+    importers_[type]->Initialize(base::BindOnce(
+        &BraveWalletServiceDelegateImpl::ContinueIsExternalWalletInitialized,
+        weak_ptr_factory_.GetWeakPtr(), type, std::move(callback)));
+  }
 }
 
 void BraveWalletServiceDelegateImpl::ContinueIsExternalWalletInitialized(
-    std::unique_ptr<ExternalWalletsImporter> importer,
+    mojom::ExternalWalletType type,
     IsExternalWalletInitializedCallback callback,
     bool init_success) {
-  DCHECK(importer);
+  DCHECK(importers_[type]);
   if (init_success) {
-    std::move(callback).Run(importer->IsExternalWalletInitialized());
+    std::move(callback).Run(importers_[type]->IsExternalWalletInitialized());
   } else {
     std::move(callback).Run(false);
   }
@@ -93,24 +94,29 @@ void BraveWalletServiceDelegateImpl::GetImportInfoFromExternalWallet(
     mojom::ExternalWalletType type,
     const std::string& password,
     GetImportInfoCallback callback) {
-  std::unique_ptr<ExternalWalletsImporter> importer =
-      std::make_unique<ExternalWalletsImporter>(type, context_);
-  ExternalWalletsImporter* importer_ptr = importer.get();
-  importer_ptr->Initialize(base::BindOnce(
-      &BraveWalletServiceDelegateImpl::ContinueGetImportInfoFromExternalWallet,
-      weak_ptr_factory_.GetWeakPtr(), std::move(importer), password,
-      std::move(callback)));
+  if (!importers_[type])
+    importers_[type] =
+        std::make_unique<ExternalWalletsImporter>(type, context_);
+  if (importers_[type]->IsInitialized()) {
+    ContinueGetImportInfoFromExternalWallet(type, password, std::move(callback),
+                                            true);
+  } else {
+    importers_[type]->Initialize(base::BindOnce(
+        &BraveWalletServiceDelegateImpl::
+            ContinueGetImportInfoFromExternalWallet,
+        weak_ptr_factory_.GetWeakPtr(), type, password, std::move(callback)));
+  }
 }
 
 void BraveWalletServiceDelegateImpl::ContinueGetImportInfoFromExternalWallet(
-    std::unique_ptr<ExternalWalletsImporter> importer,
+    mojom::ExternalWalletType type,
     const std::string& password,
     GetImportInfoCallback callback,
     bool init_success) {
-  DCHECK(importer);
+  DCHECK(importers_[type]);
   if (init_success) {
-    DCHECK(importer->IsInitialized());
-    importer->GetImportInfo(password, std::move(callback));
+    DCHECK(importers_[type]->IsInitialized());
+    importers_[type]->GetImportInfo(password, std::move(callback));
   } else {
     std::move(callback).Run(false, ImportInfo(), ImportError::kInternalError);
   }

--- a/browser/brave_wallet/brave_wallet_service_delegate_impl.h
+++ b/browser/brave_wallet/brave_wallet_service_delegate_impl.h
@@ -9,6 +9,7 @@
 #include <memory>
 #include <string>
 
+#include "base/containers/flat_map.h"
 #include "base/memory/raw_ptr.h"
 #include "base/memory/weak_ptr.h"
 #include "base/observer_list.h"
@@ -25,8 +26,6 @@ class BrowserContext;
 }
 
 namespace brave_wallet {
-
-class ExternalWalletsImporter;
 
 class BraveWalletServiceDelegateImpl : public BraveWalletServiceDelegate,
                                        public TabStripModelObserver,
@@ -84,20 +83,22 @@ class BraveWalletServiceDelegateImpl : public BraveWalletServiceDelegate,
  private:
   friend class BraveWalletServiceDelegateImplUnitTest;
 
-  void ContinueIsExternalWalletInitialized(
-      std::unique_ptr<ExternalWalletsImporter> importer,
-      IsExternalWalletInitializedCallback,
-      bool init_success);
-  void ContinueGetImportInfoFromExternalWallet(
-      std::unique_ptr<ExternalWalletsImporter> importer,
-      const std::string& password,
-      GetImportInfoCallback callback,
-      bool init_success);
+  void ContinueIsExternalWalletInitialized(mojom::ExternalWalletType type,
+                                           IsExternalWalletInitializedCallback,
+                                           bool init_success);
+  void ContinueGetImportInfoFromExternalWallet(mojom::ExternalWalletType type,
+                                               const std::string& password,
+                                               GetImportInfoCallback callback,
+                                               bool init_success);
 
   url::Origin GetActiveOriginInternal();
   void FireActiveOriginChanged();
 
   raw_ptr<content::BrowserContext> context_ = nullptr;
+  base::flat_map<mojom::ExternalWalletType,
+                 std::unique_ptr<ExternalWalletsImporter>>
+      importers_;
+
   BrowserTabStripTracker browser_tab_strip_tracker_;
   base::ObserverList<BraveWalletServiceDelegate::Observer> observer_list_;
 


### PR DESCRIPTION
Uplift of #15221
Resolves https://github.com/brave/brave-browser/issues/25612

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.