### PR TITLE
[Brave News] Fix bug where direct feeds didn't show up as followed

### DIFF
--- a/browser/brave_news/brave_news_tab_helper.cc
+++ b/browser/brave_news/brave_news_tab_helper.cc
@@ -71,10 +71,18 @@ BraveNewsTabHelper::GetAvailableFeeds() {
 bool BraveNewsTabHelper::IsSubscribed(const FeedDetails& feed_details) {
   auto* publisher = controller_->publisher_controller()->GetPublisherForFeed(
       feed_details.feed_url);
-  return publisher &&
-         (publisher->user_enabled_status ==
-              brave_news::mojom::UserEnabled::ENABLED ||
-          publisher->type == brave_news::mojom::PublisherType::DIRECT_SOURCE);
+  if (!publisher)
+    return false;
+
+  // When a direct feed exists, it is always subscribed (there is no way to have
+  // an unsubscribed direct feed).
+  if (publisher->type == brave_news::mojom::PublisherType::DIRECT_SOURCE)
+    return true;
+
+  // Otherwise, it's a combined feed, so just return whether the user has
+  // enabled it.
+  return publisher->user_enabled_status ==
+         brave_news::mojom::UserEnabled::ENABLED;
 }
 
 bool BraveNewsTabHelper::IsSubscribed() {

--- a/browser/brave_news/brave_news_tab_helper.cc
+++ b/browser/brave_news/brave_news_tab_helper.cc
@@ -71,8 +71,10 @@ BraveNewsTabHelper::GetAvailableFeeds() {
 bool BraveNewsTabHelper::IsSubscribed(const FeedDetails& feed_details) {
   auto* publisher = controller_->publisher_controller()->GetPublisherForFeed(
       feed_details.feed_url);
-  return publisher && publisher->user_enabled_status ==
-                          brave_news::mojom::UserEnabled::ENABLED;
+  return publisher &&
+         (publisher->user_enabled_status ==
+              brave_news::mojom::UserEnabled::ENABLED ||
+          publisher->type == brave_news::mojom::PublisherType::DIRECT_SOURCE);
 }
 
 bool BraveNewsTabHelper::IsSubscribed() {


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Follow up for https://github.com/brave/brave-core/pull/15963, which fixed it's original issue but broke the button toggle state.

## Submitter Checklist:

- [ ] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

1. With #brave-news-subscribe-button enabled
2. Navigate to theatlantic.com
3. Follow `Best of the Atlantic`
4. The button state should update