### PR TITLE
Check old rfh matches stored rfh in BraveWalletProviderDelegateImpl when RenderFrameHostChanged is triggered (uplift to 1.45.x)

### DIFF
--- a/browser/brave_wallet/brave_wallet_provider_delegate_impl.cc
+++ b/browser/brave_wallet/brave_wallet_provider_delegate_impl.cc
@@ -250,10 +250,11 @@ void BraveWalletProviderDelegateImpl::WebContentsDestroyed() {
   web_contents_ = nullptr;
 }
 
+// This is for dapp inside iframe navigates away.
 void BraveWalletProviderDelegateImpl::RenderFrameHostChanged(
     content::RenderFrameHost* old_host,
     content::RenderFrameHost* new_host) {
-  if (!old_host)
+  if (!old_host || old_host != content::RenderFrameHost::FromID(host_id_))
     return;
   auto* tab_helper =
       brave_wallet::BraveWalletTabHelper::FromWebContents(web_contents_);

--- a/test/data/brave-wallet/iframe_solana_provider.html
+++ b/test/data/brave-wallet/iframe_solana_provider.html
@@ -1,0 +1,5 @@
+<html><head><title>Solana provider in iframes</title></head>
+<body>
+    <iframe src="solana_provider.html" id="test-iframe-0"></iframe>
+    <iframe src="solana_provider.html" id="test-iframe-1"></iframe>
+</body></html>


### PR DESCRIPTION
Uplift of #15376
Resolves https://github.com/brave/brave-browser/issues/25802

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.