### PR TITLE
Add settings option to enable/disable brave translate

### DIFF
--- a/android/java/org/chromium/chrome/browser/language/settings/BraveLanguageSettings.java
+++ b/android/java/org/chromium/chrome/browser/language/settings/BraveLanguageSettings.java
@@ -9,8 +9,16 @@ import android.os.Bundle;
 
 import androidx.preference.PreferenceCategory;
 
+import org.chromium.chrome.R;
+import org.chromium.chrome.browser.BraveRelaunchUtils;
+import org.chromium.chrome.browser.preferences.BravePref;
+import org.chromium.chrome.browser.profiles.Profile;
+import org.chromium.components.browser_ui.settings.ChromeSwitchPreference;
+import org.chromium.components.user_prefs.UserPrefs;
+
 public class BraveLanguageSettings extends LanguageSettings {
     static final String TRANSLATION_SETTINGS_SECTION = "translation_settings_section";
+    static final String APP_LANGUAGE_SECTION = "app_language_section";
 
     @Override
     public void onCreatePreferences(Bundle savedInstanceState, String rootKey) {
@@ -20,6 +28,29 @@ public class BraveLanguageSettings extends LanguageSettings {
                 (PreferenceCategory) findPreference(TRANSLATION_SETTINGS_SECTION);
         if (translateSwitch != null) {
             getPreferenceScreen().removePreference(translateSwitch);
+        }
+
+        PreferenceCategory appLanguageSection =
+                (PreferenceCategory) findPreference(APP_LANGUAGE_SECTION);
+        if (appLanguageSection != null) {
+            boolean isBraveTranslateEnabled =
+                    UserPrefs.get(Profile.getLastUsedRegularProfile())
+                            .getBoolean(BravePref.OFFER_TRANSLATE_ENABLED);
+            ChromeSwitchPreference braveTranslateFeaturePreference =
+                    new ChromeSwitchPreference(getContext());
+            braveTranslateFeaturePreference.setTitle(
+                    getResources().getString(R.string.use_brave_translate));
+            braveTranslateFeaturePreference.setChecked(isBraveTranslateEnabled);
+            braveTranslateFeaturePreference.setOnPreferenceChangeListener(
+                    (preference, newValue) -> {
+                        UserPrefs.get(Profile.getLastUsedRegularProfile())
+                                .setBoolean(BravePref.OFFER_TRANSLATE_ENABLED, (boolean) newValue);
+                        if (getActivity() != null) {
+                            BraveRelaunchUtils.askForRelaunch(getActivity());
+                        }
+                        return true;
+                    });
+            appLanguageSection.addPreference(braveTranslateFeaturePreference);
         }
     }
 }

--- a/browser/android/preferences/BUILD.gn
+++ b/browser/android/preferences/BUILD.gn
@@ -41,6 +41,7 @@ java_cpp_strings("java_pref_names_srcjar") {
     "//brave/components/constants/pref_names.cc",
     "//brave/components/ntp_background_images/common/pref_names.cc",
     "//brave/components/omnibox/browser/brave_omnibox_prefs.cc",
+    "//components/translate/core/browser/translate_pref_names.cc",
   ]
 
   template =

--- a/browser/ui/android/strings/android_brave_strings.grd
+++ b/browser/ui/android/strings/android_brave_strings.grd
@@ -3237,6 +3237,9 @@ If you don't accept this request, VPN will not reconnect and your internet conne
     <message name="IDS_BRAVE_QUICK_ACTION_SEARCH" desc="Description for Brave QuickActionSearchAndBookmarkWidget preview">
       Brave quick action search
     </message>
+    <message name="IDS_USE_BRAVE_TRANSLATE" desc="The label of the check-box that enables the prompt to translate a page.">
+      Use Brave Translate
+    </message>
   </messages>
   </release>
 </grit>


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/26154

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

By default brave translate toast would be enable to translate the page.
We have a new setting flag `Use Brave Translate` similar to desktop under `Settings->Language`.
1. Disable `Use Brave Translate` from  `Settings->Language`
2. visit `https://fr.wikipedia.org/wiki/Wikip%C3%A9dia:Accueil_principal` 
3. Toast for Brave translate shouldn't appear. 
