### PR TITLE
Hide Media source API only for background contents.

### DIFF
--- a/browser/brave_content_browser_client.cc
+++ b/browser/brave_content_browser_client.cc
@@ -1068,7 +1068,7 @@ void BraveContentBrowserClient::OverrideWebkitPrefs(WebContents* web_contents,
   if (auto* playlist_service =
           playlist::PlaylistServiceFactory::GetForBrowserContext(
               web_contents->GetBrowserContext())) {
-    playlist_service->ConfigureWebPrefsforBackgroundWebContents(web_contents,
+    playlist_service->ConfigureWebPrefsForBackgroundWebContents(web_contents,
                                                                 web_prefs);
   }
 #endif

--- a/browser/playlist/test/playlist_render_frame_observer_browsertest.cc
+++ b/browser/playlist/test/playlist_render_frame_observer_browsertest.cc
@@ -125,6 +125,13 @@ class PlaylistRenderFrameObserverBrowserTest : public PlatformBrowserTest {
   content::ContentMockCertVerifier mock_cert_verifier_;
 };
 
+#if BUILDFLAG(IS_ANDROID)
+// TODO(sko): Fix this test on Android.
+// https://github.com/brave/brave-browser/issues/24971
+#define CheckNormalSites DISABLED_CheckNormalSites
+#else
+#define CheckNormalSites CheckNormalSites
+#endif
 IN_PROC_BROWSER_TEST_F(PlaylistRenderFrameObserverBrowserTest,
                        CheckNormalSites) {
   CheckMediaSourceAPI(GURL("http://a.com/"), APIVisibility::kVisible);

--- a/browser/playlist/test/playlist_render_frame_observer_browsertest.cc
+++ b/browser/playlist/test/playlist_render_frame_observer_browsertest.cc
@@ -71,13 +71,12 @@ class PlaylistRenderFrameObserverBrowserTest : public PlatformBrowserTest {
         visibility == APIVisibility::kHidden,
         playlist_service->ShouldDownloadOnBackground(active_web_contents));
 
-    // Then, the WebContents used for background download hides the API if it's
-    // listed.
+    // Then, the WebContents used for background download always hides the API.
     auto* background_web_contents = playlist_service->download_request_manager_
                                         ->GetBackgroundWebContentsForTesting();
     ASSERT_TRUE(content::NavigateToURL(background_web_contents, url));
-    EXPECT_EQ(visibility == APIVisibility::kVisible,
-              EvalJs(background_web_contents, "!!window.MediaSource"));
+    EXPECT_FALSE(
+        EvalJs(background_web_contents, "!!window.MediaSource").ExtractBool());
   }
 
  protected:

--- a/chromium_src/third_party/blink/common/web_preferences/web_preferences_mojom_traits.cc
+++ b/chromium_src/third_party/blink/common/web_preferences/web_preferences_mojom_traits.cc
@@ -22,9 +22,9 @@ bool StructTraits<blink::mojom::WebPreferencesDataView,
                                                                         out)) {
     return false;
   }
-
   out->force_cosmetic_filtering = data.force_cosmetic_filtering();
-  return true;
+
+  return data.ReadUrlsToHideMediaSrcApi(&out->urls_to_hide_media_src_api);
 }
 
 }  // namespace mojo

--- a/chromium_src/third_party/blink/common/web_preferences/web_preferences_mojom_traits.cc
+++ b/chromium_src/third_party/blink/common/web_preferences/web_preferences_mojom_traits.cc
@@ -23,7 +23,7 @@ bool StructTraits<blink::mojom::WebPreferencesDataView,
     return false;
   }
   out->force_cosmetic_filtering = data.force_cosmetic_filtering();
-  out->force_to_hide_media_src_api = data.force_to_hide_media_src_api();
+  out->hide_media_src_api = data.hide_media_src_api();
   return true;
 }
 

--- a/chromium_src/third_party/blink/common/web_preferences/web_preferences_mojom_traits.cc
+++ b/chromium_src/third_party/blink/common/web_preferences/web_preferences_mojom_traits.cc
@@ -24,7 +24,7 @@ bool StructTraits<blink::mojom::WebPreferencesDataView,
   }
   out->force_cosmetic_filtering = data.force_cosmetic_filtering();
 
