### PR TITLE
fix(wallet): Disable Add Hardware Accounts Button Until Checked (uplift to 1.45.x)

### DIFF
--- a/components/brave_wallet_ui/components/desktop/popup-modals/add-account-modal/hardware-wallet-connect/accounts-list.tsx
+++ b/components/brave_wallet_ui/components/desktop/popup-modals/add-account-modal/hardware-wallet-connect/accounts-list.tsx
@@ -202,7 +202,7 @@ export default function (props: Props) {
           onSubmit={onAddAccounts}
           text={getLocale('braveWalletAddCheckedAccountsHardwareWallet')}
           buttonType='primary'
-          disabled={accounts.length === 0}
+          disabled={accounts.length === 0 || selectedDerivationPaths.length === 0}
         />
       </ButtonsContainer>
     </>


### PR DESCRIPTION
Uplift of #15224

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.