### PR TITLE
Fixed sidebar's horizontal alignment is not properly set at startup (uplift to 1.46.x)

### DIFF
--- a/browser/ui/views/frame/brave_browser_view.cc
+++ b/browser/ui/views/frame/brave_browser_view.cc
@@ -211,7 +211,6 @@ BraveBrowserView::BraveBrowserView(std::unique_ptr<Browser> browser)
         prefs::kSidePanelHorizontalAlignment,
         base::BindRepeating(&BraveBrowserView::OnPreferenceChanged,
                             base::Unretained(this)));
-    UpdateSideBarHorizontalAlignment();
   }
 }
 
@@ -266,6 +265,7 @@ sidebar::Sidebar* BraveBrowserView::InitSidebar() {
   // Start Sidebar UI initialization.
   DCHECK(sidebar_container_view_);
   sidebar_container_view_->Init();
+  UpdateSideBarHorizontalAlignment();
   return sidebar_container_view_;
 }
 

--- a/browser/ui/views/sidebar/sidebar_container_view.cc
+++ b/browser/ui/views/sidebar/sidebar_container_view.cc
@@ -125,17 +125,15 @@ void SidebarContainerView::Init() {
   // Hide by default. Visibility will be controlled by show options later.
   DoHideSidebar(false);
   UpdateToolbarButtonVisibility();
-  SetSidebarOnLeft(sidebar_on_left_);
 }
 
 void SidebarContainerView::SetSidebarOnLeft(bool sidebar_on_left) {
+  DCHECK(initialized_);
+
   if (sidebar_on_left_ == sidebar_on_left)
     return;
 
   sidebar_on_left_ = sidebar_on_left;
-
-  if (!initialized_)
-    return;
 
   DCHECK(sidebar_control_view_);
   sidebar_control_view_->SetSidebarOnLeft(sidebar_on_left_);


### PR DESCRIPTION
Uplift of #15839 
Resolves https://github.com/brave/brave-browser/issues/26605
Resolves https://github.com/brave/brave-browser/issues/26612

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.