### PR TITLE
Move vpn connection state managing to global instance

### DIFF
--- a/browser/brave_vpn/brave_vpn_service_factory.cc
+++ b/browser/brave_vpn/brave_vpn_service_factory.cc
@@ -6,9 +6,9 @@
 #include "brave/browser/brave_vpn/brave_vpn_service_factory.h"
 
 #include "base/feature_list.h"
-#include "brave/browser/brave_browser_process.h"
 #include "brave/browser/profiles/profile_util.h"
 #include "brave/browser/skus/skus_service_factory.h"
+#include "brave/components/brave_vpn/brave_vpn_os_connection_api.h"
 #include "brave/components/brave_vpn/brave_vpn_service.h"
 #include "brave/components/brave_vpn/brave_vpn_utils.h"
 #include "brave/components/skus/common/features.h"
@@ -50,6 +50,12 @@ BraveVpnServiceFactory::BraveVpnServiceFactory()
           "BraveVpnService",
           BrowserContextDependencyManager::GetInstance()) {
   DependsOn(skus::SkusServiceFactory::GetInstance());
+#if BUILDFLAG(IS_WIN) || BUILDFLAG(IS_MAC)
+  auto* connection_api = BraveVPNOSConnectionAPI::GetInstance();
+  connection_api->set_shared_url_loader_factory(
+      g_browser_process->shared_url_loader_factory());
+  connection_api->set_local_prefs(g_browser_process->local_state());
+#endif
 }
 
 BraveVpnServiceFactory::~BraveVpnServiceFactory() = default;

