### PR TITLE
Merge pull request #16483 from brave/update-default-for-BraveEnableAu…

### DIFF
--- a/browser/translate/brave_translate_browsertest.cc
+++ b/browser/translate/brave_translate_browsertest.cc
@@ -311,20 +311,7 @@ IN_PROC_BROWSER_TEST_F(BraveTranslateBrowserTest, InternalTranslation) {
   EXPECT_TRUE(TranslateDownloadManager::IsSupportedLanguage("vi"));
 }
 
-class BraveTranslateBrowserNoAutoTranslateTest
-    : public BraveTranslateBrowserTest {
- public:
-  BraveTranslateBrowserNoAutoTranslateTest() {
-    scoped_feature_list_.InitAndDisableFeature(
-        features::kBraveEnableAutoTranslate);
-  }
-
- private:
-  base::test::ScopedFeatureList scoped_feature_list_;
-};
-
-IN_PROC_BROWSER_TEST_F(BraveTranslateBrowserNoAutoTranslateTest,
-                       NoAutoTranslate) {
+IN_PROC_BROWSER_TEST_F(BraveTranslateBrowserTest, NoAutoTranslate) {
   // Set auto translate from es to en.
   GetChromeTranslateClient()
       ->GetTranslatePrefs()

--- a/components/translate/core/common/brave_translate_features.cc
+++ b/components/translate/core/common/brave_translate_features.cc
@@ -20,7 +20,7 @@ const base::FeatureParam<bool> kUpdateLanguageListParam{
 
 BASE_FEATURE(kBraveEnableAutoTranslate,
              "BraveEnableAutoTranslate",
-             base::FeatureState::FEATURE_ENABLED_BY_DEFAULT);
+             base::FeatureState::FEATURE_DISABLED_BY_DEFAULT);
 }  // namespace features
 
 bool IsBraveTranslateGoAvailable() {

--- a/patches/chrome-browser-ui-views-translate-translate_bubble_view_unittest.cc.patch
+++ b/patches/chrome-browser-ui-views-translate-translate_bubble_view_unittest.cc.patch
@@ -1,0 +1,12 @@
+diff --git a/chrome/browser/ui/views/translate/translate_bubble_view_unittest.cc b/chrome/browser/ui/views/translate/translate_bubble_view_unittest.cc
+index 0aac5b4ceafd3068565a78b09430db99de3b8e29..bcc02d29419f27f757ada2be3e23c4166b29285a 100644
+--- a/chrome/browser/ui/views/translate/translate_bubble_view_unittest.cc
++++ b/chrome/browser/ui/views/translate/translate_bubble_view_unittest.cc
+@@ -189,6 +189,7 @@ class TranslateBubbleViewTest : public ChromeViewsTestBase {
+ 
+  protected:
+   void SetUp() override {
++    scoped_feature_list_.InitFromCommandLine("BraveEnableAutoTranslate", "");
+     ChromeViewsTestBase::SetUp();
+ 
+     // The bubble needs the parent as an anchor.


### PR DESCRIPTION
For https://github.com/brave/brave-browser/issues/27577

Manual uplift for https://github.com/brave/brave-core/pull/16483
The original PR landed to 1.48.x.

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
The steps are the same as (except we don't need to check steps with disabled `AutoTranslateDisabled`):
https://github.com/brave/brave-variations/pull/479#issuecomment-1340356174
