### PR TITLE
Android 13 show once notification permission dialog (uplift to 1.47.x)

### DIFF
--- a/android/java/org/chromium/chrome/browser/app/BraveActivity.java
+++ b/android/java/org/chromium/chrome/browser/app/BraveActivity.java
@@ -1245,8 +1245,11 @@ public abstract class BraveActivity<C extends ChromeActivityComponent> extends C
             };
 
     private void checkAndshowNotificationWarningDialog() {
-        if (BraveNotificationWarningDialog.shouldShowNotificationWarningDialog(this)) {
+        if (BraveNotificationWarningDialog.shouldShowNotificationWarningDialog(this)
+                && !OnboardingPrefManager.getInstance()
+                            .isNotificationPermissionEnablingDialogShown()) {
             showNotificationWarningDialog();
+            OnboardingPrefManager.getInstance().setNotificationPermissionEnablingDialogShown(true);
         } else {
             checkForNotificationData();
         }

--- a/android/java/org/chromium/chrome/browser/onboarding/OnboardingPrefManager.java
+++ b/android/java/org/chromium/chrome/browser/onboarding/OnboardingPrefManager.java
@@ -56,6 +56,8 @@ public class OnboardingPrefManager {
     private static final String PREF_P3A_CRASH_REPORTING_MESSAGE_SHOWN =
             "p3a_crash_reporting_message_shown";
     private static final String PREF_URL_FOCUS_COUNT = "url_focus_count";
+    private static final String PREF_NOTIFICATION_PERMISSION_ENABLING_DIALOG =
+            "notification_permission_enabling_dialog";
 
     private static OnboardingPrefManager sInstance;
 
@@ -340,5 +342,21 @@ public class OnboardingPrefManager {
 
         Date date = calendar.getTime();
         return date.getTime();
+    }
+
+    /**
+     * Returns the user preference for whether the Notification Permission Enabling dialog is shown.
+     */
+    public boolean isNotificationPermissionEnablingDialogShown() {
+        return mSharedPreferences.getBoolean(PREF_NOTIFICATION_PERMISSION_ENABLING_DIALOG, false);
+    }
+
+    /**
+     * Sets the user preference for whether the Notification Permission Enabling dialog is shown.
+     */
+    public void setNotificationPermissionEnablingDialogShown(boolean isShown) {
+        SharedPreferences.Editor sharedPreferencesEditor = mSharedPreferences.edit();
+        sharedPreferencesEditor.putBoolean(PREF_NOTIFICATION_PERMISSION_ENABLING_DIALOG, isShown);
+        sharedPreferencesEditor.apply();
     }
 }


### PR DESCRIPTION
Uplift of #16079
Resolves https://github.com/brave/brave-browser/issues/26930

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.