### PR TITLE
[Android] fix brave news crash on scrolling (uplift to 1.48.x)

### DIFF
--- a/android/java/org/chromium/chrome/browser/ntp/BraveNewTabPageLayout.java
+++ b/android/java/org/chromium/chrome/browser/ntp/BraveNewTabPageLayout.java
@@ -509,18 +509,23 @@ public class BraveNewTabPageLayout
 
                         int lastVisibleItemPosition =
                                 linearLayoutManager.findLastCompletelyVisibleItemPosition();
-                        if (lastVisibleItemPosition >= newsFeedPosition
+                        if (mNewsItemsFeedCard != null && mNewsItemsFeedCard.size() > 0
+                                && lastVisibleItemPosition >= newsFeedPosition
                                 && lastVisibleItemPosition > mPrevVisibleNewsCardPosition) {
                             for (int i = mPrevVisibleNewsCardPosition + 1;
                                     i <= lastVisibleItemPosition; i++) {
-                                FeedItemsCard itemsCard =
-                                        mNewsItemsFeedCard.get(i - newsFeedPosition);
-                                if (itemsCard != null) {
-                                    List<FeedItemCard> feedItems = itemsCard.getFeedItems();
-                                    // Two items are shown as two cards side by side,
-                                    // and three or more items is shown as one card as a list
-                                    mNewsSessionCardViews +=
-                                            feedItems != null && feedItems.size() == 2 ? 2 : 1;
+                                int itemCardPosition = i - newsFeedPosition;
+                                if (itemCardPosition >= 0
+                                        && itemCardPosition < mNewsItemsFeedCard.size()) {
+                                    FeedItemsCard itemsCard =
+                                            mNewsItemsFeedCard.get(itemCardPosition);
+                                    if (itemsCard != null) {
+                                        List<FeedItemCard> feedItems = itemsCard.getFeedItems();
+                                        // Two items are shown as two cards side by side,
+                                        // and three or more items is shown as one card as a list
+                                        mNewsSessionCardViews +=
+                                                feedItems != null && feedItems.size() == 2 ? 2 : 1;
+                                    }
                                 }
                             }
                             if (mBraveNewsController != null) {
@@ -982,8 +987,10 @@ public class BraveNewTabPageLayout
                     } // end page loop
 
                     processFeed(isNewContent);
-                    BraveActivity.getBraveActivity().setNewsItemsFeedCards(mNewsItemsFeedCard);
-                    BraveActivity.getBraveActivity().setLoadedFeed(true);
+                    if (BraveActivity.getBraveActivity() != null) {
+                        BraveActivity.getBraveActivity().setNewsItemsFeedCards(mNewsItemsFeedCard);
+                        BraveActivity.getBraveActivity().setLoadedFeed(true);
+                    }
                 });
             }
         };


### PR DESCRIPTION
Uplift of #16692
Resolves https://github.com/brave/brave-browser/issues/27836

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.