### PR TITLE
Make vertical tab strip work with "ScrollableTabStrip" flag

### DIFF
--- a/browser/ui/views/frame/vertical_tab_strip_region_view.cc
+++ b/browser/ui/views/frame/vertical_tab_strip_region_view.cc
@@ -19,6 +19,7 @@
 #include "chrome/browser/ui/exclusive_access/fullscreen_controller.h"
 #include "chrome/browser/ui/frame/window_frame_util.h"
 #include "chrome/browser/ui/tabs/tab_style.h"
+#include "chrome/browser/ui/views/tabs/tab_strip_scroll_container.h"
 #include "chrome/grit/generated_resources.h"
 #include "ui/base/l10n/l10n_util.h"
 #include "ui/base/metadata/metadata_impl_macros.h"
@@ -29,6 +30,7 @@
 #include "ui/views/layout/box_layout.h"
 #include "ui/views/layout/fill_layout.h"
 #include "ui/views/layout/flex_layout.h"
+#include "ui/views/view_utils.h"
 
 namespace {
 
@@ -388,6 +390,13 @@ void VerticalTabStripRegionView::UpdateLayout(bool in_destruction) {
     }
     region_view_->layout_manager_->SetOrientation(
         views::LayoutOrientation::kVertical);
+    if (base::FeatureList::IsEnabled(features::kScrollableTabStrip)) {
+      auto* scroll_container = views::AsViewClass<TabStripScrollContainer>(
+          region_view_->tab_strip_container_);
+      DCHECK(scroll_container)
+          << "TabStripScrollContainer is used by upstream at this moment.";
+      scroll_container->SetLayoutManager(std::make_unique<views::FillLayout>());
+    }
   } else {
     if (Contains(region_view_)) {
       scroll_view_->contents()->RemoveChildView(region_view_);
@@ -395,6 +404,14 @@ void VerticalTabStripRegionView::UpdateLayout(bool in_destruction) {
     }
     region_view_->layout_manager_->SetOrientation(
         views::LayoutOrientation::kHorizontal);
+    if (base::FeatureList::IsEnabled(features::kScrollableTabStrip)) {
+      auto* scroll_container = views::AsViewClass<TabStripScrollContainer>(
+          region_view_->tab_strip_container_);
+      DCHECK(scroll_container)
+          << "TabStripScrollContainer is used by upstream at this moment.";
+      scroll_container->SetLayoutManager(std::make_unique<views::FillLayout>())
+          ->SetMinimumSizeEnabled(true);
+    }
   }
 
   PreferredSizeChanged();

--- a/browser/ui/views/tabs/brave_tab_strip.cc
+++ b/browser/ui/views/tabs/brave_tab_strip.cc
@@ -14,6 +14,7 @@
 #include "chrome/browser/profiles/profile.h"
 #include "chrome/browser/themes/theme_service.h"
 #include "chrome/browser/themes/theme_service_factory.h"
+#include "chrome/browser/ui/ui_features.cc"
 #include "chrome/browser/ui/views/tabs/tab.h"
 #include "chrome/browser/ui/views/tabs/tab_strip_controller.h"
 #include "third_party/skia/include/core/SkColor.h"
@@ -78,6 +79,19 @@ SkColor BraveTabStrip::GetTabSeparatorColor() const {
                    dark_mode::BraveDarkModeType::BRAVE_DARK_MODE_TYPE_DARK;
   return dark_mode ? SkColorSetRGB(0x39, 0x38, 0x38)
                    : SkColorSetRGB(0xBE, 0xBF, 0xBF);
+}
+
+void BraveTabStrip::Layout() {
+  if (tabs::features::ShouldShowVerticalTabs(GetBrowser()) &&
+      base::FeatureList::IsEnabled(features::kScrollableTabStrip)) {
+    // Chromium implementation limits the height of tab strip, which we don't
+    // want.
+    for (auto* view : children())
+      view->SetBoundsRect(GetLocalBounds());
+    return;
+  }
+
+  TabStrip::Layout();
 }
 
 BEGIN_METADATA(BraveTabStrip, TabStrip)

--- a/browser/ui/views/tabs/brave_tab_strip.h
+++ b/browser/ui/views/tabs/brave_tab_strip.h
@@ -27,6 +27,7 @@ class BraveTabStrip : public TabStrip {
   // TabStrip overrides:
   SkColor GetTabSeparatorColor() const override;
   bool ShouldDrawStrokes() const override;
+  void Layout() override;
 
   // Exposed for testing.
   static constexpr float kBraveMinimumContrastRatioForOutlines = 1.2797f;


### PR DESCRIPTION
Overrides some chromium behaviors so that it can work even with our vertical tab strip

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/26241

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
### Manual
* Enable "Tab scrolling" flag and vertical tab strip
* Check if vertical tab strip works well.
* Switch back to horizontal tab strip
* Scrollable tab strip should work too.
