### PR TITLE
Fixd sidebar drag indicator is not hidden when it goes out

### DIFF
--- a/browser/ui/views/sidebar/sidebar_items_scroll_view.cc
+++ b/browser/ui/views/sidebar/sidebar_items_scroll_view.cc
@@ -400,6 +400,15 @@ bool SidebarItemsScrollView::CanDrop(const OSExchangeData& data) {
       ui::ClipboardFormatType::GetType(kSidebarItemDragType));
 }
 
+void SidebarItemsScrollView::OnDragExited() {
+  ClearDragIndicator();
+}
+
+void SidebarItemsScrollView::ClearDragIndicator() {
+  contents_view_->ClearDragIndicator();
+  drag_context_->set_drag_indicator_index(absl::nullopt);
+}
+
 int SidebarItemsScrollView::OnDragUpdated(const ui::DropTargetEvent& event) {
   auto ret = ui::DragDropTypes::DRAG_NONE;
 
@@ -414,8 +423,7 @@ int SidebarItemsScrollView::OnDragUpdated(const ui::DropTargetEvent& event) {
     drag_context_->set_drag_indicator_index(target_index);
     ret = ui::DragDropTypes::DRAG_MOVE;
   } else {
-    contents_view_->ClearDragIndicator();
-    drag_context_->set_drag_indicator_index(absl::nullopt);
+    ClearDragIndicator();
   }
 
   return ret;

--- a/browser/ui/views/sidebar/sidebar_items_scroll_view.h
+++ b/browser/ui/views/sidebar/sidebar_items_scroll_view.h
@@ -57,6 +57,7 @@ class SidebarItemsScrollView : public views::View,
   bool GetDropFormats(int* formats,
                       std::set<ui::ClipboardFormatType>* format_types) override;
   bool CanDrop(const OSExchangeData& data) override;
+  void OnDragExited() override;
   int OnDragUpdated(const ui::DropTargetEvent& event) override;
   views::View::DropCallback GetDropCallback(
       const ui::DropTargetEvent& event) override;
@@ -117,6 +118,7 @@ class SidebarItemsScrollView : public views::View,
 
   // Returns true if |position| is in visible contents area.
   bool IsInVisibleContentsViewBounds(const gfx::Point& position) const;
+  void ClearDragIndicator();
 
   raw_ptr<BraveBrowser> browser_ = nullptr;
   raw_ptr<views::ImageButton> up_arrow_ = nullptr;


### PR DESCRIPTION
fix https://github.com/brave/brave-browser/issues/25752

I assume that OnDragUpdated() was called when item goes out. But, it's not called now.
Instead use OnDragExited() to catch the timiing when item goes out during the dragging.

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves 

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

See the linked issue