### PR TITLE
Make a flag to disable "Change tab on scroll events"

### DIFF
--- a/browser/about_flags.cc
+++ b/browser/about_flags.cc
@@ -407,7 +407,12 @@ constexpr char kBraveVerticalTabsName[] = "Vertical tabs";
 constexpr char kBraveVerticalTabsDescription[] =
     "Move tab strip to be a vertical panel on the side of the window instead "
     "of horizontal at the top of the window.";
-#endif
+
+constexpr char kBraveChangeActiveTabOnScrollEventName[] =
+    "Change active tab on scroll event";
+constexpr char kBraveChangeActiveTabOnScrollEventDescription[] =
+    "Change the active tab when scroll events occur on tab strip.";
+#endif  // defined(TOOLKIT_VIEWS)
 
 #if BUILDFLAG(IS_ANDROID)
 constexpr char kBraveBackgroundVideoPlaybackName[] =
@@ -577,9 +582,17 @@ constexpr char kBraveAndroidSafeBrowsingDescription[] =
      flag_descriptions::kBraveVerticalTabsDescription,      \
      kOsWin | kOsMac | kOsLinux,                            \
      FEATURE_VALUE_TYPE(tabs::features::kBraveVerticalTabs)},
+#define BRAVE_CHANGE_ACTIVE_TAB_ON_SCROLL_EVENT_FEATURE_ENTRIES              \
+    {"brave-vertical-tabs",                                                  \
+     flag_descriptions::kBraveChangeActiveTabOnScrollEventName,              \
+     flag_descriptions::kBraveChangeActiveTabOnScrollEventDescription,       \
+     kOsLinux,                                                               \
+     FEATURE_VALUE_TYPE(tabs::features::kBraveChangeActiveTabOnScrollEvent)},
 #else
 #define BRAVE_VERTICAL_TABS_FEATURE_ENTRY
+#define BRAVE_CHANGE_ACTIVE_TAB_ON_SCROLL_EVENT_FEATURE_ENTRIES
 #endif  // defined(TOOLKIT_VIEWS)
+
 
 #if BUILDFLAG(IS_ANDROID)
 #define BRAVE_BACKGROUND_VIDEO_PLAYBACK_ANDROID                   \
@@ -771,4 +784,5 @@ constexpr char kBraveAndroidSafeBrowsingDescription[] =
     PLAYLIST_FEATURE_ENTRIES                                                \
     BRAVE_VERTICAL_TABS_FEATURE_ENTRY                                       \
     BRAVE_BACKGROUND_VIDEO_PLAYBACK_ANDROID                                 \
-    BRAVE_SAFE_BROWSING_ANDROID
+    BRAVE_SAFE_BROWSING_ANDROID                                             \
+    BRAVE_CHANGE_ACTIVE_TAB_ON_SCROLL_EVENT_FEATURE_ENTRIES

--- a/browser/about_flags.cc
+++ b/browser/about_flags.cc
@@ -407,11 +407,6 @@ constexpr char kBraveVerticalTabsName[] = "Vertical tabs";
 constexpr char kBraveVerticalTabsDescription[] =
     "Move tab strip to be a vertical panel on the side of the window instead "
     "of horizontal at the top of the window.";
-
-constexpr char kBraveChangeActiveTabOnScrollEventName[] =
-    "Change active tab on scroll event";
-constexpr char kBraveChangeActiveTabOnScrollEventDescription[] =
-    "Change the active tab when scroll events occur on tab strip.";
 #endif  // defined(TOOLKIT_VIEWS)
 
 #if BUILDFLAG(IS_ANDROID)
@@ -426,6 +421,13 @@ constexpr char kBraveAndroidSafeBrowsingDescription[] =
     "Enables Google Safe Browsing for determining whether a URL has been "
     "marked as a known threat.";
 #endif
+
+#if BUILDFLAG(IS_LINUX)
+constexpr char kBraveChangeActiveTabOnScrollEventName[] =
+    "Change active tab on scroll event";
+constexpr char kBraveChangeActiveTabOnScrollEventDescription[] =
+    "Change the active tab when scroll events occur on tab strip.";
+#endif  // BUILDFLAG(IS_LINUX)
 }  // namespace
 
 }  // namespace flag_descriptions
@@ -582,6 +584,11 @@ constexpr char kBraveAndroidSafeBrowsingDescription[] =
      flag_descriptions::kBraveVerticalTabsDescription,      \
      kOsWin | kOsMac | kOsLinux,                            \
      FEATURE_VALUE_TYPE(tabs::features::kBraveVerticalTabs)},
+#else
+#define BRAVE_VERTICAL_TABS_FEATURE_ENTRY
+#endif  // defined(TOOLKIT_VIEWS)
+
+#if BUILDFLAG(IS_LINUX)
 #define BRAVE_CHANGE_ACTIVE_TAB_ON_SCROLL_EVENT_FEATURE_ENTRIES              \
     {"brave-vertical-tabs",                                                  \
      flag_descriptions::kBraveChangeActiveTabOnScrollEventName,              \
@@ -589,10 +596,8 @@ constexpr char kBraveAndroidSafeBrowsingDescription[] =
      kOsLinux,                                                               \
      FEATURE_VALUE_TYPE(tabs::features::kBraveChangeActiveTabOnScrollEvent)},
 #else
