### PR TITLE
fix(wallet): Scroll Into View Bugs

### DIFF
--- a/components/brave_wallet_ui/common/hooks/use-scroll-into-view.tsx
+++ b/components/brave_wallet_ui/common/hooks/use-scroll-into-view.tsx
@@ -1,0 +1,24 @@
+// Copyright (c) 2022 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// you can obtain one at http://mozilla.org/MPL/2.0/.
+import * as React from 'react'
+
+export function useScrollIntoView () {
+  // Prevents scrolling into view again if re-render occurs
+  const alreadyScrolled = React.useRef(false)
+  const scrollIntoView = React.useCallback((ref: HTMLElement | null) => {
+    if (!alreadyScrolled.current) {
+      ref?.scrollIntoView({
+        behavior: 'smooth',
+        block: 'center',
+        inline: 'center'
+      })
+      alreadyScrolled.current = true
+    }
+  }, [alreadyScrolled])
+
+  return scrollIntoView
+}
+
+export default useScrollIntoView

--- a/components/brave_wallet_ui/components/desktop/views/accounts/account.tsx
+++ b/components/brave_wallet_ui/components/desktop/views/accounts/account.tsx
@@ -52,6 +52,7 @@ import { AccountButtonOptions } from '../../../../options/account-list-button-op
 
 // Hooks
 import { useBalance } from '../../../../common/hooks/balance'
+import { useScrollIntoView } from '../../../../common/hooks/use-scroll-into-view'
 
 // Actions
 import { getFilecoinKeyringIdFromNetwork } from '../../../../utils/network-utils'
