### PR TITLE
Add Brave license header checker.

### DIFF
--- a/PRESUBMIT.py
+++ b/PRESUBMIT.py
@@ -1,13 +1,15 @@
 # Copyright (c) 2022 The Brave Authors. All rights reserved.
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this file,
-# You can obtain one at http://mozilla.org/MPL/2.0/. */
+# You can obtain one at https://mozilla.org/MPL/2.0/.
 
 import os
 import sys
 
 USE_PYTHON3 = True
 PRESUBMIT_VERSION = '2.0.0'
+
+# pylint: disable=line-too-long
 
 
 def CheckChangeLintsClean(input_api, output_api):
@@ -26,3 +28,85 @@ def CheckPylint(input_api, output_api):
                                         '.pylintrc'),
         extra_paths_list=extra_paths_list,
         version='2.7')
+
+
+def CheckLicense(input_api, output_api):
+    """Verifies the Brave license header."""
+
+    files_to_check = input_api.DEFAULT_FILES_TO_CHECK + (r'.+\.gni?$', )
+    files_to_skip = input_api.DEFAULT_FILES_TO_SKIP + (
+        r"\.storybook/",
+        r"ios/browser/api/ledger/legacy_database/core_data_models/",
+        r'win_build_output/',
+    )
+
+    current_year = int(input_api.time.strftime('%Y'))
+    allowed_years = (str(s) for s in reversed(range(2015, current_year + 1)))
+    years_re = '(' + '|'.join(allowed_years) + ')'
+
+    # License regexp to match in NEW and MOVED files, it doesn't allow variance.
+    # Note: presubmit machinery cannot distinguish between NEW and MOVED files,
+    # that's why we cannot force this regexp to have a precise year, also
+    # uplifts may fail during year change period, so the year check is relaxed.
+    new_file_license_re = input_api.re.compile((
+        r'.*? Copyright \(c\) %(year)s The Brave Authors\. All rights reserved\.\n'
+        r'.*? This Source Code Form is subject to the terms of the Mozilla Public\n'
+        r'.*? License, v\. 2\.0\. If a copy of the MPL was not distributed with this file,\n'
+        r'.*? You can obtain one at https://mozilla.org/MPL/2\.0/\.(?: \*/)?\n'
+    ) % {'year': years_re}, input_api.re.MULTILINE)
+
+    # License regexp to match in EXISTING files, it allows some variance.
+    existing_file_license_re = input_api.re.compile((
+        r'.*? Copyright \(c\) %(year)s The Brave Authors\. All rights reserved\.\n'
+        r'.*? This Source Code Form is subject to the terms of the Mozilla Public\n'
+        r'.*? License, v\. 2\.0\. If a copy of the MPL was not distributed with this(\n.*?)? file,\n?'
+        r'.*? (y|Y)ou can obtain one at https?://mozilla.org/MPL/2\.0/\.(?: \*/)?\n'
+    ) % {'year': years_re}, input_api.re.MULTILINE)
+
+    # License template for new files. Includes current year.
+    expected_license_template = (
+        '%(comment)s Copyright (c) %(year)s The Brave Authors. All rights reserved.\n'
+        '%(comment)s This Source Code Form is subject to the terms of the Mozilla Public\n'
+        '%(comment)s License, v. 2.0. If a copy of the MPL was not distributed with this file,\n'
+        '%(comment)s You can obtain one at https://mozilla.org/MPL/2.0/.\n'
+    ) % {
+        'comment': '#',
+        'year': current_year,
+    }
+
+    assert new_file_license_re.search(expected_license_template)
+    assert existing_file_license_re.search(expected_license_template)
+
+    bad_new_files = []
+    bad_files = []
+    sources = lambda affected_file: input_api.FilterSourceFile(
+        affected_file,
+        files_to_check=files_to_check,
+        files_to_skip=files_to_skip)
+    for f in input_api.AffectedSourceFiles(sources):
+        contents = input_api.ReadFile(f, 'r')[:1000].replace('\r\n', '\n')
+        if not contents:
+            continue
+        if f.Action() == 'A':  # 'A' means "Added", also includes moved files.
+            if not new_file_license_re.search(contents):
+                bad_new_files.append(f.LocalPath())
+        else:
+            if not existing_file_license_re.search(contents):
+                bad_files.append(f.LocalPath())
+
+    # Show this to simplify copy-paste when an invalid license is found.
+    expected_license_message = (
+        f'Expected one of license headers:\n'
+        f'{expected_license_template.replace("#", "//")}\n'
+        f'{expected_license_template}')
+
+    result = []
+    if bad_new_files:
+        result.append(
+            output_api.PresubmitError(expected_license_message,
+                                      items=bad_new_files))
+    if bad_files:
+        result.append(
+            output_api.PresubmitPromptWarning(expected_license_message,
+                                              items=bad_files))
+    return result


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Add Brave license checker to `brave/PRESUBMIT.py`.

Triggers an error on new files, warning on existing files.

```
user@WDPC:~/brave/2/src/brave$ npm run presubmit

> brave-core@1.47.57 presubmit
> node ./build/commands/scripts/commands.js presubmit

------------------------------------------------------------------------------------------------------------------- /home/user/brave/2/src/brave
> git config --unset-all gerrit.host
------------------------------------------------------------------------------------------------------------------- /home/user/brave/2/src/brave
> git cl presubmit origin/master --force --upload
Running Python 3 presubmit upload checks ...
** Presubmit Warnings: 1 **
Expected one of license headers:
// Copyright (c) 2022 The Brave Authors. All rights reserved.
// This Source Code Form is subject to the terms of the Mozilla Public
// License, v. 2.0. If a copy of the MPL was not distributed with this file,
// You can obtain one at https://mozilla.org/MPL/2.0/.

# Copyright (c) 2022 The Brave Authors. All rights reserved.
# This Source Code Form is subject to the terms of the Mozilla Public
# License, v. 2.0. If a copy of the MPL was not distributed with this file,
# You can obtain one at https://mozilla.org/MPL/2.0/.

  PRESUBMIT.py

Presubmit checks took 2.6s to calculate.
There were Python 3 presubmit warnings.
```

Related https://github.com/brave/brave-browser/issues/25517

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

