### PR TITLE
Hide Rewards AC settings on brave://settings/rewards when unconnected

### DIFF
--- a/browser/brave_rewards/extension_rewards_service_observer.cc
+++ b/browser/brave_rewards/extension_rewards_service_observer.cc
@@ -283,6 +283,15 @@ void ExtensionRewardsServiceObserver::OnReconcileComplete(
   event_router->BroadcastEvent(std::move(event));
 }
 
+void ExtensionRewardsServiceObserver::OnExternalWalletConnected() {
+  if (auto* event_router = extensions::EventRouter::Get(profile_)) {
+    event_router->BroadcastEvent(std::make_unique<extensions::Event>(
+        extensions::events::BRAVE_START,
+        extensions::api::brave_rewards::OnExternalWalletConnected::kEventName,
+        base::Value::List()));
+  }
+}
+
 void ExtensionRewardsServiceObserver::OnExternalWalletLoggedOut() {
   if (auto* event_router = extensions::EventRouter::Get(profile_)) {
     event_router->BroadcastEvent(std::make_unique<extensions::Event>(

--- a/browser/brave_rewards/extension_rewards_service_observer.h
+++ b/browser/brave_rewards/extension_rewards_service_observer.h
@@ -63,6 +63,8 @@ class ExtensionRewardsServiceObserver : public RewardsServiceObserver {
       const ledger::mojom::RewardsType type,
       const ledger::mojom::ContributionProcessor processor) override;
 
+  void OnExternalWalletConnected() override;
+
   void OnExternalWalletLoggedOut() override;
 
   void OnUnblindedTokensReady(

--- a/browser/resources/settings/brave_rewards_page/brave_rewards_browser_proxy.ts
+++ b/browser/resources/settings/brave_rewards_page/brave_rewards_browser_proxy.ts
@@ -9,6 +9,7 @@ export interface BraveRewardsBrowserProxy {
   getAdsData(): Promise<any>
   getRewardsEnabled(): Promise<boolean>
   getRewardsParameters(): Promise<any>
+  getUserType(): Promise<boolean>
   isAutoContributeSupported(): Promise<boolean>
 }
 
@@ -29,6 +30,11 @@ export class BraveRewardsBrowserProxyImpl implements BraveRewardsBrowserProxy {
   getRewardsParameters () {
     return new Promise((resolve) => chrome.braveRewards.getRewardsParameters(
       (parameters) => { resolve(parameters) }))
+  }
+
+  getUserType () {
+    return new Promise((resolve) => chrome.braveRewards.getUserType(
+      (userType) => { resolve(userType) }))
   }
 
   isAutoContributeSupported () {

--- a/common/extensions/api/brave_rewards.json
+++ b/common/extensions/api/brave_rewards.json
@@ -292,6 +292,12 @@
         ]
       },
       {
+        "name": "onExternalWalletConnected",
+        "type": "function",
+        "description": "Fired when an external wallet is connected",
+        "parameters": []
+      },
+      {
         "name": "onExternalWalletLoggedOut",
         "type": "function",
         "description": "Fired when an external wallet is logged out",

--- a/components/brave_rewards/resources/page/reducers/rewards_reducer.ts
+++ b/components/brave_rewards/resources/page/reducers/rewards_reducer.ts
@@ -329,6 +329,7 @@ const rewardsReducer: Reducer<Rewards.State | undefined> = (state: Rewards.State
       const { value, error } = action.payload.result
 
       if (value) {
+        chrome.send('brave_rewards.getUserType')
         chrome.send('brave_rewards.fetchBalance')
         ui.modalRedirect = 'hide'
       } else {

--- a/components/definitions/chromel.d.ts
+++ b/components/definitions/chromel.d.ts
@@ -154,6 +154,10 @@ declare namespace chrome.braveRewards {
 
   const getExternalWalletProviders: (callback: (providers: string[]) => void) => void
 
+  const onExternalWalletConnected: {
+    addListener: (callback: () => void) => void
+  }
+
   const onExternalWalletLoggedOut: {
     addListener: (callback: () => void) => void
   }


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/27189

In addition to the main fix, I cleaned up the settings page to remove most of the warnings/errors that fell out from the recent transition to Typescript for settings pages.

Note: In testing, I discovered that brave://rewards wasn't updating to show the connected state after connecting a wallet. This PR adds `chrome.send('brave_rewards.getUserType')` to the wallet's reducer to address that.

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

### New user

- Clean profile
- Enable Rewards
- Visit brave://settings/rewards
- Ensure that no AC settings are visible
- Connect wallet
- Ensure that AC settings are now visible in brave://settings/rewards

### Legacy user

- Clean profile
- Enable Rewards
- Close browser
- Update `user_version` in Rewards preferences to be < `2.5` (Not sure if there's an easier way...!)
- Launch browser
- Verify that AC settings are visible in brave://settings/rewards
- Connect wallet
- Verify that AC settings remain visible in brave://settings/rewards