### PR TITLE
Brave News Desktop Customize Toggle fixes

### DIFF
--- a/.storybook/locale.ts
+++ b/.storybook/locale.ts
@@ -319,12 +319,6 @@ let locale: Record<string, string> = {
   showTopSites: 'Show Top Sites',
   showRewards: 'Show Rewards',
   tosAndPp: 'By turning on {{title}}, you agree to the $1Terms of Service$2 and $3Privacy Policy$4.',
-  braveTodayDisableSourceCommand: 'Disable content from $1',
-  braveTodayIntroTitle: `Today's top stories in a completely private feed, just for you.`,
-  braveTodayIntroDescription: `Brave News is ad-supported with completely private and anonymized ads matched on your device. Your personal information always stays private, per our $1privacy policy$2.`,
-  braveTodayOptInActionLabel: 'Show Brave News',
-  braveTodayOptOutActionLabel: 'No thanks',
-  braveTodayScrollHint: 'Scroll for Brave News',
   editCardsTitle: 'Edit Cards'
 }
 

--- a/browser/ui/webui/brave_webui_source.cc
+++ b/browser/ui/webui/brave_webui_source.cc
@@ -189,11 +189,7 @@ void CustomizeWebUIHTMLSource(content::WebUI* web_ui,
         { "searchPromotionSearchBoxPlaceholderLabel", IDS_BRAVE_NEW_TAB_SEARCH_PROMOTION_SEARCH_BOX_PLACEHOLDER},  // NOLINT
 
         { "braveTodayTitle", IDS_BRAVE_TODAY_TITLE },
-        { "braveTodayIntroTitle", IDS_BRAVE_TODAY_INTRO_TITLE },
-        { "braveTodayIntroDescription", IDS_BRAVE_TODAY_INTRO_DESCRIPTION },
-        { "braveTodayOptInActionLabel", IDS_BRAVE_TODAY_OPT_IN_ACTION_LABEL },
         { "braveTodayShowToolbarButton", IDS_BRAVE_TODAY_SHOW_TOOLBAR_BUTTON },
-        { "braveTodayOptOutActionLabel", IDS_BRAVE_TODAY_OPT_OUT_ACTION_LABEL },
         { "braveTodayStatusFetching", IDS_BRAVE_TODAY_STATUS_FETCHING},
         { "braveTodayActionRefresh", IDS_BRAVE_TODAY_ACTION_REFRESH},
         { "braveTodayScrollHint", IDS_BRAVE_TODAY_SCROLL_HINT},
@@ -206,11 +202,13 @@ void CustomizeWebUIHTMLSource(content::WebUI* web_ui,
         { "promoted", IDS_BRAVE_TODAY_PROMOTED },
         { "ad", IDS_BRAVE_TODAY_DISPLAY_AD_LABEL },
 
+        { "braveNewsIntroTitle", IDS_BRAVE_NEWS_INTRO_TITLE },
+        { "braveNewsIntroDescription", IDS_BRAVE_NEWS_INTRO_DESCRIPTION },
+        { "braveNewsIntroDescriptionTwo", IDS_BRAVE_NEWS_INTRO_DESCRIPTION_TWO },
+        { "braveNewsOptInActionLabel", IDS_BRAVE_NEWS_OPT_IN_ACTION_LABEL },
+        { "braveNewsOptOutActionLabel", IDS_BRAVE_NEWS_OPT_OUT_ACTION_LABEL },
         { "braveNewsBackToDashboard", IDS_BRAVE_NEWS_BACK_TO_DASHBOARD },
         { "braveNewsBackButton", IDS_BRAVE_NEWS_BACK_BUTTON },
-        { "braveNewsDisabledPlaceholderHeader", IDS_BRAVE_NEWS_DISABLED_PLACEHOLDER_HEADER },   // NOLINT
-        { "braveNewsDisabledPlaceholderSubtitle", IDS_BRAVE_NEWS_DISABLED_PLACEHOLDER_SUBTITLE },  // NOLINT
-        { "braveNewsDisabledPlaceholderEnableButton", IDS_BRAVE_NEWS_DISABLED_PLACEHOLDER_ENABLE_BUTTON },  // NOLINT
         { "braveNewsSearchPlaceholderLabel", IDS_BRAVE_NEWS_SEARCH_PLACEHOLDER_LABEL},  // NOLINT
         { "braveNewsChannelsHeader", IDS_BRAVE_NEWS_BROWSE_CHANNELS_HEADER},  // NOLINT
         { "braveNewsViewAllButton", IDS_BRAVE_NEWS_VIEW_ALL_BUTTON},

--- a/components/brave_new_tab_ui/api/brave_news/news.ts
+++ b/components/brave_new_tab_ui/api/brave_news/news.ts
@@ -37,6 +37,9 @@ class BraveNewsApi {
 
   constructor () {
     this.controller = getBraveNewsController()
+  }
+
+  update () {
     this.updateChannels()
 
     this.controller.getLocale().then(({ locale }) => {

--- a/components/brave_new_tab_ui/components/default/braveToday/cardIntro.ts
+++ b/components/brave_new_tab_ui/components/default/braveToday/cardIntro.ts
@@ -13,26 +13,34 @@ export const Intro = styled(StandardBlock)`
   font-family: Poppins;
   color: white;
   text-align: center;
-  padding: 44px 90px 36px;
+  padding: 44px 82px 36px;
   display: flex;
   flex-direction: column;
-  gap: 18px;
+  gap: 30px;
   align-items: center;
 `
 
 export const Title = styled('h2')`
-  margin: 0;
+  // Negative bottom margin counteracts line-spacing interfering
+  // with container flex gap.
+  margin: 0 0 -5px 0;
   font-weight: 600;
   font-size: 28px;
-  line-height: 38px;
+  line-height: 1.2;
 `
 
 export const Paragraph = styled('p')`
   margin: 0;
+  padding: 0;
   font-weight: 500;
   font-size: 14px;
   line-height: 17px;
   letter-spacing: 0.16px;
+
+  & + & {
+    margin-top: 10px;
+  }
+
   a {
     color: inherit;
     text-decoration: underline;

--- a/components/brave_new_tab_ui/components/default/braveToday/cards/cardNoContent.tsx
+++ b/components/brave_new_tab_ui/components/default/braveToday/cards/cardNoContent.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) 2022 The Brave Authors. All rights reserved.
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this file,
-// you can obtain one at http://mozilla.org/MPL/2.0/.
+// you can obtain one at https://mozilla.org/MPL/2.0/.
 
 import * as React from 'react'
 import { getLocale } from '../../../../../common/locale'

--- a/components/brave_new_tab_ui/components/default/braveToday/cards/cardOptIn.tsx
+++ b/components/brave_new_tab_ui/components/default/braveToday/cards/cardOptIn.tsx
@@ -14,27 +14,31 @@ type Props = {
   onDisable: () => unknown
 }
 
+const descriptionTwoTextParts = getLocaleWithTag('braveNewsIntroDescriptionTwo')
+
 export default function IntroCard (props: Props) {
   const introElementRef = React.useRef(null)
-  const descriptionTextParts = React.useMemo(() => {
-    return getLocaleWithTag('braveTodayIntroDescription')
-  }, [])
   return (
     <Card.Intro ref={introElementRef}>
       <Card.Image src={BraveTodayLogoUrl} />
-      <Card.Title>{getLocale('braveTodayIntroTitle')}</Card.Title>
-      <Card.Paragraph>
-        {descriptionTextParts.beforeTag}
-        <a href={'https://brave.com/privacy/browser/'}>
-          {descriptionTextParts.duringTag}
-        </a>
-        {descriptionTextParts.afterTag}
-      </Card.Paragraph>
+      <Card.Title>{getLocale('braveNewsIntroTitle')}</Card.Title>
+      <div>
+        <Card.Paragraph>
+          {getLocale('braveNewsIntroDescription')}
+        </Card.Paragraph>
+        <Card.Paragraph>
+          {descriptionTwoTextParts.beforeTag}
+          <a href={'https://brave.com/privacy/browser/'}>
+            {descriptionTwoTextParts.duringTag}
+          </a>
+          {descriptionTwoTextParts.afterTag}
+        </Card.Paragraph>
+      </div>
       <CardButton onClick={props.onOptIn} isMainFocus={true}>
-        {getLocale('braveTodayOptInActionLabel')}
+        {getLocale('braveNewsOptInActionLabel')}
       </CardButton>
       <TertiaryButton onClick={props.onDisable}>
-        {getLocale('braveTodayOptOutActionLabel')}
+        {getLocale('braveNewsOptOutActionLabel')}
       </TertiaryButton>
     </Card.Intro>
   )

--- a/components/brave_new_tab_ui/components/default/braveToday/customize/Configure.tsx
+++ b/components/brave_new_tab_ui/components/default/braveToday/customize/Configure.tsx
@@ -109,12 +109,24 @@ const Content = styled.div`
 `
 
 export default function Configure () {
-  const [enabled, setEnabled] = useNewTabPref('isBraveTodayOptedIn')
+  const [optInPrefEnabled, setOptInPrefEnabled] = useNewTabPref('isBraveTodayOptedIn')
+  const [showOnNTPPrefEnabled, setShowOnNTPPrefEnabled] = useNewTabPref('showToday')
   const { setCustomizePage, customizePage } = useBraveNews()
 
+  const handleEnabledChange = (shouldEnable: boolean) => {
+    if (shouldEnable) {
+      setOptInPrefEnabled(true)
+      setShowOnNTPPrefEnabled(true)
+      return
+    }
+    setShowOnNTPPrefEnabled(false)
+  }
+
+  const isBraveNewsFullyEnabled = optInPrefEnabled && showOnNTPPrefEnabled
+
   let content: JSX.Element
-  if (!enabled) {
-    content = <DisabledPlaceholder enableBraveNews={() => setEnabled(true)} />
+  if (!isBraveNewsFullyEnabled) {
+    content = <DisabledPlaceholder enableBraveNews={() => handleEnabledChange(true)} />
   } else if (customizePage === 'suggestions') {
     content = <SuggestionsPage/>
   } else if (customizePage === 'popular') {
@@ -141,15 +153,15 @@ export default function Configure () {
         <CloseButtonContainer>
           <Button onClick={() => setCustomizePage(null)}>{Cross}</Button>
         </CloseButtonContainer>
-        {enabled && <Flex direction="row" align="center" gap={8}>
+        {isBraveNewsFullyEnabled && <Flex direction="row" align="center" gap={8}>
           <HeaderText>{getLocale('braveTodayTitle')}</HeaderText>
-          <Toggle isOn={enabled} onChange={setEnabled} />
+          <Toggle isOn={true} onChange={handleEnabledChange} />
         </Flex>}
       </Header>
       <Hr />
       <Sidebar>
         <SourcesList />
-        {!enabled && <SidebarOverlay />}
+        {!isBraveNewsFullyEnabled && <SidebarOverlay />}
       </Sidebar>
       <Content>
         {content}

--- a/components/brave_new_tab_ui/components/default/braveToday/customize/Configure.tsx
+++ b/components/brave_new_tab_ui/components/default/braveToday/customize/Configure.tsx
@@ -12,7 +12,6 @@ import Button from '$web-components/button'
 import Toggle from '$web-components/toggle'
 import SourcesList from './SourcesList'
 import DisabledPlaceholder from './DisabledPlaceholder'
-import { useNewTabPref } from '../../../../hooks/usePref'
 import { useBraveNews } from './Context'
 import { getLocale } from '$web-common/locale'
 import { formatMessage } from '../../../../../brave_rewards/resources/shared/lib/locale_context'
@@ -109,24 +108,22 @@ const Content = styled.div`
 `
 
 export default function Configure () {
-  const [optInPrefEnabled, setOptInPrefEnabled] = useNewTabPref('isBraveTodayOptedIn')
-  const [showOnNTPPrefEnabled, setShowOnNTPPrefEnabled] = useNewTabPref('showToday')
-  const { setCustomizePage, customizePage } = useBraveNews()
+  const {
+    setCustomizePage,
+    customizePage,
+    toggleBraveNewsOnNTP,
+    isOptInPrefEnabled,
+    isShowOnNTPPrefEnabled
+  } = useBraveNews()
 
-  const handleEnabledChange = (shouldEnable: boolean) => {
-    if (shouldEnable) {
-      setOptInPrefEnabled(true)
-      setShowOnNTPPrefEnabled(true)
-      return
-    }
-    setShowOnNTPPrefEnabled(false)
-  }
-
-  const isBraveNewsFullyEnabled = optInPrefEnabled && showOnNTPPrefEnabled
+  // TODO(petemill): We'll probably need to have 2 toggles, or some other
+  // way to know if brave news is "enabled" when Brave News is exposed
+  // in places other than just the NTP. For now this is pretty tied to NTP.
+  const isBraveNewsFullyEnabled = isOptInPrefEnabled && isShowOnNTPPrefEnabled
 
   let content: JSX.Element
   if (!isBraveNewsFullyEnabled) {
-    content = <DisabledPlaceholder enableBraveNews={() => handleEnabledChange(true)} />
+    content = <DisabledPlaceholder enableBraveNews={() => toggleBraveNewsOnNTP(true)} />
   } else if (customizePage === 'suggestions') {
     content = <SuggestionsPage/>
   } else if (customizePage === 'popular') {
@@ -155,7 +152,7 @@ export default function Configure () {
         </CloseButtonContainer>
         {isBraveNewsFullyEnabled && <Flex direction="row" align="center" gap={8}>
           <HeaderText>{getLocale('braveTodayTitle')}</HeaderText>
-          <Toggle isOn={true} onChange={handleEnabledChange} />
+          <Toggle isOn={true} onChange={toggleBraveNewsOnNTP} />
         </Flex>}
       </Header>
       <Hr />

--- a/components/brave_new_tab_ui/components/default/braveToday/customize/Context.tsx
+++ b/components/brave_new_tab_ui/components/default/braveToday/customize/Context.tsx
@@ -5,6 +5,7 @@
 
 import * as React from 'react'
 import { useCallback, useMemo, useState } from 'react'
+import { useNewTabPref } from '../../../../hooks/usePref'
 import { Channels, Publisher, Publishers, PublisherType } from '../../../../api/brave_news'
 import { api, isPublisherEnabled } from '../../../../api/brave_news/news'
 import Modal from './Modal'
@@ -29,6 +30,9 @@ interface BraveNewsContext {
   // Publishers to suggest to the user.
   suggestedPublisherIds: string[]
   updateSuggestedPublisherIds: () => void
+  isOptInPrefEnabled: boolean | undefined
+  isShowOnNTPPrefEnabled: boolean | undefined
+  toggleBraveNewsOnNTP: (enabled: boolean) => void
 }
 
 export const BraveNewsContext = React.createContext<BraveNewsContext>({
@@ -40,7 +44,10 @@ export const BraveNewsContext = React.createContext<BraveNewsContext>({
   subscribedPublisherIds: [],
   channels: {},
   suggestedPublisherIds: [],
-  updateSuggestedPublisherIds: () => {}
+  updateSuggestedPublisherIds: () => {},
+  isOptInPrefEnabled: undefined,
+  isShowOnNTPPrefEnabled: undefined,
+  toggleBraveNewsOnNTP: (enabled: boolean) => {}
 })
 
 export function BraveNewsContextProvider (props: { children: React.ReactNode }) {
@@ -48,6 +55,16 @@ export function BraveNewsContextProvider (props: { children: React.ReactNode }) 
   const [channels, setChannels] = useState<Channels>({})
   const [publishers, setPublishers] = useState<Publishers>({})
   const [suggestedPublisherIds, setSuggestedPublisherIds] = useState<string[]>([])
+  // TODO(petemill): Pref should come from the API since it isn't NTP-related. We should
+  // not use useNewTabPref here so that we can move Brave News to a shared component.
+  // But for now we're tied to NTP.
+  const [isOptInPrefEnabled, setOptInPrefEnabled] = useNewTabPref('isBraveTodayOptedIn')
+  const [isShowOnNTPPrefEnabled, setShowOnNTPPrefEnabled] = useNewTabPref('showToday')
+
+  // Update initially and when opt-in / enabled changes
+  React.useEffect(() => {
+    api.update()
+  }, [isOptInPrefEnabled && isShowOnNTPPrefEnabled])
 
   React.useEffect(() => {
     const handler = () => setChannels(api.getChannels())
@@ -87,6 +104,15 @@ export function BraveNewsContextProvider (props: { children: React.ReactNode }) 
     sortedPublishers.filter(isPublisherEnabled).map(p => p.publisherId),
     [sortedPublishers])
 
+  const toggleBraveNewsOnNTP = (shouldEnable: boolean) => {
+    if (shouldEnable) {
+      setOptInPrefEnabled(true)
+      setShowOnNTPPrefEnabled(true)
+      return
+    }
+    setShowOnNTPPrefEnabled(false)
+  }
+
   const context = useMemo<BraveNewsContext>(() => ({
     customizePage,
     setCustomizePage,
@@ -96,8 +122,11 @@ export function BraveNewsContextProvider (props: { children: React.ReactNode }) 
     sortedPublishers,
     filteredPublisherIds,
     subscribedPublisherIds,
-    updateSuggestedPublisherIds
-  }), [customizePage, channels, publishers, suggestedPublisherIds, updateSuggestedPublisherIds])
+    updateSuggestedPublisherIds,
+    isOptInPrefEnabled,
+    isShowOnNTPPrefEnabled,
+    toggleBraveNewsOnNTP
+  }), [customizePage, channels, publishers, suggestedPublisherIds, updateSuggestedPublisherIds, isOptInPrefEnabled, isShowOnNTPPrefEnabled, toggleBraveNewsOnNTP])
 
   return <BraveNewsContext.Provider value={context}>
     {props.children}

--- a/components/brave_new_tab_ui/components/default/braveToday/customize/DisabledPlaceholder.tsx
+++ b/components/brave_new_tab_ui/components/default/braveToday/customize/DisabledPlaceholder.tsx
@@ -6,7 +6,7 @@
 import Button from '$web-components/button'
 import * as React from 'react'
 import styled from 'styled-components'
-import { getLocale } from '$web-common/locale'
+import { getLocale, getLocaleWithTag } from '$web-common/locale'
 import Flex from '../../../Flex'
 
 const TodayGraphic = <svg width="370" height="80" viewBox="0 0 370 80" fill="none" xmlns="http://www.w3.org/2000/svg">
@@ -24,17 +24,31 @@ const Container = styled(Flex)`
   height: 100%;
 `
 
-const Header = styled.span`
+const Header = styled.h3`
+  padding: 0;
+  margin: 0;
   font-size: 24px;
   font-weight: 500;
-  line-height: 1.66;
+  line-height: 1.2;
   color: var(--text2);
 `
 
-const Subtitle = styled.span`
+const Subtitle = styled.p`
+  padding: 0;
+  margin: 0;
+  max-width: 66ch;
+  text-align: center;
   font-size: 14px;
   font-weight: 500;
   color: var(--text2);
+
+  & + & {
+    margin-top: 12px;
+  }
+
+  a {
+    color: inherit;
+  }
 `
 
 const EnableButton = styled(Button)`
@@ -43,17 +57,30 @@ const EnableButton = styled(Button)`
   margin-bottom: 48px;
 `
 
+const descriptionTwoTextParts = getLocaleWithTag('braveNewsIntroDescriptionTwo')
+
 export default function DisabledPlaceholder (props: { enableBraveNews: () => void }) {
-  return <Container align="center" justify="center" direction="column" gap={12}>
-    {TodayGraphic}
-    <Header>
-      {getLocale('braveNewsDisabledPlaceholderHeader')}
-    </Header>
-    <Subtitle>
-      {getLocale('braveNewsDisabledPlaceholderSubtitle')}
-    </Subtitle>
-    <EnableButton isPrimary onClick={props.enableBraveNews}>
-      {getLocale('braveNewsDisabledPlaceholderEnableButton')}
-    </EnableButton>
-  </Container>
+  return (
+    <Container align="center" justify="center" direction="column" gap={26}>
+      {TodayGraphic}
+      <Header>
+        {getLocale('braveNewsIntroTitle')}
+      </Header>
+      <div>
+        <Subtitle>
+          {getLocale('braveNewsIntroDescription')}
+        </Subtitle>
+        <Subtitle>
+          {descriptionTwoTextParts.beforeTag}
+            <a href={'https://brave.com/privacy/browser/'}>
+              {descriptionTwoTextParts.duringTag}
+            </a>
+          {descriptionTwoTextParts.afterTag}
+        </Subtitle>
+      </div>
+      <EnableButton isPrimary onClick={props.enableBraveNews}>
+        {getLocale('braveNewsOptInActionLabel')}
+      </EnableButton>
+    </Container>
+  )
 }

--- a/components/brave_new_tab_ui/stories/today.tsx
+++ b/components/brave_new_tab_ui/stories/today.tsx
@@ -8,10 +8,12 @@ import { withKnobs, text } from '@storybook/addon-knobs'
 import ThemeProvider from '../../common/BraveCoreThemeProvider'
 import BraveTodayLoadingCard from '../components/default/braveToday/cards/cardLoading'
 import BraveTodayErrorCard from '../components/default/braveToday/cards/cardError'
+import BraveTodayOptInCard from '../components/default/braveToday/cards/cardOptIn'
 import PublisherMeta from '../components/default/braveToday/cards/PublisherMeta'
 import DisplayAdCard from '../components/default/braveToday/cards/displayAd'
-import getBraveNewsDisplayAd from './default/data/getBraveNewsDisplayAd'
 import * as BraveNews from '../api/brave_news'
+import getBraveNewsDisplayAd from './default/data/getBraveNewsDisplayAd'
+import './todayStrings'
 
 const onClick = () => alert('clicked')
 
@@ -96,6 +98,10 @@ export const Loading = () => (
 
 export const Error = () => (
   <BraveTodayErrorCard onRefresh={() => console.log('refresh clicked')} />
+)
+
+export const OptIn = () => (
+  <BraveTodayOptInCard onOptIn={() => console.log('opt-in clicked')} onDisable={() => console.log('disable clicked')} />
 )
 
 const handleDisplayAdVisit = () => alert('handle visit')

--- a/components/brave_new_tab_ui/stories/todayStrings.ts
+++ b/components/brave_new_tab_ui/stories/todayStrings.ts
@@ -1,0 +1,17 @@
+// Copyright (c) 2022 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// you can obtain one at https://mozilla.org/MPL/2.0/.
+import { provideStrings } from '../../../.storybook/locale'
+
+provideStrings({
+  braveTodayDisableSourceCommand: 'Disable content from $1',
+  braveTodayIntroTitle: 'Today\'s top stories in a completely private feed, just for you.',
+  braveTodayIntroDescription: 'Brave News is ad-supported with completely private and anonymized ads matched on your device. Your personal information always stays private, per our $1privacy policy$2.',
+  braveTodayOptInActionLabel: 'Show Brave News',
+  braveTodayOptOutActionLabel: 'No thanks',
+  braveTodayScrollHint: 'Scroll for Brave News',
+  braveNewsIntroTitle: 'Turn on Brave News, and never miss a story',
+  braveNewsIntroDescription: 'Follow your favorite sources, in a single feed. Just open a tab in Brave, scroll down, and…voila!',
+  braveNewsIntroDescriptionTwo: 'Brave News is ad-supported with private, anonymized ads. $1Learn more.$2.'
+})

--- a/components/brave_today/browser/brave_news_controller.cc
+++ b/components/brave_today/browser/brave_news_controller.cc
@@ -28,6 +28,7 @@
 #include "brave/components/brave_today/browser/brave_news_p3a.h"
 #include "brave/components/brave_today/browser/channels_controller.h"
 #include "brave/components/brave_today/browser/direct_feed_controller.h"
+#include "brave/components/brave_today/browser/locales_helper.h"
 #include "brave/components/brave_today/browser/network.h"
 #include "brave/components/brave_today/browser/suggestions_controller.h"
 #include "brave/components/brave_today/browser/unsupported_publisher_migrator.h"
@@ -37,7 +38,6 @@
 #include "brave/components/brave_today/common/brave_news.mojom.h"
 #include "brave/components/brave_today/common/features.h"
 #include "brave/components/brave_today/common/pref_names.h"
-#include "brave/components/l10n/common/locale_util.h"
 #include "components/favicon/core/favicon_service.h"
 #include "components/favicon_base/favicon_types.h"
 #include "components/history/core/browser/history_service.h"
@@ -49,6 +49,7 @@
 
 namespace brave_news {
 namespace {
+
 // The favicon size we desire. The favicons are rendered at 24x24 pixels but
 // they look quite a bit nicer if we get a 48x48 pixel icon and downscale it.
 constexpr uint32_t kDesiredFaviconSizePixels = 48;
@@ -64,17 +65,9 @@ bool IsPublisherEnabled(const mojom::Publisher* publisher) {
 
 // static
 void BraveNewsController::RegisterProfilePrefs(PrefRegistrySimple* registry) {
-  // Only default brave today to be shown for
-  // certain languages on browser startup.
-  const std::string language_code =
-      brave_l10n::GetDefaultISOLanguageCodeString();
-  const bool is_english_language = language_code == "en";
-  const bool is_japanese_language = language_code == "ja";
-  const bool brave_news_enabled_default =
-      is_english_language || is_japanese_language;
   registry->RegisterBooleanPref(prefs::kShouldShowToolbarButton, true);
   registry->RegisterBooleanPref(prefs::kNewTabPageShowToday,
-                                brave_news_enabled_default);
+                                IsUserInDefaultEnabledLocale());
   registry->RegisterBooleanPref(prefs::kBraveTodayOptedIn, false);
   registry->RegisterDictionaryPref(prefs::kBraveTodaySources);
   registry->RegisterDictionaryPref(prefs::kBraveNewsChannels);

--- a/components/brave_today/browser/brave_news_controller.h
+++ b/components/brave_today/browser/brave_news_controller.h
@@ -129,6 +129,7 @@ class BraveNewsController : public KeyedService,
   bool GetIsEnabled();
   void HandleSubscriptionsChanged();
   void Prefetch();
+  void MaybeInitPrefs();
 
   raw_ptr<PrefService> prefs_ = nullptr;
   raw_ptr<favicon::FaviconService> favicon_service_ = nullptr;

--- a/components/brave_today/browser/locales_helper.h
+++ b/components/brave_today/browser/locales_helper.h
@@ -28,6 +28,10 @@ base::flat_set<std::string> GetPublisherLocales(const Publishers& publishers);
 base::flat_set<std::string> GetMinimalLocalesSet(
     const base::flat_set<std::string>& channel_locales,
     const Publishers& publishers);
+
+// Calculate if Brave News should be enabled on the NTP by checking the
+// user's locale.
+bool IsUserInDefaultEnabledLocale();
 }  // namespace brave_news
 
 #endif  // BRAVE_COMPONENTS_BRAVE_TODAY_BROWSER_LOCALES_HELPER_H_

--- a/components/brave_today/browser/publishers_controller.cc
+++ b/components/brave_today/browser/publishers_controller.cc
@@ -241,7 +241,7 @@ void PublishersController::UpdateDefaultLocale() {
   // wants the format to be "language_COUNTRY".
   const std::string brave_news_locale =
       base::StrCat({brave_l10n::GetDefaultISOLanguageCodeString(), "_",
-                    brave_l10n::GetDefaultISOLanguageCodeString()});
+                    brave_l10n::GetDefaultISOCountryCodeString()});
 
   // Fallback to en_US, if we can't match anything else.
   // TODO(fallaciousreasoning): Implement more complicated fallback

--- a/components/resources/brave_components_strings.grd
+++ b/components/resources/brave_components_strings.grd
@@ -284,15 +284,6 @@
       <message name="IDS_BRAVE_TODAY_TITLE" translateable="false" desc="Title for Brave News news feed section">
         Brave News
       </message>
-      <message name="IDS_BRAVE_TODAY_INTRO_TITLE" desc="Title for introduction to Brave News news feed section">
-        Today's top stories in a completely private feed, just for you.
-      </message>
-      <message name="IDS_BRAVE_TODAY_INTRO_DESCRIPTION" desc="Description for introduction to Brave News news feed section. Do not translate the title Brave News.">
-        Brave News is ad-supported with completely private and anonymized ads matched on your device. Your personal information always stays private, per our <ph name="LINK_START">$1<ex>{</ex></ph>privacy policy<ph name="LINK_END">$2<ex>}</ex></ph>.
-      </message>
-      <message name="IDS_BRAVE_TODAY_OPT_IN_ACTION_LABEL" desc="Button text for opting in to Brave News">
-        Show Brave News
-      </message>
       <message name="IDS_BRAVE_TODAY_SHOW_TOOLBAR_BUTTON" desc="Button text for opting in to Brave News">
         Show Brave News button in the toolbar
       </message>
@@ -316,9 +307,6 @@
       </message>
       <message name="IDS_BRAVE_NEWS_BUBBLE_MANAGE_FEEDS" desc="The text on the button for opening the Brave News configuration page">
         Manage Feeds
-      </message>
-      <message name="IDS_BRAVE_TODAY_OPT_OUT_ACTION_LABEL" desc="Button text for opting out of Brave News">
-        No thanks
       </message>
       <message name="IDS_BRAVE_TODAY_STATUS_FETCHING" desc="Indication that the content is being downloaded...">
         Fetching…

--- a/components/resources/brave_news_strings.grdp
+++ b/components/resources/brave_news_strings.grdp
@@ -1,19 +1,25 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <grit-part>
+  <message name="IDS_BRAVE_NEWS_INTRO_TITLE" desc="Title for introduction to Brave News news feed section">
+    Turn on Brave News, and never miss a story
+  </message>
+  <message name="IDS_BRAVE_NEWS_INTRO_DESCRIPTION" desc="Description for introduction to Brave News news feed section. Do not translate the title Brave News.">
+    Follow your favorite sources, in a single feed. Just open a tab in Brave, scroll down, and… voila!
+  </message>
+  <message name="IDS_BRAVE_NEWS_INTRO_DESCRIPTION_TWO" desc="Description second paragraph for introduction to Brave News news feed section. Do not translate the title Brave News.">
+    Brave News is ad-supported with private, anonymized ads. <ph name="LINK_START">$1<ex>{</ex></ph>Learn more.<ph name="LINK_END">$2<ex>}</ex></ph>.
+  </message>
+  <message name="IDS_BRAVE_NEWS_OPT_IN_ACTION_LABEL" desc="Button text for opting in to Brave News">
+    Turn on Brave News
+  </message>
+  <message name="IDS_BRAVE_NEWS_OPT_OUT_ACTION_LABEL" desc="Button text for opting out of Brave News">
+    No thanks
+  </message>
   <message name="IDS_BRAVE_NEWS_BACK_TO_DASHBOARD" desc="Label for the back to dashboard button">
     Back to <ph name="BEGIN_BOLD">$1</ph>Dashboard<ph name="END_BOLD">$2</ph>
   </message>
   <message name="IDS_BRAVE_NEWS_BACK_BUTTON" desc="Label for the back button">
     Back
-  </message>
-  <message name="IDS_BRAVE_NEWS_DISABLED_PLACEHOLDER_HEADER" desc="Header for the brave news disabled placeholder">
-    Turn on Brave News, and never miss a story
-  </message>
-  <message name="IDS_BRAVE_NEWS_DISABLED_PLACEHOLDER_SUBTITLE" desc="Subtitle for the brave news disabled placeholder">
-    Customized news feeds, from leading sources, delivered right to your browser. All 100% private.
-  </message>
-  <message name="IDS_BRAVE_NEWS_DISABLED_PLACEHOLDER_ENABLE_BUTTON" desc="Label for the button to reenable Brave News from the disabled placeholder">
-    Turn on Brave News
   </message>
   <message name="IDS_BRAVE_NEWS_SEARCH_PLACEHOLDER_LABEL" desc="Label that displays in the searchbox when the user hasn't entered anything">
     Search for site, topic, or RSS feed


### PR DESCRIPTION
Fix https://github.com/brave/brave-browser/issues/26519
- Desktop Customize UI Toggle will only disable show-on-NTP pref
- Desktop Customize UI updates data when enabled state changes
- Make sure any new code introduced with "v2" of Brave News does not contact

Fix https://github.com/brave/brave-browser/issues/26520
- Opt-in wording change and consistency for the Desktop Customize UI and the Desktop Opt-In card

Fix https://github.com/brave/brave-browser/issues/26678
- Add es_ES, es_MX and pt_BR to list of default-enabled locales

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
On issues
