### PR TITLE
Grouping sidebar options together in settings

### DIFF
--- a/app/brave_generated_resources.grd
+++ b/app/brave_generated_resources.grd
@@ -628,12 +628,24 @@ Or change later at <ph name="SETTINGS_EXTENIONS_LINK">$2<ex>brave://settings/ext
       <if expr="enable_sidebar">
         <if expr="not use_titlecase">
           <message name="IDS_HIDE_SIDE_PANEL_TOOLBAR_BUTTON" desc="The menu item to hide the side panel icon on the toolbar">
-            Hide side panel icon
+            Hide sidebar icon 
+          </message>
+          <message name="IDS_TOOLTIP_SIDEBAR_HIDE" desc="The tooltip for the sidebar button, when closed">
+            Hide sidebar
+          </message>
+          <message name="IDS_TOOLTIP_SIDEBAR_SHOW" desc="The tooltip for the sidebar button, when closed">
+            Show sidebar
           </message>
         </if>
         <if expr="use_titlecase">
           <message name="IDS_HIDE_SIDE_PANEL_TOOLBAR_BUTTON" desc="The menu item to hide the side panel icon on the toolbar">
-            Hide Side Panel Icon
+            Hide Sidebar Icon
+          </message>
+          <message name="IDS_TOOLTIP_SIDEBAR_HIDE" desc="The tooltip for the sidebar button, when closed">
+            Hide Sidebar
+          </message>
+          <message name="IDS_TOOLTIP_SIDEBAR_SHOW" desc="The tooltip for the sidebar button, when closed">
+            Show Sidebar
           </message>
         </if>
         <message name="IDS_SIDEBAR_ITEM_CONTEXT_MENU_EDIT" desc="Menu for editing an existing item from sidebar">

--- a/app/brave_settings_strings.grdp
+++ b/app/brave_settings_strings.grdp
@@ -74,9 +74,6 @@
   <message name="IDS_SETTINGS_APPEARANCE_SETTINGS_SHOW_BOOKMARKS_BUTTON" desc="The label for whether the bookmarks button should be shown or not">
     Show bookmarks button
   </message>
-  <message name="IDS_SETTINGS_APPEARANCE_SETTINGS_SHOW_SIDE_PANEL_BUTTON" desc="The label for whether the side panel button should be shown or not">
-    Show side panel button
-  </message>
   <message name="IDS_SETTINGS_APPEARANCE_SETTINGS_LOCATION_BAR_IS_WIDE" desc="The label for whether the location bar should display wide or not">
     Use wide address bar
   </message>
@@ -116,6 +113,15 @@
   <message name="IDS_SETTINGS_SPEEDREADER_SUB_LABEL" desc="The sub-label describing Speedreader">
     Articles automatically load in reader mode, saving you time
   </message>
+
+  <if expr="enable_sidebar">
+    <message name="IDS_SETTINGS_APPEARNCE_SETTINGS_SIDEBAR_PART_TITLE" desc="Title of sidebar part in settings">
+      Sidebar
+    </message>
+    <message name="IDS_SETTINGS_APPEARANCE_SETTINGS_SHOW_SIDEBAR_BUTTON" desc="The label for whether the side panel button should be shown or not">
+      Show Sidebar button
+    </message>
+  </if>
 
   <!-- Settings / New tab page -->
   <message name="IDS_SETTINGS_NEW_TAB" desc="The text label for the New Tab settings page">

--- a/browser/resources/settings/BUILD.gn
+++ b/browser/resources/settings/BUILD.gn
@@ -8,6 +8,7 @@ import("//brave/browser/shell_integrations/buildflags/buildflags.gni")
 import("//brave/build/config.gni")
 import("//brave/components/brave_vpn/buildflags/buildflags.gni")
 import("//brave/components/brave_wayback_machine/buildflags/buildflags.gni")
+import("//brave/components/sidebar/buildflags/buildflags.gni")
 import("//brave/components/tor/buildflags/buildflags.gni")
 import("//brave/resources/brave_grit.gni")
 import("//chrome/common/features.gni")
@@ -72,6 +73,7 @@ preprocess_if_expr("preprocess") {
     "enable_brave_vpn=$enable_brave_vpn",
     "enable_extensions=$enable_extensions",
     "enable_pin_shortcut=$enable_pin_shortcut",
+    "enable_sidebar=$enable_sidebar",
   ]
   in_folder = "./"
   out_folder =

