### PR TITLE
fix(wallet): Wallet Tooltip Size Regression (uplift to 1.45.x)

### DIFF
--- a/components/brave_wallet_ui/components/shared/tooltip/style.ts
+++ b/components/brave_wallet_ui/components/shared/tooltip/style.ts
@@ -53,6 +53,7 @@ export const Tip = styled.div<{ isAddress?: boolean, maxWidth?: CSSProperties['m
   
   width: ${(p) => p.isAddress ? '180px' : 'unset'};
   max-width: ${(p) => p?.maxWidth || '100%'};
+  min-width: fit-content;
   
   word-wrap: break-word;
   white-space: ${(p) => p.isAddress || p?.maxWidth ? 'pre-line' : 'nowrap'};


### PR DESCRIPTION
Uplift of #15144
Resolves <https://github.com/brave/brave-browser/issues/25975>

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.