### PR TITLE
Change default "window title" visibility to false

### DIFF
--- a/browser/ui/tabs/brave_tab_prefs.cc
+++ b/browser/ui/tabs/brave_tab_prefs.cc
@@ -23,7 +23,7 @@ void RegisterBraveProfilePrefs(PrefRegistrySimple* registry) {
   registry->RegisterIntegerPref(kTabHoverMode, TabHoverMode::CARD);
   registry->RegisterBooleanPref(kVerticalTabsEnabled, false);
   registry->RegisterBooleanPref(kVerticalTabsCollapsed, false);
-  registry->RegisterBooleanPref(kVerticalTabsShowTitleOnWindow, true);
+  registry->RegisterBooleanPref(kVerticalTabsShowTitleOnWindow, false);
   registry->RegisterBooleanPref(kVerticalTabsFloatingEnabled, true);
 }
 

--- a/browser/ui/views/tabs/vertical_tab_strip_browsertest.cc
+++ b/browser/ui/views/tabs/vertical_tab_strip_browsertest.cc
@@ -141,11 +141,20 @@ IN_PROC_BROWSER_TEST_F(VerticalTabStripBrowserTest, WindowTitle) {
   browser()->profile()->GetPrefs()->SetBoolean(prefs::kUseCustomChromeFrame,
                                                true);
 #endif
-  // Pre-condition: Window title is "visible" by default on vertical tabs
+  // Pre-condition: Window title is "hidden" by default on vertical tabs
   ASSERT_TRUE(tabs::features::ShouldShowVerticalTabs(browser()));
-  ASSERT_TRUE(tabs::features::ShouldShowWindowTitleForVerticalTabs(browser()));
-  ASSERT_TRUE(browser_view()->ShouldShowWindowTitle());
-  ASSERT_TRUE(IsWindowTitleViewVisible());
+  ASSERT_FALSE(tabs::features::ShouldShowWindowTitleForVerticalTabs(browser()));
+  ASSERT_FALSE(browser_view()->ShouldShowWindowTitle());
+  ASSERT_FALSE(IsWindowTitleViewVisible());
+
+  // Show window title bar
+  brave::ToggleWindowTitleVisibilityForVerticalTabs(browser());
+  browser_non_client_frame_view()->Layout();
+  EXPECT_TRUE(tabs::features::ShouldShowWindowTitleForVerticalTabs(browser()));
+  EXPECT_TRUE(browser_view()->ShouldShowWindowTitle());
+  EXPECT_GE(browser_non_client_frame_view()->GetTopInset(/*restored=*/false),
+            0);
+  EXPECT_TRUE(IsWindowTitleViewVisible());
 
   // Hide window title bar
   brave::ToggleWindowTitleVisibilityForVerticalTabs(browser());
@@ -159,15 +168,6 @@ IN_PROC_BROWSER_TEST_F(VerticalTabStripBrowserTest, WindowTitle) {
             browser_non_client_frame_view()->GetTopInset(/*restored=*/false));
 #endif
   EXPECT_FALSE(IsWindowTitleViewVisible());
-
-  // Show window title bar
-  brave::ToggleWindowTitleVisibilityForVerticalTabs(browser());
-  browser_non_client_frame_view()->Layout();
-  EXPECT_TRUE(tabs::features::ShouldShowWindowTitleForVerticalTabs(browser()));
-  EXPECT_TRUE(browser_view()->ShouldShowWindowTitle());
-  EXPECT_GE(browser_non_client_frame_view()->GetTopInset(/*restored=*/false),
-            0);
-  EXPECT_TRUE(IsWindowTitleViewVisible());
 }
 
 IN_PROC_BROWSER_TEST_F(VerticalTabStripBrowserTest, NewTabVisibility) {


### PR DESCRIPTION
This is decision from our UX team.

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/26801

## Submitter Checklist:

- [ ] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
### Automated
VerticalTabStripBrowserTest.WindowTitle
