### PR TITLE
Reassign Copy keyboard shortcut to 'copy clean link'

### DIFF
--- a/browser/brave_app_controller_mac.h
+++ b/browser/brave_app_controller_mac.h
@@ -10,8 +10,15 @@
 
 // Manages logic to switch hotkey between copy and copy clean link item.
 @interface BraveAppController : AppController {
+  NSMenuItem* _copyMenuItem;
   NSMenuItem* _copyCleanLinkMenuItem;
+  absl::optional<bool> _hasSelectedURLForTesting;
 }
+
+// Testing API.
+- (void)setCopyMenuItemForTesting:(NSMenuItem*)menuItem;           // NOLINT
+- (void)setCopyCleanLinkMenuItemForTesting:(NSMenuItem*)menuItem;  // NOLINT
+- (void)setSelectedURLForTesting:(bool)selected;                   // NOLINT
 
 @end
 

--- a/browser/brave_app_controller_mac.mm
+++ b/browser/brave_app_controller_mac.mm
@@ -18,12 +18,16 @@
   [super mainMenuCreated];
 
   NSMenu* editMenu = [[[NSApp mainMenu] itemWithTag:IDC_EDIT_MENU] submenu];
+  _copyMenuItem = [editMenu itemWithTag:IDC_CONTENT_CONTEXT_COPY];
+  DCHECK(_copyMenuItem);
+  [[_copyMenuItem menu] setDelegate:self];
   _copyCleanLinkMenuItem = [editMenu itemWithTag:IDC_COPY_CLEAN_LINK];
   DCHECK(_copyCleanLinkMenuItem);
   [[_copyCleanLinkMenuItem menu] setDelegate:self];
 }
 
 - (void)dealloc {
+  [[_copyMenuItem menu] setDelegate:nil];
   [[_copyCleanLinkMenuItem menu] setDelegate:nil];
   [super dealloc];
 }
@@ -33,18 +37,36 @@
 }
 
 - (BOOL)shouldShowCleanLinkItem {
+  if (_hasSelectedURLForTesting.has_value()) {
+    return _hasSelectedURLForTesting.value();
+  }
   return brave::HasSelectedURL([self getBrowser]);
 }
 
+- (void)setKeyEquivalentToItem:(NSMenuItem*)item {
+  auto* hootkeyItem =
+      item == _copyMenuItem ? _copyMenuItem : _copyCleanLinkMenuItem;
+  auto* noHootkeyItem =
+      item == _copyMenuItem ? _copyCleanLinkMenuItem : _copyMenuItem;
+
+  [hootkeyItem setKeyEquivalent:@"c"];
+  [hootkeyItem setKeyEquivalentModifierMask:NSEventModifierFlagCommand];
+
+  [noHootkeyItem setKeyEquivalent:@""];
+  [noHootkeyItem setKeyEquivalentModifierMask:0];
+}
+
 - (void)menuNeedsUpdate:(NSMenu*)menu {
-  if (menu != [_copyCleanLinkMenuItem menu]) {
+  if (menu != [_copyMenuItem menu] && menu != [_copyCleanLinkMenuItem menu]) {
     [super menuNeedsUpdate:menu];
     return;
   }
   if ([self shouldShowCleanLinkItem]) {
     [_copyCleanLinkMenuItem setHidden:NO];
+    [self setKeyEquivalentToItem:_copyCleanLinkMenuItem];
   } else {
     [_copyCleanLinkMenuItem setHidden:YES];
+    [self setKeyEquivalentToItem:_copyMenuItem];
   }
 }
 
@@ -56,14 +78,25 @@
   return [super validateUserInterfaceItem:item];
 }
 
