### PR TITLE
Move Vertical tabs from contents container to browser view layout.

### DIFF
--- a/browser/ui/views/frame/brave_browser_view_layout.cc
+++ b/browser/ui/views/frame/brave_browser_view_layout.cc
@@ -5,10 +5,52 @@
 
 #include "brave/browser/ui/views/frame/brave_browser_view_layout.h"
 
+#include <vector>
+
 #include "brave/browser/ui/views/tabs/features.h"
+#include "chrome/browser/ui/browser.h"
+#include "chrome/browser/ui/views/bookmarks/bookmark_bar_view.h"
 #include "chrome/browser/ui/views/frame/browser_view.h"
+#include "chrome/browser/ui/views/frame/browser_view_layout_delegate.h"
+#include "chrome/browser/ui/views/infobars/infobar_container_view.h"
+#include "components/bookmarks/common/bookmark_pref_names.h"
 
 BraveBrowserViewLayout::~BraveBrowserViewLayout() = default;
+
+void BraveBrowserViewLayout::Layout(views::View* host) {
+  BrowserViewLayout::Layout(host);
+  if (!vertical_tab_strip_host_.get())
+    return;
+
+  if (!tabs::features::ShouldShowVerticalTabs(browser_view_->browser())) {
+    vertical_tab_strip_host_->SetBorder(nullptr);
+    vertical_tab_strip_host_->SetBoundsRect({});
+    return;
+  }
+
+  std::vector<views::View*> views_next_to_vertical_tabs;
+  if (ShouldPushBookmarkBarForVerticalTabs())
+    views_next_to_vertical_tabs.push_back(bookmark_bar_);
+  views_next_to_vertical_tabs.push_back(contents_container_);
+
+  gfx::Rect vertical_tab_strip_bounds = vertical_layout_rect_;
+  vertical_tab_strip_bounds.set_y(views_next_to_vertical_tabs.front()->y());
+  if (contents_separator_ &&
+      views_next_to_vertical_tabs.front() != contents_container_) {
+    vertical_tab_strip_host_->SetBorder(
+        views::CreateEmptyBorder(gfx::Insets().set_top(
+            contents_separator_->GetPreferredSize().height())));
+  } else {
+    vertical_tab_strip_host_->SetBorder(nullptr);
+  }
+
+  vertical_tab_strip_bounds.set_width(
+      vertical_tab_strip_host_->GetPreferredSize().width());
+  vertical_tab_strip_bounds.set_height(
+      views_next_to_vertical_tabs.back()->bounds().bottom() -
+      vertical_tab_strip_bounds.y());
+  vertical_tab_strip_host_->SetBoundsRect(vertical_tab_strip_bounds);
+}
 
 void BraveBrowserViewLayout::LayoutSidePanelView(
     views::View* side_panel,
@@ -20,8 +62,46 @@ void BraveBrowserViewLayout::LayoutSidePanelView(
 }
 
 int BraveBrowserViewLayout::LayoutTabStripRegion(int top) {
-  if (tabs::features::ShouldShowVerticalTabs(browser_view_->browser()))
+  if (tabs::features::ShouldShowVerticalTabs(browser_view_->browser())) {
+    // In case we're using vertical tabstrip, we can decide the position
+    // after we finish laying out views in top container.
     return top;
+  }
 
   return BrowserViewLayout::LayoutTabStripRegion(top);
+}
+
+int BraveBrowserViewLayout::LayoutBookmarkAndInfoBars(int top,
+                                                      int browser_view_y) {
+  if (!vertical_tab_strip_host_ || !ShouldPushBookmarkBarForVerticalTabs())
+    return BrowserViewLayout::LayoutBookmarkAndInfoBars(top, browser_view_y);
+
+  auto new_rect = vertical_layout_rect_;
+  new_rect.Inset(gfx::Insets().set_left(
+      vertical_tab_strip_host_->GetPreferredSize().width()));
+  base::AutoReset resetter(&vertical_layout_rect_, new_rect);
+  return BrowserViewLayout::LayoutBookmarkAndInfoBars(top, browser_view_y);
+}
+
+void BraveBrowserViewLayout::LayoutContentsContainerView(int top, int bottom) {
+  if (!vertical_tab_strip_host_) {
+    BrowserViewLayout::LayoutContentsContainerView(top, bottom);
+    return;
+  }
+
+  auto new_rect = vertical_layout_rect_;
+  new_rect.Inset(gfx::Insets().set_left(
+      vertical_tab_strip_host_->GetPreferredSize().width()));
+  base::AutoReset resetter(&vertical_layout_rect_, new_rect);
+  return BrowserViewLayout::LayoutContentsContainerView(top, bottom);
+}
+
+bool BraveBrowserViewLayout::ShouldPushBookmarkBarForVerticalTabs() {
+  // This can happen when bookmarks bar is visible on NTP. In this case
+  // we should lay out vertical tab strip next to bookmarks bar so that
+  // the tab strip doesn't move when changing the active tab.
+  return bookmark_bar_ &&
+         !browser_view_->browser()->profile()->GetPrefs()->GetBoolean(
+             bookmarks::prefs::kShowBookmarkBar) &&
+         delegate_->IsBookmarkBarVisible();
 }

--- a/browser/ui/views/frame/brave_browser_view_layout.cc
+++ b/browser/ui/views/frame/brave_browser_view_layout.cc
@@ -31,12 +31,14 @@ void BraveBrowserViewLayout::Layout(views::View* host) {
   std::vector<views::View*> views_next_to_vertical_tabs;
   if (ShouldPushBookmarkBarForVerticalTabs())
     views_next_to_vertical_tabs.push_back(bookmark_bar_);
+  if (infobar_container_->GetVisible())
+    views_next_to_vertical_tabs.push_back(infobar_container_);
   views_next_to_vertical_tabs.push_back(contents_container_);
 
   gfx::Rect vertical_tab_strip_bounds = vertical_layout_rect_;
   vertical_tab_strip_bounds.set_y(views_next_to_vertical_tabs.front()->y());
   if (contents_separator_ &&
-      views_next_to_vertical_tabs.front() != contents_container_) {
+      views_next_to_vertical_tabs.front() == bookmark_bar_) {
     vertical_tab_strip_host_->SetBorder(
         views::CreateEmptyBorder(gfx::Insets().set_top(
             contents_separator_->GetPreferredSize().height())));
@@ -81,6 +83,17 @@ int BraveBrowserViewLayout::LayoutBookmarkAndInfoBars(int top,
       vertical_tab_strip_host_->GetPreferredSize().width()));
   base::AutoReset resetter(&vertical_layout_rect_, new_rect);
   return BrowserViewLayout::LayoutBookmarkAndInfoBars(top, browser_view_y);
+}
+
+int BraveBrowserViewLayout::LayoutInfoBar(int top) {
+  if (!vertical_tab_strip_host_)
+    return BrowserViewLayout::LayoutInfoBar(top);
+
+  auto new_rect = vertical_layout_rect_;
+  new_rect.Inset(gfx::Insets().set_left(
+      vertical_tab_strip_host_->GetPreferredSize().width()));
+  base::AutoReset resetter(&vertical_layout_rect_, new_rect);
+  return BrowserViewLayout::LayoutInfoBar(top);
 }
 
 void BraveBrowserViewLayout::LayoutContentsContainerView(int top, int bottom) {

--- a/browser/ui/views/frame/brave_browser_view_layout.h
+++ b/browser/ui/views/frame/brave_browser_view_layout.h
@@ -23,6 +23,7 @@ class BraveBrowserViewLayout : public BrowserViewLayout {
                            gfx::Rect& contents_container_bounds) override;
   int LayoutTabStripRegion(int top) override;
   int LayoutBookmarkAndInfoBars(int top, int browser_view_y) override;
+  int LayoutInfoBar(int top) override;
   void LayoutContentsContainerView(int top, int bottom) override;
 
  private:

--- a/browser/ui/views/frame/brave_browser_view_layout.h
+++ b/browser/ui/views/frame/brave_browser_view_layout.h
@@ -13,10 +13,22 @@ class BraveBrowserViewLayout : public BrowserViewLayout {
   using BrowserViewLayout::BrowserViewLayout;
   ~BraveBrowserViewLayout() override;
 
+  void set_vertical_tab_strip_host(views::View* vertical_tab_strip_host) {
+    vertical_tab_strip_host_ = vertical_tab_strip_host;
+  }
+
   // BrowserViewLayout overrides:
+  void Layout(views::View* host) override;
   void LayoutSidePanelView(views::View* side_panel,
                            gfx::Rect& contents_container_bounds) override;
   int LayoutTabStripRegion(int top) override;
+  int LayoutBookmarkAndInfoBars(int top, int browser_view_y) override;
+  void LayoutContentsContainerView(int top, int bottom) override;
+
+ private:
+  bool ShouldPushBookmarkBarForVerticalTabs();
+
+  raw_ptr<views::View> vertical_tab_strip_host_ = nullptr;
 };
 
 #endif  // BRAVE_BROWSER_UI_VIEWS_FRAME_BRAVE_BROWSER_VIEW_LAYOUT_H_

--- a/browser/ui/views/frame/brave_contents_layout_manager.cc
+++ b/browser/ui/views/frame/brave_contents_layout_manager.cc
@@ -12,12 +12,10 @@
 BraveContentsLayoutManager::BraveContentsLayoutManager(
     views::View* devtools_view,
     views::View* contents_view,
-    views::View* sidebar_container_view,
-    views::View* vertical_tabs_container)
+    views::View* sidebar_container_view)
     : ContentsLayoutManager(devtools_view, contents_view),
-      sidebar_container_view_(sidebar_container_view),
-      vertical_tabs_container_(vertical_tabs_container) {
-  DCHECK(sidebar_container_view_ || vertical_tabs_container_);
+      sidebar_container_view_(sidebar_container_view) {
+  DCHECK(sidebar_container_view_);
 }
 
 BraveContentsLayoutManager::~BraveContentsLayoutManager() = default;
@@ -35,7 +33,6 @@ void BraveContentsLayoutManager::Layout(views::View* contents_container) {
   } else {
     right_side_candidate_views.push_back(sidebar_container_view_);
   }
-  left_side_candidate_views.push_back(vertical_tabs_container_);
 
   int taken_left_width = 0;
   for (auto* view : left_side_candidate_views) {

--- a/browser/ui/views/frame/brave_contents_layout_manager.h
+++ b/browser/ui/views/frame/brave_contents_layout_manager.h
@@ -13,8 +13,7 @@ class BraveContentsLayoutManager : public ContentsLayoutManager {
  public:
   BraveContentsLayoutManager(views::View* devtools_view,
                              views::View* contents_view,
-                             views::View* sidebar_container_view,
-                             views::View* vertical_tabs_container);
+                             views::View* sidebar_container_view);
   BraveContentsLayoutManager(const BraveContentsLayoutManager&) = delete;
   BraveContentsLayoutManager& operator=(const BraveContentsLayoutManager&) =
       delete;
@@ -29,7 +28,6 @@ class BraveContentsLayoutManager : public ContentsLayoutManager {
 
  private:
   raw_ptr<views::View> sidebar_container_view_ = nullptr;
-  raw_ptr<views::View> vertical_tabs_container_ = nullptr;
   bool sidebar_on_left_ = true;
 };
 

--- a/browser/ui/views/frame/vertical_tab_strip_widget_delegate_view.cc
+++ b/browser/ui/views/frame/vertical_tab_strip_widget_delegate_view.cc
@@ -142,6 +142,9 @@ void VerticalTabStripWidgetDelegateView::UpdateWidgetBounds() {
       widget->GetWindowBoundsInScreen().size() != widget_bounds.size();
   widget->SetBounds(widget_bounds);
 
+  if (auto insets = host_->GetInsets(); GetInsets() != insets)
+    SetBorder(insets.IsEmpty() ? nullptr : views::CreateEmptyBorder(insets));
+
   if (need_to_call_layout)
     Layout();
 

--- a/chromium_src/chrome/browser/ui/views/frame/browser_view_layout.h
+++ b/chromium_src/chrome/browser/ui/views/frame/browser_view_layout.h
@@ -12,9 +12,13 @@
   UnUsed() { return {}; }              \
   friend class BraveBrowserViewLayout; \
   virtual int LayoutTabStripRegion
+#define LayoutBookmarkAndInfoBars virtual LayoutBookmarkAndInfoBars
+#define LayoutContentsContainerView virtual LayoutContentsContainerView
 
 #include "src/chrome/browser/ui/views/frame/browser_view_layout.h"
 
+#undef LayoutContentsContainerView
+#undef LayoutBookmarkAndInfoBars
 #undef LayoutTabStripRegion
 #undef LayoutSidePanelView
 

--- a/chromium_src/chrome/browser/ui/views/frame/browser_view_layout.h
+++ b/chromium_src/chrome/browser/ui/views/frame/browser_view_layout.h
@@ -13,11 +13,13 @@
   friend class BraveBrowserViewLayout; \
   virtual int LayoutTabStripRegion
 #define LayoutBookmarkAndInfoBars virtual LayoutBookmarkAndInfoBars
+#define LayoutInfoBar virtual LayoutInfoBar
 #define LayoutContentsContainerView virtual LayoutContentsContainerView
 
 #include "src/chrome/browser/ui/views/frame/browser_view_layout.h"
 
 #undef LayoutContentsContainerView
+#undef LayoutInfoBar
 #undef LayoutBookmarkAndInfoBars
 #undef LayoutTabStripRegion
 #undef LayoutSidePanelView


### PR DESCRIPTION
Even when bookmark bar pref is turned off, bookmarks bar can be visible on NTP. This makes the vertical tab strip move up and down when changing the active tab between NTP and non-NTP. When this happens, drag-and-drop session could be started abruptly.

In order to avoid this, we lay out the vertical tab strip next to the bookmarks bar when it's visible only on NTP.

### DEMO

https://user-images.githubusercontent.com/5474642/209751918-e9a4c4f6-bc47-4101-bfad-ba1a6d33592c.mov


<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/25910

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
### Manual
* Turn off bookmark visibility on settings page
* Open new tab page tab and non-ntp tab.
* Switching between theme
* Vertical tag strip shouldn't move.
