### PR TITLE
Set NOT_PURCHASED state when subscription is not active

### DIFF
--- a/components/brave_vpn/brave_vpn_service.cc
+++ b/components/brave_vpn/brave_vpn_service.cc
@@ -1013,8 +1013,8 @@ void BraveVpnService::OnCredentialSummary(const std::string& domain,
           base::BindOnce(&BraveVpnService::OnPrepareCredentialsPresentation,
                          base::Unretained(this), domain));
     } else {
-      VLOG(1) << __func__ << " : Credential appears to be expired.";
-      SetPurchasedState(env, PurchasedState::EXPIRED);
+      VLOG(1) << __func__ << " : Credential is not active.";
+      SetPurchasedState(env, PurchasedState::NOT_PURCHASED);
     }
   } else {
     VLOG(1) << __func__ << " : Got invalid credential summary!";

--- a/components/brave_vpn/brave_vpn_unittest.cc
+++ b/components/brave_vpn/brave_vpn_unittest.cc
@@ -608,7 +608,7 @@ TEST_F(BraveVPNServiceTest, LoadPurchasedStateTest) {
   // Treat expired when credential with non active received.
   SetPurchasedState(env, PurchasedState::LOADING);
   OnCredentialSummary(domain, R"({ "active": false } )");
-  EXPECT_EQ(PurchasedState::EXPIRED, GetPurchasedStateSync());
+  EXPECT_EQ(PurchasedState::NOT_PURCHASED, GetPurchasedStateSync());
 
   // Treat failed when invalid string received.
   SetPurchasedState(env, PurchasedState::LOADING);


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/25793

By some reasons my account has `active: false` in server payload with not expired subscription. Setting purchase state as exired causes new requests with same result and infinite loop happen. Setting NOT_PURCHASED opens account web
 page which authorizes itself by cookies and refreshes credential for valid and everything works as result.

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

- On my side I just use clean profile and setup vpn for dev server. Need to get `active : false` with non expired subscription from server