### PR TITLE
Support overlay mode for vertical tab strip

### DIFF
--- a/browser/ui/BUILD.gn
+++ b/browser/ui/BUILD.gn
@@ -546,6 +546,8 @@ source_set("ui") {
       "views/brave_actions/brave_shields_action_view.h",
       "views/frame/vertical_tab_strip_region_view.cc",
       "views/frame/vertical_tab_strip_region_view.h",
+      "views/frame/vertical_tab_strip_widget_delegate_view.cc",
+      "views/frame/vertical_tab_strip_widget_delegate_view.h",
       "views/location_bar/brave_location_bar_view.cc",
       "views/location_bar/brave_location_bar_view.h",
       "views/location_bar/brave_star_view.cc",

--- a/browser/ui/sidebar/sidebar_browsertest.cc
+++ b/browser/ui/sidebar/sidebar_browsertest.cc
@@ -62,7 +62,7 @@ class SidebarBrowserTest : public InProcessBrowserTest {
 
   views::View* GetVerticalTabsContainer() const {
     auto* view = BrowserView::GetBrowserViewForBrowser(browser());
-    return static_cast<BraveBrowserView*>(view)->vertical_tabs_container_;
+    return static_cast<BraveBrowserView*>(view)->vertical_tab_strip_host_view_;
   }
 
   void SimulateSidebarItemClickAt(int index) const {

--- a/browser/ui/views/frame/brave_browser_view.cc
+++ b/browser/ui/views/frame/brave_browser_view.cc
@@ -18,6 +18,7 @@
 #include "brave/browser/ui/views/brave_shields/cookie_list_opt_in_bubble_host.h"
 #include "brave/browser/ui/views/frame/brave_contents_layout_manager.h"
 #include "brave/browser/ui/views/frame/vertical_tab_strip_region_view.h"
+#include "brave/browser/ui/views/frame/vertical_tab_strip_widget_delegate_view.h"
 #include "brave/browser/ui/views/location_bar/brave_location_bar_view.h"
 #include "brave/browser/ui/views/sidebar/sidebar_container_view.h"
 #include "brave/browser/ui/views/tabs/features.h"
@@ -190,15 +191,14 @@ BraveBrowserView::BraveBrowserView(std::unique_ptr<Browser> browser)
           std::move(original_side_panel)));
   unified_side_panel_ = sidebar_container_view_->side_panel();
   if (show_vertical_tabs) {
-    vertical_tabs_container_ = contents_container_->AddChildView(
-        std::make_unique<VerticalTabStripRegionView>(browser_.get(),
-                                                     tab_strip_region_view_));
+    vertical_tab_strip_host_view_ =
+        contents_container_->AddChildView(std::make_unique<views::View>());
   }
 
   contents_container_->SetLayoutManager(
       std::make_unique<BraveContentsLayoutManager>(
           devtools_web_view_, contents_web_view_, sidebar_container_view_,
-          vertical_tabs_container_));
+          vertical_tab_strip_host_view_));
   sidebar_host_view_ = AddChildView(std::make_unique<views::View>());
 
   // Make sure |find_bar_host_view_| is the last child of BrowserView by
