### PR TITLE
Add TabSearchButton on VerticalTabStripRegionView

### DIFF
--- a/browser/ui/views/frame/vertical_tab_strip_region_view.cc
+++ b/browser/ui/views/frame/vertical_tab_strip_region_view.cc
@@ -11,44 +11,48 @@
 #include "brave/browser/ui/brave_browser.h"
 #include "brave/browser/ui/tabs/brave_tab_prefs.h"
 #include "brave/browser/ui/views/tabs/brave_new_tab_button.h"
+#include "brave/browser/ui/views/tabs/brave_tab_search_button.h"
 #include "brave/browser/ui/views/tabs/features.h"
 #include "chrome/browser/themes/theme_properties.h"
 #include "chrome/browser/ui/exclusive_access/exclusive_access_manager.h"
 #include "chrome/browser/ui/exclusive_access/fullscreen_controller.h"
+#include "chrome/browser/ui/frame/window_frame_util.h"
 #include "chrome/browser/ui/tabs/tab_style.h"
-#include "chrome/browser/ui/views/tabs/tab_search_button.h"
 #include "chrome/grit/generated_resources.h"
 #include "ui/base/l10n/l10n_util.h"
 #include "ui/base/metadata/metadata_impl_macros.h"
 #include "ui/gfx/canvas.h"
 #include "ui/views/accessibility/accessibility_paint_checks.h"
+#include "ui/views/animation/ink_drop.h"
 #include "ui/views/controls/scroll_view.h"
