### PR TITLE
Include Timezone field in Contact Technical Support form

### DIFF
--- a/browser/ui/webui/brave_vpn/brave_vpn_localized_string_provider.cc
+++ b/browser/ui/webui/brave_vpn/brave_vpn_localized_string_provider.cc
@@ -73,6 +73,7 @@ void AddLocalizedStrings(content::WebUIDataSource* html_source) {
       {"braveVpnSupportNotes", IDS_BRAVE_VPN_SUPPORT_NOTES},
       {"braveVpnSupportSubmit", IDS_BRAVE_VPN_SUPPORT_SUBMIT},
       {"braveVpnConnectNotAllowed", IDS_BRAVE_VPN_CONNECT_NOT_ALLOWED},
+      {"braveVpnSupportTimezone", IDS_BRAVE_VPN_SUPPORT_TIMEZONE},
   };
 
   for (const auto& str : kLocalizedStrings) {

--- a/components/brave_vpn/browser/api/BUILD.gn
+++ b/components/brave_vpn/browser/api/BUILD.gn
@@ -26,6 +26,7 @@ source_set("api") {
     "//components/prefs",
     "//net/traffic_annotation",
     "//services/network/public/cpp",
+    "//third_party/icu",
     "//url",
   ]
 }

--- a/components/brave_vpn/browser/api/brave_vpn_api_helper.cc
+++ b/components/brave_vpn/browser/api/brave_vpn_api_helper.cc
@@ -20,6 +20,7 @@
 #include "brave/components/brave_vpn/common/pref_names.h"
 #include "brave/components/skus/browser/skus_utils.h"
 #include "components/prefs/pref_service.h"
+#include "third_party/icu/source/i18n/unicode/timezone.h"
 
 namespace brave_vpn {
 
@@ -69,11 +70,21 @@ std::vector<Hostname> ParseHostnames(const base::Value::List& hostnames_value) {
   return hostnames;
 }
 
+std::string GetTimeZoneName() {
+  std::unique_ptr<icu::TimeZone> zone(icu::TimeZone::createDefault());
+  icu::UnicodeString id;
+  zone->getID(id);
+  std::string current_time_zone;
+  id.toUTF8String<std::string>(current_time_zone);
+  return current_time_zone;
+}
+
 base::Value::Dict GetValueWithTicketInfos(
     const std::string& email,
     const std::string& subject,
     const std::string& body,
-    const std::string& subscriber_credential) {
+    const std::string& subscriber_credential,
+    const std::string& timezone) {
   base::Value::Dict dict;
 
   std::string email_trimmed, subject_trimmed, body_trimmed, body_encoded;
@@ -94,8 +105,8 @@ base::Value::Dict GetValueWithTicketInfos(
   dict.Set(kSupportTicketSubjectKey, subject_trimmed);
   dict.Set(kSupportTicketSupportTicketKey, body_encoded);
   dict.Set(kSupportTicketPartnerClientIdKey, "com.brave.browser");
+  dict.Set(kSupportTicketTimezoneKey, timezone);
 
   return dict;
 }
-
 }  // namespace brave_vpn

--- a/components/brave_vpn/browser/api/brave_vpn_api_helper.h
+++ b/components/brave_vpn/browser/api/brave_vpn_api_helper.h
@@ -24,11 +24,13 @@ struct Hostname;
 std::unique_ptr<Hostname> PickBestHostname(
     const std::vector<Hostname>& hostnames);
 std::vector<Hostname> ParseHostnames(const base::Value::List& hostnames);
+std::string GetTimeZoneName();
 base::Value::Dict GetValueWithTicketInfos(
     const std::string& email,
     const std::string& subject,
     const std::string& body,
-    const std::string& subscriber_credential);
+    const std::string& subscriber_credential,
+    const std::string& timezone);
 
 }  // namespace brave_vpn
 

