### PR TITLE
Hides NTP SI toggle in OFAC countries. (uplift to 1.48.x)

### DIFF
--- a/components/brave_new_tab_ui/containers/newTab/settings/backgroundImage.tsx
+++ b/components/brave_new_tab_ui/containers/newTab/settings/backgroundImage.tsx
@@ -189,7 +189,7 @@ class BackgroundImageSettings extends React.PureComponent<Props, State> {
               </StyledCustomBackgroundSettings>
             )}
             <div style={{ height: '16px' }}/>
-            {braveRewardsSupported && (
+            {braveRewardsSupported && !this.props.newTabData.rewardsState.isUnsupportedRegion && (
               <SettingsRow>
                 <SponsoredImageToggle
                   onChange={toggleBrandedWallpaperOptIn}


### PR DESCRIPTION
Uplift of #16607
Resolves https://github.com/brave/brave-browser/issues/27717

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.