### PR TITLE
Don't show current year for license header in existing files.

### DIFF
--- a/PRESUBMIT.py
+++ b/PRESUBMIT.py
@@ -104,18 +104,22 @@ def CheckLicense(input_api, output_api):
     assert existing_file_license_re.search(multiline_comment_expected_license)
 
     # Show this to simplify copy-paste when an invalid license is found.
-    expected_license_message = (
-        f'Expected one of license headers:\n'
-        f'{expected_license_template.replace("#", "//")}\n'
-        f'{multiline_comment_expected_license}\n'
-        f'{expected_license_template}')
+    expected_licenses = (f'{expected_license_template.replace("#", "//")}\n'
+                         f'{multiline_comment_expected_license}\n'
+                         f'{expected_license_template}')
 
     result = []
     if bad_new_files:
+        expected_license_message = (
+            f'Expected one of license headers in new files:\n'
+            f'{expected_licenses}')
         result.append(
             output_api.PresubmitError(expected_license_message,
                                       items=bad_new_files))
     if bad_files:
+        expected_license_message = (
+            f'Expected one of license headers in existing files:\n'
+            f'{expected_licenses.replace(f"{current_year}", "<year>")}')
         result.append(
             output_api.PresubmitPromptWarning(expected_license_message,
                                               items=bad_files))


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
To not encourage overwriting the license year in existing files, this message will be shown instead:
```
Expected one of license headers in existing files:
// Copyright (c) <year> The Brave Authors. All rights reserved.
// This Source Code Form is subject to the terms of the Mozilla Public
// License, v. 2.0. If a copy of the MPL was not distributed with this file,
// You can obtain one at https://mozilla.org/MPL/2.0/.

/* Copyright (c) <year> The Brave Authors. All rights reserved.
 * This Source Code Form is subject to the terms of the Mozilla Public
 * License, v. 2.0. If a copy of the MPL was not distributed with this file,
 * You can obtain one at https://mozilla.org/MPL/2.0/. */

# Copyright (c) <year> The Brave Authors. All rights reserved.
# This Source Code Form is subject to the terms of the Mozilla Public
# License, v. 2.0. If a copy of the MPL was not distributed with this file,
# You can obtain one at https://mozilla.org/MPL/2.0/.
```

Related https://github.com/brave/brave-browser/issues/25517

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

