### PR TITLE
Brave notification permission issue fix

### DIFF
--- a/android/java/org/chromium/chrome/browser/brave_stats/BraveStatsBottomSheetDialogFragment.java
+++ b/android/java/org/chromium/chrome/browser/brave_stats/BraveStatsBottomSheetDialogFragment.java
@@ -211,11 +211,12 @@ public class BraveStatsBottomSheetDialogFragment extends BottomSheetDialogFragme
     @Override
     public void onResume() {
         super.onResume();
-        if (BravePermissionUtils.hasPermission(
-                    getContext(), PermissionConstants.NOTIFICATION_PERMISSION)) {
-            statsNotificationView.setVisibility(View.GONE);
-        } else {
+        if (!BravePermissionUtils.hasPermission(
+                    getContext(), PermissionConstants.NOTIFICATION_PERMISSION)
+                || BravePermissionUtils.isGeneralNotificationPermissionBlocked(getActivity())) {
             statsNotificationView.setVisibility(View.VISIBLE);
+        } else {
+            statsNotificationView.setVisibility(View.GONE);
         }
     }
 
@@ -224,8 +225,9 @@ public class BraveStatsBottomSheetDialogFragment extends BottomSheetDialogFragme
         btnDismiss.setOnClickListener(v -> { statsNotificationView.setVisibility(View.GONE); });
         View notificationOnButton = view.findViewById(R.id.notification_on_button);
         notificationOnButton.setOnClickListener(v -> {
-            if (getActivity().shouldShowRequestPermissionRationale(
-                        PermissionConstants.NOTIFICATION_PERMISSION)
+            if (BravePermissionUtils.isGeneralNotificationPermissionBlocked(getActivity())
+                    || getActivity().shouldShowRequestPermissionRationale(
+                            PermissionConstants.NOTIFICATION_PERMISSION)
                     || (!BuildInfo.isAtLeastT() || !BuildInfo.targetsAtLeastT())) {
                 // other than android 13 redirect to
                 // setting page and for android 13 Last time don't allow selected in permission

--- a/android/java/org/chromium/chrome/browser/notifications/BraveNotificationWarningDialog.java
+++ b/android/java/org/chromium/chrome/browser/notifications/BraveNotificationWarningDialog.java
@@ -90,12 +90,12 @@ public class BraveNotificationWarningDialog extends BraveDialogFragment {
         return false;
     }
 
-    private static boolean shouldShowRewardWarningDialog(Context context) {
+    public static boolean shouldShowRewardWarningDialog(Context context) {
         return BravePermissionUtils.isBraveAdsNotificationPermissionBlocked(context)
                 && isBraveRewardsEnabled();
     }
 
-    private static boolean shouldShowPrivacyWarningDialog(Context context) {
+    public static boolean shouldShowPrivacyWarningDialog(Context context) {
         return BravePermissionUtils.isGeneralNotificationPermissionBlocked(context)
                 && isPrivacyReportsEnabled();
     }

--- a/android/java/org/chromium/chrome/browser/rewards/BraveRewardsPanel.java
+++ b/android/java/org/chromium/chrome/browser/rewards/BraveRewardsPanel.java
@@ -947,8 +947,9 @@ public class BraveRewardsPanel
     }
 
     private void requestNotificationPermission() {
-        if (mActivity.shouldShowRequestPermissionRationale(
-                    PermissionConstants.NOTIFICATION_PERMISSION)
+        if (BravePermissionUtils.isBraveAdsNotificationPermissionBlocked(mAnchorView.getContext())
+                || mActivity.shouldShowRequestPermissionRationale(
+                        PermissionConstants.NOTIFICATION_PERMISSION)
                 || (!BuildInfo.isAtLeastT() || !BuildInfo.targetsAtLeastT())) {
             // other than android 13 redirect to
             // setting page and for android 13 Last time don't allow selected in permission
@@ -1586,15 +1587,15 @@ public class BraveRewardsPanel
             btnContinue.setOnClickListener((new View.OnClickListener() {
                 @Override
                 public void onClick(View v) {
-                    if (BravePermissionUtils.hasPermission(mAnchorView.getContext(),
-                                PermissionConstants.NOTIFICATION_PERMISSION)) {
-                        if (countrySpinner != null) {
-                            mBraveRewardsNativeWorker.CreateRewardsWallet(sortedCountryMap.get(
-                                    countrySpinner.getSelectedItem().toString()));
-                        }
-                    } else {
-                        // else request notification permission
+                    if (!BravePermissionUtils.hasPermission(mAnchorView.getContext(),
+                                PermissionConstants.NOTIFICATION_PERMISSION)
+                            || BravePermissionUtils.isBraveAdsNotificationPermissionBlocked(
+                                    mAnchorView.getContext())) {
                         requestNotificationPermission();
+                    }
+                    if (countrySpinner != null) {
+                        mBraveRewardsNativeWorker.CreateRewardsWallet(
+                                sortedCountryMap.get(countrySpinner.getSelectedItem().toString()));
                     }
                 }
             }));

--- a/browser/ui/android/strings/android_brave_strings.grd
+++ b/browser/ui/android/strings/android_brave_strings.grd
@@ -204,7 +204,7 @@ This file contains all "about" strings.  It is set to NOT be translated, in tran
         Turn notifications back on if you'd like to keep earning BAT and receiving weekly privacy reports.
       </message>
       <message name="IDS_NOTIFICATION_BRAVE_DIALOG_DESCRIPTION_ONLY_REWARDS" desc="Text description for When ONLY Brave Rewards is TURNED ON.">
-        Turn notifications back on if you'd like to keep earning BAT
+        Turn notifications back on if you'd like to keep earning BAT.
       </message>
       <message name="IDS_NOTIFICATION_BRAVE_DIALOG_DESCRIPTION_ONLY_PRIVACY" desc="Text description for When ONLY Privacy Report is TURNED ON.">
         Turn notifications back on if you'd like to keep receiving weekly privacy reports.


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves 
https://github.com/brave/brave-browser/issues/27851
https://github.com/brave/brave-browser/issues/27852
https://github.com/brave/brave-browser/issues/27853

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

In this PR there are 3 changes
1. If "Brave Ads" notification channel is off then also redirect to setting page.
2. Get weekly privacy UI , show notification request UI if "General" notification channel is off
3. Dot was missing in description in one modal

One more changes in this PR.
if notification permission is not there still allow to create reward wallet.
STR
1. NO notification permission
2. Rewards setup
3. country select
4. click continue
5. redirect to setting page
6. don't give permission
7. Still it will create wallet



Below two video for Get weekly privacy UI 
https://user-images.githubusercontent.com/32419898/213454850-070afeb3-b3aa-4fd9-8ae8-ddb229aca3fc.mp4
https://user-images.githubusercontent.com/32419898/213454871-45f0989a-0bf4-4e62-9b3b-bdfd7e15716d.mp4

Rewards Panel

https://user-images.githubusercontent.com/32419898/213757806-e267ae6f-99af-47e7-a521-516b2a4e9e61.mp4



Dot at the end
![Screenshot_20230120-135111](https://user-images.githubusercontent.com/32419898/213679410-4383e7d9-cc99-48b1-ad61-718bde90cea9.png)


