### PR TITLE
[iOS] Fix #991- URLFormatter Options Exports

### DIFF
--- a/ios/browser/api/url/url_formatter.h
+++ b/ios/browser/api/url/url_formatter.h
@@ -18,17 +18,61 @@ OBJC_EXPORT BraveURLSchemeDisplay const BraveURLSchemeDisplayOmitHttpAndHttps;
 /// Omit cryptographic (i.e. https and wss).
 OBJC_EXPORT BraveURLSchemeDisplay const BraveURLSchemeDisplayOmitCryptographic;
 
+NS_SWIFT_NAME(URLFormatter.FormatType)
+typedef NS_OPTIONS(NSUInteger, BraveURLFormatterFormatType) {
+  BraveURLFormatterFormatTypeOmitNothing = 0,
+  BraveURLFormatterFormatTypeOmitUsernamePassword = 1 << 0,
+  BraveURLFormatterFormatTypeOmitHTTP = 1 << 1,
+  BraveURLFormatterFormatTypeOmitTrailingSlashOnBareHostname = 1 << 2,
+  BraveURLFormatterFormatTypeOmitHTTPS = 1 << 3,
+  BraveURLFormatterFormatTypeOmitTrivialSubdomains = 1 << 5,
+  BraveURLFormatterFormatTypeTrimAfterHost = 1 << 6,
+  BraveURLFormatterFormatTypeOmitFileScheme = 1 << 7,
+  BraveURLFormatterFormatTypeOmitMailToScheme = 1 << 8,
+  BraveURLFormatterFormatTypeOmitMobilePrefix = 1 << 9,
+
+  /// Omits Username & Password, HTTP (not HTTPS), and Trailing Slash
+  BraveURLFormatterFormatTypeOmitDefaults =
+      BraveURLFormatterFormatTypeOmitUsernamePassword |
+      BraveURLFormatterFormatTypeOmitHTTP |
+      BraveURLFormatterFormatTypeOmitTrailingSlashOnBareHostname
+};
+
+NS_SWIFT_NAME(URLFormatter.UnescapeRule)
+typedef NS_OPTIONS(NSUInteger, BraveURLFormatterUnescapeRule) {
+  BraveURLFormatterUnescapeRuleNone = 0,
+  BraveURLFormatterUnescapeRuleNormal = 1 << 0,
+  BraveURLFormatterUnescapeRuleSpaces = 1 << 1,
+  BraveURLFormatterUnescapeRulePathSeparators = 1 << 2,
+  BraveURLFormatterUnescapeRuleSpecialCharsExceptPathSeparators = 1 << 3,
+  BraveURLFormatterUnescapeRuleReplacePlusWithSpace = 1 << 4
+};
+
 OBJC_EXPORT
 NS_SWIFT_NAME(URLFormatter)
 @interface BraveURLFormatter : NSObject
 - (instancetype)init NS_UNAVAILABLE;
+
+/// Format a URL "origin/host" for Security Display
+/// origin - The origin of the URL to format
+/// schemeDisplay - Determines whether or not to omit the scheme
 + (NSString*)formatURLOriginForSecurityDisplay:(NSString*)origin
                                  schemeDisplay:
                                      (BraveURLSchemeDisplay)schemeDisplay;
+
+/// Format a URL "origin/host" omitting the scheme, path, and trivial
+/// sub-domains. origin - The origin to be formatted
 + (NSString*)formatURLOriginForDisplayOmitSchemePathAndTrivialSubdomains:
     (NSString*)origin;
 
-+ (NSString*)formatURL:(NSString*)url;
+/// Format a URL
+/// url - The URL string to be formatted
+/// formatTypes - Formatter options when formatting the URL. Typically used to
+/// omit certain parts of a URL unescapeOptions - Options passed to the
+/// formatter for UN-Escaping parts of a URL
++ (NSString*)formatURL:(NSString*)url
+           formatTypes:(BraveURLFormatterFormatType)formatTypes
+       unescapeOptions:(BraveURLFormatterUnescapeRule)unescapeOptions;
 @end
 
 NS_ASSUME_NONNULL_END

--- a/ios/browser/api/url/url_formatter.mm
+++ b/ios/browser/api/url/url_formatter.mm
@@ -49,10 +49,14 @@ BraveURLSchemeDisplay const BraveURLSchemeDisplayOmitCryptographic =
   return base::SysUTF16ToNSString(result) ?: @"";
 }
 
-+ (NSString*)formatURL:(NSString*)url {
++ (NSString*)formatURL:(NSString*)url
+           formatTypes:(BraveURLFormatterFormatType)formatTypes
+       unescapeOptions:(BraveURLFormatterUnescapeRule)unescapeOptions {
   std::u16string result = url_formatter::FormatUrl(
-      GURL(base::SysNSStringToUTF8(url)), url_formatter::kFormatUrlOmitDefaults,
-      base::UnescapeRule::SPACES, nullptr, nullptr, nullptr);
+      GURL(base::SysNSStringToUTF8(url)),
+      static_cast<url_formatter::FormatUrlType>(formatTypes),
+      static_cast<base::UnescapeRule::Type>(unescapeOptions), nullptr, nullptr,
+      nullptr);
   return base::SysUTF16ToNSString(result) ?: @"";
 }
 @end


### PR DESCRIPTION
## Security Review
- https://github.com/brave/security/issues/1166

## Summary
- Export `ALL options` for iOS `URLFormatter` since we cannot handle all scenarios with one function call.
- iOS needs to handle URL Formatting for Shields, Display, Security Display, and various other scenarios.

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/internal/issues/991

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

