### PR TITLE
[iOS] Load cpp type mappings info for correct move only/copyable codegen

### DIFF
--- a/build/ios/mojom/gen_model_wrappers.py
+++ b/build/ios/mojom/gen_model_wrappers.py
@@ -1,3 +1,7 @@
+# Copyright (c) 2023 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
 """Generates Obj-C++ source files from a mojom.Module."""
 
 import argparse
@@ -8,7 +12,10 @@ import sys
 import json
 
 _current_dir = os.path.dirname(os.path.realpath(__file__))
-sys.path.insert(1, os.path.join(_current_dir, *([os.pardir] * 4 + ['mojo/public/tools/mojom'])))
+sys.path.insert(
+    1,
+    os.path.join(_current_dir,
+                 *([os.pardir] * 4 + ['mojo/public/tools/mojom'])))
 
 # pylint: disable=import-error,wrong-import-position
 import mojom.fileutil as fileutil
@@ -16,11 +23,13 @@ from mojom.generate import template_expander
 from mojom.generate.module import Module
 
 def parse_args():
-    parser = argparse.ArgumentParser(description='Generate Obj-C files from mojo definitions')
+    parser = argparse.ArgumentParser(
+        description='Generate Obj-C files from mojo definitions')
     parser.add_argument('--mojom-module', nargs=1)
     parser.add_argument('--output-dir', nargs=1)
     parser.add_argument('--exclude', nargs=1, required=False)
     return parser.parse_args()
+
 
 def load_cpp_typemap_info(module_dir):
     # Attempt to load base typemap info if available
@@ -31,6 +40,7 @@ def load_cpp_typemap_info(module_dir):
             return json.load(f)['c++'] if not None else {}
     return {}
 
+
 def main():
     args = parse_args()
     mojom_module = args.mojom_module[0]
@@ -40,7 +50,8 @@ def main():
     generator_module = importlib.import_module('mojom_objc_generator')
     bytecode_path = os.path.join(output_dir, "objc_templates_bytecode")
     fileutil.EnsureDirectoryExists(bytecode_path)
-    template_expander.PrecompileTemplates({"objc": generator_module}, bytecode_path)
+    template_expander.PrecompileTemplates({"objc": generator_module},
+                                          bytecode_path)
     generator = generator_module.Generator(None)
     generator.bytecode_path = bytecode_path
     generator.excludedTypes = excluded.split(',')

--- a/build/ios/mojom/mojom_objc_generator.py
+++ b/build/ios/mojom/mojom_objc_generator.py
@@ -1,4 +1,10 @@
-# pylint: disable=import-error,too-many-return-statements,no-self-use,too-many-branches
+# Copyright (c) 2023 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+
+# pylint: disable=import-error,too-many-return-statements,no-self-use
+# pylint: disable=too-many-branches
 
 import os
 
@@ -599,27 +605,28 @@ class Generator(generator.Generator):
             self._GetFullMojomNameForKind(kind) in self.typemap
 
     def _ShouldPassParamByValue(self, kind):
-        return ((not mojom.IsReferenceKind(kind)) or self._IsMoveOnlyKind(kind) or
-            self._IsCopyablePassByValue(kind))
+        return ((not mojom.IsReferenceKind(kind)) or self._IsMoveOnlyKind(kind)
+                or self._IsCopyablePassByValue(kind))
 
     def _IsCopyablePassByValue(self, kind):
         if not self._IsTypemappedKind(kind):
             return False
-        return self.typemap[self._GetFullMojomNameForKind(kind)][
-            "copyable_pass_by_value"]
+        return self.typemap[self._GetFullMojomNameForKind(
+            kind)]["copyable_pass_by_value"]
 
     def _IsMoveOnlyKind(self, kind):
         if self._IsTypemappedKind(kind):
             if mojom.IsEnumKind(kind):
                 return False
