### PR TITLE
Android private search fix

### DIFF
--- a/android/java/org/chromium/chrome/browser/app/BraveActivity.java
+++ b/android/java/org/chromium/chrome/browser/app/BraveActivity.java
@@ -268,11 +268,11 @@ public abstract class BraveActivity<C extends ChromeActivityComponent> extends C
 
             BraveVpnUtils.reportBackgroundUsageP3A();
         }
-        Tab tab = getActivityTab();
-        if (tab != null) {
+        Profile profile = getCurrentTabModel().getProfile();
+        if (profile != null) {
             // Set proper active DSE whenever brave returns to foreground.
             // If active tab is private, set private DSE as an active DSE.
-            BraveSearchEngineUtils.updateActiveDSE(tab.isIncognito());
+            BraveSearchEngineUtils.updateActiveDSE(profile);
         }
 
         // The check on mNativeInitialized is mostly to ensure that mojo
@@ -292,11 +292,11 @@ public abstract class BraveActivity<C extends ChromeActivityComponent> extends C
         if (BraveVpnUtils.isBraveVpnFeatureEnable()) {
             BraveVpnNativeWorker.getInstance().removeObserver(this);
         }
-        Tab tab = getActivityTab();
-        if (tab != null && tab.isIncognito()) {
+        Profile profile = getCurrentTabModel().getProfile();
+        if (profile != null && profile.isOffTheRecord()) {
             // Set normal DSE as an active DSE when brave goes in background
             // because currently set DSE is used by outside of brave(ex, brave search widget).
-            BraveSearchEngineUtils.updateActiveDSE(false);
+            BraveSearchEngineUtils.updateActiveDSE(profile);
         }
         super.onPauseWithNative();
     }
@@ -1191,11 +1191,13 @@ public abstract class BraveActivity<C extends ChromeActivityComponent> extends C
     private void checkForYandexSE() {
         String countryCode = Locale.getDefault().getCountry();
         if (yandexRegions.contains(countryCode)) {
-            TemplateUrl yandexTemplateUrl =
-                    BraveSearchEngineUtils.getTemplateUrlByShortName(OnboardingPrefManager.YANDEX);
+            Profile lastUsedRegularProfile = Profile.getLastUsedRegularProfile();
+            TemplateUrl yandexTemplateUrl = BraveSearchEngineUtils.getTemplateUrlByShortName(
+                    lastUsedRegularProfile, OnboardingPrefManager.YANDEX);
             if (yandexTemplateUrl != null) {
-                BraveSearchEngineUtils.setDSEPrefs(yandexTemplateUrl, false);
-                BraveSearchEngineUtils.setDSEPrefs(yandexTemplateUrl, true);
+                BraveSearchEngineUtils.setDSEPrefs(yandexTemplateUrl, lastUsedRegularProfile);
+                BraveSearchEngineUtils.setDSEPrefs(yandexTemplateUrl,
+                        lastUsedRegularProfile.getPrimaryOTRProfile(/* createIfNeeded= */ true));
             }
         }
     }

--- a/android/java/org/chromium/chrome/browser/onboarding/SearchEngineOnboardingFragment.java
+++ b/android/java/org/chromium/chrome/browser/onboarding/SearchEngineOnboardingFragment.java
@@ -29,7 +29,8 @@ import org.chromium.base.Log;
 import org.chromium.chrome.R;
 import org.chromium.chrome.browser.onboarding.OnboardingPrefManager;
 import org.chromium.chrome.browser.onboarding.SearchEngineEnum;
-import org.chromium.chrome.browser.search_engines.TemplateUrlServiceFactory;
+import org.chromium.chrome.browser.profiles.Profile;
+import org.chromium.chrome.browser.search_engines.BraveTemplateUrlServiceFactory;
 import org.chromium.chrome.browser.settings.BraveSearchEngineUtils;
 import org.chromium.components.search_engines.TemplateUrl;
 import org.chromium.components.search_engines.TemplateUrlService;
@@ -45,10 +46,17 @@ public class SearchEngineOnboardingFragment extends Fragment {
 
     private Button btnSave;
 
-    private TemplateUrl selectedSearchEngine;
+    private Profile mProfile;
+    private TemplateUrl mSelectedSearchEngine;
 
     public SearchEngineOnboardingFragment() {
         // Required empty public constructor
+    }
+
+    @Override
+    public void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        mProfile = Profile.getLastUsedRegularProfile();
     }
 
     @Override
@@ -67,10 +75,12 @@ public class SearchEngineOnboardingFragment extends Fragment {
     }
 
     private void refreshData() {
-        TemplateUrlService templateUrlService = TemplateUrlServiceFactory.get();
+        TemplateUrlService templateUrlService =
+                BraveTemplateUrlServiceFactory.getForProfile(mProfile);
         List<TemplateUrl> templateUrls = templateUrlService.getTemplateUrls();
         TemplateUrl defaultSearchEngineTemplateUrl =
-            BraveSearchEngineUtils.getTemplateUrlByShortName(BraveSearchEngineUtils.getDSEShortName(false));
+                BraveSearchEngineUtils.getTemplateUrlByShortName(
+                        mProfile, BraveSearchEngineUtils.getDSEShortName(mProfile, false));
 
         Iterator<TemplateUrl> iterator = templateUrls.iterator();
         Set<String> templateUrlSet = new HashSet<String>();
@@ -153,12 +163,14 @@ public class SearchEngineOnboardingFragment extends Fragment {
         btnSave.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View view) {
-                if (selectedSearchEngine == null) {
-                    selectedSearchEngine = BraveSearchEngineUtils.getTemplateUrlByShortName(BraveSearchEngineUtils.getDSEShortName(false));
+                if (mSelectedSearchEngine == null) {
+                    mSelectedSearchEngine = BraveSearchEngineUtils.getTemplateUrlByShortName(
+                            mProfile, BraveSearchEngineUtils.getDSEShortName(mProfile, false));
                 }
-                if (selectedSearchEngine != null) {
-                    BraveSearchEngineUtils.setDSEPrefs(selectedSearchEngine, false);
-                    BraveSearchEngineUtils.setDSEPrefs(selectedSearchEngine, true);
+                if (mSelectedSearchEngine != null) {
+                    BraveSearchEngineUtils.setDSEPrefs(mSelectedSearchEngine, mProfile);
+                    BraveSearchEngineUtils.setDSEPrefs(mSelectedSearchEngine,
+                            mProfile.getPrimaryOTRProfile(/* createIfNeeded= */ true));
                 }
                 getActivity().finish();
             }
@@ -166,6 +178,6 @@ public class SearchEngineOnboardingFragment extends Fragment {
     }
 
     private void searchEngineSelected(int position, List<TemplateUrl> templateUrls) {
-        selectedSearchEngine = templateUrls.get(position);
+        mSelectedSearchEngine = templateUrls.get(position);
     }
 }

--- a/android/java/org/chromium/chrome/browser/search_engines/BUILD.gn
+++ b/android/java/org/chromium/chrome/browser/search_engines/BUILD.gn
@@ -7,18 +7,20 @@ import("//build/config/android/rules.gni")
 
 android_library("java") {
   sources = [
-    "BraveBaseSearchEngineAdapter.java",
-    "BravePrivateSearchEnginePreference.java",
-    "BraveSearchEngineAdapter.java",
-    "BraveSearchEnginePrefHelper.java",
-    "BraveSearchEnginePreference.java",
-    "BraveStandardSearchEnginePreference.java",
+    "BraveTemplateUrlServiceFactory.java",
+    "settings/BraveBaseSearchEngineAdapter.java",
+    "settings/BravePrivateSearchEnginePreference.java",
+    "settings/BraveSearchEngineAdapter.java",
+    "settings/BraveSearchEnginePrefHelper.java",
+    "settings/BraveSearchEnginePreference.java",
+    "settings/BraveStandardSearchEnginePreference.java",
   ]
   deps = [
     ":java_resources",
     "//base:base_java",
     "//base:jni_java",
     "//build/android:build_java",
+    "//chrome/browser/profiles/android:java",
     "//chrome/browser/search_engines/android:java",
     "//components/search_engines/android:java",
     "//third_party/androidx:androidx_annotation_annotation_java",
@@ -29,7 +31,10 @@ android_library("java") {
 }
 
 generate_jni("jni_headers") {
-  sources = [ "BraveSearchEnginePrefHelper.java" ]
+  sources = [
+    "BraveTemplateUrlServiceFactory.java",
+    "settings/BraveSearchEnginePrefHelper.java",
+  ]
 }
 
 android_resources("java_resources") {

--- a/android/java/org/chromium/chrome/browser/search_engines/BraveTemplateUrlServiceFactory.java
+++ b/android/java/org/chromium/chrome/browser/search_engines/BraveTemplateUrlServiceFactory.java
@@ -1,0 +1,78 @@
+/* Copyright (c) 2022 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.chromium.chrome.browser.search_engines;
+
+import androidx.annotation.Nullable;
+import androidx.annotation.VisibleForTesting;
+
+import org.chromium.base.Log;
+import org.chromium.base.ThreadUtils;
+import org.chromium.base.annotations.NativeMethods;
+import org.chromium.chrome.browser.profiles.Profile;
+import org.chromium.components.search_engines.TemplateUrlService;
+
+import java.lang.reflect.InvocationTargetException;
+
+public class BraveTemplateUrlServiceFactory {
+    private static final String TAG = "BraveTemplateUrlServiceFactory";
+
+    private static TemplateUrlService sNormalTemplateUrlService;
+    private static @Nullable Profile sProfile;
+
+    private BraveTemplateUrlServiceFactory() {}
+
+    /**
+     * @return The singleton instance of {@link TemplateUrlService} for profile, based on current
+     *         active tab model.
+     * All TemplateUrlServiceFactory.get() calls are redirected here.
+     */
+    public static TemplateUrlService get() {
+        ThreadUtils.assertOnUiThread();
+
+        if (sProfile != null) return getForProfile(sProfile);
+
+        return BraveTemplateUrlServiceFactoryJni.get().getTemplateUrlService();
+    }
+
+    /**
+     * @return The singleton instance of {@link TemplateUrlService} for each profile, creating it if
+     *         necessary.
+     */
+    public static TemplateUrlService getForProfile(Profile profile) {
+        ThreadUtils.assertOnUiThread();
+
+        if (!profile.isOffTheRecord()) {
+            if (sNormalTemplateUrlService == null) {
+                sNormalTemplateUrlService =
+                        BraveTemplateUrlServiceFactoryJni.get().getTemplateUrlServiceByProfile(
+                                profile);
+            }
+            return sNormalTemplateUrlService;
+        } else {
+            // Do not cache OTR service. It will be destroyed every time
+            // a new private tab model is created
+            return BraveTemplateUrlServiceFactoryJni.get().getTemplateUrlServiceByProfile(profile);
+        }
+    }
+
+    @VisibleForTesting
+    public static void setInstanceForTesting(
+            TemplateUrlService normalService, TemplateUrlService otrService) {
+        sNormalTemplateUrlService = normalService;
+    }
+
+    public static void setCurrentProfile(@Nullable Profile profile) {
+        sProfile = profile;
+    }
+
+    // Natives interface is public to allow mocking in tests outside of
+    // org.chromium.chrome.browser.search_engines package.
+    @NativeMethods
+    public interface Natives {
+        TemplateUrlService getTemplateUrlService();
+        TemplateUrlService getTemplateUrlServiceByProfile(Profile profile);
+    }
+}

--- a/android/java/org/chromium/chrome/browser/settings/BraveSearchEngineUtils.java
+++ b/android/java/org/chromium/chrome/browser/settings/BraveSearchEngineUtils.java
@@ -8,7 +8,8 @@ package org.chromium.chrome.browser.settings;
 import android.content.SharedPreferences;
 
 import org.chromium.base.ContextUtils;
-import org.chromium.chrome.browser.search_engines.TemplateUrlServiceFactory;
+import org.chromium.chrome.browser.profiles.Profile;
+import org.chromium.chrome.browser.search_engines.BraveTemplateUrlServiceFactory;
 import org.chromium.chrome.browser.search_engines.settings.BraveSearchEngineAdapter;
 import org.chromium.chrome.browser.tabmodel.TabModelSelector;
 import org.chromium.chrome.browser.widget.quickactionsearchandbookmark.QuickActionSearchAndBookmarkWidgetProvider;
@@ -21,29 +22,56 @@ public class BraveSearchEngineUtils {
 
         // For first-run initialization, it needs default TemplateUrl.
         // So, doing it after TemplateUrlService is loaded to get it if it isn't loaded yet.
-        if (TemplateUrlServiceFactory.get().isLoaded())  {
-            doInitializeBraveSearchEngineStates();
+        // Init on current (regular) profile only, leave the rest to observer, since
+        // user shouldn't be able to go directly into a private tab on first run.
+        Profile profile = tabModelSelector.getCurrentModel().getProfile();
+        if (profile == null) profile = Profile.getLastUsedRegularProfile().getOriginalProfile();
+        if (BraveTemplateUrlServiceFactory.getForProfile(profile.getOriginalProfile()).isLoaded()) {
+            doInitializeBraveSearchEngineStates(profile.getOriginalProfile());
             return;
         }
 
-        TemplateUrlServiceFactory.get().registerLoadListener(
-            new TemplateUrlService.LoadListener() {
-                @Override
-                public void onTemplateUrlServiceLoaded() {
-                    TemplateUrlServiceFactory.get().unregisterLoadListener(this);
-                    doInitializeBraveSearchEngineStates();
-                }
-            });
+        // Regular profile
+        final Profile regularProfile = profile.getOriginalProfile();
+        BraveTemplateUrlServiceFactory.getForProfile(regularProfile)
+                .registerLoadListener(new TemplateUrlService.LoadListener() {
+                    @Override
+                    public void onTemplateUrlServiceLoaded() {
+                        BraveTemplateUrlServiceFactory.getForProfile(regularProfile)
+                                .unregisterLoadListener(this);
+                        doInitializeBraveSearchEngineStates(regularProfile);
+                    }
+                });
     }
 
-    static private void initializeDSEPrefs() {
+    // There is no point in creating service for OTR profile in advance since they change
+    // This is for SearchEngineTabModelSelectorObserver when called on an OTR profile
+    static public void initializePrivateBraveSearchEngineStates(Profile oTRProfile) {
+        TemplateUrlService templateUrlService =
+                BraveTemplateUrlServiceFactory.getForProfile(oTRProfile);
+        if (!templateUrlService.isLoaded()) {
+            templateUrlService.registerLoadListener(new TemplateUrlService.LoadListener() {
+                @Override
+                public void onTemplateUrlServiceLoaded() {
+                    BraveTemplateUrlServiceFactory.getForProfile(oTRProfile)
+                            .unregisterLoadListener(this);
+                    doInitializeBraveSearchEngineStates(oTRProfile);
+                }
+            });
+            templateUrlService.load();
+        } else {
+            doInitializeBraveSearchEngineStates(oTRProfile);
+        }
+    }
+
+    static private void initializeDSEPrefs(Profile profile) {
         // At first run, we should set initial default prefs to each standard/private DSE prefs.
         // Those pref values will be used until user change DES options explicitly.
         final String notInitialized = "notInitialized";
         if (notInitialized.equals(ContextUtils.getAppSharedPreferences().getString(
                     BraveSearchEngineAdapter.STANDARD_DSE_SHORTNAME, notInitialized))) {
-            TemplateUrl templateUrl =
-                    TemplateUrlServiceFactory.get().getDefaultSearchEngineTemplateUrl();
+            TemplateUrl templateUrl = BraveTemplateUrlServiceFactory.getForProfile(profile)
+                                              .getDefaultSearchEngineTemplateUrl();
 
             SharedPreferences.Editor sharedPreferencesEditor =
                     ContextUtils.getAppSharedPreferences().edit();
@@ -55,30 +83,30 @@ public class BraveSearchEngineUtils {
         }
     }
 
-    static private void doInitializeBraveSearchEngineStates() {
-        assert TemplateUrlServiceFactory.get().isLoaded();
+    static private void doInitializeBraveSearchEngineStates(Profile profile) {
+        assert BraveTemplateUrlServiceFactory.getForProfile(profile).isLoaded();
 
-        initializeDSEPrefs();
-        // Initially set standard dse as an active DSE.
-        updateActiveDSE(false);
+        initializeDSEPrefs(profile);
+        updateActiveDSE(profile);
     }
 
-    static public void setDSEPrefs(TemplateUrl templateUrl, boolean isPrivate) {
-        BraveSearchEngineAdapter.setDSEPrefs(templateUrl, isPrivate);
-        if (!isPrivate && templateUrl != null)
+    static public void setDSEPrefs(TemplateUrl templateUrl, Profile profile) {
+        BraveSearchEngineAdapter.setDSEPrefs(templateUrl, profile);
+        if (!profile.isOffTheRecord() && templateUrl != null) {
             QuickActionSearchAndBookmarkWidgetProvider.updateSearchEngine(
                     templateUrl.getShortName());
+        }
     }
 
-    static public void updateActiveDSE(boolean isPrivate) {
-        BraveSearchEngineAdapter.updateActiveDSE(isPrivate);
+    static public void updateActiveDSE(Profile profile) {
+        BraveSearchEngineAdapter.updateActiveDSE(profile);
     }
 
-    static public String getDSEShortName(boolean isPrivate) {
-        return BraveSearchEngineAdapter.getDSEShortName(isPrivate);
+    static public String getDSEShortName(Profile profile, boolean javaOnly) {
+        return BraveSearchEngineAdapter.getDSEShortName(profile, javaOnly);
     }
 
-    static public TemplateUrl getTemplateUrlByShortName(String name) {
-        return BraveSearchEngineAdapter.getTemplateUrlByShortName(name);
+    static public TemplateUrl getTemplateUrlByShortName(Profile profile, String name) {
+        return BraveSearchEngineAdapter.getTemplateUrlByShortName(profile, name);
     }
 }

--- a/android/java/org/chromium/chrome/browser/settings/BraveSearchEnginesPreferences.java
+++ b/android/java/org/chromium/chrome/browser/settings/BraveSearchEnginesPreferences.java
@@ -12,6 +12,7 @@ import androidx.preference.Preference;
 
 import org.chromium.chrome.R;
 import org.chromium.chrome.browser.privacy.settings.PrivacySettings;
+import org.chromium.chrome.browser.profiles.Profile;
 import org.chromium.components.browser_ui.settings.SettingsUtils;
 
 public class BraveSearchEnginesPreferences extends BravePreferenceFragment {
@@ -32,12 +33,15 @@ public class BraveSearchEnginesPreferences extends BravePreferenceFragment {
     }
 
     private void updateSearchEnginePreference() {
+        Profile lastUsedRegularProfile = Profile.getLastUsedRegularProfile();
         Preference searchEnginePreference = findPreference(PREF_STANDARD_SEARCH_ENGINE);
         searchEnginePreference.setEnabled(true);
-        searchEnginePreference.setSummary(BraveSearchEngineUtils.getDSEShortName(false));
+        searchEnginePreference.setSummary(
+                BraveSearchEngineUtils.getDSEShortName(lastUsedRegularProfile, false));
 
         searchEnginePreference = findPreference(PREF_PRIVATE_SEARCH_ENGINE);
         searchEnginePreference.setEnabled(true);
-        searchEnginePreference.setSummary(BraveSearchEngineUtils.getDSEShortName(true));
+        searchEnginePreference.setSummary(BraveSearchEngineUtils.getDSEShortName(
+                lastUsedRegularProfile.getPrimaryOTRProfile(/* createIfNeeded= */ true), true));
     }
 }

--- a/android/java/org/chromium/chrome/browser/settings/SearchEngineTabModelSelectorObserver.java
+++ b/android/java/org/chromium/chrome/browser/settings/SearchEngineTabModelSelectorObserver.java
@@ -31,7 +31,11 @@ public class SearchEngineTabModelSelectorObserver implements TabModelSelectorObs
 
     @Override
     public void onTabModelSelected(TabModel newModel, TabModel oldModel) {
-        BraveSearchEngineUtils.updateActiveDSE(mTabModelSelector.isIncognitoSelected());
+        if (newModel.getProfile().isOffTheRecord()) {
+            BraveSearchEngineUtils.initializePrivateBraveSearchEngineStates(newModel.getProfile());
+        } else {
+            BraveSearchEngineUtils.updateActiveDSE(newModel.getProfile());
+        }
     }
 
     @Override

--- a/android/java/org/chromium/chrome/browser/widget/quickactionsearchandbookmark/QuickActionSearchAndBookmarkWidgetProvider.java
+++ b/android/java/org/chromium/chrome/browser/widget/quickactionsearchandbookmark/QuickActionSearchAndBookmarkWidgetProvider.java
@@ -199,7 +199,9 @@ public class QuickActionSearchAndBookmarkWidgetProvider extends AppWidgetProvide
 
     private static void setDefaultSearchEngineString(RemoteViews views) {
         TemplateUrl templateUrl = BraveSearchEngineUtils.getTemplateUrlByShortName(
-                BraveSearchEngineUtils.getDSEShortName(false));
+                Profile.getLastUsedRegularProfile().getOriginalProfile(),
+                BraveSearchEngineUtils.getDSEShortName(
+                        Profile.getLastUsedRegularProfile().getOriginalProfile(), false));
         if (templateUrl != null) {
             String searchWithDefaultSearchEngine = ContextUtils.getApplicationContext().getString(
                     R.string.search_with_search_engine, templateUrl.getShortName());

--- a/android/java/proguard.flags
+++ b/android/java/proguard.flags
@@ -37,3 +37,7 @@
     *** setContentSettingException(...);
     *** setContentSetting(...);
 }
+
+-keep class org.chromium.chrome.browser.search_engines.TemplateUrlServiceFactory {
+    *** get(...);
+}

--- a/android/javatests/org/chromium/chrome/browser/BytecodeTest.java
+++ b/android/javatests/org/chromium/chrome/browser/BytecodeTest.java
@@ -110,6 +110,7 @@ import org.chromium.components.browser_ui.widget.scrim.ScrimCoordinator;
 import org.chromium.components.omnibox.AutocompleteMatch;
 import org.chromium.components.omnibox.AutocompleteResult;
 import org.chromium.components.permissions.PermissionDialogController;
+import org.chromium.components.search_engines.TemplateUrlService;
 import org.chromium.content_public.browser.BrowserContextHandle;
 import org.chromium.ui.ViewProvider;
 import org.chromium.ui.base.WindowAndroid;
@@ -499,6 +500,9 @@ public class BytecodeTest {
         Assert.assertTrue(methodExists("org/chromium/components/browser_ui/site_settings/Website",
                 "setContentSetting", true, void.class, BrowserContextHandle.class, int.class,
                 int.class));
+        Assert.assertTrue(
+                methodExists("org/chromium/chrome/browser/search_engines/TemplateUrlServiceFactory",
+                        "get", true, TemplateUrlService.class));
         // NOTE: Add new checks above. For each new check in this method add proguard exception in
         // `brave/android/java/proguard.flags` file under `Add methods for invocation below`
         // section. Both test and regular apks should have the same exceptions.

--- a/browser/search_engines/brave_search_engine_pref_helper_android.cc
+++ b/browser/search_engines/brave_search_engine_pref_helper_android.cc
@@ -3,7 +3,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-#include "brave/android/java/org/chromium/chrome/browser/search_engines/settings/jni_headers/BraveSearchEnginePrefHelper_jni.h"
+#include "brave/android/java/org/chromium/chrome/browser/search_engines/jni_headers/BraveSearchEnginePrefHelper_jni.h"
 
 #include "brave/components/brave_search/browser/prefs.h"
 #include "chrome/browser/profiles/profile.h"

--- a/browser/search_engines/brave_template_url_service_factory_android.cc
+++ b/browser/search_engines/brave_template_url_service_factory_android.cc
@@ -1,0 +1,40 @@
+/* Copyright (c) 2022 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "brave/android/java/org/chromium/chrome/browser/search_engines/jni_headers/BraveTemplateUrlServiceFactory_jni.h"
+#include "chrome/browser/profiles/profile.h"
+#include "chrome/browser/profiles/profile_android.h"
+#include "chrome/browser/profiles/profile_manager.h"
+#include "chrome/browser/search_engines/template_url_service_factory.h"
+#include "chrome/browser/ui/android/tab_model/tab_model.h"
+#include "chrome/browser/ui/android/tab_model/tab_model_list.h"
+#include "components/search_engines/template_url_service.h"
+
+static TemplateURLService* GetTemplateUrlService(Profile* profile) {
+  return TemplateURLServiceFactory::GetForProfile(profile);
+}
+
+static Profile* GetProfileFromTabModelList() {
+  for (const TabModel* model : TabModelList::models()) {
+    if (model->IsActiveModel()) {
+      return model->GetProfile();
+    }
+  }
+
+  return ProfileManager::GetLastUsedProfileAllowedByPolicy();
+}
+
+static base::android::ScopedJavaLocalRef<jobject>
+JNI_BraveTemplateUrlServiceFactory_GetTemplateUrlService(JNIEnv* env) {
+  return GetTemplateUrlService(GetProfileFromTabModelList())->GetJavaObject();
+}
+
+static base::android::ScopedJavaLocalRef<jobject>
+JNI_BraveTemplateUrlServiceFactory_GetTemplateUrlServiceByProfile(
+    JNIEnv* env,
+    const base::android::JavaParamRef<jobject>& j_profile) {
+  Profile* profile = ProfileAndroid::FromProfileAndroid(j_profile);
+  return GetTemplateUrlService(profile)->GetJavaObject();
+}

--- a/browser/search_engines/sources.gni
+++ b/browser/search_engines/sources.gni
@@ -24,11 +24,14 @@ brave_browser_search_engines_deps = [
 if (is_android) {
   brave_browser_search_engines_sources += [
     "//brave/browser/search_engines/brave_search_engine_pref_helper_android.cc",
+    "//brave/browser/search_engines/brave_template_url_service_factory_android.cc",
   ]
 
   brave_browser_search_engines_deps += [
+    "//brave/android/java/org/chromium/chrome/browser/search_engines:jni_headers",
     "//brave/components/brave_search/browser",
     "//chrome/browser/profiles:profile",
+    "//chrome/browser/ui",
     "//components/prefs",
   ]
 } else {

--- a/browser/ui/android/omnibox/BUILD.gn
+++ b/browser/ui/android/omnibox/BUILD.gn
@@ -25,7 +25,7 @@ android_library("java") {
   deps = [
     ":java_resources",
     "//base:base_java",
-    "//brave/android/java/org/chromium/chrome/browser/search_engines/settings:java",
+    "//brave/android/java/org/chromium/chrome/browser/search_engines:java",
     "//brave/build/android:android_brave_strings_grd",
     "//brave/components/p3a_utils",
     "//chrome/browser/commerce/merchant_viewer/android:java",

--- a/browser/ui/android/omnibox/java/src/org/chromium/chrome/browser/omnibox/suggestions/BraveDropdownItemViewInfoListBuilder.java
+++ b/browser/ui/android/omnibox/java/src/org/chromium/chrome/browser/omnibox/suggestions/BraveDropdownItemViewInfoListBuilder.java
@@ -23,6 +23,7 @@ import org.chromium.chrome.browser.omnibox.R;
 import org.chromium.chrome.browser.omnibox.UrlBarEditingTextStateProvider;
 import org.chromium.chrome.browser.omnibox.suggestions.basic.BasicSuggestionProcessor.BookmarkState;
 import org.chromium.chrome.browser.omnibox.suggestions.brave_search.BraveSearchBannerProcessor;
+import org.chromium.chrome.browser.profiles.Profile;
 import org.chromium.chrome.browser.search_engines.settings.BraveSearchEngineAdapter;
 import org.chromium.chrome.browser.tab.Tab;
 import org.chromium.components.omnibox.AutocompleteMatch;
@@ -99,7 +100,10 @@ class BraveDropdownItemViewInfoListBuilder extends DropdownItemViewInfoListBuild
                 && mUrlBarEditingTextProvider.getTextWithoutAutocomplete().length() > 0
                 && activeTab != null && !activeTab.isIncognito()
                 && mBraveSearchEngineDefaultRegions.contains(Locale.getDefault().getCountry())
-                && !BraveSearchEngineAdapter.getDSEShortName(false).equals("Brave")
+                && !BraveSearchEngineAdapter
+                            .getDSEShortName(
+                                    Profile.fromWebContents(activeTab.getWebContents()), false)
+                            .equals("Brave")
                 && !OmniboxPrefManager.getInstance().isBraveSearchPromoBannerDismissed()
                 && !OmniboxPrefManager.getInstance()
                             .isBraveSearchPromoBannerDismissedCurrentSession()) {

--- a/build/android/BUILD.gn
+++ b/build/android/BUILD.gn
@@ -204,5 +204,5 @@ generate_jni("jni_headers") {
     "//brave/android/java/org/chromium/chrome/browser/vpn/BraveVpnNativeWorker.java",
   ]
 
-  deps = [ "//brave/android/java/org/chromium/chrome/browser/search_engines/settings:jni_headers" ]
+  deps = [ "//brave/android/java/org/chromium/chrome/browser/search_engines:jni_headers" ]
 }

--- a/build/android/bytecode/BUILD.gn
+++ b/build/android/bytecode/BUILD.gn
@@ -73,6 +73,7 @@ java_binary("java_bytecode_rewriter") {
     "//brave/build/android/bytecode/java/org/brave/bytecode/BraveTabSwitcherModeTopToolbarClassAdapter.java",
     "//brave/build/android/bytecode/java/org/brave/bytecode/BraveTabUiThemeProviderClassAdapter.java",
     "//brave/build/android/bytecode/java/org/brave/bytecode/BraveTabbedActivityClassAdapter.java",
+    "//brave/build/android/bytecode/java/org/brave/bytecode/BraveTemplateUrlServiceFactoryClassAdapter.java",
     "//brave/build/android/bytecode/java/org/brave/bytecode/BraveThemeUtilsClassAdapter.java",
     "//brave/build/android/bytecode/java/org/brave/bytecode/BraveTileViewClassAdapter.java",
     "//brave/build/android/bytecode/java/org/brave/bytecode/BraveToolbarLayoutClassAdapter.java",

--- a/build/android/bytecode/bytecode_rewriter.gni
+++ b/build/android/bytecode/bytecode_rewriter.gni
@@ -2,7 +2,7 @@ import("//build/config/python.gni")
 
 brave_bytecode_jars = [
   "obj/brave/android/features/tab_ui/java.javac.jar",
-  "obj/brave/android/java/org/chromium/chrome/browser/search_engines/settings/java.javac.jar",
+  "obj/brave/android/java/org/chromium/chrome/browser/search_engines/java.javac.jar",
   "obj/brave/browser/notifications/java.javac.jar",
   "obj/brave/browser/ui/android/logo/java.javac.jar",
   "obj/brave/browser/ui/android/omnibox/java.javac.jar",
@@ -12,6 +12,7 @@ brave_bytecode_jars = [
   "obj/chrome/android/chrome_java.javac.jar",
   "obj/chrome/android/features/tab_ui/java.javac.jar",
   "obj/chrome/browser/flags/java.javac.jar",
+  "obj/chrome/browser/locale/delegate_java.javac.jar",
   "obj/chrome/browser/notifications/java.javac.jar",
   "obj/chrome/browser/partnercustomizations/java.javac.jar",
   "obj/chrome/browser/safe_browsing/android/java.javac.jar",
@@ -20,6 +21,7 @@ brave_bytecode_jars = [
   "obj/chrome/browser/ui/android/appmenu/internal/java.javac.jar",
   "obj/chrome/browser/ui/android/logo/java.javac.jar",
   "obj/chrome/browser/ui/android/omnibox/java.javac.jar",
+  "obj/chrome/browser/ui/android/searchactivityutils/java.javac.jar",
   "obj/chrome/browser/ui/android/theme/java.javac.jar",
   "obj/chrome/browser/ui/android/toolbar/java.javac.jar",
   "obj/components/browser_ui/notifications/android/java.javac.jar",

--- a/build/android/bytecode/java/org/brave/bytecode/BraveClassAdapter.java
+++ b/build/android/bytecode/java/org/brave/bytecode/BraveClassAdapter.java
@@ -73,6 +73,7 @@ public class BraveClassAdapter {
         chain = new BraveTabSwitcherModeTopToolbarClassAdapter(chain);
         chain = new BraveTabUiThemeProviderClassAdapter(chain);
         chain = new BraveTabbedActivityClassAdapter(chain);
+        chain = new BraveTemplateUrlServiceFactoryClassAdapter(chain);
         chain = new BraveThemeUtilsClassAdapter(chain);
         chain = new BraveTileViewClassAdapter(chain);
         chain = new BraveToolbarLayoutClassAdapter(chain);

--- a/build/android/bytecode/java/org/brave/bytecode/BraveTemplateUrlServiceFactoryClassAdapter.java
+++ b/build/android/bytecode/java/org/brave/bytecode/BraveTemplateUrlServiceFactoryClassAdapter.java
@@ -1,0 +1,22 @@
+/* Copyright (c) 2022 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.brave.bytecode;
+
+import org.objectweb.asm.ClassVisitor;
+
+public class BraveTemplateUrlServiceFactoryClassAdapter extends BraveClassVisitor {
+    static String sTemplateUrlServiceFactory =
+            "org/chromium/chrome/browser/search_engines/TemplateUrlServiceFactory";
+
+    static String sBraveTemplateUrlServiceFactory =
+            "org/chromium/chrome/browser/search_engines/BraveTemplateUrlServiceFactory";
+
+    public BraveTemplateUrlServiceFactoryClassAdapter(ClassVisitor visitor) {
+        super(visitor);
+
+        changeMethodOwner(sTemplateUrlServiceFactory, "get", sBraveTemplateUrlServiceFactory);
+    }
+}

--- a/build/android/config.gni
+++ b/build/android/config.gni
@@ -14,7 +14,7 @@ brave_android_manifest_includes = [
 ]
 
 brave_chrome_java_deps = [
-  "//brave/android/java/org/chromium/chrome/browser/search_engines/settings:java",
+  "//brave/android/java/org/chromium/chrome/browser/search_engines:java",
   "//brave/browser/notifications/android:brave_java",
   "//brave/browser/notifications/android:java",
   "//brave/browser/safe_browsing/android/java/src/org/chromium/chrome/browser/safe_browsing/settings:java",


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves brave/brave-browser/issues/25821
Resolves brave/brave-browser/issues/26483

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

### test 1 (the issue)

1. Open a private tab.
2. Search for something.
3. Change the default search engine for private tabs (Settings -> Search engines -> Private Tab).
4. Navigate back to existing private tab OR open a new private tab.
5. Search for something, new search engine shall be used.

### test 2 (upgrading from and old version)

1. When upgraded from old version, the search settings for regular and private tab shall remain then same as before.

### test 3 (private tabs initialization)

1. Clear all tabs.
2. Open a private tab. Tap on url bar and search anything.
3. Clear private tabs and go back to a regular tab.
4. Open a private tab and search in the url bar again.
5. Repeat for 2-3 times.
6. Nothing extraordinary shall happen during the process.

### test 4 (onboarding - non-Brave default)

1. Set Android locale to anywhere Brave Search IS NOT default, reset/reinstall Brave.
2. Get through onboarding and tap url bar twice to get the search onboarding fragment.
3. Choose any one of the search options.
4. Check in settings that search settings for both regular and private tabs are set to the search engine that was just being chosen.


### test 4 (onboarding - Brave default)

1. Set Android locale to anywhere Brave Search IS default, reset/reinstall Brave.
2. Check in settings that Brave search is set for both regular and private tabs.
