### PR TITLE
fix brave news feed ads crash in android

### DIFF
--- a/android/java/org/chromium/chrome/browser/brave_news/CardBuilderFeedCard.java
+++ b/android/java/org/chromium/chrome/browser/brave_news/CardBuilderFeedCard.java
@@ -702,8 +702,10 @@ public class CardBuilderFeedCard {
     }
 
     private void openUrlAndSaveEvent(DisplayAd adData) {
-        mBraveNewsController.onDisplayAdVisit(adData.uuid, adData.creativeInstanceId);
-        openUrlInSameTabAndSavePosition(adData.targetUrl.url);
+        if (mBraveNewsController != null) {
+            mBraveNewsController.onDisplayAdVisit(adData.uuid, adData.creativeInstanceId);
+            openUrlInSameTabAndSavePosition(adData.targetUrl.url);
+        }
     }
 
     private void addElementsToSingleLayout(ViewGroup view, int index, int itemType) {
@@ -1275,24 +1277,27 @@ public class CardBuilderFeedCard {
         view.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {
-                if (isPromo) {
-                    // Updates the no. of promotion cards visited
-                    mBraveNewsController.onPromotedItemVisit(
-                            mNewsItem.getUuid(), creativeInstanceId);
-                } else if (displayAd != null) {
-                    // Updates the no. of ads cards visited
-                    mBraveNewsController.onDisplayAdVisit(
-                            displayAd.uuid, displayAd.creativeInstanceId);
-                } else {
-                    // Brave News updates the no. of "normal" cards visited
-                    int visitedNewsCardsCount = SharedPreferencesManager.getInstance().readInt(
-                            BravePreferenceKeys.BRAVE_NEWS_CARDS_VISITED);
-                    visitedNewsCardsCount++;
-                    SharedPreferencesManager.getInstance().writeInt(
-                            BravePreferenceKeys.BRAVE_NEWS_CARDS_VISITED, visitedNewsCardsCount);
-                    if (visitedNewsCardsCount > 0) {
-                        mBraveNewsController.onSessionCardVisitsCountChanged(
-                                (short) visitedNewsCardsCount);
+                if (mBraveNewsController != null) {
+                    if (isPromo) {
+                        // Updates the no. of promotion cards visited
+                        mBraveNewsController.onPromotedItemVisit(
+                                mNewsItem.getUuid(), creativeInstanceId);
+                    } else if (displayAd != null) {
+                        // Updates the no. of ads cards visited
+                        mBraveNewsController.onDisplayAdVisit(
+                                displayAd.uuid, displayAd.creativeInstanceId);
+                    } else {
+                        // Brave News updates the no. of "normal" cards visited
+                        int visitedNewsCardsCount = SharedPreferencesManager.getInstance().readInt(
+                                BravePreferenceKeys.BRAVE_NEWS_CARDS_VISITED);
+                        visitedNewsCardsCount++;
+                        SharedPreferencesManager.getInstance().writeInt(
+                                BravePreferenceKeys.BRAVE_NEWS_CARDS_VISITED,
+                                visitedNewsCardsCount);
+                        if (visitedNewsCardsCount > 0) {
+                            mBraveNewsController.onSessionCardVisitsCountChanged(
+                                    (short) visitedNewsCardsCount);
+                        }
                     }
                 }
             }
@@ -1335,28 +1340,30 @@ public class CardBuilderFeedCard {
         }
 
         final Url adImageUrl = imageUrlTemp;
-
-        mBraveNewsController.getImageData(adImageUrl, imageData -> {
-            if (imageData != null) {
-                Bitmap decodedByte = BitmapFactory.decodeByteArray(imageData, 0, imageData.length);
-                Glide.with(mActivity)
-                        .asBitmap()
-                        .load(decodedByte)
-                        .fitCenter()
-                        .priority(Priority.IMMEDIATE)
-                        .diskCacheStrategy(DiskCacheStrategy.ALL)
-                        .into(new CustomTarget<Bitmap>() {
-                            @Override
-                            public void onResourceReady(@NonNull Bitmap resource,
-                                    @Nullable Transition<? super Bitmap> transition) {
-                                imageView.setImageBitmap(resource);
-                            }
-                            @Override
-                            public void onLoadCleared(@Nullable Drawable placeholder) {}
-                        });
-                imageView.setClipToOutline(true);
-            }
-        });
+        if (mBraveNewsController != null) {
+            mBraveNewsController.getImageData(adImageUrl, imageData -> {
+                if (imageData != null) {
+                    Bitmap decodedByte =
+                            BitmapFactory.decodeByteArray(imageData, 0, imageData.length);
+                    Glide.with(mActivity)
+                            .asBitmap()
+                            .load(decodedByte)
+                            .fitCenter()
+                            .priority(Priority.IMMEDIATE)
+                            .diskCacheStrategy(DiskCacheStrategy.ALL)
+                            .into(new CustomTarget<Bitmap>() {
+                                @Override
+                                public void onResourceReady(@NonNull Bitmap resource,
+                                        @Nullable Transition<? super Bitmap> transition) {
+                                    imageView.setImageBitmap(resource);
+                                }
+                                @Override
+                                public void onLoadCleared(@Nullable Drawable placeholder) {}
+                            });
+                    imageView.setClipToOutline(true);
+                }
+            });
+        }
     }
 
     private void setImage(ImageView imageView, String type, int index) {
@@ -1382,19 +1389,21 @@ public class CardBuilderFeedCard {
             }
 
             Url itemImageUrl = getImage(itemMetaData);
-            mBraveNewsController.getImageData(itemImageUrl, imageData -> {
-                if (imageData != null) {
-                    GranularRoundedCorners radius = new GranularRoundedCorners(15, 15, 15, 15);
-                    if (!type.equals("paired")) {
-                        radius = new GranularRoundedCorners(30, 30, 0, 0);
-                    }
-                    RequestOptions requestOptions = new RequestOptions();
-                    requestOptions =
-                            requestOptions.centerInside().transform(new CenterCrop(), radius);
+            if (mBraveNewsController != null) {
+                mBraveNewsController.getImageData(itemImageUrl, imageData -> {
+                    if (imageData != null) {
+                        GranularRoundedCorners radius = new GranularRoundedCorners(15, 15, 15, 15);
+                        if (!type.equals("paired")) {
+                            radius = new GranularRoundedCorners(30, 30, 0, 0);
+                        }
+                        RequestOptions requestOptions = new RequestOptions();
+                        requestOptions =
+                                requestOptions.centerInside().transform(new CenterCrop(), radius);
 
-                    mGlide.load(imageData).centerCrop().apply(requestOptions).into(imageView);
-                }
-            });
+                        mGlide.load(imageData).centerCrop().apply(requestOptions).into(imageView);
+                    }
+                });
+            }
         }
     }
 

--- a/android/java/org/chromium/chrome/browser/ntp/BraveNewTabPageLayout.java
+++ b/android/java/org/chromium/chrome/browser/ntp/BraveNewTabPageLayout.java
@@ -471,8 +471,10 @@ public class BraveNewTabPageLayout
                                 if (mCardType.equals("promo") && !mCardType.equals("displayad")) {
                                     if (!mUuid.equals("") && !mCreativeInstanceId.equals("")) {
                                         mVisibleCard.setViewStatSent(true);
-                                        mBraveNewsController.onPromotedItemView(
-                                                mUuid, mCreativeInstanceId);
+                                        if (mBraveNewsController != null) {
+                                            mBraveNewsController.onPromotedItemView(
+                                                    mUuid, mCreativeInstanceId);
+                                        }
                                     }
                                 }
                             }
@@ -494,8 +496,10 @@ public class BraveNewTabPageLayout
                                             feedItems != null && feedItems.size() == 2 ? 2 : 1;
                                 }
                             }
