### PR TITLE
Use local script when component isn't updated yet

### DIFF
--- a/browser/playlist/test/playlist_download_request_manager_browsertests.cc
+++ b/browser/playlist/test/playlist_download_request_manager_browsertests.cc
@@ -61,7 +61,7 @@ class PlaylistDownloadRequestManagerBrowserTest : public PlatformBrowserTest {
     ASSERT_TRUE(content::NavigateToURL(active_web_contents, url));
 
     // Run script and find media files
-    ASSERT_FALSE(component_manager_->script().empty());
+    ASSERT_FALSE(component_manager_->GetMediaDetectorScript().empty());
     playlist::PlaylistDownloadRequestManager::Request request;
     request.url_or_contents = active_web_contents->GetWeakPtr();
     request.callback =

--- a/components/playlist/media_detector_component_manager.cc
+++ b/components/playlist/media_detector_component_manager.cc
@@ -261,12 +261,12 @@ bool MediaDetectorComponentManager::ShouldHideMediaSrcAPI(
 }
 
 const std::string& MediaDetectorComponentManager::GetMediaDetectorScript() {
-  if (!script_.empty()) {
-    RegisterIfNeeded();
+  if (!script_.empty())
     return script_;
-  }
 
-  // In case we have yet to fetch the script, use local script instead.
+  // In case we have yet to fetch the script, use local script instead. At the
+  // same time, fetch the script from component.
+  RegisterIfNeeded();
   return GetLocalScript();
 }
 

--- a/components/playlist/media_detector_component_manager.cc
+++ b/components/playlist/media_detector_component_manager.cc
@@ -27,60 +27,7 @@ std::string ReadScript(const base::FilePath& path) {
   return contents;
 }
 
-}  // namespace
-
-MediaDetectorComponentManager::MediaDetectorComponentManager(
-    component_updater::ComponentUpdateService* component_update_service)
-    : component_update_service_(component_update_service) {
-  // TODO(sko) This list should be dynamically updated from the playlist.
-  // Once it's done, remove this line.
-  SetUseLocalListToHideMediaSrcAPI();
-}
-
-MediaDetectorComponentManager::~MediaDetectorComponentManager() = default;
-
-void MediaDetectorComponentManager::AddObserver(Observer* observer) {
-  observer_list_.AddObserver(observer);
-}
-
-void MediaDetectorComponentManager::RemoveObserver(Observer* observer) {
-  observer_list_.RemoveObserver(observer);
-}
-
-void MediaDetectorComponentManager::RegisterIfNeeded() {
-  if (register_requested_)
-    return;
-
-  register_requested_ = true;
-  RegisterMediaDetectorComponent(
-      component_update_service_,
-      base::BindRepeating(&MediaDetectorComponentManager::OnComponentReady,
-                          weak_factory_.GetWeakPtr()));
-}
-
-void MediaDetectorComponentManager::OnComponentReady(
-    const base::FilePath& install_path) {
-  base::ThreadPool::PostTaskAndReplyWithResult(
-      FROM_HERE, base::MayBlock(),
-      base::BindOnce(&ReadScript, GetScriptPath(install_path)),
-      base::BindOnce(&MediaDetectorComponentManager::OnGetScript,
-                     weak_factory_.GetWeakPtr()));
-}
-
-void MediaDetectorComponentManager::OnGetScript(const std::string& script) {
-  if (script.empty()) {
-    LOG(ERROR) << __FUNCTION__ << " script is empty!";
-    return;
-  }
-
-  script_ = script;
-
-  for (auto& observer : observer_list_)
-    observer.OnScriptReady(script_);
-}
-
-void MediaDetectorComponentManager::SetUseLocalScriptForTesting() {
-  register_requested_ = true;
+const std::string& GetLocalScript() {
   // This script is modified version of
   // https://github.com/brave/brave-ios/blob/development/Client/Frontend/UserContent/UserScripts/Playlist.js
   static const std::string kScript = R"-(
@@ -243,7 +190,65 @@ void MediaDetectorComponentManager::SetUseLocalScriptForTesting() {
 })();
   )-";
 
