### PR TITLE
Adds checks on the home page preference existence on Android (uplift to 1.46.x)

### DIFF
--- a/android/java/org/chromium/chrome/browser/settings/BraveMainPreferencesBase.java
+++ b/android/java/org/chromium/chrome/browser/settings/BraveMainPreferencesBase.java
@@ -83,7 +83,6 @@ public class BraveMainPreferencesBase
     private static final String PREF_BRAVE_REWARDS = "brave_rewards";
     private static final String PREF_BRAVE_WALLET = "brave_wallet";
     private static final String PREF_BRAVE_VPN = "brave_vpn";
-    private static final String PREF_HOMEPAGE = "homepage";
     private static final String PREF_USE_CUSTOM_TABS = "use_custom_tabs";
     private static final String PREF_LANGUAGES = "languages";
     private static final String PREF_BRAVE_LANGUAGES = "brave_languages";
@@ -130,7 +129,7 @@ public class BraveMainPreferencesBase
         removePreferenceIfPresent(MainSettings.PREF_GOOGLE_SERVICES);
         removePreferenceIfPresent(PREF_LANGUAGES);
         removePreferenceIfPresent(PREF_BASICS_SECTION);
-        // removePreferenceIfPresent(PREF_HOMEPAGE);
+        // removePreferenceIfPresent(MainSettings.PREF_HOMEPAGE);
 
         // removePreferenceIfPresent(PREF_USE_CUSTOM_TABS);
         removePreferenceIfPresent(PREF_ADVANCED_SECTION);
@@ -221,7 +220,10 @@ public class BraveMainPreferencesBase
         findPreference(PREF_GENERAL_SECTION).setOrder(++generalOrder);
 
         findPreference(PREF_BRAVE_SEARCH_ENGINES).setOrder(++generalOrder);
-        findPreference(PREF_HOMEPAGE).setOrder(++generalOrder);
+        Preference preference = findPreference(MainSettings.PREF_HOMEPAGE);
+        if (preference != null) {
+            preference.setOrder(++generalOrder);
+        }
         findPreference(PREF_PASSWORDS).setOrder(++generalOrder);
         findPreference(PREF_SYNC).setOrder(++generalOrder);
         findPreference(PREF_BRAVE_STATS).setOrder(++generalOrder);
@@ -275,7 +277,7 @@ public class BraveMainPreferencesBase
 
         // We don't have home button on top toolbar at the moment
         if (!DeviceFormFactor.isTablet() && !BottomToolbarConfiguration.isBottomToolbarEnabled()) {
-            removePreferenceIfPresent(PREF_HOMEPAGE);
+            removePreferenceIfPresent(MainSettings.PREF_HOMEPAGE);
         }
     }
 
@@ -307,7 +309,7 @@ public class BraveMainPreferencesBase
         updatePreferenceIcon(PREF_ADDRESSES, R.drawable.ic_addresses);
         updatePreferenceIcon(PREF_NOTIFICATIONS, R.drawable.ic_notification);
         updatePreferenceIcon(MainSettings.PREF_DEVELOPER, R.drawable.ic_info);
-        updatePreferenceIcon(PREF_HOMEPAGE, R.drawable.ic_homepage);
+        updatePreferenceIcon(MainSettings.PREF_HOMEPAGE, R.drawable.ic_homepage);
     }
 
     private void updateSearchEnginePreference() {
@@ -338,7 +340,10 @@ public class BraveMainPreferencesBase
     private void overrideChromiumPreferences() {
         // Replace fragment.
         findPreference(PREF_SHIELDS_AND_PRIVACY).setFragment(BravePrivacySettings.class.getName());
-        findPreference(PREF_HOMEPAGE).setFragment(BraveHomepageSettings.class.getName());
+        Preference preference = findPreference(MainSettings.PREF_HOMEPAGE);
+        if (preference != null) {
+            preference.setFragment(BraveHomepageSettings.class.getName());
+        }
     }
 
     private void setPreferenceListeners() {


### PR DESCRIPTION
Uplift of #15741
Resolves https://github.com/brave/brave-browser/issues/26440

Pre-approval checklist: 
- [ ] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.