### PR TITLE
Make a preference to control caching behavior for playlist item

### DIFF
--- a/browser/playlist/playlist_service_factory.cc
+++ b/browser/playlist/playlist_service_factory.cc
@@ -63,6 +63,7 @@ void PlaylistServiceFactory::RegisterProfilePrefs(
   registry->RegisterDictionaryPref(kPlaylistsPref,
                                    base::Value(std::move(dict)));
   registry->RegisterDictionaryPref(kPlaylistItemsPref);
+  registry->RegisterBooleanPref(kPlaylistCacheByDefault, true);
 }
 
 PlaylistServiceFactory::PlaylistServiceFactory()

--- a/browser/ui/webui/playlist_page_handler.cc
+++ b/browser/ui/webui/playlist_page_handler.cc
@@ -11,9 +11,11 @@
 
 #include "brave/browser/playlist/playlist_service_factory.h"
 #include "brave/components/playlist/playlist_constants.h"
+#include "brave/components/playlist/pref_names.h"
 #include "chrome/browser/profiles/profile.h"
 #include "chrome/browser/ui/browser.h"
 #include "chrome/browser/ui/browser_finder.h"
+#include "components/prefs/pref_service.h"
 
 using PlaylistId = playlist::PlaylistService::PlaylistId;
 using PlaylistItemId = playlist::PlaylistService::PlaylistItemId;
@@ -75,8 +77,9 @@ void PlaylistPageHandler::GetPlaylist(
 
 void PlaylistPageHandler::AddMediaFilesFromPageToPlaylist(const std::string& id,
                                                           const GURL& url) {
-  GetPlaylistService(profile_)->RequestDownloadMediaFilesFromPage(id,
-                                                                  url.spec());
+  GetPlaylistService(profile_)->AddMediaFilesFromPageToPlaylist(
+      id, url.spec(),
+      profile_->GetPrefs()->GetBoolean(playlist::kPlaylistCacheByDefault));
 }
 
 void PlaylistPageHandler::AddMediaFilesFromOpenTabsToPlaylist(
@@ -91,8 +94,9 @@ void PlaylistPageHandler::AddMediaFilesFromOpenTabsToPlaylist(
   for (auto i = 0; i < tab_strip_model->count(); i++) {
     if (auto* contents = tab_strip_model->GetWebContentsAt(i);
         contents != web_contents_) {
-      GetPlaylistService(profile_)->RequestDownloadMediaFilesFromContents(
-          playlist_id, contents);
+      GetPlaylistService(profile_)->AddMediaFilesFromContentsToPlaylist(
+          playlist_id, contents,
+          profile_->GetPrefs()->GetBoolean(playlist::kPlaylistCacheByDefault));
     }
   }
 }

--- a/components/playlist/playlist_service.h
+++ b/components/playlist/playlist_service.h
@@ -93,16 +93,18 @@ class PlaylistService : public KeyedService,
 
   // Finds media files from |contents| or |url| and adds them to given
   // |playlist_id|.
-  void RequestDownloadMediaFilesFromContents(const std::string& playlist_id,
-                                             content::WebContents* contents);
-  void RequestDownloadMediaFilesFromPage(const std::string& playlist_id,
-                                         const std::string& url);
+  void AddMediaFilesFromContentsToPlaylist(const std::string& playlist_id,
+                                           content::WebContents* contents,
+                                           bool cache);
+  void AddMediaFilesFromPageToPlaylist(const std::string& playlist_id,
+                                       const std::string& url,
+                                       bool cache);
 
   // Add given |items| to the |playlist_id|. Usually follows after
   // FindMediaFilesFromContents().
-  void RequestDownloadMediaFilesFromItems(
-      const std::string& playlist_id,
-      const std::vector<PlaylistItemInfo>& items);
+  void AddMediaFilesFromItems(const std::string& playlist_id,
+                              bool cache,
+                              const std::vector<PlaylistItemInfo>& items);
 
   // Unlike Request methods above, do nothing with prefs or downloading. Just
   // find media files from given |contents| and return them via callback.
@@ -157,6 +159,7 @@ class PlaylistService : public KeyedService,
   FRIEND_TEST_ALL_PREFIXES(PlaylistServiceUnitTest, MediaRecoverTest);
   FRIEND_TEST_ALL_PREFIXES(PlaylistServiceUnitTest, DeleteItem);
   FRIEND_TEST_ALL_PREFIXES(PlaylistServiceUnitTest, RemoveAndRestoreLocalData);
+  FRIEND_TEST_ALL_PREFIXES(PlaylistServiceUnitTest, CachingBehavior);
 
   // KeyedService overrides:
   void Shutdown() override;
@@ -176,9 +179,10 @@ class PlaylistService : public KeyedService,
   bool ShouldDownloadOnBackground(content::WebContents* contents) const;
 
   void OnPlaylistItemDirCreated(const PlaylistItemInfo& info,
+                                bool cache,
                                 bool directory_ready);
 
-  void CreatePlaylistItem(const PlaylistItemInfo& info);
+  void CreatePlaylistItem(const PlaylistItemInfo& info, bool cache);
   void DownloadThumbnail(const PlaylistItemInfo& info);
   void DownloadMediaFile(const PlaylistItemInfo& info);
 

--- a/components/playlist/pref_names.h
+++ b/components/playlist/pref_names.h
@@ -24,6 +24,9 @@ constexpr char kPlaylistsPref[] = "brave.playlist.lists";
 // it's metadata(such as, title, media file path and etc..).
 constexpr char kPlaylistItemsPref[] = "brave.playlist.items";
 
+// Boolean pref indicates that we should cache media file when adding items.
+constexpr char kPlaylistCacheByDefault[] = "brave.playlist.cache";
+
 }  // namespace playlist
 
 #endif  // BRAVE_COMPONENTS_PLAYLIST_PREF_NAMES_H_


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/27358

Introduce a new preference named "kPlaylistCacheByDefault". When this is disabled, we don't cache media file of new playlist item.

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
PlaylistServiceUnitTest.CachingBehavior
