### PR TITLE
Added separator to sidebar ctx menu between show sidebar and position (uplift to 1.48.x)

### DIFF
--- a/browser/ui/views/sidebar/sidebar_control_view.cc
+++ b/browser/ui/views/sidebar/sidebar_control_view.cc
@@ -160,6 +160,8 @@ void SidebarControlView::ShowContextMenuForViewImpl(
       static_cast<int>(ShowSidebarOption::kShowNever),
       brave_l10n::GetLocalizedResourceUTF16String(
           IDS_SIDEBAR_SHOW_OPTION_NEVER));
+  context_menu_model_->AddSeparator(
+      ui::MenuSeparatorType::BOTH_SIDE_PADDED_SEPARATOR);
   context_menu_model_->AddTitle(brave_l10n::GetLocalizedResourceUTF16String(
       IDS_SIDEBAR_MENU_MODEL_POSITION_OPTION_TITLE));
   context_menu_model_->AddItemWithStringId(

--- a/chromium_src/ui/base/models/menu_separator_types.h
+++ b/chromium_src/ui/base/models/menu_separator_types.h
@@ -1,0 +1,15 @@
+// Copyright (c) 2023 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#ifndef BRAVE_CHROMIUM_SRC_UI_BASE_MODELS_MENU_SEPARATOR_TYPES_H_
+#define BRAVE_CHROMIUM_SRC_UI_BASE_MODELS_MENU_SEPARATOR_TYPES_H_
+
+#define PADDED_SEPARATOR BOTH_SIDE_PADDED_SEPARATOR, PADDED_SEPARATOR
+
+#include "src/ui/base/models/menu_separator_types.h"
+
+#undef PADDED_SEPARATOR
+
+#endif  // BRAVE_CHROMIUM_SRC_UI_BASE_MODELS_MENU_SEPARATOR_TYPES_H_

--- a/chromium_src/ui/views/controls/menu/menu_separator.cc
+++ b/chromium_src/ui/views/controls/menu/menu_separator.cc
@@ -1,0 +1,12 @@
+// Copyright (c) 2023 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#define BRAVE_MENU_SEPARATOR_ON_PAINT               \
+  else if (type_ == ui::BOTH_SIDE_PADDED_SEPARATOR) \
+      paint_rect.Inset(gfx::Insets::VH(0, 8));
+
+#include "src/ui/views/controls/menu/menu_separator.cc"
+
+#undef BRAVE_MENU_SEPARATOR_ON_PAINT

--- a/patches/ui-views-controls-menu-menu_separator.cc.patch
+++ b/patches/ui-views-controls-menu-menu_separator.cc.patch
@@ -1,0 +1,12 @@
+diff --git a/ui/views/controls/menu/menu_separator.cc b/ui/views/controls/menu/menu_separator.cc
+index be7ca4059bc2d7f78419dbf863fdb7c74070e9dc..6391ae9d86b0d66cca37d98f71506c2733b12edd 100644
+--- a/ui/views/controls/menu/menu_separator.cc
++++ b/ui/views/controls/menu/menu_separator.cc
+@@ -43,6 +43,7 @@ void MenuSeparator::OnPaint(gfx::Canvas* canvas) {
+   if (type_ == ui::PADDED_SEPARATOR)
+     paint_rect.Inset(
+         gfx::Insets::TLBR(0, menu_config.padded_separator_left_margin, 0, 0));
++  BRAVE_MENU_SEPARATOR_ON_PAINT
+   else if (menu_config.use_outer_border)
+     paint_rect.Inset(gfx::Insets::VH(0, 1));
+ 


### PR DESCRIPTION
Uplift of #16717
fix https://github.com/brave/brave-browser/issues/27880

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.