### PR TITLE
Archive native symbols to 7z.

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -379,6 +379,12 @@ create_dist_template("create_native_symbols_dist") {
   deps = [ "app/$current_os:symbol_dist_resources" ]
 }
 
+create_dist_template("create_native_symbols_dist_7z") {
+  output = "$brave_dist_dir/$brave_product_name-v$brave_version-$brave_platform-$target_arch-native-symbols.7z"
+  dir_inputs = [ "$brave_product_name.pdb.syms" ]
+  deps = [ "app/$current_os:symbol_dist_resources" ]
+}
+
 create_dist_template("create_symbols_dist") {
   if (is_android) {
     output = "$brave_dist_dir/$brave_product_name-v$brave_version-$brave_platform-$target_android_base-$target_cpu-symbols-$target_android_output_format.zip"
@@ -388,7 +394,10 @@ create_dist_template("create_symbols_dist") {
 
   deps = [ "app/$current_os:symbol_dist_resources" ]
   if (brave_debug_symbol_level == 2 && is_win) {
-    deps += [ ":create_native_symbols_dist" ]
+    deps += [
+      ":create_native_symbols_dist",
+      ":create_native_symbols_dist_7z",
+    ]
   }
 
   dir_inputs = [ "$brave_product_name.breakpad.syms" ]

--- a/script/create-dist.py
+++ b/script/create-dist.py
@@ -2,11 +2,9 @@
 
 import optparse
 import sys
-import glob
 import os
-import shutil
 import gn_helpers
-from lib.util import scoped_cwd, make_zip
+from lib.util import scoped_cwd, make_zip, make_7z
 
 
 sys.path.append(os.path.join(os.path.dirname(__file__),
@@ -41,7 +39,12 @@ def main():
     base_dir = options.base_dir
 
     with scoped_cwd(base_dir):
-        make_zip(output, inputs, dir_inputs)
+        if output.endswith('.zip'):
+            make_zip(output, inputs, dir_inputs)
+        elif output.endswith('.7z'):
+            make_7z(output, inputs, dir_inputs)
+        else:
+            assert False, "Invalid archive type: " + output
 
 
 if __name__ == '__main__':

--- a/script/lib/util.py
+++ b/script/lib/util.py
@@ -164,7 +164,7 @@ def make_zip(zip_file_path, files, dirs):
 def make_7z(archive_file_path, files, dirs):
     safe_unlink(archive_file_path)
     files += dirs
-    execute([get_lzma_exec(), 'a', '-t7z', archive_file_path] + files)
+    execute([get_lzma_exec(), 'a', '-t7z', '-mx7', archive_file_path] + files)
 
 
 def rm_rf(path):

--- a/script/repack-archive.py
+++ b/script/repack-archive.py
@@ -4,21 +4,7 @@ import argparse
 import sys
 import os
 import subprocess
-from lib.util import scoped_cwd, make_zip, tempdir
-
-
-def GetLZMAExec():
-    root_src_dir = os.path.abspath(os.path.join(
-        os.path.dirname(__file__), *[os.pardir] * 2))
-    if sys.platform == 'win32':
-        lzma_exec = os.path.join(root_src_dir, "third_party",
-                                 "lzma_sdk", "bin", "win64", "7za.exe")
-    elif sys.platform == 'darwin':
-        lzma_exec = os.path.join(root_src_dir, "..", "..", "third_party",
-                                 "lzma_sdk", "bin", "mac64", "7zz")
-    else:
-        lzma_exec = '7zr'  # Use system 7zr.
-    return lzma_exec
+from lib.util import scoped_cwd, make_zip, tempdir, get_lzma_exec
 
 
 def main():
@@ -31,8 +17,7 @@ def main():
     args = parser.parse_args()
 
     temp_dir = tempdir('brave_archive')
-    lzma_exec = GetLZMAExec()
-    cmd = [lzma_exec, 'x', args.input, '-y', '-o' + temp_dir]
+    cmd = [get_lzma_exec(), 'x', args.input, '-y', '-o' + temp_dir]
     subprocess.check_call(cmd, stdout=subprocess.PIPE, shell=False)
     with scoped_cwd(os.path.join(temp_dir, args.target_dir)):
         make_zip(args.output, [], ['.'])


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
After landing https://github.com/brave/brave-core/pull/15780 we can decrease the native symbols archive even more by migrating it to 7z. Which will allow us to publish those symbols directly to GitHub along with other files.

This PR will add 7z archive and will keep zip for now, so we can migrate our build jobs.

![image](https://user-images.githubusercontent.com/5928869/199976983-8e659da7-c7c2-4de0-b4e0-9af7995cf4f7.png)


Resolves https://github.com/brave/brave-browser/issues/26541

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

