### PR TITLE
Reset window controls position when NC inset changes on Mac

### DIFF
--- a/browser/ui/views/frame/brave_browser_frame_mac.h
+++ b/browser/ui/views/frame/brave_browser_frame_mac.h
@@ -21,6 +21,7 @@ class BraveBrowserFrameMac : public BrowserFrameMac {
 
  private:
   raw_ptr<Browser> browser_;
+  raw_ptr<BrowserView> browser_view_;
 };
 
 #endif  // BRAVE_BROWSER_UI_VIEWS_FRAME_BRAVE_BROWSER_FRAME_MAC_H_

--- a/browser/ui/views/frame/brave_browser_frame_mac.mm
+++ b/browser/ui/views/frame/brave_browser_frame_mac.mm
@@ -7,22 +7,31 @@
 
 #include "brave/browser/ui/views/tabs/features.h"
 #include "chrome/browser/ui/views/frame/browser_view.h"
+#include "chrome/browser/ui/views/toolbar/toolbar_view.h"
 
 BraveBrowserFrameMac::BraveBrowserFrameMac(BrowserFrame* browser_frame,
                                            BrowserView* browser_view)
     : BrowserFrameMac(browser_frame, browser_view),
-      browser_(browser_view->browser()) {}
+      browser_(browser_view->browser()),
+      browser_view_(browser_view) {}
 
 BraveBrowserFrameMac::~BraveBrowserFrameMac() = default;
 
 void BraveBrowserFrameMac::GetWindowFrameTitlebarHeight(
     bool* override_titlebar_height,
     float* titlebar_height) {
-  // Don't override titlebar height if the browser supports vertical tab strip
-  // so that it can overlay our client view. The visibility of title bar will be
-  // controlled by BrowserNonClientFrameViewMac::UpdateWindowTitleVisibility.
-  if (tabs::features::ShouldShowVerticalTabs(browser_))
+  if (tabs::features::ShouldShowVerticalTabs(browser_)) {
+    if (!tabs::features::ShouldShowWindowTitleForVerticalTabs(browser_)) {
+      // In this case, titlbar height should be the same as toolbar height.
+      *titlebar_height = browser_view_->toolbar()->GetPreferredSize().height();
+      *override_titlebar_height = true;
+      return;
+    }
+
+    // Otherwise, don't override titlebar height. The titlbar will be aligned
+    // to the center of the given height automatically.
     return;
+  }
 
   return BrowserFrameMac::GetWindowFrameTitlebarHeight(override_titlebar_height,
                                                        titlebar_height);

--- a/browser/ui/views/frame/brave_browser_non_client_frame_view_mac.h
+++ b/browser/ui/views/frame/brave_browser_non_client_frame_view_mac.h
@@ -26,6 +26,7 @@ class BraveBrowserNonClientFrameViewMac : public BrowserNonClientFrameViewMac {
  private:
   bool ShouldShowWindowTitleForVerticalTabs() const;
   void UpdateWindowTitleVisibility();
+  void UpdateWindowTitleAndControls();
 
   // BrowserNonClientFrameViewMac overrides:
   void OnPaint(gfx::Canvas* canvas) override;

--- a/browser/ui/views/frame/brave_browser_non_client_frame_view_mac.mm
+++ b/browser/ui/views/frame/brave_browser_non_client_frame_view_mac.mm
@@ -31,7 +31,7 @@ BraveBrowserNonClientFrameViewMac::BraveBrowserNonClientFrameViewMac(
     show_vertical_tabs_.Init(
         brave_tabs::kVerticalTabsEnabled, prefs,
         base::BindRepeating(
-            &BraveBrowserNonClientFrameViewMac::UpdateWindowTitleVisibility,
+            &BraveBrowserNonClientFrameViewMac::UpdateWindowTitleAndControls,
             base::Unretained(this)));
     show_title_bar_on_vertical_tabs_.Init(
         brave_tabs::kVerticalTabsShowTitleOnWindow, prefs,
@@ -89,4 +89,12 @@ int BraveBrowserNonClientFrameViewMac::NonClientHitTest(
   }
 
   return BrowserNonClientFrameViewMac::NonClientHitTest(point);
+}
+
+void BraveBrowserNonClientFrameViewMac::UpdateWindowTitleAndControls() {
+  UpdateWindowTitleVisibility();
+
+  // In case title visibility wasn't changed and only vertical tab strip enabled
+  // state changed, we should reset controls positions manually.
+  frame()->ResetWindowControlsPosition();
 }

--- a/chromium_src/components/remote_cocoa/app_shim/native_widget_ns_window_bridge.h
+++ b/chromium_src/components/remote_cocoa/app_shim/native_widget_ns_window_bridge.h
@@ -9,6 +9,7 @@
 // Override a method from our NativeWidgetNSWindow mojo extension
 #define OnSizeChanged                              \
   SetWindowTitleVisibility(bool visible) override; \
+  void ResetWindowControlsPosition() override;     \
   void OnSizeChanged
 
 #include "src/components/remote_cocoa/app_shim/native_widget_ns_window_bridge.h"

--- a/chromium_src/components/remote_cocoa/app_shim/native_widget_ns_window_bridge.mm
+++ b/chromium_src/components/remote_cocoa/app_shim/native_widget_ns_window_bridge.mm
@@ -30,6 +30,19 @@ void NativeWidgetNSWindowBridge::SetWindowTitleVisibility(bool visible) {
 void NativeWidgetNSWindowBridge::ResetWindowControlsPosition() {
   // Call undocumented method of NSThemeFrame in order to reset window controls'
   // position.
+  //
+  // As for undocumented APIs, they're found by dumping Appkit classes with
+  // `class-dump` script.
+  // https://chromium.googlesource.com/external/github.com/nygard/class-dump/
+  //
+  //  There are a few sources to find dumpled headers:
+  // [1] Qt:
+  // https://github.com/qt/qt/blob/0a2f2382541424726168804be2c90b91381608c6/src/gui/kernel/qnsthemeframe_mac_p.h#L121
+  // [2] macos_headers:
+  // https://github.com/w0lfschild/macOS_headers/blob/a5c2da62810189aa7ea71e6a3e1c98d98bb6620e/macOS/Frameworks/AppKit/1348.17/NSThemeFrame.h#L393
+  //
+  // If this behavior is broken, we should run `class-dump` by ourselves and
+  // find out what can be used instead of this.
   NSView* frameView = window_.get().contentView.superview;
   DCHECK([frameView isKindOfClass:[NSThemeFrame class]]);
   [frameView performSelector:@selector(_resetTitleBarButtons)];

--- a/chromium_src/components/remote_cocoa/app_shim/native_widget_ns_window_bridge.mm
+++ b/chromium_src/components/remote_cocoa/app_shim/native_widget_ns_window_bridge.mm
@@ -8,13 +8,15 @@
 namespace remote_cocoa {
 
 void NativeWidgetNSWindowBridge::SetWindowTitleVisibility(bool visible) {
-  NSUInteger style_mask = [window_ styleMask];
+  NSUInteger styleMask = [window_ styleMask];
   if (visible)
-    style_mask |= NSWindowStyleMaskTitled;
+    styleMask |= NSWindowStyleMaskTitled;
   else
-    style_mask &= ~NSWindowStyleMaskTitled;
+    styleMask &= ~NSWindowStyleMaskTitled;
 
-  [window_ setStyleMask:style_mask];
+  [window_ setStyleMask:styleMask];
+
+  ResetWindowControlsPosition();
 
   // Sometimes title is not visible until window is resized. In order to avoid
   // this, reset title to force it to be visible.
@@ -23,6 +25,14 @@ void NativeWidgetNSWindowBridge::SetWindowTitleVisibility(bool visible) {
     window_.get().title = @"";
     window_.get().title = title;
   }
+}
+
+void NativeWidgetNSWindowBridge::ResetWindowControlsPosition() {
+  // Call undocumented method of NSThemeFrame in order to reset window controls'
+  // position.
+  NSView* frameView = window_.get().contentView.superview;
+  DCHECK([frameView isKindOfClass:[NSThemeFrame class]]);
+  [frameView performSelector:@selector(_resetTitleBarButtons)];
 }
 
 }  // namespace remote_cocoa

--- a/chromium_src/components/remote_cocoa/app_shim/native_widget_ns_window_bridge.mm
+++ b/chromium_src/components/remote_cocoa/app_shim/native_widget_ns_window_bridge.mm
@@ -45,7 +45,11 @@ void NativeWidgetNSWindowBridge::ResetWindowControlsPosition() {
   // find out what can be used instead of this.
   NSView* frameView = window_.get().contentView.superview;
   DCHECK([frameView isKindOfClass:[NSThemeFrame class]]);
-  [frameView performSelector:@selector(_resetTitleBarButtons)];
+  SEL selector = @selector(_resetTitleBarButtons);
+  if ([frameView respondsToSelector:selector])
+    [frameView performSelector:selector];
+  else
+    LOG(ERROR) << "Failed to find selector for resetting window controls";
 }
 
 }  // namespace remote_cocoa

--- a/chromium_src/components/remote_cocoa/common/native_widget_ns_window.mojom
+++ b/chromium_src/components/remote_cocoa/common/native_widget_ns_window.mojom
@@ -8,4 +8,6 @@ module remote_cocoa.mojom;
 [BraveExtend]
 interface NativeWidgetNSWindow {
   SetWindowTitleVisibility(bool visible);
+
+  ResetWindowControlsPosition();
 };

--- a/chromium_src/ui/views/widget/native_widget_mac.h
+++ b/chromium_src/ui/views/widget/native_widget_mac.h
@@ -14,6 +14,7 @@
     return overridden_window_title_visibility_.has_value(); \
   }                                                         \
   bool GetOverriddenWindowTitleVisibility() const;          \
+  void ResetWindowControlsPosition();                       \
                                                             \
  private:                                                   \
   absl::optional<bool> overridden_window_title_visibility_; \

--- a/chromium_src/ui/views/widget/native_widget_mac.mm
+++ b/chromium_src/ui/views/widget/native_widget_mac.mm
@@ -24,4 +24,8 @@ bool NativeWidgetMac::GetOverriddenWindowTitleVisibility() const {
   return *overridden_window_title_visibility_;
 }
 
+void NativeWidgetMac::ResetWindowControlsPosition() {
+  GetNSWindowMojo()->ResetWindowControlsPosition();
+}
+
 }  // namespace views

--- a/chromium_src/ui/views/widget/widget.cc
+++ b/chromium_src/ui/views/widget/widget.cc
@@ -16,6 +16,10 @@ void Widget::SetWindowTitleVisibility(bool visible) {
       ->SetWindowTitleVisibility(visible);
 }
 
+void Widget::ResetWindowControlsPosition() {
+  static_cast<NativeWidgetMac*>(native_widget_)->ResetWindowControlsPosition();
+}
+
 }  // namespace views
 
 #endif  // defined(OS_MAC)

--- a/chromium_src/ui/views/widget/widget.h
+++ b/chromium_src/ui/views/widget/widget.h
@@ -11,6 +11,7 @@
 #if BUILDFLAG(IS_MAC)
 #define UnlockPaintAsActive               \
   SetWindowTitleVisibility(bool visible); \
+  void ResetWindowControlsPosition();     \
   void UnlockPaintAsActive
 #else
 #define UnlockPaintAsActive UnlockPaintAsActive


### PR DESCRIPTION
Previously on Mac, window control's y coordinate wasn't adjusted when options changes, even though the options affect the non-client area's height. In order to solve this, make a call to undocumented method of NSThemeFrame: _resetButtons when it's needed.

Also, adjust window controls' y position when title is hidden with vertical tab strip enabled so that it could be aligned with toolbar's height

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/26736

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
### Manual: 
* Change "Use vertical tabs" or "Show Window Title Bar" menu from tab context menu
* See if window controls are aligned middle vertically.
