### PR TITLE
[Android] Adds additional detection for ad ref code (uplift to 1.45.x)

### DIFF
--- a/android/java/org/chromium/chrome/browser/util/BraveReferrer.java
+++ b/android/java/org/chromium/chrome/browser/util/BraveReferrer.java
@@ -36,7 +36,8 @@ public class BraveReferrer implements InstallReferrerStateListener {
     private static final String APP_CHROME_DIR = "app_chrome";
     private static final String PROMO_CODE_FILE_NAME = "promoCode";
     private static final String BRAVE_REFERRER_RECEIVED = "brave_referrer_received";
-    private static final String GOOGLE_ADS_REFERRAL_CODE = "UAC001";
+    private static final String PLAY_STORE_AD_REFERRAL_CODE = "UAC001";
+    private static final String GOOGLE_SEARCH_AD_REFERRAL_CODE = "UAC002";
 
     private String promoCodeFilePath;
     private InstallReferrerClient referrerClient;
@@ -135,7 +136,14 @@ public class BraveReferrer implements InstallReferrerStateListener {
                     if (urpc == null || urpc.isEmpty()) {
                         urpc = uri.getQueryParameter("gclid");
                         if (urpc != null && !urpc.isEmpty()) {
-                            urpc = GOOGLE_ADS_REFERRAL_CODE;
+                            urpc = PLAY_STORE_AD_REFERRAL_CODE;
+                        }
+                    }
+                    if (urpc == null || urpc.isEmpty()) {
+                        // This detection was found empirically. Unfortunately we are not able to
+                        // get any more info from the referrer at the moment.
+                        if (referrer.contains("gclid")) {
+                            urpc = GOOGLE_SEARCH_AD_REFERRAL_CODE;
                         }
                     }
                     if (urpc != null && !urpc.isEmpty()) {


### PR DESCRIPTION
Uplift of #16004
Resolves https://github.com/brave/brave-browser/issues/26845

Pre-approval checklist: 
- [ ] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [ ] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [ ] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [ ] The associated issue milestone is set to the smallest version that the changes is landed on.