### PR TITLE
Fix macOS delta updates

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -48,7 +48,7 @@ hooks = [
     'name': 'download_sparkle',
     'pattern': '.',
     'condition': 'checkout_mac and download_prebuilt_sparkle',
-    'action': ['vpython3', 'build/mac/download_sparkle.py', '1.24.2'],
+    'action': ['vpython3', 'build/mac/download_sparkle.py', '1.24.3'],
   },
   {
     'name': 'download_rust_deps',

--- a/DEPS
+++ b/DEPS
@@ -9,7 +9,7 @@ deps = {
     "condition": "checkout_win",
   },
   "vendor/sparkle": {
-    "url": "https://github.com/brave/Sparkle.git@1ba10369c4a7fe4b791b5a8d8ef130bd808087b7",
+    "url": "https://github.com/brave/Sparkle.git@8721f93f694244f9ff41fe975a92617ac5f63f9a",
     "condition": "checkout_mac",
   },
   "vendor/bip39wally-core-native": "https://github.com/brave-intl/bat-native-bip39wally-core.git@0d3a8713a2b388d2156fe49a70ef3f7cdb44b190",
@@ -48,7 +48,7 @@ hooks = [
     'name': 'download_sparkle',
     'pattern': '.',
     'condition': 'checkout_mac and download_prebuilt_sparkle',
-    'action': ['vpython3', 'build/mac/download_sparkle.py', '1ba10369c4a7fe4b791b5a8d8ef130bd808087b7'],
+    'action': ['vpython3', 'build/mac/download_sparkle.py', '1.24.3'],
   },
   {
     'name': 'download_rust_deps',

--- a/DEPS
+++ b/DEPS
@@ -9,7 +9,7 @@ deps = {
     "condition": "checkout_win",
   },
   "vendor/sparkle": {
-    "url": "https://github.com/brave/Sparkle.git@f69ba7b7fae7dda475ba6cda12fba8d72270478d",
+    "url": "https://github.com/brave/Sparkle.git@1ba10369c4a7fe4b791b5a8d8ef130bd808087b7",
     "condition": "checkout_mac",
   },
   "vendor/bip39wally-core-native": "https://github.com/brave-intl/bat-native-bip39wally-core.git@0d3a8713a2b388d2156fe49a70ef3f7cdb44b190",

--- a/DEPS
+++ b/DEPS
@@ -48,7 +48,7 @@ hooks = [
     'name': 'download_sparkle',
     'pattern': '.',
     'condition': 'checkout_mac and download_prebuilt_sparkle',
-    'action': ['vpython3', 'build/mac/download_sparkle.py', '1.24.3'],
+    'action': ['vpython3', 'build/mac/download_sparkle.py', '1.24.2'],
   },
   {
     'name': 'download_rust_deps',

--- a/DEPS
+++ b/DEPS
@@ -48,7 +48,7 @@ hooks = [
     'name': 'download_sparkle',
     'pattern': '.',
     'condition': 'checkout_mac and download_prebuilt_sparkle',
-    'action': ['vpython3', 'build/mac/download_sparkle.py', '1.24.2'],
+    'action': ['vpython3', 'build/mac/download_sparkle.py', '1ba10369c4a7fe4b791b5a8d8ef130bd808087b7'],
   },
   {
     'name': 'download_rust_deps',

--- a/browser/mac/sparkle_glue.mm
+++ b/browser/mac/sparkle_glue.mm
@@ -26,6 +26,15 @@
 
 namespace {
 
+std::string GetUpdateChannel() {
+  std::string channel_name = brave::GetChannelName();
+  if (channel_name == "release")
+    channel_name = "stable";
+  return base::SysInfo::OperatingSystemArchitecture() == "x86_64"
+             ? channel_name
+             : channel_name + "-arm64";
+}
+
 NSString* GetVersionFromAppcastItem(id item) {
   return [item performSelector:@selector(displayVersionString)];
 }

--- a/browser/mac/sparkle_glue.mm
+++ b/browser/mac/sparkle_glue.mm
@@ -26,15 +26,6 @@
 
 namespace {
 
-std::string GetUpdateChannel() {
-  std::string channel_name = brave::GetChannelName();
-  if (channel_name == "release")
-    channel_name = "stable";
-  return base::SysInfo::OperatingSystemArchitecture() == "x86_64"
-             ? channel_name
-             : channel_name + "-arm64";
-}
-
 NSString* GetVersionFromAppcastItem(id item) {
   return [item performSelector:@selector(displayVersionString)];
 }

--- a/browser/mac/sparkle_glue.mm
+++ b/browser/mac/sparkle_glue.mm
@@ -490,9 +490,7 @@ class PerformBridge : public base::RefCountedThreadSafe<PerformBridge> {
         command->GetSwitchValueASCII(switches::kUpdateFeedURL));
   }
 
-  return [NSString stringWithFormat:@"https://updates.bravesoftware.com/"
-                                    @"sparkle/Brave-Browser/%s/appcast.xml",
-                                    GetUpdateChannel().c_str()];
+  return [NSString stringWithFormat:@"http://127.0.0.1:8000/appcast.xml"];
 }
 @end
 

--- a/browser/mac/sparkle_glue.mm
+++ b/browser/mac/sparkle_glue.mm
@@ -490,7 +490,9 @@ class PerformBridge : public base::RefCountedThreadSafe<PerformBridge> {
         command->GetSwitchValueASCII(switches::kUpdateFeedURL));
   }
 
-  return [NSString stringWithFormat:@"http://127.0.0.1:8000/appcast.xml"];
+  return [NSString stringWithFormat:@"https://updates.bravesoftware.com/"
+                                    @"sparkle/Brave-Browser/%s/appcast.xml",
+                                    GetUpdateChannel().c_str()];
 }
 @end
 


### PR DESCRIPTION
Resolves https://github.com/brave/brave-browser/issues/27398.

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on

## Test Plan:

This change affects Brave's auto-update implementation. If we break something there, then millions of users will no longer receive automatic updates. They would all have to manually upgrade Brave to a fixed version. To avoid this, it is important that we test this change thoroughly.

The most important thing to test is that automatic updates still work. This can be tested by installing a version of Brave that is not the latest public one, and starting it from the command line with the following command:

    /Applications/Brave\ Browser\ Nightly.app/Contents/MacOS/Brave\ Browser\ Nightly --enable-logging=stderr

(Adjust for other channels accordingly.)

After a while, you should see:

```
brave update: did finish loading appcast
brave update: did find valid update
brave update: willDownloadUpdate
brave update: will install update on quit
```

### Background vs. on-demand updates

Brave's version is shown in `brave://settings/help`. So when you relaunch Brave after the steps above, you should see the new version. However: Opening `brave://settings/help` performs an _on-demand update check_. While this can be useful for testing, it is not the typical way in which users receive new versions. Most people will receive updates silently in the background while Brave is running. To test such _background updates_, launch Brave and make sure that `brave://settings/help` is _not_ open. Then wait for a few minutes, maybe watching logs as described above. In short, it would be good to test both background and on-demand updates. And when testing background updates, it's important that you do not have `brave://settings/help` open.

### Full vs. delta updates

Brave's installer is 130 MB in size. When we publish an update, we can (and do) upload the full installer for the new version to our update server. However, this means that users who receive the new version via automatic updates will download 130 MB every time. To reduce this bandwidth, we also serve _delta updates_. These are much smaller (say < 20 MB) and only send what's changed between the user's current version of Brave and the latest one. What was broken in the issue linked to at the top is the delta update mechanism. So Brave attempted to apply a delta update. This failed and Brave fell back to downloading the full update. We should test whether the fix in this PR was successful. That is, whether delta updates now work correctly and do not fall back to downloading the full version.

Our delta updates currently have the following restriction: We only generate them from the one previous version. So say there's already version 1 and version 2 comes out. Then we generate a delta from version 1 -> version 2. But now suppose version 3 comes out and you're on version 1. Then there is a delta from 2->3, but no delta from 1->3. To test the delta functionality, you need to be on version 2. Or speaking more in Brave terms, you need to be on the Brave public release before the current one. For example, suppose the latest _public_ Nightly release is v1.49.3 and the ones before that are v1.49.2 and v1.48.111. Then you must install v1.49.2 or you will not receive a delta.

To check whether you received a delta or a full update, you can use Fiddler Everywhere to inspect network traffic. Make sure you see a network request that downloads a `.delta` file from `updates-cdn.bravesoftware.com` (or `updates-cdn2`). If you see a `.dmg` file being downloaded as well, then Brave fell back to the full installer and the delta did not apply correctly. So in other words, we want to see a `.delta` file in network requests, but not a `.dmg`. Another indicator that Brave fell back to the full update is when you see two lines `willDownloadUpdate` in the log output above.

### Platforms and versions

Because this change affects critical functionality, it should be tested on as many platforms as possible. It would also be good to test both: An update from a Brave version that doesn't yet have the change to a version of Brave that does. And an update from and to a Brave version that both have the change. The former does not necessarily have to happen via a delta (because deltas are currently broken anyways). But the latter does.