### PR TITLE
Support IPNS for redirect gateway resources feature

### DIFF
--- a/browser/ipfs/ipfs_tab_helper.h
+++ b/browser/ipfs/ipfs_tab_helper.h
@@ -93,7 +93,16 @@ class IPFSTabHelper : public content::WebContentsObserver,
   FRIEND_TEST_ALL_PREFIXES(
       IpfsTabHelperUnitTest,
       GatewayLikeUrlParsed_AutoRedirectDisabled_WithDnsLink);
-
+  FRIEND_TEST_ALL_PREFIXES(IpfsTabHelperUnitTest, GatewayIPNS_Redirect);
+  FRIEND_TEST_ALL_PREFIXES(IpfsTabHelperUnitTest,
+                           GatewayIPNS_NoRedirect_WhenNoDnsLinkRecord);
+  FRIEND_TEST_ALL_PREFIXES(IpfsTabHelperUnitTest, GatewayIPNS_ResolveUrl);
+  FRIEND_TEST_ALL_PREFIXES(IpfsTabHelperUnitTest,
+                           GatewayIPNS_Redirect_LibP2PKey);
+  FRIEND_TEST_ALL_PREFIXES(IpfsTabHelperUnitTest,
+                           GatewayIPNS_Redirect_LibP2PKey_NoAutoRedirect);
+  FRIEND_TEST_ALL_PREFIXES(IpfsTabHelperUnitTest,
+                           GatewayIPNS_No_Redirect_WhenNoDnsLink);
   friend class content::WebContentsUserData<IPFSTabHelper>;
   explicit IPFSTabHelper(content::WebContents* web_contents);
 
@@ -102,7 +111,7 @@ class IPFSTabHelper : public content::WebContentsObserver,
   bool IsDNSLinkCheckEnabled() const;
   bool IsAutoRedirectIPFSResourcesEnabled() const;
   void IPFSResourceLinkResolved(const GURL& ipfs);
-  void DNSLinkResolved(const GURL& ipfs);
+  void DNSLinkResolved(const GURL& ipfs, bool is_gateway_url);
   void MaybeCheckDNSLinkRecord(const net::HttpResponseHeaders* headers);
   void UpdateDnsLinkButtonState();
   absl::optional<GURL> ResolveIPFSUrlFromGatewayLikeUrl(const GURL& gurl);
@@ -117,8 +126,13 @@ class IPFSTabHelper : public content::WebContentsObserver,
       content::NavigationHandle* navigation_handle) override;
   void UpdateLocationBar();
 
-  void CheckDNSLinkRecord(absl::optional<std::string> x_ipfs_path_header);
-  void HostResolvedCallback(absl::optional<std::string> x_ipfs_path_header,
+  void CheckDNSLinkRecord(const GURL& gurl,
+                          bool is_gateway_url,
+                          absl::optional<std::string> x_ipfs_path_header);
+  void HostResolvedCallback(const GURL& current,
+                            const GURL& url,
+                            bool is_gateway_url,
+                            absl::optional<std::string> x_ipfs_path_header,
                             const std::string& host,
                             const absl::optional<std::string>& dnslink);
 

--- a/components/ipfs/ipfs_utils.h
+++ b/components/ipfs/ipfs_utils.h
@@ -20,6 +20,7 @@ bool IsIpfsDisabledByFeatureOrPolicy(PrefService* prefs);
 bool IsIpfsMenuEnabled(PrefService* prefs);
 bool IsIpfsDisabledByPolicy(PrefService* prefs);
 bool IsValidCID(const std::string& cid);
+bool IsValidIPNSCID(const std::string& cid);
 bool HasIPFSPath(const GURL& url);
 bool IsDefaultGatewayURL(const GURL& url, PrefService* prefs);
 bool IsLocalGatewayURL(const GURL& url);
@@ -67,7 +68,8 @@ bool IsIpfsResolveMethodDisabled(PrefService* prefs);
 bool IsIpfsResolveMethodAsk(PrefService* prefs);
 std::string GetRegistryDomainFromIPNS(const GURL& url);
 bool IsValidCIDOrDomain(const std::string& value);
-absl::optional<GURL> TranslateToCurrentGatewayUrl(const GURL& url);
+std::string DecodeSingleLabelForm(const std::string& input);
+absl::optional<GURL> ExtractSourceFromGateway(const GURL& url);
 
 }  // namespace ipfs
 


### PR DESCRIPTION
Resolves https://github.com/brave/brave-browser/issues/26485

Supports IPNS for the redirect gateway resources feature.
Redirects \*.ipns.ipfs.io or ipfs.io/ipns/*  to the configured gateway.
\* may be libp2p key (k2k4r8k4oiuzuccssu5jj27hrth43yqoq55wvm46e7ygqokvlz4ixmfn) or url\single-labeled url.
If * is not libp2p key then at first we check dnslink for such url like we do for the redirect dnslink feature.

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
1) Test that "Redirect IPFS resources to the configured IPFS gateway" feature works correctly for /ipfs/ urls.
2) Check that ipns gateway urls also works correctly. ex: 

      en-wikipedia--on--ipfs-org.ipns.ipfs.io/wiki/Wood/
      ipfs.io/ipns/en-wikipedia--on--ipfs-org/wiki/Wood/
      ipfs.io/ipns/en.wikipedia-on-ipfs.org/wiki/Wood/
      ipfs.io/ipns/k2k4r8k4oiuzuccssu5jj27hrth43yqoq55wvm46e7ygqokvlz4ixmfn
      k2k4r8k4oiuzuccssu5jj27hrth43yqoq55wvm46e7ygqokvlz4ixmfn.ipns.ipfs.io
      
      This urls should be redirected to the configured gateway when the feature is enabled
      Otherwise redirect button should be shown in the addressbar
      
      Also gateway ipns urls without dnslink should not be redirected:
      blablabla.ipns.ipfs.io should end in error page
3) Check that dnslink redirect feature is working correctly: https://en.wikipedia-on-ipfs.org/wiki/Wood/  redirects to ipns://en.wikipedia-on-ipfs.org/wiki/Wood/ if the feature is enabled or redirect button is shown in the addressbar

Also there is a scheme that is also can be used for testing 
https://github.com/ipfs/ipfs-docs/blob/feat/how-to-implement-support-in-a-web-browser.md/docs/how-to/detect-ipfs-on-web.md