### PR TITLE
(Wallet) Implement NFT asset details screen

### DIFF
--- a/android/brave_java_resources.gni
+++ b/android/brave_java_resources.gni
@@ -754,6 +754,7 @@ brave_java_resources = [
   "java/res/layout/activity_brave_wallet_dapps.xml",
   "java/res/layout/activity_buy_send_swap.xml",
   "java/res/layout/activity_network_selector.xml",
+  "java/res/layout/activity_nft_detail.xml",
   "java/res/layout/activity_onboarding.xml",
   "java/res/layout/activity_split_tunnel.xml",
   "java/res/layout/activity_welcome_onboarding.xml",

--- a/android/brave_java_sources.gni
+++ b/android/brave_java_sources.gni
@@ -91,6 +91,7 @@ brave_java_sources = [
   "../../brave/android/java/org/chromium/chrome/browser/crypto_wallet/activities/BraveWalletDAppsActivity.java",
   "../../brave/android/java/org/chromium/chrome/browser/crypto_wallet/activities/BuySendSwapActivity.java",
   "../../brave/android/java/org/chromium/chrome/browser/crypto_wallet/activities/NetworkSelectorActivity.java",
+  "../../brave/android/java/org/chromium/chrome/browser/crypto_wallet/activities/NftDetailActivity.java",
   "../../brave/android/java/org/chromium/chrome/browser/crypto_wallet/adapters/AccountSpinnerAdapter.java",
   "../../brave/android/java/org/chromium/chrome/browser/crypto_wallet/adapters/ApproveTxFragmentPageAdapter.java",
   "../../brave/android/java/org/chromium/chrome/browser/crypto_wallet/adapters/CreateAccountAdapter.java",

--- a/android/java/AndroidManifest.xml
+++ b/android/java/AndroidManifest.xml
@@ -102,9 +102,9 @@
     tools:ignore="LockedOrientationActivity"/>
 
 <activity android:name="org.chromium.chrome.browser.crypto_wallet.activities.NftDetailActivity"
-android:theme="@style/Theme.Chromium.Activity"
-android:screenOrientation="sensorPortrait"
-tools:ignore="LockedOrientationActivity"/>
+    android:theme="@style/Theme.Chromium.Activity"
+    android:screenOrientation="sensorPortrait"
+    tools:ignore="LockedOrientationActivity"/>
 
 <activity
     android:name="org.chromium.chrome.browser.vpn.split_tunnel.SplitTunnelActivity"

--- a/android/java/AndroidManifest.xml
+++ b/android/java/AndroidManifest.xml
@@ -101,6 +101,11 @@
     android:screenOrientation="sensorPortrait"
     tools:ignore="LockedOrientationActivity"/>
 
+<activity android:name="org.chromium.chrome.browser.crypto_wallet.activities.NftDetailActivity"
+android:theme="@style/Theme.Chromium.Activity"
+android:screenOrientation="sensorPortrait"
+tools:ignore="LockedOrientationActivity"/>
+
 <activity
     android:name="org.chromium.chrome.browser.vpn.split_tunnel.SplitTunnelActivity"
     android:theme="@style/Theme.Chromium.Activity"

--- a/android/java/org/chromium/chrome/browser/app/domain/PortfolioModel.java
+++ b/android/java/org/chromium/chrome/browser/app/domain/PortfolioModel.java
@@ -140,7 +140,7 @@ public class PortfolioModel implements BraveWalletServiceObserverImplDelegate {
         }
     }
 
-    public class NftDataModel {
+    public static class NftDataModel {
         public BlockchainToken token;
         public NetworkInfo networkInfo;
         public Erc721MetaData erc721MetaData;
@@ -153,7 +153,7 @@ public class PortfolioModel implements BraveWalletServiceObserverImplDelegate {
         }
     }
 
-    public class Erc721MetaData implements Serializable {
+    public static class Erc721MetaData implements Serializable {
         public String mDescription;
         public String mImageUrl;
         public String mName;

--- a/android/java/org/chromium/chrome/browser/crypto_wallet/activities/NftDetailActivity.java
+++ b/android/java/org/chromium/chrome/browser/crypto_wallet/activities/NftDetailActivity.java
@@ -35,8 +35,7 @@ import org.chromium.chrome.browser.crypto_wallet.util.Utils;
 import org.chromium.chrome.browser.util.TabUtils;
 import org.chromium.ui.text.NoUnderlineClickableSpan;
 
-public class NftDetailActivity
-        extends BraveWalletBaseActivity {
+public class NftDetailActivity extends BraveWalletBaseActivity {
     private static final String TOKEN_ID_FORMAT = "#%s";
     private static final String NFT_URL_FORMAT = "%s/token/%s?a=%s";
     private String mNftName;
@@ -57,9 +56,14 @@ public class NftDetailActivity
         BraveActivity activity = BraveActivity.getBraveActivity();
 
         if (activity != null) {
-            NetworkInfo networkInfo = activity.getWalletModel().getCryptoModel().getNetworkModel().mDefaultNetwork.getValue();
+            NetworkInfo networkInfo = activity.getWalletModel()
+                                              .getCryptoModel()
+                                              .getNetworkModel()
+                                              .mDefaultNetwork.getValue();
             mNetworkName = networkInfo.chainName;
-            mBlockExplorerUrl = networkInfo.blockExplorerUrls.length > 0 ? networkInfo.blockExplorerUrls[0] : "";
+            mBlockExplorerUrl = networkInfo.blockExplorerUrls.length > 0
+                    ? networkInfo.blockExplorerUrls[0]
+                    : "";
         }
 
         // Calculate half screen height and assign it to NFT image view,
@@ -78,7 +82,9 @@ public class NftDetailActivity
             mContractAddress = getIntent().getStringExtra(Utils.ASSET_CONTRACT_ADDRESS);
             mNftTokenHex = getIntent().getStringExtra(Utils.NFT_TOKEN_ID_HEX);
             mNftTokenId = Utils.hexToIntString(mNftTokenHex);
-            PortfolioModel.Erc721MetaData erc721MetaData = (PortfolioModel.Erc721MetaData) getIntent().getSerializableExtra(Utils.NFT_META_DATA);
+            PortfolioModel.Erc721MetaData erc721MetaData =
+                    (PortfolioModel.Erc721MetaData) getIntent().getSerializableExtra(
+                            Utils.NFT_META_DATA);
             setMetadata(erc721MetaData);
         }
 
@@ -106,7 +112,8 @@ public class NftDetailActivity
         SpannableString spannable = new SpannableString(tokenStr);
 
         if (!TextUtils.isEmpty(mBlockExplorerUrl)) {
-            String url = String.format(NFT_URL_FORMAT, mBlockExplorerUrl, mContractAddress, mNftTokenId);
+            String url =
+                    String.format(NFT_URL_FORMAT, mBlockExplorerUrl, mContractAddress, mNftTokenId);
             NoUnderlineClickableSpan linkSpan = new NoUnderlineClickableSpan(this,
                     R.color.brave_link, (textView) -> { TabUtils.openLinkWithFocus(this, url); });
             spannable.setSpan(linkSpan, 0, spannable.length(), Spanned.SPAN_EXCLUSIVE_EXCLUSIVE);
@@ -140,14 +147,18 @@ public class NftDetailActivity
         ImageLoader.getLoadNftRequest(imageUrl, this, false)
                 .listener(new RequestListener<Drawable>() {
                     @Override
-                    public boolean onLoadFailed(GlideException glideException, Object model, Target<Drawable> target, boolean isFirstResource) {
+                    public boolean onLoadFailed(GlideException glideException, Object model,
+                            Target<Drawable> target, boolean isFirstResource) {
                         setNftImageAsNotAvailable();
                         return false;
                     }
 
                     @Override
-                    public boolean onResourceReady(Drawable resource, Object model, Target<Drawable> target, DataSource dataSource, boolean isFirstResource) {
-                        target.onResourceReady(resource, new DrawableCrossFadeTransition(250, true));
+                    public boolean onResourceReady(Drawable resource, Object model,
+                            Target<Drawable> target, DataSource dataSource,
+                            boolean isFirstResource) {
+                        target.onResourceReady(
+                                resource, new DrawableCrossFadeTransition(250, true));
                         return true;
                     }
                 })

--- a/android/java/org/chromium/chrome/browser/crypto_wallet/activities/NftDetailActivity.java
+++ b/android/java/org/chromium/chrome/browser/crypto_wallet/activities/NftDetailActivity.java
@@ -164,7 +164,7 @@ public class NftDetailActivity extends BraveWalletBaseActivity {
                 // Hide description layout in case of an empty string.
                 mNftDescriptionLayout.setVisibility(View.GONE);
             }
-            if (!TextUtils.isEmpty(imageUrl)) {
+            if (ImageLoader.isSupported(imageUrl)) {
                 loadNftImage(imageUrl);
             } else {
                 setNftImageAsNotAvailable();

--- a/android/java/org/chromium/chrome/browser/crypto_wallet/activities/NftDetailActivity.java
+++ b/android/java/org/chromium/chrome/browser/crypto_wallet/activities/NftDetailActivity.java
@@ -117,7 +117,7 @@ public class NftDetailActivity
     }
 
     private void setMetadata(PortfolioModel.Erc721MetaData erc721MetaData) {
-        // In case of no errors proceed to assign descrption and fetch NFT image.
+        // In case of no errors proceed to assign description and fetch NFT image.
         if (erc721MetaData.mErrCode == 0) {
             String description = erc721MetaData.mDescription;
             String imageUrl = erc721MetaData.mImageUrl;

--- a/android/java/org/chromium/chrome/browser/crypto_wallet/activities/NftDetailActivity.java
+++ b/android/java/org/chromium/chrome/browser/crypto_wallet/activities/NftDetailActivity.java
@@ -1,0 +1,161 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+package org.chromium.chrome.browser.crypto_wallet.activities;
+
+import android.app.Activity;
+import android.content.Intent;
+import android.graphics.drawable.Drawable;
+import android.text.SpannableString;
+import android.text.Spanned;
+import android.text.TextUtils;
+import android.text.method.LinkMovementMethod;
+import android.view.View;
+import android.widget.Button;
+import android.widget.ImageView;
+import android.widget.TextView;
+
+import androidx.appcompat.widget.Toolbar;
+
+import com.bumptech.glide.load.DataSource;
+import com.bumptech.glide.load.engine.GlideException;
+import com.bumptech.glide.request.RequestListener;
+import com.bumptech.glide.request.target.Target;
+import com.bumptech.glide.request.transition.DrawableCrossFadeTransition;
+
+import org.chromium.brave_wallet.mojom.NetworkInfo;
+import org.chromium.chrome.R;
+import org.chromium.chrome.browser.app.BraveActivity;
+import org.chromium.chrome.browser.app.domain.PortfolioModel;
+import org.chromium.chrome.browser.crypto_wallet.util.AndroidUtils;
+import org.chromium.chrome.browser.crypto_wallet.util.ImageLoader;
+import org.chromium.chrome.browser.crypto_wallet.util.Utils;
+import org.chromium.chrome.browser.util.TabUtils;
+import org.chromium.ui.text.NoUnderlineClickableSpan;
+
+public class NftDetailActivity
+        extends BraveWalletBaseActivity {
+    private static final String TOKEN_ID_FORMAT = "#%s";
+    private static final String NFT_URL_FORMAT = "%s/token/%s?a=%s";
+    private String mNftName;
+    private String mChainId;
+    private String mContractAddress;
+    private String mNftTokenId;
+    private String mNftTokenHex;
+    private String mNetworkName;
+    private String mBlockExplorerUrl;
+
+    private ImageView mNftImageView;
+    private TextView mImageNotAvailableText;
+
+    @Override
+    protected void triggerLayoutInflation() {
+        setContentView(R.layout.activity_nft_detail);
+
+        BraveActivity activity = BraveActivity.getBraveActivity();
+
+        if (activity != null) {
+            NetworkInfo networkInfo = activity.getWalletModel().getCryptoModel().getNetworkModel().mDefaultNetwork.getValue();
+            mNetworkName = networkInfo.chainName;
+            mBlockExplorerUrl = networkInfo.blockExplorerUrls.length > 0 ? networkInfo.blockExplorerUrls[0] : "";
+        }
+
+        // Calculate halft screen height and assign it to NFT image view,
+        // or "Image not found" text view (that will pop up in case of issues).
+        int halfScreenHeight = AndroidUtils.getScreenHeight() / 2;
+
+        mNftImageView = findViewById(R.id.nft_detail_image);
+        mNftImageView.getLayoutParams().height = halfScreenHeight;
+
+        mImageNotAvailableText = findViewById(R.id.nft_detail_image_not_available);
+        mImageNotAvailableText.getLayoutParams().height = halfScreenHeight;
+
+        if (getIntent() != null) {
+            mChainId = getIntent().getStringExtra(Utils.CHAIN_ID);
+            mNftName = getIntent().getStringExtra(Utils.ASSET_NAME);
+            mContractAddress = getIntent().getStringExtra(Utils.ASSET_CONTRACT_ADDRESS);
+            mNftTokenHex = getIntent().getStringExtra(Utils.NFT_TOKEN_ID_HEX);
+            mNftTokenId = Utils.hexToIntString(mNftTokenHex);
+            PortfolioModel.Erc721MetaData erc721MetaData = (PortfolioModel.Erc721MetaData) getIntent().getSerializableExtra(Utils.NFT_META_DATA);
+            setMetadata(erc721MetaData);
+        }
+
+        Toolbar toolbar = findViewById(R.id.toolbar);
+        setSupportActionBar(toolbar);
+        getSupportActionBar().setDisplayHomeAsUpEnabled(true);
+
+        Button btnSend = findViewById(R.id.btn_send);
+        // TODO(simone): Enable if it's the NFT owner.
+        btnSend.setVisibility(View.GONE);
+
+        TextView nftDetailTitle = findViewById(R.id.nft_detail_title);
+        nftDetailTitle.setText(Utils.formatErc721TokenTitle(mNftName, mNftTokenId));
+
+        TextView nftName = findViewById(R.id.nft_name);
+        nftName.setText(mNftName);
+
+        TextView networkName = findViewById(R.id.blockchain_content);
+        networkName.setText(mNetworkName);
+        TextView tokenStandard = findViewById(R.id.token_standard_content);
+        tokenStandard.setText(R.string.brave_wallet_nft_erc_721);
+        TextView tokenIdView = findViewById(R.id.token_id_content);
+
+        String tokenStr = String.format(TOKEN_ID_FORMAT, mNftTokenId);
+        SpannableString spannable = new SpannableString(tokenStr);
+
+        if (!TextUtils.isEmpty(mBlockExplorerUrl)) {
+            String url = String.format(NFT_URL_FORMAT, mBlockExplorerUrl, mContractAddress, mNftTokenId);
+            NoUnderlineClickableSpan linkSpan = new NoUnderlineClickableSpan(this,
+                    R.color.brave_link, (textView) -> { TabUtils.openLinkWithFocus(this, url); });
+            spannable.setSpan(linkSpan, 0, spannable.length(), Spanned.SPAN_EXCLUSIVE_EXCLUSIVE);
+        }
+        tokenIdView.setText(spannable);
+        tokenIdView.setMovementMethod(LinkMovementMethod.getInstance());
+        onInitialLayoutInflationComplete();
+    }
+
+    private void setMetadata(PortfolioModel.Erc721MetaData erc721MetaData) {
+        // In case of no errors proceed to assign descrption and fetch NFT image.
+        if (erc721MetaData.mErrCode == 0) {
+            String description = erc721MetaData.mDescription;
+            String imageUrl = erc721MetaData.mImageUrl;
+            if (!TextUtils.isEmpty(description)) {
+                TextView descriptionContent = findViewById(R.id.description_content);
+                descriptionContent.setText(description);
+            } else {
+                // Hide description layout in case of an empty string.
+                findViewById(R.id.nft_description).setVisibility(View.GONE);
+            }
+            if (!TextUtils.isEmpty(imageUrl)) {
+                loadNftImage(imageUrl);
+            } else {
+                setNftImageAsNotAvailable();
+            }
+        }
+    }
+
+    private void loadNftImage(String imageUrl) {
+        ImageLoader.getLoadNftRequest(imageUrl, this, false)
+                .listener(new RequestListener<Drawable>() {
+                    @Override
+                    public boolean onLoadFailed(GlideException glideException, Object model, Target<Drawable> target, boolean isFirstResource) {
+                        setNftImageAsNotAvailable();
+                        return false;
+                    }
+
+                    @Override
+                    public boolean onResourceReady(Drawable resource, Object model, Target<Drawable> target, DataSource dataSource, boolean isFirstResource) {
+                        target.onResourceReady(resource, new DrawableCrossFadeTransition(250, true));
+                        return true;
+                    }
+                })
+                .into(mNftImageView);
+    }
+
+    private void setNftImageAsNotAvailable() {
+        mNftImageView.setVisibility(View.GONE);
+        mImageNotAvailableText.setVisibility(View.VISIBLE);
+    }
+}

--- a/android/java/org/chromium/chrome/browser/crypto_wallet/activities/NftDetailActivity.java
+++ b/android/java/org/chromium/chrome/browser/crypto_wallet/activities/NftDetailActivity.java
@@ -1,4 +1,4 @@
-/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+/* Copyright (c) 2023 The Brave Authors. All rights reserved.
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at https://mozilla.org/MPL/2.0/. */
@@ -62,7 +62,7 @@ public class NftDetailActivity
             mBlockExplorerUrl = networkInfo.blockExplorerUrls.length > 0 ? networkInfo.blockExplorerUrls[0] : "";
         }
 
-        // Calculate halft screen height and assign it to NFT image view,
+        // Calculate half screen height and assign it to NFT image view,
         // or "Image not found" text view (that will pop up in case of issues).
         int halfScreenHeight = AndroidUtils.getScreenHeight() / 2;
 

--- a/android/java/org/chromium/chrome/browser/crypto_wallet/activities/NftDetailActivity.java
+++ b/android/java/org/chromium/chrome/browser/crypto_wallet/activities/NftDetailActivity.java
@@ -63,7 +63,7 @@ public class NftDetailActivity
         }
 
         // Calculate half screen height and assign it to NFT image view,
-        // or "Image not found" text view (that will pop up in case of issues).
+        // and "Image not found" text view (that will pop up in case of issues).
         int halfScreenHeight = AndroidUtils.getScreenHeight() / 2;
 
         mNftImageView = findViewById(R.id.nft_detail_image);

--- a/android/java/org/chromium/chrome/browser/crypto_wallet/adapters/WalletCoinAdapter.java
+++ b/android/java/org/chromium/chrome/browser/crypto_wallet/adapters/WalletCoinAdapter.java
@@ -198,7 +198,7 @@ public class WalletCoinAdapter extends RecyclerView.Adapter<WalletCoinAdapter.Vi
                 if (walletListItemModel.hasNftImageLink()
                         && ImageLoader.isSupported(nftDataModel.erc721MetaData.mImageUrl)) {
                     String url = nftDataModel.erc721MetaData.mImageUrl;
-                    ImageLoader.loadNft(url, holder.iconImg, context, false);
+                    ImageLoader.getLoadNftRequest(url, context, false).into(holder.iconImg);
                 } else {
                     Utils.setBlockiesBitmapCustomAsset(mExecutor, mHandler, holder.iconImg,
                             walletListItemModel.getBlockchainToken().contractAddress,

--- a/android/java/org/chromium/chrome/browser/crypto_wallet/adapters/WalletCoinAdapter.java
+++ b/android/java/org/chromium/chrome/browser/crypto_wallet/adapters/WalletCoinAdapter.java
@@ -198,7 +198,7 @@ public class WalletCoinAdapter extends RecyclerView.Adapter<WalletCoinAdapter.Vi
                 if (walletListItemModel.hasNftImageLink()
                         && ImageLoader.isSupported(nftDataModel.erc721MetaData.mImageUrl)) {
                     String url = nftDataModel.erc721MetaData.mImageUrl;
-                    ImageLoader.getLoadNftRequest(url, context, false).into(holder.iconImg);
+                    ImageLoader.createLoadNftRequest(url, context, false).into(holder.iconImg);
                 } else {
                     Utils.setBlockiesBitmapCustomAsset(mExecutor, mHandler, holder.iconImg,
                             walletListItemModel.getBlockchainToken().contractAddress,

--- a/android/java/org/chromium/chrome/browser/crypto_wallet/fragments/PortfolioFragment.java
+++ b/android/java/org/chromium/chrome/browser/crypto_wallet/fragments/PortfolioFragment.java
@@ -355,7 +355,7 @@ public class PortfolioFragment
             PortfolioModel.NftDataModel selectedNft = null;
             if (mPortfolioModel != null) {
                 List<PortfolioModel.NftDataModel> nftModels = mPortfolioModel.mNftModels.getValue();
-                for (PortfolioModel.NftDataModel nftDataModel: nftModels) {
+                for (PortfolioModel.NftDataModel nftDataModel : nftModels) {
                     if (nftDataModel.token.tokenId.equals(asset.tokenId)) {
                         selectedNft = nftDataModel;
                         break;
@@ -366,7 +366,7 @@ public class PortfolioFragment
                 return;
             }
 
-             Utils.openNftDetailActivity(getActivity(), selectedNetwork.chainId, asset, selectedNft);
+            Utils.openNftDetailActivity(getActivity(), selectedNetwork.chainId, asset, selectedNft);
         } else {
             Utils.openAssetDetailsActivity(getActivity(), selectedNetwork.chainId, asset);
         }

--- a/android/java/org/chromium/chrome/browser/crypto_wallet/fragments/PortfolioFragment.java
+++ b/android/java/org/chromium/chrome/browser/crypto_wallet/fragments/PortfolioFragment.java
@@ -350,11 +350,26 @@ public class PortfolioFragment
         if (selectedNetwork == null) {
             return;
         }
+
         if (asset.isErc721 || asset.isNft) {
-            // TODO: show nft details of clicked nft
-            return;
+            PortfolioModel.NftDataModel selectedNft = null;
+            if (mPortfolioModel != null) {
+                List<PortfolioModel.NftDataModel> nftModels = mPortfolioModel.mNftModels.getValue();
+                for (PortfolioModel.NftDataModel nftDataModel: nftModels) {
+                    if (nftDataModel.token.tokenId.equals(asset.tokenId)) {
+                        selectedNft = nftDataModel;
+                        break;
+                    }
+                }
+            }
+            if (selectedNft == null) {
+                return;
+            }
+
+             Utils.openNftDetailActivity(getActivity(), selectedNetwork.chainId, asset, selectedNft);
+        } else {
+            Utils.openAssetDetailsActivity(getActivity(), selectedNetwork.chainId, asset);
         }
-        Utils.openAssetDetailsActivity(getActivity(), selectedNetwork.chainId, asset);
     }
 
     private void openNetworkSelection() {

--- a/android/java/org/chromium/chrome/browser/crypto_wallet/fragments/PortfolioFragment.java
+++ b/android/java/org/chromium/chrome/browser/crypto_wallet/fragments/PortfolioFragment.java
@@ -7,6 +7,7 @@ package org.chromium.chrome.browser.crypto_wallet.fragments;
 
 import android.annotation.SuppressLint;
 import android.app.Activity;
+import android.content.Intent;
 import android.os.Bundle;
 import android.view.LayoutInflater;
 import android.view.MotionEvent;
@@ -48,6 +49,7 @@ import org.chromium.chrome.browser.app.domain.PortfolioModel;
 import org.chromium.chrome.browser.app.domain.WalletModel;
 import org.chromium.chrome.browser.crypto_wallet.BlockchainRegistryFactory;
 import org.chromium.chrome.browser.crypto_wallet.activities.BraveWalletActivity;
+import org.chromium.chrome.browser.crypto_wallet.activities.NftDetailActivity;
 import org.chromium.chrome.browser.crypto_wallet.adapters.WalletCoinAdapter;
 import org.chromium.chrome.browser.crypto_wallet.listeners.OnWalletListItemClick;
 import org.chromium.chrome.browser.crypto_wallet.observers.ApprovedTxObserver;
@@ -353,20 +355,20 @@ public class PortfolioFragment
 
         if (asset.isErc721 || asset.isNft) {
             PortfolioModel.NftDataModel selectedNft = null;
-            if (mPortfolioModel != null) {
-                List<PortfolioModel.NftDataModel> nftModels = mPortfolioModel.mNftModels.getValue();
-                for (PortfolioModel.NftDataModel nftDataModel : nftModels) {
-                    if (nftDataModel.token.tokenId.equals(asset.tokenId)) {
-                        selectedNft = nftDataModel;
-                        break;
-                    }
+            List<PortfolioModel.NftDataModel> nftModels = mPortfolioModel.mNftModels.getValue();
+            for (PortfolioModel.NftDataModel nftDataModel : nftModels) {
+                if (nftDataModel.token.tokenId.equals(asset.tokenId)) {
+                    selectedNft = nftDataModel;
+                    break;
                 }
             }
             if (selectedNft == null) {
                 return;
             }
 
-            Utils.openNftDetailActivity(getActivity(), selectedNetwork.chainId, asset, selectedNft);
+            Intent intent = NftDetailActivity.getIntent(
+                    getContext(), selectedNetwork.chainId, asset, selectedNft);
+            startActivity(intent);
         } else {
             Utils.openAssetDetailsActivity(getActivity(), selectedNetwork.chainId, asset);
         }

--- a/android/java/org/chromium/chrome/browser/crypto_wallet/fragments/PortfolioFragment.java
+++ b/android/java/org/chromium/chrome/browser/crypto_wallet/fragments/PortfolioFragment.java
@@ -1,7 +1,7 @@
 /* Copyright (c) 2021 The Brave Authors. All rights reserved.
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
- * You can obtain one at http://mozilla.org/MPL/2.0/. */
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 package org.chromium.chrome.browser.crypto_wallet.fragments;
 
@@ -96,6 +96,7 @@ public class PortfolioFragment
     private SmoothLineChartEquallySpaced mChartES;
     private PortfolioModel mPortfolioModel;
     private ProgressBar mPbAssetDiscovery;
+    private List<PortfolioModel.NftDataModel> mNftDataModels;
 
     public static PortfolioFragment newInstance() {
         return new PortfolioFragment();
@@ -204,6 +205,7 @@ public class PortfolioFragment
                 });
         mPortfolioModel.mNftModels.observe(getViewLifecycleOwner(), nftDataModels -> {
             if (nftDataModels.isEmpty() || mPortfolioModel.mPortfolioHelper == null) return;
+            mNftDataModels = nftDataModels;
             setUpNftList(nftDataModels, mPortfolioModel.mPortfolioHelper.getPerTokenCryptoSum(),
                     mPortfolioModel.mPortfolioHelper.getPerTokenFiatSum());
         });
@@ -355,8 +357,7 @@ public class PortfolioFragment
 
         if (asset.isErc721 || asset.isNft) {
             PortfolioModel.NftDataModel selectedNft = null;
-            List<PortfolioModel.NftDataModel> nftModels = mPortfolioModel.mNftModels.getValue();
-            for (PortfolioModel.NftDataModel nftDataModel : nftModels) {
+            for (PortfolioModel.NftDataModel nftDataModel : mNftDataModels) {
                 if (nftDataModel.token.tokenId.equals(asset.tokenId)) {
                     selectedNft = nftDataModel;
                     break;

--- a/android/java/org/chromium/chrome/browser/crypto_wallet/util/AndroidUtils.java
+++ b/android/java/org/chromium/chrome/browser/crypto_wallet/util/AndroidUtils.java
@@ -91,6 +91,10 @@ public class AndroidUtils {
         }
     }
 
+    /**
+     * Gets device screen height in pixels, excluding the navigation bar (if visible) and insets.
+     * @return device screen height in pixels.
+     */
     public static int getScreenHeight() {
         return Resources.getSystem().getDisplayMetrics().heightPixels;
     }

--- a/android/java/org/chromium/chrome/browser/crypto_wallet/util/AndroidUtils.java
+++ b/android/java/org/chromium/chrome/browser/crypto_wallet/util/AndroidUtils.java
@@ -6,6 +6,7 @@
 package org.chromium.chrome.browser.crypto_wallet.util;
 
 import android.content.Context;
+import android.content.res.Resources;
 import android.graphics.Typeface;
 import android.os.Build;
 import android.text.Html;
@@ -88,5 +89,9 @@ public class AndroidUtils {
         for (View view : views) {
             view.setVisibility(visibility);
         }
+    }
+
+    public static int getScreenHeight() {
+        return Resources.getSystem().getDisplayMetrics().heightPixels;
     }
 }

--- a/android/java/org/chromium/chrome/browser/crypto_wallet/util/ImageLoader.java
+++ b/android/java/org/chromium/chrome/browser/crypto_wallet/util/ImageLoader.java
@@ -45,6 +45,7 @@ public class ImageLoader {
     }
 
     private static boolean isValidImgUrl(String url) {
-        return URLUtil.isDataUrl(url) || URLUtil.isNetworkUrl(url);
+        // Only "data:" or HTTPS URLs.
+        return URLUtil.isDataUrl(url) || URLUtil.isHttpsUrl(url);
     }
 }

--- a/android/java/org/chromium/chrome/browser/crypto_wallet/util/ImageLoader.java
+++ b/android/java/org/chromium/chrome/browser/crypto_wallet/util/ImageLoader.java
@@ -24,7 +24,7 @@ import java.util.List;
 public class ImageLoader {
     private static final List<String> ANIMATED_LIST = Arrays.asList(".gif");
 
-    public static RequestBuilder<Drawable> getLoadNftRequest(
+    public static RequestBuilder<Drawable> createLoadNftRequest(
             String url, Context context, boolean isCircular) {
         RequestBuilder<Drawable> request =
                 Glide.with(context).load(url).transform(new CenterInside(), new RoundedCorners(24));

--- a/android/java/org/chromium/chrome/browser/crypto_wallet/util/ImageLoader.java
+++ b/android/java/org/chromium/chrome/browser/crypto_wallet/util/ImageLoader.java
@@ -8,6 +8,7 @@ package org.chromium.chrome.browser.crypto_wallet.util;
 import android.content.Context;
 import android.graphics.drawable.Drawable;
 import android.text.TextUtils;
+import android.webkit.URLUtil;
 import android.widget.ImageView;
 
 import com.bumptech.glide.Glide;
@@ -35,7 +36,7 @@ public class ImageLoader {
     }
 
     public static boolean isSupported(String url) {
-        return !isSvg(url);
+        return isValidImgUrl(url) && !isSvg(url);
     }
 
     public static boolean isSvg(String url) {
@@ -44,6 +45,6 @@ public class ImageLoader {
     }
 
     private static boolean isValidImgUrl(String url) {
-        return !TextUtils.isEmpty(url);
+        return URLUtil.isDataUrl(url) || URLUtil.isNetworkUrl(url);
     }
 }

--- a/android/java/org/chromium/chrome/browser/crypto_wallet/util/ImageLoader.java
+++ b/android/java/org/chromium/chrome/browser/crypto_wallet/util/ImageLoader.java
@@ -24,21 +24,15 @@ import java.util.List;
 public class ImageLoader {
     private static final List<String> ANIMATED_LIST = Arrays.asList(".gif");
 
-    public static void loadNft(
-            String url, ImageView imageView, Context context, boolean isCircular) {
-        loadImg(url, imageView, context, isCircular);
-    }
-
-    public static void loadImg(
-            String url, ImageView imageView, Context context, boolean isCircular) {
+    public static RequestBuilder<Drawable> getLoadNftRequest(
+            String url, Context context, boolean isCircular) {
         RequestBuilder<Drawable> request =
                 Glide.with(context).load(url).transform(new CenterInside(), new RoundedCorners(24));
         if (isCircular) {
             request = request.circleCrop();
         }
-        request.priority(Priority.IMMEDIATE)
-                .diskCacheStrategy(DiskCacheStrategy.ALL)
-                .into(imageView);
+        return request.priority(Priority.IMMEDIATE)
+                .diskCacheStrategy(DiskCacheStrategy.ALL);
     }
 
     public static boolean isSupported(String url) {

--- a/android/java/org/chromium/chrome/browser/crypto_wallet/util/ImageLoader.java
+++ b/android/java/org/chromium/chrome/browser/crypto_wallet/util/ImageLoader.java
@@ -31,8 +31,7 @@ public class ImageLoader {
         if (isCircular) {
             request = request.circleCrop();
         }
-        return request.priority(Priority.IMMEDIATE)
-                .diskCacheStrategy(DiskCacheStrategy.ALL);
+        return request.priority(Priority.IMMEDIATE).diskCacheStrategy(DiskCacheStrategy.ALL);
     }
 
     public static boolean isSupported(String url) {

--- a/android/java/org/chromium/chrome/browser/crypto_wallet/util/Utils.java
+++ b/android/java/org/chromium/chrome/browser/crypto_wallet/util/Utils.java
@@ -150,8 +150,6 @@ public class Utils {
     public static final String ADDRESS = "address";
     public static final String NAME = "name";
     public static final String COIN_TYPE = "coinType";
-    public static final String NFT_TOKEN_ID_HEX = "nftTokenIdHex";
-    public static final String NFT_META_DATA = "nftMetaData";
     public static final String ISIMPORTED = "isImported";
     public static final String ISUPDATEACCOUNT = "isUpdateAccount";
     public static final String SWAP_EXCHANGE_PROXY = "0xdef1c0ded9bec7f1a1670819833240f027b25eff";
@@ -260,17 +258,6 @@ public class Utils {
     public static void openBuySendSwapActivity(
             Activity activity, BuySendSwapActivity.ActivityType activityType) {
         openBuySendSwapActivity(activity, activityType, null);
-    }
-
-    public static void openNftDetailActivity(Activity activity, String chainId,
-            BlockchainToken asset, PortfolioModel.NftDataModel nftDataModel) {
-        Intent assetDetailIntent = new Intent(activity, NftDetailActivity.class);
-        assetDetailIntent.putExtra(CHAIN_ID, chainId);
-        assetDetailIntent.putExtra(ASSET_NAME, asset.name);
-        assetDetailIntent.putExtra(ASSET_CONTRACT_ADDRESS, asset.contractAddress);
-        assetDetailIntent.putExtra(NFT_TOKEN_ID_HEX, asset.tokenId);
-        assetDetailIntent.putExtra(NFT_META_DATA, nftDataModel.erc721MetaData);
-        activity.startActivity(assetDetailIntent);
     }
 
     public static void openAssetDetailsActivity(

--- a/android/java/org/chromium/chrome/browser/crypto_wallet/util/Utils.java
+++ b/android/java/org/chromium/chrome/browser/crypto_wallet/util/Utils.java
@@ -88,6 +88,7 @@ import org.chromium.chrome.browser.app.domain.PortfolioModel;
 import org.chromium.chrome.browser.crypto_wallet.activities.AssetDetailActivity;
 import org.chromium.chrome.browser.crypto_wallet.activities.BraveWalletBaseActivity;
 import org.chromium.chrome.browser.crypto_wallet.activities.BuySendSwapActivity;
+import org.chromium.chrome.browser.crypto_wallet.activities.NftDetailActivity;
 import org.chromium.chrome.browser.crypto_wallet.adapters.WalletCoinAdapter;
 import org.chromium.chrome.browser.crypto_wallet.fragments.ApproveTxBottomSheetDialogFragment;
 import org.chromium.chrome.browser.crypto_wallet.listeners.OnWalletListItemClick;
@@ -149,6 +150,8 @@ public class Utils {
     public static final String ADDRESS = "address";
     public static final String NAME = "name";
     public static final String COIN_TYPE = "coinType";
+    public static final String NFT_TOKEN_ID_HEX = "nftTokenIdHex";
+    public static final String NFT_META_DATA = "nftMetaData";
     public static final String ISIMPORTED = "isImported";
     public static final String ISUPDATEACCOUNT = "isUpdateAccount";
     public static final String SWAP_EXCHANGE_PROXY = "0xdef1c0ded9bec7f1a1670819833240f027b25eff";
@@ -257,6 +260,17 @@ public class Utils {
     public static void openBuySendSwapActivity(
             Activity activity, BuySendSwapActivity.ActivityType activityType) {
         openBuySendSwapActivity(activity, activityType, null);
+    }
+
+    public static void openNftDetailActivity(
+            Activity activity, String chainId, BlockchainToken asset, PortfolioModel.NftDataModel nftDataModel) {
+        Intent assetDetailIntent = new Intent(activity, NftDetailActivity.class);
+        assetDetailIntent.putExtra(CHAIN_ID, chainId);
+        assetDetailIntent.putExtra(ASSET_NAME, asset.name);
+        assetDetailIntent.putExtra(ASSET_CONTRACT_ADDRESS, asset.contractAddress);
+        assetDetailIntent.putExtra(NFT_TOKEN_ID_HEX, asset.tokenId);
+        assetDetailIntent.putExtra(NFT_META_DATA, nftDataModel.erc721MetaData);
+        activity.startActivity(assetDetailIntent);
     }
 
     public static void openAssetDetailsActivity(

--- a/android/java/org/chromium/chrome/browser/crypto_wallet/util/Utils.java
+++ b/android/java/org/chromium/chrome/browser/crypto_wallet/util/Utils.java
@@ -262,8 +262,8 @@ public class Utils {
         openBuySendSwapActivity(activity, activityType, null);
     }
 
-    public static void openNftDetailActivity(
-            Activity activity, String chainId, BlockchainToken asset, PortfolioModel.NftDataModel nftDataModel) {
+    public static void openNftDetailActivity(Activity activity, String chainId,
+            BlockchainToken asset, PortfolioModel.NftDataModel nftDataModel) {
         Intent assetDetailIntent = new Intent(activity, NftDetailActivity.class);
         assetDetailIntent.putExtra(CHAIN_ID, chainId);
         assetDetailIntent.putExtra(ASSET_NAME, asset.name);

--- a/android/java/res/layout/activity_nft_detail.xml
+++ b/android/java/res/layout/activity_nft_detail.xml
@@ -1,0 +1,215 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright (c) 2022 The Brave Authors. All rights reserved.
+     This Source Code Form is subject to the terms of the Mozilla Public
+     License, v. 2.0. If a copy of the MPL was not distributed with this file,
+     You can obtain one at https://mozilla.org/MPL/2.0/.
+-->
+<ScrollView
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="@color/wallet_bg"
+    android:fillViewport="true">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:animateLayoutChanges="true"
+        android:orientation="vertical">
+
+        <androidx.appcompat.widget.Toolbar
+            android:id="@+id/toolbar"
+            android:layout_width="match_parent"
+            android:layout_height="?attr/actionBarSize"
+            android:background="@color/wallet_toolbar_bg_color"
+            android:translationZ="10dp"
+            android:layout_marginBottom="8dp"
+            android:gravity="center_vertical">
+
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="horizontal">
+
+                <TextView
+                    android:id="@+id/nft_title_text"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:textSize="20sp"
+                    android:textColor="@color/wallet_text_color"
+                    android:gravity="center_vertical"
+                    android:text="@string/brave_wallet_nft_detail_toolbar"
+                    android:layout_marginEnd="20dp"/>
+
+            </LinearLayout>
+
+        </androidx.appcompat.widget.Toolbar>
+
+        <ImageView
+            android:id="@+id/nft_detail_image"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="16dp"
+            android:layout_marginEnd="16dp"
+            android:layout_marginBottom="16dp"
+            android:src="@color/modern_grey_100"
+            android:contentDescription="@null"/>
+
+        <TextView
+            android:id="@+id/nft_detail_image_not_available"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="16dp"
+            android:layout_marginEnd="16dp"
+            android:layout_marginBottom="16dp"
+            android:gravity="center"
+            android:text="@string/brave_wallet_nft_image_not_available"
+            android:textColor="@color/wallet_secondary_text_color"
+            android:textSize="14sp"
+            android:visibility="gone"/>
+
+        <TextView
+            android:id="@+id/nft_detail_title"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="16dp"
+            android:layout_marginEnd="16dp"
+            android:layout_marginBottom="8dp"
+            android:textColor="@color/wallet_text_color"
+            android:textStyle="bold"
+            android:textSize="32sp" />
+
+        <TextView
+            android:id="@+id/nft_name"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:textSize="14sp"
+            android:layout_marginStart="16dp"
+            android:layout_marginEnd="16dp"
+            android:layout_marginBottom="16dp"
+            android:textColor="@color/wallet_secondary_text_color" />
+
+        <androidx.appcompat.widget.AppCompatButton
+            android:id="@+id/btn_send"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="16dp"
+            android:layout_marginEnd="16dp"
+            android:layout_marginBottom="16dp"
+            android:gravity="center"
+            android:background="@drawable/crypto_wallet_blue_button"
+            android:text="@string/send"
+            android:textAllCaps="false"
+            android:textSize="16sp"
+            android:paddingTop="8dp"
+            android:paddingBottom="8dp"
+            android:paddingStart="16dp"
+            android:paddingEnd="16dp"
+            android:textColor="@android:color/white"
+            style="?android:attr/borderlessButtonStyle"/>
+
+        <LinearLayout
+            android:id="@+id/nft_description"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="16dp"
+            android:layout_marginEnd="16dp"
+            android:layout_marginBottom="16dp"
+            android:gravity="center"
+            android:orientation="vertical">
+            <TextView
+                android:id="@+id/description_label"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginBottom="8dp"
+                android:text="@string/brave_wallet_nft_description"
+                android:textColor="@color/wallet_secondary_text_color"
+                android:textStyle="bold"
+                android:textSize="14sp" />
+            <TextView
+                android:id="@+id/description_content"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:textColor="@color/wallet_secondary_text_color"
+                android:textSize="14sp" />
+        </LinearLayout>
+
+        <LinearLayout
+            android:id="@+id/nft_blockchain"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="16dp"
+            android:layout_marginEnd="16dp"
+            android:layout_marginBottom="8dp"
+            android:orientation="horizontal">
+            <TextView
+                android:id="@+id/blockchain_label"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/brave_wallet_nft_blockchain"
+                android:textColor="@color/wallet_secondary_text_color"
+                android:textStyle="bold"
+                android:textSize="14sp" />
+            <TextView
+                android:id="@+id/blockchain_content"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:textColor="@color/wallet_secondary_text_color"
+                android:textSize="14sp"
+                android:gravity="end" />
+        </LinearLayout>
+
+        <LinearLayout
+            android:id="@+id/nft_token_standard"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="16dp"
+            android:layout_marginEnd="16dp"
+            android:layout_marginBottom="8dp"
+            android:orientation="horizontal">
+            <TextView
+                android:id="@+id/token_standard_label"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/brave_wallet_nft_token_standard"
+                android:textColor="@color/wallet_secondary_text_color"
+                android:textStyle="bold"
+                android:textSize="14sp" />
+            <TextView
+                android:id="@+id/token_standard_content"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:textColor="@color/wallet_secondary_text_color"
+                android:textSize="14sp"
+                android:gravity="end" />
+        </LinearLayout>
+
+        <LinearLayout
+            android:id="@+id/nft_token_id"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="16dp"
+            android:layout_marginEnd="16dp"
+            android:layout_marginBottom="8dp"
+            android:orientation="horizontal">
+            <TextView
+                android:id="@+id/token_id_label"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/brave_wallet_nft_token_id"
+                android:textColor="@color/wallet_secondary_text_color"
+                android:textStyle="bold"
+                android:textSize="14sp" />
+            <TextView
+                android:id="@+id/token_id_content"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:textColor="@color/wallet_secondary_text_color"
+                android:textSize="14sp"
+                android:gravity="end"
+                />
+        </LinearLayout>
+
+    </LinearLayout>
+
+</ScrollView>

--- a/android/java/res/layout/activity_nft_detail.xml
+++ b/android/java/res/layout/activity_nft_detail.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- Copyright (c) 2022 The Brave Authors. All rights reserved.
+<!-- Copyright (c) 2023 The Brave Authors. All rights reserved.
      This Source Code Form is subject to the terms of the Mozilla Public
      License, v. 2.0. If a copy of the MPL was not distributed with this file,
      You can obtain one at https://mozilla.org/MPL/2.0/.

--- a/android/java/res/layout/activity_nft_detail.xml
+++ b/android/java/res/layout/activity_nft_detail.xml
@@ -70,20 +70,17 @@
 
         <TextView
             android:id="@+id/nft_detail_title"
+            style="@style/BraveWalletTextViewTitle"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_marginStart="16dp"
             android:layout_marginEnd="16dp"
             android:layout_marginBottom="8dp"
-            android:textColor="@color/wallet_text_color"
-            android:textStyle="bold"
             android:textSize="32sp" />
 
         <TextView
             android:id="@+id/nft_name"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:textSize="14sp"
+            style="@style/BraveWalletTextView"
             android:layout_marginStart="16dp"
             android:layout_marginEnd="16dp"
             android:layout_marginBottom="16dp"
@@ -119,19 +116,19 @@
             android:orientation="vertical">
             <TextView
                 android:id="@+id/description_label"
+                style="@style/BraveWalletTextView"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:layout_marginBottom="8dp"
                 android:text="@string/brave_wallet_nft_description"
                 android:textColor="@color/wallet_secondary_text_color"
-                android:textStyle="bold"
-                android:textSize="14sp" />
+                android:textStyle="bold" />
             <TextView
                 android:id="@+id/description_content"
+                style="@style/BraveWalletTextView"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:textColor="@color/wallet_secondary_text_color"
-                android:textSize="14sp" />
+                android:textColor="@color/wallet_secondary_text_color" />
         </LinearLayout>
 
         <LinearLayout
@@ -144,18 +141,16 @@
             android:orientation="horizontal">
             <TextView
                 android:id="@+id/blockchain_label"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
+                style="@style/BraveWalletTextView"
                 android:text="@string/brave_wallet_nft_blockchain"
                 android:textColor="@color/wallet_secondary_text_color"
-                android:textStyle="bold"
-                android:textSize="14sp" />
+                android:textStyle="bold" />
             <TextView
                 android:id="@+id/blockchain_content"
+                style="@style/BraveWalletTextView"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:textColor="@color/wallet_secondary_text_color"
-                android:textSize="14sp"
                 android:gravity="end" />
         </LinearLayout>
 
@@ -169,18 +164,16 @@
             android:orientation="horizontal">
             <TextView
                 android:id="@+id/token_standard_label"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
+                style="@style/BraveWalletTextView"
                 android:text="@string/brave_wallet_nft_token_standard"
                 android:textColor="@color/wallet_secondary_text_color"
-                android:textStyle="bold"
-                android:textSize="14sp" />
+                android:textStyle="bold" />
             <TextView
                 android:id="@+id/token_standard_content"
+                style="@style/BraveWalletTextView"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:textColor="@color/wallet_secondary_text_color"
-                android:textSize="14sp"
                 android:gravity="end" />
         </LinearLayout>
 
@@ -194,12 +187,10 @@
             android:orientation="horizontal">
             <TextView
                 android:id="@+id/token_id_label"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
+                style="@style/BraveWalletTextView"
                 android:text="@string/brave_wallet_nft_token_id"
                 android:textColor="@color/wallet_secondary_text_color"
-                android:textStyle="bold"
-                android:textSize="14sp" />
+                android:textStyle="bold" />
             <TextView
                 android:id="@+id/token_id_content"
                 android:layout_width="match_parent"

--- a/browser/ui/android/strings/android_brave_strings.grd
+++ b/browser/ui/android/strings/android_brave_strings.grd
@@ -2047,7 +2047,7 @@ Are you sure you want to do this?
       Blockchain
     </message>
     <message name="IDS_BRAVE_WALLET_NFT_TOKEN_STANDARD" desc="Token standard text for Brave wallet NFT asset detail.">
-      Token standard
+      Token Standard
     </message>
     <message name="IDS_BRAVE_WALLET_NFT_ERC_721" desc="Type of NFT token standard. It does not need to be translated.">
       ERC 721

--- a/browser/ui/android/strings/android_brave_strings.grd
+++ b/browser/ui/android/strings/android_brave_strings.grd
@@ -2037,6 +2037,27 @@ Are you sure you want to do this?
     <message name="IDS_BRAVE_WALLET_TOOLBAR_LOCK" desc="Title for brave wallet toolbar lock option.">
       Lock
     </message>
+    <message name="IDS_BRAVE_WALLET_NFT_DETAIL_TOOLBAR" desc="Title for Brave wallet NFT detail screen toolbar.">
+      NFT Detail
+    </message>
+    <message name="IDS_BRAVE_WALLET_NFT_DESCRIPTION" desc="Description text for Brave wallet NFT asset detail.">
+      Description
+    </message>
+    <message name="IDS_BRAVE_WALLET_NFT_BLOCKCHAIN" desc="Blockchain text for Brave wallet NFT asset detail.">
+      Blockchain
+    </message>
+    <message name="IDS_BRAVE_WALLET_NFT_TOKEN_STANDARD" desc="Token standard text for Brave wallet NFT asset detail.">
+      Token standard
+    </message>
+    <message name="IDS_BRAVE_WALLET_NFT_ERC_721" desc="Type of NFT token standard. It does not need to be translated.">
+      ERC 721
+    </message>
+    <message name="IDS_BRAVE_WALLET_NFT_TOKEN_ID" desc="Token ID text for brave wallet NFT asset detail.">
+      Token ID
+    </message>
+    <message name="IDS_BRAVE_WALLET_NFT_IMAGE_NOT_AVAILABLE" desc="Text message for image not available when loading NFT image.">
+      Image not available
+    </message>
     <message name="IDS_BRAVE_WALLET_SETTINGS_AUTOLOCK_OPTION" desc="Title for brave wallet automatically lock.">
       Automatically lock Brave Wallet
     </message>


### PR DESCRIPTION
## Resolves https://github.com/brave/brave-browser/issues/27276

Implements new NFT asset detail screen supporting GIF, BMP, PNG and JPG images.

https://user-images.githubusercontent.com/3308503/212389665-46eaee7c-9957-47b2-8a95-dd118942caa4.mov

## Security Review

Requested security review: https://github.com/brave/security/issues/1168.

## Light Theme

<img width="377" alt="Android_SDK_built_for_x86_and_Comparing_master___simone_nft-detail-screen_·_brave_brave-core" src="https://user-images.githubusercontent.com/3308503/212390078-80d15532-3caf-4574-8b8a-ad0b19ca4518.png">

## Dark Theme

<img width="376" alt="Android_SDK_built_for_x86" src="https://user-images.githubusercontent.com/3308503/212390308-be14a13c-7a71-4b1f-8b1a-e2746ca528e6.png">


## Related Issues

- [Add support for Solana NFT in NFT detail screen](https://github.com/brave/brave-browser/issues/27803)
- [Show "Send" button in NFT detail screen for owned NFTs](https://github.com/brave/brave-browser/issues/27802)
- [Add SVG support to NFT images](https://github.com/brave/brave-browser/issues/27800)



## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [x] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

- Open the wallet section
- If not already present, add a new NFT selecting "Edit visible assets" > "Add custom assets"
(E.g `0x59468516a8259058bad1ca5f8f4bff190d30e066`, id `183` -[ Invisible Friends](https://opensea.io/assets/ethereum/0x59468516a8259058bad1ca5f8f4bff190d30e066/183))
- Tap on the NFT item
- Observe the new NFT detail screen loads correctly image, title and description.
