### PR TITLE
fix: do not use first pubkey as to addr for unknown instruction (uplift to 1.46.x)

### DIFF
--- a/components/brave_wallet_ui/common/hooks/transaction-parser.ts
+++ b/components/brave_wallet_ui/common/hooks/transaction-parser.ts
@@ -325,11 +325,7 @@ export function useTransactionParser (
 
               return acc
             }
-            case 'Unknown': {
-              if (!to) {
-                to = solTxData?.instructions[0]?.accountMetas[0]?.pubkey.toString() ?? ''
-              }
-            }
+            case 'Unknown':
             default: return acc.plus(lamportsAmount)
           }
         }, new Amount(0)) ?? 0


### PR DESCRIPTION
Uplift of #16275
Resolves https://github.com/brave/brave-browser/issues/27187

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.