### PR TITLE
[iOS] Update `enable_ipfs` buildflag & register IPFS prefs on iOS (uplift to 1.46.x)

### DIFF
--- a/chromium_src/ios/chrome/browser/prefs/BUILD.gn
+++ b/chromium_src/ios/chrome/browser/prefs/BUILD.gn
@@ -3,12 +3,18 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this file,
 # You can obtain one at http://mozilla.org/MPL/2.0/.
 
+import("//brave/components/ipfs/buildflags/buildflags.gni")
+
 group("prefs") {
   deps = [
     "//brave/components/brave_sync:prefs",
     "//brave/components/brave_wallet/browser",
+    "//brave/components/ipfs/buildflags",
     "//brave/components/p3a",
     "//brave/components/p3a:buildflags",
     "//brave/ios/browser/brave_stats",
   ]
+  if (enable_ipfs) {
+    deps += [ "//brave/components/ipfs" ]
+  }
 }

--- a/chromium_src/ios/chrome/browser/prefs/DEPS
+++ b/chromium_src/ios/chrome/browser/prefs/DEPS
@@ -1,6 +1,7 @@
 include_rules = [
   "+brave/components/brave_sync",
   "+brave/components/brave_wallet/browser",
+  "+brave/components/ipfs",
   "+brave/components/p3a",
   "+brave/ios/browser/brave_stats",
 ]

--- a/chromium_src/ios/chrome/browser/prefs/browser_prefs.mm
+++ b/chromium_src/ios/chrome/browser/prefs/browser_prefs.mm
@@ -6,16 +6,24 @@
 #include "brave/components/brave_sync/brave_sync_prefs.h"
 #include "brave/components/brave_wallet/browser/brave_wallet_prefs.h"
 #include "brave/components/brave_wallet/browser/keyring_service.h"
+#include "brave/components/ipfs/buildflags/buildflags.h"
 #include "brave/components/p3a/brave_p3a_service.h"
 #include "brave/components/p3a/buildflags.h"
 #include "brave/ios/browser/brave_stats/brave_stats_prefs.h"
 #include "components/pref_registry/pref_registry_syncable.h"
+
+#if BUILDFLAG(ENABLE_IPFS)
+#include "brave/components/ipfs/ipfs_service.h"
+#endif
 
 void BraveRegisterBrowserStatePrefs(
     user_prefs::PrefRegistrySyncable* registry) {
   brave_sync::Prefs::RegisterProfilePrefs(registry);
   brave_wallet::RegisterProfilePrefs(registry);
   brave_wallet::RegisterProfilePrefsForMigration(registry);
+#if BUILDFLAG(ENABLE_IPFS)
+  ipfs::IpfsService::RegisterProfilePrefs(registry);
+#endif
 }
 
 void BraveRegisterLocalStatePrefs(PrefRegistrySimple* registry) {

--- a/components/ipfs/buildflags/buildflags.gni
+++ b/components/ipfs/buildflags/buildflags.gni
@@ -1,5 +1,5 @@
 declare_args() {
-  enable_ipfs = !is_ios
+  enable_ipfs = true
 }
 
 declare_args() {


### PR DESCRIPTION
Uplift of #15911
Resolves https://github.com/brave/brave-browser/issues/26699

Pre-approval checklist: 
- [ ] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [ ] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [ ] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [ ] The associated issue milestone is set to the smallest version that the changes is landed on.