### PR TITLE
Restore missing iOS browser prefs patch (uplift to 1.46.x)

### DIFF
--- a/patches/ios-chrome-browser-prefs-browser_prefs.mm.patch
+++ b/patches/ios-chrome-browser-prefs-browser_prefs.mm.patch
@@ -1,0 +1,26 @@
+diff --git a/ios/chrome/browser/prefs/browser_prefs.mm b/ios/chrome/browser/prefs/browser_prefs.mm
+index 2c80c4a63d8f9342c712968866175871e933ee44..b9683670dc6c04733cb402710577978324847193 100644
+--- a/ios/chrome/browser/prefs/browser_prefs.mm
++++ b/ios/chrome/browser/prefs/browser_prefs.mm
+@@ -194,6 +194,7 @@ void RegisterLocalStatePrefs(PrefRegistrySimple* registry) {
+   // times a user should see autofill branding animation after installation.
+   registry->RegisterIntegerPref(
+       prefs::kAutofillBrandingIconAnimationRemainingCountPrefName, 2);
++  BRAVE_REGISTER_LOCAL_STATE_PREFS
+ }
+ 
+ void RegisterBrowserStatePrefs(user_prefs::PrefRegistrySyncable* registry) {
+@@ -312,6 +313,7 @@ void RegisterBrowserStatePrefs(user_prefs::PrefRegistrySyncable* registry) {
+                              PrefRegistry::LOSSY_PREF);
+ 
+   registry->RegisterDictionaryPref(kPrefPromoObject);
++  BRAVE_REGISTER_BROWSER_STATE_PREFS
+ }
+ 
+ // This method should be periodically pruned of year+ old migrations.
+@@ -362,4 +364,5 @@ void MigrateObsoleteBrowserStatePrefs(PrefService* prefs) {
+ 
+   // Added 09/2022
+   prefs->ClearPref(kDataSaverEnabled);
++  BRAVE_MIGRATE_OBSOLETE_BROWSER_STATE_PREFS
+ }


### PR DESCRIPTION
Uplift of #15533
Resolves https://github.com/brave/brave-browser/issues/26128

Pre-approval checklist: 
- [ ] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.