### PR TITLE
Fixes a crash on dynamically added vpn preference on Android (uplift to 1.46.x)

### DIFF
--- a/android/java/org/chromium/chrome/browser/settings/BraveMainPreferencesBase.java
+++ b/android/java/org/chromium/chrome/browser/settings/BraveMainPreferencesBase.java
@@ -44,7 +44,7 @@ import org.chromium.ui.base.DeviceFormFactor;
 
 import java.util.HashMap;
 
-// This exculdes some settings in main settings screen.
+// This excludes some settings in main settings screen.
 public class BraveMainPreferencesBase
         extends BravePreferenceFragment implements Preference.OnPreferenceChangeListener {
     // sections
@@ -91,6 +91,7 @@ public class BraveMainPreferencesBase
     private static final String PREF_DOWNLOADS = "brave_downloads";
 
     private final HashMap<String, Preference> mRemovedPreferences = new HashMap<>();
+    private Preference mVpnCalloutPreference;
 
     @Override
     public void onCreate(Bundle savedInstanceState) {
@@ -192,10 +193,14 @@ public class BraveMainPreferencesBase
         if (BraveVpnPrefUtils.shouldShowCallout() && !BraveVpnPrefUtils.isSubscriptionPurchase()
                 && BraveVpnUtils.isBraveVpnFeatureEnable()
                 && InAppPurchaseWrapper.getInstance().isSubscriptionSupported()) {
-            VpnCalloutPreference vpnCalloutPreference = new VpnCalloutPreference(getActivity());
-            vpnCalloutPreference.setKey(PREF_BRAVE_VPN_CALLOUT);
-            vpnCalloutPreference.setOrder(firstSectionOrder);
-            getPreferenceScreen().addPreference(vpnCalloutPreference);
+            if (getActivity() != null && mVpnCalloutPreference == null) {
+                mVpnCalloutPreference = new VpnCalloutPreference(getActivity());
+            }
+            if (mVpnCalloutPreference != null) {
+                mVpnCalloutPreference.setKey(PREF_BRAVE_VPN_CALLOUT);
+                mVpnCalloutPreference.setOrder(firstSectionOrder);
+                getPreferenceScreen().addPreference(mVpnCalloutPreference);
+            }
         }
 
         findPreference(PREF_FEATURES_SECTION).setOrder(++firstSectionOrder);


### PR DESCRIPTION
Uplift of #15773
Resolves https://github.com/brave/brave-browser/issues/26440

Pre-approval checklist: 
- [ ] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.