### PR TITLE
Slash character appearing in Android 13 warning dialog (uplift to 1.48.x)

### DIFF
--- a/browser/ui/android/strings/android_brave_strings.grd
+++ b/browser/ui/android/strings/android_brave_strings.grd
@@ -207,7 +207,7 @@ This file contains all "about" strings.  It is set to NOT be translated, in tran
         Turn notifications back on if you'd like to keep earning BAT
       </message>
       <message name="IDS_NOTIFICATION_BRAVE_DIALOG_DESCRIPTION_ONLY_PRIVACY" desc="Text description for When ONLY Privacy Report is TURNED ON.">
-        Turn notifications back on if you\'d like to keep receiving weekly privacy reports.
+        Turn notifications back on if you'd like to keep receiving weekly privacy reports.
       </message>
      <message name="IDS_NOTIFICATION_OS_DIALOG_HEADER_BOTH_REWARDS_PRIVACY" desc="Text header for When BOTH Brave Rewards and Privacy Report are TURNED ON.">
         You're not earning Rewards or receiving Privacy Reports


### PR DESCRIPTION
Uplift of #16616
Resolves https://github.com/brave/brave-browser/issues/27740

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.