### PR TITLE
fix(wallet): Dismiss Panel UI After Reject

### DIFF
--- a/components/brave_wallet_ui/panel/async/wallet_panel_async_handler.ts
+++ b/components/brave_wallet_ui/panel/async/wallet_panel_async_handler.ts
@@ -802,7 +802,11 @@ handler.on(WalletActions.transactionStatusChanged.type, async (store: Store, pay
       BraveWallet.TransactionStatus.Approved]
       .includes(payload.txInfo.txStatus)
   ) {
-    if (state.selectedPanel === 'approveTransaction' && walletState.pendingTransactions.length === 0) {
+    if ((
+      state.selectedPanel === 'approveTransaction' ||
+      payload.txInfo.txStatus === BraveWallet.TransactionStatus.Rejected
+    ) && walletState.pendingTransactions.length === 0
+    ) {
       const apiProxy = getWalletPanelApiProxy()
       apiProxy.panelHandler.closeUI()
     }


### PR DESCRIPTION
## Description 
Fixes a bug where the `Panel` UI would not close after `Rejecting` a transaction

<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves <https://github.com/brave/brave-browser/issues/23673>

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

1. Go to https://pwgoom.csb.app/ and connect your wallet
2. Click on `Sign and Send Transaction`
3. Reject the transaction, the panel should not stay open and return to the `Main` screen.

Before:

https://user-images.githubusercontent.com/40611140/211923766-ca9d92dd-22a0-4cb7-849b-2bd308e31a2a.mov

After:

https://user-images.githubusercontent.com/40611140/211922756-dcede98d-ffc7-4b1f-a260-583cefef568b.mov
