### PR TITLE
crash notifications is null on Android 6 (uplift to 1.46.x)

### DIFF
--- a/android/java/org/chromium/chrome/browser/settings/BraveMainPreferencesBase.java
+++ b/android/java/org/chromium/chrome/browser/settings/BraveMainPreferencesBase.java
@@ -141,17 +141,19 @@ public class BraveMainPreferencesBase
 
     private void notificationClick() {
         Preference notifications = findPreference(PREF_NOTIFICATIONS);
-        notifications.setOnPreferenceClickListener(preference -> {
-            mNotificationClicked = true;
+        if (notifications != null) {
+            notifications.setOnPreferenceClickListener(preference -> {
+                mNotificationClicked = true;
 
-            Intent intent = new Intent();
-            intent.setAction(Settings.ACTION_APP_NOTIFICATION_SETTINGS);
-            intent.putExtra(Settings.EXTRA_APP_PACKAGE,
-                    ContextUtils.getApplicationContext().getPackageName());
-            startActivity(intent);
-            // We handle the click so the default action isn't triggered.
-            return true;
-        });
+                Intent intent = new Intent();
+                intent.setAction(Settings.ACTION_APP_NOTIFICATION_SETTINGS);
+                intent.putExtra(Settings.EXTRA_APP_PACKAGE,
+                        ContextUtils.getApplicationContext().getPackageName());
+                startActivity(intent);
+                // We handle the click so the default action isn't triggered.
+                return true;
+            });
+        }
     }
 
     private void updateBravePreferences() {


### PR DESCRIPTION
Uplift of #16090
Resolves https://github.com/brave/brave-browser/issues/26988

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.