### PR TITLE
Add flag to control autotranslate feature

### DIFF
--- a/browser/translate/brave_translate_browsertest.cc
+++ b/browser/translate/brave_translate_browsertest.cc
@@ -310,6 +310,40 @@ IN_PROC_BROWSER_TEST_F(BraveTranslateBrowserTest, InternalTranslation) {
   EXPECT_TRUE(TranslateDownloadManager::IsSupportedLanguage("ar"));
   EXPECT_TRUE(TranslateDownloadManager::IsSupportedLanguage("vi"));
 }
+
+class BraveTranslateBrowserNoAutoTranslateTest
+    : public BraveTranslateBrowserTest {
+ public:
+  BraveTranslateBrowserNoAutoTranslateTest() {
+    scoped_feature_list_.InitAndDisableFeature(
+        features::kBraveEnableAutoTranslate);
+  }
+
+ private:
+  base::test::ScopedFeatureList scoped_feature_list_;
+};
+
+IN_PROC_BROWSER_TEST_F(BraveTranslateBrowserNoAutoTranslateTest,
+                       NoAutoTranslate) {
+  // Set auto translate from es to en.
+  GetChromeTranslateClient()
+      ->GetTranslatePrefs()
+      ->AddLanguagePairToAlwaysTranslateList("es", "en");
+  ResetObserver();
+  ASSERT_TRUE(ui_test_utils::NavigateToURL(
+      browser(), embedded_test_server()->GetURL("/espanol_page.html")));
+  WaitUntilLanguageDetermined();
+
+  auto* bubble = TranslateBubbleController::FromWebContents(
+                     browser()->tab_strip_model()->GetActiveWebContents())
+                     ->GetTranslateBubble();
+  ASSERT_TRUE(bubble);
+
+  // Check that the we see BEFORE translation bubble (not in-progress bubble).
+  ASSERT_EQ(bubble->GetWindowTitle(),
+            brave_l10n::GetLocalizedResourceUTF16String(
+                IDS_TRANSLATE_BUBBLE_BEFORE_TRANSLATE_TITLE));
+}
 #endif  // BUILDFLAG(ENABLE_BRAVE_TRANSLATE_GO)
 
 class BraveTranslateBrowserGoogleRedirectTest

--- a/chromium_src/chrome/browser/ui/android/infobars/translate_compact_infobar.cc
+++ b/chromium_src/chrome/browser/ui/android/infobars/translate_compact_infobar.cc
@@ -1,0 +1,26 @@
+/* Copyright (c) 2022 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "chrome/browser/ui/android/infobars/translate_compact_infobar.h"
+
+#include "brave/components/translate/core/common/brave_translate_features.h"
+#include "chrome/android/chrome_jni_headers/TranslateCompactInfoBar_jni.h"
+#include "components/translate/core/browser/translate_driver.h"
+
+#define IsIncognito IsIncognito_ChromiumImpl
+#include "src/chrome/browser/ui/android/infobars/translate_compact_infobar.cc"
+#undef IsIncognito
+
+jboolean TranslateCompactInfoBar::IsIncognito(
+    JNIEnv* env,
+    const base::android::JavaParamRef<jobject>& obj) {
+  if (!translate::IsBraveAutoTranslateEnabled()) {
+    // Setting incognito mode disables UI elements related to auto
+    // translate. "Never translate <something>" options should still work.
+    return true;
+  }
+
+  return IsIncognito_ChromiumImpl(env, obj);
+}

--- a/chromium_src/chrome/browser/ui/android/infobars/translate_compact_infobar.h
+++ b/chromium_src/chrome/browser/ui/android/infobars/translate_compact_infobar.h
@@ -1,0 +1,17 @@
+/* Copyright (c) 2022 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_CHROMIUM_SRC_CHROME_BROWSER_UI_ANDROID_INFOBARS_TRANSLATE_COMPACT_INFOBAR_H_
+#define BRAVE_CHROMIUM_SRC_CHROME_BROWSER_UI_ANDROID_INFOBARS_TRANSLATE_COMPACT_INFOBAR_H_
+
+// Add a method that will be used to redirect chromium impl in .cc file.
+#define action_flags_                \
+  action_flags_;                     \
+  jboolean IsIncognito_ChromiumImpl( \
+      JNIEnv* env, const base::android::JavaParamRef<jobject>& obj)
+#include "src/chrome/browser/ui/android/infobars/translate_compact_infobar.h"
+#undef action_flags_
+
+#endif  // BRAVE_CHROMIUM_SRC_CHROME_BROWSER_UI_ANDROID_INFOBARS_TRANSLATE_COMPACT_INFOBAR_H_

--- a/chromium_src/chrome/browser/ui/views/translate/translate_bubble_view.h
+++ b/chromium_src/chrome/browser/ui/views/translate/translate_bubble_view.h
@@ -6,15 +6,33 @@
 #ifndef BRAVE_CHROMIUM_SRC_CHROME_BROWSER_UI_VIEWS_TRANSLATE_TRANSLATE_BUBBLE_VIEW_H_
 #define BRAVE_CHROMIUM_SRC_CHROME_BROWSER_UI_VIEWS_TRANSLATE_TRANSLATE_BUBBLE_VIEW_H_
 
+class TranslateBubbleView;
+using BraveTranslateBubbleView = TranslateBubbleView;
+
 #define TranslateBubbleView TranslateBubbleView_ChromiumImpl
 #define CreateTranslateIcon virtual CreateTranslateIcon
+#define is_in_incognito_window_           \
+  unused_is_in_incognito_window_ = false; \
+  friend BraveTranslateBubbleView;        \
+  bool is_in_incognito_window_ /* make the field non-constant */
 #include "src/chrome/browser/ui/views/translate/translate_bubble_view.h"
