### PR TITLE
Fixed possible DCHECK on the ads service start.

### DIFF
--- a/components/brave_ads/browser/ads_service_impl.cc
+++ b/components/brave_ads/browser/ads_service_impl.cc
@@ -448,7 +448,7 @@ bool AdsServiceImpl::CanStartBatAdsService() const {
 void AdsServiceImpl::MaybeStartBatAdsService() {
   CancelRestartBatAdsService();
 
-  if (!CanStartBatAdsService()) {
+  if (bat_ads_service_.is_bound() || !CanStartBatAdsService()) {
     return;
   }
 
@@ -542,6 +542,10 @@ void AdsServiceImpl::InitializeDatabase() {
       base_path_.AppendASCII("database.sqlite"));
 }
 
+bool AdsServiceImpl::ShouldRewardUser() const {
+  return IsEnabled();
+}
+
 void AdsServiceImpl::InitializeRewardsWallet() {
   rewards_service_->GetRewardsWallet(
       base::BindOnce(&AdsServiceImpl::OnInitializeRewardsWallet, AsWeakPtr()));
@@ -553,13 +557,13 @@ void AdsServiceImpl::OnInitializeRewardsWallet(
     return;
   }
 
-  if (!wallet) {
+  if (wallet) {
+    bat_ads_->OnRewardsWalletDidChange(
+        wallet->payment_id, base::Base64Encode(wallet->recovery_seed));
+  } else if (ShouldRewardUser()) {
     VLOG(0) << "Failed to initialize Rewards wallet";
-    return;
+    return Shutdown();
   }
-
-  bat_ads_->OnRewardsWalletDidChange(wallet->payment_id,
-                                     base::Base64Encode(wallet->recovery_seed));
 
   InitializeBatAds();
 }
@@ -686,7 +690,7 @@ void AdsServiceImpl::InitializePrefChangeRegistrar() {
 }
 
 void AdsServiceImpl::OnEnabledPrefChanged() {
-  if (!IsEnabled()) {
+  if (!CanStartBatAdsService()) {
     return Shutdown();
   }
 

--- a/components/brave_ads/browser/ads_service_impl.h
+++ b/components/brave_ads/browser/ads_service_impl.h
@@ -125,6 +125,8 @@ class AdsServiceImpl : public AdsService,
   void OnInitializeBasePathDirectory(bool success);
   void Initialize();
   void InitializeDatabase();
+
+  bool ShouldRewardUser() const;
   void InitializeRewardsWallet();
   void OnInitializeRewardsWallet(ledger::mojom::RewardsWalletPtr wallet);
   void InitializeBatAds();


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/26524

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

### Case 1
- Start Brave on fresh profile
- Opt-in to Brave News
- Check that `Brave Ads` are initialized (there is `Successfully initialized ads` message in rewards-internals log)
- Restart the Brave browser
- Check that `Brave Ads` are initialized (there is `Successfully initialized ads` message in rewards-internals log)
- Opt-in to Brave Rewards
- Check that `Brave Ads` were not initialized again
- Turn off `Brave Private Ads`
- Check that there is `Utility: Brave Ads Service` in the Brave `Task Manager`
- Turn on `Brave Private Ads`
- Check that `Brave Ads` were not initialized again

### Case 2
- Start Brave on fresh profile
- Opt-in to Brave Rewards
- Check that `Brave Ads` are initialized (there is `Successfully initialized ads` message in rewards-internals log)
- Restart the Brave browser
- Check that `Brave Ads` are initialized (there is `Successfully initialized ads` message in rewards-internals log)
- Opt-in to Brave News
- Check that `Brave Ads` were not initialized again
- Turn off `Brave Private Ads`
- Turn off `Show Brave News`
- Check that there is no `Utility: Brave Ads Service` in the Brave `Task Manager`
