### PR TITLE
Add workaround for rare lld crashes during release MacOS builds.

### DIFF
--- a/chromium_src/build/toolchain/apple/linker_driver.py
+++ b/chromium_src/build/toolchain/apple/linker_driver.py
@@ -1,0 +1,29 @@
+# Copyright (c) 2022 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import subprocess
+
+import override_utils
+
+
+def _is_lld_with_lto_call(*popenargs, **kwargs):
+    cmd = kwargs.get("args")
+    if cmd is None:
+        cmd = popenargs[0]
+    return cmd[0].endswith(
+        '/clang++') and '-fuse-ld=lld' in cmd and '-flto=thin' in cmd
+
+
+@override_utils.override_function(subprocess)
+def check_call(original_function, *popenargs, **kwargs):
+    try:
+        return original_function(*popenargs, **kwargs)
+    except subprocess.CalledProcessError as e:
+        # Restart lld link if a previous run has failed.
+        # https://github.com/brave/brave-browser/issues/23734
+        if _is_lld_with_lto_call(*popenargs, **kwargs):
+            print('Restarting lld because of the failure:', e)
+            return original_function(*popenargs, **kwargs)
+        raise

--- a/patches/build-toolchain-apple-linker_driver.py.patch
+++ b/patches/build-toolchain-apple-linker_driver.py.patch
@@ -1,0 +1,12 @@
+diff --git a/build/toolchain/apple/linker_driver.py b/build/toolchain/apple/linker_driver.py
+index ad1e12c28d3a24e455b4778e8208e751de012fd9..47e83e5d816602c80d8370c86e1830c1d90ebb30 100755
+--- a/build/toolchain/apple/linker_driver.py
++++ b/build/toolchain/apple/linker_driver.py
+@@ -352,6 +352,7 @@ def _remove_path(path):
+             os.unlink(path)
+ 
+ 
++from import_inline import inline_file_from_src; inline_file_from_src('brave/chromium_src/build/toolchain/apple/linker_driver.py', globals(), locals())
+ if __name__ == '__main__':
+     LinkerDriver(sys.argv).run()
+     sys.exit(0)


### PR DESCRIPTION
<!-- Add brave-browser issue bellow that this PR will resolve -->
LLVM issue is created, so we hope that they will fix this and we can remove this workaround later.
Other info regarding this lld bug is here: https://github.com/brave/brave-browser/issues/23734#issuecomment-1262169448

Related https://github.com/brave/brave-browser/issues/23734 

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

