### PR TITLE
Support hiding window title when using vertical tab strip

### DIFF
--- a/app/brave_generated_resources.grd
+++ b/app/brave_generated_resources.grd
@@ -804,7 +804,7 @@ Or change later at <ph name="SETTINGS_EXTENIONS_LINK">$2<ex>brave://settings/ext
           Bookmark all tabs...
         </message>
         <message name="IDS_TAB_CXMENU_SHOW_TITLE_BAR" desc="The label of the tab context menu item for showing window title when vertical tab strip is enabled.">
-          Show window title
+          Show title bar
         </message>
       </if>
       <if expr="use_titlecase">
@@ -812,7 +812,7 @@ Or change later at <ph name="SETTINGS_EXTENIONS_LINK">$2<ex>brave://settings/ext
           Bookmark All Tabs...
         </message>
         <message name="IDS_TAB_CXMENU_SHOW_TITLE_BAR" desc="The label of the tab context menu item for showing window title when vertical tab strip is enabled.">
-          Show Window Title
+          Show title bar
         </message>
       </if>
 

--- a/app/brave_generated_resources.grd
+++ b/app/brave_generated_resources.grd
@@ -797,14 +797,22 @@ Or change later at <ph name="SETTINGS_EXTENIONS_LINK">$2<ex>brave://settings/ext
         Brave is made available to you under the <ph name="BEGIN_LINK_MPL">&lt;a target="_blank" href="$1"&gt;</ph>Mozilla Public License 2.0<ph name="END_LINK_MPL">&lt;/a&gt;</ph> (MPL) and includes <ph name="BEGIN_LINK_OSS">&lt;a target="_blank" href="$2"&gt;</ph>open source software<ph name="END_LINK_OSS">&lt;/a&gt;</ph> under a variety of other licenses.
         You can read <ph name="BEGIN_LINK_BUILD_INSTRUCTIONS">&lt;a target="_blank" href="$3"&gt;</ph>instructions on how to download and build for yourself<ph name="END_LINK_BUILD_INSTRUCTIONS">&lt;/a&gt;</ph> the specific <ph name="BEGIN_LINK_SOURCE_CODE">&lt;a target="_blank" href="$4"&gt;</ph>source code used to create this copy<ph name="END_LINK_SOURCE_CODE">&lt;/a&gt;</ph>.
       </message>
+
+      <!-- Brave's tab context menu -->
       <if expr="not use_titlecase">
         <message name="IDS_TAB_CXMENU_BOOKMARK_ALL_TABS" desc="The label of the tab context menu item for creating a bookmark folder containing an entry for each open tab.">
           Bookmark all tabs...
+        </message>
+        <message name="IDS_TAB_CXMENU_SHOW_TITLE_BAR" desc="The label of the tab context menu item for showing window title when vertical tab strip is enabled.">
+          Show window title
         </message>
       </if>
       <if expr="use_titlecase">
         <message name="IDS_TAB_CXMENU_BOOKMARK_ALL_TABS" desc="In Title Case: The label of the tab context menu item for creating a bookmark folder containing an entry for each open tab.">
           Bookmark All Tabs...
+        </message>
+        <message name="IDS_TAB_CXMENU_SHOW_TITLE_BAR" desc="The label of the tab context menu item for showing window title when vertical tab strip is enabled.">
+          Show Window Title
         </message>
       </if>
 

