### PR TITLE
Replaced autofill popup pwd settings entry icon (uplift to 1.45.x)

### DIFF
--- a/chromium_src/chrome/browser/ui/views/autofill/autofill_popup_view_native_views.cc
+++ b/chromium_src/chrome/browser/ui/views/autofill/autofill_popup_view_native_views.cc
@@ -1,0 +1,12 @@
+/* Copyright (c) 2022 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "chrome/app/vector_icons/vector_icons.h"
+
+#define kMonoColorProductIcon vector_icons::kSettingsIcon
+
+#include "src/chrome/browser/ui/views/autofill/autofill_popup_view_native_views.cc"
+
+#undef kMonoColorProductIcon


### PR DESCRIPTION
Uplift of #15526
fix https://github.com/brave/brave-browser/issues/26089

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.