### PR TITLE
Solana auto discovery

### DIFF
--- a/browser/brave_wallet/asset_discovery_manager_unittest.cc
+++ b/browser/brave_wallet/asset_discovery_manager_unittest.cc
@@ -5,6 +5,7 @@
 
 #include "brave/components/brave_wallet/browser/asset_discovery_manager.h"
 
+#include "base/base64.h"
 #include "base/memory/raw_ptr.h"
 #include "base/strings/strcat.h"
 #include "base/test/bind.h"
@@ -66,7 +67,7 @@ void UpdateCustomNetworks(PrefService* prefs,
   }
 }
 
-const std::vector<std::string>& GetAssetDiscoverySupportedChainsForTest() {
+const std::vector<std::string>& GetAssetDiscoverySupportedEthChainsForTest() {
   static base::NoDestructor<std::vector<std::string>>
       asset_discovery_supported_chains({mojom::kMainnetChainId,
                                         mojom::kPolygonMainnetChainId,
@@ -162,7 +163,7 @@ class AssetDiscoveryManagerUnitTest : public testing::Test {
     asset_discovery_manager_ = std::make_unique<AssetDiscoveryManager>(
         wallet_service_.get(), json_rpc_service_, keyring_service_, GetPrefs());
     asset_discovery_manager_->SetSupportedChainsForTesting(
-        GetAssetDiscoverySupportedChainsForTest());
+        GetAssetDiscoverySupportedEthChainsForTest());
     wallet_service_observer_ =
         std::make_unique<TestBraveWalletServiceObserverForAssetDiscovery>();
     wallet_service_->AddObserver(wallet_service_observer_->GetReceiver());
@@ -174,6 +175,33 @@ class AssetDiscoveryManagerUnitTest : public testing::Test {
           if (request.url.spec() == intended_url) {
             url_loader_factory_.ClearResponses();
             url_loader_factory_.AddResponse(request.url.spec(), content);
+          }
+        }));
+  }
+
+  // SetInterceptorForDiscoverSolAssets takes a map of addresses to responses
+  // and adds the response if the address if found in the request string
+  void SetInterceptorForDiscoverSolAssets(
+      GURL& intended_url,
+      const std::map<std::string, std::string>& requests) {
+    url_loader_factory_.SetInterceptor(base::BindLambdaForTesting(
+        [&, intended_url, requests](const network::ResourceRequest& request) {
+          if (request.url.spec() == intended_url) {
+            base::StringPiece request_string(
+                request.request_body->elements()
+                    ->at(0)
+                    .As<network::DataElementBytes>()
+                    .AsStringPiece());
+            std::string response;
+            for (auto const& [key, val] : requests) {
+              if (request_string.find(key) != std::string::npos) {
+                response = val;
+                break;
+              }
+            }
+            ASSERT_FALSE(response.empty());
+            url_loader_factory_.ClearResponses();
+            url_loader_factory_.AddResponse(request.url.spec(), response);
           }
         }));
   }
@@ -209,23 +237,51 @@ class AssetDiscoveryManagerUnitTest : public testing::Test {
                                                ->at(0)
                                                .As<network::DataElementBytes>()
                                                .AsStringPiece());
-          const auto expected_from_block =
-              expected_from_blocks.find(request.url.spec())->second;
-          const auto expected_to_block =
-              expected_to_blocks.find(request.url.spec())->second;
 
-          EXPECT_NE(request_string.find(base::StringPrintf(
-                        "\"fromBlock\":\"%s\"", expected_from_block.c_str())),
-                    std::string::npos);
-          EXPECT_NE(request_string.find(base::StringPrintf(
-                        "\"toBlock\":\"%s\"", expected_to_block.c_str())),
-                    std::string::npos);
+          // Verify fromBlock and toBlock's requested match expected for ETH
+          // chains
+          auto it = expected_from_blocks.find(request.url.spec());
+          if (it != expected_from_blocks.end()) {
+            const auto& expected_from_block = it->second;
+            EXPECT_NE(request_string.find(base::StringPrintf(
+                          "\"fromBlock\":\"%s\"", expected_from_block.c_str())),
+                      std::string::npos);
+          }
+          // Same for toBlock
+          it = expected_to_blocks.find(request.url.spec());
+          if (it != expected_to_blocks.end()) {
+            const auto& expected_to_block = it->second;
+            EXPECT_NE(request_string.find(base::StringPrintf(
+                          "\"toBlock\":\"%s\"", expected_to_block.c_str())),
+                      std::string::npos);
+          }
           url_loader_factory_.ClearResponses();
           for (const auto& kv : responses) {
             url_loader_factory_.AddResponse(kv.first, kv.second);
           }
           return;
         }));
