### PR TITLE
Show custom backgrounds on "Upload your own" button if any.

### DIFF
--- a/components/brave_new_tab_ui/containers/newTab/settings/backgroundImage.tsx
+++ b/components/brave_new_tab_ui/containers/newTab/settings/backgroundImage.tsx
@@ -28,6 +28,7 @@ import { defaultSolidBackgroundColor, solidColorsForBackground, gradientColorsFo
 import SponsoredImageToggle from './sponsoredImagesToggle'
 
 import { RANDOM_SOLID_COLOR_VALUE, RANDOM_GRADIENT_COLOR_VALUE, MAX_CUSTOM_IMAGE_BACKGROUNDS } from 'gen/brave/components/brave_new_tab_ui/brave_new_tab_page.mojom.m.js'
+import BackgroundImageTiles from './backgroundImageTiles'
 
 interface Props {
   newTabData: NewTab.State
@@ -88,15 +89,18 @@ class BackgroundImageSettings extends React.PureComponent<Props, State> {
     this.setState({ location: Location.GRADIENT_COLORS })
   }
 
-  renderUploadButton = (onClick: () => void, checked: boolean, showTitle: boolean) => {
+  renderUploadButton = (onClick: () => void, checked: boolean, showTitle: boolean, sampleImages?: NewTab.ImageBackground[]) => {
     return (
       <StyledCustomBackgroundOption onClick={onClick}>
         <StyledSelectionBorder selected={checked}>
           <StyledUploadIconContainer selected={checked}>
-            <UploadIcon />
-            <StyledUploadLabel>
-              {getLocale('customBackgroundImageOptionUploadLabel')}
-            </StyledUploadLabel>
+            { sampleImages?.length
+              ? <BackgroundImageTiles images={sampleImages}/>
+              : (<>
+                  <UploadIcon />
+                  <StyledUploadLabel> {getLocale('customBackgroundImageOptionUploadLabel')} </StyledUploadLabel>
+                </>)
+            }
           </StyledUploadIconContainer>
         </StyledSelectionBorder>
         {showTitle && (
@@ -145,7 +149,7 @@ class BackgroundImageSettings extends React.PureComponent<Props, State> {
             </SettingsRow>
             {showBackgroundImage && featureCustomBackgroundEnabled && (
               <StyledCustomBackgroundSettings>
-                {this.renderUploadButton(this.onClickCustomBackground, usingCustomImageBackground, /* showTitle= */ true)}
+                {this.renderUploadButton(this.onClickCustomBackground, usingCustomImageBackground, /* showTitle= */ true, this.props.newTabData.customImageBackgrounds)}
                 <StyledCustomBackgroundOption
                   onClick={this.onClickBraveBackground}
                 >

--- a/components/brave_new_tab_ui/containers/newTab/settings/backgroundImageTiles.tsx
+++ b/components/brave_new_tab_ui/containers/newTab/settings/backgroundImageTiles.tsx
@@ -1,0 +1,52 @@
+
+// Copyright (c) 2020 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// you can obtain one at http://mozilla.org/MPL/2.0/.
+
+import * as React from 'react'
+import styled, { css } from 'styled-components'
+
+import { StyledCustomBackgroundOptionImage } from '../../../components/default'
+
+interface Props {
+  images: NewTab.ImageBackground[]
+}
+
+const RectangularBackgroundImage = styled(StyledCustomBackgroundOptionImage)`
+  border-radius: 0;
+`
+
+const StyledGrid = styled.div<Props>`
+  display: grid;
+  ${p => p.images.length === 4
+    ? css`
+      grid-template-rows: repeat(2, auto);
+      grid-template-columns: repeat(2, auto);`
+    : css`
+      grid-template-rows: repeat(1, auto);
+      grid-template-columns: repeat(${p.images.length}, auto);`
+  }
+  width: 100%;
+  height: 100%;
+
+  ${p => p.images.length === 4
+    ? css`
+      & > :nth-child(1) { border-radius: 10px 0 0 0 }
+      & > :nth-child(2) { border-radius: 0 10px 0 0 }
+      & > :nth-child(3) { border-radius: 0 0 0 10px }
+      & > :nth-child(4) { border-radius: 0 0 10px 0 }`
+    : css`
+      & > :first-child { border-radius: 10px 0 0 10px }
+      & > :last-child { border-radius: 0 10px 10px 0 }`
+  }
+  & > :only-child { border-radius: 10px }
+`
+
+export default function BackgroundImageTiles ({ images }: Props) {
+  images = images.slice(0, 4)
+  return (
+    <StyledGrid images={images}>
+        {images.map(image => <RectangularBackgroundImage key={image.wallpaperImageUrl} selected={false} image={image.wallpaperImageUrl}/>)}
+    </StyledGrid>)
+}

--- a/components/brave_new_tab_ui/containers/newTab/settings/backgroundImageTiles.tsx
+++ b/components/brave_new_tab_ui/containers/newTab/settings/backgroundImageTiles.tsx
@@ -1,5 +1,4 @@
-
-// Copyright (c) 2020 The Brave Authors. All rights reserved.
+// Copyright (c) 2022 The Brave Authors. All rights reserved.
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this file,
 // you can obtain one at http://mozilla.org/MPL/2.0/.


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/26335

### Overview
<img width="464" alt="image" src="https://user-images.githubusercontent.com/5474642/199940495-4537bfb0-de84-4076-a111-184f569c8022.png">


### When has no image
<img width="222" alt="image" src="https://user-images.githubusercontent.com/5474642/199939078-90113a0b-4ed3-454e-a0a0-30a55e0ba9d6.png">

### When has 1 image
<img width="218" alt="image" src="https://user-images.githubusercontent.com/5474642/199939017-490c1f47-accd-43c3-965a-a7da0d635784.png">

### When has 2 images
<img width="216" alt="image" src="https://user-images.githubusercontent.com/5474642/199938318-e94cd6bb-c985-46fb-8f39-6f425131a50a.png">

### When has 3 images
<img width="235" alt="image" src="https://user-images.githubusercontent.com/5474642/199939587-a7ea5cff-797c-4f38-8445-79591b7e8e54.png">

### When has 4 >= images

<img width="219" alt="image" src="https://user-images.githubusercontent.com/5474642/199938586-f1b6e886-4c69-46d2-b9f5-ea126706f0fd.png">


## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
### Manual
* When there's no custom background, the upload icon should be visible.
* Otherwise, at most 4 uploaded backgrounds should be visible on the button.


