### PR TITLE
Refactor sidebar item's tooltip handling

### DIFF
--- a/browser/ui/sidebar/sidebar_model.cc
+++ b/browser/ui/sidebar/sidebar_model.cc
@@ -131,12 +131,12 @@ void SidebarModel::OnItemMoved(const SidebarItem& item,
 
 void SidebarModel::OnItemUpdated(const SidebarItem& item,
                                  const SidebarItemUpdate& update) {
+  for (Observer& obs : observers_)
+    obs.OnItemUpdated(item, update);
+
   // New url needs its favicon.
-  if (update.url_updated) {
-    for (Observer& obs : observers_)
-      obs.OnWillUpdateFavicon(item, update.index);
+  if (update.url_updated)
     FetchFavicon(item);
-  }
 }
 
 void SidebarModel::OnWillRemoveItem(const SidebarItem& item, size_t index) {

--- a/browser/ui/sidebar/sidebar_model.h
+++ b/browser/ui/sidebar/sidebar_model.h
@@ -58,7 +58,8 @@ class SidebarModel : public SidebarService::Observer,
     virtual void OnItemRemoved(size_t index) {}
     virtual void OnActiveIndexChanged(absl::optional<size_t> old_index,
                                       absl::optional<size_t> new_index) {}
-    virtual void OnWillUpdateFavicon(const SidebarItem& item, size_t index) {}
+    virtual void OnItemUpdated(const SidebarItem& item,
+                               const SidebarItemUpdate& update) {}
     virtual void OnFaviconUpdatedForItem(const SidebarItem& item,
                                          const gfx::ImageSkia& image) {}
 

--- a/browser/ui/sidebar/sidebar_unittest.cc
+++ b/browser/ui/sidebar/sidebar_unittest.cc
@@ -48,8 +48,8 @@ class MockSidebarModelObserver : public SidebarModel::Observer {
                absl::optional<size_t> new_index),
               (override));
   MOCK_METHOD(void,
-              OnWillUpdateFavicon,
-              (const SidebarItem& item, size_t index),
+              OnItemUpdated,
+              (const SidebarItem& item, const SidebarItemUpdate& update),
               (override));
   MOCK_METHOD(void,
               OnFaviconUpdatedForItem,
@@ -100,15 +100,17 @@ TEST_F(SidebarModelTest, ItemsChangedTest) {
   EXPECT_EQ(items_count, service()->items().size());
 
   // Update last item w/ url change.
-  EXPECT_CALL(observer_, OnWillUpdateFavicon(testing::_, items_count - 1))
-      .Times(1);
+  SidebarItemUpdate expected_update{(items_count - 1), false, true};
+  EXPECT_CALL(observer_, OnItemUpdated(testing::_, expected_update)).Times(1);
   service()->UpdateItem(GURL("https://www.brave.com/"),
                         GURL("https://brave.com/"), u"brave software",
                         u"brave software");
   testing::Mock::VerifyAndClearExpectations(&observer_);
 
   // Update last item w/o url change.
-  EXPECT_CALL(observer_, OnWillUpdateFavicon(testing::_, testing::_)).Times(0);
+  expected_update.url_updated = false;
+  expected_update.title_updated = true;
+  EXPECT_CALL(observer_, OnItemUpdated(testing::_, expected_update)).Times(1);
   service()->UpdateItem(GURL("https://brave.com/"), GURL("https://brave.com/"),
                         u"brave software", u"brave");
   testing::Mock::VerifyAndClearExpectations(&observer_);

--- a/browser/ui/views/sidebar/sidebar_button_view.cc
+++ b/browser/ui/views/sidebar/sidebar_button_view.cc
@@ -8,9 +8,7 @@
 #include "ui/gfx/color_palette.h"
 #include "ui/views/controls/focus_ring.h"
 
-SidebarButtonView::SidebarButtonView(Delegate* delegate,
-                                     const std::u16string& accessible_name)
-    : delegate_(delegate) {
+SidebarButtonView::SidebarButtonView(const std::u16string& accessible_name) {
   // Locate image at center of the button.
   SetImageHorizontalAlignment(views::ImageButton::ALIGN_CENTER);
   SetImageVerticalAlignment(views::ImageButton::ALIGN_MIDDLE);
@@ -29,10 +27,7 @@ gfx::Size SidebarButtonView::CalculatePreferredSize() const {
 }
 
 std::u16string SidebarButtonView::GetTooltipText(const gfx::Point& p) const {
-  if (!delegate_)
-    return views::ImageButton::GetTooltipText(p);
-
-  return delegate_->GetTooltipTextFor(this);
+  return GetAccessibleName();
 }
 
 BEGIN_METADATA(SidebarButtonView, views::ImageButton)

--- a/browser/ui/views/sidebar/sidebar_button_view.h
+++ b/browser/ui/views/sidebar/sidebar_button_view.h
@@ -8,7 +8,6 @@
 
 #include <string>
 
-#include "base/memory/raw_ptr.h"
 #include "ui/views/controls/button/image_button.h"
 
 class SidebarButtonView : public views::ImageButton {
@@ -16,16 +15,7 @@ class SidebarButtonView : public views::ImageButton {
   METADATA_HEADER(SidebarButtonView);
   static const int kSidebarButtonSize = 42;
 
-  class Delegate {
-   public:
-    virtual std::u16string GetTooltipTextFor(const views::View* view) const = 0;
-
-   protected:
-    virtual ~Delegate() = default;
-  };
-
-  explicit SidebarButtonView(Delegate* delegate,
-                             const std::u16string& accessible_name);
+  explicit SidebarButtonView(const std::u16string& accessible_name);
   ~SidebarButtonView() override;
 
   SidebarButtonView(const SidebarButtonView&) = delete;
@@ -34,9 +24,6 @@ class SidebarButtonView : public views::ImageButton {
   // views::ImageButton overrides:
   gfx::Size CalculatePreferredSize() const override;
   std::u16string GetTooltipText(const gfx::Point& p) const override;
-
- private:
-  raw_ptr<Delegate> delegate_ = nullptr;
 };
 
 #endif  // BRAVE_BROWSER_UI_VIEWS_SIDEBAR_SIDEBAR_BUTTON_VIEW_H_

--- a/browser/ui/views/sidebar/sidebar_control_view.cc
+++ b/browser/ui/views/sidebar/sidebar_control_view.cc
@@ -173,15 +173,6 @@ void SidebarControlView::MenuClosed(ui::SimpleMenuModel* source) {
   delegate_->MenuClosed();
 }
 
-std::u16string SidebarControlView::GetTooltipTextFor(
-    const views::View* view) const {
-  if (view == sidebar_settings_view_)
-    return brave_l10n::GetLocalizedResourceUTF16String(
-        IDS_SIDEBAR_SETTINGS_BUTTON_TOOLTIP);
-
-  return std::u16string();
-}
-
 void SidebarControlView::OnItemAdded(const sidebar::SidebarItem& item,
                                      size_t index,
                                      bool user_gesture) {
@@ -198,12 +189,12 @@ void SidebarControlView::AddChildViews() {
 
   sidebar_item_add_view_ = AddChildView(std::make_unique<SidebarItemAddButton>(
       browser_, brave_l10n::GetLocalizedResourceUTF16String(
-                    IDS_SIDEBAR_ADD_ITEM_BUBBLE_TITLE)));
+                    IDS_SIDEBAR_ADD_ITEM_BUTTON_TOOLTIP)));
   sidebar_item_add_view_->set_context_menu_controller(this);
 
   sidebar_settings_view_ = AddChildView(std::make_unique<SidebarButtonView>(
-      this, brave_l10n::GetLocalizedResourceUTF16String(
-                IDS_SIDEBAR_SETTINGS_BUTTON_TOOLTIP)));
+      brave_l10n::GetLocalizedResourceUTF16String(
+          IDS_SIDEBAR_SETTINGS_BUTTON_TOOLTIP)));
 
   sidebar_settings_view_->SetCallback(
       base::BindRepeating(&SidebarControlView::OnButtonPressed,

--- a/browser/ui/views/sidebar/sidebar_control_view.h
+++ b/browser/ui/views/sidebar/sidebar_control_view.h
@@ -35,7 +35,6 @@ class SidebarBrowserTest;
 class SidebarControlView : public views::View,
                            public views::ContextMenuController,
                            public ui::SimpleMenuModel::Delegate,
-                           public SidebarButtonView::Delegate,
                            public sidebar::SidebarModel::Observer {
  public:
   METADATA_HEADER(SidebarControlView);
@@ -66,9 +65,6 @@ class SidebarControlView : public views::View,
   void ExecuteCommand(int command_id, int event_flags) override;
   bool IsCommandIdChecked(int command_id) const override;
   void MenuClosed(ui::SimpleMenuModel* source) override;
-
-  // SidebarButtonView::Delegate overrides:
-  std::u16string GetTooltipTextFor(const views::View* view) const override;
 
   // sidebar::SidebarModel::Observer overrides:
   void OnItemAdded(const sidebar::SidebarItem& item,

--- a/browser/ui/views/sidebar/sidebar_item_add_button.cc
+++ b/browser/ui/views/sidebar/sidebar_item_add_button.cc
@@ -14,7 +14,6 @@
 #include "brave/browser/ui/color/brave_color_id.h"
 #include "brave/browser/ui/views/sidebar/sidebar_add_item_bubble_delegate_view.h"
 #include "brave/components/l10n/common/locale_util.h"
-#include "brave/grit/brave_generated_resources.h"
 #include "brave/grit/brave_theme_resources.h"
 #include "ui/base/metadata/metadata_impl_macros.h"
 #include "ui/base/resource/resource_bundle.h"
@@ -24,7 +23,7 @@
 SidebarItemAddButton::SidebarItemAddButton(
     BraveBrowser* browser,
     const std::u16string& accessible_name)
-    : SidebarButtonView(nullptr, accessible_name), browser_(browser) {
+    : SidebarButtonView(accessible_name), browser_(browser) {
   UpdateButtonImages();
 
   on_enabled_changed_subscription_ =
@@ -39,8 +38,6 @@ SidebarItemAddButton::SidebarItemAddButton(
                           base::Unretained(this)),
       std::make_unique<views::Button::DefaultButtonControllerDelegate>(this));
   SetButtonController(std::move(menu_button_controller));
-  SetTooltipText(brave_l10n::GetLocalizedResourceUTF16String(
-      IDS_SIDEBAR_ADD_ITEM_BUTTON_TOOLTIP));
 }
 
 SidebarItemAddButton::~SidebarItemAddButton() = default;

--- a/browser/ui/views/sidebar/sidebar_item_view.cc
+++ b/browser/ui/views/sidebar/sidebar_item_view.cc
@@ -13,9 +13,8 @@
 #include "ui/color/color_provider.h"
 #include "ui/gfx/canvas.h"
 
-SidebarItemView::SidebarItemView(Delegate* delegate,
-                                 const std::u16string& accessible_name)
-    : SidebarButtonView(delegate, accessible_name) {}
+SidebarItemView::SidebarItemView(const std::u16string& accessible_name)
+    : SidebarButtonView(accessible_name) {}
 
 SidebarItemView::~SidebarItemView() = default;
 

--- a/browser/ui/views/sidebar/sidebar_item_view.h
+++ b/browser/ui/views/sidebar/sidebar_item_view.h
@@ -13,8 +13,7 @@
 class SidebarItemView : public SidebarButtonView {
  public:
   METADATA_HEADER(SidebarItemView);
-  explicit SidebarItemView(Delegate* delegate,
-                           const std::u16string& accessible_name);
+  explicit SidebarItemView(const std::u16string& accessible_name);
   ~SidebarItemView() override;
 
   SidebarItemView(const SidebarItemView&) = delete;

--- a/browser/ui/views/sidebar/sidebar_items_contents_view.h
+++ b/browser/ui/views/sidebar/sidebar_items_contents_view.h
@@ -31,7 +31,6 @@ class BraveBrowser;
 class SidebarItemView;
 
 class SidebarItemsContentsView : public views::View,
-                                 public SidebarButtonView::Delegate,
                                  public views::ContextMenuController,
                                  public views::WidgetObserver,
                                  public ui::SimpleMenuModel::Delegate {
@@ -47,9 +46,6 @@ class SidebarItemsContentsView : public views::View,
   // views::View overrides:
   gfx::Size CalculatePreferredSize() const override;
   void OnThemeChanged() override;
-
-  // SidebarButtonView::Delegate overrides:
-  std::u16string GetTooltipTextFor(const views::View* view) const override;
 
   // views::ContextMenuController overrides:
   void ShowContextMenuForViewImpl(views::View* source,
@@ -75,6 +71,8 @@ class SidebarItemsContentsView : public views::View,
 
   void SetImageForItem(const sidebar::SidebarItem& item,
                        const gfx::ImageSkia& image);
+  void UpdateItem(const sidebar::SidebarItem& item,
+                  const sidebar::SidebarItemUpdate& update);
 
   // |source| is drag source view.
   // |position| is in local coordinate space of |source|.

--- a/browser/ui/views/sidebar/sidebar_items_scroll_view.cc
+++ b/browser/ui/views/sidebar/sidebar_items_scroll_view.cc
@@ -231,10 +231,10 @@ void SidebarItemsScrollView::OnActiveIndexChanged(
   contents_view_->OnActiveIndexChanged(old_index, new_index);
 }
 
-void SidebarItemsScrollView::OnWillUpdateFavicon(
+void SidebarItemsScrollView::OnItemUpdated(
     const sidebar::SidebarItem& item,
-    size_t index) {
-  contents_view_->SetDefaultImageAt(index, item);
+    const sidebar::SidebarItemUpdate& update) {
+  contents_view_->UpdateItem(item, update);
 }
 
 void SidebarItemsScrollView::OnFaviconUpdatedForItem(

--- a/browser/ui/views/sidebar/sidebar_items_scroll_view.h
+++ b/browser/ui/views/sidebar/sidebar_items_scroll_view.h
@@ -85,8 +85,8 @@ class SidebarItemsScrollView : public views::View,
   void OnItemRemoved(size_t index) override;
   void OnActiveIndexChanged(absl::optional<size_t> old_index,
                             absl::optional<size_t> new_index) override;
-  void OnWillUpdateFavicon(const sidebar::SidebarItem& item,
-                           size_t index) override;
+  void OnItemUpdated(const sidebar::SidebarItem& item,
+                     const sidebar::SidebarItemUpdate& update) override;
   void OnFaviconUpdatedForItem(const sidebar::SidebarItem& item,
                                const gfx::ImageSkia& image) override;
 

--- a/components/sidebar/sidebar_service.cc
+++ b/components/sidebar/sidebar_service.cc
@@ -387,7 +387,7 @@ void SidebarService::UpdateItem(const GURL& old_url,
 
   auto item_iter = base::ranges::find(items_, old_url, &SidebarItem::url);
   if (item_iter != items_.end()) {
-    const int index = std::distance(items_.begin(), item_iter);
+    const size_t index = std::distance(items_.begin(), item_iter);
     DCHECK(IsEditableItemAt(index));
     item_iter->url = new_url;
     item_iter->title = new_title;

--- a/components/sidebar/sidebar_service.h
+++ b/components/sidebar/sidebar_service.h
@@ -24,7 +24,7 @@ class PrefService;
 namespace sidebar {
 
 struct SidebarItemUpdate {
-  int index = -1;
+  size_t index = 0;
   bool title_updated = false;
   bool url_updated = false;
 


### PR DESCRIPTION
fix https://github.com/brave/brave-browser/issues/25665

No behavioral change.

When title is updated, its accessible name should be updated also.
Use accessible name as a tooltip because both are same always.

Crash happens when item button's tooltip is requested during the item removing phase because item is already deleted from the service. Instead of asking service for getting title, using its accessible name as a tooltip fixes.

<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves 

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
`npm run test brave_unit_tests -- --filter=Sidebar*`
