### PR TITLE
Display history sync diagnostic info

### DIFF
--- a/browser/about_flags.cc
+++ b/browser/about_flags.cc
@@ -383,6 +383,12 @@ constexpr char kAllowIncognitoPermissionInheritanceDescription[] =
     "in incognito profile if they are less permissive, for ex. Geolocation "
     "BLOCK will be automatically set to BLOCK in incognito.";
 
+constexpr char kBraveSyncHistoryDiagnosticsName[] =
+    "Enable Brave Sync History Diagnostics";
+constexpr char kBraveSyncHistoryDiagnosticsDescription[] =
+    "Brave Sync History Diagnostics flag displays additional sync related "
+    "information on History page";
+
 // Blink features.
 constexpr char kFileSystemAccessAPIName[] = "File System Access API";
 constexpr char kFileSystemAccessAPIDescription[] =
@@ -788,6 +794,11 @@ constexpr char kBraveChangeActiveTabOnScrollEventDescription[] =
       flag_descriptions::kTranslateDescription,                             \
       kOsDesktop | kOsAndroid,                                              \
       FEATURE_VALUE_TYPE(translate::kTranslate)},                           \
+    {"brave-sync-history-diagnostics",                                      \
+      flag_descriptions::kBraveSyncHistoryDiagnosticsName,                  \
+      flag_descriptions::kBraveSyncHistoryDiagnosticsDescription,           \
+      kOsAll, FEATURE_VALUE_TYPE(                                           \
+          brave_sync::features::kBraveSyncHistoryDiagnostics)},             \
     BRAVE_IPFS_FEATURE_ENTRIES                                              \
     BRAVE_NATIVE_WALLET_FEATURE_ENTRIES                                     \
     BRAVE_NEWS_FEATURE_ENTRIES                                              \

--- a/build/config/brave_build.gni
+++ b/build/config/brave_build.gni
@@ -1,3 +1,8 @@
+# Copyright (c) 2019 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+
 # Add imports here for things that need to be available in chromium code.
 # This file is included in most gn files either directly or through
 # import("//build/config/chrome_build.gni") in compiler.gni
@@ -14,6 +19,7 @@ import("//brave/components/content_settings/core/browser/sources.gni")
 import("//brave/components/omnibox/browser/sources.gni")
 import("//brave/components/search_engines/sources.gni")
 import("//brave/components/sync/driver/sources.gni")
+import("//brave/components/sync/sources.gni")
 import("//brave/components/sync_device_info/sources.gni")
 import("//brave/components/update_client/sources.gni")
 import("//brave/installer/linux/sources.gni")

--- a/chromium_src/components/history/core/browser/DEPS
+++ b/chromium_src/components/history/core/browser/DEPS
@@ -1,0 +1,3 @@
+include_rules = [
+  "+brave/components/brave_sync",
+]

--- a/chromium_src/components/history/core/browser/history_backend.cc
+++ b/chromium_src/components/history/core/browser/history_backend.cc
@@ -6,7 +6,9 @@
 #include <string>
 
 #include "base/check.h"
+#include "base/feature_list.h"
 #include "base/strings/strcat.h"
+#include "brave/components/brave_sync/features.h"
 // Forward include to avoid re-define of URLResult::set_blocked_visit
 #include "components/history/core/browser/history_types.h"
 #include "components/history/core/browser/url_row.h"
@@ -56,13 +58,18 @@ bool ShouldSyncVisit(int typed_count, ui::PageTransition transition) {
 
 std::u16string GetDiagnosticTitle(const history::URLResult& url_result,
                                   const history::VisitRow& visit) {
-  return base::StrCat(
-      {u"ShouldSync:",
-       ShouldSyncVisit(url_result.typed_count(), visit.transition) ? u"1"
-                                                                   : u"0",
-       u" ", std::u16string(u"TypedCount:"),
-       base::NumberToString16(url_result.typed_count()), u" ",
-       GetTransitionString(visit.transition), u" ", url_result.title()});
+  if (base::FeatureList::IsEnabled(
+          brave_sync::features::kBraveSyncHistoryDiagnostics)) {
+    return base::StrCat(
+        {u"ShouldSync:",
+         ShouldSyncVisit(url_result.typed_count(), visit.transition) ? u"1"
+                                                                     : u"0",
+         u" ", std::u16string(u"TypedCount:"),
+         base::NumberToString16(url_result.typed_count()), u" ",
+         GetTransitionString(visit.transition), u" ", url_result.title()});
+  } else {
+    return url_result.title();
+  }
 }
 
 }  // namespace

