### PR TITLE
[Brave News Uplift]: Don't show subscribe button until opted in to Brave News #16161

### DIFF
--- a/browser/ui/views/brave_actions/brave_news_action_view.cc
+++ b/browser/ui/views/brave_actions/brave_news_action_view.cc
@@ -77,6 +77,9 @@ BraveNewsActionView::BraveNewsActionView(Profile* profile,
                     profile->GetPrefs(),
                     base::BindRepeating(&BraveNewsActionView::Update,
                                         base::Unretained(this)));
+  opted_in_.Init(brave_news::prefs::kBraveTodayOptedIn, profile->GetPrefs(),
+                 base::BindRepeating(&BraveNewsActionView::Update,
+                                     base::Unretained(this)));
   news_enabled_.Init(brave_news::prefs::kNewTabPageShowToday,
                      profile->GetPrefs(),
                      base::BindRepeating(&BraveNewsActionView::Update,
@@ -105,7 +108,8 @@ void BraveNewsActionView::Init() {
 }
 
 void BraveNewsActionView::Update() {
-  if (!should_show_.GetValue() || !news_enabled_.GetValue()) {
+  if (!should_show_.GetValue() || !opted_in_.GetValue() ||
+      !news_enabled_.GetValue()) {
     SetVisible(false);
     return;
   }

--- a/browser/ui/views/brave_actions/brave_news_action_view.h
+++ b/browser/ui/views/brave_actions/brave_news_action_view.h
@@ -57,6 +57,7 @@ class BraveNewsActionView : public views::LabelButton,
   SkColor GetIconColor(bool subscribed) const;
 
   BooleanPrefMember should_show_;
+  BooleanPrefMember opted_in_;
   BooleanPrefMember news_enabled_;
 
   base::raw_ptr<Profile> profile_;


### PR DESCRIPTION
Uplift of https://github.com/brave/brave-core/pull/16161 which fixes https://github.com/brave/brave-browser/issues/27057 to 1.46.x