### PR TITLE
Move Aurora to the top of preloading network (after mainnet) (uplift to 1.46.x)

### DIFF
--- a/components/brave_wallet/browser/brave_wallet_utils.cc
+++ b/components/brave_wallet/browser/brave_wallet_utils.cc
@@ -262,13 +262,13 @@ const std::vector<const mojom::NetworkInfo*>& GetKnownEthNetworks() {
   static base::NoDestructor<std::vector<const mojom::NetworkInfo*>> networks({
       // clang-format off
       GetEthMainnet(),
+      GetAuroraMainnet(),
       GetPolygonMainnet(),
       GetBscMainnet(),
       GetCeloMainnet(),
       GetAvalancheMainnet(),
       GetFantomOperaMainnet(),
       GetOptimismMainnet(),
-      GetAuroraMainnet(),
       GetGoerliTestNetwork(),
       GetSepoliaTestNetwork(),
       GetEthLocalhost(),

--- a/components/brave_wallet/browser/brave_wallet_utils_unittest.cc
+++ b/components/brave_wallet/browser/brave_wallet_utils_unittest.cc
@@ -799,8 +799,8 @@ TEST(BraveWalletUtilsUnitTest, GetAllChainsTest) {
   // Custom Polygon chain takes place of known one.
   // Custom unknown chain becomes last.
   auto expected_chains = std::move(known_chains);
-  EXPECT_EQ(expected_chains[1]->chain_id, mojom::kPolygonMainnetChainId);
-  expected_chains[1] = chain1.Clone();
+  EXPECT_EQ(expected_chains[2]->chain_id, mojom::kPolygonMainnetChainId);
+  expected_chains[2] = chain1.Clone();
   expected_chains.push_back(chain2.Clone());
 
   auto all_chains = GetAllChains(&prefs, mojom::CoinType::ETH);
@@ -1003,11 +1003,11 @@ TEST(BraveWalletUtilsUnitTest, GetChain) {
 
 TEST(BraveWalletUtilsUnitTest, GetAllKnownEthNetworkIds) {
   const std::vector<std::string> expected_network_ids(
-      {"mainnet", mojom::kPolygonMainnetChainId,
+      {"mainnet", mojom::kAuroraMainnetChainId, mojom::kPolygonMainnetChainId,
        mojom::kBinanceSmartChainMainnetChainId, mojom::kCeloMainnetChainId,
        mojom::kAvalancheMainnetChainId, mojom::kFantomMainnetChainId,
-       mojom::kOptimismMainnetChainId, mojom::kAuroraMainnetChainId, "goerli",
-       "sepolia", "http://localhost:7545/"});
+       mojom::kOptimismMainnetChainId, "goerli", "sepolia",
+       "http://localhost:7545/"});
   ASSERT_EQ(GetAllKnownNetworksForTesting().size(),
             expected_network_ids.size());
   EXPECT_EQ(GetAllKnownEthNetworkIds(), expected_network_ids);

--- a/components/brave_wallet/browser/json_rpc_service_unittest.cc
+++ b/components/brave_wallet/browser/json_rpc_service_unittest.cc
@@ -1322,10 +1322,10 @@ TEST_F(JsonRpcServiceUnitTest, GetKnownNetworks) {
   values.push_back(NetworkInfoToValue(chain1));
   UpdateCustomNetworks(prefs(), &values);
 
-  EXPECT_CALL(
-      callback,
-      Run(ElementsAreArray({"0x1", "0x89", "0x38", "0xa4ec", "0xa86a", "0xfa",
-                            "0xa", "0x4e454152", "0x5", "0xaa36a7", "0x539"})));
+  EXPECT_CALL(callback,
+              Run(ElementsAreArray({"0x1", "0x4e454152", "0x89", "0x38",
+                                    "0xa4ec", "0xa86a", "0xfa", "0xa", "0x5",
+                                    "0xaa36a7", "0x539"})));
   json_rpc_service_->GetKnownNetworks(mojom::CoinType::ETH, callback.Get());
   testing::Mock::VerifyAndClearExpectations(&callback);
 }


### PR DESCRIPTION
Uplift of #16283
Resolves https://github.com/brave/brave-browser/issues/27227

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.