### PR TITLE
Tune 'tab insert/remove' animation in vertical tabs

### DIFF
--- a/browser/ui/views/tabs/brave_tab_container.cc
+++ b/browser/ui/views/tabs/brave_tab_container.cc
@@ -27,7 +27,14 @@ BraveTabContainer::BraveTabContainer(
       tabs::features::ShouldShowVerticalTabs());
 }
 
-BraveTabContainer::~BraveTabContainer() = default;
+BraveTabContainer::~BraveTabContainer() {
+  // When the last tab is closed and tab strip is being destructed, the
+  // animation for the last removed tab could have been scheduled but not
+  // finished yet. In this case, stop the animation before checking if all
+  // closed tabs were cleaned up from OnTabCloseAnimationCompleted().
+  CancelAnimation();
+  DCHECK(closing_tabs_.empty()) << "There are dangling closed tabs.";
+}
 
 gfx::Size BraveTabContainer::CalculatePreferredSize() const {
   if (!tabs::features::ShouldShowVerticalTabs())

--- a/browser/ui/views/tabs/brave_tab_container.cc
+++ b/browser/ui/views/tabs/brave_tab_container.cc
@@ -5,6 +5,8 @@
 
 #include "brave/browser/ui/views/tabs/brave_tab_container.h"
 
+#include <algorithm>
+
 #include "brave/browser/ui/views/tabs/features.h"
 #include "chrome/browser/ui/layout_constants.h"
 #include "chrome/browser/ui/tabs/tab_style.h"
@@ -28,13 +30,29 @@ BraveTabContainer::BraveTabContainer(
 BraveTabContainer::~BraveTabContainer() = default;
 
 gfx::Size BraveTabContainer::CalculatePreferredSize() const {
-  if (tabs::features::ShouldShowVerticalTabs()) {
-    auto slots_bounds = layout_helper_->CalculateIdealBounds({});
-    return gfx::Size(TabStyle::GetStandardWidth(),
-                     slots_bounds.empty() ? 0 : slots_bounds.back().bottom());
+  if (!tabs::features::ShouldShowVerticalTabs())
+    return TabContainerImpl::CalculatePreferredSize();
+
+  const int tab_count = tabs_view_model_.view_size();
+  int height = 0;
+  if (bounds_animator_.IsAnimating() && tab_count) {
+    // When removing a tab in the middle of tabs, the last tab's current bottom
+    // could be greater than ideal bounds bottom.
+    height = tabs_view_model_.view_at(tab_count - 1)->bounds().bottom();
   }
 
-  return TabContainerImpl::CalculatePreferredSize();
+  if (!closing_tabs_.empty()) {
+    // When closing trailing tabs, the last tab's current bottom could be
+    // greater than ideal bounds bottom. Note that closing tabs are not in
+    // tabs_view_model_ so we have to check again here.
+    for (auto* tab : closing_tabs_)
+      height = std::max(height, tab->bounds().bottom());
+  }
+
+  const auto slots_bounds = layout_helper_->CalculateIdealBounds({});
+  height =
+      std::max(height, slots_bounds.empty() ? 0 : slots_bounds.back().bottom());
+  return gfx::Size(TabStyle::GetStandardWidth(), height);
 }
 
 void BraveTabContainer::UpdateClosingModeOnRemovedTab(int model_index,
@@ -57,6 +75,7 @@ gfx::Rect BraveTabContainer::GetTargetBoundsForClosingTab(
       (former_model_index > 0)
           ? tabs_view_model_.ideal_bounds(former_model_index - 1).bottom()
           : 0);
+  target_bounds.set_height(0);
   return target_bounds;
 }
 
@@ -76,6 +95,41 @@ bool BraveTabContainer::ShouldTabBeVisible(const Tab* tab) const {
     return true;
 
   return TabContainerImpl::ShouldTabBeVisible(tab);
+}
+
+void BraveTabContainer::StartInsertTabAnimation(int model_index) {
+  if (!tabs::features::ShouldShowVerticalTabs()) {
+    TabContainerImpl::StartInsertTabAnimation(model_index);
+    return;
+  }
+
+  ExitTabClosingMode();
+
+  gfx::Rect bounds = GetTabAtModelIndex(model_index)->bounds();
+  bounds.set_height(GetLayoutConstant(TAB_HEIGHT));
+  bounds.set_width(TabStyle::GetStandardWidth());
+  bounds.set_x(-TabStyle::GetStandardWidth());
+  bounds.set_y((model_index > 0)
+                   ? tabs_view_model_.ideal_bounds(model_index - 1).bottom()
+                   : 0);
+  GetTabAtModelIndex(model_index)->SetBoundsRect(bounds);
+
+  // Animate in to the full width.
+  StartBasicAnimation();
+}
+
+void BraveTabContainer::RemoveTab(int index, bool was_active) {
+  if (tabs::features::ShouldShowVerticalTabs())
+    closing_tabs_.insert(tabs_view_model_.view_at(index));
+
+  TabContainerImpl::RemoveTab(index, was_active);
+}
+
+void BraveTabContainer::OnTabCloseAnimationCompleted(Tab* tab) {
+  if (tabs::features::ShouldShowVerticalTabs())
+    closing_tabs_.erase(tab);
+
+  TabContainerImpl::OnTabCloseAnimationCompleted(tab);
 }
 
 BEGIN_METADATA(BraveTabContainer, TabContainerImpl)

--- a/browser/ui/views/tabs/brave_tab_container.h
+++ b/browser/ui/views/tabs/brave_tab_container.h
@@ -29,6 +29,12 @@ class BraveTabContainer : public TabContainerImpl {
   void EnterTabClosingMode(absl::optional<int> override_width,
                            CloseTabSource source) override;
   bool ShouldTabBeVisible(const Tab* tab) const override;
+  void StartInsertTabAnimation(int model_index) override;
+  void RemoveTab(int index, bool was_active) override;
+  void OnTabCloseAnimationCompleted(Tab* tab) override;
+
+ private:
+  base::flat_set<Tab*> closing_tabs_;
 };
 
 #endif  // BRAVE_BROWSER_UI_VIEWS_TABS_BRAVE_TAB_CONTAINER_H_

--- a/chromium_src/chrome/browser/ui/views/tabs/tab_container_impl.h
+++ b/chromium_src/chrome/browser/ui/views/tabs/tab_container_impl.h
@@ -15,11 +15,13 @@
 
 #define UpdateClosingModeOnRemovedTab virtual UpdateClosingModeOnRemovedTab
 #define GetTargetBoundsForClosingTab virtual GetTargetBoundsForClosingTab
+#define StartInsertTabAnimation virtual StartInsertTabAnimation
 #define ShouldTabBeVisible virtual ShouldTabBeVisible
 
 #include "src/chrome/browser/ui/views/tabs/tab_container_impl.h"
 
 #undef ShouldTabBeVisible
+#undef StartInsertTabAnimation
 #undef GetTargetBoundsForClosingTab
 #undef UpdateClosingModeOnRemovedTab
 #undef ExitTabClosingMode


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/25853

* Insertion animation The animation starts from where the horizontal tab starts. We should customize this animation to start from the left side of the vertical tab strip.

* Remove animation Align tab containers bottom to the last visible tab's bottom so that the height of container could be animated.


### Demo

https://user-images.githubusercontent.com/5474642/194979676-f403daa8-0d71-417e-99bd-6a1c83bfb4cc.mov



## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
* When adding tabs, tab should be slide in from left to right
* When removing tabs, tab containers bottom should be animated