+  }
+
+  void TestDiscoverSolAssets(
+      const std::vector<std::string>& account_addresses,
+      const std::vector<std::string>& expected_contract_addresses) {
+    asset_discovery_manager_->SetDiscoverAssetsCompletedCallbackForTesting(
+        base::BindLambdaForTesting(
+            [&](const std::string& chain_id,
+                const std::vector<mojom::BlockchainTokenPtr> discovered_assets,
+                absl::optional<mojom::ProviderError> error,
+                const std::string& error_message) {
+              ASSERT_FALSE(error);
+              ASSERT_EQ(discovered_assets.size(),
+                        expected_contract_addresses.size());
+              for (size_t i = 0; i < discovered_assets.size(); i++) {
+                EXPECT_EQ(discovered_assets[i]->contract_address,
+                          expected_contract_addresses[i]);
+              }
+            }));
+    asset_discovery_manager_->DiscoverSolAssets(account_addresses, false);
+    base::RunLoop().RunUntilIdle();
   }
 
   void TestDiscoverAssets(
@@ -237,7 +293,7 @@ class AssetDiscoveryManagerUnitTest : public testing::Test {
       const std::string& expected_error_message,
       const std::string& expected_next_asset_discovery_from_block) {
     // Set remaining chains to 1 in order since this value needs to end at
-    // 0 by the end of the DiscoverAssets call in order to trigger the
+    // 0 by the end of the DiscoverEthAssets call in order to trigger the
     // event and it will not be set by an outer
     // DiscoverAssetsOnAllSupportedChains* call in this unit test.
     asset_discovery_manager_->remaining_chains_ = 1;
@@ -245,9 +301,11 @@ class AssetDiscoveryManagerUnitTest : public testing::Test {
         base::BindLambdaForTesting(
             [&](const std::string& chain_id,
                 const std::vector<mojom::BlockchainTokenPtr> discovered_assets,
-                mojom::ProviderError error, const std::string& error_message) {
+                absl::optional<mojom::ProviderError> error,
+                const std::string& error_message) {
               EXPECT_EQ(chain_id, chain_id);
-              EXPECT_EQ(expected_error, error);
+              ASSERT_TRUE(error);
+              EXPECT_EQ(*error, expected_error);
               EXPECT_EQ(expected_error_message, error_message);
               ASSERT_EQ(expected_token_contract_addresses.size(),
                         discovered_assets.size());
@@ -256,7 +314,7 @@ class AssetDiscoveryManagerUnitTest : public testing::Test {
                           discovered_assets[i]->contract_address);
               }
             }));
-    asset_discovery_manager_->DiscoverAssets(
+    asset_discovery_manager_->DiscoverEthAssets(
         chain_id, mojom::CoinType::ETH, account_addresses, false,
         kEthereumBlockTagEarliest, kEthereumBlockTagLatest);
     wallet_service_observer_->WaitForOnDiscoverAssetsCompleted(
@@ -276,24 +334,31 @@ class AssetDiscoveryManagerUnitTest : public testing::Test {
   }
 
   void TestDiscoverAssetsOnAllSupportedChainsAccountsAdded(
+      mojom::CoinType coin,
       const std::vector<std::string>& account_addresses,
       const base::Time expected_assets_last_discovered_at_pref,
       const base::Value::Dict& expected_next_asset_discovery_from_blocks,
       const std::vector<std::string>& expected_token_contract_addresses = {}) {
-    std::vector<std::string> expected_chain_ids_remaining =
-        GetAssetDiscoverySupportedChainsForTest();
+    std::vector<std::string> expected_chain_ids_remaining;
+    if (coin == mojom::CoinType::ETH) {
+      expected_chain_ids_remaining =
+          GetAssetDiscoverySupportedEthChainsForTest();
+    } else {
+      expected_chain_ids_remaining = {mojom::kSolanaMainnet};
+    }
     asset_discovery_manager_->SetDiscoverAssetsCompletedCallbackForTesting(
         base::BindLambdaForTesting(
             [&](const std::string& chain_id,
                 const std::vector<mojom::BlockchainTokenPtr> discovered_assets,
-                mojom::ProviderError error, const std::string& error_message) {
+                absl::optional<mojom::ProviderError> error,
+                const std::string& error_message) {
               expected_chain_ids_remaining.erase(
                   std::remove(expected_chain_ids_remaining.begin(),
                               expected_chain_ids_remaining.end(), chain_id),
                   expected_chain_ids_remaining.end());
             }));
     asset_discovery_manager_->DiscoverAssetsOnAllSupportedChainsAccountsAdded(
-        account_addresses);
+        coin, account_addresses);
     base::RunLoop().RunUntilIdle();
     EXPECT_EQ(expected_chain_ids_remaining.size(), 0u);
     EXPECT_EQ(GetPrefs()->GetTime(kBraveWalletLastDiscoveredAssetsAt),
@@ -305,27 +370,28 @@ class AssetDiscoveryManagerUnitTest : public testing::Test {
   }
 
   void TestDiscoverAssetsOnAllSupportedChainsRefresh(
-      const std::vector<std::string>& account_addresses,
+      std::map<mojom::CoinType, std::vector<std::string>>& addresses,
       base::OnceCallback<void(base::Time previous, base::Time current)>
           assets_last_discovered_at_test_fn,
       const base::Value::Dict& expected_next_asset_discovery_from_blocks,
       const std::vector<std::string>& expected_token_contract_addresses,
       std::vector<std::string> expected_chain_ids_remaining =
-          GetAssetDiscoverySupportedChainsForTest()) {
+          GetAssetDiscoverySupportedEthChainsForTest()) {
     const base::Time previous_assets_last_discovered_at =
         GetPrefs()->GetTime(kBraveWalletLastDiscoveredAssetsAt);
     asset_discovery_manager_->SetDiscoverAssetsCompletedCallbackForTesting(
         base::BindLambdaForTesting(
             [&](const std::string& chain_id,
                 const std::vector<mojom::BlockchainTokenPtr> discovered_assets,
-                mojom::ProviderError error, const std::string& error_message) {
+                absl::optional<mojom::ProviderError> error,
+                const std::string& error_message) {
               expected_chain_ids_remaining.erase(
                   std::remove(expected_chain_ids_remaining.begin(),
                               expected_chain_ids_remaining.end(), chain_id),
                   expected_chain_ids_remaining.end());
             }));
     asset_discovery_manager_->DiscoverAssetsOnAllSupportedChainsRefresh(
-        account_addresses);
+        addresses);
     wallet_service_observer_->WaitForOnDiscoverAssetsCompleted(
         expected_token_contract_addresses);
     EXPECT_EQ(expected_chain_ids_remaining.size(), 0u);
@@ -363,7 +429,7 @@ class AssetDiscoveryManagerUnitTest : public testing::Test {
   data_decoder::test::InProcessDataDecoder in_process_data_decoder_;
 };
 
-TEST_F(AssetDiscoveryManagerUnitTest, DiscoverAssets) {
+TEST_F(AssetDiscoveryManagerUnitTest, DiscoverEthAssets) {
   auto* blockchain_registry = BlockchainRegistry::GetInstance();
   TokenListMap token_list_map;
   std::string response;
@@ -685,6 +751,7 @@ TEST_F(AssetDiscoveryManagerUnitTest, DiscoverAssets) {
 
 TEST_F(AssetDiscoveryManagerUnitTest,
        DiscoverAssetsOnAllSupportedChainsAccountsAdded) {
+  // Ethereum
   // Send valid requests that yield no results and verify
   // 1. OnDiscoverAssetsCompleted is called exactly once for each supported
   // chain
@@ -697,7 +764,7 @@ TEST_F(AssetDiscoveryManagerUnitTest,
   const std::string default_response =
       R"({ "jsonrpc":"2.0", "id":1, "result":[] })";
   for (const std::string& supported_chain_id :
-       GetAssetDiscoverySupportedChainsForTest()) {
+       GetAssetDiscoverySupportedEthChainsForTest()) {
     GURL network_url = GetNetwork(supported_chain_id, mojom::CoinType::ETH);
     responses[network_url.spec()] = default_response;
     expected_from_blocks[network_url.spec()] = kEthereumBlockTagEarliest;
@@ -710,8 +777,78 @@ TEST_F(AssetDiscoveryManagerUnitTest,
   SetDiscoverAssetsOnAllSupportedChainsInterceptor(
       responses, expected_from_blocks, expected_to_blocks);
   TestDiscoverAssetsOnAllSupportedChainsAccountsAdded(
-      {"0xB4B2802129071b2B9eBb8cBB01EA1E4D14B34961"}, assets_last_discovered_at,
-      expected_next_asset_discovery_from_blocks);
+      mojom::CoinType::ETH, {"0xB4B2802129071b2B9eBb8cBB01EA1E4D14B34961"},
+      assets_last_discovered_at, expected_next_asset_discovery_from_blocks);
+
+  // Solana
+  auto* blockchain_registry = BlockchainRegistry::GetInstance();
+  TokenListMap token_list_map;
+  std::string token_list_json = R"({
+    "88j24JNwWLmJCjn2tZQ5jJzyaFtnusS2qsKup9NeDnd8": {
+      "name": "Wrapped SOL",
+      "logo": "So11111111111111111111111111111111111111112.png",
+      "erc20": false,
+      "symbol": "SOL",
+      "decimals": 9,
+      "chainId": "0x65",
+      "coingeckoId": "solana"
+    },
+    "EybFzCH4nBYEr7FD4wLWBvNZbEGgjy4kh584bGQntr1b": {
+      "name": "USD Coin",
+      "logo": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v.png",
+      "erc20": false,
+      "symbol": "USDC",
+      "decimals": 6,
+      "chainId": "0x65",
+      "coingeckoId": "usd-coin"
+    }
+  })";
+  ASSERT_TRUE(
+      ParseTokenList(token_list_json, &token_list_map, mojom::CoinType::SOL));
+  blockchain_registry->UpdateTokenList(std::move(token_list_map));
+  auto expected_network_url =
+      GetNetwork(mojom::kSolanaMainnet, mojom::CoinType::SOL);
+  SetInterceptor(expected_network_url, R"({
+    "jsonrpc": "2.0",
+    "result": {
+      "context": {
+        "apiVersion": "1.13.5",
+        "slot": 166895942
+      },
+      "value": [
+        {
+          "account": {
+            "data": [
+              "z6cxAUoRHIupvmezOL4EAsTLlwKTgwxzCg/xcNWSEu42kEWUG3BArj8SJRSnd1faFt2Tm0Ey/qtGnPdOOlQlugEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+              "base64"
+            ],
+            "executable": false,
+            "lamports": 2039280,
+            "owner": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA",
+            "rentEpoch": 361
+          },
+          "pubkey": "5gjGaTE41sPVS1Dzwg43ipdj9NTtApZLcK55ihRuVb6Y"
+        },
+        {
+          "account": {
+            "data": [
+              "afxiYbRCtH5HgLYFzytARQOXmFT6HhvNzk2Baxua+lM2kEWUG3BArj8SJRSnd1faFt2Tm0Ey/qtGnPdOOlQlugEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+              "base64"
+            ],
+            "executable": false,
+            "lamports": 2039280,
+            "owner": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA",
+            "rentEpoch": 361
+          },
+          "pubkey": "81ZdQjbr7FhEPmcyGJtG8BAUyWxAjb2iSiWFEQn8i8Da"
+        }
+      ]
+    },
+    "id": 1
+  })");
+  TestDiscoverAssetsOnAllSupportedChainsAccountsAdded(
+      mojom::CoinType::SOL, {"4fzcQKyGFuk55uJaBZtvTHh42RBxbrZMuXzsGQvBJbwF"},
+      assets_last_discovered_at, expected_next_asset_discovery_from_blocks);
 }
 
 TEST_F(AssetDiscoveryManagerUnitTest,
@@ -722,7 +859,7 @@ TEST_F(AssetDiscoveryManagerUnitTest,
   // 2. kBraveWalletAssetsLastDiscoveredAt pref is updated
   // 3. kBraveWalletNextAssetDiscoveryFromBlocks pref is not updated
   const std::vector<std::string>& supported_chain_ids =
-      GetAssetDiscoverySupportedChainsForTest();
+      GetAssetDiscoverySupportedEthChainsForTest();
   std::map<std::string, std::string> responses;
   std::map<std::string, std::string> expected_from_blocks;
   std::map<std::string, std::string> expected_to_blocks;
@@ -734,11 +871,15 @@ TEST_F(AssetDiscoveryManagerUnitTest,
     expected_to_blocks[network_url.spec()] = kEthereumBlockTagLatest;
   }
 
+  std::map<mojom::CoinType, std::vector<std::string>> addresses = {
+      {mojom::CoinType::ETH, {"0xB4B2802129071b2B9eBb8cBB01EA1E4D14B34961"}},
+      {mojom::CoinType::SOL, {}}};
+
   base::Value::Dict expected_next_asset_discovery_from_blocks;  // Expect empty
   SetDiscoverAssetsOnAllSupportedChainsInterceptor(
       responses, expected_from_blocks, expected_to_blocks);
   TestDiscoverAssetsOnAllSupportedChainsRefresh(
-      {"0xB4B2802129071b2B9eBb8cBB01EA1E4D14B34961"},
+      addresses,
       base::BindLambdaForTesting([&](base::Time previous, base::Time current) {
         EXPECT_TRUE(previous < current);
       }),
@@ -753,7 +894,7 @@ TEST_F(AssetDiscoveryManagerUnitTest,
   // actually tested since the value is null...)
   expected_next_asset_discovery_from_blocks.clear();
   TestDiscoverAssetsOnAllSupportedChainsRefresh(
-      {"0xB4B2802129071b2B9eBb8cBB01EA1E4D14B34961"},
+      addresses,
       base::BindLambdaForTesting([&](base::Time previous, base::Time current) {
         EXPECT_EQ(previous, current);
       }),
@@ -898,7 +1039,7 @@ TEST_F(AssetDiscoveryManagerUnitTest,
   SetDiscoverAssetsOnAllSupportedChainsInterceptor(
       responses, expected_from_blocks, expected_to_blocks);
   TestDiscoverAssetsOnAllSupportedChainsRefresh(
-      {"0xB4B2802129071b2B9eBb8cBB01EA1E4D14B34961"},
+      addresses,
       base::BindLambdaForTesting([&](base::Time previous, base::Time current) {
         EXPECT_TRUE(previous < current);
       }),
@@ -956,12 +1097,171 @@ TEST_F(AssetDiscoveryManagerUnitTest,
   SetDiscoverAssetsOnAllSupportedChainsInterceptor(
       responses, expected_from_blocks, expected_to_blocks);
   TestDiscoverAssetsOnAllSupportedChainsRefresh(
-      {"0xB4B2802129071b2B9eBb8cBB01EA1E4D14B34961"},
+      addresses,
       base::BindLambdaForTesting([&](base::Time previous, base::Time current) {
         EXPECT_TRUE(previous < current);
       }),
       expected_next_asset_discovery_from_blocks,
       {"0x6B175474E89094C44Da98b954EedeAC495271d0F"});
+}
+
+TEST_F(AssetDiscoveryManagerUnitTest,
+       MultiChainDiscoverAssetsOnAllSupportedChainsRefresh) {
+  // Add ETH assets to registry
+  std::string eth_token_list = R"({
+      "0x0d8775f648430679a709e98d2b0cb6250d2887ef": {
+        "name": "Basic Attention Token",
+        "logo": "bat.svg",
+        "erc20": true,
+        "symbol": "BAT",
+        "chainId": "0x1",
+        "decimals": 18
+      },
+      "0x6B175474E89094C44Da98b954EedeAC495271d0F": {
+        "name": "Dai Stablecoin",
+        "logo": "dai.svg",
+        "erc20": true,
+        "symbol": "DAI",
+        "chainId": "0x1",
+        "decimals": 18
+      }})";
+  auto* blockchain_registry = BlockchainRegistry::GetInstance();
+  TokenListMap token_list_map;
+  ASSERT_TRUE(
+      ParseTokenList(eth_token_list, &token_list_map, mojom::CoinType::ETH));
+  blockchain_registry->UpdateTokenList(std::move(token_list_map));
+
+  // Set up mock RPC responses with a map from chain_id -> mock response  (ETH
+  // only)
+  std::map<std::string, std::string> responses;
+  std::map<std::string, std::string> expected_from_blocks;
+  std::map<std::string, std::string> expected_to_blocks;
+  const std::string default_response =
+      R"({ "jsonrpc":"2.0", "id":1, "result":[] })";
+  for (const std::string& supported_chain_id :
+       GetAssetDiscoverySupportedEthChainsForTest()) {
+    GURL network_url = GetNetwork(supported_chain_id, mojom::CoinType::ETH);
+    responses[network_url.spec()] = default_response;
+    expected_from_blocks[network_url.spec()] = kEthereumBlockTagEarliest;
+    expected_to_blocks[network_url.spec()] = kEthereumBlockTagLatest;
+  }
+
+  // Create response for Ethereum eth_getLogs request
+  GURL network_url = GetNetwork(mojom::kMainnetChainId, mojom::CoinType::ETH);
+  responses[network_url.spec()] = R"({
+    "jsonrpc":"2.0",
+    "id":1,
+    "result":[
+      {
+        "address":"0x6B175474E89094C44Da98b954EedeAC495271d0F",
+        "blockHash":"0x2961ceb6c16bab72a55f79e394a35f2bf1c62b30446e3537280f7c22c3115e6e",
+        "blockNumber":"0xd6464d",
+        "data":"0x00000000000000000000000000000000000000000000000555aff1f0fae8c000",
+        "logIndex":"0x159",
+        "removed":false,
+        "topics":[
+          "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef",
+          "0x000000000000000000000000503828976d22510aad0201ac7ec88293211d23da",
+          "0x000000000000000000000000b4b2802129071b2b9ebb8cbb01ea1e4d14b34961"
+        ],
+        "transactionHash":"0x2e652b70966c6a05f4b3e68f20d6540b7a5ab712385464a7ccf62774d39b7066",
+        "transactionIndex":"0x9f"
+      }
+    ]
+  })";
+  auto expected_next_asset_discovery_from_blocks =
+      GetPrefs()->GetDict(kBraveWalletNextAssetDiscoveryFromBlocks).Clone();
+  expected_next_asset_discovery_from_blocks.SetByDottedPath(
+      base::StrCat({kEthereumPrefKey, ".", mojom::kMainnetChainId}),
+      "0xd6464e");
+
+  // Add SOL assets to registry
+  std::string sol_token_list_json = R"({
+    "88j24JNwWLmJCjn2tZQ5jJzyaFtnusS2qsKup9NeDnd8": {
+      "name": "Wrapped SOL",
+      "logo": "So11111111111111111111111111111111111111112.png",
+      "erc20": false,
+      "symbol": "SOL",
+      "decimals": 9,
+      "chainId": "0x65",
+      "coingeckoId": "solana"
+    },
+    "EybFzCH4nBYEr7FD4wLWBvNZbEGgjy4kh584bGQntr1b": {
+      "name": "USD Coin",
+      "logo": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v.png",
+      "erc20": false,
+      "symbol": "USDC",
+      "decimals": 6,
+      "chainId": "0x65",
+      "coingeckoId": "usd-coin"
+    }
+  })";
+  ASSERT_TRUE(ParseTokenList(sol_token_list_json, &token_list_map,
+                             mojom::CoinType::SOL));
+  for (auto& list_pair : token_list_map) {
+    blockchain_registry->UpdateTokenList(list_pair.first,
+                                         std::move(list_pair.second));
+  }
+
+  // Create response for Solana getTokenAccountsByOwner RPC request
+  network_url = GetNetwork(mojom::kSolanaMainnet, mojom::CoinType::SOL);
+  responses[network_url.spec()] = R"({
+    "jsonrpc": "2.0",
+    "result": {
+      "context": {
+        "apiVersion": "1.13.5",
+        "slot": 166895942
+      },
+      "value": [
+        {
+          "account": {
+            "data": [
+              "z6cxAUoRHIupvmezOL4EAsTLlwKTgwxzCg/xcNWSEu42kEWUG3BArj8SJRSnd1faFt2Tm0Ey/qtGnPdOOlQlugEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+              "base64"
+            ],
+            "executable": false,
+            "lamports": 2039280,
+            "owner": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA",
+            "rentEpoch": 361
+          },
+          "pubkey": "5gjGaTE41sPVS1Dzwg43ipdj9NTtApZLcK55ihRuVb6Y"
+        },
+        {
+          "account": {
+            "data": [
+              "afxiYbRCtH5HgLYFzytARQOXmFT6HhvNzk2Baxua+lM2kEWUG3BArj8SJRSnd1faFt2Tm0Ey/qtGnPdOOlQlugEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+              "base64"
+            ],
+            "executable": false,
+            "lamports": 2039280,
+            "owner": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA",
+            "rentEpoch": 361
+          },
+          "pubkey": "81ZdQjbr7FhEPmcyGJtG8BAUyWxAjb2iSiWFEQn8i8Da"
+        }
+      ]
+    },
+    "id": 1
+  })";
+
+  // Queue the responses for ETH and SOL
+  std::map<mojom::CoinType, std::vector<std::string>> addresses = {
+      {mojom::CoinType::ETH, {"0xB4B2802129071b2B9eBb8cBB01EA1E4D14B34961"}},
+      {mojom::CoinType::SOL, {"4fzcQKyGFuk55uJaBZtvTHh42RBxbrZMuXzsGQvBJbwF"}}};
+  SetDiscoverAssetsOnAllSupportedChainsInterceptor(
+      responses, expected_from_blocks, expected_to_blocks);
+
+  // Verify all three addresses (1 ETH and 2 SOL are discovered)
+  // and that the next asset discovery from block is updated
+  TestDiscoverAssetsOnAllSupportedChainsRefresh(
+      addresses,
+      base::BindLambdaForTesting([&](base::Time previous, base::Time current) {
+        EXPECT_TRUE(previous < current);
+      }),
+      expected_next_asset_discovery_from_blocks,
+      {"88j24JNwWLmJCjn2tZQ5jJzyaFtnusS2qsKup9NeDnd8",
+       "EybFzCH4nBYEr7FD4wLWBvNZbEGgjy4kh584bGQntr1b",
+       "0x6B175474E89094C44Da98b954EedeAC495271d0F"});
 }
 
 TEST_F(AssetDiscoveryManagerUnitTest, KeyringServiceObserver) {
@@ -985,8 +1285,7 @@ TEST_F(AssetDiscoveryManagerUnitTest, KeyringServiceObserver) {
       "erc721":true,
       "symbol":"LilNouns",
       "chainId":"0x1"
-    },
-    "0x6e84a6216eA6dACC71eE8E6b0a5B7322EEbC0fDd":{
+    }, "0x6e84a6216eA6dACC71eE8E6b0a5B7322EEbC0fDd":{
       "name":"JoeToken",
       "logo":"joe.svg",
       "erc20":true,
@@ -1206,6 +1505,270 @@ TEST_F(AssetDiscoveryManagerUnitTest, KeyringServiceObserver) {
       mojom::kMainnetChainId, mojom::CoinType::ETH, GetPrefs());
   EXPECT_EQ(user_assets[user_assets.size() - 1]->symbol, "RAI");
   EXPECT_EQ(user_assets.size(), 6u);
+}
+
+TEST_F(AssetDiscoveryManagerUnitTest, DecodeMintAddress) {
+  // Invalid (data too short)
+  absl::optional<std::vector<uint8_t>> data_short = base::Base64Decode("YQ==");
+  ASSERT_TRUE(data_short);
+  absl::optional<SolanaAddress> mint_address =
+      asset_discovery_manager_->DecodeMintAddress(*data_short);
+  ASSERT_FALSE(mint_address);
+
+  // Valid
+  absl::optional<std::vector<uint8_t>> data = base::Base64Decode(
+      "afxiYbRCtH5HgLYFzytARQOXmFT6HhvNzk2Baxua+"
+      "lM2kEWUG3BArj8SJRSnd1faFt2Tm0Ey/"
+      "qtGnPdOOlQlugEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+      "QAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+      "AAA");
+  ASSERT_TRUE(data);
+  mint_address = asset_discovery_manager_->DecodeMintAddress(*data);
+  ASSERT_TRUE(mint_address);
+  EXPECT_EQ(mint_address.value().ToBase58(),
+            "88j24JNwWLmJCjn2tZQ5jJzyaFtnusS2qsKup9NeDnd8");
+}
+
+TEST_F(AssetDiscoveryManagerUnitTest, DiscoverSolAssets) {
+  auto* blockchain_registry = BlockchainRegistry::GetInstance();
+  TokenListMap token_list_map;
+  std::string token_list_json = R"({
+    "88j24JNwWLmJCjn2tZQ5jJzyaFtnusS2qsKup9NeDnd8": {
+      "name": "Wrapped SOL",
+      "logo": "So11111111111111111111111111111111111111112.png",
+      "erc20": false,
+      "symbol": "SOL",
+      "decimals": 9,
+      "chainId": "0x65",
+      "coingeckoId": "solana"
+    },
+    "EybFzCH4nBYEr7FD4wLWBvNZbEGgjy4kh584bGQntr1b": {
+      "name": "USD Coin",
+      "logo": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v.png",
+      "erc20": false,
+      "symbol": "USDC",
+      "decimals": 6,
+      "chainId": "0x65",
+      "coingeckoId": "usd-coin"
+    }
+  })";
+  ASSERT_TRUE(
+      ParseTokenList(token_list_json, &token_list_map, mojom::CoinType::SOL));
+  blockchain_registry->UpdateTokenList(std::move(token_list_map));
+
+  // Empy account address
+  TestDiscoverSolAssets({}, {});
+
+  // Invalid
+  TestDiscoverSolAssets({"ABC"}, {});
+
+  // Empty response (no tokens found) yields success
+  auto expected_network_url =
+      GetNetwork(mojom::kSolanaMainnet, mojom::CoinType::SOL);
+  SetInterceptor(expected_network_url, R"({
+    "jsonrpc": "2.0",
+    "result": {
+      "context": {
+        "apiVersion": "1.13.5",
+        "slot": 171155478
+      },
+      "value": []
+    },
+    "id": 1
+  })");
+  TestDiscoverSolAssets({"4fzcQKyGFuk55uJaBZtvTHh42RBxbrZMuXzsGQvBJbwF"}, {});
+
+  // Invalid response (no tokens found) yields
+  SetLimitExceededJsonErrorResponse();
+  TestDiscoverSolAssets({"4fzcQKyGFuk55uJaBZtvTHh42RBxbrZMuXzsGQvBJbwF"}, {});
+
+  // Valid response containing both tokens should add both tokens
+  SetInterceptor(expected_network_url, R"({
+    "jsonrpc": "2.0",
+    "result": {
+      "context": {
+        "apiVersion": "1.13.5",
+        "slot": 166895942
+      },
+      "value": [
+        {
+          "account": {
+            "data": [
+              "z6cxAUoRHIupvmezOL4EAsTLlwKTgwxzCg/xcNWSEu42kEWUG3BArj8SJRSnd1faFt2Tm0Ey/qtGnPdOOlQlugEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+              "base64"
+            ],
+            "executable": false,
+            "lamports": 2039280,
+            "owner": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA",
+            "rentEpoch": 361
+          },
+          "pubkey": "5gjGaTE41sPVS1Dzwg43ipdj9NTtApZLcK55ihRuVb6Y"
+        },
+        {
+          "account": {
+            "data": [
+              "afxiYbRCtH5HgLYFzytARQOXmFT6HhvNzk2Baxua+lM2kEWUG3BArj8SJRSnd1faFt2Tm0Ey/qtGnPdOOlQlugEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+              "base64"
+            ],
+            "executable": false,
+            "lamports": 2039280,
+            "owner": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA",
+            "rentEpoch": 361
+          },
+          "pubkey": "81ZdQjbr7FhEPmcyGJtG8BAUyWxAjb2iSiWFEQn8i8Da"
+        }
+      ]
+    },
+    "id": 1
+  })");
+  TestDiscoverSolAssets({"4fzcQKyGFuk55uJaBZtvTHh42RBxbrZMuXzsGQvBJbwF"},
+                        {"88j24JNwWLmJCjn2tZQ5jJzyaFtnusS2qsKup9NeDnd8",
+                         "EybFzCH4nBYEr7FD4wLWBvNZbEGgjy4kh584bGQntr1b"});
+
+  // Making the same call again should not add any tokens (they've already been
+  // added)
+  TestDiscoverSolAssets({"4fzcQKyGFuk55uJaBZtvTHh42RBxbrZMuXzsGQvBJbwF"}, {});
+
+  // Should merge tokens from multiple accounts
+  // (4fzcQKyGFuk55uJaBZtvTHh42RBxbrZMuXzsGQvBJbwF and
+  // 8RFACUfst117ARQLezvK4cKVR8ZHvW2xUfdUoqWnTuEB) Owner
+  // 4fzcQKyGFuk55uJaBZtvTHh42RBxbrZMuXzsGQvBJbwF has mints
+  // BEARs6toGY6fRGsmz2Se8NDuR2NVPRmJuLPpeF8YxCq2 and
+  // ADJqxHJRfFBpyxVQ2YS8nBhfW6dumdDYGU21B4AmYLZJ
+  const std::string first_response = R"({
+    "jsonrpc": "2.0",
+    "result": {
+      "context": {
+        "apiVersion": "1.13.5",
+        "slot": 166895942
+      },
+      "value": [
+        {
+          "account": {
+            "data": [
+              "l/QUsV2gleWOBK7DT7McygX06DWutQjr6AinX510aVU2kEWUG3BArj8SJRSnd1faFt2Tm0Ey/qtGnPdOOlQluoAsOSueAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+              "base64"
+            ],
+            "executable": false,
+            "lamports": 2039280,
+            "owner": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA",
+            "rentEpoch": 0
+          },
+          "pubkey": "BhZnyGAe58uHHdFQgej8ShuDGy9JL1tbs29Bqx3FRgy1"
+        },
+        {
+          "account": {
+            "data": [
+              "iOBUDkpieWsUu53IBhROGzPicXkIYV2OIGUzsFvIlvU2kEWUG3BArj8SJRSnd1faFt2Tm0Ey/qtGnPdOOlQlugDkC1QCAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+              "base64"
+            ],
+            "executable": false,
+            "lamports": 2039280,
+            "owner": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA",
+            "rentEpoch": 0
+          },
+          "pubkey": "3Ra8B4XsnumedGgKvfussaTLxrhyxFAqMkGmst8UqX3k"
+        }
+      ]
+    },
+    "id": 1
+  })";
+
+  // Owner 8RFACUfst117ARQLezvK4cKVR8ZHvW2xUfdUoqWnTuEB has mints
+  // 7vfCXTUXx5WJV5JADk17DUJ4ksgau7utNKj4b963voxs and
+  // 4zLh7YPr8NfrNP4bzTXaYaE72QQc3A8mptbtqUspRz5g
+  const std::string second_response = R"({
+    "jsonrpc": "2.0",
+    "result": {
+      "context": {
+        "apiVersion": "1.13.5",
+        "slot": 166895942
+      },
+      "value": [
+        {
+          "account": {
+            "data": [
+              "O0NuqIea7HUvvwtwGehJ95pVsBSH6xpS3rvbymg9TMNuN8HO+P8En+NLC+JfUEsxJnxEYiI50JuYlZKuo/DnTAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+              "base64"
+            ],
+            "executable": false,
+            "lamports": 2039280,
+            "owner": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA",
+            "rentEpoch": 361
+          },
+          "pubkey": "56iYTYcGgVj3kQ1eTApSp9BJRAvjNfZ7AFbdyeKfGPLK"
+        },
+        {
+          "account": {
+            "data": [
+              "ZuUYihMIoduQttMfP73KjD3yZ4yBEt/dPRksWjzEV6huN8HO+P8En+NLC+JfUEsxJnxEYiI50JuYlZKuo/DnTCeWHwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+              "base64"
+            ],
+            "executable": false,
+            "lamports": 2039280,
+            "owner": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA",
+            "rentEpoch": 361
+          },
+          "pubkey": "dUomT6JpMrZioLeLgtLfcUQpqHsA2jiH9vvz8HDsbyZ"
+        }
+      ]
+    },
+    "id": 1
+  })";
+
+  const std::map<std::string, std::string> requests = {
+      {"4fzcQKyGFuk55uJaBZtvTHh42RBxbrZMuXzsGQvBJbwF", first_response},
+      {"8RFACUfst117ARQLezvK4cKVR8ZHvW2xUfdUoqWnTuEB", second_response},
+  };
+  SetInterceptorForDiscoverSolAssets(expected_network_url, requests);
+
+  // Add BEARs6toGY6fRGsmz2Se8NDuR2NVPRmJuLPpeF8YxCq2,
+  // ADJqxHJRfFBpyxVQ2YS8nBhfW6dumdDYGU21B4AmYLZJ,
+  // 7vfCXTUXx5WJV5JADk17DUJ4ksgau7utNKj4b963voxs, and
+  // 4zLh7YPr8NfrNP4bzTXaYaE72QQc3A8mptbtqUspRz5g to token list
+  token_list_json = R"({
+    "BEARs6toGY6fRGsmz2Se8NDuR2NVPRmJuLPpeF8YxCq2": {
+      "name": "Tesla Inc.",
+      "logo": "2inRoG4DuMRRzZxAt913CCdNZCu2eGsDD9kZTrsj2DAZ.png",
+      "erc20": false,
+      "symbol": "TSLA",
+      "decimals": 8,
+      "chainId": "0x65"
+    },
+    "ADJqxHJRfFBpyxVQ2YS8nBhfW6dumdDYGU21B4AmYLZJ": {
+      "name": "Apple Inc.",
+      "logo": "8bpRdBGPt354VfABL5xugP3pmYZ2tQjzRcqjg2kmwfbF.png",
+      "erc20": false,
+      "symbol": "AAPL",
+      "decimals": 8,
+      "chainId": "0x65"
+    },
+    "7vfCXTUXx5WJV5JADk17DUJ4ksgau7utNKj4b963voxs": {
+      "name": "Microsoft Corporation",
+      "logo": "3vhcrQfEn8ashuBfE82F3MtEDFcBCEFfFw1ZgM3xj1s8.png",
+      "erc20": false,
+      "symbol": "MSFT",
+      "decimals": 8,
+      "chainId": "0x65"
+    },
+    "4zLh7YPr8NfrNP4bzTXaYaE72QQc3A8mptbtqUspRz5g": {
+      "name": "MicroStrategy Incorporated.",
+      "logo": "ASwYCbLedk85mRdPnkzrUXbbYbwe26m71af9rzrhC2Qz.png",
+      "erc20": false,
+      "symbol": "MSTR",
+      "decimals": 8,
+      "chainId": "0x65"
+    }
+  })";
+  ASSERT_TRUE(
+      ParseTokenList(token_list_json, &token_list_map, mojom::CoinType::SOL));
+  blockchain_registry->UpdateTokenList(std::move(token_list_map));
+  TestDiscoverSolAssets({"4fzcQKyGFuk55uJaBZtvTHh42RBxbrZMuXzsGQvBJbwF",
+                         "8RFACUfst117ARQLezvK4cKVR8ZHvW2xUfdUoqWnTuEB"},
+                        {"4zLh7YPr8NfrNP4bzTXaYaE72QQc3A8mptbtqUspRz5g",
+                         "7vfCXTUXx5WJV5JADk17DUJ4ksgau7utNKj4b963voxs",
+                         "ADJqxHJRfFBpyxVQ2YS8nBhfW6dumdDYGU21B4AmYLZJ",
+                         "BEARs6toGY6fRGsmz2Se8NDuR2NVPRmJuLPpeF8YxCq2"});
 }
 
 }  // namespace brave_wallet

