### PR TITLE
[Rewards] Updates tipping banner text when logged out.

### DIFF
--- a/browser/ui/webui/brave_webui_source.cc
+++ b/browser/ui/webui/brave_webui_source.cc
@@ -802,6 +802,7 @@ void CustomizeWebUIHTMLSource(content::WebUI* web_ui,
         { "tweetAboutSupport", IDS_BRAVE_REWARDS_TIP_TWEET_ABOUT_SUPPORT },
         { "unverifiedTextMore", IDS_BRAVE_UI_SITE_UNVERIFIED_TEXT_MORE },
         { "welcome", IDS_BRAVE_UI_WELCOME },
+        { "youAreCurrentlyLoggedOut", IDS_BRAVE_REWARDS_TIP_YOU_ARE_CURRENTLY_LOGGED_OUT},  // NOLINT
       }
     }, {
       std::string("rewards-internals"), {

--- a/components/brave_rewards/resources/tip/components/bat_tip_form.tsx
+++ b/components/brave_rewards/resources/tip/components/bat_tip_form.tsx
@@ -19,8 +19,12 @@ import { SadFaceIcon } from './icons/sad_face'
 import { PaperAirplaneIcon } from './icons/paper_airplane_icon'
 import { CalendarIcon } from './icons/calendar_icon'
 import { LoadingIcon } from '../../shared/components/icons/loading_icon'
+import { NewTabLink } from '../../shared/components/new_tab_link'
 
 import * as style from './bat_tip_form.style'
+
+import * as mojom from '../../shared/lib/mojom'
+import * as urls from '../../shared/lib/rewards_urls'
 
 const minimumTip = 0.25
 const maximumTip = 100
@@ -41,6 +45,8 @@ export function BatTipForm (props: Props) {
 
   const [rewardsParameters, setRewardsParameters] = React.useState(
     host.state.rewardsParameters)
+  const [externalWalletInfo, setExternalWalletInfo] = React.useState(
+    host.state.externalWalletInfo)
 
   const [tipAmount, setTipAmount] = React.useState(props.defaultTipAmount)
   const [tipProcessing, setTipProcessing] = React.useState(false)
@@ -50,6 +56,7 @@ export function BatTipForm (props: Props) {
   React.useEffect(() => {
     return host.addListener((state) => {
       setRewardsParameters(state.rewardsParameters)
+      setExternalWalletInfo(state.externalWalletInfo)
     })
   }, [host])
 
@@ -157,7 +164,21 @@ export function BatTipForm (props: Props) {
             </style.minimumAmount>
           : props.tipKind === 'one-time' && tipAmount > props.userBalance
             ? <style.notEnoughFunds>
-              <SadFaceIcon /> {getString('notEnoughTokens')}
+                <SadFaceIcon />&nbsp;
+                {
+                  externalWalletInfo &&
+                    externalWalletInfo.status === mojom.WalletStatus.kLoggedOut
+                    ? formatMessage(getString('youAreCurrentlyLoggedOut'), {
+                      tags: {
+                        $1: (content) => (
+                          <NewTabLink key='link' href={urls.settingsURL}>
+                            {content}
+                          </NewTabLink>
+                        )
+                      }
+                    })
+                    : getString('notEnoughTokens')
+                }
             </style.notEnoughFunds>
           : showCustomInput
             ? <FormSubmitButton onClick={onSubmitCustomTip}>

--- a/components/resources/brave_components_strings.grd
+++ b/components/resources/brave_components_strings.grd
@@ -684,6 +684,7 @@
       <message name="IDS_BRAVE_REWARDS_TIP_TIP_IS_PENDING" desc="">You’ve set up a pending tip!</message>
       <message name="IDS_BRAVE_REWARDS_TIP_TIP_POST_SUBTITLE" desc="">for their post</message>
       <message name="IDS_BRAVE_REWARDS_TIP_TWEET_ABOUT_SUPPORT" desc="">Tweet about your support</message>
+      <message name="IDS_BRAVE_REWARDS_TIP_YOU_ARE_CURRENTLY_LOGGED_OUT" desc="">You are currently <ph name="BEGIN_LINK">$1</ph>logged out.<ph name="LINK_END">$2</ph></message>
 
       <!-- WebUI brave ui resources -->
       <message name="IDS_BRAVE_UI_ACTIVITY_COPY" desc=""> Brave Software. Brave is a registered trademark of Brave Software. Site names may be trademarks or registered trademarks of the site owner.</message>


### PR DESCRIPTION
Fixes brave/brave-browser#27792

## Submitter Checklist:

- [ ] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

Added by @Miyayes: 

1. New Rewards profile
2. Connect custodian such as Uphold or Gemini to an account that has 0.0 BAT
3. Go into tipping banner for a site and make sure text says that you don't have any tokens.
4. Go into Uphold and expire your OAuth token
5. Wait until Rewards panel picks this up and you're in logged out state.
6. Go into tipping banner, and check for this new message text. 