### PR TITLE
Added don't show again button to obsolete system infobar (uplift to 1.47.x)

### DIFF
--- a/app/brave_generated_resources.grd
+++ b/app/brave_generated_resources.grd
@@ -595,6 +595,10 @@ Or change later at <ph name="SETTINGS_EXTENIONS_LINK">$2<ex>brave://settings/ext
         <message name="IDS_WEB_DISCOVERY_INFOBAR_NO_THANKS_LABEL" desc="The text for no thanks button in infobar">
           No thanks
         </message>
+        <!-- obsolete system InfoBar -->
+        <message name="IDS_OBSOLERE_SYSTEM_INFOBAR_DONT_SHOW_BUTTON" desc="The text for don't show again button">
+          Don't show again
+        </message>
       </if>
 
       <!-- Brave Ads -->

--- a/browser/brave_browser_process_impl.cc
+++ b/browser/brave_browser_process_impl.cc
@@ -41,8 +41,10 @@
 #include "build/build_config.h"
 #include "chrome/browser/component_updater/component_updater_utils.h"
 #include "chrome/browser/net/system_network_context_manager.h"
+#include "chrome/browser/obsolete_system/obsolete_system.h"
 #include "chrome/common/buildflags.h"
 #include "chrome/common/chrome_paths.h"
+#include "chrome/common/pref_names.h"
 #include "components/component_updater/component_updater_service.h"
 #include "components/component_updater/timer_update_scheduler.h"
 #include "content/public/browser/browser_thread.h"
@@ -153,6 +155,14 @@ void BraveBrowserProcessImpl::Init() {
 #endif
 
   InitSystemRequestHandlerCallback();
+
+#if !BUILDFLAG(IS_ANDROID)
+  if (!ObsoleteSystem::IsObsoleteNowOrSoon()) {
+    // Clear to show unsupported warning infobar again even if user
+    // suppressed it from previous os.
+    local_state()->ClearPref(prefs::kSuppressUnsupportedOSWarning);
+  }
+#endif
 }
 
 #if !BUILDFLAG(IS_ANDROID)

