### PR TITLE
Local state pref to use from Java

### DIFF
--- a/android/brave_java_sources.gni
+++ b/android/brave_java_sources.gni
@@ -24,6 +24,7 @@ brave_java_sources = [
   "../../brave/android/java/org/chromium/chrome/browser/BraveHelper.java",
   "../../brave/android/java/org/chromium/chrome/browser/BraveIntentHandler.java",
   "../../brave/android/java/org/chromium/chrome/browser/BraveLaunchIntentDispatcher.java",
+  "../../brave/android/java/org/chromium/chrome/browser/BraveLocalState.java",
   "../../brave/android/java/org/chromium/chrome/browser/BraveRelaunchUtils.java",
   "../../brave/android/java/org/chromium/chrome/browser/BraveRewardsBalance.java",
   "../../brave/android/java/org/chromium/chrome/browser/BraveRewardsDonationSentActivity.java",

--- a/android/java/org/chromium/chrome/browser/BraveLocalState.java
+++ b/android/java/org/chromium/chrome/browser/BraveLocalState.java
@@ -1,0 +1,35 @@
+/* Copyright (c) 2022 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+package org.chromium.chrome.browser;
+
+import org.chromium.base.annotations.JNINamespace;
+import org.chromium.base.annotations.NativeMethods;
+import org.chromium.components.prefs.PrefService;
+
+/**
+ * Helper for retrieving a {@link PrefService} from a browser local state.
+ */
+@JNINamespace("chrome::android")
+public class BraveLocalState {
+    /** Returns the {@link PrefService} associated with the browser's local state */
+    public static PrefService get() {
+        return BraveLocalStateJni.get().getPrefService();
+    }
+
+    /** Makes local state data be written to the disk asap */
+    public static void commitPendingWrite() {
+        BraveLocalStateJni.get().commitPendingWrite();
+    }
+
+    @NativeMethods
+    public interface Natives {
+        // this method cannot be called 'get', because of the error:
+        // method get() is already defined in class BraveLocalStateJni
+        PrefService getPrefService();
+
+        void commitPendingWrite();
+    }
+}

--- a/android/java/org/chromium/chrome/browser/crypto_wallet/activities/BuySendSwapActivity.java
+++ b/android/java/org/chromium/chrome/browser/crypto_wallet/activities/BuySendSwapActivity.java
@@ -69,6 +69,7 @@ import org.chromium.brave_wallet.mojom.TxData;
 import org.chromium.brave_wallet.mojom.TxData1559;
 import org.chromium.brave_wallet.mojom.TxDataUnion;
 import org.chromium.chrome.R;
+import org.chromium.chrome.browser.BraveLocalState;
 import org.chromium.chrome.browser.app.BraveActivity;
 import org.chromium.chrome.browser.app.domain.SendModel;
 import org.chromium.chrome.browser.app.domain.WalletModel;
@@ -88,7 +89,7 @@ import org.chromium.chrome.browser.crypto_wallet.util.WalletNativeUtils;
 import org.chromium.chrome.browser.crypto_wallet.util.WalletUtils;
 import org.chromium.chrome.browser.decentralized_dns.EnsOffchainResolveMethod;
 import org.chromium.chrome.browser.flags.ChromeFeatureList;
-import org.chromium.chrome.browser.preferences.BravePrefServiceBridge;
+import org.chromium.chrome.browser.preferences.BravePref;
 import org.chromium.chrome.browser.qrreader.BarcodeTracker;
 import org.chromium.chrome.browser.qrreader.BarcodeTrackerFactory;
 import org.chromium.chrome.browser.qrreader.CameraSource;
@@ -1220,8 +1221,8 @@ public class BuySendSwapActivity extends BraveWalletBaseActivity
 
             Button mBtnEnableEnsOffchainLookup = findViewById(R.id.btn_enable_ens_offchain_lookup);
             mBtnEnableEnsOffchainLookup.setOnClickListener(v -> {
-                BravePrefServiceBridge.getInstance().setENSOffchainResolveMethod(
-                        EnsOffchainResolveMethod.ENABLED);
+                BraveLocalState.get().setInteger(
+                        BravePref.ENS_OFFCHAIN_RESOLVE_METHOD, EnsOffchainResolveMethod.ENABLED);
                 mEnsOffchainLookupSection.setVisibility(View.GONE);
                 maybeResolveWalletAddress();
             });

--- a/android/java/org/chromium/chrome/browser/crypto_wallet/util/BalanceHelper.java
+++ b/android/java/org/chromium/chrome/browser/crypto_wallet/util/BalanceHelper.java
@@ -19,8 +19,10 @@ import org.chromium.brave_wallet.mojom.KeyringService;
 import org.chromium.brave_wallet.mojom.NetworkInfo;
 import org.chromium.brave_wallet.mojom.ProviderError;
 import org.chromium.chrome.browser.BraveConfig;
+import org.chromium.chrome.browser.BraveLocalState;
 import org.chromium.chrome.browser.crypto_wallet.activities.BraveWalletBaseActivity;
 import org.chromium.chrome.browser.crypto_wallet.util.AssetUtils;
+import org.chromium.chrome.browser.preferences.BravePref;
 import org.chromium.chrome.browser.preferences.BravePrefServiceBridge;
 import org.chromium.mojo.bindings.Callbacks;
 
@@ -192,7 +194,7 @@ public class BalanceHelper {
                 && jsonRpcService != null;
 
         boolean P3AEnabled =
-                BraveConfig.P3A_ENABLED && BravePrefServiceBridge.getInstance().getP3AEnabled();
+                BraveConfig.P3A_ENABLED && BraveLocalState.get().getBoolean(BravePref.P3A_ENABLED);
 
         HashMap<Integer, HashSet<String>> activeAddresses = new HashMap<Integer, HashSet<String>>();
         for (int coinType : Utils.P3ACoinTypes)

--- a/android/java/org/chromium/chrome/browser/decentralized_dns/settings/ENSSettingsFragment.java
+++ b/android/java/org/chromium/chrome/browser/decentralized_dns/settings/ENSSettingsFragment.java
@@ -11,7 +11,8 @@ import androidx.annotation.Nullable;
 import androidx.preference.PreferenceFragmentCompat;
 
 import org.chromium.chrome.R;
-import org.chromium.chrome.browser.preferences.BravePrefServiceBridge;
+import org.chromium.chrome.browser.BraveLocalState;
+import org.chromium.chrome.browser.preferences.BravePref;
 import org.chromium.components.browser_ui.settings.SettingsUtils;
 
 public class ENSSettingsFragment extends PreferenceFragmentCompat {
@@ -27,10 +28,10 @@ public class ENSSettingsFragment extends PreferenceFragmentCompat {
                 (RadioButtonGroupDDnsResolveMethodPreference) findPreference(
                         PREF_ENS_RESOLVE_METHOD);
         radioButtonGroupDDnsResolveMethodPreference.initialize(
-                BravePrefServiceBridge.getInstance().getENSResolveMethod());
+                BraveLocalState.get().getInteger(BravePref.ENS_RESOLVE_METHOD));
         radioButtonGroupDDnsResolveMethodPreference.setOnPreferenceChangeListener(
                 (preference, newValue) -> {
-                    BravePrefServiceBridge.getInstance().setENSResolveMethod((int) newValue);
+                    BraveLocalState.get().setInteger(BravePref.ENS_RESOLVE_METHOD, (int) newValue);
                     return true;
                 });
 
@@ -39,11 +40,11 @@ public class ENSSettingsFragment extends PreferenceFragmentCompat {
                         (RadioButtonGroupEnsOffchainResolveMethodPreference) findPreference(
                                 PREF_ENS_OFFCHAIN_LOOKUP_METHOD);
         radioButtonGroupEnsOffchainResolveMethodPreference.initialize(
-                BravePrefServiceBridge.getInstance().getENSOffchainResolveMethod());
+                BraveLocalState.get().getInteger(BravePref.ENS_OFFCHAIN_RESOLVE_METHOD));
         radioButtonGroupEnsOffchainResolveMethodPreference.setOnPreferenceChangeListener(
                 (preference, newValue) -> {
-                    BravePrefServiceBridge.getInstance().setENSOffchainResolveMethod(
-                            (int) newValue);
+                    BraveLocalState.get().setInteger(
+                            BravePref.ENS_OFFCHAIN_RESOLVE_METHOD, (int) newValue);
                     return true;
                 });
     }

--- a/android/java/org/chromium/chrome/browser/decentralized_dns/settings/SnsSettingsFragment.java
+++ b/android/java/org/chromium/chrome/browser/decentralized_dns/settings/SnsSettingsFragment.java
@@ -11,7 +11,8 @@ import androidx.annotation.Nullable;
 import androidx.preference.PreferenceFragmentCompat;
 
 import org.chromium.chrome.R;
-import org.chromium.chrome.browser.preferences.BravePrefServiceBridge;
+import org.chromium.chrome.browser.BraveLocalState;
+import org.chromium.chrome.browser.preferences.BravePref;
 import org.chromium.components.browser_ui.settings.SettingsUtils;
 
 public class SnsSettingsFragment extends PreferenceFragmentCompat {
@@ -27,12 +28,12 @@ public class SnsSettingsFragment extends PreferenceFragmentCompat {
                         PREF_SNS_RESOLVE_METHOD);
 
         radioButtonGroupDDnsResolveMethodPreference.initialize(
-                BravePrefServiceBridge.getInstance().getSnsResolveMethod());
+                BraveLocalState.get().getInteger(BravePref.SNS_RESOLVE_METHOD));
 
         radioButtonGroupDDnsResolveMethodPreference.setOnPreferenceChangeListener(
                 (preference, newValue) -> {
                     int method = (int) newValue;
-                    BravePrefServiceBridge.getInstance().setSnsResolveMethod(method);
+                    BraveLocalState.get().setInteger(BravePref.SNS_RESOLVE_METHOD, method);
                     return true;
                 });
     }

--- a/android/java/org/chromium/chrome/browser/decentralized_dns/settings/UnstoppableDomainsSettingsFragment.java
+++ b/android/java/org/chromium/chrome/browser/decentralized_dns/settings/UnstoppableDomainsSettingsFragment.java
@@ -11,7 +11,8 @@ import androidx.annotation.Nullable;
 import androidx.preference.PreferenceFragmentCompat;
 
 import org.chromium.chrome.R;
-import org.chromium.chrome.browser.preferences.BravePrefServiceBridge;
+import org.chromium.chrome.browser.BraveLocalState;
+import org.chromium.chrome.browser.preferences.BravePref;
 import org.chromium.components.browser_ui.settings.SettingsUtils;
 
 public class UnstoppableDomainsSettingsFragment extends PreferenceFragmentCompat {
@@ -28,12 +29,13 @@ public class UnstoppableDomainsSettingsFragment extends PreferenceFragmentCompat
                         PREF_UNSTOPPABLE_DOMAINS_RESOLVE_METHOD);
 
         radioButtonGroupDDnsResolveMethodPreference.initialize(
-                BravePrefServiceBridge.getInstance().getUnstoppableDomainsResolveMethod());
+                BraveLocalState.get().getInteger(BravePref.UNSTOPPABLE_DOMAINS_RESOLVE_METHOD));
 
         radioButtonGroupDDnsResolveMethodPreference.setOnPreferenceChangeListener(
                 (preference, newValue) -> {
                     int method = (int) newValue;
-                    BravePrefServiceBridge.getInstance().setUnstoppableDomainsResolveMethod(method);
+                    BraveLocalState.get().setInteger(
+                            BravePref.UNSTOPPABLE_DOMAINS_RESOLVE_METHOD, method);
                     return true;
                 });
     }

