### PR TITLE
[Android] fix widget resize top tile icons cut off (uplift to 1.47.x)

### DIFF
--- a/android/java/org/chromium/chrome/browser/widget/quickactionsearchandbookmark/QuickActionSearchAndBookmarkWidgetProvider.java
+++ b/android/java/org/chromium/chrome/browser/widget/quickactionsearchandbookmark/QuickActionSearchAndBookmarkWidgetProvider.java
@@ -78,8 +78,8 @@ public class QuickActionSearchAndBookmarkWidgetProvider extends AppWidgetProvide
 
     private static final int TOTAL_TILES = 16;
     private static final int TILES_PER_ROW = 4;
-    private static final int MIN_VISIBLE_HEIGHT_ROW_1 = 116;
-    private static final int MIN_VISIBLE_HEIGHT_ROW_2 = 184;
+    private static final int MIN_VISIBLE_HEIGHT_ROW_1 = 125;
+    private static final int MIN_VISIBLE_HEIGHT_ROW_2 = 220;
     private static final int MIN_VISIBLE_HEIGHT_ROW_3 = 252;
     private static final int MIN_VISIBLE_HEIGHT_ROW_4 = 320;
     private static final int DESIRED_ICON_SIZE = 44;


### PR DESCRIPTION
Uplift of #16772
Resolves https://github.com/brave/brave-browser/issues/26645

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.