### PR TITLE
Double check vpn status whenever os network status changed

### DIFF
--- a/components/brave_vpn/brave_vpn_os_connection_api.cc
+++ b/components/brave_vpn/brave_vpn_os_connection_api.cc
@@ -29,11 +29,13 @@ using ConnectionState = mojom::ConnectionState;
 BraveVPNOSConnectionAPI::BraveVPNOSConnectionAPI() {
   base::PowerMonitor::AddPowerSuspendObserver(this);
   net::NetworkChangeNotifier::AddDNSObserver(this);
+  net::NetworkChangeNotifier::AddNetworkChangeObserver(this);
 }
 
 BraveVPNOSConnectionAPI::~BraveVPNOSConnectionAPI() {
   base::PowerMonitor::RemovePowerSuspendObserver(this);
   net::NetworkChangeNotifier::RemoveDNSObserver(this);
+  net::NetworkChangeNotifier::RemoveNetworkChangeObserver(this);
 }
 
 void BraveVPNOSConnectionAPI::AddObserver(Observer* observer) {
@@ -269,6 +271,14 @@ void BraveVPNOSConnectionAPI::OnDNSChanged() {
     Connect();
     reconnect_on_resume_ = false;
   }
+}
+
+void BraveVPNOSConnectionAPI::OnNetworkChanged(
+    net::NetworkChangeNotifier::ConnectionType type) {
+  VLOG(2) << __func__ << " : " << type;
+  // It's rare but sometimes Brave doesn't get vpn status update from OS.
+  // Checking here will make vpn status update properly in that situation.
+  CheckConnection();
 }
 
 void BraveVPNOSConnectionAPI::UpdateAndNotifyConnectionStateChange(

--- a/components/brave_vpn/brave_vpn_os_connection_api.h
+++ b/components/brave_vpn/brave_vpn_os_connection_api.h
@@ -30,8 +30,10 @@ class BraveVpnAPIRequest;
 struct Hostname;
 
 // Interface for managing OS' vpn connection.
-class BraveVPNOSConnectionAPI : public base::PowerSuspendObserver,
-                                public net::NetworkChangeNotifier::DNSObserver {
+class BraveVPNOSConnectionAPI
+    : public base::PowerSuspendObserver,
+      public net::NetworkChangeNotifier::NetworkChangeObserver,
+      public net::NetworkChangeNotifier::DNSObserver {
  public:
   class Observer : public base::CheckedObserver {
    public:
@@ -108,6 +110,10 @@ class BraveVPNOSConnectionAPI : public base::PowerSuspendObserver,
 
   // net::NetworkChangeNotifier::DNSObserver
   void OnDNSChanged() override;
+
+  // net::NetworkChangeNotifier::NetworkChangeObserver
+  void OnNetworkChanged(
+      net::NetworkChangeNotifier::ConnectionType type) override;
 
   void CreateVPNConnection();
   std::string GetSelectedRegion() const;

--- a/components/brave_vpn/brave_vpn_unittest.cc
+++ b/components/brave_vpn/brave_vpn_unittest.cc
@@ -288,6 +288,10 @@ class BraveVPNServiceTest : public testing::Test {
   }
   void Suspend() { GetBraveVPNConnectionAPI()->OnSuspend(); }
   void OnDNSChanged() { GetBraveVPNConnectionAPI()->OnDNSChanged(); }
+  void OnNetworkChanged() {
+    GetBraveVPNConnectionAPI()->OnNetworkChanged(
+        net::NetworkChangeNotifier::CONNECTION_WIFI);
+  }
 
   void SetSelectedRegion(const std::string& region) {
     service_->SetSelectedRegion(region);
@@ -1147,6 +1151,18 @@ TEST_F(BraveVPNServiceTest, CheckConnectionStateAfterPurchased) {
   testing::Mock::VerifyAndClearExpectations(&api);
   EXPECT_CALL(api, CheckConnectionImpl(testing::_)).Times(1);
   SetPurchasedState(env, PurchasedState::PURCHASED);
+  testing::Mock::VerifyAndClearExpectations(&api);
+
+  SetMockConnectionAPI(nullptr);
+}
+
+TEST_F(BraveVPNServiceTest, CheckConnectionStateAfterNetworkStateChanged) {
+  MockBraveVPNOSConnectionAPI api;
+  SetMockConnectionAPI(&api);
+  std::string env = skus::GetDefaultEnvironment();
+
+  EXPECT_CALL(api, CheckConnectionImpl(testing::_)).Times(1);
+  OnNetworkChanged();
   testing::Mock::VerifyAndClearExpectations(&api);
 
   SetMockConnectionAPI(nullptr);


### PR DESCRIPTION
fix https://github.com/brave/brave-browser/issues/27026

It's rare but sometimes Brave doesn't get vpn status change noti on Windows.
When it happens, network status observer can give opportunity for getting proper vpn status.

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves 

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

`BraveVPNServiceTest.CheckConnectionStateAfterNetworkStateChanged`