-#define BRAVE_VERTICAL_TABS_FEATURE_ENTRY
 #define BRAVE_CHANGE_ACTIVE_TAB_ON_SCROLL_EVENT_FEATURE_ENTRIES
-#endif  // defined(TOOLKIT_VIEWS)
-
+#endif
 
 #if BUILDFLAG(IS_ANDROID)
 #define BRAVE_BACKGROUND_VIDEO_PLAYBACK_ANDROID                   \

--- a/browser/ui/views/frame/brave_browser_root_view.cc
+++ b/browser/ui/views/frame/brave_browser_root_view.cc
@@ -16,10 +16,12 @@ BraveBrowserRootView::~BraveBrowserRootView() = default;
 
 bool BraveBrowserRootView::OnMouseWheel(const ui::MouseWheelEvent& event) {
   // Bypass BrowserRootView::OnMouseWheel() to avoid tab cycling feature.
+#if BUILDFLAG(IS_LINUX)
   if (!base::FeatureList::IsEnabled(
           tabs::features::kBraveChangeActiveTabOnScrollEvent)) {
     return RootView::OnMouseWheel(event);
   }
+#endif
 
   // As vertical tabs are always in a scroll view, we should prefer scrolling
   // to tab cycling.

--- a/browser/ui/views/frame/brave_browser_root_view.cc
+++ b/browser/ui/views/frame/brave_browser_root_view.cc
@@ -16,6 +16,11 @@ BraveBrowserRootView::~BraveBrowserRootView() = default;
 
 bool BraveBrowserRootView::OnMouseWheel(const ui::MouseWheelEvent& event) {
   // Bypass BrowserRootView::OnMouseWheel() to avoid tab cycling feature.
+  if (!base::FeatureList::IsEnabled(
+          tabs::features::kBraveChangeActiveTabOnScrollEvent)) {
+    return RootView::OnMouseWheel(event);
+  }
+
   // As vertical tabs are always in a scroll view, we should prefer scrolling
   // to tab cycling.
   if (tabs::features::ShouldShowVerticalTabs(browser_))

--- a/browser/ui/views/tabs/features.cc
+++ b/browser/ui/views/tabs/features.cc
@@ -30,6 +30,14 @@ BASE_FEATURE(kBraveVerticalTabs,
              "BraveVerticalTabs",
              base::FEATURE_DISABLED_BY_DEFAULT);
 
+BASE_FEATURE(kBraveChangeActiveTabOnScrollEvent,
+             "BraveChangeActiveTabOnScrollEvent",
+#if BUILDFLAG(IS_LINUX)
+             base::FEATURE_ENABLED_BY_DEFAULT);
+#else
+             base::FEATURE_DISABLED_BY_DEFAULT);
+#endif  // BUILDFLAG(IS_LINUX)
+
 bool SupportsVerticalTabs(const Browser* browser) {
   if (!browser) {
     // During unit tests, |browser| can be null.

--- a/browser/ui/views/tabs/features.cc
+++ b/browser/ui/views/tabs/features.cc
@@ -30,12 +30,10 @@ BASE_FEATURE(kBraveVerticalTabs,
              "BraveVerticalTabs",
              base::FEATURE_DISABLED_BY_DEFAULT);
 
+#if BUILDFLAG(IS_LINUX)
 BASE_FEATURE(kBraveChangeActiveTabOnScrollEvent,
              "BraveChangeActiveTabOnScrollEvent",
-#if BUILDFLAG(IS_LINUX)
              base::FEATURE_ENABLED_BY_DEFAULT);
-#else
-             base::FEATURE_DISABLED_BY_DEFAULT);
 #endif  // BUILDFLAG(IS_LINUX)
 
 bool SupportsVerticalTabs(const Browser* browser) {

--- a/browser/ui/views/tabs/features.h
+++ b/browser/ui/views/tabs/features.h
@@ -19,7 +19,11 @@ namespace features {
 
 BASE_DECLARE_FEATURE(kBraveVerticalTabs);
 
+#if BUILDFLAG(IS_LINUX)
+// This flag controls the behavior of browser_default::kScrollEventChangesTab,
+// which is true only when it's Linux.
 BASE_DECLARE_FEATURE(kBraveChangeActiveTabOnScrollEvent);
+#endif  // BUILDFLAG(IS_LINUX)
 
 // Returns true if the current |browser| might ever support vertical tabs.
 bool SupportsVerticalTabs(const Browser* browser);

--- a/browser/ui/views/tabs/features.h
+++ b/browser/ui/views/tabs/features.h
@@ -11,10 +11,6 @@
 #include "base/compiler_specific.h"
 #include "base/feature_list.h"
 
-namespace base {
-struct LOGICALLY_CONST Feature;
-}  // namespace base
-
 class Browser;
 class BrowserFrame;
 
@@ -22,6 +18,8 @@ namespace tabs {
 namespace features {
 
 BASE_DECLARE_FEATURE(kBraveVerticalTabs);
+
+BASE_DECLARE_FEATURE(kBraveChangeActiveTabOnScrollEvent);
 
 // Returns true if the current |browser| might ever support vertical tabs.
 bool SupportsVerticalTabs(const Browser* browser);


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/27694

On linux, users can switch the active tab with wheel scroll. But for some users, it feels annoying. so it'd be good to have a flag to disable that.

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
### Manual
When the flag("Change the active tab on scroll events") is disabled, scrolling wheel on tab strip shouldn't change the active tab.
