### PR TITLE
Cached guardian's subscriber credentials

### DIFF
--- a/components/brave_vpn/brave_vpn_api_request.cc
+++ b/components/brave_vpn/brave_vpn_api_request.cc
@@ -213,18 +213,20 @@ void BraveVpnAPIRequest::GetSubscriberCredentialV12(
                {{"Brave-Payments-Environment", environment}});
 }
 
-void BraveVpnAPIRequest::CreateSupportTicket(ResponseCallback callback,
-                                             const std::string& email,
-                                             const std::string& subject,
-                                             const std::string& body) {
+void BraveVpnAPIRequest::CreateSupportTicket(
+    ResponseCallback callback,
+    const std::string& email,
+    const std::string& subject,
+    const std::string& body,
+    const std::string& subscriber_credential) {
   auto internal_callback =
       base::BindOnce(&BraveVpnAPIRequest::OnCreateSupportTicket,
                      weak_ptr_factory_.GetWeakPtr(), std::move(callback));
 
-  OAuthRequest(
-      GetURLWithPath(kVpnHost, kCreateSupportTicket), "POST",
-      CreateJSONRequestBody(GetValueWithTicketInfos(email, subject, body)),
-      std::move(internal_callback));
+  OAuthRequest(GetURLWithPath(kVpnHost, kCreateSupportTicket), "POST",
+               CreateJSONRequestBody(GetValueWithTicketInfos(
+                   email, subject, body, subscriber_credential)),
+               std::move(internal_callback));
 }
 
 void BraveVpnAPIRequest::OAuthRequest(

--- a/components/brave_vpn/brave_vpn_api_request.h
+++ b/components/brave_vpn/brave_vpn_api_request.h
@@ -71,7 +71,8 @@ class BraveVpnAPIRequest {
   void CreateSupportTicket(ResponseCallback callback,
                            const std::string& email,
                            const std::string& subject,
-                           const std::string& body);
+                           const std::string& body,
+                           const std::string& subscriber_credential);
 
  private:
   using URLRequestCallback = base::OnceCallback<void(APIRequestResult)>;

--- a/components/brave_vpn/brave_vpn_constants.h
+++ b/components/brave_vpn/brave_vpn_constants.h
@@ -100,6 +100,9 @@ constexpr char kCreateSubscriberCredentialV12[] =
     "api/v1.2/subscriber-credential/create";
 constexpr int kP3AIntervalHours = 24;
 
+constexpr char kSubscriberCredentialKey[] = "credential";
+constexpr char kSubscriberCredentialExpirationKey[] = "expiration";
+
 #if !BUILDFLAG(IS_ANDROID)
 constexpr char kTokenNoLongerValid[] = "Token No Longer Valid";
 #endif  // !BUILDFLAG(IS_ANDROID)

--- a/components/brave_vpn/brave_vpn_os_connection_api.h
+++ b/components/brave_vpn/brave_vpn_os_connection_api.h
@@ -35,7 +35,6 @@ class BraveVPNOSConnectionAPI : public base::PowerSuspendObserver,
  public:
   class Observer : public base::CheckedObserver {
    public:
-    virtual void OnGetInvalidToken() = 0;
     virtual void OnConnectionStateChanged(mojom::ConnectionState state) = 0;
 
    protected:
@@ -74,7 +73,6 @@ class BraveVPNOSConnectionAPI : public base::PowerSuspendObserver,
   void ToggleConnection();
   void RemoveVPNConnection();
   void CheckConnection();
-  void SetSkusCredential(const std::string& credential);
   void ResetConnectionInfo();
   std::string GetHostname() const;
 
@@ -121,8 +119,6 @@ class BraveVPNOSConnectionAPI : public base::PowerSuspendObserver,
                         bool success);
   void ParseAndCacheHostnames(const std::string& region,
                               const base::Value::List& hostnames_value);
-  void OnGetSubscriberCredentialV12(const std::string& subscriber_credential,
-                                    bool success);
   void OnGetProfileCredentials(const std::string& profile_credential,
                                bool success);
 
@@ -134,7 +130,6 @@ class BraveVPNOSConnectionAPI : public base::PowerSuspendObserver,
   bool reconnect_on_resume_ = false;
   bool prevent_creation_ = false;
   std::string target_vpn_entry_name_;
-  std::string skus_credential_;
   mojom::ConnectionState connection_state_ =
       mojom::ConnectionState::DISCONNECTED;
   BraveVPNConnectionInfo connection_info_;

--- a/components/brave_vpn/brave_vpn_service.cc
+++ b/components/brave_vpn/brave_vpn_service.cc
@@ -459,8 +459,9 @@ void BraveVpnService::CreateSupportTicket(
   auto internal_callback =
       base::BindOnce(&BraveVpnService::OnCreateSupportTicket,
                      weak_ptr_factory_.GetWeakPtr(), std::move(callback));
-  api_request_.CreateSupportTicket(std::move(internal_callback), email, subject,
-                                   body);
+  api_request_.CreateSupportTicket(
+      std::move(internal_callback), email, subject, body,
+      ::brave_vpn::GetSubscriberCredential(local_prefs_));
 }
 
 void BraveVpnService::GetSupportData(GetSupportDataCallback callback) {
@@ -756,10 +757,11 @@ void BraveVpnService::ScheduleSubscriberCredentialRefresh() {
   if (!expiration_time)
     return;
 
+  auto expiration_time_delta = *expiration_time - base::Time::Now();
   VLOG(2) << "Schedule subscriber credential fetching after "
-          << *expiration_time - base::Time::Now();
+          << expiration_time_delta;
   subs_cred_refresh_timer_.Start(
-      FROM_HERE, *expiration_time - base::Time::Now(),
+      FROM_HERE, expiration_time_delta,
       base::BindOnce(&BraveVpnService::RefreshSubscriberCredential,
                      base::Unretained(this)));
 }

--- a/components/brave_vpn/brave_vpn_service.h
+++ b/components/brave_vpn/brave_vpn_service.h
@@ -95,7 +95,6 @@ class BraveVpnService :
   void Connect() override;
   void Disconnect() override;
   void GetAllRegions(GetAllRegionsCallback callback) override;
-  void GetDeviceRegion(GetDeviceRegionCallback callback) override;
   void GetSelectedRegion(GetSelectedRegionCallback callback) override;
   void SetSelectedRegion(mojom::RegionPtr region) override;
   void GetProductUrls(GetProductUrlsCallback callback) override;
@@ -168,7 +167,6 @@ class BraveVpnService :
   friend class ::BraveBrowserCommandControllerTest;
 
   // BraveVPNOSConnectionAPI::Observer overrides:
-  void OnGetInvalidToken() override;
   void OnConnectionStateChanged(mojom::ConnectionState state) override;
 
   void LoadCachedRegionData();
@@ -216,6 +214,12 @@ class BraveVpnService :
   void OnPrepareCredentialsPresentation(
       const std::string& domain,
       const std::string& credential_as_cookie);
+  void OnGetSubscriberCredentialV12(const base::Time& expiration_time,
+                                    const std::string& subscriber_credential,
+                                    bool success);
+
+  // Check initial purchased/connected state.
+  void CheckInitialState();
 
 #if !BUILDFLAG(IS_ANDROID)
   std::vector<mojom::Region> regions_;
@@ -242,7 +246,6 @@ class BraveVpnService :
   absl::optional<mojom::PurchasedState> purchased_state_;
   mojo::RemoteSet<mojom::ServiceObserver> observers_;
   BraveVpnAPIRequest api_request_;
-  std::string skus_credential_;
   base::RepeatingTimer p3a_timer_;
   base::WeakPtrFactory<BraveVpnService> weak_ptr_factory_{this};
 };

--- a/components/brave_vpn/brave_vpn_service.h
+++ b/components/brave_vpn/brave_vpn_service.h
@@ -217,6 +217,8 @@ class BraveVpnService :
   void OnGetSubscriberCredentialV12(const base::Time& expiration_time,
                                     const std::string& subscriber_credential,
                                     bool success);
+  void ScheduleSubscriberCredentialRefresh();
+  void RefreshSubscriberCredential();
 
   // Check initial purchased/connected state.
   void CheckInitialState();
@@ -247,6 +249,7 @@ class BraveVpnService :
   mojo::RemoteSet<mojom::ServiceObserver> observers_;
   BraveVpnAPIRequest api_request_;
   base::RepeatingTimer p3a_timer_;
+  base::OneShotTimer subs_cred_refresh_timer_;
   base::WeakPtrFactory<BraveVpnService> weak_ptr_factory_{this};
 };
 

--- a/components/brave_vpn/brave_vpn_service_helper.cc
+++ b/components/brave_vpn/brave_vpn_service_helper.cc
@@ -155,9 +155,11 @@ std::vector<mojom::Region> ParseRegionList(
   return regions;
 }
 
-base::Value::Dict GetValueWithTicketInfos(const std::string& email,
-                                          const std::string& subject,
-                                          const std::string& body) {
+base::Value::Dict GetValueWithTicketInfos(
+    const std::string& email,
+    const std::string& subject,
+    const std::string& body,
+    const std::string& subscriber_credential) {
   base::Value::Dict dict;
 
   std::string email_trimmed, subject_trimmed, body_trimmed, body_encoded;
@@ -173,7 +175,7 @@ base::Value::Dict GetValueWithTicketInfos(const std::string& email,
   dict.Set("partner-client-id", "com.brave.browser");
 
   // optional (but encouraged) fields
-  dict.Set("subscriber-credential", "");
+  dict.Set("subscriber-credential", subscriber_credential);
   dict.Set("payment-validation-method", "brave-premium");
   dict.Set("payment-validation-data", "");
 

--- a/components/brave_vpn/brave_vpn_service_helper.cc
+++ b/components/brave_vpn/brave_vpn_service_helper.cc
@@ -6,13 +6,19 @@
 #include "brave/components/brave_vpn/brave_vpn_service_helper.h"
 
 #include <algorithm>
+#include <utility>
 
 #include "base/base64.h"
+#include "base/json/values_util.h"
 #include "base/notreached.h"
 #include "base/ranges/algorithm.h"
+#include "base/time/time.h"
+#include "base/values.h"
 #include "brave/components/brave_vpn/brave_vpn_constants.h"
 #include "brave/components/brave_vpn/brave_vpn_data_types.h"
+#include "brave/components/brave_vpn/pref_names.h"
 #include "brave/components/skus/browser/skus_utils.h"
+#include "components/prefs/pref_service.h"
 #include "third_party/abseil-cpp/absl/types/optional.h"
 
 namespace brave_vpn {
@@ -182,6 +188,62 @@ mojom::RegionPtr GetRegionPtrWithNameFromRegionList(
   if (it != region_list.end())
     return it->Clone();
   return mojom::RegionPtr();
+}
+
+bool IsValidCredentialSummary(const base::Value& summary) {
+  DCHECK(summary.is_dict());
+  const bool active = summary.GetDict().FindBool("active").value_or(false);
+  const int remaining_credential_count =
+      summary.GetDict().FindInt("remaining_credential_count").value_or(0);
+  return active && remaining_credential_count > 0;
+}
+
+bool HasValidSubscriberCredential(PrefService* local_prefs) {
+  const base::Value::Dict& sub_cred_dict =
+      local_prefs->GetDict(prefs::kBraveVPNSubscriberCredential);
+  if (sub_cred_dict.empty())
+    return false;
+
+  const std::string* cred = sub_cred_dict.FindString(kSubscriberCredentialKey);
+  const base::Value* expiration_time_value =
+      sub_cred_dict.Find(kSubscriberCredentialExpirationKey);
+
+  if (!cred || !expiration_time_value)
+    return false;
+
+  if (cred->empty())
+    return false;
+
+  auto expiration_time = base::ValueToTime(expiration_time_value);
+  if (!expiration_time || expiration_time < base::Time::Now())
+    return false;
+
+  return true;
+}
+
+std::string GetSubscriberCredential(PrefService* local_prefs) {
+  if (!HasValidSubscriberCredential(local_prefs))
+    return "";
+  const base::Value::Dict& sub_cred_dict =
+      local_prefs->GetDict(prefs::kBraveVPNSubscriberCredential);
+  const std::string* cred = sub_cred_dict.FindString(kSubscriberCredentialKey);
+  DCHECK(cred);
+  return *cred;
+}
+
+void SetSubscriberCredential(PrefService* local_prefs,
+                             const std::string& subscriber_credential,
+                             const base::Time& expiration_time) {
+  base::Value::Dict cred_dict;
+  cred_dict.Set(kSubscriberCredentialKey, subscriber_credential);
+  cred_dict.Set(kSubscriberCredentialExpirationKey,
+                base::TimeToValue(expiration_time));
+  local_prefs->SetDict(prefs::kBraveVPNSubscriberCredential,
+                       std::move(cred_dict));
+}
+
+void ClearSubscriberCredential(PrefService* local_prefs) {
+  local_prefs->ClearPref(prefs::kBraveVPNSubscriberCredential);
 }
 
 }  // namespace brave_vpn

--- a/components/brave_vpn/brave_vpn_service_helper.cc
+++ b/components/brave_vpn/brave_vpn_service_helper.cc
@@ -19,7 +19,6 @@
 #include "brave/components/brave_vpn/pref_names.h"
 #include "brave/components/skus/browser/skus_utils.h"
 #include "components/prefs/pref_service.h"
-#include "third_party/abseil-cpp/absl/types/optional.h"
 
 namespace brave_vpn {
 
@@ -229,6 +228,22 @@ std::string GetSubscriberCredential(PrefService* local_prefs) {
   const std::string* cred = sub_cred_dict.FindString(kSubscriberCredentialKey);
   DCHECK(cred);
   return *cred;
+}
+
+absl::optional<base::Time> GetExpirationTime(PrefService* local_prefs) {
+  if (!HasValidSubscriberCredential(local_prefs))
+    return absl::nullopt;
+
+  const base::Value::Dict& sub_cred_dict =
+      local_prefs->GetDict(prefs::kBraveVPNSubscriberCredential);
+
+  const base::Value* expiration_time_value =
+      sub_cred_dict.Find(kSubscriberCredentialExpirationKey);
+
+  if (!expiration_time_value)
+    return absl::nullopt;
+
+  return base::ValueToTime(expiration_time_value);
 }
 
 void SetSubscriberCredential(PrefService* local_prefs,

--- a/components/brave_vpn/brave_vpn_service_helper.h
+++ b/components/brave_vpn/brave_vpn_service_helper.h
@@ -34,9 +34,11 @@ std::unique_ptr<Hostname> PickBestHostname(
 std::vector<Hostname> ParseHostnames(const base::Value::List& hostnames);
 std::vector<mojom::Region> ParseRegionList(
     const base::Value::List& region_list);
-base::Value::Dict GetValueWithTicketInfos(const std::string& email,
-                                          const std::string& subject,
-                                          const std::string& body);
+base::Value::Dict GetValueWithTicketInfos(
+    const std::string& email,
+    const std::string& subject,
+    const std::string& body,
+    const std::string& subscriber_credential);
 mojom::RegionPtr GetRegionPtrWithNameFromRegionList(
     const std::string& name,
     const std::vector<mojom::Region> region_list);

--- a/components/brave_vpn/brave_vpn_service_helper.h
+++ b/components/brave_vpn/brave_vpn_service_helper.h
@@ -13,6 +13,13 @@
 #include "base/values.h"
 #include "brave/components/brave_vpn/mojom/brave_vpn.mojom.h"
 
+class PrefService;
+
+namespace base {
+class Time;
+class Value;
+}  // namespace base
+
 namespace brave_vpn {
 
 struct Hostname;
@@ -32,6 +39,13 @@ base::Value::Dict GetValueWithTicketInfos(const std::string& email,
 mojom::RegionPtr GetRegionPtrWithNameFromRegionList(
     const std::string& name,
     const std::vector<mojom::Region> region_list);
+bool IsValidCredentialSummary(const base::Value& summary);
+bool HasValidSubscriberCredential(PrefService* local_prefs);
+std::string GetSubscriberCredential(PrefService* local_prefs);
+void SetSubscriberCredential(PrefService* local_prefs,
+                             const std::string& subscriber_credential,
+                             const base::Time& expiration_time);
+void ClearSubscriberCredential(PrefService* local_prefs);
 
 }  // namespace brave_vpn
 

--- a/components/brave_vpn/brave_vpn_service_helper.h
+++ b/components/brave_vpn/brave_vpn_service_helper.h
@@ -12,6 +12,7 @@
 
 #include "base/values.h"
 #include "brave/components/brave_vpn/mojom/brave_vpn.mojom.h"
+#include "third_party/abseil-cpp/absl/types/optional.h"
 
 class PrefService;
 
@@ -42,6 +43,7 @@ mojom::RegionPtr GetRegionPtrWithNameFromRegionList(
 bool IsValidCredentialSummary(const base::Value& summary);
 bool HasValidSubscriberCredential(PrefService* local_prefs);
 std::string GetSubscriberCredential(PrefService* local_prefs);
+absl::optional<base::Time> GetExpirationTime(PrefService* local_prefs);
 void SetSubscriberCredential(PrefService* local_prefs,
                              const std::string& subscriber_credential,
                              const base::Time& expiration_time);

--- a/components/brave_vpn/brave_vpn_utils.cc
+++ b/components/brave_vpn/brave_vpn_utils.cc
@@ -35,10 +35,10 @@ void RegisterVPNLocalStatePrefs(PrefRegistrySimple* registry) {
   registry->RegisterBooleanPref(prefs::kBraveVPNShowDNSPolicyWarningDialog,
                                 true);
 #endif
-  registry->RegisterStringPref(prefs::kBraveVPNEEnvironment,
+  registry->RegisterStringPref(prefs::kBraveVPNEnvironment,
                                skus::GetDefaultEnvironment());
   registry->RegisterDictionaryPref(prefs::kBraveVPNRootPref);
-
+  registry->RegisterDictionaryPref(prefs::kBraveVPNSubscriberCredential);
   registry->RegisterBooleanPref(prefs::kBraveVPNLocalStateMigrated, false);
 }
 

--- a/components/brave_vpn/mojom/brave_vpn.mojom
+++ b/components/brave_vpn/mojom/brave_vpn.mojom
@@ -54,10 +54,6 @@ interface ServiceHandler {
   [EnableIfNot=is_android]
   GetAllRegions() => (array<Region> regions);
 
-  // Gets region based on user's device timezone
-  [EnableIfNot=is_android]
-  GetDeviceRegion() => (Region device_region);
-
   [EnableIfNot=is_android]
   GetSelectedRegion() => (Region current_region);
 

--- a/components/brave_vpn/pref_names.h
+++ b/components/brave_vpn/pref_names.h
@@ -20,7 +20,10 @@ constexpr char kBraveVPNSelectedRegion[] =
     "brave.brave_vpn.selected_region_name";
 constexpr char kBraveVPNShowDNSPolicyWarningDialog[] =
     "brave.brave_vpn.show_dns_policy_warning_dialog";
-constexpr char kBraveVPNEEnvironment[] = "brave.brave_vpn.env";
+constexpr char kBraveVPNEnvironment[] = "brave.brave_vpn.env";
+// Dict that has subscriber credential its expiration date.
+constexpr char kBraveVPNSubscriberCredential[] =
+    "brave.brave_vpn.subscriber_credential";
 
 #if BUILDFLAG(IS_ANDROID)
 extern const char kBraveVPNPurchaseTokenAndroid[];

--- a/components/brave_vpn/resources/panel/stories/mock-data/api.ts
+++ b/components/brave_vpn/resources/panel/stories/mock-data/api.ts
@@ -19,7 +19,6 @@ BraveVPN.setPanelBrowserApiForTesting({
     disconnect: doNothing,
     loadPurchasedState: doNothing,
     getAllRegions: () => Promise.resolve({ regions: mockRegionList }),
-    getDeviceRegion: () => Promise.resolve({ deviceRegion: mockRegionList[0] }),
     getSelectedRegion: () => Promise.resolve({ currentRegion: mockRegionList[1] }),
     setSelectedRegion: doNothing,
     getProductUrls: () => Promise.resolve({

--- a/components/brave_vpn/switches.h
+++ b/components/brave_vpn/switches.h
@@ -12,7 +12,6 @@ namespace switches {
 
 // Use for simulation instead of calling os platform apis.
 constexpr char kBraveVPNSimulation[] = "brave-vpn-simulate";
-constexpr char kBraveVPNTestMonthlyPass[] = "brave-vpn-test-monthly-pass";
 
 }  // namespace switches
 


### PR DESCRIPTION
fix https://github.com/brave/brave-browser/issues/26254

With this caching, we only need to ask skus credentials when subscriber credential is expired.

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves 

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

`npm run test brave_unit_tests -- --filter=*VPN*`