### PR TITLE
Fill empty signatures for non-fee-payer signers if not passed by dApp.

### DIFF
--- a/components/brave_wallet/browser/solana_message.h
+++ b/components/brave_wallet/browser/solana_message.h
@@ -60,6 +60,11 @@ class SolanaMessage {
   static absl::optional<SolanaMessage> FromValue(
       const base::Value::Dict& value);
 
+  void SetInstructionsForTesting(
+      const std::vector<SolanaInstruction>& instructions) {
+    instructions_ = instructions;
+  }
+
  private:
   FRIEND_TEST_ALL_PREFIXES(SolanaMessageUnitTest, GetUniqueAccountMetas);
 


### PR DESCRIPTION
This is to ensure the solana-web3 transactions created from our serialized signed transaction bytes will always have the signatures property array with the length equal to num of required signers to make sure our fee payer signature won't be dropped in Transaction._compile(). (https://github.com/solana-labs/solana-web3.js/blob/8b3cab18fc7977be34f02ec4f1121da7b8b89162/src/transaction/legacy.ts#L526-L537) 

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/26061

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
1. Run https://ec4rte.csb.app/ and open devtool to see console.
2. Connect with Brave Wallet and click Sign Transaction.
3. In the devtool console, expand the object print under Brave signed tx and check signatures property, should look like below:

<img width="1679" alt="Screen Shot 2022-10-15 at 9 56 22 PM" src="https://user-images.githubusercontent.com/4730197/196090873-b25ac445-57f5-43eb-ab1e-b557888499f8.png">
