### PR TITLE
Cancel vpn connect request more quickly

### DIFF
--- a/components/brave_vpn/browser/connection/BUILD.gn
+++ b/components/brave_vpn/browser/connection/BUILD.gn
@@ -76,6 +76,7 @@ source_set("unit_tests") {
     "//brave/components/brave_vpn/common/mojom",
     "//components/sync_preferences:test_support",
     "//content/test:test_support",
+    "//services/network:test_support",
     "//testing/gtest",
     "//third_party/abseil-cpp:absl",
   ]

--- a/components/brave_vpn/browser/connection/brave_vpn_os_connection_api_base.h
+++ b/components/brave_vpn/browser/connection/brave_vpn_os_connection_api_base.h
@@ -117,6 +117,8 @@ class BraveVPNOSConnectionAPIBase
   virtual void UpdateAndNotifyConnectionStateChange(
       mojom::ConnectionState state);
   BraveVpnAPIRequest* GetAPIRequest();
+  // True when do quick cancel.
+  bool QuickCancelIfPossible();
 
   bool cancel_connecting_ = false;
   bool needs_connect_ = false;
@@ -128,6 +130,11 @@ class BraveVPNOSConnectionAPIBase
   raw_ptr<PrefService> local_prefs_ = nullptr;
   std::unique_ptr<Hostname> hostname_;
   base::ObserverList<Observer> observers_;
+  // Only not null when there is active network request.
+  // When network request is done, we reset this so we can know
+  // whether we're waiting the response or not.
+  // We can cancel connecting request quickly when fetching hostnames or
+  // profile credentials is not yet finished by reset this.
   std::unique_ptr<BraveVpnAPIRequest> api_request_;
   scoped_refptr<network::SharedURLLoaderFactory> url_loader_factory_;
 };


### PR DESCRIPTION
When we're in connecting state and still waiting to get hostnames or profile credentials from guardians,
we can cancel very quickly by reset api_request.

fix https://github.com/brave/brave-browser/issues/27427

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves 

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

`BraveVPNOSConnectionAPIUnitTest.CancelConnectingTest`

See the linked issue