### PR TITLE
[Android] fix brave news v2 rss crash

### DIFF
--- a/android/java/org/chromium/chrome/browser/settings/BraveNewsPreferencesTypeAdapter.java
+++ b/android/java/org/chromium/chrome/browser/settings/BraveNewsPreferencesTypeAdapter.java
@@ -90,24 +90,26 @@ public class BraveNewsPreferencesTypeAdapter extends RecyclerView.Adapter<Recycl
 
         } else if (holder instanceof NewsPreferencesViewHolder) {
             NewsPreferencesViewHolder viewHolder = (NewsPreferencesViewHolder) holder;
-            if (mBraveNewsPreferencesType.equalsIgnoreCase(
-                        BraveNewsPreferencesType.PopularSources.toString())
-                    || mBraveNewsPreferencesType.equalsIgnoreCase(
-                            BraveNewsPreferencesType.Suggested.toString())) {
+            if ((mBraveNewsPreferencesType.equalsIgnoreCase(
+                         BraveNewsPreferencesType.PopularSources.toString())
+                        || mBraveNewsPreferencesType.equalsIgnoreCase(
+                                BraveNewsPreferencesType.Suggested.toString()))
+                    && position < mPublisherList.size()) {
                 setSource(position, viewHolder, mPublisherList.get(position));
 
             } else if (mBraveNewsPreferencesType.equalsIgnoreCase(
                                BraveNewsPreferencesType.Following.toString())) {
                 if (mChannelList.size() > 0 && position < mChannelList.size()) {
                     setChannel(position, viewHolder, mChannelList.get(position));
-                } else {
+                } else if (mPublisherList.size() > 0 && position - mChannelList.size() >= 0
+                        && (position - mChannelList.size()) < mPublisherList.size()) {
                     setSource(position, viewHolder,
                             mPublisherList.get(position - mChannelList.size()));
                 }
 
             } else if (mBraveNewsPreferencesType.equalsIgnoreCase(
                                BraveNewsPreferencesType.Search.toString())) {
-                if (mChannelList.size() > 0 && position <= mChannelList.size()) {
+                if (mChannelList.size() > 0 && position < getChannelItemsCount()) {
                     setChannel(position, viewHolder, mChannelList.get(position - ONE_ITEM_SPACE));
                 } else if (position == getItemCount() - ONE_ITEM_SPACE
                         && (mBraveNewsPreferencesSearchType
@@ -118,8 +120,7 @@ public class BraveNewsPreferencesTypeAdapter extends RecyclerView.Adapter<Recycl
                                         == BraveNewsPreferencesSearchType.NotFound)) {
                     setSearchUrl(position, viewHolder);
                 } else if (mBraveNewsPreferencesSearchType
-                                == BraveNewsPreferencesSearchType.NewSource
-                        && position <= getItemCount() - mFeedSearchResultItemList.size()) {
+                        == BraveNewsPreferencesSearchType.NewSource) {
                     int resultPosition = 0;
                     if (mChannelList.size() > 0) {
                         resultPosition = mChannelList.size() + ONE_ITEM_SPACE;
@@ -127,13 +128,17 @@ public class BraveNewsPreferencesTypeAdapter extends RecyclerView.Adapter<Recycl
                     resultPosition += mPublisherList.size() + ONE_ITEM_SPACE;
 
                     setFeedSearchResultItem(position - resultPosition, viewHolder);
-                } else {
+
+                } else if (position - getChannelItemsCount() - ONE_ITEM_SPACE >= 0
+                        && position - getChannelItemsCount() - ONE_ITEM_SPACE
+                                < mPublisherList.size()) {
                     setSource(position, viewHolder,
                             mPublisherList.get(position - getChannelItemsCount() - ONE_ITEM_SPACE));
                 }
 
             } else if (mBraveNewsPreferencesType.equalsIgnoreCase(
-                               BraveNewsPreferencesType.Channels.toString())) {
+                               BraveNewsPreferencesType.Channels.toString())
+                    && position < getChannelItemsCount()) {
                 setChannel(position, viewHolder, mChannelList.get(position));
             }
         }
@@ -170,7 +175,7 @@ public class BraveNewsPreferencesTypeAdapter extends RecyclerView.Adapter<Recycl
     }
 
     private void setFeedSearchResultItem(int position, NewsPreferencesViewHolder viewHolder) {
-        if (position < mFeedSearchResultItemList.size()) {
+        if (position >= 0 && position < mFeedSearchResultItemList.size()) {
             FeedSearchResultItem feedSearchResultItem = mFeedSearchResultItemList.get(position);
 
             viewHolder.name.setText(feedSearchResultItem.feedTitle);
@@ -372,10 +377,8 @@ public class BraveNewsPreferencesTypeAdapter extends RecyclerView.Adapter<Recycl
 
         mFeedSearchResultItemList = feedSearchResultItemList;
         mBraveNewsPreferencesSearchType = braveNewsPreferencesSearchType;
-
         if (braveNewsPreferencesSearchType == BraveNewsPreferencesSearchType.NewSource) {
-            int itemsInserted = feedSearchResultItemList.size();
-            notifyItemRangeInserted(startPosition, itemsInserted);
+            notifyItemRangeInserted(startPosition, feedSearchResultItemList.size());
         } else if (braveNewsPreferencesSearchType == BraveNewsPreferencesSearchType.NotFound) {
             notifyItemRangeInserted(startPosition, ONE_ITEM_SPACE);
         }


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/27952

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
   1. open `brave://flags`
   2. tap to `Enable` `Brave News v2`
   3. tap to `Relaunch` Brave
   4. tap the 3-dots menu
   5. tap `Settings` -> `Brave News` or `Brave News`, top-level menu item
   6. enter `pravda.com.ua` into the `Search for site, topic or RSS feed` textfield
   7. tap `Get Feeds`
   8. It should not crash and displays list of rss items from that site

https://user-images.githubusercontent.com/11678818/214128418-cd5fe05a-1874-44d7-96c9-f8b89d959f5d.mp4
