### PR TITLE
Adds extra validations on a wallet sign message screen on Android (uplift to 1.46.x)

### DIFF
--- a/android/java/org/chromium/chrome/browser/crypto_wallet/fragments/dapps/DAppsMessageFragment.java
+++ b/android/java/org/chromium/chrome/browser/crypto_wallet/fragments/dapps/DAppsMessageFragment.java
@@ -15,9 +15,11 @@ import android.widget.TextView;
 import org.chromium.brave_wallet.mojom.SignMessageRequest;
 import org.chromium.chrome.R;
 import org.chromium.chrome.browser.crypto_wallet.util.Utils;
+import org.chromium.chrome.browser.crypto_wallet.util.Validations;
 
 public class DAppsMessageFragment extends BaseDAppsFragment {
     private SignMessageRequest mCurrentSignMessageRequest;
+    private boolean mUnicodeEscapeVersion;
 
     public DAppsMessageFragment(SignMessageRequest currentSignMessageRequest) {
         mCurrentSignMessageRequest = currentSignMessageRequest;
@@ -30,6 +32,23 @@ public class DAppsMessageFragment extends BaseDAppsFragment {
         View view = inflater.inflate(R.layout.fragment_dapps_message, container, false);
         TextView signMessageText = view.findViewById(R.id.sign_message_text);
         signMessageText.setText(mCurrentSignMessageRequest.message);
+        mUnicodeEscapeVersion = false;
+        if (Validations.hasUnicode(mCurrentSignMessageRequest.message)) {
+            view.findViewById(R.id.non_ascii_warning_layout).setVisibility(View.VISIBLE);
+            TextView warningLinkText = view.findViewById(R.id.non_ascii_warning_text_link);
+            warningLinkText.setOnClickListener(v -> {
+                if (!mUnicodeEscapeVersion) {
+                    warningLinkText.setText(getString(R.string.wallet_non_ascii_characters_ascii));
+                    signMessageText.setText(
+                            Validations.unicodeEscape(mCurrentSignMessageRequest.message));
+                } else {
+                    warningLinkText.setText(
+                            getString(R.string.wallet_non_ascii_characters_original));
+                    signMessageText.setText(mCurrentSignMessageRequest.message);
+                }
+                mUnicodeEscapeVersion = !mUnicodeEscapeVersion;
+            });
+        }
 
         return view;
     }

--- a/android/java/org/chromium/chrome/browser/crypto_wallet/util/Validations.java
+++ b/android/java/org/chromium/chrome/browser/crypto_wallet/util/Validations.java
@@ -141,4 +141,32 @@ public class Validations {
             }
         }
     }
