### PR TITLE
Add popular sources section to Brave News

### DIFF
--- a/browser/ui/webui/brave_webui_source.cc
+++ b/browser/ui/webui/brave_webui_source.cc
@@ -247,6 +247,8 @@ void CustomizeWebUIHTMLSource(content::WebUI* web_ui,
         { "braveNewsChannel-Top Sources", IDS_BRAVE_NEWS_CHANNEL_TOP_SOURCES},
         { "braveNewsChannel-Weather", IDS_BRAVE_NEWS_CHANNEL_WEATHER},
         { "braveNewsChannel-World News", IDS_BRAVE_NEWS_CHANNEL_WORLD_NEWS},
+        { "braveNewsPopularTitle", IDS_BRAVE_NEWS_POPULAR_TITLE},
+
 
         { "addWidget", IDS_BRAVE_NEW_TAB_WIDGET_ADD },
         { "hideWidget", IDS_BRAVE_NEW_TAB_WIDGET_HIDE },

--- a/components/brave_new_tab_ui/components/default/braveToday/customize/Discover.tsx
+++ b/components/brave_new_tab_ui/components/default/braveToday/customize/Discover.tsx
@@ -16,6 +16,7 @@ import DiscoverSection from './DiscoverSection'
 import FeedCard, { DirectFeedCard } from './FeedCard'
 import useSearch from './useSearch'
 import Suggestions from './Suggestions'
+import Popular from './Popular'
 
 const Header = styled.span`
   font-size: 24px;
@@ -73,6 +74,7 @@ function Home () {
   return (
     <>
       <Suggestions/>
+      <Popular/>
       <DiscoverSection name={getLocale('braveNewsChannelsHeader')}>
       {visibleChannelIds.map(channelName =>
         <ChannelCard key={channelName} channelName={channelName} />

--- a/components/brave_new_tab_ui/components/default/braveToday/customize/Popular.tsx
+++ b/components/brave_new_tab_ui/components/default/braveToday/customize/Popular.tsx
@@ -1,3 +1,8 @@
+// Copyright (c) 2022 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// you can obtain one at http://mozilla.org/MPL/2.0/.
+
 import * as React from 'react'
 import styled from 'styled-components'
 import Button from '$web-components/button'

--- a/components/brave_new_tab_ui/components/default/braveToday/customize/Popular.tsx
+++ b/components/brave_new_tab_ui/components/default/braveToday/customize/Popular.tsx
@@ -1,0 +1,45 @@
+import * as React from 'react'
+import styled from 'styled-components'
+import Button from '$web-components/button'
+import { useBraveNews } from './Context'
+import DiscoverSection from './DiscoverSection'
+import FeedCard from './FeedCard'
+import { getLocale } from '$web-common/locale'
+
+const LoadMoreButtonContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+  grid-column: 2;
+`
+
+const DEFAULT_SUGGESTIONS_COUNT = 3
+
+export default function Suggestions () {
+  const { filteredPublisherIds, publishers } = useBraveNews()
+  const [showAll, setShowAll] = React.useState(false)
+  const popularPublisherIds = React.useMemo(() => filteredPublisherIds.map(id => publishers[id])
+    .filter(p => p.rank !== 0) // Rank of zero is unranked
+    .sort((a, b) => a.rank - b.rank)
+    .map(p => p.publisherId), [filteredPublisherIds, publishers])
+
+  const popularPublishersTruncated = React.useMemo(() => showAll
+    ? popularPublisherIds
+    : popularPublisherIds.slice(0, DEFAULT_SUGGESTIONS_COUNT), [popularPublisherIds, showAll])
+
+  if (!popularPublisherIds.length) {
+    return null
+  }
+
+  return (
+    <DiscoverSection name={'Popular Sources'}>
+      {popularPublishersTruncated.map(s => <FeedCard key={s} publisherId={s} />)}
+      {!showAll && popularPublisherIds.length > DEFAULT_SUGGESTIONS_COUNT &&
+      <LoadMoreButtonContainer>
+        <Button onClick={() => setShowAll(true)}>
+          {getLocale('braveNewsShowMoreButton')}
+        </Button>
+      </LoadMoreButtonContainer>}
+    </DiscoverSection>
+  )
+}

--- a/components/brave_new_tab_ui/components/default/braveToday/customize/Popular.tsx
+++ b/components/brave_new_tab_ui/components/default/braveToday/customize/Popular.tsx
@@ -37,7 +37,7 @@ export default function Suggestions () {
   }
 
   return (
-    <DiscoverSection name={'Popular Sources'}>
+    <DiscoverSection name={getLocale('braveNewsPopularTitle')}>
       {popularPublishersTruncated.map(s => <FeedCard key={s} publisherId={s} />)}
       {!showAll && popularPublisherIds.length > DEFAULT_SUGGESTIONS_COUNT &&
       <LoadMoreButtonContainer>

--- a/components/brave_new_tab_ui/components/default/braveToday/customize/Suggestions.tsx
+++ b/components/brave_new_tab_ui/components/default/braveToday/customize/Suggestions.tsx
@@ -1,3 +1,8 @@
+// Copyright (c) 2022 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// you can obtain one at http://mozilla.org/MPL/2.0/.
+
 import * as React from 'react'
 import styled from 'styled-components'
 import Button from '$web-components/button'

--- a/components/brave_today/browser/publishers_parsing.cc
+++ b/components/brave_today/browser/publishers_parsing.cc
@@ -113,6 +113,10 @@ bool ParseCombinedPublisherList(const std::string& json,
       publisher->background_color = *background_color;
     }
 
+    // We consider '0' to be unranked, as mojo doesn't support nullable
+    // primitives.
+    publisher->rank = publisher_dict.FindInt("rank").value_or(0);
+
     // TODO(petemill): Validate
     publishers->insert_or_assign(publisher->publisher_id, std::move(publisher));
   }

--- a/components/brave_today/browser/publishers_parsing.cc
+++ b/components/brave_today/browser/publishers_parsing.cc
@@ -27,6 +27,9 @@ mojom::LocaleInfoPtr ParseLocaleInfo(const base::Value::Dict& publisher_dict,
   // has been updated. https://github.com/brave/brave-browser/issues/26307
   if (locale_entry.is_string()) {
     result->locale = locale_entry.GetString();
+
+    // We consider '0' to be unranked, as mojo doesn't support nullable
+    // primitives.
     result->rank = publisher_dict.FindInt("rank").value_or(0);
     auto* channels_raw = publisher_dict.FindList("channels");
     if (channels_raw) {
@@ -112,10 +115,6 @@ bool ParseCombinedPublisherList(const std::string& json,
     if (background_color) {
       publisher->background_color = *background_color;
     }
-
-    // We consider '0' to be unranked, as mojo doesn't support nullable
-    // primitives.
-    publisher->rank = publisher_dict.FindInt("rank").value_or(0);
 
     // TODO(petemill): Validate
     publishers->insert_or_assign(publisher->publisher_id, std::move(publisher));

--- a/components/brave_today/common/brave_news.mojom
+++ b/components/brave_today/common/brave_news.mojom
@@ -125,6 +125,11 @@ struct Publisher {
   // a site when viewing a webcontents.
   url.mojom.Url site_url;
 
+  // The ranking of the source.
+  // Mojo doesn't support nullable primitives, so we consider a rank of 0 to be
+  // unranked.
+  uint32 rank;
+
   // Identifies whether the user has manually set the publisher on and off,
   // so that we may know if the source should follow the `is_enabled`
   // remote-provided value (which may change), or not.

--- a/components/brave_today/common/brave_news.mojom
+++ b/components/brave_today/common/brave_news.mojom
@@ -92,6 +92,10 @@ enum PublisherType {
 
 struct LocaleInfo {
   string locale;
+
+  // The ranking of the source.
+  // Mojo doesn't support nullable primitives, so we consider a rank of 0 to be
+  // unranked.
   uint32 rank;
   array<string> channels;
 };
@@ -124,11 +128,6 @@ struct Publisher {
   // The url of the site. Used to determine whether the user is subscribed to
   // a site when viewing a webcontents.
   url.mojom.Url site_url;
-
-  // The ranking of the source.
-  // Mojo doesn't support nullable primitives, so we consider a rank of 0 to be
-  // unranked.
-  uint32 rank;
 
   // Identifies whether the user has manually set the publisher on and off,
   // so that we may know if the source should follow the `is_enabled`

--- a/components/resources/brave_news_strings.grdp
+++ b/components/resources/brave_news_strings.grdp
@@ -60,6 +60,9 @@
   <message name="IDS_BRAVE_NEWS_SUGGESTIONS_TITLE" desc="Title of the suggested sources section">
     Suggestions
   </message>
+  <message name="IDS_BRAVE_NEWS_POPULAR_TITLE" desc="Title of the popular sources section">
+    Popular
+  </message>
   <message name="IDS_BRAVE_NEWS_SUGGESTIONS_SUBTITLE" desc="Subtitle of the suggested sources section">
     Some sources you might like. Suggestions are anonymous and matched only on your device.
   </message>


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/24324

**Note:** This PR doesn't add a new page like the issue and the UX design, it simply adds the same UI as the Suggestions section. I think we need to have a chat with the UX folks about exactly how this should work.

Popular sources, default
![image](https://user-images.githubusercontent.com/7678024/197426142-889cd35c-4de1-4910-8052-0dc5918596ff.png)

Popular sources, more loaded
![image](https://user-images.githubusercontent.com/7678024/197426173-76e34b0e-39e6-492b-8e9f-4df7e07357e5.png)


## Submitter Checklist:

- [ ] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
1. Enable the Brave News V2 flag
2. In the customize brave news dialog, there should be a popular sources section.
