### PR TITLE
Fix HTTPSE redirects having stronger precedence over adblock redirects (uplift to 1.45.x)

### DIFF
--- a/browser/brave_shields/ad_block_service_browsertest.cc
+++ b/browser/brave_shields/ad_block_service_browsertest.cc
@@ -28,6 +28,7 @@
 #include "brave/components/brave_shields/browser/ad_block_subscription_service_manager_observer.h"
 #include "brave/components/brave_shields/browser/brave_shields_util.h"
 #include "brave/components/brave_shields/browser/filter_list_catalog_entry.h"
+#include "brave/components/brave_shields/browser/test_filters_provider.h"
 #include "brave/components/brave_shields/common/brave_shield_constants.h"
 #include "brave/components/brave_shields/common/features.h"
 #include "brave/components/brave_shields/common/pref_names.h"

--- a/browser/net/brave_httpse_network_delegate_helper.cc
+++ b/browser/net/brave_httpse_network_delegate_helper.cc
@@ -54,7 +54,7 @@ int OnBeforeURLRequest_HttpsePreFileWork(
   DCHECK_CURRENTLY_ON(BrowserThread::UI);
 
   // Don't try to overwrite an already set URL by another delegate (adblock/tp)
-  if (!ctx->new_url_spec.empty()) {
+  if (!ctx->new_url_spec.empty() || !ctx->mock_data_url.empty()) {
     return net::OK;
   }
 

--- a/components/brave_shields/browser/ad_block_service.h
+++ b/components/brave_shields/browser/ad_block_service.h
@@ -30,6 +30,7 @@ class AdBlockServiceTest;
 class BraveAdBlockTPNetworkDelegateHelperTest;
 class DomainBlockTest;
 class EphemeralStorage1pDomainBlockBrowserTest;
+class HTTPSEverywhereServiceTest;
 class PerfPredictorTabHelperTest;
 class PrefChangeRegistrar;
 class PrefService;
@@ -137,6 +138,7 @@ class AdBlockService {
   friend class ::AdBlockServiceTest;
   friend class ::DomainBlockTest;
   friend class ::EphemeralStorage1pDomainBlockBrowserTest;
+  friend class ::HTTPSEverywhereServiceTest;
   friend class ::PerfPredictorTabHelperTest;
 
   static std::string g_ad_block_dat_file_version_;


### PR DESCRIPTION
Uplift of #15754
Resolves https://github.com/brave/brave-browser/issues/26415

Pre-approval checklist: 
- [ ] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [ ] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [ ] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [ ] The associated issue milestone is set to the smallest version that the changes is landed on.