### PR TITLE
Don't take vertical tab strip into account when calculating the min window size

### DIFF
--- a/browser/ui/views/tabs/vertical_tab_strip_browsertest.cc
+++ b/browser/ui/views/tabs/vertical_tab_strip_browsertest.cc
@@ -191,7 +191,7 @@ IN_PROC_BROWSER_TEST_F(VerticalTabStripBrowserTest, MinHeight) {
   brave::ToggleVerticalTabStrip(browser());
   browser_non_client_frame_view()->Layout();
 
-  // TabStripRegionView's mih height shouldn't affect that of browser window.
+  // TabStripRegionView's min height shouldn't affect that of browser window.
   const auto min_size = browser_view()->GetMinimumSize();
   auto* layout = browser_view()->tab_strip_region_view()->SetLayoutManager(
       std::make_unique<TallLayoutManager>());

--- a/chromium_src/chrome/browser/ui/views/frame/browser_view_layout.cc
+++ b/chromium_src/chrome/browser/ui/views/frame/browser_view_layout.cc
@@ -6,10 +6,18 @@
 #include "chrome/browser/ui/views/frame/browser_view_layout.h"
 
 #include "brave/browser/ui/views/side_panel/brave_side_panel.h"
+#include "chrome/browser/ui/browser.h"
 #include "chrome/browser/ui/views/frame/browser_view.h"
+#include "chrome/browser/ui/views/frame/browser_view_layout_delegate.h"
 #include "chrome/browser/ui/views/side_panel/side_panel.h"
 #include "chrome/browser/ui/views/side_search/side_search_browser_controller.h"
+
+// Double check if the tab strip is actually visible to calculate constraints.
+#define SupportsWindowFeature(FEATURE)                                       \
+  SupportsWindowFeature(FEATURE) && (FEATURE != Browser::FEATURE_TABSTRIP || \
+                                     delegate_->IsTabStripVisible());
 
 #define SidePanel BraveSidePanel
 #include "src/chrome/browser/ui/views/frame/browser_view_layout.cc"
 #undef SidePanel
+#undef SupportsWindowFeature

--- a/chromium_src/chrome/browser/ui/views/frame/tab_strip_region_view.h
+++ b/chromium_src/chrome/browser/ui/views/frame/tab_strip_region_view.h
@@ -6,9 +6,10 @@
 #ifndef BRAVE_CHROMIUM_SRC_CHROME_BROWSER_UI_VIEWS_FRAME_TAB_STRIP_REGION_VIEW_H_
 #define BRAVE_CHROMIUM_SRC_CHROME_BROWSER_UI_VIEWS_FRAME_TAB_STRIP_REGION_VIEW_H_
 
-#define FrameColorsChanged                 \
-  UnUsed_FrameColorsChanged() {}           \
-  friend class VerticalTabStripRegionView; \
+#define FrameColorsChanged                                          \
+  UnUsed_FrameColorsChanged() {}                                    \
+  friend class VerticalTabStripRegionView;                          \
+  FRIEND_TEST_ALL_PREFIXES(VerticalTabStripBrowserTest, MinHeight); \
   void FrameColorsChanged
 #include "src/chrome/browser/ui/views/frame/tab_strip_region_view.h"
 #undef FrameColorsChanged


### PR DESCRIPTION
This is a trial to fix a bug, where window grows too tall and becomes unresizable.

The exact steps to reproduce was not found, but it seems somehow the min height is set to window. As min size could be cached internally, this could have happen when the min size isn't flushed.

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/26577

## Submitter Checklist:

- [ ] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

