### PR TITLE
Fixed selected region is not updated when it's updated from other panels

### DIFF
--- a/components/brave_vpn/brave_vpn_service.cc
+++ b/components/brave_vpn/brave_vpn_service.cc
@@ -76,6 +76,13 @@ BraveVpnService::BraveVpnService(
   if (preference && !preference->IsDefaultValue()) {
     ReloadPurchasedState();
   }
+
+  pref_change_registrar_.Init(local_prefs_);
+  pref_change_registrar_.Add(
+      prefs::kBraveVPNSelectedRegion,
+      base::BindRepeating(&BraveVpnService::OnPreferenceChanged,
+                          base::Unretained(this)));
+
 #endif  // !BUILDFLAG(IS_ANDROID)
 
   InitP3A();
@@ -471,6 +478,16 @@ void BraveVpnService::OnCreateSupportTicket(
   VLOG(2) << "OnCreateSupportTicket success=" << success
           << "\nresponse_code=" << api_request_result.response_code();
   std::move(callback).Run(success, api_request_result.body());
+}
+
+void BraveVpnService::OnPreferenceChanged(const std::string& pref_name) {
+  if (pref_name == prefs::kBraveVPNSelectedRegion) {
+    for (const auto& obs : observers_) {
+      obs->OnSelectedRegionChanged(
+          GetRegionPtrWithNameFromRegionList(GetSelectedRegion(), regions_));
+    }
+    return;
+  }
 }
 #endif  // !BUILDFLAG(IS_ANDROID)
 

--- a/components/brave_vpn/brave_vpn_service.h
+++ b/components/brave_vpn/brave_vpn_service.h
@@ -20,6 +20,7 @@
 #include "brave/components/skus/common/skus_sdk.mojom.h"
 #include "build/build_config.h"
 #include "components/keyed_service/core/keyed_service.h"
+#include "components/prefs/pref_change_registrar.h"
 #include "mojo/public/cpp/bindings/pending_remote.h"
 #include "mojo/public/cpp/bindings/receiver_set.h"
 #include "mojo/public/cpp/bindings/remote_set.h"
@@ -195,6 +196,8 @@ class BraveVpnService :
   void OnCreateSupportTicket(CreateSupportTicketCallback callback,
                              APIRequestResult api_request_result);
 
+  void OnPreferenceChanged(const std::string& pref_name);
+
   BraveVPNOSConnectionAPI* GetBraveVPNConnectionAPI() const;
 #endif  // !BUILDFLAG(IS_ANDROID)
 
@@ -236,6 +239,8 @@ class BraveVpnService :
   // Only for testing.
   std::string test_timezone_;
   bool is_simulation_ = false;
+
+  PrefChangeRegistrar pref_change_registrar_;
 #endif  // !BUILDFLAG(IS_ANDROID)
 
   SEQUENCE_CHECKER(sequence_checker_);

--- a/components/brave_vpn/brave_vpn_service_observer.h
+++ b/components/brave_vpn/brave_vpn_service_observer.h
@@ -27,6 +27,7 @@ class BraveVPNServiceObserver : public mojom::ServiceObserver {
   void OnPurchasedStateChanged(mojom::PurchasedState state) override {}
 #if !BUILDFLAG(IS_ANDROID)
   void OnConnectionStateChanged(mojom::ConnectionState state) override {}
+  void OnSelectedRegionChanged(mojom::RegionPtr region) override {}
 #endif  // !BUILDFLAG(IS_ANDROID)
 
  private:

--- a/components/brave_vpn/mojom/brave_vpn.mojom
+++ b/components/brave_vpn/mojom/brave_vpn.mojom
@@ -29,6 +29,9 @@ interface ServiceObserver {
   [EnableIfNot=is_android]
   OnConnectionStateChanged(ConnectionState state);
 
+  [EnableIfNot=is_android]
+  OnSelectedRegionChanged(Region region);
+
   OnPurchasedStateChanged(PurchasedState state);
 };
 

--- a/components/brave_vpn/resources/panel/state/actions.ts
+++ b/components/brave_vpn/resources/panel/state/actions.ts
@@ -29,6 +29,10 @@ export type initializedPayload = {
   productUrls: ProductUrls
 }
 
+export type selectedRegionPayload = {
+  region: Region
+}
+
 export const connect = createAction('connect')
 export const disconnect = createAction('disconnect')
 export const connectionFailed = createAction('connectionFailed')
@@ -45,3 +49,4 @@ export const showMainView = createAction<showMainViewPayload>('showMainView')
 export const toggleRegionSelector = createAction<ToggleRegionSelectorPayload>('toggleRegionSelector', (isSelectingRegion) => ({ isSelectingRegion }))
 export const connectionStateChanged = createAction<ConnectionStatePayload>('connectionStateChanged')
 export const connectToNewRegion = createAction<ConnectToNewRegionPayload>('connectToNewRegion', (region) => ({ region }))
+export const selectedRegionChanged = createAction<selectedRegionPayload>('selectedRegionChanged')

--- a/components/brave_vpn/resources/panel/state/reducer.ts
+++ b/components/brave_vpn/resources/panel/state/reducer.ts
@@ -75,6 +75,13 @@ reducer.on(Actions.connectionStateChanged, (state, payload): RootState => {
   }
 })
 
+reducer.on(Actions.selectedRegionChanged, (state, payload): RootState => {
+  return {
+    ...state,
+    currentRegion: payload.region
+  }
+})
+
 reducer.on(Actions.retryConnect, (state): RootState => {
   return {
     ...state,

--- a/components/brave_vpn/resources/panel/state/store.ts
+++ b/components/brave_vpn/resources/panel/state/store.ts
@@ -8,7 +8,7 @@ import { createStore, applyMiddleware } from 'redux'
 import reducer from './reducer'
 import asyncHandler from './async'
 import * as Actions from './actions'
-import getPanelBrowserAPI, { ServiceObserverReceiver, ConnectionState, PurchasedState } from '../api/panel_browser_api'
+import getPanelBrowserAPI, { ServiceObserverReceiver, ConnectionState, PurchasedState, Region } from '../api/panel_browser_api'
 
 const store = createStore(
   reducer,
@@ -17,11 +17,13 @@ const store = createStore(
 
 // Register the observer earlier
 const observer = {
-  onConnectionCreated: () => { /**/ },
-  onConnectionRemoved: () => { /**/ },
   onConnectionStateChanged: (connectionStatus: ConnectionState) => {
     store.dispatch(Actions.connectionStateChanged({ connectionStatus }))
   },
+  onSelectedRegionChanged: (region: Region) => {
+    store.dispatch(Actions.selectedRegionChanged({ region }))
+  },
+
   onPurchasedStateChanged: (state: PurchasedState) => {
     switch (state) {
       case PurchasedState.PURCHASED:


### PR DESCRIPTION
fix https://github.com/brave/brave-browser/issues/25790

While VPN panel is running, selected state could be changed from another window's vpn panel.
In that case, this panel can't know about new selected region.
Fixed by observing selected region change.

Note: This PR depends on https://github.com/brave/brave-core/pull/15502
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves 

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

`BraveVPNServiceTest.SelectedRegionChangedUpdateTest`

1. Set purchased state
2. Connect to any region in current window(`window-a`)
3. Create another window (`window-b`)
4. Open VPN panel from `window_b` and  check both windows's panel has selected region
5. Change region and reconnect with `window-a`'s vpn panel
6. Check `window-b`'s vpn panel has same selected region

Note: window-a and window-b could be same profile or different profile