### PR TITLE
Set the Rewards enabled pref to true if AC or Ads are enabled (uplift to 1.45.x)

### DIFF
--- a/components/brave_rewards/browser/rewards_service_impl.cc
+++ b/components/brave_rewards/browser/rewards_service_impl.cc
@@ -452,6 +452,12 @@ void RewardsServiceImpl::CheckPreferences() {
 
   if (is_ac_enabled || is_ads_enabled) {
     StartLedgerProcessIfNecessary();
+
+    // If the user has enabled Ads or AC, but the "enabled" pref is missing, set
+    // the "enabled" pref to true.
+    if (!profile_->GetPrefs()->GetUserPrefValue(prefs::kEnabled)) {
+      profile_->GetPrefs()->SetBoolean(prefs::kEnabled, true);
+    }
   }
 }
 


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Uplift of #15161 (partial)
Resolves https://github.com/brave/brave-browser/issues/26484

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [ ] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [ ] The associated issue milestone is set to the smallest version that the changes is landed on.

## Test Steps

- Start browser with a clean profile and enable Rewards.
- Close browser.
- Open the `Preferences` file in a text editor.
- Find the "enabled" property (under "brave" and "rewards"), and delete it.
- Start the browser and visit the Rewards page.
- Verify that the Rewards page is displayed correctly.