-            return self.typemap[self._GetFullMojomNameForKind(kind)]["move_only"]
+            return self.typemap[self._GetFullMojomNameForKind(
+                kind)]["move_only"]
         if mojom.IsStructKind(kind) or mojom.IsUnionKind(kind):
             return True
         if mojom.IsArrayKind(kind):
             return self._IsMoveOnlyKind(kind.kind)
         if mojom.IsMapKind(kind):
-            return (self._IsMoveOnlyKind(kind.value_kind) or
-                self._IsMoveOnlyKind(kind.key_kind))
+            return (self._IsMoveOnlyKind(kind.value_kind)
+                    or self._IsMoveOnlyKind(kind.key_kind))
         if mojom.IsAnyHandleOrInterfaceKind(kind):
             return True
         return False

--- a/build/ios/mojom/mojom_objc_generator.py
+++ b/build/ios/mojom/mojom_objc_generator.py
@@ -461,19 +461,7 @@ class Generator(generator.Generator):
         return set(remotes)
 
     def _GetExpectedCppParamType(self, kind):
-        def is_move_only_kind(kind):
-            if mojom.IsStructKind(kind) or mojom.IsUnionKind(kind):
-                return True
-            if mojom.IsArrayKind(kind):
-                return is_move_only_kind(kind.kind)
-            if mojom.IsMapKind(kind):
-                return (is_move_only_kind(kind.value_kind) or
-                        is_move_only_kind(kind.key_kind))
-            if mojom.IsAnyHandleOrInterfaceKind(kind):
-                return True
-            return False
-        should_pass_param_by_value = ((not mojom.IsReferenceKind(kind)) or
-                                      is_move_only_kind(kind))
+        should_pass_param_by_value = self._ShouldPassParamByValue(kind)
         typemap = MojoTypemapForKind(kind, False)
         typestring = typemap.ExpectedCppType()
         if (mojom.IsNullableKind(kind)
@@ -602,6 +590,39 @@ class Generator(generator.Generator):
             return "%s ? %s : nil" % (
                 accessor, typemap.CppToObjC(value_accessor))
         return typemap.CppToObjC(accessor)
+
+    def _GetFullMojomNameForKind(self, kind):
+        return kind.qualified_name
+
+    def _IsTypemappedKind(self, kind):
+        return hasattr(kind, "name") and \
+            self._GetFullMojomNameForKind(kind) in self.typemap
+
+    def _ShouldPassParamByValue(self, kind):
+        return ((not mojom.IsReferenceKind(kind)) or self._IsMoveOnlyKind(kind) or
+            self._IsCopyablePassByValue(kind))
+
+    def _IsCopyablePassByValue(self, kind):
+        if not self._IsTypemappedKind(kind):
+            return False
+        return self.typemap[self._GetFullMojomNameForKind(kind)][
+            "copyable_pass_by_value"]
+
+    def _IsMoveOnlyKind(self, kind):
+        if self._IsTypemappedKind(kind):
+            if mojom.IsEnumKind(kind):
+                return False
+            return self.typemap[self._GetFullMojomNameForKind(kind)]["move_only"]
+        if mojom.IsStructKind(kind) or mojom.IsUnionKind(kind):
+            return True
+        if mojom.IsArrayKind(kind):
+            return self._IsMoveOnlyKind(kind.kind)
+        if mojom.IsMapKind(kind):
+            return (self._IsMoveOnlyKind(kind.value_kind) or
+                self._IsMoveOnlyKind(kind.key_kind))
+        if mojom.IsAnyHandleOrInterfaceKind(kind):
+            return True
+        return False
 
     def _ConstObjCAssign(self, constant):
         kind = constant.kind


### PR DESCRIPTION
This loads base mojom type mappings (url/origin/time/etc.) and updates the codegen for Obj-C wrappers to use the correct definition of said mappings in C++ function definitions.

This fixes an issue where if a `GURL` was referenced in a interface functions return type it would fail to generate a buildable Obj-C wrapper because `GURL` would be used instead of `const GURL&` in a param context.

Resolves https://github.com/brave/brave-browser/issues/27807

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

