### PR TITLE
Fix cr107 settings page does not get brave's default avatar icon (uplift to 1.45.x)

### DIFF
--- a/chromium_src/chrome/browser/profiles/profile_avatar_icon_util.cc
+++ b/chromium_src/chrome/browser/profiles/profile_avatar_icon_util.cc
@@ -44,6 +44,13 @@ size_t GetBraveAvatarIconStartIndex();
 #define BRAVE_GET_MODERN_AVATAR_ICON_START_INDEX  \
   return GetBraveAvatarIconStartIndex();
 
+#define BRAVE_GET_ICONS_AND_LABELS_FOR_PROFILE_AVATAR_SELECTOR_NOT_SIGNED_IN \
+  avatars.erase(avatars.begin());                                            \
+  generic_avatar_info = GetDefaultProfileAvatarIconAndLabel_Brave(           \
+      colors.default_avatar_fill_color, colors.default_avatar_stroke_color,  \
+      selected_avatar_idx == GetPlaceholderAvatarIndex());                   \
+  avatars.Insert(avatars.begin(), base::Value(std::move(generic_avatar_info)));
+
 }  // namespace profiles
 
 // Override some functions (see implementations for details).
@@ -57,6 +64,7 @@ size_t GetBraveAvatarIconStartIndex();
 #include "src/chrome/browser/profiles/profile_avatar_icon_util.cc"
 #undef BRAVE_GET_DEFAULT_AVATAR_ICON_RESOURCE_INFO
 #undef BRAVE_GET_MODERN_AVATAR_ICON_START_INDEX
+#undef BRAVE_GET_ICONS_AND_LABELS_FOR_PROFILE_AVATAR_SELECTOR_NOT_SIGNED_IN
 #undef IsDefaultAvatarIconUrl
 #undef GetGuestAvatar
 #undef GetPlaceholderAvatarIconWithColors
@@ -197,6 +205,13 @@ base::Value::Dict GetDefaultProfileAvatarIconAndLabel(SkColor fill_color,
                                    brave_l10n::GetLocalizedResourceUTF16String(
                                        IDS_BRAVE_AVATAR_LABEL_PLACEHOLDER),
                                    index, selected, /*is_gaia_avatar=*/false);
+}
+base::Value::Dict GetDefaultProfileAvatarIconAndLabel_Brave(
+    SkColor fill_color,
+    SkColor stroke_color,
+    bool selected) {
+  return GetDefaultProfileAvatarIconAndLabel(fill_color, stroke_color,
+                                             selected);
 }
 
 }  // namespace profiles

--- a/chromium_src/chrome/browser/profiles/profile_avatar_icon_util.h
+++ b/chromium_src/chrome/browser/profiles/profile_avatar_icon_util.h
@@ -11,6 +11,11 @@
 namespace profiles {
   // Access original value for tests
   extern const size_t kBraveDefaultAvatarIconsCount;
+  // Provide direct access to custom implementation
+  base::Value::Dict GetDefaultProfileAvatarIconAndLabel_Brave(
+      SkColor fill_color,
+      SkColor stroke_color,
+      bool selected);
 }  // namespace profiles
 
 #endif  // BRAVE_CHROMIUM_SRC_CHROME_BROWSER_PROFILES_PROFILE_AVATAR_ICON_UTIL_H_

--- a/patches/chrome-browser-profiles-profile_avatar_icon_util.cc.patch
+++ b/patches/chrome-browser-profiles-profile_avatar_icon_util.cc.patch
@@ -1,5 +1,5 @@
 diff --git a/chrome/browser/profiles/profile_avatar_icon_util.cc b/chrome/browser/profiles/profile_avatar_icon_util.cc
-index 9acede502b82e75da554c3b0ae3d7fb7fec4a731..76c745e509263902387c308ac32e060f34d5a8d9 100644
+index 9acede502b82e75da554c3b0ae3d7fb7fec4a731..2b1dca7fb45309cb561c56e2487cb657636d3b73 100644
 --- a/chrome/browser/profiles/profile_avatar_icon_util.cc
 +++ b/chrome/browser/profiles/profile_avatar_icon_util.cc
 @@ -275,7 +275,7 @@ constexpr size_t kDefaultAvatarIconsCount = 1;
@@ -27,3 +27,11 @@ index 9acede502b82e75da554c3b0ae3d7fb7fec4a731..76c745e509263902387c308ac32e060f
    static const IconResourceInfo resource_info[kDefaultAvatarIconsCount] = {
    // Old avatar icons:
  #if !BUILDFLAG(IS_ANDROID)
+@@ -669,6 +671,7 @@ base::Value::List GetIconsAndLabelsForProfileAvatarSelector(
+         selected_avatar_idx == GetPlaceholderAvatarIndex());
+     avatars.Insert(avatars.begin(),
+                    base::Value(std::move(generic_avatar_info)));
++    BRAVE_GET_ICONS_AND_LABELS_FOR_PROFILE_AVATAR_SELECTOR_NOT_SIGNED_IN
+     return avatars;
+   }
+ 


### PR DESCRIPTION
Uplift of #15547
Resolves https://github.com/brave/brave-browser/issues/26073

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.