--- a/browser/ui/views/toolbar/brave_vpn_button.cc
+++ b/browser/ui/views/toolbar/brave_vpn_button.cc
@@ -197,7 +197,7 @@ void BraveVPNButton::UpdateButtonState() {
 }
 
 bool BraveVPNButton::IsConnected() {
-  return service_->is_connected();
+  return service_->IsConnected();
 }
 
 void BraveVPNButton::OnButtonPressed(const ui::Event& event) {

--- a/browser/ui/views/toolbar/brave_vpn_status_label.cc
+++ b/browser/ui/views/toolbar/brave_vpn_status_label.cc
@@ -90,7 +90,7 @@ gfx::Size BraveVPNStatusLabel::CalculatePreferredSize() const {
 }
 
 void BraveVPNStatusLabel::UpdateState() {
-  const auto state = service_->connection_state();
+  const auto state = service_->GetConnectionState();
 
   SetText(brave_l10n::GetLocalizedResourceUTF16String(
       GetStringIdForConnectionState(state)));

--- a/browser/ui/views/toolbar/brave_vpn_toggle_button.cc
+++ b/browser/ui/views/toolbar/brave_vpn_toggle_button.cc
@@ -55,7 +55,7 @@ void BraveVPNToggleButton::OnButtonPressed(const ui::Event& event) {
 }
 
 void BraveVPNToggleButton::UpdateState() {
-  const auto state = service_->connection_state();
+  const auto state = service_->GetConnectionState();
   bool is_on = (state == ConnectionState::CONNECTING ||
                 state == ConnectionState::CONNECTED);
   SetIsOn(is_on);

--- a/components/brave_vpn/brave_vpn_constants.h
+++ b/components/brave_vpn/brave_vpn_constants.h
@@ -87,6 +87,22 @@ constexpr char kRegionNamePrettyKey[] = "name-pretty";
 constexpr char kRegionCountryIsoCodeKey[] = "country-iso-code";
 constexpr char kCreateSupportTicket[] = "api/v1.2/partners/support-ticket";
 
+constexpr char kVpnHost[] = "connect-api.guardianapp.com";
+constexpr char kAllServerRegions[] = "api/v1/servers/all-server-regions";
+constexpr char kTimezonesForRegions[] =
+    "api/v1.1/servers/timezones-for-regions";
+constexpr char kHostnameForRegion[] = "api/v1.2/servers/hostnames-for-region";
+constexpr char kProfileCredential[] = "api/v1.1/register-and-create";
+constexpr char kCredential[] = "api/v1.3/device/";
+constexpr char kVerifyPurchaseToken[] = "api/v1.1/verify-purchase-token";
+constexpr char kCreateSubscriberCredentialV12[] =
+    "api/v1.2/subscriber-credential/create";
+constexpr int kP3AIntervalHours = 24;
+
+#if !BUILDFLAG(IS_ANDROID)
+constexpr char kTokenNoLongerValid[] = "Token No Longer Valid";
+#endif  // !BUILDFLAG(IS_ANDROID)
+
 }  // namespace brave_vpn
 
 #endif  // BRAVE_COMPONENTS_BRAVE_VPN_BRAVE_VPN_CONSTANTS_H_

--- a/components/brave_vpn/brave_vpn_os_connection_api.cc
+++ b/components/brave_vpn/brave_vpn_os_connection_api.cc
@@ -5,10 +5,35 @@
 
 #include "brave/components/brave_vpn/brave_vpn_os_connection_api.h"
 
+#include <utility>
+#include <vector>
+
+#include "base/bind.h"
+#include "base/check_is_test.h"
+#include "base/json/json_reader.h"
+#include "base/power_monitor/power_monitor.h"
+#include "brave/components/brave_vpn/brave_vpn_constants.h"
+#include "brave/components/brave_vpn/brave_vpn_data_types.h"
+#include "brave/components/brave_vpn/brave_vpn_service_helper.h"
+#include "brave/components/brave_vpn/brave_vpn_utils.h"
+#include "brave/components/brave_vpn/pref_names.h"
+#include "brave/components/brave_vpn/vpn_response_parser.h"
+#include "components/prefs/pref_service.h"
+#include "third_party/abseil-cpp/absl/types/optional.h"
+
 namespace brave_vpn {
 
-BraveVPNOSConnectionAPI::BraveVPNOSConnectionAPI() = default;
-BraveVPNOSConnectionAPI::~BraveVPNOSConnectionAPI() = default;
+using ConnectionState = mojom::ConnectionState;
+
+BraveVPNOSConnectionAPI::BraveVPNOSConnectionAPI() {
+  base::PowerMonitor::AddPowerSuspendObserver(this);
+  net::NetworkChangeNotifier::AddDNSObserver(this);
+}
+
+BraveVPNOSConnectionAPI::~BraveVPNOSConnectionAPI() {
+  base::PowerMonitor::RemovePowerSuspendObserver(this);
+  net::NetworkChangeNotifier::RemoveDNSObserver(this);
+}
 
 void BraveVPNOSConnectionAPI::AddObserver(Observer* observer) {
   observers_.AddObserver(observer);
@@ -16,6 +41,527 @@ void BraveVPNOSConnectionAPI::AddObserver(Observer* observer) {
 
 void BraveVPNOSConnectionAPI::RemoveObserver(Observer* observer) {
   observers_.RemoveObserver(observer);
+}
+
+void BraveVPNOSConnectionAPI::SetConnectionState(mojom::ConnectionState state) {
+  UpdateAndNotifyConnectionStateChange(state);
+}
+
+bool BraveVPNOSConnectionAPI::IsInProgress() const {
+  return connection_state_ == ConnectionState::DISCONNECTING ||
+         connection_state_ == ConnectionState::CONNECTING;
+}
+
+void BraveVPNOSConnectionAPI::CreateVPNConnection() {
+  if (cancel_connecting_) {
+    UpdateAndNotifyConnectionStateChange(ConnectionState::DISCONNECTED);
+    cancel_connecting_ = false;
+    return;
+  }
+
+  if (prevent_creation_) {
+    CHECK_IS_TEST();
+    return;
+  }
+  CreateVPNConnectionImpl(connection_info_);
+}
+
+void BraveVPNOSConnectionAPI::Connect() {
+  if (IsInProgress()) {
+    VLOG(2) << __func__ << ": Current state: " << connection_state_
+            << " : prevent connecting while previous operation is in-progress";
+    return;
+  }
+
+  DCHECK(!cancel_connecting_);
+
+  // User can ask connect again when user want to change region.
+  if (connection_state() == ConnectionState::CONNECTED) {
+    // Disconnect first and then create again to setup for new region.
+    // Set needs_connect to connect again after disconnected.
+    needs_connect_ = true;
+    Disconnect();
+    return;
+  }
+
+  VLOG(2) << __func__ << " : start connecting!";
+  UpdateAndNotifyConnectionStateChange(ConnectionState::CONNECTING);
+
+  if (!IsNetworkAvailable()) {
+    VLOG(2) << __func__ << ": Network is not available, failed to connect";
+    UpdateAndNotifyConnectionStateChange(ConnectionState::CONNECT_FAILED);
+    return;
+  }
+
+  if (GetIsSimulation() || connection_info_.IsValid()) {
+    VLOG(2) << __func__
+            << " : direct connect as we already have valid connection info.";
+    ConnectImpl(target_vpn_entry_name_);
+    return;
+  }
+
+  // If user doesn't select region explicitely, use default device region.
+  std::string target_region_name = GetSelectedRegion();
+  if (target_region_name.empty()) {
+    target_region_name = GetDeviceRegion();
+    VLOG(2) << __func__ << " : start connecting with valid default_region: "
+            << target_region_name;
+  }
+  DCHECK(!target_region_name.empty());
+  FetchHostnamesForRegion(target_region_name);
+}
+
+void BraveVPNOSConnectionAPI::Disconnect() {
+  if (connection_state_ == ConnectionState::DISCONNECTED) {
+    VLOG(2) << __func__ << " : already disconnected";
+    return;
+  }
+
+  if (connection_state_ == ConnectionState::DISCONNECTING) {
+    VLOG(2) << __func__ << " : disconnecting in progress";
+    return;
+  }
+
+  if (GetIsSimulation() || connection_state_ != ConnectionState::CONNECTING) {
+    VLOG(2) << __func__ << " : start disconnecting!";
+    UpdateAndNotifyConnectionStateChange(ConnectionState::DISCONNECTING);
+    DisconnectImpl(target_vpn_entry_name_);
+    return;
+  }
+
+  cancel_connecting_ = true;
+  VLOG(2) << __func__ << " : Start cancelling connect request";
+  UpdateAndNotifyConnectionStateChange(ConnectionState::DISCONNECTING);
+}
+
+void BraveVPNOSConnectionAPI::ToggleConnection() {
+  const bool can_disconnect =
+      (connection_state_ == ConnectionState::CONNECTED ||
+       connection_state_ == ConnectionState::CONNECTING);
+  can_disconnect ? Disconnect() : Connect();
+}
+
+void BraveVPNOSConnectionAPI::RemoveVPNConnection() {
+  VLOG(2) << __func__;
+  RemoveVPNConnectionImpl(target_vpn_entry_name_);
+}
+
+void BraveVPNOSConnectionAPI::CheckConnection() {
+  CheckConnectionImpl(target_vpn_entry_name_);
+}
+
+void BraveVPNOSConnectionAPI::SetSkusCredential(const std::string& credential) {
+  skus_credential_ = credential;
+}
+
+void BraveVPNOSConnectionAPI::ResetConnectionInfo() {
+  VLOG(2) << __func__;
+  connection_info_.Reset();
+}
+
+std::string BraveVPNOSConnectionAPI::GetHostname() const {
+  return hostname_ ? hostname_->hostname : "";
+}
+
+bool BraveVPNOSConnectionAPI::GetIsSimulation() const {
+  return false;
+}
+
+void BraveVPNOSConnectionAPI::OnCreated() {
+  VLOG(2) << __func__;
+
+  if (cancel_connecting_) {
+    UpdateAndNotifyConnectionStateChange(ConnectionState::DISCONNECTED);
+    cancel_connecting_ = false;
+    return;
+  }
+
+  // It's time to ask connecting to os after vpn entry is created.
+  ConnectImpl(target_vpn_entry_name_);
+}
+
+void BraveVPNOSConnectionAPI::OnCreateFailed() {
+  VLOG(2) << __func__;
+
+  // Clear connecting cancel request.
+  if (cancel_connecting_)
+    cancel_connecting_ = false;
+
+  UpdateAndNotifyConnectionStateChange(ConnectionState::CONNECT_NOT_ALLOWED);
+}
+
+void BraveVPNOSConnectionAPI::OnConnected() {
+  VLOG(2) << __func__;
+
+  if (cancel_connecting_) {
+    // As connect is done, we don't need more for cancelling.
+    // Just start normal Disconenct() process.
+    cancel_connecting_ = false;
+    DisconnectImpl(target_vpn_entry_name_);
+    return;
+  }
+
+  UpdateAndNotifyConnectionStateChange(ConnectionState::CONNECTED);
+}
+
+void BraveVPNOSConnectionAPI::OnIsConnecting() {
+  VLOG(2) << __func__;
+
+  if (!cancel_connecting_)
+    UpdateAndNotifyConnectionStateChange(ConnectionState::CONNECTING);
+}
+
+void BraveVPNOSConnectionAPI::OnConnectFailed() {
+  cancel_connecting_ = false;
+
+  // Clear previously used connection info if failed.
+  connection_info_.Reset();
+
+  UpdateAndNotifyConnectionStateChange(ConnectionState::CONNECT_FAILED);
+}
+
+void BraveVPNOSConnectionAPI::OnDisconnected() {
+  UpdateAndNotifyConnectionStateChange(IsNetworkAvailable()
+                                           ? ConnectionState::DISCONNECTED
+                                           : ConnectionState::CONNECT_FAILED);
+
+  if (needs_connect_) {
+    needs_connect_ = false;
+
+    if (connection_state_ == ConnectionState::DISCONNECTED)
+      Connect();
+  }
+}
+
+void BraveVPNOSConnectionAPI::OnIsDisconnecting() {
+  VLOG(2) << __func__;
+  UpdateAndNotifyConnectionStateChange(ConnectionState::DISCONNECTING);
+}
+
+void BraveVPNOSConnectionAPI::OnSuspend() {
+  // Set reconnection state in case if computer/laptop is going to sleep.
+  // The disconnection event will be fired after waking up and we want to
+  // restore the connection.
+  if (connection_state_ == ConnectionState::CONNECTED) {
+    Disconnect();
+    reconnect_on_resume_ = true;
+  }
+  VLOG(2) << __func__
+          << " Should reconnect when resume:" << reconnect_on_resume_;
+}
+
+void BraveVPNOSConnectionAPI::OnResume() {
+#if BUILDFLAG(IS_MAC)
+  OnDNSChanged();
+#endif  // BUILDFLAG(IS_MAC)
+}
+
+void BraveVPNOSConnectionAPI::OnDNSChanged() {
+  if (!IsNetworkAvailable() ||
+      // This event is triggered before going to sleep while vpn is still
+      // active. Vpn is presented as CONNECTION_UNKNOWN and so we have to skip
+      // this to be notified only when default network active without VPN to
+      // reconnect.
+      net::NetworkChangeNotifier::GetConnectionType() ==
+          net::NetworkChangeNotifier::CONNECTION_UNKNOWN)
+    return;
+
+  VLOG(2) << __func__ << " Should reconnect:" << reconnect_on_resume_;
+  if (reconnect_on_resume_) {
+    Connect();
+    reconnect_on_resume_ = false;
+  }
+}
+
+void BraveVPNOSConnectionAPI::UpdateAndNotifyConnectionStateChange(
+    ConnectionState state) {
+  // this is a simple state machine for handling connection state
+  if (connection_state_ == state)
+    return;
+
+#if BUILDFLAG(IS_WIN)
+  // On Windows, we get disconnected status update twice.
+  // When user connects to different region while connected,
+  // we disconnect current connection and connect to newly selected
+  // region. To do that we monitor |DISCONNECTED| state and start
+  // connect when we get that state. But, Windows sends disconnected state
+  // noti again. So, ignore second one.
+  // On exception - we allow from connecting to disconnected in canceling
+  // scenario.
+  if (connection_state_ == ConnectionState::CONNECTING &&
+      state == ConnectionState::DISCONNECTED && !cancel_connecting_) {
+    VLOG(2) << __func__ << ": Ignore disconnected state while connecting";
+    return;
+  }
+
+  // On Windows, we could get disconnected state after connect failed.
+  // To make connect failed state as a last state, ignore disconnected state.
+  if (connection_state_ == ConnectionState::CONNECT_FAILED &&
+      state == ConnectionState::DISCONNECTED) {
+    VLOG(2) << __func__ << ": Ignore disconnected state after connect failed";
+    return;
+  }
+#endif  // BUILDFLAG(IS_WIN)
+  VLOG(2) << __func__ << " : changing from " << connection_state_ << " to "
+          << state;
+
+  connection_state_ = state;
+  for (auto& obs : observers_)
+    obs.OnConnectionStateChanged(connection_state_);
+}
+
+api_request_helper::APIRequestHelper*
+BraveVPNOSConnectionAPI::GetAPIRequestHelper() {
+  if (!url_loader_factory_) {
+    CHECK_IS_TEST();
+    return nullptr;
+  }
+
+  if (!api_request_helper_) {
+    api_request_helper_ =
+        std::make_unique<api_request_helper::APIRequestHelper>(
+            GetNetworkTrafficAnnotationTag(), url_loader_factory_);
+  }
+
+  return api_request_helper_.get();
+}
+
+std::string BraveVPNOSConnectionAPI::GetDeviceRegion() const {
+  return local_prefs_->GetString(prefs::kBraveVPNDeviceRegion);
+}
+
+std::string BraveVPNOSConnectionAPI::GetSelectedRegion() const {
+  return local_prefs_->GetString(prefs::kBraveVPNSelectedRegion);
+}
+
+std::string BraveVPNOSConnectionAPI::GetCurrentEnvironment() const {
+  return local_prefs_->GetString(prefs::kBraveVPNEEnvironment);
+}
+
+void BraveVPNOSConnectionAPI::FetchHostnamesForRegion(const std::string& name) {
+  VLOG(2) << __func__;
+  // Hostname will be replaced with latest one.
+  hostname_.reset();
+
+  // Unretained is safe here becasue this class owns request helper.
+  GetHostnamesForRegion(
+      base::BindOnce(&BraveVPNOSConnectionAPI::OnFetchHostnames,
+                     base::Unretained(this), name),
+      name);
+}
+
+void BraveVPNOSConnectionAPI::GetHostnamesForRegion(ResponseCallback callback,
+                                                    const std::string& region) {
+  auto internal_callback =
+      base::BindOnce(&BraveVPNOSConnectionAPI::OnGetResponse,
+                     weak_ptr_factory_.GetWeakPtr(), std::move(callback));
+  GURL base_url = GetURLWithPath(kVpnHost, kHostnameForRegion);
+  base::Value::Dict dict;
+  dict.Set("region", region);
+  std::string request_body = CreateJSONRequestBody(dict);
+  OAuthRequest(base_url, "POST", request_body, std::move(internal_callback));
+}
+
+void BraveVPNOSConnectionAPI::OnFetchHostnames(const std::string& region,
+                                               const std::string& hostnames,
+                                               bool success) {
+  VLOG(2) << __func__;
+  if (cancel_connecting_) {
+    UpdateAndNotifyConnectionStateChange(ConnectionState::DISCONNECTED);
+    cancel_connecting_ = false;
+    return;
+  }
+
+  if (!success) {
+    VLOG(2) << __func__ << " : failed to fetch hostnames for " << region;
+    UpdateAndNotifyConnectionStateChange(ConnectionState::CONNECT_FAILED);
+    return;
+  }
+
+  absl::optional<base::Value> value = base::JSONReader::Read(hostnames);
+  if (value && value->is_list()) {
+    ParseAndCacheHostnames(region, value->GetList());
+    return;
+  }
+
+  VLOG(2) << __func__ << " : failed to fetch hostnames for " << region;
+  UpdateAndNotifyConnectionStateChange(ConnectionState::CONNECT_FAILED);
+}
+
+void BraveVPNOSConnectionAPI::ParseAndCacheHostnames(
+    const std::string& region,
+    const base::Value::List& hostnames_value) {
+  std::vector<Hostname> hostnames = ParseHostnames(hostnames_value);
+
+  if (hostnames.empty()) {
+    VLOG(2) << __func__ << " : got empty hostnames list for " << region;
+    UpdateAndNotifyConnectionStateChange(ConnectionState::CONNECT_FAILED);
+    return;
+  }
+
+  hostname_ = PickBestHostname(hostnames);
+  if (hostname_->hostname.empty()) {
+    VLOG(2) << __func__ << " : got empty hostnames list for " << region;
+    UpdateAndNotifyConnectionStateChange(ConnectionState::CONNECT_FAILED);
+    return;
+  }
+
+  VLOG(2) << __func__ << " : Picked " << hostname_->hostname << ", "
+          << hostname_->display_name << ", " << hostname_->is_offline << ", "
+          << hostname_->capacity_score;
+
+  if (skus_credential_.empty()) {
+    VLOG(2) << __func__ << " : skus_credential is empty";
+    UpdateAndNotifyConnectionStateChange(ConnectionState::CONNECT_FAILED);
+    return;
+  }
+
+  // Get subscriber credentials and then get EAP credentials with it to create
+  // OS VPN entry.
+  VLOG(2) << __func__ << " : request subscriber credential:"
+          << GetBraveVPNPaymentsEnv(GetCurrentEnvironment());
+  GetSubscriberCredentialV12(
+      base::BindOnce(&BraveVPNOSConnectionAPI::OnGetSubscriberCredentialV12,
+                     base::Unretained(this)));
+}
+
+void BraveVPNOSConnectionAPI::GetSubscriberCredentialV12(
+    ResponseCallback callback) {
+  auto internal_callback =
+      base::BindOnce(&BraveVPNOSConnectionAPI::OnGetSubscriberCredential,
+                     weak_ptr_factory_.GetWeakPtr(), std::move(callback));
+
+  const GURL base_url =
+      GetURLWithPath(kVpnHost, kCreateSubscriberCredentialV12);
+  base::Value::Dict dict;
+  dict.Set("validation-method", "brave-premium");
+  dict.Set("brave-vpn-premium-monthly-pass", skus_credential_);
+  std::string request_body = CreateJSONRequestBody(dict);
+  OAuthRequest(base_url, "POST", request_body, std::move(internal_callback),
+               {{"Brave-Payments-Environment",
+                 GetBraveVPNPaymentsEnv(GetCurrentEnvironment())}});
+}
+
+void BraveVPNOSConnectionAPI::OnGetSubscriberCredential(
+    ResponseCallback callback,
+    api_request_helper::APIRequestResult api_request_result) {
+  bool success = api_request_result.response_code() == 200;
+  std::string error;
+  std::string subscriber_credential =
+      ParseSubscriberCredentialFromJson(api_request_result.body(), &error);
+  if (!success) {
+    subscriber_credential = error;
+    VLOG(1) << __func__ << " Response from API was not HTTP 200 (Received "
+            << api_request_result.response_code() << ")";
+  }
+  std::move(callback).Run(subscriber_credential, success);
+}
+
+void BraveVPNOSConnectionAPI::OnGetSubscriberCredentialV12(
+    const std::string& subscriber_credential,
+    bool success) {
+  if (cancel_connecting_) {
+    UpdateAndNotifyConnectionStateChange(ConnectionState::DISCONNECTED);
+    cancel_connecting_ = false;
+    return;
+  }
+
+  if (!success) {
+    VLOG(2) << __func__ << " : failed to get subscriber credential";
+    if (subscriber_credential == kTokenNoLongerValid) {
+      for (auto& obs : observers_)
+        obs.OnGetInvalidToken();
+    }
+    UpdateAndNotifyConnectionStateChange(ConnectionState::CONNECT_FAILED);
+    return;
+  }
+
+  VLOG(2) << __func__ << " : received subscriber credential";
+  // TODO(bsclifton): consider storing `subscriber_credential` for
+  // support ticket use-case (see `CreateSupportTicket`).
+  GetProfileCredentials(
+      base::BindOnce(&BraveVPNOSConnectionAPI::OnGetProfileCredentials,
+                     base::Unretained(this)),
+      subscriber_credential, hostname_->hostname);
+}
+
+void BraveVPNOSConnectionAPI::GetProfileCredentials(
+    ResponseCallback callback,
+    const std::string& subscriber_credential,
+    const std::string& hostname) {
+  auto internal_callback =
+      base::BindOnce(&BraveVPNOSConnectionAPI::OnGetResponse,
+                     weak_ptr_factory_.GetWeakPtr(), std::move(callback));
+  GURL base_url = GetURLWithPath(hostname, kProfileCredential);
+  base::Value::Dict dict;
+  dict.Set("subscriber-credential", subscriber_credential);
+  std::string request_body = CreateJSONRequestBody(dict);
+  OAuthRequest(base_url, "POST", request_body, std::move(internal_callback));
+}
+
+void BraveVPNOSConnectionAPI::OnGetProfileCredentials(
+    const std::string& profile_credential,
+    bool success) {
+  if (cancel_connecting_) {
+    UpdateAndNotifyConnectionStateChange(ConnectionState::DISCONNECTED);
+    cancel_connecting_ = false;
+    return;
+  }
+
+  if (!success) {
+    VLOG(2) << __func__ << " : failed to get profile credential";
+    UpdateAndNotifyConnectionStateChange(ConnectionState::CONNECT_FAILED);
+    return;
+  }
+
+  VLOG(2) << __func__ << " : received profile credential";
+
+  absl::optional<base::Value> value =
+      base::JSONReader::Read(profile_credential);
+  if (value && value->is_dict()) {
+    constexpr char kUsernameKey[] = "eap-username";
+    constexpr char kPasswordKey[] = "eap-password";
+    const auto& dict = value->GetDict();
+    const std::string* username = dict.FindString(kUsernameKey);
+    const std::string* password = dict.FindString(kPasswordKey);
+    if (!username || !password) {
+      VLOG(2) << __func__ << " : it's invalid profile credential";
+      UpdateAndNotifyConnectionStateChange(ConnectionState::CONNECT_FAILED);
+      return;
+    }
+
+    connection_info_.SetConnectionInfo(
+        target_vpn_entry_name_, hostname_->hostname, *username, *password);
+    // Let's create os vpn entry with |connection_info_|.
+    CreateVPNConnection();
+    return;
+  }
+
+  VLOG(2) << __func__ << " : it's invalid profile credential";
+  UpdateAndNotifyConnectionStateChange(ConnectionState::CONNECT_FAILED);
+}
+
+void BraveVPNOSConnectionAPI::OnGetResponse(
+    ResponseCallback callback,
+    api_request_helper::APIRequestResult result) {
+  // NOTE: |api_request_helper_| uses JsonSanitizer to sanitize input made with
+  // requests. |body| will be empty when the response from service is invalid
+  // json.
+  const bool success = result.response_code() == 200;
+  std::move(callback).Run(result.body(), success);
+}
+
+void BraveVPNOSConnectionAPI::OAuthRequest(
+    const GURL& url,
+    const std::string& method,
+    const std::string& post_data,
+    URLRequestCallback callback,
+    const base::flat_map<std::string, std::string>& headers) {
+  if (!GetAPIRequestHelper())
+    return;
+
+  GetAPIRequestHelper()->Request(method, url, post_data, "application/json",
+                                 true, std::move(callback), headers);
 }
 
 }  // namespace brave_vpn

--- a/components/brave_vpn/brave_vpn_os_connection_api.h
+++ b/components/brave_vpn/brave_vpn_os_connection_api.h
@@ -6,27 +6,37 @@
 #ifndef BRAVE_COMPONENTS_BRAVE_VPN_BRAVE_VPN_OS_CONNECTION_API_H_
 #define BRAVE_COMPONENTS_BRAVE_VPN_BRAVE_VPN_OS_CONNECTION_API_H_
 
+#include <memory>
 #include <string>
 
+#include "base/memory/raw_ptr.h"
+#include "base/memory/scoped_refptr.h"
+#include "base/memory/weak_ptr.h"
 #include "base/observer_list.h"
 #include "base/observer_list_types.h"
+#include "base/power_monitor/power_observer.h"
+#include "base/values.h"
+#include "brave/components/api_request_helper/api_request_helper.h"
 #include "brave/components/brave_vpn/brave_vpn_connection_info.h"
+#include "brave/components/brave_vpn/mojom/brave_vpn.mojom.h"
+#include "net/base/network_change_notifier.h"
+#include "services/network/public/cpp/shared_url_loader_factory.h"
+#include "url/gurl.h"
+
+class PrefService;
 
 namespace brave_vpn {
 
+struct Hostname;
+
 // Interface for managing OS' vpn connection.
-class BraveVPNOSConnectionAPI {
+class BraveVPNOSConnectionAPI : public base::PowerSuspendObserver,
+                                public net::NetworkChangeNotifier::DNSObserver {
  public:
   class Observer : public base::CheckedObserver {
    public:
-    virtual void OnCreated() = 0;
-    virtual void OnCreateFailed() = 0;
-    virtual void OnRemoved() = 0;
-    virtual void OnConnected() = 0;
-    virtual void OnIsConnecting() = 0;
-    virtual void OnConnectFailed() = 0;
-    virtual void OnDisconnected() = 0;
-    virtual void OnIsDisconnecting() = 0;
+    virtual void OnGetInvalidToken() = 0;
+    virtual void OnConnectionStateChanged(mojom::ConnectionState state) = 0;
 
    protected:
     ~Observer() override = default;
@@ -41,24 +51,122 @@ class BraveVPNOSConnectionAPI {
   void AddObserver(Observer* observer);
   void RemoveObserver(Observer* observer);
 
+  void set_shared_url_loader_factory(
+      scoped_refptr<network::SharedURLLoaderFactory> url_loader_factory) {
+    url_loader_factory_ = url_loader_factory;
+  }
+
+  void set_local_prefs(PrefService* prefs) { local_prefs_ = prefs; }
   void set_target_vpn_entry_name(const std::string& name) {
     target_vpn_entry_name_ = name;
   }
-  std::string target_vpn_entry_name() const { return target_vpn_entry_name_; }
 
-  virtual void CreateVPNConnection(const BraveVPNConnectionInfo& info) = 0;
-  virtual void UpdateVPNConnection(const BraveVPNConnectionInfo& info) = 0;
-  virtual void Connect(const std::string& name) = 0;
-  virtual void Disconnect(const std::string& name) = 0;
-  virtual void RemoveVPNConnection(const std::string& name) = 0;
-  virtual void CheckConnection(const std::string& name) = 0;
+  const BraveVPNConnectionInfo& connection_info() const {
+    return connection_info_;
+  }
+  mojom::ConnectionState connection_state() const { return connection_state_; }
+
+  void SetConnectionState(mojom::ConnectionState state);
+  bool IsInProgress() const;
+
+  void Connect();
+  void Disconnect();
+  void ToggleConnection();
+  void RemoveVPNConnection();
+  void CheckConnection();
+  void SetSkusCredential(const std::string& credential);
+  void ResetConnectionInfo();
+  std::string GetHostname() const;
 
  protected:
   BraveVPNOSConnectionAPI();
-  virtual ~BraveVPNOSConnectionAPI();
+  ~BraveVPNOSConnectionAPI() override;
 
+  // Subclass should add platform dependent impls.
+  virtual void CreateVPNConnectionImpl(const BraveVPNConnectionInfo& info) = 0;
+  virtual void ConnectImpl(const std::string& name) = 0;
+  virtual void DisconnectImpl(const std::string& name) = 0;
+  virtual void RemoveVPNConnectionImpl(const std::string& name) = 0;
+  virtual void CheckConnectionImpl(const std::string& name) = 0;
+  virtual bool GetIsSimulation() const;
+
+  // Subclass should call below callbacks whenever corresponding event happens.
+  void OnCreated();
+  void OnCreateFailed();
+  void OnConnected();
+  void OnIsConnecting();
+  void OnConnectFailed();
+  void OnDisconnected();
+  void OnIsDisconnecting();
+
+  std::string target_vpn_entry_name() const { return target_vpn_entry_name_; }
+
+ private:
+  friend class BraveVPNServiceTest;
+
+  using URLRequestCallback =
+      base::OnceCallback<void(api_request_helper::APIRequestResult)>;
+  using ResponseCallback =
+      base::OnceCallback<void(const std::string&, bool success)>;
+
+  // base::PowerMonitor
+  void OnSuspend() override;
+  void OnResume() override;
+
+  // net::NetworkChangeNotifier::DNSObserver
+  void OnDNSChanged() override;
+
+  void CreateVPNConnection();
+  std::string GetSelectedRegion() const;
+  std::string GetDeviceRegion() const;
+  std::string GetCurrentEnvironment() const;
+  void FetchHostnamesForRegion(const std::string& name);
+  void GetHostnamesForRegion(ResponseCallback callback,
+                             const std::string& region);
+  void OnFetchHostnames(const std::string& region,
+                        const std::string& hostnames,
+                        bool success);
+  void ParseAndCacheHostnames(const std::string& region,
+                              const base::Value::List& hostnames_value);
+  void GetSubscriberCredentialV12(ResponseCallback callback);
+  void OnGetSubscriberCredentialV12(const std::string& subscriber_credential,
+                                    bool success);
+  void OnGetSubscriberCredential(
+      ResponseCallback callback,
+      api_request_helper::APIRequestResult api_request_result);
+  void GetProfileCredentials(ResponseCallback callback,
+                             const std::string& subscriber_credential,
+                             const std::string& hostname);
+  void OnGetProfileCredentials(const std::string& profile_credential,
+                               bool success);
+
+  void UpdateAndNotifyConnectionStateChange(mojom::ConnectionState state);
+  api_request_helper::APIRequestHelper* GetAPIRequestHelper();
+
+  void OAuthRequest(
+      const GURL& url,
+      const std::string& method,
+      const std::string& post_data,
+      URLRequestCallback callback,
+      const base::flat_map<std::string, std::string>& headers = {});
+  void OnGetResponse(ResponseCallback callback,
+                     api_request_helper::APIRequestResult result);
+
+  bool cancel_connecting_ = false;
+  bool needs_connect_ = false;
+  bool reconnect_on_resume_ = false;
+  bool prevent_creation_ = false;
   std::string target_vpn_entry_name_;
+  std::string skus_credential_;
+  mojom::ConnectionState connection_state_ =
+      mojom::ConnectionState::DISCONNECTED;
+  BraveVPNConnectionInfo connection_info_;
+  raw_ptr<PrefService> local_prefs_ = nullptr;
+  std::unique_ptr<Hostname> hostname_;
   base::ObserverList<Observer> observers_;
+  std::unique_ptr<api_request_helper::APIRequestHelper> api_request_helper_;
+  scoped_refptr<network::SharedURLLoaderFactory> url_loader_factory_;
+  base::WeakPtrFactory<BraveVPNOSConnectionAPI> weak_ptr_factory_{this};
 };
 
 }  // namespace brave_vpn

--- a/components/brave_vpn/brave_vpn_os_connection_api_mac.h
+++ b/components/brave_vpn/brave_vpn_os_connection_api_mac.h
@@ -28,16 +28,14 @@ class BraveVPNOSConnectionAPIMac : public BraveVPNOSConnectionAPI {
 
  private:
   // BraveVPNOSConnectionAPI overrides:
-  void CreateVPNConnection(const BraveVPNConnectionInfo& info) override;
-  void UpdateVPNConnection(const BraveVPNConnectionInfo& info) override;
-  void RemoveVPNConnection(const std::string& name) override;
-  void Connect(const std::string& name) override;
-  void Disconnect(const std::string& name) override;
-  void CheckConnection(const std::string& name) override;
+  void CreateVPNConnectionImpl(const BraveVPNConnectionInfo& info) override;
+  void RemoveVPNConnectionImpl(const std::string& name) override;
+  void ConnectImpl(const std::string& name) override;
+  void DisconnectImpl(const std::string& name) override;
+  void CheckConnectionImpl(const std::string& name) override;
   void ObserveVPNConnectionChange();
 
   id vpn_observer_ = nil;
-  BraveVPNConnectionInfo info_;
 };
 
 }  // namespace brave_vpn

--- a/components/brave_vpn/brave_vpn_os_connection_api_sim.cc
+++ b/components/brave_vpn/brave_vpn_os_connection_api_sim.cc
@@ -22,7 +22,7 @@ BraveVPNOSConnectionAPI* BraveVPNOSConnectionAPI::GetInstanceForTest() {
 BraveVPNOSConnectionAPISim::BraveVPNOSConnectionAPISim() = default;
 BraveVPNOSConnectionAPISim::~BraveVPNOSConnectionAPISim() = default;
 
-void BraveVPNOSConnectionAPISim::CreateVPNConnection(
+void BraveVPNOSConnectionAPISim::CreateVPNConnectionImpl(
     const BraveVPNConnectionInfo& info) {
   base::SequencedTaskRunnerHandle::Get()->PostTask(
       FROM_HERE,
@@ -30,12 +30,7 @@ void BraveVPNOSConnectionAPISim::CreateVPNConnection(
                      weak_factory_.GetWeakPtr(), info.connection_name(), true));
 }
 
-void BraveVPNOSConnectionAPISim::UpdateVPNConnection(
-    const BraveVPNConnectionInfo& info) {
-  NOTIMPLEMENTED();
-}
-
-void BraveVPNOSConnectionAPISim::Connect(const std::string& name) {
+void BraveVPNOSConnectionAPISim::ConnectImpl(const std::string& name) {
   disconnect_requested_ = false;
 
   // Determine connection success randomly.
@@ -65,7 +60,7 @@ void BraveVPNOSConnectionAPISim::Connect(const std::string& name) {
       base::Seconds(1));
 }
 
-void BraveVPNOSConnectionAPISim::Disconnect(const std::string& name) {
+void BraveVPNOSConnectionAPISim::DisconnectImpl(const std::string& name) {
   disconnect_requested_ = true;
 
   base::SequencedTaskRunnerHandle::Get()->PostTask(
@@ -77,14 +72,19 @@ void BraveVPNOSConnectionAPISim::Disconnect(const std::string& name) {
                                 weak_factory_.GetWeakPtr(), name, true));
 }
 
-void BraveVPNOSConnectionAPISim::RemoveVPNConnection(const std::string& name) {
+void BraveVPNOSConnectionAPISim::RemoveVPNConnectionImpl(
+    const std::string& name) {
   base::SequencedTaskRunnerHandle::Get()->PostTask(
       FROM_HERE, base::BindOnce(&BraveVPNOSConnectionAPISim::OnRemoved,
                                 weak_factory_.GetWeakPtr(), name, true));
 }
 
-void BraveVPNOSConnectionAPISim::CheckConnection(const std::string& name) {
+void BraveVPNOSConnectionAPISim::CheckConnectionImpl(const std::string& name) {
   // Do nothing.
+}
+
+bool BraveVPNOSConnectionAPISim::GetIsSimulation() const {
+  return true;
 }
 
 void BraveVPNOSConnectionAPISim::OnCreated(const std::string& name,
@@ -92,8 +92,7 @@ void BraveVPNOSConnectionAPISim::OnCreated(const std::string& name,
   if (!success)
     return;
 
-  for (Observer& obs : observers_)
-    obs.OnCreated();
+  BraveVPNOSConnectionAPI::OnCreated();
 }
 
 void BraveVPNOSConnectionAPISim::OnConnected(const std::string& name,
@@ -104,13 +103,12 @@ void BraveVPNOSConnectionAPISim::OnConnected(const std::string& name,
     return;
   }
 
-  for (Observer& obs : observers_)
-    success ? obs.OnConnected() : obs.OnConnectFailed();
+  success ? BraveVPNOSConnectionAPI::OnConnected()
+          : BraveVPNOSConnectionAPI::OnConnectFailed();
 }
 
 void BraveVPNOSConnectionAPISim::OnIsConnecting(const std::string& name) {
-  for (Observer& obs : observers_)
-    obs.OnIsConnecting();
+  BraveVPNOSConnectionAPI::OnIsConnecting();
 }
 
 void BraveVPNOSConnectionAPISim::OnDisconnected(const std::string& name,
@@ -118,22 +116,14 @@ void BraveVPNOSConnectionAPISim::OnDisconnected(const std::string& name,
   if (!success)
     return;
 
-  for (Observer& obs : observers_)
-    obs.OnDisconnected();
+  BraveVPNOSConnectionAPI::OnDisconnected();
 }
 
 void BraveVPNOSConnectionAPISim::OnIsDisconnecting(const std::string& name) {
-  for (Observer& obs : observers_)
-    obs.OnIsDisconnecting();
+  BraveVPNOSConnectionAPI::OnIsDisconnecting();
 }
 
 void BraveVPNOSConnectionAPISim::OnRemoved(const std::string& name,
-                                           bool success) {
-  if (!success)
-    return;
-
-  for (Observer& obs : observers_)
-    obs.OnRemoved();
-}
+                                           bool success) {}
 
 }  // namespace brave_vpn

--- a/components/brave_vpn/brave_vpn_os_connection_api_sim.h
+++ b/components/brave_vpn/brave_vpn_os_connection_api_sim.h
@@ -27,12 +27,12 @@ class BraveVPNOSConnectionAPISim : public BraveVPNOSConnectionAPI {
   ~BraveVPNOSConnectionAPISim() override;
 
   // BraveVPNOSConnectionAPI overrides:
-  void CreateVPNConnection(const BraveVPNConnectionInfo& info) override;
-  void UpdateVPNConnection(const BraveVPNConnectionInfo& info) override;
-  void RemoveVPNConnection(const std::string& name) override;
-  void Connect(const std::string& name) override;
-  void Disconnect(const std::string& name) override;
-  void CheckConnection(const std::string& name) override;
+  void CreateVPNConnectionImpl(const BraveVPNConnectionInfo& info) override;
+  void RemoveVPNConnectionImpl(const std::string& name) override;
+  void ConnectImpl(const std::string& name) override;
+  void DisconnectImpl(const std::string& name) override;
+  void CheckConnectionImpl(const std::string& name) override;
+  bool GetIsSimulation() const override;
 
  private:
   void OnCreated(const std::string& name, bool success);

--- a/components/brave_vpn/brave_vpn_os_connection_api_win.h
+++ b/components/brave_vpn/brave_vpn_os_connection_api_win.h
@@ -34,12 +34,11 @@ class BraveVPNOSConnectionAPIWin : public BraveVPNOSConnectionAPI,
 
  private:
   // BraveVPNOSConnectionAPI overrides:
-  void CreateVPNConnection(const BraveVPNConnectionInfo& info) override;
-  void UpdateVPNConnection(const BraveVPNConnectionInfo& info) override;
-  void RemoveVPNConnection(const std::string& name) override;
-  void Connect(const std::string& name) override;
-  void Disconnect(const std::string& name) override;
-  void CheckConnection(const std::string& name) override;
+  void CreateVPNConnectionImpl(const BraveVPNConnectionInfo& info) override;
+  void RemoveVPNConnectionImpl(const std::string& name) override;
+  void ConnectImpl(const std::string& name) override;
+  void DisconnectImpl(const std::string& name) override;
+  void CheckConnectionImpl(const std::string& name) override;
 
   // base::win::ObjectWatcher::Delegate overrides:
   void OnObjectSignaled(HANDLE object) override;

--- a/components/brave_vpn/brave_vpn_service.cc
+++ b/components/brave_vpn/brave_vpn_service.cc
@@ -13,92 +13,32 @@
 #include "base/json/json_writer.h"
 #include "base/strings/utf_string_conversions.h"
 #include "base/time/time.h"
+#include "brave/components/brave_vpn/brave_vpn_constants.h"
+#include "brave/components/brave_vpn/brave_vpn_service_helper.h"
 #include "brave/components/brave_vpn/brave_vpn_utils.h"
 #include "brave/components/brave_vpn/pref_names.h"
 #include "brave/components/brave_vpn/vpn_response_parser.h"
 #include "brave/components/p3a_utils/feature_usage.h"
 #include "brave/components/skus/browser/skus_utils.h"
 #include "components/prefs/pref_service.h"
-#include "net/base/network_change_notifier.h"
 #include "net/cookies/cookie_inclusion_status.h"
 #include "net/cookies/parsed_cookie.h"
 #include "third_party/abseil-cpp/absl/types/optional.h"
 #include "url/url_util.h"
 
-#include "brave/components/brave_vpn/brave_vpn_service_helper.h"
 #if !BUILDFLAG(IS_ANDROID)
 #include "base/bind.h"
 #include "base/command_line.h"
 #include "base/logging.h"
 #include "base/notreached.h"
-#include "base/power_monitor/power_monitor.h"
 #include "base/strings/string_split.h"
 #include "base/strings/string_util.h"
-#include "brave/components/brave_vpn/brave_vpn_constants.h"
 #include "brave/components/brave_vpn/switches.h"
 #include "brave/components/version_info/version_info.h"
 #include "components/prefs/scoped_user_pref_update.h"
 #include "components/version_info/version_info.h"
 #include "third_party/icu/source/i18n/unicode/timezone.h"
 #endif  // !BUILDFLAG(IS_ANDROID)
-
-namespace {
-
-constexpr char kVpnHost[] = "connect-api.guardianapp.com";
-
-constexpr char kAllServerRegions[] = "api/v1/servers/all-server-regions";
-constexpr char kTimezonesForRegions[] =
-    "api/v1.1/servers/timezones-for-regions";
-constexpr char kHostnameForRegion[] = "api/v1.2/servers/hostnames-for-region";
-constexpr char kProfileCredential[] = "api/v1.1/register-and-create";
-constexpr char kCredential[] = "api/v1.3/device/";
-constexpr char kVerifyPurchaseToken[] = "api/v1.1/verify-purchase-token";
-constexpr char kCreateSubscriberCredentialV12[] =
-    "api/v1.2/subscriber-credential/create";
-constexpr int kP3AIntervalHours = 24;
-
-#if !BUILDFLAG(IS_ANDROID)
-constexpr char kTokenNoLongerValid[] = "Token No Longer Valid";
-#endif  // !BUILDFLAG(IS_ANDROID)
-
-net::NetworkTrafficAnnotationTag GetNetworkTrafficAnnotationTag() {
-  return net::DefineNetworkTrafficAnnotation("brave_vpn_service", R"(
-      semantics {
-        sender: "Brave VPN Service"
-        description:
-          "This service is used to communicate with Guardian VPN apis"
-          "on behalf of the user interacting with the Brave VPN."
-        trigger:
-          "Triggered by user connecting the Brave VPN."
-        data:
-          "Servers, hosts and credentials for Brave VPN"
-        destination: WEBSITE
-      }
-      policy {
-        cookies_allowed: NO
-        policy_exception_justification:
-          "Not implemented."
-      }
-    )");
-}
-
-GURL GetURLWithPath(const std::string& host, const std::string& path) {
-  return GURL(std::string(url::kHttpsScheme) + "://" + host).Resolve(path);
-}
-
-std::string CreateJSONRequestBody(base::ValueView node) {
-  std::string json;
-  base::JSONWriter::Write(node, &json);
-  return json;
-}
-
-#if !BUILDFLAG(IS_ANDROID)
-bool IsNetworkAvailable() {
-  return net::NetworkChangeNotifier::GetConnectionType() !=
-         net::NetworkChangeNotifier::CONNECTION_NONE;
-}
-#endif  // !BUILDFLAG(IS_ANDROID)
-}  // namespace
 
 namespace brave_vpn {
 
@@ -136,8 +76,6 @@ BraveVpnService::BraveVpnService(
   if (preference && !preference->IsDefaultValue()) {
     ReloadPurchasedState();
   }
-  base::PowerMonitor::AddPowerSuspendObserver(this);
-  net::NetworkChangeNotifier::AddDNSObserver(this);
 #endif  // !BUILDFLAG(IS_ANDROID)
 
   InitP3A();
@@ -173,252 +111,65 @@ void BraveVpnService::ScheduleBackgroundRegionDataFetch() {
                           base::Unretained(this), true));
 }
 
-void BraveVpnService::OnCreated() {
-  DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
-  VLOG(2) << __func__;
-  if (cancel_connecting_) {
-    UpdateAndNotifyConnectionStateChange(ConnectionState::DISCONNECTED);
-    cancel_connecting_ = false;
-    return;
-  }
-
-  for (const auto& obs : observers_)
-    obs->OnConnectionCreated();
-
-  // It's time to ask connecting to os after vpn entry is created.
-  GetBraveVPNConnectionAPI()->Connect(GetConnectionInfo().connection_name());
+void BraveVpnService::OnGetInvalidToken() {
+  SetPurchasedState(GetCurrentEnvironment(), PurchasedState::EXPIRED);
 }
 
-void BraveVpnService::OnCreateFailed() {
+void BraveVpnService::OnConnectionStateChanged(mojom::ConnectionState state) {
   DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
   VLOG(2) << __func__;
 
-  // Clear connecting cancel request.
-  if (cancel_connecting_)
-    cancel_connecting_ = false;
-
-  UpdateAndNotifyConnectionStateChange(ConnectionState::CONNECT_NOT_ALLOWED);
-}
-
-void BraveVpnService::OnRemoved() {
-  DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
-  VLOG(2) << __func__;
-  for (const auto& obs : observers_)
-    obs->OnConnectionRemoved();
-}
-
-void BraveVpnService::UpdateAndNotifyConnectionStateChange(
-    ConnectionState state,
-    bool force) {
-  // this is a simple state machine for handling connection state
-  DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
   // Ignore connection state change request for non purchased user.
   // This can be happened when user controls vpn via os settings.
   if (!is_purchased_user())
     return;
 
-  if (connection_state_ == state)
-    return;
-#if BUILDFLAG(IS_WIN)
-  // On Windows, we get disconnected status update twice.
-  // When user connects to different region while connected,
-  // we disconnect current connection and connect to newly selected
-  // region. To do that we monitor |DISCONNECTED| state and start
-  // connect when we get that state. But, Windows sends disconnected state
-  // noti again. So, ignore second one.
-  // On exception - we allow from connecting to disconnected in canceling
-  // scenario.
-  if (connection_state_ == ConnectionState::CONNECTING &&
-      state == ConnectionState::DISCONNECTED && !cancel_connecting_) {
-    VLOG(2) << __func__ << ": Ignore disconnected state while connecting";
-    return;
+  if (state == ConnectionState::CONNECTED) {
+    RecordP3A(true);
   }
 
-  // On Windows, we could get disconnected state after connect failed.
-  // To make connect failed state as a last state, ignore disconnected state.
-  if (!force && connection_state_ == ConnectionState::CONNECT_FAILED &&
-      state == ConnectionState::DISCONNECTED) {
-    VLOG(2) << __func__ << ": Ignore disconnected state after connect failed";
-    return;
-  }
-#endif  // BUILDFLAG(IS_WIN)
-  VLOG(2) << __func__ << " : changing from " << connection_state_ << " to "
-          << state;
-
-  connection_state_ = state;
   for (const auto& obs : observers_)
-    obs->OnConnectionStateChanged(connection_state_);
+    obs->OnConnectionStateChanged(state);
 }
 
-void BraveVpnService::OnConnected() {
+mojom::ConnectionState BraveVpnService::GetConnectionState() const {
+  DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
+  return GetBraveVPNConnectionAPI()->connection_state();
+}
+
+bool BraveVpnService::IsConnected() const {
+  return GetConnectionState() == ConnectionState::CONNECTED;
+}
+
+void BraveVpnService::RemoveVPNConnection() {
   DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
   VLOG(2) << __func__;
-
-  if (cancel_connecting_) {
-    // As connect is done, we don't need more for cancelling.
-    // Just start normal Disconenct() process.
-    cancel_connecting_ = false;
-    GetBraveVPNConnectionAPI()->Disconnect(kBraveVPNEntryName);
-    return;
-  }
-
-  UpdateAndNotifyConnectionStateChange(ConnectionState::CONNECTED);
-
-  RecordP3A(true);
-}
-
-void BraveVpnService::OnIsConnecting() {
-  DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
-  VLOG(2) << __func__;
-
-  if (!cancel_connecting_)
-    UpdateAndNotifyConnectionStateChange(ConnectionState::CONNECTING);
-}
-
-void BraveVpnService::OnConnectFailed() {
-  DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
-  VLOG(2) << __func__;
-
-  cancel_connecting_ = false;
-
-  // Clear previously used connection info if failed.
-  connection_info_.Reset();
-  UpdateAndNotifyConnectionStateChange(ConnectionState::CONNECT_FAILED);
-}
-
-void BraveVpnService::OnDisconnected() {
-  DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
-  VLOG(2) << __func__;
-  UpdateAndNotifyConnectionStateChange(!IsNetworkAvailable()
-                                           ? ConnectionState::CONNECT_FAILED
-                                           : ConnectionState::DISCONNECTED);
-  if (needs_connect_) {
-    needs_connect_ = false;
-    Connect();
-  }
-}
-
-void BraveVpnService::OnIsDisconnecting() {
-  DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
-  VLOG(2) << __func__;
-  UpdateAndNotifyConnectionStateChange(ConnectionState::DISCONNECTING);
-}
-
-void BraveVpnService::CreateVPNConnection() {
-  DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
-  if (cancel_connecting_) {
-    UpdateAndNotifyConnectionStateChange(ConnectionState::DISCONNECTED);
-    cancel_connecting_ = false;
-    return;
-  }
-
-  GetBraveVPNConnectionAPI()->CreateVPNConnection(GetConnectionInfo());
-}
-
-void BraveVpnService::RemoveVPNConnnection() {
-  DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
-  VLOG(2) << __func__;
-  GetBraveVPNConnectionAPI()->RemoveVPNConnection(kBraveVPNEntryName);
+  GetBraveVPNConnectionAPI()->RemoveVPNConnection();
 }
 
 void BraveVpnService::Connect() {
   DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
 
-  if (connection_state_ == ConnectionState::DISCONNECTING ||
-      connection_state_ == ConnectionState::CONNECTING) {
-    VLOG(2) << __func__ << ": Current state: " << connection_state_
-            << " : prevent connecting while previous operation is in-progress";
-    return;
-  }
-
-  DCHECK(!cancel_connecting_);
-
-  // User can ask connect again when user want to change region.
-  if (connection_state_ == ConnectionState::CONNECTED) {
-    // Disconnect first and then create again to setup for new region.
-    needs_connect_ = true;
-    Disconnect();
-    return;
-  }
-
-  VLOG(2) << __func__ << " : start connecting!";
-  UpdateAndNotifyConnectionStateChange(ConnectionState::CONNECTING);
-
-  if (!IsNetworkAvailable()) {
-    VLOG(2) << __func__ << ": Network is not available, failed to connect";
-    UpdateAndNotifyConnectionStateChange(ConnectionState::CONNECT_FAILED);
-    return;
-  }
-
-  if (is_simulation_ || connection_info_.IsValid()) {
-    VLOG(2) << __func__
-            << " : direct connect as we already have valid connection info.";
-    GetBraveVPNConnectionAPI()->Connect(GetConnectionInfo().connection_name());
-    return;
-  }
-
-  // If user doesn't select region explicitely, use default device region.
-  std::string target_region_name = GetSelectedRegion();
-  if (target_region_name.empty()) {
-    target_region_name = GetDeviceRegion();
-    VLOG(2) << __func__ << " : start connecting with valid default_region: "
-            << target_region_name;
-  }
-  DCHECK(!target_region_name.empty());
-  FetchHostnamesForRegion(target_region_name);
+  GetBraveVPNConnectionAPI()->Connect();
 }
 
 void BraveVpnService::Disconnect() {
   DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
-  if (connection_state_ == ConnectionState::DISCONNECTED) {
-    VLOG(2) << __func__ << " : already disconnected";
-    return;
-  }
 
-  if (connection_state_ == ConnectionState::DISCONNECTING) {
-    VLOG(2) << __func__ << " : disconnecting in progress";
-    return;
-  }
-
-  if (is_simulation_ || connection_state_ != ConnectionState::CONNECTING) {
-    VLOG(2) << __func__ << " : start disconnecting!";
-    UpdateAndNotifyConnectionStateChange(ConnectionState::DISCONNECTING);
-    GetBraveVPNConnectionAPI()->Disconnect(kBraveVPNEntryName);
-    return;
-  }
-
-  cancel_connecting_ = true;
-  VLOG(2) << __func__ << " : Start cancelling connect request";
-  UpdateAndNotifyConnectionStateChange(ConnectionState::DISCONNECTING);
+  GetBraveVPNConnectionAPI()->Disconnect();
 }
 
 void BraveVpnService::ToggleConnection() {
   DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
-  const bool can_disconnect =
-      (connection_state_ == ConnectionState::CONNECTED ||
-       connection_state_ == ConnectionState::CONNECTING);
-  can_disconnect ? Disconnect() : Connect();
-}
 
-const BraveVPNConnectionInfo& BraveVpnService::GetConnectionInfo() {
-  DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
-  return connection_info_;
+  GetBraveVPNConnectionAPI()->ToggleConnection();
 }
 
 void BraveVpnService::GetConnectionState(GetConnectionStateCallback callback) {
   DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
-  VLOG(2) << __func__ << " : " << connection_state_;
-  std::move(callback).Run(connection_state_);
-}
-
-void BraveVpnService::ResetConnectionState() {
-  DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
-  // Reset is allowed only when it has failed state.
-  if (connection_state_ != ConnectionState::CONNECT_NOT_ALLOWED &&
-      connection_state_ != ConnectionState::CONNECT_FAILED)
-    return;
-
-  UpdateAndNotifyConnectionStateChange(ConnectionState::DISCONNECTED, true);
+  const auto state = GetBraveVPNConnectionAPI()->connection_state();
+  VLOG(2) << __func__ << " : " << state;
+  std::move(callback).Run(state);
 }
 
 void BraveVpnService::FetchRegionData(bool background_fetch) {
@@ -658,9 +409,10 @@ void BraveVpnService::GetSelectedRegion(GetSelectedRegionCallback callback) {
 
 void BraveVpnService::SetSelectedRegion(mojom::RegionPtr region_ptr) {
   DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
-  if (connection_state_ == ConnectionState::DISCONNECTING ||
-      connection_state_ == ConnectionState::CONNECTING) {
-    VLOG(2) << __func__ << ": Current state: " << connection_state_
+  auto connection_state = GetConnectionState();
+  if (connection_state == ConnectionState::DISCONNECTING ||
+      connection_state == ConnectionState::CONNECTING) {
+    VLOG(2) << __func__ << ": Current state: " << connection_state
             << " : prevent changing selected region while previous operation "
                "is in-progress";
     return;
@@ -671,7 +423,7 @@ void BraveVpnService::SetSelectedRegion(mojom::RegionPtr region_ptr) {
 
   // As new selected region is used, |connection_info_| for previous selected
   // should be cleared.
-  connection_info_.Reset();
+  GetBraveVPNConnectionAPI()->ResetConnectionInfo();
 }
 
 void BraveVpnService::GetProductUrls(GetProductUrlsCallback callback) {
@@ -699,158 +451,12 @@ void BraveVpnService::GetSupportData(GetSupportDataCallback callback) {
   std::string brave_version =
       version_info::GetBraveVersionWithoutChromiumMajorVersion();
   std::string os_version = version_info::GetOSType();
-  std::string vpn_hostname = hostname_ ? hostname_->hostname : "";
-  std::move(callback).Run(brave_version, os_version, vpn_hostname);
+
+  std::move(callback).Run(brave_version, os_version,
+                          GetBraveVPNConnectionAPI()->GetHostname());
 }
 
-void BraveVpnService::FetchHostnamesForRegion(const std::string& name) {
-  DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
-  VLOG(2) << __func__;
-  // Hostname will be replaced with latest one.
-  hostname_.reset();
-
-  // Unretained is safe here becasue this class owns request helper.
-  GetHostnamesForRegion(base::BindOnce(&BraveVpnService::OnFetchHostnames,
-                                       base::Unretained(this), name),
-                        name);
-}
-
-void BraveVpnService::OnFetchHostnames(const std::string& region,
-                                       const std::string& hostnames,
-                                       bool success) {
-  DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
-  VLOG(2) << __func__;
-  if (cancel_connecting_) {
-    UpdateAndNotifyConnectionStateChange(ConnectionState::DISCONNECTED);
-    cancel_connecting_ = false;
-    return;
-  }
-
-  if (!success) {
-    VLOG(2) << __func__ << " : failed to fetch hostnames for " << region;
-    UpdateAndNotifyConnectionStateChange(ConnectionState::CONNECT_FAILED);
-    return;
-  }
-
-  absl::optional<base::Value> value = base::JSONReader::Read(hostnames);
-  if (value && value->is_list()) {
-    ParseAndCacheHostnames(region, value->GetList());
-    return;
-  }
-
-  VLOG(2) << __func__ << " : failed to fetch hostnames for " << region;
-  UpdateAndNotifyConnectionStateChange(ConnectionState::CONNECT_FAILED);
-}
-
-void BraveVpnService::ParseAndCacheHostnames(
-    const std::string& region,
-    const base::Value::List& hostnames_value) {
-  DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
-  std::vector<Hostname> hostnames = ParseHostnames(hostnames_value);
-
-  if (hostnames.empty()) {
-    VLOG(2) << __func__ << " : got empty hostnames list for " << region;
-    UpdateAndNotifyConnectionStateChange(ConnectionState::CONNECT_FAILED);
-    return;
-  }
-
-  hostname_ = PickBestHostname(hostnames);
-  if (hostname_->hostname.empty()) {
-    VLOG(2) << __func__ << " : got empty hostnames list for " << region;
-    UpdateAndNotifyConnectionStateChange(ConnectionState::CONNECT_FAILED);
-    return;
-  }
-
-  VLOG(2) << __func__ << " : Picked " << hostname_->hostname << ", "
-          << hostname_->display_name << ", " << hostname_->is_offline << ", "
-          << hostname_->capacity_score;
-
-  if (skus_credential_.empty()) {
-    VLOG(2) << __func__ << " : skus_credential is empty";
-    UpdateAndNotifyConnectionStateChange(ConnectionState::CONNECT_FAILED);
-    return;
-  }
-
-  // Get subscriber credentials and then get EAP credentials with it to create
-  // OS VPN entry.
-  VLOG(2) << __func__ << " : request subscriber credential:"
-          << GetBraveVPNPaymentsEnv(GetCurrentEnvironment());
-  GetSubscriberCredentialV12(base::BindOnce(
-      &BraveVpnService::OnGetSubscriberCredentialV12, base::Unretained(this)));
-}
-
-void BraveVpnService::OnGetSubscriberCredentialV12(
-    const std::string& subscriber_credential,
-    bool success) {
-  DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
-  if (cancel_connecting_) {
-    UpdateAndNotifyConnectionStateChange(ConnectionState::DISCONNECTED);
-    cancel_connecting_ = false;
-    return;
-  }
-
-  if (!success) {
-    VLOG(2) << __func__ << " : failed to get subscriber credential";
-    UpdateAndNotifyConnectionStateChange(ConnectionState::CONNECT_FAILED);
-    if (subscriber_credential == kTokenNoLongerValid) {
-      SetPurchasedState(GetCurrentEnvironment(), PurchasedState::EXPIRED);
-    }
-    return;
-  }
-
-  VLOG(2) << __func__ << " : received subscriber credential";
-  // TODO(bsclifton): consider storing `subscriber_credential` for
-  // support ticket use-case (see `CreateSupportTicket`).
-  GetProfileCredentials(
-      base::BindOnce(&BraveVpnService::OnGetProfileCredentials,
-                     base::Unretained(this)),
-      subscriber_credential, hostname_->hostname);
-}
-
-void BraveVpnService::OnGetProfileCredentials(
-    const std::string& profile_credential,
-    bool success) {
-  DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
-  if (cancel_connecting_) {
-    UpdateAndNotifyConnectionStateChange(ConnectionState::DISCONNECTED);
-    cancel_connecting_ = false;
-    return;
-  }
-
-  if (!success) {
-    VLOG(2) << __func__ << " : failed to get profile credential";
-    UpdateAndNotifyConnectionStateChange(ConnectionState::CONNECT_FAILED);
-    return;
-  }
-
-  VLOG(2) << __func__ << " : received profile credential";
-
-  absl::optional<base::Value> value =
-      base::JSONReader::Read(profile_credential);
-  if (value && value->is_dict()) {
-    constexpr char kUsernameKey[] = "eap-username";
-    constexpr char kPasswordKey[] = "eap-password";
-    const auto& dict = value->GetDict();
-    const std::string* username = dict.FindString(kUsernameKey);
-    const std::string* password = dict.FindString(kPasswordKey);
-    if (!username || !password) {
-      VLOG(2) << __func__ << " : it's invalid profile credential";
-      UpdateAndNotifyConnectionStateChange(ConnectionState::CONNECT_FAILED);
-      return;
-    }
-
-    connection_info_.SetConnectionInfo(kBraveVPNEntryName, hostname_->hostname,
-                                       *username, *password);
-    // Let's create os vpn entry with |connection_info_|.
-    CreateVPNConnection();
-    return;
-  }
-
-  VLOG(2) << __func__ << " : it's invalid profile credential";
-  UpdateAndNotifyConnectionStateChange(ConnectionState::CONNECT_FAILED);
-}
-
-BraveVPNOSConnectionAPI* BraveVpnService::GetBraveVPNConnectionAPI() {
+BraveVPNOSConnectionAPI* BraveVpnService::GetBraveVPNConnectionAPI() const {
   if (is_simulation_)
     return BraveVPNOSConnectionAPI::GetInstanceForTest();
   return BraveVPNOSConnectionAPI::GetInstance();
@@ -866,41 +472,6 @@ void BraveVpnService::OnCreateSupportTicket(
           << "\nresponse_code=" << api_request_result.response_code();
   std::move(callback).Run(success, api_request_result.body());
 }
-void BraveVpnService::OnSuspend() {
-  // Set reconnection state in case if computer/laptop is going to sleep.
-  // The disconnection event will be fired after waking up and we want to
-  // restore the connection.
-  if (is_connected()) {
-    Disconnect();
-    reconnect_on_resume_ = true;
-  }
-  VLOG(2) << __func__
-          << " Should reconnect when resume:" << reconnect_on_resume_;
-}
-
-void BraveVpnService::OnResume() {
-#if BUILDFLAG(IS_MAC)
-  OnDNSChanged();
-#endif  // BUILDFLAG(IS_MAC)
-}
-
-void BraveVpnService::OnDNSChanged() {
-  if (!IsNetworkAvailable() ||
-      // This event is triggered before going to sleep while vpn is still
-      // active. Vpn is presented as CONNECTION_UNKNOWN and so we have to skip
-      // this to be notified only when default network active without VPN to
-      // reconnect.
-      net::NetworkChangeNotifier::GetConnectionType() ==
-          net::NetworkChangeNotifier::CONNECTION_UNKNOWN)
-    return;
-
-  VLOG(2) << __func__ << " Should reconnect:" << reconnect_on_resume_;
-  if (reconnect_on_resume_) {
-    Connect();
-    reconnect_on_resume_ = false;
-  }
-}
-
 #endif  // !BUILDFLAG(IS_ANDROID)
 
 #if BUILDFLAG(IS_ANDROID)
@@ -975,7 +546,8 @@ void BraveVpnService::LoadPurchasedState(const std::string& domain) {
 #if !BUILDFLAG(IS_ANDROID)
   if (!IsNetworkAvailable()) {
     VLOG(2) << __func__ << ": Network is not available, failed to connect";
-    UpdateAndNotifyConnectionStateChange(ConnectionState::CONNECT_FAILED);
+    GetBraveVPNConnectionAPI()->SetConnectionState(
+        ConnectionState::CONNECT_FAILED);
     return;
   }
 #endif
@@ -995,7 +567,7 @@ void BraveVpnService::LoadPurchasedState(const std::string& domain) {
       FetchRegionData(false);
     }
 
-    GetBraveVPNConnectionAPI()->CheckConnection(kBraveVPNEntryName);
+    GetBraveVPNConnectionAPI()->CheckConnection();
     return;
   }
 #endif  // !BUILDFLAG(IS_ANDROID) && !defined(OFFICIAL_BUILD)
@@ -1087,6 +659,8 @@ void BraveVpnService::OnPrepareCredentialsPresentation(
 #if BUILDFLAG(IS_ANDROID)
   SetPurchasedState(env, PurchasedState::PURCHASED);
 #else
+  GetBraveVPNConnectionAPI()->SetSkusCredential(skus_credential_);
+
   LoadCachedRegionData();
 
   // Only fetch when we don't have cache.
@@ -1097,10 +671,11 @@ void BraveVpnService::OnPrepareCredentialsPresentation(
   }
 
   ScheduleBackgroundRegionDataFetch();
-  GetBraveVPNConnectionAPI()->CheckConnection(kBraveVPNEntryName);
+  GetBraveVPNConnectionAPI()->CheckConnection();
 #endif
 }
 
+// TODO(simonhong): Should move p3a to BraveVPNOSConnectionAPI?
 void BraveVpnService::InitP3A() {
   p3a_timer_.Start(FROM_HERE, base::Hours(kP3AIntervalHours), this,
                    &BraveVpnService::OnP3AInterval);
@@ -1202,8 +777,6 @@ void BraveVpnService::Shutdown() {
 #if !BUILDFLAG(IS_ANDROID)
   observed_.Reset();
   receivers_.Clear();
-  base::PowerMonitor::RemovePowerSuspendObserver(this);
-  net::NetworkChangeNotifier::RemoveDNSObserver(this);
 #endif  // !BUILDFLAG(IS_ANDROID)
 }
 

--- a/components/brave_vpn/brave_vpn_service.h
+++ b/components/brave_vpn/brave_vpn_service.h
@@ -31,13 +31,11 @@
 #include <memory>
 #include <vector>
 
-#include "base/power_monitor/power_observer.h"
 #include "base/scoped_observation.h"
 #include "base/timer/timer.h"
 #include "brave/components/brave_vpn/brave_vpn_connection_info.h"
 #include "brave/components/brave_vpn/brave_vpn_data_types.h"
 #include "brave/components/brave_vpn/brave_vpn_os_connection_api.h"
-#include "net/base/network_change_notifier.h"
 #endif  // !BUILDFLAG(IS_ANDROID)
 
 namespace network {
@@ -63,8 +61,6 @@ constexpr char kLastUsageTimeHistogramName[] = "Brave.VPN.LastUsageTime";
 class BraveVpnService :
 #if !BUILDFLAG(IS_ANDROID)
     public BraveVPNOSConnectionAPI::Observer,
-    public base::PowerSuspendObserver,
-    public net::NetworkChangeNotifier::DNSObserver,
 #endif
     public mojom::ServiceHandler,
     public KeyedService {
@@ -91,18 +87,14 @@ class BraveVpnService :
 
 #if !BUILDFLAG(IS_ANDROID)
   void ToggleConnection();
-  void RemoveVPNConnnection();
-  bool is_connected() const {
-    return connection_state_ == mojom::ConnectionState::CONNECTED;
-  }
-  mojom::ConnectionState connection_state() const { return connection_state_; }
+  void RemoveVPNConnection();
+  mojom::ConnectionState GetConnectionState() const;
+  bool IsConnected() const;
 
   // mojom::vpn::ServiceHandler
   void GetConnectionState(GetConnectionStateCallback callback) override;
-  void ResetConnectionState() override;
   void Connect() override;
   void Disconnect() override;
-  void CreateVPNConnection() override;
   void GetAllRegions(GetAllRegionsCallback callback) override;
   void GetDeviceRegion(GetDeviceRegionCallback callback) override;
   void GetSelectedRegion(GetSelectedRegionCallback callback) override;
@@ -113,13 +105,6 @@ class BraveVpnService :
                            const std::string& body,
                            CreateSupportTicketCallback callback) override;
   void GetSupportData(GetSupportDataCallback callback) override;
-
-  // base::PowerMonitor
-  void OnSuspend() override;
-  void OnResume() override;
-
-  // net::NetworkChangeNotifier::DNSObserver
-  void OnDNSChanged() override;
 #else
   // mojom::vpn::ServiceHandler
   void GetPurchaseToken(GetPurchaseTokenCallback callback) override;
@@ -179,28 +164,15 @@ class BraveVpnService :
  private:
   friend class BraveVPNServiceTest;
 
-  void InitP3A();
-  void OnP3AInterval();
-
 #if !BUILDFLAG(IS_ANDROID)
   friend class ::BraveAppMenuBrowserTest;
   friend class ::BraveBrowserCommandControllerTest;
 
   // BraveVPNOSConnectionAPI::Observer overrides:
-  void OnCreated() override;
-  void OnCreateFailed() override;
-  void OnRemoved() override;
-  void OnConnected() override;
-  void OnIsConnecting() override;
-  void OnConnectFailed() override;
-  void OnDisconnected() override;
-  void OnIsDisconnecting() override;
+  void OnGetInvalidToken() override;
+  void OnConnectionStateChanged(mojom::ConnectionState state) override;
 
-  const BraveVPNConnectionInfo& GetConnectionInfo();
   void LoadCachedRegionData();
-  void UpdateAndNotifyConnectionStateChange(mojom::ConnectionState state,
-                                            bool force = false);
-
   void FetchRegionData(bool background_fetch);
   void OnFetchRegionList(bool background_fetch,
                          const std::string& region_list,
@@ -209,12 +181,6 @@ class BraveVpnService :
                                bool save_to_prefs = false);
   void OnFetchTimezones(const std::string& timezones_list, bool success);
   void SetDeviceRegionWithTimezone(const base::Value::List& timezons_value);
-  void FetchHostnamesForRegion(const std::string& name);
-  void OnFetchHostnames(const std::string& region,
-                        const std::string& hostnames,
-                        bool success);
-  void ParseAndCacheHostnames(const std::string& region,
-                              const base::Value::List& hostnames_value);
   void SetDeviceRegion(const std::string& name);
   void SetSelectedRegion(const std::string& name);
   std::string GetDeviceRegion() const;
@@ -226,14 +192,10 @@ class BraveVpnService :
   void ScheduleBackgroundRegionDataFetch();
   void ScheduleFetchRegionDataIfNeeded();
 
-  void OnGetSubscriberCredentialV12(const std::string& subscriber_credential,
-                                    bool success);
-  void OnGetProfileCredentials(const std::string& profile_credential,
-                               bool success);
   void OnCreateSupportTicket(CreateSupportTicketCallback callback,
                              APIRequestResult api_request_result);
 
-  BraveVPNOSConnectionAPI* GetBraveVPNConnectionAPI();
+  BraveVPNOSConnectionAPI* GetBraveVPNConnectionAPI() const;
 #endif  // !BUILDFLAG(IS_ANDROID)
 
   using URLRequestCallback = base::OnceCallback<void(APIRequestResult)>;
@@ -241,15 +203,16 @@ class BraveVpnService :
   // KeyedService overrides:
   void Shutdown() override;
 
+  void InitP3A();
+  void OnP3AInterval();
+
   void OAuthRequest(
       const GURL& url,
       const std::string& method,
       const std::string& post_data,
       URLRequestCallback callback,
       const base::flat_map<std::string, std::string>& headers = {});
-
   void OnGetResponse(ResponseCallback callback, APIRequestResult request);
-
   void OnGetSubscriberCredential(ResponseCallback callback,
                                  APIRequestResult request);
   mojom::PurchasedState GetPurchasedStateSync() const;
@@ -263,17 +226,8 @@ class BraveVpnService :
       const std::string& domain,
       const std::string& credential_as_cookie);
 
-  raw_ptr<PrefService> local_prefs_ = nullptr;
-  raw_ptr<PrefService> profile_prefs_ = nullptr;
 #if !BUILDFLAG(IS_ANDROID)
   std::vector<mojom::Region> regions_;
-  std::unique_ptr<Hostname> hostname_;
-  BraveVPNConnectionInfo connection_info_;
-  bool cancel_connecting_ = false;
-  mojom::ConnectionState connection_state_ =
-      mojom::ConnectionState::DISCONNECTED;
-  bool needs_connect_ = false;
-  bool reconnect_on_resume_ = false;
   base::ScopedObservation<BraveVPNOSConnectionAPI,
                           BraveVPNOSConnectionAPI::Observer>
       observed_{this};
@@ -284,10 +238,11 @@ class BraveVpnService :
   bool is_simulation_ = false;
 #endif  // !BUILDFLAG(IS_ANDROID)
 
-  mojo::ReceiverSet<mojom::ServiceHandler> receivers_;
-
   SEQUENCE_CHECKER(sequence_checker_);
 
+  raw_ptr<PrefService> local_prefs_ = nullptr;
+  raw_ptr<PrefService> profile_prefs_ = nullptr;
+  mojo::ReceiverSet<mojom::ServiceHandler> receivers_;
   base::RepeatingCallback<mojo::PendingRemote<skus::mojom::SkusService>()>
       skus_service_getter_;
   mojo::Remote<skus::mojom::SkusService> skus_service_;

--- a/components/brave_vpn/brave_vpn_service_observer.h
+++ b/components/brave_vpn/brave_vpn_service_observer.h
@@ -27,8 +27,6 @@ class BraveVPNServiceObserver : public mojom::ServiceObserver {
   void OnPurchasedStateChanged(mojom::PurchasedState state) override {}
 #if !BUILDFLAG(IS_ANDROID)
   void OnConnectionStateChanged(mojom::ConnectionState state) override {}
-  void OnConnectionCreated() override {}
-  void OnConnectionRemoved() override {}
 #endif  // !BUILDFLAG(IS_ANDROID)
 
  private:

--- a/components/brave_vpn/brave_vpn_unittest.cc
+++ b/components/brave_vpn/brave_vpn_unittest.cc
@@ -13,6 +13,7 @@
 #include "base/run_loop.h"
 #include "base/test/metrics/histogram_tester.h"
 #include "base/test/scoped_feature_list.h"
+#include "brave/components/brave_vpn/brave_vpn_os_connection_api.h"
 #include "brave/components/brave_vpn/brave_vpn_service.h"
 #include "brave/components/brave_vpn/brave_vpn_service_helper.h"
 #include "brave/components/brave_vpn/brave_vpn_utils.h"
@@ -133,8 +134,6 @@ class TestBraveVPNServiceObserver : public mojom::ServiceObserver {
       std::move(purchased_callback_).Run();
   }
 #if !BUILDFLAG(IS_ANDROID)
-  void OnConnectionCreated() override {}
-  void OnConnectionRemoved() override {}
   void OnConnectionStateChanged(ConnectionState state) override {
     connection_state_ = state;
     if (connection_state_callback_)
@@ -209,6 +208,9 @@ class BraveVPNServiceTest : public testing::Test {
         &profile_pref_service_,
         base::BindRepeating(&BraveVPNServiceTest::GetSkusService,
                             base::Unretained(this)));
+#if !BUILDFLAG(IS_ANDROID)
+    GetBraveVPNConnectionAPI()->set_local_prefs(&local_pref_service_);
+#endif
   }
   mojo::PendingRemote<skus::mojom::SkusService> GetSkusService() {
     if (!skus_service_) {
@@ -250,11 +252,17 @@ class BraveVPNServiceTest : public testing::Test {
 
   std::vector<mojom::Region>& regions() const { return service_->regions_; }
 
-  std::unique_ptr<Hostname>& hostname() { return service_->hostname_; }
+  std::unique_ptr<Hostname>& hostname() {
+    return GetBraveVPNConnectionAPI()->hostname_;
+  }
 
-  bool& cancel_connecting() { return service_->cancel_connecting_; }
+  bool& cancel_connecting() {
+    return GetBraveVPNConnectionAPI()->cancel_connecting_;
+  }
 
-  ConnectionState& connection_state() { return service_->connection_state_; }
+  ConnectionState& connection_state() {
+    return GetBraveVPNConnectionAPI()->connection_state_;
+  }
 
   void OnCredentialSummary(const std::string& domain,
                            const std::string& summary) {
@@ -262,10 +270,10 @@ class BraveVPNServiceTest : public testing::Test {
   }
 
   void UpdateAndNotifyConnectionStateChange(mojom::ConnectionState state) {
-    service_->UpdateAndNotifyConnectionStateChange(state);
+    GetBraveVPNConnectionAPI()->UpdateAndNotifyConnectionStateChange(state);
   }
-  void Suspend() { service_->OnSuspend(); }
-  void OnDNSChanged() { service_->OnDNSChanged(); }
+  void Suspend() { GetBraveVPNConnectionAPI()->OnSuspend(); }
+  void OnDNSChanged() { GetBraveVPNConnectionAPI()->OnDNSChanged(); }
 
   void OnFetchRegionList(bool background_fetch,
                          const std::string& region_list,
@@ -280,38 +288,51 @@ class BraveVPNServiceTest : public testing::Test {
   void OnFetchHostnames(const std::string& region,
                         const std::string& hostnames,
                         bool success) {
-    service_->OnFetchHostnames(region, hostnames, success);
+    GetBraveVPNConnectionAPI()->OnFetchHostnames(region, hostnames, success);
   }
 
   std::string& skus_credential() { return service_->skus_credential_; }
 
-  bool& is_simulation() { return service_->is_simulation_; }
+  void SetSkusCredential(const std::string& credential) {
+    service_->skus_credential_ = credential;
+    GetBraveVPNConnectionAPI()->SetSkusCredential(credential);
+  }
 
-  bool& needs_connect() { return service_->needs_connect_; }
-  bool& reconnect_on_resume() { return service_->reconnect_on_resume_; }
+  bool& prevent_creation() {
+    return GetBraveVPNConnectionAPI()->prevent_creation_;
+  }
 
-  void Connect() { service_->Connect(); }
+  bool& needs_connect() { return GetBraveVPNConnectionAPI()->needs_connect_; }
+  bool& reconnect_on_resume() {
+    return GetBraveVPNConnectionAPI()->reconnect_on_resume_;
+  }
 
-  void Disconnect() { service_->Disconnect(); }
+  void Connect() { GetBraveVPNConnectionAPI()->Connect(); }
 
-  void CreateVPNConnection() { service_->CreateVPNConnection(); }
-  void OnCreated() { service_->OnCreated(); }
+  void Disconnect() { GetBraveVPNConnectionAPI()->Disconnect(); }
+
+  void CreateVPNConnection() {
+    GetBraveVPNConnectionAPI()->CreateVPNConnection();
+  }
+  void OnCreated() { GetBraveVPNConnectionAPI()->OnCreated(); }
   void LoadCachedRegionData() { service_->LoadCachedRegionData(); }
 
-  void OnConnected() { service_->OnConnected(); }
-  void OnConnectFailed() { service_->OnConnectFailed(); }
-  void OnDisconnected() { service_->OnDisconnected(); }
+  void OnConnected() { GetBraveVPNConnectionAPI()->OnConnected(); }
+  void OnConnectFailed() { GetBraveVPNConnectionAPI()->OnConnectFailed(); }
+  void OnDisconnected() { GetBraveVPNConnectionAPI()->OnDisconnected(); }
 
   const BraveVPNConnectionInfo& GetConnectionInfo() {
-    return service_->GetConnectionInfo();
+    return GetBraveVPNConnectionAPI()->connection_info();
   }
   void OnGetSubscriberCredentialV12(const std::string& subscriber_credential,
                                     bool success) {
-    service_->OnGetSubscriberCredentialV12(subscriber_credential, success);
+    GetBraveVPNConnectionAPI()->OnGetSubscriberCredentialV12(
+        subscriber_credential, success);
   }
   void OnGetProfileCredentials(const std::string& profile_credential,
                                bool success) {
-    service_->OnGetProfileCredentials(profile_credential, success);
+    GetBraveVPNConnectionAPI()->OnGetProfileCredentials(profile_credential,
+                                                        success);
   }
 
   void OnPrepareCredentialsPresentation(
@@ -319,6 +340,11 @@ class BraveVPNServiceTest : public testing::Test {
       const std::string& credential_as_cookie) {
     service_->OnPrepareCredentialsPresentation(domain, credential_as_cookie);
   }
+
+  BraveVPNOSConnectionAPI* GetBraveVPNConnectionAPI() {
+    return service_->GetBraveVPNConnectionAPI();
+  }
+
   void SetDeviceRegion(const std::string& name) {
     service_->SetDeviceRegion(name);
   }
@@ -707,21 +733,24 @@ TEST_F(BraveVPNServiceTest, CancelConnectingTest) {
 }
 
 TEST_F(BraveVPNServiceTest, ConnectionStateUpdateWithPurchasedStateTest) {
+  TestBraveVPNServiceObserver observer;
+  AddObserver(observer.GetReceiver());
+
   std::string env = skus::GetDefaultEnvironment();
   SetPurchasedState(env, PurchasedState::PURCHASED);
   connection_state() = ConnectionState::CONNECTING;
   UpdateAndNotifyConnectionStateChange(ConnectionState::CONNECTED);
-  EXPECT_EQ(ConnectionState::CONNECTED, connection_state());
-
-  SetPurchasedState(env, PurchasedState::NOT_PURCHASED);
-  connection_state() = ConnectionState::CONNECTING;
-  UpdateAndNotifyConnectionStateChange(ConnectionState::CONNECTED);
-  EXPECT_NE(ConnectionState::CONNECTED, connection_state());
+  {
+    base::RunLoop loop;
+    observer.WaitConnectionStateChange(loop.QuitClosure());
+    loop.Run();
+  }
+  EXPECT_EQ(ConnectionState::CONNECTED, observer.GetConnectionState());
 }
 
 TEST_F(BraveVPNServiceTest, ConnectionInfoTest) {
   // Having skus_credential is pre-requisite before try connecting.
-  skus_credential() = "test_credentials";
+  SetSkusCredential("test_credentials");
   // Check valid connection info is set when valid hostname and profile
   // credential are fetched.
   connection_state() = ConnectionState::CONNECTING;
@@ -729,7 +758,7 @@ TEST_F(BraveVPNServiceTest, ConnectionInfoTest) {
   EXPECT_EQ(ConnectionState::CONNECTING, connection_state());
 
   // To prevent real os vpn entry creation.
-  is_simulation() = true;
+  prevent_creation() = true;
   OnGetProfileCredentials(GetProfileCredentialData(), true);
   EXPECT_EQ(ConnectionState::CONNECTING, connection_state());
   EXPECT_TRUE(GetConnectionInfo().IsValid());
@@ -970,8 +999,6 @@ TEST_F(BraveVPNServiceTest, ResumeAfterSuspend) {
             net::NetworkChangeNotifier::GetConnectionType());
   OnDNSChanged();
   EXPECT_TRUE(reconnect_on_resume());
-  mock_notifier.mock_network_change_notifier()->SetConnectionType(
-      net::NetworkChangeNotifier::CONNECTION_UNKNOWN);
 
   mock_notifier.mock_network_change_notifier()->SetConnectionType(
       net::NetworkChangeNotifier::CONNECTION_ETHERNET);

--- a/components/brave_vpn/brave_vpn_utils.h
+++ b/components/brave_vpn/brave_vpn_utils.h
@@ -8,8 +8,12 @@
 
 #include <string>
 
+#include "base/values.h"
+#include "net/traffic_annotation/network_traffic_annotation.h"
+
 class PrefRegistrySimple;
 class PrefService;
+class GURL;
 namespace user_prefs {
 class PrefRegistrySyncable;
 }  // namespace user_prefs
@@ -22,6 +26,14 @@ void MigrateVPNSettings(PrefService* profile_prefs, PrefService* local_prefs);
 void RegisterLocalStatePrefs(PrefRegistrySimple* registry);
 void RegisterProfilePrefs(user_prefs::PrefRegistrySyncable* registry);
 void RegisterAndroidProfilePrefs(PrefRegistrySimple* registry);
+net::NetworkTrafficAnnotationTag GetNetworkTrafficAnnotationTag();
+GURL GetURLWithPath(const std::string& host, const std::string& path);
+std::string CreateJSONRequestBody(base::ValueView node);
+
+#if !BUILDFLAG(IS_ANDROID)
+bool IsNetworkAvailable();
+#endif  // !BUILDFLAG(IS_ANDROID)
+
 }  // namespace brave_vpn
 
 #endif  // BRAVE_COMPONENTS_BRAVE_VPN_BRAVE_VPN_UTILS_H_

--- a/components/brave_vpn/mojom/brave_vpn.mojom
+++ b/components/brave_vpn/mojom/brave_vpn.mojom
@@ -27,12 +27,6 @@ interface PanelHandler {
 
 interface ServiceObserver {
   [EnableIfNot=is_android]
-  OnConnectionCreated();
-
-  [EnableIfNot=is_android]
-  OnConnectionRemoved();
-
-  [EnableIfNot=is_android]
   OnConnectionStateChanged(ConnectionState state);
 
   OnPurchasedStateChanged(PurchasedState state);
@@ -46,12 +40,6 @@ interface ServiceHandler {
 
   [EnableIfNot=is_android]
   GetConnectionState() => (ConnectionState state);
-
-  [EnableIfNot=is_android]
-  ResetConnectionState();
-
-  [EnableIfNot=is_android]
-  CreateVPNConnection();
 
   [EnableIfNot=is_android]
   Connect();

--- a/components/brave_vpn/resources/panel/stories/mock-data/api.ts
+++ b/components/brave_vpn/resources/panel/stories/mock-data/api.ts
@@ -15,7 +15,6 @@ BraveVPN.setPanelBrowserApiForTesting({
     addObserver: doNothing,
     getPurchasedState: () => Promise.resolve({ state: BraveVPN.PurchasedState.LOADING }),
     getConnectionState: () => Promise.resolve({ state: BraveVPN.ConnectionState.CONNECTED }),
-    createVPNConnection: doNothing,
     connect: doNothing,
     disconnect: doNothing,
     loadPurchasedState: doNothing,
@@ -38,7 +37,6 @@ BraveVPN.setPanelBrowserApiForTesting({
     createSupportTicket: (email: string, subject: string, body: string) => Promise.resolve({
       success: true,
       response: 'OK'
-    }),
-    resetConnectionState: doNothing
+    })
   }
 })


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->

Initially vpn state was per-profile. However, we decided to share vpn state between all profiles.
With this change, one profile can have same vpn status if other profile is purchased user.
So far vpn service manages two states. The one is purchased state and the other is connection state.
Purchased state is still per-profile because skus service is per profile.
Although purchased state is managed by each profile, same state is shared for all profiles eventually
because skus service's internal data is global.
In this PR connection state managing is moved from per-profile vpn service to BraveVPNOSConnectionAPI
global instance. Before this PR, BraveVPNOSConnectionAPI didn't have state and only provided abstract interface
for os dependent vpn command such as connect or disconnect. In the os system, there is only one connection state.
So, connection state also should be managed globally. With that each profile can see same connection state.

Resolves https://github.com/brave/brave-browser/issues/25789

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

`npm run test brave_unit_tests --filter=*VPN*`

See the linked issue for manu test step