+
+    public static boolean hasUnicode(String str) {
+        for (int i = 0; i < str.length(); i++) {
+            if (str.codePointAt(i) > 127) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    public static String unicodeEscape(String str) {
+        String res = "";
+
+        for (int i = 0; i < str.length(); i++) {
+            if (str.codePointAt(i) > 127) {
+                String hexStr = Integer.toHexString(str.codePointAt(i));
+                while (hexStr.length() < 4) {
+                    hexStr = "0" + hexStr;
+                }
+                res += "\\u" + hexStr;
+            } else {
+                res += str.charAt(i);
+            }
+        }
+
+        return res;
+    }
 }

--- a/android/java/res/layout/fragment_dapps_message.xml
+++ b/android/java/res/layout/fragment_dapps_message.xml
@@ -7,6 +7,39 @@
     android:background="@color/wallet_bg"
     tools:context=".browser.crypto_wallet.fragments.dapps.DAppsMessageFragment">
 
+    <LinearLayout
+        android:id="@+id/non_ascii_warning_layout"
+        android:background="@drawable/wallet_top_banner_bg"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        android:visibility="gone"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent">
+
+        <TextView
+            android:layout_weight="1"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_margin="8dp"
+            android:textSize="16sp"
+            android:textColor="@color/wallet_error_text_color"
+            android:drawablePadding="2dp"
+            app:drawableStartCompat="@drawable/ic_warning"
+            android:text="@string/wallet_non_ascii_characters"/>
+
+        <TextView
+            android:id="@+id/non_ascii_warning_text_link"
+            android:layout_weight="1"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_margin="8dp"
+            android:textSize="16sp"
+            android:textColor="@color/brave_link"
+            android:text="@string/wallet_non_ascii_characters_original"/>
+
+    </LinearLayout>
+
     <EditText
         android:id="@+id/sign_message_text"
         style="@style/BraveWalletEditTextBordered"
@@ -20,7 +53,10 @@
         android:longClickable="false"
         android:importantForAutofill="no"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/non_ascii_warning_layout"
+        android:lines="12"
+        android:scrollbars="vertical"
+        android:fadeScrollbars="false"
         tools:ignore="LabelFor" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/android/javatests/org/chromium/chrome/browser/brave_wallet/BraveWalletUtilsTest.java
+++ b/android/javatests/org/chromium/chrome/browser/brave_wallet/BraveWalletUtilsTest.java
@@ -6,7 +6,9 @@
 package org.chromium.chrome.browser.brave_wallet;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 import androidx.test.filters.SmallTest;
@@ -26,6 +28,7 @@ import org.chromium.brave_wallet.mojom.SwapParams;
 import org.chromium.brave_wallet.mojom.TxData;
 import org.chromium.brave_wallet.mojom.TxData1559;
 import org.chromium.chrome.browser.crypto_wallet.util.Utils;
+import org.chromium.chrome.browser.crypto_wallet.util.Validations;
 import org.chromium.chrome.test.ChromeJUnit4ClassRunner;
 import org.chromium.url.mojom.Url;
 
@@ -611,5 +614,20 @@ public class BraveWalletUtilsTest {
                     + "but only after all places where it's created are fixed.\n";
             fail(message + "\n" + getStackTrace(exc));
         }
+    }
+
+    @Test
+    @SmallTest
+    public void validateHasUnicode() {
+        assertTrue(Validations.hasUnicode("Sign into \u202e EVIL"));
+        assertFalse(Validations.hasUnicode("Sign into LIVE"));
+    }
+
+    @Test
+    @SmallTest
+    public void validateUnicodeEscape() {
+        assertEquals(Validations.unicodeEscape("Sign into \u202e EVIL"), "Sign into \\u202e EVIL");
+        assertEquals(Validations.unicodeEscape("Sign into \u00ff EVIL"), "Sign into \\u00ff EVIL");
+        assertEquals(Validations.unicodeEscape("Sign into \u012e EVIL"), "Sign into \\u012e EVIL");
     }
 }

--- a/browser/ui/android/strings/android_brave_strings.grd
+++ b/browser/ui/android/strings/android_brave_strings.grd
@@ -3207,6 +3207,15 @@ If you don't accept this request, VPN will not reconnect and your internet conne
     <message name="IDS_BRAVE_WALLET_SOLANA_SKIP_PREFLIGHT" desc="Name of Solana instruction 'programID' param">
       Skip Preflight:
     </message>
+    <message name="IDS_WALLET_NON_ASCII_CHARACTERS" desc="A warning about Non-ASCII characters detected in a message">
+      NON-ASCII characters detected!
+    </message>
+    <message name="IDS_WALLET_NON_ASCII_CHARACTERS_ORIGINAL" desc="A title to view an original message if Unicode characters detected">
+      View original message
+    </message>
+    <message name="IDS_WALLET_NON_ASCII_CHARACTERS_ASCII" desc="A title to view an ASCII message if Unicode characters detected">
+      View message in ASCII encoding
+    </message>
   </messages>
   </release>
 </grit>


### PR DESCRIPTION
Uplift of https://github.com/brave/brave-core/pull/15806
Resolves https://github.com/brave/brave-browser/issues/26372