### PR TITLE
Don't update bg images data when new images are not fetched yet (uplift to 1.46.x)

### DIFF
--- a/components/brave_new_tab_ui/data/backgrounds.ts
+++ b/components/brave_new_tab_ui/data/backgrounds.ts
@@ -14,7 +14,7 @@ export const images: NewTab.BraveBackground[] = [{
 // then you must also update `script/generate_licenses.py`
 
 export const updateImages = (newImages: NewTab.BraveBackground[]) => {
-  if (!newImages) {
+  if (!newImages.length) {
     // This can happen when the component for NTP is not downloaded yet on
     // a fresh profile.
     return


### PR DESCRIPTION
Uplift of #15561
Resolves https://github.com/brave/brave-browser/issues/26135

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.