--- a/components/brave_wallet/browser/asset_discovery_manager.h
+++ b/components/brave_wallet/browser/asset_discovery_manager.h
@@ -6,15 +6,18 @@
 #ifndef BRAVE_COMPONENTS_BRAVE_WALLET_BROWSER_ASSET_DISCOVERY_MANAGER_H_
 #define BRAVE_COMPONENTS_BRAVE_WALLET_BROWSER_ASSET_DISCOVERY_MANAGER_H_
 
+#include <map>
 #include <string>
 #include <utility>
 #include <vector>
 
+#include "base/barrier_callback.h"
 #include "base/memory/raw_ptr.h"
 #include "base/memory/weak_ptr.h"
 #include "brave/components/api_request_helper/api_request_helper.h"
 #include "brave/components/brave_wallet/common/brave_wallet.mojom.h"
 #include "brave/components/brave_wallet/common/brave_wallet_types.h"
+#include "brave/components/brave_wallet/common/solana_address.h"
 #include "mojo/public/cpp/bindings/receiver.h"
 
 class PrefService;
@@ -59,15 +62,15 @@ class AssetDiscoveryManager : public mojom::KeyringServiceObserver {
       base::RepeatingCallback<void(
           const std::string& chain_id,
           std::vector<mojom::BlockchainTokenPtr> discovered_assets_for_chain,
-          mojom::ProviderError error,
+          absl::optional<mojom::ProviderError> error,
           const std::string& error_message)>;
   // Called by frontend via BraveWalletService.
   // Subject to client side rate limiting based on
   // kBraveWalletLastDiscoveredAssetsAt pref value. Only runs eth_getLogs
   // against block range between
-  // kBraveWalletNextAssetDiscoveryFromBlocks pref and "latest".
+  // kBraveWalletNextAssetDiscoveryFromBlocks pref and "latest" for ETH chains.
   void DiscoverAssetsOnAllSupportedChainsRefresh(
-      const std::vector<std::string>& account_addresses);
+      std::map<mojom::CoinType, std::vector<std::string>>& account_addresses);
 
   void SetSupportedChainsForTesting(
       const std::vector<std::string> supported_chains_for_testing) {
@@ -81,29 +84,47 @@ class AssetDiscoveryManager : public mojom::KeyringServiceObserver {
 
  private:
   friend class AssetDiscoveryManagerUnitTest;
-  FRIEND_TEST_ALL_PREFIXES(AssetDiscoveryManagerUnitTest, DiscoverAssets);
+  FRIEND_TEST_ALL_PREFIXES(AssetDiscoveryManagerUnitTest, DiscoverEthAssets);
   FRIEND_TEST_ALL_PREFIXES(AssetDiscoveryManagerUnitTest,
                            DiscoverAssetsOnAllSupportedChainsRefresh);
 
-  const std::vector<std::string>& GetAssetDiscoverySupportedChains();
+  const std::vector<std::string>& GetAssetDiscoverySupportedEthChains();
 
-  void DiscoverAssets(const std::string& chain_id,
-                      mojom::CoinType coin,
-                      const std::vector<std::string>& account_addresses,
-                      bool update_prefs,
-                      const std::string& from_block,
-                      const std::string& to_block);
+  void DiscoverSolAssets(const std::vector<std::string>& account_addresses,
+                         bool triggered_by_accounts_added);
 
-  void OnGetAllTokensDiscoverAssets(
-      const std::string& chain_id,
-      const std::vector<std::string>& account_addresses,
-      std::vector<mojom::BlockchainTokenPtr> user_assets,
-      bool update_prefs,
-      const std::string& from_block,
-      const std::string& to_block,
-      std::vector<mojom::BlockchainTokenPtr> token_list);
+  void OnGetSolanaTokenAccountsByOwner(
+      base::OnceCallback<void(std::vector<SolanaAddress>)> barrier_callback,
+      const std::vector<SolanaAccountInfo>& token_accounts,
+      mojom::SolanaProviderError error,
+      const std::string& error_message);
 
-  void OnGetTransferLogs(
+  void MergeDiscoveredSolanaAssets(
+      bool triggered_by_accounts_added,
+      const std::vector<std::vector<SolanaAddress>>&
+          all_discovered_contract_addresses);
+
+  void OnGetSolanaTokenRegistry(
+      bool triggered_by_accounts_added,
+      const base::flat_set<std::string>& discovered_contract_addresses,
+      std::vector<mojom::BlockchainTokenPtr> sol_token_registry);
+
+  void DiscoverEthAssets(const std::string& chain_id,
+                         mojom::CoinType coin,
+                         const std::vector<std::string>& account_addresses,
+                         bool triggered_by_accounts_added,
+                         const std::string& from_block,
+                         const std::string& to_block);
+
+  void OnGetEthTokenRegistry(const std::string& chain_id,
+                             const std::vector<std::string>& account_addresses,
+                             std::vector<mojom::BlockchainTokenPtr> user_assets,
+                             bool triggered_by_accounts_added,
+                             const std::string& from_block,
+                             const std::string& to_block,
+                             std::vector<mojom::BlockchainTokenPtr> token_list);
+
+  void OnGetTokenTransferLogs(
       base::flat_map<std::string, mojom::BlockchainTokenPtr>& tokens_to_search,
       bool triggered_by_accounts_added,
       const std::string& chain_id,
@@ -112,10 +133,12 @@ class AssetDiscoveryManager : public mojom::KeyringServiceObserver {
       mojom::ProviderError error,
       const std::string& error_message);
 
+  // CompleteDiscoverAssets signals that the discover assets request has
+  // completed for a given chain_id
   void CompleteDiscoverAssets(
       const std::string& chain_id,
       std::vector<mojom::BlockchainTokenPtr> discovered_assets,
-      mojom::ProviderError error,
+      absl::optional<mojom::ProviderError> error,
       const std::string& error_message,
       bool triggered_by_accounts_added);
 
@@ -123,11 +146,24 @@ class AssetDiscoveryManager : public mojom::KeyringServiceObserver {
   // Rate limits will be ignored, and eth_getLogs query
   // will run against all blocks, "earliest" to "latest".
   void DiscoverAssetsOnAllSupportedChainsAccountsAdded(
+      mojom::CoinType coin,
       const std::vector<std::string>& account_addresses);
 
-  // The number of supported chain_ids to search for assets for the current
-  // DiscoverAssetsOnAllSupportedChainsRefresh request. Not used for
-  // DiscoverAssetsOnAllSupportedChainsAccountsAdded requests.
+  friend class AssetDiscoveryManagerUnitTest;
+  FRIEND_TEST_ALL_PREFIXES(AssetDiscoveryManagerUnitTest, DecodeMintAddress);
+
+  static absl::optional<SolanaAddress> DecodeMintAddress(
+      const std::vector<uint8_t>& data);
+
+  // remaining_chains_ is the number of chain IDs remaining for an in-flight
+  // DiscoverAssetsOnAllSupportedChainsRefresh call to be completed.
+  // When no call is in-flight, remaining_chains_ is 0.  When a call is
+  // in-flight, remaining_chains_ is > 0 and the AssetDiscoverManager will
+  // refuse to process additional  DiscoverAssetsOnAllSupportedChainsRefresh
+  // calls.
+  //
+  // DiscoverAssetsOnAllSupportedChainsAccountsAdded does not read from or write
+  // to remaining_chains_ and thus those calls will always processed.
   int remaining_chains_ = 0;
   std::vector<mojom::BlockchainTokenPtr> discovered_assets_;
   std::vector<std::string> supported_chains_for_testing_;

--- a/components/brave_wallet/browser/brave_wallet_service.cc
+++ b/components/brave_wallet/browser/brave_wallet_service.cc
@@ -5,6 +5,7 @@
 
 #include "brave/components/brave_wallet/browser/brave_wallet_service.h"
 
+#include <map>
 #include <utility>
 #include <vector>
 
@@ -1371,16 +1372,27 @@ void BraveWalletService::Base58Encode(
 }
 
 void BraveWalletService::DiscoverAssetsOnAllSupportedChains() {
+  std::map<mojom::CoinType, std::vector<std::string>> addresses;
+  // Fetch ETH addresses
   mojom::KeyringInfoPtr keyring_info = keyring_service_->GetKeyringInfoSync(
       brave_wallet::mojom::kDefaultKeyringId);
-
-  std::vector<std::string> account_addresses;
+  std::vector<std::string> eth_account_addresses;
   for (auto& account_info : keyring_info->account_infos) {
-    account_addresses.push_back(account_info->address);
+    eth_account_addresses.push_back(account_info->address);
   }
+  addresses[mojom::CoinType::ETH] = std::move(eth_account_addresses);
 
-  asset_discovery_manager_.DiscoverAssetsOnAllSupportedChainsRefresh(
-      account_addresses);
+  // Fetch SOL addresses
+  keyring_info = keyring_service_->GetKeyringInfoSync(
+      brave_wallet::mojom::kSolanaKeyringId);
+  std::vector<std::string> sol_account_addresses;
+  for (const auto& account_info : keyring_info->account_infos) {
+    sol_account_addresses.push_back(account_info->address);
+  }
+  addresses[mojom::CoinType::SOL] = std::move(sol_account_addresses);
+
+  // Discover assets owned by the SOL and ETH addresses on all supported chains
+  asset_discovery_manager_.DiscoverAssetsOnAllSupportedChainsRefresh(addresses);
 }
 
 void BraveWalletService::CancelAllSuggestedTokenCallbacks() {

--- a/components/brave_wallet/browser/json_rpc_response_parser.cc
+++ b/components/brave_wallet/browser/json_rpc_response_parser.cc
@@ -111,10 +111,11 @@ absl::optional<std::string> ConvertMultiUint64ToString(
 }
 
 absl::optional<std::string> ConvertMultiUint64InObjectArrayToString(
-    const std::string& path,
+    const std::string& path_to_list,
+    const std::string& path_to_object,
     const std::vector<std::string>& keys,
     const std::string& json) {
-  if (path.empty() || json.empty() || keys.empty())
+  if (path_to_list.empty() || json.empty() || keys.empty())
     return absl::nullopt;
 
   std::string converted_json(json);
@@ -122,7 +123,7 @@ absl::optional<std::string> ConvertMultiUint64InObjectArrayToString(
     if (key.empty())
       return absl::nullopt;
     converted_json = std::string(json::convert_uint64_in_object_array_to_string(
-        path, key, converted_json));
+        path_to_list, path_to_object, key, converted_json));
     if (converted_json.empty())
       return absl::nullopt;
   }

--- a/components/brave_wallet/browser/json_rpc_response_parser.h
+++ b/components/brave_wallet/browser/json_rpc_response_parser.h
@@ -69,7 +69,8 @@ absl::optional<std::string> ConvertMultiUint64ToString(
     const std::string& json);
 
 absl::optional<std::string> ConvertMultiUint64InObjectArrayToString(
-    const std::string& path,
+    const std::string& path_to_list,
+    const std::string& path_to_object,
     const std::vector<std::string>& keys,
     const std::string& json);
 

--- a/components/brave_wallet/browser/json_rpc_response_parser_unittest.cc
+++ b/components/brave_wallet/browser/json_rpc_response_parser_unittest.cc
@@ -237,16 +237,16 @@ TEST(JsonRpcResponseParserUnitTest, ConvertMultiUint64InObjectArrayToString) {
            {"key1":"18446744073709551615","key2":"18446744073709551615"}
            ]}})";
   EXPECT_EQ(ParseJson(*ConvertMultiUint64InObjectArrayToString(
-                "/result/array", {"key1", "key2"}, json)),
+                "/result/array", "", {"key1", "key2"}, json)),
             ParseJson(expected_json));
 
   EXPECT_FALSE(
-      ConvertMultiUint64InObjectArrayToString("", {"key1", "key2"}, json));
-  EXPECT_FALSE(ConvertMultiUint64InObjectArrayToString("/result/array",
+      ConvertMultiUint64InObjectArrayToString("", "", {"key1", "key2"}, json));
+  EXPECT_FALSE(ConvertMultiUint64InObjectArrayToString("/result/array", "",
                                                        {"key1", ""}, json));
   EXPECT_FALSE(
-      ConvertMultiUint64InObjectArrayToString("/result/array", {}, json));
-  EXPECT_FALSE(ConvertMultiUint64InObjectArrayToString("/result/array",
+      ConvertMultiUint64InObjectArrayToString("/result/array", "", {}, json));
+  EXPECT_FALSE(ConvertMultiUint64InObjectArrayToString("/result/array", "",
                                                        {"key1", "key2"}, ""));
 
   // Fail all if one of the key fails.
@@ -254,8 +254,23 @@ TEST(JsonRpcResponseParserUnitTest, ConvertMultiUint64InObjectArrayToString) {
               {"key1":18446744073709551615,"key2":18446744073709551615},
               {"key1":-1,"key2":1}
               ]}})";
