### PR TITLE
Ignore disconnected status while changing region

### DIFF
--- a/components/brave_vpn/brave_vpn_os_connection_api.cc
+++ b/components/brave_vpn/brave_vpn_os_connection_api.cc
@@ -65,7 +65,7 @@ void BraveVPNOSConnectionAPI::CreateVPNConnection() {
   CreateVPNConnectionImpl(connection_info_);
 }
 
-void BraveVPNOSConnectionAPI::Connect(bool ignore_network_state) {
+void BraveVPNOSConnectionAPI::Connect() {
   if (IsInProgress()) {
     VLOG(2) << __func__ << ": Current state: " << connection_state_
             << " : prevent connecting while previous operation is in-progress";
@@ -87,12 +87,6 @@ void BraveVPNOSConnectionAPI::Connect(bool ignore_network_state) {
 
   VLOG(2) << __func__ << " : start connecting!";
   UpdateAndNotifyConnectionStateChange(ConnectionState::CONNECTING);
-
-  if (!ignore_network_state && !IsNetworkAvailable()) {
-    VLOG(2) << __func__ << ": Network is not available, failed to connect";
-    UpdateAndNotifyConnectionStateChange(ConnectionState::CONNECT_FAILED);
-    return;
-  }
 
   if (GetIsSimulation() || connection_info_.IsValid()) {
     VLOG(2) << __func__
@@ -218,16 +212,11 @@ void BraveVPNOSConnectionAPI::OnConnectFailed() {
 }
 
 void BraveVPNOSConnectionAPI::OnDisconnected() {
-  UpdateAndNotifyConnectionStateChange(IsNetworkAvailable()
-                                           ? ConnectionState::DISCONNECTED
-                                           : ConnectionState::CONNECT_FAILED);
+  UpdateAndNotifyConnectionStateChange(ConnectionState::DISCONNECTED);
 
   if (needs_connect_) {
     needs_connect_ = false;
-    // Right after disconnected, network could be unavailable shortly.
-    // In this situation, connect process should go ahead because
-    // because BraveVpnAPIRequest could handle network failure by retrying.
-    Connect(true /* ignore_network_state */);
+    Connect();
   }
 }
 
@@ -238,9 +227,9 @@ void BraveVPNOSConnectionAPI::OnIsDisconnecting() {
 
 void BraveVPNOSConnectionAPI::OnNetworkChanged(
     net::NetworkChangeNotifier::ConnectionType type) {
-  VLOG(2) << __func__ << " : " << type;
   // It's rare but sometimes Brave doesn't get vpn status update from OS.
   // Checking here will make vpn status update properly in that situation.
+  VLOG(2) << __func__ << " : " << type;
   CheckConnection();
 }
 
@@ -258,10 +247,7 @@ void BraveVPNOSConnectionAPI::UpdateAndNotifyConnectionStateChange(
   // So, don't notify this disconnected state change while connecting because
   // it's temporal state.
   if (connection_state_ == ConnectionState::CONNECTING &&
-      state == ConnectionState::DISCONNECTED) {
-    // When cancelling, status should be changed from disconnecting to
-    // disconnected.
-    DCHECK(!cancel_connecting_);
+      state == ConnectionState::DISCONNECTED && !cancel_connecting_) {
     VLOG(2) << __func__ << ": Ignore disconnected state while connecting";
     return;
   }

--- a/components/brave_vpn/brave_vpn_os_connection_api.h
+++ b/components/brave_vpn/brave_vpn_os_connection_api.h
@@ -67,7 +67,7 @@ class BraveVPNOSConnectionAPI
   void SetConnectionState(mojom::ConnectionState state);
   bool IsInProgress() const;
 
-  void Connect(bool ignore_network_state = false);
+  void Connect();
   void Disconnect();
   void ToggleConnection();
   void RemoveVPNConnection();

--- a/components/brave_vpn/brave_vpn_os_connection_api_mac.mm
+++ b/components/brave_vpn/brave_vpn_os_connection_api_mac.mm
@@ -198,8 +198,28 @@ void BraveVPNOSConnectionAPIMac::CreateVPNConnectionImpl(
         OnCreateFailed();
         return;
       }
-      VLOG(2) << "Create - saveToPrefs success";
-      OnCreated();
+      // Load & save twice avoid connect failure.
+      // This load & save twice hack could eliminate connect failure
+      // when os vpn entry needs to be newly created during the connect
+      // process.
+      VLOG(2) << "Create - load & save again.";
+      [vpn_manager loadFromPreferencesWithCompletionHandler:^(
+                       NSError* load_again_error) {
+        if (load_again_error) {
+          OnCreateFailed();
+          return;
+        }
+
+        [vpn_manager saveToPreferencesWithCompletionHandler:^(
+                         NSError* save_again_error) {
+          if (save_again_error) {
+            OnCreateFailed();
+            return;
+          }
+          OnCreated();
+        }];
+      }];
+
     }];
   }];
 }

--- a/components/brave_vpn/brave_vpn_service.cc
+++ b/components/brave_vpn/brave_vpn_service.cc
@@ -585,14 +585,6 @@ void BraveVpnService::LoadPurchasedState(const std::string& domain) {
     return;
   }
 
-#if !BUILDFLAG(IS_ANDROID)
-  if (!IsNetworkAvailable()) {
-    VLOG(2) << __func__ << ": Network is not available, failed to connect";
-    GetBraveVPNConnectionAPI()->SetConnectionState(
-        ConnectionState::CONNECT_FAILED);
-    return;
-  }
-#endif
   if (!purchased_state_.has_value())
     SetPurchasedState(requested_env, PurchasedState::LOADING);
 

--- a/components/brave_vpn/brave_vpn_unittest.cc
+++ b/components/brave_vpn/brave_vpn_unittest.cc
@@ -870,70 +870,6 @@ TEST_F(BraveVPNServiceTest, NeedsConnectTest) {
   EXPECT_EQ(ConnectionState::CONNECTING, connection_state());
 }
 
-TEST_F(BraveVPNServiceTest, OnDisconnectedWithoutNetwork) {
-  std::string env = skus::GetDefaultEnvironment();
-  // Connection state can be changed with purchased.
-  SetPurchasedState(env, PurchasedState::PURCHASED);
-
-  SetDeviceRegion("eu-es");
-  auto network_change_notifier = net::NetworkChangeNotifier::CreateIfNeeded();
-  net::test::ScopedMockNetworkChangeNotifier mock_notifier;
-  mock_notifier.mock_network_change_notifier()->SetConnectionType(
-      net::NetworkChangeNotifier::CONNECTION_NONE);
-  EXPECT_EQ(net::NetworkChangeNotifier::CONNECTION_NONE,
-            net::NetworkChangeNotifier::GetConnectionType());
-
-  // Handle connect after disconnect current connection.
-  // When we need another connect, it should make next connect call
-  // even if network is not available.
-  connection_state() = ConnectionState::CONNECTED;
-  needs_connect() = true;
-  OnDisconnected();
-  EXPECT_FALSE(needs_connect());
-  EXPECT_EQ(ConnectionState::CONNECTING, connection_state());
-
-  // Set connect failed when we don't want another connect.
-  connection_state() = ConnectionState::CONNECTED;
-  needs_connect() = false;
-  OnDisconnected();
-  EXPECT_EQ(ConnectionState::CONNECT_FAILED, connection_state());
-}
-
-TEST_F(BraveVPNServiceTest, ConnectWithoutNetwork) {
-  std::string env = skus::GetDefaultEnvironment();
-  SetPurchasedState(env, PurchasedState::PURCHASED);
-  auto network_change_notifier = net::NetworkChangeNotifier::CreateIfNeeded();
-  net::test::ScopedMockNetworkChangeNotifier mock_notifier;
-  mock_notifier.mock_network_change_notifier()->SetConnectionType(
-      net::NetworkChangeNotifier::CONNECTION_NONE);
-  EXPECT_EQ(net::NetworkChangeNotifier::CONNECTION_NONE,
-            net::NetworkChangeNotifier::GetConnectionType());
-
-  // Handle connect without network.
-  connection_state() = ConnectionState::DISCONNECTED;
-  EXPECT_EQ(net::NetworkChangeNotifier::CONNECTION_NONE,
-            net::NetworkChangeNotifier::GetConnectionType());
-  TestBraveVPNServiceObserver observer;
-  AddObserver(observer.GetReceiver());
-  {
-    // State changed to Connecting.
-    base::RunLoop loop;
-    observer.WaitConnectionStateChange(loop.QuitClosure());
-    Connect();
-    loop.Run();
-    EXPECT_EQ(observer.GetConnectionState(), ConnectionState::CONNECTING);
-  }
-  {
-    // State changed to connection failed.
-    base::RunLoop loop;
-    observer.WaitConnectionStateChange(loop.QuitClosure());
-    loop.Run();
-    EXPECT_EQ(observer.GetConnectionState(), ConnectionState::CONNECT_FAILED);
-    EXPECT_FALSE(needs_connect());
-    EXPECT_EQ(ConnectionState::CONNECT_FAILED, connection_state());
-  }
-}
-
 TEST_F(BraveVPNServiceTest, LoadRegionDataFromPrefsTest) {
   std::string env = skus::GetDefaultEnvironment();
   // Initially, prefs doesn't have region data.
@@ -957,29 +893,6 @@ TEST_F(BraveVPNServiceTest, LoadRegionDataFromPrefsTest) {
   SetPurchasedState(env, PurchasedState::LOADING);
   LoadCachedRegionData();
   EXPECT_FALSE(regions().empty());
-}
-
-// Load purchased state without connection.
-TEST_F(BraveVPNServiceTest, PurchasedStateWithoutConnection) {
-  std::string env = skus::GetDefaultEnvironment();
-  std::string domain = skus::GetDomain("vpn", env);
-  TestBraveVPNServiceObserver observer;
-  AddObserver(observer.GetReceiver());
-  EXPECT_EQ(PurchasedState::NOT_PURCHASED, GetPurchasedStateSync());
-  SetPurchasedState(env, PurchasedState::PURCHASED);
-
-  EXPECT_EQ(PurchasedState::PURCHASED, GetPurchasedStateSync());
-  connection_state() = ConnectionState::CONNECTED;
-  auto network_change_notifier = net::NetworkChangeNotifier::CreateIfNeeded();
-  net::test::ScopedMockNetworkChangeNotifier mock_notifier;
-  mock_notifier.mock_network_change_notifier()->SetConnectionType(
-      net::NetworkChangeNotifier::CONNECTION_NONE);
-  EXPECT_EQ(net::NetworkChangeNotifier::CONNECTION_NONE,
-            net::NetworkChangeNotifier::GetConnectionType());
-  LoadPurchasedState(domain);
-  base::RunLoop().RunUntilIdle();
-  EXPECT_EQ(PurchasedState::PURCHASED, GetPurchasedStateSync());
-  EXPECT_EQ(observer.GetConnectionState(), ConnectionState::CONNECT_FAILED);
 }
 
 TEST_F(BraveVPNServiceTest, LoadPurchasedStateForAnotherEnvFailed) {

--- a/components/brave_vpn/brave_vpn_unittest.cc
+++ b/components/brave_vpn/brave_vpn_unittest.cc
@@ -1148,6 +1148,15 @@ TEST_F(BraveVPNServiceTest, CheckConnectionStateAfterNetworkStateChanged) {
 
   SetMockConnectionAPI(nullptr);
 }
+
+// Ignore disconnected state change while connected. See the comment at
+// BraveVPNOSConnectionAPI::UpdateAndNotifyConnectionStateChange().
+TEST_F(BraveVPNServiceTest, IgnoreDisconnectedStateWhileConnecting) {
+  connection_state() = ConnectionState::CONNECTING;
+  UpdateAndNotifyConnectionStateChange(ConnectionState::DISCONNECTED);
+  EXPECT_EQ(ConnectionState::CONNECTING, connection_state());
+}
+
 #endif
 
 TEST_F(BraveVPNServiceTest, GetPurchasedStateSync) {

--- a/components/brave_vpn/brave_vpn_utils.cc
+++ b/components/brave_vpn/brave_vpn_utils.cc
@@ -21,7 +21,6 @@
 #include "components/pref_registry/pref_registry_syncable.h"
 #include "components/prefs/pref_registry_simple.h"
 #include "components/prefs/pref_service.h"
-#include "net/base/network_change_notifier.h"
 
 namespace brave_vpn {
 
@@ -115,12 +114,5 @@ void RegisterLocalStatePrefs(PrefRegistrySimple* registry) {
       prefs::kBraveVPNUsedSecondDay, prefs::kBraveVPNDaysInMonthUsed);
   RegisterVPNLocalStatePrefs(registry);
 }
-
-#if !BUILDFLAG(IS_ANDROID)
-bool IsNetworkAvailable() {
-  return net::NetworkChangeNotifier::GetConnectionType() !=
-         net::NetworkChangeNotifier::CONNECTION_NONE;
-}
-#endif  // !BUILDFLAG(IS_ANDROID)
 
 }  // namespace brave_vpn

--- a/components/brave_vpn/brave_vpn_utils.h
+++ b/components/brave_vpn/brave_vpn_utils.h
@@ -25,10 +25,6 @@ void RegisterLocalStatePrefs(PrefRegistrySimple* registry);
 void RegisterProfilePrefs(user_prefs::PrefRegistrySyncable* registry);
 void RegisterAndroidProfilePrefs(PrefRegistrySimple* registry);
 
-#if !BUILDFLAG(IS_ANDROID)
-bool IsNetworkAvailable();
-#endif  // !BUILDFLAG(IS_ANDROID)
-
 }  // namespace brave_vpn
 
 #endif  // BRAVE_COMPONENTS_BRAVE_VPN_BRAVE_VPN_UTILS_H_


### PR DESCRIPTION
fix https://github.com/brave/brave-browser/issues/27267
fix https://github.com/brave/brave-browser/issues/27196

When user changes region while connected, status should be connecting till region change completes.

Also removed network status checking with `IsNetworkAvailable()`.
Instead of using `IsNetworkAvailable()`, vpn service will get actual state by issuing network request.

Also do load & save prefs twice when creating vpn entry on macOS to fix connect failure when there is no os vpn entry on macOS

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves 

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

