### PR TITLE
Display brave:// protocol for internal urls when hovered

### DIFF
--- a/browser/ui/brave_browser.cc
+++ b/browser/ui/brave_browser.cc
@@ -163,6 +163,17 @@ void BraveBrowser::ResetTryToCloseWindow() {
   Browser::ResetTryToCloseWindow();
 }
 
+void BraveBrowser::UpdateTargetURL(content::WebContents* source,
+                                   const GURL& url) {
+  GURL target_url = url;
+  if (url.SchemeIs(content::kChromeUIScheme)) {
+    GURL::Replacements replacements;
+    replacements.SetSchemeStr(content::kBraveUIScheme);
+    target_url = target_url.ReplaceComponents(replacements);
+  }
+  Browser::UpdateTargetURL(source, target_url);
+}
+
 bool BraveBrowser::ShouldAskForBrowserClosingBeforeHandlers() {
   if (g_suppress_dialog_for_testing)
     return false;

--- a/browser/ui/brave_browser.h
+++ b/browser/ui/brave_browser.h
@@ -46,6 +46,7 @@ class BraveBrowser : public Browser {
   bool TryToCloseWindow(
       bool skip_beforeunload,
       const base::RepeatingCallback<void(bool)>& on_close_confirmed) override;
+  void UpdateTargetURL(content::WebContents* source, const GURL& url) override;
   void ResetTryToCloseWindow() override;
 
   void TabStripEmpty() override;


### PR DESCRIPTION
Replaces chrome://. This is another unfortunate side effect of us still using chrome:// as the protocol which is neccessary as there are many checks for that string specifically and we're not at a point to change that at the moment. However, this is probably the most visible place remaining where Brave still shows chrome:// and so changing it to brave:// is helpful to avoid confusion.

This was also attempted similarly in https://github.com/brave/brave-core/pull/1825 and reverted by https://github.com/brave/brave-core/pull/2188, so first I'm seeing which tests fail.

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/2566

## Submitter Checklist:

- [ ] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

