### PR TITLE
Add flag to control autotranslate feature (uplift to 1.47.x)

### DIFF
--- a/browser/translate/brave_translate_browsertest.cc
+++ b/browser/translate/brave_translate_browsertest.cc
@@ -310,6 +310,40 @@ IN_PROC_BROWSER_TEST_F(BraveTranslateBrowserTest, InternalTranslation) {
   EXPECT_TRUE(TranslateDownloadManager::IsSupportedLanguage("ar"));
   EXPECT_TRUE(TranslateDownloadManager::IsSupportedLanguage("vi"));
 }
+
+class BraveTranslateBrowserNoAutoTranslateTest
+    : public BraveTranslateBrowserTest {
+ public:
+  BraveTranslateBrowserNoAutoTranslateTest() {
+    scoped_feature_list_.InitAndDisableFeature(
+        features::kBraveEnableAutoTranslate);
+  }
+
+ private:
+  base::test::ScopedFeatureList scoped_feature_list_;
+};
+
+IN_PROC_BROWSER_TEST_F(BraveTranslateBrowserNoAutoTranslateTest,
+                       NoAutoTranslate) {
+  // Set auto translate from es to en.
+  GetChromeTranslateClient()
+      ->GetTranslatePrefs()
+      ->AddLanguagePairToAlwaysTranslateList("es", "en");
+  ResetObserver();
+  ASSERT_TRUE(ui_test_utils::NavigateToURL(
+      browser(), embedded_test_server()->GetURL("/espanol_page.html")));
+  WaitUntilLanguageDetermined();
+
+  auto* bubble = TranslateBubbleController::FromWebContents(
+                     browser()->tab_strip_model()->GetActiveWebContents())
+                     ->GetTranslateBubble();
+  ASSERT_TRUE(bubble);
+
+  // Check that the we see BEFORE translation bubble (not in-progress bubble).
+  ASSERT_EQ(bubble->GetWindowTitle(),
+            brave_l10n::GetLocalizedResourceUTF16String(
+                IDS_TRANSLATE_BUBBLE_BEFORE_TRANSLATE_TITLE));
+}
 #endif  // BUILDFLAG(ENABLE_BRAVE_TRANSLATE_GO)
 
 class BraveTranslateBrowserGoogleRedirectTest

--- a/chromium_src/chrome/browser/ui/android/infobars/translate_compact_infobar.cc
+++ b/chromium_src/chrome/browser/ui/android/infobars/translate_compact_infobar.cc
@@ -1,0 +1,26 @@
+/* Copyright (c) 2022 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "chrome/browser/ui/android/infobars/translate_compact_infobar.h"
+
+#include "brave/components/translate/core/common/brave_translate_features.h"
+#include "chrome/android/chrome_jni_headers/TranslateCompactInfoBar_jni.h"
+#include "components/translate/core/browser/translate_driver.h"
+
+#define IsIncognito IsIncognito_ChromiumImpl
+#include "src/chrome/browser/ui/android/infobars/translate_compact_infobar.cc"
+#undef IsIncognito
+
+jboolean TranslateCompactInfoBar::IsIncognito(
+    JNIEnv* env,
+    const base::android::JavaParamRef<jobject>& obj) {
+  if (!translate::IsBraveAutoTranslateEnabled()) {
+    // Setting incognito mode disables UI elements related to auto
+    // translate. "Never translate <something>" options should still work.
+    return true;
+  }
+
+  return IsIncognito_ChromiumImpl(env, obj);
+}

--- a/chromium_src/chrome/browser/ui/android/infobars/translate_compact_infobar.h
+++ b/chromium_src/chrome/browser/ui/android/infobars/translate_compact_infobar.h
@@ -1,0 +1,17 @@
+/* Copyright (c) 2022 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_CHROMIUM_SRC_CHROME_BROWSER_UI_ANDROID_INFOBARS_TRANSLATE_COMPACT_INFOBAR_H_
+#define BRAVE_CHROMIUM_SRC_CHROME_BROWSER_UI_ANDROID_INFOBARS_TRANSLATE_COMPACT_INFOBAR_H_
+
+// Add a method that will be used to redirect chromium impl in .cc file.
+#define action_flags_                \
+  action_flags_;                     \
+  jboolean IsIncognito_ChromiumImpl( \
+      JNIEnv* env, const base::android::JavaParamRef<jobject>& obj)
+#include "src/chrome/browser/ui/android/infobars/translate_compact_infobar.h"
+#undef action_flags_
+
+#endif  // BRAVE_CHROMIUM_SRC_CHROME_BROWSER_UI_ANDROID_INFOBARS_TRANSLATE_COMPACT_INFOBAR_H_

--- a/chromium_src/chrome/browser/ui/views/translate/translate_bubble_view.h
+++ b/chromium_src/chrome/browser/ui/views/translate/translate_bubble_view.h
@@ -6,15 +6,33 @@
 #ifndef BRAVE_CHROMIUM_SRC_CHROME_BROWSER_UI_VIEWS_TRANSLATE_TRANSLATE_BUBBLE_VIEW_H_
 #define BRAVE_CHROMIUM_SRC_CHROME_BROWSER_UI_VIEWS_TRANSLATE_TRANSLATE_BUBBLE_VIEW_H_
 
+class TranslateBubbleView;
+using BraveTranslateBubbleView = TranslateBubbleView;
+
 #define TranslateBubbleView TranslateBubbleView_ChromiumImpl
 #define CreateTranslateIcon virtual CreateTranslateIcon
+#define is_in_incognito_window_           \
+  unused_is_in_incognito_window_ = false; \
+  friend BraveTranslateBubbleView;        \
+  bool is_in_incognito_window_ /* make the field non-constant */
 #include "src/chrome/browser/ui/views/translate/translate_bubble_view.h"
