### PR TITLE
Android updates: fix URL for link and allow for `connect-receipt-test` (uplift to 1.47.x)

### DIFF
--- a/android/java/org/chromium/chrome/browser/vpn/utils/BraveVpnUtils.java
+++ b/android/java/org/chromium/chrome/browser/vpn/utils/BraveVpnUtils.java
@@ -53,9 +53,10 @@ public class BraveVpnUtils {
     public static final String VERIFY_CREDENTIALS_FAILED = "verify_credentials_failed";
     public static final String DESKTOP_CREDENTIAL = "desktop_credential";
 
-    private static final String BRAVE_ACCOUNT_PROD_PAGE_URL = "https://account.brave.com";
+    private static final String BRAVE_ACCOUNT_PROD_PAGE_URL =
+            "https://account.brave.com?intent=connect-receipt&product=vpn";
     private static final String BRAVE_ACCOUNT_STAGING_PAGE_URL =
-            "https://account.bravesoftware.com";
+            "https://account.bravesoftware.com?intent=connect-receipt&product=vpn";
 
     public static boolean mIsServerLocationChanged;
     public static boolean mUpdateProfileAfterSplitTunnel;

--- a/components/brave_vpn/renderer/android/vpn_render_frame_observer.cc
+++ b/components/brave_vpn/renderer/android/vpn_render_frame_observer.cc
@@ -106,10 +106,11 @@ bool VpnRenderFrameObserver::IsAllowed() {
 
   GURL current_url(
       render_frame()->GetWebFrame()->GetDocument().Url().GetString().Utf8());
-  return ExtractParam(current_url, kIntentParamName) == kIntentParamValue &&
-         (ExtractParam(current_url, kProductParamName) == kProductParamValue ||
-          ExtractParam(current_url, kProductParamName) ==
-              kIntentParamTestValue);
+
+  std::string intent = ExtractParam(current_url, kIntentParamName);
+  std::string product = ExtractParam(current_url, kProductParamName);
+  return (intent == kIntentParamValue || intent == kIntentParamTestValue) &&
+         product == kProductParamValue;
 }
 
 void VpnRenderFrameObserver::OnDestruct() {

--- a/components/brave_vpn/renderer/android/vpn_render_frame_observer.cc
+++ b/components/brave_vpn/renderer/android/vpn_render_frame_observer.cc
@@ -27,6 +27,7 @@ namespace {
 
 char kIntentParamName[] = "intent";
 char kIntentParamValue[] = "connect-receipt";
+char kIntentParamTestValue[] = "connect-receipt-test";
 char kProductParamName[] = "product";
 char kProductParamValue[] = "vpn";
 
@@ -106,7 +107,9 @@ bool VpnRenderFrameObserver::IsAllowed() {
   GURL current_url(
       render_frame()->GetWebFrame()->GetDocument().Url().GetString().Utf8());
   return ExtractParam(current_url, kIntentParamName) == kIntentParamValue &&
-         ExtractParam(current_url, kProductParamName) == kProductParamValue;
+         (ExtractParam(current_url, kProductParamName) == kProductParamValue ||
+          ExtractParam(current_url, kProductParamName) ==
+              kIntentParamTestValue);
 }
 
 void VpnRenderFrameObserver::OnDestruct() {


### PR DESCRIPTION
Uplift of #16407
Uplift of https://github.com/brave/brave-core/pull/16436
Fixes https://github.com/brave/brave-browser/issues/27452
Fixes https://github.com/brave/brave-browser/issues/27451
Fixes https://github.com/brave/brave-browser/issues/27473

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.