### PR TITLE
Disable warning about Manifest v2 deprecation

### DIFF
--- a/browser/brave_browser_main_extra_parts.cc
+++ b/browser/brave_browser_main_extra_parts.cc
@@ -21,6 +21,10 @@
 #include "chrome/browser/first_run/first_run.h"
 #endif  // !BUILDFLAG(IS_ANDROID)
 
+#if BUILDFLAG(ENABLE_EXTENSIONS)
+#include "extensions/common/extension.h"
+#endif  // BUILDFLAG(ENABLE_EXTENSIONS)
+
 namespace {
 
 // Records default values for some histograms because we want these stats to be
@@ -53,6 +57,14 @@ void RecordInitialP3AValues() {
 BraveBrowserMainExtraParts::BraveBrowserMainExtraParts() = default;
 
 BraveBrowserMainExtraParts::~BraveBrowserMainExtraParts() = default;
+
+void BraveBrowserMainExtraParts::PreProfileInit() {
+#if BUILDFLAG(ENABLE_EXTENSIONS)
+  // Disable warnings related to Manifest V2 deprecation
+  extensions::Extension::
+      set_silence_deprecated_manifest_version_warnings_for_testing(true);
+#endif  // BUILDFLAG(ENABLE_EXTENSIONS)
+}
 
 void BraveBrowserMainExtraParts::PostBrowserStart() {
   g_brave_browser_process->StartBraveServices();

--- a/browser/brave_browser_main_extra_parts.h
+++ b/browser/brave_browser_main_extra_parts.h
@@ -21,6 +21,7 @@ class BraveBrowserMainExtraParts : public ChromeBrowserMainExtraParts {
   // ChromeBrowserMainExtraParts overrides.
   void PostBrowserStart() override;
   void PreMainMessageLoopRun() override;
+  void PreProfileInit() override;
 };
 
 #endif  // BRAVE_BROWSER_BRAVE_BROWSER_MAIN_EXTRA_PARTS_H_

--- a/browser/extensions/mv2_warning_unittest.cc
+++ b/browser/extensions/mv2_warning_unittest.cc
@@ -1,0 +1,42 @@
+/* Copyright (c) 2022 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "brave/browser/brave_browser_main_extra_parts.h"
+#include "extensions/common/extension.h"
+#include "extensions/common/value_builder.h"
+#include "testing/gtest/include/gtest/gtest.h"
+
+class Mv2WarningUnitTest : public testing::Test {
+ public:
+  Mv2WarningUnitTest() {}
+  ~Mv2WarningUnitTest() override = default;
+};
+
+TEST(Mv2WarningTest, ExtensionManifestVersions) {
+  auto main_extra_parts = BraveBrowserMainExtraParts();
+  main_extra_parts.PreProfileInit();
+
+  auto get_manifest = [](absl::optional<int> manifest_version) {
+    extensions::DictionaryBuilder builder;
+    builder.Set("name", "My Extension")
+        .Set("version", "0.1")
+        .Set("description", "An awesome extension");
+    if (manifest_version)
+      builder.Set("manifest_version", *manifest_version);
+    return builder.Build();
+  };
+
+  std::string error;
+  scoped_refptr<extensions::Extension> extension =
+      extensions::Extension::Create(
+          base::FilePath(), extensions::mojom::ManifestLocation::kUnpacked,
+          *get_manifest(2).get(),
+          extensions::Extension::InitFromValueFlags::NO_FLAGS, &error);
+
+  ASSERT_NE(extension, nullptr);
+
+  auto& warnings = extension->install_warnings();
+  EXPECT_EQ(warnings.size(), 0UL);
+}

--- a/test/BUILD.gn
+++ b/test/BUILD.gn
@@ -474,6 +474,7 @@ test("brave_unit_tests") {
       "//brave/browser/extensions/api/brave_extensions_api_client_unittest.cc",
       "//brave/browser/extensions/chrome_content_verifier_delegate_unittest.cc",
       "//brave/browser/extensions/install_verifier_unittest.cc",
+      "//brave/browser/extensions/mv2_warning_unittest.cc",
       "//brave/chromium_src/extensions/browser/sandboxed_unpacker_unittest.cc",
       "//brave/common/importer/chrome_importer_utils_unittest.cc",
       "//chrome/browser/extensions/extension_service_test_base.cc",

--- a/test/filters/browser_tests.filter
+++ b/test/filters/browser_tests.filter
@@ -9,6 +9,13 @@
 # display an additional confirmation infobar for P3A
 -All/PageSpecificSiteDataDialogBrowserTest.*/*
 
+# These tests fail because they expect an additional Manifest V2 deprecation
+# warning, which is disabled in Brave.
+-ErrorConsoleBrowserTest.BadAPIArgumentsRuntimeError
+-ErrorConsoleBrowserTest.BadAPIPermissionsRuntimeError
+-ErrorConsoleBrowserTest.BrowserActionRuntimeError
+-WindowOpenApiTest.OpenLockedFullscreenWindowNonChromeOS
+
 # These tests fail because of the following failed expectation in prerender_test_util.cc:
 # Expected: (host_id) != (RenderFrameHost::kNoFrameTreeNodeId), actual: -1 vs -1
 # kPrerender2 feature is disabled in Brave.


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/26207

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

1. Download a Chromium build of a Manifest V2 extension. For example, download `uBlock0_1.44.5b17.chromium.zip` from [here](https://github.com/gorhill/uBlock/releases/tag/1.44.5b17)
2. Unzip the downloaded extension
3. Visit brave://extensions
4. Ensure `Developer mode` is enabled (there is a toggle in the top-right corner)
5. Click the `Load unpacked` button at the top-left corner, navigate to the unzipped extension directory, and choose `Select folder`.
6. The extension should be installed. Ensure that there is no `Errors` button to the right of the `Details` and `Remove` buttons on the newly installed extension.