+#undef is_in_incognito_window_
 #undef CreateTranslateIcon
 #undef TranslateBubbleView
 
+#include "brave/components/translate/core/common/brave_translate_features.h"
+
 class TranslateBubbleView : public TranslateBubbleView_ChromiumImpl {
  public:
-  using TranslateBubbleView_ChromiumImpl::TranslateBubbleView_ChromiumImpl;
+  template <class... Args>
+  explicit TranslateBubbleView(Args&&... args)
+      : TranslateBubbleView_ChromiumImpl(std::forward<Args>(args)...) {
+    if (!translate::IsBraveAutoTranslateEnabled()) {
+      // Setting incognito mode disables UI elements connected to auto
+      // translate. "Never translate lang" options should still work.
+      is_in_incognito_window_ = true;
+    }
+  }
 
   std::unique_ptr<views::ImageView> CreateTranslateIcon() override;
 };

--- a/chromium_src/components/translate/core/browser/translate_prefs.cc
+++ b/chromium_src/components/translate/core/browser/translate_prefs.cc
@@ -7,6 +7,23 @@
 // chromium_src/chrome/browser/prefs/browser_prefs.cc
 #include "components/translate/core/browser/translate_prefs.h"
 
+#include "brave/components/translate/core/common/brave_translate_features.h"
+
 #define MigrateObsoleteProfilePrefs MigrateObsoleteProfilePrefs_ChromiumImpl
+#define TranslatePrefs TranslatePrefs_ChromiumImpl
 #include "src/components/translate/core/browser/translate_prefs.cc"
+#undef TranslatePrefs
 #undef MigrateObsoleteProfilePrefs
+
+namespace translate {
+
+bool TranslatePrefs::ShouldAutoTranslate(base::StringPiece source_language,
+                                         std::string* target_language) {
+  if (!IsBraveAutoTranslateEnabled()) {
+    return false;
+  }
+
+  return TranslatePrefs_ChromiumImpl::ShouldAutoTranslate(source_language,
+                                                          target_language);
+}
+}  // namespace translate

--- a/chromium_src/components/translate/core/browser/translate_prefs.h
+++ b/chromium_src/components/translate/core/browser/translate_prefs.h
@@ -9,7 +9,21 @@
 // This is done to allow the same renaming in
 // chromium_src/chrome/browser/prefs/browser_prefs.cc
 #define MigrateObsoleteProfilePrefs MigrateObsoleteProfilePrefs_ChromiumImpl
+#define TranslatePrefs TranslatePrefs_ChromiumImpl
 #include "src/components/translate/core/browser/translate_prefs.h"
+#undef TranslatePrefs
 #undef MigrateObsoleteProfilePrefs
+
+namespace translate {
+class TranslatePrefs : public TranslatePrefs_ChromiumImpl {
+ public:
+  using TranslatePrefs_ChromiumImpl::TranslatePrefs_ChromiumImpl;
+
+  // Override to control by Brave features. No virtual because TranslatePrefs
+  // doesn't have a virtual dtor and the method isn't used inside the impl.
+  bool ShouldAutoTranslate(base::StringPiece source_language,
+                           std::string* target_language);
+};
+}  // namespace translate
 
 #endif  // BRAVE_CHROMIUM_SRC_COMPONENTS_TRANSLATE_CORE_BROWSER_TRANSLATE_PREFS_H_

