### PR TITLE
Prevent multiple closing confirm dialog creation

### DIFF
--- a/browser/ui/views/frame/brave_browser_view.cc
+++ b/browser/ui/views/frame/brave_browser_view.cc
@@ -432,10 +432,13 @@ void BraveBrowserView::OnTabStripModelChanged(
 
 views::CloseRequestResult BraveBrowserView::OnWindowCloseRequested() {
   if (GetBraveBrowser()->ShouldAskForBrowserClosingBeforeHandlers()) {
-    WindowClosingConfirmDialogView::Show(
-        browser(),
-        base::BindOnce(&BraveBrowserView::OnWindowClosingConfirmResponse,
-                       weak_ptr_.GetWeakPtr()));
+    if (!closing_confirm_dialog_activated_) {
+      WindowClosingConfirmDialogView::Show(
+          browser(),
+          base::BindOnce(&BraveBrowserView::OnWindowClosingConfirmResponse,
+                         weak_ptr_.GetWeakPtr()));
+      closing_confirm_dialog_activated_ = true;
+    }
     return views::CloseRequestResult::kCannotClose;
   }
 
@@ -443,6 +446,9 @@ views::CloseRequestResult BraveBrowserView::OnWindowCloseRequested() {
 }
 
 void BraveBrowserView::OnWindowClosingConfirmResponse(bool allowed_to_close) {
+  DCHECK(closing_confirm_dialog_activated_);
+  closing_confirm_dialog_activated_ = false;
+
   auto* browser = GetBraveBrowser();
   // Set to Browser instance because Browser instance knows about the result
   // of any warning handlers or beforeunload handlers.

--- a/browser/ui/views/frame/brave_browser_view.h
+++ b/browser/ui/views/frame/brave_browser_view.h
@@ -116,6 +116,7 @@ class BraveBrowserView : public BrowserView {
   sidebar::Sidebar* InitSidebar() override;
   void UpdateSideBarHorizontalAlignment();
 
+  bool closing_confirm_dialog_activated_ = false;
   raw_ptr<SidebarContainerView> sidebar_container_view_ = nullptr;
   raw_ptr<views::View> sidebar_host_view_ = nullptr;
   raw_ptr<views::View> vertical_tab_strip_host_view_ = nullptr;


### PR DESCRIPTION
fix https://github.com/brave/brave-browser/issues/27474

On linux, user can request windows closing with Alt+F4 while
closing confirm dialog is running.


<!-- Add brave-browser issue below that this PR will resolve -->
Resolves 

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

`WindowClosingConfirmBrowserTest.TestWithTwoNTPTabs`

Please see linked issue.