### PR TITLE
fix(wallet): Wrap Long NFT Names in Send

### DIFF
--- a/components/brave_wallet_ui/page/screens/send/components/select-token-button/select-token-button.style.ts
+++ b/components/brave_wallet_ui/page/screens/send/components/select-token-button/select-token-button.style.ts
@@ -6,7 +6,7 @@
 import styled from 'styled-components'
 
 // Shared Styles
-import { Icon, StyledButton } from '../../shared.styles'
+import { Icon, StyledButton, Text } from '../../shared.styles'
 
 import {
   AssetIconProps,
@@ -61,4 +61,10 @@ export const IconsWrapper = styled.div<{
   flex-direction: row;
   position: relative;
   margin-right: ${(p) => p.marginRight || '6px'};
+`
+
+export const ButtonText = styled(Text) <{ isNFT: boolean }>`
+  max-width: ${(p) => p.isNFT ? '250px' : 'unset'};
+  overflow: hidden;
+  white-space: ${(p) => p.isNFT ? 'pre-wrap' : 'nowrap'};
 `

--- a/components/brave_wallet_ui/page/screens/send/components/select-token-button/select-token-button.tsx
+++ b/components/brave_wallet_ui/page/screens/send/components/select-token-button/select-token-button.tsx
@@ -33,9 +33,10 @@ import {
   NetworkIconWrapper,
   Button,
   ButtonIcon,
-  IconsWrapper
+  IconsWrapper,
+  ButtonText
 } from './select-token-button.style'
-import { Row, Text } from '../../shared.styles'
+import { Row } from '../../shared.styles'
 
 interface Props {
   onClick: () => void
@@ -86,13 +87,14 @@ export const SelectTokenButton = (props: Props) => {
             )}
           </IconsWrapper>
         )}
-        <Text
+        <ButtonText
           isBold={token !== undefined}
           textColor={token !== undefined ? 'text01' : 'text03'}
           textSize={token !== undefined ? '18px' : '16px'}
+          isNFT={selectedSendOption === 'nft'}
         >
           {buttonText}
-        </Text>
+        </ButtonText>
       </Row>
       <ButtonIcon size={12} icon={CaratDownIcon} />
     </Button>


### PR DESCRIPTION
## Description 
Fixes a bug where long `NFT` names were not wrapping in the `Send` tab.

<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves <https://github.com/brave/brave-browser/issues/27521>

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
1. Add a `NFT` with a really long name
2. Go to the `Send` tab and select an `NFT` to send
3. The name should be wrapped and not go off the screen.

Before:

![Screenshot 2022-12-22 at 9 58 33 AM](https://user-images.githubusercontent.com/40611140/209188448-f76665f7-283b-43eb-8bf2-53d67092051d.png)

After:

![Screenshot 2022-12-22 at 10 49 32 AM](https://user-images.githubusercontent.com/40611140/209188482-bdc988fe-5c4a-4aa5-8baa-f8d490fb9d90.png)
