### PR TITLE
Sync all history

### DIFF
--- a/browser/about_flags.cc
+++ b/browser/about_flags.cc
@@ -397,6 +397,11 @@ constexpr char kBraveSyncHistoryDiagnosticsName[] =
 constexpr char kBraveSyncHistoryDiagnosticsDescription[] =
     "Brave Sync History Diagnostics flag displays additional sync related "
     "information on History page";
+constexpr char kBraveSyncSendAllHistoryName[] =
+    "Send All History to Brave Sync";
+constexpr char kBraveSyncSendAllHistoryDescription[] =
+    "With Send All History flag all sync entries are sent to Sync server "
+    "including transitions of link, bookmark, reload, etc";
 
 // Blink features.
 constexpr char kFileSystemAccessAPIName[] = "File System Access API";
@@ -829,6 +834,11 @@ constexpr char kRestrictEventSourcePoolDescription[] =
       flag_descriptions::kRestrictEventSourcePoolDescription,               \
       kOsAll, FEATURE_VALUE_TYPE(                                           \
           blink::features::kRestrictEventSourcePool)},                      \
+    {"brave-sync-send-all-history",                                         \
+      flag_descriptions::kBraveSyncSendAllHistoryName,                      \
+      flag_descriptions::kBraveSyncSendAllHistoryDescription,               \
+      kOsAll, FEATURE_VALUE_TYPE(                                           \
+          brave_sync::features::kBraveSyncSendAllHistory)},                 \
     BRAVE_IPFS_FEATURE_ENTRIES                                              \
     BRAVE_NATIVE_WALLET_FEATURE_ENTRIES                                     \
     BRAVE_NEWS_FEATURE_ENTRIES                                              \

--- a/chromium_src/components/history/core/browser/DEPS
+++ b/chromium_src/components/history/core/browser/DEPS
@@ -1,3 +1,4 @@
 include_rules = [
   "+brave/components/brave_sync",
+  "+brave/components/history/core/browser/sync",
 ]

--- a/chromium_src/components/history/core/browser/history_backend.cc
+++ b/chromium_src/components/history/core/browser/history_backend.cc
@@ -9,6 +9,7 @@
 #include "base/feature_list.h"
 #include "base/strings/strcat.h"
 #include "brave/components/brave_sync/features.h"
+#include "brave/components/history/core/browser/sync/brave_typed_url_sync_bridge.h"
 // Forward include to avoid re-define of URLResult::set_blocked_visit
 #include "components/history/core/browser/history_types.h"
 #include "components/history/core/browser/url_row.h"
