### PR TITLE
Fix #27100: Revert Rust 1.1.0 to 1.0.0

### DIFF
--- a/script/deps_config.py
+++ b/script/deps_config.py
@@ -8,7 +8,7 @@ import os
 # Version number and URL for pre-configured rust dependency package
 # e.g. rust_deps_mac_0.1.0.gz
 DEPS_PACKAGES_URL = "https://brave-build-deps-public.s3.brave.com"
-RUST_DEPS_PACKAGE_VERSION = "1.1.0"
+RUST_DEPS_PACKAGE_VERSION = "1.0.0"
 MAC_TOOLCHAIN_ROOT = os.path.join(os.path.dirname(os.path.dirname(
                                   os.path.dirname(__file__))),
                                   'build', 'mac_files')


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/27100

We could also do:
```
diff --git a/build/commands/lib/config.js b/build/commands/lib/config.js
index e41a8deede..84772a6dfc 100644
--- a/build/commands/lib/config.js
+++ b/build/commands/lib/config.js
@@ -505,6 +505,9 @@ Config.prototype.buildArgs = function () {
     if (this.targetEnvironment) {
       args.target_environment = this.targetEnvironment
     }
+    if (this.targetArch == 'x64' && this.isDebug()) {
+      args.use_lld = false
+    }
     args.enable_dsyms = true
     args.enable_stripping = !this.isComponentBuild()
     // Component builds are not supported for iOS:
diff --git a/build/rust/BUILD.gn b/build/rust/BUILD.gn
index 72fb9f5735..34575c7270 100644
--- a/build/rust/BUILD.gn
+++ b/build/rust/BUILD.gn
@@ -19,7 +19,7 @@ config("strip_rust_symbols") {
     # Too many personalities workaround. Will be fixed in llvm see
     # https://reviews.llvm.org/D135728
     if (!is_component_build && !use_lld) {
-      ldflags = [ "-Wl,-no_compact_unwind" ]
+      ldflags += [ "-Wl,-no_compact_unwind" ]
     }
   }
 }
```
if we wanted to compile 1.1.0 with `ld` instead of `lld`

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

