### PR TITLE
Fixed issue with loading transaction list for selected assets

### DIFF
--- a/components/brave_wallet_ui/components/desktop/portfolio-transaction-item/index.tsx
+++ b/components/brave_wallet_ui/components/desktop/portfolio-transaction-item/index.tsx
@@ -65,6 +65,8 @@ import { StatusBubble } from '../../shared/style'
 import TransactionFeesTooltip from '../transaction-fees-tooltip'
 import TransactionPopup, { TransactionPopupItem } from '../transaction-popup'
 import TransactionTimestampTooltip from '../transaction-timestamp-tooltip'
+import { useUnsafeWalletSelector } from '../../../common/hooks/use-safe-selector'
+import { WalletSelectors } from '../../../../../components/brave_wallet_ui/common/selectors'
 
 export interface Props {
   transaction: ParsedTransaction
@@ -90,6 +92,7 @@ export const PortfolioTransactionItem = React.forwardRef<HTMLDivElement, Props>(
 
   // redux
   const dispatch = useDispatch()
+  const selectedNetwork = useUnsafeWalletSelector(WalletSelectors.selectedNetwork)
 
   // selectors
   const selectNetworkById = React.useMemo(makeSelectNetworkByIdFromQuery, [])
@@ -119,7 +122,7 @@ export const PortfolioTransactionItem = React.forwardRef<HTMLDivElement, Props>(
   const [showTransactionPopup, setShowTransactionPopup] = React.useState<boolean>(false)
 
   // custom hooks
-  const onClickViewOnBlockExplorer = useExplorer(txNetwork)
+  const onClickViewOnBlockExplorer = useExplorer(selectedNetwork)
 
   // methods
   const onShowTransactionPopup = React.useCallback(() => {

--- a/components/brave_wallet_ui/components/desktop/views/portfolio/components/accounts-and-transctions-list/index.tsx
+++ b/components/brave_wallet_ui/components/desktop/views/portfolio/components/accounts-and-transctions-list/index.tsx
@@ -78,10 +78,12 @@ export const AccountsAndTransactionsList = ({
   }, [selectedAsset])
 
   const selectedAssetsNetwork = React.useMemo(() => {
-    if (!selectedAsset) {
+    if (selectedNetwork) {
       return selectedNetwork
+    } else if (selectedAsset) {
+      return getTokensNetwork(networkList, selectedAsset)
     }
-    return getTokensNetwork(networkList, selectedAsset)
+    return undefined
   }, [selectedNetwork, selectedAsset, networkList])
 
   const filteredAccountsByCoinType = React.useMemo(() => {
@@ -96,7 +98,7 @@ export const AccountsAndTransactionsList = ({
       return filteredAccountsByCoinType.filter((account) => Number(account.nativeBalanceRegistry[selectedAssetsNetwork.chainId] ?? 0) !== 0)
     }
     return filteredAccountsByCoinType
-  }, [selectedAsset, filteredAccountsByCoinType])
+  }, [selectedAsset, filteredAccountsByCoinType, selectedNetwork])
 
   const nonRejectedTransactions = React.useMemo(() => {
     return selectedAssetTransactions


### PR DESCRIPTION
Fixed opening of the incorrect block explorer launched with the correct transaction hash [#26069]


The original issue [#26069], contains describe the problem on the "Portfolio" page, which has now been fixed
But in context of the problem resolution, have been found next two places with the same issue:
- "Activity" section
- "Account details" section

After the fix, for both of them:
we display transaction list for "active network" 
the URL for "block explorer", will be taken from the "active network".



<!-- Add brave-browser issue below that this PR will resolve
Resolves [brave-browser/issues/26069](https://github.com/brave/brave-browser/issues/26069) -->

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues/26069) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
Go through the steps described in the [Issue #26069]
Then check the that BW loads the correct block explorer for the "Activity" and  "Account details" section

