### PR TITLE
Add copy clean link to the macOS application menu bar

### DIFF
--- a/browser/brave_app_controller_mac.h
+++ b/browser/brave_app_controller_mac.h
@@ -1,0 +1,18 @@
+/* Copyright (c) 2023 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_BROWSER_BRAVE_APP_CONTROLLER_MAC_H_
+#define BRAVE_BROWSER_BRAVE_APP_CONTROLLER_MAC_H_
+
+#import "chrome/browser/app_controller_mac.h"
+
+// Manages logic to switch hotkey between copy and copy clean link item.
+@interface BraveAppController : AppController {
+  NSMenuItem* _copyCleanLinkMenuItem;
+}
+
+@end
+
+#endif  // BRAVE_BROWSER_BRAVE_APP_CONTROLLER_MAC_H_

--- a/browser/brave_app_controller_mac.mm
+++ b/browser/brave_app_controller_mac.mm
@@ -1,0 +1,70 @@
+/* Copyright (c) 2023 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#import "brave/browser/brave_app_controller_mac.h"
+
+#include "brave/app/brave_command_ids.h"
+#include "brave/browser/ui/browser_commands.h"
+#include "chrome/app/chrome_command_ids.h"
+#include "chrome/browser/ui/browser.h"
+#include "chrome/browser/ui/browser_commands.h"
+#include "chrome/browser/ui/browser_finder.h"
+#include "chrome/grit/generated_resources.h"
+
+@implementation BraveAppController
+
+- (void)mainMenuCreated {
+  [super mainMenuCreated];
+
+  NSMenu* editMenu = [[[NSApp mainMenu] itemWithTag:IDC_EDIT_MENU] submenu];
+  _copyCleanLinkMenuItem = [editMenu itemWithTag:IDC_COPY_CLEAN_LINK];
+  DCHECK(_copyCleanLinkMenuItem);
+  [[_copyCleanLinkMenuItem menu] setDelegate:self];
+}
+
+- (void)dealloc {
+  [[_copyCleanLinkMenuItem menu] setDelegate:nil];
+  [super dealloc];
+}
+
+- (Browser*)getBrowser {
+  return chrome::FindBrowserWithProfile([self lastProfileIfLoaded]);
+}
+
+- (BOOL)shouldShowCleanLinkItem {
+  return brave::HasSelectedURL([self getBrowser]);
+}
+
+- (void)menuNeedsUpdate:(NSMenu*)menu {
+  if (menu != [_copyCleanLinkMenuItem menu]) {
+    [super menuNeedsUpdate:menu];
+    return;
+  }
+  if ([self shouldShowCleanLinkItem]) {
+    [_copyCleanLinkMenuItem setHidden:NO];
+  } else {
+    [_copyCleanLinkMenuItem setHidden:YES];
+  }
+}
+
+- (BOOL)validateUserInterfaceItem:(id<NSValidatedUserInterfaceItem>)item {
+  NSInteger tag = [item tag];
+  if (tag == IDC_COPY_CLEAN_LINK) {
+    return [self shouldShowCleanLinkItem];
+  }
+  return [super validateUserInterfaceItem:item];
+}
+
+- (void)executeCommand:(id)sender withProfile:(Profile*)profile {
+  NSInteger tag = [sender tag];
+  if (tag == IDC_COPY_CLEAN_LINK) {
+    chrome::ExecuteCommand([self getBrowser], IDC_COPY_CLEAN_LINK);
+    return;
+  }
+
+  [super executeCommand:sender withProfile:profile];
+}
+
+@end  // @implementation BraveAppController

--- a/browser/brave_app_controller_mac.mm
+++ b/browser/brave_app_controller_mac.mm
@@ -11,7 +11,6 @@
 #include "chrome/browser/ui/browser.h"
 #include "chrome/browser/ui/browser_commands.h"
 #include "chrome/browser/ui/browser_finder.h"
-#include "chrome/grit/generated_resources.h"
 
 @implementation BraveAppController
 

--- a/browser/brave_app_controller_mac_browsertest.mm
+++ b/browser/brave_app_controller_mac_browsertest.mm
@@ -1,0 +1,88 @@
+/* Copyright (c) 2023 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "base/memory/raw_ptr.h"
+
+#import <Cocoa/Cocoa.h>
+#import <Foundation/Foundation.h>
+#import <objc/runtime.h>
+#include <stddef.h>
+
+#include <string>
+
+#include "base/mac/foundation_util.h"
+#include "base/mac/scoped_nsobject.h"
+#include "base/mac/scoped_objc_class_swizzler.h"
+#include "brave/app/brave_command_ids.h"
+#include "brave/browser/brave_app_controller_mac.h"
+#include "brave/browser/ui/views/frame/brave_browser_view.h"
+#include "chrome/app/chrome_command_ids.h"
+#include "chrome/browser/ui/browser.h"
+#include "chrome/browser/ui/browser_finder.h"
+#include "chrome/browser/ui/browser_window.h"
+#include "chrome/browser/ui/location_bar/location_bar.h"
+#include "chrome/test/base/in_process_browser_test.h"
+#include "chrome/test/base/ui_test_utils.h"
+#include "components/omnibox/browser/omnibox_view.h"
+#include "content/public/test/browser_test.h"
+
+namespace {
+
+const char kTestingPage[] = "/empty.html";
+
+using BraveAppControllerBrowserTest = InProcessBrowserTest;
+
+IN_PROC_BROWSER_TEST_F(BraveAppControllerBrowserTest, CopyLinkItemVisible) {
+  ASSERT_TRUE(embedded_test_server()->Start());
+  GURL url = embedded_test_server()->GetURL(kTestingPage);
+  ASSERT_TRUE(ui_test_utils::NavigateToURL(browser(), url));
+  EXPECT_EQ(1u, chrome::GetTotalBrowserCount());
+
+  BraveBrowserView* browser_view = static_cast<BraveBrowserView*>(
+      BraveBrowserView::GetBrowserViewForBrowser(browser()));
+  OmniboxView* omnibox_view = browser_view->GetLocationBar()->GetOmniboxView();
+  omnibox_view->SelectAll(false);
+  EXPECT_TRUE(browser_view->HasSelectedURL());
+
+  BraveAppController* ac = base::mac::ObjCCastStrict<BraveAppController>(
+      [[NSApplication sharedApplication] delegate]);
+  ASSERT_TRUE(ac);
+  base::scoped_nsobject<NSMenu> edit_submenu(
+      [[[NSApp mainMenu] itemWithTag:IDC_EDIT_MENU] submenu],
+      base::scoped_policy::RETAIN);
+
+  base::scoped_nsobject<NSMenuItem> clean_link_menu_item(
+      [edit_submenu itemWithTag:IDC_COPY_CLEAN_LINK],
+      base::scoped_policy::RETAIN);
+
+  [ac menuNeedsUpdate:[clean_link_menu_item menu]];
+  base::RunLoop().RunUntilIdle();
+  EXPECT_FALSE([clean_link_menu_item isHidden]);
+}
+
+IN_PROC_BROWSER_TEST_F(BraveAppControllerBrowserTest, CopyLinkItemNotVisible) {
+  EXPECT_EQ(1u, chrome::GetTotalBrowserCount());
+  OmniboxView* omnibox_view =
+      browser()->window()->GetLocationBar()->GetOmniboxView();
+  omnibox_view->SetUserText(u"any text");
+  omnibox_view->SelectAll(false);
+  EXPECT_TRUE(omnibox_view->IsSelectAll());
+  AppController* ac = base::mac::ObjCCastStrict<AppController>(
+      [[NSApplication sharedApplication] delegate]);
+  ASSERT_TRUE(ac);
+  base::scoped_nsobject<NSMenu> edit_submenu(
+      [[[NSApp mainMenu] itemWithTag:IDC_EDIT_MENU] submenu],
+      base::scoped_policy::RETAIN);
+
+  base::scoped_nsobject<NSMenuItem> clean_link_menu_item(
+      [edit_submenu itemWithTag:IDC_COPY_CLEAN_LINK],
+      base::scoped_policy::RETAIN);
+
+  [ac menuNeedsUpdate:[clean_link_menu_item menu]];
+
+  EXPECT_TRUE([clean_link_menu_item isHidden]);
+}
+
+}  // namespace

--- a/browser/sources.gni
+++ b/browser/sources.gni
@@ -231,11 +231,14 @@ brave_chrome_browser_deps = [
 
 if (is_mac) {
   brave_chrome_browser_sources += [
+    "//brave/browser/brave_app_controller_mac.h",
+    "//brave/browser/brave_app_controller_mac.mm",
     "//brave/browser/brave_browser_main_parts_mac.h",
     "//brave/browser/brave_browser_main_parts_mac.mm",
     "//brave/browser/brave_shell_integration_mac.h",
     "//brave/browser/brave_shell_integration_mac.mm",
   ]
+  brave_chrome_browser_deps += [ "//brave/app:command_ids" ]
 }
 
 if (enable_sparkle) {

--- a/browser/ui/BUILD.gn
+++ b/browser/ui/BUILD.gn
@@ -253,6 +253,8 @@ source_set("ui") {
       "views/omnibox/brave_omnibox_popup_contents_view.h",
       "views/omnibox/brave_omnibox_result_view.cc",
       "views/omnibox/brave_omnibox_result_view.h",
+      "views/omnibox/brave_omnibox_view_views.cc",
+      "views/omnibox/brave_omnibox_view_views.h",
       "views/omnibox/brave_rounded_omnibox_results_frame.cc",
       "views/omnibox/brave_rounded_omnibox_results_frame.h",
       "views/omnibox/brave_search_conversion_promotion_view.cc",

--- a/browser/ui/brave_browser_window.cc
+++ b/browser/ui/brave_browser_window.cc
@@ -18,8 +18,16 @@ gfx::Rect BraveBrowserWindow::GetShieldsBubbleRect() {
   return gfx::Rect();
 }
 
+// static
+BraveBrowserWindow* BraveBrowserWindow::From(BrowserWindow* window) {
+  return static_cast<BraveBrowserWindow*>(window);
+}
+
 #if defined(TOOLKIT_VIEWS)
 sidebar::Sidebar* BraveBrowserWindow::InitSidebar() {
   return nullptr;
+}
+bool BraveBrowserWindow::HasSelectedURL() const {
+  return false;
 }
 #endif

--- a/browser/ui/brave_browser_window.cc
+++ b/browser/ui/brave_browser_window.cc
@@ -27,6 +27,7 @@ BraveBrowserWindow* BraveBrowserWindow::From(BrowserWindow* window) {
 sidebar::Sidebar* BraveBrowserWindow::InitSidebar() {
   return nullptr;
 }
+
 bool BraveBrowserWindow::HasSelectedURL() const {
   return false;
 }

--- a/browser/ui/brave_browser_window.h
+++ b/browser/ui/brave_browser_window.h
@@ -28,6 +28,8 @@ class BraveBrowserWindow : public BrowserWindow {
  public:
   ~BraveBrowserWindow() override {}
 
+  static BraveBrowserWindow* From(BrowserWindow*);
+
   virtual void StartTabCycling() {}
 
   // Returns the rectangle info of the Shield's panel.
@@ -45,6 +47,7 @@ class BraveBrowserWindow : public BrowserWindow {
 
 #if defined(TOOLKIT_VIEWS)
   virtual sidebar::Sidebar* InitSidebar();
+  virtual bool HasSelectedURL() const;
 #endif
 
   virtual void ShowBraveVPNBubble() {}

--- a/browser/ui/browser_commands.cc
+++ b/browser/ui/browser_commands.cc
@@ -277,4 +277,9 @@ void ToggleSidebarPosition(Browser* browser) {
                     !prefs->GetBoolean(prefs::kSidePanelHorizontalAlignment));
 }
 
+bool HasSelectedURL(Browser* browser) {
+  DCHECK(browser);
+  return BraveBrowserWindow::From(browser->window())->HasSelectedURL();
+}
+
 }  // namespace brave

--- a/browser/ui/browser_commands.h
+++ b/browser/ui/browser_commands.h
@@ -10,7 +10,7 @@ class Browser;
 class GURL;
 
 namespace brave {
-
+bool HasSelectedURL(Browser* browser);
 void NewOffTheRecordWindowTor(Browser*);
 void NewTorConnectionForSite(Browser*);
 void AddNewProfile();

--- a/browser/ui/views/frame/brave_browser_view.cc
+++ b/browser/ui/views/frame/brave_browser_view.cc
@@ -21,6 +21,7 @@
 #include "brave/browser/ui/views/frame/vertical_tab_strip_region_view.h"
 #include "brave/browser/ui/views/frame/vertical_tab_strip_widget_delegate_view.h"
 #include "brave/browser/ui/views/location_bar/brave_location_bar_view.h"
+#include "brave/browser/ui/views/omnibox/brave_omnibox_view_views.h"
 #include "brave/browser/ui/views/sidebar/sidebar_container_view.h"
 #include "brave/browser/ui/views/tabs/features.h"
 #include "brave/browser/ui/views/toolbar/bookmark_button.h"
@@ -376,6 +377,12 @@ speedreader::SpeedreaderBubbleView* BraveBrowserView::ShowSpeedreaderBubble(
 #else
   return nullptr;
 #endif
+}
+
+bool BraveBrowserView::HasSelectedURL() const {
+  return static_cast<BraveOmniboxViewViews*>(
+             GetLocationBarView()->omnibox_view())
+      ->SelectedTextIsURL();
 }
 
 WalletButton* BraveBrowserView::GetWalletButton() {

--- a/browser/ui/views/frame/brave_browser_view.h
+++ b/browser/ui/views/frame/brave_browser_view.h
@@ -74,7 +74,7 @@ class BraveBrowserView : public BrowserView {
 #endif
   bool ShouldShowWindowTitle() const override;
   void OnThemeChanged() override;
-
+  bool HasSelectedURL() const override;
   views::View* sidebar_host_view() { return sidebar_host_view_; }
   bool IsSidebarVisible() const;
 
@@ -114,6 +114,7 @@ class BraveBrowserView : public BrowserView {
   BraveBrowser* GetBraveBrowser() const;
 
   sidebar::Sidebar* InitSidebar() override;
+
   void UpdateSideBarHorizontalAlignment();
 
   bool closing_confirm_dialog_activated_ = false;

--- a/browser/ui/views/frame/brave_browser_view.h
+++ b/browser/ui/views/frame/brave_browser_view.h
@@ -74,7 +74,7 @@ class BraveBrowserView : public BrowserView {
 #endif
   bool ShouldShowWindowTitle() const override;
   void OnThemeChanged() override;
-  bool HasSelectedURL() const override;
+
   views::View* sidebar_host_view() { return sidebar_host_view_; }
   bool IsSidebarVisible() const;
 
@@ -114,7 +114,7 @@ class BraveBrowserView : public BrowserView {
   BraveBrowser* GetBraveBrowser() const;
 
   sidebar::Sidebar* InitSidebar() override;
-
+  bool HasSelectedURL() const override;
   void UpdateSideBarHorizontalAlignment();
 
   bool closing_confirm_dialog_activated_ = false;

--- a/browser/ui/views/omnibox/brave_omnibox_view_views.cc
+++ b/browser/ui/views/omnibox/brave_omnibox_view_views.cc
@@ -17,18 +17,6 @@
 #include "components/omnibox/browser/omnibox_edit_model.h"
 #include "ui/base/clipboard/scoped_clipboard_writer.h"
 
-BraveOmniboxViewViews::BraveOmniboxViewViews(
-    OmniboxEditController* controller,
-    std::unique_ptr<OmniboxClient> client,
-    bool popup_window_mode,
-    LocationBarView* location_bar,
-    const gfx::FontList& font_list)
-    : OmniboxViewViews(controller,
-                       std::move(client),
-                       popup_window_mode,
-                       location_bar,
-                       font_list) {}
-
 BraveOmniboxViewViews::~BraveOmniboxViewViews() = default;
 
 bool BraveOmniboxViewViews::SelectedTextIsURL() {

--- a/browser/ui/views/omnibox/brave_omnibox_view_views.cc
+++ b/browser/ui/views/omnibox/brave_omnibox_view_views.cc
@@ -1,0 +1,41 @@
+/* Copyright (c) 2023 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "brave/browser/ui/views/omnibox/brave_omnibox_view_views.h"
+
+#include <utility>
+
+#include "brave/app/brave_command_ids.h"
+#include "brave/browser/url_sanitizer/url_sanitizer_service_factory.h"
+#include "brave/components/url_sanitizer/browser/url_sanitizer_service.h"
+#include "chrome/browser/profiles/profile.h"
+#include "chrome/browser/ui/views/location_bar/location_bar_view.h"
+#include "chrome/grit/generated_resources.h"
+#include "components/omnibox/browser/omnibox_edit_controller.h"
+#include "components/omnibox/browser/omnibox_edit_model.h"
+#include "ui/base/clipboard/scoped_clipboard_writer.h"
+
+BraveOmniboxViewViews::BraveOmniboxViewViews(
+    OmniboxEditController* controller,
+    std::unique_ptr<OmniboxClient> client,
+    bool popup_window_mode,
+    LocationBarView* location_bar,
+    const gfx::FontList& font_list)
+    : OmniboxViewViews(controller,
+                       std::move(client),
+                       popup_window_mode,
+                       location_bar,
+                       font_list) {}
+
+BraveOmniboxViewViews::~BraveOmniboxViewViews() = default;
+
+bool BraveOmniboxViewViews::SelectedTextIsURL() {
+  GURL url;
+  bool write_url = false;
+  std::u16string selected_text = GetSelectedText();
+  model()->AdjustTextForCopy(GetSelectedRange().GetMin(), &selected_text, &url,
+                             &write_url);
+  return write_url;
+}

--- a/browser/ui/views/omnibox/brave_omnibox_view_views.h
+++ b/browser/ui/views/omnibox/brave_omnibox_view_views.h
@@ -6,24 +6,11 @@
 #ifndef BRAVE_BROWSER_UI_VIEWS_OMNIBOX_BRAVE_OMNIBOX_VIEW_VIEWS_H_
 #define BRAVE_BROWSER_UI_VIEWS_OMNIBOX_BRAVE_OMNIBOX_VIEW_VIEWS_H_
 
-#include <memory>
-
 #include "chrome/browser/ui/views/omnibox/omnibox_view_views.h"
-
-class OmniboxEditController;
-class OmniboxClient;
-class LocationBarView;
-namespace gfx {
-class FontList;
-}  // namespace gfx
 
 class BraveOmniboxViewViews : public OmniboxViewViews {
  public:
-  BraveOmniboxViewViews(OmniboxEditController* controller,
-                        std::unique_ptr<OmniboxClient> client,
-                        bool popup_window_mode,
-                        LocationBarView* location_bar,
-                        const gfx::FontList& font_list);
+  using OmniboxViewViews::OmniboxViewViews;
 
   BraveOmniboxViewViews(const BraveOmniboxViewViews&) = delete;
   BraveOmniboxViewViews& operator=(const BraveOmniboxViewViews&) = delete;

--- a/browser/ui/views/omnibox/brave_omnibox_view_views.h
+++ b/browser/ui/views/omnibox/brave_omnibox_view_views.h
@@ -1,0 +1,35 @@
+/* Copyright (c) 2023 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_BROWSER_UI_VIEWS_OMNIBOX_BRAVE_OMNIBOX_VIEW_VIEWS_H_
+#define BRAVE_BROWSER_UI_VIEWS_OMNIBOX_BRAVE_OMNIBOX_VIEW_VIEWS_H_
+
+#include <memory>
+
+#include "chrome/browser/ui/views/omnibox/omnibox_view_views.h"
+
+class OmniboxEditController;
+class OmniboxClient;
+class LocationBarView;
+namespace gfx {
+class FontList;
+}  // namespace gfx
+
+class BraveOmniboxViewViews : public OmniboxViewViews {
+ public:
+  BraveOmniboxViewViews(OmniboxEditController* controller,
+                        std::unique_ptr<OmniboxClient> client,
+                        bool popup_window_mode,
+                        LocationBarView* location_bar,
+                        const gfx::FontList& font_list);
+
+  BraveOmniboxViewViews(const BraveOmniboxViewViews&) = delete;
+  BraveOmniboxViewViews& operator=(const BraveOmniboxViewViews&) = delete;
+  ~BraveOmniboxViewViews() override;
+
+  bool SelectedTextIsURL();
+};
+
+#endif  // BRAVE_BROWSER_UI_VIEWS_OMNIBOX_BRAVE_OMNIBOX_VIEW_VIEWS_H_

--- a/chromium_src/chrome/browser/chrome_browser_main_mac.mm
+++ b/chromium_src/chrome/browser/chrome_browser_main_mac.mm
@@ -8,3 +8,4 @@
 
 #define AppController BraveAppController
 #include "src/chrome/browser/chrome_browser_main_mac.mm"
+#undef AppController

--- a/chromium_src/chrome/browser/chrome_browser_main_mac.mm
+++ b/chromium_src/chrome/browser/chrome_browser_main_mac.mm
@@ -1,0 +1,10 @@
+/* Copyright (c) 2023 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "chrome/browser/chrome_browser_main_mac.h"
+#import "brave/browser/brave_app_controller_mac.h"
+
+#define AppController BraveAppController
+#include "src/chrome/browser/chrome_browser_main_mac.mm"

--- a/chromium_src/chrome/browser/ui/cocoa/main_menu_builder.mm
+++ b/chromium_src/chrome/browser/ui/cocoa/main_menu_builder.mm
@@ -5,6 +5,11 @@
 
 #include "brave/app/brave_command_ids.h"
 #include "brave/grit/brave_generated_resources.h"
+#include "chrome/grit/generated_resources.h"
+
+namespace {
+constexpr int kPasteMacResourceId = IDS_PASTE_MAC;
+}
 
 #define BRAVE_BUILD_FILE_MENU                       \
   Item(IDS_NEW_OFFTHERECORD_WINDOW_TOR)             \
@@ -14,5 +19,13 @@
   Item(IDS_REPORT_BROKEN_SITE_MAC)                    \
       .command_id(IDC_SHOW_BRAVE_WEBCOMPAT_REPORTER),
 
+#undef IDS_PASTE_MAC
+#define IDS_PASTE_MAC IDS_COPY_CLEAN_LINK) \
+                    .command_id(IDC_COPY_CLEAN_LINK) \
+                    .target(app_delegate), \
+        Item(kPasteMacResourceId
+
 #include "src/chrome/browser/ui/cocoa/main_menu_builder.mm"
 #undef BRAVE_WEBCOMPAT_REPORTER_MENU_ENTRY
+#undef IDS_PASTE_MAC
+#define IDS_PASTE_MAC kPasteMacResourceId

--- a/chromium_src/chrome/browser/ui/views/location_bar/location_bar_view.cc
+++ b/chromium_src/chrome/browser/ui/views/location_bar/location_bar_view.cc
@@ -5,6 +5,8 @@
 
 #include "base/containers/adapters.h"
 #include "brave/browser/ui/omnibox/brave_omnibox_client_impl.h"
+#include "brave/browser/ui/views/omnibox/brave_omnibox_view_views.h"
+#include "chrome/browser/ui/views/omnibox/omnibox_view_views.h"
 
 #define BRAVE_LAYOUT_TRAILING_DECORATIONS                                 \
   auto right_most = GetTrailingViews();                                   \
@@ -13,9 +15,11 @@
       trailing_decorations.AddDecoration(0, height(), false, 0, 0, item); \
   }
 
+#define OmniboxViewViews BraveOmniboxViewViews
 #define ChromeOmniboxClient BraveOmniboxClientImpl
 #include "src/chrome/browser/ui/views/location_bar/location_bar_view.cc"
 #undef ChromeOmniboxClient
+#undef OmniboxViewViews
 #undef BRAVE_LAYOUT_TRAILING_DECORATIONS
 
 std::vector<views::View*> LocationBarView::GetTrailingViews() {

--- a/chromium_src/chrome/browser/ui/views/omnibox/omnibox_view_views.h
+++ b/chromium_src/chrome/browser/ui/views/omnibox/omnibox_view_views.h
@@ -1,0 +1,15 @@
+/* Copyright (c) 2023 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_CHROMIUM_SRC_CHROME_BROWSER_UI_VIEWS_OMNIBOX_OMNIBOX_VIEW_VIEWS_H_
+#define BRAVE_CHROMIUM_SRC_CHROME_BROWSER_UI_VIEWS_OMNIBOX_OMNIBOX_VIEW_VIEWS_H_
+
+#define friendly_suggestion_text_ \
+  friendly_suggestion_text_;      \
+  friend class BraveOmniboxViewViews
+#include "src/chrome/browser/ui/views/omnibox/omnibox_view_views.h"
+#undef friendly_suggestion_text_
+
+#endif  // BRAVE_CHROMIUM_SRC_CHROME_BROWSER_UI_VIEWS_OMNIBOX_OMNIBOX_VIEW_VIEWS_H_

--- a/test/BUILD.gn
+++ b/test/BUILD.gn
@@ -941,6 +941,7 @@ test("brave_browser_tests") {
 
   if (is_mac) {
     sources += [
+      "//brave/browser/brave_app_controller_mac_browsertest.mm",
       "//chrome/browser/ui/test/test_browser_dialog_mac.h",
       "//chrome/browser/ui/test/test_browser_dialog_mac.mm",
     ]


### PR DESCRIPTION
Resolves https://github.com/brave/brave-browser/issues/26825
Resolves https://github.com/brave/brave-browser/issues/27676

- No selected URL -> No Menu item
<img width="651" alt="image" src="https://user-images.githubusercontent.com/2965009/208679784-5c026972-4d16-47ea-9d25-73c595434ed6.png">

- Selected text is not a url -> No Menu item
<img width="662" alt="image" src="https://user-images.githubusercontent.com/2965009/208679607-326f129b-d496-4082-8a71-51110723afa0.png">

- URL selected  -> Menu item added
<img width="650" alt="image" src="https://user-images.githubusercontent.com/2965009/208679829-8ed5cd93-58d1-4e5a-9f5a-b8291201c1cd.png">

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

- Copy clean link Item should be visible if user has selected a url in the omnibox, otherwise the item should not be visible in the Mac menu
