### PR TITLE
Fix Uint64 and Uint32 decode in solana_instruction_data_decoder.cc (uplift to 1.46.x)

### DIFF
--- a/components/brave_wallet/browser/solana_instruction_data_decoder.cc
+++ b/components/brave_wallet/browser/solana_instruction_data_decoder.cc
@@ -9,11 +9,13 @@
 #include <utility>
 
 #include "base/containers/flat_map.h"
+#include "base/containers/span.h"
 #include "base/no_destructor.h"
 #include "base/notreached.h"
 #include "base/sys_byteorder.h"
 #include "brave/components/brave_wallet/common/brave_wallet_constants.h"
 #include "brave/components/brave_wallet/common/solana_utils.h"
+#include "build/build_config.h"
 #include "components/grit/brave_components_strings.h"
 #include "ui/base/l10n/l10n_util.h"
 
@@ -631,15 +633,13 @@ absl::optional<uint32_t> DecodeUint32(const std::vector<uint8_t>& input,
   }
 
   // Read bytes in little endian order.
-  uint32_t uint32_le = 0;
-  for (size_t i = offset; i < offset + sizeof(uint32_t); i++) {
-    uint32_le <<= 8;
-    uint32_le |= input[i];
-  }
+  base::span<const uint8_t> s =
+      base::make_span(input.begin() + offset, sizeof(uint32_t));
+  uint32_t uint32_le = *reinterpret_cast<const uint32_t*>(s.data());
 
   offset += sizeof(uint32_t);
 
-#if defined(ARCH_CPU_LITTE_ENDIAN)
+#if defined(ARCH_CPU_LITTLE_ENDIAN)
   return uint32_le;
 #else
   return base::ByteSwap(uint32_le);
@@ -662,15 +662,13 @@ absl::optional<uint64_t> DecodeUint64(const std::vector<uint8_t>& input,
   }
 
   // Read bytes in little endian order.
-  uint64_t uint64_le = 0;
-  for (size_t i = offset; i < offset + sizeof(uint64_t); i++) {
-    uint64_le <<= 8;
-    uint64_le |= input[i];
-  }
+  base::span<const uint8_t> s =
+      base::make_span(input.begin() + offset, sizeof(uint64_t));
+  uint64_t uint64_le = *reinterpret_cast<const uint64_t*>(s.data());
 
   offset += sizeof(uint64_t);
 
-#if defined(ARCH_CPU_LITTE_ENDIAN)
+#if defined(ARCH_CPU_LITTLE_ENDIAN)
   return uint64_le;
 #else
   return base::ByteSwap(uint64_le);


### PR DESCRIPTION
Uplift of #15598
Resolves https://github.com/brave/brave-browser/issues/26175

Pre-approval checklist: 
- [ ] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [ ] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [ ] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [ ] The associated issue milestone is set to the smallest version that the changes is landed on.