### PR TITLE
fix(wallet): Prevent users from changing asset/network on sardine widget (uplift to 1.45.x)

### DIFF
--- a/components/brave_wallet/browser/asset_ratio_service.cc
+++ b/components/brave_wallet/browser/asset_ratio_service.cc
@@ -144,6 +144,8 @@ GURL AssetRatioService::GetSardineBuyURL(const std::string chain_id,
   url = net::AppendQueryParameter(url, "fiat_amount", amount);
   url = net::AppendQueryParameter(url, "fiat_currency", currency_code);
   url = net::AppendQueryParameter(url, "client_token", auth_token);
+  url = net::AppendQueryParameter(url, "fixed_asset_type", symbol);
+  url = net::AppendQueryParameter(url, "fixed_network", sardine_network_name);
   return url;
 }
 

--- a/components/brave_wallet/browser/asset_ratio_service_unittest.cc
+++ b/components/brave_wallet/browser/asset_ratio_service_unittest.cc
@@ -163,7 +163,8 @@ TEST_F(AssetRatioServiceUnitTest, GetBuyUrlV1Sardine) {
                   "https://crypto.sardine.ai/"
                   "?address=0xdeadbeef&network=ethereum&asset_type=USDC&fiat_"
                   "amount=55000000&fiat_currency=USD&client_token=74618e17-"
-                  "a537-4f5d-ab4d-9916739560b1",
+                  "a537-4f5d-ab4d-9916739560b1&fixed_asset_type=USDC&fixed_"
+                  "network=ethereum",
                   absl::nullopt);
 
   // Timeout yields error


### PR DESCRIPTION
Uplift of #15374
Resolves https://github.com/brave/brave-browser/issues/25839

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.