-  EXPECT_FALSE(ConvertMultiUint64InObjectArrayToString("/result/array",
+  EXPECT_FALSE(ConvertMultiUint64InObjectArrayToString("/result/array", "",
                                                        {"key1", "key2"}, json));
+
+  // Works for nested keys
+  json =
+      R"({"result":{"array":[
+           {"sub_path":{"key1":18446744073709551615,"key2":18446744073709551615}},
+           {"sub_path":{"key1":18446744073709551615,"key2":18446744073709551615}}
+           ]}})";
+  expected_json =
+      R"({"result":{"array":[
+           {"sub_path": {"key1":"18446744073709551615","key2":"18446744073709551615"}},
+           {"sub_path": {"key1":"18446744073709551615","key2":"18446744073709551615"}}
+           ]}})";
+  EXPECT_EQ(ParseJson(*ConvertMultiUint64InObjectArrayToString(
+                "/result/array", "/sub_path", {"key1", "key2"}, json)),
+            ParseJson(expected_json));
 }
 
 TEST(JsonRpcResponseParserUnitTest, ConvertInt64ToString) {

--- a/components/brave_wallet/browser/json_rpc_service.cc
+++ b/components/brave_wallet/browser/json_rpc_service.cc
@@ -2626,7 +2626,7 @@ void JsonRpcService::GetSolanaSignatureStatuses(
       solana::getSignatureStatuses(tx_signatures), true,
       network_urls_[mojom::CoinType::SOL], std::move(internal_callback),
       base::BindOnce(&ConvertMultiUint64InObjectArrayToString, "/result/value",
-                     std::vector<std::string>({"slot", "confirmations"})));
+                     "", std::vector<std::string>({"slot", "confirmations"})));
 }
 
 void JsonRpcService::OnGetSolanaSignatureStatuses(
@@ -2767,6 +2767,46 @@ void JsonRpcService::OnGetSolanaBlockHeight(
   }
 
   std::move(callback).Run(block_height, mojom::SolanaProviderError::kSuccess,
+                          "");
+}
+
+void JsonRpcService::GetSolanaTokenAccountsByOwner(
+    const SolanaAddress& pubkey,
+    GetSolanaTokenAccountsByOwnerCallback callback) {
+  auto internal_callback =
+      base::BindOnce(&JsonRpcService::OnGetSolanaTokenAccountsByOwner,
+                     weak_ptr_factory_.GetWeakPtr(), std::move(callback));
+  RequestInternal(
+      solana::getTokenAccountsByOwner(pubkey.ToBase58()), true,
+      network_urls_[mojom::CoinType::SOL], std::move(internal_callback),
+      base::BindOnce(&ConvertMultiUint64InObjectArrayToString, "/result/value",
+                     "/account",
+                     std::vector<std::string>({"lamports", "rentEpoch"})));
+}
+
+void JsonRpcService::OnGetSolanaTokenAccountsByOwner(
+    GetSolanaTokenAccountsByOwnerCallback callback,
+    APIRequestResult api_request_result) {
+  if (!api_request_result.Is2XXResponseCode()) {
+    std::move(callback).Run(
+        {}, mojom::SolanaProviderError::kInternalError,
+        l10n_util::GetStringUTF8(IDS_WALLET_INTERNAL_ERROR));
+    return;
+  }
+
+  std::vector<SolanaAccountInfo> token_accounts;
+  if (!solana::ParseGetTokenAccountsByOwner(api_request_result.value_body(),
+                                            &token_accounts)) {
+    mojom::SolanaProviderError error;
+    std::string error_message;
+    ParseErrorResult<mojom::SolanaProviderError>(
+        api_request_result.value_body(), &error, &error_message);
+    std::move(callback).Run(std::vector<SolanaAccountInfo>(), error,
+                            error_message);
+    return;
+  }
+
+  std::move(callback).Run(token_accounts, mojom::SolanaProviderError::kSuccess,
                           "");
 }
 

