### PR TITLE
Let CI distinguish test compilation and test run failures

### DIFF
--- a/build/commands/lib/applyPatches.js
+++ b/build/commands/lib/applyPatches.js
@@ -1,7 +1,7 @@
 const config = require('../lib/config')
 const util = require('../lib/util')
 
-const applyPatches = (buildConfig = config.defaultBuildConfig, options) => {
+const applyPatches = (buildConfig = config.defaultBuildConfig, options = {}) => {
   async function RunCommand () {
     config.buildConfig = buildConfig
     config.update(options)

--- a/build/commands/lib/build.js
+++ b/build/commands/lib/build.js
@@ -18,7 +18,7 @@ const checkVersionsMatch = () => {
   }
 }
 
-const build = (buildConfig = config.defaultBuildConfig, options) => {
+const build = (buildConfig = config.defaultBuildConfig, options = {}) => {
   config.buildConfig = buildConfig
   config.update(options)
   checkVersionsMatch()

--- a/build/commands/lib/createDist.js
+++ b/build/commands/lib/createDist.js
@@ -3,7 +3,7 @@ const util = require('../lib/util')
 const path = require('path')
 const fs = require('fs-extra')
 
-const createDist = (buildConfig = config.defaultBuildConfig, options) => {
+const createDist = (buildConfig = config.defaultBuildConfig, options = {}) => {
   config.buildConfig = buildConfig
   config.update(options)
   util.touchOverriddenFiles()

--- a/build/commands/lib/gnCheck.js
+++ b/build/commands/lib/gnCheck.js
@@ -1,7 +1,7 @@
 const config = require('../lib/config')
 const util = require('../lib/util')
 
-const gnCheck = (buildConfig = config.defaultBuildConfig, options) => {
+const gnCheck = (buildConfig = config.defaultBuildConfig, options = {}) => {
   config.buildConfig = buildConfig
   config.update(options)
   util.run('gn', ['check', config.outputDir, '//brave/*'], config.defaultOptions)

--- a/build/commands/lib/test.js
+++ b/build/commands/lib/test.js
@@ -152,8 +152,8 @@ const runTests = (passthroughArgs, suite, buildConfig, options) => {
         // Specify emulator to run tests on
         braveArgs.push(`--avd-config tools/android/avd/proto/generic_android28.textpb`)
       }
-      let options = config.defaultOptions
-      if (options.output)
+      let runOptions = config.defaultrunOptions
+      if (runOptions.output)
         // When test results are saved to a file, callers (such as CI) generate
         // and analyze test reports as a next step. These callers are typically
         // not interested in the exit code of running the tests, because they
@@ -162,8 +162,8 @@ const runTests = (passthroughArgs, suite, buildConfig, options) => {
         // produce an exit code, such as test compilation failures. By ignoring
         // the test exit code here, we give callers a chance to distinguish test
         // failures (by looking at the output file) from compilation errors.
-        options.continueOnFail = true
-      util.run(path.join(config.outputDir, getTestBinary(testSuite)), braveArgs, options)
+        runOptions.continueOnFail = true
+      util.run(path.join(config.outputDir, getTestBinary(testSuite)), braveArgs, runOptions)
     })
   }
 }

--- a/build/commands/lib/test.js
+++ b/build/commands/lib/test.js
@@ -157,8 +157,4 @@ const runTests = (passthroughArgs, suite, buildConfig, options) => {
   }
 }
 
-module.exports = {
-  test,
-  buildTests,
-  runTests
-}
+module.exports = test

--- a/build/commands/lib/test.js
+++ b/build/commands/lib/test.js
@@ -138,7 +138,7 @@ const runTests = (passthroughArgs, suite, buildConfig, options) => {
     ], config.defaultOptions)
   } else {
     // Run the tests
-    getTestsToRun(config, suite).forEach((testSuite) => {
+    getTestsToRun(config, suite).every((testSuite) => {
       if (options.output) {
         braveArgs.splice(braveArgs.indexOf('--gtest_output=xml:' + options.output), 1)
         braveArgs.push(`--gtest_output=xml:${testSuite}.xml`)
@@ -153,7 +153,7 @@ const runTests = (passthroughArgs, suite, buildConfig, options) => {
         braveArgs.push(`--avd-config tools/android/avd/proto/generic_android28.textpb`)
       }
       let runOptions = config.defaultOptions
-      if (runOptions.output)
+      if (options.output)
         // When test results are saved to a file, callers (such as CI) generate
         // and analyze test reports as a next step. These callers are typically
         // not interested in the exit code of running the tests, because they
@@ -163,7 +163,10 @@ const runTests = (passthroughArgs, suite, buildConfig, options) => {
         // the test exit code here, we give callers a chance to distinguish test
         // failures (by looking at the output file) from compilation errors.
         runOptions.continueOnFail = true
-      util.run(path.join(config.outputDir, getTestBinary(testSuite)), braveArgs, runOptions)
+      let prog = util.run(path.join(config.outputDir, getTestBinary(testSuite)), braveArgs, runOptions)
+      // Don't run other tests if one has failed already, especially because
+      // this would overwrite the --output file (if given).
+      return prog.status === 0
     })
   }
 }

--- a/build/commands/lib/test.js
+++ b/build/commands/lib/test.js
@@ -152,7 +152,18 @@ const runTests = (passthroughArgs, suite, buildConfig, options) => {
         // Specify emulator to run tests on
         braveArgs.push(`--avd-config tools/android/avd/proto/generic_android28.textpb`)
       }
-      util.run(path.join(config.outputDir, getTestBinary(testSuite)), braveArgs, config.defaultOptions)
+      let options = config.defaultOptions
+      if (options.output)
+        // When test results are saved to a file, callers (such as CI) generate
+        // and analyze test reports as a next step. These callers are typically
+        // not interested in the exit code of running the tests, because they
+        // get the information about test success or failure from the output
+        // file. On the other hand, callers are interested in errors that
+        // produce an exit code, such as test compilation failures. By ignoring
+        // the test exit code here, we give callers a chance to distinguish test
+        // failures (by looking at the output file) from compilation errors.
+        options.continueOnFail = true
+      util.run(path.join(config.outputDir, getTestBinary(testSuite)), braveArgs, options)
     })
   }
 }

--- a/build/commands/lib/test.js
+++ b/build/commands/lib/test.js
@@ -53,7 +53,30 @@ const getApplicableFilters = (suite) => {
   return filterFilePaths
 }
 
-const test = (passthroughArgs, suite, buildConfig = config.defaultBuildConfig, options) => {
+const test = (passthroughArgs, suite, buildConfig = config.defaultBuildConfig, options = {}) => {
+  buildTests(suite, buildConfig, options)
+  runTests(passthroughArgs, suite, buildConfig, options)
+}
+
+const buildTests = (suite, buildConfig = config.defaultBuildConfig, options = {}) => {
+  config.buildConfig = buildConfig
+  config.update(options)
+
+  let testSuites = [
+    'brave_unit_tests',
+    'brave_browser_tests',
+    'brave_network_audit_tests',
+  ]
+  if (testSuites.includes(suite)) {
+    config.buildTarget = 'brave/test:' + suite
+  } else {
+    config.buildTarget = suite
+  }
+  util.touchOverriddenFiles()
+  util.buildTarget()
+}
+
+const runTests = (passthroughArgs, suite, buildConfig, options) => {
   config.buildConfig = buildConfig
   config.update(options)
 
@@ -96,20 +119,6 @@ const test = (passthroughArgs, suite, buildConfig = config.defaultBuildConfig, o
 
   braveArgs = braveArgs.concat(passthroughArgs)
 
-  // Build the tests
-  let testSuites = [
-    'brave_unit_tests',
-    'brave_browser_tests',
-    'brave_network_audit_tests',
-  ]
-  if (testSuites.includes(suite)) {
-    config.buildTarget = 'brave/test:' + suite
-  } else {
-    config.buildTarget = suite
-  }
-  util.touchOverriddenFiles()
-  util.buildTarget()
-
   // Filter out upstream tests that are known to fail for Brave
   let upstreamTestSuites = [
     'unit_tests',
@@ -148,4 +157,8 @@ const test = (passthroughArgs, suite, buildConfig = config.defaultBuildConfig, o
   }
 }
 
-module.exports = test
+module.exports = {
+  test,
+  buildTests,
+  runTests
+}

--- a/build/commands/lib/test.js
+++ b/build/commands/lib/test.js
@@ -152,7 +152,7 @@ const runTests = (passthroughArgs, suite, buildConfig, options) => {
         // Specify emulator to run tests on
         braveArgs.push(`--avd-config tools/android/avd/proto/generic_android28.textpb`)
       }
-      let runOptions = config.defaultrunOptions
+      let runOptions = config.defaultOptions
       if (runOptions.output)
         // When test results are saved to a file, callers (such as CI) generate
         // and analyze test reports as a next step. These callers are typically

--- a/build/commands/scripts/commands.js
+++ b/build/commands/scripts/commands.js
@@ -244,51 +244,26 @@ program
     build('Release', options)
   })
 
-// We have a single `test` command for developer convenience. It consists of
-// two steps: Building and running. However, if it fails, then it is unclear
-// which of the two steps failed. This is a problem in CI, where we don't
-// want to produce test reports when building fails. So we also have separate
-// `build_tests` and `run_tests` commands.
-
-const testCommand = program.command('test <suite>');
-const buildTestsCommand = program.command('build_tests <suite>');
-const runTestsCommand = program.command('run_tests <suite>');
-
-[testCommand, buildTestsCommand, runTestsCommand].forEach((command) => {
-  command
-    .arguments('[build_config]')
-    .option('-C <build_dir>', 'build config (out/Debug, out/Release')
-    .option('--target_os <target_os>', 'target OS')
-    .option('--target_arch <target_arch>', 'target architecture')
-});
-
-[testCommand, buildTestsCommand].forEach((command) => {
-  command
-    .option('--use_goma [arg]', 'whether to use Goma for building', JSON.parse)
-    .option('--goma_offline', 'use offline mode for goma')
-});
-
-[testCommand, runTestsCommand].forEach((command) => {
-  command
-    .allowUnknownOption(true)
-    .option('--v [log_level]', 'set log level to [log_level]', parseInteger, '0')
-    .option('--vmodule [modules]', 'verbose log from specific modules')
-    .option('--filter <filter>', 'set test filter')
-    .option('--output <output>', 'set test output (results) file path')
-    .option('--disable_brave_extension', 'disable loading the Brave extension')
-    .option('--single_process', 'uses a single process to run tests to help with debugging')
-    .option('--test_launcher_jobs <test_launcher_jobs>', 'Number of jobs to launch', parseInteger, '4')
-    .option('--target_environment <target_environment>', 'target environment (device, catalyst, simulator)')
-    .option('--run_disabled_tests', 'run disabled tests')
-    .option('--manual_android_test_device', 'indicates that Android test device is run manually')
-});
-
-testCommand
-  .action(test.test.bind(null, parsedArgs.unknown))
-buildTestsCommand
-  .action(test.buildTests)
-runTestsCommand
-  .action(test.runTests.bind(null, parsedArgs.unknown))
+program
+  .command('test <suite>')
+  .allowUnknownOption(true)
+  .option('-C <build_dir>', 'build config (out/Debug, out/Release')
+  .option('--v [log_level]', 'set log level to [log_level]', parseInteger, '0')
+  .option('--vmodule [modules]', 'verbose log from specific modules')
+  .option('--filter <filter>', 'set test filter')
+  .option('--output <output>', 'set test output (results) file path')
+  .option('--disable_brave_extension', 'disable loading the Brave extension')
+  .option('--single_process', 'uses a single process to run tests to help with debugging')
+  .option('--test_launcher_jobs <test_launcher_jobs>', 'Number of jobs to launch', parseInteger, '4')
+  .option('--target_os <target_os>', 'target OS')
+  .option('--target_arch <target_arch>', 'target architecture')
+  .option('--target_environment <target_environment>', 'target environment (device, catalyst, simulator)')
+  .option('--run_disabled_tests', 'run disabled tests')
+  .option('--manual_android_test_device', 'indicates that Android test device is run manually')
+  .option('--use_goma [arg]', 'whether to use Goma for building', JSON.parse)
+  .option('--goma_offline', 'use offline mode for goma')
+  .arguments('[build_config]')
+  .action(test.bind(null, parsedArgs.unknown))
 
 program
   .command('lint')

--- a/package.json
+++ b/package.json
@@ -28,8 +28,6 @@
     "format": "node ./build/commands/scripts/commands.js format",
     "mass_rename": "node ./build/commands/scripts/commands.js mass_rename",
     "test": "node ./build/commands/scripts/commands.js test",
-    "build_tests": "node ./build/commands/scripts/commands.js build_tests",
-    "run_tests": "node ./build/commands/scripts/commands.js run_tests",
     "test:scripts": "jest build/commands/lib build/commands/scripts",
     "test-security": "npm run check_security && npm run audit_deps && npm run network-audit",
     "tslint": "npm run eslint",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,8 @@
     "format": "node ./build/commands/scripts/commands.js format",
     "mass_rename": "node ./build/commands/scripts/commands.js mass_rename",
     "test": "node ./build/commands/scripts/commands.js test",
+    "build_tests": "node ./build/commands/scripts/commands.js build_tests",
+    "run_tests": "node ./build/commands/scripts/commands.js run_tests",
     "test:scripts": "jest build/commands/lib build/commands/scripts",
     "test-security": "npm run check_security && npm run audit_deps && npm run network-audit",
     "tslint": "npm run eslint",


### PR DESCRIPTION
Prerequisite for https://github.com/brave/devops/issues/8517.

At the moment, we have a single command for running tests: `npm run test`. This both builds and runs the tests. If the command fails, then it is unclear whether the failure was in building or running the tests. This leads to confusing error messages in our CI. The present PR is a preparation for fixing this.

This PR also incorporates a few small refactorings. Most notably, it introduces internal `buidTests` and `runTests` functions that better separate those concerns.

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

