### PR TITLE
Bumped deep-object-diff from 1.1.0 to 1.1.9 to address GHSA-653v-rqx9-j85p, a.k.a. CVE-2022-41713 (uplift to 1.45.x)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5978,7 +5978,7 @@
         "@emotion/styled": "^10.0.27",
         "@storybook/client-logger": "6.4.13",
         "core-js": "^3.8.2",
-        "deep-object-diff": "^1.1.0",
+        "deep-object-diff": "^1.1.9",
         "emotion-theming": "^10.0.27",
         "global": "^4.4.0",
         "memoizerific": "^1.11.3",
@@ -11579,9 +11579,9 @@
       "dev": true
     },
     "node_modules/deep-object-diff": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/deep-object-diff/-/deep-object-diff-1.1.0.tgz",
-      "integrity": "sha512-b+QLs5vHgS+IoSNcUE4n9HP2NwcHj7aqnJWsjPtuG75Rh5TOaGt0OjAYInh77d5T16V5cRDC+Pw/6ZZZiETBGw==",
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/deep-object-diff/-/deep-object-diff-1.1.9.tgz",
+      "integrity": "sha512-Rn+RuwkmkDwCi2/oXOFS9Gsr5lJZu/yTGpK7wAaAIE75CC+LCGEZHpY6VQJa/RoJcrmaA/docWJZvYohlNkWPA==",
       "dev": true
     },
     "node_modules/deepmerge": {
@@ -32591,7 +32591,7 @@
         "@emotion/styled": "^10.0.27",
         "@storybook/client-logger": "6.4.13",
         "core-js": "^3.8.2",
-        "deep-object-diff": "^1.1.0",
+        "deep-object-diff": "^1.1.9",
         "emotion-theming": "^10.0.27",
         "global": "^4.4.0",
         "memoizerific": "^1.11.3",
@@ -37082,9 +37082,9 @@
       "dev": true
     },
     "deep-object-diff": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/deep-object-diff/-/deep-object-diff-1.1.0.tgz",
-      "integrity": "sha512-b+QLs5vHgS+IoSNcUE4n9HP2NwcHj7aqnJWsjPtuG75Rh5TOaGt0OjAYInh77d5T16V5cRDC+Pw/6ZZZiETBGw==",
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/deep-object-diff/-/deep-object-diff-1.1.9.tgz",
+      "integrity": "sha512-Rn+RuwkmkDwCi2/oXOFS9Gsr5lJZu/yTGpK7wAaAIE75CC+LCGEZHpY6VQJa/RoJcrmaA/docWJZvYohlNkWPA==",
       "dev": true
     },
     "deepmerge": {


### PR DESCRIPTION
Uplift of #15934
Resolves https://github.com/brave/brave-browser/issues/26619
Resolves https://github.com/brave/brave-browser/issues/26745

Pre-approval checklist: 
- [ ] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [ ] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [ ] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [ ] The associated issue milestone is set to the smallest version that the changes is landed on.