### PR TITLE
fix(wallet): Re-add Token Once Hidden

### DIFF
--- a/components/brave_wallet_ui/components/desktop/views/portfolio/portfolio-asset.tsx
+++ b/components/brave_wallet_ui/components/desktop/views/portfolio/portfolio-asset.tsx
@@ -442,6 +442,15 @@ export const PortfolioAsset = (props: Props) => {
 
   const onHideAsset = React.useCallback(() => {
     if (!selectedAsset) return
+    if (
+      fullTokenList.some((asset) =>
+        asset.contractAddress.toLowerCase() ===
+        selectedAsset.contractAddress.toLowerCase())
+    ) {
+      dispatch(WalletActions.removeUserAsset(selectedAsset))
+    } else {
+      dispatch(WalletActions.setUserAssetVisible({ token: selectedAsset, isVisible: false }))
+    }
     dispatch(WalletActions.setUserAssetVisible({ token: selectedAsset, isVisible: false }))
     dispatch(WalletActions.refreshBalancesAndPriceHistory())
     dispatch(WalletPageActions.selectAsset({
@@ -451,7 +460,7 @@ export const PortfolioAsset = (props: Props) => {
     if (showHideTokenModel) setShowHideTokenModal(false)
     if (showTokenDetailsModal) setShowTokenDetailsModal(false)
     history.push(WalletRoutes.Portfolio)
-  }, [selectedAsset, showTokenDetailsModal])
+  }, [selectedAsset, showTokenDetailsModal, fullTokenList])
 
   const onViewOnExplorer = React.useCallback(() => {
     if (selectedAsset) {


### PR DESCRIPTION
## Description 
Fixes a bug where you were not able to re-add a token once hidden in the `Hide Token` modal.

Context: (We only allow to `hide` a token if it is a `custom` token added by the user, otherwise we just remove the token from the user's visible assets list. In this regression the `Hide Token` modal was calling the `setUserAssetVisible` method for any token, therefor user's were not able to re-add that token in the `Visible Assets` modal. Additional methods have been added which will allow user's to get unstuck if they had done this.)

<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves <https://github.com/brave/brave-browser/issues/26023>

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
1. Go to the `Portfolio` page and select a `erc-20` token
2. Click on the `More` menu and then `hide` the token
3. Go back to the `Portfolio` page and open the `Visible Assets` modal
4. You should be able to re-add the token.

Before:

https://user-images.githubusercontent.com/40611140/213318912-2a315d4a-e619-49ce-b4f8-f3b28904aa14.mov

After:

https://user-images.githubusercontent.com/40611140/213318509-c483ffab-83d4-413a-8a85-4ef312e118c5.mov
