### PR TITLE
New Tab Page: Wait for prefs to make their way to state before deciding whether Brave News should peek or not

### DIFF
--- a/components/brave_new_tab_ui/containers/newTab/index.tsx
+++ b/components/brave_new_tab_ui/containers/newTab/index.tsx
@@ -144,20 +144,6 @@ class NewTabPage extends React.Component<Props, State> {
       this.trackBrandedWallpaperNotificationAutoDismiss()
     }
     this.checkShouldOpenSettings()
-    // Only prompt for brave today if we're not scrolling down.
-    const shouldPromptBraveToday =
-      this.props.newTabData.featureFlagBraveNewsPromptEnabled &&
-      this.props.newTabData.showToday &&
-      !this.props.todayData.articleScrollTo
-    if (shouldPromptBraveToday) {
-      this.braveNewsPromptTimerId = window.setTimeout(() => {
-        if (window.scrollY > 0) {
-          // Don't do anything if user has already scrolled
-          return
-        }
-        this.setState({ isPromptingBraveToday: true })
-      }, 1700)
-    }
     const searchPromotionEnabled = this.props.newTabData.searchPromotionEnabled
     this.setState({
       showSearchPromotion: searchPromotionEnabled,
@@ -174,6 +160,7 @@ class NewTabPage extends React.Component<Props, State> {
   }
 
   componentDidUpdate (prevProps: Props) {
+    this.maybePeekBraveNews()
     const oldImageSource = GetBackgroundImageSrc(prevProps)
     const newImageSource = GetBackgroundImageSrc(this.props)
     this.imageSource = newImageSource
@@ -193,6 +180,30 @@ class NewTabPage extends React.Component<Props, State> {
     if (GetShouldShowBrandedWallpaperNotification(prevProps) &&
       !GetShouldShowBrandedWallpaperNotification(this.props)) {
       this.stopWaitingForBrandedWallpaperNotificationAutoDismiss()
+    }
+  }
+
+  maybePeekBraveNews () {
+    const hasPromptedBraveNews = !!this.braveNewsPromptTimerId
+    const shouldPromptBraveNews =
+      !hasPromptedBraveNews && // Don't start a prompt if we already did
+      window.scrollY === 0 && // Don't start a prompt if we are scrolled
+      this.props.newTabData.featureFlagBraveNewsPromptEnabled &&
+      this.props.newTabData.initialDataLoaded && // Wait for accurate showToday
+      this.props.newTabData.showToday &&
+      // Don't prompt if the user has navigated back and we're going to scroll
+      // down to a previous place in the feed.
+      !this.props.todayData.articleScrollTo
+    if (shouldPromptBraveNews) {
+      this.braveNewsPromptTimerId = window.setTimeout(() => {
+        if (window.scrollY > 0) {
+          // If the user happens to start scrolling whilst waiting for the timer,
+          // make sure we cancel the timer otherwise content will shift and provide
+          // a poor UX.
+          return
+        }
+        this.setState({ isPromptingBraveToday: true })
+      }, 1700)
     }
   }
 


### PR DESCRIPTION
Fixes race condition (between first render and prefs being fetched to state) which meant that some NTP page loads would unexpectedly not result in a peek of Brave News content

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/28018

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

