### PR TITLE
Move sidebar to the right when vertical tab strip is being used.

### DIFF
--- a/browser/ui/browser_commands.cc
+++ b/browser/ui/browser_commands.cc
@@ -248,7 +248,7 @@ void ToggleVerticalTabStrip(Browser* browser) {
   if (was_using_vertical_tab_strip) {
     sidebar_service->RestoreSidebarAlignmentIfNeeded();
   } else {
-    sidebar_service->MoveSidebarToRightForVerticalTabsIfNeeded();
+    sidebar_service->MoveSidebarToRightTemporarily();
   }
 }
 

--- a/browser/ui/sidebar/BUILD.gn
+++ b/browser/ui/sidebar/BUILD.gn
@@ -18,6 +18,8 @@ source_set("sidebar") {
     "sidebar_controller.h",
     "sidebar_model.cc",
     "sidebar_model.h",
+    "sidebar_service_delegate_impl.cc",
+    "sidebar_service_delegate_impl.h",
     "sidebar_service_factory.cc",
     "sidebar_service_factory.h",
     "sidebar_utils.cc",

--- a/browser/ui/sidebar/sidebar_service_delegate_impl.cc
+++ b/browser/ui/sidebar/sidebar_service_delegate_impl.cc
@@ -1,0 +1,49 @@
+/* Copyright (c) 2022 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "brave/browser/ui/sidebar/sidebar_service_delegate_impl.h"
+
+#include "base/auto_reset.h"
+#include "brave/components/sidebar/pref_names.h"
+#include "chrome/common/pref_names.h"
+#include "components/prefs/pref_service.h"
+
+SidebarServiceDelegateImpl::SidebarServiceDelegateImpl(PrefService* prefs)
+    : prefs_(prefs) {
+  sidebar_alignment_.Init(
+      prefs::kSidePanelHorizontalAlignment, prefs_,
+      base::BindRepeating(
+          &SidebarServiceDelegateImpl::OnSidebarAlignmentChanged,
+          base::Unretained(this)));
+}
+
+SidebarServiceDelegateImpl::~SidebarServiceDelegateImpl() = default;
+
+void SidebarServiceDelegateImpl::MoveSidebarToRightTemporarily() {
+  // If this value was changed by users, we should respect that.
+  if (!prefs_->FindPreference(prefs::kSidePanelHorizontalAlignment)
+           ->IsDefaultValue())
+    return;
+
+  base::AutoReset<bool> resetter(&changing_sidebar_alignment_temporarily_,
+                                 true);
+  prefs_->SetBoolean(prefs::kSidePanelHorizontalAlignment,
+                     /* align right = */ true);
+}
+
+void SidebarServiceDelegateImpl::RestoreSidebarAlignmentIfNeeded() {
+  if (!prefs_->GetBoolean(sidebar::kSidebarAlignmentChangedTemporarily))
+    return;
+
+  base::AutoReset<bool> resetter(&changing_sidebar_alignment_temporarily_,
+                                 true);
+  prefs_->ClearPref(prefs::kSidePanelHorizontalAlignment);
+}
+
+void SidebarServiceDelegateImpl::OnSidebarAlignmentChanged() {
+  prefs_->SetBoolean(
+      sidebar::kSidebarAlignmentChangedTemporarily,
+      changing_sidebar_alignment_temporarily_ && *sidebar_alignment_);
+}

