### PR TITLE
Fixes a crash in cases when there is no active tab or it has not been initialized yet on Android(uplift to 1.44.x)

### DIFF
--- a/android/java/org/chromium/chrome/browser/BraveRewardsDonationSentActivity.java
+++ b/android/java/org/chromium/chrome/browser/BraveRewardsDonationSentActivity.java
@@ -53,7 +53,7 @@ public class BraveRewardsDonationSentActivity extends Activity implements BraveR
         String publisherFavIconURL =
                 mBraveRewardsNativeWorker.GetPublisherFavIconURL(currentTabId_);
         Tab currentActiveTab = BraveRewardsHelper.currentActiveChromeTabbedActivityTab();
-        String url = currentActiveTab.getUrl().getSpec();
+        String url = currentActiveTab != null ? currentActiveTab.getUrl().getSpec() : "";
         String favicon_url = (publisherFavIconURL.isEmpty()) ? url : publisherFavIconURL;
         mIconFetcher = new org.chromium.chrome.browser.BraveRewardsHelper(currentActiveTab);
         mIconFetcher.retrieveLargeIcon(favicon_url, this);

--- a/android/java/org/chromium/chrome/browser/crypto_wallet/fragments/dapps/ConnectAccountFragment.java
+++ b/android/java/org/chromium/chrome/browser/crypto_wallet/fragments/dapps/ConnectAccountFragment.java
@@ -227,7 +227,7 @@ public class ConnectAccountFragment extends BaseDAppsFragment
 
     private GURL getCurrentHostHttpAddress() {
         ChromeTabbedActivity activity = BraveActivity.getChromeTabbedActivity();
-        if (activity != null) {
+        if (activity != null && activity.getActivityTab() != null) {
             return activity.getActivityTab().getUrl().getOrigin();
         }
         return GURL.emptyGURL();

--- a/android/java/org/chromium/chrome/browser/crypto_wallet/util/Utils.java
+++ b/android/java/org/chromium/chrome/browser/crypto_wallet/util/Utils.java
@@ -1434,7 +1434,7 @@ public class Utils {
 
     public static GURL getCurentTabUrl() {
         ChromeTabbedActivity activity = BraveActivity.getChromeTabbedActivity();
-        if (activity != null) {
+        if (activity != null && activity.getActivityTab() != null) {
             return activity.getActivityTab().getUrl().getOrigin();
         }
         return GURL.emptyGURL();
@@ -1453,7 +1453,7 @@ public class Utils {
         org.chromium.url.internal.mojom.Origin hostOrigin =
                 new org.chromium.url.internal.mojom.Origin();
         ChromeTabbedActivity activity = BraveActivity.getChromeTabbedActivity();
-        if (activity == null) {
+        if (activity == null || activity.getActivityTab() == null) {
             return hostOrigin;
         }
 

--- a/android/java/org/chromium/chrome/browser/ntp_background_images/RewardsBottomSheetDialogFragment.java
+++ b/android/java/org/chromium/chrome/browser/ntp_background_images/RewardsBottomSheetDialogFragment.java
@@ -208,7 +208,7 @@ public class RewardsBottomSheetDialogFragment extends BottomSheetDialogFragment 
 
     private void reloadTab() {
         ChromeTabbedActivity chromeTabbedActivity = BraveRewardsHelper.getChromeTabbedActivity();
-        if (chromeTabbedActivity != null) {
+        if (chromeTabbedActivity != null && chromeTabbedActivity.getActivityTab() != null) {
             Tab currentTab = chromeTabbedActivity.getActivityTab();
             SponsoredTab sponsoredTab = TabAttributes.from(currentTab).get(String.valueOf(((TabImpl)currentTab).getId()));
             sponsoredTab.setNTPImage(SponsoredImageUtil.getBackgroundImage());

--- a/android/java/org/chromium/chrome/browser/rewards/BraveRewardsPanel.java
+++ b/android/java/org/chromium/chrome/browser/rewards/BraveRewardsPanel.java
@@ -1317,7 +1317,7 @@ public class BraveRewardsPanel
         String publisherFavIconURL =
                 mBraveRewardsNativeWorker.GetPublisherFavIconURL(mCurrentTabId);
         Tab currentActiveTab = BraveRewardsHelper.currentActiveChromeTabbedActivityTab();
-        String url = currentActiveTab.getUrl().getSpec();
+        String url = currentActiveTab != null ? currentActiveTab.getUrl().getSpec() : "";
         final String favicon_url = (publisherFavIconURL.isEmpty()) ? url : publisherFavIconURL;
 
         mIconFetcher.retrieveLargeIcon(favicon_url, this);

--- a/android/java/org/chromium/chrome/browser/util/TabUtils.java
+++ b/android/java/org/chromium/chrome/browser/util/TabUtils.java
@@ -79,7 +79,7 @@ public class TabUtils {
 
     public static void openUrlInSameTab(String url) {
         BraveActivity braveActivity = BraveActivity.getBraveActivity();
-        if (braveActivity != null) {
+        if (braveActivity != null && braveActivity.getActivityTab() != null) {
             LoadUrlParams loadUrlParams = new LoadUrlParams(url);
             braveActivity.getActivityTab().loadUrl(loadUrlParams);
         }


### PR DESCRIPTION
Uplift of https://github.com/brave/brave-core/pull/15471
Resolves https://github.com/brave/brave-browser/issues/26043