### PR TITLE
[iOS] Add support for recording P3A histograms from brave-core on iOS (uplift to 1.45.x)

### DIFF
--- a/chromium_src/ios/chrome/browser/prefs/BUILD.gn
+++ b/chromium_src/ios/chrome/browser/prefs/BUILD.gn
@@ -7,6 +7,8 @@ group("prefs") {
   deps = [
     "//brave/components/brave_sync:prefs",
     "//brave/components/brave_wallet/browser",
+    "//brave/components/p3a",
+    "//brave/components/p3a:buildflags",
     "//brave/ios/browser/brave_stats",
   ]
 }

--- a/chromium_src/ios/chrome/browser/prefs/DEPS
+++ b/chromium_src/ios/chrome/browser/prefs/DEPS
@@ -1,5 +1,6 @@
 include_rules = [
   "+brave/components/brave_sync",
   "+brave/components/brave_wallet/browser",
+  "+brave/components/p3a",
   "+brave/ios/browser/brave_stats",
 ]

--- a/chromium_src/ios/chrome/browser/prefs/browser_prefs.mm
+++ b/chromium_src/ios/chrome/browser/prefs/browser_prefs.mm
@@ -6,6 +6,8 @@
 #include "brave/components/brave_sync/brave_sync_prefs.h"
 #include "brave/components/brave_wallet/browser/brave_wallet_prefs.h"
 #include "brave/components/brave_wallet/browser/keyring_service.h"
+#include "brave/components/p3a/brave_p3a_service.h"
+#include "brave/components/p3a/buildflags.h"
 #include "brave/ios/browser/brave_stats/brave_stats_prefs.h"
 #include "components/pref_registry/pref_registry_syncable.h"
 
