### PR TITLE
Remove redundant check for managed pref

### DIFF
--- a/browser/ui/brave_shields_data_controller.cc
+++ b/browser/ui/brave_shields_data_controller.cc
@@ -154,10 +154,9 @@ void BraveShieldsDataController::SetBraveShieldsEnabled(bool is_enabled) {
   if (map->GetDefaultContentSetting(ContentSettingsType::BRAVE_SHIELDS,
                                     nullptr) == is_enabled) {
     brave_shields::ResetBraveShieldsEnabled(map, GetCurrentSiteURL());
-    return;
+  } else {
+    brave_shields::SetBraveShieldsEnabled(map, is_enabled, GetCurrentSiteURL());
   }
-
-  brave_shields::SetBraveShieldsEnabled(map, is_enabled, GetCurrentSiteURL());
   ReloadWebContents();
 }
 

--- a/components/brave_shields/browser/brave_shields_util.cc
+++ b/components/brave_shields/browser/brave_shields_util.cc
@@ -579,9 +579,7 @@ bool IsBraveShieldsManaged(PrefService* prefs,
   DCHECK(map);
   content_settings::SettingInfo info;
   map->GetWebsiteSetting(url, url, ContentSettingsType::BRAVE_SHIELDS, &info);
-  return (prefs->IsManagedPreference(kManagedBraveShieldsDisabledForUrls) ||
-          prefs->IsManagedPreference(kManagedBraveShieldsEnabledForUrls)) &&
-         info.source == content_settings::SettingSource::SETTING_SOURCE_POLICY;
+  return info.source == content_settings::SettingSource::SETTING_SOURCE_POLICY;
 }
 
 void SetHTTPSEverywhereEnabled(HostContentSettingsMap* map,


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/27691

Content settings `PolicyProvider` takes both non-admin and admin policies but `IsManaged` indicates only set by admin so we have different behaviour when policies applied but the popup is not locked. Removed redundant check for managed prefs.

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

- steps from issue