--- a/components/brave_wallet/browser/json_rpc_service.h
+++ b/components/brave_wallet/browser/json_rpc_service.h
@@ -417,6 +417,14 @@ class JsonRpcService : public KeyedService, public mojom::JsonRpcService {
                               const std::string& error_message)>;
   void GetSolanaBlockHeight(GetSolanaBlockHeightCallback callback);
 
+  using GetSolanaTokenAccountsByOwnerCallback = base::OnceCallback<void(
+      const std::vector<SolanaAccountInfo>& token_accounts,
+      mojom::SolanaProviderError error,
+      const std::string& error_message)>;
+  void GetSolanaTokenAccountsByOwner(
+      const SolanaAddress& pubkey,
+      GetSolanaTokenAccountsByOwnerCallback callback);
+
  private:
   void FireNetworkChanged(mojom::CoinType coin);
   void FirePendingRequestCompleted(const std::string& chain_id,
@@ -563,6 +571,9 @@ class JsonRpcService : public KeyedService, public mojom::JsonRpcService {
                                 APIRequestResult api_request_result);
   void OnGetSolanaBlockHeight(GetSolanaBlockHeightCallback callback,
                               APIRequestResult api_request_result);
+  void OnGetSolanaTokenAccountsByOwner(
+      GetSolanaTokenAccountsByOwnerCallback callback,
+      APIRequestResult api_request_result);
 
   scoped_refptr<network::SharedURLLoaderFactory> url_loader_factory_;
   std::unique_ptr<APIRequestHelper> api_request_helper_;

--- a/components/brave_wallet/browser/json_rpc_service_unittest.cc
+++ b/components/brave_wallet/browser/json_rpc_service_unittest.cc
@@ -1387,6 +1387,26 @@ class JsonRpcServiceUnitTest : public testing::Test {
     run_loop.Run();
   }
 
+  void TestGetSolanaTokenAccountsByOwner(
+      const SolanaAddress& solana_address,
+      const std::vector<SolanaAccountInfo>& expected_token_accounts,
+      mojom::SolanaProviderError expected_error,
+      const std::string& expected_error_message) {
+    base::RunLoop run_loop;
+    json_rpc_service_->GetSolanaTokenAccountsByOwner(
+        solana_address,
+        base::BindLambdaForTesting(
+            [&](const std::vector<SolanaAccountInfo>& token_accounts,
+                mojom::SolanaProviderError error,
+                const std::string& error_message) {
+              EXPECT_EQ(token_accounts, expected_token_accounts);
+              EXPECT_EQ(error, expected_error);
+              EXPECT_EQ(error_message, expected_error_message);
+              run_loop.Quit();
+            }));
+    run_loop.Run();
+  }
+
   void GetFilEstimateGas(const std::string& from,
                          const std::string& to,
                          const std::string& value,
@@ -4348,6 +4368,110 @@ TEST_F(JsonRpcServiceUnitTest, GetSolanaBlockHeight) {
   SetHTTPRequestTimeoutInterceptor();
   TestGetSolanaBlockHeight(0, mojom::SolanaProviderError::kInternalError,
                            l10n_util::GetStringUTF8(IDS_WALLET_INTERNAL_ERROR));
+}
+
+TEST_F(JsonRpcServiceUnitTest, GetSolanaTokenAccountsByOwner) {
+  EXPECT_TRUE(SetNetwork(mojom::kLocalhostChainId, mojom::CoinType::SOL));
+  auto expected_network_url =
+      GetNetwork(mojom::kLocalhostChainId, mojom::CoinType::SOL);
+
+  // Valid
+  SetInterceptor(expected_network_url, "getTokenAccountsByOwner", "", R"({
+    "jsonrpc": "2.0",
+    "result": {
+      "context": {
+        "apiVersion": "1.13.5",
+        "slot": 166895942
+      },
+      "value": [
+        {
+          "account": {
+            "data": [
+              "z6cxAUoRHIupvmezOL4EAsTLlwKTgwxzCg/xcNWSEu42kEWUG3BArj8SJRSnd1faFt2Tm0Ey/qtGnPdOOlQlugEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+              "base64"
+            ],
+            "executable": false,
+            "lamports": 2039280,
+            "owner": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA",
+            "rentEpoch": 361
+          },
+          "pubkey": "5gjGaTE41sPVS1Dzwg43ipdj9NTtApZLcK55ihRuVb6Y"
+        },
+        {
+          "account": {
+            "data": [
+              "afxiYbRCtH5HgLYFzytARQOXmFT6HhvNzk2Baxua+lM2kEWUG3BArj8SJRSnd1faFt2Tm0Ey/qtGnPdOOlQlugEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+              "base64"
+            ],
+            "executable": false,
+            "lamports": 2039280,
+            "owner": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA",
+            "rentEpoch": 361
+          },
+          "pubkey": "81ZdQjbr7FhEPmcyGJtG8BAUyWxAjb2iSiWFEQn8i8Da"
+        }
+      ]
+    },
+    "id": 1
+  })");
+  // Create expected account infos
+  std::vector<SolanaAccountInfo> expected_account_infos;
+  SolanaAccountInfo account_info;
+  account_info.data =
+      "z6cxAUoRHIupvmezOL4EAsTLlwKTgwxzCg/"
+      "xcNWSEu42kEWUG3BArj8SJRSnd1faFt2Tm0Ey/"
+      "qtGnPdOOlQlugEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+      "QAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+      "AAA";
+  account_info.executable = false;
+  account_info.lamports = 2039280;
+  account_info.owner = "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA";
+  account_info.rent_epoch = 361;
+
+  expected_account_infos.push_back(std::move(account_info));
+  account_info.data =
+      "afxiYbRCtH5HgLYFzytARQOXmFT6HhvNzk2Baxua+"
+      "lM2kEWUG3BArj8SJRSnd1faFt2Tm0Ey/"
+      "qtGnPdOOlQlugEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+      "QAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+      "AAA";
+  account_info.executable = false;
+  account_info.lamports = 2039280;
+  account_info.owner = "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA";
+  account_info.rent_epoch = 361;
+  expected_account_infos.push_back(std::move(account_info));
+
+  absl::optional solana_address =
+      SolanaAddress::FromBase58("4fzcQKyGFuk55uJaBZtvTHh42RBxbrZMuXzsGQvBJbwF");
+  ASSERT_TRUE(solana_address);
+
+  TestGetSolanaTokenAccountsByOwner(*solana_address, expected_account_infos,
+                                    mojom::SolanaProviderError::kSuccess, "");
+
+  // Response parsing error
+  SetInterceptor(expected_network_url, "getTokenAccountsByOwner", "",
+                 R"({"jsonrpc":"2.0","id":1})");
+  TestGetSolanaTokenAccountsByOwner(
+      *solana_address, {}, mojom::SolanaProviderError::kParsingError,
+      l10n_util::GetStringUTF8(IDS_WALLET_PARSING_ERROR));
+
+  // JSON RPC error
+  SetInterceptor(expected_network_url, "getTokenAccountsByOwner", "",
+                 R"({"jsonrpc": "2.0", "id": 1,
+                     "error": {
+                       "code":-32601,
+                       "message":"method does not exist"
+                     }
+                    })");
+  TestGetSolanaTokenAccountsByOwner(*solana_address, {},
+                                    mojom::SolanaProviderError::kMethodNotFound,
+                                    "method does not exist");
+
+  // HTTP error
+  SetHTTPRequestTimeoutInterceptor();
+  TestGetSolanaTokenAccountsByOwner(
+      *solana_address, {}, mojom::SolanaProviderError::kInternalError,
+      l10n_util::GetStringUTF8(IDS_WALLET_INTERNAL_ERROR));
 }
 
 TEST_F(JsonRpcServiceUnitTest, GetFilEstimateGas) {

--- a/components/brave_wallet/browser/keyring_service.cc
+++ b/components/brave_wallet/browser/keyring_service.cc
@@ -723,6 +723,8 @@ void KeyringService::MaybeCreateDefaultSolanaAccount() {
       // to network change events.
       json_rpc_service_->SetNetwork(brave_wallet::mojom::kSolanaMainnet,
                                     mojom::CoinType::SOL, false);
+
+      NotifyAccountsAdded(mojom::CoinType::SOL, {address.value()});
     }
   }
 }