--- a/browser/ui/BUILD.gn
+++ b/browser/ui/BUILD.gn
@@ -290,6 +290,8 @@ source_set("ui") {
 
     if (is_mac) {
       sources += [
+        "views/frame/brave_browser_frame_mac.h",
+        "views/frame/brave_browser_frame_mac.mm",
         "views/frame/brave_browser_non_client_frame_view_mac.h",
         "views/frame/brave_browser_non_client_frame_view_mac.mm",
       ]

--- a/browser/ui/BUILD.gn
+++ b/browser/ui/BUILD.gn
@@ -217,6 +217,8 @@ source_set("ui") {
       "views/frame/brave_browser_view.h",
       "views/frame/brave_browser_view_layout.cc",
       "views/frame/brave_browser_view_layout.h",
+      "views/frame/brave_non_client_hit_test_helper.cc",
+      "views/frame/brave_non_client_hit_test_helper.h",
       "views/frame/brave_opaque_browser_frame_view.cc",
       "views/frame/brave_opaque_browser_frame_view.h",
       "views/frame/brave_window_frame_graphic.cc",

--- a/browser/ui/browser_commands.cc
+++ b/browser/ui/browser_commands.cc
@@ -11,6 +11,7 @@
 #include "brave/app/brave_command_ids.h"
 #include "brave/browser/debounce/debounce_service_factory.h"
 #include "brave/browser/net/brave_query_filter.h"
+#include "brave/browser/ui/tabs/brave_tab_prefs.h"
 #include "brave/browser/url_sanitizer/url_sanitizer_service_factory.h"
 #include "brave/components/brave_vpn/buildflags/buildflags.h"
 #include "brave/components/constants/pref_names.h"
@@ -223,6 +224,13 @@ void CopyLinkWithStrictCleaning(Browser* browser, const GURL& url) {
 
   ui::ScopedClipboardWriter scw(ui::ClipboardBuffer::kCopyPaste);
   scw.WriteText(base::UTF8ToUTF16(final_url.spec()));
+}
+
+void ToggleWindowTitleVisibilityForVerticalTabs(Browser* browser) {
+  auto* prefs = browser->profile()->GetOriginalProfile()->GetPrefs();
+  prefs->SetBoolean(
+      brave_tabs::kVerticalTabsShowTitleOnWindow,
+      !prefs->GetBoolean(brave_tabs::kVerticalTabsShowTitleOnWindow));
 }
 
 }  // namespace brave

--- a/browser/ui/browser_commands.h
+++ b/browser/ui/browser_commands.h
@@ -31,6 +31,8 @@ void CopySanitizedURL(Browser* browser, const GURL& url);
 // - URLSanitizerService
 void CopyLinkWithStrictCleaning(Browser* browser, const GURL& url);
 
+void ToggleWindowTitleVisibilityForVerticalTabs(Browser* browser);
+
 }  // namespace brave
 
 

--- a/browser/ui/tabs/brave_tab_menu_model.cc
+++ b/browser/ui/tabs/brave_tab_menu_model.cc
@@ -55,4 +55,5 @@ void BraveTabMenuModel::Build() {
   AddSeparator(ui::NORMAL_SEPARATOR);
   AddItemWithStringId(CommandRestoreTab, GetRestoreTabCommandStringId());
   AddItemWithStringId(CommandBookmarkAllTabs, IDS_TAB_CXMENU_BOOKMARK_ALL_TABS);
+  AddCheckItemWithStringId(CommandShowTitleBar, IDS_TAB_CXMENU_SHOW_TITLE_BAR);
 }

--- a/browser/ui/tabs/brave_tab_menu_model.h
+++ b/browser/ui/tabs/brave_tab_menu_model.h
@@ -24,6 +24,7 @@ class BraveTabMenuModel : public TabMenuModel {
     CommandStart = TabStripModel::CommandLast,
     CommandRestoreTab,
     CommandBookmarkAllTabs,
+    CommandShowTitleBar,
     CommandLast,
   };
 

--- a/browser/ui/tabs/brave_tab_prefs.cc
+++ b/browser/ui/tabs/brave_tab_prefs.cc
@@ -12,10 +12,13 @@ namespace brave_tabs {
 
 const char kTabHoverMode[] = "brave.tabs.hover_mode";
 const char kVerticalTabsCollapsed[] = "brave.tabs.vertical_tabs_collapsed";
+const char kVerticalTabsShowTitleOnWindow[] =
+    "brave.tabs.vertical_tabs_show_title_on_window";
 
 void RegisterBraveProfilePrefs(PrefRegistrySimple* registry) {
   registry->RegisterIntegerPref(kTabHoverMode, TabHoverMode::CARD);
   registry->RegisterBooleanPref(kVerticalTabsCollapsed, false);
+  registry->RegisterBooleanPref(kVerticalTabsShowTitleOnWindow, true);
 }
 
 bool AreTooltipsEnabled(PrefService* prefs) {

--- a/browser/ui/tabs/brave_tab_prefs.h
+++ b/browser/ui/tabs/brave_tab_prefs.h
@@ -15,6 +15,7 @@ enum TabHoverMode { TOOLTIP = 0, CARD = 1, CARD_WITH_PREVIEW = 2 };
 
 extern const char kTabHoverMode[];
 extern const char kVerticalTabsCollapsed[];
+extern const char kVerticalTabsShowTitleOnWindow[];
 
 void RegisterBraveProfilePrefs(PrefRegistrySimple* registry);
 

--- a/browser/ui/views/frame/brave_browser_frame_mac.h
+++ b/browser/ui/views/frame/brave_browser_frame_mac.h
@@ -1,0 +1,26 @@
+/* Copyright (c) 2022 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_BROWSER_UI_VIEWS_FRAME_BRAVE_BROWSER_FRAME_MAC_H_
+#define BRAVE_BROWSER_UI_VIEWS_FRAME_BRAVE_BROWSER_FRAME_MAC_H_
+
+#include "chrome/browser/ui/views/frame/browser_frame_mac.h"
+
+class Browser;
+
+class BraveBrowserFrameMac : public BrowserFrameMac {
+ public:
+  BraveBrowserFrameMac(BrowserFrame* browser_frame, BrowserView* browser_view);
+  ~BraveBrowserFrameMac() override;
+
+  // BrowserFrameMac:
+  void GetWindowFrameTitlebarHeight(bool* override_titlebar_height,
+                                    float* titlebar_height) override;
+
+ private:
+  raw_ptr<Browser> browser_;
+};
+
+#endif  // BRAVE_BROWSER_UI_VIEWS_FRAME_BRAVE_BROWSER_FRAME_MAC_H_

--- a/browser/ui/views/frame/brave_browser_frame_mac.mm
+++ b/browser/ui/views/frame/brave_browser_frame_mac.mm
@@ -18,8 +18,8 @@ BraveBrowserFrameMac::~BraveBrowserFrameMac() = default;
 void BraveBrowserFrameMac::GetWindowFrameTitlebarHeight(
     bool* override_titlebar_height,
     float* titlebar_height) {
-  // Don't override titlebar height if we supports vertical tab strip so that
-  // it can overlay our client view. The visibility of title bar will be
+  // Don't override titlebar height if the browser supports vertical tab strip 
+  // so that it can overlay our client view. The visibility of title bar will be
   // controlled by BrowserNonClientFrameViewMac::UpdateWindowTitleVisibility.
   if (browser_->is_type_normal() && tabs::features::ShouldShowVerticalTabs())
     return;

--- a/browser/ui/views/frame/brave_browser_frame_mac.mm
+++ b/browser/ui/views/frame/brave_browser_frame_mac.mm
@@ -1,0 +1,29 @@
+/* Copyright (c) 2022 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "brave/browser/ui/views/frame/brave_browser_frame_mac.h"
+
+#include "brave/browser/ui/views/tabs/features.h"
+#include "chrome/browser/ui/views/frame/browser_view.h"
+
+BraveBrowserFrameMac::BraveBrowserFrameMac(BrowserFrame* browser_frame,
+                                           BrowserView* browser_view)
+    : BrowserFrameMac(browser_frame, browser_view),
+      browser_(browser_view->browser()) {}
+
+BraveBrowserFrameMac::~BraveBrowserFrameMac() = default;
+
+void BraveBrowserFrameMac::GetWindowFrameTitlebarHeight(
+    bool* override_titlebar_height,
+    float* titlebar_height) {
+  // Don't override titlebar height if we supports vertical tab strip so that
+  // it can overlay our client view. The visibility of title bar will be
+  // controlled by BrowserNonClientFrameViewMac::UpdateWindowTitleVisibility.
+  if (browser_->is_type_normal() && tabs::features::ShouldShowVerticalTabs())
+    return;
+
+  return BrowserFrameMac::GetWindowFrameTitlebarHeight(override_titlebar_height,
+                                                       titlebar_height);
+}

--- a/browser/ui/views/frame/brave_browser_frame_mac.mm
+++ b/browser/ui/views/frame/brave_browser_frame_mac.mm
@@ -18,7 +18,7 @@ BraveBrowserFrameMac::~BraveBrowserFrameMac() = default;
 void BraveBrowserFrameMac::GetWindowFrameTitlebarHeight(
     bool* override_titlebar_height,
     float* titlebar_height) {
-  // Don't override titlebar height if the browser supports vertical tab strip 
+  // Don't override titlebar height if the browser supports vertical tab strip
   // so that it can overlay our client view. The visibility of title bar will be
   // controlled by BrowserNonClientFrameViewMac::UpdateWindowTitleVisibility.
   if (browser_->is_type_normal() && tabs::features::ShouldShowVerticalTabs())

--- a/browser/ui/views/frame/brave_browser_non_client_frame_view_mac.h
+++ b/browser/ui/views/frame/brave_browser_non_client_frame_view_mac.h
@@ -24,11 +24,16 @@ class BraveBrowserNonClientFrameViewMac : public BrowserNonClientFrameViewMac {
       const BraveBrowserNonClientFrameViewMac&) = delete;
 
  private:
+  bool ShouldShowWindowTitleForVerticalTabs() const;
+  void UpdateWindowTitleVisibility();
+
   // BrowserNonClientFrameViewMac overrides:
   void OnPaint(gfx::Canvas* canvas) override;
   int GetTopInset(bool restored) const override;
 
   std::unique_ptr<BraveWindowFrameGraphic> frame_graphic_;
+
+  BooleanPrefMember show_title_bar_on_vertical_tabs_;
 };
 
 #endif  // BRAVE_BROWSER_UI_VIEWS_FRAME_BRAVE_BROWSER_NON_CLIENT_FRAME_VIEW_MAC_H_

--- a/browser/ui/views/frame/brave_browser_non_client_frame_view_mac.h
+++ b/browser/ui/views/frame/brave_browser_non_client_frame_view_mac.h
@@ -30,6 +30,7 @@ class BraveBrowserNonClientFrameViewMac : public BrowserNonClientFrameViewMac {
   // BrowserNonClientFrameViewMac overrides:
   void OnPaint(gfx::Canvas* canvas) override;
   int GetTopInset(bool restored) const override;
+  int NonClientHitTest(const gfx::Point& point) override;
 
   std::unique_ptr<BraveWindowFrameGraphic> frame_graphic_;
 

--- a/browser/ui/views/frame/brave_browser_non_client_frame_view_mac.mm
+++ b/browser/ui/views/frame/brave_browser_non_client_frame_view_mac.mm
@@ -7,9 +7,11 @@
 
 #include "brave/browser/ui/views/frame/brave_browser_non_client_frame_view_mac.h"
 
+#include "brave/browser/ui/tabs/brave_tab_prefs.h"
 #include "brave/browser/ui/views/frame/brave_window_frame_graphic.h"
 #include "brave/browser/ui/views/tabs/features.h"
 #include "chrome/browser/ui/browser.h"
+#include "chrome/browser/ui/view_ids.h"
 #include "chrome/browser/ui/views/frame/browser_view.h"
 #include "ui/gfx/geometry/insets.h"
 #include "ui/gfx/geometry/rect.h"
@@ -20,6 +22,15 @@ BraveBrowserNonClientFrameViewMac::BraveBrowserNonClientFrameViewMac(
     : BrowserNonClientFrameViewMac(frame, browser_view) {
   frame_graphic_ = std::make_unique<BraveWindowFrameGraphic>(
       browser_view->browser()->profile());
+
+  if (tabs::features::ShouldShowVerticalTabs()) {
+    show_title_bar_on_vertical_tabs_.Init(
+        brave_tabs::kVerticalTabsShowTitleOnWindow,
+        browser_view->browser()->profile()->GetOriginalProfile()->GetPrefs(),
+        base::BindRepeating(
+            &BraveBrowserNonClientFrameViewMac::UpdateWindowTitleVisibility,
+            base::Unretained(this)));
+  }
 }
 
 BraveBrowserNonClientFrameViewMac::~BraveBrowserNonClientFrameViewMac() = default;
@@ -41,10 +52,23 @@ void BraveBrowserNonClientFrameViewMac::OnPaint(gfx::Canvas* canvas) {
 }
 
 int BraveBrowserNonClientFrameViewMac::GetTopInset(bool restored) const {
-  if (tabs::features::ShouldShowVerticalTabs()) {
+  if (ShouldShowWindowTitleForVerticalTabs()) {
     // Set minimum top inset to show caption buttons on frame.
-    return 18;
+    return 30;
   }
 
   return BrowserNonClientFrameViewMac::GetTopInset(restored);
+}
+
+bool BraveBrowserNonClientFrameViewMac::ShouldShowWindowTitleForVerticalTabs()
+    const {
+  return tabs::features::ShouldShowWindowTitleForVerticalTabs(
+      browser_view()->browser());
+}
+
+void BraveBrowserNonClientFrameViewMac::UpdateWindowTitleVisibility() {
+  if (!browser_view()->browser()->is_type_normal())
+    return;
+
+  frame()->SetWindowTitleVisibility(ShouldShowWindowTitleForVerticalTabs());
 }

--- a/browser/ui/views/frame/brave_browser_non_client_frame_view_mac.mm
+++ b/browser/ui/views/frame/brave_browser_non_client_frame_view_mac.mm
@@ -8,11 +8,13 @@
 #include "brave/browser/ui/views/frame/brave_browser_non_client_frame_view_mac.h"
 
 #include "brave/browser/ui/tabs/brave_tab_prefs.h"
+#include "brave/browser/ui/views/frame/brave_non_client_hit_test_helper.h"
 #include "brave/browser/ui/views/frame/brave_window_frame_graphic.h"
 #include "brave/browser/ui/views/tabs/features.h"
 #include "chrome/browser/ui/browser.h"
 #include "chrome/browser/ui/view_ids.h"
 #include "chrome/browser/ui/views/frame/browser_view.h"
+#include "ui/base/hit_test.h"
 #include "ui/gfx/geometry/insets.h"
 #include "ui/gfx/geometry/rect.h"
 #include "ui/gfx/scoped_canvas.h"
@@ -71,4 +73,14 @@ void BraveBrowserNonClientFrameViewMac::UpdateWindowTitleVisibility() {
     return;
 
   frame()->SetWindowTitleVisibility(ShouldShowWindowTitleForVerticalTabs());
+}
+
+int BraveBrowserNonClientFrameViewMac::NonClientHitTest(
+    const gfx::Point& point) {
+  if (auto res = brave::NonClientHitTest(browser_view(), point);
+      res != HTNOWHERE) {
+    return res;
+  }
+
+  return BrowserNonClientFrameViewMac::NonClientHitTest(point);
 }

--- a/browser/ui/views/frame/brave_browser_view.cc
+++ b/browser/ui/views/frame/brave_browser_view.cc
@@ -502,7 +502,7 @@ bool BraveBrowserView::ShouldShowWindowTitle() const {
   if (BrowserView::ShouldShowWindowTitle())
     return true;
 
-  if (tabs::features::ShouldShowVerticalTabs() && browser_->is_type_normal())
+  if (tabs::features::ShouldShowWindowTitleForVerticalTabs(browser()))
     return true;
 
   return false;

--- a/browser/ui/views/frame/brave_glass_browser_frame_view.cc
+++ b/browser/ui/views/frame/brave_glass_browser_frame_view.cc
@@ -5,10 +5,12 @@
 
 #include "brave/browser/ui/views/frame/brave_glass_browser_frame_view.h"
 
+#include "brave/browser/ui/views/frame/brave_non_client_hit_test_helper.h"
 #include "brave/browser/ui/views/frame/brave_window_frame_graphic.h"
 #include "brave/browser/ui/views/tabs/features.h"
 #include "chrome/browser/ui/browser.h"
 #include "chrome/browser/ui/views/frame/browser_view.h"
+#include "ui/base/hit_test.h"
 #include "ui/gfx/geometry/insets.h"
 #include "ui/gfx/geometry/rect.h"
 #include "ui/gfx/scoped_canvas.h"
@@ -47,4 +49,12 @@ int BraveGlassBrowserFrameView::GetTopInset(bool restored) const {
   }
 
   return GlassBrowserFrameView::GetTopInset(restored);
+}
+int BraveGlassBrowserFrameView::NonClientHitTest(const gfx::Point& point) {
+  if (auto res = brave::NonClientHitTest(browser_view(), point);
+      res != HTNOWHERE) {
+    return res;
+  }
+
+  return GlassBrowserFrameView::NonClientHitTest(point);
 }

--- a/browser/ui/views/frame/brave_glass_browser_frame_view.cc
+++ b/browser/ui/views/frame/brave_glass_browser_frame_view.cc
@@ -6,6 +6,7 @@
 #include "brave/browser/ui/views/frame/brave_glass_browser_frame_view.h"
 
 #include "brave/browser/ui/views/frame/brave_window_frame_graphic.h"
+#include "brave/browser/ui/views/tabs/features.h"
 #include "chrome/browser/ui/browser.h"
 #include "chrome/browser/ui/views/frame/browser_view.h"
 #include "ui/gfx/geometry/insets.h"
@@ -35,4 +36,15 @@ void BraveGlassBrowserFrameView::OnPaint(gfx::Canvas* canvas) {
     canvas->ClipRect(bounds_to_frame_graphic);
   }
   frame_graphic_->Paint(canvas, bounds_to_frame_graphic);
+}
+
+int BraveGlassBrowserFrameView::GetTopInset(bool restored) const {
+  if (browser_view()->browser()->is_type_normal() &&
+      tabs::features::ShouldShowVerticalTabs()) {
+    if (!tabs::features::ShouldShowWindowTitleForVerticalTabs(
+            browser_view()->browser()))
+      return 0;
+  }
+
+  return GlassBrowserFrameView::GetTopInset(restored);
 }

--- a/browser/ui/views/frame/brave_glass_browser_frame_view.cc
+++ b/browser/ui/views/frame/brave_glass_browser_frame_view.cc
@@ -41,8 +41,7 @@ void BraveGlassBrowserFrameView::OnPaint(gfx::Canvas* canvas) {
 }
 
 int BraveGlassBrowserFrameView::GetTopInset(bool restored) const {
-  if (browser_view()->browser()->is_type_normal() &&
-      tabs::features::ShouldShowVerticalTabs()) {
+  if (tabs::features::ShouldShowVerticalTabs()) {
     if (!tabs::features::ShouldShowWindowTitleForVerticalTabs(
             browser_view()->browser()))
       return 0;

--- a/browser/ui/views/frame/brave_glass_browser_frame_view.h
+++ b/browser/ui/views/frame/brave_glass_browser_frame_view.h
@@ -25,6 +25,7 @@ class BraveGlassBrowserFrameView : public GlassBrowserFrameView {
   // GlassBrowserFrameView overrides:
   void OnPaint(gfx::Canvas* canvas) override;
   int GetTopInset(bool restored) const override;
+  int NonClientHitTest(const gfx::Point& point) override;
 
   std::unique_ptr<BraveWindowFrameGraphic> frame_graphic_;
 };

--- a/browser/ui/views/frame/brave_glass_browser_frame_view.h
+++ b/browser/ui/views/frame/brave_glass_browser_frame_view.h
@@ -24,6 +24,7 @@ class BraveGlassBrowserFrameView : public GlassBrowserFrameView {
  private:
   // GlassBrowserFrameView overrides:
   void OnPaint(gfx::Canvas* canvas) override;
+  int GetTopInset(bool restored) const override;
 
   std::unique_ptr<BraveWindowFrameGraphic> frame_graphic_;
 };

--- a/browser/ui/views/frame/brave_non_client_hit_test_helper.cc
+++ b/browser/ui/views/frame/brave_non_client_hit_test_helper.cc
@@ -1,0 +1,23 @@
+/* Copyright (c) 2022 The Brave Authors. All rights reserved.
+* This Source Code Form is subject to the terms of the Mozilla Public
+* License, v. 2.0. If a copy of the MPL was not distributed with this file,
+* You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "brave/browser/ui/views/frame/brave_non_client_hit_test_helper.h"
+
+#include "chrome/browser/ui/views/frame/browser_view.h"
+#include "ui/base/hit_test.h"
+#include "ui/views/window/hit_test_utils.h"
+#include "chrome/browser/ui/views/toolbar/toolbar_view.h"
+
+namespace brave {
+
+int NonClientHitTest(BrowserView* browser_view, const gfx::Point& point) {
+  if (!browser_view->toolbar() || !browser_view->toolbar()->GetVisible())
+    return HTNOWHERE;
+
+  return views::GetHitTestComponent(browser_view->toolbar(), point);
+}
+
+}  // brave
+

--- a/browser/ui/views/frame/brave_non_client_hit_test_helper.cc
+++ b/browser/ui/views/frame/brave_non_client_hit_test_helper.cc
@@ -1,14 +1,14 @@
 /* Copyright (c) 2022 The Brave Authors. All rights reserved.
-* This Source Code Form is subject to the terms of the Mozilla Public
-* License, v. 2.0. If a copy of the MPL was not distributed with this file,
-* You can obtain one at http://mozilla.org/MPL/2.0/. */
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 #include "brave/browser/ui/views/frame/brave_non_client_hit_test_helper.h"
 
 #include "chrome/browser/ui/views/frame/browser_view.h"
+#include "chrome/browser/ui/views/toolbar/toolbar_view.h"
 #include "ui/base/hit_test.h"
 #include "ui/views/window/hit_test_utils.h"
-#include "chrome/browser/ui/views/toolbar/toolbar_view.h"
 
 namespace brave {
 
@@ -19,5 +19,4 @@ int NonClientHitTest(BrowserView* browser_view, const gfx::Point& point) {
   return views::GetHitTestComponent(browser_view->toolbar(), point);
 }
 
-}  // brave
-
+}  // namespace brave

--- a/browser/ui/views/frame/brave_non_client_hit_test_helper.h
+++ b/browser/ui/views/frame/brave_non_client_hit_test_helper.h
@@ -1,14 +1,14 @@
 /* Copyright (c) 2022 The Brave Authors. All rights reserved.
-* This Source Code Form is subject to the terms of the Mozilla Public
-* License, v. 2.0. If a copy of the MPL was not distributed with this file,
-* You can obtain one at http://mozilla.org/MPL/2.0/. */
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 #ifndef BRAVE_BROWSER_UI_VIEWS_FRAME_BRAVE_NON_CLIENT_HIT_TEST_HELPER_H_
 #define BRAVE_BROWSER_UI_VIEWS_FRAME_BRAVE_NON_CLIENT_HIT_TEST_HELPER_H_
 
 namespace gfx {
 class Point;
-}  // gfx
+}  // namespace gfx
 
 class BrowserView;
 
@@ -19,6 +19,6 @@ namespace brave {
 // case, caller should depend on the default behavior.
 int NonClientHitTest(BrowserView* browser_view, const gfx::Point& point);
 
-}  // brave
+}  // namespace brave
 
 #endif  // BRAVE_BROWSER_UI_VIEWS_FRAME_BRAVE_NON_CLIENT_HIT_TEST_HELPER_H_

