### PR TITLE
Store last vpn connect error string

### DIFF
--- a/components/brave_vpn/browser/connection/brave_vpn_os_connection_api.h
+++ b/components/brave_vpn/browser/connection/brave_vpn_os_connection_api.h
@@ -52,6 +52,9 @@ class BraveVPNOSConnectionAPI {
   virtual void AddObserver(Observer* observer) = 0;
   virtual void RemoveObserver(Observer* observer) = 0;
   virtual void SetConnectionState(mojom::ConnectionState state) = 0;
+  // Returns user friendly error string if existed.
+  // Otherwise returns empty.
+  virtual std::string GetLastConnectionError() const = 0;
 };
 
 }  // namespace brave_vpn

--- a/components/brave_vpn/browser/connection/brave_vpn_os_connection_api_base.cc
+++ b/components/brave_vpn/browser/connection/brave_vpn_os_connection_api_base.cc
@@ -45,6 +45,10 @@ void BraveVPNOSConnectionAPIBase::SetConnectionState(
   UpdateAndNotifyConnectionStateChange(state);
 }
 
+std::string BraveVPNOSConnectionAPIBase::GetLastConnectionError() const {
+  return last_connection_error_;
+}
+
 bool BraveVPNOSConnectionAPIBase::IsInProgress() const {
   return connection_state_ == ConnectionState::DISCONNECTING ||
          connection_state_ == ConnectionState::CONNECTING;
@@ -89,6 +93,7 @@ void BraveVPNOSConnectionAPIBase::Connect() {
   }
 
   VLOG(2) << __func__ << " : start connecting!";
+  last_connection_error_.clear();
   UpdateAndNotifyConnectionStateChange(ConnectionState::CONNECTING);
 
   if (connection_info_.IsValid()) {
@@ -237,6 +242,12 @@ void BraveVPNOSConnectionAPIBase::OnDisconnected() {
 void BraveVPNOSConnectionAPIBase::OnIsDisconnecting() {
   VLOG(2) << __func__;
   UpdateAndNotifyConnectionStateChange(ConnectionState::DISCONNECTING);
+}
+
+void BraveVPNOSConnectionAPIBase::SetLastConnectionError(
+    const std::string& error) {
+  VLOG(2) << __func__ << " : " << error;
+  last_connection_error_ = error;
 }
 
 void BraveVPNOSConnectionAPIBase::OnNetworkChanged(

--- a/components/brave_vpn/browser/connection/brave_vpn_os_connection_api_base.h
+++ b/components/brave_vpn/browser/connection/brave_vpn_os_connection_api_base.h
@@ -56,7 +56,7 @@ class BraveVPNOSConnectionAPIBase
   void AddObserver(Observer* observer) override;
   void RemoveObserver(Observer* observer) override;
   void SetConnectionState(mojom::ConnectionState state) override;
-  void SetPreventCreationForTesting(bool value);
+  std::string GetLastConnectionError() const override;
 
  protected:
   BraveVPNOSConnectionAPIBase();
@@ -78,6 +78,7 @@ class BraveVPNOSConnectionAPIBase
   void OnDisconnected();
   void OnIsDisconnecting();
 
+  void SetLastConnectionError(const std::string& error);
   std::string target_vpn_entry_name() const { return target_vpn_entry_name_; }
 
  private:
@@ -97,6 +98,9 @@ class BraveVPNOSConnectionAPIBase
   FRIEND_TEST_ALL_PREFIXES(BraveVPNOSConnectionAPIUnitTest, NeedsConnectTest);
   FRIEND_TEST_ALL_PREFIXES(BraveVPNOSConnectionAPIUnitTest,
                            IgnoreDisconnectedStateWhileConnecting);
+  FRIEND_TEST_ALL_PREFIXES(BraveVPNOSConnectionAPIUnitTest,
+                           ClearLastConnectionErrorWhenNewConnectionStart);
+
   // net::NetworkChangeNotifier::NetworkChangeObserver
   void OnNetworkChanged(
       net::NetworkChangeNotifier::ConnectionType type) override;
@@ -113,17 +117,18 @@ class BraveVPNOSConnectionAPIBase
                               const base::Value::List& hostnames_value);
   void OnGetProfileCredentials(const std::string& profile_credential,
                                bool success);
-
-  virtual void UpdateAndNotifyConnectionStateChange(
-      mojom::ConnectionState state);
+  void UpdateAndNotifyConnectionStateChange(mojom::ConnectionState state);
   BraveVpnAPIRequest* GetAPIRequest();
   // True when do quick cancel.
   bool QuickCancelIfPossible();
+
+  void SetPreventCreationForTesting(bool value);
 
   bool cancel_connecting_ = false;
   bool needs_connect_ = false;
   bool prevent_creation_ = false;
   std::string target_vpn_entry_name_;
+  std::string last_connection_error_;
   mojom::ConnectionState connection_state_ =
       mojom::ConnectionState::DISCONNECTED;
   BraveVPNConnectionInfo connection_info_;

--- a/components/brave_vpn/browser/connection/brave_vpn_os_connection_api_sim.cc
+++ b/components/brave_vpn/browser/connection/brave_vpn_os_connection_api_sim.cc
@@ -131,11 +131,6 @@ bool BraveVPNOSConnectionAPISim::IsConnectionChecked() const {
   return check_connection_called_;
 }
 
-void BraveVPNOSConnectionAPISim::UpdateAndNotifyConnectionStateChange(
-    mojom::ConnectionState state) {
-  BraveVPNOSConnectionAPIBase::UpdateAndNotifyConnectionStateChange(state);
-}
-
 void BraveVPNOSConnectionAPISim::OnConnected(const std::string& name,
                                              bool success) {
   // Cancelling connecting request simulation.

--- a/components/brave_vpn/browser/connection/brave_vpn_os_connection_api_sim.h
+++ b/components/brave_vpn/browser/connection/brave_vpn_os_connection_api_sim.h
@@ -46,9 +46,6 @@ class BraveVPNOSConnectionAPISim : public BraveVPNOSConnectionAPIBase {
   void DisconnectImpl(const std::string& name) override;
   void CheckConnectionImpl(const std::string& name) override;
 
-  void UpdateAndNotifyConnectionStateChange(
-      mojom::ConnectionState state) override;
-
  private:
   friend class BraveVPNServiceTest;
 

--- a/components/brave_vpn/browser/connection/brave_vpn_os_connection_api_unittest.cc
+++ b/components/brave_vpn/browser/connection/brave_vpn_os_connection_api_unittest.cc
@@ -268,4 +268,20 @@ TEST_F(BraveVPNOSConnectionAPIUnitTest,
   EXPECT_EQ(mojom::ConnectionState::CONNECTING, test_api->GetConnectionState());
 }
 
+TEST_F(BraveVPNOSConnectionAPIUnitTest,
+       ClearLastConnectionErrorWhenNewConnectionStart) {
+  auto* test_api =
+      static_cast<BraveVPNOSConnectionAPIBase*>(GetConnectionAPI());
+
+  // Prepare valid connection info.
+  test_api->OnFetchHostnames("region-a", kHostNamesTestData, true);
+  test_api->OnGetProfileCredentials(kProfileCredentialData, true);
+
+  const std::string last_error = "Last error";
+  test_api->SetLastConnectionError(last_error);
+  EXPECT_EQ(last_error, test_api->GetLastConnectionError());
+  test_api->Connect();
+  EXPECT_TRUE(test_api->GetLastConnectionError().empty());
+}
+
 }  // namespace brave_vpn

--- a/components/brave_vpn/browser/connection/win/brave_vpn_os_connection_api_win.h
+++ b/components/brave_vpn/browser/connection/win/brave_vpn_os_connection_api_win.h
@@ -14,6 +14,7 @@
 #include "base/win/windows_types.h"
 #include "brave/components/brave_vpn/browser/connection/brave_vpn_connection_info.h"
 #include "brave/components/brave_vpn/browser/connection/brave_vpn_os_connection_api_base.h"
+#include "brave/components/brave_vpn/browser/connection/win/utils.h"
 
 namespace brave_vpn {
 namespace internal {
@@ -44,10 +45,12 @@ class BraveVPNOSConnectionAPIWin : public BraveVPNOSConnectionAPIBase,
   // base::win::ObjectWatcher::Delegate overrides:
   void OnObjectSignaled(HANDLE object) override;
 
-  void OnCreated(const std::string& name, bool success);
-  void OnConnected(bool success);
-  void OnDisconnected(bool success);
-  void OnRemoved(const std::string& name, bool success);
+  void OnCreated(const std::string& name,
+                 const internal::RasOperationResult& result);
+  void OnConnected(const internal::RasOperationResult& result);
+  void OnDisconnected(const internal::RasOperationResult& result);
+  void OnRemoved(const std::string& name,
+                 const internal::RasOperationResult& result);
   void OnCheckConnection(const std::string& name,
                          internal::CheckConnectionResult result);
 

--- a/components/brave_vpn/browser/connection/win/utils.h
+++ b/components/brave_vpn/browser/connection/win/utils.h
@@ -22,16 +22,23 @@ enum class CheckConnectionResult {
   DISCONNECTED,
 };
 
-void PrintRasError(DWORD error);
+struct RasOperationResult {
+  bool success;
+  // If not success, store user friendly error description.
+  std::string error_description;
+};
+
+// Returns human readable error description.
+std::string GetRasErrorMessage(DWORD error);
 std::wstring GetPhonebookPath(const std::wstring& entry_name);
 
-bool CreateEntry(const std::wstring& entry_name,
-                 const std::wstring& hostname,
-                 const std::wstring& username,
-                 const std::wstring& password);
-bool RemoveEntry(const std::wstring& entry_name);
-bool DisconnectEntry(const std::wstring& entry_name);
-bool ConnectEntry(const std::wstring& entry_name);
+RasOperationResult CreateEntry(const std::wstring& entry_name,
+                               const std::wstring& hostname,
+                               const std::wstring& username,
+                               const std::wstring& password);
+RasOperationResult RemoveEntry(const std::wstring& entry_name);
+RasOperationResult DisconnectEntry(const std::wstring& entry_name);
+RasOperationResult ConnectEntry(const std::wstring& entry_name);
 CheckConnectionResult CheckConnection(const std::wstring& entry_name);
 
 }  // namespace internal


### PR DESCRIPTION
fix https://github.com/brave/brave-browser/issues/27439

It's cleared when new connection starts.
Last error can get with BraveVPNOSConnectionAPI::GetLastConnectionError().

This PR doesn't have functional change.

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves 

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

`BraveVPNOSConnectionAPIUnitTest.ClearLastConnectionErrorWhenNewConnectionStart`