### PR TITLE
Disable tab cycling when 'vertical tabs' feature is enabled

### DIFF
--- a/browser/ui/BUILD.gn
+++ b/browser/ui/BUILD.gn
@@ -206,6 +206,8 @@ source_set("ui") {
       "views/download/brave_download_item_view.h",
       "views/frame/brave_browser_frame.cc",
       "views/frame/brave_browser_frame.h",
+      "views/frame/brave_browser_root_view.cc",
+      "views/frame/brave_browser_root_view.h",
       "views/frame/brave_browser_view.cc",
       "views/frame/brave_browser_view.h",
       "views/frame/brave_browser_view_layout.cc",

--- a/browser/ui/views/frame/brave_browser_frame.cc
+++ b/browser/ui/views/frame/brave_browser_frame.cc
@@ -7,6 +7,7 @@
 
 #include "brave/browser/profiles/profile_util.h"
 #include "brave/browser/themes/brave_private_window_theme_supplier.h"
+#include "brave/browser/ui/views/frame/brave_browser_root_view.h"
 #include "chrome/browser/profiles/profile.h"
 #include "chrome/browser/themes/theme_service.h"
 #include "chrome/browser/themes/theme_service_factory.h"
@@ -50,4 +51,9 @@ BraveBrowserFrame::GetCustomTheme() const {
   }
 
   return BrowserFrame::GetCustomTheme();
+}
+
+views::internal::RootView* BraveBrowserFrame::CreateRootView() {
+  root_view_ = new BraveBrowserRootView(browser_view_, this);
+  return root_view_;
 }

--- a/browser/ui/views/frame/brave_browser_frame.h
+++ b/browser/ui/views/frame/brave_browser_frame.h
@@ -26,6 +26,7 @@ class BraveBrowserFrame : public BrowserFrame {
 #endif
   ui::ColorProviderManager::ThemeInitializerSupplier* GetCustomTheme()
       const override;
+  views::internal::RootView* CreateRootView() override;
 
  private:
   raw_ptr<BrowserView> view_ = nullptr;

--- a/browser/ui/views/frame/brave_browser_root_view.cc
+++ b/browser/ui/views/frame/brave_browser_root_view.cc
@@ -1,0 +1,20 @@
+/* Copyright (c) 2022 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "brave/browser/ui/views/frame/brave_browser_root_view.h"
+
+#include "brave/browser/ui/views/tabs/features.h"
+
+BraveBrowserRootView::~BraveBrowserRootView() = default;
+
+bool BraveBrowserRootView::OnMouseWheel(const ui::MouseWheelEvent& event) {
+  // Bypass BrowserRootView::OnMouseWheel() to avoid tab cycling feature.
+  // As vertical tabs are always in a scroll view, we should prefer scrolling
+  // to tab cycling.
+  if (tabs::features::ShouldShowVerticalTabs())
+    return RootView::OnMouseWheel(event);
+
+  return BrowserRootView::OnMouseWheel(event);
+}

--- a/browser/ui/views/frame/brave_browser_root_view.h
+++ b/browser/ui/views/frame/brave_browser_root_view.h
@@ -1,0 +1,20 @@
+/* Copyright (c) 2022 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_BROWSER_UI_VIEWS_FRAME_BRAVE_BROWSER_ROOT_VIEW_H_
+#define BRAVE_BROWSER_UI_VIEWS_FRAME_BRAVE_BROWSER_ROOT_VIEW_H_
+
+#include "chrome/browser/ui/views/frame/browser_root_view.h"
+
+class BraveBrowserRootView : public BrowserRootView {
+ public:
+  using BrowserRootView::BrowserRootView;
+  ~BraveBrowserRootView() override;
+
+  // BrowserRootView:
+  bool OnMouseWheel(const ui::MouseWheelEvent& event) override;
+};
+
+#endif  // BRAVE_BROWSER_UI_VIEWS_FRAME_BRAVE_BROWSER_ROOT_VIEW_H_

--- a/chromium_src/chrome/browser/ui/views/frame/browser_frame.h
+++ b/chromium_src/chrome/browser/ui/views/frame/browser_frame.h
@@ -1,0 +1,18 @@
+/* Copyright (c) 2022 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_CHROMIUM_SRC_CHROME_BROWSER_UI_VIEWS_FRAME_BROWSER_FRAME_H_
+#define BRAVE_CHROMIUM_SRC_CHROME_BROWSER_UI_VIEWS_FRAME_BROWSER_FRAME_H_
+
+#define SelectNativeTheme         \
+  SelectNativeTheme_Unused() {}   \
+  friend class BraveBrowserFrame; \
+  void SelectNativeTheme
+
+#include "src/chrome/browser/ui/views/frame/browser_frame.h"
+
+#undef SelectNativeTheme
+
+#endif  // BRAVE_CHROMIUM_SRC_CHROME_BROWSER_UI_VIEWS_FRAME_BROWSER_FRAME_H_


### PR DESCRIPTION
On Linux, there's a feature once called 'tab cycling', which switches the active tab on mouse wheel events. But this doesn't go well with vertical tabs as they are in scroll view. Also, upstream has disabled this feature when scrollable tabstrip is enabled. In favor of this, disable tab cycling when vertical tabstrip is enabled.

<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/25667

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

