### PR TITLE
Fixes leaking of full version via navigator.userAgentData.getHighEntropyValues

### DIFF
--- a/browser/brave_content_browser_client.cc
+++ b/browser/brave_content_browser_client.cc
@@ -1066,37 +1066,19 @@ void BraveContentBrowserClient::OverrideWebkitPrefs(WebContents* web_contents,
 blink::UserAgentMetadata BraveContentBrowserClient::GetUserAgentMetadata() {
   blink::UserAgentMetadata metadata =
       ChromeContentBrowserClient::GetUserAgentMetadata();
-  if (metadata.brand_version_list.size() == 2) {
-    // some logic copied from upstream GetUserAgentBrandList and
-    // GenerateBrandVersionList
-    std::string major_version_string = version_info::GetMajorVersionNumber();
-    int seed = 0;
-    DCHECK(base::StringToInt(major_version_string, &seed));
-    DCHECK_GE(seed, 0);
-    blink::UserAgentBrandVersion greasey_bv =
-        metadata.brand_version_list[seed % 2];
-    blink::UserAgentBrandVersion chromium_bv =
-        metadata.brand_version_list[(seed + 1) % 2];
-    blink::UserAgentBrandVersion brave_bv = {
-        l10n_util::GetStringUTF8(IDS_PRODUCT_NAME), chromium_bv.version};
-    const int npermutations = 6;  // 3!
-    int permutation = seed % npermutations;
-    const std::vector<std::vector<int>> orders{{0, 1, 2}, {0, 2, 1}, {1, 0, 2},
-                                               {1, 2, 0}, {2, 0, 1}, {2, 1, 0}};
-    const std::vector<int> order = orders[permutation];
-    blink::UserAgentBrandList greased_brand_version_list(3);
-    greased_brand_version_list[order[0]] = greasey_bv;
-    greased_brand_version_list[order[1]] = chromium_bv;
-    greased_brand_version_list[order[2]] = brave_bv;
-    metadata.brand_version_list = greased_brand_version_list;
-    greasey_bv.version = base::StrCat({greasey_bv.version, ".0.0.0"});
-    chromium_bv.version = base::StrCat({chromium_bv.version, ".0.0.0"});
-    brave_bv.version = base::StrCat({brave_bv.version, ".0.0.0"});
-    blink::UserAgentBrandList greased_brand_full_version_list(3);
-    greased_brand_full_version_list[order[0]] = greasey_bv;
-    greased_brand_full_version_list[order[1]] = chromium_bv;
-    greased_brand_full_version_list[order[2]] = brave_bv;
-    metadata.brand_full_version_list = greased_brand_full_version_list;
+  // Expect the brand version lists to have brand version, chromium_version, and
+  // greased version.
+  DCHECK_EQ(3UL, metadata.brand_version_list.size());
+  DCHECK_EQ(3UL, metadata.brand_full_version_list.size());
+  // Zero out the last 3 version components in full version list versions.
+  for (auto& brand_version : metadata.brand_full_version_list) {
+    base::Version version(brand_version.version);
+    brand_version.version =
+        base::StrCat({base::NumberToString(version.components()[0]), ".0.0.0"});
   }
+  // Zero out the last 3 version components in full version.
+  base::Version version(metadata.full_version);
+  metadata.full_version =
+      base::StrCat({base::NumberToString(version.components()[0]), ".0.0.0"});
   return metadata;
 }


### PR DESCRIPTION
Fixes brave/brave-browser#23491

It seems `uaFullVersion` was always leaking but the `fullVersionList` started leaking because of the change in
https://github.com/brave/brave-core/pull/14155 where brand was added to `GetUserAgentBrandList` function in
`components/embedder_support/user_agent_utils.cc` which broke the `BraveContentBrowserClient::GetUserAgentMetadata` expectation that the brand list would only contain 2 items (instead of now 3).

This fix adjusts the `BraveContentBrowserClient::GetUserAgentMetadata` expectations and removes adding the Brave brand to the lists because it's already there. Now we just zero out the 3 last components of the full versions list and `uaFullVersion` string.

Also, adds a browser test to check the sizes of the lists and versions values.

## Submitter Checklist:

- [ ] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

