### PR TITLE
Try to check connection when purchased state is set (uplift to 1.46.x)

### DIFF
--- a/components/brave_vpn/BUILD.gn
+++ b/components/brave_vpn/BUILD.gn
@@ -133,6 +133,7 @@ source_set("unit_tests") {
       "//net:test_support",
       "//services/data_decoder/public/cpp:test_support",
       "//services/network:test_support",
+      "//testing/gmock",
       "//testing/gtest",
       "//third_party/abseil-cpp:absl",
     ]

--- a/components/brave_vpn/brave_vpn_service.cc
+++ b/components/brave_vpn/brave_vpn_service.cc
@@ -29,6 +29,7 @@
 
 #if !BUILDFLAG(IS_ANDROID)
 #include "base/bind.h"
+#include "base/check_is_test.h"
 #include "base/command_line.h"
 #include "base/logging.h"
 #include "base/notreached.h"
@@ -98,7 +99,6 @@ void BraveVpnService::CheckInitialState() {
     }
 
     ScheduleBackgroundRegionDataFetch();
-    GetBraveVPNConnectionAPI()->CheckConnection();
 #endif
   } else {
     ClearSubscriberCredential(local_prefs_);
@@ -135,7 +135,7 @@ void BraveVpnService::ScheduleBackgroundRegionDataFetch() {
 
 void BraveVpnService::OnConnectionStateChanged(mojom::ConnectionState state) {
   DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
-  VLOG(2) << __func__;
+  VLOG(2) << __func__ << " " << state;
 
   // Ignore connection state change request for non purchased user.
   // This can be happened when user controls vpn via os settings.
@@ -474,6 +474,11 @@ void BraveVpnService::GetSupportData(GetSupportDataCallback callback) {
 }
 
 BraveVPNOSConnectionAPI* BraveVpnService::GetBraveVPNConnectionAPI() const {
+  if (mock_connection_api_) {
+    CHECK_IS_TEST();
+    return mock_connection_api_;
+  }
+
   if (is_simulation_)
     return BraveVPNOSConnectionAPI::GetInstanceForTest();
   return BraveVPNOSConnectionAPI::GetInstance();
@@ -745,7 +750,6 @@ void BraveVpnService::OnGetSubscriberCredentialV12(
   }
 
   ScheduleBackgroundRegionDataFetch();
-  GetBraveVPNConnectionAPI()->CheckConnection();
 #endif
 }
 
@@ -842,9 +846,15 @@ void BraveVpnService::SetPurchasedState(const std::string& env,
   }
 
   purchased_state_ = state;
+  VLOG(2) << __func__ << " " << state;
 
   for (const auto& obs : observers_)
     obs->OnPurchasedStateChanged(purchased_state_.value());
+
+#if !BUILDFLAG(IS_ANDROID)
+  if (state == PurchasedState::PURCHASED)
+    GetBraveVPNConnectionAPI()->CheckConnection();
+#endif
 }
 
 void BraveVpnService::SetCurrentEnvironment(const std::string& env) {

--- a/components/brave_vpn/brave_vpn_service.h
+++ b/components/brave_vpn/brave_vpn_service.h
@@ -196,6 +196,10 @@ class BraveVpnService :
   void OnPreferenceChanged(const std::string& pref_name);
 
   BraveVPNOSConnectionAPI* GetBraveVPNConnectionAPI() const;
+
+  void set_mock_brave_vpn_connection_api(BraveVPNOSConnectionAPI* api) {
+    mock_connection_api_ = api;
+  }
 #endif  // !BUILDFLAG(IS_ANDROID)
 
   // KeyedService overrides:
@@ -233,6 +237,7 @@ class BraveVpnService :
   // Only for testing.
   std::string test_timezone_;
   bool is_simulation_ = false;
+  raw_ptr<BraveVPNOSConnectionAPI> mock_connection_api_ = nullptr;
 
   PrefChangeRegistrar pref_change_registrar_;
 #endif  // !BUILDFLAG(IS_ANDROID)


### PR DESCRIPTION
Uplift of #15758
fix https://github.com/brave/brave-browser/issues/26349

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.