### PR TITLE
[Cr108 Follow up] Removed hiding of link on Passwords page.

### DIFF
--- a/browser/resources/settings/brave_overrides/passwords_section.ts
+++ b/browser/resources/settings/brave_overrides/passwords_section.ts
@@ -13,11 +13,5 @@ RegisterPolymerTemplateModifications({
     } else {
       checkPasswordsLinkRow.remove()
     }
-    const manageLink = templateContent.querySelector('#manageLink')
-    if (!manageLink) {
-      console.error('[Brave Settings Overrides] Could not find manageLink in passwords_section')
-    } else {
-      manageLink.remove()
-    }
   }
 })


### PR DESCRIPTION
The link no longer exists so we don't need to hide it.

Chromium change:

https://chromium.googlesource.com/chromium/src/+/0ec0534fe2b9c66e69f5fb2750a57dc9eec65e08

commit 0ec0534fe2b9c66e69f5fb2750a57dc9eec65e08
Author: Mohamed Amir Yosef <mamir@chromium.org>
Date:   Fri Aug 19 12:58:58 2022 +0000

    [Passwords] Clean up UPM from Setting UI

    In addition, this CL remove all obsolete resources (images and strings)

    Bug: 1310270

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves 

## Submitter Checklist:

- [ ] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