-                            mBraveNewsController.onSessionCardViewsCountChanged(
-                                    (short) mNewsSessionCardViews);
+                            if (mBraveNewsController != null) {
+                                mBraveNewsController.onSessionCardViewsCountChanged(
+                                        (short) mNewsSessionCardViews);
+                            }
                             mPrevVisibleNewsCardPosition = lastVisibleItemPosition;
                         }
                     }
@@ -508,15 +512,17 @@ public class BraveNewTabPageLayout
                         mFeedHash = SharedPreferencesManager.getInstance().readString(
                                 BravePreferenceKeys.BRAVE_NEWS_FEED_HASH, "");
                         //@TODO alex optimize feed availability check
-                        mBraveNewsController.isFeedUpdateAvailable(
-                                mFeedHash, isNewsFeedAvailable -> {
-                                    if (isNewsFeedAvailable) {
-                                        mPrevVisibleNewsCardPosition =
-                                                mPrevVisibleNewsCardPosition + 1;
+                        if (mBraveNewsController != null) {
+                            mBraveNewsController.isFeedUpdateAvailable(
+                                    mFeedHash, isNewsFeedAvailable -> {
+                                        if (isNewsFeedAvailable) {
+                                            mPrevVisibleNewsCardPosition =
+                                                    mPrevVisibleNewsCardPosition + 1;
 
-                                        setNewContentChanges(true);
-                                    }
-                                });
+                                            setNewContentChanges(true);
+                                        }
+                                    });
+                        }
 
                         Rect rvRect = new Rect();
                         mRecyclerView.getGlobalVisibleRect(rvRect);
@@ -593,7 +599,9 @@ public class BraveNewTabPageLayout
                                                                             .isDisplayAdAlreadyAdded(
                                                                                     mUuid)
                                                                     && visiblePercentageFinal
-                                                                            > MINIMUM_VISIBLE_HEIGHT_THRESHOLD) {
+                                                                            > MINIMUM_VISIBLE_HEIGHT_THRESHOLD
+                                                                    && mBraveNewsController
+                                                                            != null) {
                                                                 mVisibleCard.setViewStatSent(true);
                                                                 mBraveNewsController.onDisplayAdView(
                                                                         mUuid, mCreativeInstanceId);


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/25933

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [x] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [x] New files have MPL-2.0 license header
- [x] Adequate test coverage exists to prevent regressions
- [x] Major classes, functions and non-trivial code blocks are well-commented
- [x] Changes in component dependencies are properly reflected in `gn`
- [x] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [x] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
1. Enable Brave News via the NTP
2. Click on any of the ads appearing within the news feed. It should not crash the app