### PR TITLE
Unlock wallet with commandline

### DIFF
--- a/components/brave_wallet/browser/keyring_service.h
+++ b/components/brave_wallet/browser/keyring_service.h
@@ -405,6 +405,7 @@ class KeyringService : public KeyedService, public mojom::KeyringService {
                            const std::string keyring_id);
 
   bool ValidatePasswordInternal(const std::string& password);
+  void MaybeUnlockWithCommandLine();
 
   std::unique_ptr<base::OneShotTimer> auto_lock_timer_;
   std::unique_ptr<PrefChangeRegistrar> pref_change_registrar_;

--- a/components/brave_wallet/common/BUILD.gn
+++ b/components/brave_wallet/common/BUILD.gn
@@ -43,6 +43,8 @@ static_library("common") {
     "solana_address.h",
     "string_utils.cc",
     "string_utils.h",
+    "switches.cc",
+    "switches.h",
     "value_conversion_utils.cc",
     "value_conversion_utils.h",
   ]

--- a/components/brave_wallet/common/switches.cc
+++ b/components/brave_wallet/common/switches.cc
@@ -1,0 +1,14 @@
+// Copyright (c) 2022 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// you can obtain one at http://mozilla.org/MPL/2.0/.
+
+#include "brave/components/brave_wallet/common/switches.h"
+
+namespace brave_wallet {
+namespace switches {
+
+const char kDevWalletPassword[] = "dev-wallet-password";
+
+}  // namespace switches
+}  // namespace brave_wallet

--- a/components/brave_wallet/common/switches.h
+++ b/components/brave_wallet/common/switches.h
@@ -1,0 +1,18 @@
+// Copyright (c) 2022 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// you can obtain one at http://mozilla.org/MPL/2.0/.
+
+#ifndef BRAVE_COMPONENTS_BRAVE_WALLET_COMMON_SWITCHES_H_
+#define BRAVE_COMPONENTS_BRAVE_WALLET_COMMON_SWITCHES_H_
+
+namespace brave_wallet {
+namespace switches {
+
+// Allows auto unlocking wallet password with command line.
+extern const char kDevWalletPassword[];
+
+}  // namespace switches
+}  // namespace brave_wallet
+
+#endif  // BRAVE_COMPONENTS_BRAVE_WALLET_COMMON_SWITCHES_H_


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/26663
`--dev-wallet-password="my_dummy_password"` unlocks wallet on startup

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
`--dev-wallet-password="my_dummy_password"` unlocks wallet on startup only for dev builds(OFFICIAL_BUILD=false) and should not work for our production builds