### PR TITLE
Add box shadow to Rewards page promo cards

### DIFF
--- a/components/brave_rewards/resources/page/components/sidebar_promotion_panel.style.ts
+++ b/components/brave_rewards/resources/page/components/sidebar_promotion_panel.style.ts
@@ -29,6 +29,9 @@ export const rewardsTourPromo = styled.div``
 export const promotion = styled.div`
   color: #000;
   background: #fff;
+  box-shadow:
+    0px 0px 1px rgba(0, 0, 0, 0.11),
+    0px 0.5px 1.5px rgba(0, 0, 0, 0.1);
   border-radius: 8px;
   min-height: 157px;
   cursor: pointer;

--- a/components/brave_rewards/resources/shared/components/onboarding/rewards_tour_promo.style.ts
+++ b/components/brave_rewards/resources/shared/components/onboarding/rewards_tour_promo.style.ts
@@ -14,7 +14,7 @@ export const root = styled.div`
     linear-gradient(279.66deg, #694CD9 0%, #7D186C 100%);
   background-repeat: no-repeat;
   background-size: cover;
-  border-radius: 12px;
+  border-radius: 8px;
   font-family: var(--brave-font-heading);
   color: var(--brave-palette-white);
   padding: 28px 16px 18px;


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/27329

Also adjusts the border radius of the "rewards tour promo". A box shadow was not added to that card, as it was not visible with the card's dark background.

## Submitter Checklist:

- [ ] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

<img width="401" alt="Screen Shot 2022-12-20 at 11 52 42 AM" src="https://user-images.githubusercontent.com/5995084/208722355-44a8c1d0-4e40-4034-82a3-48ca8f7ac821.png">