--- a/chromium_src/components/translate/core/browser/translate_ui_delegate.cc
+++ b/chromium_src/components/translate/core/browser/translate_ui_delegate.cc
@@ -1,0 +1,32 @@
+/* Copyright (c) 2022 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "components/translate/core/browser/translate_ui_delegate.h"
+
+#include "brave/components/translate/core/common/brave_translate_features.h"
+
+#define TranslateUIDelegate TranslateUIDelegate_ChromiumImpl
+#include "src/components/translate/core/browser/translate_ui_delegate.cc"
+#undef TranslateUIDelegate
+
+namespace translate {
+
+bool TranslateUIDelegate::ShouldShowAlwaysTranslateShortcut() const {
+  if (!IsBraveAutoTranslateEnabled())
+    return false;
+
+  return TranslateUIDelegate_ChromiumImpl::ShouldShowAlwaysTranslateShortcut();
+}
+
+#if BUILDFLAG(IS_ANDROID) || BUILDFLAG(IS_IOS)
+bool TranslateUIDelegate::ShouldAutoAlwaysTranslate() {
+  if (!IsBraveAutoTranslateEnabled())
+    return false;
+
+  return TranslateUIDelegate_ChromiumImpl::ShouldAutoAlwaysTranslate();
+}
+#endif  // BUILDFLAG(IS_ANDROID) || BUILDFLAG(IS_IOS)
+
+}  // namespace translate

--- a/chromium_src/components/translate/core/browser/translate_ui_delegate.h
+++ b/chromium_src/components/translate/core/browser/translate_ui_delegate.h
@@ -1,0 +1,32 @@
+/* Copyright (c) 2022 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_CHROMIUM_SRC_COMPONENTS_TRANSLATE_CORE_BROWSER_TRANSLATE_UI_DELEGATE_H_
+#define BRAVE_CHROMIUM_SRC_COMPONENTS_TRANSLATE_CORE_BROWSER_TRANSLATE_UI_DELEGATE_H_
+
+#define TranslateUIDelegate TranslateUIDelegate_ChromiumImpl
+#define ShouldShowAlwaysTranslateShortcut \
+  virtual ShouldShowAlwaysTranslateShortcut
+#define ShouldAutoAlwaysTranslate virtual ShouldAutoAlwaysTranslate
+#include "src/components/translate/core/browser/translate_ui_delegate.h"
+#undef ShouldAutoAlwaysTranslate
+#undef ShouldShowAlwaysTranslateShortcut
+#undef TranslateUIDelegate
+
+namespace translate {
+
+class TranslateUIDelegate : public TranslateUIDelegate_ChromiumImpl {
+ public:
+  using TranslateUIDelegate_ChromiumImpl::TranslateUIDelegate_ChromiumImpl;
+  bool ShouldShowAlwaysTranslateShortcut() const override;
+
+#if BUILDFLAG(IS_ANDROID) || BUILDFLAG(IS_IOS)
+  bool ShouldAutoAlwaysTranslate() override;
+#endif  // BUILDFLAG(IS_ANDROID) || BUILDFLAG(IS_IOS)
+};
+
+}  // namespace translate
+
+#endif  // BRAVE_CHROMIUM_SRC_COMPONENTS_TRANSLATE_CORE_BROWSER_TRANSLATE_UI_DELEGATE_H_

--- a/components/translate/core/common/brave_translate_features.cc
+++ b/components/translate/core/common/brave_translate_features.cc
@@ -18,6 +18,9 @@ BASE_FEATURE(kUseBraveTranslateGo,
 const base::FeatureParam<bool> kUpdateLanguageListParam{
     &kUseBraveTranslateGo, "update-languages", false};
 
+BASE_FEATURE(kBraveEnableAutoTranslate,
+             "BraveEnableAutoTranslate",
+             base::FeatureState::FEATURE_ENABLED_BY_DEFAULT);
 }  // namespace features
 
 bool IsBraveTranslateGoAvailable() {
@@ -33,6 +36,10 @@ bool UseGoogleTranslateEndpoint() {
   return IsBraveTranslateGoAvailable() &&
          base::CommandLine::ForCurrentProcess()->HasSwitch(
              switches::kBraveTranslateUseGoogleEndpoint);
+}
+
+bool IsBraveAutoTranslateEnabled() {
+  return base::FeatureList::IsEnabled(features::kBraveEnableAutoTranslate);
 }
 
 }  // namespace translate

--- a/components/translate/core/common/brave_translate_features.h
+++ b/components/translate/core/common/brave_translate_features.h
@@ -17,6 +17,8 @@ BASE_DECLARE_FEATURE(kUseBraveTranslateGo);
 extern const base::FeatureParam<bool> kUpdateLanguageListParam;
 extern const base::FeatureParam<bool> kReplaceSecurityOriginParam;
 
+BASE_DECLARE_FEATURE(kBraveEnableAutoTranslate);
+
 }  // namespace features
 
 // The translate engine can work the folowing ways:
@@ -33,6 +35,10 @@ bool ShouldUpdateLanguagesList();
 // True if the actual translate requests in the scripts are redirected to the
 // google translate endpoint. False by default, use it only for local testing.
 bool UseGoogleTranslateEndpoint();
+
+// True if automatic translation logic is enabled.
+// Includes core logic and UI elements.
+bool IsBraveAutoTranslateEnabled();
 
 }  // namespace translate
 


### PR DESCRIPTION
Uplift of #16185
Resolves https://github.com/brave/brave-browser/issues/27040

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.