### PR TITLE
Reset preferred size of vertical tab strip region when parent widget bounds changes

### DIFF
--- a/browser/ui/views/frame/brave_browser_view.h
+++ b/browser/ui/views/frame/brave_browser_view.h
@@ -96,6 +96,7 @@ class BraveBrowserView : public BrowserView {
   friend class sidebar::SidebarBrowserTest;
 
   FRIEND_TEST_ALL_PREFIXES(VerticalTabStripBrowserTest, VisualState);
+  FRIEND_TEST_ALL_PREFIXES(VerticalTabStripBrowserTest, Fullscreen);
 
   static void SetDownloadConfirmReturnForTesting(bool allow);
 

--- a/browser/ui/views/frame/vertical_tab_strip_widget_delegate_view.cc
+++ b/browser/ui/views/frame/vertical_tab_strip_widget_delegate_view.cc
@@ -114,7 +114,9 @@ void VerticalTabStripWidgetDelegateView::OnViewIsDeleting(
 void VerticalTabStripWidgetDelegateView::OnWidgetBoundsChanged(
     views::Widget* widget,
     const gfx::Rect& new_bounds) {
-  UpdateWidgetBounds();
+  // The parent widget could be resized because fullscreen status changed.
+  // Try resetting preferred size.
+  ChildPreferredSizeChanged(region_view_);
 }
 
 void VerticalTabStripWidgetDelegateView::UpdateWidgetBounds() {

--- a/browser/ui/views/tabs/vertical_tab_strip_browsertest.cc
+++ b/browser/ui/views/tabs/vertical_tab_strip_browsertest.cc
@@ -338,7 +338,14 @@ IN_PROC_BROWSER_TEST_F(VerticalTabStripBrowserTest, SidebarAlignment) {
   EXPECT_TRUE(prefs->GetBoolean(prefs::kSidePanelHorizontalAlignment));
 }
 
-IN_PROC_BROWSER_TEST_F(VerticalTabStripBrowserTest, Fullscreen) {
+#if BUILDFLAG(IS_MAC)
+// Mac test bots are not able to enter fullscreen.
+#define MAYBE_Fullscreen DISABLED_Fullscreen
+#else
+#define MAYBE_Fullscreen Fullscreen
+#endif
+
+IN_PROC_BROWSER_TEST_F(VerticalTabStripBrowserTest, MAYBE_Fullscreen) {
   ToggleVerticalTabStrip();
   ASSERT_TRUE(browser_view()
                   ->vertical_tab_strip_host_view_->GetPreferredSize()

--- a/browser/ui/views/tabs/vertical_tab_strip_browsertest.cc
+++ b/browser/ui/views/tabs/vertical_tab_strip_browsertest.cc
@@ -3,6 +3,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+#include "base/test/bind.h"
 #include "base/test/scoped_feature_list.h"
 #include "brave/browser/ui/browser_commands.h"
 #include "brave/browser/ui/tabs/brave_tab_prefs.h"
@@ -13,6 +14,8 @@
 #include "build/build_config.h"
 #include "chrome/browser/ui/browser.h"
 #include "chrome/browser/ui/browser_tabstrip.h"
+#include "chrome/browser/ui/exclusive_access/exclusive_access_manager.h"
+#include "chrome/browser/ui/exclusive_access/fullscreen_controller.h"
 #include "chrome/browser/ui/views/frame/browser_non_client_frame_view.h"
 #include "chrome/browser/ui/views/frame/browser_view.h"
 #include "chrome/browser/ui/views/frame/tab_strip_region_view.h"
@@ -287,4 +290,54 @@ IN_PROC_BROWSER_TEST_F(VerticalTabStripBrowserTest, SidebarAlignment) {
   EXPECT_FALSE(prefs->FindPreference(prefs::kSidePanelHorizontalAlignment)
                    ->IsDefaultValue());
   EXPECT_TRUE(prefs->GetBoolean(prefs::kSidePanelHorizontalAlignment));
+}
+
+IN_PROC_BROWSER_TEST_F(VerticalTabStripBrowserTest, Fullscreen) {
+  ToggleVerticalTabStrip();
+  ASSERT_TRUE(browser_view()
+                  ->vertical_tab_strip_host_view_->GetPreferredSize()
+                  .width());
+  auto* fullscreen_controller =
+      browser_view()->GetExclusiveAccessManager()->fullscreen_controller();
+  fullscreen_controller->ToggleBrowserFullscreenMode();
+
+  // Vertical tab strip should be visible on browser fullscreen.
+  ASSERT_TRUE(fullscreen_controller->IsFullscreenForBrowser());
+  ASSERT_TRUE(browser_view()->IsFullscreen());
+  EXPECT_TRUE(browser_view()
+                  ->vertical_tab_strip_host_view_->GetPreferredSize()
+                  .width());
+
+  fullscreen_controller->ToggleBrowserFullscreenMode();
+  ASSERT_FALSE(fullscreen_controller->IsFullscreenForBrowser());
+  ASSERT_FALSE(browser_view()->IsFullscreen());
+
+  // Vertical tab strip should become invisible on tab fullscreen.
+  fullscreen_controller->EnterFullscreenModeForTab(browser_view()
+                                                       ->browser()
+                                                       ->tab_strip_model()
+                                                       ->GetActiveWebContents()
+                                                       ->GetPrimaryMainFrame());
+  ASSERT_TRUE(fullscreen_controller->IsTabFullscreen());
+
+  base::RunLoop run_loop;
+  auto wait_until = base::BindLambdaForTesting(
+      [&](base::RepeatingCallback<bool()> predicate) {
+        if (predicate.Run())
+          return;
+
+        base::RepeatingTimer scheduler;
+        scheduler.Start(FROM_HERE, base::Milliseconds(100),
+                        base::BindLambdaForTesting([&]() {
+                          if (predicate.Run())
+                            run_loop.Quit();
+                        }));
+        run_loop.Run();
+      });
+
+  wait_until.Run(base::BindLambdaForTesting([&]() {
+    return !browser_view()
+                ->vertical_tab_strip_host_view_->GetPreferredSize()
+                .width();
+  }));
 }


### PR DESCRIPTION
In order to reset the region when fullscreen status changes, reset preferred size together.

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/27462

## Submitter Checklist:

- [ ] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
### Automated
VerticalTabStripBrowserTest.Fullscreen