@@ -80,6 +81,9 @@ std::u16string GetDiagnosticTitle(const history::URLResult& url_result,
   set_title(GetDiagnosticTitle(url_result, visit)); \
   url_result.set_blocked_visit
 
+#define TypedURLSyncBridge BraveTypedURLSyncBridge
+
 #include "src/components/history/core/browser/history_backend.cc"
 
+#undef TypedURLSyncBridge
 #undef set_blocked_visit

--- a/chromium_src/components/history/core/browser/history_backend.h
+++ b/chromium_src/components/history/core/browser/history_backend.h
@@ -1,0 +1,13 @@
+/* Copyright (c) 2023 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_CHROMIUM_SRC_COMPONENTS_HISTORY_CORE_BROWSER_HISTORY_BACKEND_H_
+#define BRAVE_CHROMIUM_SRC_COMPONENTS_HISTORY_CORE_BROWSER_HISTORY_BACKEND_H_
+
+#define TypedURLSyncBridge BraveTypedURLSyncBridge
+#include "src/components/history/core/browser/history_backend.h"
+#undef TypedURLSyncBridge
+
+#endif  // BRAVE_CHROMIUM_SRC_COMPONENTS_HISTORY_CORE_BROWSER_HISTORY_BACKEND_H_

--- a/chromium_src/components/history/core/browser/sync/brave_typed_url_sync_bridge_unittest.cc
+++ b/chromium_src/components/history/core/browser/sync/brave_typed_url_sync_bridge_unittest.cc
@@ -1,0 +1,83 @@
+/* Copyright (c) 2023 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+// Run all TypedURLSyncBridgeTest again but with kBraveSyncSendAllHistory
+// feature enabled
+
+#include "brave/components/history/core/browser/sync/brave_typed_url_sync_bridge.h"
+#include "base/test/scoped_feature_list.h"
+#include "brave/components/brave_sync/features.h"
+
+#define BRAVE_TEST_MEMBERS_DECLARE                    \
+  base::test::ScopedFeatureList scoped_feature_list_; \
+  int kVisitThrottleThreshold;                        \
+  int kVisitThrottleMultiple;
+
+#define BRAVE_TEST_MEMBERS_INIT                                       \
+  scoped_feature_list_.InitWithFeatures(                              \
+      {brave_sync::features::kBraveSyncSendAllHistory}, {});          \
+  /* Need these overrides only for                               */   \
+  /* BraveTypedURLSyncBridgeTest.ThrottleVisitLocalTypedUrl only */   \
+  kVisitThrottleThreshold =                                           \
+      typed_url_sync_bridge_->GetSendAllFlagVisitThrottleThreshold(); \
+  kVisitThrottleMultiple =                                            \
+      typed_url_sync_bridge_->GetSendAllFlagVisitThrottleMultiple();
+
+#define TypedURLSyncBridge BraveTypedURLSyncBridge
+#define TypedURLSyncBridgeTest BraveTypedURLSyncBridgeTest
+#include "src/components/history/core/browser/sync/typed_url_sync_bridge_unittest.cc"
+#undef TypedURLSyncBridgeTest
+#undef TypedURLSyncBridge
+#undef BRAVE_TEST_MEMBERS_INIT
+#undef BRAVE_TEST_MEMBERS_DECLARE
+
+namespace {
+
+bool IsSendAllHistoryEnabled() {
+  return base::FeatureList::IsEnabled(
+      brave_sync::features::kBraveSyncSendAllHistory);
+}
+
+}  // namespace
+
+namespace history {
+
+URLRow MakeUrlRow(int visit_count, int typed_count) {
+  URLRow urlRow;
+  urlRow.set_visit_count(visit_count);
+  urlRow.set_typed_count(typed_count);
+  return urlRow;
+}
+
+TEST_F(BraveTypedURLSyncBridgeTest, BraveShouldSyncVisit) {
+  ASSERT_TRUE(IsSendAllHistoryEnabled());
+
+  EXPECT_TRUE(
+      bridge()->ShouldSyncVisit(MakeUrlRow(1, 0), ui::PAGE_TRANSITION_LINK));
+  EXPECT_TRUE(
+      bridge()->ShouldSyncVisit(MakeUrlRow(1, 0), ui::PAGE_TRANSITION_TYPED));
+  EXPECT_TRUE(
+      bridge()->ShouldSyncVisit(MakeUrlRow(20, 0), ui::PAGE_TRANSITION_LINK));
+  EXPECT_FALSE(
+      bridge()->ShouldSyncVisit(MakeUrlRow(21, 0), ui::PAGE_TRANSITION_LINK));
+  EXPECT_TRUE(
+      bridge()->ShouldSyncVisit(MakeUrlRow(30, 0), ui::PAGE_TRANSITION_LINK));
+
+  {
+    base::test::ScopedFeatureList scoped_feature_list2;
+    scoped_feature_list2.InitWithFeatures(
+        {}, {brave_sync::features::kBraveSyncSendAllHistory});
+    EXPECT_FALSE(
+        bridge()->ShouldSyncVisit(MakeUrlRow(1, 0), ui::PAGE_TRANSITION_LINK));
+    EXPECT_TRUE(
+        bridge()->ShouldSyncVisit(MakeUrlRow(1, 1), ui::PAGE_TRANSITION_TYPED));
+    EXPECT_FALSE(bridge()->ShouldSyncVisit(MakeUrlRow(20, 20),
+                                           ui::PAGE_TRANSITION_LINK));
+    EXPECT_TRUE(bridge()->ShouldSyncVisit(MakeUrlRow(20, 20),
+                                          ui::PAGE_TRANSITION_TYPED));
+  }
+}
+
+}  // namespace history

--- a/chromium_src/components/history/core/browser/sync/chromium_typed_url_sync_bridge_unittest.cc
+++ b/chromium_src/components/history/core/browser/sync/chromium_typed_url_sync_bridge_unittest.cc
@@ -1,0 +1,28 @@
+/* Copyright (c) 2023 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include <vector>
+
+#include "base/test/scoped_feature_list.h"
+#include "brave/components/brave_sync/features.h"
+#include "brave/components/history/core/browser/sync/brave_typed_url_sync_bridge.h"
+#include "components/history/core/browser/sync/typed_url_sync_bridge.h"
+#include "components/sync/model/model_type_sync_bridge.h"
+
+#define BRAVE_TEST_MEMBERS_DECLARE \
+  base::test::ScopedFeatureList scoped_feature_list_;
+
+#define BRAVE_TEST_MEMBERS_INIT          \
+  scoped_feature_list_.InitWithFeatures( \
+      {}, {brave_sync::features::kBraveSyncSendAllHistory});
+
+#define TypedURLSyncBridge BraveTypedURLSyncBridge
+
+#include "src/components/history/core/browser/sync/typed_url_sync_bridge_unittest.cc"
+
+#undef TypedURLSyncBridge
+
+#undef BRAVE_TEST_MEMBERS_INIT
+#undef BRAVE_TEST_MEMBERS_DECLARE

--- a/chromium_src/components/history/core/browser/sync/typed_url_sync_bridge.cc
+++ b/chromium_src/components/history/core/browser/sync/typed_url_sync_bridge.cc
@@ -1,0 +1,50 @@
+/* Copyright (c) 2023 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "components/history/core/browser/sync/typed_url_sync_bridge.h"
+
+#include "brave/components/brave_sync/features.h"
+#include "ui/base/page_transition_types.h"
+
+namespace {
+
+bool IsSendAllHistoryEnabled() {
+  return base::FeatureList::IsEnabled(
+      brave_sync::features::kBraveSyncSendAllHistory);
+}
+
+}  // namespace
+
+// }  // namespace ui
+
+#define BRAVE_TYPED_URL_SYNC_BRIDGE_ON_URL_VISITED_REPLACE_SHOULD_SYNC_VISIT \
+  if (!ShouldSyncVisit(url_row, visit_row.transition)) {                     \
+    return;                                                                  \
+  }                                                                          \
+  /* Suppress cpplint error: (cpplint) If/else bodies with multiple */       \
+  /* statements require braces  [readability/braces] [4]            */       \
+  /* NOLINTNEXTLINE */                                                       \
+  if (false)
+
+#include "src/components/history/core/browser/sync/typed_url_sync_bridge.cc"
+
+#undef BRAVE_TYPED_URL_SYNC_BRIDGE_ON_URL_VISITED_REPLACE_SHOULD_SYNC_VISIT
+
+namespace history {
+
+// static
+bool TypedURLSyncBridge::HasTypedUrl(const std::vector<VisitRow>& visits) {
+  if (IsSendAllHistoryEnabled()) {
+    // We are ignoring only reload transitions, so any other like typed,
+    // link, bookmark - are accepted as worth to be synced.
+    return base::ranges::any_of(visits, [](const VisitRow& visit) {
+      return !ui::PageTransitionCoreTypeIs(visit.transition,
+                                           ui::PAGE_TRANSITION_RELOAD);
+    });
+  }
+  return ::history::HasTypedUrl(visits);
+}
+
+}  // namespace history

--- a/chromium_src/components/history/core/browser/sync/typed_url_sync_bridge.h
+++ b/chromium_src/components/history/core/browser/sync/typed_url_sync_bridge.h
@@ -1,0 +1,22 @@
+/* Copyright (c) 2023 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_CHROMIUM_SRC_COMPONENTS_HISTORY_CORE_BROWSER_SYNC_TYPED_URL_SYNC_BRIDGE_H_
+#define BRAVE_CHROMIUM_SRC_COMPONENTS_HISTORY_CORE_BROWSER_SYNC_TYPED_URL_SYNC_BRIDGE_H_
+
+#define ShouldSyncVisit                                            \
+  ShouldSyncVisitUnused();                                         \
+  static bool HasTypedUrl(const std::vector<VisitRow>& visits);    \
+  virtual bool ShouldSyncVisit(const URLRow& url_row,              \
+                               ui::PageTransition transition) = 0; \
+  friend class BraveTypedURLSyncBridge;                            \
+  friend class BraveTypedURLSyncBridgeTest;                        \
+  bool ShouldSyncVisit
+
+#include "src/components/history/core/browser/sync/typed_url_sync_bridge.h"
+
+#undef ShouldSyncVisit
+
+#endif  // BRAVE_CHROMIUM_SRC_COMPONENTS_HISTORY_CORE_BROWSER_SYNC_TYPED_URL_SYNC_BRIDGE_H_

--- a/components/brave_sync/features.cc
+++ b/components/brave_sync/features.cc
@@ -21,5 +21,12 @@ BASE_FEATURE(kBraveSyncHistoryDiagnostics,
              "BraveSyncHistoryDiagnostics",
              base::FEATURE_DISABLED_BY_DEFAULT);
 
+// When this feature is enabled, Sync sends to remote server all the history
+// entries, including page transition beyond typed url (link, bookmark, reload,
+// etc).
+BASE_FEATURE(kBraveSyncSendAllHistory,
+             "BraveSyncSendAllHistory",
+             base::FEATURE_DISABLED_BY_DEFAULT);
+
 }  // namespace features
 }  // namespace brave_sync

--- a/components/brave_sync/features.h
+++ b/components/brave_sync/features.h
@@ -15,6 +15,8 @@ BASE_DECLARE_FEATURE(kBraveSync);
 
 BASE_DECLARE_FEATURE(kBraveSyncHistoryDiagnostics);
 
+BASE_DECLARE_FEATURE(kBraveSyncSendAllHistory);
+
 }  // namespace features
 }  // namespace brave_sync
 

--- a/components/history/core/browser/sources.gni
+++ b/components/history/core/browser/sources.gni
@@ -1,0 +1,12 @@
+# Copyright (c) 2023 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+
+brave_components_history_core_browser_sources = [
+  "//brave/components/history/core/browser/sync/brave_typed_url_sync_bridge.cc",
+  "//brave/components/history/core/browser/sync/brave_typed_url_sync_bridge.h",
+]
+
+brave_components_history_core_browser_deps =
+    [ "//brave/components/brave_sync:features" ]

--- a/components/history/core/browser/sync/brave_typed_url_sync_bridge.cc
+++ b/components/history/core/browser/sync/brave_typed_url_sync_bridge.cc
@@ -1,0 +1,48 @@
+/* Copyright (c) 2023 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "brave/components/history/core/browser/sync/brave_typed_url_sync_bridge.h"
+
+#include <memory>
+#include <utility>
+
+#include "brave/components/brave_sync/features.h"
+
+namespace history {
+
+// For the case when kBraveSyncSendAllHistory feature is enabled,
+// we want to send to the sync server first 20 visits and then each 10th
+namespace {
+const int kSendAllFlagVisitThrottleThreshold = 20;
+const int kSendAllFlagVisitThrottleMultiple = 10;
+}  // namespace
+
+BraveTypedURLSyncBridge::BraveTypedURLSyncBridge(
+    HistoryBackend* history_backend,
+    TypedURLSyncMetadataDatabase* sync_metadata_store,
+    std::unique_ptr<syncer::ModelTypeChangeProcessor> change_processor)
+    : TypedURLSyncBridge(history_backend,
+                         sync_metadata_store,
+                         std::move(change_processor)) {}
+
+bool BraveTypedURLSyncBridge::ShouldSyncVisit(const URLRow& url_row,
+                                              ui::PageTransition transition) {
+  if (base::FeatureList::IsEnabled(
+          brave_sync::features::kBraveSyncSendAllHistory)) {
+    return url_row.visit_count() < kSendAllFlagVisitThrottleThreshold ||
+           (url_row.visit_count() % kSendAllFlagVisitThrottleMultiple) == 0;
+  }
+  return TypedURLSyncBridge::ShouldSyncVisit(url_row.typed_count(), transition);
+}
+
+int BraveTypedURLSyncBridge::GetSendAllFlagVisitThrottleThreshold() {
+  return kSendAllFlagVisitThrottleThreshold;
+}
+
+int BraveTypedURLSyncBridge::GetSendAllFlagVisitThrottleMultiple() {
+  return kSendAllFlagVisitThrottleMultiple;
+}
+
+}  // namespace history

--- a/components/history/core/browser/sync/brave_typed_url_sync_bridge.h
+++ b/components/history/core/browser/sync/brave_typed_url_sync_bridge.h
@@ -1,0 +1,38 @@
+/* Copyright (c) 2023 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_COMPONENTS_HISTORY_CORE_BROWSER_SYNC_BRAVE_TYPED_URL_SYNC_BRIDGE_H_
+#define BRAVE_COMPONENTS_HISTORY_CORE_BROWSER_SYNC_BRAVE_TYPED_URL_SYNC_BRIDGE_H_
+
+#include <memory>
+
+#include "components/history/core/browser/sync/typed_url_sync_bridge.h"
+
+namespace history {
+
+class BraveTypedURLSyncBridge : public TypedURLSyncBridge {
+ public:
+  BraveTypedURLSyncBridge(
+      HistoryBackend* history_backend,
+      TypedURLSyncMetadataDatabase* sync_metadata_store,
+      std::unique_ptr<syncer::ModelTypeChangeProcessor> change_processor);
+
+  BraveTypedURLSyncBridge(const BraveTypedURLSyncBridge&) = delete;
+  BraveTypedURLSyncBridge& operator=(const BraveTypedURLSyncBridge&) = delete;
+
+  ~BraveTypedURLSyncBridge() override = default;
+  bool ShouldSyncVisit(const URLRow& url_row,
+                       ui::PageTransition transition) override;
+
+  static int GetSendAllFlagVisitThrottleThreshold();
+  static int GetSendAllFlagVisitThrottleMultiple();
+
+ private:
+  friend class BraveTypedURLSyncBridgeTest;
+};
+
+}  // namespace history
+
+#endif  // BRAVE_COMPONENTS_HISTORY_CORE_BROWSER_SYNC_BRAVE_TYPED_URL_SYNC_BRIDGE_H_

--- a/patches/components-history-core-browser-BUILD.gn.patch
+++ b/patches/components-history-core-browser-BUILD.gn.patch
@@ -1,0 +1,12 @@
+diff --git a/components/history/core/browser/BUILD.gn b/components/history/core/browser/BUILD.gn
+index 7ef197effead5ea14abca72fc94ae38a71d9a392..b139fbe80d4a3472f8c169f18b85229d6b6ca3b1 100644
+--- a/components/history/core/browser/BUILD.gn
++++ b/components/history/core/browser/BUILD.gn
+@@ -156,6 +156,7 @@ static_library("browser") {
+       "android/visit_sql_handler.h",
+     ]
+   }
++  import("//brave/components/history/core/browser/sources.gni") sources += brave_components_history_core_browser_sources deps += brave_components_history_core_browser_deps
+ }
+ 
+ bundle_data("unit_tests_bundle_data") {

--- a/patches/components-history-core-browser-sync-typed_url_sync_bridge.cc.patch
+++ b/patches/components-history-core-browser-sync-typed_url_sync_bridge.cc.patch
@@ -1,0 +1,12 @@
+diff --git a/components/history/core/browser/sync/typed_url_sync_bridge.cc b/components/history/core/browser/sync/typed_url_sync_bridge.cc
+index eb0494be3942e1ae0eab89ca56d64be60b493ab5..271543163ce723e4c8f203625f0a92aea9ec0b8d 100644
+--- a/components/history/core/browser/sync/typed_url_sync_bridge.cc
++++ b/components/history/core/browser/sync/typed_url_sync_bridge.cc
+@@ -387,6 +387,7 @@ void TypedURLSyncBridge::OnURLVisited(HistoryBackend* history_backend,
+   if (!change_processor()->IsTrackingMetadata()) {
+     return;  // Sync processor not yet ready, don't sync.
+   }
++  BRAVE_TYPED_URL_SYNC_BRIDGE_ON_URL_VISITED_REPLACE_SHOULD_SYNC_VISIT
+   if (!ShouldSyncVisit(url_row.typed_count(), visit_row.transition)) {
+     return;
+   }

--- a/patches/components-history-core-browser-sync-typed_url_sync_bridge_unittest.cc.patch
+++ b/patches/components-history-core-browser-sync-typed_url_sync_bridge_unittest.cc.patch
@@ -1,0 +1,20 @@
+diff --git a/components/history/core/browser/sync/typed_url_sync_bridge_unittest.cc b/components/history/core/browser/sync/typed_url_sync_bridge_unittest.cc
+index 202d83dbe2d976f61ef064b3853078b94ce87424..322d997dd24da308056ba44df0827981064bae14 100644
+--- a/components/history/core/browser/sync/typed_url_sync_bridge_unittest.cc
++++ b/components/history/core/browser/sync/typed_url_sync_bridge_unittest.cc
+@@ -346,6 +346,7 @@ class TypedURLSyncBridgeTest : public testing::Test {
+     typed_url_sync_bridge_->Init();
+     typed_url_sync_bridge_->history_backend_observation_.Reset();
+     fake_history_backend_->SetTypedURLSyncBridgeForTest(std::move(bridge));
++    BRAVE_TEST_MEMBERS_INIT
+   }
+ 
+   void TearDown() override { fake_history_backend_->Closing(); }
+@@ -553,6 +554,7 @@ class TypedURLSyncBridgeTest : public testing::Test {
+   scoped_refptr<TestHistoryBackendForSync> fake_history_backend_;
+   raw_ptr<TypedURLSyncBridge> typed_url_sync_bridge_ = nullptr;
+   NiceMock<MockModelTypeChangeProcessor> mock_processor_;
++  BRAVE_TEST_MEMBERS_DECLARE
+ };
+ 
+ // Add two typed urls locally and verify bridge can get them from GetAllData.

--- a/test/BUILD.gn
+++ b/test/BUILD.gn
@@ -104,6 +104,8 @@ test("brave_unit_tests") {
     "//brave/chromium_src/chrome/browser/lookalikes/lookalike_url_navigation_throttle_unittest.cc",
     "//brave/chromium_src/chrome/browser/signin/account_consistency_disabled_unittest.cc",
     "//brave/chromium_src/components/autofill/core/browser/autofill_experiments_unittest.cc",
+    "//brave/chromium_src/components/history/core/browser/sync/brave_typed_url_sync_bridge_unittest.cc",
+    "//brave/chromium_src/components/history/core/browser/sync/chromium_typed_url_sync_bridge_unittest.cc",
     "//brave/chromium_src/components/variations/service/field_trial_unittest.cc",
     "//brave/chromium_src/components/version_info/brave_version_info_unittest.cc",
     "//brave/chromium_src/net/cookies/brave_canonical_cookie_unittest.cc",


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves [brave/brave-browser/issues/28062](https://github.com/brave/brave-browser/issues/28062)

Follow up for https://github.com/brave/brave-core/pull/16478 .

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
1. Prepare 3 devices or profiles: desktop1, desktop2 and android1
2. On each device go to brave://flags/#brave-sync-send-all-history search for `Send All` flags, enable `Send All History to Brave Sync`, restart.

OS | Screenshot
-------|-------------------
&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;`Android`&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; |![image](https://user-images.githubusercontent.com/24739341/214928314-6c133b23-8f17-44e6-b840-eeee6b109ae5.png)
&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;`Desktop`&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; |![image](https://user-images.githubusercontent.com/24739341/214927813-44264d8d-5251-43be-89fa-43519eafdb84.png)


4. Join all devices to the same sync chain, enable History type
5. On desktop1 navigate through the bottom links:
	brave.com => FAQ => Search => Blog
6. On desktop2 open brave://history/ end ensure the history is equal.
The same on android1: App menu => History. Ensure all the visits get synced.

OS | Screenshot
-------|-------------------
&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; `Android` &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; | ![image](https://user-images.githubusercontent.com/24739341/214929041-314d60bd-3250-4658-9efc-6ff1e4e3eb5e.png)
&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; Desktop &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; | ![image](https://user-images.githubusercontent.com/24739341/214929116-6ea0c4d7-b7d1-41b0-914f-33b365c03b68.png)


7. On desktop1 open brave://bookmarks/, create manually bookmark for BAT => https://basicattentiontoken.org/, do navigation through this button on bookmarks panel
![image](https://user-images.githubusercontent.com/24739341/214930617-4ccaa300-1350-4ad1-8c7a-e432df811279.png)

9. Ensure on desktop2 and android1 there is entry for BAT visit. You may need to reload page or re-open screen to make it refreshed.

OS | Screenshot
-------|-------------------
&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; `Android` &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; | ![image](https://user-images.githubusercontent.com/24739341/214930880-9481a564-b3aa-43c0-904d-c91e70fd9574.png) 
&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; Desktop &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; | ![image](https://user-images.githubusercontent.com/24739341/214931082-833ff2e5-8591-4ac2-bda6-b9c91dfaa525.png)