@@ -818,6 +820,7 @@ void KeyringService::RestoreWallet(const std::string& mnemonic,
       if (address) {
         SetPrefForKeyring(profile_prefs_, kSelectedAccount,
                           base::Value(*address), mojom::kSolanaKeyringId);
+        NotifyAccountsAdded(mojom::CoinType::SOL, {address.value()});
       }
     } else {
       MaybeCreateDefaultSolanaAccount();

--- a/components/brave_wallet/browser/solana_requests.cc
+++ b/components/brave_wallet/browser/solana_requests.cc
@@ -99,6 +99,24 @@ std::string getBlockHeight() {
   return GetJsonRpcString("getBlockHeight");
 }
 
+std::string getTokenAccountsByOwner(const std::string& pubkey) {
+  base::Value::List params;
+  params.Append(pubkey);
+
+  // Set encoding to base64 because the document says base58 is currently the
+  // default value but is slow and deprecated.
+  base::Value::Dict program;
+  base::Value::Dict encoding;
+  program.Set("programId", mojom::kSolanaTokenProgramId);
+  encoding.Set("encoding", "base64");
+  params.Append(std::move(program));
+  params.Append(std::move(encoding));
+
+  base::Value::Dict dictionary =
+      GetJsonRpcDictionary("getTokenAccountsByOwner", std::move(params));
+  return GetJSON(dictionary);
+}
+
 }  // namespace solana
 
 }  // namespace brave_wallet