-  return data.ReadUrlsToHideMediaSrcApi(&out->urls_to_hide_media_src_api);
+  return data.ReadUrlsToHideMediaSrcApi(&out->sites_to_hide_media_src_api);
 }
 
 }  // namespace mojo

--- a/chromium_src/third_party/blink/common/web_preferences/web_preferences_mojom_traits.cc
+++ b/chromium_src/third_party/blink/common/web_preferences/web_preferences_mojom_traits.cc
@@ -23,8 +23,8 @@ bool StructTraits<blink::mojom::WebPreferencesDataView,
     return false;
   }
   out->force_cosmetic_filtering = data.force_cosmetic_filtering();
-
-  return data.ReadUrlsToHideMediaSrcApi(&out->sites_to_hide_media_src_api);
+  out->force_to_hide_media_src_api = data.force_to_hide_media_src_api();
+  return true;
 }
 
 }  // namespace mojo

--- a/chromium_src/third_party/blink/public/common/web_preferences/web_preferences.h
+++ b/chromium_src/third_party/blink/public/common/web_preferences/web_preferences.h
@@ -12,6 +12,8 @@
 
 #undef WebPreferences
 
+#include "net/base/schemeful_site.h"
+
 namespace blink {
 
 namespace web_pref {
@@ -26,7 +28,7 @@ struct BLINK_COMMON_EXPORT WebPreferences : public WebPreferences_ChromiumImpl {
   WebPreferences& operator=(WebPreferences&& other);
 
   bool force_cosmetic_filtering = false;
-  std::vector<GURL> urls_to_hide_media_src_api;
+  std::vector<net::SchemefulSite> sites_to_hide_media_src_api;
 };
 
 }  // namespace web_pref

--- a/chromium_src/third_party/blink/public/common/web_preferences/web_preferences.h
+++ b/chromium_src/third_party/blink/public/common/web_preferences/web_preferences.h
@@ -26,6 +26,7 @@ struct BLINK_COMMON_EXPORT WebPreferences : public WebPreferences_ChromiumImpl {
   WebPreferences& operator=(WebPreferences&& other);
 
   bool force_cosmetic_filtering = false;
+  std::vector<GURL> urls_to_hide_media_src_api;
 };
 
 }  // namespace web_pref

--- a/chromium_src/third_party/blink/public/common/web_preferences/web_preferences.h
+++ b/chromium_src/third_party/blink/public/common/web_preferences/web_preferences.h
@@ -12,8 +12,6 @@
 
 #undef WebPreferences
 
-#include "net/base/schemeful_site.h"
-
 namespace blink {
 
 namespace web_pref {
@@ -28,7 +26,7 @@ struct BLINK_COMMON_EXPORT WebPreferences : public WebPreferences_ChromiumImpl {
   WebPreferences& operator=(WebPreferences&& other);
 
   bool force_cosmetic_filtering = false;
-  std::vector<net::SchemefulSite> sites_to_hide_media_src_api;
+  bool force_to_hide_media_src_api = false;
 };
 
 }  // namespace web_pref

--- a/chromium_src/third_party/blink/public/common/web_preferences/web_preferences.h
+++ b/chromium_src/third_party/blink/public/common/web_preferences/web_preferences.h
@@ -26,7 +26,7 @@ struct BLINK_COMMON_EXPORT WebPreferences : public WebPreferences_ChromiumImpl {
   WebPreferences& operator=(WebPreferences&& other);
 
   bool force_cosmetic_filtering = false;
-  bool force_to_hide_media_src_api = false;
+  bool hide_media_src_api = false;
 };
 
 }  // namespace web_pref

--- a/chromium_src/third_party/blink/public/common/web_preferences/web_preferences_mojom_traits.h
+++ b/chromium_src/third_party/blink/public/common/web_preferences/web_preferences_mojom_traits.h
@@ -27,6 +27,11 @@ struct BLINK_COMMON_EXPORT StructTraits<blink::mojom::WebPreferencesDataView,
     return r.force_cosmetic_filtering;
   }
 
+  static std::vector<GURL> urls_to_hide_media_src_api(
+      const blink::web_pref::WebPreferences& r) {
+    return r.urls_to_hide_media_src_api;
+  }
+
   static bool Read(blink::mojom::WebPreferencesDataView r,
                    blink::web_pref::WebPreferences* out);
 };

