### PR TITLE
Added don't show again button to obsolete system infobar

### DIFF
--- a/app/brave_generated_resources.grd
+++ b/app/brave_generated_resources.grd
@@ -595,6 +595,10 @@ Or change later at <ph name="SETTINGS_EXTENIONS_LINK">$2<ex>brave://settings/ext
         <message name="IDS_WEB_DISCOVERY_INFOBAR_NO_THANKS_LABEL" desc="The text for no thanks button in infobar">
           No thanks
         </message>
+        <!-- obsolete system InfoBar -->
+        <message name="IDS_OBSOLERE_SYSTEM_INFOBAR_DONT_SHOW_BUTTON" desc="The text for don't show again button">
+          Don't show again
+        </message>
       </if>
 
       <!-- Brave Ads -->

--- a/browser/brave_browser_process_impl.cc
+++ b/browser/brave_browser_process_impl.cc
@@ -41,8 +41,10 @@
 #include "build/build_config.h"
 #include "chrome/browser/component_updater/component_updater_utils.h"
 #include "chrome/browser/net/system_network_context_manager.h"
+#include "chrome/browser/obsolete_system/obsolete_system.h"
 #include "chrome/common/buildflags.h"
 #include "chrome/common/chrome_paths.h"
+#include "chrome/common/pref_names.h"
 #include "components/component_updater/component_updater_service.h"
 #include "components/component_updater/timer_update_scheduler.h"
 #include "content/public/browser/browser_thread.h"
@@ -153,6 +155,14 @@ void BraveBrowserProcessImpl::Init() {
 #endif
 
   InitSystemRequestHandlerCallback();
+
+#if !BUILDFLAG(IS_ANDROID)
+  if (!ObsoleteSystem::IsObsoleteNowOrSoon()) {
+    // Clear to show unsupported warning infobar again even if user
+    // suppressed it from previous os.
+    local_state()->ClearPref(prefs::kSuppressUnsupportedOSWarning);
+  }
+#endif
 }
 
 #if !BUILDFLAG(IS_ANDROID)

