### PR TITLE
WIP: move vertical tabs out of contents layout

### DIFF
--- a/browser/ui/views/frame/brave_browser_view_layout.cc
+++ b/browser/ui/views/frame/brave_browser_view_layout.cc
@@ -19,6 +19,26 @@ void BraveBrowserViewLayout::LayoutSidePanelView(
   return;
 }
 
+void BraveBrowserViewLayout::Layout(views::View* host) {
+  BrowserViewLayout::Layout(host);
+  if (!vertical_tab_strip_host_view_)
+    return;
+
+  const auto vertical_tab_strip_width = vertical_tab_strip_host_view_->GetPreferredSize().width();
+  for (auto* child : host->children()) {
+    if (child == vertical_tab_strip_host_view_) {
+      gfx::Rect bounds = vertical_layout_rect_;
+      bounds.set_width(vertical_tab_strip_width);
+      vertical_tab_strip_host_view_->SetBoundsRect(bounds);
+      continue;
+    }
+
+    gfx::Rect child_bounds = child->bounds();
+    child_bounds.Inset(gfx::Insets().set_left(vertical_tab_strip_width));
+    child->SetBoundsRect(child_bounds);
+  }
+}
+
 int BraveBrowserViewLayout::LayoutTabStripRegion(int top) {
   if (tabs::features::ShouldShowVerticalTabs(browser_view_->browser()))
     return top;

--- a/browser/ui/views/frame/brave_browser_view_layout.h
+++ b/browser/ui/views/frame/brave_browser_view_layout.h
@@ -7,16 +7,23 @@
 #define BRAVE_BROWSER_UI_VIEWS_FRAME_BRAVE_BROWSER_VIEW_LAYOUT_H_
 
 #include "chrome/browser/ui/views/frame/browser_view_layout.h"
-
 class BraveBrowserViewLayout : public BrowserViewLayout {
  public:
   using BrowserViewLayout::BrowserViewLayout;
   ~BraveBrowserViewLayout() override;
 
+  void set_vertical_tab_strip_host_view(views::View* view) {
+    vertical_tab_strip_host_view_ = view;
+  }
+
   // BrowserViewLayout overrides:
+  void Layout(views::View* host) override;
   void LayoutSidePanelView(views::View* side_panel,
                            gfx::Rect& contents_container_bounds) override;
   int LayoutTabStripRegion(int top) override;
+
+ private:
+  raw_ptr<views::View> vertical_tab_strip_host_view_ = nullptr;
 };
 
 #endif  // BRAVE_BROWSER_UI_VIEWS_FRAME_BRAVE_BROWSER_VIEW_LAYOUT_H_

--- a/browser/ui/views/frame/brave_contents_layout_manager.cc
+++ b/browser/ui/views/frame/brave_contents_layout_manager.cc
@@ -12,12 +12,10 @@
 BraveContentsLayoutManager::BraveContentsLayoutManager(
     views::View* devtools_view,
     views::View* contents_view,
-    views::View* sidebar_container_view,
-    views::View* vertical_tabs_container)
+    views::View* sidebar_container_view)
     : ContentsLayoutManager(devtools_view, contents_view),
-      sidebar_container_view_(sidebar_container_view),
-      vertical_tabs_container_(vertical_tabs_container) {
-  DCHECK(sidebar_container_view_ || vertical_tabs_container_);
+      sidebar_container_view_(sidebar_container_view) {
+  DCHECK(sidebar_container_view_);
 }
 
 BraveContentsLayoutManager::~BraveContentsLayoutManager() = default;
@@ -35,7 +33,6 @@ void BraveContentsLayoutManager::Layout(views::View* contents_container) {
   } else {
     right_side_candidate_views.push_back(sidebar_container_view_);
   }
-  left_side_candidate_views.push_back(vertical_tabs_container_);
 
   int taken_left_width = 0;
   for (auto* view : left_side_candidate_views) {

--- a/browser/ui/views/frame/brave_contents_layout_manager.h
+++ b/browser/ui/views/frame/brave_contents_layout_manager.h
@@ -13,8 +13,7 @@ class BraveContentsLayoutManager : public ContentsLayoutManager {
  public:
   BraveContentsLayoutManager(views::View* devtools_view,
                              views::View* contents_view,
-                             views::View* sidebar_container_view,
-                             views::View* vertical_tabs_container);
+                             views::View* sidebar_container_view);
   BraveContentsLayoutManager(const BraveContentsLayoutManager&) = delete;
   BraveContentsLayoutManager& operator=(const BraveContentsLayoutManager&) =
       delete;
@@ -29,7 +28,6 @@ class BraveContentsLayoutManager : public ContentsLayoutManager {
 
  private:
   raw_ptr<views::View> sidebar_container_view_ = nullptr;
-  raw_ptr<views::View> vertical_tabs_container_ = nullptr;
   bool sidebar_on_left_ = true;
 };
 


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/26688

https://user-images.githubusercontent.com/5474642/201449240-2c05162e-4fb9-4bdc-bdd9-69cb0160d7b9.mov


## Submitter Checklist:

- [ ] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