--- a/browser/ui/views/frame/brave_non_client_hit_test_helper.h
+++ b/browser/ui/views/frame/brave_non_client_hit_test_helper.h
@@ -1,0 +1,24 @@
+/* Copyright (c) 2022 The Brave Authors. All rights reserved.
+* This Source Code Form is subject to the terms of the Mozilla Public
+* License, v. 2.0. If a copy of the MPL was not distributed with this file,
+* You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_BROWSER_UI_VIEWS_FRAME_BRAVE_NON_CLIENT_HIT_TEST_HELPER_H_
+#define BRAVE_BROWSER_UI_VIEWS_FRAME_BRAVE_NON_CLIENT_HIT_TEST_HELPER_H_
+
+namespace gfx {
+class Point;
+}  // gfx
+
+class BrowserView;
+
+namespace brave {
+
+// Helper function to set additional draggable area in client view.
+// Returns HTNOWHERE if the point is not what we're interested in. In that
+// case, caller should depend on the default behavior.
+int NonClientHitTest(BrowserView* browser_view, const gfx::Point& point);
+
+}  // brave
+
+#endif  // BRAVE_BROWSER_UI_VIEWS_FRAME_BRAVE_NON_CLIENT_HIT_TEST_HELPER_H_

--- a/browser/ui/views/frame/brave_non_client_hit_test_helper_browsertest.cc
+++ b/browser/ui/views/frame/brave_non_client_hit_test_helper_browsertest.cc
@@ -1,0 +1,37 @@
+/* Copyright (c) 2022 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "chrome/browser/ui/views/frame/browser_non_client_frame_view.h"
+#include "chrome/browser/ui/views/frame/browser_view.h"
+#include "chrome/browser/ui/views/toolbar/reload_button.h"
+#include "chrome/browser/ui/views/toolbar/toolbar_view.h"
+#include "chrome/test/base/in_process_browser_test.h"
+#include "content/public/test/browser_test.h"
+#include "ui/base/hit_test.h"
+
+using BraveNonClientHitTestHelperBrowserTest = InProcessBrowserTest;
+
+IN_PROC_BROWSER_TEST_F(BraveNonClientHitTestHelperBrowserTest, Toolbar) {
+  auto* browser_view = static_cast<BrowserView*>(browser()->window());
+  auto* toolbar = browser_view->toolbar();
+  auto* frame_view = browser_view->frame()->GetFrameView();
+
+  gfx::Point point;
+  views::View::ConvertPointToWidget(toolbar, &point);
+
+  // Dragging a window with the toolbar on it should work.
+  EXPECT_EQ(HTCAPTION, frame_view->NonClientHitTest(point));
+
+  // It shouldn't be perceived as a HTCAPTION when it's not visible.
+  toolbar->SetVisible(false);
+  EXPECT_NE(HTCAPTION, frame_view->NonClientHitTest(point));
+
+  // A coordinate on children of toolbar shouldn't be HTCAPTION so that users
+  // can interact with them. Checks a typical child of toolbar as a sanity
+  // check.
+  toolbar->SetVisible(true);
+  views::View::ConvertPointToWidget(toolbar->reload_button(), &point);
+  EXPECT_NE(HTCAPTION, frame_view->NonClientHitTest(point));
+}

--- a/browser/ui/views/frame/brave_non_client_hit_test_helper_browsertest.cc
+++ b/browser/ui/views/frame/brave_non_client_hit_test_helper_browsertest.cc
@@ -32,7 +32,7 @@ IN_PROC_BROWSER_TEST_F(BraveNonClientHitTestHelperBrowserTest, Toolbar) {
   // can interact with them. Checks a typical child of toolbar as a sanity
   // check.
   toolbar->SetVisible(true);
-  point = {};
+  point = gfx::Point();
   views::View::ConvertPointToWidget(toolbar->reload_button(), &point);
   EXPECT_NE(HTCAPTION, frame_view->NonClientHitTest(point));
 }

--- a/browser/ui/views/frame/brave_non_client_hit_test_helper_browsertest.cc
+++ b/browser/ui/views/frame/brave_non_client_hit_test_helper_browsertest.cc
@@ -32,6 +32,7 @@ IN_PROC_BROWSER_TEST_F(BraveNonClientHitTestHelperBrowserTest, Toolbar) {
   // can interact with them. Checks a typical child of toolbar as a sanity
   // check.
   toolbar->SetVisible(true);
+  point = {};
   views::View::ConvertPointToWidget(toolbar->reload_button(), &point);
   EXPECT_NE(HTCAPTION, frame_view->NonClientHitTest(point));
 }

--- a/browser/ui/views/frame/brave_opaque_browser_frame_view.cc
+++ b/browser/ui/views/frame/brave_opaque_browser_frame_view.cc
@@ -7,10 +7,12 @@
 
 #include <memory>
 
+#include "brave/browser/ui/views/frame/brave_non_client_hit_test_helper.h"
 #include "brave/browser/ui/views/frame/brave_window_frame_graphic.h"
 #include "chrome/browser/ui/browser.h"
 #include "chrome/browser/ui/views/frame/browser_view.h"
 #include "chrome/browser/ui/views/frame/opaque_browser_frame_view_layout.h"
+#include "ui/base/hit_test.h"
 #include "ui/gfx/geometry/insets.h"
 #include "ui/gfx/geometry/rect.h"
 #include "ui/gfx/scoped_canvas.h"
@@ -39,4 +41,13 @@ void BraveOpaqueBrowserFrameView::OnPaint(gfx::Canvas* canvas) {
     canvas->ClipRect(bounds_to_frame_graphic);
   }
   frame_graphic_->Paint(canvas, bounds_to_frame_graphic);
+}
+
+int BraveOpaqueBrowserFrameView::NonClientHitTest(const gfx::Point& point) {
+  if (auto res = brave::NonClientHitTest(browser_view(), point);
+      res != HTNOWHERE) {
+    return res;
+  }
+
+  return OpaqueBrowserFrameView::NonClientHitTest(point);
 }

--- a/browser/ui/views/frame/brave_opaque_browser_frame_view.h
+++ b/browser/ui/views/frame/brave_opaque_browser_frame_view.h
@@ -25,6 +25,7 @@ class BraveOpaqueBrowserFrameView : public OpaqueBrowserFrameView {
 
   // OpaqueBrowserFrameView overrides:
   void OnPaint(gfx::Canvas* canvas) override;
+  int NonClientHitTest(const gfx::Point& point) override;
 
  private:
   std::unique_ptr<BraveWindowFrameGraphic> frame_graphic_;

--- a/browser/ui/views/tabs/brave_tab_context_menu_contents.cc
+++ b/browser/ui/views/tabs/brave_tab_context_menu_contents.cc
@@ -5,6 +5,7 @@
 
 #include "brave/browser/ui/views/tabs/brave_tab_context_menu_contents.h"
 
+#include "brave/browser/ui/browser_commands.h"
 #include "brave/browser/ui/tabs/brave_tab_menu_model.h"
 #include "brave/browser/ui/tabs/brave_tab_prefs.h"
 #include "brave/browser/ui/views/tabs/brave_browser_tab_strip_controller.h"
@@ -51,11 +52,8 @@ void BraveTabContextMenuContents::RunMenuAt(
 
 bool BraveTabContextMenuContents::IsCommandIdChecked(int command_id) const {
   if (command_id == BraveTabMenuModel::CommandShowTitleBar) {
-    return controller_->browser()
-        ->profile()
-        ->GetOriginalProfile()
-        ->GetPrefs()
-        ->GetBoolean(brave_tabs::kVerticalTabsShowTitleOnWindow);
+    return tabs::features::ShouldShowWindowTitleForVerticalTabs(
+        controller_->browser());
   }
 
   return false;
@@ -135,11 +133,8 @@ void BraveTabContextMenuContents::ExecuteBraveCommand(int command_id) {
       chrome::BookmarkAllTabs(browser_);
       return;
     case BraveTabMenuModel::CommandShowTitleBar: {
-      auto* browser = controller_->browser();
-      browser->profile()->GetOriginalProfile()->GetPrefs()->SetBoolean(
-          brave_tabs::kVerticalTabsShowTitleOnWindow,
-          !IsCommandIdChecked(command_id));
-      BrowserView::GetBrowserViewForBrowser(browser)->InvalidateLayout();
+      brave::ToggleWindowTitleVisibilityForVerticalTabs(browser_);
+      BrowserView::GetBrowserViewForBrowser(browser_)->InvalidateLayout();
       return;
     }
     default:

--- a/browser/ui/views/tabs/brave_tab_context_menu_contents.h
+++ b/browser/ui/views/tabs/brave_tab_context_menu_contents.h
@@ -42,6 +42,7 @@ class BraveTabContextMenuContents : public ui::SimpleMenuModel::Delegate {
   // ui::SimpleMenuModel::Delegate overrides:
   bool IsCommandIdChecked(int command_id) const override;
   bool IsCommandIdEnabled(int command_id) const override;
+  bool IsCommandIdVisible(int command_id) const override;
   bool GetAcceleratorForCommandId(int command_id,
                                   ui::Accelerator* accelerator) const override;
   void ExecuteCommand(int command_id, int event_flags) override;

--- a/browser/ui/views/tabs/brave_tab_strip.cc
+++ b/browser/ui/views/tabs/brave_tab_strip.cc
@@ -25,6 +25,9 @@ BraveTabStrip::BraveTabStrip(std::unique_ptr<TabStripController> controller)
 BraveTabStrip::~BraveTabStrip() = default;
 
 bool BraveTabStrip::ShouldDrawStrokes() const {
+  if (tabs::features::ShouldShowVerticalTabs())
+    return false;
+
   if (!TabStrip::ShouldDrawStrokes())
     return false;
 

--- a/browser/ui/views/tabs/features.cc
+++ b/browser/ui/views/tabs/features.cc
@@ -72,7 +72,7 @@ std::pair<int, int> GetLeadingTrailingCaptionButtonWidth(
   }
 
   // In this case, we use OpaqueBrowserFrameView. OpaqueBrowserFrameView has
-  // two types of frame button per platform but on Window, it uses image
+  // two types of frame button per platform but on Windows, it uses image
   // buttons. See OpaqueBrowserFrameView::GetFrameButtonStyle().
   int width = 0;
   // Uses image icons

--- a/browser/ui/views/tabs/features.cc
+++ b/browser/ui/views/tabs/features.cc
@@ -5,7 +5,22 @@
 
 #include "brave/browser/ui/views/tabs/features.h"
 
-#include "base/feature_list.h"
+#include "brave/browser/ui/tabs/brave_tab_prefs.h"
+#include "chrome/browser/profiles/profile.h"
+#include "chrome/browser/ui/browser.h"
+#include "components/prefs/pref_service.h"
+
+#if !BUILDFLAG(IS_MAC)
+#include "chrome/browser/ui/frame/window_frame_util.h"
+#include "chrome/browser/ui/views/frame/browser_view.h"
+#include "chrome/browser/ui/views/frame/opaque_browser_frame_view_layout.h"
+#include "ui/base/theme_provider.h"
+#include "ui/views/resources/grit/views_resources.h"
+#endif
+
+#if BUILDFLAG(IS_LINUX)
+#include "ui/views/window/caption_button_layout_constants.h"
+#endif
 
 namespace tabs {
 namespace features {
@@ -17,6 +32,60 @@ bool ShouldShowVerticalTabs() {
   // TODO(sangwoo.ko) This should consider pref too.
   // https://github.com/brave/brave-browser/issues/23467
   return base::FeatureList::IsEnabled(features::kBraveVerticalTabs);
+}
+
+bool ShouldShowWindowTitleForVerticalTabs(const Browser* browser) {
+  DCHECK(browser);
+
+  if (!ShouldShowVerticalTabs())
+    return false;
+
+  if (!browser->is_type_normal())
+    return false;
+
+  return browser->profile()->GetOriginalProfile()->GetPrefs()->GetBoolean(
+      brave_tabs::kVerticalTabsShowTitleOnWindow);
+}
+
+std::pair<int, int> GetLeadingTrailingCaptionButtonWidth(
+    const BrowserFrame* frame) {
+#if BUILDFLAG(IS_MAC)
+  // On Mac, window caption buttons are drawn by the system.
+  return {80, 0};
+#elif BUILDFLAG(IS_LINUX)
+  // On Linux, we can't overlay caption buttons on toolbar.
+  return {0, 0};
+#elif BUILDFLAG(IS_WIN)
+  if (frame->ShouldUseNativeFrame()) {
+    // In this case, we usd GlassBrowserFrameView. Native frame will be set to
+    // the HWND and and GlassBrowserFrameView will draw frame and window caption
+    // button.
+    auto size = WindowFrameUtil::GetWindows10GlassCaptionButtonAreaSize();
+    if (WindowFrameUtil::IsWin10TabSearchCaptionButtonEnabled(
+            BrowserView::GetBrowserViewForNativeWindow(frame->GetNativeWindow())
+                ->browser())) {
+      size.set_width(
+          size.width() + WindowFrameUtil::kWindows10GlassCaptionButtonWidth +
+          WindowFrameUtil::kWindows10GlassCaptionButtonVisualSpacing);
+    }
+    return {0, size.width()};
+  }
+
+  // In this case, we use OpaqueBrowserFrameView. OpaqueBrowserFrameView has
+  // two types of frame button per platform but on Window, it uses image
+  // buttons. See OpaqueBrowserFrameView::GetFrameButtonStyle().
+  int width = 0;
+  // Uses image icons
+  const ui::ThemeProvider* tp = frame->GetThemeProvider();
+  DCHECK(tp);
+  for (auto image_id : {IDR_MINIMIZE, IDR_MAXIMIZE, IDR_CLOSE}) {
+    if (const gfx::ImageSkia* image = tp->GetImageSkiaNamed(image_id))
+      width += image->width();
+  }
+  return {0, width};
+#else
+#error "not handled platform"
+#endif
 }
 
 }  // namespace features

--- a/browser/ui/views/tabs/features.h
+++ b/browser/ui/views/tabs/features.h
@@ -14,10 +14,6 @@ namespace base {
 struct LOGICALLY_CONST Feature;
 }  // namespace base
 
-namespace views {
-class View;
-}  // namespace views
-
 class Browser;
 class BrowserFrame;
 

--- a/browser/ui/views/tabs/features.h
+++ b/browser/ui/views/tabs/features.h
@@ -6,11 +6,20 @@
 #ifndef BRAVE_BROWSER_UI_VIEWS_TABS_FEATURES_H_
 #define BRAVE_BROWSER_UI_VIEWS_TABS_FEATURES_H_
 
+#include <utility>
+
 #include "base/compiler_specific.h"
 
 namespace base {
 struct LOGICALLY_CONST Feature;
 }  // namespace base
+
+namespace views {
+class View;
+}  // namespace views
+
+class Browser;
+class BrowserFrame;
 
 namespace tabs {
 namespace features {
@@ -19,6 +28,14 @@ extern const base::Feature kBraveVerticalTabs;
 
 // Returns true when users chose to use vertical tabs
 bool ShouldShowVerticalTabs();
+
+// Returns true when we should show window title on window frame when vertical
+// tab strip is enabled.
+bool ShouldShowWindowTitleForVerticalTabs(const Browser* browser);
+
+// Returns window caption buttons' width based on the current platform
+std::pair<int, int> GetLeadingTrailingCaptionButtonWidth(
+    const BrowserFrame* frame);
 
 }  // namespace features
 }  // namespace tabs

--- a/browser/ui/views/tabs/vertical_tab_strip_browsertest.cc
+++ b/browser/ui/views/tabs/vertical_tab_strip_browsertest.cc
@@ -60,7 +60,7 @@ class VerticalTabStripBrowserTest : public InProcessBrowserTest {
           ->ShouldShowWindowTitle();
     }
 
-    return native_widget->overridden_window_title_visibility();
+    return native_widget->GetOverriddenWindowTitleVisibility();
 #elif BUILDFLAG(IS_WIN)
     if (browser_view()->GetWidget()->ShouldUseNativeFrame()) {
       return static_cast<const GlassBrowserFrameView*>(

--- a/browser/ui/views/tabs/vertical_tab_strip_browsertest.cc
+++ b/browser/ui/views/tabs/vertical_tab_strip_browsertest.cc
@@ -17,6 +17,10 @@
 #include "chrome/browser/ui/views/frame/glass_browser_frame_view.h"
 #endif
 
+#if BUILDFLAG(IS_LINUX)
+#include "chrome/common/pref_names.h"
+#endif
+
 #if BUILDFLAG(IS_MAC)
 #include "ui/views/widget/native_widget_mac.h"
 #endif
@@ -81,6 +85,10 @@ class VerticalTabStripBrowserTest : public InProcessBrowserTest {
 };
 
 IN_PROC_BROWSER_TEST_F(VerticalTabStripBrowserTest, WindowTitle) {
+#if BUILDFLAG(IS_LINUX)
+  browser()->profile()->GetPrefs()->SetBoolean(prefs::kUseCustomChromeFrame,
+                                               true);
+#endif
   // Pre-condition: Window title is "visible" by default on vertical tabs
   ASSERT_TRUE(tabs::features::ShouldShowVerticalTabs());
   ASSERT_TRUE(tabs::features::ShouldShowWindowTitleForVerticalTabs(browser()));

--- a/browser/ui/views/tabs/vertical_tab_strip_browsertest.cc
+++ b/browser/ui/views/tabs/vertical_tab_strip_browsertest.cc
@@ -1,0 +1,111 @@
+/* Copyright (c) 2022 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "base/test/scoped_feature_list.h"
+#include "brave/browser/ui/browser_commands.h"
+#include "brave/browser/ui/views/tabs/features.h"
+#include "build/build_config.h"
+#include "chrome/browser/ui/browser.h"
+#include "chrome/browser/ui/views/frame/browser_non_client_frame_view.h"
+#include "chrome/browser/ui/views/frame/browser_view.h"
+#include "chrome/test/base/in_process_browser_test.h"
+#include "content/public/test/browser_test.h"
+
+#if BUILDFLAG(IS_WIN)
+#include "chrome/browser/ui/views/frame/glass_browser_frame_view.h"
+#endif
+
+#if BUILDFLAG(IS_MAC)
+#include "ui/views/widget/native_widget_mac.h"
+#endif
+
+#if defined(USE_AURA)
+#include "chrome/browser/ui/views/frame/opaque_browser_frame_view.h"
+#endif
+
+class VerticalTabStripBrowserTest : public InProcessBrowserTest {
+ public:
+  VerticalTabStripBrowserTest()
+      : feature_list_(tabs::features::kBraveVerticalTabs) {}
+
+  ~VerticalTabStripBrowserTest() override = default;
+
+  const BrowserView* browser_view() const {
+    return static_cast<BrowserView*>(browser()->window());
+  }
+  BrowserView* browser_view() {
+    return static_cast<BrowserView*>(browser()->window());
+  }
+  BrowserNonClientFrameView* browser_non_client_frame_view() {
+    return browser_view()->frame()->GetFrameView();
+  }
+  const BrowserNonClientFrameView* browser_non_client_frame_view() const {
+    return browser_view()->frame()->GetFrameView();
+  }
+
+  // Returns the visibility of window title is actually changed by a frame or
+  // a widget. If we can't access to actual title view, returns a value which
+  // window title will be synchronized to.
+  bool IsWindowTitleViewVisible() const {
+#if BUILDFLAG(IS_MAC)
+    auto* native_widget = static_cast<const views::NativeWidgetMac*>(
+        browser_view()->GetWidget()->native_widget_private());
+    if (!native_widget->has_overridden_window_title_visibility()) {
+      // Returns default visibility
+      return browser_view()
+          ->GetWidget()
+          ->widget_delegate()
+          ->ShouldShowWindowTitle();
+    }
+
+    return native_widget->overridden_window_title_visibility();
+#elif BUILDFLAG(IS_WIN)
+    if (browser_view()->GetWidget()->ShouldUseNativeFrame()) {
+      return static_cast<const GlassBrowserFrameView*>(
+                 browser_non_client_frame_view())
+          ->window_title_for_testing()
+          ->GetVisible();
+    }
+#endif
+
+#if defined(USE_AURA)
+    return static_cast<const OpaqueBrowserFrameView*>(
+               browser_non_client_frame_view())
+        ->ShouldShowWindowTitle();
+#endif
+  }
+
+  base::test::ScopedFeatureList feature_list_;
+};
+
+IN_PROC_BROWSER_TEST_F(VerticalTabStripBrowserTest, WindowTitle) {
+  // Pre-condition: Window title is "visible" by default on vertical tabs
+  ASSERT_TRUE(tabs::features::ShouldShowVerticalTabs());
+  ASSERT_TRUE(tabs::features::ShouldShowWindowTitleForVerticalTabs(browser()));
+  ASSERT_TRUE(browser_view()->ShouldShowWindowTitle());
+  ASSERT_TRUE(IsWindowTitleViewVisible());
+
+  // Hide window title bar
+  brave::ToggleWindowTitleVisibilityForVerticalTabs(browser());
+  browser_non_client_frame_view()->Layout();
+  EXPECT_FALSE(tabs::features::ShouldShowWindowTitleForVerticalTabs(browser()));
+  EXPECT_FALSE(browser_view()->ShouldShowWindowTitle());
+#if !BUILDFLAG(IS_LINUX)
+  // TODO(sko) For now, we can't hide window title bar entirely on Linux.
+  // We're using a minimum height for it.
+  EXPECT_EQ(0,
+            browser_non_client_frame_view()->GetTopInset(/*restored=*/false));
+#endif
+  EXPECT_FALSE(IsWindowTitleViewVisible());
+
+  // Show window title bar
+  brave::ToggleWindowTitleVisibilityForVerticalTabs(browser());
+  browser_non_client_frame_view()->Layout();
+  EXPECT_TRUE(tabs::features::ShouldShowWindowTitleForVerticalTabs(browser()));
+  EXPECT_TRUE(browser_view()->ShouldShowWindowTitle());
+  EXPECT_GE(browser_non_client_frame_view()->GetTopInset(/*restored=*/false),
+            0);
+  EXPECT_TRUE(IsWindowTitleViewVisible());
+}

