### PR TITLE
Split pinned tabs and non-pinned tabs area for vertical tab strip

### DIFF
--- a/browser/ui/views/frame/brave_browser_non_client_frame_view_mac.mm
+++ b/browser/ui/views/frame/brave_browser_non_client_frame_view_mac.mm
@@ -26,7 +26,7 @@ BraveBrowserNonClientFrameViewMac::BraveBrowserNonClientFrameViewMac(
   frame_graphic_ =
       std::make_unique<BraveWindowFrameGraphic>(browser->profile());
 
-  if (tabs::features::ShouldShowVerticalTabs(browser)) {
+  if (tabs::features::SupportsVerticalTabs(browser)) {
     auto* prefs = browser->profile()->GetOriginalProfile()->GetPrefs();
     show_vertical_tabs_.Init(
         brave_tabs::kVerticalTabsEnabled, prefs,
@@ -96,5 +96,7 @@ void BraveBrowserNonClientFrameViewMac::UpdateWindowTitleAndControls() {
 
   // In case title visibility wasn't changed and only vertical tab strip enabled
   // state changed, we should reset controls positions manually.
-  frame()->ResetWindowControlsPosition();
+  base::SequencedTaskRunnerHandle::Get()->PostTask(
+      FROM_HERE, base::BindOnce(&views::Widget::ResetWindowControlsPosition,
+                                base::Unretained(frame())));
 }

--- a/browser/ui/views/frame/brave_browser_non_client_frame_view_mac.mm
+++ b/browser/ui/views/frame/brave_browser_non_client_frame_view_mac.mm
@@ -1,7 +1,7 @@
-/* Copyright 2020 The Brave Authors. All rights reserved.
+/* Copyright (c) 2020 The Brave Authors. All rights reserved.
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
- * You can obtain one at http://mozilla.org/MPL/2.0/. */
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 #include <memory>
 

--- a/browser/ui/views/frame/brave_browser_non_client_frame_view_mac.mm
+++ b/browser/ui/views/frame/brave_browser_non_client_frame_view_mac.mm
@@ -98,5 +98,5 @@ void BraveBrowserNonClientFrameViewMac::UpdateWindowTitleAndControls() {
   // state changed, we should reset controls positions manually.
   base::SequencedTaskRunnerHandle::Get()->PostTask(
       FROM_HERE, base::BindOnce(&views::Widget::ResetWindowControlsPosition,
-                                base::Unretained(frame())));
+                                frame()->GetWeakPtr()));
 }

--- a/browser/ui/views/frame/vertical_tab_strip_region_view.cc
+++ b/browser/ui/views/frame/vertical_tab_strip_region_view.cc
@@ -320,6 +320,12 @@ void VerticalTabStripRegionView::SetState(State state) {
 
   mouse_enter_timer_.Stop();
   state_ = state;
+
+  region_view_->tab_strip_->SetAvailableWidthCallback(base::BindRepeating(
+      &VerticalTabStripRegionView::GetPreferredWidthForState,
+      base::Unretained(this), state_));
+  region_view_->tab_strip_->tab_container_->InvalidateIdealBounds();
+
   PreferredSizeChanged();
 }
 
@@ -341,8 +347,11 @@ VerticalTabStripRegionView::ExpandTabStripForDragging() {
 }
 
 gfx::Vector2d VerticalTabStripRegionView::GetOffsetForDraggedTab() const {
-  return {0, scroll_view_header_->GetPreferredSize().height() +
-                 (tabs::kVerticalTabHeight / 2)};
+  return {0, scroll_view_header_->GetPreferredSize().height()};
+}
+
+int VerticalTabStripRegionView::GetAvailableWidthForTabContainer() {
+  return GetPreferredWidthForState(state_);
 }
 
 gfx::Size VerticalTabStripRegionView::CalculatePreferredSize() const {
@@ -409,6 +418,7 @@ void VerticalTabStripRegionView::UpdateLayout(bool in_destruction) {
       original_parent_of_region_view_->RemoveChildView(region_view_);
       scroll_view_->contents()->AddChildView(region_view_.get());
     }
+
     region_view_->layout_manager_->SetOrientation(
         views::LayoutOrientation::kVertical);
     if (base::FeatureList::IsEnabled(features::kScrollableTabStrip)) {
@@ -424,8 +434,13 @@ void VerticalTabStripRegionView::UpdateLayout(bool in_destruction) {
   } else {
     if (Contains(region_view_)) {
       scroll_view_->contents()->RemoveChildView(region_view_);
-      original_parent_of_region_view_->AddChildView(region_view_.get());
+      // TabStrip should be added before other views so that we can preserve
+      // the z-order. At this moment, tab strip is the first child of the
+      // parent view.
+      // https://github.com/chromium/chromium/blob/bdcef78b63f64119bbe950386b2495a045629f0e/chrome/browser/ui/views/frame/browser_view.cc#L904
+      original_parent_of_region_view_->AddChildViewAt(region_view_.get(), 0);
     }
+
     region_view_->layout_manager_->SetOrientation(
         views::LayoutOrientation::kHorizontal);
     if (base::FeatureList::IsEnabled(features::kScrollableTabStrip)) {
@@ -513,15 +528,18 @@ gfx::Size VerticalTabStripRegionView::GetPreferredSizeForState(
   if (IsTabFullscreen())
     return {};
 
-  if (state == State::kExpanded || state == State::kFloating) {
-    return {TabStyle::GetStandardWidth(),
-            View::CalculatePreferredSize().height()};
-  }
+  return {GetPreferredWidthForState(state),
+          View::CalculatePreferredSize().height()};
+}
+
+int VerticalTabStripRegionView::GetPreferredWidthForState(State state) const {
+  if (state == State::kExpanded || state == State::kFloating)
+    return TabStyle::GetStandardWidth();
 
   DCHECK_EQ(state, State::kCollapsed)
       << "If a new state was added, " << __FUNCTION__
       << " should be revisited.";
-  return {tabs::kVerticalTabMinWidth, View::CalculatePreferredSize().height()};
+  return tabs::kVerticalTabMinWidth;
 }
 
 TabStripScrollContainer*

--- a/browser/ui/views/frame/vertical_tab_strip_region_view.cc
+++ b/browser/ui/views/frame/vertical_tab_strip_region_view.cc
@@ -207,6 +207,7 @@ class ScrollContentsView : public views::View {
     if (base::FeatureList::IsEnabled(features::kScrollableTabStrip))
       return;
 
+    container_->UpdateNewTabButtonVisibility();
     if (height() == GetPreferredSize().height())
       return;
 

--- a/browser/ui/views/frame/vertical_tab_strip_region_view.h
+++ b/browser/ui/views/frame/vertical_tab_strip_region_view.h
@@ -60,6 +60,9 @@ class VerticalTabStripRegionView : public views::View {
 
   int GetAvailableWidthForTabContainer();
 
+  // This should be called when height of this view or tab strip changes.
+  void UpdateNewTabButtonVisibility();
+
   // views::View:
   gfx::Size CalculatePreferredSize() const override;
   gfx::Size GetMinimumSize() const override;
@@ -77,7 +80,6 @@ class VerticalTabStripRegionView : public views::View {
 
   void UpdateLayout(bool in_destruction = false);
 
-  void UpdateNewTabButtonVisibility();
   void UpdateTabSearchButtonVisibility();
 
   void OnCollapsedPrefChanged();

--- a/browser/ui/views/frame/vertical_tab_strip_region_view.h
+++ b/browser/ui/views/frame/vertical_tab_strip_region_view.h
@@ -58,6 +58,8 @@ class VerticalTabStripRegionView : public views::View {
   [[nodiscard]] ScopedStateResetter ExpandTabStripForDragging();
   gfx::Vector2d GetOffsetForDraggedTab() const;
 
+  int GetAvailableWidthForTabContainer();
+
   // views::View:
   gfx::Size CalculatePreferredSize() const override;
   gfx::Size GetMinimumSize() const override;
@@ -84,6 +86,7 @@ class VerticalTabStripRegionView : public views::View {
   void ScheduleFloatingModeTimer();
 
   gfx::Size GetPreferredSizeForState(State state) const;
+  int GetPreferredWidthForState(State state) const;
 
   // Returns valid object only when the related flag is enabled.
   TabStripScrollContainer* GetTabStripScrollContainer();

--- a/browser/ui/views/frame/vertical_tab_strip_region_view.h
+++ b/browser/ui/views/frame/vertical_tab_strip_region_view.h
@@ -116,8 +116,6 @@ class VerticalTabStripRegionView : public views::View {
 
   bool mouse_events_for_test_ = false;
 
-  absl::optional<gfx::Size> last_layout_size_;
-
   base::WeakPtrFactory<VerticalTabStripRegionView> weak_factory_{this};
 };
 

--- a/browser/ui/views/frame/vertical_tab_strip_widget_delegate_view.cc
+++ b/browser/ui/views/frame/vertical_tab_strip_widget_delegate_view.cc
@@ -48,8 +48,11 @@ VerticalTabStripWidgetDelegateView* VerticalTabStripWidgetDelegateView::Create(
   return delegate_view;
 }
 
-VerticalTabStripWidgetDelegateView::~VerticalTabStripWidgetDelegateView() =
-    default;
+VerticalTabStripWidgetDelegateView::~VerticalTabStripWidgetDelegateView() {
+  // Child views will be deleted after this. Marks `region_view_` nullptr
+  // so that they dont' access the `region_view_` via this view.
+  region_view_ = nullptr;
+}
 
 VerticalTabStripWidgetDelegateView::VerticalTabStripWidgetDelegateView(
     BrowserView* browser_view,

--- a/browser/ui/views/tabs/brave_compound_tab_container.cc
+++ b/browser/ui/views/tabs/brave_compound_tab_container.cc
@@ -76,5 +76,19 @@ int BraveCompoundTabContainer::GetAvailableWidthForUnpinnedTabContainer(
       available_width_callback);
 }
 
+void BraveCompoundTabContainer::TransferTabBetweenContainers(
+    int from_model_index,
+    int to_model_index) {
+  CompoundTabContainer::TransferTabBetweenContainers(from_model_index,
+                                                     to_model_index);
+  if (to_model_index < NumPinnedTabs() &&
+      !pinned_tab_container_->GetVisible()) {
+    // When the browser was initialized without any pinned tabs, pinned tabs
+    // could be hidden initially by the FlexLayout.
+    pinned_tab_container_->SetVisible(true);
+    Layout();
+  }
+}
+
 BEGIN_METADATA(BraveCompoundTabContainer, CompoundTabContainer)
 END_METADATA

--- a/browser/ui/views/tabs/brave_compound_tab_container.cc
+++ b/browser/ui/views/tabs/brave_compound_tab_container.cc
@@ -6,11 +6,13 @@
 #include "brave/browser/ui/views/tabs/brave_compound_tab_container.h"
 
 #include <memory>
+#include <utility>
+#include <vector>
 
 #include "brave/browser/ui/tabs/brave_tab_prefs.h"
 #include "brave/browser/ui/views/tabs/brave_tab_container.h"
 #include "brave/browser/ui/views/tabs/features.h"
-#include "chrome/browser/ui/ui_features.cc"
+#include "chrome/browser/ui/ui_features.h"
 #include "ui/base/metadata/metadata_impl_macros.h"
 #include "ui/views/layout/fill_layout.h"
 #include "ui/views/layout/flex_layout.h"

--- a/browser/ui/views/tabs/brave_compound_tab_container.h
+++ b/browser/ui/views/tabs/brave_compound_tab_container.h
@@ -10,12 +10,29 @@
 
 class BraveCompoundTabContainer : public CompoundTabContainer {
  public:
+  METADATA_HEADER(BraveCompoundTabContainer);
+
   BraveCompoundTabContainer(raw_ref<TabContainerController> controller,
                             TabHoverCardController* hover_card_controller,
                             TabDragContextBase* drag_context,
                             TabSlotController& tab_slot_controller,
                             views::View* scroll_contents_view);
   ~BraveCompoundTabContainer() override;
+
+  // Combine results of TabContainerImpl::LockLayout() for pinned tabs and
+  // un pinned tabs.
+  base::OnceClosure LockLayout();
+
+  // CompoundTabContainer:
+  void SetAvailableWidthCallback(
+      base::RepeatingCallback<int()> available_width_callback) override;
+  int GetAvailableWidthForUnpinnedTabContainer(
+      base::RepeatingCallback<int()> available_width_callback) override;
+
+ private:
+  void UpdateLayout();
+
+  base::raw_ref<TabSlotController> tab_slot_controller_;
 };
 
 #endif  // BRAVE_BROWSER_UI_VIEWS_TABS_BRAVE_COMPOUND_TAB_CONTAINER_H_

--- a/browser/ui/views/tabs/brave_compound_tab_container.h
+++ b/browser/ui/views/tabs/brave_compound_tab_container.h
@@ -28,6 +28,8 @@ class BraveCompoundTabContainer : public CompoundTabContainer {
       base::RepeatingCallback<int()> available_width_callback) override;
   int GetAvailableWidthForUnpinnedTabContainer(
       base::RepeatingCallback<int()> available_width_callback) override;
+  void TransferTabBetweenContainers(int from_model_index,
+                                    int to_model_index) override;
 
  private:
   void UpdateLayout();

--- a/browser/ui/views/tabs/brave_tab.cc
+++ b/browser/ui/views/tabs/brave_tab.cc
@@ -61,10 +61,16 @@ absl::optional<SkColor> BraveTab::GetGroupColor() const {
 void BraveTab::UpdateIconVisibility() {
   Tab::UpdateIconVisibility();
   if (IsAtMinWidthForVerticalTabStrip()) {
-    const bool is_active = IsActive();
-    center_icon_ = true;
-    showing_icon_ = !is_active && !showing_alert_indicator_;
-    showing_close_button_ = is_active;
+    if (data().pinned) {
+      center_icon_ = true;
+      showing_icon_ = !showing_alert_indicator_;
+      showing_close_button_ = false;
+    } else {
+      const bool is_active = IsActive();
+      center_icon_ = true;
+      showing_icon_ = !is_active && !showing_alert_indicator_;
+      showing_close_button_ = is_active;
+    }
   }
 }
 
@@ -72,7 +78,7 @@ void BraveTab::Layout() {
   Tab::Layout();
   if (IsAtMinWidthForVerticalTabStrip()) {
     if (showing_close_button_) {
-      close_button_->SetX(bounds().CenterPoint().x() -
+      close_button_->SetX(GetLocalBounds().CenterPoint().x() -
                           (close_button_->width() / 2));
       close_button_->SetButtonPadding({});
     }
@@ -90,5 +96,5 @@ bool BraveTab::ShouldRenderAsNormalTab() const {
 
 bool BraveTab::IsAtMinWidthForVerticalTabStrip() const {
   return tabs::features::ShouldShowVerticalTabs(controller()->GetBrowser()) &&
-         width() == tabs::kVerticalTabMinWidth;
+         width() <= tabs::kVerticalTabMinWidth;
 }

--- a/browser/ui/views/tabs/brave_tab.h
+++ b/browser/ui/views/tabs/brave_tab.h
@@ -18,6 +18,7 @@ class BraveTab : public Tab {
   BraveTab& operator=(const BraveTab&) = delete;
   ~BraveTab() override;
 
+  // Tab:
   std::u16string GetTooltipText(const gfx::Point& p) const override;
 
   // Overridden because we moved alert button to left side in the tab whereas

--- a/browser/ui/views/tabs/brave_tab_container.cc
+++ b/browser/ui/views/tabs/brave_tab_container.cc
@@ -117,11 +117,15 @@ gfx::Rect BraveTabContainer::GetTargetBoundsForClosingTab(
                                                           former_model_index);
 
   gfx::Rect target_bounds = tab->bounds();
-  target_bounds.set_y(
-      (former_model_index > 0)
-          ? tabs_view_model_.ideal_bounds(former_model_index - 1).bottom()
-          : 0);
-  target_bounds.set_height(0);
+  if (tab->data().pinned) {
+    target_bounds.set_width(0);
+  } else {
+    target_bounds.set_y(
+        (former_model_index > 0)
+            ? tabs_view_model_.ideal_bounds(former_model_index - 1).bottom()
+            : 0);
+    target_bounds.set_height(0);
+  }
   return target_bounds;
 }
 
@@ -187,6 +191,10 @@ void BraveTabContainer::OnTabCloseAnimationCompleted(Tab* tab) {
     closing_tabs_.erase(tab);
 
   TabContainerImpl::OnTabCloseAnimationCompleted(tab);
+
+  // we might have to hide this container entirely
+  if (!tabs_view_model_.view_size())
+    PreferredSizeChanged();
 }
 
 void BraveTabContainer::UpdateLayoutOrientation() {

--- a/browser/ui/views/tabs/brave_tab_container.h
+++ b/browser/ui/views/tabs/brave_tab_container.h
@@ -21,6 +21,13 @@ class BraveTabContainer : public TabContainerImpl {
                     views::View* scroll_contents_view);
   ~BraveTabContainer() override;
 
+  // Calling this will freeze this view's layout. When the returned closure
+  // runs, layout will be unlocked and run immediately.
+  // This is to avoid accessing invalid index during reconstruction
+  // of TabContainer. In addition, we can avoid redundant layout as a side
+  // effect.
+  base::OnceClosure LockLayout();
+
   // TabContainer:
   gfx::Size CalculatePreferredSize() const override;
   void UpdateClosingModeOnRemovedTab(int model_index, bool was_active) override;
@@ -32,13 +39,20 @@ class BraveTabContainer : public TabContainerImpl {
   void StartInsertTabAnimation(int model_index) override;
   void RemoveTab(int index, bool was_active) override;
   void OnTabCloseAnimationCompleted(Tab* tab) override;
+  void CompleteAnimationAndLayout() override;
 
  private:
   void UpdateLayoutOrientation();
 
+  void OnUnlockLayout();
+
   base::flat_set<Tab*> closing_tabs_;
 
+  raw_ptr<TabDragContext> drag_context_;
+
   BooleanPrefMember show_vertical_tabs_;
+
+  bool layout_locked_ = false;
 };
 
 #endif  // BRAVE_BROWSER_UI_VIEWS_TABS_BRAVE_TAB_CONTAINER_H_

--- a/browser/ui/views/tabs/brave_tab_strip.cc
+++ b/browser/ui/views/tabs/brave_tab_strip.cc
@@ -197,11 +197,13 @@ void BraveTabStrip::UpdateTabContainer() {
     auto* vertical_region_view =
         browser_view->vertical_tab_strip_widget_delegate_view()
             ->vertical_tab_strip_region_view();
-    DCHECK(vertical_region_view);
+    // `vertical_region_view` can be null if it's in destruction.
+    if (vertical_region_view) {
+      SetAvailableWidthCallback(base::BindRepeating(
+          &VerticalTabStripRegionView::GetAvailableWidthForTabContainer,
+          base::Unretained(vertical_region_view)));
+    }
 
-    SetAvailableWidthCallback(base::BindRepeating(
-        &VerticalTabStripRegionView::GetAvailableWidthForTabContainer,
-        base::Unretained(vertical_region_view)));
     tab_container_->SetLayoutManager(std::make_unique<views::FlexLayout>())
         ->SetOrientation(views::LayoutOrientation::kVertical);
   } else {

--- a/browser/ui/views/tabs/brave_tab_strip.cc
+++ b/browser/ui/views/tabs/brave_tab_strip.cc
@@ -10,16 +10,26 @@
 #include "brave/browser/profiles/profile_util.h"
 #include "brave/browser/themes/brave_dark_mode_utils.h"
 #include "brave/browser/ui/tabs/brave_tab_prefs.h"
+#include "brave/browser/ui/views/frame/brave_browser_view.h"
+#include "brave/browser/ui/views/frame/vertical_tab_strip_region_view.h"
+#include "brave/browser/ui/views/frame/vertical_tab_strip_widget_delegate_view.h"
+#include "brave/browser/ui/views/tabs/brave_compound_tab_container.h"
+#include "brave/browser/ui/views/tabs/brave_tab.h"
+#include "brave/browser/ui/views/tabs/brave_tab_container.h"
+#include "brave/browser/ui/views/tabs/brave_tab_hover_card_controller.h"
 #include "brave/browser/ui/views/tabs/features.h"
 #include "chrome/browser/profiles/profile.h"
 #include "chrome/browser/themes/theme_service.h"
 #include "chrome/browser/themes/theme_service_factory.h"
+#include "chrome/browser/ui/tabs/tab_group.h"
+#include "chrome/browser/ui/tabs/tab_group_model.h"
 #include "chrome/browser/ui/ui_features.h"
 #include "chrome/browser/ui/views/tabs/tab.h"
 #include "chrome/browser/ui/views/tabs/tab_container.h"
 #include "chrome/browser/ui/views/tabs/tab_strip_controller.h"
 #include "third_party/skia/include/core/SkColor.h"
 #include "ui/base/metadata/metadata_impl_macros.h"
+#include "ui/views/layout/flex_layout.h"
 
 BraveTabStrip::BraveTabStrip(std::unique_ptr<TabStripController> controller)
     : TabStrip(std::move(controller)) {}
@@ -58,6 +68,39 @@ void BraveTabStrip::UpdateHoverCard(Tab* tab, HoverCardUpdateType update_type) {
   TabStrip::UpdateHoverCard(tab, update_type);
 }
 
+void BraveTabStrip::MaybeStartDrag(
+    TabSlotView* source,
+    const ui::LocatedEvent& event,
+    const ui::ListSelectionModel& original_selection) {
+  if (tabs::features::ShouldShowVerticalTabs(GetBrowser())) {
+    // When it's vertical tab strip, all the dragged tabs are either pinned or
+    // unpinned.
+    const bool source_is_pinned =
+        source->GetTabSlotViewType() == TabSlotView::ViewType::kTab &&
+        static_cast<Tab*>(source)->data().pinned;
+    for (size_t index : original_selection.selected_indices()) {
+      if (controller_->IsTabPinned(index) != source_is_pinned)
+        return;
+    }
+  }
+
+  TabStrip::MaybeStartDrag(source, event, original_selection);
+}
+
+void BraveTabStrip::AddedToWidget() {
+  TabStrip::AddedToWidget();
+
+  if (BrowserView::GetBrowserViewForBrowser(GetBrowser())) {
+    UpdateTabContainer();
+  } else {
+    // Schedule UpdateTabContainer(). At this point, BrowserWindow could still
+    // be being created and it could be unbound to Browser.
+    base::SequencedTaskRunnerHandle::Get()->PostTask(
+        FROM_HERE, base::BindOnce(&BraveTabStrip::UpdateTabContainer,
+                                  base::Unretained(this)));
+  }
+}
+
 SkColor BraveTabStrip::GetTabSeparatorColor() const {
   if (tabs::features::ShouldShowVerticalTabs(GetBrowser()))
     return SK_ColorTRANSPARENT;
@@ -80,6 +123,94 @@ SkColor BraveTabStrip::GetTabSeparatorColor() const {
                    dark_mode::BraveDarkModeType::BRAVE_DARK_MODE_TYPE_DARK;
   return dark_mode ? SkColorSetRGB(0x39, 0x38, 0x38)
                    : SkColorSetRGB(0xBE, 0xBF, 0xBF);
+}
+
+void BraveTabStrip::UpdateTabContainer() {
+  auto* browser = GetBrowser();
+  DCHECK(browser);
+  const bool using_vertical_tabs =
+      tabs::features::ShouldShowVerticalTabs(browser);
+  const bool should_use_compound_tab_container =
+      using_vertical_tabs ||
+      base::FeatureList::IsEnabled(features::kSplitTabStrip);
+  const bool is_using_compound_tab_container =
+      tab_container_->GetClassName() ==
+      BraveCompoundTabContainer::kViewClassName;
+  base::ScopedClosureRunner layout_lock;
+  if (should_use_compound_tab_container != is_using_compound_tab_container) {
+    // Resets TabContainer to use.
+    RemoveChildViewT(
+        static_cast<views::View*>(base::to_address(tab_container_)));
+
+    if (should_use_compound_tab_container) {
+      auto* brave_tab_container =
+          AddChildView(std::make_unique<BraveCompoundTabContainer>(
+              raw_ref<TabContainerController>::from_ptr(this),
+              hover_card_controller_.get(), GetDragContext(), *this, this));
+      tab_container_ = *brave_tab_container;
+      layout_lock =
+          base::ScopedClosureRunner(brave_tab_container->LockLayout());
+    } else {
+      auto* brave_tab_container =
+          AddChildView(std::make_unique<BraveTabContainer>(
+              *this, hover_card_controller_.get(), GetDragContext(), *this,
+              this));
+      tab_container_ = *brave_tab_container;
+      layout_lock =
+          base::ScopedClosureRunner(brave_tab_container->LockLayout());
+    }
+
+    // Resets TabSlotViews for the new TabContainer.
+    base::flat_set<tab_groups::TabGroupId> groups;
+    auto* model = GetBrowser()->tab_strip_model();
+    for (int i = 0; i < model->count(); i++) {
+      auto data = TabRendererData::FromTabInModel(model, i);
+      const bool pinned = data.pinned;
+      auto* tab = tab_container_->AddTab(
+          std::make_unique<BraveTab>(this), i,
+          pinned ? TabPinned::kPinned : TabPinned::kUnpinned);
+
+      tab->set_context_menu_controller(&context_menu_controller_);
+      tab->AddObserver(this);
+
+      tab->SetData(std::move(data));
+    }
+
+    auto* group_model = model->group_model();
+    for (auto group_id : group_model->ListTabGroups()) {
+      auto* group = group_model->GetTabGroup(group_id);
+      tab_container_->OnGroupCreated(group_id);
+      const auto tabs = group->ListTabs();
+      for (auto i = tabs.start(); i < tabs.end(); i++)
+        AddTabToGroup(group_id, i);
+
+      auto* visual_data = group->visual_data();
+      tab_container_->OnGroupVisualsChanged(group_id, visual_data, visual_data);
+    }
+  }
+
+  // Update layout of TabContainer
+  if (using_vertical_tabs) {
+    auto* browser_view = static_cast<BraveBrowserView*>(
+        BrowserView::GetBrowserViewForBrowser(browser));
+    DCHECK(browser_view);
+    auto* vertical_region_view =
+        browser_view->vertical_tab_strip_widget_delegate_view()
+            ->vertical_tab_strip_region_view();
+    DCHECK(vertical_region_view);
+
+    SetAvailableWidthCallback(base::BindRepeating(
+        &VerticalTabStripRegionView::GetAvailableWidthForTabContainer,
+        base::Unretained(vertical_region_view)));
+    tab_container_->SetLayoutManager(std::make_unique<views::FlexLayout>())
+        ->SetOrientation(views::LayoutOrientation::kVertical);
+  } else {
+    SetAvailableWidthCallback(base::NullCallback());
+    if (should_use_compound_tab_container) {
+      tab_container_->SetLayoutManager(std::make_unique<views::FlexLayout>())
+          ->SetOrientation(views::LayoutOrientation::kVertical);
+    }
+  }
 }
 
 void BraveTabStrip::Layout() {

--- a/browser/ui/views/tabs/brave_tab_strip.h
+++ b/browser/ui/views/tabs/brave_tab_strip.h
@@ -14,15 +14,24 @@ class Tab;
 class BraveTabStrip : public TabStrip {
  public:
   METADATA_HEADER(BraveTabStrip);
+
   explicit BraveTabStrip(std::unique_ptr<TabStripController> controller);
   ~BraveTabStrip() override;
   BraveTabStrip(const BraveTabStrip&) = delete;
   BraveTabStrip& operator=(const BraveTabStrip&) = delete;
 
+  // TabStrip:
   void UpdateHoverCard(Tab* tab, HoverCardUpdateType update_type) override;
+  void MaybeStartDrag(
+      TabSlotView* source,
+      const ui::LocatedEvent& event,
+      const ui::ListSelectionModel& original_selection) override;
+  void AddedToWidget() override;
 
  private:
   FRIEND_TEST_ALL_PREFIXES(ColorPaletteTest, LightThemeMinimumContrast);
+
+  void UpdateTabContainer();
 
   // TabStrip overrides:
   SkColor GetTabSeparatorColor() const override;

--- a/browser/ui/views/tabs/brave_tab_strip_layout_helper.cc
+++ b/browser/ui/views/tabs/brave_tab_strip_layout_helper.cc
@@ -5,6 +5,8 @@
 
 #include "brave/browser/ui/views/tabs/brave_tab_strip_layout_helper.h"
 
+#include <limits>
+
 #include "brave/browser/ui/views/tabs/brave_tab_group_header.h"
 #include "chrome/browser/ui/layout_constants.h"
 #include "chrome/browser/ui/tabs/tab_style.h"

--- a/browser/ui/views/tabs/brave_tab_strip_layout_helper.cc
+++ b/browser/ui/views/tabs/brave_tab_strip_layout_helper.cc
@@ -82,19 +82,19 @@ std::vector<gfx::Rect> CalculateBoundsForVerticalDraggedViews(
     const int height = view->height();
     if (view->GetTabSlotViewType() == TabSlotView::ViewType::kTab) {
       if (const Tab* tab = static_cast<const Tab*>(view); tab->data().pinned) {
-        /* In case it's a pinned tab, lay out them horizontally */
+        // In case it's a pinned tab, lay out them horizontally
         bounds.emplace_back(x, y, tabs::kVerticalTabMinWidth, height);
         constexpr int kStackedOffset = 4;
         x += kStackedOffset;
         continue;
       }
       if (view->group().has_value()) {
-        /* In case it's a tab in a group, set left padding */
+        // In case it's a tab in a group, set left padding
         x = BraveTabGroupHeader::GetLeftPaddingForVerticalTabs();
       }
     }
     bounds.emplace_back(x, y, TabStyle::GetStandardWidth() - x, height);
-    /* unpinned dragged tabs are laid out vertically */
+    // unpinned dragged tabs are laid out vertically
     y += height;
   }
   return bounds;
@@ -120,13 +120,13 @@ void UpdateInsertionIndexForVerticalTabs(
       candidate_index == 0 ? gfx::Rect()
                            : tab_container->GetIdealBounds(candidate_index - 1);
   if (tab_strip_controller->IsTabPinned(first_dragged_tab_index)) {
-    /* Pinned tabs are laid out in a grid. */
+    // Pinned tabs are laid out in a grid.
     distance = std::sqrt(
         std::pow(dragged_bounds.x() - candidate_bounds.CenterPoint().x(), 2) +
         std::pow(dragged_bounds.y() - candidate_bounds.CenterPoint().y(), 2));
   } else {
-    /* Unpinned tabs are laid out vertically. So we consider only y */
-    /* coordinate */
+    // Unpinned tabs are laid out vertically. So we consider only y
+    // coordinate
     distance = std::abs(dragged_bounds.y() - candidate_bounds.bottom());
   }
   if (distance < min_distance) {

--- a/browser/ui/views/tabs/brave_tab_strip_layout_helper.cc
+++ b/browser/ui/views/tabs/brave_tab_strip_layout_helper.cc
@@ -6,6 +6,7 @@
 #include "brave/browser/ui/views/tabs/brave_tab_strip_layout_helper.h"
 
 #include "brave/browser/ui/views/tabs/brave_tab_group_header.h"
+#include "chrome/browser/ui/layout_constants.h"
 #include "chrome/browser/ui/tabs/tab_style.h"
 #include "chrome/browser/ui/tabs/tab_types.h"
 #include "chrome/browser/ui/views/tabs/tab_strip_layout.h"
@@ -23,7 +24,38 @@ std::vector<gfx::Rect> CalculateVerticalTabBounds(
 
   std::vector<gfx::Rect> bounds;
   gfx::Rect rect;
+  bool last_tab_was_pinned = false;
+
   for (const auto& tab : tabs) {
+    if (tab.state().pinned() == TabPinned::kPinned) {
+      if (!bounds.empty()) {
+        if (bounds.back().right() + tab.GetMinimumWidth() <
+            width.value_or(TabStyle::GetStandardWidth())) {
+          rect.set_x(bounds.back().right());
+        } else {
+          // New line
+          rect.set_x(0);
+          rect.set_y(bounds.back().bottom());
+        }
+      }
+      rect.set_width(kVerticalTabMinWidth);
+      rect.set_height(kVerticalTabHeight);
+      bounds.push_back(rect);
+      last_tab_was_pinned = true;
+      continue;
+    }
+
+    if (last_tab_was_pinned) {
+      // This could happen on start-up.
+      gfx::Rect empty_rect;
+      empty_rect.set_y(bounds.back().bottom());
+      bounds.push_back(empty_rect);
+      continue;
+    }
+
+    // This method is called by two separated containers. One contains only
+    // pinned tabs and the other contains only non-pinned tabs. So we don't need
+    // to consider the last pinned tab's bottom coordinate here.
     rect.set_x(tab.is_tab_in_group()
                    ? BraveTabGroupHeader::GetLeftPaddingForVerticalTabs()
                    : 0);

--- a/browser/ui/views/tabs/brave_tab_strip_layout_helper.cc
+++ b/browser/ui/views/tabs/brave_tab_strip_layout_helper.cc
@@ -28,19 +28,21 @@ std::vector<gfx::Rect> CalculateVerticalTabBounds(
 
   for (const auto& tab : tabs) {
     if (tab.state().pinned() == TabPinned::kPinned) {
-      if (!bounds.empty()) {
-        if (bounds.back().right() + tab.GetMinimumWidth() <
+      rect.set_width(kVerticalTabMinWidth);
+      rect.set_height(kVerticalTabHeight);
+      bounds.push_back(rect);
+
+      if (tab.state().open() == TabOpen::kOpen) {
+        if (rect.right() + tab.GetMinimumWidth() <
             width.value_or(TabStyle::GetStandardWidth())) {
-          rect.set_x(bounds.back().right());
+          rect.set_x(rect.right());
         } else {
           // New line
           rect.set_x(0);
           rect.set_y(bounds.back().bottom());
         }
       }
-      rect.set_width(kVerticalTabMinWidth);
-      rect.set_height(kVerticalTabHeight);
-      bounds.push_back(rect);
+
       last_tab_was_pinned = true;
       continue;
     }

--- a/browser/ui/views/tabs/brave_tab_strip_layout_helper.h
+++ b/browser/ui/views/tabs/brave_tab_strip_layout_helper.h
@@ -9,6 +9,7 @@
 #include <vector>
 
 #include "brave/browser/ui/views/sidebar/sidebar_item_view.h"
+#include "components/tab_groups/tab_group_id.h"
 #include "third_party/abseil-cpp/absl/types/optional.h"
 
 namespace gfx {
@@ -17,6 +18,9 @@ class Rect;
 
 class TabStripLayoutHelper;
 class TabWidthConstraints;
+class TabStripController;
+class TabContainer;
+class TabSlotView;
 struct TabLayoutConstants;
 
 namespace tabs {
@@ -28,6 +32,20 @@ std::vector<gfx::Rect> CalculateVerticalTabBounds(
     const TabLayoutConstants& layout_constants,
     const std::vector<TabWidthConstraints>& tabs,
     absl::optional<int> width);
+
+std::vector<gfx::Rect> CalculateBoundsForVerticalDraggedViews(
+    const std::vector<TabSlotView*>& views);
+
+void UpdateInsertionIndexForVerticalTabs(
+    const gfx::Rect& dragged_bounds,
+    int first_dragged_tab_index,
+    int num_dragged_tabs,
+    absl::optional<tab_groups::TabGroupId> dragged_group,
+    int candidate_index,
+    TabStripController* tab_strip_controller,
+    TabContainer* tab_container,
+    int& min_distance,
+    int& min_distance_index);
 
 }  // namespace tabs
 

--- a/browser/ui/views/tabs/brave_tab_strip_layout_helper.h
+++ b/browser/ui/views/tabs/brave_tab_strip_layout_helper.h
@@ -17,7 +17,6 @@ class Rect;
 
 class TabStripLayoutHelper;
 class TabWidthConstraints;
-class TabWidthConstraints;
 struct TabLayoutConstants;
 
 namespace tabs {

--- a/browser/ui/views/toolbar/brave_toolbar_view.cc
+++ b/browser/ui/views/toolbar/brave_toolbar_view.cc
@@ -287,7 +287,8 @@ void BraveToolbarView::UpdateBookmarkVisibility() {
 }
 
 void BraveToolbarView::UpdateHorizontalPadding() {
-  if (tabs::features::ShouldShowWindowTitleForVerticalTabs(browser())) {
+  if (!tabs::features::ShouldShowVerticalTabs(browser()) ||
+      tabs::features::ShouldShowWindowTitleForVerticalTabs(browser())) {
     SetBorder(nullptr);
   } else {
     auto [leading, trailing] =

--- a/chromium_src/chrome/browser/ui/views/tabs/compound_tab_container.h
+++ b/chromium_src/chrome/browser/ui/views/tabs/compound_tab_container.h
@@ -1,0 +1,21 @@
+/* Copyright (c) 2022 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_CHROMIUM_SRC_CHROME_BROWSER_UI_VIEWS_TABS_COMPOUND_TAB_CONTAINER_H_
+#define BRAVE_CHROMIUM_SRC_CHROME_BROWSER_UI_VIEWS_TABS_COMPOUND_TAB_CONTAINER_H_
+
+#define NumPinnedTabs                     \
+  NumPinnedTabs_Unused() { return {}; }   \
+  friend class BraveCompoundTabContainer; \
+  int NumPinnedTabs
+#define GetAvailableWidthForUnpinnedTabContainer \
+  virtual GetAvailableWidthForUnpinnedTabContainer
+
+#include "src/chrome/browser/ui/views/tabs/compound_tab_container.h"
+
+#undef GetAvailableWidthForUnpinnedTabContainer
+#undef NumPinnedTabs
+
+#endif  // BRAVE_CHROMIUM_SRC_CHROME_BROWSER_UI_VIEWS_TABS_COMPOUND_TAB_CONTAINER_H_

--- a/chromium_src/chrome/browser/ui/views/tabs/compound_tab_container.h
+++ b/chromium_src/chrome/browser/ui/views/tabs/compound_tab_container.h
@@ -12,9 +12,11 @@
   int NumPinnedTabs
 #define GetAvailableWidthForUnpinnedTabContainer \
   virtual GetAvailableWidthForUnpinnedTabContainer
+#define TransferTabBetweenContainers virtual TransferTabBetweenContainers
 
 #include "src/chrome/browser/ui/views/tabs/compound_tab_container.h"
 
+#undef TransferTabBetweenContainers
 #undef GetAvailableWidthForUnpinnedTabContainer
 #undef NumPinnedTabs
 

--- a/chromium_src/chrome/browser/ui/views/tabs/compound_tab_container.h
+++ b/chromium_src/chrome/browser/ui/views/tabs/compound_tab_container.h
@@ -1,7 +1,7 @@
 /* Copyright (c) 2022 The Brave Authors. All rights reserved.
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
- * You can obtain one at http://mozilla.org/MPL/2.0/. */
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 #ifndef BRAVE_CHROMIUM_SRC_CHROME_BROWSER_UI_VIEWS_TABS_COMPOUND_TAB_CONTAINER_H_
 #define BRAVE_CHROMIUM_SRC_CHROME_BROWSER_UI_VIEWS_TABS_COMPOUND_TAB_CONTAINER_H_

--- a/chromium_src/chrome/browser/ui/views/tabs/tab_drag_controller.cc
+++ b/chromium_src/chrome/browser/ui/views/tabs/tab_drag_controller.cc
@@ -7,6 +7,7 @@
 
 #include "brave/browser/ui/views/frame/brave_browser_view.h"
 #include "brave/browser/ui/views/frame/vertical_tab_strip_widget_delegate_view.h"
+#include "brave/browser/ui/views/tabs/features.h"
 #include "chrome/browser/ui/views/frame/browser_view.h"
 #include "ui/views/view.h"
 #include "ui/views/widget/root_view.h"
@@ -26,8 +27,19 @@
       view->GetWidget()->GetTopLevelWidget()->GetRootView(), point)
 #define GetRestoredBounds GetTopLevelWidget()->GetRestoredBounds
 
+// Remove drag threshold when it's vertical tab strip
+#define GetHorizontalDragThreshold()                          \
+  GetHorizontalDragThreshold() -                              \
+      (tabs::features::ShouldShowVerticalTabs(                \
+           BrowserView::GetBrowserViewForNativeWindow(        \
+               GetAttachedBrowserWidget()->GetNativeWindow()) \
+               ->browser())                                   \
+           ? attached_context_->GetHorizontalDragThreshold()  \
+           : 0)
+
 #include "src/chrome/browser/ui/views/tabs/tab_drag_controller.cc"
 
+#undef GetHorizontalDragThreshold
 #undef GetRestoredBounds
 #undef ConvertPointToWidget
 #undef GetBrowserViewForNativeWindow
@@ -77,20 +89,27 @@ gfx::Point TabDragController::GetAttachedDragPoint(
 
   gfx::Point tab_loc(point_in_screen);
   views::View::ConvertPointFromScreen(attached_context_, &tab_loc);
+  const int x = drag_data_.front().pinned ? tab_loc.x() - mouse_offset_.x() : 0;
   const int y = tab_loc.y() - mouse_offset_.y();
-  return gfx::Point(0, std::max(0, y));
+  return {x, y};
 }
 
 void TabDragController::MoveAttached(const gfx::Point& point_in_screen,
                                      bool just_attached) {
-  gfx::Point new_point_in_screen = point_in_screen;
-  if (is_showing_vertical_tabs_) {
-    // As MoveAttached() compare point_in_screen.x() and last_move_screen_loc_,
-    // override x with y so that calculate offset for vertical mode.
-    new_point_in_screen.set_x(new_point_in_screen.y());
-  }
+  TabDragControllerChromium::MoveAttached(point_in_screen, just_attached);
+  if (!is_showing_vertical_tabs_)
+    return;
 
-  TabDragControllerChromium::MoveAttached(new_point_in_screen, just_attached);
+  // Update |last_move_screen_loc_| only when tab strip actually changed just
+  // like Chromium impl does. But we set y coordinate as we're in vertical
+  // tab strip.
+  WebContents* last_contents = drag_data_.back().contents;
+  auto* attached_model = attached_context_->GetTabStripModel();
+  int index_of_last_item = attached_model->GetIndexOfWebContents(last_contents);
+  if (index_of_last_item !=
+      attached_model->GetIndexOfWebContents(last_contents)) {
+    last_move_screen_loc_ = point_in_screen.y();
+  }
 }
 
 absl::optional<tab_groups::TabGroupId>
@@ -225,10 +244,14 @@ gfx::Rect TabDragController::CalculateDraggedBrowserBounds(
   auto bounds = TabDragControllerChromium::CalculateDraggedBrowserBounds(
       source, point_in_screen, drag_bounds);
   if (is_showing_vertical_tabs_) {
-    // Revert back y coordinate adjustment done by Chromium impl.
-    bounds.set_y(point_in_screen.y());
+    // Revert back coordinate adjustment done by Chromium impl.
+    bounds.set_origin(point_in_screen);
 
-    // Adjust y coordinate so that dragged tabs are under cursor.
+    // Adjust coordinate so that dragged tabs are under cursor.
+    DCHECK(!drag_bounds->empty());
+    bounds.Offset(-(mouse_offset_.OffsetFromOrigin()));
+    bounds.Offset({-drag_bounds->front().x(), 0});
+
     auto* browser_view = static_cast<BraveBrowserView*>(
         BrowserView::GetBrowserViewForNativeWindow(
             GetAttachedBrowserWidget()->GetNativeWindow()));
@@ -238,7 +261,7 @@ gfx::Rect TabDragController::CalculateDraggedBrowserBounds(
         browser_view->vertical_tab_strip_widget_delegate_view();
     DCHECK(widget_delegate_view);
 
-    bounds.Offset({0, GetVerticalTabStripWidgetOffset().y()});
+    bounds.Offset(GetVerticalTabStripWidgetOffset());
     bounds.Offset(-widget_delegate_view->vertical_tab_strip_region_view()
                        ->GetOffsetForDraggedTab());
   }
@@ -262,4 +285,22 @@ gfx::Vector2d TabDragController::GetVerticalTabStripWidgetOffset() {
   auto tabstrip_widget_bounds = tabstrip_widget->GetWindowBoundsInScreen();
 
   return browser_widget_bounds.origin() - tabstrip_widget_bounds.origin();
+}
+
+void TabDragController::InitDragData(TabSlotView* view,
+                                     TabDragData* drag_data) {
+  // This seems to be a bug from upstream. If the `view` is a group header,
+  // there can't be contents or pinned state which are bound to this `view`.
+  if (view->GetTabSlotViewType() == TabSlotView::ViewType::kTabGroupHeader) {
+    absl::optional<tab_groups::TabGroupId> tab_group_id = view->group();
+    DCHECK(tab_group_id.has_value());
+    drag_data->tab_group_data = TabDragData::TabGroupData{
+        tab_group_id.value(), *source_context_->GetTabStripModel()
+                                   ->group_model()
+                                   ->GetTabGroup(tab_group_id.value())
+                                   ->visual_data()};
+    return;
+  }
+
+  TabDragControllerChromium::InitDragData(view, drag_data);
 }

--- a/chromium_src/chrome/browser/ui/views/tabs/tab_drag_controller.h
+++ b/chromium_src/chrome/browser/ui/views/tabs/tab_drag_controller.h
@@ -28,9 +28,11 @@ using TabDragControllerBrave = TabDragController;
 #define CalculateNonMaximizedDraggedBrowserBounds \
   virtual CalculateNonMaximizedDraggedBrowserBounds
 #define CalculateDraggedBrowserBounds virtual CalculateDraggedBrowserBounds
+#define InitDragData virtual InitDragData
 
 #include "src/chrome/browser/ui/views/tabs/tab_drag_controller.h"
 
+#undef InitDragData
 #undef CalculateDraggedBrowserBounds
 #undef CalculateNonMaximizedDraggedBrowserBounds
 #undef DetachAndAttachToNewContext
@@ -82,6 +84,8 @@ class TabDragController : public TabDragControllerChromium {
       TabDragContext* source,
       const gfx::Point& point_in_screen,
       std::vector<gfx::Rect>* drag_bounds) override;
+
+  void InitDragData(TabSlotView* view, TabDragData* drag_data) override;
 
  private:
   gfx::Vector2d GetVerticalTabStripWidgetOffset();

--- a/chromium_src/chrome/browser/ui/views/tabs/tab_strip.cc
+++ b/chromium_src/chrome/browser/ui/views/tabs/tab_strip.cc
@@ -86,7 +86,6 @@
 
 #include "src/chrome/browser/ui/views/tabs/tab_strip.cc"
 
-#undef kSplitTabStrip
 #undef BRAVE_CALCULATE_BOUNDS_FOR_DRAGGED_VIEWS
 #undef BRAVE_CALCULATE_INSERTION_INDEX
 #undef TabHoverCardController

--- a/chromium_src/chrome/browser/ui/views/tabs/tab_strip.cc
+++ b/chromium_src/chrome/browser/ui/views/tabs/tab_strip.cc
@@ -27,61 +27,18 @@
 #define CompoundTabContainer BraveCompoundTabContainer
 #define TabContainerImpl BraveTabContainer
 #define TabHoverCardController BraveTabHoverCardController
-#define BRAVE_CALCULATE_INSERTION_INDEX                                        \
-  if (tabs::features::ShouldShowVerticalTabs(tab_strip_->GetBrowser())) {      \
-    if (dragged_group.has_value() && candidate_index != 0 &&                   \
-        tab_strip_->controller_->IsTabPinned(candidate_index - 1))             \
-      continue;                                                                \
-    int distance = std::numeric_limits<int>::max();                            \
-    const gfx::Rect candidate_bounds =                                         \
-        candidate_index == 0                                                   \
-            ? gfx::Rect()                                                      \
-            : tab_strip_->tab_container_->GetIdealBounds(candidate_index - 1); \
-    if (tab_strip_->controller_->IsTabPinned(first_dragged_tab_index)) {       \
-      /* Pinned tabs are laid out in a grid. */                                \
-      distance = std::sqrt(                                                    \
-          std::pow(dragged_bounds.x() - candidate_bounds.CenterPoint().x(),    \
-                   2) +                                                        \
-          std::pow(dragged_bounds.y() - candidate_bounds.CenterPoint().y(),    \
-                   2));                                                        \
-    } else {                                                                   \
-      /* Unpinned tabs are laid out vertically. So we consider only y */       \
-      /* coordinate */                                                         \
-      distance = std::abs(dragged_bounds.y() - candidate_bounds.bottom());     \
-    }                                                                          \
-    if (distance < min_distance) {                                             \
-      min_distance = distance;                                                 \
-      min_distance_index = candidate_index;                                    \
-    }                                                                          \
-    continue;                                                                  \
+#define BRAVE_CALCULATE_INSERTION_INDEX                                       \
+  if (tabs::features::ShouldShowVerticalTabs(tab_strip_->GetBrowser())) {     \
+    tabs::UpdateInsertionIndexForVerticalTabs(                                \
+        dragged_bounds, first_dragged_tab_index, num_dragged_tabs,            \
+        dragged_group, candidate_index, tab_strip_->controller_.get(),        \
+        &tab_strip_->tab_container_.get(), min_distance, min_distance_index); \
+    continue;                                                                 \
   }
 
-#define BRAVE_CALCULATE_BOUNDS_FOR_DRAGGED_VIEWS                           \
-  if (tabs::features::ShouldShowVerticalTabs(tab_strip_->GetBrowser())) {  \
-    std::vector<gfx::Rect> bounds;                                         \
-    int x = 0;                                                             \
-    int y = 0;                                                             \
-    for (const TabSlotView* view : views) {                                \
-      const int height = view->height();                                   \
-      if (view->GetTabSlotViewType() == TabSlotView::ViewType::kTab) {     \
-        if (const Tab* tab = static_cast<const Tab*>(view);                \
-            tab->data().pinned) {                                          \
-          /* In case it's a pinned tab, lay out them horizontally */       \
-          bounds.emplace_back(x, y, tabs::kVerticalTabMinWidth, height);   \
-          constexpr int kStackedOffset = 4;                                \
-          x += kStackedOffset;                                             \
-          continue;                                                        \
-        }                                                                  \
-        if (view->group().has_value()) {                                   \
-          /* In case it's a tab in a group, set left padding */            \
-          x = BraveTabGroupHeader::GetLeftPaddingForVerticalTabs();        \
-        }                                                                  \
-      }                                                                    \
-      bounds.emplace_back(x, y, TabStyle::GetStandardWidth() - x, height); \
-      /* unpinned dragged tabs are laid out vertically */                  \
-      y += height;                                                         \
-    }                                                                      \
-    return bounds;                                                         \
+#define BRAVE_CALCULATE_BOUNDS_FOR_DRAGGED_VIEWS                          \
+  if (tabs::features::ShouldShowVerticalTabs(tab_strip_->GetBrowser())) { \
+    return tabs::CalculateBoundsForVerticalDraggedViews(views);           \
   }
 
 #include "src/chrome/browser/ui/views/tabs/tab_strip.cc"

--- a/chromium_src/chrome/browser/ui/views/tabs/tab_strip.cc
+++ b/chromium_src/chrome/browser/ui/views/tabs/tab_strip.cc
@@ -5,11 +5,14 @@
 
 #include "chrome/browser/ui/views/tabs/tab_strip.h"
 
+#include <cmath>
+
 #include "brave/browser/ui/views/tabs/brave_compound_tab_container.h"
 #include "brave/browser/ui/views/tabs/brave_tab.h"
 #include "brave/browser/ui/views/tabs/brave_tab_group_header.h"
 #include "brave/browser/ui/views/tabs/brave_tab_hover_card_controller.h"
 #include "brave/browser/ui/views/tabs/features.h"
+#include "chrome/browser/ui/ui_features.h"
 #include "chrome/browser/ui/views/tabs/browser_tab_strip_controller.h"
 #include "chrome/browser/ui/views/tabs/compound_tab_container.h"
 #include "chrome/browser/ui/views/tabs/tab_container.h"
@@ -24,33 +27,58 @@
 #define CompoundTabContainer BraveCompoundTabContainer
 #define TabContainerImpl BraveTabContainer
 #define TabHoverCardController BraveTabHoverCardController
-#define BRAVE_CALCULATE_INSERTION_INDEX                                       \
-  if (tabs::features::ShouldShowVerticalTabs(tab_strip_->GetBrowser())) {     \
-    const int ideal_y =                                                       \
-        candidate_index == 0                                                  \
-            ? 0                                                               \
-            : tab_strip_->tab_container_->GetIdealBounds(candidate_index - 1) \
-                  .bottom();                                                  \
-    const int distance = std::abs(dragged_bounds.y() - ideal_y);              \
-    if (distance < min_distance) {                                            \
-      min_distance = distance;                                                \
-      min_distance_index = candidate_index;                                   \
-    }                                                                         \
-    continue;                                                                 \
+#define BRAVE_CALCULATE_INSERTION_INDEX                                        \
+  if (tabs::features::ShouldShowVerticalTabs(tab_strip_->GetBrowser())) {      \
+    if (dragged_group.has_value() && candidate_index != 0 &&                   \
+        tab_strip_->controller_->IsTabPinned(candidate_index - 1))             \
+      continue;                                                                \
+    int distance = std::numeric_limits<int>::max();                            \
+    const gfx::Rect candidate_bounds =                                         \
+        candidate_index == 0                                                   \
+            ? gfx::Rect()                                                      \
+            : tab_strip_->tab_container_->GetIdealBounds(candidate_index - 1); \
+    if (tab_strip_->controller_->IsTabPinned(first_dragged_tab_index)) {       \
+      /* Pinned tabs are laid out in a grid. */                                \
+      distance = std::sqrt(                                                    \
+          std::pow(dragged_bounds.x() - candidate_bounds.CenterPoint().x(),    \
+                   2) +                                                        \
+          std::pow(dragged_bounds.y() - candidate_bounds.CenterPoint().y(),    \
+                   2));                                                        \
+    } else {                                                                   \
+      /* Unpinned tabs are laid out vertically. So we consider only y */       \
+      /* coordinate */                                                         \
+      distance = std::abs(dragged_bounds.y() - candidate_bounds.bottom());     \
+    }                                                                          \
+    if (distance < min_distance) {                                             \
+      min_distance = distance;                                                 \
+      min_distance_index = candidate_index;                                    \
+    }                                                                          \
+    continue;                                                                  \
   }
 
 #define BRAVE_CALCULATE_BOUNDS_FOR_DRAGGED_VIEWS                           \
   if (tabs::features::ShouldShowVerticalTabs(tab_strip_->GetBrowser())) {  \
     std::vector<gfx::Rect> bounds;                                         \
+    int x = 0;                                                             \
     int y = 0;                                                             \
     for (const TabSlotView* view : views) {                                \
-      int x = 0;                                                           \
-      if (view->GetTabSlotViewType() == TabSlotView::ViewType::kTab &&     \
-          view->group().has_value()) {                                     \
-        x = BraveTabGroupHeader::GetLeftPaddingForVerticalTabs();          \
-      }                                                                    \
       const int height = view->height();                                   \
+      if (view->GetTabSlotViewType() == TabSlotView::ViewType::kTab) {     \
+        if (const Tab* tab = static_cast<const Tab*>(view);                \
+            tab->data().pinned) {                                          \
+          /* In case it's a pinned tab, lay out them horizontally */       \
+          bounds.emplace_back(x, y, tabs::kVerticalTabMinWidth, height);   \
+          constexpr int kStackedOffset = 4;                                \
+          x += kStackedOffset;                                             \
+          continue;                                                        \
+        }                                                                  \
+        if (view->group().has_value()) {                                   \
+          /* In case it's a tab in a group, set left padding */            \
+          x = BraveTabGroupHeader::GetLeftPaddingForVerticalTabs();        \
+        }                                                                  \
+      }                                                                    \
       bounds.emplace_back(x, y, TabStyle::GetStandardWidth() - x, height); \
+      /* unpinned dragged tabs are laid out vertically */                  \
       y += height;                                                         \
     }                                                                      \
     return bounds;                                                         \
@@ -58,6 +86,7 @@
 
 #include "src/chrome/browser/ui/views/tabs/tab_strip.cc"
 
+#undef kSplitTabStrip
 #undef BRAVE_CALCULATE_BOUNDS_FOR_DRAGGED_VIEWS
 #undef BRAVE_CALCULATE_INSERTION_INDEX
 #undef TabHoverCardController


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/27066
Resolves https://github.com/brave/brave-browser/issues/26948

### Demo
https://user-images.githubusercontent.com/5474642/204832208-b682a7d4-cc80-4ab8-a471-91ccb4b66509.mov

Previously, we can't tell unpinned tabs from pinned tabs as they
look alike. In order to solve this, we need to change layout constraints
of pinned tabs - Use grid layout for pinned tabs.

In order to do this, make use of CompoundTabContainer from upstream.
CompoundTabContainer consists of two TabContainerImpl. One is for pinned
tabs and the other is for unpinned tabs. With this we can easily
distinguish pinned tabs and unpinned tabs. In addition, we have another
feature request to make unpinned tabs sticky, which means pinned tabs
should be out of scroll area. Thus, using CompoundTabContainer would be
a good move for that as well.

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
### Manual
- Enable vertical tabs
- Pin some tabs
- Check if the pinned tabs are laid out in a grid, when the vertical tab strip is expanded
- Check if other functionality of tab strip works well.
