### PR TITLE
Adjust vertical tabs size

### DIFF
--- a/browser/ui/views/frame/vertical_tab_strip_region_view.cc
+++ b/browser/ui/views/frame/vertical_tab_strip_region_view.cc
@@ -12,6 +12,7 @@
 #include "brave/browser/ui/tabs/brave_tab_prefs.h"
 #include "brave/browser/ui/views/tabs/brave_new_tab_button.h"
 #include "brave/browser/ui/views/tabs/brave_tab_search_button.h"
+#include "brave/browser/ui/views/tabs/brave_tab_strip_layout_helper.h"
 #include "brave/browser/ui/views/tabs/features.h"
 #include "chrome/browser/themes/theme_properties.h"
 #include "chrome/browser/ui/exclusive_access/exclusive_access_manager.h"
@@ -44,7 +45,7 @@ class ToggleButton : public views::Button {
     // text.
     // https://github.com/brave/brave-browser/issues/24717
     SetProperty(views::kSkipAccessibilityPaintChecks, true);
-    SetPreferredSize(gfx::Size{GetIconWidth(), GetIconWidth()});
+    SetPreferredSize(gfx::Size{tabs::kVerticalTabMinWidth, GetIconWidth()});
   }
   ~ToggleButton() override = default;
 
@@ -70,8 +71,7 @@ class ToggleButton : public views::Button {
 
     const int icon_inset = ui::TouchUiController::Get()->touch_ui() ? 10 : 9;
     gfx::Rect icon_bounds(gfx::Size(icon_width, height()));
-    if (expanded)
-      icon_bounds.set_x(width() - icon_width);
+    icon_bounds.set_x((width() - icon_width) / 2);
     icon_bounds.Inset(gfx::Insets::VH(icon_inset, icon_inset * 1.5));
 
     if (expanded) {
@@ -432,8 +432,7 @@ gfx::Size VerticalTabStripRegionView::GetPreferredSizeForState(
   DCHECK_EQ(state, State::kCollapsed)
       << "If a new state was added, " << __FUNCTION__
       << " should be revisited.";
-  return {TabStyle::GetPinnedWidth() - TabStyle::GetTabOverlap(),
-          View::CalculatePreferredSize().height()};
+  return {tabs::kVerticalTabMinWidth, View::CalculatePreferredSize().height()};
 }
 
 BEGIN_METADATA(VerticalTabStripRegionView, views::View)

--- a/browser/ui/views/sidebar/sidebar_button_view.h
+++ b/browser/ui/views/sidebar/sidebar_button_view.h
@@ -13,7 +13,7 @@
 class SidebarButtonView : public views::ImageButton {
  public:
   METADATA_HEADER(SidebarButtonView);
-  static const int kSidebarButtonSize = 42;
+  static constexpr int kSidebarButtonSize = 42;
 
   explicit SidebarButtonView(const std::u16string& accessible_name);
   ~SidebarButtonView() override;

--- a/browser/ui/views/tabs/brave_tab.cc
+++ b/browser/ui/views/tabs/brave_tab.cc
@@ -57,3 +57,38 @@ absl::optional<SkColor> BraveTab::GetGroupColor() const {
 
   return Tab::GetGroupColor();
 }
+
+void BraveTab::UpdateIconVisibility() {
+  Tab::UpdateIconVisibility();
+  if (IsAtMinWidthForVerticalTabStrip()) {
+    const bool is_active = IsActive();
+    center_icon_ = true;
+    showing_icon_ = !is_active && !showing_alert_indicator_;
+    showing_close_button_ = is_active;
+  }
+}
+
+void BraveTab::Layout() {
+  Tab::Layout();
+  if (IsAtMinWidthForVerticalTabStrip()) {
+    if (showing_close_button_) {
+      close_button_->SetX(bounds().CenterPoint().x() -
+                          (close_button_->width() / 2));
+      close_button_->SetButtonPadding({});
+    }
+  }
+}
+
+bool BraveTab::ShouldRenderAsNormalTab() const {
+  if (IsAtMinWidthForVerticalTabStrip()) {
+    // Returns false to hide title
+    return false;
+  }
+
+  return Tab::ShouldRenderAsNormalTab();
+}
+
+bool BraveTab::IsAtMinWidthForVerticalTabStrip() const {
+  return tabs::features::ShouldShowVerticalTabs(controller()->GetBrowser()) &&
+         width() == tabs::kVerticalTabMinWidth;
+}

--- a/browser/ui/views/tabs/brave_tab.h
+++ b/browser/ui/views/tabs/brave_tab.h
@@ -28,6 +28,13 @@ class BraveTab : public Tab {
   void ActiveStateChanged() override;
 
   absl::optional<SkColor> GetGroupColor() const override;
+
+  void UpdateIconVisibility() override;
+  bool ShouldRenderAsNormalTab() const override;
+  void Layout() override;
+
+ private:
+  bool IsAtMinWidthForVerticalTabStrip() const;
 };
 
 #endif  // BRAVE_BROWSER_UI_VIEWS_TABS_BRAVE_TAB_H_

--- a/browser/ui/views/tabs/brave_tab_strip_layout_helper.cc
+++ b/browser/ui/views/tabs/brave_tab_strip_layout_helper.cc
@@ -28,8 +28,8 @@ std::vector<gfx::Rect> CalculateVerticalTabBounds(
                    ? BraveTabGroupHeader::GetLeftPaddingForVerticalTabs()
                    : 0);
     rect.set_width(width.value_or(tabs.front().GetPreferredWidth()) - rect.x());
-    rect.set_height(
-        tab.state().open() == TabOpen::kOpen ? layout_constants.tab_height : 0);
+    rect.set_height(tab.state().open() == TabOpen::kOpen ? kVerticalTabHeight
+                                                         : 0);
     bounds.push_back(rect);
     if (tab.state().open() == TabOpen::kOpen)
       rect.set_y(rect.bottom());

--- a/browser/ui/views/tabs/brave_tab_strip_layout_helper.h
+++ b/browser/ui/views/tabs/brave_tab_strip_layout_helper.h
@@ -8,6 +8,7 @@
 
 #include <vector>
 
+#include "brave/browser/ui/views/sidebar/sidebar_item_view.h"
 #include "third_party/abseil-cpp/absl/types/optional.h"
 
 namespace gfx {
@@ -20,6 +21,9 @@ class TabWidthConstraints;
 struct TabLayoutConstants;
 
 namespace tabs {
+
+constexpr int kVerticalTabMinWidth = SidebarButtonView::kSidebarButtonSize;
+constexpr int kVerticalTabHeight = SidebarButtonView::kSidebarButtonSize;
 
 std::vector<gfx::Rect> CalculateVerticalTabBounds(
     const TabLayoutConstants& layout_constants,

--- a/chromium_src/chrome/browser/ui/views/tabs/tab.h
+++ b/chromium_src/chrome/browser/ui/views/tabs/tab.h
@@ -20,7 +20,13 @@ class BraveTab;
 
 #define ActiveStateChanged virtual ActiveStateChanged
 #define GetGroupColor virtual GetGroupColor
+#define UpdateIconVisibility virtual UpdateIconVisibility
+#define ShouldRenderAsNormalTab virtual ShouldRenderAsNormalTab
+
 #include "src/chrome/browser/ui/views/tabs/tab.h"
+
+#undef ShouldRenderAsNormalTab
+#undef UpdateIconVisibility
 #undef GetGroupColor
 #undef ActiveStateChanged
 #undef GetWidthOfLargestSelectableRegion


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/26463

* Make height the same as that of sidebar button

* Make min width the same as that of sidebar button
  * In this case, sub controls' visibility will be as if the tab is pinned.

### Screenshots
<img width="335" alt="image" src="https://user-images.githubusercontent.com/5474642/199421738-ab549405-30e0-49ff-b735-796801fb64bc.png">

* active tabs shows close button
* inactive tabs should show alert indicator, such as speaker, or favicon.

<img width="321" alt="image" src="https://user-images.githubusercontent.com/5474642/199409338-4a31c8bc-5fbc-4d64-9d6e-bcda43082a40.png">



## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

