### PR TITLE
fix(wallet): New Nav zIndex

### DIFF
--- a/components/brave_wallet_ui/components/desktop/buy-send-swap-deposit-nav/buy-send-swap-deposit-nav.style.ts
+++ b/components/brave_wallet_ui/components/desktop/buy-send-swap-deposit-nav/buy-send-swap-deposit-nav.style.ts
@@ -19,5 +19,5 @@ export const Wrapper = styled.div<{ isTab?: boolean }>`
   top: ${(p) => p.isTab ? '100px' : 'unset'};
   left: ${(p) => p.isTab ? '32px' : 'unset'};
   overflow: ${(p) => p.isTab ? 'visible' : 'hidden'};
-  z-index: 40;
+  z-index: ${(p) => p.isTab ? 10 : 'unset'};
 `


### PR DESCRIPTION
## Description 
Fixes a bug where zIndex was to high on the new Nav, that it was visible when popovers were open.

<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves <https://github.com/brave/brave-browser/issues/27044>

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
1. Open the `Visible Assets` modal, the nav should not be visible.
2. Nav to the `Send` page and click on `Select Token`, the nav should not be visible.
3. Nav to the `Swap` page and click on `Select Token` , the nav should not be visible.

Before:

![Screen Shot 2022-11-29 at 2 15 55 PM](https://user-images.githubusercontent.com/40611140/204641069-8260f3b8-81ac-4d20-a946-2b72bc045b23.png)

![Screen Shot 2022-11-29 at 2 16 14 PM](https://user-images.githubusercontent.com/40611140/204641071-4cefdd01-2e64-4859-9550-8f189cab2611.png)

![Screen Shot 2022-11-29 at 2 16 31 PM](https://user-images.githubusercontent.com/40611140/204641072-b5bbaa11-020c-4c90-8840-a923572c2bc3.png)


After:

![Screen Shot 2022-11-29 at 2 26 56 PM](https://user-images.githubusercontent.com/40611140/204641105-f64e6b2e-1891-4ef7-843f-1dee2d96b4d7.png)

![Screen Shot 2022-11-29 at 2 26 42 PM](https://user-images.githubusercontent.com/40611140/204641108-ccc5167b-dce1-41d5-a636-a0c654189e83.png)

![Screen Shot 2022-11-29 at 2 26 33 PM](https://user-images.githubusercontent.com/40611140/204641110-6ad505e6-1ccf-42f8-b558-e60da0d6632f.png)

