### PR TITLE
Don't take tab strip height into account when calculating that of window

### DIFF
--- a/browser/ui/views/frame/brave_browser_non_client_frame_view_mac.h
+++ b/browser/ui/views/frame/brave_browser_non_client_frame_view_mac.h
@@ -22,6 +22,7 @@ class BraveBrowserNonClientFrameViewMac : public BrowserNonClientFrameViewMac {
       const BraveBrowserNonClientFrameViewMac&) = delete;
   BraveBrowserNonClientFrameViewMac& operator=(
       const BraveBrowserNonClientFrameViewMac&) = delete;
+  gfx::Size GetMinimumSize() const override;
 
  private:
   bool ShouldShowWindowTitleForVerticalTabs() const;

--- a/browser/ui/views/frame/brave_browser_non_client_frame_view_mac.mm
+++ b/browser/ui/views/frame/brave_browser_non_client_frame_view_mac.mm
@@ -107,6 +107,8 @@ gfx::Size BraveBrowserNonClientFrameViewMac::GetMinimumSize() const {
     // implementation.
     auto size = frame()->client_view()->GetMinimumSize();
     size.SetToMax(gfx::Size(0, (size.width() * 3) / 4));
+    // Note that we can't set empty bounds on Mac.
+    size.SetToMax({1, 1});
     return size;
   }
 

--- a/browser/ui/views/frame/brave_browser_non_client_frame_view_mac.mm
+++ b/browser/ui/views/frame/brave_browser_non_client_frame_view_mac.mm
@@ -106,8 +106,7 @@ gfx::Size BraveBrowserNonClientFrameViewMac::GetMinimumSize() const {
     // In order to ignore tab strip height, skip BrowserNonClientFrameViewMac's
     // implementation.
     auto size = frame()->client_view()->GetMinimumSize();
-    // Note that we can't set empty size for the widget.
-    size.SetToMax({1, 1});
+    size.SetToMax(gfx::Size(0, (size.width() * 3) / 4));
     return size;
   }
 

--- a/browser/ui/views/frame/brave_browser_non_client_frame_view_mac.mm
+++ b/browser/ui/views/frame/brave_browser_non_client_frame_view_mac.mm
@@ -100,3 +100,16 @@ void BraveBrowserNonClientFrameViewMac::UpdateWindowTitleAndControls() {
       FROM_HERE, base::BindOnce(&views::Widget::ResetWindowControlsPosition,
                                 frame()->GetWeakPtr()));
 }
+
+gfx::Size BraveBrowserNonClientFrameViewMac::GetMinimumSize() const {
+  if (tabs::features::ShouldShowVerticalTabs(browser_view()->browser())) {
+    // In order to ignore tab strip height, skip BrowserNonClientFrameViewMac's
+    // implementation.
+    auto size = frame()->client_view()->GetMinimumSize();
+    // Note that we can't set empty size for the widget.
+    size.SetToMax({1, 1});
+    return size;
+  }
+
+  return BrowserNonClientFrameViewMac::GetMinimumSize();
+}

--- a/browser/ui/views/sidebar/sidebar_show_options_event_detect_widget.cc
+++ b/browser/ui/views/sidebar/sidebar_show_options_event_detect_widget.cc
@@ -117,7 +117,7 @@ void SidebarShowOptionsEventDetectWidget::AdjustWidgetBounds() {
   contents_view_->SetPreferredSize(rect.size());
 
 #if BUILDFLAG(IS_MAC)
-  // On Mac, we can set empty bounds for the widget.
+  // On Mac, we can't set empty bounds for the widget.
   if (rect.IsEmpty())
     rect.set_size({kWidgetNarrowWidth, 1});
 #endif

--- a/browser/ui/views/sidebar/sidebar_show_options_event_detect_widget.cc
+++ b/browser/ui/views/sidebar/sidebar_show_options_event_detect_widget.cc
@@ -115,5 +115,11 @@ void SidebarShowOptionsEventDetectWidget::AdjustWidgetBounds() {
   rect.set_width(kWidgetNarrowWidth);
 
   contents_view_->SetPreferredSize(rect.size());
+
+#if BUILDFLAG(IS_MAC)
+  // On Mac, we can set empty bounds for the widget.
+  if (rect.IsEmpty())
+    rect.set_size({kWidgetNarrowWidth, 1});
+#endif
   widget_->SetBounds(rect);
 }


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/27442

This allows users to make window smaller on mac.

## Submitter Checklist:

- [ ] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

### Automated
VerticalTabStripBrowserTest.MinHeight

### Manual
Users should be able to make the window smaller than tabstrip's height.
