### PR TITLE
feat(wallet): Add Fiat Balance to Account Sections

### DIFF
--- a/components/brave_wallet_ui/page/screens/send/components/select-token-modal/select-token-modal.tsx
+++ b/components/brave_wallet_ui/page/screens/send/components/select-token-modal/select-token-modal.tsx
@@ -23,6 +23,8 @@ import useSend from '../../../../../common/hooks/send'
 import { getLocale } from '../../../../../../common/locale'
 import { getFilecoinKeyringIdFromNetwork, getTokensNetwork } from '../../../../../utils/network-utils'
 import { getBalance } from '../../../../../utils/balance-utils'
+import { computeFiatAmount } from '../../../../../utils/pricing-utils'
+import Amount from '../../../../../utils/amount'
 
 // Options
 import { AllNetworksOption } from '../../../../../options/network-filter-options'
@@ -57,6 +59,8 @@ export const SelectTokenModal = React.forwardRef<HTMLDivElement, Props>(
     const networks = useUnsafeWalletSelector(WalletSelectors.networkList)
     const accounts = useUnsafeWalletSelector(WalletSelectors.accounts)
     const userVisibleTokensInfo = useUnsafeWalletSelector(WalletSelectors.userVisibleTokensInfo)
+    const spotPrices = useUnsafeWalletSelector(WalletSelectors.transactionSpotPrices)
+    const defaultCurrencies = useUnsafeWalletSelector(WalletSelectors.defaultCurrencies)
 
     // State
     const [searchValue, setSearchValue] = React.useState<string>('')
@@ -119,6 +123,19 @@ export const SelectTokenModal = React.forwardRef<HTMLDivElement, Props>(
       )
     }, [getTokensByNetwork, searchValue])
 
+    const getAccountFiatValue = React.useCallback((account: WalletAccountType) => {
+      const amounts = getTokensBySearchValue(account).map((token) => {
+        const balance = getBalance(account, token)
+        return computeFiatAmount(spotPrices, { decimals: token.decimals, symbol: token.symbol, value: balance }).format()
+      })
+      const reducedAmounts = amounts.reduce(function (a, b) {
+        return a !== '' && b !== ''
+          ? new Amount(a).plus(b).format()
+          : ''
+      })
+      return new Amount(reducedAmounts).formatAsFiat(defaultCurrencies.fiat)
+    }, [getTokensBySearchValue, spotPrices, defaultCurrencies.fiat])
+
     const onSelectSendAsset = React.useCallback((token: BraveWallet.BlockchainToken, account: WalletAccountType) => {
       selectSendAsset(token)
       dispatch(WalletActions.selectAccount(account))
@@ -165,6 +182,13 @@ export const SelectTokenModal = React.forwardRef<HTMLDivElement, Props>(
             >
               {account.name}
             </Text>
+            <Text
+              textColor='text03'
+              textSize='14px'
+              isBold={false}
+            >
+              {getAccountFiatValue(account)}
+            </Text>
           </AccountSection>
           <Column columnWidth='full' horizontalPadding={8}>
             <VerticalSpacer size={8} />
@@ -179,7 +203,7 @@ export const SelectTokenModal = React.forwardRef<HTMLDivElement, Props>(
           </Column>
         </Column>
       )
-    }, [getTokensBySearchValue, emptyTokensList])
+    }, [getTokensBySearchValue, getAccountFiatValue, emptyTokensList])
 
     // render
     return (


### PR DESCRIPTION
## Description 
Added a `Fiat balance` for each `Account` section in the `Select Token` modal.

<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves <https://github.com/brave/brave-browser/issues/26838>

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [x] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [x] New files have MPL-2.0 license header
- [x] Adequate test coverage exists to prevent regressions
- [x] Major classes, functions and non-trivial code blocks are well-commented
- [x] Changes in component dependencies are properly reflected in `gn`
- [x] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [x] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

1. Go to brave://wallet/send
2. Select an asset to send
3. Each `Account` section should have a `Fiat Balance` and should change depending on `Search` value.

https://user-images.githubusercontent.com/40611140/202499677-d826a0eb-d073-4131-bd09-93a5b14ab3b0.mov
