### PR TITLE
Call takeRecords when cosmetic filters MutationObserver is disconnected

### DIFF
--- a/components/cosmetic_filters/resources/data/content_cosmetic.ts
+++ b/components/cosmetic_filters/resources/data/content_cosmetic.ts
@@ -164,7 +164,7 @@ const UseMutationObserver = () => {
   selectorsPollingIntervalId = undefined
 
   if (!cosmeticObserver) {
-    cosmeticObserver = new MutationObserver(handleMutations)
+    cosmeticObserver = new MutationObserver(handleMutations as MutationCallback)
   }
 
   const observerConfig = {
@@ -176,13 +176,17 @@ const UseMutationObserver = () => {
 }
 
 const UseSelectorsPolling = () => {
+  const mutations = cosmeticObserver?.takeRecords()
   cosmeticObserver?.disconnect()
+  if (mutations) {
+    handleMutations(mutations)
+  }
   selectorsPollingIntervalId = window.setInterval(querySelectors,
                                                  selectorsPollingIntervalMs)
   window.setTimeout(UseMutationObserver, returnToMutationObserverIntervalMs)
 }
 
-const handleMutations: MutationCallback = (mutations: MutationRecord[]) => {
+const handleMutations = (mutations: MutationRecord[]) => {
   // Callback to c++ renderer process
   // @ts-expect-error
   const eventId: number | undefined = cf_worker.onHandleMutationsBegin?.()


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/26492

As per [MDN docs](https://developer.mozilla.org/en-US/docs/Web/API/MutationObserver/takeRecords), `MutationObserver` has a `takeRecords` method that should be called before any disconnects.

> The most common use case for this is to immediately fetch all pending mutation records immediately prior to disconnecting the observer, so that any pending mutations can be processed when shutting down the observer.

We aren't calling that anywhere at the moment, and I suspect it's contributing to the associated issue. This PR seems to help but doesn't fix it 100%, by my testing. I suspect more work can be done here.

## Submitter Checklist:

- [ ] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

