### PR TITLE
Fixes mark as inappropriate behaves as Save in 30-day ads history - 1.46.x

### DIFF
--- a/browser/ui/webui/brave_rewards_page_ui.cc
+++ b/browser/ui/webui/brave_rewards_page_ui.cc
@@ -1423,7 +1423,7 @@ void RewardsDOMHandler::ToggleFlaggedAd(const base::Value::List& args) {
 
   AllowJavascript();
 
-  ads_service_->ToggleSavedAd(
+  ads_service_->ToggleFlaggedAd(
       dict->Clone(), base::BindOnce(&RewardsDOMHandler::OnToggleFlaggedAd,
                                     weak_factory_.GetWeakPtr()));
 }


### PR DESCRIPTION
Uplift of https://github.com/brave/brave-core/pull/15655
Resolves https://github.com/brave/brave-browser/issues/26220

- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR.
- [x] You have tested your change on Nightly. 
- [x] The PR milestones match the branch they are landing to. 

After you merge: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.

