### PR TITLE
fix: do not use first pubkey as to addr for unknown instruction (uplift to 1.47.x)

### DIFF
--- a/components/brave_wallet_ui/utils/tx-utils.ts
+++ b/components/brave_wallet_ui/utils/tx-utils.ts
@@ -144,10 +144,7 @@ export const getToAddressesFromSolanaTransaction = (
         return newAccountPubkey.toString() ?? ''
       }
 
-      case 'Unknown': {
-        return solanaTxData?.instructions[0]?.accountMetas[0]?.pubkey.toString() ?? ''
-      }
-
+      case 'Unknown':
       default: return to ?? ''
     }
   })


### PR DESCRIPTION
Uplift of #16275
Resolves https://github.com/brave/brave-browser/issues/27187

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.