### PR TITLE
Fix HTTPSE redirects having stronger precedence over adblock redirects

### DIFF
--- a/browser/brave_shields/ad_block_service_browsertest.cc
+++ b/browser/brave_shields/ad_block_service_browsertest.cc
@@ -28,6 +28,7 @@
 #include "brave/components/brave_shields/browser/ad_block_subscription_service_manager_observer.h"
 #include "brave/components/brave_shields/browser/brave_shields_util.h"
 #include "brave/components/brave_shields/browser/filter_list_catalog_entry.h"
+#include "brave/components/brave_shields/browser/test_filters_provider.h"
 #include "brave/components/brave_shields/common/brave_shield_constants.h"
 #include "brave/components/brave_shields/common/features.h"
 #include "brave/components/brave_shields/common/pref_names.h"

--- a/browser/net/brave_httpse_network_delegate_helper.cc
+++ b/browser/net/brave_httpse_network_delegate_helper.cc
@@ -54,7 +54,7 @@ int OnBeforeURLRequest_HttpsePreFileWork(
   DCHECK_CURRENTLY_ON(BrowserThread::UI);
 
   // Don't try to overwrite an already set URL by another delegate (adblock/tp)
-  if (!ctx->new_url_spec.empty()) {
+  if (!ctx->new_url_spec.empty() || !ctx->mock_data_url.empty()) {
     return net::OK;
   }
 

--- a/components/brave_shields/browser/ad_block_service.h
+++ b/components/brave_shields/browser/ad_block_service.h
@@ -30,6 +30,7 @@ class AdBlockServiceTest;
 class BraveAdBlockTPNetworkDelegateHelperTest;
 class DomainBlockTest;
 class EphemeralStorage1pDomainBlockBrowserTest;
+class HTTPSEverywhereServiceTest;
 class PerfPredictorTabHelperTest;
 class PrefChangeRegistrar;
 class PrefService;
@@ -138,6 +139,7 @@ class AdBlockService {
   friend class ::AdBlockServiceTest;
   friend class ::DomainBlockTest;
   friend class ::EphemeralStorage1pDomainBlockBrowserTest;
+  friend class ::HTTPSEverywhereServiceTest;
   friend class ::PerfPredictorTabHelperTest;
 
   static std::string g_ad_block_dat_file_version_;


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/26415

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

Note the STR from the associated issue:

> 1. Add this as a custom filter:
> `||google-analytics.com/analytics.js$script,redirect=google-analytics.com/analytics.js` [...]
> 
> 2. go to http://markkystreams.com/ [...]
> 
> 3. Open shields and it will say `google-analytics.com/analytics.js` was upgraded and blocked.
> 
> 4. Open DevTools and you will see analytics is in the source list, so Shields information is not accurate since the script wasn't blocked, because if it was, it wouldn't be in the list and it wasn't redirected since the script is the same analytics script used by the page, not the uBlock one.

In step 3, verify that `http://www.google-analytics.com/analytics.js` appears in the counter menu next to the `Block trackers and ads` setting rather than the `Upgrade connections to HTTPS` setting.

In step 4, verify that the `analytics.js` entry in the network panel has contents (`Response` tab) starting with the `uBlock Origin` copyright header.