### PR TITLE
Introduce clang-tidy config for brave/ directory.

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,83 @@
+---
+  InheritParentConfig: true
+  Checks:           readability-function-cognitive-complexity,
+                    readability-identifier-naming,
+  CheckOptions:
+    - key:          readability-function-cognitive-complexity.IgnoreMacros
+      value:        1
+    - key:          readability-identifier-naming.ClassCase
+      value:        CamelCase
+    # Allow class names with underscores for MAYBE_ tests and other rare cases.
+    - key:          readability-identifier-naming.ClassIgnoredRegexp
+      value:        ^.*_.*$
+    - key:          readability-identifier-naming.ClassConstantCase
+      value:        CamelCase
+    - key:          readability-identifier-naming.ClassConstantPrefix
+      value:        k
+    - key:          readability-identifier-naming.ClassMemberCase
+      value:        lower_case
+    - key:          readability-identifier-naming.ClassMemberSuffix
+      value:        _
+    - key:          readability-identifier-naming.ConstexprVariableCase
+      value:        CamelCase
+    - key:          readability-identifier-naming.ConstexprVariablePrefix
+      value:        k
+    - key:          readability-identifier-naming.EnumCase
+      value:        CamelCase
+    - key:          readability-identifier-naming.FunctionCase
+      value:        CamelCase
+    - key:          readability-identifier-naming.GlobalConstantCase
+      value:        CamelCase
+    - key:          readability-identifier-naming.GlobalConstantPrefix
+      value:        k
+    - key:          readability-identifier-naming.GlobalVariableCase
+      value:        lower_case
+    - key:          readability-identifier-naming.GlobalVariablePrefix
+      value:        g_
+    - key:          readability-identifier-naming.LocalVariableCase
+      value:        lower_case
+    - key:          readability-identifier-naming.MethodCase
+      value:        CamelCase
+    # Allow lower_case for inline method names.
+    - key:          readability-identifier-naming.MethodIgnoredRegexp
+      value:        ^[a-z\d_]*$
+    - key:          readability-identifier-naming.NamespaceCase
+      value:        lower_case
+    # Allow unusual namespaces like WTF, IPC and other non-lower_case ones.
+    - key:          readability-identifier-naming.NamespaceIgnoredRegexp
+      value:        ^[A-Z][a-zA-Z\d]*$
+    - key:          readability-identifier-naming.ParameterCase
+      value:        lower_case
+    - key:          readability-identifier-naming.PrivateMemberCase
+      value:        lower_case
+    - key:          readability-identifier-naming.PrivateMemberSuffix
+      value:        _
+    - key:          readability-identifier-naming.ProtectedMemberCase
+      value:        lower_case
+    - key:          readability-identifier-naming.ProtectedMemberSuffix
+      value:        _
+    - key:          readability-identifier-naming.PublicMemberCase
+      value:        lower_case
+    - key:          readability-identifier-naming.TypeAliasCase
+      value:        CamelCase
+    # Allow lower_case for names like iterator, size_type, ...
+    - key:          readability-identifier-naming.TypeAliasIgnoredRegexp
+      value:        ^[a-z\d_]*$
+    - key:          readability-identifier-naming.TypedefCase
+      value:        CamelCase
+    # Allow lower_case for names like iterator, size_type, ...
+    - key:          readability-identifier-naming.TypedefIgnoredRegexp
+      value:        ^[a-z\d_]*$
+    - key:          readability-identifier-naming.ScopedEnumConstantCase
+      value:        CamelCase
+    - key:          readability-identifier-naming.ScopedEnumConstantPrefix
+      value:        k
+    - key:          readability-identifier-naming.StaticConstantCase
+      value:        CamelCase
+    - key:          readability-identifier-naming.StaticConstantPrefix
+      value:        k
+    - key:          readability-identifier-naming.StaticVariableCase
+      value:        lower_case
+    - key:          readability-identifier-naming.UnionCase
+      value:        CamelCase
+...


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
The `identifier-naming` rules were manually crafted to adhere to Chromium style. Please refer to `clang-tidy` source code to understand the order in which some of these checks are applied, because most checks fallback to more generic version and are shared with similar types (for ex. `ClassCase` is also applied to `structs`).

Docs:
https://clang.llvm.org/extra/clang-tidy/checks/readability/identifier-naming.html
Source code: https://github.com/llvm/llvm-project/blob/main/clang-tools-extra/clang-tidy/readability/IdentifierNamingCheck.cpp

#### [EnumConstantCase](https://clang.llvm.org/extra/clang-tidy/checks/readability/identifier-naming.html#cmdoption-arg-enumconstantcase)
Not used. Simple `enum`s are hard to style, because in global scope it's preferred to have `ALL_CAPS_VALUE` style, but in class scope it is fine to have `kSomeValue` style.

#### [LocalConstantCase](https://clang.llvm.org/extra/clang-tidy/checks/readability/identifier-naming.html#cmdoption-arg-localconstantcase)
Not used, because it enforces all local `const` variables such as `const GURL url = origin.GetURL();` to be `const GURL kUrl`.

In cases like `const size_t kSomeConstant = 10;` clang-tidy will ask you to use `some_constant` name which might be counter-intuitive, but you should actually write `constexpr size_t kSomeConstant = 10;` in this case. If it's not possible, write `static const <type> kSomeConstant = ...;`. The priority is:
1. `constexpr <type> kVar = ...;`. For example: `constexpr char kVal[] = "abc";`, `constexpr const char* kValues[] = {"abc", "def"};`.
3. `static const <type> kVar = ...;` **make sure the variable is a true constant, i.e. it doesn't depend on the context!**
4. `const <type> var = ...;`

#### [PublicMemberSuffix](https://clang.llvm.org/extra/clang-tidy/checks/readability/identifier-naming.html#cmdoption-arg-publicmembersuffix)

Not used to allow public members without `_` suffix in `struct`s.


Resolves https://github.com/brave/brave-browser/issues/27889

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

