### PR TITLE
Implemented Support eth_subscribe with logs param

### DIFF
--- a/components/brave_wallet/browser/BUILD.gn
+++ b/components/brave_wallet/browser/BUILD.gn
@@ -1,3 +1,8 @@
+# Copyright (c) 2023 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+
 import("//brave/build/config.gni")
 import("//brave/components/ipfs/buildflags/buildflags.gni")
 import("//build/config/features.gni")
@@ -51,6 +56,8 @@ static_library("browser") {
     "eth_data_parser.h",
     "eth_gas_utils.cc",
     "eth_gas_utils.h",
+    "eth_logs_tracker.cc",
+    "eth_logs_tracker.h",
     "eth_nonce_tracker.cc",
     "eth_nonce_tracker.h",
     "eth_pending_tx_tracker.cc",

--- a/components/brave_wallet/browser/asset_discovery_manager.cc
+++ b/components/brave_wallet/browser/asset_discovery_manager.cc
@@ -1,4 +1,4 @@
-/* Copyright (c) 2023 The Brave Authors. All rights reserved.
+/* Copyright (c) 2022 The Brave Authors. All rights reserved.
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at https://mozilla.org/MPL/2.0/. */

--- a/components/brave_wallet/browser/asset_discovery_manager.cc
+++ b/components/brave_wallet/browser/asset_discovery_manager.cc
@@ -1,7 +1,7 @@
-/* Copyright 2022 The Brave Authors. All rights reserved.
+/* Copyright (c) 2023 The Brave Authors. All rights reserved.
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
- * You can obtain one at http://mozilla.org/MPL/2.0/. */
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 #include "brave/components/brave_wallet/browser/asset_discovery_manager.h"
 
@@ -185,6 +185,7 @@ void AssetDiscoveryManager::OnGetTransferLogs(
     bool triggered_by_accounts_added,
     const std::string& chain_id,
     const std::vector<Log>& logs,
+    base::Value rawlogs,
     mojom::ProviderError error,
     const std::string& error_message) {
   if (error != mojom::ProviderError::kSuccess) {

--- a/components/brave_wallet/browser/asset_discovery_manager.h
+++ b/components/brave_wallet/browser/asset_discovery_manager.h
@@ -1,4 +1,4 @@
-/* Copyright (c) 2023 The Brave Authors. All rights reserved.
+/* Copyright (c) 2022 The Brave Authors. All rights reserved.
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at https://mozilla.org/MPL/2.0/. */

--- a/components/brave_wallet/browser/asset_discovery_manager.h
+++ b/components/brave_wallet/browser/asset_discovery_manager.h
@@ -1,7 +1,7 @@
-/* Copyright 2022 The Brave Authors. All rights reserved.
+/* Copyright (c) 2023 The Brave Authors. All rights reserved.
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
- * You can obtain one at http://mozilla.org/MPL/2.0/. */
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 #ifndef BRAVE_COMPONENTS_BRAVE_WALLET_BROWSER_ASSET_DISCOVERY_MANAGER_H_
 #define BRAVE_COMPONENTS_BRAVE_WALLET_BROWSER_ASSET_DISCOVERY_MANAGER_H_
@@ -52,6 +52,7 @@ class AssetDiscoveryManager : public mojom::KeyringServiceObserver {
   using APIRequestResult = api_request_helper::APIRequestResult;
   using EthGetLogsCallback =
       base::OnceCallback<void(const std::vector<Log>& logs,
+                              base::Value rawlogs,
                               mojom::ProviderError error,
                               const std::string& error_message)>;
   using DiscoverAssetsCompletedCallbackForTesting =
@@ -107,6 +108,7 @@ class AssetDiscoveryManager : public mojom::KeyringServiceObserver {
       bool triggered_by_accounts_added,
       const std::string& chain_id,
       const std::vector<Log>& logs,
+      base::Value rawlogs,
       mojom::ProviderError error,
       const std::string& error_message);
 

--- a/components/brave_wallet/browser/brave_wallet_constants.h
+++ b/components/brave_wallet/browser/brave_wallet_constants.h
@@ -1097,6 +1097,7 @@ constexpr char kSolanaFeeRecipient[] =
     "3NUW8hWoCnLgJwWCVnwdFo2Dsz8bKwLac9A3VgS2jLUQ";
 
 constexpr int64_t kBlockTrackerDefaultTimeInSeconds = 20;
+constexpr int64_t kLogTrackerDefaultTimeInSeconds = 20;
 
 constexpr char kPolygonMainnetEndpoint[] = "https://mainnet-polygon.brave.com/";
 

--- a/components/brave_wallet/browser/eth_logs_tracker.cc
+++ b/components/brave_wallet/browser/eth_logs_tracker.cc
@@ -11,7 +11,7 @@
 namespace brave_wallet {
 
 EthLogsTracker::EthLogsTracker(JsonRpcService* json_rpc_service)
-    : json_rpc_service_(json_rpc_service), weak_factory_(this) {
+    : json_rpc_service_(json_rpc_service) {
   DCHECK(json_rpc_service_);
 }
 

--- a/components/brave_wallet/browser/eth_logs_tracker.cc
+++ b/components/brave_wallet/browser/eth_logs_tracker.cc
@@ -1,0 +1,62 @@
+/* Copyright (c) 2023 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "brave/components/brave_wallet/browser/eth_logs_tracker.h"
+
+#include <string>
+#include <vector>
+
+namespace brave_wallet {
+
+EthLogsTracker::EthLogsTracker(JsonRpcService* json_rpc_service)
+    : json_rpc_service_(json_rpc_service), weak_factory_(this) {
+  DCHECK(json_rpc_service_);
+}
+
+EthLogsTracker::~EthLogsTracker() = default;
+
+void EthLogsTracker::Start(base::TimeDelta interval) {
+  timer_.Start(FROM_HERE, interval,
+               base::BindRepeating(&EthLogsTracker::GetLogs,
+                                   weak_factory_.GetWeakPtr()));
+}
+
+void EthLogsTracker::Stop() {
+  timer_.Stop();
+}
+
+bool EthLogsTracker::IsRunning() const {
+  return timer_.IsRunning();
+}
+
+void EthLogsTracker::AddObserver(EthLogsTracker::Observer* observer) {
+  observers_.AddObserver(observer);
+}
+
+void EthLogsTracker::RemoveObserver(EthLogsTracker::Observer* observer) {
+  observers_.RemoveObserver(observer);
+}
+
+void EthLogsTracker::GetLogs() {
+  const auto chain_id = json_rpc_service_->GetChainId(mojom::CoinType::ETH);
+
+  json_rpc_service_->EthGetLogs(
+      chain_id, {}, {}, {}, {},
+      base::BindOnce(&EthLogsTracker::OnGetLogs, weak_factory_.GetWeakPtr()));
+}
+
+void EthLogsTracker::OnGetLogs([[maybe_unused]] const std::vector<Log>& logs,
+                               base::Value rawlogs,
+                               mojom::ProviderError error,
+                               const std::string& error_message) {
+  if (error == mojom::ProviderError::kSuccess && rawlogs.is_dict()) {
+    for (auto& observer : observers_)
+      observer.OnLogsReceived(rawlogs.Clone());
+  } else {
+    LOG(ERROR) << "OnGetLogs failed";
+  }
+}
+
+}  // namespace brave_wallet

--- a/components/brave_wallet/browser/eth_logs_tracker.h
+++ b/components/brave_wallet/browser/eth_logs_tracker.h
@@ -1,0 +1,65 @@
+/* Copyright (c) 2023 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_COMPONENTS_BRAVE_WALLET_BROWSER_ETH_LOGS_TRACKER_H_
+#define BRAVE_COMPONENTS_BRAVE_WALLET_BROWSER_ETH_LOGS_TRACKER_H_
+
+#include <string>
+#include <vector>
+
+#include "base/memory/raw_ptr.h"
+#include "base/observer_list.h"
+#include "base/observer_list_types.h"
+#include "base/time/time.h"
+#include "base/timer/timer.h"
+#include "brave/components/brave_wallet/browser/json_rpc_service.h"
+#include "brave/components/brave_wallet/common/brave_wallet.mojom.h"
+#include "brave/components/brave_wallet/common/brave_wallet_types.h"
+
+namespace brave_wallet {
+
+class JsonRpcService;
+
+class EthLogsTracker {
+ public:
+  explicit EthLogsTracker(JsonRpcService* json_rpc_service);
+  EthLogsTracker(const EthLogsTracker&) = delete;
+  EthLogsTracker& operator=(const EthLogsTracker&) = delete;
+  EthLogsTracker(const EthLogsTracker&&) = delete;
+  EthLogsTracker& operator=(const EthLogsTracker&&) = delete;
+
+  virtual ~EthLogsTracker();
+
+  class Observer : public base::CheckedObserver {
+   public:
+    virtual void OnLogsReceived(base::Value rawlogs) = 0;
+  };
+
+  // If timer is already running, it will be replaced with new interval
+  void Start(base::TimeDelta interval);
+  void Stop();
+  bool IsRunning() const;
+
+  void AddObserver(Observer* observer);
+  void RemoveObserver(Observer* observer);
+
+ private:
+  void GetLogs();
+  void OnGetLogs(const std::vector<Log>& logs,
+                 base::Value rawlogs,
+                 mojom::ProviderError error,
+                 const std::string& error_message);
+
+  base::RepeatingTimer timer_;
+  raw_ptr<JsonRpcService> json_rpc_service_ = nullptr;
+
+  base::ObserverList<Observer> observers_;
+
+  base::WeakPtrFactory<EthLogsTracker> weak_factory_;
+};
+
+}  // namespace brave_wallet
+
+#endif  // BRAVE_COMPONENTS_BRAVE_WALLET_BROWSER_ETH_LOGS_TRACKER_H_

--- a/components/brave_wallet/browser/eth_logs_tracker.h
+++ b/components/brave_wallet/browser/eth_logs_tracker.h
@@ -30,7 +30,7 @@ class EthLogsTracker {
   EthLogsTracker(const EthLogsTracker&&) = delete;
   EthLogsTracker& operator=(const EthLogsTracker&&) = delete;
 
-  virtual ~EthLogsTracker();
+  ~EthLogsTracker();
 
   class Observer : public base::CheckedObserver {
    public:
@@ -57,7 +57,7 @@ class EthLogsTracker {
 
   base::ObserverList<Observer> observers_;
 
-  base::WeakPtrFactory<EthLogsTracker> weak_factory_;
+  base::WeakPtrFactory<EthLogsTracker> weak_factory_{this};
 };
 
 }  // namespace brave_wallet

--- a/components/brave_wallet/browser/ethereum_provider_impl.h
+++ b/components/brave_wallet/browser/ethereum_provider_impl.h
@@ -378,7 +378,6 @@ class EthereumProviderImpl final
   // EthLogsTracker::Observer:
   void OnLogsReceived(base::Value rawlogs) override;
   bool UnsubscribeLogObserver(const std::string& subscription_id);
-  std::string GenerateSubscriptionHexBytes();
 
   raw_ptr<HostContentSettingsMap> host_content_settings_map_ = nullptr;
   std::unique_ptr<BraveWalletProviderDelegate> delegate_;

--- a/components/brave_wallet/browser/json_rpc_service.cc
+++ b/components/brave_wallet/browser/json_rpc_service.cc
@@ -2187,7 +2187,7 @@ void JsonRpcService::EthGetLogs(const std::string& chain_id,
   auto network_url = GetNetworkURL(prefs_, chain_id, mojom::CoinType::ETH);
   if (!network_url.is_valid()) {
     std::move(callback).Run(
-        std::vector<Log>(), mojom::ProviderError::kInternalError,
+        std::vector<Log>(), {}, mojom::ProviderError::kInternalError,
         l10n_util::GetStringUTF8(IDS_WALLET_INTERNAL_ERROR));
     return;
   }
@@ -2206,18 +2206,19 @@ void JsonRpcService::OnEthGetLogs(EthGetLogsCallback callback,
   std::vector<Log> logs;
   if (!api_request_result.Is2XXResponseCode()) {
     std::move(callback).Run(
-        logs, mojom::ProviderError::kInternalError,
+        logs, {}, mojom::ProviderError::kInternalError,
         l10n_util::GetStringUTF8(IDS_WALLET_INTERNAL_ERROR));
     return;
   }
 
   if (!eth::ParseEthGetLogs(api_request_result.value_body(), &logs)) {
-    std::move(callback).Run(logs, mojom::ProviderError::kParsingError,
+    std::move(callback).Run(logs, {}, mojom::ProviderError::kParsingError,
                             l10n_util::GetStringUTF8(IDS_WALLET_PARSING_ERROR));
     return;
   }
 
-  std::move(callback).Run(logs, mojom::ProviderError::kSuccess, "");
+  std::move(callback).Run(logs, api_request_result.value_body().Clone(),
+                          mojom::ProviderError::kSuccess, "");
 }
 
 void JsonRpcService::GetSupportsInterface(

--- a/components/brave_wallet/browser/json_rpc_service.h
+++ b/components/brave_wallet/browser/json_rpc_service.h
@@ -90,6 +90,7 @@ class JsonRpcService : public KeyedService, public mojom::JsonRpcService {
       const std::string& error_message)>;
   using EthGetLogsCallback =
       base::OnceCallback<void(const std::vector<Log>& logs,
+                              base::Value rawlogs,
                               mojom::ProviderError error,
                               const std::string& error_message)>;
   void GetBlockNumber(GetBlockNumberCallback callback);

--- a/components/brave_wallet/browser/json_rpc_service_unittest.cc
+++ b/components/brave_wallet/browser/json_rpc_service_unittest.cc
@@ -1172,14 +1172,14 @@ class JsonRpcServiceUnitTest : public testing::Test {
     json_rpc_service_->EthGetLogs(
         chain_id, from_block, to_block, std::move(contract_addresses),
         std::move(topics),
-        base::BindLambdaForTesting([&](const std::vector<Log>& logs,
-                                       mojom::ProviderError error,
-                                       const std::string& error_message) {
-          EXPECT_EQ(logs, expected_logs);
-          EXPECT_EQ(error, expected_error);
-          EXPECT_EQ(error_message, expected_error_message);
-          run_loop.Quit();
-        }));
+        base::BindLambdaForTesting(
+            [&](const std::vector<Log>& logs, base::Value rawlogs,
+                mojom::ProviderError error, const std::string& error_message) {
+              EXPECT_EQ(logs, expected_logs);
+              EXPECT_EQ(error, expected_error);
+              EXPECT_EQ(error_message, expected_error_message);
+              run_loop.Quit();
+            }));
     run_loop.Run();
   }
 

--- a/components/brave_wallet/common/web3_provider_constants.h
+++ b/components/brave_wallet/common/web3_provider_constants.h
@@ -48,6 +48,7 @@ constexpr char kWeb3ClientVersion[] = "web3_clientVersion";
 constexpr char kEthSubscribe[] = "eth_subscribe";
 constexpr char kEthUnsubscribe[] = "eth_unsubscribe";
 constexpr char kEthSubscribeNewHeads[] = "newHeads";
+constexpr char kEthSubscribeLogs[] = "logs";
 
 // We currently don't handle it until MetaMask point it to v3 or v4 other than
 // v1 or v2


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
This extends support for a `eth_subscribe` method that can be used in Ethereum provider requests.
See a description of this here: https://docs.infura.io/infura/networks/ethereum/json-rpc-methods/subscription-methods/eth_subscribe
In addition to previously implemented `newHeads` (https://github.com/brave/brave-browser/issues/21350), this adds new `logs` parameter support, but for now filtering options is not supported. It requires the follow up implementation


Resolves https://github.com/brave/brave-browser/issues/27283

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

Use `eth_subscribe` to listen for new logs. You should see a console message in the developer console matching the same subscription ID every 20 seconds. You can subscribe multiple times, each time will give a new subscription ID.
Ex:
`window.ethereum.on('message', (x, y, z) => console.log('message event: ', x, y, z))
window.ethereum.send({ id:5, method: 'eth_subscribe', params:["logs"]}, console.log)
`

Use `eth_unsubscribe` to stop listening to an event by putting the subscription ID from the `eth_subscribe` call. It should stop ending events and return true to the console when you unsubscribe successfully from something.

`window.ethereum.on('message', (x, y, z) => console.log('message event: ', x, y, z))
window.ethereum.send({ id:5, method: 'eth_unsubscribe', params:["0x0b4fcbf913cf950c936489965ba189df"]}, console.log)
`
where `0x0b4fcbf913cf950c936489965ba189df` - subscription identifier returned by subscription method