### PR TITLE
Updated window7/8 deprecation url (uplift to 1.46.x)

### DIFF
--- a/chromium_src/chrome/common/url_constants.cc
+++ b/chromium_src/chrome/common/url_constants.cc
@@ -250,7 +250,8 @@ const char kChromeCleanerLearnMoreURL[] =
 const char kWindowsXPVistaDeprecationURL[] =
     "https://support.brave.com/";
 
-const char kWindows78DeprecationURL[] = "https://support.brave.com/";
+const char kWindows78DeprecationURL[] =
+    "https://support.brave.com/hc/en-us/articles/11197967945613";
 #endif  // BUILDFLAG(IS_WIN)
 
 const char kChromeSyncLearnMoreURL[] = "https://support.brave.com/";


### PR DESCRIPTION
Uplift of #16248
fix https://github.com/brave/brave-browser/issues/27176

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.