### PR TITLE
Use a generic cxx version reference.

### DIFF
--- a/build/rust/Cargo.lock
+++ b/build/rust/Cargo.lock
@@ -551,7 +551,7 @@ dependencies = [
 
 [[package]]
 name = "cxx"
-version = "1.0.81"
+version = "1.0.68"
 dependencies = [
  "cxxbridge-macro",
  "link-cplusplus",
@@ -559,9 +559,9 @@ dependencies = [
 
 [[package]]
 name = "cxxbridge-macro"
-version = "1.0.81"
+version = "1.0.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b846f081361125bfc8dc9d3940c84e1fd83ba54bbca7b17cd29483c828be0704"
+checksum = "34fa7e395dc1c001083c7eed28c8f0f0b5a225610f3b6284675f444af6fab86b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2880,7 +2880,3 @@ dependencies = [
  "syn",
  "synstructure",
 ]
-
-[[patch.unused]]
-name = "cxx"
-version = "1.0.68"

--- a/components/brave_today/rust/Cargo.toml
+++ b/components/brave_today/rust/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-cxx = { path = "../../../../third_party/rust/cxx/v1/crate"}
+cxx = "1.0"
 feed-rs = { git = "https://github.com/feed-rs/feed-rs", rev = "f88f21a65f997499962aacb2f746a82382547160" }
 log = "0.4.14"
 lazy_static = "1.4.0"

--- a/components/brave_wallet/rust/Cargo.toml
+++ b/components/brave_wallet/rust/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-cxx = { path = "../../../../third_party/rust/cxx/v1/crate"}
+cxx = "1.0"
 ed25519-dalek-bip32 = "0.2.0"
 curve25519-dalek = "3.2.0"
 

--- a/components/filecoin/rs/Cargo.toml
+++ b/components/filecoin/rs/Cargo.toml
@@ -9,7 +9,7 @@ publish = false
 base64 = "0.13.0"
 blake2b_simd = "1.0"
 bls-signatures = { version = "0.12", default-features = false, features = ["pairing"] }
-cxx = { path = "../../../../third_party/rust/cxx/v1/crate"}
+cxx = "1.0"
 fvm_shared = { version = "0.7.0 " }
 libsecp256k1 = "0.7"
 num_bigint_chainsafe = { package = "forest_bigint", version = "0.1.2"}

--- a/components/json/rs/Cargo.toml
+++ b/components/json/rs/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 publish = false
 
 [dependencies]
-cxx = { path = "../../../../third_party/rust/cxx/v1/crate"}
+cxx = "1.0"
 serde = {version = "1.0", features = ["derive"]}
 serde_json = {version = "1.0"}
 libc = "0.2.58"

--- a/components/skus/browser/rs/cxx/Cargo.toml
+++ b/components/skus/browser/rs/cxx/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-cxx = { path = "../../../../../../third_party/rust/cxx/v1/crate"}
+cxx = "1.0"
 async-trait = "0.1.61"
 futures = "0.3.19"
 libc = { version = "0.2" }


### PR DESCRIPTION
We want to control the version of cxx we use from the top-level build/rust/Cargo.{toml|lock} so reference a generic "1.0" version in the individual crates instead of trying to reference the correct vendored copy directly with a relative path, which is error-prone and harder to review.

This reverts us from the the chromium-vendored 1.0.81 to our own vendored 1.0.68.

Building with 1.0.81 has been working fine. However, we use the `cxxbridge` command-line tool to generate related binding files are part of the build, preferring this to the less-controlled `build.rs` pattern also supported by the cxx crate. Our setup scripts try to install a matching version of the tool to avoid any compatibility issues. Unfortunately, while the current releases of the crate itself build fine, recent versions of the cxxbridge tool require clap 4.0, which has a minimum-supported rust toolchain version of 1.60, which is newer than we currently support.

Between the two choices of splitting the crate and tool versions or using our older vendored copy, this commit chooses the later.

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves 

## Submitter Checklist:

- [ ] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

