### PR TITLE
Brave News Location Bar Button gets updated more accurately

### DIFF
--- a/browser/brave_news/brave_news_tab_helper.cc
+++ b/browser/brave_news/brave_news_tab_helper.cc
@@ -46,15 +46,18 @@ BraveNewsTabHelper::~BraveNewsTabHelper() = default;
 const std::vector<BraveNewsTabHelper::FeedDetails>
 BraveNewsTabHelper::GetAvailableFeeds() {
   std::vector<FeedDetails> feeds;
-
   base::flat_set<GURL> seen_feeds;
-  auto* default_publisher =
-      controller_->publisher_controller()->GetPublisherForSite(
-          GetWebContents().GetLastCommittedURL());
-  if (default_publisher) {
-    seen_feeds.insert(default_publisher->feed_source);
-    feeds.push_back(
-        {default_publisher->feed_source, default_publisher->publisher_name});
+
+  auto current_url = GetWebContents().GetLastCommittedURL();
+  if (!current_url.is_empty() && !current_url.host().empty()) {
+    auto* default_publisher =
+        controller_->publisher_controller()->GetPublisherForSite(current_url);
+
+    if (default_publisher) {
+      seen_feeds.insert(default_publisher->feed_source);
+      feeds.push_back(
+          {default_publisher->feed_source, default_publisher->publisher_name});
+    }
   }
 
   for (const auto& rss_feed : rss_page_feeds_) {

--- a/browser/ui/views/location_bar/brave_location_bar_view.cc
+++ b/browser/ui/views/location_bar/brave_location_bar_view.cc
@@ -37,6 +37,7 @@
 #include "ui/gfx/geometry/skia_conversions.h"
 #include "ui/gfx/image/image_skia.h"
 #include "ui/gfx/paint_vector_icon.h"
+#include "ui/views/animation/ink_drop.h"
 #include "ui/views/controls/highlight_path_generator.h"
 
 #if BUILDFLAG(ENABLE_TOR)
@@ -95,7 +96,10 @@ void BraveLocationBarView::Init() {
       !browser_->profile()->IsOffTheRecord()) {
     brave_news_location_view_ =
         AddChildView(std::make_unique<BraveNewsLocationView>(
-            browser_->profile(), browser_->tab_strip_model()));
+            browser_->profile(), this, this));
+    brave_news_location_view_->SetVisible(false);
+    views::InkDrop::Get(brave_news_location_view_)
+        ->SetVisibleOpacity(GetPageActionInkDropVisibleOpacity());
   }
 #if BUILDFLAG(ENABLE_TOR)
   onion_location_view_ =
@@ -149,6 +153,10 @@ void BraveLocationBarView::Update(content::WebContents* contents) {
     ipfs_location_view_->Update(contents, show_page_actions);
 #endif
 
+  if (brave_news_location_view_) {
+    brave_news_location_view_->Update();
+  }
+
   LocationBarView::Update(contents);
 
   if (!ShouldShowIPFSLocationView())
@@ -192,7 +200,7 @@ void BraveLocationBarView::OnChanged() {
 #endif
 
   if (brave_news_location_view_) {
-    brave_news_location_view_->SetVisible(!hide_page_actions);
+    brave_news_location_view_->Update();
   }
 
   // OnChanged calls Layout

--- a/browser/ui/views/location_bar/brave_location_bar_view.cc
+++ b/browser/ui/views/location_bar/brave_location_bar_view.cc
@@ -8,6 +8,7 @@
 #include <memory>
 #include <utility>
 
+#include "base/containers/contains.h"
 #include "base/feature_list.h"
 #include "brave/app/vector_icons/vector_icons.h"
 #include "brave/browser/profiles/profile_util.h"
@@ -267,13 +268,16 @@ void BraveLocationBarView::OnThemeChanged() {
   RefreshBackground();
 }
 
-void BraveLocationBarView::ChildPreferredSizeChanged(views::View* child) {
-  LocationBarView::ChildPreferredSizeChanged(child);
-
-  if (child != brave_actions_)
-    return;
-
-  Layout();
+void BraveLocationBarView::ChildVisibilityChanged(views::View* child) {
+  LocationBarView::ChildVisibilityChanged(child);
+  // Normally, PageActionIcons are in a container which is always visible, only
+  // the size changes when an icon is shown or hidden. The LocationBarView
+  // does not listen to ChildVisibilityChanged events so we must make we Layout
+  // and re-caculate trailing decorator positions when a child changes.
+  if (base::Contains(GetTrailingViews(), child)) {
+    Layout();
+    SchedulePaint();
+  }
 }
 
 int BraveLocationBarView::GetBorderRadius() const {

--- a/browser/ui/views/location_bar/brave_location_bar_view.h
+++ b/browser/ui/views/location_bar/brave_location_bar_view.h
@@ -60,7 +60,7 @@ class BraveLocationBarView : public LocationBarView {
   // views::View:
   gfx::Size CalculatePreferredSize() const override;
   void OnThemeChanged() override;
-  void ChildPreferredSizeChanged(views::View* child) override;
+  void ChildVisibilityChanged(views::View* child) override;
 
   int GetBorderRadius() const override;
 

--- a/browser/ui/views/location_bar/brave_news_location_view.cc
+++ b/browser/ui/views/location_bar/brave_news_location_view.cc
@@ -10,210 +10,154 @@
 #include <vector>
 
 #include "base/bind.h"
+#include "base/functional/callback_forward.h"
 #include "brave/app/vector_icons/vector_icons.h"
 #include "brave/browser/brave_news/brave_news_tab_helper.h"
 #include "brave/browser/ui/views/brave_news/brave_news_bubble_view.h"
 #include "brave/components/brave_today/common/pref_names.h"
 #include "chrome/browser/profiles/profile.h"
-#include "chrome/browser/ui/tabs/tab_strip_model.h"
-#include "chrome/browser/ui/tabs/tab_strip_model_observer.h"
-#include "chrome/browser/ui/views/chrome_layout_provider.h"
-#include "chrome/browser/ui/views/toolbar/toolbar_ink_drop_util.h"
+#include "chrome/browser/ui/views/page_action/page_action_icon_view.h"
 #include "components/grit/brave_components_strings.h"
-#include "components/prefs/pref_member.h"
+#include "content/public/browser/web_contents.h"
 #include "ui/base/l10n/l10n_util.h"
 #include "ui/gfx/color_utils.h"
-#include "ui/gfx/geometry/insets.h"
-#include "ui/gfx/geometry/size.h"
 #include "ui/gfx/geometry/skia_conversions.h"
-#include "ui/gfx/paint_vector_icon.h"
 #include "ui/native_theme/native_theme.h"
-#include "ui/views/animation/ink_drop.h"
-#include "ui/views/border.h"
-#include "ui/views/controls/button/label_button.h"
-#include "ui/views/controls/button/label_button_border.h"
-#include "ui/views/controls/button/menu_button_controller.h"
-#include "ui/views/layout/flex_layout_view.h"
-#include "ui/views/layout/layout_types.h"
-#include "ui/views/view.h"
+#include "ui/views/bubble/bubble_dialog_delegate_view.h"
 
 namespace {
+
 constexpr SkColor kSubscribedLightColor = SkColorSetRGB(76, 84, 210);
 constexpr SkColor kSubscribedDarkColor = SkColorSetRGB(115, 122, 222);
 
-class BraveNewsButtonView : public views::LabelButton,
-                            public TabStripModelObserver,
-                            public BraveNewsTabHelper::PageFeedsObserver {
- public:
-  BraveNewsButtonView(Profile* profile, TabStripModel* tab_strip)
-      : views::LabelButton(
-            base::BindRepeating(&BraveNewsButtonView::ButtonPressed,
-                                base::Unretained(this))),
-        profile_(profile),
-        tab_strip_(tab_strip) {
-    DCHECK(profile_);
-    SetAccessibleName(
-        l10n_util::GetStringUTF16(IDS_BRAVE_NEWS_ACTION_VIEW_TOOLTIP));
-    SetHorizontalAlignment(gfx::HorizontalAlignment::ALIGN_CENTER);
-
-    auto* ink_drop = views::InkDrop::Get(this);
-    ink_drop->SetMode(views::InkDropHost::InkDropMode::ON);
-    ink_drop->SetBaseColorCallback(base::BindRepeating(
-        [](views::View* host) { return GetToolbarInkDropBaseColor(host); },
-        this));
-    ink_drop->SetVisibleOpacity(kToolbarInkDropVisibleOpacity);
-    SetHasInkDropActionOnClick(true);
-
-    tab_strip_->AddObserver(this);
-    if (tab_strip_->GetActiveWebContents()) {
-      BraveNewsTabHelper::FromWebContents(tab_strip_->GetActiveWebContents())
-          ->AddObserver(this);
-    }
-
-    should_show_.Init(brave_news::prefs::kShouldShowToolbarButton,
-                      profile->GetPrefs(),
-                      base::BindRepeating(&BraveNewsButtonView::Update,
-                                          base::Unretained(this)));
-    opted_in_.Init(brave_news::prefs::kBraveTodayOptedIn, profile->GetPrefs(),
-                   base::BindRepeating(&BraveNewsButtonView::Update,
-                                       base::Unretained(this)));
-    news_enabled_.Init(brave_news::prefs::kNewTabPageShowToday,
-                       profile->GetPrefs(),
-                       base::BindRepeating(&BraveNewsButtonView::Update,
-                                           base::Unretained(this)));
-
-    auto menu_button_controller = std::make_unique<views::MenuButtonController>(
-        this,
-        base::BindRepeating(&BraveNewsButtonView::ButtonPressed,
-                            base::Unretained(this)),
-        std::make_unique<views::Button::DefaultButtonControllerDelegate>(this));
-    SetButtonController(std::move(menu_button_controller));
-
-    Update();
-  }
-  ~BraveNewsButtonView() override = default;
-  BraveNewsButtonView(const BraveNewsButtonView&) = delete;
-  BraveNewsButtonView& operator=(const BraveNewsButtonView&) = delete;
-
-  void Update() {
-    if (!should_show_.GetValue() || !news_enabled_.GetValue() ||
-        !opted_in_.GetValue()) {
-      SetVisible(false);
-      return;
-    }
-
-    auto* contents = tab_strip_->GetActiveWebContents();
-    bool subscribed = false;
-    bool has_feeds = false;
-    absl::optional<BraveNewsTabHelper::FeedDetails> feed;
-
-    if (contents) {
-      auto* tab_helper = BraveNewsTabHelper::FromWebContents(contents);
-      subscribed = tab_helper->IsSubscribed();
-      has_feeds = !tab_helper->GetAvailableFeeds().empty();
-    }
-
-    auto image = gfx::CreateVectorIcon(kBraveNewsSubscribeIcon, 16,
-                                       GetIconColor(subscribed));
-    SetImage(ButtonState::STATE_NORMAL, image);
-    SetVisible(has_feeds);
-  }
-
-  // views::LabelButton:
-  std::unique_ptr<views::LabelButtonBorder> CreateDefaultBorder()
-      const override {
-    std::unique_ptr<views::LabelButtonBorder> border =
-        LabelButton::CreateDefaultBorder();
-    border->set_insets(gfx::Insets::VH(3, 0));
-    return border;
-  }
-
-  std::u16string GetTooltipText(const gfx::Point& p) const override {
-    return l10n_util::GetStringUTF16(IDS_BRAVE_NEWS_ACTION_VIEW_TOOLTIP);
-  }
-
-  SkPath GetHighlightPath() const {
-    gfx::Rect rect(GetPreferredSize());
-    const int radii = ChromeLayoutProvider::Get()->GetCornerRadiusMetric(
-        views::Emphasis::kMaximum, rect.size());
-    SkPath path;
-    path.addRoundRect(gfx::RectToSkRect(rect), radii, radii);
-    return path;
-  }
-
-  // TabStripModelObserver:
-  void OnTabStripModelChanged(
-      TabStripModel* tab_strip_model,
-      const TabStripModelChange& change,
-      const TabStripSelectionChange& selection) override {
-    if (selection.active_tab_changed()) {
-      if (selection.old_contents) {
-        BraveNewsTabHelper::FromWebContents(selection.old_contents)
-            ->RemoveObserver(this);
-      }
-
-      if (selection.new_contents) {
-        BraveNewsTabHelper::FromWebContents(selection.new_contents)
-            ->AddObserver(this);
-      }
-    }
-
-    Update();
-  }
-
-  // BraveNewsTabHelper::PageFeedsObserver:
-  void OnAvailableFeedsChanged(
-      const std::vector<BraveNewsTabHelper::FeedDetails>& feeds) override {
-    Update();
-  }
-
-  // views::View:
-  void OnThemeChanged() override {
-    views::LabelButton::OnThemeChanged();
-    Update();
-  }
-
- private:
-  void ButtonPressed() {
-    // If the bubble is already open, do nothing.
-    if (bubble_widget_) {
-      return;
-    }
-
-    bubble_widget_ =
-        BraveNewsBubbleView::Show(this, tab_strip_->GetActiveWebContents());
-  }
-
-  SkColor GetIconColor(bool subscribed) const {
-    if (!subscribed)
-      return color_utils::DeriveDefaultIconColor(GetCurrentTextColor());
-
-    auto is_dark = GetNativeTheme()->GetPreferredColorScheme() ==
-                   ui::NativeTheme::PreferredColorScheme::kDark;
-    return is_dark ? kSubscribedDarkColor : kSubscribedLightColor;
-  }
-
-  BooleanPrefMember should_show_;
-  BooleanPrefMember opted_in_;
-  BooleanPrefMember news_enabled_;
-
-  base::raw_ptr<Profile> profile_;
-  base::raw_ptr<TabStripModel> tab_strip_;
-  base::WeakPtr<views::Widget> bubble_widget_;
-};
 }  // namespace
 
-BraveNewsLocationView::BraveNewsLocationView(Profile* profile,
-                                             TabStripModel* tab_strip_model) {
-  SetBorder(views::CreateEmptyBorder(gfx::Insets::VH(3, 3)));
+BraveNewsLocationView::BraveNewsLocationView(
+    Profile* profile,
+    IconLabelBubbleView::Delegate* icon_label_bubble_delegate,
+    PageActionIconView::Delegate* page_action_icon_delegate)
+    : PageActionIconView(/*command_updater=*/nullptr,
+                         /*command_id=*/0,
+                         icon_label_bubble_delegate,
+                         page_action_icon_delegate,
+                         "BraveNewsFollow") {
+  SetLabel(l10n_util::GetStringUTF16(IDS_BRAVE_NEWS_ACTION_VIEW_TOOLTIP));
 
-  SetLayoutManager(std::make_unique<views::FlexLayout>())
-      ->SetMainAxisAlignment(views::LayoutAlignment::kCenter)
-      .SetCrossAxisAlignment(views::LayoutAlignment::kCenter);
+  last_contents_ = GetWebContents();
+  if (last_contents_) {
+    BraveNewsTabHelper::FromWebContents(last_contents_)->AddObserver(this);
+  }
 
-  auto* button = AddChildView(
-      std::make_unique<BraveNewsButtonView>(profile, tab_strip_model));
-  button->SetPreferredSize(gfx::Size(34, 24));
+  should_show_.Init(brave_news::prefs::kShouldShowToolbarButton,
+                    profile->GetPrefs(),
+                    base::BindRepeating(&BraveNewsLocationView::UpdateImpl,
+                                        base::Unretained(this)));
+  opted_in_.Init(brave_news::prefs::kBraveTodayOptedIn, profile->GetPrefs(),
+                 base::BindRepeating(&BraveNewsLocationView::UpdateImpl,
+                                     base::Unretained(this)));
+  news_enabled_.Init(brave_news::prefs::kNewTabPageShowToday,
+                     profile->GetPrefs(),
+                     base::BindRepeating(&BraveNewsLocationView::UpdateImpl,
+                                         base::Unretained(this)));
+
+  Update();
 }
 
 BraveNewsLocationView::~BraveNewsLocationView() = default;
+
+views::BubbleDialogDelegate* BraveNewsLocationView::GetBubble() const {
+  return bubble_view_;
+}
+
+void BraveNewsLocationView::UpdateImpl() {
+  auto* contents = GetWebContents();
+  BraveNewsTabHelper* tab_helper =
+      contents ? BraveNewsTabHelper::FromWebContents(contents) : nullptr;
+
+  // When the active tab changes, subscribe to notification when
+  // it has found a feed, and update display with current state.
+  if (contents != last_contents_) {
+    // Unobserve old Tab
+    if (last_contents_) {
+      BraveNewsTabHelper::FromWebContents(last_contents_)->RemoveObserver(this);
+    }
+    last_contents_ = contents;
+    // Observe new Tab
+    if (contents) {
+      tab_helper->AddObserver(this);
+    }
+  }
+
+  // Don't show the icon if preferences don't allow
+  if (!tab_helper || !should_show_.GetValue() || !news_enabled_.GetValue() ||
+      !opted_in_.GetValue()) {
+    SetVisible(false);
+    return;
+  }
+
+  // Icon color changes if any feeds are being followed
+  bool subscribed = false;
+  subscribed = tab_helper->IsSubscribed();
+  SetIconColor(GetIconColor(subscribed));
+
+  // Don't show icon if there are no feeds
+  const bool has_feeds = !tab_helper->GetAvailableFeeds().empty();
+  const bool is_visible = has_feeds || IsBubbleShowing();
+  SetVisible(is_visible);
+}
+
+const gfx::VectorIcon& BraveNewsLocationView::GetVectorIcon() const {
+  return kBraveNewsSubscribeIcon;
+}
+
+std::u16string BraveNewsLocationView::GetTextForTooltipAndAccessibleName()
+    const {
+  return l10n_util::GetStringUTF16(IDS_BRAVE_NEWS_ACTION_VIEW_TOOLTIP);
+}
+
+bool BraveNewsLocationView::ShouldShowLabel() const {
+  return false;
+}
+
+void BraveNewsLocationView::OnAvailableFeedsChanged(
+    const std::vector<BraveNewsTabHelper::FeedDetails>& feeds) {
+  Update();
+}
+
+void BraveNewsLocationView::OnThemeChanged() {
+  views::LabelButton::OnThemeChanged();
+  Update();
+}
+
+void BraveNewsLocationView::OnExecuting(
+    PageActionIconView::ExecuteSource execute_source) {
+  // If the bubble is already open, do nothing.
+  if (IsBubbleShowing()) {
+    return;
+  }
+
+  auto* contents = GetWebContents();
+  if (!contents) {
+    return;
+  }
+
+  bubble_view_ = new BraveNewsBubbleView(this, contents);
+  bubble_view_->SetCloseCallback(base::BindOnce(
+      &BraveNewsLocationView::OnBubbleClosed, base::Unretained(this)));
+  auto* bubble_widget =
+      views::BubbleDialogDelegateView::CreateBubble(bubble_view_);
+  bubble_widget->Show();
+}
+
+void BraveNewsLocationView::OnBubbleClosed() {
+  bubble_view_ = nullptr;
+}
+
+SkColor BraveNewsLocationView::GetIconColor(bool subscribed) const {
+  if (!subscribed)
+    return color_utils::DeriveDefaultIconColor(GetCurrentTextColor());
+
+  auto is_dark = GetNativeTheme()->GetPreferredColorScheme() ==
+                 ui::NativeTheme::PreferredColorScheme::kDark;
+  return is_dark ? kSubscribedDarkColor : kSubscribedLightColor;
+}

--- a/browser/ui/views/location_bar/brave_news_location_view.h
+++ b/browser/ui/views/location_bar/brave_news_location_view.h
@@ -6,17 +6,62 @@
 #ifndef BRAVE_BROWSER_UI_VIEWS_LOCATION_BAR_BRAVE_NEWS_LOCATION_VIEW_H_
 #define BRAVE_BROWSER_UI_VIEWS_LOCATION_BAR_BRAVE_NEWS_LOCATION_VIEW_H_
 
+#include <string>
+#include <vector>
+
+#include "brave/browser/brave_news/brave_news_tab_helper.h"
+#include "chrome/browser/ui/views/page_action/page_action_icon_view.h"
+#include "components/prefs/pref_member.h"
+#include "ui/gfx/vector_icon_types.h"
 #include "ui/views/view.h"
 
 class Profile;
-class TabStripModel;
+class BraveNewsBubbleView;
 
-class BraveNewsLocationView : public views::View {
+namespace content {
+class WebContents;
+}  // namespace content
+
+// LocationBar action for Brave News which shows a bubble allowing the user to
+// manage feed subscriptions for the current Tab
+class BraveNewsLocationView : public PageActionIconView,
+                              public BraveNewsTabHelper::PageFeedsObserver {
  public:
-  BraveNewsLocationView(Profile* profile, TabStripModel* tab_strip_model);
+  BraveNewsLocationView(
+      Profile* profile,
+      IconLabelBubbleView::Delegate* icon_label_bubble_delegate,
+      PageActionIconView::Delegate* page_action_icon_delegate);
   BraveNewsLocationView(const BraveNewsLocationView&) = delete;
   BraveNewsLocationView& operator=(const BraveNewsLocationView&) = delete;
   ~BraveNewsLocationView() override;
+
+  // PageActionIconView:
+  views::BubbleDialogDelegate* GetBubble() const override;
+  void UpdateImpl() override;
+  std::u16string GetTextForTooltipAndAccessibleName() const override;
+  bool ShouldShowLabel() const override;
+
+  // BraveNewsTabHelper::PageFeedsObserver:
+  void OnAvailableFeedsChanged(
+      const std::vector<BraveNewsTabHelper::FeedDetails>& feeds) override;
+
+  // views::View:
+  void OnThemeChanged() override;
+
+ protected:
+  // PageActionIconView:
+  void OnExecuting(PageActionIconView::ExecuteSource execute_source) override;
+  const gfx::VectorIcon& GetVectorIcon() const override;
+
+ private:
+  SkColor GetIconColor(bool subscribed) const;
+  void OnBubbleClosed();
+
+  raw_ptr<content::WebContents> last_contents_;
+  BooleanPrefMember should_show_;
+  BooleanPrefMember opted_in_;
+  BooleanPrefMember news_enabled_;
+  raw_ptr<BraveNewsBubbleView> bubble_view_;
 };
 
 #endif  // BRAVE_BROWSER_UI_VIEWS_LOCATION_BAR_BRAVE_NEWS_LOCATION_VIEW_H_

--- a/browser/ui/views/location_bar/brave_news_location_view.h
+++ b/browser/ui/views/location_bar/brave_news_location_view.h
@@ -9,6 +9,7 @@
 #include <string>
 #include <vector>
 
+#include "base/scoped_observation.h"
 #include "brave/browser/brave_news/brave_news_tab_helper.h"
 #include "chrome/browser/ui/views/page_action/page_action_icon_view.h"
 #include "components/prefs/pref_member.h"
@@ -18,14 +19,11 @@
 class Profile;
 class BraveNewsBubbleView;
 
-namespace content {
-class WebContents;
-}  // namespace content
-
 // LocationBar action for Brave News which shows a bubble allowing the user to
 // manage feed subscriptions for the current Tab
 class BraveNewsLocationView : public PageActionIconView,
-                              public BraveNewsTabHelper::PageFeedsObserver {
+                              public BraveNewsTabHelper::PageFeedsObserver,
+                              public content::WebContentsObserver {
  public:
   BraveNewsLocationView(
       Profile* profile,
@@ -48,6 +46,9 @@ class BraveNewsLocationView : public PageActionIconView,
   // views::View:
   void OnThemeChanged() override;
 
+  // content::WebContentsObserver
+  void WebContentsDestroyed() override;
+
  protected:
   // PageActionIconView:
   void OnExecuting(PageActionIconView::ExecuteSource execute_source) override;
@@ -57,7 +58,9 @@ class BraveNewsLocationView : public PageActionIconView,
   void UpdateIconColor(bool subscribed);
   void OnBubbleClosed();
 
-  raw_ptr<content::WebContents> last_contents_;
+  base::ScopedObservation<BraveNewsTabHelper,
+                          BraveNewsTabHelper::PageFeedsObserver>
+      page_feeds_observer_{this};
   BooleanPrefMember should_show_;
   BooleanPrefMember opted_in_;
   BooleanPrefMember news_enabled_;

--- a/browser/ui/views/location_bar/brave_news_location_view.h
+++ b/browser/ui/views/location_bar/brave_news_location_view.h
@@ -64,7 +64,7 @@ class BraveNewsLocationView : public PageActionIconView,
   BooleanPrefMember should_show_;
   BooleanPrefMember opted_in_;
   BooleanPrefMember news_enabled_;
-  raw_ptr<BraveNewsBubbleView> bubble_view_;
+  raw_ptr<BraveNewsBubbleView> bubble_view_ = nullptr;
 };
 
 #endif  // BRAVE_BROWSER_UI_VIEWS_LOCATION_BAR_BRAVE_NEWS_LOCATION_VIEW_H_

--- a/browser/ui/views/location_bar/brave_news_location_view.h
+++ b/browser/ui/views/location_bar/brave_news_location_view.h
@@ -54,7 +54,7 @@ class BraveNewsLocationView : public PageActionIconView,
   const gfx::VectorIcon& GetVectorIcon() const override;
 
  private:
-  SkColor GetIconColor(bool subscribed) const;
+  void UpdateIconColor(bool subscribed);
   void OnBubbleClosed();
 
   raw_ptr<content::WebContents> last_contents_;

--- a/browser/ui/views/location_bar/ipfs_location_view.cc
+++ b/browser/ui/views/location_bar/ipfs_location_view.cc
@@ -126,7 +126,7 @@ class IPFSLocationButtonView : public views::LabelButton {
 }  // namespace
 
 IPFSLocationView::IPFSLocationView(Profile* profile) {
-  SetBorder(views::CreateEmptyBorder(gfx::Insets::VH(3, 3)));
+  SetBorder(views::CreateEmptyBorder(gfx::Insets::VH(1, 3)));
   SetVisible(false);
   // automatic layout
   auto vertical_container_layout = std::make_unique<views::BoxLayout>(

--- a/browser/ui/views/location_bar/onion_location_view.cc
+++ b/browser/ui/views/location_bar/onion_location_view.cc
@@ -142,7 +142,7 @@ class OnionLocationButtonView : public views::LabelButton {
 }  // namespace
 
 OnionLocationView::OnionLocationView(Profile* profile) {
-  SetBorder(views::CreateEmptyBorder(gfx::Insets::VH(3, 3)));
+  SetBorder(views::CreateEmptyBorder(gfx::Insets::VH(1, 3)));
   SetVisible(false);
   // automatic layout
   auto vertical_container_layout = std::make_unique<views::BoxLayout>(

--- a/chromium_src/chrome/browser/ui/views/location_bar/location_bar_view.cc
+++ b/chromium_src/chrome/browser/ui/views/location_bar/location_bar_view.cc
@@ -8,11 +8,12 @@
 #include "brave/browser/ui/views/omnibox/brave_omnibox_view_views.h"
 #include "chrome/browser/ui/views/omnibox/omnibox_view_views.h"
 
-#define BRAVE_LAYOUT_TRAILING_DECORATIONS                                 \
-  auto right_most = GetTrailingViews();                                   \
-  for (auto* item : base::Reversed(right_most)) {                         \
-    if (item->GetVisible())                                               \
-      trailing_decorations.AddDecoration(0, height(), false, 0, 0, item); \
+#define BRAVE_LAYOUT_TRAILING_DECORATIONS                                   \
+  auto right_most = GetTrailingViews();                                     \
+  for (auto* item : base::Reversed(right_most)) {                           \
+    if (item->GetVisible())                                                 \
+      trailing_decorations.AddDecoration(vertical_padding, location_height, \
+                                         false, 0, 0, item);                \
   }
 
 #define OmniboxViewViews BraveOmniboxViewViews

--- a/components/brave_today/browser/publishers_controller.cc
+++ b/components/brave_today/browser/publishers_controller.cc
@@ -55,6 +55,12 @@ const mojom::Publisher* PublishersController::GetPublisherForSite(
     return nullptr;
 
   const auto& site_host = site_url.host();
+
+  // Can't match a Publisher from an empty host
+  if (site_host.empty()) {
+    return nullptr;
+  }
+
   for (const auto& kv : publishers_) {
     const auto& publisher_host = kv.second->site_url.host();
     // When https://github.com/brave/brave-browser/issues/26092 is fixed, this


### PR DESCRIPTION
BraveNewsTabHelper (and Brave News' PublishersController) handles empty Urls better. This fixes the issue that `PublishersController::GetPublisherForSite` was finding a `Publisher` match for an empty Url.

The button is now a PageActionIconView so we can benefit from the intended semantics of a page-specific button like this:
- call Update() more frequently and use a delegate to check if it should be shown, so that the button cannot lose the state of whether page actions should be shown.
- Be provided a WebContents and not have to inspect the tab strip independently.
- Fixes InkDrop to stay highlighted when bubble is showing.

Fixed LocationBar to more accurately provide intended height to Brave's decorators.
Also fixed BraveLocationBar so that if we change a trailing decorator View's visibility outside of the normal Update cycle, then Layout is re-computed. The LocationBar hasn't previously had to do this as it's kept immediate children visible and responded to children's PreferredSize changes via their own children's visibility changing.

<img width="1116" alt="image" src="https://user-images.githubusercontent.com/741836/212251380-921bc044-2847-4d4a-9695-752deae52b91.png">


<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/27727

## Submitter Checklist:

- [ ] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