-- (void)executeCommand:(id)sender withProfile:(Profile*)profile {
+- (void)commandDispatch:(id)sender {
   NSInteger tag = [sender tag];
   if (tag == IDC_COPY_CLEAN_LINK) {
     chrome::ExecuteCommand([self getBrowser], IDC_COPY_CLEAN_LINK);
     return;
   }
 
-  [super executeCommand:sender withProfile:profile];
+  [super commandDispatch:sender];
+}
+
+- (void)setCopyMenuItemForTesting:(NSMenuItem*)menuItem {
+  _copyMenuItem = menuItem;
+}
+
+- (void)setCopyCleanLinkMenuItemForTesting:(NSMenuItem*)menuItem {
+  _copyCleanLinkMenuItem = menuItem;
+}
+- (void)setSelectedURLForTesting:(bool)value {
+  _hasSelectedURLForTesting = value;
 }
 
 @end  // @implementation BraveAppController

--- a/browser/brave_app_controller_mac_unittest.mm
+++ b/browser/brave_app_controller_mac_unittest.mm
@@ -1,0 +1,77 @@
+/* Copyright (c) 2023 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#import <Cocoa/Cocoa.h>
+
+#import "brave/browser/brave_app_controller_mac.h"
+#include "content/public/test/browser_task_environment.h"
+#include "testing/platform_test.h"
+
+class BraveAppControllerTest : public PlatformTest {
+ protected:
+  BraveAppControllerTest() {}
+
+  void SetUp() override {
+    PlatformTest::SetUp();
+    braveAppController_.reset([[BraveAppController alloc] init]);
+    copyMenuItem_.reset([[NSMenuItem alloc] initWithTitle:@""
+                                                   action:0
+                                            keyEquivalent:@""]);
+    [braveAppController_ setCopyMenuItemForTesting:copyMenuItem_];
+
+    copyCleanLinkMenuItem_.reset([[NSMenuItem alloc] initWithTitle:@""
+                                                            action:0
+                                                     keyEquivalent:@""]);
+    [braveAppController_
+        setCopyCleanLinkMenuItemForTesting:copyCleanLinkMenuItem_];
+  }
+
+  void TearDown() override {
+    [braveAppController_ setCopyMenuItemForTesting:nil];
+    [braveAppController_ setCopyCleanLinkMenuItemForTesting:nil];
+    PlatformTest::TearDown();
+  }
+
+  void CheckHotkeysOnCopyItem() {
+    [braveAppController_ setSelectedURLForTesting:false];
+
+    [braveAppController_ menuNeedsUpdate:[copyMenuItem_ menu]];
+
+    EXPECT_TRUE([[copyMenuItem_ keyEquivalent] isEqualToString:@"c"]);
+    EXPECT_EQ([copyMenuItem_ keyEquivalentModifierMask],
+              NSEventModifierFlagCommand);
+
+    EXPECT_TRUE([[copyCleanLinkMenuItem_ keyEquivalent] isEqualToString:@""]);
+    EXPECT_EQ([copyCleanLinkMenuItem_ keyEquivalentModifierMask], 0UL);
+    EXPECT_TRUE([copyCleanLinkMenuItem_ isHidden]);
+  }
+
+  void CheckHotkeysOnCleanLinkItem() {
+    [braveAppController_ setSelectedURLForTesting:true];
+
+    [braveAppController_ menuNeedsUpdate:[copyMenuItem_ menu]];
+
+    EXPECT_TRUE([[copyMenuItem_ keyEquivalent] isEqualToString:@""]);
+    EXPECT_EQ([copyMenuItem_ keyEquivalentModifierMask], 0UL);
+
+    EXPECT_TRUE([[copyCleanLinkMenuItem_ keyEquivalent] isEqualToString:@"c"]);
+    EXPECT_EQ([copyCleanLinkMenuItem_ keyEquivalentModifierMask],
+              NSEventModifierFlagCommand);
+    EXPECT_FALSE([copyCleanLinkMenuItem_ isHidden]);
+  }
+
+  base::scoped_nsobject<BraveAppController> braveAppController_;
+  base::scoped_nsobject<NSMenuItem> copyMenuItem_;
+  base::scoped_nsobject<NSMenuItem> copyCleanLinkMenuItem_;
+  content::BrowserTaskEnvironment task_environment_;
+};
+
+TEST_F(BraveAppControllerTest, OnlyCopyItem) {
+  CheckHotkeysOnCopyItem();
+}
+
+TEST_F(BraveAppControllerTest, CleanLinkItemAdded) {
+  CheckHotkeysOnCleanLinkItem();
+}

--- a/browser/ui/views/omnibox/brave_omnibox_view_views.h
+++ b/browser/ui/views/omnibox/brave_omnibox_view_views.h
@@ -16,7 +16,14 @@ class BraveOmniboxViewViews : public OmniboxViewViews {
   BraveOmniboxViewViews& operator=(const BraveOmniboxViewViews&) = delete;
   ~BraveOmniboxViewViews() override;
 
-  bool SelectedTextIsURL();
+  // views::Textfield:
+  void ExecuteCommand(int command_id, int event_flags) override;
+
+  // views::TextfieldController:
+  bool SelectedTextIsURL() override;
+  bool IsCleanLinkCommand(int command_id) const override;
+  void OnSanitizedCopy(ui::ClipboardBuffer clipboard_buffer) override;
+  void UpdateContextMenu(ui::SimpleMenuModel* menu_contents) override;
 };
 
 #endif  // BRAVE_BROWSER_UI_VIEWS_OMNIBOX_BRAVE_OMNIBOX_VIEW_VIEWS_H_

--- a/browser/ui/views/omnibox/brave_omnibox_view_views_browsertest.cc
+++ b/browser/ui/views/omnibox/brave_omnibox_view_views_browsertest.cc
@@ -90,3 +90,54 @@ IN_PROC_BROWSER_TEST_F(BraveOmniboxViewViewsTest, DoNotSanitizeInternalURLS) {
                            /* data_dst = */ nullptr, &text_from_clipboard);
   EXPECT_EQ(text_from_clipboard, "brave://settings/?utm_ad=1");
 }
