### PR TITLE
Yahoo and Twitter query params

### DIFF
--- a/browser/net/brave_query_filter.cc
+++ b/browser/net/brave_query_filter.cc
@@ -55,6 +55,8 @@ static constexpr auto kSimpleQueryStringTrackers =
          "ss_email_id",
          // https://github.com/brave/brave-browser/issues/25238
          "bsft_uid", "bsft_clkid",
+         // https://github.com/brave/brave-browser/issues/25691
+         "guce_referrer", "guce_referrer_sig",
          // https://github.com/brave/brave-browser/issues/26295
          "vgo_ee"});
 

--- a/browser/net/brave_query_filter.cc
+++ b/browser/net/brave_query_filter.cc
@@ -71,6 +71,9 @@ static constexpr auto kScopedQueryStringTrackers =
         {"igshid", "instagram.com"},
         // https://github.com/brave/brave-browser/issues/26756
         {"t", "twitter.com"},
+        // https://github.com/brave/brave-browser/issues/26966
+        {"ref_src", "twitter.com"},
+        {"ref_url", "twitter.com"},
     });
 
 // Remove tracking query parameters from a GURL, leaving all


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves brave/brave-browser#25691 and brave/brave-browser#26966.

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Query-String-Filter

## Test Plan:

Note: this test will only work once. After you've loaded twitter.com, you'll need to clear the profile again before you can attempt this test.

1. Open <https://brave.com/?guce_referrer=1234&guce_referrer_sig=abcd&ref_src=foobar> and confirm that the URL bar only shows `https://brave.com/?ref_src=foobar`.
2. Open <https://twitter.com/mysk_co/status/1594515229915979776?ref_src=twsrc%5Etfw%7Ctwcamp%5Etweetembed%7Ctwterm%5E1594515229915979776%7Ctwgr%5E51cd898085c2bbd4756e89db45ddf3a06fe8ce49%7Ctwcon%5Es1_&ref_url=https%3A%2F%2Fwww.macrumors.com%2F2022%2F11%2F21%2Fapple-device-analytics-identifying-user%2F> and confirm that the URL bar only shows `https://twitter.com/mysk_co/status/1594515229915979776`.