### PR TITLE
Fix URL loader overwrite caused by two metrics uploaded at the same time (uplift to 1.47.x)

### DIFF
--- a/components/p3a/brave_p3a_uploader.h
+++ b/components/p3a/brave_p3a_uploader.h
@@ -1,7 +1,7 @@
-/* Copyright 2019 The Brave Authors. All rights reserved.
+/* Copyright (c) 2019 The Brave Authors. All rights reserved.
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
- * You can obtain one at http://mozilla.org/MPL/2.0/. */
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 #ifndef BRAVE_COMPONENTS_P3A_BRAVE_P3A_UPLOADER_H_
 #define BRAVE_COMPONENTS_P3A_BRAVE_P3A_UPLOADER_H_
@@ -10,6 +10,7 @@
 #include <string>
 
 #include "base/callback.h"
+#include "base/containers/flat_map.h"
 #include "base/memory/ref_counted.h"
 #include "brave/components/p3a/metric_log_type.h"
 #include "url/gurl.h"
@@ -59,7 +60,8 @@ class BraveP3AUploader {
   const GURL p3a_creative_endpoint_;
   const GURL p2a_endpoint_;
   const UploadCallback on_upload_complete_;
-  std::unique_ptr<network::SimpleURLLoader> url_loader_;
+  base::flat_map<MetricLogType, std::unique_ptr<network::SimpleURLLoader>>
+      url_loaders_;
 };
 
 }  // namespace brave


### PR DESCRIPTION
Uplift of #16361

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.