### PR TITLE
[Brave News] Fix bug where opting in when subscribed to feeds would cause a crash.

### DIFF
--- a/components/brave_today/browser/brave_news_controller.cc
+++ b/components/brave_today/browser/brave_news_controller.cc
@@ -689,17 +689,17 @@ void BraveNewsController::MaybeInitPrefs() {
 
 void BraveNewsController::OnPublishersUpdated(
     brave_news::PublishersController*) {
-  publishers_controller_.GetOrFetchPublishers(base::BindOnce(
-      [](BraveNewsController* controller, Publishers publishers) {
-        // TODO(fallaciousreasoning): Make this more granular. It's fine for now
-        // but we should be able to just let the frontend know what's changed.
-        auto event = mojom::PublishersEvent::New();
-        event->addedOrUpdated = std::move(publishers);
-        for (const auto& observer : controller->publishers_listeners_) {
-          observer->Changed(event->Clone());
-        }
-      },
-      base::Unretained(this)));
+  // TODO(fallaciousreasoning): Make this more granular. It's fine for now
+  // but we should be able to just let the frontend know what's changed.
+  auto event = mojom::PublishersEvent::New();
+  for (const auto& [id, publisher] :
+       publishers_controller_.GetLastPublishers()) {
+    event->addedOrUpdated.insert({id, publisher->Clone()});
+  }
+
+  for (const auto& observer : publishers_listeners_) {
+    observer->Changed(event->Clone());
+  }
 }
 
 }  // namespace brave_news

--- a/components/brave_today/browser/brave_news_controller.cc
+++ b/components/brave_today/browser/brave_news_controller.cc
@@ -104,6 +104,7 @@ BraveNewsController::BraveNewsController(
                               &publishers_controller_,
                               &api_request_helper_,
                               history_service),
+      publishers_observation_(this),
       weak_ptr_factory_(this) {
   DCHECK(prefs_);
   // Set up preference listeners
@@ -120,6 +121,8 @@ BraveNewsController::BraveNewsController(
       prefs::kBraveNewsChannels,
       base::BindRepeating(&BraveNewsController::HandleSubscriptionsChanged,
                           base::Unretained(this)));
+
+  publishers_observation_.Observe(&publishers_controller_);
 
   p3a::RecordAtInit(prefs_);
   // Monitor kBraveTodaySources and update feed / publisher cache
@@ -424,20 +427,8 @@ void BraveNewsController::SetPublisherPref(const std::string& publisher_id,
           } else {
             update->SetBoolKey(publisher_id,
                                (new_status == mojom::UserEnabled::ENABLED));
+            controller->publishers_controller_.EnsurePublishersIsUpdating();
           }
-          // Force an update of publishers and feed to include or ignore
-          // content from the affected publisher.
-          // And if in the middle of update, that's ok because
-          // consideration of source preferences is done after the remote fetch
-          // is completed.
-          for (const auto& listener : controller->publishers_listeners_) {
-            auto event = mojom::PublishersEvent::New();
-            auto copy = publisher->Clone();
-            copy->user_enabled_status = new_status;
-            event->addedOrUpdated[publisher_id] = std::move(copy);
-            listener->Changed(std::move(event));
-          }
-          controller->publishers_controller_.EnsurePublishersIsUpdating();
         }
       },
       publisher_id, new_status, base::Unretained(this)));
@@ -694,6 +685,21 @@ void BraveNewsController::MaybeInitPrefs() {
           base::Unretained(&channels_controller_)));
     }
   }
+}
+
+void BraveNewsController::OnPublishersUpdated(
+    brave_news::PublishersController*) {
+  publishers_controller_.GetOrFetchPublishers(base::BindOnce(
+      [](BraveNewsController* controller, Publishers publishers) {
+        // TODO(fallaciousreasoning): Make this more granular. It's fine for now
+        // but we should be able to just let the frontend know what's changed.
+        auto event = mojom::PublishersEvent::New();
+        event->addedOrUpdated = std::move(publishers);
+        for (const auto& observer : controller->publishers_listeners_) {
+          observer->Changed(event->Clone());
+        }
+      },
+      base::Unretained(this)));
 }
 
 }  // namespace brave_news

--- a/components/brave_today/browser/brave_news_controller.h
+++ b/components/brave_today/browser/brave_news_controller.h
@@ -13,6 +13,7 @@
 #include "base/callback_forward.h"
 #include "base/containers/flat_map.h"
 #include "base/memory/raw_ptr.h"
+#include "base/scoped_observation.h"
 #include "base/task/cancelable_task_tracker.h"
 #include "base/timer/timer.h"
 #include "brave/components/api_request_helper/api_request_helper.h"
@@ -57,7 +58,8 @@ namespace brave_news {
 // owning prefs data.
 // Controls remote feed update logic via Timer and prefs values.
 class BraveNewsController : public KeyedService,
-                            public mojom::BraveNewsController {
+                            public mojom::BraveNewsController,
+                            public PublishersController::Observer {
  public:
   static void RegisterProfilePrefs(PrefRegistrySimple* registry);
 
@@ -128,6 +130,9 @@ class BraveNewsController : public KeyedService,
                        const std::string& creative_instance_id) override;
   void OnDisplayAdPurgeOrphanedEvents() override;
 
+  // PublishersController::Observer:
+  void OnPublishersUpdated(brave_news::PublishersController*) override;
+
  private:
   void ConditionallyStartOrStopTimer();
   void CheckForFeedsUpdate();
@@ -156,6 +161,8 @@ class BraveNewsController : public KeyedService,
   base::RepeatingTimer timer_publishers_update_;
   base::CancelableTaskTracker task_tracker_;
 
+  base::ScopedObservation<PublishersController, PublishersController::Observer>
+      publishers_observation_;
   mojo::ReceiverSet<mojom::BraveNewsController> receivers_;
   mojo::RemoteSet<mojom::PublishersListener> publishers_listeners_;
   base::WeakPtrFactory<BraveNewsController> weak_ptr_factory_;

--- a/components/brave_today/browser/publishers_controller.cc
+++ b/components/brave_today/browser/publishers_controller.cc
@@ -80,6 +80,10 @@ const mojom::Publisher* PublishersController::GetPublisherForFeed(
   return nullptr;
 }
 
+const Publishers& PublishersController::GetLastPublishers() const {
+  return publishers_;
+}
+
 void PublishersController::AddObserver(Observer* observer) {
   observers_.AddObserver(observer);
 }

--- a/components/brave_today/browser/publishers_controller.h
+++ b/components/brave_today/browser/publishers_controller.h
@@ -48,6 +48,7 @@ class PublishersController {
   // live longer, take a clone.
   const mojom::Publisher* GetPublisherForSite(const GURL& site_url) const;
   const mojom::Publisher* GetPublisherForFeed(const GURL& feed_url) const;
+  const Publishers& GetLastPublishers() const;
 
   void AddObserver(Observer* observer);
   void RemoveObserver(Observer* observer);


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/27052

This fixes the bug because GetSuggestions depends on GetPublishers, so if GetPublishers pushes the results to the client it's impossible to get into a situation where we have suggestions but no publishers.

## Submitter Checklist:

- [ ] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

1. Subscribe to a direct feed
2. Ensure Brave News is disabled (via the toggle on the NTP)
3. Reload
4. Enable Brave News
5. The tab should not crash.
