### PR TITLE
Added more null check when checking NTP search conversion (uplift to 1.45.x)

### DIFF
--- a/components/brave_search_conversion/utils.cc
+++ b/components/brave_search_conversion/utils.cc
@@ -33,7 +33,11 @@ bool IsNTPPromotionEnabled(PrefService* prefs, TemplateURLService* service) {
 
   // Don't need to prompt for conversion if user uses brave as a default
   // provider.
-  auto id = service->GetDefaultSearchProvider()->data().prepopulate_id;
+  auto* template_url = service->GetDefaultSearchProvider();
+  if (!template_url)
+    return false;
+
+  const auto id = template_url->prepopulate_id();
   if (id == TemplateURLPrepopulateData::PREPOPULATED_ENGINE_ID_BRAVE ||
       id == TemplateURLPrepopulateData::PREPOPULATED_ENGINE_ID_BRAVE_TOR) {
     return false;


### PR DESCRIPTION
Uplift of #15381

Pre-approval checklist: 
- [ ] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.