+
+IN_PROC_BROWSER_TEST_F(BraveOmniboxViewViewsTest,
+                       CopyCleanedURLToClipboardByHotkey) {
+  brave::URLSanitizerServiceFactory::GetForBrowserContext(browser()->profile())
+      ->Initialize(R"([
+    { "include": [ "*://*/*"], "params": ["utm_content"] }
+  ])");
+  const std::string test_url(
+      "https://dev-pages.bravesoftware.com/clean-urls/"
+      "exempted/"
+      "?brave_testing1=foo&brave_testing2=bar&brave_testing3=keep&&;b&"
+      "d&utm_content=removethis&e=&f=g&=end");
+  ASSERT_TRUE(ui_test_utils::NavigateToURL(browser(), GURL(test_url)));
+
+  omnibox_view()->SelectAll(true);
+
+  auto* textfield = static_cast<views::Textfield*>(omnibox_view());
+  textfield->AcceleratorPressed(
+      ui::Accelerator(ui::VKEY_C, ui::EF_PLATFORM_ACCELERATOR));
+  ui::Clipboard* clipboard = ui::Clipboard::GetForCurrentThread();
+  std::string text_from_clipboard;
+  clipboard->ReadAsciiText(ui::ClipboardBuffer::kCopyPaste,
+                           /* data_dst = */ nullptr, &text_from_clipboard);
+  EXPECT_EQ(text_from_clipboard,
+            "https://dev-pages.bravesoftware.com/clean-urls/exempted/"
+            "?brave_testing1=foo&brave_testing2=bar&brave_testing3=keep&&;b&d&"
+            "e=&f=g&=end");
+}
+
+IN_PROC_BROWSER_TEST_F(BraveOmniboxViewViewsTest, CopyTextToClipboardByHotkey) {
+  brave::URLSanitizerServiceFactory::GetForBrowserContext(browser()->profile())
+      ->Initialize(R"([
+    { "include": [ "*://*/*"], "params": ["utm_content"] }
+  ])");
+  const std::string test_text(
+      "exempted/"
+      "?brave_testing1=foo&brave_testing2=bar&brave_testing3=keep&&;b&"
+      "d&utm_content=removethis&e=&f=g&=end");
+  auto* textfield = static_cast<views::Textfield*>(omnibox_view());
+  textfield->SetText(base::UTF8ToUTF16(test_text));
+
+  omnibox_view()->SelectAll(true);
+
+  textfield->AcceleratorPressed(
+      ui::Accelerator(ui::VKEY_C, ui::EF_PLATFORM_ACCELERATOR));
+  ui::Clipboard* clipboard = ui::Clipboard::GetForCurrentThread();
+  std::string text_from_clipboard;
+  clipboard->ReadAsciiText(ui::ClipboardBuffer::kCopyPaste,
+                           /* data_dst = */ nullptr, &text_from_clipboard);
+  EXPECT_EQ(text_from_clipboard, test_text);
+}

