### PR TITLE
Brave News Source Suggestions

### DIFF
--- a/browser/ui/webui/brave_webui_source.cc
+++ b/browser/ui/webui/brave_webui_source.cc
@@ -212,7 +212,7 @@ void CustomizeWebUIHTMLSource(content::WebUI* web_ui,
         { "braveNewsDisabledPlaceholderEnableButton", IDS_BRAVE_NEWS_DISABLED_PLACEHOLDER_ENABLE_BUTTON },  // NOLINT
         { "braveNewsSearchPlaceholderLabel", IDS_BRAVE_NEWS_SEARCH_PLACEHOLDER_LABEL},  // NOLINT
         { "braveNewsChannelsHeader", IDS_BRAVE_NEWS_BROWSE_CHANNELS_HEADER},  // NOLINT
-        { "braveNewsLoadMoreCategoriesButton", IDS_BRAVE_NEWS_LOAD_MORE_CATEGORIES_BUTTON },  // NOLINT
+        { "braveNewsShowMoreButton", IDS_BRAVE_NEWS_SHOW_MORE_BUTTON},
         { "braveNewsAllSourcesHeader", IDS_BRAVE_NEWS_ALL_SOURCES_HEADER},
         { "braveNewsFeedsHeading", IDS_BRAVE_NEWS_FEEDS_HEADING},
         { "braveNewsFollowButtonFollowing", IDS_BRAVE_NEWS_FOLLOW_BUTTON_FOLLOWING},  // NOLINT
@@ -223,6 +223,8 @@ void CustomizeWebUIHTMLSource(content::WebUI* web_ui,
         { "braveNewsSearchResultsLocalResults", IDS_BRAVE_NEWS_SEARCH_RESULTS_LOCAL_RESULTS},  // NOLINT
         { "braveNewsSearchResultsDirectResults", IDS_BRAVE_NEWS_SEARCH_RESULTS_DIRECT_RESULTS},  // NOLINT
         { "braveNewsSearchQueryTooShort", IDS_BRAVE_NEWS_SEARCH_QUERY_TOO_SHORT},  // NOLINT
+        { "braveNewsSuggestionsTitle", IDS_BRAVE_NEWS_SUGGESTIONS_TITLE},
+        { "braveNewsSuggestionsSubtitle", IDS_BRAVE_NEWS_SUGGESTIONS_SUBTITLE},
 
         { "addWidget", IDS_BRAVE_NEW_TAB_WIDGET_ADD },
         { "hideWidget", IDS_BRAVE_NEW_TAB_WIDGET_HIDE },

--- a/components/brave_new_tab_ui/components/default/braveToday/customize/Context.tsx
+++ b/components/brave_new_tab_ui/components/default/braveToday/customize/Context.tsx
@@ -24,6 +24,8 @@ interface BraveNewsContext {
   filteredPublisherIds: string[]
   // Publishers the user is directly subscribed to
   subscribedPublisherIds: string[]
+  // Publishers to suggest to the user.
+  suggestedPublisherIds: string[]
 }
 
 export const BraveNewsContext = React.createContext<BraveNewsContext>({
@@ -33,13 +35,15 @@ export const BraveNewsContext = React.createContext<BraveNewsContext>({
   sortedPublishers: [],
   filteredPublisherIds: [],
   subscribedPublisherIds: [],
-  channels: {}
+  channels: {},
+  suggestedPublisherIds: []
 })
 
 export function BraveNewsContextProvider (props: { children: React.ReactNode }) {
   const [customizePage, setCustomizePage] = useState<NewsPage>(null)
   const [channels, setChannels] = useState<Channels>({})
   const [publishers, setPublishers] = useState<Publishers>({})
+  const [suggestedPublisherIds, setSuggestedPublisherIds] = useState<string[]>([])
 
   React.useEffect(() => {
     const handler = () => setChannels(api.getChannels())
@@ -47,6 +51,12 @@ export function BraveNewsContextProvider (props: { children: React.ReactNode }) 
 
     api.addChannelsListener(handler)
     return () => api.removeChannelsListener(handler)
+  }, [])
+
+  const updateSuggestedPublishers = useCallback(async () => {
+    setSuggestedPublisherIds([])
+    const { suggestedPublisherIds } = await api.controller.getSuggestedPublisherIds()
+    setSuggestedPublisherIds(suggestedPublisherIds)
   }, [])
 
   React.useEffect(() => {
@@ -72,11 +82,16 @@ export function BraveNewsContextProvider (props: { children: React.ReactNode }) 
     sortedPublishers.filter(isPublisherEnabled).map(p => p.publisherId),
     [sortedPublishers])
 
-  const context = useMemo(() => ({
+  React.useEffect(() => {
+    updateSuggestedPublishers()
+  }, [])
+
+  const context = useMemo<BraveNewsContext>(() => ({
     customizePage,
     setCustomizePage,
     channels,
     publishers,
+    suggestedPublisherIds,
     sortedPublishers,
     filteredPublisherIds,
     subscribedPublisherIds

--- a/components/brave_new_tab_ui/components/default/braveToday/customize/Discover.tsx
+++ b/components/brave_new_tab_ui/components/default/braveToday/customize/Discover.tsx
@@ -15,6 +15,7 @@ import ChannelCard from './ChannelCard'
 import DiscoverSection from './DiscoverSection'
 import FeedCard, { DirectFeedCard } from './FeedCard'
 import useSearch from './useSearch'
+import Suggestions from './Suggestions'
 
 const Header = styled.span`
   font-size: 24px;
@@ -68,6 +69,7 @@ function Home () {
 
   return (
     <>
+      <Suggestions/>
       <DiscoverSection name={getLocale('braveNewsChannelsHeader')}>
       {visibleChannelIds.map(channelId =>
         <ChannelCard key={channelId} channelName={channelId} />

--- a/components/brave_new_tab_ui/components/default/braveToday/customize/Discover.tsx
+++ b/components/brave_new_tab_ui/components/default/braveToday/customize/Discover.tsx
@@ -76,7 +76,7 @@ function Home () {
       )}
       {!showingAllCategories && <LoadMoreButtonContainer>
         <Button onClick={() => setShowingAllCategories(true)}>
-            {getLocale('braveNewsLoadMoreCategoriesButton')}
+            {getLocale('braveNewsShowMoreButton')}
         </Button>
       </LoadMoreButtonContainer>}
       </DiscoverSection>

--- a/components/brave_new_tab_ui/components/default/braveToday/customize/Suggestions.tsx
+++ b/components/brave_new_tab_ui/components/default/braveToday/customize/Suggestions.tsx
@@ -27,16 +27,23 @@ export default function Suggestions () {
   const filteredSuggestions = React.useMemo(() => suggestedPublisherIds
     .slice(0, showAll ? undefined : DEFAULT_SUGGESTIONS_COUNT), [suggestedPublisherIds, showAll])
 
-  return filteredSuggestions.length
-    ? <DiscoverSection name={getLocale('braveNewsSuggestionsTitle')} subtitle={<>
+  if (!filteredSuggestions.length) {
+    return null
+  }
+
+  return (
+    <DiscoverSection name={getLocale('braveNewsSuggestionsTitle')} subtitle={
       <Subtitle>{getLocale('braveNewsSuggestionsSubtitle')}</Subtitle>
-    </>}>
-      {filteredSuggestions.map(s => <FeedCard key={s} publisherId={s} />)}
-      {!showAll && suggestedPublisherIds.length > DEFAULT_SUGGESTIONS_COUNT && <LoadMoreButtonContainer>
+    }>
+      {filteredSuggestions.map(s =>
+        <FeedCard key={s} publisherId={s} />)
+      }
+      {!showAll && suggestedPublisherIds.length > DEFAULT_SUGGESTIONS_COUNT &&
+      <LoadMoreButtonContainer>
         <Button onClick={() => setShowAll(true)}>
           {getLocale('braveNewsShowMoreButton')}
         </Button>
       </LoadMoreButtonContainer>}
     </DiscoverSection>
-    : null
+  )
 }

--- a/components/brave_new_tab_ui/components/default/braveToday/customize/Suggestions.tsx
+++ b/components/brave_new_tab_ui/components/default/braveToday/customize/Suggestions.tsx
@@ -13,6 +13,12 @@ const LoadMoreButtonContainer = styled.div`
   grid-column: 2;
 `
 
+const Subtitle = styled.span`
+  font-weight: 400;
+  font-size: 12px;
+  color: var(--text2);
+`
+
 const DEFAULT_SUGGESTIONS_COUNT = 3
 
 export default function Suggestions () {
@@ -22,11 +28,13 @@ export default function Suggestions () {
     .slice(0, showAll ? undefined : DEFAULT_SUGGESTIONS_COUNT), [suggestedPublisherIds, showAll])
 
   return filteredSuggestions.length
-    ? <DiscoverSection name='Suggestions'>
+    ? <DiscoverSection name={getLocale('braveNewsSuggestionsTitle')} subtitle={<>
+      <Subtitle>{getLocale('braveNewsSuggestionsSubtitle')}</Subtitle>
+    </>}>
       {filteredSuggestions.map(s => <FeedCard key={s} publisherId={s} />)}
       {!showAll && suggestedPublisherIds.length > DEFAULT_SUGGESTIONS_COUNT && <LoadMoreButtonContainer>
         <Button onClick={() => setShowAll(true)}>
-          {getLocale('braveNewsLoadMoreCategoriesButton')}
+          {getLocale('braveNewsShowMoreButton')}
         </Button>
       </LoadMoreButtonContainer>}
     </DiscoverSection>

--- a/components/brave_new_tab_ui/components/default/braveToday/customize/Suggestions.tsx
+++ b/components/brave_new_tab_ui/components/default/braveToday/customize/Suggestions.tsx
@@ -1,0 +1,34 @@
+import * as React from 'react'
+import styled from 'styled-components'
+import Button from '$web-components/button'
+import { useBraveNews } from './Context'
+import DiscoverSection from './DiscoverSection'
+import FeedCard from './FeedCard'
+import { getLocale } from '$web-common/locale'
+
+const LoadMoreButtonContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+  grid-column: 2;
+`
+
+const DEFAULT_SUGGESTIONS_COUNT = 3
+
+export default function Suggestions () {
+  const { suggestedPublisherIds } = useBraveNews()
+  const [showAll, setShowAll] = React.useState(false)
+  const filteredSuggestions = React.useMemo(() => suggestedPublisherIds
+    .slice(0, showAll ? undefined : DEFAULT_SUGGESTIONS_COUNT), [suggestedPublisherIds, showAll])
+
+  return filteredSuggestions.length
+    ? <DiscoverSection name='Suggestions'>
+      {filteredSuggestions.map(s => <FeedCard key={s} publisherId={s} />)}
+      {!showAll && suggestedPublisherIds.length > DEFAULT_SUGGESTIONS_COUNT && <LoadMoreButtonContainer>
+        <Button onClick={() => setShowAll(true)}>
+          {getLocale('braveNewsLoadMoreCategoriesButton')}
+        </Button>
+      </LoadMoreButtonContainer>}
+    </DiscoverSection>
+    : null
+}

--- a/components/brave_today/browser/BUILD.gn
+++ b/components/brave_today/browser/BUILD.gn
@@ -27,6 +27,8 @@ static_library("browser") {
     "publishers_controller.h",
     "publishers_parsing.cc",
     "publishers_parsing.h",
+    "suggestions_controller.cc",
+    "suggestions_controller.h",
     "unsupported_publisher_migrator.cc",
     "unsupported_publisher_migrator.h",
     "urls.cc",

--- a/components/brave_today/browser/brave_news_controller.cc
+++ b/components/brave_today/browser/brave_news_controller.cc
@@ -175,13 +175,7 @@ void BraveNewsController::GetPublishers(GetPublishersCallback callback) {
 
 void BraveNewsController::GetSuggestedPublisherIds(
     GetSuggestedPublisherIdsCallback callback) {
-  publishers_controller_.GetLocale(base::BindOnce(
-      [](BraveNewsController* controller,
-         GetSuggestedPublisherIdsCallback callback, const std::string& locale) {
-        controller->suggestions_controller_.GetSuggestedPublisherIds(
-            locale, std::move(callback));
-      },
-      base::Unretained(this), std::move(callback)));
+  suggestions_controller_.GetSuggestedPublisherIds(std::move(callback));
 }
 
 void BraveNewsController::FindFeeds(const GURL& possible_feed_or_site_url,

--- a/components/brave_today/browser/brave_news_controller.cc
+++ b/components/brave_today/browser/brave_news_controller.cc
@@ -28,6 +28,7 @@
 #include "brave/components/brave_today/browser/channels_controller.h"
 #include "brave/components/brave_today/browser/direct_feed_controller.h"
 #include "brave/components/brave_today/browser/network.h"
+#include "brave/components/brave_today/browser/suggestions_controller.h"
 #include "brave/components/brave_today/browser/unsupported_publisher_migrator.h"
 #include "brave/components/brave_today/browser/urls.h"
 #include "brave/components/brave_today/common/brave_news.mojom-forward.h"
@@ -99,6 +100,11 @@ BraveNewsController::BraveNewsController(
                        history_service,
                        &api_request_helper_,
                        prefs_),
+      suggestions_controller_(prefs_,
+                              &channels_controller_,
+                              &publishers_controller_,
+                              &api_request_helper_,
+                              history_service),
       weak_ptr_factory_(this) {
   DCHECK(prefs_);
   // Set up preference listeners
@@ -165,6 +171,17 @@ void BraveNewsController::GetFeed(GetFeedCallback callback) {
 
 void BraveNewsController::GetPublishers(GetPublishersCallback callback) {
   publishers_controller_.GetOrFetchPublishers(std::move(callback));
+}
+
+void BraveNewsController::GetSuggestedPublisherIds(
+    GetSuggestedPublisherIdsCallback callback) {
+  publishers_controller_.GetLocale(base::BindOnce(
+      [](BraveNewsController* controller,
+         GetSuggestedPublisherIdsCallback callback, const std::string& locale) {
+        controller->suggestions_controller_.GetSuggestedPublisherIds(
+            locale, std::move(callback));
+      },
+      base::Unretained(this), std::move(callback)));
 }
 
 void BraveNewsController::FindFeeds(const GURL& possible_feed_or_site_url,

--- a/components/brave_today/browser/brave_news_controller.h
+++ b/components/brave_today/browser/brave_news_controller.h
@@ -19,6 +19,7 @@
 #include "brave/components/brave_today/browser/direct_feed_controller.h"
 #include "brave/components/brave_today/browser/feed_controller.h"
 #include "brave/components/brave_today/browser/publishers_controller.h"
+#include "brave/components/brave_today/browser/suggestions_controller.h"
 #include "brave/components/brave_today/browser/unsupported_publisher_migrator.h"
 #include "brave/components/brave_today/common/brave_news.mojom-forward.h"
 #include "brave/components/brave_today/common/brave_news.mojom.h"
@@ -76,6 +77,8 @@ class BraveNewsController : public KeyedService,
   void GetLocale(GetLocaleCallback callback) override;
   void GetFeed(GetFeedCallback callback) override;
   void GetPublishers(GetPublishersCallback callback) override;
+  void GetSuggestedPublisherIds(
+      GetSuggestedPublisherIdsCallback callback) override;
   void FindFeeds(const GURL& possible_feed_or_site_url,
                  FindFeedsCallback callback) override;
   void GetChannels(GetChannelsCallback callback) override;
@@ -127,6 +130,7 @@ class BraveNewsController : public KeyedService,
   PublishersController publishers_controller_;
   ChannelsController channels_controller_;
   FeedController feed_controller_;
+  SuggestionsController suggestions_controller_;
 
   PrefChangeRegistrar pref_change_registrar_;
   base::OneShotTimer timer_prefetch_;

--- a/components/brave_today/browser/suggestions_controller.cc
+++ b/components/brave_today/browser/suggestions_controller.cc
@@ -165,6 +165,17 @@ void SuggestionsController::GetSuggestedPublisherIds(
                         controller->channels_controller_
                             ->GetChannelsFromPublishers(locale, publishers,
                                                         controller->prefs_);
+                    // For each source
+                    //   score[source] += !subscribed ? [0.4 - 1] * normalized_visits[host]
+                    //   if !subscribed: continue
+                    //   for each similar_source which is not subscribed
+                    //     score[similar_source] += [0 - 0.4] * similarity[source][similar_source]
+                    // 
+                    // For each visited page
+                    //   if not has_source: continue
+                    //   
+                    //   for each similar_source of similar_sources[source]:
+                    //      score[similar_source] += [0 - 0.3] * similarity[source][similar_source]    
                     if (!similarity_lookup.contains(locale)) {
                       std::move(callback).Run({});
                       return;

--- a/components/brave_today/browser/suggestions_controller.cc
+++ b/components/brave_today/browser/suggestions_controller.cc
@@ -1,0 +1,287 @@
+// Copyright (c) 2022 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// you can obtain one at http://mozilla.org/MPL/2.0/.
+
+#include "brave/components/brave_today/browser/suggestions_controller.h"
+
+#include <algorithm>
+#include <unordered_set>
+#include <utility>
+
+#include "base/barrier_callback.h"
+#include "base/bind.h"
+#include "base/callback_forward.h"
+#include "base/containers/flat_map.h"
+#include "base/containers/flat_set.h"
+#include "base/json/json_reader.h"
+#include "base/logging.h"
+#include "base/one_shot_event.h"
+#include "base/strings/string_util.h"
+#include "base/values.h"
+#include "brave/components/api_request_helper/api_request_helper.h"
+#include "brave/components/brave_today/browser/channels_controller.h"
+#include "brave/components/brave_today/browser/locales_helper.h"
+#include "brave/components/brave_today/browser/publishers_controller.h"
+#include "brave/components/brave_today/browser/urls.h"
+#include "components/history/core/browser/history_service.h"
+#include "components/history/core/browser/history_types.h"
+
+namespace brave_news {
+namespace {
+using GetSuggestedPublisherIdsCallback =
+    mojom::BraveNewsController::GetSuggestedPublisherIdsCallback;
+double GetEnabledScore(const mojom::PublisherPtr& publisher,
+                       const Channels& channels) {
+  if (publisher->user_enabled_status == mojom::UserEnabled::ENABLED)
+    return 1;
+
+  if (publisher->user_enabled_status == mojom::UserEnabled::NOT_MODIFIED) {
+    // TODO(fallaciousreasoning): Confirm how we should handle subscribed
+    // channels.
+    // TODO(fallaciousreasoning): How do we handle locales here? I could be
+    // subscribed to en_US Top Sources but that shouldn't affect es_MX Top
+    // sources?
+  }
+
+  return 0;
+}
+
+base::flat_map<std::string, double> GetVisitWeightings(
+    const Publishers& publishers,
+    const history::QueryResults& history) {
+  base::flat_set<std::string> publisher_hosts;
+  for (const auto& [_, publisher] : publishers) {
+    publisher_hosts.insert(publisher->site_url.host());
+  }
+
+  base::flat_map<std::string, double> weightings;
+  for (const auto& entry : history)
+    weightings[entry.url().host()] += 1;
+
+  if (!weightings.size())
+    return weightings;
+
+  auto max_visits =
+      base::ranges::max(weightings, [](const auto& a, const auto& b) {
+        return a.second < b.second;
+      }).second;
+
+  // Normalize the visit counts by dividing by the maximum number of visits.
+  for (auto& it : weightings) {
+    it.second /= max_visits;
+  }
+  return weightings;
+}
+
+// Visit weighting should be from 0.4 - 1.0, so we don't completely unweight
+// unvisited sources.
+double GetVisitWeighting(const mojom::PublisherPtr& publisher,
+                         base::flat_map<std::string, double> visit_weightings) {
+  constexpr double kMax = 1;
+  constexpr double kMin = 0.4;
+  constexpr double kRange = kMax - kMin;
+
+  const auto host_name = publisher->site_url.host();
+  const auto& it = visit_weightings.find(host_name);
+  if (it == visit_weightings.end()) {
+    return kMin;
+  }
+
+  return it->second * kRange + kMin;
+}
+
+SuggestionsController::SimilarityLookup ParseSimilarityResponse(
+    const std::string& json,
+    const std::string& locale) {
+  SuggestionsController::SimilarityLookup result;
+  absl::optional<base::Value> records_v =
+      base::JSONReader::Read(json, base::JSON_PARSE_CHROMIUM_EXTENSIONS |
+                                       base::JSONParserOptions::JSON_PARSE_RFC);
+  if (!records_v) {
+    LOG(ERROR) << "Invalid response, could not parse JSON, JSON is: " << json;
+    return result;
+  }
+
+  if (!records_v->is_dict()) {
+    return result;
+  }
+
+  SuggestionsController::PublisherSimilarities similarities;
+
+  for (const auto it : records_v->GetDict()) {
+    const auto& for_publisher = it.first;
+    const auto& similarity_list = it.second.GetList();
+    for (const auto& similarity : similarity_list) {
+      const auto& dict = similarity.GetDict();
+      similarities[for_publisher].push_back(
+          {.publisher_id = *dict.FindString("source"),
+           .score = dict.FindDouble("score").value()});
+    }
+  }
+
+  result[locale] = std::move(similarities);
+  return result;
+}
+
+}  // namespace
+SuggestionsController::SuggestionsController(
+    PrefService* prefs,
+    ChannelsController* channels_controller,
+    PublishersController* publishers_controller,
+    api_request_helper::APIRequestHelper* api_request_helper,
+    history::HistoryService* history_service)
+    : prefs_(prefs),
+      channels_controller_(channels_controller),
+      publishers_controller_(publishers_controller),
+      api_request_helper_(api_request_helper),
+      history_service_(history_service),
+      on_current_update_complete_(new base::OneShotEvent()) {}
+SuggestionsController::~SuggestionsController() = default;
+
+void SuggestionsController::GetSuggestedPublisherIds(
+    const std::string& locale,
+    GetSuggestedPublisherIdsCallback callback) {
+  // TODO(fallaciousreasoning): I have a feeling that this will work better if
+  // we can squash the similarity matrices from all the sources the user is
+  // subscribed to into a single dictionary. That way, we can give them
+  // suggestions from multiple locales at once, and consumers of this API won't
+  // need to pass in a locale.
+  GetOrFetchSimilarityMatrix(base::BindOnce(
+      [](SuggestionsController* controller, std::string locale,
+         GetSuggestedPublisherIdsCallback callback) {
+        controller->publishers_controller_->GetOrFetchPublishers(base::BindOnce(
+            [](SuggestionsController* controller, std::string locale,
+               GetSuggestedPublisherIdsCallback callback,
+               Publishers publishers) {
+              auto onHistory = base::BindOnce(
+                  [](SuggestionsController* controller, std::string locale,
+                     Publishers publishers,
+                     GetSuggestedPublisherIdsCallback callback,
+                     history::QueryResults results) {
+                    const auto& similarity_lookup =
+                        controller->similarity_lookup_;
+                    const auto& channels =
+                        controller->channels_controller_
+                            ->GetChannelsFromPublishers(locale, publishers,
+                                                        controller->prefs_);
+                    if (!similarity_lookup.contains(locale)) {
+                      std::move(callback).Run({});
+                      return;
+                    }
+
+                    auto visit_weightings =
+                        GetVisitWeightings(publishers, results);
+                    base::flat_map<std::string, double> scores;
+
+                    const auto& lookup = similarity_lookup.at(locale);
+                    for (const auto& [publisher_id, publisher] : publishers) {
+                      const auto& similarity_info_it =
+                          lookup.find(publisher_id);
+                      if (similarity_info_it == lookup.end())
+                        continue;
+
+                      auto enabled_score = GetEnabledScore(publisher, channels);
+                      auto visit_weighting =
+                          GetVisitWeighting(publisher, visit_weightings);
+                      for (const auto& info : similarity_info_it->second) {
+                        const auto score =
+                            (1 - GetEnabledScore(publishers[info.publisher_id],
+                                                 channels)) *
+                            enabled_score * visit_weighting * info.score;
+                        scores[info.publisher_id] += score;
+                      }
+                    }
+
+                    std::vector<std::string> result;
+                    for (const auto& [publisher_id, score] : scores) {
+                      // Either the source it was similar to was disabled, or
+                      // the source is already enabled.
+                      if (score == 0)
+                        continue;
+                      result.push_back(publisher_id);
+                    }
+
+                    std::sort(result.begin(), result.end(),
+                              [scores](const std::string& a_id,
+                                       const std::string& b_id) {
+                                return scores.at(a_id) > scores.at(b_id);
+                              });
+
+                    std::move(callback).Run(std::move(result));
+                  },
+                  base::Unretained(controller), std::move(locale),
+                  std::move(publishers), std::move(callback));
+
+              history::QueryOptions options;
+              options.max_count = 2000;
+              options.SetRecentDayRange(14);
+              controller->history_service_->QueryHistory(
+                  std::u16string(), options, std::move(onHistory),
+                  &controller->task_tracker_);
+            },
+            base::Unretained(controller), locale, std::move(callback)));
+      },
+      base::Unretained(this), locale, std::move(callback)));
+}
+
+void SuggestionsController::EnsureSimilarityMatrixIsUpdating() {
+  if (is_update_in_progress_) {
+    return;
+  }
+  is_update_in_progress_ = true;
+
+  publishers_controller_->GetOrFetchPublishers(base::BindOnce(
+      [](SuggestionsController* controller, Publishers publishers) {
+        auto locales = GetMinimalLocalesSet(
+            controller->channels_controller_->GetChannelLocales(), publishers);
+        auto completed_callback = base::BarrierCallback<SimilarityLookup>(
+            locales.size(),
+            base::BindOnce(
+                [](SuggestionsController* controller,
+                   std::vector<SimilarityLookup> similarity_matrices) {
+                  SimilarityLookup flattened;
+                  for (const auto& locale_lookup : similarity_matrices) {
+                    for (const auto& [key, value] : locale_lookup) {
+                      flattened[std::move(key)] = std::move(value);
+                    }
+                  }
+
+                  controller->similarity_lookup_ = std::move(flattened);
+                  controller->on_current_update_complete_->Signal();
+                  controller->is_update_in_progress_ = false;
+                  controller->on_current_update_complete_ =
+                      std::make_unique<base::OneShotEvent>();
+                },
+                base::Unretained(controller)));
+
+        for (const auto& locale : locales) {
+          const GURL url("https://" + brave_today::GetHostname() +
+                         "/source-suggestions/source_similarity_t10." + locale +
+                         ".json");
+          controller->api_request_helper_->Request(
+              "GET", url, "", "", true,
+              base::BindOnce(
+                  [](SuggestionsController* controller, std::string locale,
+                     base::RepeatingCallback<void(SimilarityLookup)> callback,
+                     api_request_helper::APIRequestResult api_request_result) {
+                    callback.Run(ParseSimilarityResponse(
+                        api_request_result.body(), locale));
+                  },
+                  base::Unretained(controller), locale, completed_callback));
+        }
+      },
+      base::Unretained(this)));
+}
+
+void SuggestionsController::GetOrFetchSimilarityMatrix(
+    base::OnceClosure callback) {
+  if (!similarity_lookup_.empty() && !is_update_in_progress_) {
+    std::move(callback).Run();
+    return;
+  }
+
+  on_current_update_complete_->Post(FROM_HERE, std::move(callback));
+  EnsureSimilarityMatrixIsUpdating();
+}
+}  // namespace brave_news

--- a/components/brave_today/browser/suggestions_controller.cc
+++ b/components/brave_today/browser/suggestions_controller.cc
@@ -208,11 +208,10 @@ void SuggestionsController::GetSuggestedPublisherIdsWithHistory(
 
     for (const auto& info : similarity_info_it->second) {
       const auto& similar_publisher = publishers.at(info.publisher_id);
-      // Don't suggest similar publishers which are already enabled.
-      // TODO(fallaciousreasoning): Maybe we shouldn't suggest explicitly
-      // disabled publishers either?
-      if (similar_publisher->user_enabled_status ==
-          mojom::UserEnabled::ENABLED) {
+      // Don't suggest similar publishers which are already enabled,
+      // or which are explicitly disabled.
+      if (similar_publisher->user_enabled_status !=
+          mojom::UserEnabled::NOT_MODIFIED) {
         continue;
       }
 

--- a/components/brave_today/browser/suggestions_controller.cc
+++ b/components/brave_today/browser/suggestions_controller.cc
@@ -82,6 +82,7 @@ double GetVisitWeighting(const mojom::PublisherPtr& publisher,
     // The |site_urls| we receive from Brave News aren't terribly accurate, and
     // many of them are missing bits and pieces. This is a simple middle ground
     // while we wait for them to be fixed.
+    // Relevant issue: https://github.com/brave/news-aggregator/issues/58
     if (!base::StartsWith(host_name, "www.")) {
       it = visit_weightings.find("www." + host_name);
     }

--- a/components/brave_today/browser/suggestions_controller.h
+++ b/components/brave_today/browser/suggestions_controller.h
@@ -34,7 +34,6 @@ class SuggestionsController {
 
   using PublisherSimilarities =
       base::flat_map<std::string, std::vector<PublisherSimilarity>>;
-  using SimilarityLookup = base::flat_map<std::string, PublisherSimilarities>;
 
   explicit SuggestionsController(
       PrefService* prefs,
@@ -46,16 +45,15 @@ class SuggestionsController {
   SuggestionsController& operator=(const SuggestionsController&) = delete;
   ~SuggestionsController();
 
-  void GetSuggestedPublisherIds(const std::string& locale,
-                                GetSuggestedPublisherIdsCallback callback);
+  void GetSuggestedPublisherIds(GetSuggestedPublisherIdsCallback callback);
   void EnsureSimilarityMatrixIsUpdating();
 
  private:
   void GetOrFetchSimilarityMatrix(base::OnceClosure callback);
-  void GetSuggestedPublisherIdsWithHistory(const std::string& locale,
-                                Publishers publishers,
-                                GetSuggestedPublisherIdsCallback callback,
-                                history::QueryResults history);
+  void GetSuggestedPublisherIdsWithHistory(
+      Publishers publishers,
+      GetSuggestedPublisherIdsCallback callback,
+      history::QueryResults history);
 
   bool is_update_in_progress_ = false;
   raw_ptr<PrefService> prefs_;
@@ -68,7 +66,8 @@ class SuggestionsController {
   raw_ptr<history::HistoryService> history_service_;
   std::unique_ptr<base::OneShotEvent> on_current_update_complete_;
 
-  SimilarityLookup similarity_lookup_;
+  std::string locale_;
+  PublisherSimilarities similarities_;
 };
 }  // namespace brave_news
 

--- a/components/brave_today/browser/suggestions_controller.h
+++ b/components/brave_today/browser/suggestions_controller.h
@@ -20,8 +20,11 @@
 #include "brave/components/brave_today/browser/channels_controller.h"
 #include "brave/components/brave_today/browser/publishers_controller.h"
 #include "components/history/core/browser/history_service.h"
+#include "components/history/core/browser/history_types.h"
 
 namespace brave_news {
+using GetSuggestedPublisherIdsCallback =
+    mojom::BraveNewsController::GetSuggestedPublisherIdsCallback;
 class SuggestionsController {
  public:
   struct PublisherSimilarity {
@@ -32,6 +35,7 @@ class SuggestionsController {
   using PublisherSimilarities =
       base::flat_map<std::string, std::vector<PublisherSimilarity>>;
   using SimilarityLookup = base::flat_map<std::string, PublisherSimilarities>;
+
   explicit SuggestionsController(
       PrefService* prefs,
       ChannelsController* channels_controller,
@@ -42,13 +46,16 @@ class SuggestionsController {
   SuggestionsController& operator=(const SuggestionsController&) = delete;
   ~SuggestionsController();
 
-  void GetSuggestedPublisherIds(
-      const std::string& locale,
-      mojom::BraveNewsController::GetSuggestedPublisherIdsCallback callback);
+  void GetSuggestedPublisherIds(const std::string& locale,
+                                GetSuggestedPublisherIdsCallback callback);
   void EnsureSimilarityMatrixIsUpdating();
 
  private:
   void GetOrFetchSimilarityMatrix(base::OnceClosure callback);
+  void GetSuggestedPublisherIdsWithHistory(const std::string& locale,
+                                Publishers publishers,
+                                GetSuggestedPublisherIdsCallback callback,
+                                history::QueryResults history);
 
   bool is_update_in_progress_ = false;
   raw_ptr<PrefService> prefs_;

--- a/components/brave_today/common/brave_news.mojom
+++ b/components/brave_today/common/brave_news.mojom
@@ -149,6 +149,7 @@ interface BraveNewsController {
 
   GetFeed() => (Feed feed);
   GetPublishers() => (map<string, Publisher> publishers);
+  GetSuggestedPublisherIds() => (array<string> suggested_publisher_ids);
   GetChannels() => (map<string, Channel> channels);
   SetChannelSubscribed(string channel_id, bool subscribed) => (Channel updated);
   // Look at the incoming url and return results

--- a/components/resources/brave_components_strings.grd
+++ b/components/resources/brave_components_strings.grd
@@ -369,7 +369,7 @@
       <message name="IDS_BRAVE_NEWS_BROWSE_CHANNELS_HEADER" desc="Header for the channel section">
         Channels
       </message>
-      <message name="IDS_BRAVE_NEWS_LOAD_MORE_CATEGORIES_BUTTON" desc="Label for the button to show more categories">
+      <message name="IDS_BRAVE_NEWS_SHOW_MORE_BUTTON" desc="Label for the button to show more items from a limited selection. For example, this might show more categories, or more suggested publishers">
         Show more
       </message>
       <message name="IDS_BRAVE_NEWS_ALL_SOURCES_HEADER" desc="Header for the all sources section">
@@ -407,6 +407,12 @@
       </message>
       <message name="IDS_BRAVE_NEWS_SEARCH_QUERY_TOO_SHORT" desc="Message displayed when there are no results due to search query being too short">
         Keep typing to search sources
+      </message>
+      <message name="IDS_BRAVE_NEWS_SUGGESTIONS_TITLE" desc="Title of the suggested sources section">
+        Suggestions
+      </message>
+      <message name="IDS_BRAVE_NEWS_SUGGESTIONS_SUBTITLE" desc="Subtitle of the suggested sources section">
+        Some sources you might like. Suggestions are anonymous and matched only on your device.
       </message>
 
       <message name="IDS_BRAVE_NEW_TAB_STATS_TAB" desc="Brave Stats title">Brave Stats</message>


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/25563

## Limitations
This PR isn't a complete implementation of suggestions, but I think it's a good first pass, and provides sensible suggestions. I'm documenting a few of the limitations here:
- Suggestions are based only on:
    a) Whether a source has been visited
    b) How similar a source is to subscribed sources.
    c) How similar a source is to visited sources.
- Only the users current locale is used for suggestions. In future we should be able to incrementally improve this.

## Submitter Checklist:

- [ ] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

1. Enable the brave://flags/#brave-news-v2 flag
2. Subscribe to the `The Drive` publisher
3. Reload the new tab page
4. In the Brave News dialog there should be a suggestions row. It should include (if the similarity matrix hasn't been changed), `PopularMechanics`, `Forbes`, `Car and Driver`. Suggestions may (or may not) be slightly different