@@ -18,6 +20,9 @@ void BraveRegisterBrowserStatePrefs(
 
 void BraveRegisterLocalStatePrefs(PrefRegistrySimple* registry) {
   brave_stats::RegisterLocalStatePrefs(registry);
+#if BUILDFLAG(BRAVE_P3A_ENABLED)
+  brave::BraveP3AService::RegisterPrefs(registry, false);
+#endif
 }
 
 void BraveMigrateObsoleteBrowserStatePrefs(PrefService* prefs) {

--- a/components/brave_stats/browser/brave_stats_updater_util.cc
+++ b/components/brave_stats/browser/brave_stats_updater_util.cc
@@ -41,6 +41,8 @@ std::string GetPlatformIdentifier() {
   return "android-bc";
 #elif BUILDFLAG(IS_LINUX)
   return "linux-bc";
+#elif BUILDFLAG(IS_IOS)
+  return "ios";
 #else
   return std::string();
 #endif

--- a/components/p3a/BUILD.gn
+++ b/components/p3a/BUILD.gn
@@ -1,3 +1,4 @@
+import("//brave/components/brave_referrals/buildflags/buildflags.gni")
 import("//brave/components/p3a/buildflags.gni")
 import("//build/buildflag_header.gni")
 
@@ -31,7 +32,7 @@ static_library("p3a") {
 
   deps = [
     "//base",
-    "//brave/components/brave_referrals/common",
+    "//brave/components/brave_referrals/buildflags",
     "//brave/components/brave_stats/browser",
     "//brave/components/p3a:buildflags",
     "//brave/components/p3a_utils",
@@ -39,9 +40,20 @@ static_library("p3a") {
     "//brave/vendor/brave_base",
     "//components/metrics",
     "//components/prefs",
-    "//content/public/browser",
-    "//content/public/common",
     "//services/network/public/cpp",
     "//url",
   ]
+
+  if (enable_brave_referrals) {
+    deps += [ "//brave/components/brave_referrals/common" ]
+  }
+
+  if (is_ios) {
+    deps += [ "//ios/web/public/thread" ]
+  } else {
+    deps += [
+      "//content/public/browser",
+      "//content/public/common",
+    ]
+  }
 }

--- a/components/p3a/DEPS
+++ b/components/p3a/DEPS
@@ -1,6 +1,7 @@
 include_rules = [
   "+brave/components/version_info",
   "+content/public/browser",
+  "+ios/web/public/thread",
   "+services/network/public",
   "+third_party/metrics_proto",
 ]

--- a/ios/BUILD.gn
+++ b/ios/BUILD.gn
@@ -12,6 +12,7 @@ import("//brave/ios/browser/api/certificate/headers.gni")
 import("//brave/ios/browser/api/favicon/headers.gni")
 import("//brave/ios/browser/api/ledger/headers.gni")
 import("//brave/ios/browser/api/opentabs/headers.gni")
+import("//brave/ios/browser/api/p3a/headers.gni")
 import("//brave/ios/browser/api/qr_code/headers.gni")
 import("//brave/ios/browser/api/skus/headers.gni")
 import("//brave/ios/browser/api/url/headers.gni")
@@ -49,6 +50,7 @@ group("brave_ios_tests") {
 brave_core_public_headers = [
   "//brave/build/ios/mojom/public/base/base_values.h",
   "//brave/ios/app/brave_core_main.h",
+  "//brave/ios/app/brave_core_switches.h",
   "//brave/ios/browser/brave_wallet/brave_wallet_factory_wrappers.h",
   "//brave/ios/browser/skus/skus_sdk_factory_wrappers.h",
   "//brave/ios/browser/api/bookmarks/brave_bookmarks_api.h",
@@ -78,6 +80,7 @@ brave_core_public_headers += browser_api_opentabs_public_headers
 brave_core_public_headers += browser_api_qr_code_public_headers
 brave_core_public_headers += skus_public_headers
 brave_core_public_headers += browser_api_url_public_headers
+brave_core_public_headers += brave_p3a_public_headers
 
 action("brave_core_umbrella_header") {
   script = "//build/config/ios/generate_umbrella_header.py"

--- a/ios/app/BUILD.gn
+++ b/ios/app/BUILD.gn
@@ -17,6 +17,8 @@ source_set("app") {
   sources = [
     "brave_core_main.h",
     "brave_core_main.mm",
+    "brave_core_switches.h",
+    "brave_core_switches.mm",
     "brave_main_delegate.h",
     "brave_main_delegate.mm",
   ]
@@ -27,6 +29,8 @@ source_set("app") {
     "//brave/components/brave_sync:constants",
     "//brave/components/brave_wallet/browser",
     "//brave/components/constants",
+    "//brave/components/p3a",
+    "//brave/components/p3a:buildflags",
     "//brave/components/skus/browser",
     "//brave/components/update_client:buildflags",
     "//brave/ios/app/resources",
@@ -40,6 +44,7 @@ source_set("app") {
     "//brave/ios/browser/api/history",
     "//brave/ios/browser/api/ledger",
     "//brave/ios/browser/api/opentabs",
+    "//brave/ios/browser/api/p3a",
     "//brave/ios/browser/api/password",
     "//brave/ios/browser/api/qr_code",
     "//brave/ios/browser/api/skus:skus_mojom_wrappers",

--- a/ios/app/DEPS
+++ b/ios/app/DEPS
@@ -7,6 +7,7 @@ include_rules = [
   "+components/component_updater/component_updater_service.h",
   "+components/component_updater/component_updater_switches.h",
   "+components/component_updater/installer_policies",
+  "+components/prefs",
   "+components/sync/driver",
   "+components/sync/base",
   "+components/browser_sync",
@@ -17,4 +18,5 @@ include_rules = [
   "+ios/public/provider/chrome/browser/chrome_browser_provider.h",
   "+ios/public/provider/chrome/browser/ui_utils/ui_utils_api.h",
   "+ios/web/public/init/web_main.h",
+  "+services/network/public/cpp/shared_url_loader_factory.h",
 ]

--- a/ios/app/brave_core_main.h
+++ b/ios/app/brave_core_main.h
@@ -8,10 +8,13 @@
 
 #import <Foundation/Foundation.h>
 
+#import "brave_core_switches.h"  // NOLINT
+
 @class BraveBookmarksAPI;
 @class BraveHistoryAPI;
 @class BravePasswordAPI;
 @class BraveOpenTabsAPI;
+@class BraveP3AUtils;
 @class BraveSendTabAPI;
 @class BraveSyncAPI;
 @class BraveSyncProfileServiceIOS;
@@ -21,31 +24,6 @@
 @class BraveTabGeneratorAPI;
 
 NS_ASSUME_NONNULL_BEGIN
-
-typedef NSString* BraveCoreSwitch NS_STRING_ENUM;
-/// Overrides the component updater source. Defaults to the CI provided value
-///
-/// Expected value: url-source={url}
-OBJC_EXPORT const BraveCoreSwitch BraveCoreSwitchComponentUpdater;
-/// Overrides Chromium VLOG verbosity. Defaults to only printing from folders
-/// existing within a `brave` subfolder up to level 5.
-///
-/// Expected value: {folder-expression}={level}
-OBJC_EXPORT const BraveCoreSwitch BraveCoreSwitchVModule;
-/// Overrides the sync service base URL. Defaults to the CI provided value
-///
-/// Expected value: A URL string
-OBJC_EXPORT const BraveCoreSwitch BraveCoreSwitchSyncURL;
-/// Sets a number of overrides for the ads & ledger services such as which
-/// environment its using, debug mode, etc.
-///
-/// Expected value: A comma-separated list of flags, including:
-///     - staging={bool}
-////    - development={bool}
-///     - debug={bool}
-///     - reconcile-interval={int}
-///     - retry-interval={int}
-OBJC_EXPORT const BraveCoreSwitch BraveCoreSwitchRewardsFlags;
 
 typedef int BraveCoreLogSeverity NS_TYPED_ENUM;
 OBJC_EXPORT const BraveCoreLogSeverity BraveCoreLogSeverityFatal;
@@ -91,8 +69,8 @@ OBJC_EXPORT
 - (instancetype)initWithUserAgent:(NSString*)userAgent;
 
 - (instancetype)initWithUserAgent:(NSString*)userAgent
-               additionalSwitches:(NSDictionary<BraveCoreSwitch, NSString*>*)
-                                      additionalSwitches;
+               additionalSwitches:
+                   (NSArray<BraveCoreSwitch*>*)additionalSwitches;
 
 - (void)scheduleLowPriorityStartupTasks;
 
@@ -101,6 +79,11 @@ OBJC_EXPORT
 @property(readonly) BraveStats* braveStats;
 
 @property(readonly) AdblockService* adblockService;
+
+- (void)initializeP3AServiceForChannel:(NSString*)channel
+                         weekOfInstall:(NSString*)weekOfInstall;
+
+@property(readonly) BraveP3AUtils* p3aUtils;
 
 @end
 

--- a/ios/app/brave_core_main.mm
+++ b/ios/app/brave_core_main.mm
@@ -8,13 +8,16 @@
 #import <Foundation/Foundation.h>
 #import <UIKit/UIKit.h>
 
-#include "base/base_switches.h"
 #include "base/compiler_specific.h"
 #include "base/logging.h"
 #include "base/memory/ref_counted.h"
+#include "base/memory/scoped_refptr.h"
 #include "base/strings/sys_string_conversions.h"
 #include "brave/components/brave_component_updater/browser/brave_on_demand_updater.h"
 #include "brave/components/brave_wallet/browser/wallet_data_files_installer.h"
+#include "brave/components/p3a/brave_p3a_service.h"
+#include "brave/components/p3a/buildflags.h"
+#include "brave/components/p3a/histograms_braveizer.h"
 #include "brave/ios/app/brave_main_delegate.h"
 #include "brave/ios/browser/api/bookmarks/brave_bookmarks_api+private.h"
 #include "brave/ios/browser/api/brave_shields/adblock_service+private.h"
@@ -24,18 +27,18 @@
 #include "brave/ios/browser/api/opentabs/brave_opentabs_api+private.h"
 #include "brave/ios/browser/api/opentabs/brave_sendtab_api+private.h"
 #include "brave/ios/browser/api/opentabs/brave_tabgenerator_api+private.h"
+#include "brave/ios/browser/api/p3a/brave_p3a_utils+private.h"
 #include "brave/ios/browser/api/password/brave_password_api+private.h"
 #include "brave/ios/browser/api/sync/brave_sync_api+private.h"
 #include "brave/ios/browser/api/sync/driver/brave_sync_profile_service+private.h"
 #include "brave/ios/browser/brave_web_client.h"
 #include "brave/ios/browser/component_updater/component_updater_utils.h"
-#include "components/component_updater/component_updater_switches.h"
 #include "components/component_updater/installer_policies/safety_tips_component_installer.h"
 #include "components/history/core/browser/history_service.h"
 #include "components/keyed_service/core/service_access_type.h"
 #include "components/password_manager/core/browser/password_store.h"
+#include "components/prefs/pref_service.h"
 #include "components/send_tab_to_self/send_tab_to_self_sync_service.h"
-#include "components/sync/base/command_line_switches.h"
 #include "ios/chrome/app/startup/provider_registration.h"
 #include "ios/chrome/app/startup_tasks.h"
 #include "ios/chrome/browser/application_context.h"
@@ -58,19 +61,11 @@
 #include "ios/public/provider/chrome/browser/chrome_browser_provider.h"
 #include "ios/public/provider/chrome/browser/ui_utils/ui_utils_api.h"
 #include "ios/web/public/init/web_main.h"
+#include "services/network/public/cpp/shared_url_loader_factory.h"
 
 // Chromium logging is global, therefore we cannot link this to the instance in
 // question
 static BraveCoreLogHandler _Nullable _logHandler = nil;
-
-const BraveCoreSwitch BraveCoreSwitchComponentUpdater =
-    base::SysUTF8ToNSString(switches::kComponentUpdater);
-const BraveCoreSwitch BraveCoreSwitchVModule =
-    base::SysUTF8ToNSString(switches::kVModule);
-const BraveCoreSwitch BraveCoreSwitchSyncURL =
-    base::SysUTF8ToNSString(syncer::kSyncServiceURL);
-// There is no exposed switch for rewards
-const BraveCoreSwitch BraveCoreSwitchRewardsFlags = @"rewards";
 
 const BraveCoreLogSeverity BraveCoreLogSeverityFatal = logging::LOGGING_FATAL;
 const BraveCoreLogSeverity BraveCoreLogSeverityError = logging::LOGGING_ERROR;
@@ -87,6 +82,8 @@ const BraveCoreLogSeverity BraveCoreLogSeverityVerbose =
   std::unique_ptr<Browser> _browser;
   BrowserList* _browserList;
   ChromeBrowserState* _mainBrowserState;
+  scoped_refptr<brave::BraveP3AService> _p3a_service;
+  scoped_refptr<brave::HistogramsBraveizer> _histogram_braveizer;
 }
 @property(nonatomic) BraveBookmarksAPI* bookmarksAPI;
 @property(nonatomic) BraveHistoryAPI* historyAPI;
@@ -102,12 +99,12 @@ const BraveCoreLogSeverity BraveCoreLogSeverityVerbose =
 @implementation BraveCoreMain
 
 - (instancetype)initWithUserAgent:(NSString*)userAgent {
-  return [self initWithUserAgent:userAgent additionalSwitches:@{}];
+  return [self initWithUserAgent:userAgent additionalSwitches:@[]];
 }
 
 - (instancetype)initWithUserAgent:(NSString*)userAgent
-               additionalSwitches:(NSDictionary<BraveCoreSwitch, NSString*>*)
-                                      additionalSwitches {
+               additionalSwitches:
+                   (NSArray<BraveCoreSwitch*>*)additionalSwitches {
   if ((self = [super init])) {
     [[NSNotificationCenter defaultCenter]
         addObserver:self
@@ -138,14 +135,13 @@ const BraveCoreLogSeverity BraveCoreLogSeverityVerbose =
     NSMutableArray* arguments =
         [[[NSProcessInfo processInfo] arguments] mutableCopy];
     NSMutableArray* switches = [[NSMutableArray alloc] init];
-    for (NSString* key in additionalSwitches) {
-      if (![additionalSwitches[key] isKindOfClass:NSString.class]) {
-        continue;
+    for (BraveCoreSwitch* sv in additionalSwitches) {
+      if (!sv.value) {
+        [switches addObject:[NSString stringWithFormat:@"--%@", sv.key]];
+      } else {
+        [switches
+            addObject:[NSString stringWithFormat:@"--%@=%@", sv.key, sv.value]];
       }
-      [switches
-          addObject:[NSString stringWithFormat:@"--%@=%@", key,
-                                               static_cast<NSString*>(
-                                                   additionalSwitches[key])]];
     }
     [arguments addObjectsFromArray:switches];
     params.argc = [arguments count];
@@ -367,6 +363,24 @@ static bool CustomLogHandler(int severity,
 
 - (BraveStats*)braveStats {
   return [[BraveStats alloc] initWithBrowserState:_mainBrowserState];
+}
+
+- (void)initializeP3AServiceForChannel:(NSString*)channel
+                         weekOfInstall:(NSString*)weekOfInstall {
+#if BUILDFLAG(BRAVE_P3A_ENABLED)
+  _p3a_service = base::MakeRefCounted<brave::BraveP3AService>(
+      GetApplicationContext()->GetLocalState(),
+      base::SysNSStringToUTF8(channel), base::SysNSStringToUTF8(weekOfInstall));
+  _p3a_service->InitCallbacks();
+  _p3a_service->Init(GetApplicationContext()->GetSharedURLLoaderFactory());
+  _histogram_braveizer = brave::HistogramsBraveizer::Create();
+#endif  // BUILDFLAG(BRAVE_P3A_ENABLED)
+}
+
+- (BraveP3AUtils*)p3aUtils {
+  return [[BraveP3AUtils alloc]
+      initWithBrowserState:_mainBrowserState
+                localState:GetApplicationContext()->GetLocalState()];
 }
 
 @end

--- a/ios/app/brave_core_switches.h
+++ b/ios/app/brave_core_switches.h
@@ -1,0 +1,76 @@
+/* Copyright (c) 2022 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_IOS_APP_BRAVE_CORE_SWITCHES_H_
+#define BRAVE_IOS_APP_BRAVE_CORE_SWITCHES_H_
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+typedef NSString* BraveCoreSwitchKey NS_STRING_ENUM;
+/// Overrides the component updater source. Defaults to the CI provided value
+///
+/// Expected value: url-source={url}
+OBJC_EXPORT const BraveCoreSwitchKey BraveCoreSwitchKeyComponentUpdater;
+/// Overrides Chromium VLOG verbosity. Defaults to only printing from folders
+/// existing within a `brave` subfolder up to level 5.
+///
+/// Expected value: {folder-expression}={level}
+OBJC_EXPORT const BraveCoreSwitchKey BraveCoreSwitchKeyVModule;
+/// Overrides the sync service base URL. Defaults to the CI provided value
+///
+/// Expected value: A URL string
+OBJC_EXPORT const BraveCoreSwitchKey BraveCoreSwitchKeySyncURL;
+/// Sets a number of overrides for the ads & ledger services such as which
+/// environment its using, debug mode, etc.
+///
+/// Expected value: A comma-separated list of flags, including:
+///     - staging={bool}
+////    - development={bool}
+///     - debug={bool}
+///     - reconcile-interval={int}
+///     - retry-interval={int}
+OBJC_EXPORT const BraveCoreSwitchKey BraveCoreSwitchKeyRewardsFlags;
+/// Overrides the number of seconds to upload P3A metrics
+///
+/// Expected value: A number (in seconds)
+OBJC_EXPORT const BraveCoreSwitchKey
+    BraveCoreSwitchKeyP3AUploadIntervalSeconds NS_SWIFT_NAME(p3aUploadIntervalSeconds);  // NOLINT
+/// Avoid upload interval randomization
+OBJC_EXPORT const BraveCoreSwitchKey
+    BraveCoreSwitchKeyP3ADoNotRandomizeUploadInterval NS_SWIFT_NAME(p3aDoNotRandomizeUploadInterval);  // NOLINT
+/// Interval between restarting the uploading process for all gathered values
+///
+/// Expected value: A number (in seconds)
+OBJC_EXPORT const BraveCoreSwitchKey
+    BraveCoreSwitchKeyP3ATypicalRotationIntervalSeconds NS_SWIFT_NAME(p3aTypicalRotationIntervalSeconds);  // NOLINT
+/// Overrides the P3A cloud backend URL.
+///
+/// Expected value: A URL string
+OBJC_EXPORT const BraveCoreSwitchKey
+    BraveCoreSwitchKeyP3AUploadServerURL NS_SWIFT_NAME(p3aUploadServerURL);
+/// Do not try to resent values even if a cloud returned an HTTP error, just
+/// continue the normal process.
+OBJC_EXPORT const BraveCoreSwitchKey
+    BraveCoreSwitchKeyP3AIgnoreServerErrors NS_SWIFT_NAME(p3aIgnoreServerErrors);  // NOLINT
+
+/// Defines a switch that may be overriden on launch.
+///
+/// These are essentially the same as passing a command line argument in the
+/// format `--key=value` (or `--key` if you do not require a value)
+OBJC_EXPORT
+@interface BraveCoreSwitch : NSObject
+@property(readonly) BraveCoreSwitchKey key;
+@property(readonly, nullable) NSString* value;
+- (instancetype)initWithKey:(BraveCoreSwitchKey)key;
+- (instancetype)initWithKey:(BraveCoreSwitchKey)key
+                      value:(nullable NSString*)value NS_DESIGNATED_INITIALIZER;
+- (instancetype)init NS_UNAVAILABLE;
+@end
+
+NS_ASSUME_NONNULL_END
+
+#endif  // BRAVE_IOS_APP_BRAVE_CORE_SWITCHES_H_

--- a/ios/app/brave_core_switches.mm
+++ b/ios/app/brave_core_switches.mm
@@ -1,0 +1,49 @@
+/* Copyright (c) 2022 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "brave/ios/app/brave_core_switches.h"
+
+#include "base/base_switches.h"
+#include "base/strings/sys_string_conversions.h"
+#include "brave/components/p3a/brave_p3a_switches.h"
+#include "components/component_updater/component_updater_switches.h"
+#include "components/sync/base/command_line_switches.h"
+
+#if !defined(__has_feature) || !__has_feature(objc_arc)
+#error "This file requires ARC support."
+#endif
+
+const BraveCoreSwitchKey BraveCoreSwitchKeyComponentUpdater =
+    base::SysUTF8ToNSString(switches::kComponentUpdater);
+const BraveCoreSwitchKey BraveCoreSwitchKeyVModule =
+    base::SysUTF8ToNSString(switches::kVModule);
+const BraveCoreSwitchKey BraveCoreSwitchKeySyncURL =
+    base::SysUTF8ToNSString(syncer::kSyncServiceURL);
+// There is no exposed switch for rewards
+const BraveCoreSwitchKey BraveCoreSwitchKeyRewardsFlags = @"rewards";
+const BraveCoreSwitchKey BraveCoreSwitchKeyP3AUploadIntervalSeconds =
+    base::SysUTF8ToNSString(brave::switches::kP3AUploadIntervalSeconds);
+const BraveCoreSwitchKey BraveCoreSwitchKeyP3ADoNotRandomizeUploadInterval =
+    base::SysUTF8ToNSString(brave::switches::kP3ADoNotRandomizeUploadInterval);
+const BraveCoreSwitchKey BraveCoreSwitchKeyP3ATypicalRotationIntervalSeconds =
+    base::SysUTF8ToNSString(brave::switches::kP3ARotationIntervalSeconds);
+const BraveCoreSwitchKey BraveCoreSwitchKeyP3AUploadServerURL =
+    base::SysUTF8ToNSString(brave::switches::kP3AUploadServerUrl);
+const BraveCoreSwitchKey BraveCoreSwitchKeyP3AIgnoreServerErrors =
+    base::SysUTF8ToNSString(brave::switches::kP3AIgnoreServerErrors);
+
+@implementation BraveCoreSwitch
+- (instancetype)initWithKey:(BraveCoreSwitchKey)key {
+  return [self initWithKey:key value:nil];
+}
+- (instancetype)initWithKey:(BraveCoreSwitchKey)key
+                      value:(nullable NSString*)value {
+  if ((self = [super init])) {
+    _key = [key copy];
+    _value = [value copy];
+  }
+  return self;
+}
+@end

--- a/ios/browser/BUILD.gn
+++ b/ios/browser/BUILD.gn
@@ -27,6 +27,7 @@ source_set("browser") {
     "api/history",
     "api/net",
     "api/opentabs",
+    "api/p3a",
     "api/password",
     "api/sync",
     "api/url",

--- a/ios/browser/api/p3a/BUILD.gn
+++ b/ios/browser/api/p3a/BUILD.gn
@@ -1,0 +1,32 @@
+# Copyright (c) 2022 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at http://mozilla.org/MPL/2.0/.
+
+source_set("p3a") {
+  configs += [ "//build/config/compiler:enable_arc" ]
+  sources = [
+    "brave_histograms_controller+private.h",
+    "brave_histograms_controller.h",
+    "brave_histograms_controller.mm",
+    "brave_p3a_utils+private.h",
+    "brave_p3a_utils.h",
+    "brave_p3a_utils.mm",
+  ]
+  deps = [
+    "//base",
+    "//brave/components/p3a",
+    "//components/prefs",
+    "//ios/chrome/browser",
+    "//ios/chrome/browser/browser_state",
+    "//ios/components/webui:url_constants",
+    "//ios/web/public",
+    "//ios/web/public/webui",
+    "//ios/web/ui",
+    "//ios/web/web_state",
+    "//ios/web/web_state:web_state_impl_header",
+    "//net",
+    "//ui/base",
+    "//url",
+  ]
+}

--- a/ios/browser/api/p3a/brave_histograms_controller+private.h
+++ b/ios/browser/api/p3a/brave_histograms_controller+private.h
@@ -1,0 +1,21 @@
+/* Copyright (c) 2022 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_IOS_BROWSER_API_P3A_BRAVE_HISTOGRAMS_CONTROLLER_PRIVATE_H_
+#define BRAVE_IOS_BROWSER_API_P3A_BRAVE_HISTOGRAMS_CONTROLLER_PRIVATE_H_
+
+#include "brave/ios/browser/api/p3a/brave_histograms_controller.h"
+
+class ChromeBrowserState;
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface BraveHistogramsController (Private)
+- (instancetype)initWithBrowserState:(ChromeBrowserState*)mainBrowserState;
+@end
+
+NS_ASSUME_NONNULL_END
+
+#endif  // BRAVE_IOS_BROWSER_API_P3A_BRAVE_HISTOGRAMS_CONTROLLER_PRIVATE_H_

--- a/ios/browser/api/p3a/brave_histograms_controller.h
+++ b/ios/browser/api/p3a/brave_histograms_controller.h
@@ -1,0 +1,22 @@
+/* Copyright (c) 2022 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_IOS_BROWSER_API_P3A_BRAVE_HISTOGRAMS_CONTROLLER_H_
+#define BRAVE_IOS_BROWSER_API_P3A_BRAVE_HISTOGRAMS_CONTROLLER_H_
+
+#import <Foundation/Foundation.h>
+#import <UIKit/UIKit.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+/// Displays the `chrome://histograms` web page to verify P3A histograms
+OBJC_EXPORT
+@interface BraveHistogramsController : UIViewController
+- (instancetype)init NS_UNAVAILABLE;
+@end
+
+NS_ASSUME_NONNULL_END
+
+#endif  // BRAVE_IOS_BROWSER_API_P3A_BRAVE_HISTOGRAMS_CONTROLLER_H_

--- a/ios/browser/api/p3a/brave_histograms_controller.mm
+++ b/ios/browser/api/p3a/brave_histograms_controller.mm
@@ -1,0 +1,114 @@
+/* Copyright (c) 2022 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "brave/ios/browser/api/p3a/brave_histograms_controller.h"
+
+#include "base/strings/sys_string_conversions.h"
+#include "ios/chrome/browser/browser_state/chrome_browser_state.h"
+#include "ios/chrome/browser/chrome_url_constants.h"
+#include "ios/components/webui/web_ui_url_constants.h"
+#include "ios/web/public/browser_state.h"
+#include "ios/web/public/navigation/navigation_manager.h"
+#include "ios/web/public/web_state.h"
+#include "ios/web/public/web_state_delegate_bridge.h"
+#include "ios/web/public/web_state_observer_bridge.h"
+#include "ios/web/public/webui/web_ui_ios.h"
+#include "ios/web/web_state/ui/crw_web_controller.h"
+#include "ios/web/web_state/ui/wk_web_view_configuration_provider.h"
+#include "ios/web/web_state/web_state_impl.h"
+#include "ios/web/webui/web_ui_ios_impl.h"
+#include "net/base/mac/url_conversions.h"
+
+#if !defined(__has_feature) || !__has_feature(objc_arc)
+#error "This file requires ARC support."
+#endif
+
+@interface BraveHistogramsController () <CRWWebStateDelegate,
+                                         CRWWebStateObserver> {
+  std::unique_ptr<web::WebState> _webState;
+  std::unique_ptr<web::WebStateObserverBridge> _webStateObserver;
+  std::unique_ptr<web::WebStateDelegateBridge> _webStateDelegate;
+
+  WKWebView* _webView;
+  CRWWebController* _webController;
+}
+@end
+
+@implementation BraveHistogramsController
+
+- (instancetype)initWithBrowserState:(ChromeBrowserState*)mainBrowserState {
+  if ((self = [super init])) {
+    web::WebState::CreateParams webStateCreateParams(mainBrowserState);
+    _webState = web::WebState::Create(webStateCreateParams);
+
+    _webStateObserver = std::make_unique<web::WebStateObserverBridge>(self);
+    _webState->AddObserver(_webStateObserver.get());
+
+    _webStateDelegate = std::make_unique<web::WebStateDelegateBridge>(self);
+    _webState->SetDelegate(_webStateDelegate.get());
+
+    _webController =
+        static_cast<web::WebStateImpl*>(_webState.get())->GetWebController();
+    _webView = [_webController ensureWebViewCreated];
+  }
+  return self;
+}
+
+- (void)dealloc {
+  [[_webController view] removeFromSuperview];
+  _webController = nullptr;
+  _webView = nullptr;
+  _webState->RemoveObserver(_webStateObserver.get());
+  _webStateObserver.reset();
+  _webState.reset();
+}
+
+- (void)loadView {
+  self.view = [_webController view];
+}
+
+- (void)viewDidLoad {
+  [super viewDidLoad];
+
+  [self loadURL:[NSString stringWithFormat:@"%s://%s", kChromeUIScheme,
+                                           kChromeUIHistogramHost]];
+}
+
+- (void)loadURL:(NSString*)urlString {
+  GURL url = net::GURLWithNSURL([NSURL URLWithString:urlString]);
+  web::NavigationManager::WebLoadParams params(url);
+  params.transition_type = ui::PAGE_TRANSITION_TYPED;
+  _webState->GetNavigationManager()->LoadURLWithParams(params);
+}
+
+- (void)webState:(web::WebState*)webState
+    didStartNavigation:(web::NavigationContext*)navigation {
+}
+
+- (void)webState:(web::WebState*)webState
+    didFinishNavigation:(web::NavigationContext*)navigation {
+}
+
+- (void)webState:(web::WebState*)webState didLoadPageWithSuccess:(BOOL)success {
+  DCHECK_EQ(_webState.get(), webState);
+}
+
+// MARK: - WebStateDelegate implementation.
+
+- (void)webState:(web::WebState*)webView
+    contextMenuConfigurationForParams:(const web::ContextMenuParams&)params
+                    completionHandler:(void (^)(UIContextMenuConfiguration*))
+                                          completionHandler {
+  completionHandler(nil);
+}
+
+- (void)webStateDestroyed:(web::WebState*)webState {
+  // The WebState is owned by the current instance, and the observer bridge
+  // is unregistered before the WebState is destroyed, so this event should
+  // never happen.
+  NOTREACHED();
+}
+
+@end

--- a/ios/browser/api/p3a/brave_p3a_utils+private.h
+++ b/ios/browser/api/p3a/brave_p3a_utils+private.h
@@ -1,0 +1,23 @@
+/* Copyright (c) 2022 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_IOS_BROWSER_API_P3A_BRAVE_P3A_UTILS_PRIVATE_H_
+#define BRAVE_IOS_BROWSER_API_P3A_BRAVE_P3A_UTILS_PRIVATE_H_
+
+#include "brave/ios/browser/api/p3a/brave_p3a_utils.h"
+
+class ChromeBrowserState;
+class PrefService;
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface BraveP3AUtils (Private)
+- (instancetype)initWithBrowserState:(ChromeBrowserState*)mainBrowserState
+                          localState:(PrefService*)localState;
+@end
+
+NS_ASSUME_NONNULL_END
+
+#endif  // BRAVE_IOS_BROWSER_API_P3A_BRAVE_P3A_UTILS_PRIVATE_H_

--- a/ios/browser/api/p3a/brave_p3a_utils.h
+++ b/ios/browser/api/p3a/brave_p3a_utils.h
@@ -1,0 +1,27 @@
+/* Copyright (c) 2022 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_IOS_BROWSER_API_P3A_BRAVE_P3A_UTILS_H_
+#define BRAVE_IOS_BROWSER_API_P3A_BRAVE_P3A_UTILS_H_
+
+#import <Foundation/Foundation.h>
+
+@class BraveHistogramsController;
+
+typedef NSString* HistogramKeyName;
+
+NS_ASSUME_NONNULL_BEGIN
+
+OBJC_EXPORT
+@interface BraveP3AUtils : NSObject
+@property(nonatomic) bool isP3AEnabled;
+@property(nonatomic) bool isNoticeAcknowledged;
+- (BraveHistogramsController*)histogramsController;
+- (instancetype)init NS_UNAVAILABLE;
+@end
+
+NS_ASSUME_NONNULL_END
+
+#endif  // BRAVE_IOS_BROWSER_API_P3A_BRAVE_P3A_UTILS_H_

--- a/ios/browser/api/p3a/brave_p3a_utils.mm
+++ b/ios/browser/api/p3a/brave_p3a_utils.mm
@@ -1,0 +1,54 @@
+/* Copyright (c) 2022 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "brave/ios/browser/api/p3a/brave_p3a_utils.h"
+
+#include "base/metrics/histogram_functions.h"
+#include "base/metrics/histogram_macros.h"
+#include "base/strings/sys_string_conversions.h"
+#include "brave/components/p3a/pref_names.h"
+#include "brave/ios/browser/api/p3a/brave_histograms_controller+private.h"
+#include "components/prefs/pref_service.h"
+#include "ios/chrome/browser/browser_state/chrome_browser_state.h"
+
+#if !defined(__has_feature) || !__has_feature(objc_arc)
+#error "This file requires ARC support."
+#endif
+
+@implementation BraveP3AUtils {
+  ChromeBrowserState* _browserState;
+  PrefService* _localState;
+}
+
+- (instancetype)initWithBrowserState:(ChromeBrowserState*)mainBrowserState
+                          localState:(PrefService*)localState {
+  if ((self = [super init])) {
+    _browserState = mainBrowserState;
+    _localState = localState;
+  }
+  return self;
+}
+
+- (bool)isP3AEnabled {
+  return _localState->GetBoolean(brave::kP3AEnabled);
+}
+
+- (void)setIsP3AEnabled:(bool)isP3AEnabled {
+  _localState->SetBoolean(brave::kP3AEnabled, isP3AEnabled);
+}
+
+- (bool)isNoticeAcknowledged {
+  return _localState->GetBoolean(brave::kP3ANoticeAcknowledged);
+}
+
+- (void)setIsNoticeAcknowledged:(bool)isNoticeAcknowledged {
+  _localState->SetBoolean(brave::kP3ANoticeAcknowledged, isNoticeAcknowledged);
+}
+
+- (BraveHistogramsController*)histogramsController {
+  return [[BraveHistogramsController alloc] initWithBrowserState:_browserState];
+}
+
+@end

--- a/ios/browser/api/p3a/headers.gni
+++ b/ios/browser/api/p3a/headers.gni
@@ -1,0 +1,9 @@
+# Copyright (c) 2022 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at http://mozilla.org/MPL/2.0/.
+
+brave_p3a_public_headers = [
+  "//brave/ios/browser/api/p3a/brave_histograms_controller.h",
+  "//brave/ios/browser/api/p3a/brave_p3a_utils.h",
+]


### PR DESCRIPTION
Uplift of #15343

Had some merge conflicts getting it into 1.45.x so changes are slightly different than what landed in nightly

Pre-approval checklist: 
- [ ] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.