--- a/chromium_src/third_party/blink/public/common/web_preferences/web_preferences_mojom_traits.h
+++ b/chromium_src/third_party/blink/public/common/web_preferences/web_preferences_mojom_traits.h
@@ -15,8 +15,6 @@
 
 #undef WebPreferences
 
-#include "net/base/schemeful_site.h"
-
 namespace mojo {
 
 template <>
@@ -29,9 +27,9 @@ struct BLINK_COMMON_EXPORT StructTraits<blink::mojom::WebPreferencesDataView,
     return r.force_cosmetic_filtering;
   }
 
-  static std::vector<net::SchemefulSite> urls_to_hide_media_src_api(
+  static bool force_to_hide_media_src_api(
       const blink::web_pref::WebPreferences& r) {
-    return r.sites_to_hide_media_src_api;
+    return r.force_to_hide_media_src_api;
   }
 
   static bool Read(blink::mojom::WebPreferencesDataView r,

--- a/chromium_src/third_party/blink/public/common/web_preferences/web_preferences_mojom_traits.h
+++ b/chromium_src/third_party/blink/public/common/web_preferences/web_preferences_mojom_traits.h
@@ -15,6 +15,8 @@
 
 #undef WebPreferences
 
+#include "net/base/schemeful_site.h"
+
 namespace mojo {
 
 template <>
@@ -27,9 +29,9 @@ struct BLINK_COMMON_EXPORT StructTraits<blink::mojom::WebPreferencesDataView,
     return r.force_cosmetic_filtering;
   }
 
-  static std::vector<GURL> urls_to_hide_media_src_api(
+  static std::vector<net::SchemefulSite> urls_to_hide_media_src_api(
       const blink::web_pref::WebPreferences& r) {
-    return r.urls_to_hide_media_src_api;
+    return r.sites_to_hide_media_src_api;
   }
 
   static bool Read(blink::mojom::WebPreferencesDataView r,

--- a/chromium_src/third_party/blink/public/common/web_preferences/web_preferences_mojom_traits.h
+++ b/chromium_src/third_party/blink/public/common/web_preferences/web_preferences_mojom_traits.h
@@ -27,9 +27,8 @@ struct BLINK_COMMON_EXPORT StructTraits<blink::mojom::WebPreferencesDataView,
     return r.force_cosmetic_filtering;
   }
 
-  static bool force_to_hide_media_src_api(
-      const blink::web_pref::WebPreferences& r) {
-    return r.force_to_hide_media_src_api;
+  static bool hide_media_src_api(const blink::web_pref::WebPreferences& r) {
+    return r.hide_media_src_api;
   }
 
   static bool Read(blink::mojom::WebPreferencesDataView r,

--- a/chromium_src/third_party/blink/public/mojom/webpreferences/web_preferences.mojom
+++ b/chromium_src/third_party/blink/public/mojom/webpreferences/web_preferences.mojom
@@ -5,10 +5,8 @@
 
 module blink.mojom;
 
-import "services/network/public/mojom/schemeful_site.mojom";
-
 [BraveExtend]
 struct WebPreferences {
   bool force_cosmetic_filtering;
-  array<network.mojom.SchemefulSite> urls_to_hide_media_src_api;
+  bool force_to_hide_media_src_api;
 };

--- a/chromium_src/third_party/blink/public/mojom/webpreferences/web_preferences.mojom
+++ b/chromium_src/third_party/blink/public/mojom/webpreferences/web_preferences.mojom
@@ -5,7 +5,10 @@
 
 module blink.mojom;
 
+import "url/mojom/url.mojom";
+
 [BraveExtend]
 struct WebPreferences {
   bool force_cosmetic_filtering;
+  array<url.mojom.Url> urls_to_hide_media_src_api;
 };

--- a/chromium_src/third_party/blink/public/mojom/webpreferences/web_preferences.mojom
+++ b/chromium_src/third_party/blink/public/mojom/webpreferences/web_preferences.mojom
@@ -5,10 +5,10 @@
 
 module blink.mojom;
 
-import "url/mojom/url.mojom";
+import "services/network/public/mojom/schemeful_site.mojom";
 
 [BraveExtend]
 struct WebPreferences {
   bool force_cosmetic_filtering;
-  array<url.mojom.Url> urls_to_hide_media_src_api;
+  array<network.mojom.SchemefulSite> urls_to_hide_media_src_api;
 };

--- a/chromium_src/third_party/blink/public/mojom/webpreferences/web_preferences.mojom
+++ b/chromium_src/third_party/blink/public/mojom/webpreferences/web_preferences.mojom
@@ -7,6 +7,13 @@ module blink.mojom;
 
 [BraveExtend]
 struct WebPreferences {
+  // If |force_cosmetic_filters| is true, cosmetic filters will be applied to
+  // regardless of contents settings. This is used for Playlist so that it can
+  // remove ads from the page.
   bool force_cosmetic_filtering;
-  bool force_to_hide_media_src_api;
+
+  // If |hide_media_src_api| is true, PlaylistRenderFrameObserver will hide
+  // the media source API from the page. This is used by Playlist so that
+  // it can get downloadable media urls instead of blob url.
+  bool hide_media_src_api;
 };

--- a/components/playlist/media_detector_component_manager.cc
+++ b/components/playlist/media_detector_component_manager.cc
@@ -248,9 +248,10 @@ void MediaDetectorComponentManager::SetUseLocalScriptForTesting() {
 
 bool MediaDetectorComponentManager::ShouldHideMediaSrcAPI(
     const GURL& url) const {
+  net::SchemefulSite schemeful_site(url);
   return base::ranges::any_of(sites_to_hide_media_src_api_,
-                              [&url](const auto& site_to_hide) {
-                                return site_to_hide == net::SchemefulSite(url);
+                              [&schemeful_site](const auto& site_to_hide) {
+                                return site_to_hide == schemeful_site;
                               });
 }
 

--- a/components/playlist/media_detector_component_manager.cc
+++ b/components/playlist/media_detector_component_manager.cc
@@ -11,6 +11,7 @@
 #include "base/logging.h"
 #include "base/task/thread_pool.h"
 #include "brave/components/playlist/media_detector_component_installer.h"
+#include "url/gurl.h"
 
 namespace playlist {
 
@@ -30,7 +31,11 @@ std::string ReadScript(const base::FilePath& path) {
 
 MediaDetectorComponentManager::MediaDetectorComponentManager(
     component_updater::ComponentUpdateService* component_update_service)
-    : component_update_service_(component_update_service) {}
+    : component_update_service_(component_update_service) {
+  // TODO(sko) This list should be dynamically updated from the playlist.
+  // Once it's done, remove this line.
+  SetUseLocalListToHideMediaSrcAPIForTesting();
+}
 
 MediaDetectorComponentManager::~MediaDetectorComponentManager() = default;
 
@@ -239,6 +244,22 @@ void MediaDetectorComponentManager::SetUseLocalScriptForTesting() {
   )-";
 
   OnGetScript(kScript);
+}
+
+bool MediaDetectorComponentManager::ShouldHideMediaSrcAPI(
+    const GURL& url) const {
+  return base::ranges::any_of(urls_to_hide_media_src_api_,
+                              [&url](const auto& url_to_hide) {
+                                return url_to_hide.host() == url.host();
+                              });
+}
+
+void MediaDetectorComponentManager::
+    SetUseLocalListToHideMediaSrcAPIForTesting() {
+  urls_to_hide_media_src_api_ = {GURL("https://www.youtube.com"),
+                                 GURL("http://www.youtube.com"),
+                                 GURL("https://youtube.com"),
+                                 GURL("http://youtube.com")};
 }
 
 }  // namespace playlist

--- a/components/playlist/media_detector_component_manager.cc
+++ b/components/playlist/media_detector_component_manager.cc
@@ -34,7 +34,7 @@ MediaDetectorComponentManager::MediaDetectorComponentManager(
     : component_update_service_(component_update_service) {
   // TODO(sko) This list should be dynamically updated from the playlist.
   // Once it's done, remove this line.
-  SetUseLocalListToHideMediaSrcAPIForTesting();
+  SetUseLocalListToHideMediaSrcAPI();
 }
 
 MediaDetectorComponentManager::~MediaDetectorComponentManager() = default;
@@ -248,18 +248,15 @@ void MediaDetectorComponentManager::SetUseLocalScriptForTesting() {
 
 bool MediaDetectorComponentManager::ShouldHideMediaSrcAPI(
     const GURL& url) const {
-  return base::ranges::any_of(urls_to_hide_media_src_api_,
-                              [&url](const auto& url_to_hide) {
-                                return url_to_hide.host() == url.host();
+  return base::ranges::any_of(sites_to_hide_media_src_api_,
+                              [&url](const auto& site_to_hide) {
+                                return site_to_hide == net::SchemefulSite(url);
                               });
 }
 
-void MediaDetectorComponentManager::
-    SetUseLocalListToHideMediaSrcAPIForTesting() {
-  urls_to_hide_media_src_api_ = {GURL("https://www.youtube.com"),
-                                 GURL("http://www.youtube.com"),
-                                 GURL("https://youtube.com"),
-                                 GURL("http://youtube.com")};
+void MediaDetectorComponentManager::SetUseLocalListToHideMediaSrcAPI() {
+  sites_to_hide_media_src_api_ = {
+      {net::SchemefulSite(GURL("https://youtube.com"))}};
 }
 
 }  // namespace playlist

--- a/components/playlist/media_detector_component_manager.h
+++ b/components/playlist/media_detector_component_manager.h
@@ -7,6 +7,7 @@
 #define BRAVE_COMPONENTS_PLAYLIST_MEDIA_DETECTOR_COMPONENT_MANAGER_H_
 
 #include <string>
+#include <vector>
 
 #include "base/memory/weak_ptr.h"
 #include "base/observer_list.h"
@@ -18,6 +19,8 @@ class FilePath;
 namespace component_updater {
 class ComponentUpdateService;
 }  // namespace component_updater
+
+class GURL;
 
 namespace playlist {
 
@@ -47,6 +50,13 @@ class MediaDetectorComponentManager {
 
   void SetUseLocalScriptForTesting();
 
+  bool ShouldHideMediaSrcAPI(const GURL& url) const;
+  void SetUseLocalListToHideMediaSrcAPIForTesting();
+
+  std::vector<GURL> urls_to_hide_media_src_api() const {
+    return urls_to_hide_media_src_api_;
+  }
+
  private:
   void OnComponentReady(const base::FilePath& install_path);
   void OnGetScript(const std::string& script);
@@ -55,6 +65,8 @@ class MediaDetectorComponentManager {
   raw_ptr<component_updater::ComponentUpdateService> component_update_service_;
 
   std::string script_;
+
+  std::vector<GURL> urls_to_hide_media_src_api_;
 
   base::ObserverList<Observer> observer_list_;
   base::WeakPtrFactory<MediaDetectorComponentManager> weak_factory_{this};

--- a/components/playlist/media_detector_component_manager.h
+++ b/components/playlist/media_detector_component_manager.h
@@ -11,6 +11,7 @@
 
 #include "base/memory/weak_ptr.h"
 #include "base/observer_list.h"
+#include "net/base/schemeful_site.h"
 
 namespace base {
 class FilePath;
@@ -19,8 +20,6 @@ class FilePath;
 namespace component_updater {
 class ComponentUpdateService;
 }  // namespace component_updater
-
-class GURL;
 
 namespace playlist {
 
@@ -51,10 +50,10 @@ class MediaDetectorComponentManager {
   void SetUseLocalScriptForTesting();
 
   bool ShouldHideMediaSrcAPI(const GURL& url) const;
-  void SetUseLocalListToHideMediaSrcAPIForTesting();
+  void SetUseLocalListToHideMediaSrcAPI();
 
-  std::vector<GURL> urls_to_hide_media_src_api() const {
-    return urls_to_hide_media_src_api_;
+  const std::vector<net::SchemefulSite>& sites_to_hide_media_src_api() const {
+    return sites_to_hide_media_src_api_;
   }
 
  private:
@@ -66,7 +65,7 @@ class MediaDetectorComponentManager {
 
   std::string script_;
 
-  std::vector<GURL> urls_to_hide_media_src_api_;
+  std::vector<net::SchemefulSite> sites_to_hide_media_src_api_;
 
   base::ObserverList<Observer> observer_list_;
   base::WeakPtrFactory<MediaDetectorComponentManager> weak_factory_{this};

--- a/components/playlist/playlist_download_request_manager.cc
+++ b/components/playlist/playlist_download_request_manager.cc
@@ -256,11 +256,13 @@ void PlaylistDownloadRequestManager::DestroyWebContents() {
   web_contents_.reset();
 }
 
-void PlaylistDownloadRequestManager::ConfigureWebPrefsforBackgroundWebContents(
+void PlaylistDownloadRequestManager::ConfigureWebPrefsForBackgroundWebContents(
     content::WebContents* web_contents,
     blink::web_pref::WebPreferences* web_prefs) {
   if (web_contents_ && web_contents_.get() == web_contents) {
     web_prefs->force_cosmetic_filtering = true;
+    web_prefs->urls_to_hide_media_src_api =
+        media_detector_component_manager_->urls_to_hide_media_src_api();
   }
 }
 

--- a/components/playlist/playlist_download_request_manager.cc
+++ b/components/playlist/playlist_download_request_manager.cc
@@ -261,8 +261,8 @@ void PlaylistDownloadRequestManager::ConfigureWebPrefsForBackgroundWebContents(
     blink::web_pref::WebPreferences* web_prefs) {
   if (web_contents_ && web_contents_.get() == web_contents) {
     web_prefs->force_cosmetic_filtering = true;
-    web_prefs->urls_to_hide_media_src_api =
-        media_detector_component_manager_->urls_to_hide_media_src_api();
+    web_prefs->sites_to_hide_media_src_api =
+        media_detector_component_manager_->sites_to_hide_media_src_api();
   }
 }
 

--- a/components/playlist/playlist_download_request_manager.cc
+++ b/components/playlist/playlist_download_request_manager.cc
@@ -261,7 +261,7 @@ void PlaylistDownloadRequestManager::ConfigureWebPrefsForBackgroundWebContents(
     blink::web_pref::WebPreferences* web_prefs) {
   if (web_contents_ && web_contents_.get() == web_contents) {
     web_prefs->force_cosmetic_filtering = true;
-    web_prefs->force_to_hide_media_src_api = true;
+    web_prefs->hide_media_src_api = true;
   }
 }
 

--- a/components/playlist/playlist_download_request_manager.cc
+++ b/components/playlist/playlist_download_request_manager.cc
@@ -261,8 +261,7 @@ void PlaylistDownloadRequestManager::ConfigureWebPrefsForBackgroundWebContents(
     blink::web_pref::WebPreferences* web_prefs) {
   if (web_contents_ && web_contents_.get() == web_contents) {
     web_prefs->force_cosmetic_filtering = true;
-    web_prefs->sites_to_hide_media_src_api =
-        media_detector_component_manager_->sites_to_hide_media_src_api();
+    web_prefs->force_to_hide_media_src_api = true;
   }
 }
 

--- a/components/playlist/playlist_download_request_manager.h
+++ b/components/playlist/playlist_download_request_manager.h
@@ -71,11 +71,15 @@ class PlaylistDownloadRequestManager
   void GetMediaFilesFromPage(Request request);
 
   // Update |web_prefs| if we want for |web_contents|.
-  void ConfigureWebPrefsforBackgroundWebContents(
+  void ConfigureWebPrefsForBackgroundWebContents(
       content::WebContents* web_contents,
       blink::web_pref::WebPreferences* web_prefs);
 
   content::WebContents* GetBackgroundWebContentsForTesting();
+
+  MediaDetectorComponentManager* media_detector_component_manager() {
+    return media_detector_component_manager_;
+  }
 
  private:
   // Calling this will trigger loading |url| on a web contents,
@@ -111,7 +115,7 @@ class PlaylistDownloadRequestManager
   std::list<Request> pending_requests_;
 
   // Used to inject js script to get playlist item metadata to download
-  // its media files/thumbnail images and get titile.
+  // its media files/thumbnail images and get title.
   std::unique_ptr<content::WebContents> web_contents_;
 
   // The number of requested data fetching.

--- a/components/playlist/playlist_download_request_manager.h
+++ b/components/playlist/playlist_download_request_manager.h
@@ -77,7 +77,8 @@ class PlaylistDownloadRequestManager
 
   content::WebContents* GetBackgroundWebContentsForTesting();
 
-  MediaDetectorComponentManager* media_detector_component_manager() {
+  const MediaDetectorComponentManager* media_detector_component_manager()
+      const {
     return media_detector_component_manager_;
   }
 

--- a/components/playlist/playlist_service.h
+++ b/components/playlist/playlist_service.h
@@ -34,8 +34,9 @@ class BrowserContext;
 class WebContents;
 }  // namespace content
 
-class PrefService;
 class CosmeticFilteringPlaylistFlagEnabledTest;
+class PlaylistRenderFrameObserverBrowserTest;
+class PrefService;
 
 namespace playlist {
 
@@ -125,12 +126,14 @@ class PlaylistService : public KeyedService,
   base::FilePath GetPlaylistItemDirPath(const std::string& id) const;
 
   // Update |web_prefs| if we want for |web_contents|.
-  void ConfigureWebPrefsforBackgroundWebContents(
+  void ConfigureWebPrefsForBackgroundWebContents(
       content::WebContents* web_contents,
       blink::web_pref::WebPreferences* web_prefs);
 
  private:
   friend class ::CosmeticFilteringPlaylistFlagEnabledTest;
+  friend class ::PlaylistRenderFrameObserverBrowserTest;
+
   FRIEND_TEST_ALL_PREFIXES(PlaylistBrowserTest, ApiFunctions);
   FRIEND_TEST_ALL_PREFIXES(PlaylistBrowserTest, CreatePlaylist);
   FRIEND_TEST_ALL_PREFIXES(PlaylistBrowserTest, CreatePlaylistItem);
@@ -152,6 +155,8 @@ class PlaylistService : public KeyedService,
   // Called when thumbnail image file is downloaded.
   void OnThumbnailDownloaded(const std::string& id,
                              const base::FilePath& path) override;
+
+  bool ShouldDownloadOnBackground(content::WebContents* contents) const;
 
   void OnPlaylistItemDirCreated(const PlaylistItemInfo& info,
                                 bool directory_ready);

--- a/components/playlist/renderer/DEPS
+++ b/components/playlist/renderer/DEPS
@@ -5,5 +5,6 @@
 
 include_rules = [
   "+content/public/renderer",
+  "+third_party/blink/public/platform",
   "+third_party/blink/public/web",
 ]

--- a/components/playlist/renderer/playlist_render_frame_observer.cc
+++ b/components/playlist/renderer/playlist_render_frame_observer.cc
@@ -13,7 +13,6 @@
 #include "third_party/blink/public/platform/web_string.h"
 #include "third_party/blink/public/web/web_local_frame.h"
 #include "third_party/blink/public/web/web_script_source.h"
-#include "third_party/blink/renderer/platform/network/blink_schemeful_site.h"
 
 namespace playlist {
 
@@ -30,8 +29,7 @@ void PlaylistRenderFrameObserver::RunScriptsAtDocumentStart() {
   if (base::ranges::any_of(
           render_frame()->GetBlinkPreferences().sites_to_hide_media_src_api,
           [&current_origin](const auto& site) {
-            return blink::BlinkSchemefulSite(site) ==
-                   blink::BlinkSchemefulSite(current_origin);
+            return site == net::SchemefulSite(current_origin);
           })) {
     HideMediaSourceAPI();
   }

--- a/components/playlist/renderer/playlist_render_frame_observer.cc
+++ b/components/playlist/renderer/playlist_render_frame_observer.cc
@@ -24,15 +24,10 @@ PlaylistRenderFrameObserver::PlaylistRenderFrameObserver(
 PlaylistRenderFrameObserver::~PlaylistRenderFrameObserver() = default;
 
 void PlaylistRenderFrameObserver::RunScriptsAtDocumentStart() {
-  const auto current_origin =
-      render_frame()->GetWebFrame()->GetSecurityOrigin();
-  if (base::ranges::any_of(
-          render_frame()->GetBlinkPreferences().sites_to_hide_media_src_api,
-          [&current_origin](const auto& site) {
-            return site == net::SchemefulSite(current_origin);
-          })) {
-    HideMediaSourceAPI();
-  }
+  if (!render_frame()->GetBlinkPreferences().force_to_hide_media_src_api)
+    return;
+
+  HideMediaSourceAPI();
 }
 
 void PlaylistRenderFrameObserver::OnDestruct() {

--- a/components/playlist/renderer/playlist_render_frame_observer.cc
+++ b/components/playlist/renderer/playlist_render_frame_observer.cc
@@ -7,10 +7,10 @@
 
 #include <vector>
 
-#include "base/feature_list.h"
-#include "base/no_destructor.h"
 #include "brave/components/playlist/features.h"
 #include "content/public/renderer/render_frame.h"
+#include "third_party/blink/public/common/web_preferences/web_preferences.h"
+#include "third_party/blink/public/platform/web_string.h"
 #include "third_party/blink/public/web/web_local_frame.h"
 #include "third_party/blink/public/web/web_script_source.h"
 
@@ -24,17 +24,14 @@ PlaylistRenderFrameObserver::PlaylistRenderFrameObserver(
 PlaylistRenderFrameObserver::~PlaylistRenderFrameObserver() = default;
 
 void PlaylistRenderFrameObserver::RunScriptsAtDocumentStart() {
-  // TODO(sko) This list should be dynamically updated from browser process.
-  // For now, we hardcode the list of domains that we want to run scripts at.
-  static const base::NoDestructor<std::vector<blink::WebSecurityOrigin>>
-      origins{
-          {blink::WebSecurityOrigin::Create(GURL("https://www.youtube.com"))}};
-
   const auto current_origin =
       render_frame()->GetWebFrame()->GetSecurityOrigin();
-  if (base::ranges::any_of(*origins, [&current_origin](const auto& origin) {
-        return origin.IsSameOriginWith(current_origin);
-      })) {
+  if (base::ranges::any_of(
+          render_frame()->GetBlinkPreferences().urls_to_hide_media_src_api,
+          [&current_origin](const auto& url) {
+            return blink::WebSecurityOrigin::Create(url).IsSameOriginWith(
+                current_origin);
+          })) {
     HideMediaSourceAPI();
   }
 }

--- a/components/playlist/renderer/playlist_render_frame_observer.cc
+++ b/components/playlist/renderer/playlist_render_frame_observer.cc
@@ -13,6 +13,7 @@
 #include "third_party/blink/public/platform/web_string.h"
 #include "third_party/blink/public/web/web_local_frame.h"
 #include "third_party/blink/public/web/web_script_source.h"
+#include "third_party/blink/renderer/platform/network/blink_schemeful_site.h"
 
 namespace playlist {
 
@@ -27,10 +28,10 @@ void PlaylistRenderFrameObserver::RunScriptsAtDocumentStart() {
   const auto current_origin =
       render_frame()->GetWebFrame()->GetSecurityOrigin();
   if (base::ranges::any_of(
-          render_frame()->GetBlinkPreferences().urls_to_hide_media_src_api,
-          [&current_origin](const auto& url) {
-            return blink::WebSecurityOrigin::Create(url).IsSameOriginWith(
-                current_origin);
+          render_frame()->GetBlinkPreferences().sites_to_hide_media_src_api,
+          [&current_origin](const auto& site) {
+            return blink::BlinkSchemefulSite(site) ==
+                   blink::BlinkSchemefulSite(current_origin);
           })) {
     HideMediaSourceAPI();
   }

--- a/components/playlist/renderer/playlist_render_frame_observer.cc
+++ b/components/playlist/renderer/playlist_render_frame_observer.cc
@@ -24,7 +24,7 @@ PlaylistRenderFrameObserver::PlaylistRenderFrameObserver(
 PlaylistRenderFrameObserver::~PlaylistRenderFrameObserver() = default;
 
 void PlaylistRenderFrameObserver::RunScriptsAtDocumentStart() {
-  if (!render_frame()->GetBlinkPreferences().force_to_hide_media_src_api)
+  if (!render_frame()->GetBlinkPreferences().hide_media_src_api)
     return;
 
   HideMediaSourceAPI();


### PR DESCRIPTION
Resolves https://github.com/brave/brave-browser/issues/25765  - Youtube resolution is limited
Resolves https://github.com/brave/brave-browser/issues/25130  - streaming contents are unusable

And also as a side effect, 
Resolves https://github.com/brave/brave-browser/issues/25338  - thumbnail isn't correct(youtube implementation dependent, and not occur when using background contents)


Reportedly, media source API also affects video quality. Now that we have critical downside, We shouldn't hide the API for tabs' web contents.

<!-- Add brave-browser issue bellow that this PR will resolve -->

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

