### PR TITLE
Allow for VPN on Desktop release channel

### DIFF
--- a/chromium_src/chrome/browser/unexpire_flags.cc
+++ b/chromium_src/chrome/browser/unexpire_flags.cc
@@ -22,15 +22,6 @@ bool IsFlagExpired(const flags_ui::FlagsStorage* storage,
   version_info::Channel channel = chrome::GetChannel();
 #endif
 
-#if BUILDFLAG(ENABLE_BRAVE_VPN)
-  // Enable VPN feature except stable.
-  if (base::EqualsCaseInsensitiveASCII(kBraveVPNFeatureInternalName,
-                                       internal_name) &&
-      channel == version_info::Channel::STABLE) {
-    return true;
-  }
-#endif
-
 #if BUILDFLAG(ENABLE_PLAYLIST)
   // Enable playlist feature only for nightly/development.
   if (base::EqualsCaseInsensitiveASCII(kPlaylistFeatureInternalName,

--- a/chromium_src/chrome/browser/unexpire_flags.cc
+++ b/chromium_src/chrome/browser/unexpire_flags.cc
@@ -5,7 +5,6 @@
 
 #include "base/strings/string_util.h"
 #include "brave/browser/brave_features_internal_names.h"
-#include "brave/components/brave_vpn/buildflags/buildflags.h"
 #include "brave/components/playlist/buildflags/buildflags.h"
 #include "chrome/common/channel_info.h"
 #include "components/version_info/version_info.h"
@@ -18,11 +17,9 @@ namespace flags {
 
 bool IsFlagExpired(const flags_ui::FlagsStorage* storage,
                    const char* internal_name) {
-#if BUILDFLAG(ENABLE_BRAVE_VPN) || BUILDFLAG(ENABLE_PLAYLIST)
-  version_info::Channel channel = chrome::GetChannel();
-#endif
-
 #if BUILDFLAG(ENABLE_PLAYLIST)
+  version_info::Channel channel = chrome::GetChannel();
+
   // Enable playlist feature only for nightly/development.
   if (base::EqualsCaseInsensitiveASCII(kPlaylistFeatureInternalName,
                                        internal_name) &&


### PR DESCRIPTION
It's still disabled by default so we can roll out via Griffin

Fixes https://github.com/brave/brave-browser/issues/26867

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

