### PR TITLE
Update ads status header hosts list.

### DIFF
--- a/browser/brave_search/brave_search_browsertest.cc
+++ b/browser/brave_search/brave_search_browsertest.cc
@@ -41,7 +41,7 @@ namespace {
 
 const char kEmbeddedTestServerDirectory[] = "brave-search";
 const char kAllowedDomain[] = "search.brave.com";
-const char kAllowedDomainDev[] = "search-dev.brave.com";
+const char kAllowedDomainDev[] = "search.brave.software";
 const char kNotAllowedDomain[] = "brave.com";
 const char kAdsStatusHeaderName[] = "X-Brave-Ads-Enabled";
 const char kAdsStatusHeaderValue[] = "1";

--- a/components/brave_search/common/brave_search_utils.cc
+++ b/components/brave_search/common/brave_search_utils.cc
@@ -19,8 +19,9 @@
 namespace {
 
 constexpr auto kVettedHosts = base::MakeFixedFlatSet<base::StringPiece>(
-    {"search.brave.com", "search-dev.brave.com", "search-dev-local.brave.com",
-     "search.brave.software", "search.bravesoftware.com"});
+    {"search.brave.com", "search.brave.software", "search.bravesoftware.com",
+     "safesearch.brave.com", "safesearch.brave.software",
+     "safesearch.bravesoftware.com", "search-dev-local.brave.com"});
 
 }  // namespace
 


### PR DESCRIPTION
Send ads status header to safesearch.brave.com, safesearch.brave.software, safesearch.bravesoftware.com also.

The `X-Brave-Ads-Enabled` header description: https://github.com/brave/brave-browser/wiki/Custom-Headers#x-brave-ads-enabled

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/26904

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

**Run Brave browser with fresh profile**
- Open https://safesearch.brave.com/
- make sure that X-Brave-Ads-Enabled header is not set in the request
- type query in the search box and press submit
- make sure that X-Brave-Ads-Enabled header is not set in the request

**Enable Brave Private Ads**
- Open https://safesearch.brave.com/
- make sure that X-Brave-Ads-Enabled: 1 header is presented in request
- type query in the search box and press submit
- make sure that X-Brave-Ads-Enabled: 1 header is presented in request
