### PR TITLE
Added separator to sidebar ctx menu between show sidebar and position

### DIFF
--- a/browser/ui/views/sidebar/sidebar_control_view.cc
+++ b/browser/ui/views/sidebar/sidebar_control_view.cc
@@ -160,6 +160,8 @@ void SidebarControlView::ShowContextMenuForViewImpl(
       static_cast<int>(ShowSidebarOption::kShowNever),
       brave_l10n::GetLocalizedResourceUTF16String(
           IDS_SIDEBAR_SHOW_OPTION_NEVER));
+  context_menu_model_->AddSeparator(
+      ui::MenuSeparatorType::BOTH_SIDE_PADDED_SEPARATOR);
   context_menu_model_->AddTitle(brave_l10n::GetLocalizedResourceUTF16String(
       IDS_SIDEBAR_MENU_MODEL_POSITION_OPTION_TITLE));
   context_menu_model_->AddItemWithStringId(

--- a/chromium_src/ui/base/models/menu_separator_types.h
+++ b/chromium_src/ui/base/models/menu_separator_types.h
@@ -1,0 +1,15 @@
+// Copyright (c) 2023 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#ifndef BRAVE_CHROMIUM_SRC_UI_BASE_MODELS_MENU_SEPARATOR_TYPES_H_
+#define BRAVE_CHROMIUM_SRC_UI_BASE_MODELS_MENU_SEPARATOR_TYPES_H_
+
+#define PADDED_SEPARATOR BOTH_SIDE_PADDED_SEPARATOR, PADDED_SEPARATOR
+
+#include "src/ui/base/models/menu_separator_types.h"
+
+#undef PADDED_SEPARATOR
+
+#endif  // BRAVE_CHROMIUM_SRC_UI_BASE_MODELS_MENU_SEPARATOR_TYPES_H_

--- a/chromium_src/ui/views/controls/menu/menu_separator.cc
+++ b/chromium_src/ui/views/controls/menu/menu_separator.cc
@@ -1,0 +1,12 @@
+// Copyright (c) 2023 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#define BRAVE_MENU_SEPARATOR_ON_PAINT               \
+  else if (type_ == ui::BOTH_SIDE_PADDED_SEPARATOR) \
+      paint_rect.Inset(gfx::Insets::VH(0, 8));
+
+#include "src/ui/views/controls/menu/menu_separator.cc"
+
+#undef BRAVE_MENU_SEPARATOR_ON_PAINT

--- a/patches/ui-views-controls-menu-menu_separator.cc.patch
+++ b/patches/ui-views-controls-menu-menu_separator.cc.patch
@@ -1,0 +1,12 @@
+diff --git a/ui/views/controls/menu/menu_separator.cc b/ui/views/controls/menu/menu_separator.cc
+index be7ca4059bc2d7f78419dbf863fdb7c74070e9dc..6391ae9d86b0d66cca37d98f71506c2733b12edd 100644
+--- a/ui/views/controls/menu/menu_separator.cc
++++ b/ui/views/controls/menu/menu_separator.cc
+@@ -43,6 +43,7 @@ void MenuSeparator::OnPaint(gfx::Canvas* canvas) {
+   if (type_ == ui::PADDED_SEPARATOR)
+     paint_rect.Inset(
+         gfx::Insets::TLBR(0, menu_config.padded_separator_left_margin, 0, 0));
++  BRAVE_MENU_SEPARATOR_ON_PAINT
+   else if (menu_config.use_outer_border)
+     paint_rect.Inset(gfx::Insets::VH(0, 1));
+ 


### PR DESCRIPTION
fix https://github.com/brave/brave-browser/issues/27880

New separator type(`BOTH_SIDE_PADDED_SEPARATOR`) is introduced to have padding on both side.

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves 

<img width="165" alt="image" src="https://user-images.githubusercontent.com/6786187/213176416-134d2e85-463a-46d4-b4a7-d4d0c35091ba.png">

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

Please see the linked issue