### PR TITLE
Uplift 1.47.x - Brave News won't include items with non-http-or-https destination urls

### DIFF
--- a/components/brave_today/browser/direct_feed_controller.h
+++ b/components/brave_today/browser/direct_feed_controller.h
@@ -12,6 +12,7 @@
 #include <vector>
 
 #include "base/callback_forward.h"
+#include "base/gtest_prod_util.h"
 #include "base/memory/scoped_refptr.h"
 #include "brave/components/brave_today/common/brave_news.mojom-forward.h"
 #include "brave/components/brave_today/common/brave_news.mojom-shared.h"
@@ -78,6 +79,15 @@ class DirectFeedController {
  private:
   using SimpleURLLoaderList =
       std::list<std::unique_ptr<network::SimpleURLLoader>>;
+
+  FRIEND_TEST_ALL_PREFIXES(BraveNewsDirectFeed, ParseToArticle);
+  FRIEND_TEST_ALL_PREFIXES(BraveNewsDirectFeed, ParseOnlyAllowsHTTPLinks);
+
+  // Convert from a parsed feed's FeedData to the mojom Article objects used
+  // in Brave News.
+  static void BuildArticles(Articles& articles,
+                            const FeedData& data,
+                            const std::string& publisher_id);
   void DownloadFeedContent(const GURL& feed_url,
                            const std::string& publisher_id,
                            GetArticlesCallback callback);

--- a/components/brave_today/browser/direct_feed_controller_unittest.cc
+++ b/components/brave_today/browser/direct_feed_controller_unittest.cc
@@ -280,6 +280,43 @@ TEST(BraveNewsDirectFeed, ParseFeedRegression) {
             std::string::npos);
 }
 
