### PR TITLE
fix(wallet): Hide fiat balances in NFT details page (uplift to 1.46.x)

### DIFF
--- a/components/brave_wallet_ui/components/desktop/portfolio-account-item/index.tsx
+++ b/components/brave_wallet_ui/components/desktop/portfolio-account-item/index.tsx
@@ -46,6 +46,7 @@ interface Props {
   selectedNetwork: BraveWallet.NetworkInfo
   name: string
   hideBalances?: boolean
+  isNft?: boolean
 }
 
 export const PortfolioAccountItem = (props: Props) => {
@@ -58,7 +59,8 @@ export const PortfolioAccountItem = (props: Props) => {
     defaultCurrencies,
     hideBalances,
     name,
-    spotPrices
+    spotPrices,
+    isNft
   } = props
 
   // Routing
@@ -118,9 +120,11 @@ export const PortfolioAccountItem = (props: Props) => {
             size='small'
             hideBalances={hideBalances ?? false}
           >
-            <FiatBalanceText>
-              {fiatBalance.formatAsFiat(defaultCurrencies.fiat)}
-            </FiatBalanceText>
+            {!isNft &&
+              <FiatBalanceText>
+                {fiatBalance.formatAsFiat(defaultCurrencies.fiat)}
+              </FiatBalanceText>
+            }
             <AssetBalanceText>{`${formattedAssetBalance} ${assetTicker}`}</AssetBalanceText>
           </WithHideBalancePlaceholder>
         </BalanceColumn>

--- a/components/brave_wallet_ui/components/desktop/views/portfolio/components/accounts-and-transctions-list/index.tsx
+++ b/components/brave_wallet_ui/components/desktop/views/portfolio/components/accounts-and-transctions-list/index.tsx
@@ -132,6 +132,7 @@ const AccountsAndTransactionsList = (props: Props) => {
               assetBalance={getBalance(account, selectedAsset)}
               selectedNetwork={selectedAssetsNetwork}
               hideBalances={hideBalances}
+              isNft={isNonFungibleToken}
             />
           )}
           <ButtonRow>


### PR DESCRIPTION
Uplift of #15967
Resolves https://github.com/brave/brave-browser/issues/26797

Pre-approval checklist: 
- [ ] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [ ] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [ ] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [ ] The associated issue milestone is set to the smallest version that the changes is landed on.