--- a/browser/ui/sidebar/sidebar_service_delegate_impl.h
+++ b/browser/ui/sidebar/sidebar_service_delegate_impl.h
@@ -1,0 +1,33 @@
+/* Copyright (c) 2022 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_BROWSER_UI_SIDEBAR_SIDEBAR_SERVICE_DELEGATE_IMPL_H_
+#define BRAVE_BROWSER_UI_SIDEBAR_SIDEBAR_SERVICE_DELEGATE_IMPL_H_
+
+#include "brave/components/sidebar/sidebar_service_delegate.h"
+#include "components/prefs/pref_member.h"
+
+class PrefService;
+
+class SidebarServiceDelegateImpl : public sidebar::SidebarServiceDelegate {
+ public:
+  explicit SidebarServiceDelegateImpl(PrefService* prefs);
+  ~SidebarServiceDelegateImpl() override;
+
+  // sidebar::SidebarServiceDelegate:
+  void MoveSidebarToRightTemporarily() override;
+  void RestoreSidebarAlignmentIfNeeded() override;
+
+ private:
+  void OnSidebarAlignmentChanged();
+
+  raw_ptr<PrefService> prefs_;
+
+  bool changing_sidebar_alignment_temporarily_ = false;
+
+  BooleanPrefMember sidebar_alignment_;
+};
+
+#endif  // BRAVE_BROWSER_UI_SIDEBAR_SIDEBAR_SERVICE_DELEGATE_IMPL_H_

--- a/browser/ui/sidebar/sidebar_service_factory.cc
+++ b/browser/ui/sidebar/sidebar_service_factory.cc
@@ -5,6 +5,9 @@
 
 #include "brave/browser/ui/sidebar/sidebar_service_factory.h"
 
+#include <memory>
+
+#include "brave/browser/ui/sidebar/sidebar_service_delegate_impl.h"
 #include "brave/components/sidebar/sidebar_service.h"
 #include "chrome/browser/profiles/incognito_helpers.h"
 #include "chrome/browser/profiles/profile.h"
@@ -31,7 +34,9 @@ SidebarServiceFactory::~SidebarServiceFactory() = default;
 
 KeyedService* SidebarServiceFactory::BuildServiceInstanceFor(
     content::BrowserContext* context) const {
-  return new SidebarService(Profile::FromBrowserContext(context)->GetPrefs());
+  auto* prefs = Profile::FromBrowserContext(context)->GetPrefs();
+  return new SidebarService(
+      prefs, std::make_unique<SidebarServiceDelegateImpl>(prefs));
 }
 
 content::BrowserContext* SidebarServiceFactory::GetBrowserContextToUse(

--- a/browser/ui/views/frame/brave_browser_view.cc
+++ b/browser/ui/views/frame/brave_browser_view.cc
@@ -30,6 +30,7 @@
 #include "brave/components/speedreader/common/buildflags.h"
 #include "brave/components/translate/core/common/buildflags.h"
 #include "chrome/browser/ui/browser_commands.h"
+#include "chrome/browser/ui/color/chrome_color_id.h"
 #include "chrome/browser/ui/frame/window_frame_util.h"
 #include "chrome/browser/ui/views/frame/contents_layout_manager.h"
 #include "chrome/browser/ui/views/frame/tab_strip_region_view.h"
@@ -236,8 +237,9 @@ void BraveBrowserView::OnPreferenceChanged(const std::string& pref_name) {
 void BraveBrowserView::UpdateSideBarHorizontalAlignment() {
   DCHECK(sidebar_container_view_);
 
-  const bool on_left = !GetProfile()->GetPrefs()->GetBoolean(
-      prefs::kSidePanelHorizontalAlignment);
+  const bool on_left =
+      !GetProfile()->GetOriginalProfile()->GetPrefs()->GetBoolean(
+          prefs::kSidePanelHorizontalAlignment);
 
   sidebar_container_view_->SetSidebarOnLeft(on_left);
   static_cast<BraveContentsLayoutManager*>(GetContentsLayoutManager())
@@ -507,6 +509,19 @@ bool BraveBrowserView::ShouldShowWindowTitle() const {
     return true;
 
   return false;
+}
+
+void BraveBrowserView::OnThemeChanged() {
+  BrowserView::OnThemeChanged();
+  if (vertical_tab_strip_host_view_) {
+    const auto background_color = GetColorProvider()->GetColor(kColorToolbar);
+    vertical_tab_strip_host_view_->SetBackground(
+        views::CreateSolidBackground(background_color));
+  }
+}
+
+bool BraveBrowserView::IsSidebarVisible() const {
+  return sidebar_container_view_ && sidebar_container_view_->IsSidebarVisible();
 }
 
 BraveBrowser* BraveBrowserView::GetBraveBrowser() const {

--- a/browser/ui/views/frame/brave_browser_view.h
+++ b/browser/ui/views/frame/brave_browser_view.h
@@ -80,8 +80,10 @@ class BraveBrowserView : public BrowserView {
   bool GetSupportsTitle() const override;
 #endif
   bool ShouldShowWindowTitle() const override;
+  void OnThemeChanged() override;
 
   views::View* sidebar_host_view() { return sidebar_host_view_; }
+  bool IsSidebarVisible() const;
 
   VerticalTabStripWidgetDelegateView*
   vertical_tab_strip_widget_delegate_view() {

--- a/browser/ui/views/frame/vertical_tab_strip_region_view.cc
+++ b/browser/ui/views/frame/vertical_tab_strip_region_view.cc
@@ -403,10 +403,7 @@ void VerticalTabStripRegionView::UpdateLayout(bool in_destruction) {
 
 void VerticalTabStripRegionView::OnThemeChanged() {
   View::OnThemeChanged();
-
-  const auto background_color = GetColorProvider()->GetColor(kColorToolbar);
-  SetBackground(views::CreateSolidBackground(background_color));
-  scroll_view_->SetBackgroundColor(background_color);
+  scroll_view_->SetBackgroundColor(GetColorProvider()->GetColor(kColorToolbar));
 
   new_tab_button_->FrameColorsChanged();
 }

--- a/browser/ui/views/frame/vertical_tab_strip_widget_delegate_view.cc
+++ b/browser/ui/views/frame/vertical_tab_strip_widget_delegate_view.cc
@@ -8,8 +8,10 @@
 #include <utility>
 
 #include "base/check.h"
+#include "brave/browser/ui/views/frame/brave_browser_view.h"
 #include "brave/browser/ui/views/frame/vertical_tab_strip_region_view.h"
 #include "chrome/browser/ui/views/frame/browser_view.h"
+#include "chrome/common/pref_names.h"
 #include "ui/base/metadata/metadata_impl_macros.h"
 #include "ui/views/layout/fill_layout.h"
 #include "ui/views/widget/widget.h"
@@ -137,12 +139,52 @@ void VerticalTabStripWidgetDelegateView::UpdateWidgetBounds() {
 
   if (need_to_call_layout)
     Layout();
+
+#if BUILDFLAG(IS_MAC)
+  UpdateClip();
+#endif
 }
 
 void VerticalTabStripWidgetDelegateView::OnWidgetDestroying(
     views::Widget* widget) {
   widget_observation_.Reset();
 }
+
+#if BUILDFLAG(IS_MAC)
+void VerticalTabStripWidgetDelegateView::UpdateClip() {
+  // On mac, child window can be drawn out of parent window. We should clip
+  // the border line and corner radius manually.
+  SkPath path;
+  const bool is_vertical_tab_right_most =
+      !static_cast<BraveBrowserView*>(browser_view_)->IsSidebarVisible() ||
+      !browser_view_->browser()
+           ->profile()
+           ->GetOriginalProfile()
+           ->GetPrefs()
+           ->GetBoolean(prefs::kSidePanelHorizontalAlignment);
+
+  if (is_vertical_tab_right_most) {
+    // We should clip the bottom-left corner too.
+    // The corner radius value refers to the that of menu widget. Looks like fit
+    // for us.
+    // https://github.com/chromium/chromium/blob/371d67fd9c7db16c32f22e3ba247a07aa5e81487/ui/views/controls/menu/menu_config_mac.mm#L35
+    constexpr int kCornerRadius = 8;
+    path.moveTo(1, 0);
+    path.lineTo(width(), 0);
+    path.lineTo(width(), height() - 1);
+    path.lineTo(1 + kCornerRadius, height() - 1);
+    path.rArcTo(kCornerRadius, kCornerRadius, 0, SkPath::kSmall_ArcSize,
+                SkPathDirection::kCW, -kCornerRadius, -kCornerRadius);
+    path.close();
+  } else {
+    path.lineTo(width(), 0);
+    path.lineTo(width(), height() - 1);
+    path.lineTo(0, height() - 1);
+    path.close();
+  }
+  SetClipPath(path);
+}
+#endif
 
 BEGIN_METADATA(VerticalTabStripWidgetDelegateView, views::View)
 END_METADATA

--- a/browser/ui/views/frame/vertical_tab_strip_widget_delegate_view.cc
+++ b/browser/ui/views/frame/vertical_tab_strip_widget_delegate_view.cc
@@ -155,7 +155,7 @@ void VerticalTabStripWidgetDelegateView::UpdateClip() {
   // On mac, child window can be drawn out of parent window. We should clip
   // the border line and corner radius manually.
   SkPath path;
-  const bool is_vertical_tab_right_most =
+  const bool is_vertical_tab_left_most =
       !static_cast<BraveBrowserView*>(browser_view_)->IsSidebarVisible() ||
       !browser_view_->browser()
            ->profile()
@@ -163,10 +163,10 @@ void VerticalTabStripWidgetDelegateView::UpdateClip() {
            ->GetPrefs()
            ->GetBoolean(prefs::kSidePanelHorizontalAlignment);
 
-  if (is_vertical_tab_right_most) {
+  if (is_vertical_tab_left_most) {
     // We should clip the bottom-left corner too.
-    // The corner radius value refers to the that of menu widget. Looks like fit
-    // for us.
+    // The corner radius value refers to the that of menu widget. Looks fit for
+    // us.
     // https://github.com/chromium/chromium/blob/371d67fd9c7db16c32f22e3ba247a07aa5e81487/ui/views/controls/menu/menu_config_mac.mm#L35
     constexpr int kCornerRadius = 8;
     path.moveTo(1, 0);

--- a/browser/ui/views/frame/vertical_tab_strip_widget_delegate_view.h
+++ b/browser/ui/views/frame/vertical_tab_strip_widget_delegate_view.h
@@ -67,6 +67,10 @@ class VerticalTabStripWidgetDelegateView : public views::WidgetDelegateView,
                                      views::View* host);
   void UpdateWidgetBounds();
 
+#if BUILDFLAG(IS_MAC)
+  void UpdateClip();
+#endif
+
   raw_ptr<BrowserView> browser_view_ = nullptr;
   raw_ptr<views::View> host_ = nullptr;
   raw_ptr<VerticalTabStripRegionView> region_view_ = nullptr;

--- a/browser/ui/views/sidebar/sidebar_container_view.cc
+++ b/browser/ui/views/sidebar/sidebar_container_view.cc
@@ -145,6 +145,10 @@ void SidebarContainerView::SetSidebarOnLeft(bool sidebar_on_left) {
                       : BraveSidePanel::kHorizontalAlignRight);
 }
 
+bool SidebarContainerView::IsSidebarVisible() const {
+  return sidebar_control_view_ && sidebar_control_view_->GetVisible();
+}
+
 void SidebarContainerView::SetSidebarShowOption(
     sidebar::SidebarService::ShowSidebarOption show_option) {
   UpdateSidebarVisibility(show_option);

--- a/browser/ui/views/sidebar/sidebar_container_view.h
+++ b/browser/ui/views/sidebar/sidebar_container_view.h
@@ -60,6 +60,8 @@ class SidebarContainerView
   void Init();
   void SetSidebarOnLeft(bool sidebar_on_left);
 
+  bool IsSidebarVisible() const;
+
   BraveSidePanel* side_panel() { return side_panel_; }
 
   // Sidebar overrides:

--- a/browser/ui/views/tabs/vertical_tab_strip_browsertest.cc
+++ b/browser/ui/views/tabs/vertical_tab_strip_browsertest.cc
@@ -11,8 +11,8 @@
 #include "brave/browser/ui/views/frame/vertical_tab_strip_widget_delegate_view.h"
 #include "brave/browser/ui/views/tabs/features.h"
 #include "build/build_config.h"
-#include "chrome/browser/ui/browser_tabstrip.h"
 #include "chrome/browser/ui/browser.h"
+#include "chrome/browser/ui/browser_tabstrip.h"
 #include "chrome/browser/ui/views/frame/browser_non_client_frame_view.h"
 #include "chrome/browser/ui/views/frame/browser_view.h"
 #include "chrome/browser/ui/views/frame/tab_strip_region_view.h"
@@ -26,10 +26,6 @@
 
 #if BUILDFLAG(IS_WIN)
 #include "chrome/browser/ui/views/frame/glass_browser_frame_view.h"
-#endif
-
-#if BUILDFLAG(IS_LINUX)
-#include "chrome/common/pref_names.h"
 #endif
 
 #if BUILDFLAG(IS_MAC)
@@ -270,8 +266,8 @@ IN_PROC_BROWSER_TEST_F(VerticalTabStripBrowserTest, SidebarAlignment) {
                    ->IsDefaultValue());
   EXPECT_TRUE(prefs->GetBoolean(prefs::kSidePanelHorizontalAlignment));
 
-  // When disabling vertical tab strip, sidebar should be restored to the default
-  // position.
+  // When disabling vertical tab strip, sidebar should be restored to the
+  // default position.
   ToggleVerticalTabStrip();
   EXPECT_TRUE(prefs->FindPreference(prefs::kSidePanelHorizontalAlignment)
                   ->IsDefaultValue());
@@ -286,7 +282,7 @@ IN_PROC_BROWSER_TEST_F(VerticalTabStripBrowserTest, SidebarAlignment) {
 
   // Turning off vertical tab strip also shouldn't affect sidebar's position.
   prefs->SetBoolean(prefs::kSidePanelHorizontalAlignment, true);
-      ToggleVerticalTabStrip();
+  ToggleVerticalTabStrip();
   ToggleVerticalTabStrip();
   EXPECT_FALSE(prefs->FindPreference(prefs::kSidePanelHorizontalAlignment)
                    ->IsDefaultValue());

--- a/chromium_src/chrome/browser/ui/views/toolbar/side_panel_toolbar_button.cc
+++ b/chromium_src/chrome/browser/ui/views/toolbar/side_panel_toolbar_button.cc
@@ -57,7 +57,7 @@ class SidePanelMenuModel : public ui::SimpleMenuModel,
 
 SidePanelToolbarButton::SidePanelToolbarButton(Browser* browser)
     : SidePanelToolbarButton_ChromiumImpl(browser) {
-  auto* prefs = browser->profile()->GetPrefs();
+  auto* prefs = browser->profile()->GetOriginalProfile()->GetPrefs();
 
   SetMenuModel(std::make_unique<SidePanelMenuModel>(prefs));
 

--- a/components/sidebar/BUILD.gn
+++ b/components/sidebar/BUILD.gn
@@ -15,6 +15,7 @@ static_library("sidebar") {
     "sidebar_item.h",
     "sidebar_service.cc",
     "sidebar_service.h",
+    "sidebar_service_delegate.h",
   ]
 
   deps = [

--- a/components/sidebar/pref_names.h
+++ b/components/sidebar/pref_names.h
@@ -14,6 +14,8 @@ constexpr char kSidebarHiddenBuiltInItems[] =
 constexpr char kSidebarShowOption[] = "brave.sidebar.sidebar_show_option";
 constexpr char kSidebarItemAddedFeedbackBubbleShowCount[] =
     "brave.sidebar.item_added_feedback_bubble_shown_count";
+constexpr char kSidebarAlignmentChangedForVerticalTabs[] =
+    "brave.sidebar.sidebar_alignment_changed_for_vertical_tabs";
 
 }  // namespace sidebar
 

--- a/components/sidebar/pref_names.h
+++ b/components/sidebar/pref_names.h
@@ -14,7 +14,10 @@ constexpr char kSidebarHiddenBuiltInItems[] =
 constexpr char kSidebarShowOption[] = "brave.sidebar.sidebar_show_option";
 constexpr char kSidebarItemAddedFeedbackBubbleShowCount[] =
     "brave.sidebar.item_added_feedback_bubble_shown_count";
-constexpr char kSidebarAlignmentChangedForVerticalTabs[] =
+
+// Indicates that sidebar alignment was changed by the browser itself, not by
+// users.
+constexpr char kSidebarAlignmentChangedTemporarily[] =
     "brave.sidebar.sidebar_alignment_changed_for_vertical_tabs";
 
 }  // namespace sidebar

--- a/components/sidebar/sidebar_service.cc
+++ b/components/sidebar/sidebar_service.cc
@@ -11,6 +11,7 @@
 #include <utility>
 #include <vector>
 
+#include "base/check_is_test.h"
 #include "base/containers/contains.h"
 #include "base/feature_list.h"
 #include "base/logging.h"
@@ -440,10 +441,20 @@ void SidebarService::SetSidebarShowOption(ShowSidebarOption show_options) {
 }
 
 void SidebarService::MoveSidebarToRightTemporarily() {
+  if (!delegate_) {
+    CHECK_IS_TEST();
+    return;
+  }
+
   delegate_->MoveSidebarToRightTemporarily();
 }
 
 void SidebarService::RestoreSidebarAlignmentIfNeeded() {
+  if (!delegate_) {
+    CHECK_IS_TEST();
+    return;
+  }
+
   delegate_->RestoreSidebarAlignmentIfNeeded();
 }
 

--- a/components/sidebar/sidebar_service.cc
+++ b/components/sidebar/sidebar_service.cc
@@ -11,7 +11,6 @@
 #include <utility>
 #include <vector>
 
-#include "base/auto_reset.h"
 #include "base/containers/contains.h"
 #include "base/feature_list.h"
 #include "base/logging.h"
@@ -25,7 +24,7 @@
 #include "brave/components/sidebar/constants.h"
 #include "brave/components/sidebar/pref_names.h"
 #include "brave/components/sidebar/sidebar_item.h"
-#include "chrome/common/pref_names.h"
+#include "brave/components/sidebar/sidebar_service_delegate.h"
 #include "components/grit/brave_components_strings.h"
 #include "components/prefs/pref_registry_simple.h"
 #include "components/prefs/pref_service.h"
@@ -80,10 +79,12 @@ void SidebarService::RegisterProfilePrefs(PrefRegistrySimple* registry,
           ? static_cast<int>(ShowSidebarOption::kShowNever)
           : static_cast<int>(ShowSidebarOption::kShowAlways));
   registry->RegisterIntegerPref(kSidebarItemAddedFeedbackBubbleShowCount, 0);
-  registry->RegisterBooleanPref(kSidebarAlignmentChangedForVerticalTabs, false);
+  registry->RegisterBooleanPref(kSidebarAlignmentChangedTemporarily, false);
 }
 
-SidebarService::SidebarService(PrefService* prefs) : prefs_(prefs) {
+SidebarService::SidebarService(PrefService* prefs,
+                               std::unique_ptr<SidebarServiceDelegate> delegate)
+    : prefs_(prefs), delegate_(std::move(delegate)) {
   DCHECK(prefs_);
   MigratePrefSidebarBuiltInItemsToHidden();
 
@@ -94,10 +95,6 @@ SidebarService::SidebarService(PrefService* prefs) : prefs_(prefs) {
   pref_change_registrar_.Init(prefs_);
   pref_change_registrar_.Add(
       kSidebarShowOption,
-      base::BindRepeating(&SidebarService::OnPreferenceChanged,
-                          base::Unretained(this)));
-  pref_change_registrar_.Add(
-      prefs::kSidePanelHorizontalAlignment,
       base::BindRepeating(&SidebarService::OnPreferenceChanged,
                           base::Unretained(this)));
 }
@@ -442,24 +439,12 @@ void SidebarService::SetSidebarShowOption(ShowSidebarOption show_options) {
   prefs_->SetInteger(kSidebarShowOption, static_cast<int>(show_options));
 }
 
-void SidebarService::MoveSidebarToRightForVerticalTabsIfNeeded() {
-  if (!prefs_->FindPreference(prefs::kSidePanelHorizontalAlignment)
-           ->IsDefaultValue())
-    return;
-
-  base::AutoReset<bool> resetter(&changing_sidebar_alignment_for_vertical_tabs_,
-                                 true);
-  prefs_->SetBoolean(prefs::kSidePanelHorizontalAlignment,
-                     /* align right = */ true);
+void SidebarService::MoveSidebarToRightTemporarily() {
+  delegate_->MoveSidebarToRightTemporarily();
 }
 
 void SidebarService::RestoreSidebarAlignmentIfNeeded() {
-  if (!prefs_->GetBoolean(kSidebarAlignmentChangedForVerticalTabs))
-    return;
-
-  base::AutoReset<bool> resetter(&changing_sidebar_alignment_for_vertical_tabs_,
-                                 true);
-  prefs_->ClearPref(prefs::kSidePanelHorizontalAlignment);
+  delegate_->RestoreSidebarAlignmentIfNeeded();
 }
 
 void SidebarService::LoadSidebarItems() {
@@ -651,13 +636,6 @@ void SidebarService::OnPreferenceChanged(const std::string& pref_name) {
   if (pref_name == kSidebarShowOption) {
     for (Observer& obs : observers_)
       obs.OnShowSidebarOptionChanged(GetSidebarShowOption());
-    return;
-  }
-
-  if (pref_name == prefs::kSidePanelHorizontalAlignment) {
-    prefs_->SetBoolean(kSidebarAlignmentChangedForVerticalTabs,
-                       changing_sidebar_alignment_for_vertical_tabs_ &&
-                           prefs_->GetBoolean(pref_name));
     return;
   }
 }

--- a/components/sidebar/sidebar_service.h
+++ b/components/sidebar/sidebar_service.h
@@ -6,6 +6,7 @@
 #ifndef BRAVE_COMPONENTS_SIDEBAR_SIDEBAR_SERVICE_H_
 #define BRAVE_COMPONENTS_SIDEBAR_SIDEBAR_SERVICE_H_
 
+#include <memory>
 #include <string>
 #include <vector>
 
@@ -22,6 +23,8 @@ class PrefRegistrySimple;
 class PrefService;
 
 namespace sidebar {
+
+class SidebarServiceDelegate;
 
 struct SidebarItemUpdate {
   size_t index = 0;
@@ -74,7 +77,8 @@ class SidebarService : public KeyedService {
   static void RegisterProfilePrefs(PrefRegistrySimple* registry,
                                    version_info::Channel channel);
 
-  explicit SidebarService(PrefService* prefs);
+  SidebarService(PrefService* prefs,
+                 std::unique_ptr<SidebarServiceDelegate> delegate);
   ~SidebarService() override;
 
   const std::vector<SidebarItem>& items() const { return items_; }
@@ -97,7 +101,7 @@ class SidebarService : public KeyedService {
   ShowSidebarOption GetSidebarShowOption() const;
   void SetSidebarShowOption(ShowSidebarOption show_options);
 
-  void MoveSidebarToRightForVerticalTabsIfNeeded();
+  void MoveSidebarToRightTemporarily();
   void RestoreSidebarAlignmentIfNeeded();
 
   absl::optional<SidebarItem> GetDefaultPanelItem() const;
@@ -120,9 +124,10 @@ class SidebarService : public KeyedService {
   void MigratePrefSidebarBuiltInItemsToHidden();
 
   raw_ptr<PrefService> prefs_ = nullptr;
-  std::vector<SidebarItem> items_;
 
-  bool changing_sidebar_alignment_for_vertical_tabs_ = false;
+  std::unique_ptr<SidebarServiceDelegate> delegate_;
+
+  std::vector<SidebarItem> items_;
 
   base::ObserverList<Observer> observers_;
   PrefChangeRegistrar pref_change_registrar_;

--- a/components/sidebar/sidebar_service.h
+++ b/components/sidebar/sidebar_service.h
@@ -97,6 +97,9 @@ class SidebarService : public KeyedService {
   ShowSidebarOption GetSidebarShowOption() const;
   void SetSidebarShowOption(ShowSidebarOption show_options);
 
+  void MoveSidebarToRightForVerticalTabsIfNeeded();
+  void RestoreSidebarAlignmentIfNeeded();
+
   absl::optional<SidebarItem> GetDefaultPanelItem() const;
   bool IsEditableItemAt(size_t index) const;
 
@@ -118,6 +121,9 @@ class SidebarService : public KeyedService {
 
   raw_ptr<PrefService> prefs_ = nullptr;
   std::vector<SidebarItem> items_;
+
+  bool changing_sidebar_alignment_for_vertical_tabs_ = false;
+
   base::ObserverList<Observer> observers_;
   PrefChangeRegistrar pref_change_registrar_;
 };

--- a/components/sidebar/sidebar_service_delegate.h
+++ b/components/sidebar/sidebar_service_delegate.h
@@ -1,0 +1,24 @@
+/* Copyright (c) 2022 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_COMPONENTS_SIDEBAR_SIDEBAR_SERVICE_DELEGATE_H_
+#define BRAVE_COMPONENTS_SIDEBAR_SIDEBAR_SERVICE_DELEGATE_H_
+
+namespace sidebar {
+
+class SidebarServiceDelegate {
+ public:
+  SidebarServiceDelegate() = default;
+  SidebarServiceDelegate(const SidebarServiceDelegate&) = delete;
+  SidebarServiceDelegate& operator=(const SidebarServiceDelegate&) = delete;
+  virtual ~SidebarServiceDelegate() = default;
+
+  virtual void MoveSidebarToRightTemporarily() = 0;
+  virtual void RestoreSidebarAlignmentIfNeeded() = 0;
+};
+
+}  // namespace sidebar
+
+#endif  // BRAVE_COMPONENTS_SIDEBAR_SIDEBAR_SERVICE_DELEGATE_H_

--- a/components/sidebar/sidebar_service_unittest.cc
+++ b/components/sidebar/sidebar_service_unittest.cc
@@ -14,6 +14,7 @@
 #include "brave/components/sidebar/pref_names.h"
 #include "brave/components/sidebar/sidebar_item.h"
 #include "brave/components/sidebar/sidebar_service.h"
+#include "brave/components/sidebar/sidebar_service_delegate.h"
 #include "components/prefs/testing_pref_service.h"
 #include "components/version_info/channel.h"
 #include "testing/gmock/include/gmock/gmock.h"
@@ -62,7 +63,7 @@ class SidebarServiceTest : public testing::Test {
   void TearDown() override { ResetService(); }
 
   void InitService() {
-    service_ = std::make_unique<SidebarService>(&prefs_);
+    service_ = std::make_unique<SidebarService>(&prefs_, nullptr);
     service_->AddObserver(&observer_);
   }
 


### PR DESCRIPTION
When a user didn't specify any preference over sidebar position, we move sidebar to the right side when vertical tabs are visible on the left side.

But when the user has chosen sidebar position, we should respect that. So we don't adjust the position automatically.

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/26855

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
### Automated
* VerticalTabStripBrowserTest.SidebarAlignment

### Manual
#### Basic behavior
1. Clear profile
2. Open up browser and enable the vertical tab strip flag.
3. En/disable vertical tab strip via tab context menu
4. Check if sidebar moves to right/left respectively.

#### Corner case: When user selected sidebar position explicitly - sidebar shouldn't move
1. Go to settings > apperance > sidebar > Show on right
2. Select any value
3. En/disable vertical tab strip via tab context menu
4. Check if the position that the user selected is respected.
