### PR TITLE
Improved label's proper height calculation in first run dlg on mac

### DIFF
--- a/chromium_src/chrome/browser/ui/cocoa/first_run_dialog_controller.mm
+++ b/chromium_src/chrome/browser/ui/cocoa/first_run_dialog_controller.mm
@@ -73,11 +73,10 @@
                                          weight:NSFontWeightSemibold]];
   [headerLabel sizeToFit];
   [headerLabel setLineBreakMode:NSLineBreakByWordWrapping];
-  int defaultHeight = NSHeight(headerLabel.frame);
-  int numOfLines =
-      static_cast<int>(NSWidth(headerLabel.frame)) / contentsWidth + 1;
+  CGSize preferredSize =
+      [headerLabel sizeThatFits:CGSizeMake(contentsWidth, 0)];
   [headerLabel
-      setFrame:NSMakeRect(0, 0, contentsWidth, defaultHeight * numOfLines)];
+      setFrame:NSMakeRect(0, 0, preferredSize.width, preferredSize.height)];
 
   std::u16string contentsString = brave_l10n::GetLocalizedResourceUTF16String(
       IDS_FIRSTRUN_DLG_CONTENTS_TEXT);
@@ -88,11 +87,9 @@
                                            weight:NSFontWeightRegular]];
   [contentsLabel sizeToFit];
   [contentsLabel setLineBreakMode:NSLineBreakByWordWrapping];
-  defaultHeight = NSHeight(contentsLabel.frame);
-  numOfLines =
-      static_cast<int>(NSWidth(contentsLabel.frame)) / contentsWidth + 1;
+  preferredSize = [contentsLabel sizeThatFits:CGSizeMake(contentsWidth, 0)];
   [contentsLabel
-      setFrame:NSMakeRect(0, 0, contentsWidth, defaultHeight * numOfLines)];
+      setFrame:NSMakeRect(0, 0, preferredSize.width, preferredSize.height)];
 
   // It's time to calculate window's height as we can get all controls' final
   // heights.


### PR DESCRIPTION
Resolves: https://github.com/brave/brave-browser/issues/26098

With sizeThatFits method, we can get proper size for provided width.


## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

<img width="423" alt="Screen Shot 2022-10-19 at 1 56 43 AM" src="https://user-images.githubusercontent.com/6786187/196498024-54c62f57-b480-4f04-bfe3-0f92868e00ff.png">
