### PR TITLE
Brave notification permission issue fix (uplift to 1.48.x)

### DIFF
--- a/android/java/org/chromium/chrome/browser/brave_stats/BraveStatsBottomSheetDialogFragment.java
+++ b/android/java/org/chromium/chrome/browser/brave_stats/BraveStatsBottomSheetDialogFragment.java
@@ -211,11 +211,12 @@ public class BraveStatsBottomSheetDialogFragment extends BottomSheetDialogFragme
     @Override
     public void onResume() {
         super.onResume();
-        if (BravePermissionUtils.hasPermission(
-                    getContext(), PermissionConstants.NOTIFICATION_PERMISSION)) {
-            statsNotificationView.setVisibility(View.GONE);
-        } else {
+        if (!BravePermissionUtils.hasPermission(
+                    getContext(), PermissionConstants.NOTIFICATION_PERMISSION)
+                || BravePermissionUtils.isGeneralNotificationPermissionBlocked(getActivity())) {
             statsNotificationView.setVisibility(View.VISIBLE);
+        } else {
+            statsNotificationView.setVisibility(View.GONE);
         }
     }
 
@@ -224,8 +225,9 @@ public class BraveStatsBottomSheetDialogFragment extends BottomSheetDialogFragme
         btnDismiss.setOnClickListener(v -> { statsNotificationView.setVisibility(View.GONE); });
         View notificationOnButton = view.findViewById(R.id.notification_on_button);
         notificationOnButton.setOnClickListener(v -> {
-            if (getActivity().shouldShowRequestPermissionRationale(
-                        PermissionConstants.NOTIFICATION_PERMISSION)
+            if (BravePermissionUtils.isGeneralNotificationPermissionBlocked(getActivity())
+                    || getActivity().shouldShowRequestPermissionRationale(
+                            PermissionConstants.NOTIFICATION_PERMISSION)
                     || (!BuildInfo.isAtLeastT() || !BuildInfo.targetsAtLeastT())) {
                 // other than android 13 redirect to
                 // setting page and for android 13 Last time don't allow selected in permission

--- a/android/java/org/chromium/chrome/browser/rewards/BraveRewardsPanel.java
+++ b/android/java/org/chromium/chrome/browser/rewards/BraveRewardsPanel.java
@@ -948,8 +948,9 @@ public class BraveRewardsPanel
     }
 
     private void requestNotificationPermission() {
-        if (mActivity.shouldShowRequestPermissionRationale(
-                    PermissionConstants.NOTIFICATION_PERMISSION)
+        if (BravePermissionUtils.isBraveAdsNotificationPermissionBlocked(mAnchorView.getContext())
+                || mActivity.shouldShowRequestPermissionRationale(
+                        PermissionConstants.NOTIFICATION_PERMISSION)
                 || (!BuildInfo.isAtLeastT() || !BuildInfo.targetsAtLeastT())) {
             // other than android 13 redirect to
             // setting page and for android 13 Last time don't allow selected in permission
@@ -1587,15 +1588,15 @@ public class BraveRewardsPanel
             btnContinue.setOnClickListener((new View.OnClickListener() {
                 @Override
                 public void onClick(View v) {
-                    if (BravePermissionUtils.hasPermission(mAnchorView.getContext(),
-                                PermissionConstants.NOTIFICATION_PERMISSION)) {
-                        if (countrySpinner != null) {
-                            mBraveRewardsNativeWorker.CreateRewardsWallet(sortedCountryMap.get(
-                                    countrySpinner.getSelectedItem().toString()));
-                        }
-                    } else {
-                        // else request notification permission
+                    if (!BravePermissionUtils.hasPermission(mAnchorView.getContext(),
+                                PermissionConstants.NOTIFICATION_PERMISSION)
+                            || BravePermissionUtils.isBraveAdsNotificationPermissionBlocked(
+                                    mAnchorView.getContext())) {
                         requestNotificationPermission();
+                    }
+                    if (countrySpinner != null) {
+                        mBraveRewardsNativeWorker.CreateRewardsWallet(
+                                sortedCountryMap.get(countrySpinner.getSelectedItem().toString()));
                     }
                 }
             }));

--- a/browser/ui/android/strings/android_brave_strings.grd
+++ b/browser/ui/android/strings/android_brave_strings.grd
@@ -204,7 +204,7 @@ This file contains all "about" strings.  It is set to NOT be translated, in tran
         Turn notifications back on if you'd like to keep earning BAT and receiving weekly privacy reports.
       </message>
       <message name="IDS_NOTIFICATION_BRAVE_DIALOG_DESCRIPTION_ONLY_REWARDS" desc="Text description for When ONLY Brave Rewards is TURNED ON.">
-        Turn notifications back on if you'd like to keep earning BAT
+        Turn notifications back on if you'd like to keep earning BAT.
       </message>
       <message name="IDS_NOTIFICATION_BRAVE_DIALOG_DESCRIPTION_ONLY_PRIVACY" desc="Text description for When ONLY Privacy Report is TURNED ON.">
         Turn notifications back on if you'd like to keep receiving weekly privacy reports.


### PR DESCRIPTION
Uplift of https://github.com/brave/brave-core/pull/16740
Resolves https://github.com/brave/brave-browser/issues/27851
Resolves https://github.com/brave/brave-browser/issues/27852
Resolves https://github.com/brave/brave-browser/issues/27853

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.