--- a/components/brave_wallet/browser/solana_requests.h
+++ b/components/brave_wallet/browser/solana_requests.h
@@ -26,6 +26,7 @@ std::string getSignatureStatuses(const std::vector<std::string>& tx_signatures);
 std::string getAccountInfo(const std::string& pubkey);
 std::string getFeeForMessage(const std::string& message);
 std::string getBlockHeight();
+std::string getTokenAccountsByOwner(const std::string& pubkey);
 
 }  // namespace solana
 

--- a/components/brave_wallet/browser/solana_requests_unittest.cc
+++ b/components/brave_wallet/browser/solana_requests_unittest.cc
@@ -100,6 +100,12 @@ TEST(SolanaRequestsUnitTest, getBlockHeight) {
       R"({"id":1,"jsonrpc":"2.0","method":"getBlockHeight","params":[]})");
 }
 
+TEST(SolanaRequestsUnitTest, getTokenAccountsByOwner) {
+  ASSERT_EQ(
+      getTokenAccountsByOwner("pubkey"),
+      R"({"id":1,"jsonrpc":"2.0","method":"getTokenAccountsByOwner","params":["pubkey",{"programId":"TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"},{"encoding":"base64"}]})");
+}
+
 }  // namespace solana
 
 }  // namespace brave_wallet

