### PR TITLE
Fix crash : should pass top level widget to get non client view

### DIFF
--- a/chromium_src/chrome/browser/ui/views/tabs/tab_drag_controller.cc
+++ b/chromium_src/chrome/browser/ui/views/tabs/tab_drag_controller.cc
@@ -26,6 +26,10 @@
   views::View::ConvertPointFromScreen(    \
       view->GetWidget()->GetTopLevelWidget()->GetRootView(), point)
 #define GetRestoredBounds GetTopLevelWidget()->GetRestoredBounds
+#define non_client_view()                                    \
+  non_client_view()                                          \
+      ? source->GetWidget()->non_client_view()->frame_view() \
+      : source->GetWidget()->GetTopLevelWidget()->non_client_view()
 
 // Remove drag threshold when it's vertical tab strip
 #define GetHorizontalDragThreshold()                          \
@@ -39,6 +43,7 @@
 
 #include "src/chrome/browser/ui/views/tabs/tab_drag_controller.cc"
 
+#undef non_client_view
 #undef GetHorizontalDragThreshold
 #undef GetRestoredBounds
 #undef ConvertPointToWidget
@@ -242,7 +247,8 @@ gfx::Rect TabDragController::CalculateDraggedBrowserBounds(
     TabDragContext* source,
     const gfx::Point& point_in_screen,
     std::vector<gfx::Rect>* drag_bounds) {
-  // This method is called when creating new browser by detaching tabs.
+  // This method is called when creating new browser by detaching tabs and
+  // when dragging all tabs in maximized window.
   auto bounds = TabDragControllerChromium::CalculateDraggedBrowserBounds(
       source, point_in_screen, drag_bounds);
   if (is_showing_vertical_tabs_) {


### PR DESCRIPTION
As vertical tabs are attached to another widget, we should return top level widget for the case.

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/27796

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
* active vertical tabs
* Maximize the window
* Drag a single tab, which moves browser
* There should'nt be crash.
