### PR TITLE
[Brave News]: Fix for incorrectly styled buttons on OSX

### DIFF
--- a/chromium_src/ui/views/controls/button/md_text_button.cc
+++ b/chromium_src/ui/views/controls/button/md_text_button.cc
@@ -207,6 +207,15 @@ void MdTextButton::SetLoading(bool loading) {
   UpdateColors();
 }
 
+void MdTextButton::UpdateBackgroundColor() {
+  // Handled via |UpdateColorsForBrave|.
+  if (kind_ != kOld) {
+    return;
+  }
+
+  MdTextButtonBase::UpdateBackgroundColor();
+}
+
 void MdTextButton::UpdateOldColorsForBrave() {
   if (GetProminent()) {
     return;

--- a/chromium_src/ui/views/controls/button/md_text_button.h
+++ b/chromium_src/ui/views/controls/button/md_text_button.h
@@ -8,26 +8,28 @@
 
 #include "third_party/abseil-cpp/absl/types/optional.h"
 #include "ui/gfx/vector_icon_types.h"
+#include "ui/views/controls/button/label_button.h"
 
 // Rename MdTextButton to MdTextButtonBase
 #define MdTextButton MdTextButtonBase
 
-// Define a Brave-specific method we can get called from UpdateColors() to
-// extend its functionality instead of defining UpdateColors() "virtual" and
-// overriding it in our version of the MdTextButton class because there are some
-// subclasses that define their own UpdateColors() method (OmniboxChipButton)
-// now, which would not work with the virtual + override approach.
-#define UpdateColors                       \
-  UpdateColors_Unused();                   \
+// Define a Brave-specific method to be called from UpdateColors() to extend its
+// functionality instead of defining UpdateColors() "virtual" and overriding it
+// in our version of the MdTextButton class because there are some subclasses
+// that define their own UpdateColors() method (OmniboxChipButton) now, which
+// would not work with the virtual + override approach.
+// Note: We redefine UpdateBackgroundColor because we want it to be protected.
+#define UpdateBackgroundColor              \
+  UpdateBackgroundColor_Unused();          \
                                            \
  protected:                                \
   virtual void UpdateColorsForBrave() = 0; \
   virtual void UpdateIconForBrave() = 0;   \
-  void UpdateColors
+  void UpdateBackgroundColor
 
 #include "src/ui/views/controls/button/md_text_button.h"
 
-#undef UpdateColors
+#undef UpdateBackgroundColor
 #undef MdTextButton
 
 namespace views {
@@ -63,6 +65,7 @@ class VIEWS_EXPORT MdTextButton : public MdTextButtonBase {
   void UpdateOldColorsForBrave();
 
   // MdTextButtonBase:
+  void UpdateBackgroundColor() override;
   void UpdateColorsForBrave() override;
   void UpdateIconForBrave() override;
 


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/26262

Before
![image](https://user-images.githubusercontent.com/7678024/203881099-9f851bd2-0d11-43e6-800e-4d7c463b9d83.png)

After
![image](https://user-images.githubusercontent.com/7678024/203881134-8de76e75-9def-4359-9678-9c136c4c7529.png)


## Submitter Checklist:

- [ ] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

