### PR TITLE
Recover connect failure after deleting vpn entry from os settings (uplift to 1.45.x)

### DIFF
--- a/components/brave_vpn/brave_vpn_service.cc
+++ b/components/brave_vpn/brave_vpn_service.cc
@@ -289,6 +289,9 @@ void BraveVpnService::OnConnectFailed() {
   VLOG(2) << __func__;
 
   cancel_connecting_ = false;
+
+  // Clear previously used connection info if failed.
+  connection_info_.Reset();
   UpdateAndNotifyConnectionStateChange(ConnectionState::CONNECT_FAILED);
 }
 

--- a/components/brave_vpn/brave_vpn_unittest.cc
+++ b/components/brave_vpn/brave_vpn_unittest.cc
@@ -297,7 +297,7 @@ class BraveVPNServiceTest : public testing::Test {
   void LoadCachedRegionData() { service_->LoadCachedRegionData(); }
 
   void OnConnected() { service_->OnConnected(); }
-
+  void OnConnectFailed() { service_->OnConnectFailed(); }
   void OnDisconnected() { service_->OnDisconnected(); }
 
   const BraveVPNConnectionInfo& GetConnectionInfo() {
@@ -734,6 +734,14 @@ TEST_F(BraveVPNServiceTest, ConnectionInfoTest) {
   // Check cached connection info is cleared when user set new selected region.
   connection_state() = ConnectionState::DISCONNECTED;
   service_->SetSelectedRegion(mojom::Region().Clone());
+  EXPECT_FALSE(GetConnectionInfo().IsValid());
+
+  // Fill connection info again.
+  OnGetProfileCredentials(GetProfileCredentialData(), true);
+  EXPECT_TRUE(GetConnectionInfo().IsValid());
+
+  // Check cached connection info is cleared when connect failed.
+  OnConnectFailed();
   EXPECT_FALSE(GetConnectionInfo().IsValid());
 }
 


### PR DESCRIPTION
Uplift of #15404
fix https://github.com/brave/brave-browser/issues/25895

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.