### PR TITLE
Try to check connection when purchased state is set

### DIFF
--- a/components/brave_vpn/BUILD.gn
+++ b/components/brave_vpn/BUILD.gn
@@ -133,6 +133,7 @@ source_set("unit_tests") {
       "//net:test_support",
       "//services/data_decoder/public/cpp:test_support",
       "//services/network:test_support",
+      "//testing/gmock",
       "//testing/gtest",
       "//third_party/abseil-cpp:absl",
     ]

--- a/components/brave_vpn/brave_vpn_service.cc
+++ b/components/brave_vpn/brave_vpn_service.cc
@@ -29,6 +29,7 @@
 
 #if !BUILDFLAG(IS_ANDROID)
 #include "base/bind.h"
+#include "base/check_is_test.h"
 #include "base/command_line.h"
 #include "base/logging.h"
 #include "base/notreached.h"
@@ -98,7 +99,6 @@ void BraveVpnService::CheckInitialState() {
     }
 
     ScheduleBackgroundRegionDataFetch();
-    GetBraveVPNConnectionAPI()->CheckConnection();
 #endif
   } else {
     ClearSubscriberCredential(local_prefs_);
@@ -135,7 +135,7 @@ void BraveVpnService::ScheduleBackgroundRegionDataFetch() {
 
 void BraveVpnService::OnConnectionStateChanged(mojom::ConnectionState state) {
   DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
-  VLOG(2) << __func__;
+  VLOG(2) << __func__ << " " << state;
 
   // Ignore connection state change request for non purchased user.
   // This can be happened when user controls vpn via os settings.
@@ -474,6 +474,11 @@ void BraveVpnService::GetSupportData(GetSupportDataCallback callback) {
 }
 
 BraveVPNOSConnectionAPI* BraveVpnService::GetBraveVPNConnectionAPI() const {
+  if (mock_connection_api_) {
+    CHECK_IS_TEST();
+    return mock_connection_api_;
+  }
+
   if (is_simulation_)
     return BraveVPNOSConnectionAPI::GetInstanceForTest();
   return BraveVPNOSConnectionAPI::GetInstance();
@@ -745,7 +750,6 @@ void BraveVpnService::OnGetSubscriberCredentialV12(
   }
 
   ScheduleBackgroundRegionDataFetch();
-  GetBraveVPNConnectionAPI()->CheckConnection();
 #endif
 }
 
@@ -842,9 +846,15 @@ void BraveVpnService::SetPurchasedState(const std::string& env,
   }
 
   purchased_state_ = state;
+  VLOG(2) << __func__ << " " << state;
 
   for (const auto& obs : observers_)
     obs->OnPurchasedStateChanged(purchased_state_.value());
+
+#if !BUILDFLAG(IS_ANDROID)
+  if (state == PurchasedState::PURCHASED)
+    GetBraveVPNConnectionAPI()->CheckConnection();
+#endif
 }
 
 void BraveVpnService::SetCurrentEnvironment(const std::string& env) {

--- a/components/brave_vpn/brave_vpn_service.h
+++ b/components/brave_vpn/brave_vpn_service.h
@@ -196,6 +196,10 @@ class BraveVpnService :
   void OnPreferenceChanged(const std::string& pref_name);
 
   BraveVPNOSConnectionAPI* GetBraveVPNConnectionAPI() const;
+
+  void set_mock_brave_vpn_connection_api(BraveVPNOSConnectionAPI* api) {
+    mock_connection_api_ = api;
+  }
 #endif  // !BUILDFLAG(IS_ANDROID)
 
   // KeyedService overrides:
@@ -233,6 +237,7 @@ class BraveVpnService :
   // Only for testing.
   std::string test_timezone_;
   bool is_simulation_ = false;
+  raw_ptr<BraveVPNOSConnectionAPI> mock_connection_api_ = nullptr;
 
   PrefChangeRegistrar pref_change_registrar_;
 #endif  // !BUILDFLAG(IS_ANDROID)


### PR DESCRIPTION
fix https://github.com/brave/brave-browser/issues/26349

From the previous refactoring, vpn service only notify connection state change when it's already purchased.
That change could make regression in below scenario.
1. Launch browser
2. Purchased state checking in progress
3. Checking connection state and got connection state
4. Connection state is not notified to service observer as purchased state checking is not finished.
5. Purchased state checking is finished
6. BraveVPNOSConnectionAPI doesn't notify for subsquent connection check request because connection state is still same

This PR fixes this issue by checking connection state when purchased state is set as PURCHASED.

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves 

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

See the linked issue.

`BraveVPNServiceTest.CheckConnectionStateAfterPurchased`