### PR TITLE
Improve tab activation for builtin sidebar shortcut items

### DIFF
--- a/browser/ui/sidebar/sidebar_browsertest.cc
+++ b/browser/ui/sidebar/sidebar_browsertest.cc
@@ -3,6 +3,9 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+#include "base/bind.h"
+#include "base/run_loop.h"
+#include "base/test/bind.h"
 #include "base/test/scoped_feature_list.h"
 #include "brave/browser/ui/brave_browser.h"
 #include "brave/browser/ui/browser_commands.h"
@@ -18,7 +21,9 @@
 #include "brave/browser/ui/views/sidebar/sidebar_items_scroll_view.h"
 #include "brave/browser/ui/views/tabs/features.h"
 #include "brave/components/sidebar/sidebar_service.h"
+#include "build/build_config.h"
 #include "chrome/browser/ui/browser_finder.h"
+#include "chrome/browser/ui/browser_window.h"
 #include "chrome/browser/ui/tabs/tab_strip_model.h"
 #include "chrome/common/pref_names.h"
 #include "chrome/test/base/in_process_browser_test.h"
@@ -107,6 +112,28 @@ class SidebarBrowserTest : public InProcessBrowserTest {
            !GetSidePanel()->IsRightAligned() &&
            GetSidebarControlView()->sidebar_on_left_;
   }
+
+  void WaitUntil(base::RepeatingCallback<bool()> condition) {
+    if (condition.Run())
+      return;
+
+    base::RepeatingTimer scheduler;
+    scheduler.Start(FROM_HERE, base::Milliseconds(100),
+                    base::BindLambdaForTesting([this, &condition]() {
+                      if (condition.Run())
+                        run_loop_->Quit();
+                    }));
+    Run();
+  }
+
+  void Run() {
+    run_loop_ = std::make_unique<base::RunLoop>();
+    run_loop()->Run();
+  }
+
+  base::RunLoop* run_loop() const { return run_loop_.get(); }
+
+  std::unique_ptr<base::RunLoop> run_loop_;
 };
 
 IN_PROC_BROWSER_TEST_F(SidebarBrowserTest, BasicTest) {
@@ -239,6 +266,23 @@ IN_PROC_BROWSER_TEST_F(SidebarBrowserTest, IterateBuiltInWebTypeTest) {
   // Click wallet item and then first wallet tab(index 0) is activated.
   SimulateSidebarItemClickAt(1);
   EXPECT_EQ(0, tab_model()->active_index());
+
+  // Checking windows' activation state is flaky in browser tests.
+#if !BUILDFLAG(IS_MAC)
+  auto* browser2 = CreateBrowser(browser()->profile());
+  WaitUntil(base::BindLambdaForTesting(
+      [&]() { return browser2->window()->IsActive(); }));
+
+  // |browser2| doesn't have any wallet tab. So, clicking wallet sidebar item
+  // activates other browser's first wallet tab.
+  static_cast<BraveBrowser*>(browser2)->sidebar_controller()->ActivateItemAt(1);
+
+  // Wait till browser() is activated.
+  WaitUntil(base::BindLambdaForTesting(
+      [&]() { return browser()->window()->IsActive(); }));
+
+  EXPECT_EQ(0, tab_model()->active_index());
+#endif
 }
 
 // Test sidebar's initial horizontal option is set properly.

--- a/browser/ui/sidebar/sidebar_controller.h
+++ b/browser/ui/sidebar/sidebar_controller.h
@@ -73,6 +73,10 @@ class SidebarController : public SidebarService::Observer {
   // Otherwise, load URL in the active tab.
   void IterateOrLoadAtActiveTab(const GURL& url);
 
+  // Try to find a tab that loads |url| from other browsers
+  // and activate it if found.
+  bool ActiveTabFromOtherBrowsersForHost(const GURL& url);
+
   raw_ptr<BraveBrowser> browser_ = nullptr;
   // Interface to view.
   raw_ptr<Sidebar> sidebar_ = nullptr;

--- a/browser/ui/views/frame/brave_browser_view.cc
+++ b/browser/ui/views/frame/brave_browser_view.cc
@@ -490,6 +490,21 @@ void BraveBrowserView::MaybeShowReadingListInSidePanelIPH() {
   // Do nothing.
 }
 
+void BraveBrowserView::OnWidgetActivationChanged(views::Widget* widget,
+                                                 bool active) {
+  BrowserView::OnWidgetActivationChanged(widget, active);
+
+  // For updating sidebar's item state.
+  // As we can activate other window's Talk tab with current window's sidebar
+  // Talk item, sidebar Talk item should have activated state if other windows
+  // have Talk tab. It would be complex to get updated when Talk tab is opened
+  // from other windows. So, simply trying to update when window activation
+  // state is changed. With this, active window could have correct sidebar item
+  // state.
+  if (sidebar_container_view_)
+    sidebar_container_view_->UpdateSidebar();
+}
+
 bool BraveBrowserView::ShouldShowWindowTitle() const {
   if (BrowserView::ShouldShowWindowTitle())
     return true;

--- a/browser/ui/views/frame/brave_browser_view.h
+++ b/browser/ui/views/frame/brave_browser_view.h
@@ -106,6 +106,7 @@ class BraveBrowserView : public BrowserView {
       Browser::DownloadCloseType dialog_type,
       base::OnceCallback<void(bool)> callback) override;
   void MaybeShowReadingListInSidePanelIPH() override;
+  void OnWidgetActivationChanged(views::Widget* widget, bool active) override;
 
   void StopTabCycling();
   void UpdateSearchTabsButtonState();


### PR DESCRIPTION
Try to activate a related tab from all browser windows not just from
current window. With this change, user can activate talk(or wallet) tab
from another browser window.

fix https://github.com/brave/brave-browser/issues/27794

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves 

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

`SidebarBrowserTest.IterateBuiltInWebTypeTest`

See the linked issue for manual test