### PR TITLE
Remove "ShareHubIcon" on internal pages.

### DIFF
--- a/chromium_src/chrome/browser/ui/sharing_hub/sharing_hub_bubble_controller_desktop_impl.cc
+++ b/chromium_src/chrome/browser/ui/sharing_hub/sharing_hub_bubble_controller_desktop_impl.cc
@@ -1,0 +1,27 @@
+/* Copyright (c) 2022 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "chrome/browser/ui/sharing_hub/sharing_hub_bubble_controller_desktop_impl.h"
+
+#define ShouldOfferOmniboxIcon ShouldOfferOmniboxIcon_ChromiumImpl
+
+#include "src/chrome/browser/ui/sharing_hub/sharing_hub_bubble_controller_desktop_impl.cc"
+
+#undef ShouldOfferOmniboxIcon
+
+namespace sharing_hub {
+
+bool SharingHubBubbleControllerDesktopImpl::ShouldOfferOmniboxIcon() {
+  const GURL url = GetWebContents().GetLastCommittedURL();
+
+  // To disable share icons in internal pages.
+  if (url.is_valid() && !url.SchemeIsHTTPOrHTTPS()) {
+    return false;
+  }
+
+  return ShouldOfferOmniboxIcon_ChromiumImpl();
+}
+
+}  // namespace sharing_hub

--- a/chromium_src/chrome/browser/ui/sharing_hub/sharing_hub_bubble_controller_desktop_impl.h
+++ b/chromium_src/chrome/browser/ui/sharing_hub/sharing_hub_bubble_controller_desktop_impl.h
@@ -1,0 +1,22 @@
+/* Copyright (c) 2022 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_CHROMIUM_SRC_CHROME_BROWSER_UI_SHARING_HUB_SHARING_HUB_BUBBLE_CONTROLLER_DESKTOP_IMPL_H_
+#define BRAVE_CHROMIUM_SRC_CHROME_BROWSER_UI_SHARING_HUB_SHARING_HUB_BUBBLE_CONTROLLER_DESKTOP_IMPL_H_
+
+//  This header must be included before the macro definition, so the virtual
+//  declaration of "ShouldOfferOmniboxIcon" will not be changed using the
+//  property of header guard.
+#include "chrome/browser/ui/sharing_hub/sharing_hub_bubble_controller.h"
+
+#define ShouldOfferOmniboxIcon           \
+  ShouldOfferOmniboxIcon_ChromiumImpl(); \
+  bool ShouldOfferOmniboxIcon
+
+#include "src/chrome/browser/ui/sharing_hub/sharing_hub_bubble_controller_desktop_impl.h"
+
+#undef ShouldOfferOmniboxIcon
+
+#endif  // BRAVE_CHROMIUM_SRC_CHROME_BROWSER_UI_SHARING_HUB_SHARING_HUB_BUBBLE_CONTROLLER_DESKTOP_IMPL_H_


### PR DESCRIPTION
As "ShareHubIcon" in the omnibox copies link with "chrome" scheme instead of "brave" and due to the rare usage on internal pages.

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/27484

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

