### PR TITLE
Updated VPN panel's message when vpn entry creation is failed on Win (uplift to 1.46.x)

### DIFF
--- a/components/brave_vpn/brave_vpn_constants.h
+++ b/components/brave_vpn/brave_vpn_constants.h
@@ -11,6 +11,8 @@
 #include "ui/base/webui/web_ui_util.h"
 
 namespace brave_vpn {
+
+#if !BUILDFLAG(IS_ANDROID)
 constexpr webui::LocalizedString kLocalizedStrings[] = {
     {"braveVpn", IDS_BRAVE_VPN},
     {"braveVpnConnect", IDS_BRAVE_VPN_CONNECT},
@@ -71,6 +73,7 @@ constexpr webui::LocalizedString kLocalizedStrings[] = {
     {"braveVpnSupportSubmit", IDS_BRAVE_VPN_SUPPORT_SUBMIT},
     {"braveVpnConnectNotAllowed", IDS_BRAVE_VPN_CONNECT_NOT_ALLOWED},
 };
+#endif
 
 constexpr char kManageUrlProd[] = "https://account.brave.com/account/";
 constexpr char kManageUrlStaging[] =

--- a/components/resources/brave_vpn_strings.grdp
+++ b/components/resources/brave_vpn_strings.grdp
@@ -200,9 +200,17 @@
     Submit
   </message>
 
-  <message name="IDS_BRAVE_VPN_CONNECT_NOT_ALLOWED" desc="A highlited note on the main panel when permission from the user is not allowed to create a VPN profile on OS-level">
-    VPN connection failed. Please try connecting again, and be sure to click Allow to enable Brave's VPN configuration.
-  </message>
+  <if expr="is_win">
+    <message name="IDS_BRAVE_VPN_CONNECT_NOT_ALLOWED" desc="A highlited note on the main panel when permission from the user is not allowed to create a VPN profile on OS-level">
+      Failed to write the VPN config. This may happen if you don't have permission or if you haven't run Windows Update recently.
+    </message>
+  </if>
+
+  <if expr="is_macosx">
+    <message name="IDS_BRAVE_VPN_CONNECT_NOT_ALLOWED" desc="A highlited note on the main panel when permission from the user is not allowed to create a VPN profile on OS-level">
+      VPN connection failed. Please try connecting again, and be sure to click Allow to enable Brave's VPN configuration.
+    </message>
+  </if>
 
   <message name="IDS_BRAVE_VPN_DNS_CHANGE_ALERT" desc="A text shown to user when he changed DNS settings with Brave VPN enabled">
     Turning off secure DNS or using default servers on Windows may reveal the names of the sites you visit to your Internet service provider. Brave does not recommend doing this. Do you want to do it anyways?


### PR DESCRIPTION
Uplift of #16013
fix https://github.com/brave/brave-browser/issues/26852

Pre-approval checklist: 
- [ ] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [ ] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [ ] The associated issue milestone is set to the smallest version that the changes is landed on.