--- a/browser/ui/views/toolbar/brave_toolbar_view.cc
+++ b/browser/ui/views/toolbar/brave_toolbar_view.cc
@@ -12,6 +12,8 @@
 #include "base/bind.h"
 #include "brave/app/brave_command_ids.h"
 #include "brave/browser/brave_wallet/brave_wallet_context_utils.h"
+#include "brave/browser/ui/tabs/brave_tab_prefs.h"
+#include "brave/browser/ui/views/tabs/features.h"
 #include "brave/browser/ui/views/toolbar/bookmark_button.h"
 #include "brave/browser/ui/views/toolbar/wallet_button.h"
 #include "brave/components/brave_vpn/buildflags/buildflags.h"
@@ -28,8 +30,10 @@
 #include "chrome/browser/ui/views/bookmarks/bookmark_bubble_view.h"
 #include "components/bookmarks/common/bookmark_pref_names.h"
 #include "components/prefs/pref_service.h"
+#include "ui/base/hit_test.h"
 #include "ui/base/window_open_disposition.h"
 #include "ui/events/event.h"
+#include "ui/views/window/hit_test_utils.h"
 
 #if BUILDFLAG(ENABLE_BRAVE_VPN)
 #include "brave/browser/brave_vpn/vpn_utils.h"
@@ -115,6 +119,9 @@ BraveToolbarView::~BraveToolbarView() = default;
 void BraveToolbarView::Init() {
   ToolbarView::Init();
 
+  // This will allow us to move this window by dragging toolbar
+  views::SetHitTestComponent(this, HTCAPTION);
+
   // For non-normal mode, we don't have to more.
   if (display_mode_ != DisplayMode::NORMAL) {
     brave_initialized_ = true;
@@ -142,6 +149,16 @@ void BraveToolbarView::Init() {
       kLocationBarIsWide, profile->GetPrefs(),
       base::BindRepeating(&BraveToolbarView::OnLocationBarIsWideChanged,
                           base::Unretained(this)));
+
+  if (tabs::features::ShouldShowVerticalTabs()) {
+    show_title_bar_on_vertical_tabs_.Init(
+        brave_tabs::kVerticalTabsShowTitleOnWindow,
+        profile->GetOriginalProfile()->GetPrefs(),
+        base::BindRepeating(
+            &BraveToolbarView::OnShowTitleBarOnVerticalTabsChanged,
+            base::Unretained(this)));
+    OnShowTitleBarOnVerticalTabsChanged();
+  }
 
   const auto callback = [](Browser* browser, int command,
                            const ui::Event& event) {
@@ -265,6 +282,18 @@ void BraveToolbarView::UpdateBookmarkVisibility() {
                         show_bookmarks_button_.GetValue());
 }
 
+void BraveToolbarView::OnShowTitleBarOnVerticalTabsChanged() {
+  if (tabs::features::ShouldShowWindowTitleForVerticalTabs(browser())) {
+    SetBorder(nullptr);
+  } else {
+    auto [leading, trailing] =
+        tabs::features::GetLeadingTrailingCaptionButtonWidth(
+            browser_view_->frame());
+    SetBorder(views::CreateEmptyBorder(
+        gfx::Insets().set_left(leading).set_right(trailing)));
+  }
+}
+
 void BraveToolbarView::ShowBookmarkBubble(
     const GURL& url,
     bool already_bookmarked,
@@ -282,6 +311,17 @@ void BraveToolbarView::ShowBookmarkBubble(
   BookmarkBubbleView::ShowBubble(anchor_view, GetWebContents(), bookmark_,
                                  observer, std::move(delegate),
                                  browser_->profile(), url, already_bookmarked);
+}
+
+void BraveToolbarView::ViewHierarchyChanged(
+    const views::ViewHierarchyChangedDetails& details) {
+  ToolbarView::ViewHierarchyChanged(details);
+
+  if (details.is_add && details.parent == this) {
+    // Mark children of this view as client area so that they are not perceived
+    // as client area.
+    views::SetHitTestComponent(details.child, HTCLIENT);
+  }
 }
 
 void BraveToolbarView::Layout() {

--- a/browser/ui/views/toolbar/brave_toolbar_view.h
+++ b/browser/ui/views/toolbar/brave_toolbar_view.h
@@ -44,12 +44,15 @@ class BraveToolbarView : public ToolbarView,
   void ShowBookmarkBubble(const GURL& url,
                           bool already_bookmarked,
                           bookmarks::BookmarkBubbleObserver* observer) override;
+  void ViewHierarchyChanged(
+      const views::ViewHierarchyChangedDetails& details) override;
 
  private:
   void LoadImages() override;
   void ResetLocationBarBounds();
   void ResetButtonBounds();
   void UpdateBookmarkVisibility();
+  void OnShowTitleBarOnVerticalTabsChanged();
 
   // ProfileAttributesStorage::Observer:
   void OnProfileAdded(const base::FilePath& profile_path) override;
@@ -70,6 +73,9 @@ class BraveToolbarView : public ToolbarView,
   BooleanPrefMember show_bookmarks_button_;
 
   BooleanPrefMember location_bar_is_wide_;
+
+  BooleanPrefMember show_title_bar_on_vertical_tabs_;
+
   // Whether this toolbar has been initialized.
   bool brave_initialized_ = false;
   // Tracks profile count to determine whether profile switcher should be shown.

--- a/chromium_src/chrome/browser/ui/views/frame/browser_frame_view_layout_linux.cc
+++ b/chromium_src/chrome/browser/ui/views/frame/browser_frame_view_layout_linux.cc
@@ -3,14 +3,41 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+#include "base/check_is_test.h"
 #include "brave/browser/ui/views/tabs/features.h"
+#include "chrome/browser/ui/views/frame/browser_view.h"
+#include "ui/views/window/caption_button_layout_constants.h"
 
 #include "src/chrome/browser/ui/views/frame/browser_frame_view_layout_linux.cc"
 
 int BrowserFrameViewLayoutLinux::NonClientTopHeight(bool restored) const {
-  if (tabs::features::ShouldShowVerticalTabs()) {
-    // Set minimum height to show caption buttons.
-    return 50;
+  if (!view_) {
+    CHECK_IS_TEST();
+    return OpaqueBrowserFrameViewLayout::NonClientTopHeight(restored);
+  }
+
+  if (view_->browser_view()->browser()->is_type_normal() &&
+      tabs::features::ShouldShowVerticalTabs()) {
+    if (!view_->ShouldShowCaptionButtons()) {
+      // In this case, the window manager might be forcibly providing system
+      // window title or it's in fullscreen mode. We shouldn't show title bar
+      // in this case.
+      return OpaqueBrowserFrameViewLayout::NonClientTopHeight(restored);
+    }
+
+    if (tabs::features::ShouldShowWindowTitleForVerticalTabs(
+            view_->browser_view()->browser())) {
+      return 30;
+    }
+
+    // TODO(sko) For now, I couldn't find a way to overlay caption buttons
+    // on toolbar. Once it gets possible, we shouldn't reserve non client top
+    // height.
+    if (view_->ShouldShowCaptionButtons()) {
+      // Uses the same caption height defined in
+      // c/b/u/v/frame/opaque_browser_frame_view_layout.cc
+      return 18;
+    }
   }
 
   return OpaqueBrowserFrameViewLayout::NonClientTopHeight(restored);

--- a/chromium_src/chrome/browser/ui/views/frame/browser_frame_view_layout_linux.cc
+++ b/chromium_src/chrome/browser/ui/views/frame/browser_frame_view_layout_linux.cc
@@ -25,19 +25,24 @@ int BrowserFrameViewLayoutLinux::NonClientTopHeight(bool restored) const {
       return OpaqueBrowserFrameViewLayout::NonClientTopHeight(restored);
     }
 
-    if (tabs::features::ShouldShowWindowTitleForVerticalTabs(
-            view_->browser_view()->browser())) {
-      return 30;
-    }
-
     // TODO(sko) For now, I couldn't find a way to overlay caption buttons
     // on toolbar. Once it gets possible, we shouldn't reserve non client top
-    // height.
-    if (view_->ShouldShowCaptionButtons()) {
-      // Uses the same caption height defined in
-      // c/b/u/v/frame/opaque_browser_frame_view_layout.cc
-      return 18;
-    }
+    // height when window title isn't visible.
+
+    // Adding 2px of vertical padding puts at least 1 px of space on the top and
+    // bottom of the element.
+    constexpr int kVerticalPadding = 2;
+    // delegate_->GetIconSize() also considers the default font's height so
+    // title will be visible.
+    const int icon_height = FrameEdgeInsets(restored).top() +
+                            delegate_->GetIconSize() + kVerticalPadding;
+
+    const int caption_button_height =
+        DefaultCaptionButtonY(restored) +
+        18 /*kCaptionButtonHeight in OpaqueBrowserFrameView*/ +
+        kCaptionButtonBottomPadding;
+    return std::max(icon_height, caption_button_height) +
+           kCaptionButtonBottomPadding;
   }
 
   return OpaqueBrowserFrameViewLayout::NonClientTopHeight(restored);

--- a/chromium_src/chrome/browser/ui/views/frame/browser_frame_view_linux.cc
+++ b/chromium_src/chrome/browser/ui/views/frame/browser_frame_view_linux.cc
@@ -1,0 +1,14 @@
+/* Copyright (c) 2022 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "chrome/browser/ui/views/frame/browser_frame_view_linux.h"
+#include "brave/browser/ui/views/frame/brave_opaque_browser_frame_view.h"
+
+#define OpaqueBrowserFrameView(frame, browser_view, layout) \
+  BraveOpaqueBrowserFrameView(frame, browser_view, layout)
+
+#include "src/chrome/browser/ui/views/frame/browser_frame_view_linux.cc"
+
+#undef OpaqueBrowserFrameView

--- a/chromium_src/chrome/browser/ui/views/frame/browser_frame_view_linux.h
+++ b/chromium_src/chrome/browser/ui/views/frame/browser_frame_view_linux.h
@@ -16,4 +16,9 @@
 
 #undef OpaqueBrowserFrameView
 
+// Sanity check at compile time.
+static_assert(
+    std::is_base_of_v<BraveOpaqueBrowserFrameView, BrowserFrameViewLinux>,
+    "BrowserFrameViewLinux should be a child of BraveOpaqueBrowserFrameView");
+
 #endif  // BRAVE_CHROMIUM_SRC_CHROME_BROWSER_UI_VIEWS_FRAME_BROWSER_FRAME_VIEW_LINUX_H_

--- a/chromium_src/chrome/browser/ui/views/frame/browser_frame_view_linux.h
+++ b/chromium_src/chrome/browser/ui/views/frame/browser_frame_view_linux.h
@@ -1,0 +1,19 @@
+/* Copyright (c) 2022 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_CHROMIUM_SRC_CHROME_BROWSER_UI_VIEWS_FRAME_BROWSER_FRAME_VIEW_LINUX_H_
+#define BRAVE_CHROMIUM_SRC_CHROME_BROWSER_UI_VIEWS_FRAME_BROWSER_FRAME_VIEW_LINUX_H_
+
+#include "chrome/browser/ui/views/frame/opaque_browser_frame_view.h"
+
+// Make BrowserFrameViewLinux extends our BraveOpaqueBrowserFrameView
+#include "brave/browser/ui/views/frame/brave_opaque_browser_frame_view.h"
+#define OpaqueBrowserFrameView BraveOpaqueBrowserFrameView
+
+#include "src/chrome/browser/ui/views/frame/browser_frame_view_linux.h"
+
+#undef OpaqueBrowserFrameView
+
+#endif  // BRAVE_CHROMIUM_SRC_CHROME_BROWSER_UI_VIEWS_FRAME_BROWSER_FRAME_VIEW_LINUX_H_

--- a/chromium_src/chrome/browser/ui/views/frame/browser_non_client_frame_view_factory_views.cc
+++ b/chromium_src/chrome/browser/ui/views/frame/browser_non_client_frame_view_factory_views.cc
@@ -3,6 +3,9 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+#include <functional>
+#include <type_traits>
+
 #include "build/build_config.h"
 
 #if BUILDFLAG(IS_WIN)
@@ -10,12 +13,24 @@
 #define GlassBrowserFrameView BraveGlassBrowserFrameView
 #endif
 
+// This file is included for all platform by upstream source code and we need
+// to include this first to avoid #define conflicts.
+#include "chrome/browser/ui/views/frame/browser_frame_view_linux.h"
+
 #include "brave/browser/ui/views/frame/brave_opaque_browser_frame_view.h"
 #define OpaqueBrowserFrameView BraveOpaqueBrowserFrameView
 
 #include "src/chrome/browser/ui/views/frame/browser_non_client_frame_view_factory_views.cc"
 
 #undef OpaqueBrowserFrameView
+
+// A sanity check for our macro
+static_assert(
+    std::is_same_v<std::unique_ptr<BraveOpaqueBrowserFrameView>,
+                   decltype(std::function{
+                       chrome::CreateOpaqueBrowserFrameView})::result_type>,
+    "CreateOpaqueBrowserFrameView is not returning "
+    "BraveOpaqueBrowserFrameView");
 
 #if BUILDFLAG(IS_WIN)
 #undef GlassBrowserFrameView

--- a/chromium_src/chrome/browser/ui/views/frame/browser_non_client_frame_view_mac.h
+++ b/chromium_src/chrome/browser/ui/views/frame/browser_non_client_frame_view_mac.h
@@ -1,0 +1,18 @@
+/* Copyright (c) 2022 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_CHROMIUM_SRC_CHROME_BROWSER_UI_VIEWS_FRAME_BROWSER_NON_CLIENT_FRAME_VIEW_MAC_H_
+#define BRAVE_CHROMIUM_SRC_CHROME_BROWSER_UI_VIEWS_FRAME_BROWSER_NON_CLIENT_FRAME_VIEW_MAC_H_
+
+#define PaintThemedFrame                          \
+  PaintThemedFrame_Unused() {}                    \
+  friend class BraveBrowserNonClientFrameViewMac; \
+  void PaintThemedFrame
+
+#include "src/chrome/browser/ui/views/frame/browser_non_client_frame_view_mac.h"
+
+#undef PaintThemedFrame
+
+#endif  // BRAVE_CHROMIUM_SRC_CHROME_BROWSER_UI_VIEWS_FRAME_BROWSER_NON_CLIENT_FRAME_VIEW_MAC_H_

--- a/chromium_src/chrome/browser/ui/views/frame/native_browser_frame_factory_mac.mm
+++ b/chromium_src/chrome/browser/ui/views/frame/native_browser_frame_factory_mac.mm
@@ -1,0 +1,12 @@
+/* Copyright 2022 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "brave/browser/ui/views/frame/brave_browser_frame_mac.h"
+
+#define BrowserFrameMac BraveBrowserFrameMac
+
+#include "src/chrome/browser/ui/views/frame/native_browser_frame_factory_mac.mm"
+
+#undef BrowserFrameMac

--- a/chromium_src/components/remote_cocoa/app_shim/native_widget_ns_window_bridge.h
+++ b/chromium_src/components/remote_cocoa/app_shim/native_widget_ns_window_bridge.h
@@ -1,0 +1,18 @@
+/* Copyright (c) 2022 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_CHROMIUM_SRC_COMPONENTS_REMOTE_COCOA_APP_SHIM_NATIVE_WIDGET_NS_WINDOW_BRIDGE_H_
+#define BRAVE_CHROMIUM_SRC_COMPONENTS_REMOTE_COCOA_APP_SHIM_NATIVE_WIDGET_NS_WINDOW_BRIDGE_H_
+
+// Override a method from our NativeWidgetNSWindow mojo extension
+#define OnSizeChanged                              \
+  SetWindowTitleVisibility(bool visible) override; \
+  void OnSizeChanged
+
+#include "src/components/remote_cocoa/app_shim/native_widget_ns_window_bridge.h"
+
+#undef OnSizeChanged
+
+#endif  // BRAVE_CHROMIUM_SRC_COMPONENTS_REMOTE_COCOA_APP_SHIM_NATIVE_WIDGET_NS_WINDOW_BRIDGE_H_

--- a/chromium_src/components/remote_cocoa/app_shim/native_widget_ns_window_bridge.mm
+++ b/chromium_src/components/remote_cocoa/app_shim/native_widget_ns_window_bridge.mm
@@ -1,0 +1,28 @@
+/* Copyright (c) 2022 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "src/components/remote_cocoa/app_shim/native_widget_ns_window_bridge.mm"
+
+namespace remote_cocoa {
+
+void NativeWidgetNSWindowBridge::SetWindowTitleVisibility(bool visible) {
+  NSUInteger style_mask = [window_ styleMask];
+  if (visible)
+    style_mask |= NSWindowStyleMaskTitled;
+  else
+    style_mask &= ~NSWindowStyleMaskTitled;
+
+  [window_ setStyleMask:style_mask];
+
+  // Sometimes title is not visible until window is resized. In order to avoid
+  // this, reset title to force it to be visible.
+  if (visible) {
+    NSString* title = window_.get().title;
+    window_.get().title = @"";
+    window_.get().title = title;
+  }
+}
+
+}  // namespace remote_cocoa

--- a/chromium_src/components/remote_cocoa/common/native_widget_ns_window.mojom
+++ b/chromium_src/components/remote_cocoa/common/native_widget_ns_window.mojom
@@ -1,0 +1,11 @@
+// Copyright (c) 2022 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at http://mozilla.org/MPL/2.0/.
+
+module remote_cocoa.mojom;
+
+[BraveExtend]
+interface NativeWidgetNSWindow {
+  SetWindowTitleVisibility(bool visible);
+};

--- a/chromium_src/ui/views/cocoa/native_widget_mac_ns_window_host.h
+++ b/chromium_src/ui/views/cocoa/native_widget_mac_ns_window_host.h
@@ -1,0 +1,17 @@
+/* Copyright (c) 2022 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_CHROMIUM_SRC_UI_VIEWS_COCOA_NATIVE_WIDGET_MAC_NS_WINDOW_HOST_H_
+#define BRAVE_CHROMIUM_SRC_UI_VIEWS_COCOA_NATIVE_WIDGET_MAC_NS_WINDOW_HOST_H_
+
+#define OnWidgetInitDone                  \
+  SetWindowTitleVisibility(bool visible); \
+  void OnWidgetInitDone
+
+#include "src/ui/views/cocoa/native_widget_mac_ns_window_host.h"
+
+#undef OnWidgetInitDone
+
+#endif  // BRAVE_CHROMIUM_SRC_UI_VIEWS_COCOA_NATIVE_WIDGET_MAC_NS_WINDOW_HOST_H_

--- a/chromium_src/ui/views/cocoa/native_widget_mac_ns_window_host.mm
+++ b/chromium_src/ui/views/cocoa/native_widget_mac_ns_window_host.mm
@@ -1,0 +1,14 @@
+/* Copyright (c) 2022 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "src/ui/views/cocoa/native_widget_mac_ns_window_host.mm"
+
+namespace views {
+
+void NativeWidgetMacNSWindowHost::SetWindowTitleVisibility(bool visible) {
+  GetNSWindowMojo()->SetWindowTitleVisibility(visible);
+}
+
+}  // namespace views

--- a/chromium_src/ui/views/widget/native_widget_mac.h
+++ b/chromium_src/ui/views/widget/native_widget_mac.h
@@ -1,0 +1,19 @@
+/* Copyright (c) 2022 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_CHROMIUM_SRC_UI_VIEWS_WIDGET_NATIVE_WIDGET_MAC_H_
+#define BRAVE_CHROMIUM_SRC_UI_VIEWS_WIDGET_NATIVE_WIDGET_MAC_H_
+
+#include "ui/views/widget/native_widget_private.h"
+
+#define SetWindowIcons                    \
+  SetWindowTitleVisibility(bool visible); \
+  void SetWindowIcons
+
+#include "src/ui/views/widget/native_widget_mac.h"
+
+#undef SetWindowIcons
+
+#endif  // BRAVE_CHROMIUM_SRC_UI_VIEWS_WIDGET_NATIVE_WIDGET_MAC_H_

--- a/chromium_src/ui/views/widget/native_widget_mac.h
+++ b/chromium_src/ui/views/widget/native_widget_mac.h
@@ -13,9 +13,7 @@
   bool has_overridden_window_title_visibility() const {     \
     return overridden_window_title_visibility_.has_value(); \
   }                                                         \
-  bool overridden_window_title_visibility() const {         \
-    return overridden_window_title_visibility_.value();     \
-  }                                                         \
+  bool GetOverriddenWindowTitleVisibility() const;          \
                                                             \
  private:                                                   \
   absl::optional<bool> overridden_window_title_visibility_; \

--- a/chromium_src/ui/views/widget/native_widget_mac.h
+++ b/chromium_src/ui/views/widget/native_widget_mac.h
@@ -8,8 +8,19 @@
 
 #include "ui/views/widget/native_widget_private.h"
 
-#define SetWindowIcons                    \
-  SetWindowTitleVisibility(bool visible); \
+#define SetWindowIcons                                      \
+  SetWindowTitleVisibility(bool visible);                   \
+  bool has_overridden_window_title_visibility() const {     \
+    return overridden_window_title_visibility_.has_value(); \
+  }                                                         \
+  bool overridden_window_title_visibility() const {         \
+    return overridden_window_title_visibility_.value();     \
+  }                                                         \
+                                                            \
+ private:                                                   \
+  absl::optional<bool> overridden_window_title_visibility_; \
+                                                            \
+ public:                                                    \
   void SetWindowIcons
 
 #include "src/ui/views/widget/native_widget_mac.h"

--- a/chromium_src/ui/views/widget/native_widget_mac.mm
+++ b/chromium_src/ui/views/widget/native_widget_mac.mm
@@ -1,0 +1,14 @@
+/* Copyright (c) 2022 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "src/ui/views/widget/native_widget_mac.mm"
+
+namespace views {
+
+void NativeWidgetMac::SetWindowTitleVisibility(bool visible) {
+  GetNSWindowMojo()->SetWindowTitleVisibility(visible);
+}
+
+}  // namespace views

--- a/chromium_src/ui/views/widget/native_widget_mac.mm
+++ b/chromium_src/ui/views/widget/native_widget_mac.mm
@@ -8,7 +8,13 @@
 namespace views {
 
 void NativeWidgetMac::SetWindowTitleVisibility(bool visible) {
+  if (overridden_window_title_visibility_.has_value() &&
+      visible == *overridden_window_title_visibility_) {
+    return;
+  }
+
   GetNSWindowMojo()->SetWindowTitleVisibility(visible);
+  overridden_window_title_visibility_ = visible;
 }
 
 }  // namespace views

--- a/chromium_src/ui/views/widget/native_widget_mac.mm
+++ b/chromium_src/ui/views/widget/native_widget_mac.mm
@@ -17,4 +17,11 @@ void NativeWidgetMac::SetWindowTitleVisibility(bool visible) {
   overridden_window_title_visibility_ = visible;
 }
 
+bool NativeWidgetMac::GetOverriddenWindowTitleVisibility() const {
+  DCHECK(has_overridden_window_title_visibility())
+      << "Didn't call SetWindowTitleVisibility(). Use "
+         "WidgetDelegate::ShouldShowWindowTitle() instead.";
+  return *overridden_window_title_visibility_;
+}
+
 }  // namespace views

--- a/chromium_src/ui/views/widget/widget.cc
+++ b/chromium_src/ui/views/widget/widget.cc
@@ -1,0 +1,21 @@
+/* Copyright (c) 2022 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "src/ui/views/widget/widget.cc"
+
+#if BUILDFLAG(IS_MAC)
+
+#include "ui/views/widget/native_widget_mac.h"
+
+namespace views {
+
+void Widget::SetWindowTitleVisibility(bool visible) {
+  static_cast<NativeWidgetMac*>(native_widget_)
+      ->SetWindowTitleVisibility(visible);
+}
+
+}  // namespace views
+
+#endif  // defined(OS_MAC)

--- a/chromium_src/ui/views/widget/widget.h
+++ b/chromium_src/ui/views/widget/widget.h
@@ -1,0 +1,23 @@
+/* Copyright (c) 2022 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_CHROMIUM_SRC_UI_VIEWS_WIDGET_WIDGET_H_
+#define BRAVE_CHROMIUM_SRC_UI_VIEWS_WIDGET_WIDGET_H_
+
+#include "build/build_config.h"
+
+#if BUILDFLAG(IS_MAC)
+#define UnlockPaintAsActive               \
+  SetWindowTitleVisibility(bool visible); \
+  void UnlockPaintAsActive
+#else
+#define UnlockPaintAsActive UnlockPaintAsActive
+#endif
+
+#include "src/ui/views/widget/widget.h"
+
+#undef UnlockPaintAsActive
+
+#endif  // BRAVE_CHROMIUM_SRC_UI_VIEWS_WIDGET_WIDGET_H_

--- a/test/BUILD.gn
+++ b/test/BUILD.gn
@@ -1067,11 +1067,13 @@ test("brave_browser_tests") {
       "//brave/browser/ui/views/brave_actions/brave_actions_container_browsertest.cc",
       "//brave/browser/ui/views/brave_ads/notification_ad_popup_browsertest.cc",
       "//brave/browser/ui/views/brave_shields/cookie_list_opt_in_browsertest.cc",
+      "//brave/browser/ui/views/frame/brave_non_client_hit_test_helper_browsertest.cc",
       "//brave/browser/ui/views/frame/brave_tabs_search_button_browsertest.cc",
       "//brave/browser/ui/views/omnibox/brave_omnibox_view_views_browsertest.cc",
       "//brave/browser/ui/views/omnibox/omnibox_autocomplete_browsertest.cc",
       "//brave/browser/ui/views/profiles/brave_profile_menu_view_browsertest.cc",
       "//brave/browser/ui/views/tabs/brave_tab_context_menu_contents_browsertest.cc",
+      "//brave/browser/ui/views/tabs/vertical_tab_strip_browsertest.cc",
       "//brave/browser/ui/views/toolbar/brave_toolbar_view_browsertest.cc",
       "//brave/browser/ui/views/toolbar/wallet_button_browsertest.cc",
     ]


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/25473
Resolves https://github.com/brave/brave-browser/issues/25757

Add a tab context menu to hide window title when vertical tab strip is enabled. When hiding window title, we can claim title area so that users can use taller contents area.

* On Mac and Window, toolbar will take the title area.
* On Linux, title area will be as short as possible
  * can't overlay caption buttons on toolbar for now.

Also, we should make it easy to move window when hiding window title as there's almost no non-client area. Thus, enable dragging windows by dragging toolbar area.

### Windows glass frame

#### no title
<img width="1123" alt="image" src="https://user-images.githubusercontent.com/5474642/196432449-7e3324f3-f1ef-481b-a1b5-489f3aa5866c.png">

#### with title
<img width="1116" alt="image" src="https://user-images.githubusercontent.com/5474642/196432507-7df7cafb-c4c7-4200-81d7-4605a05ee4d0.png">

### Windows opaque frame
#### with title
<img width="1110" alt="image" src="https://user-images.githubusercontent.com/5474642/196882501-21b41ce0-e575-4ba1-bff7-c8c2abd44008.png">

#### no title
<img width="1118" alt="image" src="https://user-images.githubusercontent.com/5474642/196882563-07c8b5ad-aa53-4ddb-a71b-9d94b50a95a0.png">


### Mac
#### With title
<img width="1148" alt="image" src="https://user-images.githubusercontent.com/5474642/196432910-598acf08-1b17-40a0-9272-fcd9e87a1f81.png">

#### no title
<img width="1158" alt="image" src="https://user-images.githubusercontent.com/5474642/196432975-61fcb01a-1b7f-4bff-9181-82e7cc1ff15b.png">

### Linux
#### With title
<img width="1271" alt="image" src="https://user-images.githubusercontent.com/5474642/196867305-6a52b56c-2e0a-4a61-85bd-de0a0e105e91.png">

#### No title
<img width="1270" alt="image" src="https://user-images.githubusercontent.com/5474642/196867347-a1a22aa3-9291-4a37-8b91-9c106db8b662.png">


## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
### Manual
* When using vertical tab strip, there should be a context menu item to show/hide window title
* When toggling window title state, window title visibility should be changed
* When hiding window title, non client area should be at minimum size.
* Dragging toolbar will moving the window

### Automated
VerticalTabstripBrowserTest.WindowTitleVisibility.Toolbar
BraveNonClientHitTestHelperBrowserTest.WindowTitle