### PR TITLE
Reset background to "Random Brave background" when there's no custom images

### DIFF
--- a/browser/ui/webui/new_tab_page/brave_new_tab_page_handler.cc
+++ b/browser/ui/webui/new_tab_page/brave_new_tab_page_handler.cc
@@ -299,13 +299,15 @@ void BraveNewTabPageHandler::OnRemoveCustomImageBackground(
 
   auto background_pref = NTPBackgroundPrefs(profile_->GetPrefs());
   background_pref.RemoveCustomImageFromList(file_name);
-  if (background_pref.GetType() == NTPBackgroundPrefs::Type::kCustomImage &&
-      absl::get<std::string>(background_pref.GetSelectedValue()) == file_name) {
+  if (background_pref.GetType() == NTPBackgroundPrefs::Type::kCustomImage) {
     if (auto custom_images = background_pref.GetCustomImageList();
-        !custom_images.empty()) {
+        !custom_images.empty() &&
+        absl::get<std::string>(background_pref.GetSelectedValue()) ==
+            file_name) {
+      // Reset to the next candidate after we've removed the chosen one.
       background_pref.SetSelectedValue(custom_images.front());
-    } else {
-      // Reset to default
+    } else if (custom_images.empty()) {
+      // Reset to default when there's no available custom images.
       background_pref.SetType(NTPBackgroundPrefs::Type::kBrave);
       background_pref.SetSelectedValue({});
       background_pref.SetShouldUseRandomValue(true);


### PR DESCRIPTION
The previous implementation was resetting background only when the removed image was the chosen one.

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/26337

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
* Upload custom image and toggle on "Refresh on every new tab"
* Remove the custom image
* Check if the toggle is getting off
* Go back to backgroun setting page and check if the "Brave backgrounds" are selected.
