### PR TITLE
fix(wallet): Hiding NFTs with same Contracts

### DIFF
--- a/components/brave_wallet_ui/components/desktop/popup-modals/edit-visible-assets-modal/index.tsx
+++ b/components/brave_wallet_ui/components/desktop/popup-modals/edit-visible-assets-modal/index.tsx
@@ -14,6 +14,7 @@ import { AllNetworksOption } from '../../../../options/network-filter-options'
 
 // utils
 import { getLocale } from '../../../../../common/locale'
+import { checkIfTokensMatch } from '../../../../utils/asset-utils'
 
 // components
 import {
@@ -168,19 +169,11 @@ const EditVisibleAssetsModal = ({ onClose }: Props) => {
   }, [tokenList])
 
   const findUpdatedTokenInfo = React.useCallback((token: BraveWallet.BlockchainToken) => {
-    return updatedTokensList.find((t) =>
-      t.symbol.toLowerCase() === token.symbol.toLowerCase() &&
-      t.contractAddress.toLowerCase() === token.contractAddress.toLowerCase() &&
-      t.chainId === token.chainId)
+    return updatedTokensList.find((t) => checkIfTokensMatch(t, token))
   }, [updatedTokensList])
 
   const isUserToken = React.useCallback((token: BraveWallet.BlockchainToken) => {
-    return updatedTokensList.some(t =>
-    (
-      t.contractAddress.toLowerCase() === token.contractAddress.toLowerCase() &&
-      t.chainId === token.chainId &&
-      t.symbol.toLowerCase() === token.symbol.toLowerCase())
-    )
+    return updatedTokensList.some(t => checkIfTokensMatch(t, token))
   }, [updatedTokensList])
 
   const isAssetSelected = React.useCallback((token: BraveWallet.BlockchainToken): boolean => {
@@ -214,10 +207,7 @@ const EditVisibleAssetsModal = ({ onClose }: Props) => {
   // to help the user get un-stuck.
   const findNonCustomTokenWithVisibleFalse = React.useCallback((token: BraveWallet.BlockchainToken) => {
     return userVisibleTokensInfo.some((t) =>
-      t.contractAddress.toLowerCase() === token.contractAddress.toLowerCase() &&
-      t.symbol.toLowerCase() === token.symbol.toLowerCase() &&
-      t.chainId === token.chainId &&
-      t.tokenId === token.tokenId &&
+      checkIfTokensMatch(t, token) &&
       !t.visible)
   }, [userVisibleTokensInfo])
 
@@ -225,10 +215,7 @@ const EditVisibleAssetsModal = ({ onClose }: Props) => {
     if (isUserToken(token)) {
       if (isCustom || token.contractAddress === '' || (!isCustom && findNonCustomTokenWithVisibleFalse(token))) {
         const updatedToken = selected ? { ...token, visible: true } : { ...token, visible: false }
-        const tokenIndex = updatedTokensList.findIndex((t) =>
-          t.contractAddress.toLowerCase() === token.contractAddress.toLowerCase() &&
-          t.symbol.toLowerCase() === token.symbol.toLowerCase() &&
-          t.chainId === token.chainId)
+        const tokenIndex = updatedTokensList.findIndex((t) => checkIfTokensMatch(t, token))
         let newList = [...updatedTokensList]
         newList.splice(tokenIndex, 1, updatedToken)
         setUpdatedTokensList(newList)

--- a/components/brave_wallet_ui/utils/asset-utils.test.ts
+++ b/components/brave_wallet_ui/utils/asset-utils.test.ts
@@ -1,0 +1,30 @@
+// Copyright (c) 2023 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import { checkIfTokensMatch } from './asset-utils'
+import { mockEthToken, mockBasicAttentionToken, mockMoonCatNFT } from '../stories/mock-data/mock-asset-options'
+
+const ethToken = mockEthToken
+const batToken = mockBasicAttentionToken
+const nftTokenOne = mockMoonCatNFT
+const nftTokenTwo = { ...mockMoonCatNFT, tokenId: '0x42a7' }
+
+describe('Check if tokens match', () => {
+  test('Comparing BAT to BAT, should match.', () => {
+    expect(checkIfTokensMatch(batToken, batToken)).toBeTruthy()
+  })
+
+  test('Comparing BAT to ETH, should not match.', () => {
+    expect(checkIfTokensMatch(batToken, ethToken)).toBeFalsy()
+  })
+
+  test('Comparing NFTs with the same tokenId, should match.', () => {
+    expect(checkIfTokensMatch(nftTokenOne, nftTokenOne)).toBeTruthy()
+  })
+
+  test('Comparing NFTs with different tokenIds, should not match.', () => {
+    expect(checkIfTokensMatch(nftTokenOne, nftTokenTwo)).toBeFalsy()
+  })
+})

--- a/components/brave_wallet_ui/utils/asset-utils.ts
+++ b/components/brave_wallet_ui/utils/asset-utils.ts
@@ -234,3 +234,13 @@ export const formatTokenBalance = (
         .formatAsAsset(decimalPlaces ?? 6, selectedAsset?.symbol ?? '')
     : ''
 }
+
+export const checkIfTokensMatch = (
+  tokenOne: BraveWallet.BlockchainToken,
+  tokenTwo: BraveWallet.BlockchainToken
+): boolean => {
+  return tokenOne.symbol.toLowerCase() === tokenTwo.symbol.toLowerCase() &&
+    tokenOne.contractAddress.toLowerCase() === tokenTwo.contractAddress.toLowerCase() &&
+    tokenOne.chainId === tokenTwo.chainId &&
+    tokenOne.tokenId === tokenTwo.tokenId
+}


### PR DESCRIPTION
## Description 
Fixes a bug where you were not able hide NFT's with duplicate contract addresses

<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves <https://github.com/brave/brave-browser/issues/27906>

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [x] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [x] New files have MPL-2.0 license header
- [x] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [x] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [x] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
   1. Add 2 NFT's with the same contract address
   2. Open the `Visible Assets` modal
   3. It should allow you to hide an individual NFT with the same contract address.

Before:

https://user-images.githubusercontent.com/40611140/213521434-0b89cbf6-32b3-4e83-aec1-4d5ff823f968.mov

After:

https://user-images.githubusercontent.com/40611140/213521473-27625b94-b52e-42f8-909b-29ac6ad2c16f.mov
