### PR TITLE
Log served ad events before viewed ad events

### DIFF
--- a/vendor/bat-native-ads/src/bat/ads/internal/ads/ad_events/new_tab_page_ads/new_tab_page_ad_event_handler.cc
+++ b/vendor/bat-native-ads/src/bat/ads/internal/ads/ad_events/new_tab_page_ads/new_tab_page_ad_event_handler.cc
@@ -136,8 +136,11 @@ void EventHandler::FireEvent(const NewTabPageAdInfo& ad,
             !ShouldRewardUser()) {
           // Fire an ad served event if Brave Ads are disabled and the ad
           // wasn't served by ads library.
-          FireEvent(placement_id, creative_instance_id,
-                    mojom::NewTabPageAdEventType::kServed);
+          const auto served_ad_event =
+              AdEventFactory::Build(mojom::NewTabPageAdEventType::kServed);
+          served_ad_event->FireEvent(ad);
+
+          NotifyNewTabPageAdEvent(ad, mojom::NewTabPageAdEventType::kServed);
         }
 
         const auto ad_event = AdEventFactory::Build(event_type);

--- a/vendor/bat-native-ads/src/bat/ads/internal/ads/ad_events/promoted_content_ads/promoted_content_ad_event_handler.cc
+++ b/vendor/bat-native-ads/src/bat/ads/internal/ads/ad_events/promoted_content_ads/promoted_content_ad_event_handler.cc
@@ -135,8 +135,12 @@ void EventHandler::FireEvent(
         if (event_type == mojom::PromotedContentAdEventType::kViewed) {
           // We must fire an ad served event due to promoted content ads not
           // being delivered by the library
-          FireEvent(placement_id, creative_instance_id,
-                    mojom::PromotedContentAdEventType::kServed);
+          const auto served_ad_event =
+              AdEventFactory::Build(mojom::PromotedContentAdEventType::kServed);
+          served_ad_event->FireEvent(ad);
+
+          NotifyPromotedContentAdEvent(
+              ad, mojom::PromotedContentAdEventType::kServed);
         }
 
         const auto ad_event = AdEventFactory::Build(event_type);


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/26816

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

Confirm "served" ad events appear before "view" ad events in the `Default/ads_service/database.sqlite` ad_events database table for new tab page and promoted content ads.