### PR TITLE
Return valid JSON in `credential_summary_task`

### DIFF
--- a/components/skus/browser/rs/cxx/src/lib.rs
+++ b/components/skus/browser/rs/cxx/src/lib.rs
@@ -473,8 +473,8 @@ async fn credential_summary_task(
         .map_err(|e| e.into())
     {
         Ok(Some(summary)) => callback.0(callback_state.into_raw(), ffi::SkusResult::Ok, &summary),
-        Ok(None) => callback.0(callback_state.into_raw(), ffi::SkusResult::Ok, ""),
-        Err(e) => callback.0(callback_state.into_raw(), e, ""),
+        Ok(None) => callback.0(callback_state.into_raw(), ffi::SkusResult::Ok, "{}"), // none, empty
+        Err(e) => callback.0(callback_state.into_raw(), e, "{}"), // none, empty
     }
 }
 

--- a/components/skus/browser/skus_service_unittest.cc
+++ b/components/skus/browser/skus_service_unittest.cc
@@ -329,7 +329,7 @@ TEST_F(SkusServiceTestUnitTest, CredentialSummaryFailed) {
 
   prefs()->Set(skus::prefs::kSkusState, std::move(state));
   auto credentials = GetCredentialsSummary(domain);
-  EXPECT_TRUE(credentials.empty());
+  EXPECT_EQ(credentials, "{}");
 }
 
 TEST_F(SkusServiceTestUnitTest, CredentialSummaryWrongEnv) {
@@ -338,5 +338,5 @@ TEST_F(SkusServiceTestUnitTest, CredentialSummaryWrongEnv) {
   state.SetStringKey("skus:staging", testing_payload);
   prefs()->Set(skus::prefs::kSkusState, std::move(state));
   auto credentials = GetCredentialsSummary("vpn.brave.software");
-  EXPECT_TRUE(credentials.empty());
+  EXPECT_EQ(credentials, "{}");
 }


### PR DESCRIPTION
This was preventing credentials from being issued. We had a specific work-around on the account.brave.com page but this is the proper fix.

Per @husobee, here is the scenario that happens when doing a recover (which is different than buying it and immediately using).
> 1.) accounts site calls `handleRecovery`
> 2.) accounts site calls `recoverCredsIfRequired`
> 3.) accounts site calls `skus.credential_summary` to see if there are any creds for this order in storage
> 4.) skus sdk calls cxx implementation resulting in `credential_summary_task`, and since we have Ok(None) for credentials the cxx implementation sends back `""`

Fixes https://github.com/brave/brave-browser/issues/27483

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