@@ -77,6 +78,7 @@ export const Account = ({
 
   // custom hooks
   const getBalance = useBalance(networkList)
+  const scrollIntoView = useScrollIntoView()
 
   // memos
   const selectedAccount = React.useMemo(() => {
@@ -173,19 +175,11 @@ export const Account = ({
     return false
   }, [transactionID])
 
-  // Prevents scrolling into view again if re-render occurs
-  let ignore = false
-
-  const scrollIntoView = React.useCallback((id: string, ref: HTMLDivElement | null) => {
-    if (checkIsTransactionFocused(id) && !ignore) {
-      ref?.scrollIntoView({
-        behavior: 'smooth',
-        block: 'center',
-        inline: 'center'
-      })
-      ignore = true
+  const handleScrollIntoView = React.useCallback((id: string, ref: HTMLDivElement | null) => {
+    if (checkIsTransactionFocused(id)) {
+      scrollIntoView(ref)
     }
-  }, [checkIsTransactionFocused, ignore])
+  }, [checkIsTransactionFocused, scrollIntoView])
 
   // redirect (asset not found)
   if (!selectedAccount) {
@@ -263,7 +257,7 @@ export const Account = ({
               account={selectedAccount}
               accounts={accounts}
               displayAccountName={false}
-              ref={(ref) => scrollIntoView(transaction.id, ref)}
+              ref={(ref) => handleScrollIntoView(transaction.id, ref)}
               isFocused={checkIsTransactionFocused(transaction.id)}
             />
           )}

--- a/components/brave_wallet_ui/page/screens/fund-wallet/deposit-funds.tsx
+++ b/components/brave_wallet_ui/page/screens/fund-wallet/deposit-funds.tsx
@@ -36,6 +36,7 @@ import { AllNetworksOption } from '../../../options/network-filter-options'
 import { useIsMounted } from '../../../common/hooks/useIsMounted'
 import { useCopyToClipboard } from '../../../common/hooks/use-copy-to-clipboard'
 import { usePrevNetwork } from '../../../common/hooks'
+import { useScrollIntoView } from '../../../common/hooks/use-scroll-into-view'
 
 // style
 import { Column, CopyButton, HorizontalSpace, LoadingIcon, Row, VerticalSpace } from '../../../components/shared/style'
@@ -80,6 +81,7 @@ export const DepositFundsScreen = () => {
   const isMounted = useIsMounted()
   const { prevNetwork } = usePrevNetwork()
   const { copyToClipboard, isCopied, resetCopyState } = useCopyToClipboard()
+  const scrollIntoView = useScrollIntoView()
 
   // state
   const [showDepositAddress, setShowDepositAddress] = React.useState<boolean>(false)
@@ -240,15 +242,11 @@ export const DepositFundsScreen = () => {
     return false
   }, [selectedAsset])
 
-  const scrollIntoView = React.useCallback((asset: BraveWallet.BlockchainToken, ref: HTMLButtonElement | null) => {
+  const handleScrollIntoView = React.useCallback((asset: BraveWallet.BlockchainToken, ref: HTMLButtonElement | null) => {
     if (checkIsDepositAssetSelected(asset)) {
-      ref?.scrollIntoView({
-        behavior: 'smooth',
-        block: 'center',
-        inline: 'center'
-      })
+      scrollIntoView(ref)
     }
-  }, [checkIsDepositAssetSelected])
+  }, [checkIsDepositAssetSelected, scrollIntoView])
 
   // effects
   React.useEffect(() => {
@@ -351,7 +349,7 @@ export const DepositFundsScreen = () => {
                         token={asset}
                         tokenNetwork={getTokensNetwork(mainnetsList, asset)}
                         onClick={setSelectedAsset}
-                        ref={(ref) => scrollIntoView(asset, ref)} />}
+                        ref={(ref) => handleScrollIntoView(asset, ref)} />}
                   />
                   : <Column>
                     <LoadingIcon

--- a/components/brave_wallet_ui/page/screens/fund-wallet/fund-wallet.tsx
+++ b/components/brave_wallet_ui/page/screens/fund-wallet/fund-wallet.tsx
@@ -33,6 +33,7 @@ import { SelectBuyOption } from '../../../components/buy-send-swap/select-buy-op
 // hooks
 import { usePrevNetwork } from '../../../common/hooks/previous-network'
 import { useMultiChainBuyAssets } from '../../../common/hooks/use-multi-chain-buy-assets'
+import { useScrollIntoView } from '../../../common/hooks/use-scroll-into-view'
 
 // style
 import { Column, Flex, LoadingIcon, Row, VerticalSpace } from '../../../components/shared/style'
@@ -83,6 +84,7 @@ export const FundWalletScreen = () => {
     setBuyAmount,
     setSelectedAsset
   } = useMultiChainBuyAssets()
+  const scrollIntoView = useScrollIntoView()
 
   // state
   const [showBuyOptions, setShowBuyOptions] = React.useState<boolean>(false)
@@ -177,20 +179,17 @@ export const FundWalletScreen = () => {
   const checkIsBuyAssetSelected = React.useCallback((asset: BraveWallet.BlockchainToken) => {
     if (selectedAsset) {
       return selectedAsset.contractAddress.toLowerCase() === asset.contractAddress.toLowerCase() &&
-        selectedAsset.symbol.toLowerCase() === asset.symbol.toLowerCase()
+        selectedAsset.symbol.toLowerCase() === asset.symbol.toLowerCase() &&
+        selectedAsset.chainId === asset.chainId
     }
     return false
   }, [selectedAsset])
 
-  const scrollIntoView = React.useCallback((asset: BraveWallet.BlockchainToken, ref: HTMLButtonElement | null) => {
+  const handleScrollIntoView = React.useCallback((asset: BraveWallet.BlockchainToken, ref: HTMLButtonElement | null) => {
     if (checkIsBuyAssetSelected(asset)) {
-      ref?.scrollIntoView({
-        behavior: 'smooth',
-        block: 'center',
-        inline: 'center'
-      })
+      scrollIntoView(ref)
     }
-  }, [checkIsBuyAssetSelected])
+  }, [checkIsBuyAssetSelected, scrollIntoView])
 
   // effects
   React.useEffect(() => {
@@ -298,7 +297,7 @@ export const FundWalletScreen = () => {
                         token={asset}
                         tokenNetwork={getTokensNetwork(buyAssetNetworks, asset)}
                         onClick={setSelectedAsset}
-                        ref={(ref) => scrollIntoView(asset, ref)} />}
+                        ref={(ref) => handleScrollIntoView(asset, ref)} />}
                   />
                   : <Column>
                     <LoadingIcon


### PR DESCRIPTION
## Description 
1. Added a `useScrollIntoView` hook
2. Fixes a bug where multiple `ETH` assets were scrolling into view
3. Fixes a bug where `Fund Asset` kept scrolling into view


<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves <https://github.com/brave/brave-browser/issues/25862>
Resolves <https://github.com/brave/brave-browser/issues/25865>

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

### Testing Recurring Scroll Bug

1. Open market data page
2. Select "Buy" for any asset
3. The fund-wallet page is shown and the Asset should scroll into view
4. Scroll away from the asset, it should not scroll back into view

Before:

https://user-images.githubusercontent.com/40611140/194651086-6b8372ba-38f9-42e8-a370-eddc13ed695d.mov

After:

https://user-images.githubusercontent.com/40611140/194651123-a309803a-7b69-474b-9822-9d473d30b07c.mov

### Testing multiple `ETH` assets scrolling into view

1. Open market data page
2. Select "Buy" for ETH
3. The fund-wallet page is shown and ETH on the `Ethereum Mainnet` should be the only one selected/scrolled into view.

Before:

https://user-images.githubusercontent.com/30185185/194641426-55c43fb5-35e6-4e42-a3d9-8b468cf97386.mov

After:

https://user-images.githubusercontent.com/40611140/194651419-99df9040-fafd-48a5-8ed3-03f982b51a7f.mov
