### PR TITLE
Add .style.yapf.

### DIFF
--- a/.style.yapf
+++ b/.style.yapf
@@ -2,8 +2,8 @@
 based_on_style = pep8
 
 # PEP-8 limits to 79 chars. Chromium uses 80 chars everywhere.
-column_limit=80
+column_limit = 80
 
 # Workaround yapf dict formatting bug.
 # See for details: https://github.com/google/yapf/issues/392
-allow_split_before_dict_value=False
+allow_split_before_dict_value = False

--- a/.style.yapf
+++ b/.style.yapf
@@ -1,0 +1,9 @@
+[style]
+based_on_style = pep8
+
+# PEP-8 limits to 79 chars. Chromium uses 80 chars everywhere.
+column_limit=80
+
+# Workaround yapf dict formatting bug.
+# See for details: https://github.com/google/yapf/issues/392
+allow_split_before_dict_value=False


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
We have a [PR](https://github.com/brave/brave-core/pull/16351) in review which revealed a yapf dict formatting bug. I don't want to merge that PR with such weird formatting (it's enforced via format checks). Instead we can introduce a correct style which won't trigger this issue.

This PR adds style config with Chromium defaults and a workaround for dict formatting.
PEP-8 style has INDENT_WIDTH=4 by default, most of our files are formatted with indent=4, that's why I didn't add it explicitly to the config.

Resolves https://github.com/brave/brave-browser/issues/27467

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

