### PR TITLE
Fixed extensions import from Chromium based browsers

### DIFF
--- a/browser/importer/brave_external_process_importer_host.cc
+++ b/browser/importer/brave_external_process_importer_host.cc
@@ -31,25 +31,44 @@
 namespace {
 
 #if BUILDFLAG(ENABLE_EXTENSIONS)
-absl::optional<base::Value::Dict> GetChromeExtensionsList(
-    const base::FilePath& secured_preference_path) {
-  if (!base::PathExists(secured_preference_path))
+constexpr char kChromePreferencesFile[] = "Preferences";
+
+absl::optional<base::Value::Dict> GetChromeExtensionsListFromFile(
+    const base::FilePath& preference_path) {
+  if (!base::PathExists(preference_path))
     return absl::nullopt;
 
-  std::string secured_preference_content;
-  base::ReadFileToString(secured_preference_path, &secured_preference_content);
-  absl::optional<base::Value> secured_preference =
-      base::JSONReader::Read(secured_preference_content);
-  DCHECK(secured_preference);
-  DCHECK(secured_preference->is_dict());
+  std::string preference_content;
+  base::ReadFileToString(preference_path, &preference_content);
+  absl::optional<base::Value> preference =
+      base::JSONReader::Read(preference_content);
+  DCHECK(preference);
+  DCHECK(preference->is_dict());
 
-  if (auto* extensions = secured_preference->GetDict().FindDictByDottedPath(
+  if (auto* extensions = preference->GetDict().FindDictByDottedPath(
           kChromeExtensionsListPath)) {
     return std::move(*extensions);
   }
   return absl::nullopt;
 }
 
+absl::optional<base::Value::Dict> GetChromeExtensionsList(
+    const base::FilePath& profile_path) {
+
+  auto list_from_secure_preference = GetChromeExtensionsListFromFile(profile_path.AppendASCII(
+      kChromeExtensionsPreferencesFile));
+  auto list_from_preferences = GetChromeExtensionsListFromFile(profile_path.AppendASCII(
+      kChromePreferencesFile));
+  if (!list_from_secure_preference.has_value())
+    return list_from_preferences;
+  
+  if (list_from_secure_preference.has_value() && list_from_preferences.has_value()) {
+    list_from_secure_preference->Merge(std::move(list_from_preferences.value()));
+    return list_from_secure_preference;
+  }
+  
+  return list_from_secure_preference;
+}
 // Silent installer via websotre w/o any prompt or bubble.
 class WebstoreInstallerForImporting
     : public extensions::WebstoreInstallWithPrompt {
@@ -76,13 +95,11 @@ BraveExternalProcessImporterHost::~BraveExternalProcessImporterHost() = default;
 
 #if BUILDFLAG(ENABLE_EXTENSIONS)
 void BraveExternalProcessImporterHost::LaunchExtensionsImport() {
-  const base::FilePath pref_file = source_profile_.source_path.AppendASCII(
-      kChromeExtensionsPreferencesFile);
   base::ThreadPool::PostTaskAndReplyWithResult(
       FROM_HERE,
       {base::MayBlock(), base::TaskPriority::USER_VISIBLE,
        base::TaskShutdownBehavior::CONTINUE_ON_SHUTDOWN},
-      base::BindOnce(&GetChromeExtensionsList, pref_file),
+      base::BindOnce(&GetChromeExtensionsList, source_profile_.source_path),
       base::BindOnce(
           &BraveExternalProcessImporterHost::OnGetChromeExtensionsList,
           weak_ptr_factory_.GetWeakPtr()));

--- a/browser/importer/brave_external_process_importer_host.h
+++ b/browser/importer/brave_external_process_importer_host.h
@@ -54,7 +54,7 @@ class BraveExternalProcessImporterHost : public ExternalProcessImporterHost {
 #if BUILDFLAG(ENABLE_EXTENSIONS)
   void LaunchExtensionsImport();
   void OnGetChromeExtensionsList(
-      absl::optional<base::Value::Dict> extensions_list);
+      absl::optional<std::vector<std::string>> extensions_list);
 #endif
   bool do_not_launch_import_for_testing_ = false;
   MockedInstallCallback install_extension_callback_for_testing_;

--- a/browser/importer/brave_external_process_importer_host_unittest.cc
+++ b/browser/importer/brave_external_process_importer_host_unittest.cc
@@ -75,7 +75,7 @@ class BraveExternalProcessImporterHostUnitTest : public testing::Test {
                        .AppendASCII("Chrome")
                        .AppendASCII("Secure Preferences"),
                    GetProductProfilePath("Chrome").AppendASCII(
-                       kChromeExtensionsPreferencesFile));
+                       kChromeSecurePreferencesFile));
     for (auto i = 0; i < 4; i++) {
       const std::string id = "id" + std::to_string(i);
       brave::CreateTestingStore(GetExtensionLocalSettingsPath("Chrome", id), id,

--- a/common/importer/chrome_importer_utils.cc
+++ b/common/importer/chrome_importer_utils.cc
@@ -31,8 +31,6 @@ using extensions::Manifest;
 
 namespace {
 #if BUILDFLAG(ENABLE_EXTENSIONS)
-// Pref file that holds installed extension list.
-constexpr char kChromePreferencesFile[] = "Preferences";
 
 absl::optional<base::Value::Dict> GetChromeExtensionsListFromFile(
     const base::FilePath& preference_path) {
@@ -93,7 +91,7 @@ std::vector<std::string> GetImportableListFromChromeExtensionsList(
 absl::optional<base::Value::Dict> GetChromeExtensionsList(
     const base::FilePath& profile_path) {
   auto list_from_secure_preference = GetChromeExtensionsListFromFile(
-      profile_path.AppendASCII(kChromeExtensionsPreferencesFile));
+      profile_path.AppendASCII(kChromeSecurePreferencesFile));
 
   auto list_from_preferences = GetChromeExtensionsListFromFile(
       profile_path.AppendASCII(kChromePreferencesFile));

--- a/common/importer/chrome_importer_utils.cc
+++ b/common/importer/chrome_importer_utils.cc
@@ -30,6 +30,8 @@ using extensions::Manifest;
 #endif
 
 namespace {
+// Pref file that holds installed extension list.
+constexpr char kChromePreferencesFile[] = "Preferences";
 
 #if BUILDFLAG(ENABLE_EXTENSIONS)
 bool HasImportableExtensions(const base::FilePath& secured_preference_path) {
@@ -42,7 +44,7 @@ bool HasImportableExtensions(const base::FilePath& secured_preference_path) {
       base::JSONReader::Read(secured_preference_content);
   DCHECK(secured_preference);
   DCHECK(secured_preference->is_dict());
-
+  LOG(ERROR) << "secured_preference_path:" << secured_preference_path;
   if (auto* extensions = secured_preference->GetDict().FindDictByDottedPath(
           kChromeExtensionsListPath)) {
     auto extensions_list =
@@ -153,8 +155,6 @@ bool ChromeImporterCanImport(const base::FilePath& profile,
     profile.Append(base::FilePath::StringType(FILE_PATH_LITERAL("History")));
   base::FilePath passwords =
     profile.Append(base::FilePath::StringType(FILE_PATH_LITERAL("Login Data")));
-  base::FilePath secured_preference =
-      profile.AppendASCII(kChromeExtensionsPreferencesFile);
   if (base::PathExists(bookmarks))
     *services_supported |= importer::FAVORITES;
   if (base::PathExists(history))
@@ -164,7 +164,9 @@ bool ChromeImporterCanImport(const base::FilePath& profile,
   if (HasPaymentMethods(profile.Append(kWebDataFilename)))
     *services_supported |= importer::PAYMENTS;
 #if BUILDFLAG(ENABLE_EXTENSIONS)
-  if (HasImportableExtensions(secured_preference))
+  if (HasImportableExtensions(profile.AppendASCII(kChromeExtensionsPreferencesFile)))
+    *services_supported |= importer::EXTENSIONS;
+  if (HasImportableExtensions(profile.AppendASCII(kChromePreferencesFile)))
     *services_supported |= importer::EXTENSIONS;
 #endif
 

--- a/common/importer/chrome_importer_utils.h
+++ b/common/importer/chrome_importer_utils.h
@@ -33,7 +33,6 @@ base::FilePath GetEdgeUserDataFolder();
 base::FilePath GetVivaldiUserDataFolder();
 base::FilePath GetOperaUserDataFolder();
 base::FilePath GetYandexUserDataFolder();
-
 #if BUILDFLAG(IS_LINUX)
 base::FilePath GetOperaSnapUserDataFolder();
 #endif
@@ -42,8 +41,8 @@ bool ChromeImporterCanImport(const base::FilePath& profile,
                              uint16_t* services_supported);
 
 #if BUILDFLAG(ENABLE_EXTENSIONS)
-std::vector<std::string> GetImportableListFromChromeExtensionsList(
-    const base::Value::Dict& extension_list);
+absl::optional<std::vector<std::string>> GetImportableChromeExtensionsList(
+    const base::FilePath& profile_path);
 #endif
 
 #endif  // BRAVE_COMMON_IMPORTER_CHROME_IMPORTER_UTILS_H_

--- a/common/importer/chrome_importer_utils_unittest.cc
+++ b/common/importer/chrome_importer_utils_unittest.cc
@@ -42,7 +42,7 @@ class BraveChromeImporterUtilsTest : public testing::Test {
 };
 
 TEST_F(BraveChromeImporterUtilsTest, GetChromeExtensionsListPreferences) {
-  CopyTestFileToProfile("Preferences", "Preferences");
+  CopyTestFileToProfile(kChromePreferencesFile, kChromePreferencesFile);
   auto extensions_list =
       GetImportableChromeExtensionsList(GetTestProfilePath());
   EXPECT_TRUE(extensions_list);
@@ -54,7 +54,7 @@ TEST_F(BraveChromeImporterUtilsTest, GetChromeExtensionsListPreferences) {
 
 TEST_F(BraveChromeImporterUtilsTest, GetChromeExtensionsListSecurePreferences) {
   CopyTestFileToProfile("Secure_Preferences_for_extension_import",
-                        kChromeExtensionsPreferencesFile);
+                        kChromeSecurePreferencesFile);
   auto extensions_list =
       GetImportableChromeExtensionsList(GetTestProfilePath());
   EXPECT_TRUE(extensions_list);
@@ -65,7 +65,7 @@ TEST_F(BraveChromeImporterUtilsTest, GetChromeExtensionsListSecurePreferences) {
 
 TEST_F(BraveChromeImporterUtilsTest, ExtensionImportTest) {
   CopyTestFileToProfile("Secure_Preferences_for_extension_import",
-                        kChromeExtensionsPreferencesFile);
+                        kChromeSecurePreferencesFile);
   CopyTestFileToProfile("Preferences", "Preferences");
   auto extensions_list =
       GetImportableChromeExtensionsList(GetTestProfilePath());
@@ -74,7 +74,6 @@ TEST_F(BraveChromeImporterUtilsTest, ExtensionImportTest) {
   // We don't import theme, pre-installed extensions, disabled extensions and
   // installed by default (1 from Secure Preferences, 1 from Preferences)
   EXPECT_EQ(3u, extensions_list->size());
-
   EXPECT_EQ(extensions_list.value(),
             std::vector<std::string>({"aeblfdkhhhdcdjpifhhbdiojplfjncoa",
                                       "jldhpllghnbhlbpcmnajkpdmadaolakh",
@@ -125,8 +124,8 @@ TEST_F(BraveChromeImporterUtilsTest, GetChromeUserDataFolder) {
 
 TEST_F(BraveChromeImporterUtilsTest, ChromeImporterCanImport) {
   CopyTestFileToProfile("Secure_Preferences_for_extension_import",
-                        kChromeExtensionsPreferencesFile);
-  CopyTestFileToProfile("Preferences", "Preferences");
+                        kChromeSecurePreferencesFile);
+  CopyTestFileToProfile(kChromePreferencesFile, kChromePreferencesFile);
   uint16_t services_supported = importer::NONE;
   EXPECT_TRUE(
       ChromeImporterCanImport(GetTestProfilePath(), &services_supported));

--- a/common/importer/chrome_importer_utils_unittest.cc
+++ b/common/importer/chrome_importer_utils_unittest.cc
@@ -6,56 +6,84 @@
 #include "brave/common/importer/chrome_importer_utils.h"
 #include "base/files/file_path.h"
 #include "base/files/file_util.h"
+#include "base/files/scoped_temp_dir.h"
 #include "base/json/json_reader.h"
 #include "base/path_service.h"
 #include "brave/common/importer/importer_constants.h"
 #include "brave/components/constants/brave_paths.h"
+#include "chrome/common/importer/importer_data_types.h"
 #include "testing/gtest/include/gtest/gtest.h"
 
-namespace {
-const char kTestExtensionsPreferencesFile[] =
-    "Secure_Preferences_for_extension_import";
-base::FilePath GetTestProfilePath() {
-  base::FilePath test_dir;
-  base::PathService::Get(brave::DIR_TEST_DATA, &test_dir);
-  return test_dir.AppendASCII("import").AppendASCII("chrome").AppendASCII(
-      "default");
-}
-// This sample prefs file is fetched after installing two extensions and one
-// theme from webstore with fresh profile.
-base::FilePath GetTestPreferencesPath() {
-  base::FilePath test_dir;
-  base::PathService::Get(brave::DIR_TEST_DATA, &test_dir);
-  return test_dir.AppendASCII("import")
-      .AppendASCII("chrome")
-      .AppendASCII("default")
-      .AppendASCII(kTestExtensionsPreferencesFile);
-}
-}  // namespace
+class BraveChromeImporterUtilsTest : public testing::Test {
+ public:
+  BraveChromeImporterUtilsTest() {}
 
-TEST(ChromeImporterUtilsTest, ExtensionImportTest) {
-  base::FilePath data_path;
-  ASSERT_TRUE(base::PathService::Get(brave::DIR_TEST_DATA, &data_path));
-  base::FilePath secured_preference_path = GetTestPreferencesPath();
+  void SetUp() override {
+    EXPECT_TRUE(brave_profile_dir_.CreateUniqueTempDir());
+    base::CreateDirectory(GetTestProfilePath());
+  }
+  base::FilePath GetTestProfilePath() {
+    return brave_profile_dir_.GetPath().AppendASCII("Chrome").AppendASCII(
+        "Default");
+  }
+  void CopyTestFileToProfile(const std::string& source,
+                             const std::string& target) {
+    base::FilePath test_data_dir;
+    base::PathService::Get(brave::DIR_TEST_DATA, &test_data_dir);
+    base::CopyFile(test_data_dir.AppendASCII("import")
+                       .AppendASCII("chrome")
+                       .AppendASCII("default")
+                       .AppendASCII(source),
+                   GetTestProfilePath().AppendASCII(target));
+  }
 
-  std::string secured_preference_content;
-  base::ReadFileToString(secured_preference_path, &secured_preference_content);
-  absl::optional<base::Value> secured_preference =
-      base::JSONReader::Read(secured_preference_content);
-  ASSERT_TRUE(secured_preference);
-  ASSERT_TRUE(secured_preference->is_dict());
-  auto* extensions = secured_preference->GetDict().FindDictByDottedPath(
-      kChromeExtensionsListPath);
-  ASSERT_TRUE(extensions);
+ private:
+  base::ScopedTempDir brave_profile_dir_;
+};
+
+TEST_F(BraveChromeImporterUtilsTest, GetChromeExtensionsListPreferences) {
+  CopyTestFileToProfile("Preferences", "Preferences");
   auto extensions_list =
-      GetImportableListFromChromeExtensionsList(*extensions);
-  // Only 1 extension installed from webstore is importing target extension.
-  // We don't import theme, pre-installed extensions, disabled extensions and
-  // installed by default.
-  EXPECT_EQ(1UL, extensions_list.size());
+      GetImportableChromeExtensionsList(GetTestProfilePath());
+  EXPECT_TRUE(extensions_list);
+  EXPECT_EQ(extensions_list->size(), 2u);
+  EXPECT_EQ(extensions_list.value(),
+            std::vector<std::string>({"jldhpllghnbhlbpcmnajkpdmadaolakh",
+                                      "mefhakmgclhhfbdadeojlkbllmecialg"}));
 }
 
-TEST(ChromeImporterUtilsTest, GetChromeUserDataFolder) {
+TEST_F(BraveChromeImporterUtilsTest, GetChromeExtensionsListSecurePreferences) {
+  CopyTestFileToProfile("Secure_Preferences_for_extension_import",
+                        kChromeExtensionsPreferencesFile);
+  auto extensions_list =
+      GetImportableChromeExtensionsList(GetTestProfilePath());
+  EXPECT_TRUE(extensions_list);
+  EXPECT_EQ(extensions_list->size(), 1u);
+  EXPECT_EQ(extensions_list.value(),
+            std::vector<std::string>({"aeblfdkhhhdcdjpifhhbdiojplfjncoa"}));
+}
+
+TEST_F(BraveChromeImporterUtilsTest, ExtensionImportTest) {
+  CopyTestFileToProfile("Secure_Preferences_for_extension_import",
+                        kChromeExtensionsPreferencesFile);
+  CopyTestFileToProfile("Preferences", "Preferences");
+  auto extensions_list =
+      GetImportableChromeExtensionsList(GetTestProfilePath());
+  EXPECT_TRUE(extensions_list);
+  // Only 3 extension installed from webstore is importing target extension.
+  // We don't import theme, pre-installed extensions, disabled extensions and
+  // installed by default (1 from Secure Preferences, 1 from Preferences)
+  EXPECT_EQ(3u, extensions_list->size());
+
+  EXPECT_EQ(extensions_list.value(),
+            std::vector<std::string>({"aeblfdkhhhdcdjpifhhbdiojplfjncoa",
+                                      "jldhpllghnbhlbpcmnajkpdmadaolakh",
+                                      "mefhakmgclhhfbdadeojlkbllmecialg"}));
+}
+
+TEST_F(BraveChromeImporterUtilsTest, GetChromeUserDataFolder) {
+  CopyTestFileToProfile("Local State", "Local State");
+
   EXPECT_EQ(
       GetChromeSourceProfiles(base::FilePath(FILE_PATH_LITERAL("fake"))),
       base::JSONReader::Read(R"([{"id": "", "name": "Default" }])")->GetList());
@@ -64,16 +92,17 @@ TEST(ChromeImporterUtilsTest, GetChromeUserDataFolder) {
                 base::FilePath::StringType(FILE_PATH_LITERAL("Local State")))),
             base::JSONReader::Read(R"([
         {"id": "Default", "name": "Profile 1"},
-        {"id": "Profile 2",  "name": "Profile 2"}
+        {"id": "Profile 2", "name": "Profile 2"}
       ])")
                 ->GetList());
-
+  CopyTestFileToProfile("No Profile Local State", "No Profile Local State");
   EXPECT_EQ(
       GetChromeSourceProfiles(
           GetTestProfilePath().Append(base::FilePath::StringType(
               FILE_PATH_LITERAL("No Profile Local State")))),
       base::JSONReader::Read(R"([{"id": "", "name": "Default" }])")->GetList());
 
+  CopyTestFileToProfile("Local State With Avatar", "Local State With Avatar");
   EXPECT_EQ(GetChromeSourceProfiles(
                 GetTestProfilePath().Append(base::FilePath::StringType(
                     FILE_PATH_LITERAL("Local State With Avatar")))),
@@ -92,4 +121,14 @@ TEST(ChromeImporterUtilsTest, GetChromeUserDataFolder) {
         }
       ])")
                 ->GetList());
+}
+
+TEST_F(BraveChromeImporterUtilsTest, ChromeImporterCanImport) {
+  CopyTestFileToProfile("Secure_Preferences_for_extension_import",
+                        kChromeExtensionsPreferencesFile);
+  CopyTestFileToProfile("Preferences", "Preferences");
+  uint16_t services_supported = importer::NONE;
+  EXPECT_TRUE(
+      ChromeImporterCanImport(GetTestProfilePath(), &services_supported));
+  EXPECT_EQ(services_supported, importer::EXTENSIONS);
 }

--- a/common/importer/importer_constants.h
+++ b/common/importer/importer_constants.h
@@ -8,13 +8,10 @@
 
 #include "build/build_config.h"
 
-// Pref file that holds installed extension list.
-constexpr char kChromeExtensionsPreferencesFile[] =
-#if BUILDFLAG(IS_LINUX)
-    "Preferences";
-#else
-    "Secure Preferences";
-#endif
+// Prefs files that holds installed extension list.
+constexpr char kChromeSecurePreferencesFile[] = "Secure Preferences";
+constexpr char kChromePreferencesFile[] = "Preferences";
+
 constexpr char kChromeExtensionsListPath[] = "extensions.settings";
 constexpr char kChromeLocalStateFile[] = "Local State";
 

--- a/test/data/import/chrome/default/Preferences
+++ b/test/data/import/chrome/default/Preferences
@@ -1,1 +1,2096 @@
-{"extensions":{"settings":{"aapocclcgogkmnckokdopfmhonfmgoek":{"ack_external":true,"active_permissions":{"api":[],"manifest_permissions":[]},"app_launcher_ordinal":"w","commands":{},"content_settings":[],"creation_flags":137,"events":[],"from_bookmark":false,"from_webstore":true,"granted_permissions":{"api":[],"manifest_permissions":[]},"incognito_content_settings":[],"incognito_preferences":{},"install_time":"13226654686468813","lastpingday":"13226572800714429","location":1,"manifest":{"api_console_project_id":"889782162350","app":{"launch":{"local_path":"main.html"}},"container":"GOOGLE_DRIVE","current_locale":"en_US","default_locale":"en_US","description":"Create and edit presentations ","icons":{"128":"icon_128.png","16":"icon_16.png"},"key":"MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQDLOGW2Hoztw8m2z6SmCjm7y4Oe2o6aRqO+niYKCXhZab572by7acqFIFF0On3e3a967SwNijsTx2n+7Mt3KqWzEKtnwUZqzHYSsdZZK64vWIHIduawP0EICWRMf2RGIBEdDC6I1zErtcDiSrJWeRlnb0DHWXDXlt1YseM7RiON9wIDAQAB","manifest_version":2,"name":"Slides","offline_enabled":true,"update_url":"https://clients2.google.com/service/update2/crx","version":"0.10"},"page_ordinal":"n","path":"aapocclcgogkmnckokdopfmhonfmgoek/0.10_1","preferences":{},"regular_only_preferences":{},"state":1,"was_installed_by_default":true,"was_installed_by_oem":false,"withholding_permissions":false},"aeblfdkhhhdcdjpifhhbdiojplfjncoa":{"active_permissions":{"api":["clipboardWrite","contextMenus","downloads","downloadsInternal","idle","management","nativeMessaging","notifications","privacy","storage","tabs","webNavigation","webRequest","webRequestBlocking"],"explicit_host":["\u003Call_urls>","chrome://favicon/*"],"manifest_permissions":[],"scriptable_host":["https://*.1password.ca/*","https://*.1password.com/*","https://*.1password.eu/*","https://*.b5dev.com/*","https://*.b5local.com/*","https://*.b5staging.com/*","https://*.b5test.com/*"]},"commands":{"_execute_browser_action":{"suggested_key":"Command+Shift+X","was_assigned":true}},"content_settings":[],"creation_flags":9,"events":[],"from_bookmark":false,"from_webstore":true,"granted_permissions":{"api":["clipboardWrite","contextMenus","downloads","downloadsInternal","idle","management","nativeMessaging","notifications","privacy","storage","tabs","webNavigation","webRequest","webRequestBlocking"],"explicit_host":["\u003Call_urls>","chrome://favicon/*"],"manifest_permissions":[],"scriptable_host":["https://*.1password.ca/*","https://*.1password.com/*","https://*.1password.eu/*","https://*.b5dev.com/*","https://*.b5local.com/*","https://*.b5staging.com/*","https://*.b5test.com/*"]},"incognito_content_settings":[],"incognito_preferences":{},"install_time":"13226654735273593","location":1,"manifest":{"author":"AgileBits","background":{"scripts":["background/x.js","background/background.js"]},"browser_action":{"default_title":"1Password"},"commands":{"_execute_browser_action":{"suggested_key":{"default":"Ctrl+Shift+X","mac":"Command+Shift+X"}}},"content_scripts":[{"css":["content/b5integration.css"],"js":["content/b5.js"],"matches":["https://*.1password.com/*","https://*.b5staging.com/*","https://*.b5test.com/*","https://*.b5dev.com/*","https://*.b5local.com/*","https://*.1password.ca/*","https://*.1password.eu/*"],"run_at":"document_idle"}],"content_security_policy":"default-src 'self'; img-src 'self' https://c.1password.com https://a.1passwordentusercontent.com https://a.1passwordusercontent.com https://a.1passwordusercontent.eu https://a.1passwordusercontent.ca; connect-src https://*.1password.com wss://b5n.1password.com wss://b5n.ent.1password.com https://*.b5test.com wss://b5n.b5test.com https://*.b5dev.com wss://b5n.b5dev.com https://*.b5local.com:3000 wss://b5local.com:3001 https://*.1password.ca wss://b5n.1password.ca https://*.1password.eu wss://b5n.1password.eu https://api.pwnedpasswords.com https://f.1passwordusercontent.com https://f.1passwordentusercontent.com https://f.1passwordusercontent.eu https://f.1passwordusercontent.ca; style-src 'self' 'unsafe-inline'; script-src 'self' 'wasm-eval';","current_locale":"en_US","default_locale":"en","description":"The best way to experience 1Password in your browser. Easily sign in to sites, generate passwords, and store secure information.","homepage_url":"https://1password.com","icons":{"128":"/images/icons/onepassword-128.png","16":"/images/icons/app_icon-light_bg-color-unlocked-32.png","48":"/images/icons/onepassword-48.png"},"key":"MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAnHpaUll4uWujpAdbIXOQY2WE6hk8PllsYsnoUaj5qHXwv4IB6A9pONqGaTL2KL20u6E6XVhncY6Ae6SQSBQqiIkgjPsiG0NDNsDlju/kzBnfimKFC/bpzOrqFqbhswQHifnet5uHlpG97whTzLO3ka0M5aqB9V9mD/0qVXvNgAVVnSTULH254YqpeCcAhmsKiFZSL6OrOZmCp8kZ/OeOUK9iYWYylL7VcOXVrZf10EPrlaCNXzVk7K35dPuQ7svhA0Pgju3kngB4RLa5Iojhw3IT+B5+m8pisjOSd1oKMrRmhGs7rDhF5IEtAiVxqVp7uOOMPQj3vrbMDAzf7vqLtQIDAQAB","manifest_version":2,"minimum_chrome_version":"73","name":"1Password X – Password Manager","permissions":["\u003Call_urls>","clipboardWrite","contextMenus","idle","management","nativeMessaging","notifications","storage","tabs","webRequest","webRequestBlocking","webNavigation","privacy","downloads"],"short_name":"1Password","update_url":"https://clients2.google.com/service/update2/crx","version":"1.18.0","web_accessible_resources":["images/*","mini/images/*","inline/images/*","fonts/*","mini/fonts/*","inline/fonts/*","inline/button/injected.css","inline/menu/menu.html","inline/menu/injected.css","inline/notifications/add-account/add-account.html","inline/save-dialog/save-dialog.html","inline/save-dialog/injected.css"]},"needs_sync":true,"path":"aeblfdkhhhdcdjpifhhbdiojplfjncoa/1.18.0_0","preferences":{},"regular_only_preferences":{},"state":1,"was_installed_by_default":false,"was_installed_by_oem":false,"withholding_permissions":false},"aghfnjkcakhmadgdomlmlhhaocbkloab":{"active_permissions":{"api":[],"manifest_permissions":[]},"commands":{},"content_settings":[],"creation_flags":9,"events":[],"from_bookmark":false,"from_webstore":true,"granted_permissions":{"api":[],"manifest_permissions":[]},"incognito_content_settings":[],"incognito_preferences":{},"install_time":"13226654710521941","location":1,"manifest":{"description":"Just Black: when you're feeling extra moody","key":"MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAqxThvdYeWk6kwfNo+/HoqQSkL6iBx48w28vEPXHdhJo8OHMxS7D+1W1nhUsv4hOnb1CM2TlP/Nh9G+1Z32R9r6RmVxD1Anq9ZTZpK7VHVUxExGR4X9+TYHKWk8VGAjSBmutvayf0i0gCEkh7Pdc68ex4M0ypKGFWxBzxqw2uQ/4BLMVB/9KZJwXOC5LcaBNgq2Q74J3Dd3a90OzFXh+vC9zIyDueu3/K4F6u5bXgsgviAGIrUm7YbGhLDMxuW81zvYMlLtkA4XDDnhgk88s0G/5OwoMEyU6YdMq9R795NHsI0bPUMOOgUsPT5cytKRcQMegMassBe9EB+ktTl9CloQIDAQAB","manifest_version":2,"name":"Just Black","theme":{"colors":{"bookmark_text":[255,255,255],"frame":[0,0,0],"ntp_background":[0,0,0],"ntp_text":[125,134,142],"tab_background_text":[255,255,255],"tab_background_text_inactive":[255,255,255],"tab_background_text_incognito":[255,255,255],"tab_background_text_incognito_inactive":[255,255,255],"tab_text":[255,255,255],"toolbar":[45,45,45]},"tints":{"buttons":[0.2,0.2,0.9],"frame_inactive":[-1,-1,-1],"frame_incognito":[-1,-1,-1],"frame_incognito_inactive":[-1,-1,-1]}},"update_url":"https://clients2.google.com/service/update2/crx","version":"2"},"path":"aghfnjkcakhmadgdomlmlhhaocbkloab/2_0","preferences":{},"regular_only_preferences":{},"state":1,"was_installed_by_default":false,"was_installed_by_oem":false},"ahfgeienlihckogmohjhadlkjgocpleb":{"active_bit":true,"active_permissions":{"api":["management","system.display","system.storage","webstorePrivate","system.cpu","system.memory","system.network"],"manifest_permissions":[]},"app_launcher_ordinal":"t","commands":{},"content_settings":[],"creation_flags":1,"events":[],"from_bookmark":false,"from_webstore":false,"incognito_content_settings":[],"incognito_preferences":{},"install_time":"13226654677459804","last_launch_time":"13226654699036269","location":5,"manifest":{"app":{"launch":{"web_url":"https://chrome.google.com/webstore"},"urls":["https://chrome.google.com/webstore"]},"description":"Discover great apps, games, extensions and themes for Google Chrome.","icons":{"128":"webstore_icon_128.png","16":"webstore_icon_16.png"},"key":"MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQCtl3tO0osjuzRsf6xtD2SKxPlTfuoy7AWoObysitBPvH5fE1NaAA1/2JkPWkVDhdLBWLaIBPYeXbzlHp3y4Vv/4XG+aN5qFE3z+1RU/NqkzVYHtIpVScf3DjTYtKVL66mzVGijSoAIwbFCC3LpGdaoe6Q1rSRDp76wR6jjFzsYwQIDAQAB","name":"Web Store","permissions":["webstorePrivate","management","system.cpu","system.display","system.memory","system.network","system.storage"],"version":"0.2"},"needs_sync":true,"page_ordinal":"n","path":"/Applications/Google Chrome.app/Contents/Frameworks/Google Chrome Framework.framework/Versions/80.0.3987.116/Resources/web_store","preferences":{},"regular_only_preferences":{},"state":1,"was_installed_by_default":false,"was_installed_by_oem":false},"aohghmighlieiainnegkcijnfilokake":{"ack_external":true,"active_permissions":{"api":[],"manifest_permissions":[]},"app_launcher_ordinal":"x","commands":{},"content_settings":[],"creation_flags":137,"events":[],"from_bookmark":false,"from_webstore":true,"granted_permissions":{"api":[],"manifest_permissions":[]},"incognito_content_settings":[],"incognito_preferences":{},"install_time":"13226654686203610","lastpingday":"13226572800714429","location":1,"manifest":{"api_console_project_id":"619683526622","app":{"launch":{"local_path":"main.html"}},"container":"GOOGLE_DRIVE","current_locale":"en_US","default_locale":"en_US","description":"Create and edit documents ","icons":{"128":"icon_128.png","16":"icon_16.png"},"key":"MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQDJhLK6fk/BWTEvJhywpk7jDe4A2r0bGXGOLZW4/AdBp3IiD9o9nx4YjLAtv0tIPxi7MvFd/GUUbQBwHT5wQWONJj1z/0Rc2qBkiJA0yqXh42p0snuA8dCfdlhOLsp7/XTMEwAVasjV5hC4awl78eKfJYlZ+8fM/UldLWJ/51iBQwIDAQAB","manifest_version":2,"name":"Docs","offline_enabled":true,"update_url":"https://clients2.google.com/service/update2/crx","version":"0.10"},"page_ordinal":"n","path":"aohghmighlieiainnegkcijnfilokake/0.10_1","preferences":{},"regular_only_preferences":{},"state":1,"was_installed_by_default":true,"was_installed_by_oem":false,"withholding_permissions":false},"apdfllckaahabafndbhieahigkjlhalf":{"ack_external":true,"active_permissions":{"api":["clipboardRead","clipboardWrite","notifications"],"manifest_permissions":[]},"app_launcher_ordinal":"y","commands":{},"content_settings":[],"creation_flags":137,"events":[],"from_bookmark":false,"from_webstore":true,"granted_permissions":{"api":["clipboardRead","clipboardWrite","notifications"],"manifest_permissions":[]},"incognito_content_settings":[],"incognito_preferences":{},"install_time":"13226654683295429","lastpingday":"13226572800714429","location":1,"manifest":{"app":{"launch":{"web_url":"https://drive.google.com/?usp=chrome_app"},"urls":["http://docs.google.com/","http://drive.google.com/","https://docs.google.com/","https://drive.google.com/"]},"background":{"allow_js_access":false},"current_locale":"en_US","default_locale":"en_US","description":"Google Drive: create, share and keep all your stuff in one place.","icons":{"128":"128.png"},"key":"MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQDIl5KlKwL2TSkntkpY3naLLz5jsN0YwjhZyObcTOK6Nda4Ie21KRqZau9lx5SHcLh7pE2/S9OiArb+na2dn7YK5EvH+aRXS1ec3uxVlBhqLdnleVgwgwlg5fH95I52IeHcoeK6pR4hW/Nv39GNlI/Uqk6O6GBCCsAxYrdxww9BiQIDAQAB","manifest_version":2,"name":"Google Drive","offline_enabled":true,"options_page":"https://drive.google.com/drive/settings","permissions":["clipboardRead","clipboardWrite","notifications"],"update_url":"https://clients2.google.com/service/update2/crx","version":"14.2"},"page_ordinal":"n","path":"apdfllckaahabafndbhieahigkjlhalf/14.2_0","preferences":{},"regular_only_preferences":{},"state":1,"was_installed_by_default":true,"was_installed_by_oem":false},"blpcfgokakmgnkcojhhkbfbldkacnbeo":{"ack_external":true,"active_permissions":{"api":[],"manifest_permissions":[]},"app_launcher_ordinal":"zm","commands":{},"content_settings":[],"creation_flags":153,"events":[],"from_bookmark":true,"from_webstore":true,"granted_permissions":{"api":[],"manifest_permissions":[]},"incognito_content_settings":[],"incognito_preferences":{},"install_time":"13226654688489301","lastpingday":"13226572800714429","location":1,"manifest":{"app":{"launch":{"container":"tab","web_url":"http://www.youtube.com"},"web_content":{"enabled":true,"origin":"http://www.youtube.com"}},"current_locale":"en_US","default_locale":"en","description":"","icons":{"128":"128.png"},"key":"MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQDC/HotmFlyuz5FaHaIbVBhhL4BwbcUtsfWwzgUMpZt5ZsLB2nW/Y5xwNkkPANYGdVsJkT2GPpRRIKBO5QiJ7jPMa3EZtcZHpkygBlQLSjMhdrAKevpKgIl6YTkwzNvExY6rzVDzeE9zqnIs33eppY4S5QcoALMxuSWlMKqgFQjHQIDAQAB","manifest_version":2,"name":"YouTube","update_url":"http://clients2.google.com/service/update2/crx","version":"4.2.8"},"page_ordinal":"n","path":"blpcfgokakmgnkcojhhkbfbldkacnbeo/4.2.8_0","preferences":{},"regular_only_preferences":{},"state":1,"was_installed_by_default":true,"was_installed_by_oem":false},"felcaaldnbdncclmgdcncolpebgiejap":{"ack_external":true,"active_permissions":{"api":[],"manifest_permissions":[]},"app_launcher_ordinal":"yn","commands":{},"content_settings":[],"creation_flags":137,"events":[],"from_bookmark":false,"from_webstore":true,"granted_permissions":{"api":[],"manifest_permissions":[]},"incognito_content_settings":[],"incognito_preferences":{},"install_time":"13226654683544785","lastpingday":"13226572800714429","location":1,"manifest":{"api_console_project_id":"1083656409722","app":{"launch":{"local_path":"main.html"}},"container":"GOOGLE_DRIVE","current_locale":"en_US","default_locale":"en_US","description":"Create and edit spreadsheets","icons":{"128":"icon_128.png","16":"icon_16.png"},"key":"MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQC0AHrkP4MHPDKQI/O9LqZjtM24hKApaT3uVHeOduC06ZXWuwVRvx2wy5JUmMHfefXRG26tErgZSWpbxkm+2xfplKnT+grXF771HDgsNrNXERJHq7tnoYsWRiG3Gbs5BI4Ei+naZ/nyiWblbT4GyuD9N5yXNtoM0AnK+0FYhbO7IwIDAQAB","manifest_version":2,"name":"Sheets","offline_enabled":true,"update_url":"https://clients2.google.com/service/update2/crx","version":"1.2"},"page_ordinal":"n","path":"felcaaldnbdncclmgdcncolpebgiejap/1.2_0","preferences":{},"regular_only_preferences":{},"state":1,"was_installed_by_default":true,"was_installed_by_oem":false,"withholding_permissions":false},"gfdkimpbcpahaombhbimeihdjnejgicl":{"active_permissions":{"api":["feedbackPrivate"],"explicit_host":["chrome://resources/*"],"manifest_permissions":[]},"commands":{},"content_settings":[],"creation_flags":1,"events":["feedbackPrivate.onFeedbackRequested"],"from_bookmark":false,"from_webstore":false,"incognito_content_settings":[],"incognito_preferences":{},"install_time":"13226654677461190","location":5,"manifest":{"app":{"background":{"scripts":["js/event_handler.js"]},"content_security_policy":"default-src 'none'; script-src 'self' blob: filesystem: chrome://resources; style-src 'unsafe-inline' blob: chrome: file: filesystem: data: *; img-src * blob: chrome: file: filesystem: data:; media-src 'self' blob: filesystem:"},"description":"User feedback extension","display_in_launcher":false,"display_in_new_tab_page":false,"icons":{"192":"images/icon192.png","48":"images/icon48.png"},"incognito":"split","key":"MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQDMZElzFX2J1g1nRQ/8S3rg/1CjFyDltWOxQg+9M8aVgNVxbutEWFQz+oQzIP9BB67mJifULgiv12ToFKsae4NpEUR8sPZjiKDIHumc6pUdixOm8SJ5Rs16SMR6+VYxFUjlVW+5CA3IILptmNBxgpfyqoK0qRpBDIhGk1KDEZ4zqQIDAQAB","manifest_version":2,"name":"Feedback","permissions":["feedbackPrivate","chrome://resources/"],"version":"1.0"},"path":"/Applications/Google Chrome.app/Contents/Frameworks/Google Chrome Framework.framework/Versions/80.0.3987.116/Resources/feedback","preferences":{},"regular_only_preferences":{},"running":false,"state":1,"was_installed_by_default":false,"was_installed_by_oem":false},"ghbmnnjooekpmoecnnnilnnbdlolhkhi":{"ack_external":true,"active_permissions":{"api":["alarms","clipboardRead","clipboardWrite","identity","power","storage","unlimitedStorage","webConnectable"],"manifest_permissions":[]},"commands":{},"content_settings":[],"creation_flags":137,"events":["alarms.onAlarm","runtime.onConnectExternal"],"from_bookmark":false,"from_webstore":true,"granted_permissions":{"api":["alarms","clipboardRead","clipboardWrite","identity","power","storage","unlimitedStorage","webConnectable"],"manifest_permissions":[]},"incognito_content_settings":[],"incognito_preferences":{},"install_time":"13226654688233906","lastpingday":"13226572800714429","location":1,"manifest":{"background":{"persistent":false,"scripts":["eventpage_bin_prod.js"]},"content_capabilities":{"matches":["https://docs.google.com/*","https://drive.google.com/*"],"permissions":["clipboardRead","clipboardWrite","unlimitedStorage"]},"content_security_policy":"script-src 'self'; object-src 'self'","current_locale":"en_US","default_locale":"en_US","description":"Edit, create, and view your documents, spreadsheets, and presentations — all without internet access.","externally_connectable":{"matches":["https://docs.google.com/*","https://drive.google.com/*"]},"icons":{"128":"128.png"},"key":"MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAnF7RGLAxIon0/XeNZ4MLdP3DMkoORzEAKVg0sb89JpA/W2osTHr91Wqwdc9lW0mFcSpCYS9Y3e7cUMFo/M2ETASIuZncMiUzX2/0rrWtGQ3UuEj3KSe5PdaVZfisyJw/FebvHwirEWrhqcgzVUj9fL9YjE0G45d1zMKcc1umKvLqPyTznNuKBZ9GJREdGLRJCBmUgCkI8iwtwC+QZTUppmaD50/ksnEUXv+QkgGN07/KoNA5oAgo49Jf1XBoMv4QXtVZQlBYZl84zAsI82hb63a6Gu29U/4qMWDdI7+3Ne5TRvo6Zi3EI4M2NQNplJhik105qrz+eTLJJxvf4slrWwIDAQAB","manifest_version":2,"minimum_chrome_version":"43","name":"Google Docs Offline","permissions":["alarms","clipboardRead","clipboardWrite","identity","power","storage","unlimitedStorage"],"storage":{"managed_schema":"dasherSettingSchema.json"},"update_url":"https://clients2.google.com/service/update2/crx","version":"1.9","web_accessible_resources":["page_embed_script.js"]},"path":"ghbmnnjooekpmoecnnnilnnbdlolhkhi/1.9_0","preferences":{},"regular_only_preferences":{},"state":1,"was_installed_by_default":true,"was_installed_by_oem":false,"withholding_permissions":false},"jldhpllghnbhlbpcmnajkpdmadaolakh":{"active_permissions":{"api":["background","contextMenus","notifications","storage","tabs"],"explicit_host":["http://*.todoist.com/*","https://*.todoist.com/*"],"manifest_permissions":[],"scriptable_host":["http://*.todoist.com/*","https://*.todoist.com/*"]},"commands":{},"content_settings":[],"creation_flags":9,"events":[],"from_bookmark":false,"from_webstore":true,"granted_permissions":{"api":["background","contextMenus","notifications","storage","tabs"],"explicit_host":["http://*.todoist.com/*","https://*.todoist.com/*"],"manifest_permissions":[],"scriptable_host":["http://*.todoist.com/*","https://*.todoist.com/*"]},"incognito_content_settings":[],"incognito_preferences":{},"install_time":"13226654774154919","location":1,"manifest":{"background":{"page":"background.html"},"browser_action":{"default_icon":"todoist_256.png","default_popup":"popup.html","default_title":"Todoist"},"content_scripts":[{"all_frames":true,"js":["counter_update.js"],"matches":["http://*.todoist.com/*","https://*.todoist.com/*"]}],"current_locale":"en_US","default_locale":"en","description":"Organize work and life with Todoist for Chrome","icons":{"128":"todoist_128.png","16":"todoist_16.png","256":"todoist_256.png","48":"todoist_48.png","512":"todoist_512.png"},"key":"MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQCj5g40koD1nY0wP+LG19C2ACvjUv8oWurwruLWpDJn88qpiIRDHGBVG029Sh0q4tUmeTBhCWk7kJ6JNJ6P3iRrYZfGlJs1sb9oJdqQsmWiS3ziQHvSl3OyYT7a2hdZKi0cs0iKtrO318CS5uGGBW5EkW3oY7T12nblQgKo6PGc5QIDAQAB","manifest_version":2,"name":"Todoist for Chrome","options_ui":{"open_in_tab":false,"page":"options.html"},"permissions":["storage","tabs","background","contextMenus","notifications","http://*.todoist.com/*","https://*.todoist.com/*"],"short_name":"Todoist","update_url":"https://clients2.google.com/service/update2/crx","version":"9.9"},"needs_sync":true,"path":"jldhpllghnbhlbpcmnajkpdmadaolakh/9.9_0","preferences":{},"regular_only_preferences":{},"state":1,"was_installed_by_default":false,"was_installed_by_oem":false,"withholding_permissions":false},"kmendfapggjehodndflmmgagdbamhnfd":{"active_permissions":{"api":["cryptotokenPrivate","externally_connectable.all_urls","tabs","webConnectable"],"explicit_host":["http://*/*","https://*/*"],"manifest_permissions":[]},"commands":{},"content_settings":[],"creation_flags":1,"events":["runtime.onConnectExternal"],"from_bookmark":false,"from_webstore":false,"incognito_content_settings":[],"incognito_preferences":{},"install_time":"13226654677462231","location":5,"manifest":{"background":{"persistent":false,"scripts":["util.js","b64.js","cbor.js","sha256.js","timer.js","countdown.js","countdowntimer.js","devicestatuscodes.js","approvedorigins.js","errorcodes.js","webrequest.js","messagetypes.js","factoryregistry.js","requesthelper.js","asn1.js","enroller.js","requestqueue.js","signer.js","origincheck.js","textfetcher.js","appid.js","watchdog.js","logging.js","webrequestsender.js","window-timer.js","cryptotokenorigincheck.js","cryptotokenapprovedorigins.js","inherits.js","individualattest.js","googlecorpindividualattest.js","cryptotokenbackground.js"]},"description":"CryptoToken Component Extension","externally_connectable":{"ids":["fjajfjhkeibgmiggdfehjplbhmfkialk"],"matches":["https://*/*"]},"incognito":"split","key":"MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAq7zRobvA+AVlvNqkHSSVhh1sEWsHSqz4oR/XptkDe/Cz3+gW9ZGumZ20NCHjaac8j1iiesdigp8B1LJsd/2WWv2Dbnto4f8GrQ5MVphKyQ9WJHwejEHN2K4vzrTcwaXqv5BSTXwxlxS/mXCmXskTfryKTLuYrcHEWK8fCHb+0gvr8b/kvsi75A1aMmb6nUnFJvETmCkOCPNX5CHTdy634Ts/x0fLhRuPlahk63rdf7agxQv5viVjQFk+tbgv6aa9kdSd11Js/RZ9yZjrFgHOBWgP4jTBqud4+HUglrzu8qynFipyNRLCZsaxhm+NItTyNgesxLdxZcwOz56KD1Q4IQIDAQAB","manifest_version":2,"name":"CryptoTokenExtension","permissions":["cryptotokenPrivate","externally_connectable.all_urls","tabs","https://*/*","http://*/*"],"version":"0.9.74"},"path":"/Applications/Google Chrome.app/Contents/Frameworks/Google Chrome Framework.framework/Versions/80.0.3987.116/Resources/cryptotoken","preferences":{},"regular_only_preferences":{},"state":1,"was_installed_by_default":false,"was_installed_by_oem":false},"mfehgcgbbipciphmccgaenjidiccnmng":{"active_permissions":{"api":["cloudPrintPrivate"],"manifest_permissions":[]},"commands":{},"content_settings":[],"creation_flags":1,"events":[],"from_bookmark":false,"from_webstore":false,"incognito_content_settings":[],"incognito_preferences":{},"install_time":"13226654677457725","location":5,"manifest":{"app":{"launch":{"web_url":"https://www.google.com/cloudprint"},"urls":["https://www.google.com/cloudprint/enable_chrome_connector"]},"description":"Cloud Print","display_in_launcher":false,"icons":{},"key":"MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQDqOhnwk4+HXVfGyaNsAQdU/js1Na56diW08oF1MhZiwzSnJsEaeuMN9od9q9N4ZdK3o1xXOSARrYdE+syV7Dl31nf6qz3A6K+D5NHe6sSB9yvYlIiN37jdWdrfxxE0pRYEVYZNTe3bzq3NkcYJlOdt1UPcpJB+isXpAGUKUvt7EQIDAQAB","name":"Cloud Print","permissions":["cloudPrintPrivate"],"version":"0.1"},"path":"/Applications/Google Chrome.app/Contents/Frameworks/Google Chrome Framework.framework/Versions/80.0.3987.116/Resources/cloud_print","preferences":{},"regular_only_preferences":{},"state":1,"was_installed_by_default":false,"was_installed_by_oem":false},"mhjfbmdgcfjbbpaeojofohoefgiehjai":{"active_permissions":{"api":["contentSettings","fileSystem","fileSystem.write","metricsPrivate","resourcesPrivate"],"explicit_host":["chrome://resources/*"],"manifest_permissions":[]},"commands":{},"content_settings":[],"creation_flags":1,"events":[],"from_bookmark":false,"from_webstore":false,"incognito_content_settings":[],"incognito_preferences":{},"install_time":"13226654677462676","location":5,"manifest":{"content_security_policy":"script-src 'self' 'wasm-eval' blob: filesystem: chrome://resources; object-src * blob: externalfile: file: filesystem: data:; plugin-types application/x-google-chrome-pdf","description":"","incognito":"split","key":"MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQDN6hM0rsDYGbzQPQfOygqlRtQgKUXMfnSjhIBL7LnReAVBEd7ZmKtyN2qmSasMl4HZpMhVe2rPWVVwBDl6iyNE/Kok6E6v6V3vCLGsOpQAuuNVye/3QxzIldzG/jQAdWZiyXReRVapOhZtLjGfywCvlWq7Sl/e3sbc0vWybSDI2QIDAQAB","manifest_version":2,"mime_types":["application/pdf"],"mime_types_handler":"index.html","name":"Chrome PDF Viewer","offline_enabled":true,"permissions":["chrome://resources/","contentSettings","metricsPrivate","resourcesPrivate",{"fileSystem":["write"]}],"version":"1"},"path":"/Applications/Google Chrome.app/Contents/Frameworks/Google Chrome Framework.framework/Versions/80.0.3987.116/Resources/pdf","preferences":{},"regular_only_preferences":{},"state":1,"was_installed_by_default":false,"was_installed_by_oem":false},"neajdppkdcdipfabeoofebfddakdcjhd":{"active_permissions":{"api":["systemPrivate","ttsEngine"],"explicit_host":["https://www.google.com/*"],"manifest_permissions":[]},"commands":{},"content_settings":[],"creation_flags":1,"events":["ttsEngine.onPause","ttsEngine.onResume","ttsEngine.onSpeak","ttsEngine.onStop"],"from_bookmark":false,"from_webstore":false,"incognito_content_settings":[],"incognito_preferences":{},"install_time":"13226654677461722","location":5,"manifest":{"background":{"persistent":false,"scripts":["tts_extension.js"]},"description":"Component extension providing speech via the Google network text-to-speech service.","key":"MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA8GSbNUMGygqQTNDMFGIjZNcwXsHLzkNkHjWbuY37PbNdSDZ4VqlVjzbWqODSe+MjELdv5Keb51IdytnoGYXBMyqKmWpUrg+RnKvQ5ibWr4MW9pyIceOIdp9GrzC1WZGgTmZismYR3AjaIpufZ7xDdQQv+XrghPWCkdVqLN+qZDA1HU+DURznkMICiDDSH2sU0egm9UbWfS218bZqzKeQDiC3OnTPlaxcbJtKUuupIm5knjze3Wo9Ae9poTDMzKgchg0VlFCv3uqox+wlD8sjXBoyBCCK9HpImdVAF1a7jpdgiUHpPeV/26oYzM9/grltwNR3bzECQgSpyXp0eyoegwIDAQAB","manifest_version":2,"name":"Google Network Speech","permissions":["systemPrivate","ttsEngine","https://www.google.com/"],"tts_engine":{"voices":[{"event_types":["start","end","error"],"gender":"female","lang":"de-DE","remote":true,"voice_name":"Google Deutsch"},{"event_types":["start","end","error"],"gender":"female","lang":"en-US","remote":true,"voice_name":"Google US English"},{"event_types":["start","end","error"],"gender":"female","lang":"en-GB","remote":true,"voice_name":"Google UK English Female"},{"event_types":["start","end","error"],"gender":"male","lang":"en-GB","remote":true,"voice_name":"Google UK English Male"},{"event_types":["start","end","error"],"gender":"female","lang":"es-ES","remote":true,"voice_name":"Google español"},{"event_types":["start","end","error"],"gender":"female","lang":"es-US","remote":true,"voice_name":"Google español de Estados Unidos"},{"event_types":["start","end","error"],"gender":"female","lang":"fr-FR","remote":true,"voice_name":"Google français"},{"event_types":["start","end","error"],"gender":"female","lang":"hi-IN","remote":true,"voice_name":"Google हिन्दी"},{"event_types":["start","end","error"],"gender":"female","lang":"id-ID","remote":true,"voice_name":"Google Bahasa Indonesia"},{"event_types":["start","end","error"],"gender":"female","lang":"it-IT","remote":true,"voice_name":"Google italiano"},{"event_types":["start","end","error"],"gender":"female","lang":"ja-JP","remote":true,"voice_name":"Google 日本語"},{"event_types":["start","end","error"],"gender":"female","lang":"ko-KR","remote":true,"voice_name":"Google 한국의"},{"event_types":["start","end","error"],"gender":"female","lang":"nl-NL","remote":true,"voice_name":"Google Nederlands"},{"event_types":["start","end","error"],"gender":"female","lang":"pl-PL","remote":true,"voice_name":"Google polski"},{"event_types":["start","end","error"],"gender":"female","lang":"pt-BR","remote":true,"voice_name":"Google português do Brasil"},{"event_types":["start","end","error"],"gender":"female","lang":"ru-RU","remote":true,"voice_name":"Google русский"},{"event_types":["start","end","error"],"gender":"female","lang":"zh-CN","remote":true,"voice_name":"Google 普通话（中国大陆）"},{"event_types":["start","end","error"],"gender":"female","lang":"zh-HK","remote":true,"voice_name":"Google 粤語（香港）"},{"event_types":["start","end","error"],"gender":"female","lang":"zh-TW","remote":true,"voice_name":"Google 國語（臺灣）"}]},"version":"1.0"},"path":"/Applications/Google Chrome.app/Contents/Frameworks/Google Chrome Framework.framework/Versions/80.0.3987.116/Resources/network_speech_synthesis","preferences":{},"regular_only_preferences":{},"state":1,"was_installed_by_default":false,"was_installed_by_oem":false},"nkeimhogjdpnpccoofpliimaahmaaome":{"active_permissions":{"api":["desktopCapture","processes","webConnectable","webrtcAudioPrivate","webrtcDesktopCapturePrivate","webrtcLoggingPrivate","system.cpu","enterprise.hardwarePlatform"],"manifest_permissions":[]},"commands":{},"content_settings":[],"creation_flags":1,"events":["runtime.onConnectExternal"],"from_bookmark":false,"from_webstore":false,"incognito_content_settings":[],"incognito_preferences":{},"install_time":"13226654677460643","location":5,"manifest":{"background":{"page":"background.html","persistent":false},"externally_connectable":{"matches":["https://*.google.com/*","*://localhost/*"]},"incognito":"split","key":"MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQDAQt2ZDdPfoSe/JI6ID5bgLHRCnCu9T36aYczmhw/tnv6QZB2I6WnOCMZXJZlRdqWc7w9jo4BWhYS50Vb4weMfh/I0On7VcRwJUgfAxW2cHB+EkmtI1v4v/OU24OqIa1Nmv9uRVeX0GjhQukdLNhAE6ACWooaf5kqKlCeK+1GOkQIDAQAB","manifest_version":2,"name":"Google Hangouts","permissions":["desktopCapture","enterprise.hardwarePlatform","processes","system.cpu","webrtcAudioPrivate","webrtcDesktopCapturePrivate","webrtcLoggingPrivate"],"version":"1.3.15"},"path":"/Applications/Google Chrome.app/Contents/Frameworks/Google Chrome Framework.framework/Versions/80.0.3987.116/Resources/hangout_services","preferences":{},"regular_only_preferences":{},"state":1,"was_installed_by_default":false,"was_installed_by_oem":false},"nmmhkkegccagdldgiimedpiccmgmieda":{"ack_external":true,"active_permissions":{"api":["identity","webview"],"explicit_host":["https://payments.google.com/*","https://sandbox.google.com/*","https://www.google.com/*","https://www.googleapis.com/*"],"manifest_permissions":[]},"commands":{},"content_settings":[],"creation_flags":137,"events":["app.runtime.onLaunched","runtime.onConnectExternal"],"from_bookmark":false,"from_webstore":true,"granted_permissions":{"api":["identity","webview"],"explicit_host":["https://payments.google.com/*","https://sandbox.google.com/*","https://www.google.com/*","https://www.googleapis.com/*"],"manifest_permissions":[]},"incognito_content_settings":[],"incognito_preferences":{},"install_time":"13226654687782836","lastpingday":"13226572800714429","location":10,"manifest":{"app":{"background":{"scripts":["craw_background.js"]}},"current_locale":"en_US","default_locale":"en","description":"Chrome Web Store Payments","display_in_launcher":false,"display_in_new_tab_page":false,"icons":{"128":"images/icon_128.png","16":"images/icon_16.png"},"key":"MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQCrKfMnLqViEyokd1wk57FxJtW2XXpGXzIHBzv9vQI/01UsuP0IV5/lj0wx7zJ/xcibUgDeIxobvv9XD+zO1MdjMWuqJFcKuSS4Suqkje6u+pMrTSGOSHq1bmBVh0kpToN8YoJs/P/yrRd7FEtAXTaFTGxQL4C385MeXSjaQfiRiQIDAQAB","manifest_version":2,"minimum_chrome_version":"29","name":"Chrome Web Store Payments","oauth2":{"auto_approve":true,"client_id":"203784468217.apps.googleusercontent.com","scopes":["https://www.googleapis.com/auth/sierra","https://www.googleapis.com/auth/sierrasandbox","https://www.googleapis.com/auth/chromewebstore","https://www.googleapis.com/auth/chromewebstore.readonly"]},"permissions":["identity","webview","https://www.google.com/","https://www.googleapis.com/*","https://payments.google.com/payments/v4/js/integrator.js","https://sandbox.google.com/payments/v4/js/integrator.js"],"update_url":"https://clients2.google.com/service/update2/crx","version":"1.0.0.5"},"path":"nmmhkkegccagdldgiimedpiccmgmieda/1.0.0.5_0","preferences":{},"regular_only_preferences":{},"running":false,"state":1,"was_installed_by_default":true,"was_installed_by_oem":false},"pjkljhegncpnkpknbcohdijeoejaedia":{"ack_external":true,"active_permissions":{"api":["notifications"],"manifest_permissions":[]},"app_launcher_ordinal":"z","commands":{},"content_settings":[],"creation_flags":137,"events":[],"from_bookmark":false,"from_webstore":true,"granted_permissions":{"api":["notifications"],"manifest_permissions":[]},"incognito_content_settings":[],"incognito_preferences":{},"install_time":"13226654685955490","lastpingday":"13226572800714429","location":1,"manifest":{"app":{"launch":{"container":"tab","web_url":"https://mail.google.com/mail"},"urls":["*://mail.google.com/mail"]},"current_locale":"en_US","default_locale":"en","description":"Fast, searchable email with less spam.","icons":{"128":"128.png"},"key":"MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQDCuGglK43iAz3J9BEYK/Mz6ZhloIMMDqQSAaf3vJt4eHbTbSDsu4WdQ9dQDRcKlg8nwQdePBt0C3PSUBtiSNSS37Z3qEGfS7LCju3h6pI1Yr9MQtxw+jUa7kXXIS09VV73pEFUT/F7c6Qe8L5ZxgAcBvXBh1Fie63qb02I9XQ/CQIDAQAB","manifest_version":2,"name":"Gmail","options_page":"https://mail.google.com/mail/#settings","permissions":["notifications"],"update_url":"https://clients2.google.com/service/update2/crx","version":"8.2"},"page_ordinal":"n","path":"pjkljhegncpnkpknbcohdijeoejaedia/8.2_0","preferences":{},"regular_only_preferences":{},"state":1,"was_installed_by_default":true,"was_installed_by_oem":false},"pkedcjkdefgpdelpbcmbmeomcjbeemfm":{"ack_external":true,"active_permissions":{"api":["alarms","cast","cast.streaming","desktopCapture","gcm","identity","identity.email","management","mediaRouterPrivate","metricsPrivate","mdns","networkingPrivate","settingsPrivate","storage","tabs","tabCapture","webConnectable","webview","system.cpu"],"explicit_host":["http://*/*","https://*.google.com/*","https://hangouts.google.com/*"],"manifest_permissions":[]},"commands":{},"content_settings":[],"creation_flags":137,"events":["cast.channel.onError","cast.channel.onMessage","gcm.onMessage","identity.onSignInChanged","runtime.onStartup","runtime.onSuspend","settingsPrivate.onPrefsChanged"],"from_bookmark":false,"from_webstore":true,"granted_permissions":{"api":["alarms","cast","cast.streaming","desktopCapture","gcm","identity","identity.email","management","mediaRouterPrivate","metricsPrivate","mdns","networkingPrivate","settingsPrivate","storage","tabs","tabCapture","webConnectable","webview","system.cpu"],"explicit_host":["http://*/*","https://*.google.com/*","https://hangouts.google.com/*"],"manifest_permissions":[]},"incognito_content_settings":[],"incognito_preferences":{},"install_time":"13226654685697229","lastpingday":"13226572800714429","location":10,"manifest":{"background":{"persistent":false,"scripts":["common.js","mirroring_common.js","background_script.js"]},"content_security_policy":"default-src 'self'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; script-src 'self' https://apis.google.com https://feedback.googleusercontent.com https://www.google.com https://www.gstatic.com; child-src https://accounts.google.com https://content.googleapis.com https://www.google.com; connect-src 'self' http://*:* https://*:*; font-src https://fonts.gstatic.com; object-src 'self';","current_locale":"en_US","default_locale":"en","description":"Provider for discovery and services for mirroring of Chrome Media Router","externally_connectable":{"ids":["idmofbkcelhplfjnmmdolenpigiiiecc","ggedfkijiiammpnbdadhllnehapomdge","njjegkblellcjnakomndbaloifhcoccg"],"matches":["https://www.google.com/chromecast/*"]},"key":"MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQDNTWJoPZ9bT32yKxuuVa9LSEYobjPoXCLX3dgsZ9djDrWKNikTECjdRe3/AFXb+v8jkmmtYQPnOgSYn06J/QodDlCIG6l470+gkOoobUM7fOs1AVOse23qYUV4jbuRW3+YZlCvaWCFeczCNbGIUgKEi5B2fyQazy60AL1sLW3utQIDAQAB","manifest_version":2,"minimum_chrome_version":"37","name":"Chrome Media Router","oauth2":{"client_id":"919648714761-55j965o0km033psv3i9qls5mo3qtdrb0.apps.googleusercontent.com","scopes":["https://www.googleapis.com/auth/calendar.readonly","https://www.googleapis.com/auth/clouddevices","https://www.googleapis.com/auth/hangouts","https://www.googleapis.com/auth/hangouts.readonly","https://www.googleapis.com/auth/meetings","https://www.googleapis.com/auth/userinfo.email","https://www.googleapis.com/auth/cast-edu-messaging","https://www.googleapis.com/auth/plus.peopleapi.readwrite"]},"permissions":["alarms","cast","cast.streaming","declarativeWebRequest","desktopCapture","gcm","http://*/*","identity","identity.email","management","mdns","mediaRouterPrivate","metricsPrivate","networkingPrivate","processes","storage","system.cpu","settingsPrivate","tabCapture","tabs","webview","https://hangouts.google.com/*","https://*.google.com/cast/chromecast/home/gsse"],"update_url":"https://clients2.google.com/service/update2/crx","version":"8019.1111.0.0","web_accessible_resources":["cast_sender.js","cast_setup/*"]},"path":"pkedcjkdefgpdelpbcmbmeomcjbeemfm/8019.1111.0.0_0","preferences":{},"regular_only_preferences":{},"state":1,"was_installed_by_default":true,"was_installed_by_oem":false}}},"pinned_tabs":[],"protection":{"macs":{"browser":{"show_home_button":"B5EB34D9942F82A8AF68B991862F58F5A39251521C53E159FD5D1CB709BDF873"},"default_search_provider_data":{"template_url_data":"91DF3328DE1FEE92B3ABC654E70213225DAD1FB5E601A7BC139F808F2E34EB89"},"extensions":{"settings":{"aapocclcgogkmnckokdopfmhonfmgoek":"D1752F1ADB7DBA8B0FA550EB880B35AC42CCBCDA1B93A252F36D41130CCEEBA1","aeblfdkhhhdcdjpifhhbdiojplfjncoa":"43EFE888DDCBA9F0422E020E0DDC65A12282916DB73446EA37091D604537ADC1","aghfnjkcakhmadgdomlmlhhaocbkloab":"5FA548F25083441B74DFCF815867D24AC4B980053F0B2D414C650CBB671DA9BA","ahfgeienlihckogmohjhadlkjgocpleb":"5B019B0552263FDACB193F3AB2595D8B1F4173E0C49EBAB39C7A81197B9C7C13","aohghmighlieiainnegkcijnfilokake":"5930281902DD798ED1E908158D024F445C443D4ABA6E4D0C6F324036DFEDEA20","apdfllckaahabafndbhieahigkjlhalf":"CC185D9F762CEE0F1238B7AD4E7B4FF5881B6B595EF4CBC004DB6040DF32448D","blpcfgokakmgnkcojhhkbfbldkacnbeo":"28FF269C1003D2B826DDFEC6CB724C53251B7AC710900FACC8BAC4BFFE06D16C","felcaaldnbdncclmgdcncolpebgiejap":"E272BF994E54309694C6C9D311004E28B131FDF6FD7403E81DEFB37AA718D408","gfdkimpbcpahaombhbimeihdjnejgicl":"95341B6911D2DA6CBF30BB3554130A3763533B0B2056B9E8C16803CE4817508D","ghbmnnjooekpmoecnnnilnnbdlolhkhi":"1E64113E7CF14C1635A54218E301D30AF34590CF38490A7082CD5C0BE3C6061A","jldhpllghnbhlbpcmnajkpdmadaolakh":"7F0599476560A25894A7B046D8E76499EEDFD7A47DA19FF2722177F33B038B48","kmendfapggjehodndflmmgagdbamhnfd":"3FD3A074B3DEEC7465461884838463DA7967A540BD6C0BCE9F8356C9ECB27290","mfehgcgbbipciphmccgaenjidiccnmng":"997BD8BEA32AA61BF7BD8DB08C46D6B9D52B4BCEC93B9D321EDB5824770BFBEC","mhjfbmdgcfjbbpaeojofohoefgiehjai":"E58D38C4C2DC691934A15C36F72A051EB1E8BCB3C20269DC3DBE89AD58468CC9","neajdppkdcdipfabeoofebfddakdcjhd":"562538760D62A89E85210B930CF21FEDCC7DE041CB690B94578D8E11FCC58509","nkeimhogjdpnpccoofpliimaahmaaome":"D9837DD307B786922A67E5F09DE71B8163D8A3532DECB18639C84AE1DB0190FB","nmmhkkegccagdldgiimedpiccmgmieda":"4F7A96E4A6E4175ADE844F177CE929685CDA1D2A0956B9059849D71C075DCA81","pjkljhegncpnkpknbcohdijeoejaedia":"B110CABEAA67157C899465DAEA502BC10246FFC370624E711F9E4196C1FA8D4C","pkedcjkdefgpdelpbcmbmeomcjbeemfm":"84ED0D82AFB7ADD4B01C9CDFA62F25C34E330D98278AF62D4A9C2DE33C8EE788"}},"google":{"services":{"account_id":"53AB201B83B1C65823ECBF18EA758EBAE73CA766CC48B16E5BEC293CBDAC99D2","last_account_id":"F873A6B5855FC7B13E62BA3389654CB6235D4EA9FC11819ECBD1FBB3ACB72568","last_username":"A709F31CDDC4F95F8282AD3A724840A7A974B21EA07268650F52B305AD49CCF0"}},"homepage":"298FFD7268FD73FFDF466BBD2D9679822CF47E365F414D73DE95CF7C273B2769","homepage_is_newtabpage":"B5038F43EFD47FBC80C011499960458BF11DEBC2914017654987D6AA90B149FA","media":{"storage_id_salt":"17ABE5A224C6BB4EFFC00878EB3FAE3471E52FE7B028D27BD6CFF028D393E87B"},"pinned_tabs":"0668B53A1CF88AE3A618EBF480391FF63B7E3A1AE97A337B1DEDE5152F2F40B9","prefs":{"preference_reset_time":"4E54DAE953E6D59540B3F8A2BD5B52BF754814D84B6D1CFF78C6111D7C8DF1A4"},"safebrowsing":{"incidents_sent":"6ED043F7F75C6798BC00FD4E71F59F7F79225B7C349997EA33AAD18CF43B3061"},"search_provider_overrides":"3AE81F3E908BFD62166EC420891095D3078B106BEB02FFDEDE4AAA9554596CF9","session":{"restore_on_startup":"AED0EFEA1F0E02AF44F9F0656D395A765FA1FEF19DADBD158052A8918E1CB884","startup_urls":"70E6A80ED32C26F1609C53173B9143749776190103D06779E499D3FD42C17195"}},"super_mac":"DC1D234E854754C0422B23D3C3F565F266C5E9E145B6603010AAB918827BB79F"}}
+{
+    "extensions":
+    {
+        "settings":
+        {
+            "aapocclcgogkmnckokdopfmhonfmgoek":
+            {
+                "ack_external": true,
+                "active_permissions":
+                {
+                    "api":
+                    [],
+                    "manifest_permissions":
+                    []
+                },
+                "app_launcher_ordinal": "w",
+                "commands":
+                {},
+                "content_settings":
+                [],
+                "creation_flags": 137,
+                "events":
+                [],
+                "from_bookmark": false,
+                "from_webstore": true,
+                "granted_permissions":
+                {
+                    "api":
+                    [],
+                    "manifest_permissions":
+                    []
+                },
+                "incognito_content_settings":
+                [],
+                "incognito_preferences":
+                {},
+                "install_time": "13226654686468813",
+                "lastpingday": "13226572800714429",
+                "location": 1,
+                "manifest":
+                {
+                    "api_console_project_id": "889782162350",
+                    "app":
+                    {
+                        "launch":
+                        {
+                            "local_path": "main.html"
+                        }
+                    },
+                    "container": "GOOGLE_DRIVE",
+                    "current_locale": "en_US",
+                    "default_locale": "en_US",
+                    "description": "Create and edit presentations ",
+                    "icons":
+                    {
+                        "128": "icon_128.png",
+                        "16": "icon_16.png"
+                    },
+                    "key": "MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQDLOGW2Hoztw8m2z6SmCjm7y4Oe2o6aRqO+niYKCXhZab572by7acqFIFF0On3e3a967SwNijsTx2n+7Mt3KqWzEKtnwUZqzHYSsdZZK64vWIHIduawP0EICWRMf2RGIBEdDC6I1zErtcDiSrJWeRlnb0DHWXDXlt1YseM7RiON9wIDAQAB",
+                    "manifest_version": 2,
+                    "name": "Slides",
+                    "offline_enabled": true,
+                    "update_url": "https://clients2.google.com/service/update2/crx",
+                    "version": "0.10"
+                },
+                "page_ordinal": "n",
+                "path": "aapocclcgogkmnckokdopfmhonfmgoek/0.10_1",
+                "preferences":
+                {},
+                "regular_only_preferences":
+                {},
+                "state": 1,
+                "was_installed_by_default": true,
+                "was_installed_by_oem": false,
+                "withholding_permissions": false
+            },
+            "aghfnjkcakhmadgdomlmlhhaocbkloab":
+            {
+                "active_permissions":
+                {
+                    "api":
+                    [],
+                    "manifest_permissions":
+                    []
+                },
+                "commands":
+                {},
+                "content_settings":
+                [],
+                "creation_flags": 9,
+                "events":
+                [],
+                "from_bookmark": false,
+                "from_webstore": true,
+                "granted_permissions":
+                {
+                    "api":
+                    [],
+                    "manifest_permissions":
+                    []
+                },
+                "incognito_content_settings":
+                [],
+                "incognito_preferences":
+                {},
+                "install_time": "13226654710521941",
+                "location": 1,
+                "manifest":
+                {
+                    "description": "Just Black: when you're feeling extra moody",
+                    "key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAqxThvdYeWk6kwfNo+/HoqQSkL6iBx48w28vEPXHdhJo8OHMxS7D+1W1nhUsv4hOnb1CM2TlP/Nh9G+1Z32R9r6RmVxD1Anq9ZTZpK7VHVUxExGR4X9+TYHKWk8VGAjSBmutvayf0i0gCEkh7Pdc68ex4M0ypKGFWxBzxqw2uQ/4BLMVB/9KZJwXOC5LcaBNgq2Q74J3Dd3a90OzFXh+vC9zIyDueu3/K4F6u5bXgsgviAGIrUm7YbGhLDMxuW81zvYMlLtkA4XDDnhgk88s0G/5OwoMEyU6YdMq9R795NHsI0bPUMOOgUsPT5cytKRcQMegMassBe9EB+ktTl9CloQIDAQAB",
+                    "manifest_version": 2,
+                    "name": "Just Black",
+                    "theme":
+                    {
+                        "colors":
+                        {
+                            "bookmark_text":
+                            [
+                                255,
+                                255,
+                                255
+                            ],
+                            "frame":
+                            [
+                                0,
+                                0,
+                                0
+                            ],
+                            "ntp_background":
+                            [
+                                0,
+                                0,
+                                0
+                            ],
+                            "ntp_text":
+                            [
+                                125,
+                                134,
+                                142
+                            ],
+                            "tab_background_text":
+                            [
+                                255,
+                                255,
+                                255
+                            ],
+                            "tab_background_text_inactive":
+                            [
+                                255,
+                                255,
+                                255
+                            ],
+                            "tab_background_text_incognito":
+                            [
+                                255,
+                                255,
+                                255
+                            ],
+                            "tab_background_text_incognito_inactive":
+                            [
+                                255,
+                                255,
+                                255
+                            ],
+                            "tab_text":
+                            [
+                                255,
+                                255,
+                                255
+                            ],
+                            "toolbar":
+                            [
+                                45,
+                                45,
+                                45
+                            ]
+                        },
+                        "tints":
+                        {
+                            "buttons":
+                            [
+                                0.2,
+                                0.2,
+                                0.9
+                            ],
+                            "frame_inactive":
+                            [
+                                -1,
+                                -1,
+                                -1
+                            ],
+                            "frame_incognito":
+                            [
+                                -1,
+                                -1,
+                                -1
+                            ],
+                            "frame_incognito_inactive":
+                            [
+                                -1,
+                                -1,
+                                -1
+                            ]
+                        }
+                    },
+                    "update_url": "https://clients2.google.com/service/update2/crx",
+                    "version": "2"
+                },
+                "path": "aghfnjkcakhmadgdomlmlhhaocbkloab/2_0",
+                "preferences":
+                {},
+                "regular_only_preferences":
+                {},
+                "state": 1,
+                "was_installed_by_default": false,
+                "was_installed_by_oem": false
+            },
+            "ahfgeienlihckogmohjhadlkjgocpleb":
+            {
+                "active_bit": true,
+                "active_permissions":
+                {
+                    "api":
+                    [
+                        "management",
+                        "system.display",
+                        "system.storage",
+                        "webstorePrivate",
+                        "system.cpu",
+                        "system.memory",
+                        "system.network"
+                    ],
+                    "manifest_permissions":
+                    []
+                },
+                "app_launcher_ordinal": "t",
+                "commands":
+                {},
+                "content_settings":
+                [],
+                "creation_flags": 1,
+                "events":
+                [],
+                "from_bookmark": false,
+                "from_webstore": false,
+                "incognito_content_settings":
+                [],
+                "incognito_preferences":
+                {},
+                "install_time": "13226654677459804",
+                "last_launch_time": "13226654699036269",
+                "location": 5,
+                "manifest":
+                {
+                    "app":
+                    {
+                        "launch":
+                        {
+                            "web_url": "https://chrome.google.com/webstore"
+                        },
+                        "urls":
+                        [
+                            "https://chrome.google.com/webstore"
+                        ]
+                    },
+                    "description": "Discover great apps, games, extensions and themes for Google Chrome.",
+                    "icons":
+                    {
+                        "128": "webstore_icon_128.png",
+                        "16": "webstore_icon_16.png"
+                    },
+                    "key": "MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQCtl3tO0osjuzRsf6xtD2SKxPlTfuoy7AWoObysitBPvH5fE1NaAA1/2JkPWkVDhdLBWLaIBPYeXbzlHp3y4Vv/4XG+aN5qFE3z+1RU/NqkzVYHtIpVScf3DjTYtKVL66mzVGijSoAIwbFCC3LpGdaoe6Q1rSRDp76wR6jjFzsYwQIDAQAB",
+                    "name": "Web Store",
+                    "permissions":
+                    [
+                        "webstorePrivate",
+                        "management",
+                        "system.cpu",
+                        "system.display",
+                        "system.memory",
+                        "system.network",
+                        "system.storage"
+                    ],
+                    "version": "0.2"
+                },
+                "needs_sync": true,
+                "page_ordinal": "n",
+                "path": "/Applications/Google Chrome.app/Contents/Frameworks/Google Chrome Framework.framework/Versions/80.0.3987.116/Resources/web_store",
+                "preferences":
+                {},
+                "regular_only_preferences":
+                {},
+                "state": 1,
+                "was_installed_by_default": false,
+                "was_installed_by_oem": false
+            },
+            "aohghmighlieiainnegkcijnfilokake":
+            {
+                "ack_external": true,
+                "active_permissions":
+                {
+                    "api":
+                    [],
+                    "manifest_permissions":
+                    []
+                },
+                "app_launcher_ordinal": "x",
+                "commands":
+                {},
+                "content_settings":
+                [],
+                "creation_flags": 137,
+                "events":
+                [],
+                "from_bookmark": false,
+                "from_webstore": true,
+                "granted_permissions":
+                {
+                    "api":
+                    [],
+                    "manifest_permissions":
+                    []
+                },
+                "incognito_content_settings":
+                [],
+                "incognito_preferences":
+                {},
+                "install_time": "13226654686203610",
+                "lastpingday": "13226572800714429",
+                "location": 1,
+                "manifest":
+                {
+                    "api_console_project_id": "619683526622",
+                    "app":
+                    {
+                        "launch":
+                        {
+                            "local_path": "main.html"
+                        }
+                    },
+                    "container": "GOOGLE_DRIVE",
+                    "current_locale": "en_US",
+                    "default_locale": "en_US",
+                    "description": "Create and edit documents ",
+                    "icons":
+                    {
+                        "128": "icon_128.png",
+                        "16": "icon_16.png"
+                    },
+                    "key": "MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQDJhLK6fk/BWTEvJhywpk7jDe4A2r0bGXGOLZW4/AdBp3IiD9o9nx4YjLAtv0tIPxi7MvFd/GUUbQBwHT5wQWONJj1z/0Rc2qBkiJA0yqXh42p0snuA8dCfdlhOLsp7/XTMEwAVasjV5hC4awl78eKfJYlZ+8fM/UldLWJ/51iBQwIDAQAB",
+                    "manifest_version": 2,
+                    "name": "Docs",
+                    "offline_enabled": true,
+                    "update_url": "https://clients2.google.com/service/update2/crx",
+                    "version": "0.10"
+                },
+                "page_ordinal": "n",
+                "path": "aohghmighlieiainnegkcijnfilokake/0.10_1",
+                "preferences":
+                {},
+                "regular_only_preferences":
+                {},
+                "state": 1,
+                "was_installed_by_default": true,
+                "was_installed_by_oem": false,
+                "withholding_permissions": false
+            },
+            "apdfllckaahabafndbhieahigkjlhalf":
+            {
+                "ack_external": true,
+                "active_permissions":
+                {
+                    "api":
+                    [
+                        "clipboardRead",
+                        "clipboardWrite",
+                        "notifications"
+                    ],
+                    "manifest_permissions":
+                    []
+                },
+                "app_launcher_ordinal": "y",
+                "commands":
+                {},
+                "content_settings":
+                [],
+                "creation_flags": 137,
+                "events":
+                [],
+                "from_bookmark": false,
+                "from_webstore": true,
+                "granted_permissions":
+                {
+                    "api":
+                    [
+                        "clipboardRead",
+                        "clipboardWrite",
+                        "notifications"
+                    ],
+                    "manifest_permissions":
+                    []
+                },
+                "incognito_content_settings":
+                [],
+                "incognito_preferences":
+                {},
+                "install_time": "13226654683295429",
+                "lastpingday": "13226572800714429",
+                "location": 1,
+                "manifest":
+                {
+                    "app":
+                    {
+                        "launch":
+                        {
+                            "web_url": "https://drive.google.com/?usp=chrome_app"
+                        },
+                        "urls":
+                        [
+                            "http://docs.google.com/",
+                            "http://drive.google.com/",
+                            "https://docs.google.com/",
+                            "https://drive.google.com/"
+                        ]
+                    },
+                    "background":
+                    {
+                        "allow_js_access": false
+                    },
+                    "current_locale": "en_US",
+                    "default_locale": "en_US",
+                    "description": "Google Drive: create, share and keep all your stuff in one place.",
+                    "icons":
+                    {
+                        "128": "128.png"
+                    },
+                    "key": "MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQDIl5KlKwL2TSkntkpY3naLLz5jsN0YwjhZyObcTOK6Nda4Ie21KRqZau9lx5SHcLh7pE2/S9OiArb+na2dn7YK5EvH+aRXS1ec3uxVlBhqLdnleVgwgwlg5fH95I52IeHcoeK6pR4hW/Nv39GNlI/Uqk6O6GBCCsAxYrdxww9BiQIDAQAB",
+                    "manifest_version": 2,
+                    "name": "Google Drive",
+                    "offline_enabled": true,
+                    "options_page": "https://drive.google.com/drive/settings",
+                    "permissions":
+                    [
+                        "clipboardRead",
+                        "clipboardWrite",
+                        "notifications"
+                    ],
+                    "update_url": "https://clients2.google.com/service/update2/crx",
+                    "version": "14.2"
+                },
+                "page_ordinal": "n",
+                "path": "apdfllckaahabafndbhieahigkjlhalf/14.2_0",
+                "preferences":
+                {},
+                "regular_only_preferences":
+                {},
+                "state": 1,
+                "was_installed_by_default": true,
+                "was_installed_by_oem": false
+            },
+            "blpcfgokakmgnkcojhhkbfbldkacnbeo":
+            {
+                "ack_external": true,
+                "active_permissions":
+                {
+                    "api":
+                    [],
+                    "manifest_permissions":
+                    []
+                },
+                "app_launcher_ordinal": "zm",
+                "commands":
+                {},
+                "content_settings":
+                [],
+                "creation_flags": 153,
+                "events":
+                [],
+                "from_bookmark": true,
+                "from_webstore": true,
+                "granted_permissions":
+                {
+                    "api":
+                    [],
+                    "manifest_permissions":
+                    []
+                },
+                "incognito_content_settings":
+                [],
+                "incognito_preferences":
+                {},
+                "install_time": "13226654688489301",
+                "lastpingday": "13226572800714429",
+                "location": 1,
+                "manifest":
+                {
+                    "app":
+                    {
+                        "launch":
+                        {
+                            "container": "tab",
+                            "web_url": "http://www.youtube.com"
+                        },
+                        "web_content":
+                        {
+                            "enabled": true,
+                            "origin": "http://www.youtube.com"
+                        }
+                    },
+                    "current_locale": "en_US",
+                    "default_locale": "en",
+                    "description": "",
+                    "icons":
+                    {
+                        "128": "128.png"
+                    },
+                    "key": "MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQDC/HotmFlyuz5FaHaIbVBhhL4BwbcUtsfWwzgUMpZt5ZsLB2nW/Y5xwNkkPANYGdVsJkT2GPpRRIKBO5QiJ7jPMa3EZtcZHpkygBlQLSjMhdrAKevpKgIl6YTkwzNvExY6rzVDzeE9zqnIs33eppY4S5QcoALMxuSWlMKqgFQjHQIDAQAB",
+                    "manifest_version": 2,
+                    "name": "YouTube",
+                    "update_url": "http://clients2.google.com/service/update2/crx",
+                    "version": "4.2.8"
+                },
+                "page_ordinal": "n",
+                "path": "blpcfgokakmgnkcojhhkbfbldkacnbeo/4.2.8_0",
+                "preferences":
+                {},
+                "regular_only_preferences":
+                {},
+                "state": 1,
+                "was_installed_by_default": true,
+                "was_installed_by_oem": false
+            },
+            "felcaaldnbdncclmgdcncolpebgiejap":
+            {
+                "ack_external": true,
+                "active_permissions":
+                {
+                    "api":
+                    [],
+                    "manifest_permissions":
+                    []
+                },
+                "app_launcher_ordinal": "yn",
+                "commands":
+                {},
+                "content_settings":
+                [],
+                "creation_flags": 137,
+                "events":
+                [],
+                "from_bookmark": false,
+                "from_webstore": true,
+                "granted_permissions":
+                {
+                    "api":
+                    [],
+                    "manifest_permissions":
+                    []
+                },
+                "incognito_content_settings":
+                [],
+                "incognito_preferences":
+                {},
+                "install_time": "13226654683544785",
+                "lastpingday": "13226572800714429",
+                "location": 1,
+                "manifest":
+                {
+                    "api_console_project_id": "1083656409722",
+                    "app":
+                    {
+                        "launch":
+                        {
+                            "local_path": "main.html"
+                        }
+                    },
+                    "container": "GOOGLE_DRIVE",
+                    "current_locale": "en_US",
+                    "default_locale": "en_US",
+                    "description": "Create and edit spreadsheets",
+                    "icons":
+                    {
+                        "128": "icon_128.png",
+                        "16": "icon_16.png"
+                    },
+                    "key": "MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQC0AHrkP4MHPDKQI/O9LqZjtM24hKApaT3uVHeOduC06ZXWuwVRvx2wy5JUmMHfefXRG26tErgZSWpbxkm+2xfplKnT+grXF771HDgsNrNXERJHq7tnoYsWRiG3Gbs5BI4Ei+naZ/nyiWblbT4GyuD9N5yXNtoM0AnK+0FYhbO7IwIDAQAB",
+                    "manifest_version": 2,
+                    "name": "Sheets",
+                    "offline_enabled": true,
+                    "update_url": "https://clients2.google.com/service/update2/crx",
+                    "version": "1.2"
+                },
+                "page_ordinal": "n",
+                "path": "felcaaldnbdncclmgdcncolpebgiejap/1.2_0",
+                "preferences":
+                {},
+                "regular_only_preferences":
+                {},
+                "state": 1,
+                "was_installed_by_default": true,
+                "was_installed_by_oem": false,
+                "withholding_permissions": false
+            },
+            "gfdkimpbcpahaombhbimeihdjnejgicl":
+            {
+                "active_permissions":
+                {
+                    "api":
+                    [
+                        "feedbackPrivate"
+                    ],
+                    "explicit_host":
+                    [
+                        "chrome://resources/*"
+                    ],
+                    "manifest_permissions":
+                    []
+                },
+                "commands":
+                {},
+                "content_settings":
+                [],
+                "creation_flags": 1,
+                "events":
+                [
+                    "feedbackPrivate.onFeedbackRequested"
+                ],
+                "from_bookmark": false,
+                "from_webstore": false,
+                "incognito_content_settings":
+                [],
+                "incognito_preferences":
+                {},
+                "install_time": "13226654677461190",
+                "location": 5,
+                "manifest":
+                {
+                    "app":
+                    {
+                        "background":
+                        {
+                            "scripts":
+                            [
+                                "js/event_handler.js"
+                            ]
+                        },
+                        "content_security_policy": "default-src 'none'; script-src 'self' blob: filesystem: chrome://resources; style-src 'unsafe-inline' blob: chrome: file: filesystem: data: *; img-src * blob: chrome: file: filesystem: data:; media-src 'self' blob: filesystem:"
+                    },
+                    "description": "User feedback extension",
+                    "display_in_launcher": false,
+                    "display_in_new_tab_page": false,
+                    "icons":
+                    {
+                        "192": "images/icon192.png",
+                        "48": "images/icon48.png"
+                    },
+                    "incognito": "split",
+                    "key": "MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQDMZElzFX2J1g1nRQ/8S3rg/1CjFyDltWOxQg+9M8aVgNVxbutEWFQz+oQzIP9BB67mJifULgiv12ToFKsae4NpEUR8sPZjiKDIHumc6pUdixOm8SJ5Rs16SMR6+VYxFUjlVW+5CA3IILptmNBxgpfyqoK0qRpBDIhGk1KDEZ4zqQIDAQAB",
+                    "manifest_version": 2,
+                    "name": "Feedback",
+                    "permissions":
+                    [
+                        "feedbackPrivate",
+                        "chrome://resources/"
+                    ],
+                    "version": "1.0"
+                },
+                "path": "/Applications/Google Chrome.app/Contents/Frameworks/Google Chrome Framework.framework/Versions/80.0.3987.116/Resources/feedback",
+                "preferences":
+                {},
+                "regular_only_preferences":
+                {},
+                "running": false,
+                "state": 1,
+                "was_installed_by_default": false,
+                "was_installed_by_oem": false
+            },
+            "ghbmnnjooekpmoecnnnilnnbdlolhkhi":
+            {
+                "ack_external": true,
+                "active_permissions":
+                {
+                    "api":
+                    [
+                        "alarms",
+                        "clipboardRead",
+                        "clipboardWrite",
+                        "identity",
+                        "power",
+                        "storage",
+                        "unlimitedStorage",
+                        "webConnectable"
+                    ],
+                    "manifest_permissions":
+                    []
+                },
+                "commands":
+                {},
+                "content_settings":
+                [],
+                "creation_flags": 137,
+                "events":
+                [
+                    "alarms.onAlarm",
+                    "runtime.onConnectExternal"
+                ],
+                "from_bookmark": false,
+                "from_webstore": true,
+                "granted_permissions":
+                {
+                    "api":
+                    [
+                        "alarms",
+                        "clipboardRead",
+                        "clipboardWrite",
+                        "identity",
+                        "power",
+                        "storage",
+                        "unlimitedStorage",
+                        "webConnectable"
+                    ],
+                    "manifest_permissions":
+                    []
+                },
+                "incognito_content_settings":
+                [],
+                "incognito_preferences":
+                {},
+                "install_time": "13226654688233906",
+                "lastpingday": "13226572800714429",
+                "location": 1,
+                "manifest":
+                {
+                    "background":
+                    {
+                        "persistent": false,
+                        "scripts":
+                        [
+                            "eventpage_bin_prod.js"
+                        ]
+                    },
+                    "content_capabilities":
+                    {
+                        "matches":
+                        [
+                            "https://docs.google.com/*",
+                            "https://drive.google.com/*"
+                        ],
+                        "permissions":
+                        [
+                            "clipboardRead",
+                            "clipboardWrite",
+                            "unlimitedStorage"
+                        ]
+                    },
+                    "content_security_policy": "script-src 'self'; object-src 'self'",
+                    "current_locale": "en_US",
+                    "default_locale": "en_US",
+                    "description": "Edit, create, and view your documents, spreadsheets, and presentations — all without internet access.",
+                    "externally_connectable":
+                    {
+                        "matches":
+                        [
+                            "https://docs.google.com/*",
+                            "https://drive.google.com/*"
+                        ]
+                    },
+                    "icons":
+                    {
+                        "128": "128.png"
+                    },
+                    "key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAnF7RGLAxIon0/XeNZ4MLdP3DMkoORzEAKVg0sb89JpA/W2osTHr91Wqwdc9lW0mFcSpCYS9Y3e7cUMFo/M2ETASIuZncMiUzX2/0rrWtGQ3UuEj3KSe5PdaVZfisyJw/FebvHwirEWrhqcgzVUj9fL9YjE0G45d1zMKcc1umKvLqPyTznNuKBZ9GJREdGLRJCBmUgCkI8iwtwC+QZTUppmaD50/ksnEUXv+QkgGN07/KoNA5oAgo49Jf1XBoMv4QXtVZQlBYZl84zAsI82hb63a6Gu29U/4qMWDdI7+3Ne5TRvo6Zi3EI4M2NQNplJhik105qrz+eTLJJxvf4slrWwIDAQAB",
+                    "manifest_version": 2,
+                    "minimum_chrome_version": "43",
+                    "name": "Google Docs Offline",
+                    "permissions":
+                    [
+                        "alarms",
+                        "clipboardRead",
+                        "clipboardWrite",
+                        "identity",
+                        "power",
+                        "storage",
+                        "unlimitedStorage"
+                    ],
+                    "storage":
+                    {
+                        "managed_schema": "dasherSettingSchema.json"
+                    },
+                    "update_url": "https://clients2.google.com/service/update2/crx",
+                    "version": "1.9",
+                    "web_accessible_resources":
+                    [
+                        "page_embed_script.js"
+                    ]
+                },
+                "path": "ghbmnnjooekpmoecnnnilnnbdlolhkhi/1.9_0",
+                "preferences":
+                {},
+                "regular_only_preferences":
+                {},
+                "state": 1,
+                "was_installed_by_default": true,
+                "was_installed_by_oem": false,
+                "withholding_permissions": false
+            },
+            "jldhpllghnbhlbpcmnajkpdmadaolakh":
+            {
+                "active_permissions":
+                {
+                    "api":
+                    [
+                        "background",
+                        "contextMenus",
+                        "notifications",
+                        "storage",
+                        "tabs"
+                    ],
+                    "explicit_host":
+                    [
+                        "http://*.todoist.com/*",
+                        "https://*.todoist.com/*"
+                    ],
+                    "manifest_permissions":
+                    [],
+                    "scriptable_host":
+                    [
+                        "http://*.todoist.com/*",
+                        "https://*.todoist.com/*"
+                    ]
+                },
+                "commands":
+                {},
+                "content_settings":
+                [],
+                "creation_flags": 9,
+                "events":
+                [],
+                "from_bookmark": false,
+                "from_webstore": true,
+                "granted_permissions":
+                {
+                    "api":
+                    [
+                        "background",
+                        "contextMenus",
+                        "notifications",
+                        "storage",
+                        "tabs"
+                    ],
+                    "explicit_host":
+                    [
+                        "http://*.todoist.com/*",
+                        "https://*.todoist.com/*"
+                    ],
+                    "manifest_permissions":
+                    [],
+                    "scriptable_host":
+                    [
+                        "http://*.todoist.com/*",
+                        "https://*.todoist.com/*"
+                    ]
+                },
+                "incognito_content_settings":
+                [],
+                "incognito_preferences":
+                {},
+                "install_time": "13226654774154919",
+                "location": 1,
+                "manifest":
+                {
+                    "background":
+                    {
+                        "page": "background.html"
+                    },
+                    "browser_action":
+                    {
+                        "default_icon": "todoist_256.png",
+                        "default_popup": "popup.html",
+                        "default_title": "Todoist"
+                    },
+                    "content_scripts":
+                    [
+                        {
+                            "all_frames": true,
+                            "js":
+                            [
+                                "counter_update.js"
+                            ],
+                            "matches":
+                            [
+                                "http://*.todoist.com/*",
+                                "https://*.todoist.com/*"
+                            ]
+                        }
+                    ],
+                    "current_locale": "en_US",
+                    "default_locale": "en",
+                    "description": "Organize work and life with Todoist for Chrome",
+                    "icons":
+                    {
+                        "128": "todoist_128.png",
+                        "16": "todoist_16.png",
+                        "256": "todoist_256.png",
+                        "48": "todoist_48.png",
+                        "512": "todoist_512.png"
+                    },
+                    "key": "MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQCj5g40koD1nY0wP+LG19C2ACvjUv8oWurwruLWpDJn88qpiIRDHGBVG029Sh0q4tUmeTBhCWk7kJ6JNJ6P3iRrYZfGlJs1sb9oJdqQsmWiS3ziQHvSl3OyYT7a2hdZKi0cs0iKtrO318CS5uGGBW5EkW3oY7T12nblQgKo6PGc5QIDAQAB",
+                    "manifest_version": 2,
+                    "name": "Todoist for Chrome",
+                    "options_ui":
+                    {
+                        "open_in_tab": false,
+                        "page": "options.html"
+                    },
+                    "permissions":
+                    [
+                        "storage",
+                        "tabs",
+                        "background",
+                        "contextMenus",
+                        "notifications",
+                        "http://*.todoist.com/*",
+                        "https://*.todoist.com/*"
+                    ],
+                    "short_name": "Todoist",
+                    "update_url": "https://clients2.google.com/service/update2/crx",
+                    "version": "9.9"
+                },
+                "needs_sync": true,
+                "path": "jldhpllghnbhlbpcmnajkpdmadaolakh/9.9_0",
+                "preferences":
+                {},
+                "regular_only_preferences":
+                {},
+                "state": 1,
+                "was_installed_by_default": false,
+                "was_installed_by_oem": false,
+                "withholding_permissions": false
+            },
+            "kmendfapggjehodndflmmgagdbamhnfd":
+            {
+                "active_permissions":
+                {
+                    "api":
+                    [
+                        "cryptotokenPrivate",
+                        "externally_connectable.all_urls",
+                        "tabs",
+                        "webConnectable"
+                    ],
+                    "explicit_host":
+                    [
+                        "http://*/*",
+                        "https://*/*"
+                    ],
+                    "manifest_permissions":
+                    []
+                },
+                "commands":
+                {},
+                "content_settings":
+                [],
+                "creation_flags": 1,
+                "events":
+                [
+                    "runtime.onConnectExternal"
+                ],
+                "from_bookmark": false,
+                "from_webstore": false,
+                "incognito_content_settings":
+                [],
+                "incognito_preferences":
+                {},
+                "install_time": "13226654677462231",
+                "location": 5,
+                "manifest":
+                {
+                    "background":
+                    {
+                        "persistent": false,
+                        "scripts":
+                        [
+                            "util.js",
+                            "b64.js",
+                            "cbor.js",
+                            "sha256.js",
+                            "timer.js",
+                            "countdown.js",
+                            "countdowntimer.js",
+                            "devicestatuscodes.js",
+                            "approvedorigins.js",
+                            "errorcodes.js",
+                            "webrequest.js",
+                            "messagetypes.js",
+                            "factoryregistry.js",
+                            "requesthelper.js",
+                            "asn1.js",
+                            "enroller.js",
+                            "requestqueue.js",
+                            "signer.js",
+                            "origincheck.js",
+                            "textfetcher.js",
+                            "appid.js",
+                            "watchdog.js",
+                            "logging.js",
+                            "webrequestsender.js",
+                            "window-timer.js",
+                            "cryptotokenorigincheck.js",
+                            "cryptotokenapprovedorigins.js",
+                            "inherits.js",
+                            "individualattest.js",
+                            "googlecorpindividualattest.js",
+                            "cryptotokenbackground.js"
+                        ]
+                    },
+                    "description": "CryptoToken Component Extension",
+                    "externally_connectable":
+                    {
+                        "ids":
+                        [
+                            "fjajfjhkeibgmiggdfehjplbhmfkialk"
+                        ],
+                        "matches":
+                        [
+                            "https://*/*"
+                        ]
+                    },
+                    "incognito": "split",
+                    "key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAq7zRobvA+AVlvNqkHSSVhh1sEWsHSqz4oR/XptkDe/Cz3+gW9ZGumZ20NCHjaac8j1iiesdigp8B1LJsd/2WWv2Dbnto4f8GrQ5MVphKyQ9WJHwejEHN2K4vzrTcwaXqv5BSTXwxlxS/mXCmXskTfryKTLuYrcHEWK8fCHb+0gvr8b/kvsi75A1aMmb6nUnFJvETmCkOCPNX5CHTdy634Ts/x0fLhRuPlahk63rdf7agxQv5viVjQFk+tbgv6aa9kdSd11Js/RZ9yZjrFgHOBWgP4jTBqud4+HUglrzu8qynFipyNRLCZsaxhm+NItTyNgesxLdxZcwOz56KD1Q4IQIDAQAB",
+                    "manifest_version": 2,
+                    "name": "CryptoTokenExtension",
+                    "permissions":
+                    [
+                        "cryptotokenPrivate",
+                        "externally_connectable.all_urls",
+                        "tabs",
+                        "https://*/*",
+                        "http://*/*"
+                    ],
+                    "version": "0.9.74"
+                },
+                "path": "/Applications/Google Chrome.app/Contents/Frameworks/Google Chrome Framework.framework/Versions/80.0.3987.116/Resources/cryptotoken",
+                "preferences":
+                {},
+                "regular_only_preferences":
+                {},
+                "state": 1,
+                "was_installed_by_default": false,
+                "was_installed_by_oem": false
+            },
+            "mefhakmgclhhfbdadeojlkbllmecialg":
+            {
+                "ack_ntp_bubble": true,
+                "active_bit": false,
+                "active_permissions":
+                {
+                    "api":
+                    [
+                        "storage",
+                        "newTabPageOverride"
+                    ],
+                    "explicit_host":
+                    [],
+                    "manifest_permissions":
+                    [],
+                    "scriptable_host":
+                    []
+                },
+                "allowlist": 1,
+                "commands":
+                {},
+                "content_settings":
+                [],
+                "creation_flags": 9,
+                "events":
+                [],
+                "from_webstore": true,
+                "granted_permissions":
+                {
+                    "api":
+                    [
+                        "storage",
+                        "newTabPageOverride"
+                    ],
+                    "explicit_host":
+                    [],
+                    "manifest_permissions":
+                    [],
+                    "scriptable_host":
+                    []
+                },
+                "incognito_content_settings":
+                [],
+                "incognito_preferences":
+                {},
+                "install_time": "13317992479751595",
+                "location": 1,
+                "manifest":
+                {
+                    "author": "Leslie Zacharkow",
+                    "chrome_url_overrides":
+                    {
+                        "newtab": "public/index.html"
+                    },
+                    "description": "A new friend in every tab.",
+                    "icons":
+                    {
+                        "128": "icon128.png"
+                    },
+                    "key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAjA9ElNuqHGIuDyrztUxn0nV1CLRgjSHEKw1zfhzE/6OdWd3teRV9wq4EukIX8UKf96fhS2WsLVnTuRmF7mQuqeAIxOkSvFm4Set3YRQ5994NA8Y9un1ZGhPtjFnpoLo1pEA5PPly5/BX2y3Ci2Rb0C3wp8NdeXud4r6BKEzhPdWmkwIS+YbTWhOBR1IbP/sF6+l8EdG/Ks881p8LO0J3qepmhNDA/LjVWzJq5ARmIYeT3TnvR/qRGTY9UXfUvg3gcUWV2LBBpeil8t6Np0PVYvG44zOBhKUnYSVE6gAcXENLTJJABgRgKT1K1kDYl1N8LJZf/S/9Ix1P+wItoEinTwIDAQAB",
+                    "manifest_version": 2,
+                    "name": "Tabby Cat",
+                    "offline_enabled": true,
+                    "permissions":
+                    [
+                        "storage"
+                    ],
+                    "update_url": "https://clients2.google.com/service/update2/crx",
+                    "version": "2.0.1"
+                },
+                "needs_sync": true,
+                "path": "mefhakmgclhhfbdadeojlkbllmecialg\\2.0.1_0",
+                "preferences":
+                {},
+                "regular_only_preferences":
+                {},
+                "state": 1,
+                "was_installed_by_default": false,
+                "was_installed_by_oem": false,
+                "withholding_permissions": false
+            },
+            "mfehgcgbbipciphmccgaenjidiccnmng":
+            {
+                "active_permissions":
+                {
+                    "api":
+                    [
+                        "cloudPrintPrivate"
+                    ],
+                    "manifest_permissions":
+                    []
+                },
+                "commands":
+                {},
+                "content_settings":
+                [],
+                "creation_flags": 1,
+                "events":
+                [],
+                "from_bookmark": false,
+                "from_webstore": false,
+                "incognito_content_settings":
+                [],
+                "incognito_preferences":
+                {},
+                "install_time": "13226654677457725",
+                "location": 5,
+                "manifest":
+                {
+                    "app":
+                    {
+                        "launch":
+                        {
+                            "web_url": "https://www.google.com/cloudprint"
+                        },
+                        "urls":
+                        [
+                            "https://www.google.com/cloudprint/enable_chrome_connector"
+                        ]
+                    },
+                    "description": "Cloud Print",
+                    "display_in_launcher": false,
+                    "icons":
+                    {},
+                    "key": "MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQDqOhnwk4+HXVfGyaNsAQdU/js1Na56diW08oF1MhZiwzSnJsEaeuMN9od9q9N4ZdK3o1xXOSARrYdE+syV7Dl31nf6qz3A6K+D5NHe6sSB9yvYlIiN37jdWdrfxxE0pRYEVYZNTe3bzq3NkcYJlOdt1UPcpJB+isXpAGUKUvt7EQIDAQAB",
+                    "name": "Cloud Print",
+                    "permissions":
+                    [
+                        "cloudPrintPrivate"
+                    ],
+                    "version": "0.1"
+                },
+                "path": "/Applications/Google Chrome.app/Contents/Frameworks/Google Chrome Framework.framework/Versions/80.0.3987.116/Resources/cloud_print",
+                "preferences":
+                {},
+                "regular_only_preferences":
+                {},
+                "state": 1,
+                "was_installed_by_default": false,
+                "was_installed_by_oem": false
+            },
+            "mhjfbmdgcfjbbpaeojofohoefgiehjai":
+            {
+                "active_permissions":
+                {
+                    "api":
+                    [
+                        "contentSettings",
+                        "fileSystem",
+                        "fileSystem.write",
+                        "metricsPrivate",
+                        "resourcesPrivate"
+                    ],
+                    "explicit_host":
+                    [
+                        "chrome://resources/*"
+                    ],
+                    "manifest_permissions":
+                    []
+                },
+                "commands":
+                {},
+                "content_settings":
+                [],
+                "creation_flags": 1,
+                "events":
+                [],
+                "from_bookmark": false,
+                "from_webstore": false,
+                "incognito_content_settings":
+                [],
+                "incognito_preferences":
+                {},
+                "install_time": "13226654677462676",
+                "location": 5,
+                "manifest":
+                {
+                    "content_security_policy": "script-src 'self' 'wasm-eval' blob: filesystem: chrome://resources; object-src * blob: externalfile: file: filesystem: data:; plugin-types application/x-google-chrome-pdf",
+                    "description": "",
+                    "incognito": "split",
+                    "key": "MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQDN6hM0rsDYGbzQPQfOygqlRtQgKUXMfnSjhIBL7LnReAVBEd7ZmKtyN2qmSasMl4HZpMhVe2rPWVVwBDl6iyNE/Kok6E6v6V3vCLGsOpQAuuNVye/3QxzIldzG/jQAdWZiyXReRVapOhZtLjGfywCvlWq7Sl/e3sbc0vWybSDI2QIDAQAB",
+                    "manifest_version": 2,
+                    "mime_types":
+                    [
+                        "application/pdf"
+                    ],
+                    "mime_types_handler": "index.html",
+                    "name": "Chrome PDF Viewer",
+                    "offline_enabled": true,
+                    "permissions":
+                    [
+                        "chrome://resources/",
+                        "contentSettings",
+                        "metricsPrivate",
+                        "resourcesPrivate",
+                        {
+                            "fileSystem":
+                            [
+                                "write"
+                            ]
+                        }
+                    ],
+                    "version": "1"
+                },
+                "path": "/Applications/Google Chrome.app/Contents/Frameworks/Google Chrome Framework.framework/Versions/80.0.3987.116/Resources/pdf",
+                "preferences":
+                {},
+                "regular_only_preferences":
+                {},
+                "state": 1,
+                "was_installed_by_default": false,
+                "was_installed_by_oem": false
+            },
+            "neajdppkdcdipfabeoofebfddakdcjhd":
+            {
+                "active_permissions":
+                {
+                    "api":
+                    [
+                        "systemPrivate",
+                        "ttsEngine"
+                    ],
+                    "explicit_host":
+                    [
+                        "https://www.google.com/*"
+                    ],
+                    "manifest_permissions":
+                    []
+                },
+                "commands":
+                {},
+                "content_settings":
+                [],
+                "creation_flags": 1,
+                "events":
+                [
+                    "ttsEngine.onPause",
+                    "ttsEngine.onResume",
+                    "ttsEngine.onSpeak",
+                    "ttsEngine.onStop"
+                ],
+                "from_bookmark": false,
+                "from_webstore": false,
+                "incognito_content_settings":
+                [],
+                "incognito_preferences":
+                {},
+                "install_time": "13226654677461722",
+                "location": 5,
+                "manifest":
+                {
+                    "background":
+                    {
+                        "persistent": false,
+                        "scripts":
+                        [
+                            "tts_extension.js"
+                        ]
+                    },
+                    "description": "Component extension providing speech via the Google network text-to-speech service.",
+                    "key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA8GSbNUMGygqQTNDMFGIjZNcwXsHLzkNkHjWbuY37PbNdSDZ4VqlVjzbWqODSe+MjELdv5Keb51IdytnoGYXBMyqKmWpUrg+RnKvQ5ibWr4MW9pyIceOIdp9GrzC1WZGgTmZismYR3AjaIpufZ7xDdQQv+XrghPWCkdVqLN+qZDA1HU+DURznkMICiDDSH2sU0egm9UbWfS218bZqzKeQDiC3OnTPlaxcbJtKUuupIm5knjze3Wo9Ae9poTDMzKgchg0VlFCv3uqox+wlD8sjXBoyBCCK9HpImdVAF1a7jpdgiUHpPeV/26oYzM9/grltwNR3bzECQgSpyXp0eyoegwIDAQAB",
+                    "manifest_version": 2,
+                    "name": "Google Network Speech",
+                    "permissions":
+                    [
+                        "systemPrivate",
+                        "ttsEngine",
+                        "https://www.google.com/"
+                    ],
+                    "tts_engine":
+                    {
+                        "voices":
+                        [
+                            {
+                                "event_types":
+                                [
+                                    "start",
+                                    "end",
+                                    "error"
+                                ],
+                                "gender": "female",
+                                "lang": "de-DE",
+                                "remote": true,
+                                "voice_name": "Google Deutsch"
+                            },
+                            {
+                                "event_types":
+                                [
+                                    "start",
+                                    "end",
+                                    "error"
+                                ],
+                                "gender": "female",
+                                "lang": "en-US",
+                                "remote": true,
+                                "voice_name": "Google US English"
+                            },
+                            {
+                                "event_types":
+                                [
+                                    "start",
+                                    "end",
+                                    "error"
+                                ],
+                                "gender": "female",
+                                "lang": "en-GB",
+                                "remote": true,
+                                "voice_name": "Google UK English Female"
+                            },
+                            {
+                                "event_types":
+                                [
+                                    "start",
+                                    "end",
+                                    "error"
+                                ],
+                                "gender": "male",
+                                "lang": "en-GB",
+                                "remote": true,
+                                "voice_name": "Google UK English Male"
+                            },
+                            {
+                                "event_types":
+                                [
+                                    "start",
+                                    "end",
+                                    "error"
+                                ],
+                                "gender": "female",
+                                "lang": "es-ES",
+                                "remote": true,
+                                "voice_name": "Google español"
+                            },
+                            {
+                                "event_types":
+                                [
+                                    "start",
+                                    "end",
+                                    "error"
+                                ],
+                                "gender": "female",
+                                "lang": "es-US",
+                                "remote": true,
+                                "voice_name": "Google español de Estados Unidos"
+                            },
+                            {
+                                "event_types":
+                                [
+                                    "start",
+                                    "end",
+                                    "error"
+                                ],
+                                "gender": "female",
+                                "lang": "fr-FR",
+                                "remote": true,
+                                "voice_name": "Google français"
+                            },
+                            {
+                                "event_types":
+                                [
+                                    "start",
+                                    "end",
+                                    "error"
+                                ],
+                                "gender": "female",
+                                "lang": "hi-IN",
+                                "remote": true,
+                                "voice_name": "Google हिन्दी"
+                            },
+                            {
+                                "event_types":
+                                [
+                                    "start",
+                                    "end",
+                                    "error"
+                                ],
+                                "gender": "female",
+                                "lang": "id-ID",
+                                "remote": true,
+                                "voice_name": "Google Bahasa Indonesia"
+                            },
+                            {
+                                "event_types":
+                                [
+                                    "start",
+                                    "end",
+                                    "error"
+                                ],
+                                "gender": "female",
+                                "lang": "it-IT",
+                                "remote": true,
+                                "voice_name": "Google italiano"
+                            },
+                            {
+                                "event_types":
+                                [
+                                    "start",
+                                    "end",
+                                    "error"
+                                ],
+                                "gender": "female",
+                                "lang": "ja-JP",
+                                "remote": true,
+                                "voice_name": "Google 日本語"
+                            },
+                            {
+                                "event_types":
+                                [
+                                    "start",
+                                    "end",
+                                    "error"
+                                ],
+                                "gender": "female",
+                                "lang": "ko-KR",
+                                "remote": true,
+                                "voice_name": "Google 한국의"
+                            },
+                            {
+                                "event_types":
+                                [
+                                    "start",
+                                    "end",
+                                    "error"
+                                ],
+                                "gender": "female",
+                                "lang": "nl-NL",
+                                "remote": true,
+                                "voice_name": "Google Nederlands"
+                            },
+                            {
+                                "event_types":
+                                [
+                                    "start",
+                                    "end",
+                                    "error"
+                                ],
+                                "gender": "female",
+                                "lang": "pl-PL",
+                                "remote": true,
+                                "voice_name": "Google polski"
+                            },
+                            {
+                                "event_types":
+                                [
+                                    "start",
+                                    "end",
+                                    "error"
+                                ],
+                                "gender": "female",
+                                "lang": "pt-BR",
+                                "remote": true,
+                                "voice_name": "Google português do Brasil"
+                            },
+                            {
+                                "event_types":
+                                [
+                                    "start",
+                                    "end",
+                                    "error"
+                                ],
+                                "gender": "female",
+                                "lang": "ru-RU",
+                                "remote": true,
+                                "voice_name": "Google русский"
+                            },
+                            {
+                                "event_types":
+                                [
+                                    "start",
+                                    "end",
+                                    "error"
+                                ],
+                                "gender": "female",
+                                "lang": "zh-CN",
+                                "remote": true,
+                                "voice_name": "Google 普通话（中国大陆）"
+                            },
+                            {
+                                "event_types":
+                                [
+                                    "start",
+                                    "end",
+                                    "error"
+                                ],
+                                "gender": "female",
+                                "lang": "zh-HK",
+                                "remote": true,
+                                "voice_name": "Google 粤語（香港）"
+                            },
+                            {
+                                "event_types":
+                                [
+                                    "start",
+                                    "end",
+                                    "error"
+                                ],
+                                "gender": "female",
+                                "lang": "zh-TW",
+                                "remote": true,
+                                "voice_name": "Google 國語（臺灣）"
+                            }
+                        ]
+                    },
+                    "version": "1.0"
+                },
+                "path": "/Applications/Google Chrome.app/Contents/Frameworks/Google Chrome Framework.framework/Versions/80.0.3987.116/Resources/network_speech_synthesis",
+                "preferences":
+                {},
+                "regular_only_preferences":
+                {},
+                "state": 1,
+                "was_installed_by_default": false,
+                "was_installed_by_oem": false
+            },
+            "nkeimhogjdpnpccoofpliimaahmaaome":
+            {
+                "active_permissions":
+                {
+                    "api":
+                    [
+                        "desktopCapture",
+                        "processes",
+                        "webConnectable",
+                        "webrtcAudioPrivate",
+                        "webrtcDesktopCapturePrivate",
+                        "webrtcLoggingPrivate",
+                        "system.cpu",
+                        "enterprise.hardwarePlatform"
+                    ],
+                    "manifest_permissions":
+                    []
+                },
+                "commands":
+                {},
+                "content_settings":
+                [],
+                "creation_flags": 1,
+                "events":
+                [
+                    "runtime.onConnectExternal"
+                ],
+                "from_bookmark": false,
+                "from_webstore": false,
+                "incognito_content_settings":
+                [],
+                "incognito_preferences":
+                {},
+                "install_time": "13226654677460643",
+                "location": 5,
+                "manifest":
+                {
+                    "background":
+                    {
+                        "page": "background.html",
+                        "persistent": false
+                    },
+                    "externally_connectable":
+                    {
+                        "matches":
+                        [
+                            "https://*.google.com/*",
+                            "*://localhost/*"
+                        ]
+                    },
+                    "incognito": "split",
+                    "key": "MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQDAQt2ZDdPfoSe/JI6ID5bgLHRCnCu9T36aYczmhw/tnv6QZB2I6WnOCMZXJZlRdqWc7w9jo4BWhYS50Vb4weMfh/I0On7VcRwJUgfAxW2cHB+EkmtI1v4v/OU24OqIa1Nmv9uRVeX0GjhQukdLNhAE6ACWooaf5kqKlCeK+1GOkQIDAQAB",
+                    "manifest_version": 2,
+                    "name": "Google Hangouts",
+                    "permissions":
+                    [
+                        "desktopCapture",
+                        "enterprise.hardwarePlatform",
+                        "processes",
+                        "system.cpu",
+                        "webrtcAudioPrivate",
+                        "webrtcDesktopCapturePrivate",
+                        "webrtcLoggingPrivate"
+                    ],
+                    "version": "1.3.15"
+                },
+                "path": "/Applications/Google Chrome.app/Contents/Frameworks/Google Chrome Framework.framework/Versions/80.0.3987.116/Resources/hangout_services",
+                "preferences":
+                {},
+                "regular_only_preferences":
+                {},
+                "state": 1,
+                "was_installed_by_default": false,
+                "was_installed_by_oem": false
+            },
+            "nmmhkkegccagdldgiimedpiccmgmieda":
+            {
+                "ack_external": true,
+                "active_permissions":
+                {
+                    "api":
+                    [
+                        "identity",
+                        "webview"
+                    ],
+                    "explicit_host":
+                    [
+                        "https://payments.google.com/*",
+                        "https://sandbox.google.com/*",
+                        "https://www.google.com/*",
+                        "https://www.googleapis.com/*"
+                    ],
+                    "manifest_permissions":
+                    []
+                },
+                "commands":
+                {},
+                "content_settings":
+                [],
+                "creation_flags": 137,
+                "events":
+                [
+                    "app.runtime.onLaunched",
+                    "runtime.onConnectExternal"
+                ],
+                "from_bookmark": false,
+                "from_webstore": true,
+                "granted_permissions":
+                {
+                    "api":
+                    [
+                        "identity",
+                        "webview"
+                    ],
+                    "explicit_host":
+                    [
+                        "https://payments.google.com/*",
+                        "https://sandbox.google.com/*",
+                        "https://www.google.com/*",
+                        "https://www.googleapis.com/*"
+                    ],
+                    "manifest_permissions":
+                    []
+                },
+                "incognito_content_settings":
+                [],
+                "incognito_preferences":
+                {},
+                "install_time": "13226654687782836",
+                "lastpingday": "13226572800714429",
+                "location": 10,
+                "manifest":
+                {
+                    "app":
+                    {
+                        "background":
+                        {
+                            "scripts":
+                            [
+                                "craw_background.js"
+                            ]
+                        }
+                    },
+                    "current_locale": "en_US",
+                    "default_locale": "en",
+                    "description": "Chrome Web Store Payments",
+                    "display_in_launcher": false,
+                    "display_in_new_tab_page": false,
+                    "icons":
+                    {
+                        "128": "images/icon_128.png",
+                        "16": "images/icon_16.png"
+                    },
+                    "key": "MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQCrKfMnLqViEyokd1wk57FxJtW2XXpGXzIHBzv9vQI/01UsuP0IV5/lj0wx7zJ/xcibUgDeIxobvv9XD+zO1MdjMWuqJFcKuSS4Suqkje6u+pMrTSGOSHq1bmBVh0kpToN8YoJs/P/yrRd7FEtAXTaFTGxQL4C385MeXSjaQfiRiQIDAQAB",
+                    "manifest_version": 2,
+                    "minimum_chrome_version": "29",
+                    "name": "Chrome Web Store Payments",
+                    "oauth2":
+                    {
+                        "auto_approve": true,
+                        "client_id": "203784468217.apps.googleusercontent.com",
+                        "scopes":
+                        [
+                            "https://www.googleapis.com/auth/sierra",
+                            "https://www.googleapis.com/auth/sierrasandbox",
+                            "https://www.googleapis.com/auth/chromewebstore",
+                            "https://www.googleapis.com/auth/chromewebstore.readonly"
+                        ]
+                    },
+                    "permissions":
+                    [
+                        "identity",
+                        "webview",
+                        "https://www.google.com/",
+                        "https://www.googleapis.com/*",
+                        "https://payments.google.com/payments/v4/js/integrator.js",
+                        "https://sandbox.google.com/payments/v4/js/integrator.js"
+                    ],
+                    "update_url": "https://clients2.google.com/service/update2/crx",
+                    "version": "1.0.0.5"
+                },
+                "path": "nmmhkkegccagdldgiimedpiccmgmieda/1.0.0.5_0",
+                "preferences":
+                {},
+                "regular_only_preferences":
+                {},
+                "running": false,
+                "state": 1,
+                "was_installed_by_default": true,
+                "was_installed_by_oem": false
+            },
+            "pjkljhegncpnkpknbcohdijeoejaedia":
+            {
+                "ack_external": true,
+                "active_permissions":
+                {
+                    "api":
+                    [
+                        "notifications"
+                    ],
+                    "manifest_permissions":
+                    []
+                },
+                "app_launcher_ordinal": "z",
+                "commands":
+                {},
+                "content_settings":
+                [],
+                "creation_flags": 137,
+                "events":
+                [],
+                "from_bookmark": false,
+                "from_webstore": true,
+                "granted_permissions":
+                {
+                    "api":
+                    [
+                        "notifications"
+                    ],
+                    "manifest_permissions":
+                    []
+                },
+                "incognito_content_settings":
+                [],
+                "incognito_preferences":
+                {},
+                "install_time": "13226654685955490",
+                "lastpingday": "13226572800714429",
+                "location": 1,
+                "manifest":
+                {
+                    "app":
+                    {
+                        "launch":
+                        {
+                            "container": "tab",
+                            "web_url": "https://mail.google.com/mail"
+                        },
+                        "urls":
+                        [
+                            "*://mail.google.com/mail"
+                        ]
+                    },
+                    "current_locale": "en_US",
+                    "default_locale": "en",
+                    "description": "Fast, searchable email with less spam.",
+                    "icons":
+                    {
+                        "128": "128.png"
+                    },
+                    "key": "MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQDCuGglK43iAz3J9BEYK/Mz6ZhloIMMDqQSAaf3vJt4eHbTbSDsu4WdQ9dQDRcKlg8nwQdePBt0C3PSUBtiSNSS37Z3qEGfS7LCju3h6pI1Yr9MQtxw+jUa7kXXIS09VV73pEFUT/F7c6Qe8L5ZxgAcBvXBh1Fie63qb02I9XQ/CQIDAQAB",
+                    "manifest_version": 2,
+                    "name": "Gmail",
+                    "options_page": "https://mail.google.com/mail/#settings",
+                    "permissions":
+                    [
+                        "notifications"
+                    ],
+                    "update_url": "https://clients2.google.com/service/update2/crx",
+                    "version": "8.2"
+                },
+                "page_ordinal": "n",
+                "path": "pjkljhegncpnkpknbcohdijeoejaedia/8.2_0",
+                "preferences":
+                {},
+                "regular_only_preferences":
+                {},
+                "state": 1,
+                "was_installed_by_default": true,
+                "was_installed_by_oem": false
+            },
+            "pkedcjkdefgpdelpbcmbmeomcjbeemfm":
+            {
+                "ack_external": true,
+                "active_permissions":
+                {
+                    "api":
+                    [
+                        "alarms",
+                        "cast",
+                        "cast.streaming",
+                        "desktopCapture",
+                        "gcm",
+                        "identity",
+                        "identity.email",
+                        "management",
+                        "mediaRouterPrivate",
+                        "metricsPrivate",
+                        "mdns",
+                        "networkingPrivate",
+                        "settingsPrivate",
+                        "storage",
+                        "tabs",
+                        "tabCapture",
+                        "webConnectable",
+                        "webview",
+                        "system.cpu"
+                    ],
+                    "explicit_host":
+                    [
+                        "http://*/*",
+                        "https://*.google.com/*",
+                        "https://hangouts.google.com/*"
+                    ],
+                    "manifest_permissions":
+                    []
+                },
+                "commands":
+                {},
+                "content_settings":
+                [],
+                "creation_flags": 137,
+                "events":
+                [
+                    "cast.channel.onError",
+                    "cast.channel.onMessage",
+                    "gcm.onMessage",
+                    "identity.onSignInChanged",
+                    "runtime.onStartup",
+                    "runtime.onSuspend",
+                    "settingsPrivate.onPrefsChanged"
+                ],
+                "from_bookmark": false,
+                "from_webstore": true,
+                "granted_permissions":
+                {
+                    "api":
+                    [
+                        "alarms",
+                        "cast",
+                        "cast.streaming",
+                        "desktopCapture",
+                        "gcm",
+                        "identity",
+                        "identity.email",
+                        "management",
+                        "mediaRouterPrivate",
+                        "metricsPrivate",
+                        "mdns",
+                        "networkingPrivate",
+                        "settingsPrivate",
+                        "storage",
+                        "tabs",
+                        "tabCapture",
+                        "webConnectable",
+                        "webview",
+                        "system.cpu"
+                    ],
+                    "explicit_host":
+                    [
+                        "http://*/*",
+                        "https://*.google.com/*",
+                        "https://hangouts.google.com/*"
+                    ],
+                    "manifest_permissions":
+                    []
+                },
+                "incognito_content_settings":
+                [],
+                "incognito_preferences":
+                {},
+                "install_time": "13226654685697229",
+                "lastpingday": "13226572800714429",
+                "location": 10,
+                "manifest":
+                {
+                    "background":
+                    {
+                        "persistent": false,
+                        "scripts":
+                        [
+                            "common.js",
+                            "mirroring_common.js",
+                            "background_script.js"
+                        ]
+                    },
+                    "content_security_policy": "default-src 'self'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; script-src 'self' https://apis.google.com https://feedback.googleusercontent.com https://www.google.com https://www.gstatic.com; child-src https://accounts.google.com https://content.googleapis.com https://www.google.com; connect-src 'self' http://*:* https://*:*; font-src https://fonts.gstatic.com; object-src 'self';",
+                    "current_locale": "en_US",
+                    "default_locale": "en",
+                    "description": "Provider for discovery and services for mirroring of Chrome Media Router",
+                    "externally_connectable":
+                    {
+                        "ids":
+                        [
+                            "idmofbkcelhplfjnmmdolenpigiiiecc",
+                            "ggedfkijiiammpnbdadhllnehapomdge",
+                            "njjegkblellcjnakomndbaloifhcoccg"
+                        ],
+                        "matches":
+                        [
+                            "https://www.google.com/chromecast/*"
+                        ]
+                    },
+                    "key": "MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQDNTWJoPZ9bT32yKxuuVa9LSEYobjPoXCLX3dgsZ9djDrWKNikTECjdRe3/AFXb+v8jkmmtYQPnOgSYn06J/QodDlCIG6l470+gkOoobUM7fOs1AVOse23qYUV4jbuRW3+YZlCvaWCFeczCNbGIUgKEi5B2fyQazy60AL1sLW3utQIDAQAB",
+                    "manifest_version": 2,
+                    "minimum_chrome_version": "37",
+                    "name": "Chrome Media Router",
+                    "oauth2":
+                    {
+                        "client_id": "919648714761-55j965o0km033psv3i9qls5mo3qtdrb0.apps.googleusercontent.com",
+                        "scopes":
+                        [
+                            "https://www.googleapis.com/auth/calendar.readonly",
+                            "https://www.googleapis.com/auth/clouddevices",
+                            "https://www.googleapis.com/auth/hangouts",
+                            "https://www.googleapis.com/auth/hangouts.readonly",
+                            "https://www.googleapis.com/auth/meetings",
+                            "https://www.googleapis.com/auth/userinfo.email",
+                            "https://www.googleapis.com/auth/cast-edu-messaging",
+                            "https://www.googleapis.com/auth/plus.peopleapi.readwrite"
+                        ]
+                    },
+                    "permissions":
+                    [
+                        "alarms",
+                        "cast",
+                        "cast.streaming",
+                        "declarativeWebRequest",
+                        "desktopCapture",
+                        "gcm",
+                        "http://*/*",
+                        "identity",
+                        "identity.email",
+                        "management",
+                        "mdns",
+                        "mediaRouterPrivate",
+                        "metricsPrivate",
+                        "networkingPrivate",
+                        "processes",
+                        "storage",
+                        "system.cpu",
+                        "settingsPrivate",
+                        "tabCapture",
+                        "tabs",
+                        "webview",
+                        "https://hangouts.google.com/*",
+                        "https://*.google.com/cast/chromecast/home/gsse"
+                    ],
+                    "update_url": "https://clients2.google.com/service/update2/crx",
+                    "version": "8019.1111.0.0",
+                    "web_accessible_resources":
+                    [
+                        "cast_sender.js",
+                        "cast_setup/*"
+                    ]
+                },
+                "path": "pkedcjkdefgpdelpbcmbmeomcjbeemfm/8019.1111.0.0_0",
+                "preferences":
+                {},
+                "regular_only_preferences":
+                {},
+                "state": 1,
+                "was_installed_by_default": true,
+                "was_installed_by_oem": false
+            }
+        }
+    },
+    "pinned_tabs":
+    [],
+    "protection":
+    {
+        "macs":
+        {
+            "browser":
+            {
+                "show_home_button": "B5EB34D9942F82A8AF68B991862F58F5A39251521C53E159FD5D1CB709BDF873"
+            },
+            "default_search_provider_data":
+            {
+                "template_url_data": "91DF3328DE1FEE92B3ABC654E70213225DAD1FB5E601A7BC139F808F2E34EB89"
+            },
+            "extensions":
+            {
+                "settings":
+                {
+                    "aapocclcgogkmnckokdopfmhonfmgoek": "D1752F1ADB7DBA8B0FA550EB880B35AC42CCBCDA1B93A252F36D41130CCEEBA1",
+                    "aeblfdkhhhdcdjpifhhbdiojplfjncoa": "43EFE888DDCBA9F0422E020E0DDC65A12282916DB73446EA37091D604537ADC1",
+                    "aghfnjkcakhmadgdomlmlhhaocbkloab": "5FA548F25083441B74DFCF815867D24AC4B980053F0B2D414C650CBB671DA9BA",
+                    "ahfgeienlihckogmohjhadlkjgocpleb": "5B019B0552263FDACB193F3AB2595D8B1F4173E0C49EBAB39C7A81197B9C7C13",
+                    "aohghmighlieiainnegkcijnfilokake": "5930281902DD798ED1E908158D024F445C443D4ABA6E4D0C6F324036DFEDEA20",
+                    "apdfllckaahabafndbhieahigkjlhalf": "CC185D9F762CEE0F1238B7AD4E7B4FF5881B6B595EF4CBC004DB6040DF32448D",
+                    "blpcfgokakmgnkcojhhkbfbldkacnbeo": "28FF269C1003D2B826DDFEC6CB724C53251B7AC710900FACC8BAC4BFFE06D16C",
+                    "felcaaldnbdncclmgdcncolpebgiejap": "E272BF994E54309694C6C9D311004E28B131FDF6FD7403E81DEFB37AA718D408",
+                    "gfdkimpbcpahaombhbimeihdjnejgicl": "95341B6911D2DA6CBF30BB3554130A3763533B0B2056B9E8C16803CE4817508D",
+                    "ghbmnnjooekpmoecnnnilnnbdlolhkhi": "1E64113E7CF14C1635A54218E301D30AF34590CF38490A7082CD5C0BE3C6061A",
+                    "jldhpllghnbhlbpcmnajkpdmadaolakh": "7F0599476560A25894A7B046D8E76499EEDFD7A47DA19FF2722177F33B038B48",
+                    "kmendfapggjehodndflmmgagdbamhnfd": "3FD3A074B3DEEC7465461884838463DA7967A540BD6C0BCE9F8356C9ECB27290",
+                    "mfehgcgbbipciphmccgaenjidiccnmng": "997BD8BEA32AA61BF7BD8DB08C46D6B9D52B4BCEC93B9D321EDB5824770BFBEC",
+                    "mhjfbmdgcfjbbpaeojofohoefgiehjai": "E58D38C4C2DC691934A15C36F72A051EB1E8BCB3C20269DC3DBE89AD58468CC9",
+                    "neajdppkdcdipfabeoofebfddakdcjhd": "562538760D62A89E85210B930CF21FEDCC7DE041CB690B94578D8E11FCC58509",
+                    "nkeimhogjdpnpccoofpliimaahmaaome": "D9837DD307B786922A67E5F09DE71B8163D8A3532DECB18639C84AE1DB0190FB",
+                    "nmmhkkegccagdldgiimedpiccmgmieda": "4F7A96E4A6E4175ADE844F177CE929685CDA1D2A0956B9059849D71C075DCA81",
+                    "pjkljhegncpnkpknbcohdijeoejaedia": "B110CABEAA67157C899465DAEA502BC10246FFC370624E711F9E4196C1FA8D4C",
+                    "pkedcjkdefgpdelpbcmbmeomcjbeemfm": "84ED0D82AFB7ADD4B01C9CDFA62F25C34E330D98278AF62D4A9C2DE33C8EE788"
+                }
+            },
+            "google":
+            {
+                "services":
+                {
+                    "account_id": "53AB201B83B1C65823ECBF18EA758EBAE73CA766CC48B16E5BEC293CBDAC99D2",
+                    "last_account_id": "F873A6B5855FC7B13E62BA3389654CB6235D4EA9FC11819ECBD1FBB3ACB72568",
+                    "last_username": "A709F31CDDC4F95F8282AD3A724840A7A974B21EA07268650F52B305AD49CCF0"
+                }
+            },
+            "homepage": "298FFD7268FD73FFDF466BBD2D9679822CF47E365F414D73DE95CF7C273B2769",
+            "homepage_is_newtabpage": "B5038F43EFD47FBC80C011499960458BF11DEBC2914017654987D6AA90B149FA",
+            "media":
+            {
+                "storage_id_salt": "17ABE5A224C6BB4EFFC00878EB3FAE3471E52FE7B028D27BD6CFF028D393E87B"
+            },
+            "pinned_tabs": "0668B53A1CF88AE3A618EBF480391FF63B7E3A1AE97A337B1DEDE5152F2F40B9",
+            "prefs":
+            {
+                "preference_reset_time": "4E54DAE953E6D59540B3F8A2BD5B52BF754814D84B6D1CFF78C6111D7C8DF1A4"
+            },
+            "safebrowsing":
+            {
+                "incidents_sent": "6ED043F7F75C6798BC00FD4E71F59F7F79225B7C349997EA33AAD18CF43B3061"
+            },
+            "search_provider_overrides": "3AE81F3E908BFD62166EC420891095D3078B106BEB02FFDEDE4AAA9554596CF9",
+            "session":
+            {
+                "restore_on_startup": "AED0EFEA1F0E02AF44F9F0656D395A765FA1FEF19DADBD158052A8918E1CB884",
+                "startup_urls": "70E6A80ED32C26F1609C53173B9143749776190103D06779E499D3FD42C17195"
+            }
+        },
+        "super_mac": "DC1D234E854754C0422B23D3C3F565F266C5E9E145B6603010AAB918827BB79F"
+    }
+}

--- a/test/data/import/chrome/default/Secure_Preferences_for_extension_import
+++ b/test/data/import/chrome/default/Secure_Preferences_for_extension_import
@@ -1,1 +1,2014 @@
-{"extensions":{"settings":{"aapocclcgogkmnckokdopfmhonfmgoek":{"ack_external":true,"active_permissions":{"api":[],"manifest_permissions":[]},"app_launcher_ordinal":"w","commands":{},"content_settings":[],"creation_flags":137,"events":[],"from_bookmark":false,"from_webstore":true,"granted_permissions":{"api":[],"manifest_permissions":[]},"incognito_content_settings":[],"incognito_preferences":{},"install_time":"13226654686468813","lastpingday":"13226572800714429","location":1,"manifest":{"api_console_project_id":"889782162350","app":{"launch":{"local_path":"main.html"}},"container":"GOOGLE_DRIVE","current_locale":"en_US","default_locale":"en_US","description":"Create and edit presentations ","icons":{"128":"icon_128.png","16":"icon_16.png"},"key":"MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQDLOGW2Hoztw8m2z6SmCjm7y4Oe2o6aRqO+niYKCXhZab572by7acqFIFF0On3e3a967SwNijsTx2n+7Mt3KqWzEKtnwUZqzHYSsdZZK64vWIHIduawP0EICWRMf2RGIBEdDC6I1zErtcDiSrJWeRlnb0DHWXDXlt1YseM7RiON9wIDAQAB","manifest_version":2,"name":"Slides","offline_enabled":true,"update_url":"https://clients2.google.com/service/update2/crx","version":"0.10"},"page_ordinal":"n","path":"aapocclcgogkmnckokdopfmhonfmgoek/0.10_1","preferences":{},"regular_only_preferences":{},"state":0,"was_installed_by_default":true,"was_installed_by_oem":false,"withholding_permissions":false},"aeblfdkhhhdcdjpifhhbdiojplfjncoa":{"active_permissions":{"api":["clipboardWrite","contextMenus","downloads","downloadsInternal","idle","management","nativeMessaging","notifications","privacy","storage","tabs","webNavigation","webRequest","webRequestBlocking"],"explicit_host":["\u003Call_urls>","chrome://favicon/*"],"manifest_permissions":[],"scriptable_host":["https://*.1password.ca/*","https://*.1password.com/*","https://*.1password.eu/*","https://*.b5dev.com/*","https://*.b5local.com/*","https://*.b5staging.com/*","https://*.b5test.com/*"]},"commands":{"_execute_browser_action":{"suggested_key":"Command+Shift+X","was_assigned":true}},"content_settings":[],"creation_flags":9,"events":[],"from_bookmark":false,"from_webstore":true,"granted_permissions":{"api":["clipboardWrite","contextMenus","downloads","downloadsInternal","idle","management","nativeMessaging","notifications","privacy","storage","tabs","webNavigation","webRequest","webRequestBlocking"],"explicit_host":["\u003Call_urls>","chrome://favicon/*"],"manifest_permissions":[],"scriptable_host":["https://*.1password.ca/*","https://*.1password.com/*","https://*.1password.eu/*","https://*.b5dev.com/*","https://*.b5local.com/*","https://*.b5staging.com/*","https://*.b5test.com/*"]},"incognito_content_settings":[],"incognito_preferences":{},"install_time":"13226654735273593","location":1,"manifest":{"author":"AgileBits","background":{"scripts":["background/x.js","background/background.js"]},"browser_action":{"default_title":"1Password"},"commands":{"_execute_browser_action":{"suggested_key":{"default":"Ctrl+Shift+X","mac":"Command+Shift+X"}}},"content_scripts":[{"css":["content/b5integration.css"],"js":["content/b5.js"],"matches":["https://*.1password.com/*","https://*.b5staging.com/*","https://*.b5test.com/*","https://*.b5dev.com/*","https://*.b5local.com/*","https://*.1password.ca/*","https://*.1password.eu/*"],"run_at":"document_idle"}],"content_security_policy":"default-src 'self'; img-src 'self' https://c.1password.com https://a.1passwordentusercontent.com https://a.1passwordusercontent.com https://a.1passwordusercontent.eu https://a.1passwordusercontent.ca; connect-src https://*.1password.com wss://b5n.1password.com wss://b5n.ent.1password.com https://*.b5test.com wss://b5n.b5test.com https://*.b5dev.com wss://b5n.b5dev.com https://*.b5local.com:3000 wss://b5local.com:3001 https://*.1password.ca wss://b5n.1password.ca https://*.1password.eu wss://b5n.1password.eu https://api.pwnedpasswords.com https://f.1passwordusercontent.com https://f.1passwordentusercontent.com https://f.1passwordusercontent.eu https://f.1passwordusercontent.ca; style-src 'self' 'unsafe-inline'; script-src 'self' 'wasm-eval';","current_locale":"en_US","default_locale":"en","description":"The best way to experience 1Password in your browser. Easily sign in to sites, generate passwords, and store secure information.","homepage_url":"https://1password.com","icons":{"128":"/images/icons/onepassword-128.png","16":"/images/icons/app_icon-light_bg-color-unlocked-32.png","48":"/images/icons/onepassword-48.png"},"key":"MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAnHpaUll4uWujpAdbIXOQY2WE6hk8PllsYsnoUaj5qHXwv4IB6A9pONqGaTL2KL20u6E6XVhncY6Ae6SQSBQqiIkgjPsiG0NDNsDlju/kzBnfimKFC/bpzOrqFqbhswQHifnet5uHlpG97whTzLO3ka0M5aqB9V9mD/0qVXvNgAVVnSTULH254YqpeCcAhmsKiFZSL6OrOZmCp8kZ/OeOUK9iYWYylL7VcOXVrZf10EPrlaCNXzVk7K35dPuQ7svhA0Pgju3kngB4RLa5Iojhw3IT+B5+m8pisjOSd1oKMrRmhGs7rDhF5IEtAiVxqVp7uOOMPQj3vrbMDAzf7vqLtQIDAQAB","manifest_version":2,"minimum_chrome_version":"73","name":"1Password X – Password Manager","permissions":["\u003Call_urls>","clipboardWrite","contextMenus","idle","management","nativeMessaging","notifications","storage","tabs","webRequest","webRequestBlocking","webNavigation","privacy","downloads"],"short_name":"1Password","update_url":"https://clients2.google.com/service/update2/crx","version":"1.18.0","web_accessible_resources":["images/*","mini/images/*","inline/images/*","fonts/*","mini/fonts/*","inline/fonts/*","inline/button/injected.css","inline/menu/menu.html","inline/menu/injected.css","inline/notifications/add-account/add-account.html","inline/save-dialog/save-dialog.html","inline/save-dialog/injected.css"]},"needs_sync":true,"path":"aeblfdkhhhdcdjpifhhbdiojplfjncoa/1.18.0_0","preferences":{},"regular_only_preferences":{},"state":0,"was_installed_by_default":false,"was_installed_by_oem":false,"withholding_permissions":false},"aghfnjkcakhmadgdomlmlhhaocbkloab":{"active_permissions":{"api":[],"manifest_permissions":[]},"commands":{},"content_settings":[],"creation_flags":9,"events":[],"from_bookmark":false,"from_webstore":true,"granted_permissions":{"api":[],"manifest_permissions":[]},"incognito_content_settings":[],"incognito_preferences":{},"install_time":"13226654710521941","location":1,"manifest":{"description":"Just Black: when you're feeling extra moody","key":"MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAqxThvdYeWk6kwfNo+/HoqQSkL6iBx48w28vEPXHdhJo8OHMxS7D+1W1nhUsv4hOnb1CM2TlP/Nh9G+1Z32R9r6RmVxD1Anq9ZTZpK7VHVUxExGR4X9+TYHKWk8VGAjSBmutvayf0i0gCEkh7Pdc68ex4M0ypKGFWxBzxqw2uQ/4BLMVB/9KZJwXOC5LcaBNgq2Q74J3Dd3a90OzFXh+vC9zIyDueu3/K4F6u5bXgsgviAGIrUm7YbGhLDMxuW81zvYMlLtkA4XDDnhgk88s0G/5OwoMEyU6YdMq9R795NHsI0bPUMOOgUsPT5cytKRcQMegMassBe9EB+ktTl9CloQIDAQAB","manifest_version":2,"name":"Just Black","theme":{"colors":{"bookmark_text":[255,255,255],"frame":[0,0,0],"ntp_background":[0,0,0],"ntp_text":[125,134,142],"tab_background_text":[255,255,255],"tab_background_text_inactive":[255,255,255],"tab_background_text_incognito":[255,255,255],"tab_background_text_incognito_inactive":[255,255,255],"tab_text":[255,255,255],"toolbar":[45,45,45]},"tints":{"buttons":[0.2,0.2,0.9],"frame_inactive":[-1,-1,-1],"frame_incognito":[-1,-1,-1],"frame_incognito_inactive":[-1,-1,-1]}},"update_url":"https://clients2.google.com/service/update2/crx","version":"2"},"path":"aghfnjkcakhmadgdomlmlhhaocbkloab/2_0","preferences":{},"regular_only_preferences":{},"state":1,"was_installed_by_default":false,"was_installed_by_oem":false},"ahfgeienlihckogmohjhadlkjgocpleb":{"active_bit":true,"active_permissions":{"api":["management","system.display","system.storage","webstorePrivate","system.cpu","system.memory","system.network"],"manifest_permissions":[]},"app_launcher_ordinal":"t","commands":{},"content_settings":[],"creation_flags":1,"events":[],"from_bookmark":false,"from_webstore":false,"incognito_content_settings":[],"incognito_preferences":{},"install_time":"13226654677459804","last_launch_time":"13226654699036269","location":5,"manifest":{"app":{"launch":{"web_url":"https://chrome.google.com/webstore"},"urls":["https://chrome.google.com/webstore"]},"description":"Discover great apps, games, extensions and themes for Google Chrome.","icons":{"128":"webstore_icon_128.png","16":"webstore_icon_16.png"},"key":"MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQCtl3tO0osjuzRsf6xtD2SKxPlTfuoy7AWoObysitBPvH5fE1NaAA1/2JkPWkVDhdLBWLaIBPYeXbzlHp3y4Vv/4XG+aN5qFE3z+1RU/NqkzVYHtIpVScf3DjTYtKVL66mzVGijSoAIwbFCC3LpGdaoe6Q1rSRDp76wR6jjFzsYwQIDAQAB","name":"Web Store","permissions":["webstorePrivate","management","system.cpu","system.display","system.memory","system.network","system.storage"],"version":"0.2"},"needs_sync":true,"page_ordinal":"n","path":"/Applications/Google Chrome.app/Contents/Frameworks/Google Chrome Framework.framework/Versions/80.0.3987.116/Resources/web_store","preferences":{},"regular_only_preferences":{},"state":1,"was_installed_by_default":false,"was_installed_by_oem":false},"aohghmighlieiainnegkcijnfilokake":{"ack_external":true,"active_permissions":{"api":[],"manifest_permissions":[]},"app_launcher_ordinal":"x","commands":{},"content_settings":[],"creation_flags":137,"events":[],"from_bookmark":false,"from_webstore":true,"granted_permissions":{"api":[],"manifest_permissions":[]},"incognito_content_settings":[],"incognito_preferences":{},"install_time":"13226654686203610","lastpingday":"13226572800714429","location":1,"manifest":{"api_console_project_id":"619683526622","app":{"launch":{"local_path":"main.html"}},"container":"GOOGLE_DRIVE","current_locale":"en_US","default_locale":"en_US","description":"Create and edit documents ","icons":{"128":"icon_128.png","16":"icon_16.png"},"key":"MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQDJhLK6fk/BWTEvJhywpk7jDe4A2r0bGXGOLZW4/AdBp3IiD9o9nx4YjLAtv0tIPxi7MvFd/GUUbQBwHT5wQWONJj1z/0Rc2qBkiJA0yqXh42p0snuA8dCfdlhOLsp7/XTMEwAVasjV5hC4awl78eKfJYlZ+8fM/UldLWJ/51iBQwIDAQAB","manifest_version":2,"name":"Docs","offline_enabled":true,"update_url":"https://clients2.google.com/service/update2/crx","version":"0.10"},"page_ordinal":"n","path":"aohghmighlieiainnegkcijnfilokake/0.10_1","preferences":{},"regular_only_preferences":{},"state":1,"was_installed_by_default":true,"was_installed_by_oem":false,"withholding_permissions":false},"apdfllckaahabafndbhieahigkjlhalf":{"ack_external":true,"active_permissions":{"api":["clipboardRead","clipboardWrite","notifications"],"manifest_permissions":[]},"app_launcher_ordinal":"y","commands":{},"content_settings":[],"creation_flags":137,"events":[],"from_bookmark":false,"from_webstore":true,"granted_permissions":{"api":["clipboardRead","clipboardWrite","notifications"],"manifest_permissions":[]},"incognito_content_settings":[],"incognito_preferences":{},"install_time":"13226654683295429","lastpingday":"13226572800714429","location":1,"manifest":{"app":{"launch":{"web_url":"https://drive.google.com/?usp=chrome_app"},"urls":["http://docs.google.com/","http://drive.google.com/","https://docs.google.com/","https://drive.google.com/"]},"background":{"allow_js_access":false},"current_locale":"en_US","default_locale":"en_US","description":"Google Drive: create, share and keep all your stuff in one place.","icons":{"128":"128.png"},"key":"MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQDIl5KlKwL2TSkntkpY3naLLz5jsN0YwjhZyObcTOK6Nda4Ie21KRqZau9lx5SHcLh7pE2/S9OiArb+na2dn7YK5EvH+aRXS1ec3uxVlBhqLdnleVgwgwlg5fH95I52IeHcoeK6pR4hW/Nv39GNlI/Uqk6O6GBCCsAxYrdxww9BiQIDAQAB","manifest_version":2,"name":"Google Drive","offline_enabled":true,"options_page":"https://drive.google.com/drive/settings","permissions":["clipboardRead","clipboardWrite","notifications"],"update_url":"https://clients2.google.com/service/update2/crx","version":"14.2"},"page_ordinal":"n","path":"apdfllckaahabafndbhieahigkjlhalf/14.2_0","preferences":{},"regular_only_preferences":{},"state":1,"was_installed_by_default":true,"was_installed_by_oem":false},"blpcfgokakmgnkcojhhkbfbldkacnbeo":{"ack_external":true,"active_permissions":{"api":[],"manifest_permissions":[]},"app_launcher_ordinal":"zm","commands":{},"content_settings":[],"creation_flags":153,"events":[],"from_bookmark":true,"from_webstore":true,"granted_permissions":{"api":[],"manifest_permissions":[]},"incognito_content_settings":[],"incognito_preferences":{},"install_time":"13226654688489301","lastpingday":"13226572800714429","location":1,"manifest":{"app":{"launch":{"container":"tab","web_url":"http://www.youtube.com"},"web_content":{"enabled":true,"origin":"http://www.youtube.com"}},"current_locale":"en_US","default_locale":"en","description":"","icons":{"128":"128.png"},"key":"MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQDC/HotmFlyuz5FaHaIbVBhhL4BwbcUtsfWwzgUMpZt5ZsLB2nW/Y5xwNkkPANYGdVsJkT2GPpRRIKBO5QiJ7jPMa3EZtcZHpkygBlQLSjMhdrAKevpKgIl6YTkwzNvExY6rzVDzeE9zqnIs33eppY4S5QcoALMxuSWlMKqgFQjHQIDAQAB","manifest_version":2,"name":"YouTube","update_url":"http://clients2.google.com/service/update2/crx","version":"4.2.8"},"page_ordinal":"n","path":"blpcfgokakmgnkcojhhkbfbldkacnbeo/4.2.8_0","preferences":{},"regular_only_preferences":{},"state":1,"was_installed_by_default":true,"was_installed_by_oem":false},"felcaaldnbdncclmgdcncolpebgiejap":{"ack_external":true,"active_permissions":{"api":[],"manifest_permissions":[]},"app_launcher_ordinal":"yn","commands":{},"content_settings":[],"creation_flags":137,"events":[],"from_bookmark":false,"from_webstore":true,"granted_permissions":{"api":[],"manifest_permissions":[]},"incognito_content_settings":[],"incognito_preferences":{},"install_time":"13226654683544785","lastpingday":"13226572800714429","location":1,"manifest":{"api_console_project_id":"1083656409722","app":{"launch":{"local_path":"main.html"}},"container":"GOOGLE_DRIVE","current_locale":"en_US","default_locale":"en_US","description":"Create and edit spreadsheets","icons":{"128":"icon_128.png","16":"icon_16.png"},"key":"MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQC0AHrkP4MHPDKQI/O9LqZjtM24hKApaT3uVHeOduC06ZXWuwVRvx2wy5JUmMHfefXRG26tErgZSWpbxkm+2xfplKnT+grXF771HDgsNrNXERJHq7tnoYsWRiG3Gbs5BI4Ei+naZ/nyiWblbT4GyuD9N5yXNtoM0AnK+0FYhbO7IwIDAQAB","manifest_version":2,"name":"Sheets","offline_enabled":true,"update_url":"https://clients2.google.com/service/update2/crx","version":"1.2"},"page_ordinal":"n","path":"felcaaldnbdncclmgdcncolpebgiejap/1.2_0","preferences":{},"regular_only_preferences":{},"state":1,"was_installed_by_default":true,"was_installed_by_oem":false,"withholding_permissions":false},"gfdkimpbcpahaombhbimeihdjnejgicl":{"active_permissions":{"api":["feedbackPrivate"],"explicit_host":["chrome://resources/*"],"manifest_permissions":[]},"commands":{},"content_settings":[],"creation_flags":1,"events":["feedbackPrivate.onFeedbackRequested"],"from_bookmark":false,"from_webstore":false,"incognito_content_settings":[],"incognito_preferences":{},"install_time":"13226654677461190","location":5,"manifest":{"app":{"background":{"scripts":["js/event_handler.js"]},"content_security_policy":"default-src 'none'; script-src 'self' blob: filesystem: chrome://resources; style-src 'unsafe-inline' blob: chrome: file: filesystem: data: *; img-src * blob: chrome: file: filesystem: data:; media-src 'self' blob: filesystem:"},"description":"User feedback extension","display_in_launcher":false,"display_in_new_tab_page":false,"icons":{"192":"images/icon192.png","48":"images/icon48.png"},"incognito":"split","key":"MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQDMZElzFX2J1g1nRQ/8S3rg/1CjFyDltWOxQg+9M8aVgNVxbutEWFQz+oQzIP9BB67mJifULgiv12ToFKsae4NpEUR8sPZjiKDIHumc6pUdixOm8SJ5Rs16SMR6+VYxFUjlVW+5CA3IILptmNBxgpfyqoK0qRpBDIhGk1KDEZ4zqQIDAQAB","manifest_version":2,"name":"Feedback","permissions":["feedbackPrivate","chrome://resources/"],"version":"1.0"},"path":"/Applications/Google Chrome.app/Contents/Frameworks/Google Chrome Framework.framework/Versions/80.0.3987.116/Resources/feedback","preferences":{},"regular_only_preferences":{},"running":false,"state":1,"was_installed_by_default":false,"was_installed_by_oem":false},"ghbmnnjooekpmoecnnnilnnbdlolhkhi":{"ack_external":true,"active_permissions":{"api":["alarms","clipboardRead","clipboardWrite","identity","power","storage","unlimitedStorage","webConnectable"],"manifest_permissions":[]},"commands":{},"content_settings":[],"creation_flags":137,"events":["alarms.onAlarm","runtime.onConnectExternal"],"from_bookmark":false,"from_webstore":true,"granted_permissions":{"api":["alarms","clipboardRead","clipboardWrite","identity","power","storage","unlimitedStorage","webConnectable"],"manifest_permissions":[]},"incognito_content_settings":[],"incognito_preferences":{},"install_time":"13226654688233906","lastpingday":"13226572800714429","location":1,"manifest":{"background":{"persistent":false,"scripts":["eventpage_bin_prod.js"]},"content_capabilities":{"matches":["https://docs.google.com/*","https://drive.google.com/*"],"permissions":["clipboardRead","clipboardWrite","unlimitedStorage"]},"content_security_policy":"script-src 'self'; object-src 'self'","current_locale":"en_US","default_locale":"en_US","description":"Edit, create, and view your documents, spreadsheets, and presentations — all without internet access.","externally_connectable":{"matches":["https://docs.google.com/*","https://drive.google.com/*"]},"icons":{"128":"128.png"},"key":"MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAnF7RGLAxIon0/XeNZ4MLdP3DMkoORzEAKVg0sb89JpA/W2osTHr91Wqwdc9lW0mFcSpCYS9Y3e7cUMFo/M2ETASIuZncMiUzX2/0rrWtGQ3UuEj3KSe5PdaVZfisyJw/FebvHwirEWrhqcgzVUj9fL9YjE0G45d1zMKcc1umKvLqPyTznNuKBZ9GJREdGLRJCBmUgCkI8iwtwC+QZTUppmaD50/ksnEUXv+QkgGN07/KoNA5oAgo49Jf1XBoMv4QXtVZQlBYZl84zAsI82hb63a6Gu29U/4qMWDdI7+3Ne5TRvo6Zi3EI4M2NQNplJhik105qrz+eTLJJxvf4slrWwIDAQAB","manifest_version":2,"minimum_chrome_version":"43","name":"Google Docs Offline","permissions":["alarms","clipboardRead","clipboardWrite","identity","power","storage","unlimitedStorage"],"storage":{"managed_schema":"dasherSettingSchema.json"},"update_url":"https://clients2.google.com/service/update2/crx","version":"1.9","web_accessible_resources":["page_embed_script.js"]},"path":"ghbmnnjooekpmoecnnnilnnbdlolhkhi/1.9_0","preferences":{},"regular_only_preferences":{},"state":1,"was_installed_by_default":true,"was_installed_by_oem":false,"withholding_permissions":false},"jldhpllghnbhlbpcmnajkpdmadaolakh":{"active_permissions":{"api":["background","contextMenus","notifications","storage","tabs"],"explicit_host":["http://*.todoist.com/*","https://*.todoist.com/*"],"manifest_permissions":[],"scriptable_host":["http://*.todoist.com/*","https://*.todoist.com/*"]},"commands":{},"content_settings":[],"creation_flags":9,"events":[],"from_bookmark":false,"from_webstore":true,"granted_permissions":{"api":["background","contextMenus","notifications","storage","tabs"],"explicit_host":["http://*.todoist.com/*","https://*.todoist.com/*"],"manifest_permissions":[],"scriptable_host":["http://*.todoist.com/*","https://*.todoist.com/*"]},"incognito_content_settings":[],"incognito_preferences":{},"install_time":"13226654774154919","location":1,"manifest":{"background":{"page":"background.html"},"browser_action":{"default_icon":"todoist_256.png","default_popup":"popup.html","default_title":"Todoist"},"content_scripts":[{"all_frames":true,"js":["counter_update.js"],"matches":["http://*.todoist.com/*","https://*.todoist.com/*"]}],"current_locale":"en_US","default_locale":"en","description":"Organize work and life with Todoist for Chrome","icons":{"128":"todoist_128.png","16":"todoist_16.png","256":"todoist_256.png","48":"todoist_48.png","512":"todoist_512.png"},"key":"MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQCj5g40koD1nY0wP+LG19C2ACvjUv8oWurwruLWpDJn88qpiIRDHGBVG029Sh0q4tUmeTBhCWk7kJ6JNJ6P3iRrYZfGlJs1sb9oJdqQsmWiS3ziQHvSl3OyYT7a2hdZKi0cs0iKtrO318CS5uGGBW5EkW3oY7T12nblQgKo6PGc5QIDAQAB","manifest_version":2,"name":"Todoist for Chrome","options_ui":{"open_in_tab":false,"page":"options.html"},"permissions":["storage","tabs","background","contextMenus","notifications","http://*.todoist.com/*","https://*.todoist.com/*"],"short_name":"Todoist","update_url":"https://clients2.google.com/service/update2/crx","version":"9.9"},"needs_sync":true,"path":"jldhpllghnbhlbpcmnajkpdmadaolakh/9.9_0","preferences":{},"regular_only_preferences":{},"state":1,"was_installed_by_default":false,"was_installed_by_oem":false,"withholding_permissions":false},"kmendfapggjehodndflmmgagdbamhnfd":{"active_permissions":{"api":["cryptotokenPrivate","externally_connectable.all_urls","tabs","webConnectable"],"explicit_host":["http://*/*","https://*/*"],"manifest_permissions":[]},"commands":{},"content_settings":[],"creation_flags":1,"events":["runtime.onConnectExternal"],"from_bookmark":false,"from_webstore":false,"incognito_content_settings":[],"incognito_preferences":{},"install_time":"13226654677462231","location":5,"manifest":{"background":{"persistent":false,"scripts":["util.js","b64.js","cbor.js","sha256.js","timer.js","countdown.js","countdowntimer.js","devicestatuscodes.js","approvedorigins.js","errorcodes.js","webrequest.js","messagetypes.js","factoryregistry.js","requesthelper.js","asn1.js","enroller.js","requestqueue.js","signer.js","origincheck.js","textfetcher.js","appid.js","watchdog.js","logging.js","webrequestsender.js","window-timer.js","cryptotokenorigincheck.js","cryptotokenapprovedorigins.js","inherits.js","individualattest.js","googlecorpindividualattest.js","cryptotokenbackground.js"]},"description":"CryptoToken Component Extension","externally_connectable":{"ids":["fjajfjhkeibgmiggdfehjplbhmfkialk"],"matches":["https://*/*"]},"incognito":"split","key":"MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAq7zRobvA+AVlvNqkHSSVhh1sEWsHSqz4oR/XptkDe/Cz3+gW9ZGumZ20NCHjaac8j1iiesdigp8B1LJsd/2WWv2Dbnto4f8GrQ5MVphKyQ9WJHwejEHN2K4vzrTcwaXqv5BSTXwxlxS/mXCmXskTfryKTLuYrcHEWK8fCHb+0gvr8b/kvsi75A1aMmb6nUnFJvETmCkOCPNX5CHTdy634Ts/x0fLhRuPlahk63rdf7agxQv5viVjQFk+tbgv6aa9kdSd11Js/RZ9yZjrFgHOBWgP4jTBqud4+HUglrzu8qynFipyNRLCZsaxhm+NItTyNgesxLdxZcwOz56KD1Q4IQIDAQAB","manifest_version":2,"name":"CryptoTokenExtension","permissions":["cryptotokenPrivate","externally_connectable.all_urls","tabs","https://*/*","http://*/*"],"version":"0.9.74"},"path":"/Applications/Google Chrome.app/Contents/Frameworks/Google Chrome Framework.framework/Versions/80.0.3987.116/Resources/cryptotoken","preferences":{},"regular_only_preferences":{},"state":1,"was_installed_by_default":false,"was_installed_by_oem":false},"mfehgcgbbipciphmccgaenjidiccnmng":{"active_permissions":{"api":["cloudPrintPrivate"],"manifest_permissions":[]},"commands":{},"content_settings":[],"creation_flags":1,"events":[],"from_bookmark":false,"from_webstore":false,"incognito_content_settings":[],"incognito_preferences":{},"install_time":"13226654677457725","location":5,"manifest":{"app":{"launch":{"web_url":"https://www.google.com/cloudprint"},"urls":["https://www.google.com/cloudprint/enable_chrome_connector"]},"description":"Cloud Print","display_in_launcher":false,"icons":{},"key":"MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQDqOhnwk4+HXVfGyaNsAQdU/js1Na56diW08oF1MhZiwzSnJsEaeuMN9od9q9N4ZdK3o1xXOSARrYdE+syV7Dl31nf6qz3A6K+D5NHe6sSB9yvYlIiN37jdWdrfxxE0pRYEVYZNTe3bzq3NkcYJlOdt1UPcpJB+isXpAGUKUvt7EQIDAQAB","name":"Cloud Print","permissions":["cloudPrintPrivate"],"version":"0.1"},"path":"/Applications/Google Chrome.app/Contents/Frameworks/Google Chrome Framework.framework/Versions/80.0.3987.116/Resources/cloud_print","preferences":{},"regular_only_preferences":{},"state":1,"was_installed_by_default":false,"was_installed_by_oem":false},"mhjfbmdgcfjbbpaeojofohoefgiehjai":{"active_permissions":{"api":["contentSettings","fileSystem","fileSystem.write","metricsPrivate","resourcesPrivate"],"explicit_host":["chrome://resources/*"],"manifest_permissions":[]},"commands":{},"content_settings":[],"creation_flags":1,"events":[],"from_bookmark":false,"from_webstore":false,"incognito_content_settings":[],"incognito_preferences":{},"install_time":"13226654677462676","location":5,"manifest":{"content_security_policy":"script-src 'self' 'wasm-eval' blob: filesystem: chrome://resources; object-src * blob: externalfile: file: filesystem: data:; plugin-types application/x-google-chrome-pdf","description":"","incognito":"split","key":"MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQDN6hM0rsDYGbzQPQfOygqlRtQgKUXMfnSjhIBL7LnReAVBEd7ZmKtyN2qmSasMl4HZpMhVe2rPWVVwBDl6iyNE/Kok6E6v6V3vCLGsOpQAuuNVye/3QxzIldzG/jQAdWZiyXReRVapOhZtLjGfywCvlWq7Sl/e3sbc0vWybSDI2QIDAQAB","manifest_version":2,"mime_types":["application/pdf"],"mime_types_handler":"index.html","name":"Chrome PDF Viewer","offline_enabled":true,"permissions":["chrome://resources/","contentSettings","metricsPrivate","resourcesPrivate",{"fileSystem":["write"]}],"version":"1"},"path":"/Applications/Google Chrome.app/Contents/Frameworks/Google Chrome Framework.framework/Versions/80.0.3987.116/Resources/pdf","preferences":{},"regular_only_preferences":{},"state":1,"was_installed_by_default":false,"was_installed_by_oem":false},"neajdppkdcdipfabeoofebfddakdcjhd":{"active_permissions":{"api":["systemPrivate","ttsEngine"],"explicit_host":["https://www.google.com/*"],"manifest_permissions":[]},"commands":{},"content_settings":[],"creation_flags":1,"events":["ttsEngine.onPause","ttsEngine.onResume","ttsEngine.onSpeak","ttsEngine.onStop"],"from_bookmark":false,"from_webstore":false,"incognito_content_settings":[],"incognito_preferences":{},"install_time":"13226654677461722","location":5,"manifest":{"background":{"persistent":false,"scripts":["tts_extension.js"]},"description":"Component extension providing speech via the Google network text-to-speech service.","key":"MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA8GSbNUMGygqQTNDMFGIjZNcwXsHLzkNkHjWbuY37PbNdSDZ4VqlVjzbWqODSe+MjELdv5Keb51IdytnoGYXBMyqKmWpUrg+RnKvQ5ibWr4MW9pyIceOIdp9GrzC1WZGgTmZismYR3AjaIpufZ7xDdQQv+XrghPWCkdVqLN+qZDA1HU+DURznkMICiDDSH2sU0egm9UbWfS218bZqzKeQDiC3OnTPlaxcbJtKUuupIm5knjze3Wo9Ae9poTDMzKgchg0VlFCv3uqox+wlD8sjXBoyBCCK9HpImdVAF1a7jpdgiUHpPeV/26oYzM9/grltwNR3bzECQgSpyXp0eyoegwIDAQAB","manifest_version":2,"name":"Google Network Speech","permissions":["systemPrivate","ttsEngine","https://www.google.com/"],"tts_engine":{"voices":[{"event_types":["start","end","error"],"gender":"female","lang":"de-DE","remote":true,"voice_name":"Google Deutsch"},{"event_types":["start","end","error"],"gender":"female","lang":"en-US","remote":true,"voice_name":"Google US English"},{"event_types":["start","end","error"],"gender":"female","lang":"en-GB","remote":true,"voice_name":"Google UK English Female"},{"event_types":["start","end","error"],"gender":"male","lang":"en-GB","remote":true,"voice_name":"Google UK English Male"},{"event_types":["start","end","error"],"gender":"female","lang":"es-ES","remote":true,"voice_name":"Google español"},{"event_types":["start","end","error"],"gender":"female","lang":"es-US","remote":true,"voice_name":"Google español de Estados Unidos"},{"event_types":["start","end","error"],"gender":"female","lang":"fr-FR","remote":true,"voice_name":"Google français"},{"event_types":["start","end","error"],"gender":"female","lang":"hi-IN","remote":true,"voice_name":"Google हिन्दी"},{"event_types":["start","end","error"],"gender":"female","lang":"id-ID","remote":true,"voice_name":"Google Bahasa Indonesia"},{"event_types":["start","end","error"],"gender":"female","lang":"it-IT","remote":true,"voice_name":"Google italiano"},{"event_types":["start","end","error"],"gender":"female","lang":"ja-JP","remote":true,"voice_name":"Google 日本語"},{"event_types":["start","end","error"],"gender":"female","lang":"ko-KR","remote":true,"voice_name":"Google 한국의"},{"event_types":["start","end","error"],"gender":"female","lang":"nl-NL","remote":true,"voice_name":"Google Nederlands"},{"event_types":["start","end","error"],"gender":"female","lang":"pl-PL","remote":true,"voice_name":"Google polski"},{"event_types":["start","end","error"],"gender":"female","lang":"pt-BR","remote":true,"voice_name":"Google português do Brasil"},{"event_types":["start","end","error"],"gender":"female","lang":"ru-RU","remote":true,"voice_name":"Google русский"},{"event_types":["start","end","error"],"gender":"female","lang":"zh-CN","remote":true,"voice_name":"Google 普通话（中国大陆）"},{"event_types":["start","end","error"],"gender":"female","lang":"zh-HK","remote":true,"voice_name":"Google 粤語（香港）"},{"event_types":["start","end","error"],"gender":"female","lang":"zh-TW","remote":true,"voice_name":"Google 國語（臺灣）"}]},"version":"1.0"},"path":"/Applications/Google Chrome.app/Contents/Frameworks/Google Chrome Framework.framework/Versions/80.0.3987.116/Resources/network_speech_synthesis","preferences":{},"regular_only_preferences":{},"state":1,"was_installed_by_default":false,"was_installed_by_oem":false},"nkeimhogjdpnpccoofpliimaahmaaome":{"active_permissions":{"api":["desktopCapture","processes","webConnectable","webrtcAudioPrivate","webrtcDesktopCapturePrivate","webrtcLoggingPrivate","system.cpu","enterprise.hardwarePlatform"],"manifest_permissions":[]},"commands":{},"content_settings":[],"creation_flags":1,"events":["runtime.onConnectExternal"],"from_bookmark":false,"from_webstore":false,"incognito_content_settings":[],"incognito_preferences":{},"install_time":"13226654677460643","location":5,"manifest":{"background":{"page":"background.html","persistent":false},"externally_connectable":{"matches":["https://*.google.com/*","*://localhost/*"]},"incognito":"split","key":"MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQDAQt2ZDdPfoSe/JI6ID5bgLHRCnCu9T36aYczmhw/tnv6QZB2I6WnOCMZXJZlRdqWc7w9jo4BWhYS50Vb4weMfh/I0On7VcRwJUgfAxW2cHB+EkmtI1v4v/OU24OqIa1Nmv9uRVeX0GjhQukdLNhAE6ACWooaf5kqKlCeK+1GOkQIDAQAB","manifest_version":2,"name":"Google Hangouts","permissions":["desktopCapture","enterprise.hardwarePlatform","processes","system.cpu","webrtcAudioPrivate","webrtcDesktopCapturePrivate","webrtcLoggingPrivate"],"version":"1.3.15"},"path":"/Applications/Google Chrome.app/Contents/Frameworks/Google Chrome Framework.framework/Versions/80.0.3987.116/Resources/hangout_services","preferences":{},"regular_only_preferences":{},"state":1,"was_installed_by_default":false,"was_installed_by_oem":false},"nmmhkkegccagdldgiimedpiccmgmieda":{"ack_external":true,"active_permissions":{"api":["identity","webview"],"explicit_host":["https://payments.google.com/*","https://sandbox.google.com/*","https://www.google.com/*","https://www.googleapis.com/*"],"manifest_permissions":[]},"commands":{},"content_settings":[],"creation_flags":137,"events":["app.runtime.onLaunched","runtime.onConnectExternal"],"from_bookmark":false,"from_webstore":true,"granted_permissions":{"api":["identity","webview"],"explicit_host":["https://payments.google.com/*","https://sandbox.google.com/*","https://www.google.com/*","https://www.googleapis.com/*"],"manifest_permissions":[]},"incognito_content_settings":[],"incognito_preferences":{},"install_time":"13226654687782836","lastpingday":"13226572800714429","location":10,"manifest":{"app":{"background":{"scripts":["craw_background.js"]}},"current_locale":"en_US","default_locale":"en","description":"Chrome Web Store Payments","display_in_launcher":false,"display_in_new_tab_page":false,"icons":{"128":"images/icon_128.png","16":"images/icon_16.png"},"key":"MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQCrKfMnLqViEyokd1wk57FxJtW2XXpGXzIHBzv9vQI/01UsuP0IV5/lj0wx7zJ/xcibUgDeIxobvv9XD+zO1MdjMWuqJFcKuSS4Suqkje6u+pMrTSGOSHq1bmBVh0kpToN8YoJs/P/yrRd7FEtAXTaFTGxQL4C385MeXSjaQfiRiQIDAQAB","manifest_version":2,"minimum_chrome_version":"29","name":"Chrome Web Store Payments","oauth2":{"auto_approve":true,"client_id":"203784468217.apps.googleusercontent.com","scopes":["https://www.googleapis.com/auth/sierra","https://www.googleapis.com/auth/sierrasandbox","https://www.googleapis.com/auth/chromewebstore","https://www.googleapis.com/auth/chromewebstore.readonly"]},"permissions":["identity","webview","https://www.google.com/","https://www.googleapis.com/*","https://payments.google.com/payments/v4/js/integrator.js","https://sandbox.google.com/payments/v4/js/integrator.js"],"update_url":"https://clients2.google.com/service/update2/crx","version":"1.0.0.5"},"path":"nmmhkkegccagdldgiimedpiccmgmieda/1.0.0.5_0","preferences":{},"regular_only_preferences":{},"running":false,"state":1,"was_installed_by_default":true,"was_installed_by_oem":false},"pjkljhegncpnkpknbcohdijeoejaedia":{"ack_external":true,"active_permissions":{"api":["notifications"],"manifest_permissions":[]},"app_launcher_ordinal":"z","commands":{},"content_settings":[],"creation_flags":137,"events":[],"from_bookmark":false,"from_webstore":true,"granted_permissions":{"api":["notifications"],"manifest_permissions":[]},"incognito_content_settings":[],"incognito_preferences":{},"install_time":"13226654685955490","lastpingday":"13226572800714429","location":1,"manifest":{"app":{"launch":{"container":"tab","web_url":"https://mail.google.com/mail"},"urls":["*://mail.google.com/mail"]},"current_locale":"en_US","default_locale":"en","description":"Fast, searchable email with less spam.","icons":{"128":"128.png"},"key":"MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQDCuGglK43iAz3J9BEYK/Mz6ZhloIMMDqQSAaf3vJt4eHbTbSDsu4WdQ9dQDRcKlg8nwQdePBt0C3PSUBtiSNSS37Z3qEGfS7LCju3h6pI1Yr9MQtxw+jUa7kXXIS09VV73pEFUT/F7c6Qe8L5ZxgAcBvXBh1Fie63qb02I9XQ/CQIDAQAB","manifest_version":2,"name":"Gmail","options_page":"https://mail.google.com/mail/#settings","permissions":["notifications"],"update_url":"https://clients2.google.com/service/update2/crx","version":"8.2"},"page_ordinal":"n","path":"pjkljhegncpnkpknbcohdijeoejaedia/8.2_0","preferences":{},"regular_only_preferences":{},"state":1,"was_installed_by_default":true,"was_installed_by_oem":false},"pkedcjkdefgpdelpbcmbmeomcjbeemfm":{"ack_external":true,"active_permissions":{"api":["alarms","cast","cast.streaming","desktopCapture","gcm","identity","identity.email","management","mediaRouterPrivate","metricsPrivate","mdns","networkingPrivate","settingsPrivate","storage","tabs","tabCapture","webConnectable","webview","system.cpu"],"explicit_host":["http://*/*","https://*.google.com/*","https://hangouts.google.com/*"],"manifest_permissions":[]},"commands":{},"content_settings":[],"creation_flags":137,"events":["cast.channel.onError","cast.channel.onMessage","gcm.onMessage","identity.onSignInChanged","runtime.onStartup","runtime.onSuspend","settingsPrivate.onPrefsChanged"],"from_bookmark":false,"from_webstore":true,"granted_permissions":{"api":["alarms","cast","cast.streaming","desktopCapture","gcm","identity","identity.email","management","mediaRouterPrivate","metricsPrivate","mdns","networkingPrivate","settingsPrivate","storage","tabs","tabCapture","webConnectable","webview","system.cpu"],"explicit_host":["http://*/*","https://*.google.com/*","https://hangouts.google.com/*"],"manifest_permissions":[]},"incognito_content_settings":[],"incognito_preferences":{},"install_time":"13226654685697229","lastpingday":"13226572800714429","location":10,"manifest":{"background":{"persistent":false,"scripts":["common.js","mirroring_common.js","background_script.js"]},"content_security_policy":"default-src 'self'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; script-src 'self' https://apis.google.com https://feedback.googleusercontent.com https://www.google.com https://www.gstatic.com; child-src https://accounts.google.com https://content.googleapis.com https://www.google.com; connect-src 'self' http://*:* https://*:*; font-src https://fonts.gstatic.com; object-src 'self';","current_locale":"en_US","default_locale":"en","description":"Provider for discovery and services for mirroring of Chrome Media Router","externally_connectable":{"ids":["idmofbkcelhplfjnmmdolenpigiiiecc","ggedfkijiiammpnbdadhllnehapomdge","njjegkblellcjnakomndbaloifhcoccg"],"matches":["https://www.google.com/chromecast/*"]},"key":"MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQDNTWJoPZ9bT32yKxuuVa9LSEYobjPoXCLX3dgsZ9djDrWKNikTECjdRe3/AFXb+v8jkmmtYQPnOgSYn06J/QodDlCIG6l470+gkOoobUM7fOs1AVOse23qYUV4jbuRW3+YZlCvaWCFeczCNbGIUgKEi5B2fyQazy60AL1sLW3utQIDAQAB","manifest_version":2,"minimum_chrome_version":"37","name":"Chrome Media Router","oauth2":{"client_id":"919648714761-55j965o0km033psv3i9qls5mo3qtdrb0.apps.googleusercontent.com","scopes":["https://www.googleapis.com/auth/calendar.readonly","https://www.googleapis.com/auth/clouddevices","https://www.googleapis.com/auth/hangouts","https://www.googleapis.com/auth/hangouts.readonly","https://www.googleapis.com/auth/meetings","https://www.googleapis.com/auth/userinfo.email","https://www.googleapis.com/auth/cast-edu-messaging","https://www.googleapis.com/auth/plus.peopleapi.readwrite"]},"permissions":["alarms","cast","cast.streaming","declarativeWebRequest","desktopCapture","gcm","http://*/*","identity","identity.email","management","mdns","mediaRouterPrivate","metricsPrivate","networkingPrivate","processes","storage","system.cpu","settingsPrivate","tabCapture","tabs","webview","https://hangouts.google.com/*","https://*.google.com/cast/chromecast/home/gsse"],"update_url":"https://clients2.google.com/service/update2/crx","version":"8019.1111.0.0","web_accessible_resources":["cast_sender.js","cast_setup/*"]},"path":"pkedcjkdefgpdelpbcmbmeomcjbeemfm/8019.1111.0.0_0","preferences":{},"regular_only_preferences":{},"state":1,"was_installed_by_default":true,"was_installed_by_oem":false}}},"pinned_tabs":[],"protection":{"macs":{"browser":{"show_home_button":"B5EB34D9942F82A8AF68B991862F58F5A39251521C53E159FD5D1CB709BDF873"},"default_search_provider_data":{"template_url_data":"91DF3328DE1FEE92B3ABC654E70213225DAD1FB5E601A7BC139F808F2E34EB89"},"extensions":{"settings":{"aapocclcgogkmnckokdopfmhonfmgoek":"D1752F1ADB7DBA8B0FA550EB880B35AC42CCBCDA1B93A252F36D41130CCEEBA1","aeblfdkhhhdcdjpifhhbdiojplfjncoa":"43EFE888DDCBA9F0422E020E0DDC65A12282916DB73446EA37091D604537ADC1","aghfnjkcakhmadgdomlmlhhaocbkloab":"5FA548F25083441B74DFCF815867D24AC4B980053F0B2D414C650CBB671DA9BA","ahfgeienlihckogmohjhadlkjgocpleb":"5B019B0552263FDACB193F3AB2595D8B1F4173E0C49EBAB39C7A81197B9C7C13","aohghmighlieiainnegkcijnfilokake":"5930281902DD798ED1E908158D024F445C443D4ABA6E4D0C6F324036DFEDEA20","apdfllckaahabafndbhieahigkjlhalf":"CC185D9F762CEE0F1238B7AD4E7B4FF5881B6B595EF4CBC004DB6040DF32448D","blpcfgokakmgnkcojhhkbfbldkacnbeo":"28FF269C1003D2B826DDFEC6CB724C53251B7AC710900FACC8BAC4BFFE06D16C","felcaaldnbdncclmgdcncolpebgiejap":"E272BF994E54309694C6C9D311004E28B131FDF6FD7403E81DEFB37AA718D408","gfdkimpbcpahaombhbimeihdjnejgicl":"95341B6911D2DA6CBF30BB3554130A3763533B0B2056B9E8C16803CE4817508D","ghbmnnjooekpmoecnnnilnnbdlolhkhi":"1E64113E7CF14C1635A54218E301D30AF34590CF38490A7082CD5C0BE3C6061A","jldhpllghnbhlbpcmnajkpdmadaolakh":"7F0599476560A25894A7B046D8E76499EEDFD7A47DA19FF2722177F33B038B48","kmendfapggjehodndflmmgagdbamhnfd":"3FD3A074B3DEEC7465461884838463DA7967A540BD6C0BCE9F8356C9ECB27290","mfehgcgbbipciphmccgaenjidiccnmng":"997BD8BEA32AA61BF7BD8DB08C46D6B9D52B4BCEC93B9D321EDB5824770BFBEC","mhjfbmdgcfjbbpaeojofohoefgiehjai":"E58D38C4C2DC691934A15C36F72A051EB1E8BCB3C20269DC3DBE89AD58468CC9","neajdppkdcdipfabeoofebfddakdcjhd":"562538760D62A89E85210B930CF21FEDCC7DE041CB690B94578D8E11FCC58509","nkeimhogjdpnpccoofpliimaahmaaome":"D9837DD307B786922A67E5F09DE71B8163D8A3532DECB18639C84AE1DB0190FB","nmmhkkegccagdldgiimedpiccmgmieda":"4F7A96E4A6E4175ADE844F177CE929685CDA1D2A0956B9059849D71C075DCA81","pjkljhegncpnkpknbcohdijeoejaedia":"B110CABEAA67157C899465DAEA502BC10246FFC370624E711F9E4196C1FA8D4C","pkedcjkdefgpdelpbcmbmeomcjbeemfm":"84ED0D82AFB7ADD4B01C9CDFA62F25C34E330D98278AF62D4A9C2DE33C8EE788"}},"google":{"services":{"account_id":"53AB201B83B1C65823ECBF18EA758EBAE73CA766CC48B16E5BEC293CBDAC99D2","last_account_id":"F873A6B5855FC7B13E62BA3389654CB6235D4EA9FC11819ECBD1FBB3ACB72568","last_username":"A709F31CDDC4F95F8282AD3A724840A7A974B21EA07268650F52B305AD49CCF0"}},"homepage":"298FFD7268FD73FFDF466BBD2D9679822CF47E365F414D73DE95CF7C273B2769","homepage_is_newtabpage":"B5038F43EFD47FBC80C011499960458BF11DEBC2914017654987D6AA90B149FA","media":{"storage_id_salt":"17ABE5A224C6BB4EFFC00878EB3FAE3471E52FE7B028D27BD6CFF028D393E87B"},"pinned_tabs":"0668B53A1CF88AE3A618EBF480391FF63B7E3A1AE97A337B1DEDE5152F2F40B9","prefs":{"preference_reset_time":"4E54DAE953E6D59540B3F8A2BD5B52BF754814D84B6D1CFF78C6111D7C8DF1A4"},"safebrowsing":{"incidents_sent":"6ED043F7F75C6798BC00FD4E71F59F7F79225B7C349997EA33AAD18CF43B3061"},"search_provider_overrides":"3AE81F3E908BFD62166EC420891095D3078B106BEB02FFDEDE4AAA9554596CF9","session":{"restore_on_startup":"AED0EFEA1F0E02AF44F9F0656D395A765FA1FEF19DADBD158052A8918E1CB884","startup_urls":"70E6A80ED32C26F1609C53173B9143749776190103D06779E499D3FD42C17195"}},"super_mac":"DC1D234E854754C0422B23D3C3F565F266C5E9E145B6603010AAB918827BB79F"}}
+{
+    "extensions":
+    {
+        "settings":
+        {
+            "aapocclcgogkmnckokdopfmhonfmgoek":
+            {
+                "ack_external": true,
+                "active_permissions":
+                {
+                    "api":
+                    [],
+                    "manifest_permissions":
+                    []
+                },
+                "app_launcher_ordinal": "w",
+                "commands":
+                {},
+                "content_settings":
+                [],
+                "creation_flags": 137,
+                "events":
+                [],
+                "from_bookmark": false,
+                "from_webstore": true,
+                "granted_permissions":
+                {
+                    "api":
+                    [],
+                    "manifest_permissions":
+                    []
+                },
+                "incognito_content_settings":
+                [],
+                "incognito_preferences":
+                {},
+                "install_time": "13226654686468813",
+                "lastpingday": "13226572800714429",
+                "location": 1,
+                "manifest":
+                {
+                    "api_console_project_id": "889782162350",
+                    "app":
+                    {
+                        "launch":
+                        {
+                            "local_path": "main.html"
+                        }
+                    },
+                    "container": "GOOGLE_DRIVE",
+                    "current_locale": "en_US",
+                    "default_locale": "en_US",
+                    "description": "Create and edit presentations ",
+                    "icons":
+                    {
+                        "128": "icon_128.png",
+                        "16": "icon_16.png"
+                    },
+                    "key": "MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQDLOGW2Hoztw8m2z6SmCjm7y4Oe2o6aRqO+niYKCXhZab572by7acqFIFF0On3e3a967SwNijsTx2n+7Mt3KqWzEKtnwUZqzHYSsdZZK64vWIHIduawP0EICWRMf2RGIBEdDC6I1zErtcDiSrJWeRlnb0DHWXDXlt1YseM7RiON9wIDAQAB",
+                    "manifest_version": 2,
+                    "name": "Slides",
+                    "offline_enabled": true,
+                    "update_url": "https://clients2.google.com/service/update2/crx",
+                    "version": "0.10"
+                },
+                "page_ordinal": "n",
+                "path": "aapocclcgogkmnckokdopfmhonfmgoek/0.10_1",
+                "preferences":
+                {},
+                "regular_only_preferences":
+                {},
+                "state": 0,
+                "was_installed_by_default": true,
+                "was_installed_by_oem": false,
+                "withholding_permissions": false
+            },
+            "aghfnjkcakhmadgdomlmlhhaocbkloab":
+            {
+                "active_permissions":
+                {
+                    "api":
+                    [],
+                    "manifest_permissions":
+                    []
+                },
+                "commands":
+                {},
+                "content_settings":
+                [],
+                "creation_flags": 9,
+                "events":
+                [],
+                "from_bookmark": false,
+                "from_webstore": true,
+                "granted_permissions":
+                {
+                    "api":
+                    [],
+                    "manifest_permissions":
+                    []
+                },
+                "incognito_content_settings":
+                [],
+                "incognito_preferences":
+                {},
+                "install_time": "13226654710521941",
+                "location": 1,
+                "manifest":
+                {
+                    "description": "Just Black: when you're feeling extra moody",
+                    "key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAqxThvdYeWk6kwfNo+/HoqQSkL6iBx48w28vEPXHdhJo8OHMxS7D+1W1nhUsv4hOnb1CM2TlP/Nh9G+1Z32R9r6RmVxD1Anq9ZTZpK7VHVUxExGR4X9+TYHKWk8VGAjSBmutvayf0i0gCEkh7Pdc68ex4M0ypKGFWxBzxqw2uQ/4BLMVB/9KZJwXOC5LcaBNgq2Q74J3Dd3a90OzFXh+vC9zIyDueu3/K4F6u5bXgsgviAGIrUm7YbGhLDMxuW81zvYMlLtkA4XDDnhgk88s0G/5OwoMEyU6YdMq9R795NHsI0bPUMOOgUsPT5cytKRcQMegMassBe9EB+ktTl9CloQIDAQAB",
+                    "manifest_version": 2,
+                    "name": "Just Black",
+                    "theme":
+                    {
+                        "colors":
+                        {
+                            "bookmark_text":
+                            [
+                                255,
+                                255,
+                                255
+                            ],
+                            "frame":
+                            [
+                                0,
+                                0,
+                                0
+                            ],
+                            "ntp_background":
+                            [
+                                0,
+                                0,
+                                0
+                            ],
+                            "ntp_text":
+                            [
+                                125,
+                                134,
+                                142
+                            ],
+                            "tab_background_text":
+                            [
+                                255,
+                                255,
+                                255
+                            ],
+                            "tab_background_text_inactive":
+                            [
+                                255,
+                                255,
+                                255
+                            ],
+                            "tab_background_text_incognito":
+                            [
+                                255,
+                                255,
+                                255
+                            ],
+                            "tab_background_text_incognito_inactive":
+                            [
+                                255,
+                                255,
+                                255
+                            ],
+                            "tab_text":
+                            [
+                                255,
+                                255,
+                                255
+                            ],
+                            "toolbar":
+                            [
+                                45,
+                                45,
+                                45
+                            ]
+                        },
+                        "tints":
+                        {
+                            "buttons":
+                            [
+                                0.2,
+                                0.2,
+                                0.9
+                            ],
+                            "frame_inactive":
+                            [
+                                -1,
+                                -1,
+                                -1
+                            ],
+                            "frame_incognito":
+                            [
+                                -1,
+                                -1,
+                                -1
+                            ],
+                            "frame_incognito_inactive":
+                            [
+                                -1,
+                                -1,
+                                -1
+                            ]
+                        }
+                    },
+                    "update_url": "https://clients2.google.com/service/update2/crx",
+                    "version": "2"
+                },
+                "path": "aghfnjkcakhmadgdomlmlhhaocbkloab/2_0",
+                "preferences":
+                {},
+                "regular_only_preferences":
+                {},
+                "state": 1,
+                "was_installed_by_default": false,
+                "was_installed_by_oem": false
+            },
+            "ahfgeienlihckogmohjhadlkjgocpleb":
+            {
+                "active_bit": true,
+                "active_permissions":
+                {
+                    "api":
+                    [
+                        "management",
+                        "system.display",
+                        "system.storage",
+                        "webstorePrivate",
+                        "system.cpu",
+                        "system.memory",
+                        "system.network"
+                    ],
+                    "manifest_permissions":
+                    []
+                },
+                "app_launcher_ordinal": "t",
+                "commands":
+                {},
+                "content_settings":
+                [],
+                "creation_flags": 1,
+                "events":
+                [],
+                "from_bookmark": false,
+                "from_webstore": false,
+                "incognito_content_settings":
+                [],
+                "incognito_preferences":
+                {},
+                "install_time": "13226654677459804",
+                "last_launch_time": "13226654699036269",
+                "location": 5,
+                "manifest":
+                {
+                    "app":
+                    {
+                        "launch":
+                        {
+                            "web_url": "https://chrome.google.com/webstore"
+                        },
+                        "urls":
+                        [
+                            "https://chrome.google.com/webstore"
+                        ]
+                    },
+                    "description": "Discover great apps, games, extensions and themes for Google Chrome.",
+                    "icons":
+                    {
+                        "128": "webstore_icon_128.png",
+                        "16": "webstore_icon_16.png"
+                    },
+                    "key": "MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQCtl3tO0osjuzRsf6xtD2SKxPlTfuoy7AWoObysitBPvH5fE1NaAA1/2JkPWkVDhdLBWLaIBPYeXbzlHp3y4Vv/4XG+aN5qFE3z+1RU/NqkzVYHtIpVScf3DjTYtKVL66mzVGijSoAIwbFCC3LpGdaoe6Q1rSRDp76wR6jjFzsYwQIDAQAB",
+                    "name": "Web Store",
+                    "permissions":
+                    [
+                        "webstorePrivate",
+                        "management",
+                        "system.cpu",
+                        "system.display",
+                        "system.memory",
+                        "system.network",
+                        "system.storage"
+                    ],
+                    "version": "0.2"
+                },
+                "needs_sync": true,
+                "page_ordinal": "n",
+                "path": "/Applications/Google Chrome.app/Contents/Frameworks/Google Chrome Framework.framework/Versions/80.0.3987.116/Resources/web_store",
+                "preferences":
+                {},
+                "regular_only_preferences":
+                {},
+                "state": 1,
+                "was_installed_by_default": false,
+                "was_installed_by_oem": false
+            },
+            "aohghmighlieiainnegkcijnfilokake":
+            {
+                "ack_external": true,
+                "active_permissions":
+                {
+                    "api":
+                    [],
+                    "manifest_permissions":
+                    []
+                },
+                "app_launcher_ordinal": "x",
+                "commands":
+                {},
+                "content_settings":
+                [],
+                "creation_flags": 137,
+                "events":
+                [],
+                "from_bookmark": false,
+                "from_webstore": true,
+                "granted_permissions":
+                {
+                    "api":
+                    [],
+                    "manifest_permissions":
+                    []
+                },
+                "incognito_content_settings":
+                [],
+                "incognito_preferences":
+                {},
+                "install_time": "13226654686203610",
+                "lastpingday": "13226572800714429",
+                "location": 1,
+                "manifest":
+                {
+                    "api_console_project_id": "619683526622",
+                    "app":
+                    {
+                        "launch":
+                        {
+                            "local_path": "main.html"
+                        }
+                    },
+                    "container": "GOOGLE_DRIVE",
+                    "current_locale": "en_US",
+                    "default_locale": "en_US",
+                    "description": "Create and edit documents ",
+                    "icons":
+                    {
+                        "128": "icon_128.png",
+                        "16": "icon_16.png"
+                    },
+                    "key": "MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQDJhLK6fk/BWTEvJhywpk7jDe4A2r0bGXGOLZW4/AdBp3IiD9o9nx4YjLAtv0tIPxi7MvFd/GUUbQBwHT5wQWONJj1z/0Rc2qBkiJA0yqXh42p0snuA8dCfdlhOLsp7/XTMEwAVasjV5hC4awl78eKfJYlZ+8fM/UldLWJ/51iBQwIDAQAB",
+                    "manifest_version": 2,
+                    "name": "Docs",
+                    "offline_enabled": true,
+                    "update_url": "https://clients2.google.com/service/update2/crx",
+                    "version": "0.10"
+                },
+                "page_ordinal": "n",
+                "path": "aohghmighlieiainnegkcijnfilokake/0.10_1",
+                "preferences":
+                {},
+                "regular_only_preferences":
+                {},
+                "state": 1,
+                "was_installed_by_default": true,
+                "was_installed_by_oem": false,
+                "withholding_permissions": false
+            },
+            "apdfllckaahabafndbhieahigkjlhalf":
+            {
+                "ack_external": true,
+                "active_permissions":
+                {
+                    "api":
+                    [
+                        "clipboardRead",
+                        "clipboardWrite",
+                        "notifications"
+                    ],
+                    "manifest_permissions":
+                    []
+                },
+                "app_launcher_ordinal": "y",
+                "commands":
+                {},
+                "content_settings":
+                [],
+                "creation_flags": 137,
+                "events":
+                [],
+                "from_bookmark": false,
+                "from_webstore": true,
+                "granted_permissions":
+                {
+                    "api":
+                    [
+                        "clipboardRead",
+                        "clipboardWrite",
+                        "notifications"
+                    ],
+                    "manifest_permissions":
+                    []
+                },
+                "incognito_content_settings":
+                [],
+                "incognito_preferences":
+                {},
+                "install_time": "13226654683295429",
+                "lastpingday": "13226572800714429",
+                "location": 1,
+                "manifest":
+                {
+                    "app":
+                    {
+                        "launch":
+                        {
+                            "web_url": "https://drive.google.com/?usp=chrome_app"
+                        },
+                        "urls":
+                        [
+                            "http://docs.google.com/",
+                            "http://drive.google.com/",
+                            "https://docs.google.com/",
+                            "https://drive.google.com/"
+                        ]
+                    },
+                    "background":
+                    {
+                        "allow_js_access": false
+                    },
+                    "current_locale": "en_US",
+                    "default_locale": "en_US",
+                    "description": "Google Drive: create, share and keep all your stuff in one place.",
+                    "icons":
+                    {
+                        "128": "128.png"
+                    },
+                    "key": "MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQDIl5KlKwL2TSkntkpY3naLLz5jsN0YwjhZyObcTOK6Nda4Ie21KRqZau9lx5SHcLh7pE2/S9OiArb+na2dn7YK5EvH+aRXS1ec3uxVlBhqLdnleVgwgwlg5fH95I52IeHcoeK6pR4hW/Nv39GNlI/Uqk6O6GBCCsAxYrdxww9BiQIDAQAB",
+                    "manifest_version": 2,
+                    "name": "Google Drive",
+                    "offline_enabled": true,
+                    "options_page": "https://drive.google.com/drive/settings",
+                    "permissions":
+                    [
+                        "clipboardRead",
+                        "clipboardWrite",
+                        "notifications"
+                    ],
+                    "update_url": "https://clients2.google.com/service/update2/crx",
+                    "version": "14.2"
+                },
+                "page_ordinal": "n",
+                "path": "apdfllckaahabafndbhieahigkjlhalf/14.2_0",
+                "preferences":
+                {},
+                "regular_only_preferences":
+                {},
+                "state": 1,
+                "was_installed_by_default": true,
+                "was_installed_by_oem": false
+            },
+            "blpcfgokakmgnkcojhhkbfbldkacnbeo":
+            {
+                "ack_external": true,
+                "active_permissions":
+                {
+                    "api":
+                    [],
+                    "manifest_permissions":
+                    []
+                },
+                "app_launcher_ordinal": "zm",
+                "commands":
+                {},
+                "content_settings":
+                [],
+                "creation_flags": 153,
+                "events":
+                [],
+                "from_bookmark": true,
+                "from_webstore": true,
+                "granted_permissions":
+                {
+                    "api":
+                    [],
+                    "manifest_permissions":
+                    []
+                },
+                "incognito_content_settings":
+                [],
+                "incognito_preferences":
+                {},
+                "install_time": "13226654688489301",
+                "lastpingday": "13226572800714429",
+                "location": 1,
+                "manifest":
+                {
+                    "app":
+                    {
+                        "launch":
+                        {
+                            "container": "tab",
+                            "web_url": "http://www.youtube.com"
+                        },
+                        "web_content":
+                        {
+                            "enabled": true,
+                            "origin": "http://www.youtube.com"
+                        }
+                    },
+                    "current_locale": "en_US",
+                    "default_locale": "en",
+                    "description": "",
+                    "icons":
+                    {
+                        "128": "128.png"
+                    },
+                    "key": "MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQDC/HotmFlyuz5FaHaIbVBhhL4BwbcUtsfWwzgUMpZt5ZsLB2nW/Y5xwNkkPANYGdVsJkT2GPpRRIKBO5QiJ7jPMa3EZtcZHpkygBlQLSjMhdrAKevpKgIl6YTkwzNvExY6rzVDzeE9zqnIs33eppY4S5QcoALMxuSWlMKqgFQjHQIDAQAB",
+                    "manifest_version": 2,
+                    "name": "YouTube",
+                    "update_url": "http://clients2.google.com/service/update2/crx",
+                    "version": "4.2.8"
+                },
+                "page_ordinal": "n",
+                "path": "blpcfgokakmgnkcojhhkbfbldkacnbeo/4.2.8_0",
+                "preferences":
+                {},
+                "regular_only_preferences":
+                {},
+                "state": 1,
+                "was_installed_by_default": true,
+                "was_installed_by_oem": false
+            },
+            "felcaaldnbdncclmgdcncolpebgiejap":
+            {
+                "ack_external": true,
+                "active_permissions":
+                {
+                    "api":
+                    [],
+                    "manifest_permissions":
+                    []
+                },
+                "app_launcher_ordinal": "yn",
+                "commands":
+                {},
+                "content_settings":
+                [],
+                "creation_flags": 137,
+                "events":
+                [],
+                "from_bookmark": false,
+                "from_webstore": true,
+                "granted_permissions":
+                {
+                    "api":
+                    [],
+                    "manifest_permissions":
+                    []
+                },
+                "incognito_content_settings":
+                [],
+                "incognito_preferences":
+                {},
+                "install_time": "13226654683544785",
+                "lastpingday": "13226572800714429",
+                "location": 1,
+                "manifest":
+                {
+                    "api_console_project_id": "1083656409722",
+                    "app":
+                    {
+                        "launch":
+                        {
+                            "local_path": "main.html"
+                        }
+                    },
+                    "container": "GOOGLE_DRIVE",
+                    "current_locale": "en_US",
+                    "default_locale": "en_US",
+                    "description": "Create and edit spreadsheets",
+                    "icons":
+                    {
+                        "128": "icon_128.png",
+                        "16": "icon_16.png"
+                    },
+                    "key": "MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQC0AHrkP4MHPDKQI/O9LqZjtM24hKApaT3uVHeOduC06ZXWuwVRvx2wy5JUmMHfefXRG26tErgZSWpbxkm+2xfplKnT+grXF771HDgsNrNXERJHq7tnoYsWRiG3Gbs5BI4Ei+naZ/nyiWblbT4GyuD9N5yXNtoM0AnK+0FYhbO7IwIDAQAB",
+                    "manifest_version": 2,
+                    "name": "Sheets",
+                    "offline_enabled": true,
+                    "update_url": "https://clients2.google.com/service/update2/crx",
+                    "version": "1.2"
+                },
+                "page_ordinal": "n",
+                "path": "felcaaldnbdncclmgdcncolpebgiejap/1.2_0",
+                "preferences":
+                {},
+                "regular_only_preferences":
+                {},
+                "state": 1,
+                "was_installed_by_default": true,
+                "was_installed_by_oem": false,
+                "withholding_permissions": false
+            },
+            "gfdkimpbcpahaombhbimeihdjnejgicl":
+            {
+                "active_permissions":
+                {
+                    "api":
+                    [
+                        "feedbackPrivate"
+                    ],
+                    "explicit_host":
+                    [
+                        "chrome://resources/*"
+                    ],
+                    "manifest_permissions":
+                    []
+                },
+                "commands":
+                {},
+                "content_settings":
+                [],
+                "creation_flags": 1,
+                "events":
+                [
+                    "feedbackPrivate.onFeedbackRequested"
+                ],
+                "from_bookmark": false,
+                "from_webstore": false,
+                "incognito_content_settings":
+                [],
+                "incognito_preferences":
+                {},
+                "install_time": "13226654677461190",
+                "location": 5,
+                "manifest":
+                {
+                    "app":
+                    {
+                        "background":
+                        {
+                            "scripts":
+                            [
+                                "js/event_handler.js"
+                            ]
+                        },
+                        "content_security_policy": "default-src 'none'; script-src 'self' blob: filesystem: chrome://resources; style-src 'unsafe-inline' blob: chrome: file: filesystem: data: *; img-src * blob: chrome: file: filesystem: data:; media-src 'self' blob: filesystem:"
+                    },
+                    "description": "User feedback extension",
+                    "display_in_launcher": false,
+                    "display_in_new_tab_page": false,
+                    "icons":
+                    {
+                        "192": "images/icon192.png",
+                        "48": "images/icon48.png"
+                    },
+                    "incognito": "split",
+                    "key": "MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQDMZElzFX2J1g1nRQ/8S3rg/1CjFyDltWOxQg+9M8aVgNVxbutEWFQz+oQzIP9BB67mJifULgiv12ToFKsae4NpEUR8sPZjiKDIHumc6pUdixOm8SJ5Rs16SMR6+VYxFUjlVW+5CA3IILptmNBxgpfyqoK0qRpBDIhGk1KDEZ4zqQIDAQAB",
+                    "manifest_version": 2,
+                    "name": "Feedback",
+                    "permissions":
+                    [
+                        "feedbackPrivate",
+                        "chrome://resources/"
+                    ],
+                    "version": "1.0"
+                },
+                "path": "/Applications/Google Chrome.app/Contents/Frameworks/Google Chrome Framework.framework/Versions/80.0.3987.116/Resources/feedback",
+                "preferences":
+                {},
+                "regular_only_preferences":
+                {},
+                "running": false,
+                "state": 1,
+                "was_installed_by_default": false,
+                "was_installed_by_oem": false
+            },
+            "ghbmnnjooekpmoecnnnilnnbdlolhkhi":
+            {
+                "ack_external": true,
+                "active_permissions":
+                {
+                    "api":
+                    [
+                        "alarms",
+                        "clipboardRead",
+                        "clipboardWrite",
+                        "identity",
+                        "power",
+                        "storage",
+                        "unlimitedStorage",
+                        "webConnectable"
+                    ],
+                    "manifest_permissions":
+                    []
+                },
+                "commands":
+                {},
+                "content_settings":
+                [],
+                "creation_flags": 137,
+                "events":
+                [
+                    "alarms.onAlarm",
+                    "runtime.onConnectExternal"
+                ],
+                "from_bookmark": false,
+                "from_webstore": true,
+                "granted_permissions":
+                {
+                    "api":
+                    [
+                        "alarms",
+                        "clipboardRead",
+                        "clipboardWrite",
+                        "identity",
+                        "power",
+                        "storage",
+                        "unlimitedStorage",
+                        "webConnectable"
+                    ],
+                    "manifest_permissions":
+                    []
+                },
+                "incognito_content_settings":
+                [],
+                "incognito_preferences":
+                {},
+                "install_time": "13226654688233906",
+                "lastpingday": "13226572800714429",
+                "location": 1,
+                "manifest":
+                {
+                    "background":
+                    {
+                        "persistent": false,
+                        "scripts":
+                        [
+                            "eventpage_bin_prod.js"
+                        ]
+                    },
+                    "content_capabilities":
+                    {
+                        "matches":
+                        [
+                            "https://docs.google.com/*",
+                            "https://drive.google.com/*"
+                        ],
+                        "permissions":
+                        [
+                            "clipboardRead",
+                            "clipboardWrite",
+                            "unlimitedStorage"
+                        ]
+                    },
+                    "content_security_policy": "script-src 'self'; object-src 'self'",
+                    "current_locale": "en_US",
+                    "default_locale": "en_US",
+                    "description": "Edit, create, and view your documents, spreadsheets, and presentations — all without internet access.",
+                    "externally_connectable":
+                    {
+                        "matches":
+                        [
+                            "https://docs.google.com/*",
+                            "https://drive.google.com/*"
+                        ]
+                    },
+                    "icons":
+                    {
+                        "128": "128.png"
+                    },
+                    "key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAnF7RGLAxIon0/XeNZ4MLdP3DMkoORzEAKVg0sb89JpA/W2osTHr91Wqwdc9lW0mFcSpCYS9Y3e7cUMFo/M2ETASIuZncMiUzX2/0rrWtGQ3UuEj3KSe5PdaVZfisyJw/FebvHwirEWrhqcgzVUj9fL9YjE0G45d1zMKcc1umKvLqPyTznNuKBZ9GJREdGLRJCBmUgCkI8iwtwC+QZTUppmaD50/ksnEUXv+QkgGN07/KoNA5oAgo49Jf1XBoMv4QXtVZQlBYZl84zAsI82hb63a6Gu29U/4qMWDdI7+3Ne5TRvo6Zi3EI4M2NQNplJhik105qrz+eTLJJxvf4slrWwIDAQAB",
+                    "manifest_version": 2,
+                    "minimum_chrome_version": "43",
+                    "name": "Google Docs Offline",
+                    "permissions":
+                    [
+                        "alarms",
+                        "clipboardRead",
+                        "clipboardWrite",
+                        "identity",
+                        "power",
+                        "storage",
+                        "unlimitedStorage"
+                    ],
+                    "storage":
+                    {
+                        "managed_schema": "dasherSettingSchema.json"
+                    },
+                    "update_url": "https://clients2.google.com/service/update2/crx",
+                    "version": "1.9",
+                    "web_accessible_resources":
+                    [
+                        "page_embed_script.js"
+                    ]
+                },
+                "path": "ghbmnnjooekpmoecnnnilnnbdlolhkhi/1.9_0",
+                "preferences":
+                {},
+                "regular_only_preferences":
+                {},
+                "state": 1,
+                "was_installed_by_default": true,
+                "was_installed_by_oem": false,
+                "withholding_permissions": false
+            },
+            "aeblfdkhhhdcdjpifhhbdiojplfjncoa":
+            {
+                "active_permissions":
+                {
+                    "api":
+                    [
+                        "background",
+                        "contextMenus",
+                        "notifications",
+                        "storage",
+                        "tabs"
+                    ],
+                    "explicit_host":
+                    [
+                        "http://*.todoist.com/*",
+                        "https://*.todoist.com/*"
+                    ],
+                    "manifest_permissions":
+                    [],
+                    "scriptable_host":
+                    [
+                        "http://*.todoist.com/*",
+                        "https://*.todoist.com/*"
+                    ]
+                },
+                "commands":
+                {},
+                "content_settings":
+                [],
+                "creation_flags": 9,
+                "events":
+                [],
+                "from_bookmark": false,
+                "from_webstore": true,
+                "granted_permissions":
+                {
+                    "api":
+                    [
+                        "background",
+                        "contextMenus",
+                        "notifications",
+                        "storage",
+                        "tabs"
+                    ],
+                    "explicit_host":
+                    [
+                        "http://*.todoist.com/*",
+                        "https://*.todoist.com/*"
+                    ],
+                    "manifest_permissions":
+                    [],
+                    "scriptable_host":
+                    [
+                        "http://*.todoist.com/*",
+                        "https://*.todoist.com/*"
+                    ]
+                },
+                "incognito_content_settings":
+                [],
+                "incognito_preferences":
+                {},
+                "install_time": "13226654774154919",
+                "location": 1,
+                "manifest":
+                {
+                    "background":
+                    {
+                        "page": "background.html"
+                    },
+                    "browser_action":
+                    {
+                        "default_icon": "todoist_256.png",
+                        "default_popup": "popup.html",
+                        "default_title": "Todoist"
+                    },
+                    "content_scripts":
+                    [
+                        {
+                            "all_frames": true,
+                            "js":
+                            [
+                                "counter_update.js"
+                            ],
+                            "matches":
+                            [
+                                "http://*.todoist.com/*",
+                                "https://*.todoist.com/*"
+                            ]
+                        }
+                    ],
+                    "current_locale": "en_US",
+                    "default_locale": "en",
+                    "description": "Organize work and life with Todoist for Chrome",
+                    "icons":
+                    {
+                        "128": "todoist_128.png",
+                        "16": "todoist_16.png",
+                        "256": "todoist_256.png",
+                        "48": "todoist_48.png",
+                        "512": "todoist_512.png"
+                    },
+                    "key": "MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQCj5g40koD1nY0wP+LG19C2ACvjUv8oWurwruLWpDJn88qpiIRDHGBVG029Sh0q4tUmeTBhCWk7kJ6JNJ6P3iRrYZfGlJs1sb9oJdqQsmWiS3ziQHvSl3OyYT7a2hdZKi0cs0iKtrO318CS5uGGBW5EkW3oY7T12nblQgKo6PGc5QIDAQAB",
+                    "manifest_version": 2,
+                    "name": "Todoist for Chrome",
+                    "options_ui":
+                    {
+                        "open_in_tab": false,
+                        "page": "options.html"
+                    },
+                    "permissions":
+                    [
+                        "storage",
+                        "tabs",
+                        "background",
+                        "contextMenus",
+                        "notifications",
+                        "http://*.todoist.com/*",
+                        "https://*.todoist.com/*"
+                    ],
+                    "short_name": "Todoist",
+                    "update_url": "https://clients2.google.com/service/update2/crx",
+                    "version": "9.9"
+                },
+                "needs_sync": true,
+                "path": "jldhpllghnbhlbpcmnajkpdmadaolakh/9.9_0",
+                "preferences":
+                {},
+                "regular_only_preferences":
+                {},
+                "state": 1,
+                "was_installed_by_default": false,
+                "was_installed_by_oem": false,
+                "withholding_permissions": false
+            },
+            "kmendfapggjehodndflmmgagdbamhnfd":
+            {
+                "active_permissions":
+                {
+                    "api":
+                    [
+                        "cryptotokenPrivate",
+                        "externally_connectable.all_urls",
+                        "tabs",
+                        "webConnectable"
+                    ],
+                    "explicit_host":
+                    [
+                        "http://*/*",
+                        "https://*/*"
+                    ],
+                    "manifest_permissions":
+                    []
+                },
+                "commands":
+                {},
+                "content_settings":
+                [],
+                "creation_flags": 1,
+                "events":
+                [
+                    "runtime.onConnectExternal"
+                ],
+                "from_bookmark": false,
+                "from_webstore": false,
+                "incognito_content_settings":
+                [],
+                "incognito_preferences":
+                {},
+                "install_time": "13226654677462231",
+                "location": 5,
+                "manifest":
+                {
+                    "background":
+                    {
+                        "persistent": false,
+                        "scripts":
+                        [
+                            "util.js",
+                            "b64.js",
+                            "cbor.js",
+                            "sha256.js",
+                            "timer.js",
+                            "countdown.js",
+                            "countdowntimer.js",
+                            "devicestatuscodes.js",
+                            "approvedorigins.js",
+                            "errorcodes.js",
+                            "webrequest.js",
+                            "messagetypes.js",
+                            "factoryregistry.js",
+                            "requesthelper.js",
+                            "asn1.js",
+                            "enroller.js",
+                            "requestqueue.js",
+                            "signer.js",
+                            "origincheck.js",
+                            "textfetcher.js",
+                            "appid.js",
+                            "watchdog.js",
+                            "logging.js",
+                            "webrequestsender.js",
+                            "window-timer.js",
+                            "cryptotokenorigincheck.js",
+                            "cryptotokenapprovedorigins.js",
+                            "inherits.js",
+                            "individualattest.js",
+                            "googlecorpindividualattest.js",
+                            "cryptotokenbackground.js"
+                        ]
+                    },
+                    "description": "CryptoToken Component Extension",
+                    "externally_connectable":
+                    {
+                        "ids":
+                        [
+                            "fjajfjhkeibgmiggdfehjplbhmfkialk"
+                        ],
+                        "matches":
+                        [
+                            "https://*/*"
+                        ]
+                    },
+                    "incognito": "split",
+                    "key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAq7zRobvA+AVlvNqkHSSVhh1sEWsHSqz4oR/XptkDe/Cz3+gW9ZGumZ20NCHjaac8j1iiesdigp8B1LJsd/2WWv2Dbnto4f8GrQ5MVphKyQ9WJHwejEHN2K4vzrTcwaXqv5BSTXwxlxS/mXCmXskTfryKTLuYrcHEWK8fCHb+0gvr8b/kvsi75A1aMmb6nUnFJvETmCkOCPNX5CHTdy634Ts/x0fLhRuPlahk63rdf7agxQv5viVjQFk+tbgv6aa9kdSd11Js/RZ9yZjrFgHOBWgP4jTBqud4+HUglrzu8qynFipyNRLCZsaxhm+NItTyNgesxLdxZcwOz56KD1Q4IQIDAQAB",
+                    "manifest_version": 2,
+                    "name": "CryptoTokenExtension",
+                    "permissions":
+                    [
+                        "cryptotokenPrivate",
+                        "externally_connectable.all_urls",
+                        "tabs",
+                        "https://*/*",
+                        "http://*/*"
+                    ],
+                    "version": "0.9.74"
+                },
+                "path": "/Applications/Google Chrome.app/Contents/Frameworks/Google Chrome Framework.framework/Versions/80.0.3987.116/Resources/cryptotoken",
+                "preferences":
+                {},
+                "regular_only_preferences":
+                {},
+                "state": 1,
+                "was_installed_by_default": false,
+                "was_installed_by_oem": false
+            },
+            "mfehgcgbbipciphmccgaenjidiccnmng":
+            {
+                "active_permissions":
+                {
+                    "api":
+                    [
+                        "cloudPrintPrivate"
+                    ],
+                    "manifest_permissions":
+                    []
+                },
+                "commands":
+                {},
+                "content_settings":
+                [],
+                "creation_flags": 1,
+                "events":
+                [],
+                "from_bookmark": false,
+                "from_webstore": false,
+                "incognito_content_settings":
+                [],
+                "incognito_preferences":
+                {},
+                "install_time": "13226654677457725",
+                "location": 5,
+                "manifest":
+                {
+                    "app":
+                    {
+                        "launch":
+                        {
+                            "web_url": "https://www.google.com/cloudprint"
+                        },
+                        "urls":
+                        [
+                            "https://www.google.com/cloudprint/enable_chrome_connector"
+                        ]
+                    },
+                    "description": "Cloud Print",
+                    "display_in_launcher": false,
+                    "icons":
+                    {},
+                    "key": "MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQDqOhnwk4+HXVfGyaNsAQdU/js1Na56diW08oF1MhZiwzSnJsEaeuMN9od9q9N4ZdK3o1xXOSARrYdE+syV7Dl31nf6qz3A6K+D5NHe6sSB9yvYlIiN37jdWdrfxxE0pRYEVYZNTe3bzq3NkcYJlOdt1UPcpJB+isXpAGUKUvt7EQIDAQAB",
+                    "name": "Cloud Print",
+                    "permissions":
+                    [
+                        "cloudPrintPrivate"
+                    ],
+                    "version": "0.1"
+                },
+                "path": "/Applications/Google Chrome.app/Contents/Frameworks/Google Chrome Framework.framework/Versions/80.0.3987.116/Resources/cloud_print",
+                "preferences":
+                {},
+                "regular_only_preferences":
+                {},
+                "state": 1,
+                "was_installed_by_default": false,
+                "was_installed_by_oem": false
+            },
+            "mhjfbmdgcfjbbpaeojofohoefgiehjai":
+            {
+                "active_permissions":
+                {
+                    "api":
+                    [
+                        "contentSettings",
+                        "fileSystem",
+                        "fileSystem.write",
+                        "metricsPrivate",
+                        "resourcesPrivate"
+                    ],
+                    "explicit_host":
+                    [
+                        "chrome://resources/*"
+                    ],
+                    "manifest_permissions":
+                    []
+                },
+                "commands":
+                {},
+                "content_settings":
+                [],
+                "creation_flags": 1,
+                "events":
+                [],
+                "from_bookmark": false,
+                "from_webstore": false,
+                "incognito_content_settings":
+                [],
+                "incognito_preferences":
+                {},
+                "install_time": "13226654677462676",
+                "location": 5,
+                "manifest":
+                {
+                    "content_security_policy": "script-src 'self' 'wasm-eval' blob: filesystem: chrome://resources; object-src * blob: externalfile: file: filesystem: data:; plugin-types application/x-google-chrome-pdf",
+                    "description": "",
+                    "incognito": "split",
+                    "key": "MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQDN6hM0rsDYGbzQPQfOygqlRtQgKUXMfnSjhIBL7LnReAVBEd7ZmKtyN2qmSasMl4HZpMhVe2rPWVVwBDl6iyNE/Kok6E6v6V3vCLGsOpQAuuNVye/3QxzIldzG/jQAdWZiyXReRVapOhZtLjGfywCvlWq7Sl/e3sbc0vWybSDI2QIDAQAB",
+                    "manifest_version": 2,
+                    "mime_types":
+                    [
+                        "application/pdf"
+                    ],
+                    "mime_types_handler": "index.html",
+                    "name": "Chrome PDF Viewer",
+                    "offline_enabled": true,
+                    "permissions":
+                    [
+                        "chrome://resources/",
+                        "contentSettings",
+                        "metricsPrivate",
+                        "resourcesPrivate",
+                        {
+                            "fileSystem":
+                            [
+                                "write"
+                            ]
+                        }
+                    ],
+                    "version": "1"
+                },
+                "path": "/Applications/Google Chrome.app/Contents/Frameworks/Google Chrome Framework.framework/Versions/80.0.3987.116/Resources/pdf",
+                "preferences":
+                {},
+                "regular_only_preferences":
+                {},
+                "state": 1,
+                "was_installed_by_default": false,
+                "was_installed_by_oem": false
+            },
+            "neajdppkdcdipfabeoofebfddakdcjhd":
+            {
+                "active_permissions":
+                {
+                    "api":
+                    [
+                        "systemPrivate",
+                        "ttsEngine"
+                    ],
+                    "explicit_host":
+                    [
+                        "https://www.google.com/*"
+                    ],
+                    "manifest_permissions":
+                    []
+                },
+                "commands":
+                {},
+                "content_settings":
+                [],
+                "creation_flags": 1,
+                "events":
+                [
+                    "ttsEngine.onPause",
+                    "ttsEngine.onResume",
+                    "ttsEngine.onSpeak",
+                    "ttsEngine.onStop"
+                ],
+                "from_bookmark": false,
+                "from_webstore": false,
+                "incognito_content_settings":
+                [],
+                "incognito_preferences":
+                {},
+                "install_time": "13226654677461722",
+                "location": 5,
+                "manifest":
+                {
+                    "background":
+                    {
+                        "persistent": false,
+                        "scripts":
+                        [
+                            "tts_extension.js"
+                        ]
+                    },
+                    "description": "Component extension providing speech via the Google network text-to-speech service.",
+                    "key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA8GSbNUMGygqQTNDMFGIjZNcwXsHLzkNkHjWbuY37PbNdSDZ4VqlVjzbWqODSe+MjELdv5Keb51IdytnoGYXBMyqKmWpUrg+RnKvQ5ibWr4MW9pyIceOIdp9GrzC1WZGgTmZismYR3AjaIpufZ7xDdQQv+XrghPWCkdVqLN+qZDA1HU+DURznkMICiDDSH2sU0egm9UbWfS218bZqzKeQDiC3OnTPlaxcbJtKUuupIm5knjze3Wo9Ae9poTDMzKgchg0VlFCv3uqox+wlD8sjXBoyBCCK9HpImdVAF1a7jpdgiUHpPeV/26oYzM9/grltwNR3bzECQgSpyXp0eyoegwIDAQAB",
+                    "manifest_version": 2,
+                    "name": "Google Network Speech",
+                    "permissions":
+                    [
+                        "systemPrivate",
+                        "ttsEngine",
+                        "https://www.google.com/"
+                    ],
+                    "tts_engine":
+                    {
+                        "voices":
+                        [
+                            {
+                                "event_types":
+                                [
+                                    "start",
+                                    "end",
+                                    "error"
+                                ],
+                                "gender": "female",
+                                "lang": "de-DE",
+                                "remote": true,
+                                "voice_name": "Google Deutsch"
+                            },
+                            {
+                                "event_types":
+                                [
+                                    "start",
+                                    "end",
+                                    "error"
+                                ],
+                                "gender": "female",
+                                "lang": "en-US",
+                                "remote": true,
+                                "voice_name": "Google US English"
+                            },
+                            {
+                                "event_types":
+                                [
+                                    "start",
+                                    "end",
+                                    "error"
+                                ],
+                                "gender": "female",
+                                "lang": "en-GB",
+                                "remote": true,
+                                "voice_name": "Google UK English Female"
+                            },
+                            {
+                                "event_types":
+                                [
+                                    "start",
+                                    "end",
+                                    "error"
+                                ],
+                                "gender": "male",
+                                "lang": "en-GB",
+                                "remote": true,
+                                "voice_name": "Google UK English Male"
+                            },
+                            {
+                                "event_types":
+                                [
+                                    "start",
+                                    "end",
+                                    "error"
+                                ],
+                                "gender": "female",
+                                "lang": "es-ES",
+                                "remote": true,
+                                "voice_name": "Google español"
+                            },
+                            {
+                                "event_types":
+                                [
+                                    "start",
+                                    "end",
+                                    "error"
+                                ],
+                                "gender": "female",
+                                "lang": "es-US",
+                                "remote": true,
+                                "voice_name": "Google español de Estados Unidos"
+                            },
+                            {
+                                "event_types":
+                                [
+                                    "start",
+                                    "end",
+                                    "error"
+                                ],
+                                "gender": "female",
+                                "lang": "fr-FR",
+                                "remote": true,
+                                "voice_name": "Google français"
+                            },
+                            {
+                                "event_types":
+                                [
+                                    "start",
+                                    "end",
+                                    "error"
+                                ],
+                                "gender": "female",
+                                "lang": "hi-IN",
+                                "remote": true,
+                                "voice_name": "Google हिन्दी"
+                            },
+                            {
+                                "event_types":
+                                [
+                                    "start",
+                                    "end",
+                                    "error"
+                                ],
+                                "gender": "female",
+                                "lang": "id-ID",
+                                "remote": true,
+                                "voice_name": "Google Bahasa Indonesia"
+                            },
+                            {
+                                "event_types":
+                                [
+                                    "start",
+                                    "end",
+                                    "error"
+                                ],
+                                "gender": "female",
+                                "lang": "it-IT",
+                                "remote": true,
+                                "voice_name": "Google italiano"
+                            },
+                            {
+                                "event_types":
+                                [
+                                    "start",
+                                    "end",
+                                    "error"
+                                ],
+                                "gender": "female",
+                                "lang": "ja-JP",
+                                "remote": true,
+                                "voice_name": "Google 日本語"
+                            },
+                            {
+                                "event_types":
+                                [
+                                    "start",
+                                    "end",
+                                    "error"
+                                ],
+                                "gender": "female",
+                                "lang": "ko-KR",
+                                "remote": true,
+                                "voice_name": "Google 한국의"
+                            },
+                            {
+                                "event_types":
+                                [
+                                    "start",
+                                    "end",
+                                    "error"
+                                ],
+                                "gender": "female",
+                                "lang": "nl-NL",
+                                "remote": true,
+                                "voice_name": "Google Nederlands"
+                            },
+                            {
+                                "event_types":
+                                [
+                                    "start",
+                                    "end",
+                                    "error"
+                                ],
+                                "gender": "female",
+                                "lang": "pl-PL",
+                                "remote": true,
+                                "voice_name": "Google polski"
+                            },
+                            {
+                                "event_types":
+                                [
+                                    "start",
+                                    "end",
+                                    "error"
+                                ],
+                                "gender": "female",
+                                "lang": "pt-BR",
+                                "remote": true,
+                                "voice_name": "Google português do Brasil"
+                            },
+                            {
+                                "event_types":
+                                [
+                                    "start",
+                                    "end",
+                                    "error"
+                                ],
+                                "gender": "female",
+                                "lang": "ru-RU",
+                                "remote": true,
+                                "voice_name": "Google русский"
+                            },
+                            {
+                                "event_types":
+                                [
+                                    "start",
+                                    "end",
+                                    "error"
+                                ],
+                                "gender": "female",
+                                "lang": "zh-CN",
+                                "remote": true,
+                                "voice_name": "Google 普通话（中国大陆）"
+                            },
+                            {
+                                "event_types":
+                                [
+                                    "start",
+                                    "end",
+                                    "error"
+                                ],
+                                "gender": "female",
+                                "lang": "zh-HK",
+                                "remote": true,
+                                "voice_name": "Google 粤語（香港）"
+                            },
+                            {
+                                "event_types":
+                                [
+                                    "start",
+                                    "end",
+                                    "error"
+                                ],
+                                "gender": "female",
+                                "lang": "zh-TW",
+                                "remote": true,
+                                "voice_name": "Google 國語（臺灣）"
+                            }
+                        ]
+                    },
+                    "version": "1.0"
+                },
+                "path": "/Applications/Google Chrome.app/Contents/Frameworks/Google Chrome Framework.framework/Versions/80.0.3987.116/Resources/network_speech_synthesis",
+                "preferences":
+                {},
+                "regular_only_preferences":
+                {},
+                "state": 1,
+                "was_installed_by_default": false,
+                "was_installed_by_oem": false
+            },
+            "nkeimhogjdpnpccoofpliimaahmaaome":
+            {
+                "active_permissions":
+                {
+                    "api":
+                    [
+                        "desktopCapture",
+                        "processes",
+                        "webConnectable",
+                        "webrtcAudioPrivate",
+                        "webrtcDesktopCapturePrivate",
+                        "webrtcLoggingPrivate",
+                        "system.cpu",
+                        "enterprise.hardwarePlatform"
+                    ],
+                    "manifest_permissions":
+                    []
+                },
+                "commands":
+                {},
+                "content_settings":
+                [],
+                "creation_flags": 1,
+                "events":
+                [
+                    "runtime.onConnectExternal"
+                ],
+                "from_bookmark": false,
+                "from_webstore": false,
+                "incognito_content_settings":
+                [],
+                "incognito_preferences":
+                {},
+                "install_time": "13226654677460643",
+                "location": 5,
+                "manifest":
+                {
+                    "background":
+                    {
+                        "page": "background.html",
+                        "persistent": false
+                    },
+                    "externally_connectable":
+                    {
+                        "matches":
+                        [
+                            "https://*.google.com/*",
+                            "*://localhost/*"
+                        ]
+                    },
+                    "incognito": "split",
+                    "key": "MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQDAQt2ZDdPfoSe/JI6ID5bgLHRCnCu9T36aYczmhw/tnv6QZB2I6WnOCMZXJZlRdqWc7w9jo4BWhYS50Vb4weMfh/I0On7VcRwJUgfAxW2cHB+EkmtI1v4v/OU24OqIa1Nmv9uRVeX0GjhQukdLNhAE6ACWooaf5kqKlCeK+1GOkQIDAQAB",
+                    "manifest_version": 2,
+                    "name": "Google Hangouts",
+                    "permissions":
+                    [
+                        "desktopCapture",
+                        "enterprise.hardwarePlatform",
+                        "processes",
+                        "system.cpu",
+                        "webrtcAudioPrivate",
+                        "webrtcDesktopCapturePrivate",
+                        "webrtcLoggingPrivate"
+                    ],
+                    "version": "1.3.15"
+                },
+                "path": "/Applications/Google Chrome.app/Contents/Frameworks/Google Chrome Framework.framework/Versions/80.0.3987.116/Resources/hangout_services",
+                "preferences":
+                {},
+                "regular_only_preferences":
+                {},
+                "state": 1,
+                "was_installed_by_default": false,
+                "was_installed_by_oem": false
+            },
+            "nmmhkkegccagdldgiimedpiccmgmieda":
+            {
+                "ack_external": true,
+                "active_permissions":
+                {
+                    "api":
+                    [
+                        "identity",
+                        "webview"
+                    ],
+                    "explicit_host":
+                    [
+                        "https://payments.google.com/*",
+                        "https://sandbox.google.com/*",
+                        "https://www.google.com/*",
+                        "https://www.googleapis.com/*"
+                    ],
+                    "manifest_permissions":
+                    []
+                },
+                "commands":
+                {},
+                "content_settings":
+                [],
+                "creation_flags": 137,
+                "events":
+                [
+                    "app.runtime.onLaunched",
+                    "runtime.onConnectExternal"
+                ],
+                "from_bookmark": false,
+                "from_webstore": true,
+                "granted_permissions":
+                {
+                    "api":
+                    [
+                        "identity",
+                        "webview"
+                    ],
+                    "explicit_host":
+                    [
+                        "https://payments.google.com/*",
+                        "https://sandbox.google.com/*",
+                        "https://www.google.com/*",
+                        "https://www.googleapis.com/*"
+                    ],
+                    "manifest_permissions":
+                    []
+                },
+                "incognito_content_settings":
+                [],
+                "incognito_preferences":
+                {},
+                "install_time": "13226654687782836",
+                "lastpingday": "13226572800714429",
+                "location": 10,
+                "manifest":
+                {
+                    "app":
+                    {
+                        "background":
+                        {
+                            "scripts":
+                            [
+                                "craw_background.js"
+                            ]
+                        }
+                    },
+                    "current_locale": "en_US",
+                    "default_locale": "en",
+                    "description": "Chrome Web Store Payments",
+                    "display_in_launcher": false,
+                    "display_in_new_tab_page": false,
+                    "icons":
+                    {
+                        "128": "images/icon_128.png",
+                        "16": "images/icon_16.png"
+                    },
+                    "key": "MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQCrKfMnLqViEyokd1wk57FxJtW2XXpGXzIHBzv9vQI/01UsuP0IV5/lj0wx7zJ/xcibUgDeIxobvv9XD+zO1MdjMWuqJFcKuSS4Suqkje6u+pMrTSGOSHq1bmBVh0kpToN8YoJs/P/yrRd7FEtAXTaFTGxQL4C385MeXSjaQfiRiQIDAQAB",
+                    "manifest_version": 2,
+                    "minimum_chrome_version": "29",
+                    "name": "Chrome Web Store Payments",
+                    "oauth2":
+                    {
+                        "auto_approve": true,
+                        "client_id": "203784468217.apps.googleusercontent.com",
+                        "scopes":
+                        [
+                            "https://www.googleapis.com/auth/sierra",
+                            "https://www.googleapis.com/auth/sierrasandbox",
+                            "https://www.googleapis.com/auth/chromewebstore",
+                            "https://www.googleapis.com/auth/chromewebstore.readonly"
+                        ]
+                    },
+                    "permissions":
+                    [
+                        "identity",
+                        "webview",
+                        "https://www.google.com/",
+                        "https://www.googleapis.com/*",
+                        "https://payments.google.com/payments/v4/js/integrator.js",
+                        "https://sandbox.google.com/payments/v4/js/integrator.js"
+                    ],
+                    "update_url": "https://clients2.google.com/service/update2/crx",
+                    "version": "1.0.0.5"
+                },
+                "path": "nmmhkkegccagdldgiimedpiccmgmieda/1.0.0.5_0",
+                "preferences":
+                {},
+                "regular_only_preferences":
+                {},
+                "running": false,
+                "state": 1,
+                "was_installed_by_default": true,
+                "was_installed_by_oem": false
+            },
+            "pjkljhegncpnkpknbcohdijeoejaedia":
+            {
+                "ack_external": true,
+                "active_permissions":
+                {
+                    "api":
+                    [
+                        "notifications"
+                    ],
+                    "manifest_permissions":
+                    []
+                },
+                "app_launcher_ordinal": "z",
+                "commands":
+                {},
+                "content_settings":
+                [],
+                "creation_flags": 137,
+                "events":
+                [],
+                "from_bookmark": false,
+                "from_webstore": true,
+                "granted_permissions":
+                {
+                    "api":
+                    [
+                        "notifications"
+                    ],
+                    "manifest_permissions":
+                    []
+                },
+                "incognito_content_settings":
+                [],
+                "incognito_preferences":
+                {},
+                "install_time": "13226654685955490",
+                "lastpingday": "13226572800714429",
+                "location": 1,
+                "manifest":
+                {
+                    "app":
+                    {
+                        "launch":
+                        {
+                            "container": "tab",
+                            "web_url": "https://mail.google.com/mail"
+                        },
+                        "urls":
+                        [
+                            "*://mail.google.com/mail"
+                        ]
+                    },
+                    "current_locale": "en_US",
+                    "default_locale": "en",
+                    "description": "Fast, searchable email with less spam.",
+                    "icons":
+                    {
+                        "128": "128.png"
+                    },
+                    "key": "MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQDCuGglK43iAz3J9BEYK/Mz6ZhloIMMDqQSAaf3vJt4eHbTbSDsu4WdQ9dQDRcKlg8nwQdePBt0C3PSUBtiSNSS37Z3qEGfS7LCju3h6pI1Yr9MQtxw+jUa7kXXIS09VV73pEFUT/F7c6Qe8L5ZxgAcBvXBh1Fie63qb02I9XQ/CQIDAQAB",
+                    "manifest_version": 2,
+                    "name": "Gmail",
+                    "options_page": "https://mail.google.com/mail/#settings",
+                    "permissions":
+                    [
+                        "notifications"
+                    ],
+                    "update_url": "https://clients2.google.com/service/update2/crx",
+                    "version": "8.2"
+                },
+                "page_ordinal": "n",
+                "path": "pjkljhegncpnkpknbcohdijeoejaedia/8.2_0",
+                "preferences":
+                {},
+                "regular_only_preferences":
+                {},
+                "state": 1,
+                "was_installed_by_default": true,
+                "was_installed_by_oem": false
+            },
+            "pkedcjkdefgpdelpbcmbmeomcjbeemfm":
+            {
+                "ack_external": true,
+                "active_permissions":
+                {
+                    "api":
+                    [
+                        "alarms",
+                        "cast",
+                        "cast.streaming",
+                        "desktopCapture",
+                        "gcm",
+                        "identity",
+                        "identity.email",
+                        "management",
+                        "mediaRouterPrivate",
+                        "metricsPrivate",
+                        "mdns",
+                        "networkingPrivate",
+                        "settingsPrivate",
+                        "storage",
+                        "tabs",
+                        "tabCapture",
+                        "webConnectable",
+                        "webview",
+                        "system.cpu"
+                    ],
+                    "explicit_host":
+                    [
+                        "http://*/*",
+                        "https://*.google.com/*",
+                        "https://hangouts.google.com/*"
+                    ],
+                    "manifest_permissions":
+                    []
+                },
+                "commands":
+                {},
+                "content_settings":
+                [],
+                "creation_flags": 137,
+                "events":
+                [
+                    "cast.channel.onError",
+                    "cast.channel.onMessage",
+                    "gcm.onMessage",
+                    "identity.onSignInChanged",
+                    "runtime.onStartup",
+                    "runtime.onSuspend",
+                    "settingsPrivate.onPrefsChanged"
+                ],
+                "from_bookmark": false,
+                "from_webstore": true,
+                "granted_permissions":
+                {
+                    "api":
+                    [
+                        "alarms",
+                        "cast",
+                        "cast.streaming",
+                        "desktopCapture",
+                        "gcm",
+                        "identity",
+                        "identity.email",
+                        "management",
+                        "mediaRouterPrivate",
+                        "metricsPrivate",
+                        "mdns",
+                        "networkingPrivate",
+                        "settingsPrivate",
+                        "storage",
+                        "tabs",
+                        "tabCapture",
+                        "webConnectable",
+                        "webview",
+                        "system.cpu"
+                    ],
+                    "explicit_host":
+                    [
+                        "http://*/*",
+                        "https://*.google.com/*",
+                        "https://hangouts.google.com/*"
+                    ],
+                    "manifest_permissions":
+                    []
+                },
+                "incognito_content_settings":
+                [],
+                "incognito_preferences":
+                {},
+                "install_time": "13226654685697229",
+                "lastpingday": "13226572800714429",
+                "location": 10,
+                "manifest":
+                {
+                    "background":
+                    {
+                        "persistent": false,
+                        "scripts":
+                        [
+                            "common.js",
+                            "mirroring_common.js",
+                            "background_script.js"
+                        ]
+                    },
+                    "content_security_policy": "default-src 'self'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; script-src 'self' https://apis.google.com https://feedback.googleusercontent.com https://www.google.com https://www.gstatic.com; child-src https://accounts.google.com https://content.googleapis.com https://www.google.com; connect-src 'self' http://*:* https://*:*; font-src https://fonts.gstatic.com; object-src 'self';",
+                    "current_locale": "en_US",
+                    "default_locale": "en",
+                    "description": "Provider for discovery and services for mirroring of Chrome Media Router",
+                    "externally_connectable":
+                    {
+                        "ids":
+                        [
+                            "idmofbkcelhplfjnmmdolenpigiiiecc",
+                            "ggedfkijiiammpnbdadhllnehapomdge",
+                            "njjegkblellcjnakomndbaloifhcoccg"
+                        ],
+                        "matches":
+                        [
+                            "https://www.google.com/chromecast/*"
+                        ]
+                    },
+                    "key": "MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQDNTWJoPZ9bT32yKxuuVa9LSEYobjPoXCLX3dgsZ9djDrWKNikTECjdRe3/AFXb+v8jkmmtYQPnOgSYn06J/QodDlCIG6l470+gkOoobUM7fOs1AVOse23qYUV4jbuRW3+YZlCvaWCFeczCNbGIUgKEi5B2fyQazy60AL1sLW3utQIDAQAB",
+                    "manifest_version": 2,
+                    "minimum_chrome_version": "37",
+                    "name": "Chrome Media Router",
+                    "oauth2":
+                    {
+                        "client_id": "919648714761-55j965o0km033psv3i9qls5mo3qtdrb0.apps.googleusercontent.com",
+                        "scopes":
+                        [
+                            "https://www.googleapis.com/auth/calendar.readonly",
+                            "https://www.googleapis.com/auth/clouddevices",
+                            "https://www.googleapis.com/auth/hangouts",
+                            "https://www.googleapis.com/auth/hangouts.readonly",
+                            "https://www.googleapis.com/auth/meetings",
+                            "https://www.googleapis.com/auth/userinfo.email",
+                            "https://www.googleapis.com/auth/cast-edu-messaging",
+                            "https://www.googleapis.com/auth/plus.peopleapi.readwrite"
+                        ]
+                    },
+                    "permissions":
+                    [
+                        "alarms",
+                        "cast",
+                        "cast.streaming",
+                        "declarativeWebRequest",
+                        "desktopCapture",
+                        "gcm",
+                        "http://*/*",
+                        "identity",
+                        "identity.email",
+                        "management",
+                        "mdns",
+                        "mediaRouterPrivate",
+                        "metricsPrivate",
+                        "networkingPrivate",
+                        "processes",
+                        "storage",
+                        "system.cpu",
+                        "settingsPrivate",
+                        "tabCapture",
+                        "tabs",
+                        "webview",
+                        "https://hangouts.google.com/*",
+                        "https://*.google.com/cast/chromecast/home/gsse"
+                    ],
+                    "update_url": "https://clients2.google.com/service/update2/crx",
+                    "version": "8019.1111.0.0",
+                    "web_accessible_resources":
+                    [
+                        "cast_sender.js",
+                        "cast_setup/*"
+                    ]
+                },
+                "path": "pkedcjkdefgpdelpbcmbmeomcjbeemfm/8019.1111.0.0_0",
+                "preferences":
+                {},
+                "regular_only_preferences":
+                {},
+                "state": 1,
+                "was_installed_by_default": true,
+                "was_installed_by_oem": false
+            }
+        }
+    },
+    "pinned_tabs":
+    [],
+    "protection":
+    {
+        "macs":
+        {
+            "browser":
+            {
+                "show_home_button": "B5EB34D9942F82A8AF68B991862F58F5A39251521C53E159FD5D1CB709BDF873"
+            },
+            "default_search_provider_data":
+            {
+                "template_url_data": "91DF3328DE1FEE92B3ABC654E70213225DAD1FB5E601A7BC139F808F2E34EB89"
+            },
+            "extensions":
+            {
+                "settings":
+                {
+                    "aapocclcgogkmnckokdopfmhonfmgoek": "D1752F1ADB7DBA8B0FA550EB880B35AC42CCBCDA1B93A252F36D41130CCEEBA1",
+                    "aghfnjkcakhmadgdomlmlhhaocbkloab": "5FA548F25083441B74DFCF815867D24AC4B980053F0B2D414C650CBB671DA9BA",
+                    "ahfgeienlihckogmohjhadlkjgocpleb": "5B019B0552263FDACB193F3AB2595D8B1F4173E0C49EBAB39C7A81197B9C7C13",
+                    "aohghmighlieiainnegkcijnfilokake": "5930281902DD798ED1E908158D024F445C443D4ABA6E4D0C6F324036DFEDEA20",
+                    "apdfllckaahabafndbhieahigkjlhalf": "CC185D9F762CEE0F1238B7AD4E7B4FF5881B6B595EF4CBC004DB6040DF32448D",
+                    "blpcfgokakmgnkcojhhkbfbldkacnbeo": "28FF269C1003D2B826DDFEC6CB724C53251B7AC710900FACC8BAC4BFFE06D16C",
+                    "felcaaldnbdncclmgdcncolpebgiejap": "E272BF994E54309694C6C9D311004E28B131FDF6FD7403E81DEFB37AA718D408",
+                    "gfdkimpbcpahaombhbimeihdjnejgicl": "95341B6911D2DA6CBF30BB3554130A3763533B0B2056B9E8C16803CE4817508D",
+                    "ghbmnnjooekpmoecnnnilnnbdlolhkhi": "1E64113E7CF14C1635A54218E301D30AF34590CF38490A7082CD5C0BE3C6061A",
+                    "aeblfdkhhhdcdjpifhhbdiojplfjncoa": "7F0599476560A25894A7B046D8E76499EEDFD7A47DA19FF2722177F33B038B48",
+                    "kmendfapggjehodndflmmgagdbamhnfd": "3FD3A074B3DEEC7465461884838463DA7967A540BD6C0BCE9F8356C9ECB27290",
+                    "mfehgcgbbipciphmccgaenjidiccnmng": "997BD8BEA32AA61BF7BD8DB08C46D6B9D52B4BCEC93B9D321EDB5824770BFBEC",
+                    "mhjfbmdgcfjbbpaeojofohoefgiehjai": "E58D38C4C2DC691934A15C36F72A051EB1E8BCB3C20269DC3DBE89AD58468CC9",
+                    "neajdppkdcdipfabeoofebfddakdcjhd": "562538760D62A89E85210B930CF21FEDCC7DE041CB690B94578D8E11FCC58509",
+                    "nkeimhogjdpnpccoofpliimaahmaaome": "D9837DD307B786922A67E5F09DE71B8163D8A3532DECB18639C84AE1DB0190FB",
+                    "nmmhkkegccagdldgiimedpiccmgmieda": "4F7A96E4A6E4175ADE844F177CE929685CDA1D2A0956B9059849D71C075DCA81",
+                    "pjkljhegncpnkpknbcohdijeoejaedia": "B110CABEAA67157C899465DAEA502BC10246FFC370624E711F9E4196C1FA8D4C",
+                    "pkedcjkdefgpdelpbcmbmeomcjbeemfm": "84ED0D82AFB7ADD4B01C9CDFA62F25C34E330D98278AF62D4A9C2DE33C8EE788"
+                }
+            },
+            "google":
+            {
+                "services":
+                {
+                    "account_id": "53AB201B83B1C65823ECBF18EA758EBAE73CA766CC48B16E5BEC293CBDAC99D2",
+                    "last_account_id": "F873A6B5855FC7B13E62BA3389654CB6235D4EA9FC11819ECBD1FBB3ACB72568",
+                    "last_username": "A709F31CDDC4F95F8282AD3A724840A7A974B21EA07268650F52B305AD49CCF0"
+                }
+            },
+            "homepage": "298FFD7268FD73FFDF466BBD2D9679822CF47E365F414D73DE95CF7C273B2769",
+            "homepage_is_newtabpage": "B5038F43EFD47FBC80C011499960458BF11DEBC2914017654987D6AA90B149FA",
+            "media":
+            {
+                "storage_id_salt": "17ABE5A224C6BB4EFFC00878EB3FAE3471E52FE7B028D27BD6CFF028D393E87B"
+            },
+            "pinned_tabs": "0668B53A1CF88AE3A618EBF480391FF63B7E3A1AE97A337B1DEDE5152F2F40B9",
+            "prefs":
+            {
+                "preference_reset_time": "4E54DAE953E6D59540B3F8A2BD5B52BF754814D84B6D1CFF78C6111D7C8DF1A4"
+            },
+            "safebrowsing":
+            {
+                "incidents_sent": "6ED043F7F75C6798BC00FD4E71F59F7F79225B7C349997EA33AAD18CF43B3061"
+            },
+            "search_provider_overrides": "3AE81F3E908BFD62166EC420891095D3078B106BEB02FFDEDE4AAA9554596CF9",
+            "session":
+            {
+                "restore_on_startup": "AED0EFEA1F0E02AF44F9F0656D395A765FA1FEF19DADBD158052A8918E1CB884",
+                "startup_urls": "70E6A80ED32C26F1609C53173B9143749776190103D06779E499D3FD42C17195"
+            }
+        },
+        "super_mac": "DC1D234E854754C0422B23D3C3F565F266C5E9E145B6603010AAB918827BB79F"
+    }
+}


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/27770

The issue is that Chrome removed extensions list from `Secure Preferences` but some of the browsers still using it. Added extensions list fetching from both places `Secure Preferences` and `Preferences` files to support both ways to keep compatibility with all Chromium based browsers. 
Additionally refactored the import utils to remove existing code duplication to fetch extensions list from external importer and importer list. It allowed to add more tests to import utils.

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
- Install latest Chrome (for win I use 109.0.5414.75 (Official Build) (64-bit)) and install an extension from web store, I use jfbnmfgkohlfclfnplnlenbalpppohkm for testing
- Check `c:\Users\[username]\AppData\Local\Google\Chrome\User Data\Default\Secure Preferences` file, it should have one line without extensions info.
- Try to import from Chrome profile
- Make sure installed extension imported to Brave
- Additionally check extensions can be imported from Chrome and others Chromium based browsers who keeps information inside `Secure Preferences`, I checked with Yandex.