--- a/chromium_src/components/history/core/browser/history_backend.cc
+++ b/chromium_src/components/history/core/browser/history_backend.cc
@@ -1,0 +1,78 @@
+/* Copyright (c) 2023 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include <string>
+
+#include "base/check.h"
+#include "base/strings/strcat.h"
+// Forward include to avoid re-define of URLResult::set_blocked_visit
+#include "components/history/core/browser/history_types.h"
+#include "components/history/core/browser/url_row.h"
+#include "ui/base/page_transition_types.h"
+
+namespace {
+
+std::u16string GetTransitionString(ui::PageTransition transition_flags) {
+  std::u16string transition;
+  switch (transition_flags & ui::PAGE_TRANSITION_CORE_MASK) {
+#define TRANSITION_CASE(FLAG) \
+  case ui::FLAG:              \
+    transition = u## #FLAG;   \
+    break;
+
+    TRANSITION_CASE(PAGE_TRANSITION_LINK)
+    TRANSITION_CASE(PAGE_TRANSITION_TYPED)
+    TRANSITION_CASE(PAGE_TRANSITION_AUTO_BOOKMARK)
+    TRANSITION_CASE(PAGE_TRANSITION_AUTO_SUBFRAME)
+    TRANSITION_CASE(PAGE_TRANSITION_MANUAL_SUBFRAME)
+    TRANSITION_CASE(PAGE_TRANSITION_GENERATED)
+    TRANSITION_CASE(PAGE_TRANSITION_AUTO_TOPLEVEL)
+    TRANSITION_CASE(PAGE_TRANSITION_FORM_SUBMIT)
+    TRANSITION_CASE(PAGE_TRANSITION_RELOAD)
+    TRANSITION_CASE(PAGE_TRANSITION_KEYWORD)
+    TRANSITION_CASE(PAGE_TRANSITION_KEYWORD_GENERATED)
+
+#undef TRANSITION_CASE
+
+    default:
+      DCHECK(false);
+  }
+
+  return transition;
+}
+
+// Taken from TypedURLSyncBridge::ShouldSyncVisit, it's not static, so can't be
+// used directly
+bool ShouldSyncVisit(int typed_count, ui::PageTransition transition) {
+  static const int kTypedUrlVisitThrottleThreshold = 10;
+  static const int kTypedUrlVisitThrottleMultiple = 10;
+
+  return (ui::PageTransitionCoreTypeIs(transition, ui::PAGE_TRANSITION_TYPED) &&
+          (typed_count < kTypedUrlVisitThrottleThreshold ||
+           (typed_count % kTypedUrlVisitThrottleMultiple) == 0));
+}
+
+std::u16string GetDiagnosticTitle(const history::URLResult& url_result,
+                                  const history::VisitRow& visit) {
+  return base::StrCat(
+      {u"ShouldSync:",
+       ShouldSyncVisit(url_result.typed_count(), visit.transition) ? u"1"
+                                                                   : u"0",
+       u" ", std::u16string(u"TypedCount:"),
+       base::NumberToString16(url_result.typed_count()), u" ",
+       GetTransitionString(visit.transition), u" ", url_result.title()});
+}
+
+}  // namespace
+
+// It's possible to redefine set_blocked_visit because it appears only once at
+// history_backend.cc
+#define set_blocked_visit                           \
+  set_title(GetDiagnosticTitle(url_result, visit)); \
+  url_result.set_blocked_visit
+
+#include "src/components/history/core/browser/history_backend.cc"
+
+#undef set_blocked_visit

--- a/components/brave_sync/features.cc
+++ b/components/brave_sync/features.cc
@@ -12,5 +12,14 @@ namespace features {
 
 BASE_FEATURE(kBraveSync, "BraveSync", base::FEATURE_ENABLED_BY_DEFAULT);
 
+// When this feature is enabled through brave://flags it adds to history entry's
+// title additional info for sync diagnostics:
+// - whether history entry should be synced;
+// - typed count;
+// - page transition.
+BASE_FEATURE(kBraveSyncHistoryDiagnostics,
+             "BraveSyncHistoryDiagnostics",
+             base::FEATURE_DISABLED_BY_DEFAULT);
+
 }  // namespace features
 }  // namespace brave_sync

--- a/components/brave_sync/features.h
+++ b/components/brave_sync/features.h
@@ -13,6 +13,8 @@ namespace features {
 
 BASE_DECLARE_FEATURE(kBraveSync);
 
+BASE_DECLARE_FEATURE(kBraveSyncHistoryDiagnostics);
+
 }  // namespace features
 }  // namespace brave_sync
 

--- a/components/sync/sources.gni
+++ b/components/sync/sources.gni
@@ -1,0 +1,6 @@
+# Copyright (c) 2023 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+
+brave_components_sync_deps = [ "//brave/components/brave_sync:features" ]

--- a/patches/components-sync-BUILD.gn.patch
+++ b/patches/components-sync-BUILD.gn.patch
@@ -1,0 +1,12 @@
+diff --git a/components/sync/BUILD.gn b/components/sync/BUILD.gn
+index aa8ab6f262c519dd22c537d682e46b6f862db113..d0086f77968d8d49cce77dbcbd941a3b03476eb2 100644
+--- a/components/sync/BUILD.gn
++++ b/components/sync/BUILD.gn
+@@ -19,6 +19,7 @@ group("sync") {
+   if (is_chromeos) {
+     public_deps += [ "//components/sync/chromeos" ]
+   }
++  import("//brave/build/config/brave_build.gni") public_deps += brave_components_sync_deps
+ }
+ 
+ static_library("test_support") {


### PR DESCRIPTION
This info contains:
- whether history entry should be synced;
- typed count;
- page transition.

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/27553


The follow-up PR will be https://github.com/brave/brave-core/pull/16705

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
1. Create sync chain between Desktop and Android
2. Enable only History sync type on the devices
3. On about:flags turn`Enable Brave Sync History Diagnostics` experiment on.
4. Browse some sites on Desktop and Android using typed url and through link
5. ensure that `ShouldSync` `TypedCount` `PAGE_TRANSITION_` markers are aligned with the actual way of opening page and it actual presence in other synced device.

## Screenshots:
![Screenshot from 2022-12-28 16-56-10](https://user-images.githubusercontent.com/24739341/209834010-53e56136-b64c-4bbb-a306-8b0f5dfb1b95.png)
![Screenshot from 2022-12-28 16-55-54](https://user-images.githubusercontent.com/24739341/209834012-153ed1ba-4ca3-48b2-bfaf-f1c965c6335e.png)
![Screenshot_20221228-165648](https://user-images.githubusercontent.com/24739341/209834043-76b9c195-3c52-46a9-ad5c-0109d8975ad6.png)















