### PR TITLE
Tipping Banner crash  when tipChoices are not available

### DIFF
--- a/android/java/org/chromium/chrome/browser/rewards/BraveRewardsCustomTipFragment.java
+++ b/android/java/org/chromium/chrome/browser/rewards/BraveRewardsCustomTipFragment.java
@@ -163,7 +163,12 @@ public class BraveRewardsCustomTipFragment extends Fragment {
      * decimal points always roundedOff to floor value.
      */
     private double getBatValue(String inputValue) {
-        double rawValue = Double.parseDouble(inputValue);
+        double rawValue = 0;
+        try {
+            rawValue = Double.parseDouble(inputValue);
+        } catch (NumberFormatException e) {
+        }
+
         if (!isBatCurrencyMode) {
             // from USD to BAT
             rawValue = rawValue / exchangeRate;

--- a/android/java/org/chromium/chrome/browser/rewards/BraveRewardsTippingPanelFragment.java
+++ b/android/java/org/chromium/chrome/browser/rewards/BraveRewardsTippingPanelFragment.java
@@ -68,6 +68,10 @@ public class BraveRewardsTippingPanelFragment extends Fragment implements BraveR
     private final int TIP_SENT_REQUEST_CODE = 2;
     private final int FADE_OUT_DURATION = 500;
 
+    private static final int DEFAULT_VALUE_OPTION_1 = 1;
+    private static final int DEFAULT_VALUE_OPTION_2 = 5;
+    private static final int DEFAULT_VALUE_OPTION_3 = 10;
+
     private static final String CUSTOM_TIP_CONFIRMATION_FRAGMENT_TAG =
             "custom_tip_confirmation_fragment";
     private static final String CUSTOM_TIP_FRAGMENT_TAG = "custom_tip_fragment";
@@ -175,6 +179,13 @@ public class BraveRewardsTippingPanelFragment extends Fragment implements BraveR
 
     private void initRadioButtons(View view) {
         mTipChoices = mBraveRewardsNativeWorker.GetTipChoices();
+        // when native not giving tip choices initialize with default values
+        if (mTipChoices.length < 3) {
+            mTipChoices = new double[3];
+            mTipChoices[0] = DEFAULT_VALUE_OPTION_1;
+            mTipChoices[1] = DEFAULT_VALUE_OPTION_2;
+            mTipChoices[2] = DEFAULT_VALUE_OPTION_3;
+        }
         double rate = mBraveRewardsNativeWorker.GetWalletRate();
 
         int recurrentAmount = (int) mBraveRewardsNativeWorker.GetPublisherRecurrentDonationAmount(


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/26107
and https://github.com/brave/brave-browser/issues/26110

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [x] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [x] New files have MPL-2.0 license header
- [x] Adequate test coverage exists to prevent regressions
- [x] Major classes, functions and non-trivial code blocks are well-commented
- [x] Changes in component dependencies are properly reflected in `gn`
- [x] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [x] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
1. Go to http://duckduckgo.com/
2. click Send tip from rewards panel
Since for this web site tipChoices not available it will show default value
Currently default value 1, 5, 10 same as windows value.
![Screenshot_20221019_034200_](https://user-images.githubusercontent.com/32419898/196558876-2ab4b4ce-1217-42e6-8ffd-8e37e0edafc3.png)

When period (dot) is placed in edit box it will take default value as 0
![Screenshot_20221019_041438](https://user-images.githubusercontent.com/32419898/196559088-88249d04-96a0-4d8b-9f02-b9295fcad8a2.png)

