### PR TITLE
Implement eth_subscribe newHeads

### DIFF
--- a/browser/brave_wallet/ethereum_provider_impl_unittest.cc
+++ b/browser/brave_wallet/ethereum_provider_impl_unittest.cc
@@ -144,6 +144,12 @@ class TestEventsListener : public brave_wallet::mojom::EventsListener {
     accounts_changed_fired_ = true;
   }
 
+  void MessageEvent(const std::string& subscription_id,
+                    base::Value result) override {
+    message_event_fired_ = true;
+    last_message_ = std::move(result);
+  }
+
   bool ChainChangedFired() const {
     base::RunLoop().RunUntilIdle();
     return chain_changed_fired_;
@@ -154,9 +160,19 @@ class TestEventsListener : public brave_wallet::mojom::EventsListener {
     return accounts_changed_fired_;
   }
 
+  bool MessageEventFired() const {
+    base::RunLoop().RunUntilIdle();
+    return message_event_fired_;
+  }
+
   std::string GetChainId() const {
     base::RunLoop().RunUntilIdle();
     return chain_id_;
+  }
+
+  base::Value GetLastMessage() const {
+    base::RunLoop().RunUntilIdle();
+    return last_message_.Clone();
   }
 
   std::vector<std::string> GetLowercaseAccounts() const {
@@ -173,14 +189,18 @@ class TestEventsListener : public brave_wallet::mojom::EventsListener {
     lowercase_accounts_.clear();
     chain_changed_fired_ = false;
     accounts_changed_fired_ = false;
+    message_event_fired_ = false;
     EXPECT_FALSE(ChainChangedFired());
     EXPECT_FALSE(AccountsChangedFired());
+    EXPECT_FALSE(MessageEventFired());
   }
 
   bool chain_changed_fired_ = false;
   bool accounts_changed_fired_ = false;
+  bool message_event_fired_ = false;
   std::vector<std::string> lowercase_accounts_;
   std::string chain_id_;
+  base::Value last_message_;
 
  private:
   mojo::Receiver<brave_wallet::mojom::EventsListener> observer_receiver_{this};
@@ -189,7 +209,9 @@ class TestEventsListener : public brave_wallet::mojom::EventsListener {
 class EthereumProviderImplUnitTest : public testing::Test {
  public:
   EthereumProviderImplUnitTest()
-      : shared_url_loader_factory_(
+      : browser_task_environment_(
+            base::test::TaskEnvironment::TimeSource::MOCK_TIME),
+        shared_url_loader_factory_(
             base::MakeRefCounted<network::WeakWrapperSharedURLLoaderFactory>(
                 &url_loader_factory_)) {}
 
@@ -875,6 +897,7 @@ class EthereumProviderImplUnitTest : public testing::Test {
   raw_ptr<JsonRpcService> json_rpc_service_ = nullptr;
   raw_ptr<BraveWalletService> brave_wallet_service_ = nullptr;
   std::unique_ptr<TestEventsListener> observer_;
+  network::TestURLLoaderFactory url_loader_factory_;
 
  private:
   std::unique_ptr<ScopedTestingLocalState> local_state_;
@@ -884,7 +907,6 @@ class EthereumProviderImplUnitTest : public testing::Test {
   raw_ptr<AssetRatioService> asset_ratio_service_;
   std::unique_ptr<content::TestWebContents> web_contents_;
   std::unique_ptr<EthereumProviderImpl> provider_;
-  network::TestURLLoaderFactory url_loader_factory_;
   data_decoder::test::InProcessDataDecoder in_process_data_decoder_;
   scoped_refptr<network::SharedURLLoaderFactory> shared_url_loader_factory_;
   base::ScopedTempDir temp_dir_;
@@ -1962,6 +1984,62 @@ TEST_F(EthereumProviderImplUnitTest, AccountsChangedEvent) {
   AddEthereumPermission(GetOrigin(), 1);
   SetSelectedAccount(from(0), mojom::CoinType::ETH);
   EXPECT_FALSE(observer_->AccountsChangedFired());
+}
+
+TEST_F(EthereumProviderImplUnitTest, EthSubscribe) {
+  CreateWallet();
+
+  // Unsupported subscription type
+  std::string request_payload_json =
+      R"({"id":1,"jsonrpc:": "2.0","method":"eth_subscribe",
+          "params": ["foo"]})";
+  absl::optional<base::Value> request_payload = base::JSONReader::Read(
+      request_payload_json, base::JSON_PARSE_CHROMIUM_EXTENSIONS |
+                                base::JSONParserOptions::JSON_PARSE_RFC);
+  auto response = CommonRequestOrSendAsync(request_payload.value());
+
+  mojom::ProviderError error_code;
+  std::string error_message;
+  GetErrorCodeMessage(std::move(response.second), &error_code, &error_message);
+  EXPECT_EQ(response.first, true);
+  EXPECT_EQ(error_code, mojom::ProviderError::kInternalError);
+  EXPECT_EQ(error_message,
+            l10n_util::GetStringUTF8(IDS_WALLET_UNSUPPORTED_SUBSCRIPTION_TYPE));
+
+  url_loader_factory_.SetInterceptor(
+      base::BindLambdaForTesting([&](const network::ResourceRequest& request) {
+        url_loader_factory_.ClearResponses();
+
+        std::string header_value;
+        EXPECT_TRUE(request.headers.GetHeader("X-Eth-Method", &header_value));
+        std::string content;
+        if (header_value == "eth_blockNumber" ||
+            header_value == "getBlockHeight")
+          content = R"({"id":1,"jsonrpc":"2.0","result":"0x131131"})";
+        else if (header_value == "eth_getBlockByNumber")
+          content = R"({"id":1,"jsonrpc":"2.0","result":{"difficulty":"0x1"}})";
+        url_loader_factory_.AddResponse(request.url.spec(), content);
+      }));
+
+  // Subscribing to newHeads
+  request_payload_json =
+      R"({"id":1,"jsonrpc:": "2.0","method":"eth_subscribe",
+          "params": ["newHeads"]})";
+  request_payload = base::JSONReader::Read(
+      request_payload_json, base::JSON_PARSE_CHROMIUM_EXTENSIONS |
+                                base::JSONParserOptions::JSON_PARSE_RFC);
+  response = CommonRequestOrSendAsync(request_payload.value());
+  EXPECT_EQ(response.first, false);
+  EXPECT_TRUE(response.second.is_string());
+  browser_task_environment_.FastForwardBy(
+      base::Seconds(kBlockTrackerDefaultTimeInSeconds));
+  EXPECT_TRUE(observer_->MessageEventFired());
+  base::Value rv = observer_->GetLastMessage();
+  ASSERT_TRUE(rv.is_dict());
+  auto& dict = rv.GetDict();
+  std::string* difficulty = dict.FindString("difficulty");
+  ASSERT_TRUE(difficulty);
+  EXPECT_EQ(*difficulty, "0x1");
 }
 
 TEST_F(EthereumProviderImplUnitTest, Web3ClientVersion) {

--- a/components/brave_wallet/browser/ethereum_provider_impl.cc
+++ b/components/brave_wallet/browser/ethereum_provider_impl.cc
@@ -32,6 +32,7 @@
 #include "brave/components/brave_wallet/common/web3_provider_constants.h"
 #include "components/content_settings/core/browser/host_content_settings_map.h"
 #include "components/grit/brave_components_strings.h"
+#include "crypto/random.h"
 #include "ui/base/l10n/l10n_util.h"
 #include "url/origin.h"
 
@@ -88,6 +89,7 @@ EthereumProviderImpl::EthereumProviderImpl(
       tx_service_(tx_service),
       keyring_service_(keyring_service),
       brave_wallet_service_(brave_wallet_service),
+      eth_block_tracker_(json_rpc_service),
       prefs_(prefs),
       weak_factory_(this) {
   DCHECK(json_rpc_service);
@@ -105,10 +107,13 @@ EthereumProviderImpl::EthereumProviderImpl(
   // Get the current so we can compare for changed events
   if (delegate_)
     UpdateKnownAccounts();
+
+  eth_block_tracker_.AddObserver(this);
 }
 
 EthereumProviderImpl::~EthereumProviderImpl() {
   host_content_settings_map_->RemoveObserver(this);
+  eth_block_tracker_.RemoveObserver(this);
 }
 
 void EthereumProviderImpl::AddEthereumChain(const std::string& json_payload,
@@ -567,6 +572,43 @@ void EthereumProviderImpl::RecoverAddress(const std::string& message,
   reject = false;
   std::move(callback).Run(std::move(id), base::Value(address), reject, "",
                           false);
+}
+
+void EthereumProviderImpl::EthSubscribe(const std::string& event_type,
+                                        RequestCallback callback,
+                                        base::Value id) {
+  if (event_type != kEthSubscribeNewHeads) {
+    base::Value formed_response = GetProviderErrorDictionary(
+        mojom::ProviderError::kInternalError,
+        l10n_util::GetStringUTF8(IDS_WALLET_UNSUPPORTED_SUBSCRIPTION_TYPE));
+    bool reject = true;
+    std::move(callback).Run(std::move(id), std::move(formed_response), reject,
+                            "", false);
+    return;
+  }
+  std::vector<uint8_t> bytes(16);
+  crypto::RandBytes(&bytes.front(), bytes.size());
+  std::string hex_bytes = ToHex(bytes);
+  eth_subscriptions_.push_back(hex_bytes);
+  if (eth_subscriptions_.size() == 1)
+    eth_block_tracker_.Start(base::Seconds(kBlockTrackerDefaultTimeInSeconds));
+  std::move(callback).Run(std::move(id), base::Value(hex_bytes), false, "",
+                          false);
+}
+
+void EthereumProviderImpl::EthUnsubscribe(const std::string& subscription_id,
+                                          RequestCallback callback,
+                                          base::Value id) {
+  auto it = std::find(eth_subscriptions_.begin(), eth_subscriptions_.end(),
+                      subscription_id);
+  bool found = it != eth_subscriptions_.end();
+  if (found) {
+    if (eth_subscriptions_.size() == 1) {
+      eth_block_tracker_.Stop();
+    }
+    eth_subscriptions_.erase(it);
+  }
+  std::move(callback).Run(std::move(id), base::Value(found), false, "", false);
 }
 
 void EthereumProviderImpl::GetEncryptionPublicKey(const std::string& address,
@@ -1152,6 +1194,22 @@ void EthereumProviderImpl::CommonRequestOrSendAsync(base::ValueView input_value,
                        std::move(id), method, delegate_->GetOrigin()));
   } else if (method == kWeb3ClientVersion) {
     Web3ClientVersion(std::move(callback), std::move(id));
+  } else if (method == kEthSubscribe) {
+    std::string event_type;
+    if (!ParseEthSubscribeParams(normalized_json_request, &event_type)) {
+      SendErrorOnRequest(error, error_message, std::move(callback),
+                         std::move(id));
+      return;
+    }
+    EthSubscribe(event_type, std::move(callback), std::move(id));
+  } else if (method == kEthUnsubscribe) {
+    std::string subscription_id;
+    if (!ParseEthUnsubscribeParams(normalized_json_request, &subscription_id)) {
+      SendErrorOnRequest(error, error_message, std::move(callback),
+                         std::move(id));
+      return;
+    }
+    EthUnsubscribe(subscription_id, std::move(callback), std::move(id));
   } else {
     json_rpc_service_->Request(normalized_json_request, true, std::move(id),
                                mojom::CoinType::ETH, std::move(callback));
@@ -1582,5 +1640,28 @@ void EthereumProviderImpl::OnSendRawTransaction(
   std::move(callback).Run(std::move(id), std::move(formed_response),
                           error != mojom::ProviderError::kSuccess, "", false);
 }
+
+// EthBlockTracker::Observer:
+void EthereumProviderImpl::OnLatestBlock(uint256_t block_num) {
+  json_rpc_service_->GetBlockByNumber(
+      kEthereumBlockTagLatest,
+      base::BindOnce(&EthereumProviderImpl::OnGetBlockByNumber,
+                     weak_factory_.GetWeakPtr()));
+}
+
+void EthereumProviderImpl::OnGetBlockByNumber(
+    base::Value result,
+    mojom::ProviderError error,
+    const std::string& error_message) {
+  if (events_listener_.is_bound() && error == mojom::ProviderError::kSuccess) {
+    base::ranges::for_each(eth_subscriptions_,
+                           [this, &result](const std::string& subscription_id) {
+                             events_listener_->MessageEvent(subscription_id,
+                                                            result.Clone());
+                           });
+  }
+}
+
+void EthereumProviderImpl::OnNewBlock(uint256_t block_num) {}
 
 }  // namespace brave_wallet

--- a/components/brave_wallet/browser/ethereum_provider_impl.h
+++ b/components/brave_wallet/browser/ethereum_provider_impl.h
@@ -169,6 +169,7 @@ class EthereumProviderImpl final
   FRIEND_TEST_ALL_PREFIXES(EthereumProviderImplUnitTest, RequestEthCoinbase);
   FRIEND_TEST_ALL_PREFIXES(EthereumProviderImplUnitTest,
                            RequestEthereumPermissionsWithAccounts);
+  FRIEND_TEST_ALL_PREFIXES(EthereumProviderImplUnitTest, EthSubscribe);
   friend class EthereumProviderImplUnitTest;
 
   // mojom::BraveWalletProvider:

--- a/components/brave_wallet/browser/ethereum_provider_impl.h
+++ b/components/brave_wallet/browser/ethereum_provider_impl.h
@@ -14,6 +14,7 @@
 #include "base/containers/flat_map.h"
 #include "base/memory/raw_ptr.h"
 #include "base/memory/weak_ptr.h"
+#include "brave/components/brave_wallet/browser/eth_block_tracker.h"
 #include "brave/components/brave_wallet/common/brave_wallet.mojom.h"
 #include "brave/components/brave_wallet/common/web3_provider_constants.h"
 #include "components/content_settings/core/browser/content_settings_observer.h"
@@ -39,7 +40,8 @@ class EthereumProviderImpl final
       public mojom::JsonRpcServiceObserver,
       public mojom::TxServiceObserver,
       public brave_wallet::mojom::KeyringServiceObserver,
-      public content_settings::Observer {
+      public content_settings::Observer,
+      public EthBlockTracker::Observer {
  public:
   using GetAllowedAccountsCallback =
       base::OnceCallback<void(const std::vector<std::string>& accounts,
@@ -81,6 +83,13 @@ class EthereumProviderImpl final
   // Used for personal_ecRecover
   void RecoverAddress(const std::string& message,
                       const std::string& signature,
+                      RequestCallback callback,
+                      base::Value id);
+
+  void EthSubscribe(const std::string& event_type,
+                    RequestCallback callback,
+                    base::Value id);
+  void EthUnsubscribe(const std::string& subscription_id,
                       RequestCallback callback,
                       base::Value id);
 
@@ -353,6 +362,13 @@ class EthereumProviderImpl final
                             const std::string& tx_hash,
                             mojom::ProviderError error,
                             const std::string& error_message);
+  void OnGetBlockByNumber(base::Value result,
+                          mojom::ProviderError,
+                          const std::string&);
+
+  // EthBlockTracker::Observer:
+  void OnLatestBlock(uint256_t block_num) override;
+  void OnNewBlock(uint256_t block_num) override;
 
   raw_ptr<HostContentSettingsMap> host_content_settings_map_ = nullptr;
   std::unique_ptr<BraveWalletProviderDelegate> delegate_;
@@ -374,6 +390,8 @@ class EthereumProviderImpl final
   mojo::Receiver<brave_wallet::mojom::KeyringServiceObserver>
       keyring_observer_receiver_{this};
   std::vector<std::string> known_allowed_accounts;
+  std::vector<std::string> eth_subscriptions_;
+  EthBlockTracker eth_block_tracker_;
   bool first_known_accounts_check = true;
   PrefService* prefs_ = nullptr;
   bool wallet_onboarding_shown_ = false;

--- a/components/brave_wallet/browser/json_rpc_service.cc
+++ b/components/brave_wallet/browser/json_rpc_service.cc
@@ -1846,6 +1846,39 @@ void JsonRpcService::OnGetIsEip1559(GetIsEip1559Callback callback,
                           mojom::ProviderError::kSuccess, "");
 }
 
+void JsonRpcService::GetBlockByNumber(const std::string& block_number,
+                                      GetBlockByNumberCallback callback) {
+  auto internal_callback =
+      base::BindOnce(&JsonRpcService::OnGetBlockByNumber,
+                     weak_ptr_factory_.GetWeakPtr(), std::move(callback));
+  RequestInternal(eth::eth_getBlockByNumber(block_number, false), true,
+                  network_urls_[mojom::CoinType::ETH],
+                  std::move(internal_callback));
+}
+
+void JsonRpcService::OnGetBlockByNumber(GetBlockByNumberCallback callback,
+                                        APIRequestResult api_request_result) {
+  if (!api_request_result.Is2XXResponseCode()) {
+    std::move(callback).Run(
+        base::Value(), mojom::ProviderError::kInternalError,
+        l10n_util::GetStringUTF8(IDS_WALLET_INTERNAL_ERROR));
+    return;
+  }
+
+  auto result = ParseResultValue(api_request_result.body());
+  if (!result) {
+    mojom::ProviderError error;
+    std::string error_message;
+    ParseErrorResult<mojom::ProviderError>(api_request_result.body(), &error,
+                                           &error_message);
+    std::move(callback).Run(base::Value(), error, error_message);
+    return;
+  }
+
+  std::move(callback).Run(std::move(*result), mojom::ProviderError::kSuccess,
+                          "");
+}
+
 /*static*/
 bool JsonRpcService::IsValidDomain(const std::string& domain) {
   static const base::NoDestructor<re2::RE2> kDomainRegex(kDomainPattern);

--- a/components/brave_wallet/browser/json_rpc_service.h
+++ b/components/brave_wallet/browser/json_rpc_service.h
@@ -282,6 +282,14 @@ class JsonRpcService : public KeyedService, public mojom::JsonRpcService {
                               const std::string& error_message)>;
   void GetIsEip1559(GetIsEip1559Callback callback);
 
+  using GetBlockByNumberCallback =
+      base::OnceCallback<void(base::Value result,
+                              mojom::ProviderError error,
+                              const std::string& error_message)>;
+  // block_number can be kEthereumBlockTagLatest
+  void GetBlockByNumber(const std::string& block_number,
+                        GetBlockByNumberCallback callback);
+
   void GetERC721OwnerOf(const std::string& contract,
                         const std::string& token_id,
                         const std::string& chain_id,
@@ -490,6 +498,8 @@ class JsonRpcService : public KeyedService, public mojom::JsonRpcService {
                      APIRequestResult api_request_result);
   void OnGetIsEip1559(GetIsEip1559Callback callback,
                       APIRequestResult api_request_result);
+  void OnGetBlockByNumber(GetBlockByNumberCallback callback,
+                          APIRequestResult api_request_result);
 
   void MaybeUpdateIsEip1559(const std::string& chain_id);
   void UpdateIsEip1559(const std::string& chain_id,

--- a/components/brave_wallet/common/brave_wallet.mojom
+++ b/components/brave_wallet/common/brave_wallet.mojom
@@ -19,6 +19,9 @@ interface EventsListener {
   // Fired when the accounts have changed such as when the wallet locked, the
   // selected account changes, a new account is given permission, etc.
   AccountsChangedEvent(array<string> accounts);
+
+  // Fired when there is a message from eth_subscribe
+  MessageEvent(string subscription_id, mojo_base.mojom.Value result);
 };
 
 interface SolanaEventsListener {

--- a/components/brave_wallet/common/eth_request_helper.cc
+++ b/components/brave_wallet/common/eth_request_helper.cc
@@ -674,7 +674,39 @@ bool ParseEthSendRawTransactionParams(const std::string& json,
     return false;
 
   *signed_transaction = *signed_tx_str;
+  return true;
+}
 
+bool ParseEthSubscribeParams(const std::string& json, std::string* event_type) {
+  if (!event_type)
+    return false;
+
+  auto list = GetParamsList(json);
+  if (!list || list->size() != 1)
+    return false;
+
+  const std::string* event_type_str = (*list)[0].GetIfString();
+  if (!event_type_str)
+    return false;
+
+  *event_type = *event_type_str;
+  return true;
+}
+
+bool ParseEthUnsubscribeParams(const std::string& json,
+                               std::string* subscription_id) {
+  if (!subscription_id)
+    return false;
+
+  auto list = GetParamsList(json);
+  if (!list || list->size() != 1)
+    return false;
+
+  const std::string* subscription_id_str = (*list)[0].GetIfString();
+  if (!subscription_id_str)
+    return false;
+
+  *subscription_id = *subscription_id_str;
   return true;
 }
 

--- a/components/brave_wallet/common/eth_request_helper.h
+++ b/components/brave_wallet/common/eth_request_helper.h
@@ -74,6 +74,9 @@ bool ParseRequestPermissionsParams(
 
 bool ParseEthSendRawTransactionParams(const std::string& json,
                                       std::string* signed_transaction);
+bool ParseEthSubscribeParams(const std::string& json, std::string* event_type);
+bool ParseEthUnsubscribeParams(const std::string& json,
+                               std::string* subscription_id);
 
 }  // namespace brave_wallet
 

--- a/components/brave_wallet/common/web3_provider_constants.cc
+++ b/components/brave_wallet/common/web3_provider_constants.cc
@@ -13,6 +13,7 @@ const char kDisconnectEvent[] = "disconnect";
 namespace ethereum {
 const char kChainChangedEvent[] = "chainChanged";
 const char kAccountsChangedEvent[] = "accountsChanged";
+const char kMessageEvent[] = "message";
 }  // namespace ethereum
 
 namespace solana {

--- a/components/brave_wallet/common/web3_provider_constants.h
+++ b/components/brave_wallet/common/web3_provider_constants.h
@@ -16,6 +16,7 @@ extern const char kDisconnectEvent[];
 namespace ethereum {
 extern const char kChainChangedEvent[];
 extern const char kAccountsChangedEvent[];
+extern const char kMessageEvent[];
 }  // namespace ethereum
 
 namespace solana {
@@ -44,6 +45,9 @@ constexpr char kEthDecrypt[] = "eth_decrypt";
 constexpr char kWalletWatchAsset[] = "wallet_watchAsset";
 constexpr char kMetamaskWatchAsset[] = "metamask_watchAsset";
 constexpr char kWeb3ClientVersion[] = "web3_clientVersion";
+constexpr char kEthSubscribe[] = "eth_subscribe";
+constexpr char kEthUnsubscribe[] = "eth_unsubscribe";
+constexpr char kEthSubscribeNewHeads[] = "newHeads";
 
 // We currently don't handle it until MetaMask point it to v3 or v4 other than
 // v1 or v2

--- a/components/brave_wallet/renderer/js_ethereum_provider.cc
+++ b/components/brave_wallet/renderer/js_ethereum_provider.cc
@@ -577,4 +577,15 @@ void JSEthereumProvider::AccountsChangedEvent(
   FireEvent(ethereum::kAccountsChangedEvent, std::move(event_args));
 }
 
+void JSEthereumProvider::MessageEvent(const std::string& subscription_id,
+                                      base::Value result) {
+  base::Value::Dict event_args;
+  base::Value::Dict data;
+  data.Set("subscription", subscription_id);
+  data.Set("result", std::move(result));
+  event_args.Set("type", "eth_subscription");
+  event_args.Set("data", std::move(data));
+  FireEvent(ethereum::kMessageEvent, base::Value(std::move(event_args)));
+}
+
 }  // namespace brave_wallet

--- a/components/brave_wallet/renderer/js_ethereum_provider.h
+++ b/components/brave_wallet/renderer/js_ethereum_provider.h
@@ -44,6 +44,8 @@ class JSEthereumProvider final : public gin::Wrappable<JSEthereumProvider>,
   // mojom::EventsListener
   void AccountsChangedEvent(const std::vector<std::string>& accounts) override;
   void ChainChangedEvent(const std::string& chain_id) override;
+  void MessageEvent(const std::string& subscription_id,
+                    base::Value result) override;
 
  private:
   explicit JSEthereumProvider(content::RenderFrame* render_frame);

--- a/components/resources/wallet_strings.grdp
+++ b/components/resources/wallet_strings.grdp
@@ -9,6 +9,7 @@
   <message name="IDS_WALLET_EXPECTED_SINGLE_PARAMETER" desc="The text of the response for wallet_addEthereumChain call with empty parameters">Expected single, object parameter.</message>
   <message name="IDS_WALLET_CHAIN_EXISTS" desc="The text of the response for wallet_addEthereumChain call with existing chain id">This Chain ID is currently used</message>
   <message name="IDS_WALLET_INTERNAL_ERROR" desc="The text of the response for wallet_addEthereumChain call with internal error">An internal error has occurred</message>
+  <message name="IDS_WALLET_UNSUPPORTED_SUBSCRIPTION_TYPE" desc="The text of the response for eth_subscribe with an unsupported subscription type">Unsupported subscription type</message>
   <message name="IDS_WALLET_METHOD_NOT_SUPPORTED_ERROR" desc="The text of response when an RPC method is not supported">This RPC method is not supported.</message>
   <message name="IDS_WALLET_PARSING_ERROR" desc="There was a parsing error">A response parsing error has occurred</message>
   <message name="IDS_WALLET_REQUEST_PROCESSING_ERROR" desc="There was a request processing error">A generic request processing error has occurred</message>


### PR DESCRIPTION
This adds support for a new `eth_subscribe` method that can be used in Ethereum provider requests. 
See a description of this here: https://docs.infura.io/infura/networks/ethereum/json-rpc-methods/subscription-methods/eth_subscribe

This implementation only supports `newHeads` for now.
There's a follow up issue in https://github.com/brave/brave-browser/issues/27283 for supporting the `"logs"` param.
These params are not currently supported by MM at the time of this writing, so they are probably not used in the wild and we can sit on the implementation for now: `"newPendingTransactions"` and `"syncing""`.

As an alternative to this implementation, I considered first adding websocket support and then using Infura, but then eth_subscribe wouldn't be supported for user's HTTPS configured RPC endpoints.  So I'm starting here with querying for block updates via the block tracker.



If approved I will do another pull request for wallet-docs.

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/21350

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [x] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [x] New files have MPL-2.0 license header
- [x] Adequate test coverage exists to prevent regressions
- [x] Major classes, functions and non-trivial code blocks are well-commented
- [x] Changes in component dependencies are properly reflected in `gn`
- [x] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [x] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

- Clone https://github.com/bbondy/eth-manual-tests and start a server as per the readme
- Use `eth_subscribe` to listen for new block head. You should see a console message in the developer console matching the same subscription ID every 20 seconds.  You can subscribe multiple times, each time will give a new subscription ID.
- Use `eth_unsubscribe` to stop listening to an event by putting the subscription ID from the `eth_subscribe` call.  It should stop ending events and return true to the console when you unsubscribe successfully from something.
