### PR TITLE
Clear panel's error flag when new connection is in-progress (uplift to 1.46.x)

### DIFF
--- a/components/brave_vpn/brave_vpn_os_connection_api.h
+++ b/components/brave_vpn/brave_vpn_os_connection_api.h
@@ -68,7 +68,7 @@ class BraveVPNOSConnectionAPI : public base::PowerSuspendObserver,
   void SetConnectionState(mojom::ConnectionState state);
   bool IsInProgress() const;
 
-  void Connect();
+  void Connect(bool ignore_network_state = false);
   void Disconnect();
   void ToggleConnection();
   void RemoveVPNConnection();

--- a/components/brave_vpn/resources/panel/components/error-panel/index.tsx
+++ b/components/brave_vpn/resources/panel/components/error-panel/index.tsx
@@ -17,7 +17,7 @@ function ErrorPanel (props: Props) {
   const currentRegion = useSelector(state => state.currentRegion)
 
   const handleTryAgain = () => {
-    dispatch(Actions.retryConnect())
+    dispatch(Actions.connect())
   }
 
   const handleChooseServer = () => {

--- a/components/brave_vpn/resources/panel/state/actions.ts
+++ b/components/brave_vpn/resources/panel/state/actions.ts
@@ -36,7 +36,6 @@ export type selectedRegionPayload = {
 export const connect = createAction('connect')
 export const disconnect = createAction('disconnect')
 export const connectionFailed = createAction('connectionFailed')
-export const retryConnect = createAction('retryConnect')
 export const initialize = createAction('initialize')
 export const purchaseConfirmed = createAction('purchaseConfirmed')
 export const purchaseFailed = createAction('purchaseFailed')

--- a/components/brave_vpn/resources/panel/state/async.ts
+++ b/components/brave_vpn/resources/panel/state/async.ts
@@ -33,10 +33,6 @@ handler.on(Actions.connectToNewRegion.getType(), async (store) => {
   getPanelBrowserAPI().serviceHandler.connect()
 })
 
-handler.on(Actions.retryConnect.getType(), async (store) => {
-  store.dispatch(Actions.connect())
-})
-
 handler.on(Actions.connectionStateChanged.getType(), async (store) => {
   const state = getState(store)
 

--- a/components/brave_vpn/resources/panel/state/reducer.ts
+++ b/components/brave_vpn/resources/panel/state/reducer.ts
@@ -58,6 +58,7 @@ reducer.on(Actions.connectToNewRegion, (state, payload): RootState => {
   return {
     ...state,
     isSelectingRegion: false,
+    hasError: false,
     currentRegion: payload.region
   }
 })
@@ -72,6 +73,7 @@ reducer.on(Actions.toggleRegionSelector, (state, payload): RootState => {
 reducer.on(Actions.connectionStateChanged, (state, payload): RootState => {
   return {
     ...state,
+    hasError: payload.connectionStatus === ConnectionState.CONNECTED ? false : state.hasError,
     connectionStatus: payload.connectionStatus
   }
 })

--- a/components/brave_vpn/resources/panel/state/reducer.ts
+++ b/components/brave_vpn/resources/panel/state/reducer.ts
@@ -33,6 +33,7 @@ const reducer = createReducer<RootState>({}, defaultState)
 reducer.on(Actions.connect, (state): RootState => {
   return {
     ...state,
+    hasError: false,
     connectionStatus: ConnectionState.CONNECTING
   }
 })
@@ -79,13 +80,6 @@ reducer.on(Actions.selectedRegionChanged, (state, payload): RootState => {
   return {
     ...state,
     currentRegion: payload.region
-  }
-})
-
-reducer.on(Actions.retryConnect, (state): RootState => {
-  return {
-    ...state,
-    hasError: false
   }
 })
 


### PR DESCRIPTION
Uplift of #16052 #16062 #16065
fix https://github.com/brave/brave-browser/issues/26579
fix https://github.com/brave/brave-browser/issues/26857

Pre-approval checklist: 
- [ ] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [ ] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [ ] The associated issue milestone is set to the smallest version that the changes is landed on.