### PR TITLE
Disable warning about Manifest v2 deprecation (Uplift to 1.46.x)

### DIFF
--- a/browser/brave_browser_main_extra_parts.cc
+++ b/browser/brave_browser_main_extra_parts.cc
@@ -21,6 +21,10 @@
 #include "chrome/browser/first_run/first_run.h"
 #endif  // !BUILDFLAG(IS_ANDROID)
 
+#if BUILDFLAG(ENABLE_EXTENSIONS)
+#include "extensions/common/extension.h"
+#endif  // BUILDFLAG(ENABLE_EXTENSIONS)
+
 namespace {
 
 // Records default values for some histograms because we want these stats to be
@@ -53,6 +57,14 @@ void RecordInitialP3AValues() {
 BraveBrowserMainExtraParts::BraveBrowserMainExtraParts() = default;
 
 BraveBrowserMainExtraParts::~BraveBrowserMainExtraParts() = default;
+
+void BraveBrowserMainExtraParts::PreProfileInit() {
+#if BUILDFLAG(ENABLE_EXTENSIONS)
+  // Disable warnings related to Manifest V2 deprecation
+  extensions::Extension::
+      set_silence_deprecated_manifest_version_warnings_for_testing(true);
+#endif  // BUILDFLAG(ENABLE_EXTENSIONS)
+}
 
 void BraveBrowserMainExtraParts::PostBrowserStart() {
   g_brave_browser_process->StartBraveServices();

--- a/browser/brave_browser_main_extra_parts.h
+++ b/browser/brave_browser_main_extra_parts.h
@@ -21,6 +21,7 @@ class BraveBrowserMainExtraParts : public ChromeBrowserMainExtraParts {
   // ChromeBrowserMainExtraParts overrides.
   void PostBrowserStart() override;
   void PreMainMessageLoopRun() override;
+  void PreProfileInit() override;
 };
 
 #endif  // BRAVE_BROWSER_BRAVE_BROWSER_MAIN_EXTRA_PARTS_H_

--- a/browser/extensions/mv2_warning_unittest.cc
+++ b/browser/extensions/mv2_warning_unittest.cc
@@ -1,0 +1,42 @@
+/* Copyright (c) 2022 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "brave/browser/brave_browser_main_extra_parts.h"
+#include "extensions/common/extension.h"
+#include "extensions/common/value_builder.h"
+#include "testing/gtest/include/gtest/gtest.h"
+
+class Mv2WarningUnitTest : public testing::Test {
+ public:
+  Mv2WarningUnitTest() {}
+  ~Mv2WarningUnitTest() override = default;
+};
+
+TEST(Mv2WarningTest, ExtensionManifestVersions) {
+  auto main_extra_parts = BraveBrowserMainExtraParts();
+  main_extra_parts.PreProfileInit();
+
+  auto get_manifest = [](absl::optional<int> manifest_version) {
+    extensions::DictionaryBuilder builder;
+    builder.Set("name", "My Extension")
+        .Set("version", "0.1")
+        .Set("description", "An awesome extension");
+    if (manifest_version)
+      builder.Set("manifest_version", *manifest_version);
+    return builder.Build();
+  };
+
+  std::string error;
+  scoped_refptr<extensions::Extension> extension =
+      extensions::Extension::Create(
+          base::FilePath(), extensions::mojom::ManifestLocation::kUnpacked,
+          *get_manifest(2).get(),
+          extensions::Extension::InitFromValueFlags::NO_FLAGS, &error);
+
+  ASSERT_NE(extension, nullptr);
+
+  auto& warnings = extension->install_warnings();
+  EXPECT_EQ(warnings.size(), 0UL);
+}

--- a/test/BUILD.gn
+++ b/test/BUILD.gn
@@ -486,6 +486,7 @@ test("brave_unit_tests") {
       "//brave/browser/extensions/api/brave_extensions_api_client_unittest.cc",
       "//brave/browser/extensions/chrome_content_verifier_delegate_unittest.cc",
       "//brave/browser/extensions/install_verifier_unittest.cc",
+      "//brave/browser/extensions/mv2_warning_unittest.cc",
       "//brave/chromium_src/extensions/browser/sandboxed_unpacker_unittest.cc",
       "//brave/common/importer/chrome_importer_utils_unittest.cc",
       "//chrome/browser/extensions/extension_service_test_base.cc",


### PR DESCRIPTION
Uplift of https://github.com/brave/brave-core/pull/15628 to 1.46.x.

Yes, the original PR is in Beta... I should have done this earlier :sweat: 