--- a/chromium_src/ui/views/controls/textfield/textfield.cc
+++ b/chromium_src/ui/views/controls/textfield/textfield.cc
@@ -1,0 +1,46 @@
+// Copyright (c) 2023 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#include "ui/views/controls/textfield/textfield.h"
+#include "base/logging.h"
+#include "ui/views/controls/button/button.h"
+#include "ui/views/controls/label.h"
+#include "ui/views/controls/textfield/textfield_controller.h"
+
+namespace views {
+
+bool Textfield::AcceleratorPressed(const ui::Accelerator& accelerator) {
+  ui::KeyEvent event(
+      accelerator.key_state() == ui::Accelerator::KeyState::PRESSED
+          ? ui::ET_KEY_PRESSED
+          : ui::ET_KEY_RELEASED,
+      accelerator.key_code(), accelerator.modifiers());
+  auto command = GetCommandForKeyEvent(event);
+  if ((text_input_type_ != ui::TEXT_INPUT_TYPE_PASSWORD) &&
+      (command != ui::TextEditCommand::COPY || !controller_ ||
+       !controller_->SelectedTextIsURL())) {
+    return Textfield::AcceleratorPressed_ChromiumImpl(accelerator);
+  }
+  controller_->OnSanitizedCopy(ui::ClipboardBuffer::kCopyPaste);
+  return true;
+}
+
+}  // namespace views
+
+#define GET_ACCELERATOR_FOR_COMMAND_ID                                         \
+  if (controller_ && controller_->SelectedTextIsURL()) {                       \
+    if (command_id == kCopy) {                                                 \
+      return false;                                                            \
+    }                                                                          \
+    if (controller_->IsCleanLinkCommand(command_id)) {                         \
+      *accelerator = ui::Accelerator(ui::VKEY_C, ui::EF_PLATFORM_ACCELERATOR); \
+      return true;                                                             \
+    }                                                                          \
+  }
+
+#define AcceleratorPressed AcceleratorPressed_ChromiumImpl
+#include "src/ui/views/controls/textfield/textfield.cc"
+#undef AcceleratorPressed
+#undef GET_ACCELERATOR_FOR_COMMAND_ID

--- a/chromium_src/ui/views/controls/textfield/textfield.h
+++ b/chromium_src/ui/views/controls/textfield/textfield.h
@@ -1,0 +1,17 @@
+// Copyright (c) 2023 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#ifndef BRAVE_CHROMIUM_SRC_UI_VIEWS_CONTROLS_TEXTFIELD_TEXTFIELD_H_
+#define BRAVE_CHROMIUM_SRC_UI_VIEWS_CONTROLS_TEXTFIELD_TEXTFIELD_H_
+
+#include "ui/base/accelerators/accelerator.h"
+
+#define AcceleratorPressed                                             \
+  AcceleratorPressed_ChromiumImpl(const ui::Accelerator& accelerator); \
+  bool AcceleratorPressed
+#include "src/ui/views/controls/textfield/textfield.h"
+#undef AcceleratorPressed
+
+#endif  // BRAVE_CHROMIUM_SRC_UI_VIEWS_CONTROLS_TEXTFIELD_TEXTFIELD_H_

