### PR TITLE
Fix update branding logic to make release builds faster

### DIFF
--- a/build/commands/lib/build.js
+++ b/build/commands/lib/build.js
@@ -23,7 +23,8 @@ const build = (buildConfig = config.defaultBuildConfig, options) => {
   config.update(options)
   checkVersionsMatch()
 
-  util.touchOverriddenFilesAndUpdateBranding()
+  util.touchOverriddenFiles()
+  util.updateBranding()
 
   if (config.xcode_gen_target) {
     util.generateXcodeWorkspace()

--- a/build/commands/lib/createDist.js
+++ b/build/commands/lib/createDist.js
@@ -6,6 +6,7 @@ const fs = require('fs-extra')
 const createDist = (buildConfig = config.defaultBuildConfig, options) => {
   config.buildConfig = buildConfig
   config.update(options)
+  util.touchOverriddenFiles()
   util.updateBranding()
   // On Android CI does two builds sequentially: for aab and for apk.
   // Symbols are uploaded after 2nd build, but we need to preserve the symbols

--- a/build/commands/lib/test.js
+++ b/build/commands/lib/test.js
@@ -107,7 +107,7 @@ const test = (passthroughArgs, suite, buildConfig = config.defaultBuildConfig, o
   } else {
     config.buildTarget = suite
   }
-  util.touchOverriddenFilesAndUpdateBranding()
+  util.touchOverriddenFiles()
   util.buildTarget()
 
   // Filter out upstream tests that are known to fail for Brave

--- a/build/commands/lib/util.js
+++ b/build/commands/lib/util.js
@@ -405,7 +405,7 @@ const util = {
     }
   },
 
-  touchOverriddenFiles: () => {
+  touchOverriddenChromiumSrcFiles: () => {
     console.log('touch original files overridden by chromium_src...')
 
     // Return true when original file of |file| should be touched.
@@ -465,10 +465,9 @@ const util = {
     })
   },
 
-  touchOverriddenFilesAndUpdateBranding: () => {
-    util.touchOverriddenFiles()
+  touchOverriddenFiles: () => {
+    util.touchOverriddenChromiumSrcFiles()
     util.touchOverriddenVectorIconFiles()
-    util.updateBranding()
   },
 
   // Chromium compares pre-installed midl files and generated midl files from IDL during the build to check integrity.


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Currently MacOS tests in release branches fallback to development branding, which is incorrect.
This happens because `config.channel` is `development` in tests. Regression from: https://github.com/brave/brave-core/pull/13597

This PR:
1. disables `updateBranding()` call for `npm run test`.
2. adds `util.touchOverriddenFiles()` to `create_dist` command as it's used as a default build command in Android PR builds. This should be a no-op in most scenarios. If it's not, then we'd better fix those scenarios.
3. fixes unnecessary `BRANDING`, `app.icns` rewrites when `--channel` is passed.

Resolves https://github.com/brave/brave-browser/issues/26869

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

