### PR TITLE
Fixed sidebar's horizontal alignment is not properly set at startup

### DIFF
--- a/browser/ui/views/frame/brave_browser_view.cc
+++ b/browser/ui/views/frame/brave_browser_view.cc
@@ -211,7 +211,6 @@ BraveBrowserView::BraveBrowserView(std::unique_ptr<Browser> browser)
         prefs::kSidePanelHorizontalAlignment,
         base::BindRepeating(&BraveBrowserView::OnPreferenceChanged,
                             base::Unretained(this)));
-    UpdateSideBarHorizontalAlignment();
   }
 }
 
@@ -266,6 +265,7 @@ sidebar::Sidebar* BraveBrowserView::InitSidebar() {
   // Start Sidebar UI initialization.
   DCHECK(sidebar_container_view_);
   sidebar_container_view_->Init();
+  UpdateSideBarHorizontalAlignment();
   return sidebar_container_view_;
 }
 

--- a/browser/ui/views/sidebar/sidebar_container_view.cc
+++ b/browser/ui/views/sidebar/sidebar_container_view.cc
@@ -125,17 +125,15 @@ void SidebarContainerView::Init() {
   // Hide by default. Visibility will be controlled by show options later.
   DoHideSidebar(false);
   UpdateToolbarButtonVisibility();
-  SetSidebarOnLeft(sidebar_on_left_);
 }
 
 void SidebarContainerView::SetSidebarOnLeft(bool sidebar_on_left) {
+  DCHECK(initialized_);
+
   if (sidebar_on_left_ == sidebar_on_left)
     return;
 
   sidebar_on_left_ = sidebar_on_left;
-
-  if (!initialized_)
-    return;
 
   DCHECK(sidebar_control_view_);
   sidebar_control_view_->SetSidebarOnLeft(sidebar_on_left_);


### PR DESCRIPTION
fix https://github.com/brave/brave-browser/issues/26605
fix https://github.com/brave/brave-browser/issues/26612

Set horizontal alignment when sidebar initialization is completed.

When SidebarContainerView::SetSidebarOnLeft() is called
before sidebar is initialized, it just update |sidebar_on_left_|
and it's not propagated to children because they're not yet initialized.
After initialized, it was called but it's early returned
because |sidebar_on_left_| was set already. This bug came frome here.

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves 

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

Manual test - Please refer the linked issue
`npm run test brave_browser_tests -- --filter=SidebarBrowserTest*`