--- a/browser/ui/BUILD.gn
+++ b/browser/ui/BUILD.gn
@@ -100,6 +100,8 @@ source_set("ui") {
       "omnibox/brave_omnibox_client_impl.cc",
       "omnibox/brave_omnibox_client_impl.h",
       "session_crashed_bubble_brave.cc",
+      "startup/brave_obsolete_system_infobar_delegate.cc",
+      "startup/brave_obsolete_system_infobar_delegate.h",
       "toolbar/brave_app_menu_model.cc",
       "toolbar/brave_app_menu_model.h",
       "toolbar/brave_recent_tabs_sub_menu_model.h",

--- a/browser/ui/startup/brave_obsolete_system_infobar_delegate.cc
+++ b/browser/ui/startup/brave_obsolete_system_infobar_delegate.cc
@@ -1,0 +1,46 @@
+/* Copyright (c) 2022 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include <memory>
+
+#include "brave/browser/ui/startup/brave_obsolete_system_infobar_delegate.h"
+#include "brave/grit/brave_generated_resources.h"
+#include "chrome/browser/browser_process.h"
+#include "chrome/browser/infobars/confirm_infobar_creator.h"
+#include "chrome/common/pref_names.h"
+#include "components/infobars/content/content_infobar_manager.h"
+#include "components/infobars/core/infobar.h"
+#include "components/prefs/pref_service.h"
+#include "ui/base/l10n/l10n_util.h"
+
+// static
+void BraveObsoleteSystemInfoBarDelegate::Create(
+    infobars::ContentInfoBarManager* infobar_manager) {
+  infobar_manager->AddInfoBar(
+      CreateConfirmInfoBar(std::unique_ptr<ConfirmInfoBarDelegate>(
+          new BraveObsoleteSystemInfoBarDelegate())));
+}
+
+BraveObsoleteSystemInfoBarDelegate::BraveObsoleteSystemInfoBarDelegate() =
+    default;
+BraveObsoleteSystemInfoBarDelegate::~BraveObsoleteSystemInfoBarDelegate() =
+    default;
+
+int BraveObsoleteSystemInfoBarDelegate::GetButtons() const {
+  return BUTTON_OK;
+}
+
+std::u16string BraveObsoleteSystemInfoBarDelegate::GetButtonLabel(
+    InfoBarButton button) const {
+  return l10n_util::GetStringUTF16(
+      IDS_OBSOLERE_SYSTEM_INFOBAR_DONT_SHOW_BUTTON);
+}
+
+bool BraveObsoleteSystemInfoBarDelegate::Accept() {
+  if (PrefService* local_state = g_browser_process->local_state()) {
+    local_state->SetBoolean(prefs::kSuppressUnsupportedOSWarning, true);
+  }
+  return true;
+}

--- a/browser/ui/startup/brave_obsolete_system_infobar_delegate.h
+++ b/browser/ui/startup/brave_obsolete_system_infobar_delegate.h
@@ -1,0 +1,39 @@
+/* Copyright (c) 2022 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_BROWSER_UI_STARTUP_BRAVE_OBSOLETE_SYSTEM_INFOBAR_DELEGATE_H_
+#define BRAVE_BROWSER_UI_STARTUP_BRAVE_OBSOLETE_SYSTEM_INFOBAR_DELEGATE_H_
+
+#include <string>
+
+#include "chrome/browser/ui/startup/obsolete_system_infobar_delegate.h"
+
+namespace infobars {
+class ContentInfoBarManager;
+}  // namespace infobars
+
+// Subclassed for showing "Don't show again" button.
+// W/o this button, user will see this infobar whenever launched.
+class BraveObsoleteSystemInfoBarDelegate
+    : public ObsoleteSystemInfoBarDelegate {
+ public:
+  static void Create(infobars::ContentInfoBarManager* infobar_manager);
+
+  BraveObsoleteSystemInfoBarDelegate(
+      const BraveObsoleteSystemInfoBarDelegate&) = delete;
+  BraveObsoleteSystemInfoBarDelegate& operator=(
+      const BraveObsoleteSystemInfoBarDelegate&) = delete;
+
+ private:
+  BraveObsoleteSystemInfoBarDelegate();
+  ~BraveObsoleteSystemInfoBarDelegate() override;
+
+  // ObsoleteSystemInfoBarDelegate overrides:
+  int GetButtons() const override;
+  std::u16string GetButtonLabel(InfoBarButton button) const override;
+  bool Accept() override;
+};
+
+#endif  // BRAVE_BROWSER_UI_STARTUP_BRAVE_OBSOLETE_SYSTEM_INFOBAR_DELEGATE_H_

--- a/chromium_src/chrome/browser/ui/startup/infobar_utils.cc
+++ b/chromium_src/chrome/browser/ui/startup/infobar_utils.cc
@@ -1,8 +1,9 @@
 /* Copyright (c) 2021 The Brave Authors. All rights reserved.
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
- * You can obtain one at http://mozilla.org/MPL/2.0/. */
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+#include "brave/browser/ui/startup/brave_obsolete_system_infobar_delegate.h"
 #include "chrome/browser/ui/session_crashed_bubble.h"
 #include "chrome/browser/ui/startup/google_api_keys_infobar_delegate.h"
 #include "components/infobars/content/content_infobar_manager.h"
@@ -16,7 +17,10 @@ class BraveGoogleKeysInfoBarDelegate {
 
 #define ShowIfNotOffTheRecordProfile ShowIfNotOffTheRecordProfileBrave
 #define GoogleApiKeysInfoBarDelegate BraveGoogleKeysInfoBarDelegate
+#define ObsoleteSystemInfoBarDelegate BraveObsoleteSystemInfoBarDelegate
 
 #include "src/chrome/browser/ui/startup/infobar_utils.cc"
+
+#undef ObsoleteSystemInfoBarDelegate
 #undef GoogleApiKeysInfoBarDelegate
 #undef ShowIfNotOffTheRecordProfile

--- a/chromium_src/chrome/browser/ui/startup/obsolete_system_infobar_delegate.h
+++ b/chromium_src/chrome/browser/ui/startup/obsolete_system_infobar_delegate.h
@@ -1,0 +1,20 @@
+/* Copyright (c) 2022 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_CHROMIUM_SRC_CHROME_BROWSER_UI_STARTUP_OBSOLETE_SYSTEM_INFOBAR_DELEGATE_H_
+#define BRAVE_CHROMIUM_SRC_CHROME_BROWSER_UI_STARTUP_OBSOLETE_SYSTEM_INFOBAR_DELEGATE_H_
+
+#include "components/infobars/core/confirm_infobar_delegate.h"
+
+#define Create                                     \
+  Create_UnUsed() {}                               \
+  friend class BraveObsoleteSystemInfoBarDelegate; \
+  static void Create
+
+#include "src/chrome/browser/ui/startup/obsolete_system_infobar_delegate.h"
+
+#undef Create
+
+#endif  // BRAVE_CHROMIUM_SRC_CHROME_BROWSER_UI_STARTUP_OBSOLETE_SYSTEM_INFOBAR_DELEGATE_H_


### PR DESCRIPTION
fix https://github.com/brave/brave-browser/issues/27122

W/o this, user will see this infobar whenever brave is launched.

![Screenshot 2022-12-07 161035](https://user-images.githubusercontent.com/6786187/206115058-88074763-c2af-482c-bb5f-3e65df602743.png)


<!-- Add brave-browser issue below that this PR will resolve -->
Resolves 

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

1. Launch Brave on Win7/8 and check obsolete system infobar with `don't show again` button is shown
2. Click `don't show again` button and check infobar is hidden
3. Relaunch and check this infobar is not shown anymore