### PR TITLE
Wrap publisher names on Rewards page AC list

### DIFF
--- a/components/brave_rewards/resources/page/components/page_modal.style.ts
+++ b/components/brave_rewards/resources/page/components/page_modal.style.ts
@@ -14,6 +14,7 @@ export const root = styled.div`
 
   .layout-narrow & {
     min-width: unset;
+    margin: 0 8px;
   }
 `
 

--- a/components/brave_rewards/resources/page/components/publisher_link.style.ts
+++ b/components/brave_rewards/resources/page/components/publisher_link.style.ts
@@ -7,11 +7,12 @@ import styled from 'styled-components'
 
 export const root = styled.span`
   font-weight: 600;
-  white-space: nowrap;
 
   a {
     text-decoration: none;
     color: #3b3e4f;
+    display: inline-flex;
+    align-items: center;
   }
 `
 
@@ -40,6 +41,10 @@ export const verified = styled.div`
     background-color: #FFFFFF;
     border-radius: 50%;
   }
+`
+
+export const name = styled.span`
+  flex: 1 1 auto;
 `
 
 export const platform = styled.span``

--- a/components/brave_rewards/resources/page/components/publisher_link.tsx
+++ b/components/brave_rewards/resources/page/components/publisher_link.tsx
@@ -38,13 +38,15 @@ export function PublisherLink (props: Props) {
               </style.verified>
           }
         </style.icon>
-        {props.name}
-        {
-          platformName &&
-            <style.platform>
-              &nbsp;{getString('on')}&nbsp;{platformName}
-            </style.platform>
-        }
+        <style.name>
+          {props.name}
+          {
+            platformName &&
+              <style.platform>
+                &nbsp;{getString('on')}&nbsp;{platformName}
+              </style.platform>
+          }
+        </style.name>
       </NewTabLink>
     </style.root>
   )


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/27470

This change also ensures that newer page modals have a small side margin in narrow view.

## Submitter Checklist:

- [ ] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

Wide view after change:

<img width="594" alt="Screen Shot 2022-12-20 at 12 26 07 PM" src="https://user-images.githubusercontent.com/5995084/208730808-3b774927-d763-4042-bfe3-80f9fd042acb.png">

Narrow view after change:

<img width="344" alt="Screen Shot 2022-12-20 at 12 26 39 PM" src="https://user-images.githubusercontent.com/5995084/208730888-c1972b41-aaf2-4222-b61f-508d37ce6cba.png">
