### PR TITLE
[Android] Remove getOriginalProfile() from search utils (uplift to 1.47.x)

### DIFF
--- a/android/java/org/chromium/chrome/browser/search_engines/settings/BraveSearchEngineAdapter.java
+++ b/android/java/org/chromium/chrome/browser/search_engines/settings/BraveSearchEngineAdapter.java
@@ -37,7 +37,7 @@ public class BraveSearchEngineAdapter extends SearchEngineAdapter {
         // Only need last used profile because we are in settings
         if (mProfile == null) {
             if (!mIsPrivate) {
-                mProfile = Profile.getLastUsedRegularProfile().getOriginalProfile();
+                mProfile = Profile.getLastUsedRegularProfile();
             } else {
                 mProfile = Profile.getLastUsedRegularProfile().getPrimaryOTRProfile(
                         /* createIfNeeded= */ true);
@@ -78,7 +78,7 @@ public class BraveSearchEngineAdapter extends SearchEngineAdapter {
             // overwrite.
             if (BraveSearchEnginePrefHelper.getInstance().getFetchSEFromNative()) {
                 // Set it for normal tab only
-                setDSEPrefs(dseTemplateUrl, profile.getOriginalProfile());
+                setDSEPrefs(dseTemplateUrl, Profile.getLastUsedRegularProfile());
                 BraveSearchEnginePrefHelper.getInstance().setFetchSEFromNative(false);
             }
         }

--- a/android/java/org/chromium/chrome/browser/settings/SearchEngineTabModelSelectorObserver.java
+++ b/android/java/org/chromium/chrome/browser/settings/SearchEngineTabModelSelectorObserver.java
@@ -17,11 +17,7 @@ import org.chromium.chrome.browser.tabmodel.TabModelSelectorObserver;
  *  we use different DSE for normal and private tab.
  */
 public class SearchEngineTabModelSelectorObserver implements TabModelSelectorObserver {
-    private TabModelSelector mTabModelSelector;
-
-    public SearchEngineTabModelSelectorObserver(TabModelSelector tabModelSelector) {
-        mTabModelSelector = tabModelSelector;
-    }
+    public SearchEngineTabModelSelectorObserver() {}
 
     @Override
     public void onChange() {}
@@ -32,7 +28,7 @@ public class SearchEngineTabModelSelectorObserver implements TabModelSelectorObs
     @Override
     public void onTabModelSelected(TabModel newModel, TabModel oldModel) {
         if (newModel.getProfile().isOffTheRecord()) {
-            BraveSearchEngineUtils.initializePrivateBraveSearchEngineStates(newModel.getProfile());
+            BraveSearchEngineUtils.initializeBraveSearchEngineStates(newModel.getProfile());
         } else {
             BraveSearchEngineUtils.updateActiveDSE(newModel.getProfile());
         }

--- a/android/java/org/chromium/chrome/browser/widget/quickactionsearchandbookmark/QuickActionSearchAndBookmarkWidgetProvider.java
+++ b/android/java/org/chromium/chrome/browser/widget/quickactionsearchandbookmark/QuickActionSearchAndBookmarkWidgetProvider.java
@@ -199,9 +199,8 @@ public class QuickActionSearchAndBookmarkWidgetProvider extends AppWidgetProvide
 
     private static void setDefaultSearchEngineString(RemoteViews views) {
         TemplateUrl templateUrl = BraveSearchEngineUtils.getTemplateUrlByShortName(
-                Profile.getLastUsedRegularProfile().getOriginalProfile(),
-                BraveSearchEngineUtils.getDSEShortName(
-                        Profile.getLastUsedRegularProfile().getOriginalProfile(), false));
+                Profile.getLastUsedRegularProfile(),
+                BraveSearchEngineUtils.getDSEShortName(Profile.getLastUsedRegularProfile(), false));
         if (templateUrl != null) {
             String searchWithDefaultSearchEngine = ContextUtils.getApplicationContext().getString(
                     R.string.search_with_search_engine, templateUrl.getShortName());


### PR DESCRIPTION
Uplift of #16311
Resolves https://github.com/brave/brave-browser/issues/27273

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.