### PR TITLE
Call CancelDeferredNavigation after finishing with the NavigationHandle

### DIFF
--- a/components/brave_shields/browser/domain_block_navigation_throttle.cc
+++ b/components/brave_shields/browser/domain_block_navigation_throttle.cc
@@ -175,6 +175,9 @@ void DomainBlockNavigationThrottle::OnShouldBlockDomain(
   } else if (new_url.is_valid()) {
     content::NavigationHandle* handle = navigation_handle();
 
+    content::OpenURLParams params =
+        content::OpenURLParams::FromNavigationHandle(handle);
+
     content::WebContents* contents = handle->GetWebContents();
 
     // Cancel without an error status to surface any real errors during page
@@ -182,8 +185,6 @@ void DomainBlockNavigationThrottle::OnShouldBlockDomain(
     CancelDeferredNavigation(content::NavigationThrottle::ThrottleCheckResult(
         content::NavigationThrottle::CANCEL));
 
-    content::OpenURLParams params =
-        content::OpenURLParams::FromNavigationHandle(handle);
     params.url = new_url;
     params.transition = ui::PAGE_TRANSITION_CLIENT_REDIRECT;
     // We get a DCHECK here if we don't clear the redirect chain because


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/27791

As per the [`CancelDeferredNavigation` doc comment](https://source.chromium.org/chromium/chromium/src/+/main:content/public/browser/navigation_throttle.h;l=200-206;drc=165ca6bce1d0997d084b68ca302b20aa6edc20d4;bpv=0;bpt=1?q=canceldeferrednavigation&ss=chromium%2Fchromium%2Fsrc):
```cpp
  // Cancels a navigation that was previously deferred by this
  // NavigationThrottle. |result|'s action should be equal to either:
  //  - NavigationThrottle::CANCEL,
  //  - NavigationThrottle::CANCEL_AND_IGNORE, or
  //  - NavigationThrottle::BLOCK_REQUEST_AND_COLLAPSE.
  // Note: this may lead to the deletion of the NavigationHandle and its
  // associated NavigationThrottles, including this one.
```

It looks like we're running into the `deletion of the NavigationHandle`, so let's finish using it before calling the method.

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

