### PR TITLE
Add wallet last usage time P3A metric

### DIFF
--- a/browser/brave_wallet/brave_wallet_service_unittest.cc
+++ b/browser/brave_wallet/brave_wallet_service_unittest.cc
@@ -2261,4 +2261,33 @@ TEST_F(BraveWalletServiceUnitTest, NewUserReturningMetricMigration) {
       kBraveWalletNewUserReturningHistogramName, 1, 2);
 }
 
+TEST_F(BraveWalletServiceUnitTest, LastUsageTimeMetric) {
+  histogram_tester_->ExpectTotalCount(kBraveWalletLastUsageTimeHistogramName,
+                                      0);
+
+  GetPrefs()->SetTime(kBraveWalletLastUnlockTime, base::Time::Now());
+  task_environment_.RunUntilIdle();
+
+  histogram_tester_->ExpectUniqueSample(kBraveWalletLastUsageTimeHistogramName,
+                                        1, 1);
+
+  task_environment_.FastForwardBy(base::Days(7));
+
+  histogram_tester_->ExpectBucketCount(kBraveWalletLastUsageTimeHistogramName,
+                                       2, 1);
+
+  task_environment_.FastForwardBy(base::Days(7));
+
+  histogram_tester_->ExpectBucketCount(kBraveWalletLastUsageTimeHistogramName,
+                                       3, 1);
+  histogram_tester_->ExpectBucketCount(kBraveWalletLastUsageTimeHistogramName,
+                                       1, 7);
+
+  GetPrefs()->SetTime(kBraveWalletLastUnlockTime, base::Time::Now());
+  task_environment_.RunUntilIdle();
+
+  histogram_tester_->ExpectBucketCount(kBraveWalletLastUsageTimeHistogramName,
+                                       1, 8);
+}
+
 }  // namespace brave_wallet

--- a/components/brave_wallet/browser/brave_wallet_service.cc
+++ b/components/brave_wallet/browser/brave_wallet_service.cc
@@ -155,6 +155,8 @@ const char kBraveWalletWeeklyHistogramName[] = "Brave.Wallet.UsageDaysInWeek";
 const char kBraveWalletMonthlyHistogramName[] = "Brave.Wallet.UsageMonthly.2";
 const char kBraveWalletNewUserReturningHistogramName[] =
     "Brave.Wallet.NewUserReturning";
+const char kBraveWalletLastUsageTimeHistogramName[] =
+    "Brave.Wallet.LastUsageTime";
 
 BraveWalletService::BraveWalletService(
     std::unique_ptr<BraveWalletServiceDelegate> delegate,
@@ -951,6 +953,9 @@ void BraveWalletService::RecordWalletUsage(bool unlocked) {
   p3a_utils::RecordFeatureNewUserReturning(
       prefs_, kBraveWalletP3AFirstUnlockTime, kBraveWalletP3ALastUnlockTime,
       kBraveWalletP3AUsedSecondDay, kBraveWalletNewUserReturningHistogramName);
+  p3a_utils::RecordFeatureLastUsageTimeMetric(
+      prefs_, kBraveWalletP3ALastUnlockTime,
+      kBraveWalletLastUsageTimeHistogramName);
 }
 
 void BraveWalletService::WriteStatsToHistogram(base::Time wallet_last_used,

--- a/components/brave_wallet/browser/brave_wallet_service.h
+++ b/components/brave_wallet/browser/brave_wallet_service.h
@@ -34,6 +34,7 @@ namespace brave_wallet {
 extern const char kBraveWalletWeeklyHistogramName[];
 extern const char kBraveWalletMonthlyHistogramName[];
 extern const char kBraveWalletNewUserReturningHistogramName[];
+extern const char kBraveWalletLastUsageTimeHistogramName[];
 
 class KeyringService;
 class JsonRpcService;

--- a/components/p3a/metric_names.h
+++ b/components/p3a/metric_names.h
@@ -90,6 +90,7 @@ constexpr inline auto kCollectedTypicalHistograms =
     "Brave.Wallet.DefaultSolanaWalletSetting",
     "Brave.Wallet.DefaultWalletSetting",
     "Brave.Wallet.KeyringCreated",
+    "Brave.Wallet.LastUsageTime",
     "Brave.Wallet.NewUserReturning",
     "Brave.Wallet.OnboardingConversion.2",
     "Brave.Wallet.SolTransactionSent",


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves brave/brave-browser#26823

## Submitter Checklist:

- [ ] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

1) Start browser with fresh profile
2) Access local state page, verify that the metric does not exist in the p3a object
3) Unlock wallet
4) Verify that the metric now exists and has a value of 1
5) Close browser, fast forward the time by one week, open browser, do not unlock wallet
6) Verify that the metric has a value of 2
7) Repeat step 5-6 with different time periods to test different metric values as needed.
8) Unlock wallet
9) Verify the metric has a value of 1