--- a/components/brave_wallet/browser/solana_response_parser.h
+++ b/components/brave_wallet/browser/solana_response_parser.h
@@ -42,6 +42,8 @@ bool ParseGetAccountInfoPayload(
     absl::optional<SolanaAccountInfo>* account_info_out);
 bool ParseGetFeeForMessage(const base::Value& json_value, uint64_t* fee);
 bool ParseGetBlockHeight(const base::Value& json_value, uint64_t* block_height);
+bool ParseGetTokenAccountsByOwner(const base::Value& json_value,
+                                  std::vector<SolanaAccountInfo>* accounts);
 
 base::OnceCallback<absl::optional<std::string>(const std::string& raw_response)>
 ConverterForGetAccountInfo();

--- a/components/brave_wallet/browser/solana_response_parser_unittest.cc
+++ b/components/brave_wallet/browser/solana_response_parser_unittest.cc
@@ -356,6 +356,51 @@ TEST(SolanaResponseParserUnitTest, ParseGetBlockHeight) {
   EXPECT_DCHECK_DEATH(ParseGetBlockHeight(ParseJson(json), nullptr));
 }
 
+TEST(SolanaResponseParserUnitTest, ParseGetTokenAccountsByOwner) {
+  std::string json = R"({
+    "jsonrpc": "2.0",
+    "result": {
+      "context": {
+        "apiVersion": "1.14.10",
+        "slot": 166492586
+      },
+      "value": [
+        {
+          "account": {
+            "data": [
+              "afxiYbRCtH5HgLYFzytARQOXmFT6HhvNzk2Baxua+lM2kEWUG3BArj8SJRSnd1faFt2Tm0Ey/qtGnPdOOlQlugEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+              "base64"
+            ],
+            "executable": false,
+            "lamports": "2039280",
+            "owner": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA",
+            "rentEpoch": "361"
+          },
+          "pubkey": "81ZdQjbr7FhEPmcyGJtG8BAUyWxAjb2iSiWFEQn8i8Da"
+        },
+        {
+          "account": {
+            "data": [
+              "z6cxAUoRHIupvmezOL4EAsTLlwKTgwxzCg/xcNWSEu42kEWUG3BArj8SJRSnd1faFt2Tm0Ey/qtGnPdOOlQlugEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+              "base64"
+            ],
+            "executable": false,
+            "lamports": "2039280",
+            "owner": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA",
+            "rentEpoch": "361"
+          },
+          "pubkey": "5gjGaTE41sPVS1Dzwg43ipdj9NTtApZLcK55ihRuVb6Y"
+        }
+      ]
+    },
+    "id": 1
+  })";
+
+  std::vector<SolanaAccountInfo> token_accounts;
+  EXPECT_TRUE(ParseGetTokenAccountsByOwner(ParseJson(json), &token_accounts));
+  EXPECT_EQ(token_accounts.size(), 2u);
+}
+
 TEST(SolanaResponseParserUnitTest, ConverterForGetAccountInfo) {
   std::string json = R"(
     {


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/27246
Security review - https://github.com/brave/security/issues/1161

## Summary of changes
Adds support for automatic 'discovery' of Solana assets, meaning when new Solana accounts are added or when the frontend calls DiscoverAssetsOnAllSupportedChains(), we issue [getTokenAccountsByOwner](https://docs.solana.com/developing/clients/jsonrpc-api#gettokenaccountsbyowner) RPC calls to fetch the associated SPL token mint addresses owned by each address, checks if those tokens are in our registry, and adds them as visible asset if so.

This PR integrates this logic in the AssetDiscoveryManager which already has similar logic for Ethereum asset discovery.

I squashed to one commit, so I created this list to guide review:
1. Add `JsonRpcService::GetSolanaTokenAccountsByOwner` methods that implement the [getTokenAccountsByOwner](https://docs.solana.com/developing/clients/jsonrpc-api#gettokenaccountsbyowner) method.  1 RPC request will return all the tokens owned by a single address.
    1. Implement getTokenAccountsByOwner in `components/brave_wallet/browser/solana_requests.cc` to create the request bodies for the RPC call
    1. Modify Rust JSON converter function `convert_uint64_in_object_array_to_string` to support conversions of fields that are not at the top level of the JSON object in the array.
1. Implement core Solana asset discovery logic in AssetDiscoveryManager
    1. Implement `AssetDiscoveryManager::DiscoverSolAssets` which takes a list of Solana account addresses, and calls `JsonRpcService::GetSolanaTokenAccountsByOwner` for each concurrently using a barrier callback
    1. Implement `AssetDiscoveryManager::OnGetSolanaTokenAccountsByOwner` to handle the result of an individual RPC calls by decoding the data (base64, then borsh) to get the mint addresses returned in the RPC call, calls the barrier callback with the decoded list of mint addresses
        1. `AssetDiscoveryManager::DecodeMintAddress` does the borsh decoding to get the address
    1. `AssetDiscoveryManager::MergeDiscoveredSolanaAssets` is called with a list of lists of discovered mint addresses (for for each address).  It dedupes the addresses, then fetches the Sol token Registry
    1. `AssetDiscoveryManager::OnGetSolanaTokenRegistry` cross references the returned mint addresses with the list of token registry, and adds the token if it's in the registry
    1. Calls `AssetDiscoveryManager::CompleteDiscoverAssets` to trigger notifications and/or callbacks for tests
1. Trigger Solana asset discovery when Solana accounts are added
    1. Modify KeyringService such that `NotifyAccountsAdded()` is also called when SOL accounts are added
    1. Add a mojom::CoinType param to `DiscoverAssetsOnAllSupportedChainsAccountsAdded`, and if it's SOL, call `DiscoverSolAssets`
1. Trigger Solana asset discovery in `BraveWalletService::DiscoverAssetsOnAllSupportedChains` (this is what's called by frontends)
    1. Modify `BraveWalletService::DiscoverAssetsOnAllSupportedChains` such that it also fetches the users' Solana addresses to perform asset discovery with (calls `AssetDiscoveryManager::DiscoverAssetsOnAllSupportedChainsRefresh`)
    1. Modify `AssetDiscoveryManager::DiscoverAssetsOnAllSupportedChainsRefresh` such that it takes a map of mojom::CoinType -> vector of addresses, representing the addresses for each CoinType the user has, and now call `DiscoverSolAssets` as well as `DiscoverEthAssets` (eth)

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
Set up an account on Solana mainnet that has tokens listed our token registry, but are not added as visible assets. Add this account using each of these methods, and verify the asset is now a visible asset:
* Create wallet
* Restore wallet
* Add account (standard way)
* Import private key
* Import hardware account

When frontends have implemented calling the `DiscoverAssetsOnAllSupportedChains()` upon page refresh, then Solana tokens should automatically be added because of the work in this PR, but I don't believe there's a way to test that now, so that should be tested when those changes land.