### PR TITLE
Recover connect failure after deleting vpn entry from os settings

### DIFF
--- a/components/brave_vpn/brave_vpn_service.cc
+++ b/components/brave_vpn/brave_vpn_service.cc
@@ -289,6 +289,9 @@ void BraveVpnService::OnConnectFailed() {
   VLOG(2) << __func__;
 
   cancel_connecting_ = false;
+
+  // Clear previously used connection info if failed.
+  connection_info_.Reset();
   UpdateAndNotifyConnectionStateChange(ConnectionState::CONNECT_FAILED);
 }
 

--- a/components/brave_vpn/brave_vpn_unittest.cc
+++ b/components/brave_vpn/brave_vpn_unittest.cc
@@ -297,7 +297,7 @@ class BraveVPNServiceTest : public testing::Test {
   void LoadCachedRegionData() { service_->LoadCachedRegionData(); }
 
   void OnConnected() { service_->OnConnected(); }
-
+  void OnConnectFailed() { service_->OnConnectFailed(); }
   void OnDisconnected() { service_->OnDisconnected(); }
 
   const BraveVPNConnectionInfo& GetConnectionInfo() {
@@ -734,6 +734,14 @@ TEST_F(BraveVPNServiceTest, ConnectionInfoTest) {
   // Check cached connection info is cleared when user set new selected region.
   connection_state() = ConnectionState::DISCONNECTED;
   service_->SetSelectedRegion(mojom::Region().Clone());
+  EXPECT_FALSE(GetConnectionInfo().IsValid());
+
+  // Fill connection info again.
+  OnGetProfileCredentials(GetProfileCredentialData(), true);
+  EXPECT_TRUE(GetConnectionInfo().IsValid());
+
+  // Check cached connection info is cleared when connect failed.
+  OnConnectFailed();
   EXPECT_FALSE(GetConnectionInfo().IsValid());
 }
 


### PR DESCRIPTION
fix https://github.com/brave/brave-browser/issues/25895

For faster connecting, BraveVpnService caches previously used connection info during the runtime and can ask connecting directly by skipping os vpn entry creation step.
W/o it, BraveVpnService needs to create new credentials by asking guardian server for same region and create os vpn entry again.

However, if user deletes manually os vpn entry while BraveVpnService has cacch, connect is failed because there is no os vpn entry.

To recover this situation, BraveVpnService clears the cache when connection failed.

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves 

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [x] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [x] New files have MPL-2.0 license header
- [x] Adequate test coverage exists to prevent regressions
- [x] Major classes, functions and non-trivial code blocks are well-commented
- [x] Changes in component dependencies are properly reflected in `gn`
- [x] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [x] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

`BraveVPNServiceTest.ConnectionInfoTest`