### PR TITLE
Remove orgin.com from cookie exceptions

### DIFF
--- a/chromium_src/components/content_settings/core/common/cookie_settings_base.cc
+++ b/chromium_src/components/content_settings/core/common/cookie_settings_base.cc
@@ -25,8 +25,6 @@ namespace {
 
 constexpr char kWp[] = "https://[*.]wp.com/*";
 constexpr char kWordpress[] = "https://[*.]wordpress.com/*";
-constexpr char kOrigin[] = "https://[*.]origin.com/*";
-constexpr char kEA[] = "https://[*.]ea.com/*";
 
 bool BraveIsAllowedThirdParty(const GURL& url,
                               const GURL& first_party_url,
@@ -37,9 +35,7 @@ bool BraveIsAllowedThirdParty(const GURL& url,
       entity_list({{ContentSettingsPattern::FromString(kWp),
                     ContentSettingsPattern::FromString(kWordpress)},
                    {ContentSettingsPattern::FromString(kWordpress),
-                    ContentSettingsPattern::FromString(kWp)},
-                   {ContentSettingsPattern::FromString(kEA),
-                    ContentSettingsPattern::FromString(kOrigin)}});
+                    ContentSettingsPattern::FromString(kWp)}});
 
   if (net::registry_controlled_domains::GetDomainAndRegistry(
           url, net::registry_controlled_domains::INCLUDE_PRIVATE_REGISTRIES) ==


### PR DESCRIPTION
Removal of `origin.com`, dead site.  Now redirects too https://www.ea.com/games/library/pc-download