### PR TITLE
Brave News feed fixes

### DIFF
--- a/browser/ui/webui/brave_webui_source.cc
+++ b/browser/ui/webui/brave_webui_source.cc
@@ -226,6 +226,12 @@ void CustomizeWebUIHTMLSource(content::WebUI* web_ui,
         { "braveNewsSearchQueryTooShort", IDS_BRAVE_NEWS_SEARCH_QUERY_TOO_SHORT},  // NOLINT
         { "braveNewsSuggestionsTitle", IDS_BRAVE_NEWS_SUGGESTIONS_TITLE},
         { "braveNewsSuggestionsSubtitle", IDS_BRAVE_NEWS_SUGGESTIONS_SUBTITLE},
+        { "braveNewsErrorHeading", IDS_BRAVE_NEWS_ERROR_HEADING},
+        { "braveNewsErrorMessage", IDS_BRAVE_NEWS_ERROR_MESSAGE},
+        { "braveNewsErrorActionLabel", IDS_BRAVE_NEWS_ERROR_ACTION_LABEL},
+        { "braveNewsNoContentHeading", IDS_BRAVE_NEWS_NO_CONTENT_HEADING},
+        { "braveNewsNoContentMessage", IDS_BRAVE_NEWS_NO_CONTENT_MESSAGE},
+        { "braveNewsNoContentActionLabel", IDS_BRAVE_NEWS_NO_CONTENT_ACTION_LABEL},  // NOLINT
         // Brave News Channels
         { "braveNewsChannel-Brave", IDS_BRAVE_NEWS_CHANNEL_BRAVE},
         { "braveNewsChannel-Business", IDS_BRAVE_NEWS_CHANNEL_BUSINESS},

--- a/components/brave_new_tab_ui/async/today.ts
+++ b/components/brave_new_tab_ui/async/today.ts
@@ -130,7 +130,9 @@ handler.on<Actions.SetPublisherPrefPayload>(Actions.setPublisherPref.getType(), 
 
 handler.on(Actions.checkForUpdate.getType(), async function (store) {
   const state = store.getState() as ApplicationState
-  if (!state.today.feed || !state.today.feed.hash) {
+  // Detect if we did not get any data successfully and therefore we can try again
+  // to fetch data
+  if (!state.today.feed) {
     store.dispatch(Actions.isUpdateAvailable({ isUpdateAvailable: true }))
     return
   }

--- a/components/brave_new_tab_ui/components/default/braveToday/cards/cardError.tsx
+++ b/components/brave_new_tab_ui/components/default/braveToday/cards/cardError.tsx
@@ -5,6 +5,8 @@
 
 import * as React from 'react'
 import styled from 'styled-components'
+import Button from '$web-components/button'
+import { getLocale } from '../../../../../common/locale'
 import * as Card from '../cardIntro'
 
 const Content = styled('div')`
@@ -25,6 +27,10 @@ const Graphic = styled('div')`
   height: 46px;
 `
 
+const Action = styled('div')`
+  padding-top: 20px;
+`
+
 function Icon () {
   return (
     <svg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 64 46'>
@@ -38,7 +44,13 @@ function Icon () {
   )
 }
 
-export default function CardError () {
+interface MessageProps {
+  heading: string
+  message: string
+  actionLabel?: string
+  onActionClick?: () => unknown
+}
+export function UnidealMessageCard (props: MessageProps) {
   return (
     <Card.Intro>
       <Content>
@@ -46,12 +58,33 @@ export default function CardError () {
           <Icon />
         </Graphic>
         <Heading>
-          Oops…
+          {props.heading}
         </Heading>
         <Card.Paragraph>
-          Brave News is experiencing some issues. Try again.
+          {props.message}
         </Card.Paragraph>
+        {!!props.actionLabel && !!props.onActionClick &&
+          <Action>
+            <Button isPrimary onClick={props.onActionClick}>
+              {props.actionLabel}
+            </Button>
+          </Action>
+        }
       </Content>
     </Card.Intro>
+  )
+}
+
+interface Props {
+  onRefresh: () => unknown
+}
+export default function CardError (props: Props) {
+  return (
+    <UnidealMessageCard
+      heading={getLocale('braveNewsErrorHeading')}
+      message={getLocale('braveNewsErrorMessage')}
+      actionLabel={getLocale('braveNewsErrorActionLabel')}
+      onActionClick={props.onRefresh}
+    />
   )
 }

--- a/components/brave_new_tab_ui/components/default/braveToday/cards/cardNoContent.tsx
+++ b/components/brave_new_tab_ui/components/default/braveToday/cards/cardNoContent.tsx
@@ -1,0 +1,23 @@
+// Copyright (c) 2022 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// you can obtain one at http://mozilla.org/MPL/2.0/.
+
+import * as React from 'react'
+import { getLocale } from '../../../../../common/locale'
+import { UnidealMessageCard } from './cardError'
+
+interface Props {
+  onCustomize: () => unknown
+}
+
+export default function CardNoContent (props: Props) {
+  return (
+    <UnidealMessageCard
+      heading={getLocale('braveNewsNoContentHeading')}
+      message={getLocale('braveNewsNoContentMessage')}
+      actionLabel={getLocale('braveNewsNoContentActionLabel')}
+      onActionClick={props.onCustomize}
+    />
+  )
+}

--- a/components/brave_new_tab_ui/components/default/braveToday/content.tsx
+++ b/components/brave_new_tab_ui/components/default/braveToday/content.tsx
@@ -9,6 +9,7 @@ import * as TodayActions from '../../../actions/today_actions'
 import { Feed } from '../../../api/brave_news'
 import CardLoading from './cards/cardLoading'
 import CardError from './cards/cardError'
+import CardNoContent from './cards/cardNoContent'
 import CardLarge from './cards/_articles/cardArticleLarge'
 import CardDisplayAd from './cards/displayAd'
 import CardsGroup from './cardsGroup'
@@ -152,7 +153,11 @@ export default function BraveTodayContent (props: Props) {
     intersectionObserver.current.observe(trigger)
   }, [intersectionObserver.current])
 
-  const hasContent = feed && publishers
+  // TODO(petemill): Only way to test for error state is if there are no
+  // publishers since GetFeed and GetPublishers will always eventually return
+  // empty objects. Consider having those mojom functions provide error states.
+  const hasContent = feed && publishers && !!Object.keys(publishers).length
+
   // Loading state
   if (props.isFetching && !hasContent) {
     return <CardLoading />
@@ -160,7 +165,7 @@ export default function BraveTodayContent (props: Props) {
 
   // Error state
   if (!hasContent) {
-    return <CardError />
+    return <CardError onRefresh={props.onRefresh} />
   }
 
   // satisfy typescript sanity, should not get here
@@ -172,9 +177,16 @@ export default function BraveTodayContent (props: Props) {
   const isOnlyDisplayingPeekingCard = !props.hasInteracted && props.isPrompting
   const displayedPageCount = Math.min(props.displayedPageCount, feed.pages.length)
   const introCount = feed.featuredItem ? 2 : 1
+  const showNoContentMessage = !props.isFetching &&
+    hasContent &&
+    !feed.featuredItem &&
+    feed.pages.length === 0
   let runningCardCount = introCount
   return (
     <>
+      {/* no feed content available */}
+      {showNoContentMessage &&
+      <CardNoContent onCustomize={props.onCustomizeBraveToday} />}
       {/* featured item */}
       {feed.featuredItem && <CardLarge
         content={[feed.featuredItem]}

--- a/components/brave_new_tab_ui/stories/today.tsx
+++ b/components/brave_new_tab_ui/stories/today.tsx
@@ -95,7 +95,7 @@ export const Loading = () => (
 )
 
 export const Error = () => (
-  <BraveTodayErrorCard />
+  <BraveTodayErrorCard onRefresh={() => console.log('refresh clicked')} />
 )
 
 const handleDisplayAdVisit = () => alert('handle visit')

--- a/components/brave_today/browser/feed_building.cc
+++ b/components/brave_today/browser/feed_building.cc
@@ -429,12 +429,22 @@ bool BuildFeed(const std::vector<mojom::FeedItemPtr>& feed_items,
       break;
     }
   }
+  if (featured_article_it == articles.end()) {
+    // If there was no matching "news" article,
+    // get the highest score article.
+    featured_article_it = articles.begin();
+    VLOG(1) << "Featured item was set to the highest ranked article";
+  }
+  // When we have no articles, do not set a featured item
   if (featured_article_it != articles.end()) {
     auto item = *std::make_move_iterator(featured_article_it);
     auto article = mojom::FeedItem::NewArticle(std::move(item));
     feed->featured_item = std::move(article);
     articles.erase(featured_article_it);
+  } else {
+    VLOG(1) << "No featured item was set as there are no articles";
   }
+
   // Generate as many pages of content as possible
   // Make the pages
   int cur_page = 0;

--- a/components/brave_today/browser/feed_building.cc
+++ b/components/brave_today/browser/feed_building.cc
@@ -331,6 +331,17 @@ bool BuildFeed(const std::vector<mojom::FeedItemPtr>& feed_items,
     if (history_hosts.find(metadata->url.host()) != history_hosts.end()) {
       metadata->score -= 5;
     }
+    if (base::FeatureList::IsEnabled(
+            brave_today::features::kBraveNewsV2Feature)) {
+      // Adjust score to consider an explicit follow of the source, vs a
+      // channel-based follow
+      if (publisher->user_enabled_status ==
+          brave_news::mojom::UserEnabled::ENABLED) {
+        VLOG(1) << "Found explicit enable, adding score for: "
+                << publisher->publisher_name;
+        metadata->score -= 10;
+      }
+    }
     // Get hash at this point since we have a flat list, and our algorithm
     // will only change sorting which can be re-applied on the next
     // feed update.
@@ -407,11 +418,14 @@ bool BuildFeed(const std::vector<mojom::FeedItemPtr>& feed_items,
               return (deal_category_counts.at(a) < deal_category_counts.at(b));
             });
   VLOG(1) << "Got deal categories # " << deal_category_names_by_priority.size();
+
   // Get first headline
   std::list<mojom::ArticlePtr>::iterator featured_article_it;
   for (featured_article_it = articles.begin();
        featured_article_it != articles.end(); featured_article_it++) {
+    // Get the highest score "news" article
     if (featured_article_it->get()->data->category_name == "Top News") {
+      VLOG(1) << "Featured item was set to a \"Top News\" article";
       break;
     }
   }

--- a/components/brave_today/browser/feed_controller.cc
+++ b/components/brave_today/browser/feed_controller.cc
@@ -142,6 +142,7 @@ void FeedController::EnsureFeedIsUpdating() {
               VLOG(1) << "All feed item fetches done with item count: "
                       << total_size;
               if (total_size == 0) {
+                controller->ResetFeed();
                 controller->NotifyUpdateDone();
                 return;
               }

--- a/components/resources/brave_news_strings.grdp
+++ b/components/resources/brave_news_strings.grdp
@@ -69,6 +69,24 @@
   <message name="IDS_BRAVE_NEWS_SUGGESTIONS_SUBTITLE" desc="Subtitle of the suggested sources section">
     Some sources you might like. Suggestions are anonymous and matched only on your device.
   </message>
+  <message name="IDS_BRAVE_NEWS_ERROR_HEADING" desc="Message heading for when there is a Brave News error">
+    Oops…
+  </message>
+  <message name="IDS_BRAVE_NEWS_ERROR_MESSAGE" desc="Message body for when there is a Brave News error">
+    Brave News was unable to fetch content.
+  </message>
+  <message name="IDS_BRAVE_NEWS_ERROR_ACTION_LABEL" desc="Message action label for when there is a Brave News error">
+    Try again
+  </message>
+  <message name="IDS_BRAVE_NEWS_NO_CONTENT_HEADING" desc="Message heading for when there is no Brave News content">
+    No content
+  </message>
+  <message name="IDS_BRAVE_NEWS_NO_CONTENT_MESSAGE" desc="Message body for when there is no Brave News content">
+    Brave News has no content to show.
+  </message>
+  <message name="IDS_BRAVE_NEWS_NO_CONTENT_ACTION_LABEL" desc="Message action label for when there is no Brave News content">
+    Choose content sources
+  </message>
 
   <message name="IDS_BRAVE_NEWS_CHANNEL_BRAVE" desc="Translation of the 'Brave' channel">
     Brave


### PR DESCRIPTION
- Fix https://github.com/brave/brave-browser/issues/26277
  - Always set a featured item, even if the user follows no news-categorised sources
  - Score sources explicitly followed higher than sources shown via a channel. This will be very subtle and only really affect the first item from a source since recency has an exponential growth in score.


- Fix https://github.com/brave/brave-browser/issues/26303
  - When a user unfollows all sources and channels, remove all content from the feed without requiring a browser restart. Still requires page / content refresh.
  - Show a new no-content-configured card
  - Fix the error-getting-content card
  - Add buttons to both error cards for refresh or customize, depending on the error

<img width="1350" alt="image" src="https://user-images.githubusercontent.com/741836/200757253-93067429-e301-4693-9e7b-9e0fc19b7fb6.png">


## Submitter Checklist:

- [ ] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
On issues