--- a/android/java/org/chromium/chrome/browser/firstrun/WelcomeOnboardingActivity.java
+++ b/android/java/org/chromium/chrome/browser/firstrun/WelcomeOnboardingActivity.java
@@ -27,9 +27,11 @@ import android.widget.TextView;
 import org.chromium.base.Log;
 import org.chromium.base.ThreadUtils;
 import org.chromium.chrome.R;
+import org.chromium.chrome.browser.BraveLocalState;
 import org.chromium.chrome.browser.customtabs.CustomTabActivity;
 import org.chromium.chrome.browser.metrics.UmaSessionStats;
 import org.chromium.chrome.browser.onboarding.OnboardingPrefManager;
+import org.chromium.chrome.browser.preferences.BravePref;
 import org.chromium.chrome.browser.preferences.BravePrefServiceBridge;
 import org.chromium.chrome.browser.preferences.ChromePreferenceKeys;
 import org.chromium.chrome.browser.preferences.SharedPreferencesManager;
@@ -233,7 +235,7 @@ public class WelcomeOnboardingActivity extends FirstRunActivityBase {
             boolean isP3aEnabled = true;
 
             try {
-                isP3aEnabled = BravePrefServiceBridge.getInstance().getP3AEnabled();
+                isP3aEnabled = BraveLocalState.get().getBoolean(BravePref.P3A_ENABLED);
             } catch (Exception e) {
                 Log.e("P3aOnboarding", e.getMessage());
             }
@@ -243,8 +245,9 @@ public class WelcomeOnboardingActivity extends FirstRunActivityBase {
                 @Override
                 public void onCheckedChanged(CompoundButton buttonView, boolean isChecked) {
                     try {
-                        BravePrefServiceBridge.getInstance().setP3AEnabled(isChecked);
-                        BravePrefServiceBridge.getInstance().setP3ANoticeAcknowledged(true);
+                        BraveLocalState.get().setBoolean(BravePref.P3A_ENABLED, isChecked);
+                        BraveLocalState.get().setBoolean(BravePref.P3A_NOTICE_ACKNOWLEDGED, true);
+                        BraveLocalState.commitPendingWrite();
                     } catch (Exception e) {
                         Log.e("P3aOnboarding", e.getMessage());
                     }

--- a/android/java/org/chromium/chrome/browser/preferences/BravePrefServiceBridge.java
+++ b/android/java/org/chromium/chrome/browser/preferences/BravePrefServiceBridge.java
@@ -15,11 +15,11 @@ import org.chromium.chrome.browser.profiles.Profile;
 
 /**
  * Please don't add anything in that file. We are going to refactor it soon.
- * The only exceptions are preferences that are stored in a local_state
- * g_browser_process->local_state().
  * Check this PRs on how to handle preferences correctly:
  * https://github.com/brave/brave-core/pull/16356
  * https://github.com/brave/brave-core/pull/15905
+ * For the local_state based prefs please look on the PR:
+ * https://github.com/brave/brave-core/pull/16486
  * Contact code owners if you have additional questions.
  */
 

--- a/android/java/org/chromium/chrome/browser/preferences/BravePrefServiceBridge.java
+++ b/android/java/org/chromium/chrome/browser/preferences/BravePrefServiceBridge.java
@@ -142,10 +142,6 @@ public class BravePrefServiceBridge {
         return BravePrefServiceBridgeJni.get().getSafetynetCheckFailed();
     }
 
-    public void setSafetynetStatus(String status) {
-        BravePrefServiceBridgeJni.get().setSafetynetStatus(status);
-    }
-
     public void resetPromotionLastFetchStamp() {
         BravePrefServiceBridgeJni.get().resetPromotionLastFetchStamp();
     }
@@ -281,8 +277,6 @@ public class BravePrefServiceBridge {
 
         void setSafetynetCheckFailed(boolean value);
         boolean getSafetynetCheckFailed();
-
-        void setSafetynetStatus(String status);
 
         void resetPromotionLastFetchStamp();
         boolean getBooleanForContentSetting(int content_type);

--- a/android/java/org/chromium/chrome/browser/preferences/BravePrefServiceBridge.java
+++ b/android/java/org/chromium/chrome/browser/preferences/BravePrefServiceBridge.java
@@ -186,32 +186,12 @@ public class BravePrefServiceBridge {
         BravePrefServiceBridgeJni.get().setReferralDownloadId(downloadId);
     }
 
-    public void setP3AEnabled(boolean value) {
-        BravePrefServiceBridgeJni.get().setP3AEnabled(value);
-    }
-
-    public boolean getP3AEnabled() {
-        return BravePrefServiceBridgeJni.get().getP3AEnabled();
-    }
-
     public void setStatsReportingEnabled(boolean value) {
         BravePrefServiceBridgeJni.get().setStatsReportingEnabled(value);
     }
 
     public boolean getStatsReportingEnabled() {
         return BravePrefServiceBridgeJni.get().getStatsReportingEnabled();
-    }
-
-    public boolean hasPathP3AEnabled() {
-        return BravePrefServiceBridgeJni.get().hasPathP3AEnabled();
-    }
-
-    public void setP3ANoticeAcknowledged(boolean value) {
-        BravePrefServiceBridgeJni.get().setP3ANoticeAcknowledged(value);
-    }
-
-    public boolean getP3ANoticeAcknowledged() {
-        return BravePrefServiceBridgeJni.get().getP3ANoticeAcknowledged();
     }
 
     public void setUnstoppableDomainsResolveMethod(int method) {
@@ -320,12 +300,6 @@ public class BravePrefServiceBridge {
         void setReferralInitialization(boolean value);
         void setReferralPromoCode(String promoCode);
         void setReferralDownloadId(String downloadId);
-
-        void setP3AEnabled(boolean value);
-        boolean getP3AEnabled();
-        boolean hasPathP3AEnabled();
-        void setP3ANoticeAcknowledged(boolean value);
-        boolean getP3ANoticeAcknowledged();
 
         void setStatsReportingEnabled(boolean value);
         boolean getStatsReportingEnabled();

--- a/android/java/org/chromium/chrome/browser/preferences/BravePrefServiceBridge.java
+++ b/android/java/org/chromium/chrome/browser/preferences/BravePrefServiceBridge.java
@@ -186,14 +186,6 @@ public class BravePrefServiceBridge {
         BravePrefServiceBridgeJni.get().setReferralDownloadId(downloadId);
     }
 
-    public void setStatsReportingEnabled(boolean value) {
-        BravePrefServiceBridgeJni.get().setStatsReportingEnabled(value);
-    }
-
-    public boolean getStatsReportingEnabled() {
-        return BravePrefServiceBridgeJni.get().getStatsReportingEnabled();
-    }
-
     public void setUnstoppableDomainsResolveMethod(int method) {
         BravePrefServiceBridgeJni.get().setUnstoppableDomainsResolveMethod(method);
     }
@@ -300,9 +292,6 @@ public class BravePrefServiceBridge {
         void setReferralInitialization(boolean value);
         void setReferralPromoCode(String promoCode);
         void setReferralDownloadId(String downloadId);
-
-        void setStatsReportingEnabled(boolean value);
-        boolean getStatsReportingEnabled();
 
         void setUnstoppableDomainsResolveMethod(int method);
         int getUnstoppableDomainsResolveMethod();

--- a/android/java/org/chromium/chrome/browser/preferences/BravePrefServiceBridge.java
+++ b/android/java/org/chromium/chrome/browser/preferences/BravePrefServiceBridge.java
@@ -162,26 +162,6 @@ public class BravePrefServiceBridge {
         return BravePrefServiceBridgeJni.get().getBooleanForContentSetting(content_type);
     }
 
-    public void setReferralAndroidFirstRunTimestamp(long time) {
-        BravePrefServiceBridgeJni.get().setReferralAndroidFirstRunTimestamp(time);
-    }
-
-    public void setReferralCheckedForPromoCodeFile(boolean value) {
-        BravePrefServiceBridgeJni.get().setReferralCheckedForPromoCodeFile(value);
-    }
-
-    public void setReferralInitialization(boolean value) {
-        BravePrefServiceBridgeJni.get().setReferralInitialization(value);
-    }
-
-    public void setReferralPromoCode(String promoCode) {
-        BravePrefServiceBridgeJni.get().setReferralPromoCode(promoCode);
-    }
-
-    public void setReferralDownloadId(String downloadId) {
-        BravePrefServiceBridgeJni.get().setReferralDownloadId(downloadId);
-    }
-
     public void setUnstoppableDomainsResolveMethod(int method) {
         BravePrefServiceBridgeJni.get().setUnstoppableDomainsResolveMethod(method);
     }
@@ -280,12 +260,6 @@ public class BravePrefServiceBridge {
 
         void resetPromotionLastFetchStamp();
         boolean getBooleanForContentSetting(int content_type);
-
-        void setReferralAndroidFirstRunTimestamp(long time);
-        void setReferralCheckedForPromoCodeFile(boolean value);
-        void setReferralInitialization(boolean value);
-        void setReferralPromoCode(String promoCode);
-        void setReferralDownloadId(String downloadId);
 
         void setUnstoppableDomainsResolveMethod(int method);
         int getUnstoppableDomainsResolveMethod();

--- a/android/java/org/chromium/chrome/browser/preferences/BravePrefServiceBridge.java
+++ b/android/java/org/chromium/chrome/browser/preferences/BravePrefServiceBridge.java
@@ -162,38 +162,6 @@ public class BravePrefServiceBridge {
         return BravePrefServiceBridgeJni.get().getBooleanForContentSetting(content_type);
     }
 
-    public void setUnstoppableDomainsResolveMethod(int method) {
-        BravePrefServiceBridgeJni.get().setUnstoppableDomainsResolveMethod(method);
-    }
-
-    public int getUnstoppableDomainsResolveMethod() {
-        return BravePrefServiceBridgeJni.get().getUnstoppableDomainsResolveMethod();
-    }
-
-    public void setENSResolveMethod(int method) {
-        BravePrefServiceBridgeJni.get().setENSResolveMethod(method);
-    }
-
-    public int getENSResolveMethod() {
-        return BravePrefServiceBridgeJni.get().getENSResolveMethod();
-    }
-
-    public void setENSOffchainResolveMethod(int method) {
-        BravePrefServiceBridgeJni.get().setENSOffchainResolveMethod(method);
-    }
-
-    public int getENSOffchainResolveMethod() {
-        return BravePrefServiceBridgeJni.get().getENSOffchainResolveMethod();
-    }
-
-    public void setSnsResolveMethod(int method) {
-        BravePrefServiceBridgeJni.get().setSnsResolveMethod(method);
-    }
-
-    public int getSnsResolveMethod() {
-        return BravePrefServiceBridgeJni.get().getSnsResolveMethod();
-    }
-
     public void setWebrtcPolicy(int policy) {
         BravePrefServiceBridgeJni.get().setWebrtcPolicy(policy);
     }
@@ -260,15 +228,6 @@ public class BravePrefServiceBridge {
 
         void resetPromotionLastFetchStamp();
         boolean getBooleanForContentSetting(int content_type);
-
-        void setUnstoppableDomainsResolveMethod(int method);
-        int getUnstoppableDomainsResolveMethod();
-        void setENSResolveMethod(int method);
-        int getENSResolveMethod();
-        void setENSOffchainResolveMethod(int method);
-        int getENSOffchainResolveMethod();
-        void setSnsResolveMethod(int method);
-        int getSnsResolveMethod();
 
         void setWebrtcPolicy(int policy);
         int getWebrtcPolicy();

--- a/android/java/org/chromium/chrome/browser/privacy/settings/BravePrivacySettings.java
+++ b/android/java/org/chromium/chrome/browser/privacy/settings/BravePrivacySettings.java
@@ -434,7 +434,7 @@ public class BravePrivacySettings extends PrivacySettings implements ConnectionE
         } else if (PREF_SEND_CRASH_REPORTS.equals(key)) {
             UmaSessionStats.changeMetricsReportingConsent((boolean) newValue);
         } else if (PREF_BRAVE_STATS_USAGE_PING.equals(key)) {
-            BravePrefServiceBridge.getInstance().setStatsReportingEnabled((boolean) newValue);
+            BraveLocalState.get().setBoolean(BravePref.STATS_REPORTING_ENABLED, (boolean) newValue);
         } else if (PREF_SEARCH_SUGGESTIONS.equals(key)) {
             mPrefServiceBridge.setBoolean(Pref.SEARCH_SUGGEST_ENABLED, (boolean) newValue);
         } else if (PREF_SHOW_AUTOCOMPLETE_IN_ADDRESS_BAR.equals(key)) {
@@ -575,7 +575,7 @@ public class BravePrivacySettings extends PrivacySettings implements ConnectionE
         mSendCrashReports.setChecked(mPrivacyPrefManager.isUsageAndCrashReportingPermittedByUser());
 
         mBraveStatsUsagePing.setChecked(
-                BravePrefServiceBridge.getInstance().getStatsReportingEnabled());
+                BraveLocalState.get().getBoolean(BravePref.STATS_REPORTING_ENABLED));
 
         mWebrtcPolicy.setSummary(
                 webrtcPolicyToString(BravePrefServiceBridge.getInstance().getWebrtcPolicy()));

--- a/android/java/org/chromium/chrome/browser/privacy/settings/BravePrivacySettings.java
+++ b/android/java/org/chromium/chrome/browser/privacy/settings/BravePrivacySettings.java
@@ -19,6 +19,7 @@ import org.chromium.base.Log;
 import org.chromium.brave_shields.mojom.CookieListOptInPageAndroidHandler;
 import org.chromium.chrome.R;
 import org.chromium.chrome.browser.BraveConfig;
+import org.chromium.chrome.browser.BraveLocalState;
 import org.chromium.chrome.browser.flags.ChromeFeatureList;
 import org.chromium.chrome.browser.metrics.UmaSessionStats;
 import org.chromium.chrome.browser.preferences.BravePref;
@@ -428,7 +429,8 @@ public class BravePrivacySettings extends PrivacySettings implements ConnectionE
         } else if (PREF_CLOSE_TABS_ON_EXIT.equals(key)) {
             sharedPreferencesEditor.putBoolean(PREF_CLOSE_TABS_ON_EXIT, (boolean) newValue);
         } else if (PREF_SEND_P3A.equals(key)) {
-            BravePrefServiceBridge.getInstance().setP3AEnabled((boolean) newValue);
+            BraveLocalState.get().setBoolean(BravePref.P3A_ENABLED, (boolean) newValue);
+            BraveLocalState.commitPendingWrite();
         } else if (PREF_SEND_CRASH_REPORTS.equals(key)) {
             UmaSessionStats.changeMetricsReportingConsent((boolean) newValue);
         } else if (PREF_BRAVE_STATS_USAGE_PING.equals(key)) {
@@ -565,7 +567,7 @@ public class BravePrivacySettings extends PrivacySettings implements ConnectionE
                 getActivity().getResources().getString(R.string.send_p3a_analytics_summary));
 
         if (BraveConfig.P3A_ENABLED) {
-            mSendP3A.setChecked(BravePrefServiceBridge.getInstance().getP3AEnabled());
+            mSendP3A.setChecked(BraveLocalState.get().getBoolean(BravePref.P3A_ENABLED));
         } else {
             getPreferenceScreen().removePreference(mSendP3A);
         }

--- a/browser/android/BUILD.gn
+++ b/browser/android/BUILD.gn
@@ -1,3 +1,8 @@
+# Copyright (c) 2022 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+
 import("//brave/build/config.gni")
 import("//build/config/android/rules.gni")
 

--- a/browser/android/BUILD.gn
+++ b/browser/android/BUILD.gn
@@ -7,6 +7,7 @@ source_set("android_browser_process") {
   sources = [
     "//brave/browser/brave_ads/android/brave_ads_native_helper.cc",
     "brave_feature_util.cc",
+    "brave_local_state_android.cc",
     "brave_relaunch_utils.cc",
     "brave_shields_content_settings.cc",
     "brave_shields_content_settings.h",

--- a/browser/android/brave_local_state_android.cc
+++ b/browser/android/brave_local_state_android.cc
@@ -1,0 +1,23 @@
+/* Copyright (c) 2022 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "brave/build/android/jni_headers/BraveLocalState_jni.h"
+#include "chrome/browser/browser_process.h"
+#include "components/prefs/pref_service.h"
+
+namespace chrome {
+namespace android {
+
+static base::android::ScopedJavaLocalRef<jobject>
+JNI_BraveLocalState_GetPrefService(JNIEnv* env) {
+  return g_browser_process->local_state()->GetJavaObject();
+}
+
+static void JNI_BraveLocalState_CommitPendingWrite(JNIEnv* env) {
+  g_browser_process->local_state()->CommitPendingWrite();
+}
+
+}  // namespace android
+}  // namespace chrome

--- a/browser/android/preferences/BUILD.gn
+++ b/browser/android/preferences/BUILD.gn
@@ -44,6 +44,7 @@ java_cpp_strings("java_pref_names_srcjar") {
     "//brave/components/debounce/common/pref_names.cc",
     "//brave/components/ntp_background_images/common/pref_names.cc",
     "//brave/components/omnibox/browser/brave_omnibox_prefs.cc",
+    "//brave/components/p3a/pref_names.cc",
     "//components/translate/core/browser/translate_pref_names.cc",
   ]
 

--- a/browser/android/preferences/BUILD.gn
+++ b/browser/android/preferences/BUILD.gn
@@ -42,6 +42,7 @@ java_cpp_strings("java_pref_names_srcjar") {
     "//brave/components/constants/pref_names.cc",
     "//brave/components/de_amp/common/pref_names.cc",
     "//brave/components/debounce/common/pref_names.cc",
+    "//brave/components/decentralized_dns/core/pref_names.cc",
     "//brave/components/ntp_background_images/common/pref_names.cc",
     "//brave/components/omnibox/browser/brave_omnibox_prefs.cc",
     "//brave/components/p3a/pref_names.cc",

--- a/browser/android/preferences/brave_pref_service_bridge.cc
+++ b/browser/android/preferences/brave_pref_service_bridge.cc
@@ -364,40 +364,6 @@ jboolean JNI_BravePrefServiceBridge_GetBooleanForContentSetting(JNIEnv* env,
   }
 }
 
-void JNI_BravePrefServiceBridge_SetReferralAndroidFirstRunTimestamp(
-    JNIEnv* env,
-    jlong time) {
-  return g_browser_process->local_state()->SetTime(
-      kReferralAndroidFirstRunTimestamp, base::Time::FromJavaTime(time));
-}
-
-void JNI_BravePrefServiceBridge_SetReferralCheckedForPromoCodeFile(
-    JNIEnv* env,
-    jboolean value) {
-  return g_browser_process->local_state()->SetBoolean(
-      kReferralCheckedForPromoCodeFile, value);
-}
-
-void JNI_BravePrefServiceBridge_SetReferralInitialization(JNIEnv* env,
-                                                          jboolean value) {
-  return g_browser_process->local_state()->SetBoolean(kReferralInitialization,
-                                                      value);
-}
-
-void JNI_BravePrefServiceBridge_SetReferralPromoCode(
-    JNIEnv* env,
-    const JavaParamRef<jstring>& promoCode) {
-  return g_browser_process->local_state()->SetString(
-      kReferralPromoCode, ConvertJavaStringToUTF8(env, promoCode));
-}
-
-void JNI_BravePrefServiceBridge_SetReferralDownloadId(
-    JNIEnv* env,
-    const JavaParamRef<jstring>& downloadId) {
-  return g_browser_process->local_state()->SetString(
-      kReferralDownloadID, ConvertJavaStringToUTF8(env, downloadId));
-}
-
 jint JNI_BravePrefServiceBridge_GetWebrtcPolicy(JNIEnv* env) {
   return static_cast<int>(
       GetWebRTCIPHandlingPolicy(GetOriginalProfile()->GetPrefs()->GetString(

--- a/browser/android/preferences/brave_pref_service_bridge.cc
+++ b/browser/android/preferences/brave_pref_service_bridge.cc
@@ -18,7 +18,6 @@
 #include "brave/components/de_amp/common/pref_names.h"
 #include "brave/components/decentralized_dns/core/pref_names.h"
 #include "brave/components/ipfs/buildflags/buildflags.h"
-#include "brave/components/p3a/buildflags.h"
 #include "build/build_config.h"
 #include "chrome/browser/browser_process.h"
 #include "chrome/browser/content_settings/cookie_settings_factory.h"
@@ -32,10 +31,6 @@
 #include "components/prefs/pref_service.h"
 #include "third_party/blink/public/common/peerconnection/webrtc_ip_handling_policy.h"
 #include "url/gurl.h"
-
-#if BUILDFLAG(BRAVE_P3A_ENABLED)
-#include "brave/components/p3a/pref_names.h"
-#endif
 
 #if BUILDFLAG(ENABLE_IPFS)
 #include "brave/components/ipfs/ipfs_constants.h"
@@ -421,51 +416,6 @@ void JNI_BravePrefServiceBridge_SetWebrtcPolicy(JNIEnv* env, jint policy) {
       prefs::kWebRTCIPHandlingPolicy,
       GetWebRTCIPHandlingPreference((WebRTCIPHandlingPolicy)policy));
 }
-
-#if BUILDFLAG(BRAVE_P3A_ENABLED)
-void JNI_BravePrefServiceBridge_SetP3AEnabled(JNIEnv* env, jboolean value) {
-  /* Saving pref value to the disk as soon as the pref value
-   * is set to avoid delay in pref value update.*/
-  g_browser_process->local_state()->SetBoolean(brave::kP3AEnabled, value);
-  g_browser_process->local_state()->CommitPendingWrite();
-}
-
-static jboolean JNI_BravePrefServiceBridge_GetP3AEnabled(JNIEnv* env) {
-  return g_browser_process->local_state()->GetBoolean(brave::kP3AEnabled);
-}
-
-jboolean JNI_BravePrefServiceBridge_HasPathP3AEnabled(JNIEnv* env) {
-  return g_browser_process->local_state()->HasPrefPath(brave::kP3AEnabled);
-}
-
-void JNI_BravePrefServiceBridge_SetP3ANoticeAcknowledged(JNIEnv* env,
-                                                         jboolean value) {
-  return g_browser_process->local_state()->SetBoolean(
-      brave::kP3ANoticeAcknowledged, value);
-}
-
-jboolean JNI_BravePrefServiceBridge_GetP3ANoticeAcknowledged(JNIEnv* env) {
-  return g_browser_process->local_state()->GetBoolean(
-      brave::kP3ANoticeAcknowledged);
-}
-
-#else
-
-void JNI_BravePrefServiceBridge_SetP3AEnabled(JNIEnv* env, jboolean value) {}
-
-static jboolean JNI_BravePrefServiceBridge_GetP3AEnabled(JNIEnv* env) {
-  return false;
-}
-
-jboolean JNI_BravePrefServiceBridge_HasPathP3AEnabled(JNIEnv* env) {}
-
-void JNI_BravePrefServiceBridge_SetP3ANoticeAcknowledged(JNIEnv* env,
-                                                         jboolean value) {}
-
-jboolean JNI_BravePrefServiceBridge_GetP3ANoticeAcknowledged(JNIEnv* env) {
-  return false;
-}
-#endif  // BUILDFLAG(BRAVE_P3A_ENABLED)
 
 void JNI_BravePrefServiceBridge_SetStatsReportingEnabled(JNIEnv* env,
                                                          jboolean value) {

--- a/browser/android/preferences/brave_pref_service_bridge.cc
+++ b/browser/android/preferences/brave_pref_service_bridge.cc
@@ -417,15 +417,6 @@ void JNI_BravePrefServiceBridge_SetWebrtcPolicy(JNIEnv* env, jint policy) {
       GetWebRTCIPHandlingPreference((WebRTCIPHandlingPolicy)policy));
 }
 
-void JNI_BravePrefServiceBridge_SetStatsReportingEnabled(JNIEnv* env,
-                                                         jboolean value) {
-  g_browser_process->local_state()->SetBoolean(kStatsReportingEnabled, value);
-}
-
-jboolean JNI_BravePrefServiceBridge_GetStatsReportingEnabled(JNIEnv* env) {
-  return g_browser_process->local_state()->GetBoolean(kStatsReportingEnabled);
-}
-
 void JNI_BravePrefServiceBridge_SetUnstoppableDomainsResolveMethod(
     JNIEnv* env,
     jint method) {

--- a/browser/android/preferences/brave_pref_service_bridge.cc
+++ b/browser/android/preferences/brave_pref_service_bridge.cc
@@ -345,13 +345,6 @@ jboolean JNI_BravePrefServiceBridge_GetSafetynetCheckFailed(JNIEnv* env) {
   return GetOriginalProfile()->GetPrefs()->GetBoolean(kSafetynetCheckFailed);
 }
 
-void JNI_BravePrefServiceBridge_SetSafetynetStatus(
-    JNIEnv* env,
-    const JavaParamRef<jstring>& status) {
-  g_browser_process->local_state()->SetString(
-      kSafetynetStatus, ConvertJavaStringToUTF8(env, status));
-}
-
 void JNI_BravePrefServiceBridge_ResetPromotionLastFetchStamp(JNIEnv* env) {
   GetOriginalProfile()->GetPrefs()->SetUint64(
       brave_rewards::prefs::kPromotionLastFetchStamp, 0);

--- a/browser/android/preferences/brave_pref_service_bridge.cc
+++ b/browser/android/preferences/brave_pref_service_bridge.cc
@@ -376,50 +376,6 @@ void JNI_BravePrefServiceBridge_SetWebrtcPolicy(JNIEnv* env, jint policy) {
       GetWebRTCIPHandlingPreference((WebRTCIPHandlingPolicy)policy));
 }
 
-void JNI_BravePrefServiceBridge_SetUnstoppableDomainsResolveMethod(
-    JNIEnv* env,
-    jint method) {
-  g_browser_process->local_state()->SetInteger(
-      decentralized_dns::kUnstoppableDomainsResolveMethod, method);
-}
-
-jint JNI_BravePrefServiceBridge_GetUnstoppableDomainsResolveMethod(
-    JNIEnv* env) {
-  return g_browser_process->local_state()->GetInteger(
-      decentralized_dns::kUnstoppableDomainsResolveMethod);
-}
-
-void JNI_BravePrefServiceBridge_SetENSResolveMethod(JNIEnv* env, jint method) {
-  g_browser_process->local_state()->SetInteger(
-      decentralized_dns::kENSResolveMethod, method);
-}
-
-jint JNI_BravePrefServiceBridge_GetENSResolveMethod(JNIEnv* env) {
-  return g_browser_process->local_state()->GetInteger(
-      decentralized_dns::kENSResolveMethod);
-}
-
-void JNI_BravePrefServiceBridge_SetENSOffchainResolveMethod(JNIEnv* env,
-                                                            jint method) {
-  g_browser_process->local_state()->SetInteger(
-      decentralized_dns::kEnsOffchainResolveMethod, method);
-}
-
-jint JNI_BravePrefServiceBridge_GetENSOffchainResolveMethod(JNIEnv* env) {
-  return g_browser_process->local_state()->GetInteger(
-      decentralized_dns::kEnsOffchainResolveMethod);
-}
-
-void JNI_BravePrefServiceBridge_SetSnsResolveMethod(JNIEnv* env, jint method) {
-  g_browser_process->local_state()->SetInteger(
-      decentralized_dns::kSnsResolveMethod, method);
-}
-
-jint JNI_BravePrefServiceBridge_GetSnsResolveMethod(JNIEnv* env) {
-  return g_browser_process->local_state()->GetInteger(
-      decentralized_dns::kSnsResolveMethod);
-}
-
 void JNI_BravePrefServiceBridge_SetNewsOptIn(JNIEnv* env, jboolean value) {
   GetOriginalProfile()->GetPrefs()->SetBoolean(
       brave_news::prefs::kBraveTodayOptedIn, value);

--- a/build/android/BUILD.gn
+++ b/build/android/BUILD.gn
@@ -182,6 +182,7 @@ brave_xml_preprocessor("brave_java_xml_preprocess_resources") {
 generate_jni("jni_headers") {
   sources = [
     "//brave/android/java/org/chromium/chrome/browser/BraveFeatureUtil.java",
+    "//brave/android/java/org/chromium/chrome/browser/BraveLocalState.java",
     "//brave/android/java/org/chromium/chrome/browser/BraveRelaunchUtils.java",
     "//brave/android/java/org/chromium/chrome/browser/BraveRewardsNativeWorker.java",
     "//brave/android/java/org/chromium/chrome/browser/BraveSyncWorker.java",

--- a/components/decentralized_dns/core/BUILD.gn
+++ b/components/decentralized_dns/core/BUILD.gn
@@ -6,6 +6,7 @@
 static_library("core") {
   sources = [
     "constants.h",
+    "pref_names.cc",
     "pref_names.h",
     "utils.cc",
     "utils.h",

--- a/components/decentralized_dns/core/pref_names.cc
+++ b/components/decentralized_dns/core/pref_names.cc
@@ -1,0 +1,19 @@
+/* Copyright (c) 2023 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "brave/components/decentralized_dns/core/pref_names.h"
+
+namespace decentralized_dns {
+
+const char kUnstoppableDomainsResolveMethod[] =
+    "brave.unstoppable_domains.resolve_method";
+
+const char kENSResolveMethod[] = "brave.ens.resolve_method";
+
+const char kEnsOffchainResolveMethod[] = "brave.ens.offchain_resolve_method";
+
+const char kSnsResolveMethod[] = "brave.sns.resolve_method";
+
+}  // namespace decentralized_dns

--- a/components/decentralized_dns/core/pref_names.h
+++ b/components/decentralized_dns/core/pref_names.h
@@ -13,25 +13,23 @@ namespace decentralized_dns {
 // Disabled: Disable all unstoppable domains resolution.
 // Ask: Ask users if they want to enable support of unstoppable domains.
 // Enabled: Resolve domain name using Ethereum JSON-RPC server.
-constexpr char kUnstoppableDomainsResolveMethod[] =
-    "brave.unstoppable_domains.resolve_method";
+extern const char kUnstoppableDomainsResolveMethod[];
 
 // Used to determine which method should be used to resolve ENS domains,
 // between:
 // Disabled: Disable all ENS domains resolution.
 // Ask: Ask users if they want to enable support of ENS.
 // Enabled: Resolve domain name using Ethereum JSON-RPC server.
-constexpr char kENSResolveMethod[] = "brave.ens.resolve_method";
+extern const char kENSResolveMethod[];
 
-constexpr char kEnsOffchainResolveMethod[] =
-    "brave.ens.offchain_resolve_method";
+extern const char kEnsOffchainResolveMethod[];
 
 // Used to determine which method should be used to resolve SNS domains,
 // between:
 // Disabled: Disable all SNS domains resolution.
 // Ask: Ask users if they want to enable support of SNS.
 // Enabled: Resolve domain name using Solana JSON-RPC server.
-constexpr char kSnsResolveMethod[] = "brave.sns.resolve_method";
+extern const char kSnsResolveMethod[];
 
 }  // namespace decentralized_dns
 

--- a/components/safetynet/java/org/chromium/chrome/browser/util/SafetyNetCheck.java
+++ b/components/safetynet/java/org/chromium/chrome/browser/util/SafetyNetCheck.java
@@ -29,8 +29,9 @@ import org.chromium.base.Log;
 import org.chromium.base.annotations.CalledByNative;
 import org.chromium.base.annotations.JNINamespace;
 import org.chromium.base.annotations.NativeMethods;
+import org.chromium.chrome.browser.BraveLocalState;
 import org.chromium.chrome.browser.BraveRewardsHelper;
-import org.chromium.chrome.browser.preferences.BravePrefServiceBridge;
+import org.chromium.chrome.browser.preferences.BravePref;
 
 import java.security.SecureRandom;
 import java.util.Calendar;
@@ -171,16 +172,16 @@ public class SafetyNetCheck {
                         Log.e(TAG, "Unable to perform SafetyNet attestation: " + e);
                     }
                     attestationPassed = ctsProfileMatch && basicIntegrity;
-                    BravePrefServiceBridge.getInstance().setSafetynetStatus(attestationPassed
-                                    ? SAFETYNET_STATUS_VERIFIED_PASSED
-                                    : SAFETYNET_STATUS_VERIFIED_NOT_PASSED);
+                    BraveLocalState.get().setString(BravePref.SAFETYNET_STATUS,
+                            attestationPassed ? SAFETYNET_STATUS_VERIFIED_PASSED
+                                              : SAFETYNET_STATUS_VERIFIED_NOT_PASSED);
                     if (mSafetyNetCheckCallback != null) {
                         mSafetyNetCheckCallback.onResult(attestationPassed);
                     }
                 }
             } else {
-                BravePrefServiceBridge.getInstance().setSafetynetStatus(
-                        SAFETYNET_STATUS_NOT_VERIFIED);
+                BraveLocalState.get().setString(
+                        BravePref.SAFETYNET_STATUS, SAFETYNET_STATUS_NOT_VERIFIED);
             }
         }
         if (mNativeSafetyNetCheck == 0) return;


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/27632

Intruduced BraveLocalState class.

Removed methods from BravePrefServiceBridge which were used to access these local_state prefs:
   - BravePref.P3A_ENABLED
   - BravePref.P3A_NOTICE_ACKNOWLEDGED
   - BravePref.STATS_REPORTING_ENABLED
   - BravePref.SAFETYNET_STATUS
   - BravePref.ENS_RESOLVE_METHOD
   - BravePref.SNS_RESOLVE_METHOD
   - BravePref.UNSTOPPABLE_DOMAINS_RESOLVE_METHOD
   - BravePref.ENS_OFFCHAIN_RESOLVE_METHOD

Removed unused Java/JNI methods:
   - BravePrefServiceBridge.setReferralAndroidFirstRunTimestamp;
   - BravePrefServiceBridge.setReferralCheckedForPromoCodeFile;
   - BravePrefServiceBridge.setReferralInitialization;
   - BravePrefServiceBridge.setReferralPromoCode;
   - BravePrefServiceBridge.setReferralDownloadId.


## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
New features are not added with this PR. The test plan is required to verify nothing is broken.

I. `brave.p3a.enabled`
1. Make fresh installation
2. Launch browser, on FTRW uncheck `Share completely private and anonymous product insights about what features are being used by Brave's users.`
3. Open brave://local-state, must exist
```
 "p3a": {
         "enabled": true,
```
entry.
4. Go to app menu => Settings => Brave Shields & privacy, `Allow privacy-preserving product diagnostic (P3A)` must be unchecked
5. Check `Allow privacy-preserving product diagnostic (P3A)` switch
6. Open brave://local-state, the entry should look
```
 "p3a": {
         "enabled": false,
```


II. `brave.stats.reporting_enabled`
1. Open app menu => Settings => Brave Shields & privacy, turn off `Automatically send daily usage pings` 
2. Open brave://local-state, find `reporting_enabled` should be false
3. Open again app menu => Settings => Brave Shields & privacy, `Automatically send daily usage pings` must be unchecked


III. `safetynet.status`
According to the code, the Brave Rewards grant should be retreived successfullt to verify it works as before.


IV. `brave.unstoppable_domains.resolve_method`
1. Open app menu => Settings => Brave Shields & privacy => Unstoppable Domains, switch it to `Enabled` 
2. Open brave://local-state, find `resolve_method` near `unstoppable_domains`, it should be
```
"unstoppable_domains": {
         "resolve_method": 3
      },
```
3. Relaunch browser, open app menu => Settings => Brave Shields & privacy => Unstoppable Domains, it should still be `Enabled`

V. `brave.ens.resolve_method`
1. Open app menu => Settings => Brave Shields & privacy => Ethereum Name Service, switch to `Enabled`
2. Open brave://local-state, find `resolve_method` near `ens`, it should be
```
"ens": {
         "resolve_method": 3
      },
```
3. Relaunch browser, open app menu => Settings => Brave Shields & privacy => Ethereum Name Service, it should still be `Enabled`

VI. `brave.sns.resolve_method`
1. Open brave://flags => `Enable Solana Name Service support` => Enabled, relaunch browser
2. Open app menu => Settings => Brave Shields & privacy => Solana Name Service, switch to `Enabled`
3. Open brave://local-state, find `resolve_method` near `sns`, it should be
```
"sns": {
         "resolve_method": 3
      },
```
4. Relaunch browser, open app menu => Settings => Brave Shields & privacy => Solana Name Service, it should still be `Enabled`


VII. `brave.ens.offchain_resolve_method`
1. Open app menu => Settings => Brave Shields & privacy => Unstoppable Domains, switch `ENS offchain lookup` to `Enabled` 
2. Open brave://local-state, find `resolve_method` near `unstoppable_domains`, it should be
```
"ens": {
         "offchain_resolve_method": 2,
```
3. Relaunch browser, open app menu => Settings => Brave Shields & privacy => Unstoppable Domains, `ENS offchain lookup` should still be `Enabled`