+#undef is_in_incognito_window_
 #undef CreateTranslateIcon
 #undef TranslateBubbleView
 
+#include "brave/components/translate/core/common/brave_translate_features.h"
+
 class TranslateBubbleView : public TranslateBubbleView_ChromiumImpl {
  public:
-  using TranslateBubbleView_ChromiumImpl::TranslateBubbleView_ChromiumImpl;
+  template <class... Args>
+  explicit TranslateBubbleView(Args&&... args)
+      : TranslateBubbleView_ChromiumImpl(std::forward<Args>(args)...) {
+    if (!translate::IsBraveAutoTranslateEnabled()) {
+      // Setting incognito mode disables UI elements connected to auto
+      // translate. "Never translate lang" options should still work.
+      is_in_incognito_window_ = true;
+    }
+  }
 
   std::unique_ptr<views::ImageView> CreateTranslateIcon() override;
 };

--- a/chromium_src/components/translate/core/browser/translate_prefs.cc
+++ b/chromium_src/components/translate/core/browser/translate_prefs.cc
@@ -7,6 +7,23 @@
 // chromium_src/chrome/browser/prefs/browser_prefs.cc
 #include "components/translate/core/browser/translate_prefs.h"
 
+#include "brave/components/translate/core/common/brave_translate_features.h"
+
 #define MigrateObsoleteProfilePrefs MigrateObsoleteProfilePrefs_ChromiumImpl
+#define TranslatePrefs TranslatePrefs_ChromiumImpl
 #include "src/components/translate/core/browser/translate_prefs.cc"
+#undef TranslatePrefs
 #undef MigrateObsoleteProfilePrefs
+
+namespace translate {
+
+bool TranslatePrefs::ShouldAutoTranslate(base::StringPiece source_language,
+                                         std::string* target_language) {
+  if (!IsBraveAutoTranslateEnabled()) {
+    return false;
+  }
+
+  return TranslatePrefs_ChromiumImpl::ShouldAutoTranslate(source_language,
+                                                          target_language);
+}
+}  // namespace translate

--- a/chromium_src/components/translate/core/browser/translate_prefs.h
+++ b/chromium_src/components/translate/core/browser/translate_prefs.h
@@ -9,7 +9,21 @@
 // This is done to allow the same renaming in
 // chromium_src/chrome/browser/prefs/browser_prefs.cc
 #define MigrateObsoleteProfilePrefs MigrateObsoleteProfilePrefs_ChromiumImpl
+#define TranslatePrefs TranslatePrefs_ChromiumImpl
 #include "src/components/translate/core/browser/translate_prefs.h"