-  OnGetScript(kScript);
+  return kScript;
+}
+
+}  // namespace
+
+MediaDetectorComponentManager::MediaDetectorComponentManager(
+    component_updater::ComponentUpdateService* component_update_service)
+    : component_update_service_(component_update_service) {
+  // TODO(sko) This list should be dynamically updated from the playlist.
+  // Once it's done, remove this line.
+  SetUseLocalListToHideMediaSrcAPI();
+}
+
+MediaDetectorComponentManager::~MediaDetectorComponentManager() = default;
+
+void MediaDetectorComponentManager::AddObserver(Observer* observer) {
+  observer_list_.AddObserver(observer);
+}
+
+void MediaDetectorComponentManager::RemoveObserver(Observer* observer) {
+  observer_list_.RemoveObserver(observer);
+}
+
+void MediaDetectorComponentManager::RegisterIfNeeded() {
+  if (register_requested_)
+    return;
+
+  register_requested_ = true;
+  RegisterMediaDetectorComponent(
+      component_update_service_,
+      base::BindRepeating(&MediaDetectorComponentManager::OnComponentReady,
+                          weak_factory_.GetWeakPtr()));
+}
+
+void MediaDetectorComponentManager::OnComponentReady(
+    const base::FilePath& install_path) {
+  base::ThreadPool::PostTaskAndReplyWithResult(
+      FROM_HERE, base::MayBlock(),
+      base::BindOnce(&ReadScript, GetScriptPath(install_path)),
+      base::BindOnce(&MediaDetectorComponentManager::OnGetScript,
+                     weak_factory_.GetWeakPtr()));
+}
+
+void MediaDetectorComponentManager::OnGetScript(const std::string& script) {
+  if (script.empty()) {
+    LOG(ERROR) << __FUNCTION__ << " script is empty!";
+    return;
+  }
+
+  script_ = script;
+
+  for (auto& observer : observer_list_)
+    observer.OnScriptReady(script_);
+}
+
+void MediaDetectorComponentManager::SetUseLocalScriptForTesting() {
+  register_requested_ = true;
+
+  OnGetScript(GetLocalScript());
 }
 
 bool MediaDetectorComponentManager::ShouldHideMediaSrcAPI(
@@ -253,6 +258,16 @@ bool MediaDetectorComponentManager::ShouldHideMediaSrcAPI(
                               [&schemeful_site](const auto& site_to_hide) {
                                 return site_to_hide == schemeful_site;
                               });
+}
+
+const std::string& MediaDetectorComponentManager::GetMediaDetectorScript() {
+  if (!script_.empty()) {
+    RegisterIfNeeded();
+    return script_;
+  }
+
+  // In case we have yet to fetch the script, use local script instead.
+  return GetLocalScript();
 }
 
 void MediaDetectorComponentManager::SetUseLocalListToHideMediaSrcAPI() {

--- a/components/playlist/media_detector_component_manager.h
+++ b/components/playlist/media_detector_component_manager.h
@@ -43,9 +43,9 @@ class MediaDetectorComponentManager {
   void AddObserver(Observer* observer);
   void RemoveObserver(Observer* observer);
 
-  void RegisterIfNeeded();
-
-  std::string script() const { return script_; }
+  // Returns a script to get media from page. If the script isn't fetched
+  // from component yet, will return a local script.
+  const std::string& GetMediaDetectorScript();
 
   void SetUseLocalScriptForTesting();
 
@@ -57,6 +57,8 @@ class MediaDetectorComponentManager {
   }
 
  private:
+  void RegisterIfNeeded();
+
   void OnComponentReady(const base::FilePath& install_path);
   void OnGetScript(const std::string& script);
 

--- a/components/playlist/playlist_download_request_manager.h
+++ b/components/playlist/playlist_download_request_manager.h
@@ -37,9 +37,7 @@ namespace playlist {
 
 // This class finds media files and their thumbnails and title from a page
 // by injecting media detector script to dedicated WebContents.
-class PlaylistDownloadRequestManager
-    : public MediaDetectorComponentManager::Observer,
-      public content::WebContentsObserver {
+class PlaylistDownloadRequestManager : public content::WebContentsObserver {
  public:
   struct Request {
     using Callback =
@@ -106,9 +104,6 @@ class PlaylistDownloadRequestManager
   void DidFinishLoad(content::RenderFrameHost* render_frame_host,
                      const GURL& validated_url) override;
 
-  // MediaDetectorComponentManager::Observer overrides:
-  void OnScriptReady(const std::string& script) override;
-
   // We create |web_contents_| on demand. So, when downloading media is
   // requested, |web_contents_| may not be ready to inject js script. This
   // list caches already requested urls and used after |web_contents_| is
@@ -125,13 +120,9 @@ class PlaylistDownloadRequestManager
   int in_progress_urls_count_ = 0;
   Request::Callback callback_for_current_request_ = base::NullCallback();
 
-  std::string media_detector_script_;
   raw_ptr<content::BrowserContext> context_;
 
   raw_ptr<MediaDetectorComponentManager> media_detector_component_manager_;
-  base::ScopedObservation<MediaDetectorComponentManager,
-                          MediaDetectorComponentManager::Observer>
-      observed_{this};
   std::unique_ptr<base::RetainingOneShotTimer> web_contents_destroy_timer_;
 
   base::WeakPtrFactory<PlaylistDownloadRequestManager> weak_factory_{this};


### PR DESCRIPTION
It takes quite a long time to fetch the playlist component. While it's being downloaded, every request will be blocked. Instead of blocking the requests, use local script so that users can get the result right away.

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/27459

## Submitter Checklist:

- [ ] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

