### PR TITLE
Add dark mode check to OverrideWebkitPrefs (for Android)

### DIFF
--- a/browser/brave_content_browser_client.cc
+++ b/browser/brave_content_browser_client.cc
@@ -1046,7 +1046,9 @@ bool PreventDarkModeFingerprinting(WebContents* web_contents,
   // Always use color scheme Light if fingerprinting mode strict
   if (base::FeatureList::IsEnabled(
           brave_shields::features::kBraveDarkModeBlock) &&
-      shields_up && fingerprinting_type == ControlType::BLOCK) {
+      shields_up && fingerprinting_type == ControlType::BLOCK &&
+      prefs->preferred_color_scheme !=
+          blink::mojom::PreferredColorScheme::kLight) {
     prefs->preferred_color_scheme = blink::mojom::PreferredColorScheme::kLight;
     return true;
   }

--- a/browser/brave_content_browser_client.cc
+++ b/browser/brave_content_browser_client.cc
@@ -1033,12 +1033,8 @@ BraveContentBrowserClient::CreateThrottlesForNavigation(
   return throttles;
 }
 
-bool BraveContentBrowserClient::OverrideWebPreferencesAfterNavigation(
-    WebContents* web_contents,
-    WebPreferences* prefs) {
-  bool changed =
-      ChromeContentBrowserClient::OverrideWebPreferencesAfterNavigation(
-          web_contents, prefs);
+bool PreventDarkModeFingerprinting(WebContents* web_contents,
+                                   WebPreferences* prefs) {
   Profile* profile =
       Profile::FromBrowserContext(web_contents->GetBrowserContext());
   const GURL url = web_contents->GetLastCommittedURL();
@@ -1052,14 +1048,24 @@ bool BraveContentBrowserClient::OverrideWebPreferencesAfterNavigation(
           brave_shields::features::kBraveDarkModeBlock) &&
       shields_up && fingerprinting_type == ControlType::BLOCK) {
     prefs->preferred_color_scheme = blink::mojom::PreferredColorScheme::kLight;
-    changed = true;
+    return true;
   }
-  return changed;
+  return false;
+}
+
+bool BraveContentBrowserClient::OverrideWebPreferencesAfterNavigation(
+    WebContents* web_contents,
+    WebPreferences* prefs) {
+  bool changed =
+      ChromeContentBrowserClient::OverrideWebPreferencesAfterNavigation(
+          web_contents, prefs);
+  return PreventDarkModeFingerprinting(web_contents, prefs) || changed;
 }
 
 void BraveContentBrowserClient::OverrideWebkitPrefs(WebContents* web_contents,
                                                     WebPreferences* web_prefs) {
   ChromeContentBrowserClient::OverrideWebkitPrefs(web_contents, web_prefs);
+  PreventDarkModeFingerprinting(web_contents, web_prefs);
   // This will stop NavigatorPlugins from returning fixed plugins data and will
   // allow us to return our farbled data
   web_prefs->allow_non_empty_navigator_plugins = true;


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/25851

The TL;DR here is that for the _Prevent Dark Mode Detection By Websites_ i.e. "always return Light mode when fingerprinting=strict" feature, we currently override `BraveContentBrowserClient::OverrideWebPreferencesAfterNavigation` because that's where we call `UpdatePreferredColorScheme`. But it seems that Android's resume handler also calls `BraveContentBrowserClient::OverrideWebkitPrefs` which also calls `UpdatePreferredColorScheme`, so we need to override `OverrideWebkitPrefs` as well to capture the case where you pause Brave and then resume it on Android.

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
Please see issue