### PR TITLE
Add Brave-specific options to policy templates

### DIFF
--- a/patches/components-policy-resources-policy_templates.json.patch
+++ b/patches/components-policy-resources-policy_templates.json.patch
@@ -1,0 +1,10 @@
+diff --git a/components/policy/resources/policy_templates.json b/components/policy/resources/policy_templates.json
+index 5238b76ba5466b3015157bc33e4efe13a2213418..382aeede0591a604f48d85cac70389ce38cf619d 100644
+--- a/components/policy/resources/policy_templates.json
++++ b/components/policy/resources/policy_templates.json
+@@ -1,4 +1,4 @@
+-{
++__import__('policy_source_helper').BravePolicies() + {
+ # policy_templates.json - Metafile for policy templates
+ #
+ # The content of this file is evaluated as a Python expression.

--- a/patches/components-policy-tools-generate_policy_source.py.patch
+++ b/patches/components-policy-tools-generate_policy_source.py.patch
@@ -1,20 +1,12 @@
 diff --git a/components/policy/tools/generate_policy_source.py b/components/policy/tools/generate_policy_source.py
-index feb36d536f184b8d9f8e7284a26ba68d8b2205ea..1aa486b4811f4cd5a5e10f785f72a563297acd49 100755
+index feb36d536f184b8d9f8e7284a26ba68d8b2205ea..021536491dc2dcca662f64ea11a657a53a33dd75 100755
 --- a/components/policy/tools/generate_policy_source.py
 +++ b/components/policy/tools/generate_policy_source.py
 @@ -55,6 +55,7 @@ PLATFORM_STRINGS = {
      'chrome.win7': ['win'],
  }
  
-+from policy_source_helper import AddBravePolicies, CHROMIUM_POLICY_KEY
++from policy_source_helper import CHROMIUM_POLICY_KEY
  
  class PolicyDetails:
    """Parses a policy template and caches all its details."""
-@@ -382,6 +383,7 @@ def main():
-     chrome_major_version = ParseVersionFile(version_path)
- 
-   template_file_contents = _LoadJSONFile(template_file_name)
-+  AddBravePolicies(template_file_contents)
-   risk_tags = RiskTags(template_file_contents)
-   policy_details = [
-       PolicyDetails(policy, chrome_major_version, deprecation_milestone_buffer,

--- a/script/policy_source_helper.py
+++ b/script/policy_source_helper.py
@@ -39,29 +39,39 @@ def _add_brave_policies(template_file_contents):
     highest_id = template_file_contents['highest_id_currently_used']
     policies = [
         {
-            'name': 'TorDisabled',
-            'type': 'main',
-            'schema': {'type': 'boolean'},
-            'supported_on': ['chrome.win:78-',
-                             'chrome.mac:93-',
-                             'chrome.linux:93-'],
+            'name':
+            'TorDisabled',
+            'type':
+            'main',
+            'schema': {
+                'type': 'boolean'
+            },
+            'supported_on':
+            ['chrome.win:78-', 'chrome.mac:93-', 'chrome.linux:93-'],
             'features': {
                 'dynamic_refresh': False,
                 'per_profile': False,
                 'can_be_recommended': False,
                 'can_be_mandatory': True
             },
-            'example_value': True,
-            'id': 0,
-            'caption': '''Disables the tor feature.''',
+            'example_value':
+            True,
+            'id':
+            0,
+            'caption':
+            '''Disables the tor feature.''',
             'tags': [],
             'desc': ('''This policy allows an admin to specify that tor '''
                      '''must be disabled at startup.'''),
         },
         {
-            'name': 'IPFSEnabled',
-            'type': 'main',
-            'schema': {'type': 'boolean'},
+            'name':
+            'IPFSEnabled',
+            'type':
+            'main',
+            'schema': {
+                'type': 'boolean'
+            },
             'supported_on': ['chrome.*:87-'],
             'future_on': ['android'],
             'features': {
@@ -70,17 +80,24 @@ def _add_brave_policies(template_file_contents):
                 'can_be_recommended': False,
                 'can_be_mandatory': True
             },
-            'example_value': True,
-            'id': 1,
-            'caption': '''Enable IPFS feature''',
+            'example_value':
+            True,
+            'id':
+            1,
+            'caption':
+            '''Enable IPFS feature''',
             'tags': [],
             'desc': ('''This policy allows an admin to specify whether IPFS '''
                      '''feature can be enabled.'''),
         },
         {
-            'name': 'BraveRewardsDisabled',
-            'type': 'main',
-            'schema': {'type': 'boolean'},
+            'name':
+            'BraveRewardsDisabled',
+            'type':
+            'main',
+            'schema': {
+                'type': 'boolean'
+            },
             'supported_on': ['chrome.*:105-'],
             'features': {
                 'dynamic_refresh': False,
@@ -88,17 +105,24 @@ def _add_brave_policies(template_file_contents):
                 'can_be_recommended': False,
                 'can_be_mandatory': True
             },
-            'example_value': True,
-            'id': 2,
-            'caption': '''Disable Brave Rewards feature.''',
+            'example_value':
+            True,
+            'id':
+            2,
+            'caption':
+            '''Disable Brave Rewards feature.''',
             'tags': [],
             'desc': ('''This policy allows an admin to specify that Brave '''
                      '''Rewards feature will be disabled.'''),
         },
         {
-            'name': 'BraveWalletDisabled',
-            'type': 'main',
-            'schema': {'type': 'boolean'},
+            'name':
+            'BraveWalletDisabled',
+            'type':
+            'main',
+            'schema': {
+                'type': 'boolean'
+            },
             'supported_on': ['chrome.*:106-'],
             'features': {
                 'dynamic_refresh': False,
@@ -106,19 +130,26 @@ def _add_brave_policies(template_file_contents):
                 'can_be_recommended': False,
                 'can_be_mandatory': True
             },
-            'example_value': True,
-            'id': 3,
-            'caption': '''Disable Brave Wallet feature.''',
+            'example_value':
+            True,
+            'id':
+            3,
+            'caption':
+            '''Disable Brave Wallet feature.''',
             'tags': [],
             'desc': ('''This policy allows an admin to specify that Brave '''
                      '''Wallet feature will be disabled.'''),
         },
         {
-            'name': 'BraveShieldsDisabledForUrls',
-            'type': 'list',
+            'name':
+            'BraveShieldsDisabledForUrls',
+            'type':
+            'list',
             'schema': {
-              'type': 'array',
-              'items': { 'type': 'string' },
+                'type': 'array',
+                'items': {
+                    'type': 'string'
+                },
             },
             'supported_on': ['chrome.*:107-'],
             'features': {
@@ -128,18 +159,24 @@ def _add_brave_policies(template_file_contents):
                 'can_be_mandatory': True
             },
             'example_value': ['https://brave.com'],
-            'id': 4,
-            'caption': '''Disables Brave Shields for urls.''',
+            'id':
+            4,
+            'caption':
+            '''Disables Brave Shields for urls.''',
             'tags': [],
             'desc': ('''This policy allows an admin to specify that Brave '''
                      '''Shields disabled.'''),
         },
         {
-            'name': 'BraveShieldsEnabledForUrls',
-            'type': 'list',
+            'name':
+            'BraveShieldsEnabledForUrls',
+            'type':
+            'list',
             'schema': {
-              'type': 'array',
-              'items': { 'type': 'string' },
+                'type': 'array',
+                'items': {
+                    'type': 'string'
+                },
             },
             'supported_on': ['chrome.*:107-'],
             'features': {
@@ -149,8 +186,10 @@ def _add_brave_policies(template_file_contents):
                 'can_be_mandatory': True
             },
             'example_value': ['https://brave.com'],
-            'id': 5,
-            'caption': '''Enables Brave Shields for urls.''',
+            'id':
+            5,
+            'caption':
+            '''Enables Brave Shields for urls.''',
             'tags': [],
             'desc': ('''This policy allows an admin to specify that Brave '''
                      '''Shields enabled.'''),

--- a/script/policy_source_helper.py
+++ b/script/policy_source_helper.py
@@ -115,7 +115,7 @@ def _add_brave_policies(template_file_contents):
         },
         {
             'name': 'BraveShieldsDisabledForUrls',
-            'type': 'main',
+            'type': 'list',
             'schema': {
               'type': 'array',
               'items': { 'type': 'string' },
@@ -136,7 +136,7 @@ def _add_brave_policies(template_file_contents):
         },
         {
             'name': 'BraveShieldsEnabledForUrls',
-            'type': 'main',
+            'type': 'list',
             'schema': {
               'type': 'array',
               'items': { 'type': 'string' },

--- a/script/policy_source_helper.py
+++ b/script/policy_source_helper.py
@@ -9,7 +9,35 @@
 CHROMIUM_POLICY_KEY = 'SOFTWARE\\\\Policies\\\\BraveSoftware\\\\Brave'
 
 
-def AddBravePolicies(template_file_contents):
+class BravePolicies:  # pylint: disable=too-few-public-methods
+    """
+    We want to add Brave-specific values to policy_templates.json. Doing so in
+    policy_templates.json would produce a very large diff. This class implements
+    a trick that allows us to do it with a single-line change.
+
+    policy_templates.json is Python code that evaluates to a dictionary. It has
+    the form:
+
+        {
+        ...
+        }
+
+    We change it to:
+
+        BravePolicies() + {
+        ...
+        }
+
+    This invokes __add__(...) below. There, we can add our own values and return
+    the new dicitonary.
+    """
+
+    def __add__(self, policy_templates_dict):
+        _add_brave_policies(policy_templates_dict)
+        return policy_templates_dict
+
+
+def _add_brave_policies(template_file_contents):
     highest_id = template_file_contents['highest_id_currently_used']
     policies = [
         {

--- a/script/policy_source_helper.py
+++ b/script/policy_source_helper.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-
 # Copyright (c) 2019 The Brave Authors. All rights reserved.
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this file,


### PR DESCRIPTION
Previously, only Chromium options were there. Now we also have:

 * TorDisabled
 * IPFSEnabled
 * BraveRewardsDisabled
 * BraveWalletDisabled

Resolves https://github.com/brave/brave-browser/issues/26502.

**N.B.:** The [Group Policy documentation](https://support.brave.com/hc/en-us/articles/360039248271-Group-Policy) should be updated after merging this issue. It currently says that the above settings are not included in the templates. The change in this PR takes effect as soon as it is merged and a [Nightly release is published](https://github.com/brave/devops/issues/8818).

This change should only affect [this file on brave-browser-downloads.s3.com](https://brave-browser-downloads.s3.brave.com/latest/policy_templates.zip). It should not have any functional effects on Brave. It's just that the template file on S3 now contains some additional options.

I'm setting the milestone to 1.46.x because this change takes effect as soon as this PR was merged and a Nightly is published.

## Test plan

Check that the above settings can be now be changed via [policy_templates.zip](https://brave-browser-downloads.s3.brave.com/latest/policy_templates.zip). Please see https://github.com/brave/brave-core/pull/15440 for steps that can be used to do this.

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] **The [Group Policy documentation](https://support.brave.com/hc/en-us/articles/360039248271-Group-Policy) was updated**