+#include "ui/views/layout/box_layout.h"
 #include "ui/views/layout/fill_layout.h"
 #include "ui/views/layout/flex_layout.h"
 
 namespace {
 
-class ScrollHeaderView : public views::Button {
+class ToggleButton : public views::Button {
  public:
-  METADATA_HEADER(ScrollHeaderView);
+  METADATA_HEADER(ToggleButton);
 
-  ScrollHeaderView(Button::PressedCallback callback, TabStrip* tab_strip)
-      : Button(std::move(callback)), tab_strip_(tab_strip) {
+  ToggleButton(Button::PressedCallback callback,
+               VerticalTabStripRegionView* region_view)
+      : Button(std::move(callback)),
+        region_view_(region_view),
+        tab_strip_(region_view_->tab_strip()) {
     // TODO(sangwoo.ko) Temporary workaround before we have a proper tooltip
     // text.
     // https://github.com/brave/brave-browser/issues/24717
     SetProperty(views::kSkipAccessibilityPaintChecks, true);
+    SetPreferredSize(gfx::Size{GetIconWidth(), GetIconWidth()});
   }
-  ~ScrollHeaderView() override = default;
+  ~ToggleButton() override = default;
+
+  static int GetIconWidth() {
+    return TabStyle::GetPinnedWidth() - TabStyle::GetTabOverlap();
+  }
 
   // views::Button:
-  void OnPaintBackground(gfx::Canvas* canvas) override {
-    canvas->DrawColor(GetColorProvider()->GetColor(
-        tab_strip_->ShouldPaintAsActiveFrame()
-            ? kColorNewTabButtonBackgroundFrameActive
-            : kColorNewTabButtonBackgroundFrameInactive));
-  }
-
   void PaintButtonContents(gfx::Canvas* canvas) override {
     // Draw '>'  or '<'
     cc::PaintFlags flags;
@@ -59,9 +63,10 @@ class ScrollHeaderView : public views::Button {
     constexpr int kStrokeWidth = 2;
     flags.setStrokeWidth(kStrokeWidth);
 
-    const int icon_width =
-        TabStyle::GetPinnedWidth() - TabStyle::GetTabOverlap();
-    const bool expanded = icon_width < width();
+    const int icon_width = GetIconWidth();
+
+    const bool expanded =
+        region_view_->state() == VerticalTabStripRegionView::State::kExpanded;
 
     const int icon_inset = ui::TouchUiController::Get()->touch_ui() ? 10 : 9;
     gfx::Rect icon_bounds(gfx::Size(icon_width, height()));
@@ -88,10 +93,77 @@ class ScrollHeaderView : public views::Button {
   }
 
  private:
-  raw_ptr<TabStrip> tab_strip_ = nullptr;
+  raw_ptr<VerticalTabStripRegionView> region_view_ = nullptr;
+  raw_ptr<const TabStrip> tab_strip_ = nullptr;
 };
 
-BEGIN_METADATA(ScrollHeaderView, views::Button)
+BEGIN_METADATA(ToggleButton, views::Button)
+END_METADATA
+
+class ScrollHeaderView : public views::View {
+ public:
+  METADATA_HEADER(ScrollHeaderView);
+
+  ScrollHeaderView(views::Button::PressedCallback toggle_callback,
+                   VerticalTabStripRegionView* region_view)
+      : region_view_(region_view), tab_strip_(region_view->tab_strip()) {
+    auto* layout = SetLayoutManager(std::make_unique<views::BoxLayout>(
+        views::BoxLayout::Orientation::kHorizontal));
+
+    AddChildView(std::make_unique<ToggleButton>(std::move(toggle_callback),
+                                                region_view));
+
+    auto* spacer = AddChildView(std::make_unique<views::View>());
+    layout->SetFlexForView(spacer,
+                           1 /* resize |spacer| to fill the rest of space */);
+
+    // We layout the search button at the end, because there's no
+    // way to change its bubble arrow from TOP_RIGHT at the moment.
+    tab_search_button_ = AddChildView(
+        std::make_unique<BraveTabSearchButton>(region_view->tab_strip()));
+    tab_search_button_->SetPreferredSize(
+        gfx::Size{ToggleButton::GetIconWidth(), ToggleButton::GetIconWidth()});
+    tab_search_button_->SetTooltipText(
+        l10n_util::GetStringUTF16(IDS_TOOLTIP_TAB_SEARCH));
+    tab_search_button_->SetAccessibleName(
+        l10n_util::GetStringUTF16(IDS_ACCNAME_TAB_SEARCH));
+
+    UpdateTabSearchButtonVisibility();
+  }
+  ~ScrollHeaderView() override = default;
+
+  void UpdateTabSearchButtonVisibility() {
+    tab_search_button_->SetVisible(
+        region_view_->state() == VerticalTabStripRegionView::State::kExpanded &&
+        !WindowFrameUtil::IsWin10TabSearchCaptionButtonEnabled(
+            region_view_->browser()));
+  }
+
+  // views::View:
+  void OnThemeChanged() override {
+    View::OnThemeChanged();
+    tab_search_button_->FrameColorsChanged();
+  }
+
+  void OnBoundsChanged(const gfx::Rect& previous_bounds) override {
+    View::OnBoundsChanged(previous_bounds);
+    UpdateTabSearchButtonVisibility();
+  }
+
+  void OnPaintBackground(gfx::Canvas* canvas) override {
+    canvas->DrawColor(GetColorProvider()->GetColor(
+        tab_strip_->ShouldPaintAsActiveFrame()
+            ? kColorNewTabButtonBackgroundFrameActive
+            : kColorNewTabButtonBackgroundFrameInactive));
+  }
+
+ private:
+  raw_ptr<VerticalTabStripRegionView> region_view_ = nullptr;
+  raw_ptr<const TabStrip> tab_strip_ = nullptr;
+  raw_ptr<TabSearchButton> tab_search_button_ = nullptr;
+};
+
+BEGIN_METADATA(ScrollHeaderView, views::View)
 END_METADATA
 
 // A custom scroll view to avoid crash on Mac
@@ -171,7 +243,7 @@ VerticalTabStripRegionView::VerticalTabStripRegionView(
                 container->OnCollapsedPrefChanged();
               },
               this),
-          region_view_->tab_strip_));
+          this));
 
   scroll_contents_view_ = scroll_view_->SetContents(
       std::make_unique<ScrollContentsView>(this, region_view_->tab_strip_));

--- a/browser/ui/views/frame/vertical_tab_strip_region_view.h
+++ b/browser/ui/views/frame/vertical_tab_strip_region_view.h
@@ -25,6 +25,13 @@ class VerticalTabStripRegionView : public views::View {
   VerticalTabStripRegionView(Browser* browser, TabStripRegionView* region_view);
   ~VerticalTabStripRegionView() override;
 
+  State state() const { return state_; }
+
+  const TabStrip* tab_strip() const { return region_view_->tab_strip_; }
+  TabStrip* tab_strip() { return region_view_->tab_strip_; }
+
+  const Browser* browser() const { return browser_; }
+
   // views::View:
   gfx::Size CalculatePreferredSize() const override;
   void Layout() override;


### PR DESCRIPTION
When vertical tab strip is enabled, we should show the tab search button on it. We have a one exception for this where a tab search button is attached to the window frame on Windows 10.

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/25894

## Demo

https://user-images.githubusercontent.com/5474642/195321856-99cf98d3-ab83-418f-b9b6-0be002ba0453.mov


## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
* Tab search button should be visible when we don't have it on the window frame
* Tab search button is visible when vertical tab strip is expanded
* Clicking tab search button should show tab search webui on a bubble.
