### PR TITLE
Fix cr107 settings page does not get brave's default avatar icon

### DIFF
--- a/chromium_src/chrome/browser/profiles/profile_avatar_icon_util.cc
+++ b/chromium_src/chrome/browser/profiles/profile_avatar_icon_util.cc
@@ -44,6 +44,13 @@ size_t GetBraveAvatarIconStartIndex();
 #define BRAVE_GET_MODERN_AVATAR_ICON_START_INDEX  \
   return GetBraveAvatarIconStartIndex();
 
+#define BRAVE_GET_ICONS_AND_LABELS_FOR_PROFILE_AVATAR_SELECTOR_NOT_SIGNED_IN \
+  avatars.erase(avatars.begin());                                            \
+  generic_avatar_info = GetDefaultProfileAvatarIconAndLabel_Brave(           \
+      colors.default_avatar_fill_color, colors.default_avatar_stroke_color,  \
+      selected_avatar_idx == GetPlaceholderAvatarIndex());                   \
+  avatars.Insert(avatars.begin(), base::Value(std::move(generic_avatar_info)));
+
 }  // namespace profiles
 
 // Override some functions (see implementations for details).
@@ -57,6 +64,7 @@ size_t GetBraveAvatarIconStartIndex();
 #include "src/chrome/browser/profiles/profile_avatar_icon_util.cc"
 #undef BRAVE_GET_DEFAULT_AVATAR_ICON_RESOURCE_INFO
 #undef BRAVE_GET_MODERN_AVATAR_ICON_START_INDEX
+#undef BRAVE_GET_ICONS_AND_LABELS_FOR_PROFILE_AVATAR_SELECTOR_NOT_SIGNED_IN
 #undef IsDefaultAvatarIconUrl
 #undef GetGuestAvatar
 #undef GetPlaceholderAvatarIconWithColors
@@ -197,6 +205,13 @@ base::Value::Dict GetDefaultProfileAvatarIconAndLabel(SkColor fill_color,
                                    brave_l10n::GetLocalizedResourceUTF16String(
                                        IDS_BRAVE_AVATAR_LABEL_PLACEHOLDER),
                                    index, selected, /*is_gaia_avatar=*/false);
+}
+base::Value::Dict GetDefaultProfileAvatarIconAndLabel_Brave(
+    SkColor fill_color,
+    SkColor stroke_color,
+    bool selected) {
+  return GetDefaultProfileAvatarIconAndLabel(fill_color, stroke_color,
+                                             selected);
 }
 
 }  // namespace profiles

--- a/chromium_src/chrome/browser/profiles/profile_avatar_icon_util.h
+++ b/chromium_src/chrome/browser/profiles/profile_avatar_icon_util.h
@@ -11,6 +11,11 @@
 namespace profiles {
   // Access original value for tests
   extern const size_t kBraveDefaultAvatarIconsCount;
+  // Provide direct access to custom implementation
+  base::Value::Dict GetDefaultProfileAvatarIconAndLabel_Brave(
+      SkColor fill_color,
+      SkColor stroke_color,
+      bool selected);
 }  // namespace profiles
 
 #endif  // BRAVE_CHROMIUM_SRC_CHROME_BROWSER_PROFILES_PROFILE_AVATAR_ICON_UTIL_H_

--- a/patches/chrome-browser-profiles-profile_avatar_icon_util.cc.patch
+++ b/patches/chrome-browser-profiles-profile_avatar_icon_util.cc.patch
@@ -1,5 +1,5 @@
 diff --git a/chrome/browser/profiles/profile_avatar_icon_util.cc b/chrome/browser/profiles/profile_avatar_icon_util.cc
-index 9acede502b82e75da554c3b0ae3d7fb7fec4a731..76c745e509263902387c308ac32e060f34d5a8d9 100644
+index 9acede502b82e75da554c3b0ae3d7fb7fec4a731..2b1dca7fb45309cb561c56e2487cb657636d3b73 100644
 --- a/chrome/browser/profiles/profile_avatar_icon_util.cc
 +++ b/chrome/browser/profiles/profile_avatar_icon_util.cc
 @@ -275,7 +275,7 @@ constexpr size_t kDefaultAvatarIconsCount = 1;
@@ -27,3 +27,11 @@ index 9acede502b82e75da554c3b0ae3d7fb7fec4a731..76c745e509263902387c308ac32e060f
    static const IconResourceInfo resource_info[kDefaultAvatarIconsCount] = {
    // Old avatar icons:
  #if !BUILDFLAG(IS_ANDROID)
+@@ -669,6 +671,7 @@ base::Value::List GetIconsAndLabelsForProfileAvatarSelector(
+         selected_avatar_idx == GetPlaceholderAvatarIndex());
+     avatars.Insert(avatars.begin(),
+                    base::Value(std::move(generic_avatar_info)));
++    BRAVE_GET_ICONS_AND_LABELS_FOR_PROFILE_AVATAR_SELECTOR_NOT_SIGNED_IN
+     return avatars;
+   }
+ 


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/26073

I don't know if this is the best way to fix the issue, which is that profile_avatar_icon_util has `GetIconsAndLabelsForProfileAvatarSelector` which calls `GetDefaultProfileAvatarIconAndLabel` which we had overriden but since it's internal to the file, the override will not redirect to Brave's implementation. Instead I add a patch that directly calls our implementation and uses that result.

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

