### PR TITLE
Adds a delay on search widget show check on Android to prevent ANR (uplift to 1.47.x)

### DIFF
--- a/android/java/org/chromium/chrome/browser/toolbar/top/BraveToolbarLayoutImpl.java
+++ b/android/java/org/chromium/chrome/browser/toolbar/top/BraveToolbarLayoutImpl.java
@@ -58,6 +58,7 @@ import org.chromium.base.ThreadUtils;
 import org.chromium.base.supplier.BooleanSupplier;
 import org.chromium.base.supplier.ObservableSupplier;
 import org.chromium.base.task.AsyncTask;
+import org.chromium.base.task.PostTask;
 import org.chromium.brave_shields.mojom.CookieListOptInPageAndroidHandler;
 import org.chromium.chrome.R;
 import org.chromium.chrome.browser.BraveAdsNativeHelper;
@@ -126,6 +127,7 @@ import org.chromium.components.embedder_support.util.UrlUtilities;
 import org.chromium.components.url_formatter.UrlFormatter;
 import org.chromium.components.user_prefs.UserPrefs;
 import org.chromium.content_public.browser.NavigationHandle;
+import org.chromium.content_public.browser.UiThreadTaskTraits;
 import org.chromium.mojo.bindings.ConnectionErrorHandler;
 import org.chromium.mojo.system.MojoException;
 import org.chromium.ui.UiUtils;
@@ -1057,7 +1059,10 @@ public abstract class BraveToolbarLayoutImpl extends ToolbarLayout
             Intent searchActivityIntent = new Intent(context, SearchActivity.class);
             context.startActivity(searchActivityIntent);
         }
-        if (hasFocus) mSearchWidgetPromoPanel.showIfNeeded(this);
+        // Delay showing the panel. Otherwise there are ANRs on holding onUrlFocusChange
+        PostTask.postTask(UiThreadTaskTraits.DEFAULT, () -> {
+            if (hasFocus) mSearchWidgetPromoPanel.showIfNeeded(this);
+        });
 
         if (OnboardingPrefManager.getInstance().getUrlFocusCount() == 0) {
             OnboardingPrefManager.getInstance().updateUrlFocusCount();


### PR DESCRIPTION
Uplift of https://github.com/brave/brave-core/pull/16751
Resolves https://github.com/brave/brave-browser/issues/27903