### PR TITLE
Try to create os vpn entry whenever connect starts

### DIFF
--- a/components/brave_vpn/brave_vpn_os_connection_api.cc
+++ b/components/brave_vpn/brave_vpn_os_connection_api.cc
@@ -96,8 +96,8 @@ void BraveVPNOSConnectionAPI::Connect(bool ignore_network_state) {
 
   if (GetIsSimulation() || connection_info_.IsValid()) {
     VLOG(2) << __func__
-            << " : direct connect as we already have valid connection info.";
-    ConnectImpl(target_vpn_entry_name_);
+            << " : Create os vpn entry with cached connection_info.";
+    CreateVPNConnectionImpl(connection_info_);
     return;
   }
 


### PR DESCRIPTION
fix https://github.com/brave/brave-browser/issues/27196

When user deletes os vpn entry while browser running, browser can't know that deletion.
So, connect again w/o creating os entry causes connect error.
To fix this, try to create os vpn entry whenever connect.
As creating os vpn entry is cheap and fast, it would not hurt UX.

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves 

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

1. Launch Brave and prepare for using vpn
2. Connect and disconnect
3. Go to system setting and delete os vpn entry
4. Connect again and check connect failed doesn't happen