### PR TITLE
Use upstream breakpad symbols generator on MacOS.

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -410,8 +410,12 @@ if (should_generate_symbols) {
 }
 
 group("create_symbols_dist") {
+  # Currently on some platforms (Android, Linux) this target generate more
+  # than just symbols, so always depend on it.
+  public_deps = [ "//brave/app/$current_os:symbol_dist_resources" ]
+
   if (should_generate_symbols) {
-    public_deps = [
+    public_deps += [
       ":create_breakpad_symbols_dist",
       ":create_native_symbols_dist",
     ]

--- a/BUILD.gn
+++ b/BUILD.gn
@@ -376,25 +376,46 @@ template("create_dist_template") {
   }
 }
 
-create_dist_template("create_native_symbols_dist") {
-  output = "$brave_dist_dir/$brave_product_name-v$brave_version-$brave_platform-$target_arch-native-symbols.7z"
-  dir_inputs = [ "$brave_product_name.pdb.syms" ]
-  deps = [ "app/$current_os:symbol_dist_resources" ]
+if (should_generate_breakpad_symbols) {
+  create_dist_template("create_breakpad_symbols_dist") {
+    if (is_android) {
+      output = "$brave_dist_dir/$brave_product_name-v$brave_version-$brave_platform-$target_android_base-$target_cpu-symbols-$target_android_output_format.zip"
+    } else {
+      output = "$brave_dist_dir/$brave_product_name-v$brave_version-$brave_platform-$target_arch-symbols.zip"
+    }
+
+    deps = [ "//brave/app/$current_os:symbol_dist_resources" ]
+
+    dir_inputs = [ "$brave_product_name.breakpad.syms" ]
+  }
+
+  if (is_win) {
+    create_dist_template("create_native_symbols_dist") {
+      output = "$brave_dist_dir/$brave_product_name-v$brave_version-$brave_platform-$target_arch-native-symbols.7z"
+      dir_inputs = [ "$brave_product_name.pdb.syms" ]
+
+      deps = [ "//brave/app/win:generate_breakpad_symbols" ]
+    }
+  } else if (is_mac) {
+    copy("create_native_symbols_dist") {
+      sources = [ "$root_out_dir/$chrome_product_full_name.dSYM.tar.bz2" ]
+      outputs = [ "$brave_dist_dir/$brave_product_name-v$brave_version-$brave_platform-$target_arch-native-symbols.tar.bz2" ]
+
+      deps = [ "//chrome:chrome_dsym_archive" ]
+    }
+  } else {
+    group("create_native_symbols_dist") {
+    }
+  }
 }
 
-create_dist_template("create_symbols_dist") {
-  if (is_android) {
-    output = "$brave_dist_dir/$brave_product_name-v$brave_version-$brave_platform-$target_android_base-$target_cpu-symbols-$target_android_output_format.zip"
-  } else {
-    output = "$brave_dist_dir/$brave_product_name-v$brave_version-$brave_platform-$target_arch-symbols.zip"
+group("create_symbols_dist") {
+  if (should_generate_breakpad_symbols) {
+    deps = [
+      ":create_breakpad_symbols_dist",
+      ":create_native_symbols_dist",
+    ]
   }
-
-  deps = [ "app/$current_os:symbol_dist_resources" ]
-  if (brave_debug_symbol_level == 2 && is_win) {
-    deps += [ ":create_native_symbols_dist" ]
-  }
-
-  dir_inputs = [ "$brave_product_name.breakpad.syms" ]
 }
 
 action("create_dist_zips") {

--- a/BUILD.gn
+++ b/BUILD.gn
@@ -376,7 +376,7 @@ template("create_dist_template") {
   }
 }
 
-if (should_generate_breakpad_symbols) {
+if (should_generate_symbols) {
   create_dist_template("create_breakpad_symbols_dist") {
     if (is_android) {
       output = "$brave_dist_dir/$brave_product_name-v$brave_version-$brave_platform-$target_android_base-$target_cpu-symbols-$target_android_output_format.zip"
@@ -410,8 +410,8 @@ if (should_generate_breakpad_symbols) {
 }
 
 group("create_symbols_dist") {
-  if (should_generate_breakpad_symbols) {
-    deps = [
+  if (should_generate_symbols) {
+    public_deps = [
       ":create_breakpad_symbols_dist",
       ":create_native_symbols_dist",
     ]

--- a/app/android/BUILD.gn
+++ b/app/android/BUILD.gn
@@ -1,6 +1,6 @@
 import("//brave/build/config.gni")
 
-if (should_generate_breakpad_symbols) {
+if (should_generate_symbols) {
   action("generate_breakpad_symbols") {
     symbols_dir = "$brave_dist_dir/$brave_product_name.breakpad.syms"
     outputs = [ symbols_dir ]

--- a/app/linux/BUILD.gn
+++ b/app/linux/BUILD.gn
@@ -1,7 +1,7 @@
 import("//brave/build/config.gni")
 import("//build/linux/extract_symbols.gni")
 
-if (should_generate_breakpad_symbols) {
+if (should_generate_symbols) {
   action("generate_breakpad_symbols") {
     # host_toolchain must be used for cross-compilation case.
     # See chrome/updater/mac:syms

--- a/app/mac/BUILD.gn
+++ b/app/mac/BUILD.gn
@@ -1,14 +1,7 @@
 import("//brave/build/config.gni")
 import("//chrome/version.gni")
 
-group("dist_resources") {
-}
-
-group("symbol_dist_resources") {
-  public_deps = [ ":generate_breakpad_symbols" ]
-}
-
-if (should_generate_breakpad_symbols) {
+if (should_generate_symbols) {
   action("generate_breakpad_symbols") {
     script = "//brave/tools/mac/generate_breakpad_symbols.py"
 
@@ -28,4 +21,11 @@ if (should_generate_breakpad_symbols) {
 } else {
   group("generate_breakpad_symbols") {
   }
+}
+
+group("dist_resources") {
+}
+
+group("symbol_dist_resources") {
+  public_deps = [ ":generate_breakpad_symbols" ]
 }

--- a/app/mac/BUILD.gn
+++ b/app/mac/BUILD.gn
@@ -1,68 +1,31 @@
 import("//brave/build/config.gni")
-import("//build/util/branding.gni")
-import("//chrome/common/features.gni")
 import("//chrome/version.gni")
-
-chrome_framework_name = chrome_product_full_name + " Framework"
-chrome_helper_name = chrome_product_full_name + " Helper"
-
-# This must be same value in //chrome/BUILD.gn.
-chrome_framework_version = chrome_version_full
-
-# This list must be updated with the two targets' deps list below, and
-# the list of _dsyms in :brave_dsym_archive.
-_brave_symbols_sources = [
-  "$root_out_dir/$chrome_framework_name.framework/Versions/$chrome_framework_version/$chrome_framework_name",
-  "$root_out_dir/$chrome_helper_name.app/Contents/MacOS/$chrome_helper_name",
-  "$root_out_dir/$chrome_product_full_name.app/Contents/MacOS/$chrome_product_full_name",
-  "$root_out_dir/crashpad_handler",
-]
 
 group("dist_resources") {
 }
 
 group("symbol_dist_resources") {
-  if (should_generate_breakpad_symbols) {
-    public_deps = [
-      ":generate_breakpad_symbols",
-      "//chrome:chrome_dsym_archive",
-      "//chrome:chrome_dump_syms",
-    ]
-  }
+  public_deps = [ ":generate_breakpad_symbols" ]
 }
 
-action("generate_breakpad_symbols") {
-  # host_toolchain must be used for cross-compilation case.
-  # See chrome/updater/mac:syms
-  dump_syms = "//third_party/breakpad:dump_syms($host_toolchain)"
-  symbols_dir = "$brave_dist_dir/$brave_product_name.breakpad.syms"
-  outputs = [ symbols_dir ]
+if (should_generate_breakpad_symbols) {
+  action("generate_breakpad_symbols") {
+    script = "//brave/tools/mac/generate_breakpad_symbols.py"
 
-  sources = _brave_symbols_sources
+    symbols_dir = "$brave_dist_dir/$brave_product_name.breakpad.syms"
+    outputs = [ symbols_dir ]
+    breakpad_files_glob =
+        rebase_path(root_out_dir) + "/*-$chrome_version_full.breakpad"
 
-  binaries = []
-  foreach(_source, sources) {
-    binaries += [ rebase_path(_source) ]
+    args = [
+      "--symbols-dir=" + rebase_path(symbols_dir),
+      "--input-breakpad-files-glob=$breakpad_files_glob",
+      "--clear",
+    ]
+
+    deps = [ "//chrome:chrome_dump_syms" ]
   }
-
-  script = "//brave/tools/posix/generate_breakpad_symbols.py"
-  args = [
-    "--symbols-dir=" + rebase_path(symbols_dir),
-    "--jobs=16",
-    "--build-dir=" + rebase_path(root_out_dir),
-    "--binary=$binaries",
-    "--libchromiumcontent-dir=" + rebase_path("//"),
-    "--dump-syms-bin=" + rebase_path(get_label_info(dump_syms, "root_out_dir") +
-                                     "/" + get_label_info(dump_syms, "name")),
-    "--clear",
-  ]
-
-  deps = [
-    "//chrome:chrome_app",
-    "//chrome:chrome_dump_syms",
-    "//chrome:chrome_framework",
-    "//chrome:chrome_helper_app_default",
-    "//third_party/crashpad/crashpad/handler:crashpad_handler",
-    dump_syms,
-  ]
+} else {
+  group("generate_breakpad_symbols") {
+  }
 }

--- a/app/win/BUILD.gn
+++ b/app/win/BUILD.gn
@@ -2,15 +2,14 @@ import("//brave/build/config.gni")
 import("//build/util/branding.gni")
 import("//media/cdm/library_cdm/cdm_paths.gni")
 
-if (should_generate_breakpad_symbols) {
+if (should_generate_symbols) {
   action("generate_breakpad_symbols") {
     symbols_dir = "$brave_dist_dir/$brave_product_name.breakpad.syms"
-    outputs = [ symbols_dir ]
-
-    if (brave_debug_symbol_level == 2) {
-      platform_symbols_dir = "$brave_dist_dir/$brave_product_name.pdb.syms"
-      outputs += [ platform_symbols_dir ]
-    }
+    platform_symbols_dir = "$brave_dist_dir/$brave_product_name.pdb.syms"
+    outputs = [
+      symbols_dir,
+      platform_symbols_dir,
+    ]
 
     # We want to use x64 dump_syms for x86. The obvious way of doing this would
     # be to depend on dump_sums($host_toolchain). But on Windows, host_toolchain
@@ -29,15 +28,12 @@ if (should_generate_breakpad_symbols) {
       "--installer-config=" +
           rebase_path("//chrome/installer/mini_installer/chrome.release"),
       "--symbols-dir=" + rebase_path(symbols_dir),
+      "--platform-symbols-dir=" + rebase_path(platform_symbols_dir),
       "--build-dir=" + rebase_path(root_out_dir),
       "--dump-syms-path=" + rebase_path(dump_syms_path),
       "--verbose",
       "--clear",
     ]
-
-    if (brave_debug_symbol_level == 2) {
-      args += [ "--platform-symbols-dir=" + rebase_path(platform_symbols_dir) ]
-    }
 
     script = "//brave/tools/win/generate_breakpad_symbols.py"
   }

--- a/build/config.gni
+++ b/build/config.gni
@@ -1,3 +1,4 @@
+import("//build/config/apple/symbols.gni")
 import("//build/util/branding.gni")
 import("//chrome/version.gni")
 
@@ -53,7 +54,9 @@ declare_args() {
   }
 }
 
-should_generate_breakpad_symbols = brave_debug_symbol_level != 0
+should_generate_breakpad_symbols =
+    brave_debug_symbol_level != 0 &&
+    (!is_apple || (enable_dsyms && !is_component_build))
 
 brave_version = "$brave_version_major.$brave_version_minor.$brave_version_build"
 

--- a/build/config.gni
+++ b/build/config.gni
@@ -46,17 +46,17 @@ declare_args() {
 }
 
 declare_args() {
-  if (is_official_build) {
-    # Generate all symbols (breakpad + native) for Release builds
-    brave_debug_symbol_level = 2
-  } else {
-    brave_debug_symbol_level = 0
-  }
+  # Generate symbols for Release builds.
+  # MacOS requires dSYMs and non-component build, otherwise upstream dump syms
+  # target is a no-op.
+  should_generate_symbols =
+      is_official_build && (!is_mac || (enable_dsyms && !is_component_build))
 }
 
-should_generate_breakpad_symbols =
-    brave_debug_symbol_level != 0 &&
-    (!is_apple || (enable_dsyms && !is_component_build))
+if (should_generate_symbols && is_mac) {
+  assert(enable_dsyms && !is_component_build,
+         "Incompatible args to generate symbols on MacOS")
+}
 
 brave_version = "$brave_version_major.$brave_version_minor.$brave_version_build"
 

--- a/tools/mac/generate_breakpad_symbols.py
+++ b/tools/mac/generate_breakpad_symbols.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+# Copyright (c) 2022 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+"""Converts Chrome-generated breakpad symbols to Backtrace archive format."""
+
+import argparse
+import errno
+import glob
+import os
+import re
+import shutil
+import sys
+
+
+def mkdir_p(path):
+    """Simulates mkdir -p."""
+    try:
+        os.makedirs(path)
+    except OSError as e:
+        if e.errno == errno.EEXIST and os.path.isdir(path):
+            pass
+        else:
+            raise
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--symbols-dir',
+                        required=True,
+                        help='The directory where to write the symbols file.')
+    parser.add_argument(
+        '--input-breakpad-files-glob',
+        required=True,
+        help='The glob to search for generated breakpad files.')
+    parser.add_argument(
+        '--clear',
+        default=False,
+        action='store_true',
+        help='Clear the symbols directory before writing new symbols.')
+
+    options = parser.parse_args()
+
+    if options.clear:
+        try:
+            shutil.rmtree(options.symbols_dir)
+        except:  # pylint: disable=bare-except
+            pass
+
+    input_breakpad_files = glob.glob(options.input_breakpad_files_glob)
+    if not input_breakpad_files:
+        raise FileNotFoundError(
+            f"Cannot find breakpad files: {options.input_breakpad_files_glob}")
+
+    for input_breakpad_file in input_breakpad_files:
+        with open(input_breakpad_file, mode="r", encoding="utf-8") as f:
+            first_line = f.readline()
+
+        module_line = re.match("MODULE [^ ]+ [^ ]+ ([0-9A-F]+) (.+)",
+                               first_line)
+        if not module_line:
+            raise RuntimeError(
+                f"Unexpected breakpad MODULE line: {first_line}")
+        output_path = os.path.join(options.symbols_dir, module_line.group(2),
+                                   module_line.group(1))
+        output_breakpad_file = os.path.join(output_path,
+                                            f"{module_line.group(2)}.sym")
+
+        mkdir_p(output_path)
+        shutil.copyfile(input_breakpad_file, output_breakpad_file)
+
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Reuse upstream dSYM->breakpad symbols generator. It includes all files we need, including missing helpers.
Add dSYM archive to `dist` so we can use it later if the issue won't be fixed.

Generated symbols:
```
user@mdpc dist % ls -la brave.breakpad.syms/
total 0
drwxr-xr-x  13 user  staff  416 Nov 14 21:04 .
drwxr-xr-x   6 user  staff  192 Nov 14 21:22 ..
drwxr-xr-x   3 user  staff   96 Nov 14 21:04 Brave Browser
drwxr-xr-x   3 user  staff   96 Nov 14 21:04 Brave Browser Framework
drwxr-xr-x   3 user  staff   96 Nov 14 21:04 Brave Browser Helper
drwxr-xr-x   3 user  staff   96 Nov 14 21:04 Brave Browser Helper (Alerts)
drwxr-xr-x   3 user  staff   96 Nov 14 21:04 Brave Browser Helper (GPU)
drwxr-xr-x   3 user  staff   96 Nov 14 21:04 Brave Browser Helper (Plugin)
drwxr-xr-x   3 user  staff   96 Nov 14 21:04 Brave Browser Helper (Renderer)
drwxr-xr-x   3 user  staff   96 Nov 14 21:04 chrome_crashpad_handler
drwxr-xr-x   3 user  staff   96 Nov 14 21:04 libEGL.dylib
drwxr-xr-x   3 user  staff   96 Nov 14 21:04 libGLESv2.dylib
drwxr-xr-x   3 user  staff   96 Nov 14 21:04 libvk_swiftshader.dylib
```

Resolves https://github.com/brave/brave-browser/issues/26734

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