--- a/browser/ui/BUILD.gn
+++ b/browser/ui/BUILD.gn
@@ -96,6 +96,8 @@ source_set("ui") {
       "omnibox/brave_omnibox_client_impl.cc",
       "omnibox/brave_omnibox_client_impl.h",
       "session_crashed_bubble_brave.cc",
+      "startup/brave_obsolete_system_infobar_delegate.cc",
+      "startup/brave_obsolete_system_infobar_delegate.h",
       "toolbar/brave_app_menu_model.cc",
       "toolbar/brave_app_menu_model.h",
       "toolbar/brave_recent_tabs_sub_menu_model.h",

--- a/browser/ui/startup/brave_obsolete_system_infobar_delegate.cc
+++ b/browser/ui/startup/brave_obsolete_system_infobar_delegate.cc
@@ -1,0 +1,46 @@
+/* Copyright (c) 2022 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include <memory>
+
+#include "brave/browser/ui/startup/brave_obsolete_system_infobar_delegate.h"
+#include "brave/grit/brave_generated_resources.h"
+#include "chrome/browser/browser_process.h"
+#include "chrome/browser/infobars/confirm_infobar_creator.h"
+#include "chrome/common/pref_names.h"
+#include "components/infobars/content/content_infobar_manager.h"
+#include "components/infobars/core/infobar.h"
+#include "components/prefs/pref_service.h"
+#include "ui/base/l10n/l10n_util.h"
+
+// static
+void BraveObsoleteSystemInfoBarDelegate::Create(
+    infobars::ContentInfoBarManager* infobar_manager) {
+  infobar_manager->AddInfoBar(
+      CreateConfirmInfoBar(std::unique_ptr<ConfirmInfoBarDelegate>(
+          new BraveObsoleteSystemInfoBarDelegate())));
+}
+
+BraveObsoleteSystemInfoBarDelegate::BraveObsoleteSystemInfoBarDelegate() =
+    default;
+BraveObsoleteSystemInfoBarDelegate::~BraveObsoleteSystemInfoBarDelegate() =
+    default;
+
+int BraveObsoleteSystemInfoBarDelegate::GetButtons() const {
+  return BUTTON_OK;
+}
+
+std::u16string BraveObsoleteSystemInfoBarDelegate::GetButtonLabel(
+    InfoBarButton button) const {
+  return l10n_util::GetStringUTF16(
+      IDS_OBSOLERE_SYSTEM_INFOBAR_DONT_SHOW_BUTTON);
+}
+
+bool BraveObsoleteSystemInfoBarDelegate::Accept() {
+  if (PrefService* local_state = g_browser_process->local_state()) {
+    local_state->SetBoolean(prefs::kSuppressUnsupportedOSWarning, true);
+  }
+  return true;
+}

--- a/browser/ui/startup/brave_obsolete_system_infobar_delegate.h
+++ b/browser/ui/startup/brave_obsolete_system_infobar_delegate.h
@@ -1,0 +1,39 @@
+/* Copyright (c) 2022 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_BROWSER_UI_STARTUP_BRAVE_OBSOLETE_SYSTEM_INFOBAR_DELEGATE_H_
+#define BRAVE_BROWSER_UI_STARTUP_BRAVE_OBSOLETE_SYSTEM_INFOBAR_DELEGATE_H_
+
+#include <string>
+
+#include "chrome/browser/ui/startup/obsolete_system_infobar_delegate.h"
+
+namespace infobars {
+class ContentInfoBarManager;
+}  // namespace infobars
+
+// Subclassed for showing "Don't show again" button.
+// W/o this button, user will see this infobar whenever launched.
+class BraveObsoleteSystemInfoBarDelegate
+    : public ObsoleteSystemInfoBarDelegate {
+ public:
+  static void Create(infobars::ContentInfoBarManager* infobar_manager);
+
+  BraveObsoleteSystemInfoBarDelegate(
+      const BraveObsoleteSystemInfoBarDelegate&) = delete;
+  BraveObsoleteSystemInfoBarDelegate& operator=(
+      const BraveObsoleteSystemInfoBarDelegate&) = delete;
+
+ private:
+  BraveObsoleteSystemInfoBarDelegate();
+  ~BraveObsoleteSystemInfoBarDelegate() override;
+
+  // ObsoleteSystemInfoBarDelegate overrides:
+  int GetButtons() const override;
+  std::u16string GetButtonLabel(InfoBarButton button) const override;
+  bool Accept() override;
+};
+
+#endif  // BRAVE_BROWSER_UI_STARTUP_BRAVE_OBSOLETE_SYSTEM_INFOBAR_DELEGATE_H_

--- a/chromium_src/chrome/browser/ui/startup/infobar_utils.cc
+++ b/chromium_src/chrome/browser/ui/startup/infobar_utils.cc
@@ -1,8 +1,9 @@
 /* Copyright (c) 2021 The Brave Authors. All rights reserved.
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
- * You can obtain one at http://mozilla.org/MPL/2.0/. */
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+#include "brave/browser/ui/startup/brave_obsolete_system_infobar_delegate.h"
 #include "chrome/browser/ui/session_crashed_bubble.h"
 #include "chrome/browser/ui/startup/google_api_keys_infobar_delegate.h"
 #include "components/infobars/content/content_infobar_manager.h"
@@ -16,7 +17,10 @@ class BraveGoogleKeysInfoBarDelegate {
 
 #define ShowIfNotOffTheRecordProfile ShowIfNotOffTheRecordProfileBrave
 #define GoogleApiKeysInfoBarDelegate BraveGoogleKeysInfoBarDelegate
+#define ObsoleteSystemInfoBarDelegate BraveObsoleteSystemInfoBarDelegate
 
 #include "src/chrome/browser/ui/startup/infobar_utils.cc"
+
+#undef ObsoleteSystemInfoBarDelegate
 #undef GoogleApiKeysInfoBarDelegate
 #undef ShowIfNotOffTheRecordProfile

--- a/chromium_src/chrome/browser/ui/startup/obsolete_system_infobar_delegate.h
+++ b/chromium_src/chrome/browser/ui/startup/obsolete_system_infobar_delegate.h
@@ -1,0 +1,20 @@
+/* Copyright (c) 2022 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_CHROMIUM_SRC_CHROME_BROWSER_UI_STARTUP_OBSOLETE_SYSTEM_INFOBAR_DELEGATE_H_
+#define BRAVE_CHROMIUM_SRC_CHROME_BROWSER_UI_STARTUP_OBSOLETE_SYSTEM_INFOBAR_DELEGATE_H_
+
+#include "components/infobars/core/confirm_infobar_delegate.h"
+
+#define Create                                     \
+  Create_UnUsed() {}                               \
+  friend class BraveObsoleteSystemInfoBarDelegate; \
+  static void Create
+
+#include "src/chrome/browser/ui/startup/obsolete_system_infobar_delegate.h"
+
+#undef Create
+
+#endif  // BRAVE_CHROMIUM_SRC_CHROME_BROWSER_UI_STARTUP_OBSOLETE_SYSTEM_INFOBAR_DELEGATE_H_


### PR DESCRIPTION
Uplift of #16270
fix https://github.com/brave/brave-browser/issues/27122

Pre-approval checklist: 
- [ ] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [ ] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [ ] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [ ] The associated issue milestone is set to the smallest version that the changes is landed on.