### PR TITLE
Uplift Brave News Flag, Toggle, and Feed fixes

### DIFF
--- a/.storybook/locale.ts
+++ b/.storybook/locale.ts
@@ -326,12 +326,6 @@ let locale: Record<string, string> = {
   showTopSites: 'Show Top Sites',
   showRewards: 'Show Rewards',
   tosAndPp: 'By turning on {{title}}, you agree to the $1Terms of Service$2 and $3Privacy Policy$4.',
-  braveTodayDisableSourceCommand: 'Disable content from $1',
-  braveTodayIntroTitle: `Today's top stories in a completely private feed, just for you.`,
-  braveTodayIntroDescription: `Brave News is ad-supported with completely private and anonymized ads matched on your device. Your personal information always stays private, per our $1privacy policy$2.`,
-  braveTodayOptInActionLabel: 'Show Brave News',
-  braveTodayOptOutActionLabel: 'No thanks',
-  braveTodayScrollHint: 'Scroll for Brave News',
   editCardsTitle: 'Edit Cards'
 }
 

--- a/browser/ui/webui/brave_webui_source.cc
+++ b/browser/ui/webui/brave_webui_source.cc
@@ -189,11 +189,7 @@ void CustomizeWebUIHTMLSource(content::WebUI* web_ui,
         { "searchPromotionSearchBoxPlaceholderLabel", IDS_BRAVE_NEW_TAB_SEARCH_PROMOTION_SEARCH_BOX_PLACEHOLDER},  // NOLINT
 
         { "braveTodayTitle", IDS_BRAVE_TODAY_TITLE },
-        { "braveTodayIntroTitle", IDS_BRAVE_TODAY_INTRO_TITLE },
-        { "braveTodayIntroDescription", IDS_BRAVE_TODAY_INTRO_DESCRIPTION },
-        { "braveTodayOptInActionLabel", IDS_BRAVE_TODAY_OPT_IN_ACTION_LABEL },
         { "braveTodayShowToolbarButton", IDS_BRAVE_TODAY_SHOW_TOOLBAR_BUTTON },
-        { "braveTodayOptOutActionLabel", IDS_BRAVE_TODAY_OPT_OUT_ACTION_LABEL },
         { "braveTodayStatusFetching", IDS_BRAVE_TODAY_STATUS_FETCHING},
         { "braveTodayActionRefresh", IDS_BRAVE_TODAY_ACTION_REFRESH},
         { "braveTodayScrollHint", IDS_BRAVE_TODAY_SCROLL_HINT},
@@ -206,11 +202,13 @@ void CustomizeWebUIHTMLSource(content::WebUI* web_ui,
         { "promoted", IDS_BRAVE_TODAY_PROMOTED },
         { "ad", IDS_BRAVE_TODAY_DISPLAY_AD_LABEL },
 
+        { "braveNewsIntroTitle", IDS_BRAVE_NEWS_INTRO_TITLE },
+        { "braveNewsIntroDescription", IDS_BRAVE_NEWS_INTRO_DESCRIPTION },
+        { "braveNewsIntroDescriptionTwo", IDS_BRAVE_NEWS_INTRO_DESCRIPTION_TWO },
+        { "braveNewsOptInActionLabel", IDS_BRAVE_NEWS_OPT_IN_ACTION_LABEL },
+        { "braveNewsOptOutActionLabel", IDS_BRAVE_NEWS_OPT_OUT_ACTION_LABEL },
         { "braveNewsBackToDashboard", IDS_BRAVE_NEWS_BACK_TO_DASHBOARD },
         { "braveNewsBackButton", IDS_BRAVE_NEWS_BACK_BUTTON },
-        { "braveNewsDisabledPlaceholderHeader", IDS_BRAVE_NEWS_DISABLED_PLACEHOLDER_HEADER },   // NOLINT
-        { "braveNewsDisabledPlaceholderSubtitle", IDS_BRAVE_NEWS_DISABLED_PLACEHOLDER_SUBTITLE },  // NOLINT
-        { "braveNewsDisabledPlaceholderEnableButton", IDS_BRAVE_NEWS_DISABLED_PLACEHOLDER_ENABLE_BUTTON },  // NOLINT
         { "braveNewsSearchPlaceholderLabel", IDS_BRAVE_NEWS_SEARCH_PLACEHOLDER_LABEL},  // NOLINT
         { "braveNewsChannelsHeader", IDS_BRAVE_NEWS_BROWSE_CHANNELS_HEADER},  // NOLINT
         { "braveNewsViewAllButton", IDS_BRAVE_NEWS_VIEW_ALL_BUTTON},

--- a/browser/ui/webui/brave_webui_source.cc
+++ b/browser/ui/webui/brave_webui_source.cc
@@ -204,7 +204,7 @@ void CustomizeWebUIHTMLSource(content::WebUI* web_ui,
 
         { "braveNewsIntroTitle", IDS_BRAVE_NEWS_INTRO_TITLE },
         { "braveNewsIntroDescription", IDS_BRAVE_NEWS_INTRO_DESCRIPTION },
-        { "braveNewsIntroDescriptionTwo", IDS_BRAVE_NEWS_INTRO_DESCRIPTION_TWO },
+        { "braveNewsIntroDescriptionTwo", IDS_BRAVE_NEWS_INTRO_DESCRIPTION_TWO },  // NOLINT
         { "braveNewsOptInActionLabel", IDS_BRAVE_NEWS_OPT_IN_ACTION_LABEL },
         { "braveNewsOptOutActionLabel", IDS_BRAVE_NEWS_OPT_OUT_ACTION_LABEL },
         { "braveNewsBackToDashboard", IDS_BRAVE_NEWS_BACK_TO_DASHBOARD },

--- a/browser/ui/webui/brave_webui_source.cc
+++ b/browser/ui/webui/brave_webui_source.cc
@@ -226,6 +226,12 @@ void CustomizeWebUIHTMLSource(content::WebUI* web_ui,
         { "braveNewsSearchQueryTooShort", IDS_BRAVE_NEWS_SEARCH_QUERY_TOO_SHORT},  // NOLINT
         { "braveNewsSuggestionsTitle", IDS_BRAVE_NEWS_SUGGESTIONS_TITLE},
         { "braveNewsSuggestionsSubtitle", IDS_BRAVE_NEWS_SUGGESTIONS_SUBTITLE},
+        { "braveNewsErrorHeading", IDS_BRAVE_NEWS_ERROR_HEADING},
+        { "braveNewsErrorMessage", IDS_BRAVE_NEWS_ERROR_MESSAGE},
+        { "braveNewsErrorActionLabel", IDS_BRAVE_NEWS_ERROR_ACTION_LABEL},
+        { "braveNewsNoContentHeading", IDS_BRAVE_NEWS_NO_CONTENT_HEADING},
+        { "braveNewsNoContentMessage", IDS_BRAVE_NEWS_NO_CONTENT_MESSAGE},
+        { "braveNewsNoContentActionLabel", IDS_BRAVE_NEWS_NO_CONTENT_ACTION_LABEL},  // NOLINT
         // Brave News Channels
         { "braveNewsChannel-Brave", IDS_BRAVE_NEWS_CHANNEL_BRAVE},
         { "braveNewsChannel-Business", IDS_BRAVE_NEWS_CHANNEL_BUSINESS},

--- a/components/brave_new_tab_ui/api/brave_news/news.ts
+++ b/components/brave_new_tab_ui/api/brave_news/news.ts
@@ -37,6 +37,9 @@ class BraveNewsApi {
 
   constructor () {
     this.controller = getBraveNewsController()
+  }
+
+  update () {
     this.updateChannels()
 
     this.controller.getLocale().then(({ locale }) => {

--- a/components/brave_new_tab_ui/async/today.ts
+++ b/components/brave_new_tab_ui/async/today.ts
@@ -130,7 +130,9 @@ handler.on<Actions.SetPublisherPrefPayload>(Actions.setPublisherPref.getType(), 
 
 handler.on(Actions.checkForUpdate.getType(), async function (store) {
   const state = store.getState() as ApplicationState
-  if (!state.today.feed || !state.today.feed.hash) {
+  // Detect if we did not get any data successfully and therefore we can try again
+  // to fetch data
+  if (!state.today.feed) {
     store.dispatch(Actions.isUpdateAvailable({ isUpdateAvailable: true }))
     return
   }

--- a/components/brave_new_tab_ui/components/default/braveToday/cardIntro.ts
+++ b/components/brave_new_tab_ui/components/default/braveToday/cardIntro.ts
@@ -13,26 +13,34 @@ export const Intro = styled(StandardBlock)`
   font-family: Poppins;
   color: white;
   text-align: center;
-  padding: 44px 90px 36px;
+  padding: 44px 82px 36px;
   display: flex;
   flex-direction: column;
-  gap: 18px;
+  gap: 30px;
   align-items: center;
 `
 
 export const Title = styled('h2')`
-  margin: 0;
+  // Negative bottom margin counteracts line-spacing interfering
+  // with container flex gap.
+  margin: 0 0 -5px 0;
   font-weight: 600;
   font-size: 28px;
-  line-height: 38px;
+  line-height: 1.2;
 `
 
 export const Paragraph = styled('p')`
   margin: 0;
+  padding: 0;
   font-weight: 500;
   font-size: 14px;
   line-height: 17px;
   letter-spacing: 0.16px;
+
+  & + & {
+    margin-top: 10px;
+  }
+
   a {
     color: inherit;
     text-decoration: underline;

--- a/components/brave_new_tab_ui/components/default/braveToday/cards/cardError.tsx
+++ b/components/brave_new_tab_ui/components/default/braveToday/cards/cardError.tsx
@@ -5,6 +5,8 @@
 
 import * as React from 'react'
 import styled from 'styled-components'
+import Button from '$web-components/button'
+import { getLocale } from '../../../../../common/locale'
 import * as Card from '../cardIntro'
 
 const Content = styled('div')`
@@ -25,6 +27,10 @@ const Graphic = styled('div')`
   height: 46px;
 `
 
+const Action = styled('div')`
+  padding-top: 20px;
+`
+
 function Icon () {
   return (
     <svg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 64 46'>
@@ -38,7 +44,13 @@ function Icon () {
   )
 }
 
-export default function CardError () {
+interface MessageProps {
+  heading: string
+  message: string
+  actionLabel?: string
+  onActionClick?: () => unknown
+}
+export function UnidealMessageCard (props: MessageProps) {
   return (
     <Card.Intro>
       <Content>
@@ -46,12 +58,33 @@ export default function CardError () {
           <Icon />
         </Graphic>
         <Heading>
-          Oops…
+          {props.heading}
         </Heading>
         <Card.Paragraph>
-          Brave News is experiencing some issues. Try again.
+          {props.message}
         </Card.Paragraph>
+        {!!props.actionLabel && !!props.onActionClick &&
+          <Action>
+            <Button isPrimary onClick={props.onActionClick}>
+              {props.actionLabel}
+            </Button>
+          </Action>
+        }
       </Content>
     </Card.Intro>
+  )
+}
+
+interface Props {
+  onRefresh: () => unknown
+}
+export default function CardError (props: Props) {
+  return (
+    <UnidealMessageCard
+      heading={getLocale('braveNewsErrorHeading')}
+      message={getLocale('braveNewsErrorMessage')}
+      actionLabel={getLocale('braveNewsErrorActionLabel')}
+      onActionClick={props.onRefresh}
+    />
   )
 }

--- a/components/brave_new_tab_ui/components/default/braveToday/cards/cardNoContent.tsx
+++ b/components/brave_new_tab_ui/components/default/braveToday/cards/cardNoContent.tsx
@@ -1,0 +1,23 @@
+// Copyright (c) 2022 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// you can obtain one at http://mozilla.org/MPL/2.0/.
+
+import * as React from 'react'
+import { getLocale } from '../../../../../common/locale'
+import { UnidealMessageCard } from './cardError'
+
+interface Props {
+  onCustomize: () => unknown
+}
+
+export default function CardNoContent (props: Props) {
+  return (
+    <UnidealMessageCard
+      heading={getLocale('braveNewsNoContentHeading')}
+      message={getLocale('braveNewsNoContentMessage')}
+      actionLabel={getLocale('braveNewsNoContentActionLabel')}
+      onActionClick={props.onCustomize}
+    />
+  )
+}

--- a/components/brave_new_tab_ui/components/default/braveToday/cards/cardOptIn.tsx
+++ b/components/brave_new_tab_ui/components/default/braveToday/cards/cardOptIn.tsx
@@ -14,27 +14,31 @@ type Props = {
   onDisable: () => unknown
 }
 
+const descriptionTwoTextParts = getLocaleWithTag('braveNewsIntroDescriptionTwo')
+
 export default function IntroCard (props: Props) {
   const introElementRef = React.useRef(null)
-  const descriptionTextParts = React.useMemo(() => {
-    return getLocaleWithTag('braveTodayIntroDescription')
-  }, [])
   return (
     <Card.Intro ref={introElementRef}>
       <Card.Image src={BraveTodayLogoUrl} />
-      <Card.Title>{getLocale('braveTodayIntroTitle')}</Card.Title>
-      <Card.Paragraph>
-        {descriptionTextParts.beforeTag}
-        <a href={'https://brave.com/privacy/browser/'}>
-          {descriptionTextParts.duringTag}
-        </a>
-        {descriptionTextParts.afterTag}
-      </Card.Paragraph>
+      <Card.Title>{getLocale('braveNewsIntroTitle')}</Card.Title>
+      <div>
+        <Card.Paragraph>
+          {getLocale('braveNewsIntroDescription')}
+        </Card.Paragraph>
+        <Card.Paragraph>
+          {descriptionTwoTextParts.beforeTag}
+          <a href={'https://brave.com/privacy/browser/'}>
+            {descriptionTwoTextParts.duringTag}
+          </a>
+          {descriptionTwoTextParts.afterTag}
+        </Card.Paragraph>
+      </div>
       <CardButton onClick={props.onOptIn} isMainFocus={true}>
-        {getLocale('braveTodayOptInActionLabel')}
+        {getLocale('braveNewsOptInActionLabel')}
       </CardButton>
       <TertiaryButton onClick={props.onDisable}>
-        {getLocale('braveTodayOptOutActionLabel')}
+        {getLocale('braveNewsOptOutActionLabel')}
       </TertiaryButton>
     </Card.Intro>
   )

--- a/components/brave_new_tab_ui/components/default/braveToday/content.tsx
+++ b/components/brave_new_tab_ui/components/default/braveToday/content.tsx
@@ -9,6 +9,7 @@ import * as TodayActions from '../../../actions/today_actions'
 import { Feed } from '../../../api/brave_news'
 import CardLoading from './cards/cardLoading'
 import CardError from './cards/cardError'
+import CardNoContent from './cards/cardNoContent'
 import CardLarge from './cards/_articles/cardArticleLarge'
 import CardDisplayAd from './cards/displayAd'
 import CardsGroup from './cardsGroup'
@@ -152,7 +153,11 @@ export default function BraveTodayContent (props: Props) {
     intersectionObserver.current.observe(trigger)
   }, [intersectionObserver.current])
 
-  const hasContent = feed && publishers
+  // TODO(petemill): Only way to test for error state is if there are no
+  // publishers since GetFeed and GetPublishers will always eventually return
+  // empty objects. Consider having those mojom functions provide error states.
+  const hasContent = feed && publishers && !!Object.keys(publishers).length
+
   // Loading state
   if (props.isFetching && !hasContent) {
     return <CardLoading />
@@ -160,7 +165,7 @@ export default function BraveTodayContent (props: Props) {
 
   // Error state
   if (!hasContent) {
-    return <CardError />
+    return <CardError onRefresh={props.onRefresh} />
   }
 
   // satisfy typescript sanity, should not get here
@@ -172,9 +177,16 @@ export default function BraveTodayContent (props: Props) {
   const isOnlyDisplayingPeekingCard = !props.hasInteracted && props.isPrompting
   const displayedPageCount = Math.min(props.displayedPageCount, feed.pages.length)
   const introCount = feed.featuredItem ? 2 : 1
+  const showNoContentMessage = !props.isFetching &&
+    hasContent &&
+    !feed.featuredItem &&
+    feed.pages.length === 0
   let runningCardCount = introCount
   return (
     <>
+      {/* no feed content available */}
+      {showNoContentMessage &&
+      <CardNoContent onCustomize={props.onCustomizeBraveToday} />}
       {/* featured item */}
       {feed.featuredItem && <CardLarge
         content={[feed.featuredItem]}

--- a/components/brave_new_tab_ui/components/default/braveToday/customize/Configure.tsx
+++ b/components/brave_new_tab_ui/components/default/braveToday/customize/Configure.tsx
@@ -12,7 +12,6 @@ import Button from '$web-components/button'
 import Toggle from '$web-components/toggle'
 import SourcesList from './SourcesList'
 import DisabledPlaceholder from './DisabledPlaceholder'
-import { useNewTabPref } from '../../../../hooks/usePref'
 import { useBraveNews } from './Context'
 import { getLocale } from '$web-common/locale'
 import { formatMessage } from '../../../../../brave_rewards/resources/shared/lib/locale_context'
@@ -109,12 +108,22 @@ const Content = styled.div`
 `
 
 export default function Configure () {
-  const [enabled, setEnabled] = useNewTabPref('isBraveTodayOptedIn')
-  const { setCustomizePage, customizePage } = useBraveNews()
+  const {
+    setCustomizePage,
+    customizePage,
+    toggleBraveNewsOnNTP,
+    isOptInPrefEnabled,
+    isShowOnNTPPrefEnabled
+  } = useBraveNews()
+
+  // TODO(petemill): We'll probably need to have 2 toggles, or some other
+  // way to know if brave news is "enabled" when Brave News is exposed
+  // in places other than just the NTP. For now this is pretty tied to NTP.
+  const isBraveNewsFullyEnabled = isOptInPrefEnabled && isShowOnNTPPrefEnabled
 
   let content: JSX.Element
-  if (!enabled) {
-    content = <DisabledPlaceholder enableBraveNews={() => setEnabled(true)} />
+  if (!isBraveNewsFullyEnabled) {
+    content = <DisabledPlaceholder enableBraveNews={() => toggleBraveNewsOnNTP(true)} />
   } else if (customizePage === 'suggestions') {
     content = <SuggestionsPage/>
   } else if (customizePage === 'popular') {
@@ -141,15 +150,15 @@ export default function Configure () {
         <CloseButtonContainer>
           <Button onClick={() => setCustomizePage(null)}>{Cross}</Button>
         </CloseButtonContainer>
-        {enabled && <Flex direction="row" align="center" gap={8}>
+        {isBraveNewsFullyEnabled && <Flex direction="row" align="center" gap={8}>
           <HeaderText>{getLocale('braveTodayTitle')}</HeaderText>
-          <Toggle isOn={enabled} onChange={setEnabled} />
+          <Toggle isOn={true} onChange={toggleBraveNewsOnNTP} />
         </Flex>}
       </Header>
       <Hr />
       <Sidebar>
         <SourcesList />
-        {!enabled && <SidebarOverlay />}
+        {!isBraveNewsFullyEnabled && <SidebarOverlay />}
       </Sidebar>
       <Content>
         {content}

--- a/components/brave_new_tab_ui/components/default/braveToday/customize/Configure.tsx
+++ b/components/brave_new_tab_ui/components/default/braveToday/customize/Configure.tsx
@@ -21,13 +21,14 @@ import { PopularPage } from './Popular'
 
 const Grid = styled.div`
   width: 100%;
+  min-width: 730px;
   height: 100%;
 
   overflow: auto;
   overscroll-behavior: none;
 
   display: grid;
-  grid-template-columns: 250px auto;
+  grid-template-columns: 307px auto;
   grid-template-rows: 64px 2px auto;
 
   grid-template-areas:
@@ -86,7 +87,7 @@ const Sidebar = styled.div`
   position: relative;
   overflow: auto;
   grid-area: sidebar;
-  padding: 28px 32px;
+  padding: 28px 22px 28px 32px;
   background: var(--background2);
 `
 

--- a/components/brave_new_tab_ui/components/default/braveToday/customize/Context.tsx
+++ b/components/brave_new_tab_ui/components/default/braveToday/customize/Context.tsx
@@ -5,6 +5,7 @@
 
 import * as React from 'react'
 import { useCallback, useMemo, useState } from 'react'
+import { useNewTabPref } from '../../../../hooks/usePref'
 import { Channels, Publisher, Publishers, PublisherType } from '../../../../api/brave_news'
 import { api, isPublisherEnabled } from '../../../../api/brave_news/news'
 import Modal from './Modal'
@@ -29,6 +30,9 @@ interface BraveNewsContext {
   // Publishers to suggest to the user.
   suggestedPublisherIds: string[]
   updateSuggestedPublisherIds: () => void
+  isOptInPrefEnabled: boolean | undefined
+  isShowOnNTPPrefEnabled: boolean | undefined
+  toggleBraveNewsOnNTP: (enabled: boolean) => void
 }
 
 export const BraveNewsContext = React.createContext<BraveNewsContext>({
@@ -40,7 +44,10 @@ export const BraveNewsContext = React.createContext<BraveNewsContext>({
   subscribedPublisherIds: [],
   channels: {},
   suggestedPublisherIds: [],
-  updateSuggestedPublisherIds: () => {}
+  updateSuggestedPublisherIds: () => {},
+  isOptInPrefEnabled: undefined,
+  isShowOnNTPPrefEnabled: undefined,
+  toggleBraveNewsOnNTP: (enabled: boolean) => {}
 })
 
 export function BraveNewsContextProvider (props: { children: React.ReactNode }) {
@@ -48,6 +55,16 @@ export function BraveNewsContextProvider (props: { children: React.ReactNode }) 
   const [channels, setChannels] = useState<Channels>({})
   const [publishers, setPublishers] = useState<Publishers>({})
   const [suggestedPublisherIds, setSuggestedPublisherIds] = useState<string[]>([])
+  // TODO(petemill): Pref should come from the API since it isn't NTP-related. We should
+  // not use useNewTabPref here so that we can move Brave News to a shared component.
+  // But for now we're tied to NTP.
+  const [isOptInPrefEnabled, setOptInPrefEnabled] = useNewTabPref('isBraveTodayOptedIn')
+  const [isShowOnNTPPrefEnabled, setShowOnNTPPrefEnabled] = useNewTabPref('showToday')
+
+  // Update initially and when opt-in / enabled changes
+  React.useEffect(() => {
+    api.update()
+  }, [isOptInPrefEnabled && isShowOnNTPPrefEnabled])
 
   React.useEffect(() => {
     const handler = () => setChannels(api.getChannels())
@@ -87,6 +104,15 @@ export function BraveNewsContextProvider (props: { children: React.ReactNode }) 
     sortedPublishers.filter(isPublisherEnabled).map(p => p.publisherId),
     [sortedPublishers])
 
+  const toggleBraveNewsOnNTP = (shouldEnable: boolean) => {
+    if (shouldEnable) {
+      setOptInPrefEnabled(true)
+      setShowOnNTPPrefEnabled(true)
+      return
+    }
+    setShowOnNTPPrefEnabled(false)
+  }
+
   const context = useMemo<BraveNewsContext>(() => ({
     customizePage,
     setCustomizePage,
@@ -96,8 +122,11 @@ export function BraveNewsContextProvider (props: { children: React.ReactNode }) 
     sortedPublishers,
     filteredPublisherIds,
     subscribedPublisherIds,
-    updateSuggestedPublisherIds
-  }), [customizePage, channels, publishers, suggestedPublisherIds, updateSuggestedPublisherIds])
+    updateSuggestedPublisherIds,
+    isOptInPrefEnabled,
+    isShowOnNTPPrefEnabled,
+    toggleBraveNewsOnNTP
+  }), [customizePage, channels, publishers, suggestedPublisherIds, updateSuggestedPublisherIds, isOptInPrefEnabled, isShowOnNTPPrefEnabled, toggleBraveNewsOnNTP])
 
   return <BraveNewsContext.Provider value={context}>
     {props.children}

--- a/components/brave_new_tab_ui/components/default/braveToday/customize/DisabledPlaceholder.tsx
+++ b/components/brave_new_tab_ui/components/default/braveToday/customize/DisabledPlaceholder.tsx
@@ -6,7 +6,7 @@
 import Button from '$web-components/button'
 import * as React from 'react'
 import styled from 'styled-components'
-import { getLocale } from '$web-common/locale'
+import { getLocale, getLocaleWithTag } from '$web-common/locale'
 import Flex from '../../../Flex'
 
 const TodayGraphic = <svg width="370" height="80" viewBox="0 0 370 80" fill="none" xmlns="http://www.w3.org/2000/svg">
@@ -24,17 +24,31 @@ const Container = styled(Flex)`
   height: 100%;
 `
 
-const Header = styled.span`
+const Header = styled.h3`
+  padding: 0;
+  margin: 0;
   font-size: 24px;
   font-weight: 500;
-  line-height: 1.66;
+  line-height: 1.2;
   color: var(--text2);
 `
 
-const Subtitle = styled.span`
+const Subtitle = styled.p`
+  padding: 0;
+  margin: 0;
+  max-width: 66ch;
+  text-align: center;
   font-size: 14px;
   font-weight: 500;
   color: var(--text2);
+
+  & + & {
+    margin-top: 12px;
+  }
+
+  a {
+    color: inherit;
+  }
 `
 
 const EnableButton = styled(Button)`
@@ -43,17 +57,30 @@ const EnableButton = styled(Button)`
   margin-bottom: 48px;
 `
 
+const descriptionTwoTextParts = getLocaleWithTag('braveNewsIntroDescriptionTwo')
+
 export default function DisabledPlaceholder (props: { enableBraveNews: () => void }) {
-  return <Container align="center" justify="center" direction="column" gap={12}>
-    {TodayGraphic}
-    <Header>
-      {getLocale('braveNewsDisabledPlaceholderHeader')}
-    </Header>
-    <Subtitle>
-      {getLocale('braveNewsDisabledPlaceholderSubtitle')}
-    </Subtitle>
-    <EnableButton isPrimary onClick={props.enableBraveNews}>
-      {getLocale('braveNewsDisabledPlaceholderEnableButton')}
-    </EnableButton>
-  </Container>
+  return (
+    <Container align="center" justify="center" direction="column" gap={26}>
+      {TodayGraphic}
+      <Header>
+        {getLocale('braveNewsIntroTitle')}
+      </Header>
+      <div>
+        <Subtitle>
+          {getLocale('braveNewsIntroDescription')}
+        </Subtitle>
+        <Subtitle>
+          {descriptionTwoTextParts.beforeTag}
+            <a href={'https://brave.com/privacy/browser/'}>
+              {descriptionTwoTextParts.duringTag}
+            </a>
+          {descriptionTwoTextParts.afterTag}
+        </Subtitle>
+      </div>
+      <EnableButton isPrimary onClick={props.enableBraveNews}>
+        {getLocale('braveNewsOptInActionLabel')}
+      </EnableButton>
+    </Container>
+  )
 }

--- a/components/brave_new_tab_ui/components/default/braveToday/customize/Modal.tsx
+++ b/components/brave_new_tab_ui/components/default/braveToday/customize/Modal.tsx
@@ -11,6 +11,7 @@ import { useBraveNews } from './Context'
 const Configure = React.lazy(() => import('./Configure'))
 
 const Dialog = styled.dialog`
+  font-family: ${p => p.theme.fontFamily.body};
   border-radius: 8px;
   border: none;
   width: min(100vw, 1049px);

--- a/components/brave_new_tab_ui/components/default/braveToday/customize/SourcesList.tsx
+++ b/components/brave_new_tab_ui/components/default/braveToday/customize/SourcesList.tsx
@@ -14,7 +14,7 @@ import usePromise from '../../../../hooks/usePromise'
 
 const Title = styled.span`
   font-size: 18px;
-  font-weight: 800;
+  font-weight: 600;
   line-height: 36px;
 `
 

--- a/components/brave_new_tab_ui/components/default/braveToday/customize/SourcesListEntry.tsx
+++ b/components/brave_new_tab_ui/components/default/braveToday/customize/SourcesListEntry.tsx
@@ -7,9 +7,10 @@ import * as React from 'react'
 import styled from 'styled-components'
 import { getLocale } from '$web-common/locale'
 import Flex from '../../../Flex'
-import { useChannelSubscribed, usePublisher, usePublisherFollowed } from './Context'
 import { useLazyFavicon } from '../useUnpaddedImageUrl'
+import { useChannelSubscribed, usePublisher, usePublisherFollowed } from './Context'
 import { getTranslatedChannelName } from './ChannelCard'
+import { channels as ChannelIcons } from './Icons'
 
 interface Props {
   publisherId: string
@@ -17,6 +18,7 @@ interface Props {
 
 const ToggleButton = styled.button`
   all: unset;
+  flex: 0 0 auto;
   cursor: pointer;
   color: var(--brave-color-text02);
   &:hover {
@@ -40,7 +42,7 @@ const Container = styled(Flex)`
 `
 
 const FavIconContainer = styled.div`
-  width: 24px;
+  flex: 0 0 24px;
   height: 24px;
   flex-shrink: 0;
   border-radius: 100px;
@@ -52,12 +54,13 @@ const FavIconContainer = styled.div`
 `
 
 const Text = styled.span`
+  flex: 1 1 0;
+  word-break: break-word;
   font-size: 14px;
   font-weight: 500;
 `
 
-const ChannelNameText = styled.span`
-  font-size: 14px;
+const ChannelNameText = styled(Text)`
   font-weight: 600;
 `
 
@@ -67,33 +70,40 @@ function FavIcon (props: { publisherId: string }) {
     rootMargin: '200px 0px 200px 0px'
   })
   const [error, setError] = React.useState(false)
-  return <FavIconContainer ref={setElementRef}>
-    {url && !error && <img src={url} onError={() => setError(true)} />}
-  </FavIconContainer>
+  return (
+    <FavIconContainer ref={setElementRef}>
+      {url && !error && <img src={url} onError={() => setError(true)} />}
+    </FavIconContainer>
+  )
 }
 
 export function FeedListEntry (props: Props) {
   const publisher = usePublisher(props.publisherId)
   const { setFollowed } = usePublisherFollowed(props.publisherId)
 
-  return <Container direction="row" justify="space-between" align='center'>
-    <Flex align='center' gap={8}>
+  return (
+    <Container direction="row" justify="space-between" align='center' gap={8}>
       <FavIcon publisherId={props.publisherId} />
       <Text>{publisher.publisherName}</Text>
-    </Flex>
-    <ToggleButton onClick={() => setFollowed(false)}>
-      {getLocale('braveNewsFollowButtonFollowing')}
-    </ToggleButton>
-  </Container>
+      <ToggleButton onClick={() => setFollowed(false)}>
+        {getLocale('braveNewsFollowButtonFollowing')}
+      </ToggleButton>
+    </Container>
+  )
 }
 
 export function ChannelListEntry (props: { channelName: string }) {
   const { setSubscribed } = useChannelSubscribed(props.channelName)
 
-  return <Container direction="row" justify='space-between' align='center'>
-    <ChannelNameText>{getTranslatedChannelName(props.channelName)}</ChannelNameText>
-    <ToggleButton onClick={() => setSubscribed(false)}>
-      {getLocale('braveNewsFollowButtonFollowing')}
-    </ToggleButton>
-  </Container>
+  return (
+    <Container direction="row" justify='space-between' align='center' gap={8}>
+      <FavIconContainer>
+        {ChannelIcons[props.channelName] ?? ChannelIcons.default}
+      </FavIconContainer>
+      <ChannelNameText>{getTranslatedChannelName(props.channelName)}</ChannelNameText>
+      <ToggleButton onClick={() => setSubscribed(false)}>
+        {getLocale('braveNewsFollowButtonFollowing')}
+      </ToggleButton>
+    </Container>
+  )
 }

--- a/components/brave_new_tab_ui/stories/today.tsx
+++ b/components/brave_new_tab_ui/stories/today.tsx
@@ -95,7 +95,7 @@ export const Loading = () => (
 )
 
 export const Error = () => (
-  <BraveTodayErrorCard />
+  <BraveTodayErrorCard onRefresh={() => console.log('refresh clicked')} />
 )
 
 const handleDisplayAdVisit = () => alert('handle visit')

--- a/components/brave_new_tab_ui/stories/today.tsx
+++ b/components/brave_new_tab_ui/stories/today.tsx
@@ -8,10 +8,12 @@ import { withKnobs, text } from '@storybook/addon-knobs'
 import ThemeProvider from '../../common/BraveCoreThemeProvider'
 import BraveTodayLoadingCard from '../components/default/braveToday/cards/cardLoading'
 import BraveTodayErrorCard from '../components/default/braveToday/cards/cardError'
+import BraveTodayOptInCard from '../components/default/braveToday/cards/cardOptIn'
 import PublisherMeta from '../components/default/braveToday/cards/PublisherMeta'
 import DisplayAdCard from '../components/default/braveToday/cards/displayAd'
-import getBraveNewsDisplayAd from './default/data/getBraveNewsDisplayAd'
 import * as BraveNews from '../api/brave_news'
+import getBraveNewsDisplayAd from './default/data/getBraveNewsDisplayAd'
+import './todayStrings'
 
 const onClick = () => alert('clicked')
 
@@ -96,6 +98,10 @@ export const Loading = () => (
 
 export const Error = () => (
   <BraveTodayErrorCard onRefresh={() => console.log('refresh clicked')} />
+)
+
+export const OptIn = () => (
+  <BraveTodayOptInCard onOptIn={() => console.log('opt-in clicked')} onDisable={() => console.log('disable clicked')} />
 )
 
 const handleDisplayAdVisit = () => alert('handle visit')

--- a/components/brave_new_tab_ui/stories/todayStrings.ts
+++ b/components/brave_new_tab_ui/stories/todayStrings.ts
@@ -1,0 +1,17 @@
+// Copyright (c) 2022 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// you can obtain one at https://mozilla.org/MPL/2.0/.
+import { provideStrings } from '../../../.storybook/locale'
+
+provideStrings({
+  braveTodayDisableSourceCommand: 'Disable content from $1',
+  braveTodayIntroTitle: 'Today\'s top stories in a completely private feed, just for you.',
+  braveTodayIntroDescription: 'Brave News is ad-supported with completely private and anonymized ads matched on your device. Your personal information always stays private, per our $1privacy policy$2.',
+  braveTodayOptInActionLabel: 'Show Brave News',
+  braveTodayOptOutActionLabel: 'No thanks',
+  braveTodayScrollHint: 'Scroll for Brave News',
+  braveNewsIntroTitle: 'Turn on Brave News, and never miss a story',
+  braveNewsIntroDescription: 'Follow your favorite sources, in a single feed. Just open a tab in Brave, scroll down, and…voila!',
+  braveNewsIntroDescriptionTwo: 'Brave News is ad-supported with private, anonymized ads. $1Learn more.$2.'
+})

--- a/components/brave_today/browser/brave_news_controller.h
+++ b/components/brave_today/browser/brave_news_controller.h
@@ -129,6 +129,7 @@ class BraveNewsController : public KeyedService,
   bool GetIsEnabled();
   void HandleSubscriptionsChanged();
   void Prefetch();
+  void MaybeInitPrefs();
 
   raw_ptr<PrefService> prefs_ = nullptr;
   raw_ptr<favicon::FaviconService> favicon_service_ = nullptr;

--- a/components/brave_today/browser/channels_controller.h
+++ b/components/brave_today/browser/channels_controller.h
@@ -47,6 +47,11 @@ class ChannelsController {
                             const std::string& channel_id);
 
  private:
+  FRIEND_TEST_ALL_PREFIXES(BraveNewsFeedBuildingTest, BuildFeedV2);
+  static void SetChannelSubscribedPref(PrefService* prefs,
+                                       const std::string& locale,
+                                       const std::string& channel_id,
+                                       bool subscribed);
   raw_ptr<PrefService> prefs_;
   raw_ptr<PublishersController> publishers_controller_;
 };

--- a/components/brave_today/browser/feed_building.cc
+++ b/components/brave_today/browser/feed_building.cc
@@ -267,14 +267,16 @@ bool ShouldDisplayFeedItem(const mojom::FeedItemPtr& feed_item,
       // it belongs to are subscribed to.
       for (const auto& locale_info : publisher->locales) {
         for (const auto& channel_id : locale_info->channels) {
-          const auto& channel = channels.at(channel_id);
-          if (base::Contains(channel->subscribed_locales,
-                             locale_info->locale)) {
-            VLOG(2) << "Showing article because publisher "
-                    << data->publisher_id << ": " << publisher->publisher_name
-                    << " is in channel " << locale_info->locale << "."
-                    << channel_id << " which is subscribed to.";
-            return true;
+          if (channels.contains(channel_id)) {
+            const auto& channel = channels.at(channel_id);
+            if (base::Contains(channel->subscribed_locales,
+                               locale_info->locale)) {
+              VLOG(2) << "Showing article because publisher "
+                      << data->publisher_id << ": " << publisher->publisher_name
+                      << " is in channel " << locale_info->locale << "."
+                      << channel_id << " which is subscribed to.";
+              return true;
+            }
           }
         }
       }

--- a/components/brave_today/browser/feed_building_unittest.cc
+++ b/components/brave_today/browser/feed_building_unittest.cc
@@ -81,7 +81,7 @@ std::string GetFeedJson() {
           "score": 13.96799592432192
         },
         {
-          "category": "Technology",
+          "category": "Top News",
           "publish_time": "2021-09-01 07:01:28",
           "url": "https://www.digitaltrends.com/computing/logi-bolt-secure-wireless-connectivity/",
           "title": "Expecting Second Logitech built Bolt to make wireless mice and keyboards work better",
@@ -92,7 +92,7 @@ std::string GetFeedJson() {
           "creative_instance_id": "",
           "url_hash": "523b9f2091474c2a082c06ec17965f8c2392f871917407228bbeb51d8a55d6be",
           "padded_img": "https://pcdn.brave.com/brave-today/cache/052e832456e00a3cee51c68eee206fe71c32cba35d5e53dee2777dd132e01364.jpg.pad",
-          "score": 13.91160989810695
+          "score": 13.97160989810695
         }
       ]
     )";
@@ -114,13 +114,13 @@ std::vector<mojom::LocaleInfoPtr> CreateLocales(
 void PopulatePublishers(Publishers* publisher_list) {
   auto publisher1 = mojom::Publisher::New(
       "111", mojom::PublisherType::COMBINED_SOURCE, "First Publisher",
-      "Top News", true, CreateLocales({"en_US"}, {"Top News"}),
+      "Top News", true, CreateLocales({"en_US"}, {"Top News", "Top Sources"}),
       GURL("https://www.example.com"), absl::nullopt, absl::nullopt,
       absl::nullopt, GURL("https://first-publisher.com/feed.xml"),
       mojom::UserEnabled::NOT_MODIFIED);
   auto publisher2 = mojom::Publisher::New(
       "222", mojom::PublisherType::COMBINED_SOURCE, "Second Publisher",
-      "Top News", true, CreateLocales({"en_US"}, {"Top News"}),
+      "Top News", true, CreateLocales({"en_US"}, {"Top News", "Top Sources"}),
       GURL("https://www.example.com"), absl::nullopt, absl::nullopt,
       absl::nullopt, GURL("https://second-publisher.com/feed.xml"),
       mojom::UserEnabled::NOT_MODIFIED);
@@ -153,7 +153,11 @@ class BraveNewsFeedBuildingTest : public testing::Test {
   TestingProfile profile_;
 };
 
-TEST_F(BraveNewsFeedBuildingTest, BuildFeed) {
+TEST_F(BraveNewsFeedBuildingTest, BuildFeedV1) {
+  // Use v1 feed strategy
+  base::test::ScopedFeatureList features;
+  features.InitAndDisableFeature(brave_today::features::kBraveNewsV2Feature);
+
   Publishers publisher_list;
   PopulatePublishers(&publisher_list);
 
@@ -183,10 +187,50 @@ TEST_F(BraveNewsFeedBuildingTest, BuildFeed) {
             "live-transfer-deadline-day-will-real-madrid-land-psg-star-mbappe");
   ASSERT_EQ(feed.pages[0]->items[1]->items.size(), 1u);
   ASSERT_EQ(feed.pages[0]->items[1]->items[0]->get_article()->data->url,
-            "https://www.digitaltrends.com/computing/"
-            "logi-bolt-secure-wireless-connectivity/");
+            "https://www.example.com/an-article/");
   ASSERT_EQ(feed.pages[0]->items[2]->items.size(), 1u);
   ASSERT_EQ(feed.pages[0]->items[2]->items[0]->get_article()->data->url,
+            "https://www.digitaltrends.com/computing/"
+            "logi-bolt-secure-wireless-connectivity/");
+}
+
+TEST_F(BraveNewsFeedBuildingTest, BuildFeedV2) {
+  // Use v2 feed strategy by subscribing to a channel
+  base::test::ScopedFeatureList features;
+  features.InitAndEnableFeature(brave_today::features::kBraveNewsV2Feature);
+
+  ChannelsController::SetChannelSubscribedPref(profile_.GetPrefs(), "en_US",
+                                               "Top Sources", true);
+
+  Publishers publisher_list;
+  PopulatePublishers(&publisher_list);
+
+  std::unordered_set<std::string> history_hosts = {"www.espn.com"};
+
+  std::vector<mojom::FeedItemPtr> feed_items;
+  ParseFeedItems(GetFeedJson(), &feed_items);
+
+  mojom::Feed feed;
+
+  ASSERT_TRUE(BuildFeed(feed_items, history_hosts, &publisher_list, &feed,
+                        profile_.GetPrefs()));
+  ASSERT_EQ(feed.pages.size(), 1u);
+  // Validate featured article is top news
+  ASSERT_TRUE(feed.featured_item->is_article());
+  ASSERT_EQ(feed.featured_item->get_article()->data->url.spec(),
+            "https://www.digitaltrends.com/computing/"
+            "logi-bolt-secure-wireless-connectivity/");
+  // Validate sorted by score descending
+  ASSERT_GE(feed.pages[0]->items.size(), 2u);
+  // Because we cannot access a flat list, then select the items from each card
+  // (some cards have 1 item, some have 2, etc). If the page_content_order
+  // changes, then also change here which items we access in which order.
+  ASSERT_EQ(feed.pages[0]->items[0]->items.size(), 1u);
+  ASSERT_EQ(feed.pages[0]->items[0]->items[0]->get_article()->data->url,
+            "https://www.espn.com/soccer/blog-transfer-talk/story/4465789/"
+            "live-transfer-deadline-day-will-real-madrid-land-psg-star-mbappe");
+  ASSERT_EQ(feed.pages[0]->items[1]->items.size(), 1u);
+  ASSERT_EQ(feed.pages[0]->items[1]->items[0]->get_article()->data->url,
             "https://www.example.com/an-article/");
 }
 
@@ -221,6 +265,10 @@ TEST_F(BraveNewsFeedBuildingTest, DirectFeedsShouldAlwaysBeDisplayed) {
 }
 
 TEST_F(BraveNewsFeedBuildingTest, RemovesDefaultOffItems) {
+  // Use v1 feed strategy
+  base::test::ScopedFeatureList features;
+  features.InitAndDisableFeature(brave_today::features::kBraveNewsV2Feature);
+
   Publishers publisher_list;
   PopulatePublishers(&publisher_list);
   std::unordered_set<std::string> history_hosts = {};

--- a/components/brave_today/browser/feed_controller.cc
+++ b/components/brave_today/browser/feed_controller.cc
@@ -142,6 +142,7 @@ void FeedController::EnsureFeedIsUpdating() {
               VLOG(1) << "All feed item fetches done with item count: "
                       << total_size;
               if (total_size == 0) {
+                controller->ResetFeed();
                 controller->NotifyUpdateDone();
                 return;
               }

--- a/components/brave_today/browser/locales_helper.h
+++ b/components/brave_today/browser/locales_helper.h
@@ -28,6 +28,10 @@ base::flat_set<std::string> GetPublisherLocales(const Publishers& publishers);
 base::flat_set<std::string> GetMinimalLocalesSet(
     const base::flat_set<std::string>& channel_locales,
     const Publishers& publishers);
+
+// Calculate if Brave News should be enabled on the NTP by checking the
+// user's locale.
+bool IsUserInDefaultEnabledLocale();
 }  // namespace brave_news
 
 #endif  // BRAVE_COMPONENTS_BRAVE_TODAY_BROWSER_LOCALES_HELPER_H_

--- a/components/brave_today/browser/publishers_controller.cc
+++ b/components/brave_today/browser/publishers_controller.cc
@@ -238,7 +238,7 @@ void PublishersController::UpdateDefaultLocale() {
   // wants the format to be "language_COUNTRY".
   const std::string brave_news_locale =
       base::StrCat({brave_l10n::GetDefaultISOLanguageCodeString(), "_",
-                    brave_l10n::GetDefaultISOLanguageCodeString()});
+                    brave_l10n::GetDefaultISOCountryCodeString()});
 
   // Fallback to en_US, if we can't match anything else.
   // TODO(fallaciousreasoning): Implement more complicated fallback

--- a/components/brave_today/browser/urls_unittest.cc
+++ b/components/brave_today/browser/urls_unittest.cc
@@ -15,12 +15,20 @@
 
 class BraveNewsUrlsTest : public testing::Test {};
 
-TEST_F(BraveNewsUrlsTest, BraveNewsV2IsDisabled) {
+TEST_F(BraveNewsUrlsTest, BraveNewsV2FeatureFlag) {
+#if BUILDFLAG(IS_ANDROID)
   EXPECT_FALSE(
       base::FeatureList::IsEnabled(brave_today::features::kBraveNewsV2Feature));
+#else
+  EXPECT_TRUE(
+      base::FeatureList::IsEnabled(brave_today::features::kBraveNewsV2Feature));
+#endif
 }
 
-TEST_F(BraveNewsUrlsTest, BraveNewsUsesV1ByDefault) {
+TEST_F(BraveNewsUrlsTest, BraveNewsV1UsesLocalUrl) {
+  base::test::ScopedFeatureList features;
+  features.InitAndDisableFeature(brave_today::features::kBraveNewsV2Feature);
+
   {
     brave_l10n::test::ScopedDefaultLocale scoped_default_locale{"en_US"};
     std::string region = brave_today::GetRegionUrlPart();
@@ -44,7 +52,7 @@ TEST_F(BraveNewsUrlsTest, BraveNewsUsesV1ByDefault) {
   }
 }
 
-TEST_F(BraveNewsUrlsTest, BraveNewsV2FlagUsesGlobalFeeds) {
+TEST_F(BraveNewsUrlsTest, BraveNewsUsesGlobalFeedsWithV2) {
   base::test::ScopedFeatureList features;
   features.InitAndEnableFeature(brave_today::features::kBraveNewsV2Feature);
 

--- a/components/brave_today/common/features.cc
+++ b/components/brave_today/common/features.cc
@@ -12,8 +12,16 @@ namespace features {
 
 const base::Feature kBraveNewsFeature{"BraveNews",
                                       base::FEATURE_ENABLED_BY_DEFAULT};
-const base::Feature kBraveNewsV2Feature{"BraveNewsV2",
-                                        base::FEATURE_DISABLED_BY_DEFAULT};
+
+const base::Feature kBraveNewsV2Feature {
+  "BraveNewsV2",
+#if BUILDFLAG(IS_ANDROID)
+      base::FEATURE_DISABLED_BY_DEFAULT
+#else
+      base::FEATURE_ENABLED_BY_DEFAULT
+#endif
+};
+
 const base::Feature kBraveNewsCardPeekFeature{"BraveNewsCardPeek",
                                               base::FEATURE_ENABLED_BY_DEFAULT};
 const base::Feature kBraveNewsSubscribeButtonFeature{

--- a/components/resources/brave_components_strings.grd
+++ b/components/resources/brave_components_strings.grd
@@ -284,15 +284,6 @@
       <message name="IDS_BRAVE_TODAY_TITLE" translateable="false" desc="Title for Brave News news feed section">
         Brave News
       </message>
-      <message name="IDS_BRAVE_TODAY_INTRO_TITLE" desc="Title for introduction to Brave News news feed section">
-        Today's top stories in a completely private feed, just for you.
-      </message>
-      <message name="IDS_BRAVE_TODAY_INTRO_DESCRIPTION" desc="Description for introduction to Brave News news feed section. Do not translate the title Brave News.">
-        Brave News is ad-supported with completely private and anonymized ads matched on your device. Your personal information always stays private, per our <ph name="LINK_START">$1<ex>{</ex></ph>privacy policy<ph name="LINK_END">$2<ex>}</ex></ph>.
-      </message>
-      <message name="IDS_BRAVE_TODAY_OPT_IN_ACTION_LABEL" desc="Button text for opting in to Brave News">
-        Show Brave News
-      </message>
       <message name="IDS_BRAVE_TODAY_SHOW_TOOLBAR_BUTTON" desc="Button text for opting in to Brave News">
         Show Brave News button in the toolbar
       </message>
@@ -316,9 +307,6 @@
       </message>
       <message name="IDS_BRAVE_NEWS_BUBBLE_MANAGE_FEEDS" desc="The text on the button for opening the Brave News configuration page">
         Manage Feeds
-      </message>
-      <message name="IDS_BRAVE_TODAY_OPT_OUT_ACTION_LABEL" desc="Button text for opting out of Brave News">
-        No thanks
       </message>
       <message name="IDS_BRAVE_TODAY_STATUS_FETCHING" desc="Indication that the content is being downloaded...">
         Fetching…

--- a/components/resources/brave_news_strings.grdp
+++ b/components/resources/brave_news_strings.grdp
@@ -1,19 +1,25 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <grit-part>
+  <message name="IDS_BRAVE_NEWS_INTRO_TITLE" desc="Title for introduction to Brave News news feed section">
+    Turn on Brave News, and never miss a story
+  </message>
+  <message name="IDS_BRAVE_NEWS_INTRO_DESCRIPTION" desc="Description for introduction to Brave News news feed section. Do not translate the title Brave News.">
+    Follow your favorite sources, in a single feed. Just open a tab in Brave, scroll down, and… voila!
+  </message>
+  <message name="IDS_BRAVE_NEWS_INTRO_DESCRIPTION_TWO" desc="Description second paragraph for introduction to Brave News news feed section. Do not translate the title Brave News.">
+    Brave News is ad-supported with private, anonymized ads. <ph name="LINK_START">$1<ex>{</ex></ph>Learn more.<ph name="LINK_END">$2<ex>}</ex></ph>.
+  </message>
+  <message name="IDS_BRAVE_NEWS_OPT_IN_ACTION_LABEL" desc="Button text for opting in to Brave News">
+    Turn on Brave News
+  </message>
+  <message name="IDS_BRAVE_NEWS_OPT_OUT_ACTION_LABEL" desc="Button text for opting out of Brave News">
+    No thanks
+  </message>
   <message name="IDS_BRAVE_NEWS_BACK_TO_DASHBOARD" desc="Label for the back to dashboard button">
     Back to <ph name="BEGIN_BOLD">$1</ph>Dashboard<ph name="END_BOLD">$2</ph>
   </message>
   <message name="IDS_BRAVE_NEWS_BACK_BUTTON" desc="Label for the back button">
     Back
-  </message>
-  <message name="IDS_BRAVE_NEWS_DISABLED_PLACEHOLDER_HEADER" desc="Header for the brave news disabled placeholder">
-    Turn on Brave News, and never miss a story
-  </message>
-  <message name="IDS_BRAVE_NEWS_DISABLED_PLACEHOLDER_SUBTITLE" desc="Subtitle for the brave news disabled placeholder">
-    Customized news feeds, from leading sources, delivered right to your browser. All 100% private.
-  </message>
-  <message name="IDS_BRAVE_NEWS_DISABLED_PLACEHOLDER_ENABLE_BUTTON" desc="Label for the button to reenable Brave News from the disabled placeholder">
-    Turn on Brave News
   </message>
   <message name="IDS_BRAVE_NEWS_SEARCH_PLACEHOLDER_LABEL" desc="Label that displays in the searchbox when the user hasn't entered anything">
     Search for site, topic, or RSS feed

--- a/components/resources/brave_news_strings.grdp
+++ b/components/resources/brave_news_strings.grdp
@@ -69,6 +69,24 @@
   <message name="IDS_BRAVE_NEWS_SUGGESTIONS_SUBTITLE" desc="Subtitle of the suggested sources section">
     Some sources you might like. Suggestions are anonymous and matched only on your device.
   </message>
+  <message name="IDS_BRAVE_NEWS_ERROR_HEADING" desc="Message heading for when there is a Brave News error">
+    Oops…
+  </message>
+  <message name="IDS_BRAVE_NEWS_ERROR_MESSAGE" desc="Message body for when there is a Brave News error">
+    Brave News was unable to fetch content.
+  </message>
+  <message name="IDS_BRAVE_NEWS_ERROR_ACTION_LABEL" desc="Message action label for when there is a Brave News error">
+    Try again
+  </message>
+  <message name="IDS_BRAVE_NEWS_NO_CONTENT_HEADING" desc="Message heading for when there is no Brave News content">
+    No content
+  </message>
+  <message name="IDS_BRAVE_NEWS_NO_CONTENT_MESSAGE" desc="Message body for when there is no Brave News content">
+    Brave News has no content to show.
+  </message>
+  <message name="IDS_BRAVE_NEWS_NO_CONTENT_ACTION_LABEL" desc="Message action label for when there is no Brave News content">
+    Choose content sources
+  </message>
 
   <message name="IDS_BRAVE_NEWS_CHANNEL_BRAVE" desc="Translation of the 'Brave' channel">
     Brave


### PR DESCRIPTION
Via https://github.com/brave/brave-core/pull/15779:
- https://github.com/brave/brave-browser/issues/26494 (enable Brave News v2 by default)

Via https://github.com/brave/brave-core/pull/15814
- https://github.com/brave/brave-browser/issues/26560 (list spacing styles)

Via https://github.com/brave/brave-core/pull/15858
- https://github.com/brave/brave-browser/issues/26277 (inline ads are shown first without a featured item)
- https://github.com/brave/brave-browser/issues/26303 (feed content should be removed when unfollowing everything)

Via https://github.com/brave/brave-core/pull/15877
- https://github.com/brave/brave-browser/issues/26519 (toggle works as expected)
- https://github.com/brave/brave-browser/issues/26520 (opt-in wording change)
- https://github.com/brave/brave-browser/issues/26678 (add new locales)