### PR TITLE
fix(wallet): Hide Fiat Value in NFT Modal

### DIFF
--- a/components/brave_wallet_ui/page/screens/send/components/select-token-modal/select-token-modal.tsx
+++ b/components/brave_wallet_ui/page/screens/send/components/select-token-modal/select-token-modal.tsx
@@ -182,13 +182,15 @@ export const SelectTokenModal = React.forwardRef<HTMLDivElement, Props>(
             >
               {account.name}
             </Text>
-            <Text
-              textColor='text03'
-              textSize='14px'
-              isBold={false}
-            >
-              {getAccountFiatValue(account)}
-            </Text>
+            {selectedSendOption === 'token' &&
+              <Text
+                textColor='text03'
+                textSize='14px'
+                isBold={false}
+              >
+                {getAccountFiatValue(account)}
+              </Text>
+            }
           </AccountSection>
           <Column columnWidth='full' horizontalPadding={8}>
             <VerticalSpacer size={8} />
@@ -203,7 +205,7 @@ export const SelectTokenModal = React.forwardRef<HTMLDivElement, Props>(
           </Column>
         </Column>
       )
-    }, [getTokensBySearchValue, getAccountFiatValue, emptyTokensList])
+    }, [getTokensBySearchValue, getAccountFiatValue, emptyTokensList, selectedSendOption])
 
     // render
     return (


### PR DESCRIPTION
## Description 
Hides the account `Fiat Value` in the `Select NFT` modal

<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves <https://github.com/brave/brave-browser/issues/27370>

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [x] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [x] New files have MPL-2.0 license header
- [x] Adequate test coverage exists to prevent regressions
- [x] Major classes, functions and non-trivial code blocks are well-commented
- [x] Changes in component dependencies are properly reflected in `gn`
- [x] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [x] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
1. Go to the `Send` tab and switch to `Send NFT`.
2. Click `Select NFT`.
3. There should be no account `Fiat Values` displayed

Before:

![Screen Shot 2022-12-14 at 9 57 22 AM](https://user-images.githubusercontent.com/40611140/207645078-3e6b371f-718a-4eb0-8c8e-9ff4eab6b519.png)

After:

![Screen Shot 2022-12-14 at 9 53 14 AM](https://user-images.githubusercontent.com/40611140/207645124-f99148a0-7cc5-4af6-99e2-9a72fce1e6a4.png)
