### PR TITLE
Fixes bug #22933

### DIFF
--- a/browser/resources/settings/brave_wallet_page/add_wallet_network_dialog.html
+++ b/browser/resources/settings/brave_wallet_page/add_wallet_network_dialog.html
@@ -174,6 +174,7 @@
   <div slot="button-container" class="button-separator">
     <div class="error-text" id="currency-error" hidden="{{isCurrencyErrorHidden_}}">$i18n{walletAddNetworkDialogFillNativeCurrencyInfo}</div>
     <div class="error-text" id="submission-error" hidden="{{isSubmissionErrorHidden_}}">{{submissionErrorMessage_}}</div>
+    <div class="error-text" id="negative-decimals-error" hidden="{{isNegativeDecimalsErrorHidden_}}">{{NegativeDecimalsErrorMessage_}}</div>
     <cr-button class="action-button" on-click="onAddNetworkTap_" disabled="{{!isSubmitButtonEnabled_}}">
       $i18n{walletNetworkAdd}
     </cr-button>

--- a/browser/resources/settings/brave_wallet_page/add_wallet_network_dialog.ts
+++ b/browser/resources/settings/brave_wallet_page/add_wallet_network_dialog.ts
@@ -121,7 +121,15 @@ export class SettingsBraveAddWalletNetworkDialogElement extends SettingsBraveAdd
       },
       submissionErrorMessage_: {
         type: String,
-        value: true
+        value: true,
+      },
+      isNegativeDecimalsErrorHidden_: {
+        type: Boolean,
+        value: true,
+      },
+      NegativeDecimalsErrorMessage_: {
+        type: String,
+        value: true,
       },
       selected: {
         type: Object,
@@ -165,6 +173,8 @@ export class SettingsBraveAddWalletNetworkDialogElement extends SettingsBraveAdd
   private isCurrencyErrorHidden_: boolean;
   private isSubmissionErrorHidden_: boolean;
   private submissionErrorMessage_: string;
+  private isNegativeDecimalsErrorHidden_: boolean;
+  private NegativeDecimalsErrorMessage_: string;
   private selected: NetworkInfo;
   private currencyNameValue_: string;
   private currencySymbolValue_: string;
@@ -393,8 +403,13 @@ export class SettingsBraveAddWalletNetworkDialogElement extends SettingsBraveAdd
     this.isCurrencyErrorHidden_ = false
   }
 
+  showNegativeDecimalsError() {
+    this.NegativeDecimalsErrorMessage_ = "Please enter a positive value for currency decimals"
+    this.isNegativeDecimalsErrorHidden_ = false
+  }
+
   setSubmissionResult(success: boolean, errorMessage: string) {
-    this.isCurrencyErrorHidden_ = this.isSubmissionErrorHidden_ = true
+    this.isNegativeDecimalsErrorHidden_ = this.isCurrencyErrorHidden_ = this.isSubmissionErrorHidden_ = true
     if (!success) {
       this.isSubmissionErrorHidden_ = false
       this.submissionErrorMessage_ = errorMessage
@@ -431,6 +446,10 @@ export class SettingsBraveAddWalletNetworkDialogElement extends SettingsBraveAdd
     if ((nativeCurrency.name || nativeCurrency.symbol || nativeCurrency.decimals)) {
       if (!nativeCurrency.name || !nativeCurrency.symbol || !nativeCurrency.decimals) {
         this.showCurrencyError()
+        return;
+      }
+      else if(nativeCurrency.decimals < 0) {
+        this.showNegativeDecimalsError()
         return;
       }
       payload.nativeCurrency = nativeCurrency;


### PR DESCRIPTION
Currency decimal should not accept negative values - produces error message instead 

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/22933

## Submitter Checklist:

- [ ] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