+TEST(BraveNewsDirectFeed, ParseToArticle) {
+  // Create a feed item which should be valid as a Brave News Article
+  FeedItem item;
+  item.id = "1";
+  item.published_timestamp = 1672793966;
+  item.title = "Title";
+  item.description = "Description";
+  item.image_url = "https://example.com/image.jpg";
+  item.destination_url = "https://example.com";
+
+  FeedData data;
+  data.items.emplace_back(std::move(item));
+  Articles articles;
+  DirectFeedController::BuildArticles(articles, data, "Id1");
+  // The single item should be successfully added as an Article
+  EXPECT_EQ(articles.size(), 1u);
+}
+
+TEST(BraveNewsDirectFeed, ParseOnlyAllowsHTTPLinks) {
+  // Create a feed item which should be invalid as a Brave News Article
+  FeedItem item;
+  item.id = "1";
+  item.published_timestamp = 1672793966;
+  item.title = "Title";
+  item.description = "Description";
+  item.image_url = "https://example.com/image.jpg";
+  // A chrome: protocol should not be allowed
+  item.destination_url = "chrome://settings";
+
+  FeedData data;
+  data.items.emplace_back(std::move(item));
+  Articles articles;
+  DirectFeedController::BuildArticles(articles, data, "Id1");
+  // The single item should not be added as an Article
+  EXPECT_EQ(articles.size(), 0u);
+}
+
 TEST(BraveNewsDirectFeed, CanAddDirectFeed) {
   TestingPrefServiceSimple prefs;
   BraveNewsController::RegisterProfilePrefs(prefs.registry());

--- a/components/brave_today/browser/feed_parsing.cc
+++ b/components/brave_today/browser/feed_parsing.cc
@@ -24,6 +24,8 @@ namespace brave_news {
 
 namespace {
 
+// TODO(petemill): Accept base::Value::Dict param and use something like
+// `contains()` to avoid potential crashes dereferencing missing fields.
 bool ParseFeedItem(const base::Value& feed_item_raw,
                    mojom::FeedItemPtr* feed_item) {
   auto url_raw = *feed_item_raw.FindStringKey("url");
@@ -60,6 +62,10 @@ bool ParseFeedItem(const base::Value& feed_item_raw,
   auto url = GURL(url_raw);
   if (url.is_empty() || !url.has_host()) {
     VLOG(1) << "Could not parse item url: " << url_raw;
+    return false;
+  }
+  if (!url.SchemeIsHTTPOrHTTPS()) {
+    VLOG(1) << "Item url was not HTTP or HTTPS: " << url.spec();
     return false;
   }
   metadata->url = std::move(url);

--- a/components/brave_today/browser/feed_parsing.h
+++ b/components/brave_today/browser/feed_parsing.h
@@ -14,6 +14,10 @@
 
 namespace brave_news {
 
+// Convert from the "combined feed" hosted remotely to Brave News mojom items.
+// TODO(petemill): Rename this file to combined_feed_parsing.h or similar,
+// in order to differentiate the "Combined Feed" from
+// a "Direct Feed" (a.k.a RSS).
 bool ParseFeedItems(const std::string& json,
                     std::vector<mojom::FeedItemPtr>* feed_items);
 

--- a/components/brave_today/browser/feed_parsing_unittest.cc
+++ b/components/brave_today/browser/feed_parsing_unittest.cc
@@ -1,0 +1,73 @@
+// Copyright (c) 2023 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "base/json/json_writer.h"
+#include "base/values.h"
+#include "brave/components/brave_today/browser/feed_parsing.h"
+#include "brave/components/brave_today/common/brave_news.mojom-shared.h"
+#include "brave/components/brave_today/common/brave_news.mojom.h"
+#include "testing/gtest/include/gtest/gtest.h"
+
+namespace brave_news {
+
+namespace {
+
+base::Value GetItem(std::string url) {
+  base::Value::Dict item;
+  item.Set("content_type", base::Value("article"));
+  item.Set("url", base::Value(url));
+  item.Set("padded_img", base::Value("https://example.com/img.jpg.pad"));
+  item.Set("publisher_id", base::Value("Id1"));
+  item.Set("publisher_name", base::Value("Publisher1"));
+  item.Set("title", base::Value("Title"));
+  item.Set("description", base::Value("Description"));
+  item.Set("category", base::Value("Category1"));
+  item.Set("score", base::Value(1.0));
+  item.Set("publish_time", base::Value("2022-11-07 09:00:09"));
+  return base::Value(std::move(item));
+}
+
+}  // namespace
+
+TEST(BraveNewsFeedParsing, Success) {
+  // Create an entry which should be valid as a Brave News item
+  auto item = GetItem("https://www.hello.com");
+  base::Value::List list;
+  list.Append(std::move(item));
+
+  // ParseFeedItems currently wants a JSON string
+  std::string json_string;
+  base::JSONWriter::Write(list, &json_string);
+
+  std::vector<mojom::FeedItemPtr> feed_items;
+  EXPECT_TRUE(ParseFeedItems(json_string, &feed_items));
+
+  // The single item should be successfully parsed to a FeedItem
+  EXPECT_EQ(feed_items.size(), 1u);
+}
+
+TEST(BraveNewsFeedParsing, FailBadProtocol) {
+  // Create an entry which should be invalid as a Brave News item
+  // A chrome: protocol should not be allowed
+  auto item = GetItem("chrome://settings");
+  base::Value::List list;
+  list.Append(std::move(item));
+
+  // ParseFeedItems currently wants a JSON string
+  std::string json_string;
+  base::JSONWriter::Write(list, &json_string);
+
+  std::vector<mojom::FeedItemPtr> feed_items;
+  EXPECT_TRUE(ParseFeedItems(json_string, &feed_items));
+
+  // The single item should not be parsed to a FeedItem
+  EXPECT_EQ(feed_items.size(), 0u);
+}
+
+}  // namespace brave_news

--- a/components/brave_today/browser/test/BUILD.gn
+++ b/components/brave_today/browser/test/BUILD.gn
@@ -13,6 +13,7 @@ source_set("brave_news_unit_tests") {
     "//brave/components/brave_today/browser/channels_controller_unittest.cc",
     "//brave/components/brave_today/browser/direct_feed_controller_unittest.cc",
     "//brave/components/brave_today/browser/feed_building_unittest.cc",
+    "//brave/components/brave_today/browser/feed_parsing_unittest.cc",
     "//brave/components/brave_today/browser/html_parsing_unittest.cc",
     "//brave/components/brave_today/browser/locales_helper_unittest.cc",
     "//brave/components/brave_today/browser/publishers_controller_unittest.cc",


### PR DESCRIPTION
Uplifts https://github.com/brave/brave-browser/issues/27602 via https://github.com/brave/brave-core/pull/16519