--- a/chromium_src/ui/views/controls/textfield/textfield_controller.cc
+++ b/chromium_src/ui/views/controls/textfield/textfield_controller.cc
@@ -1,0 +1,19 @@
+// Copyright (c) 2023 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#include "ui/views/controls/textfield/textfield_controller.h"
+
+namespace views {
+
+bool TextfieldController::SelectedTextIsURL() {
+  return false;
+}
+
+bool TextfieldController::IsCleanLinkCommand(int command_id) const {
+  return false;
+}
+}  // namespace views
+
+#include "src/ui/views/controls/textfield/textfield_controller.cc"

--- a/chromium_src/ui/views/controls/textfield/textfield_controller.h
+++ b/chromium_src/ui/views/controls/textfield/textfield_controller.h
@@ -1,0 +1,19 @@
+// Copyright (c) 2023 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#ifndef BRAVE_CHROMIUM_SRC_UI_VIEWS_CONTROLS_TEXTFIELD_TEXTFIELD_CONTROLLER_H_
+#define BRAVE_CHROMIUM_SRC_UI_VIEWS_CONTROLS_TEXTFIELD_TEXTFIELD_CONTROLLER_H_
+
+#include "ui/base/clipboard/clipboard_buffer.h"
+
+#define OnAfterCutOrCopy                                    \
+  OnAfterCutOrCopy(ui::ClipboardBuffer clipboard_buffer) {} \
+  virtual bool SelectedTextIsURL();                         \
+  virtual bool IsCleanLinkCommand(int command_id) const;    \
+  virtual void OnSanitizedCopy
+#include "src/ui/views/controls/textfield/textfield_controller.h"
+#undef OnAfterCutOrCopy
+
+#endif  // BRAVE_CHROMIUM_SRC_UI_VIEWS_CONTROLS_TEXTFIELD_TEXTFIELD_CONTROLLER_H_

--- a/patches/ui-views-controls-textfield-textfield.cc.patch
+++ b/patches/ui-views-controls-textfield-textfield.cc.patch
@@ -1,0 +1,12 @@
+diff --git a/ui/views/controls/textfield/textfield.cc b/ui/views/controls/textfield/textfield.cc
+index d7a9be21c5e2459ec73f18312cdb11f3c4f20f77..44f496de52c89758775f98a56ff2e72db2180a9e 100644
+--- a/ui/views/controls/textfield/textfield.cc
++++ b/ui/views/controls/textfield/textfield.cc
+@@ -1292,6 +1292,7 @@ bool Textfield::IsCommandIdEnabled(int command_id) const {
+ 
+ bool Textfield::GetAcceleratorForCommandId(int command_id,
+                                            ui::Accelerator* accelerator) const {
++  GET_ACCELERATOR_FOR_COMMAND_ID
+   switch (command_id) {
+     case kUndo:
+       *accelerator = ui::Accelerator(ui::VKEY_Z, ui::EF_PLATFORM_ACCELERATOR);

--- a/test/BUILD.gn
+++ b/test/BUILD.gn
@@ -419,6 +419,7 @@ test("brave_unit_tests") {
 
   if (is_mac) {
     sources += [
+      "//brave/browser/brave_app_controller_mac_unittest.mm",
       "//brave/chromium_src/chrome/browser/shell_integration_unittest_mac.cc",
       "//brave/chromium_src/chrome/common/chrome_constants_unittest_mac.cc",
     ]


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/26761


Added few functions to `TextfieldController` because we cannot reach the omibox model directly from `ui` layer

Copy Clean Link is default for urls:
<img width="756" alt="image" src="https://user-images.githubusercontent.com/2965009/202199551-efc717bf-c809-4d03-bf27-503734a9e62d.png">

Copy is default for text:
<img width="544" alt="image" src="https://user-images.githubusercontent.com/2965009/202199711-ce49460e-709f-435c-b91d-ae2278e09e89.png">

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

1. Open <https://brave.com/?utm_campaign=1234>.
2. Click in the URL bar and select the URL.
3. Use the keyboard shortcut to copy (e.g. Ctrl+c on Windows).
4. Paste in a text editor
5. Check that only `https://brave.com/` was copied. The `utm_campaign` parameter was removed.