@@ -417,6 +417,15 @@ void BraveBrowserView::CreateApproveWalletBubble() {
 void BraveBrowserView::CloseWalletBubble() {
   if (GetWalletButton())
     GetWalletButton()->CloseWalletBubble();
+}
+
+void BraveBrowserView::AddedToWidget() {
+  BrowserView::AddedToWidget();
+
+  if (vertical_tab_strip_host_view_) {
+    VerticalTabStripWidgetDelegateView::Create(this,
+                                               vertical_tab_strip_host_view_);
+  }
 }
 
 void BraveBrowserView::OnTabStripModelChanged(

--- a/browser/ui/views/frame/brave_browser_view.h
+++ b/browser/ui/views/frame/brave_browser_view.h
@@ -83,6 +83,7 @@ class BraveBrowserView : public BrowserView {
   static void SetDownloadConfirmReturnForTesting(bool allow);
 
   // BrowserView overrides:
+  void AddedToWidget() override;
   void OnTabStripModelChanged(
       TabStripModel* tab_strip_model,
       const TabStripModelChange& change,
@@ -106,7 +107,7 @@ class BraveBrowserView : public BrowserView {
 
   raw_ptr<SidebarContainerView> sidebar_container_view_ = nullptr;
   raw_ptr<views::View> sidebar_host_view_ = nullptr;
-  raw_ptr<views::View> vertical_tabs_container_ = nullptr;
+  raw_ptr<views::View> vertical_tab_strip_host_view_ = nullptr;
 
 #if BUILDFLAG(ENABLE_BRAVE_VPN)
   BraveVPNPanelController vpn_panel_controller_{this};

--- a/browser/ui/views/frame/vertical_tab_strip_region_view.cc
+++ b/browser/ui/views/frame/vertical_tab_strip_region_view.cc
@@ -279,8 +279,7 @@ VerticalTabStripRegionView::VerticalTabStripRegionView(
 VerticalTabStripRegionView::~VerticalTabStripRegionView() {
   // We need to move tab strip region to its original parent to avoid crash
   // during drag and drop session.
-  in_destruction_ = true;
-  UpdateLayout();
+  UpdateLayout(true);
 }
 
 bool VerticalTabStripRegionView::IsTabFullscreen() const {
@@ -347,8 +346,8 @@ void VerticalTabStripRegionView::Layout() {
   UpdateTabSearchButtonVisibility();
 }
 
-void VerticalTabStripRegionView::UpdateLayout() {
-  if (tabs::features::ShouldShowVerticalTabs() && !in_destruction_) {
+void VerticalTabStripRegionView::UpdateLayout(bool in_destruction) {
+  if (tabs::features::ShouldShowVerticalTabs() && !in_destruction) {
     if (!Contains(region_view_)) {
       original_parent_of_region_view_ = region_view_->parent();
       original_parent_of_region_view_->RemoveChildView(region_view_);

--- a/browser/ui/views/frame/vertical_tab_strip_region_view.h
+++ b/browser/ui/views/frame/vertical_tab_strip_region_view.h
@@ -59,7 +59,7 @@ class VerticalTabStripRegionView : public views::View {
 
   void SetState(State state);
 
-  void UpdateLayout();
+  void UpdateLayout(bool in_destruction = false);
 
   void UpdateNewTabButtonVisibility();
   void UpdateTabSearchButtonVisibility();
@@ -86,8 +86,6 @@ class VerticalTabStripRegionView : public views::View {
   BooleanPrefMember collapsed_pref_;
 
   base::OneShotTimer mouse_enter_timer_;
-
-  bool in_destruction_ = false;
 };
 
 #endif  // BRAVE_BROWSER_UI_VIEWS_FRAME_VERTICAL_TAB_STRIP_REGION_VIEW_H_

--- a/browser/ui/views/frame/vertical_tab_strip_region_view.h
+++ b/browser/ui/views/frame/vertical_tab_strip_region_view.h
@@ -6,6 +6,7 @@
 #ifndef BRAVE_BROWSER_UI_VIEWS_FRAME_VERTICAL_TAB_STRIP_REGION_VIEW_H_
 #define BRAVE_BROWSER_UI_VIEWS_FRAME_VERTICAL_TAB_STRIP_REGION_VIEW_H_
 
+#include "base/timer/timer.h"
 #include "chrome/browser/ui/views/frame/tab_strip_region_view.h"
 #include "components/prefs/pref_member.h"
 
@@ -20,7 +21,20 @@ class VerticalTabStripRegionView : public views::View {
  public:
   METADATA_HEADER(VerticalTabStripRegionView);
 
-  enum class State { kCollapsed, kExpanded };
+  // We have a state machine which cycles like:
+  //
+  //               <hovered>          <pressed button>
+  //   kCollapsed <----------> kFloating ----------> kExpanded
+  //       ^        <exited>                            |
+  //       |                                            |
+  //       +--------------------------------------------+
+  //                  <press button>
+  //
+  enum class State {
+    kCollapsed,
+    kFloating,
+    kExpanded,
+  };
 
   VerticalTabStripRegionView(Browser* browser, TabStripRegionView* region_view);
   ~VerticalTabStripRegionView() override;
@@ -34,8 +48,11 @@ class VerticalTabStripRegionView : public views::View {
 
   // views::View:
   gfx::Size CalculatePreferredSize() const override;
+  gfx::Size GetMinimumSize() const override;
   void Layout() override;
   void OnThemeChanged() override;
+  void OnMouseExited(const ui::MouseEvent& event) override;
+  void OnMouseEntered(const ui::MouseEvent& event) override;
 
  private:
   bool IsTabFullscreen() const;
@@ -48,6 +65,8 @@ class VerticalTabStripRegionView : public views::View {
   void UpdateTabSearchButtonVisibility();
 
   void OnCollapsedPrefChanged();
+
+  gfx::Size GetPreferredSizeForState(State state) const;
 
   raw_ptr<Browser> browser_ = nullptr;
 
@@ -65,6 +84,10 @@ class VerticalTabStripRegionView : public views::View {
   State state_ = State::kExpanded;
 
   BooleanPrefMember collapsed_pref_;
+
+  base::OneShotTimer mouse_enter_timer_;
+
+  bool in_destruction_ = false;
 };
 
 #endif  // BRAVE_BROWSER_UI_VIEWS_FRAME_VERTICAL_TAB_STRIP_REGION_VIEW_H_

--- a/browser/ui/views/frame/vertical_tab_strip_widget_delegate_view.cc
+++ b/browser/ui/views/frame/vertical_tab_strip_widget_delegate_view.cc
@@ -62,6 +62,9 @@ VerticalTabStripWidgetDelegateView::VerticalTabStripWidgetDelegateView(
 
 void VerticalTabStripWidgetDelegateView::ChildPreferredSizeChanged(
     views::View* child) {
+  if (!host_)
+    return;
+
   // Setting minimum size for |host_| so that we can overlay vertical tabs over
   // the web view.
   auto new_host_size = region_view_->GetMinimumSize();
@@ -105,6 +108,9 @@ void VerticalTabStripWidgetDelegateView::OnWidgetBoundsChanged(
 }
 
 void VerticalTabStripWidgetDelegateView::UpdateWidgetBounds() {
+  if (!host_)
+    return;
+
   auto* widget = GetWidget();
   DCHECK(widget);
   // Convert coordinate system based on Browser's widget.

--- a/browser/ui/views/frame/vertical_tab_strip_widget_delegate_view.cc
+++ b/browser/ui/views/frame/vertical_tab_strip_widget_delegate_view.cc
@@ -1,0 +1,135 @@
+/* Copyright (c) 2022 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "brave/browser/ui/views/frame/vertical_tab_strip_widget_delegate_view.h"
+
+#include <utility>
+
+#include "base/check.h"
+#include "brave/browser/ui/views/frame/vertical_tab_strip_region_view.h"
+#include "chrome/browser/ui/views/frame/browser_view.h"
+#include "ui/base/metadata/metadata_impl_macros.h"
+#include "ui/views/layout/fill_layout.h"
+#include "ui/views/widget/widget.h"
+
+#if defined(USE_AURA)
+#include "ui/views/view_constants_aura.h"
+#endif
+
+// static
+void VerticalTabStripWidgetDelegateView::Create(BrowserView* browser_view,
+                                                views::View* host_view) {
+  DCHECK(browser_view->GetWidget());
+
+  views::Widget::InitParams params;
+  params.delegate =
+      new VerticalTabStripWidgetDelegateView(browser_view, host_view);
+  params.parent = browser_view->GetWidget()->GetNativeView();
+  params.type = views::Widget::InitParams::TYPE_CONTROL;
+  // We need this to pass the key events to the top level widget. i.e. we should
+  // not get focus.
+  params.activatable = views::Widget::InitParams::Activatable::kNo;
+
+  auto widget = std::make_unique<views::Widget>();
+  widget->Init(std::move(params));
+#if defined(USE_AURA)
+  widget->GetNativeView()->SetProperty(views::kHostViewKey, host_view);
+#endif
+  widget->Show();
+  widget.release();
+}
+
+VerticalTabStripWidgetDelegateView::~VerticalTabStripWidgetDelegateView() =
+    default;
+
+VerticalTabStripWidgetDelegateView::VerticalTabStripWidgetDelegateView(
+    BrowserView* browser_view,
+    views::View* host)
+    : browser_view_(browser_view),
+      host_(host),
+      region_view_(AddChildView(std::make_unique<VerticalTabStripRegionView>(
+          browser_view_->browser(),
+          browser_view_->tab_strip_region_view()))) {
+  SetLayoutManager(std::make_unique<views::FillLayout>());
+
+  host_view_observation_.Observe(host_);
+  widget_observation_.Observe(host_->GetWidget());
+
+  ChildPreferredSizeChanged(region_view_);
+}
+
+void VerticalTabStripWidgetDelegateView::ChildPreferredSizeChanged(
+    views::View* child) {
+  // Setting minimum size for |host_| so that we can overlay vertical tabs over
+  // the web view.
+  auto new_host_size = region_view_->GetMinimumSize();
+  if (new_host_size != host_->GetPreferredSize()) {
+    host_->SetPreferredSize(new_host_size);
+    return;
+  }
+
+  // Layout widget manually because host won't trigger layout.
+  UpdateWidgetBounds();
+}
+
+void VerticalTabStripWidgetDelegateView::OnViewVisibilityChanged(
+    views::View* observed_view,
+    views::View* starting_view) {
+  auto* widget = GetWidget();
+  if (!widget || widget->IsVisible() == observed_view->GetVisible())
+    return;
+
+  if (observed_view->GetVisible())
+    widget->Show();
+  else
+    widget->Hide();
+}
+
+void VerticalTabStripWidgetDelegateView::OnViewBoundsChanged(
+    views::View* observed_view) {
+  UpdateWidgetBounds();
+}
+
+void VerticalTabStripWidgetDelegateView::OnViewIsDeleting(
+    views::View* observed_view) {
+  host_view_observation_.Reset();
+  host_ = nullptr;
+}
+
+void VerticalTabStripWidgetDelegateView::OnWidgetBoundsChanged(
+    views::Widget* widget,
+    const gfx::Rect& new_bounds) {
+  UpdateWidgetBounds();
+}
+
+void VerticalTabStripWidgetDelegateView::UpdateWidgetBounds() {
+  auto* widget = GetWidget();
+  DCHECK(widget);
+  // Convert coordinate system based on Browser's widget.
+  gfx::Rect widget_bounds = host_->ConvertRectToWidget(host_->GetLocalBounds());
+  widget_bounds.set_width(region_view_->GetPreferredSize().width());
+  if (widget_bounds.IsEmpty()) {
+    widget->Hide();
+    return;
+  }
+
+  if (!widget->IsVisible())
+    widget->Show();
+
+  const bool need_to_call_layout =
+      widget->GetWindowBoundsInScreen().size() != widget_bounds.size();
+  widget->SetBounds(widget_bounds);
+
+  if (need_to_call_layout)
+    Layout();
+}
+
+void VerticalTabStripWidgetDelegateView::OnWidgetDestroying(
+    views::Widget* widget) {
+  widget_observation_.Reset();
+}
+
+BEGIN_METADATA(VerticalTabStripWidgetDelegateView, views::View)
+END_METADATA

--- a/browser/ui/views/frame/vertical_tab_strip_widget_delegate_view.h
+++ b/browser/ui/views/frame/vertical_tab_strip_widget_delegate_view.h
@@ -15,7 +15,7 @@
 class BrowserView;
 class VerticalTabStripRegionView;
 
-// This class wraps VerticalTabSTripRegionView and show them atop a Widget.
+// This class wraps VerticalTabStripRegionView and show them atop a Widget.
 // Vertical tab strip could be overlaps with contents web view and
 // we need a Widget to accept user events ahead of contents web view.
 // This Widget's coordinates and visibility are synchronized with a host view

--- a/browser/ui/views/frame/vertical_tab_strip_widget_delegate_view.h
+++ b/browser/ui/views/frame/vertical_tab_strip_widget_delegate_view.h
@@ -1,0 +1,74 @@
+/* Copyright (c) 2022 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_BROWSER_UI_VIEWS_FRAME_VERTICAL_TAB_STRIP_WIDGET_DELEGATE_VIEW_H_
+#define BRAVE_BROWSER_UI_VIEWS_FRAME_VERTICAL_TAB_STRIP_WIDGET_DELEGATE_VIEW_H_
+
+#include <memory>
+
+#include "ui/views/view_observer.h"
+#include "ui/views/widget/widget_delegate.h"
+#include "ui/views/widget/widget_observer.h"
+
+class BrowserView;
+class VerticalTabStripRegionView;
+
+// This class wraps VerticalTabSTripRegionView and show them atop a Widget.
+// Vertical tab strip could be overlaps with contents web view and
+// we need a Widget to accept user events ahead of contents web view.
+// This Widget's coordinates and visibility are synchronized with a host view
+// given by Create() method. The client of this class should attach this
+// to parent widget, typically BrowserView/Frame. An then this widget will be a
+// child of BrowserView's Widget with Control widget type.
+//
+// Usage:
+//  auto* host_view = AddChildView(std::make_unique<views::View>());
+//  VerticalTabStripWidgetDelegateView::Create(browser_view, host_view);
+//  host_view->SetVisible(true);  // will show up the widget
+//  host_view->SetBounds(gfx::Rect(0, 0, 100, 100));  // will layout the widget.
+//                                                    // But size could be
+//                                                    // different based on
+//                                                    // state.
+//
+class VerticalTabStripWidgetDelegateView : public views::WidgetDelegateView,
+                                           public views::ViewObserver,
+                                           public views::WidgetObserver {
+ public:
+  METADATA_HEADER(VerticalTabStripWidgetDelegateView);
+
+  static void Create(BrowserView* browser_view, views::View* host_view);
+  ~VerticalTabStripWidgetDelegateView() override;
+
+  // views::WidgetDelegateView:
+  void ChildPreferredSizeChanged(views::View* child) override;
+
+  // views::ViewObserver:
+  void OnViewVisibilityChanged(views::View* observed_view,
+                               views::View* starting_view) override;
+  void OnViewBoundsChanged(views::View* observed_view) override;
+  void OnViewIsDeleting(views::View* observed_view) override;
+
+  // views::WidgetObserver:
+  void OnWidgetBoundsChanged(views::Widget* widget,
+                             const gfx::Rect& new_bounds) override;
+  void OnWidgetDestroying(views::Widget* widget) override;
+
+ private:
+  VerticalTabStripWidgetDelegateView(BrowserView* browser_view,
+                                     views::View* host);
+  void UpdateWidgetBounds();
+
+  raw_ptr<BrowserView> browser_view_ = nullptr;
+  raw_ptr<views::View> host_ = nullptr;
+  raw_ptr<VerticalTabStripRegionView> region_view_ = nullptr;
+
+  base::ScopedObservation<views::View, views::ViewObserver>
+      host_view_observation_{this};
+
+  base::ScopedObservation<views::Widget, views::WidgetObserver>
+      widget_observation_{this};
+};
+
+#endif  // BRAVE_BROWSER_UI_VIEWS_FRAME_VERTICAL_TAB_STRIP_WIDGET_DELEGATE_VIEW_H_

--- a/chromium_src/chrome/browser/ui/views/tabs/tab_drag_controller.h
+++ b/chromium_src/chrome/browser/ui/views/tabs/tab_drag_controller.h
@@ -20,8 +20,15 @@ using TabDragControllerBrave = TabDragController;
   friend TabDragControllerBrave; \
   virtual void MoveAttached
 #define GetTabGroupForTargetIndex virtual GetTabGroupForTargetIndex
+#define GetAttachedBrowserWidget                   \
+  GetAttachedBrowserWidget_Unused() { return {}; } \
+  virtual views::Widget* GetAttachedBrowserWidget
+#define GetLocalProcessWindow virtual GetLocalProcessWindow
 
 #include "src/chrome/browser/ui/views/tabs/tab_drag_controller.h"
+
+#undef GetLocalProcessWindow
+#undef GetAttachedBrowserWidget
 #undef GetTabGroupForTargetIndex
 #undef TabDragController
 #undef MoveAttached
@@ -48,6 +55,11 @@ class TabDragController : public TabDragControllerChromium {
                     bool just_attached) override;
   absl::optional<tab_groups::TabGroupId> GetTabGroupForTargetIndex(
       const std::vector<int>& selected) override;
+  views::Widget* GetAttachedBrowserWidget() override;
+
+  Liveness GetLocalProcessWindow(const gfx::Point& screen_point,
+                                 bool exclude_dragged_view,
+                                 gfx::NativeWindow* window) override;
 };
 
 #endif  // BRAVE_CHROMIUM_SRC_CHROME_BROWSER_UI_VIEWS_TABS_TAB_DRAG_CONTROLLER_H_


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/25474

Now we have 3 states for vertical tab strip.
* Collapsed: tab strip will be the minimum size
* Expanded: tab strip will be the maximum size and contents area will be
             moved next to it.
* Floating: tab strip will be the maximum size but it'll cover some of
            contents area.

Floating state will be triggered by mouse hover state and Expanded state
will be triggered by a button on header.

Note that we need to embed VerticalTabStripRegion on another child widget.
This is because when we have a view atop web contents area, web contents
will precede the tab strip in terms of event handling. In order to handle
mouse events ahead of web contents, we need to embed the tab strip on
a widget.

### Demo

https://user-images.githubusercontent.com/5474642/195755747-fdda55b9-ee13-43a5-b492-aba1a54eb339.mov


## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