--- a/browser/resources/settings/brave_appearance_page/sidebar.html
+++ b/browser/resources/settings/brave_appearance_page/sidebar.html
@@ -1,21 +1,48 @@
 <style include="settings-shared iron-flex">
-  .settings-box.bottom-border {
-    border-top: none;
+  .border {
+    border-top: var(--cr-separator-line);
     border-bottom: var(--cr-separator-line);
   }
 </style>
-<div class="settings-box bottom-border">
-  <div class="flex" id="labelWrapper" aria-hidden="true">
-    <div class="label">$i18n{appearanceSettingsShowOptionTitle}</div>
-    <div class="secondary label" id="sub-label">
-      <span id="sub-label-text" aria-hidden="true">
-        [[sidebarShowEnabledLabel_]]
-      </span>
+
+<div class="cr-row">$i18n{sideBar}</div>
+<div class="list-frame">
+  <div class="cr-row list-item">
+    <div class="flex" id="labelWrapper" aria-hidden="true">
+      <div class="label">$i18n{appearanceSettingsShowOptionTitle}</div>
+      <div class="secondary label" id="sub-label">
+        <span id="sub-label-text" aria-hidden="true">
+          [[sidebarShowEnabledLabel_]]
+        </span>
+      </div>
     </div>
+    <settings-dropdown-menu
+      pref="{{prefs.brave.sidebar.sidebar_show_option}}"
+      on-settings-control-change="onShowOptionChanged_"
+      menu-options="[[sidebarShowOptions_]]">
+    </settings-dropdown-menu>
   </div>
-  <settings-dropdown-menu
-    pref="{{prefs.brave.sidebar.sidebar_show_option}}"
-    on-settings-control-change="onShowOptionChanged_"
-    menu-options="[[sidebarShowOptions_]]">
-  </settings-dropdown-menu>
+  <settings-toggle-button
+    class="cr-row border list-item"
+    pref="{{prefs.brave.show_side_panel_button}}"
+    label="$i18n{appearanceSettingsShowSidebarButton}">
+  </settings-toggle-button>
+  <settings-radio-group
+    pref="{{prefs.side_panel.is_right_aligned}}"
+    group-aria-label="$i18n{sideBar}">
+    <controlled-radio-button
+      class="list-item"
+      pref="[[prefs.side_panel.is_right_aligned]]"
+      label="$i18n{sidePanelAlignLeft}"
+      name="false"
+      no-extension-indicator>
+    </controlled-radio-button>
+    <controlled-radio-button
+      class="list-item"
+      pref="[[prefs.side_panel.is_right_aligned]]"
+      label="$i18n{sidePanelAlignRight}"
+      name="true"
+      no-extension-indicator>
+    </controlled-radio-button>
+  </settings-radio-group>
 </div>

--- a/browser/resources/settings/brave_appearance_page/sidebar.html
+++ b/browser/resources/settings/brave_appearance_page/sidebar.html
@@ -8,10 +8,10 @@
 <div class="cr-row">$i18n{sideBar}</div>
 <div class="list-frame">
   <div class="cr-row list-item">
-    <div class="flex" id="labelWrapper" aria-hidden="true">
+    <div class="flex" id="labelWrapper">
       <div class="label">$i18n{appearanceSettingsShowOptionTitle}</div>
       <div class="secondary label" id="sub-label">
-        <span id="sub-label-text" aria-hidden="true">
+        <span id="sub-label-text">
           [[sidebarShowEnabledLabel_]]
         </span>
       </div>

--- a/browser/resources/settings/brave_appearance_page/toolbar.html
+++ b/browser/resources/settings/brave_appearance_page/toolbar.html
@@ -7,11 +7,6 @@
 </settings-toggle-button>
 <settings-toggle-button
   class="cr-row"
-  pref="{{prefs.brave.show_side_panel_button}}"
-  label="$i18n{appearanceSettingsShowSidePanelButton}">
-</settings-toggle-button>
-<settings-toggle-button
-  class="cr-row"
   pref="{{prefs.brave.today.should_show_toolbar_button}}"
   label="$i18n{appearanceSettingsShowBraveNewsButtonLabel}">
 </settings-toggle-button>
@@ -19,6 +14,11 @@
   class="cr-row"
   pref="{{prefs.brave.location_bar_is_wide}}"
   label="$i18n{appearanceSettingsLocationBarIsWide}">
+</settings-toggle-button>
+<settings-toggle-button
+  pref="{{prefs.omnibox.prevent_url_elisions}}"
+  class="cr-row"
+  label="$i18n{showFullUrls}">
 </settings-toggle-button>
 <settings-toggle-button
   class="cr-row"
@@ -46,6 +46,9 @@
     </settings-checkbox>
   </div>
 </template>
+<if expr="enable_sidebar">
+  <settings-brave-appearance-sidebar prefs="{{prefs}}"></settings-brave-appearance-sidebar>
+</if>
 <if expr="enable_brave_vpn">
   <template is="dom-if" if="[[showBraveVPNOption_()]]">
     <settings-toggle-button
@@ -60,11 +63,6 @@
   pref="{{prefs.brave.always_show_bookmark_bar_on_ntp}}"
   class="cr-row"
   label="$i18n{appearanceSettingsAlwaysShowBookmarkBarOnNTP}">
-</settings-toggle-button>
-<settings-toggle-button
-  pref="{{prefs.omnibox.prevent_url_elisions}}"
-  class="cr-row"
-  label="$i18n{showFullUrls}">
 </settings-toggle-button>
 <settings-toggle-button
   pref="{{prefs.brave.tabs_search_show}}"

--- a/browser/resources/settings/brave_appearance_page/toolbar.ts
+++ b/browser/resources/settings/brave_appearance_page/toolbar.ts
@@ -3,12 +3,14 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this file,
 // you can obtain one at https://mozilla.org/MPL/2.0/.
 
-import {PolymerElement} from 'chrome://resources/polymer/v3_0/polymer/polymer_bundled.min.js';
+import {PolymerElement} from 'chrome://resources/polymer/v3_0/polymer/polymer_bundled.min.js'
 import {I18nMixin, I18nMixinInterface} from 'chrome://resources/cr_elements/i18n_mixin.js'
 import {loadTimeData} from "../i18n_setup.js"
-import '../settings_shared.css.js';
-import '../settings_vars.css.js';
 import {getTemplate} from './toolbar.html.js'
+
+import '../settings_shared.css.js'
+import '../settings_vars.css.js'
+import './sidebar.js'
 
 const SettingsBraveAppearanceToolbarElementBase = I18nMixin(PolymerElement) as {
   new (): PolymerElement & I18nMixinInterface

--- a/browser/resources/settings/brave_overrides/appearance_page.ts
+++ b/browser/resources/settings/brave_overrides/appearance_page.ts
@@ -60,9 +60,6 @@ RegisterPolymerTemplateModifications({
     if (!bookmarkBarToggle) {
       console.error(`[Brave Settings Overrides] Couldn't find bookmark bar toggle`)
     } else {
-      bookmarkBarToggle.insertAdjacentHTML('beforebegin', `
-        <settings-brave-appearance-sidebar prefs="{{prefs}}"></settings-brave-appearance-sidebar>
-      `)
       bookmarkBarToggle.insertAdjacentHTML('afterend', `
         <settings-brave-appearance-toolbar prefs="{{prefs}}"></settings-brave-appearance-toolbar>
       `)

--- a/browser/resources/settings/brave_overrides/appearance_page.ts
+++ b/browser/resources/settings/brave_overrides/appearance_page.ts
@@ -12,7 +12,6 @@ import {loadTimeData} from '../i18n_setup.js'
 
 import '../brave_appearance_page/super_referral.js'
 import '../brave_appearance_page/brave_theme.js'
-import '../brave_appearance_page/sidebar.js'
 import '../brave_appearance_page/toolbar.js'
 
 const superReferralStringId = 'superReferralThemeName'

--- a/browser/ui/webui/settings/brave_settings_localized_strings_provider.cc
+++ b/browser/ui/webui/settings/brave_settings_localized_strings_provider.cc
@@ -96,8 +96,6 @@ void BraveAddCommonStrings(content::WebUIDataSource* html_source,
      IDS_SETTINGS_APPEARANCE_SETTINGS_BRAVE_THEMES},
     {"appearanceSettingsShowBookmarksButton",
      IDS_SETTINGS_APPEARANCE_SETTINGS_SHOW_BOOKMARKS_BUTTON},
-    {"appearanceSettingsShowSidePanelButton",
-     IDS_SETTINGS_APPEARANCE_SETTINGS_SHOW_SIDE_PANEL_BUTTON},
     {"appearanceSettingsLocationBarIsWide",
      IDS_SETTINGS_APPEARANCE_SETTINGS_LOCATION_BAR_IS_WIDE},
     {"appearanceSettingsShowBraveRewardsButtonLabel",
@@ -127,8 +125,11 @@ void BraveAddCommonStrings(content::WebUIDataSource* html_source,
     {"appearanceSettingsTabHoverModeTooltip",
      IDS_SETTINGS_APPEARANCE_SETTINGS_BRAVE_TAB_HOVER_MODE_TOOLTIP},
 #if BUILDFLAG(ENABLE_SIDEBAR)
+    {"sideBar", IDS_SETTINGS_APPEARNCE_SETTINGS_SIDEBAR_PART_TITLE},
     {"appearanceSettingsShowOptionTitle",
      IDS_SETTINGS_SIDEBAR_SHOW_OPTION_TITLE},
+    {"appearanceSettingsShowSidebarButton",
+     IDS_SETTINGS_APPEARANCE_SETTINGS_SHOW_SIDEBAR_BUTTON},
     {"appearanceSettingsShowOptionAlways", IDS_SIDEBAR_SHOW_OPTION_ALWAYS},
     {"appearanceSettingsShowOptionMouseOver",
      IDS_SIDEBAR_SHOW_OPTION_MOUSEOVER},
@@ -699,6 +700,10 @@ void BraveAddLocalizedStrings(content::WebUIDataSource* html_source,
     };
     html_source->AddLocalizedStrings(kSessionOnlyToEphemeralStrings);
   }
+
+  // Always disable upstream's side panel align option.
+  // We add our customized option at preferred position.
+  html_source->AddBoolean("showSidePanelOptions", false);
 }
 
 }  // namespace settings

--- a/chromium_src/chrome/browser/ui/views/frame/browser_view.cc
+++ b/chromium_src/chrome/browser/ui/views/frame/browser_view.cc
@@ -14,9 +14,15 @@
 #include "brave/browser/ui/views/tabs/brave_tab_strip.h"
 #include "brave/browser/ui/views/tabs/features.h"
 #include "brave/browser/ui/views/toolbar/brave_toolbar_view.h"
+#include "brave/grit/brave_generated_resources.h"
 #include "chrome/browser/ui/browser_commands.h"
 #include "chrome/browser/ui/views/frame/tab_strip_region_view.h"
 #include "chrome/browser/ui/views/side_panel/side_panel.h"
+#include "chrome/grit/generated_resources.h"
+
+// Undef upstream's to avoid redefined error.
+#undef IDS_TOOLTIP_SIDE_PANEL_HIDE
+#undef IDS_TOOLTIP_SIDE_PANEL_SHOW
 
 #define InfoBarContainerView BraveInfoBarContainerView
 #define BrowserViewLayout BraveBrowserViewLayout
@@ -26,9 +32,13 @@
 #define SidePanel BraveSidePanel
 #define kAlignLeft kHorizontalAlignLeft
 #define kAlignRight kHorizontalAlignRight
+#define IDS_TOOLTIP_SIDE_PANEL_HIDE IDS_TOOLTIP_SIDEBAR_HIDE
+#define IDS_TOOLTIP_SIDE_PANEL_SHOW IDS_TOOLTIP_SIDEBAR_SHOW
 
 #include "src/chrome/browser/ui/views/frame/browser_view.cc"
 
+#undef IDS_TOOLTIP_SIDE_PANEL_HIDE
+#undef IDS_TOOLTIP_SIDE_PANEL_SHOW
 #undef ToolbarView
 #undef BrowserTabStripController
 #undef TabStrip


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/25717

Several sidebar options are grouped and located under autocomplete suggestion option.
`Always show ful urls` option is relocated under `Use wide address bar`

![image](https://user-images.githubusercontent.com/6786187/204675874-3bae7063-4dd5-4d27-a00c-b410341ba345.png)

Also changed sidebar toolbar button's tooltip and menu strings to `sidebar` or `Sidebar`
![image](https://user-images.githubusercontent.com/6786187/204687153-8cc7d334-11b8-4101-ae62-33cd28e0a6a7.png)


## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

1. Load brave://settings/appearance
2. Check Sidebar options are grouped together and located under autocomplete suggestion options
3. Check `Always show full URLs` is located under `Use wide address bar`
4. Check Sidebar toolbar button's tooltip and menu strings have `sidebar` or `Sidebar` on macOS