--- a/components/brave_vpn/browser/api/brave_vpn_api_helper_unittest.cc
+++ b/components/brave_vpn/browser/api/brave_vpn_api_helper_unittest.cc
@@ -13,9 +13,9 @@
 namespace brave_vpn {
 
 TEST(BraveVPNAPIHelperTest, TicketInfoTest) {
-  base::Value::Dict ticket_value =
-      GetValueWithTicketInfos("brave-vpn@brave.com", "It's cool feature",
-                              "Love the Brave VPN!", "credential");
+  base::Value::Dict ticket_value = GetValueWithTicketInfos(
+      "brave-vpn@brave.com", "It's cool feature", "Love the Brave VPN!",
+      "credential", "USA/Boston");
 
   // Check ticket dict has four required fields.
   EXPECT_TRUE(ticket_value.FindString(kSupportTicketEmailKey));
@@ -24,7 +24,9 @@ TEST(BraveVPNAPIHelperTest, TicketInfoTest) {
   const auto support_ticket_encoded =
       *ticket_value.FindString(kSupportTicketSupportTicketKey);
   EXPECT_TRUE(!support_ticket_encoded.empty());
-
+  auto* timezone = ticket_value.FindString(kSupportTicketTimezoneKey);
+  ASSERT_TRUE(timezone);
+  EXPECT_EQ(*timezone, "USA/Boston");
   // Check body contents
   std::string support_ticket_decoded;
   EXPECT_TRUE(

--- a/components/brave_vpn/browser/api/brave_vpn_api_request.cc
+++ b/components/brave_vpn/browser/api/brave_vpn_api_request.cc
@@ -231,10 +231,11 @@ void BraveVpnAPIRequest::CreateSupportTicket(
       base::BindOnce(&BraveVpnAPIRequest::OnCreateSupportTicket,
                      weak_ptr_factory_.GetWeakPtr(), std::move(callback));
 
-  OAuthRequest(GetURLWithPath(kVpnHost, kCreateSupportTicket), "POST",
-               CreateJSONRequestBody(GetValueWithTicketInfos(
-                   email, subject, body, subscriber_credential)),
-               std::move(internal_callback));
+  OAuthRequest(
+      GetURLWithPath(kVpnHost, kCreateSupportTicket), "POST",
+      CreateJSONRequestBody(GetValueWithTicketInfos(
+          email, subject, body, subscriber_credential, GetTimeZoneName())),
+      std::move(internal_callback));
 }
 
 void BraveVpnAPIRequest::OAuthRequest(

--- a/components/brave_vpn/browser/brave_vpn_service.cc
+++ b/components/brave_vpn/browser/brave_vpn_service.cc
@@ -38,7 +38,6 @@
 #include "brave/components/version_info/version_info.h"
 #include "components/prefs/scoped_user_pref_update.h"
 #include "components/version_info/version_info.h"
-#include "third_party/icu/source/i18n/unicode/timezone.h"
 #endif  // !BUILDFLAG(IS_ANDROID)
 
 namespace brave_vpn {
@@ -395,12 +394,7 @@ std::string BraveVpnService::GetCurrentTimeZone() {
   if (!test_timezone_.empty())
     return test_timezone_;
 
-  std::unique_ptr<icu::TimeZone> zone(icu::TimeZone::createDefault());
-  icu::UnicodeString id;
-  zone->getID(id);
-  std::string current_time_zone;
-  id.toUTF8String<std::string>(current_time_zone);
-  return current_time_zone;
+  return GetTimeZoneName();
 }
 
 void BraveVpnService::GetAllRegions(GetAllRegionsCallback callback) {
@@ -476,7 +470,8 @@ void BraveVpnService::GetSupportData(GetSupportDataCallback callback) {
   std::string os_version = version_info::GetOSType();
 
   std::move(callback).Run(brave_version, os_version,
-                          GetBraveVPNConnectionAPI()->GetHostname());
+                          GetBraveVPNConnectionAPI()->GetHostname(),
+                          GetTimeZoneName());
 }
 
 BraveVPNOSConnectionAPI* BraveVpnService::GetBraveVPNConnectionAPI() const {

--- a/components/brave_vpn/common/brave_vpn_constants.h
+++ b/components/brave_vpn/common/brave_vpn_constants.h
@@ -29,6 +29,7 @@ constexpr char kSupportTicketEmailKey[] = "email";
 constexpr char kSupportTicketSubjectKey[] = "subject";
 constexpr char kSupportTicketSupportTicketKey[] = "support-ticket";
 constexpr char kSupportTicketPartnerClientIdKey[] = "partner-client-id";
+constexpr char kSupportTicketTimezoneKey[] = "timezone";
 
 constexpr char kVpnHost[] = "connect-api.guardianapp.com";
 constexpr char kAllServerRegions[] = "api/v1/servers/all-server-regions";

--- a/components/brave_vpn/mojom/brave_vpn.mojom
+++ b/components/brave_vpn/mojom/brave_vpn.mojom
@@ -64,7 +64,7 @@ interface ServiceHandler {
   GetProductUrls() => (ProductUrls urls);
 
   [EnableIfNot=is_android]
-  GetSupportData() => (string app_version, string os_version, string hostname);
+  GetSupportData() => (string app_version, string os_version, string hostname, string timezone);
 
   [EnableIfNot=is_android]
   CreateSupportTicket(string email, string subject, string body) => (bool success, string response);

--- a/components/brave_vpn/resources/panel/components/contact-support/index.tsx
+++ b/components/brave_vpn/resources/panel/components/contact-support/index.tsx
@@ -243,6 +243,13 @@ function ContactSupport (props: Props) {
                 onChange={getOnChangeToggle('shareOsVersion')}
               />
             </S.OptionalValueLabel>
+            <S.OptionalValueLabel>
+              <div className={'optionalValueTitle'}>
+                <span className={'optionalValueTitleKey'}>
+                  {getLocale('braveVpnSupportTimezone')}
+                </span> {supportData?.timezone}
+              </div>
+            </S.OptionalValueLabel>
           </S.OptionalValues>
           <S.Notes>
             <p>{getLocale('braveVpnSupportNotes')}</p>

--- a/components/brave_vpn/resources/panel/stories/locale.ts
+++ b/components/brave_vpn/resources/panel/stories/locale.ts
@@ -50,6 +50,7 @@ provideStrings({
   braveVpnSupportOptionalVpnHostname: 'VPN hostname:',
   braveVpnSupportOptionalAppVersion: 'App version:',
   braveVpnSupportOptionalOsVersion: 'OS version:',
+  braveVpnSupportTimezone: 'Timezone:',
   braveVpnSupportNotes: 'Support provided in partnership with Guardian.',
   braveVpnSupportSubmit: 'Submit',
   braveVpnConnectNotAllowed: 'VPN connection failed. Please try connecting again, and be sure to click Allow to enable Brave\'s VPN configuration.'

--- a/components/brave_vpn/resources/panel/stories/mock-data/api.ts
+++ b/components/brave_vpn/resources/panel/stories/mock-data/api.ts
@@ -35,7 +35,8 @@ BraveVPN.setPanelBrowserApiForTesting({
     getSupportData: () => Promise.resolve({
       appVersion: '1',
       osVersion: '2',
-      hostname: 'site.example.com'
+      hostname: 'site.example.com',
+      timezone: 'USA/Boston'
     }),
     createSupportTicket: (email: string, subject: string, body: string) => Promise.resolve({
       success: true,

--- a/components/resources/brave_vpn_strings.grdp
+++ b/components/resources/brave_vpn_strings.grdp
@@ -245,4 +245,7 @@
   <message name="IDS_BRAVE_VPN_DNS_POLICY_CHECKBOX" desc="A text shown to user on dialog's checkbpox when he enabled Brave VPN with disabled DoH by policies">
     Do not warn me about this anymore.
   </message>
+  <message name="IDS_BRAVE_VPN_SUPPORT_TIMEZONE" desc="Label on dialog to report bug to technical support ">
+    Timezone:
+  </message>
 </grit-part>


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/25722

- Added timezone to support form on desktops
- Added timezone to `api/v1.2/partners/support-ticket` payload

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

- Check network payload request in sniffer
- Check timezone info in the dialog 