+#undef TranslatePrefs
 #undef MigrateObsoleteProfilePrefs
+
+namespace translate {
+class TranslatePrefs : public TranslatePrefs_ChromiumImpl {
+ public:
+  using TranslatePrefs_ChromiumImpl::TranslatePrefs_ChromiumImpl;
+
+  // Override to control by Brave features. No virtual because TranslatePrefs
+  // doesn't have a virtual dtor and the method isn't used inside the impl.
+  bool ShouldAutoTranslate(base::StringPiece source_language,
+                           std::string* target_language);
+};
+}  // namespace translate
 
 #endif  // BRAVE_CHROMIUM_SRC_COMPONENTS_TRANSLATE_CORE_BROWSER_TRANSLATE_PREFS_H_

--- a/chromium_src/components/translate/core/browser/translate_ui_delegate.cc
+++ b/chromium_src/components/translate/core/browser/translate_ui_delegate.cc
@@ -1,0 +1,32 @@
+/* Copyright (c) 2022 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "components/translate/core/browser/translate_ui_delegate.h"
+
+#include "brave/components/translate/core/common/brave_translate_features.h"
+
+#define TranslateUIDelegate TranslateUIDelegate_ChromiumImpl
+#include "src/components/translate/core/browser/translate_ui_delegate.cc"
+#undef TranslateUIDelegate
+
+namespace translate {
+
+bool TranslateUIDelegate::ShouldShowAlwaysTranslateShortcut() const {
+  if (!IsBraveAutoTranslateEnabled())
+    return false;
+
+  return TranslateUIDelegate_ChromiumImpl::ShouldShowAlwaysTranslateShortcut();
+}
+
+#if BUILDFLAG(IS_ANDROID) || BUILDFLAG(IS_IOS)
+bool TranslateUIDelegate::ShouldAutoAlwaysTranslate() {
+  if (!IsBraveAutoTranslateEnabled())
+    return false;
+
+  return TranslateUIDelegate_ChromiumImpl::ShouldAutoAlwaysTranslate();
+}
+#endif  // BUILDFLAG(IS_ANDROID) || BUILDFLAG(IS_IOS)
+
+}  // namespace translate

--- a/chromium_src/components/translate/core/browser/translate_ui_delegate.h
+++ b/chromium_src/components/translate/core/browser/translate_ui_delegate.h
@@ -1,0 +1,32 @@
+/* Copyright (c) 2022 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_CHROMIUM_SRC_COMPONENTS_TRANSLATE_CORE_BROWSER_TRANSLATE_UI_DELEGATE_H_
+#define BRAVE_CHROMIUM_SRC_COMPONENTS_TRANSLATE_CORE_BROWSER_TRANSLATE_UI_DELEGATE_H_
+
+#define TranslateUIDelegate TranslateUIDelegate_ChromiumImpl
+#define ShouldShowAlwaysTranslateShortcut \
+  virtual ShouldShowAlwaysTranslateShortcut
+#define ShouldAutoAlwaysTranslate virtual ShouldAutoAlwaysTranslate
+#include "src/components/translate/core/browser/translate_ui_delegate.h"
+#undef ShouldAutoAlwaysTranslate
+#undef ShouldShowAlwaysTranslateShortcut
+#undef TranslateUIDelegate
+
+namespace translate {
+
+class TranslateUIDelegate : public TranslateUIDelegate_ChromiumImpl {
+ public:
+  using TranslateUIDelegate_ChromiumImpl::TranslateUIDelegate_ChromiumImpl;
+  bool ShouldShowAlwaysTranslateShortcut() const override;
+
+#if BUILDFLAG(IS_ANDROID) || BUILDFLAG(IS_IOS)
+  bool ShouldAutoAlwaysTranslate() override;
+#endif  // BUILDFLAG(IS_ANDROID) || BUILDFLAG(IS_IOS)
+};
+
+}  // namespace translate
+
+#endif  // BRAVE_CHROMIUM_SRC_COMPONENTS_TRANSLATE_CORE_BROWSER_TRANSLATE_UI_DELEGATE_H_

--- a/components/translate/core/common/brave_translate_features.cc
+++ b/components/translate/core/common/brave_translate_features.cc
@@ -18,6 +18,9 @@ BASE_FEATURE(kUseBraveTranslateGo,
 const base::FeatureParam<bool> kUpdateLanguageListParam{
     &kUseBraveTranslateGo, "update-languages", false};
 
+BASE_FEATURE(kBraveEnableAutoTranslate,
+             "BraveEnableAutoTranslate",
+             base::FeatureState::FEATURE_ENABLED_BY_DEFAULT);
 }  // namespace features
 
 bool IsBraveTranslateGoAvailable() {
@@ -33,6 +36,10 @@ bool UseGoogleTranslateEndpoint() {
   return IsBraveTranslateGoAvailable() &&
          base::CommandLine::ForCurrentProcess()->HasSwitch(
              switches::kBraveTranslateUseGoogleEndpoint);
+}
+
+bool IsBraveAutoTranslateEnabled() {
+  return base::FeatureList::IsEnabled(features::kBraveEnableAutoTranslate);
 }
 
 }  // namespace translate

--- a/components/translate/core/common/brave_translate_features.h
+++ b/components/translate/core/common/brave_translate_features.h
@@ -17,6 +17,8 @@ BASE_DECLARE_FEATURE(kUseBraveTranslateGo);
 extern const base::FeatureParam<bool> kUpdateLanguageListParam;
 extern const base::FeatureParam<bool> kReplaceSecurityOriginParam;
 
+BASE_DECLARE_FEATURE(kBraveEnableAutoTranslate);
+
 }  // namespace features
 
 // The translate engine can work the folowing ways:
@@ -33,6 +35,10 @@ bool ShouldUpdateLanguagesList();
 // True if the actual translate requests in the scripts are redirected to the
 // google translate endpoint. False by default, use it only for local testing.
 bool UseGoogleTranslateEndpoint();
+
+// True if automatic translation logic is enabled.
+// Includes core logic and UI elements.
+bool IsBraveAutoTranslateEnabled();
 
 }  // namespace translate
 


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/27040

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
A new feature `BraveEnableAutoTranslate` is introduced. The feature is **enabled** by default.
The feature controls: 1) core logic that triggers auto-translate 2) UI elements on Desktop&Android.
Only one out of 3 desktop platform could be checked (the code is common).

The scenarios:
**Default** (Desktop & Android) nothing should be changed in auto-translate if the feature is enabled(the default). Auto-translation works, UI elements are shown.

**UI elements** (Desktop & Android) With the feature disabled the UI elements in the translate bubble **related to auto-translation** should be hidden. The option named "never translate <lang>" should be still visible and works.

**Auto-translate is enabled before** (Desktop & Android) 
1. Launch the browser without feature disabled (default);
2. Enable auto-translate `fr => en` (via the translate bubble on fr.wikipedia.org for example);
3. Close the tab and open it again, check that auto-translate works for fr.wikipedia.org;
4. Relaunch the browser with the feature disabled (`--disable-features=BraveEnableAutoTranslate`);
5. Check that auto-translate doesn't work for fr.wikipedia.org.

**Auto enabling auto-translate** (Android)
1. Launch the browser without feature disabled (default);
2. Auto-translate some French page 3 times  (for example 3 tabs with fr.wikipedia.org) and check that auto-translation for `fr=> <your lang>` has been enabled automatically on the 3rd attempt;
3. Clean the app data;
4. Launch the browser with the feature disabled (`--disable-features=BraveEnableAutoTranslate`); 
5. Repeat step 2 and check that auto-translation wasn't enabled.


The screenshots of related UI elements:
<img width="427" alt="Screenshot 2022-11-24 at 18 14 07" src="https://user-images.githubusercontent.com/45488748/205645906-1d90201a-7bc9-4d9d-9aa2-c864987f1aad.png">
<img width="324" alt="Screenshot 2022-12-02 at 19 29 31" src="https://user-images.githubusercontent.com/45488748/205645911-a7e37418-2ea8-49c1-bc1e-3647bca695a8.png">
rg (=user's action is required to translate the page).
<img width="552" alt="Screenshot 2022-11-24 at 18 12 53" src="https://user-images.githubusercontent.com/45488748/205645895-529edfad-42cb-44cf-84be-bb6be4bcd2c4.png">