### PR TITLE
Implemented filtering options for eth_subscribe with logs #27842

### DIFF
--- a/browser/brave_wallet/ethereum_provider_impl_unittest.cc
+++ b/browser/brave_wallet/ethereum_provider_impl_unittest.cc
@@ -2193,7 +2193,7 @@ TEST_F(EthereumProviderImplUnitTest, EthSubscribeLogsFiltered) {
           const absl::optional<base::Value> req_body_payload =
               base::JSONReader::Read(
                   R"({"id":1,"jsonrpc":"2.0","method":"eth_getLogs","params":
-[{"address":["0x1111"],"fromBlock":"0x2211","toBlock":"0xab65",
+[{"address":["0x1111", "0x1112"],"fromBlock":"0x2211","toBlock":"0xab65",
 "topics":["0x2edc","0xb832","0x8dc8"]}]})",
                   base::JSON_PARSE_CHROMIUM_EXTENSIONS |
                       base::JSONParserOptions::JSON_PARSE_RFC);
@@ -2213,8 +2213,8 @@ TEST_F(EthereumProviderImplUnitTest, EthSubscribeLogsFiltered) {
   // Logs subscription with parameters
   std::string request_payload_json =
       R"({"id":1,"jsonrpc:": "2.0","method":"eth_subscribe",
-          "params": ["logs", {"address": "0x1111", "fromBlock": "0x2211",
-          "toBlock": "0xab65",  "topics":  ["0x2edc", "0xb832", "0x8dc8"]}]})";
+  "params": ["logs", {"address": ["0x1111", "0x1112"], "fromBlock": "0x2211",
+  "toBlock": "0xab65",  "topics":  ["0x2edc", "0xb832", "0x8dc8"]}]})";
   absl::optional<base::Value> request_payload = base::JSONReader::Read(
       request_payload_json, base::JSON_PARSE_CHROMIUM_EXTENSIONS |
                                 base::JSONParserOptions::JSON_PARSE_RFC);

--- a/browser/brave_wallet/ethereum_provider_impl_unittest.cc
+++ b/browser/brave_wallet/ethereum_provider_impl_unittest.cc
@@ -125,6 +125,15 @@ std::vector<uint8_t> DecodeHexHash(const std::string& hash_hex) {
   return hash;
 }
 
+absl::optional<base::Value> ToValue(const network::ResourceRequest& request) {
+  base::StringPiece request_string(request.request_body->elements()
+                                       ->at(0)
+                                       .As<network::DataElementBytes>()
+                                       .AsStringPiece());
+  return base::JSONReader::Read(request_string,
+                                base::JSONParserOptions::JSON_PARSE_RFC);
+}
+
 }  // namespace
 
 class TestEventsListener : public brave_wallet::mojom::EventsListener {
@@ -2164,6 +2173,70 @@ TEST_F(EthereumProviderImplUnitTest, EthSubscribeLogs) {
                               "method":"eth_unsubscribe",
                               "params": ["%s"]})",
                                             second_subscription.c_str());
+  request_payload = base::JSONReader::Read(
+      request_payload_json, base::JSON_PARSE_CHROMIUM_EXTENSIONS |
+                                base::JSONParserOptions::JSON_PARSE_RFC);
+  response = CommonRequestOrSendAsync(request_payload.value());
+  EXPECT_FALSE(provider_->eth_logs_tracker_.IsRunning());
+}
+
+TEST_F(EthereumProviderImplUnitTest, EthSubscribeLogsFiltered) {
+  CreateWallet();
+  url_loader_factory_.SetInterceptor(
+      base::BindLambdaForTesting([&](const network::ResourceRequest& request) {
+        url_loader_factory_.ClearResponses();
+
+        std::string header_value;
+        EXPECT_TRUE(request.headers.GetHeader("X-Eth-Method", &header_value));
+
+        if (header_value == "eth_getLogs") {
+          const absl::optional<base::Value> req_body_payload =
+              base::JSONReader::Read(
+                  R"({"id":1,"jsonrpc":"2.0","method":"eth_getLogs","params":
+[{"address":["0x1111"],"fromBlock":"0x2211","toBlock":"0xab65",
+"topics":["0x2edc","0xb832","0x8dc8"]}]})",
+                  base::JSON_PARSE_CHROMIUM_EXTENSIONS |
+                      base::JSONParserOptions::JSON_PARSE_RFC);
+
+          const auto payload = ToValue(request);
+          EXPECT_EQ(*payload, req_body_payload.value());
+        }
+        url_loader_factory_.AddResponse(
+            request.url.spec(),
+            R"({"id":1,"jsonrpc":"2.0","result":[{"address":"0x91",
+                      "blockHash":"0xe8","blockNumber":"0x10","data":"0x0067",
+                      "logIndex":"0x0","removed":false,
+                      "topics":["0x4b","0x06e","0x085"],
+                      "transactionHash":"0x22f7","transactionIndex":"0x0"}]})");
+      }));
+
+  // Logs subscription with parameters
+  std::string request_payload_json =
+      R"({"id":1,"jsonrpc:": "2.0","method":"eth_subscribe",
+          "params": ["logs", {"address": "0x1111", "fromBlock": "0x2211",
+          "toBlock": "0xab65",  "topics":  ["0x2edc", "0xb832", "0x8dc8"]}]})";
+  absl::optional<base::Value> request_payload = base::JSONReader::Read(
+      request_payload_json, base::JSON_PARSE_CHROMIUM_EXTENSIONS |
+                                base::JSONParserOptions::JSON_PARSE_RFC);
+  std::string error_message;
+  auto response = CommonRequestOrSendAsync(request_payload.value());
+  EXPECT_EQ(response.first, false);
+  EXPECT_TRUE(response.second.is_string());
+  std::string subscription = *response.second.GetIfString();
+  browser_task_environment_.FastForwardBy(
+      base::Seconds(kLogTrackerDefaultTimeInSeconds));
+  EXPECT_TRUE(observer_->MessageEventFired());
+  base::Value rv = observer_->GetLastMessage();
+  ASSERT_TRUE(rv.is_dict());
+
+  std::string* address = rv.GetDict().FindString("address");
+  EXPECT_EQ(*address, "0x91");
+
+  // The first unsubscribe should not stop the block tracker
+  request_payload_json = base::StringPrintf(R"({"id":1,"jsonrpc:": "2.0",
+                              "method":"eth_unsubscribe",
+                              "params": ["%s"]})",
+                                            subscription.c_str());
   request_payload = base::JSONReader::Read(
       request_payload_json, base::JSON_PARSE_CHROMIUM_EXTENSIONS |
                                 base::JSONParserOptions::JSON_PARSE_RFC);

--- a/components/brave_wallet/browser/asset_discovery_manager.cc
+++ b/components/brave_wallet/browser/asset_discovery_manager.cc
@@ -300,9 +300,13 @@ void AssetDiscoveryManager::OnGetEthTokenRegistry(
                                  weak_ptr_factory_.GetWeakPtr(),
                                  base::OwnedRef(std::move(tokens_to_search)),
                                  triggered_by_accounts_added, chain_id);
-  json_rpc_service_->EthGetLogs(chain_id, from_block, to_block,
-                                std::move(contract_addresses_to_search),
-                                std::move(topics), std::move(callback));
+  base::Value::Dict filtering;
+  filtering.Set("fromBlock", from_block);
+  filtering.Set("toBlock", to_block);
+  filtering.Set("address", std::move(contract_addresses_to_search));
+  filtering.Set("topics", std::move(topics));
+  json_rpc_service_->EthGetLogs(chain_id, base::Value(std::move(filtering)),
+                                std::move(callback));
 }
 
 void AssetDiscoveryManager::OnGetTokenTransferLogs(

--- a/components/brave_wallet/browser/asset_discovery_manager.cc
+++ b/components/brave_wallet/browser/asset_discovery_manager.cc
@@ -305,7 +305,7 @@ void AssetDiscoveryManager::OnGetEthTokenRegistry(
   filtering.Set("toBlock", to_block);
   filtering.Set("address", std::move(contract_addresses_to_search));
   filtering.Set("topics", std::move(topics));
-  json_rpc_service_->EthGetLogs(chain_id, base::Value(std::move(filtering)),
+  json_rpc_service_->EthGetLogs(chain_id, std::move(filtering),
                                 std::move(callback));
 }
 

--- a/components/brave_wallet/browser/eth_logs_tracker.cc
+++ b/components/brave_wallet/browser/eth_logs_tracker.cc
@@ -32,9 +32,9 @@ bool EthLogsTracker::IsRunning() const {
 }
 
 void EthLogsTracker::AddSubscriber(const std::string& subscription_id,
-                                   const base::Value& params) {
-  eth_logs_subscription_info_.insert(
-      std::pair<std::string, base::Value>(subscription_id, params.Clone()));
+                                   base::Value::Dict filter) {
+  eth_logs_subscription_info_.insert(std::pair<std::string, base::Value::Dict>(
+      subscription_id, std::move(filter)));
 }
 
 void EthLogsTracker::RemoveSubscriber(const std::string& subscription_id) {
@@ -54,7 +54,7 @@ void EthLogsTracker::GetLogs() {
 
   for (auto const& esi : std::as_const(eth_logs_subscription_info_)) {
     json_rpc_service_->EthGetLogs(
-        chain_id, esi.second,
+        chain_id, esi.second.Clone(),
         base::BindOnce(&EthLogsTracker::OnGetLogs, weak_factory_.GetWeakPtr(),
                        esi.first));
   }

--- a/components/brave_wallet/browser/eth_logs_tracker.cc
+++ b/components/brave_wallet/browser/eth_logs_tracker.cc
@@ -6,7 +6,7 @@
 #include "brave/components/brave_wallet/browser/eth_logs_tracker.h"
 
 #include <string>
-#include <vector>
+#include <utility>
 
 namespace brave_wallet {
 
@@ -31,6 +31,16 @@ bool EthLogsTracker::IsRunning() const {
   return timer_.IsRunning();
 }
 
+void EthLogsTracker::AddSubscriber(const std::string& subscription_id,
+                                   const base::Value& params) {
+  eth_logs_subscription_info_.insert(
+      std::pair<std::string, base::Value>(subscription_id, params.Clone()));
+}
+
+void EthLogsTracker::RemoveSubscriber(const std::string& subscription_id) {
+  eth_logs_subscription_info_.erase(subscription_id);
+}
+
 void EthLogsTracker::AddObserver(EthLogsTracker::Observer* observer) {
   observers_.AddObserver(observer);
 }
@@ -42,18 +52,22 @@ void EthLogsTracker::RemoveObserver(EthLogsTracker::Observer* observer) {
 void EthLogsTracker::GetLogs() {
   const auto chain_id = json_rpc_service_->GetChainId(mojom::CoinType::ETH);
 
-  json_rpc_service_->EthGetLogs(
-      chain_id, {}, {}, {}, {},
-      base::BindOnce(&EthLogsTracker::OnGetLogs, weak_factory_.GetWeakPtr()));
+  for (auto const& esi : std::as_const(eth_logs_subscription_info_)) {
+    json_rpc_service_->EthGetLogs(
+        chain_id, esi.second,
+        base::BindOnce(&EthLogsTracker::OnGetLogs, weak_factory_.GetWeakPtr(),
+                       esi.first));
+  }
 }
 
-void EthLogsTracker::OnGetLogs([[maybe_unused]] const std::vector<Log>& logs,
+void EthLogsTracker::OnGetLogs(const std::string& subscription,
+                               [[maybe_unused]] const std::vector<Log>& logs,
                                base::Value rawlogs,
                                mojom::ProviderError error,
                                const std::string& error_message) {
   if (error == mojom::ProviderError::kSuccess && rawlogs.is_dict()) {
     for (auto& observer : observers_)
-      observer.OnLogsReceived(rawlogs.Clone());
+      observer.OnLogsReceived(subscription, rawlogs.Clone());
   } else {
     LOG(ERROR) << "OnGetLogs failed";
   }

--- a/components/brave_wallet/browser/eth_logs_tracker.h
+++ b/components/brave_wallet/browser/eth_logs_tracker.h
@@ -6,6 +6,7 @@
 #ifndef BRAVE_COMPONENTS_BRAVE_WALLET_BROWSER_ETH_LOGS_TRACKER_H_
 #define BRAVE_COMPONENTS_BRAVE_WALLET_BROWSER_ETH_LOGS_TRACKER_H_
 
+#include <map>
 #include <string>
 #include <vector>
 
@@ -34,7 +35,8 @@ class EthLogsTracker {
 
   class Observer : public base::CheckedObserver {
    public:
-    virtual void OnLogsReceived(base::Value rawlogs) = 0;
+    virtual void OnLogsReceived(const std::string& subscription,
+                                base::Value rawlogs) = 0;
   };
 
   // If timer is already running, it will be replaced with new interval
@@ -42,18 +44,25 @@ class EthLogsTracker {
   void Stop();
   bool IsRunning() const;
 
+  void AddSubscriber(const std::string& subscription_id,
+                     const base::Value& params);
+  void RemoveSubscriber(const std::string& subscription_id);
+
   void AddObserver(Observer* observer);
   void RemoveObserver(Observer* observer);
 
  private:
   void GetLogs();
-  void OnGetLogs(const std::vector<Log>& logs,
+  void OnGetLogs(const std::string& subscription,
+                 const std::vector<Log>& logs,
                  base::Value rawlogs,
                  mojom::ProviderError error,
                  const std::string& error_message);
 
   base::RepeatingTimer timer_;
   raw_ptr<JsonRpcService> json_rpc_service_ = nullptr;
+
+  std::map<std::string, base::Value> eth_logs_subscription_info_;
 
   base::ObserverList<Observer> observers_;
 

--- a/components/brave_wallet/browser/eth_logs_tracker.h
+++ b/components/brave_wallet/browser/eth_logs_tracker.h
@@ -45,7 +45,7 @@ class EthLogsTracker {
   bool IsRunning() const;
 
   void AddSubscriber(const std::string& subscription_id,
-                     const base::Value& params);
+                     base::Value::Dict filter);
   void RemoveSubscriber(const std::string& subscription_id);
 
   void AddObserver(Observer* observer);
@@ -62,7 +62,7 @@ class EthLogsTracker {
   base::RepeatingTimer timer_;
   raw_ptr<JsonRpcService> json_rpc_service_ = nullptr;
 
-  std::map<std::string, base::Value> eth_logs_subscription_info_;
+  std::map<std::string, base::Value::Dict> eth_logs_subscription_info_;
 
   base::ObserverList<Observer> observers_;
 

--- a/components/brave_wallet/browser/eth_requests.cc
+++ b/components/brave_wallet/browser/eth_requests.cc
@@ -336,27 +336,8 @@ std::string eth_getFilterLogs(const std::string& filter_id) {
   return GetJsonRpcString("eth_getFilterLogs", filter_id);
 }
 
-std::string eth_getLogs(const std::string& from_block_quantity_tag,
-                        const std::string& to_block_quantity_tag,
-                        base::Value::List addresses,
-                        base::Value::List topics,
-                        const std::string& block_hash) {
+std::string eth_getLogs(base::Value::Dict filter_options) {
   base::Value::List params;
-  base::Value::Dict filter_options;
-  // The `address` filter option accepts either a single address, or a list of
-  // addresses (See spec:
-  // https://ethereum.org/en/developers/docs/apis/json-rpc/#eth_getlogs). At
-  // time of writing Infura's documentation suggests they only support a single
-  // address, however we have verified they also support a list.
-  if (!addresses.empty()) {
-    filter_options.Set("address", std::move(addresses));
-  }
-  AddKeyIfNotEmpty(&filter_options, "fromBlock", from_block_quantity_tag);
-  AddKeyIfNotEmpty(&filter_options, "toBlock", to_block_quantity_tag);
-  if (!topics.empty()) {
-    filter_options.Set("topics", std::move(topics));
-  }
-  AddKeyIfNotEmpty(&filter_options, "blockhash", block_hash);
   params.Append(std::move(filter_options));
   base::Value::Dict dictionary =
       GetJsonRpcDictionary("eth_getLogs", std::move(params));

--- a/components/brave_wallet/browser/eth_requests.h
+++ b/components/brave_wallet/browser/eth_requests.h
@@ -190,11 +190,7 @@ std::string eth_getFilterChanges(const std::string& filter_id);
 // Returns an array of all logs matching filter with given id.
 std::string eth_getFilterLogs(const std::string& filter_id);
 // Returns an array of all logs matching a given filter object.
-std::string eth_getLogs(const std::string& from_block_quantity_tag,
-                        const std::string& to_block_quantity_tag,
-                        base::Value::List addresses,
-                        base::Value::List topics,
-                        const std::string& block_hash);
+std::string eth_getLogs(base::Value::Dict filter_options);
 // Returns the hash of the current block, the seedHash, and the boundary
 // condition to be met (“target”).
 std::string eth_getWork();

--- a/components/brave_wallet/browser/eth_requests_unittest.cc
+++ b/components/brave_wallet/browser/eth_requests_unittest.cc
@@ -337,10 +337,17 @@ TEST(EthRequestUnitTest, eth_getLogs) {
 
   base::Value::List addresses;
   addresses.Append(base::Value("0x8888f1f195afa192cfee860698584c030f4c9db1"));
+
+  base::Value::Dict filtering;
+  filtering.Set("fromBlock", "0x1");
+  filtering.Set("toBlock", "0x2");
+  filtering.Set("address", std::move(addresses));
+  filtering.Set("topics", std::move(topics));
+  filtering.Set(
+      "blockhash",
+      "0xb903239f8543d04b5dc1ba6579132b143087c68db1b2168786408fcbce568238");
   ASSERT_EQ(
-      eth_getLogs(
-          "0x1", "0x2", std::move(addresses), std::move(topics),
-          "0xb903239f8543d04b5dc1ba6579132b143087c68db1b2168786408fcbce568238"),
+      eth_getLogs(std::move(filtering)),
       R"({"id":1,"jsonrpc":"2.0","method":"eth_getLogs","params":[{"address":["0x8888f1f195afa192cfee860698584c030f4c9db1"],"blockhash":"0xb903239f8543d04b5dc1ba6579132b143087c68db1b2168786408fcbce568238","fromBlock":"0x1","toBlock":"0x2","topics":["0x000000000000000000000000a94f5374fce5edbc8e2a8697c15331677e6ebf0b",["0x000000000000000000000000a94f5374fce5edbc8e2a8697c15331677e6ebf0b","0x0000000000000000000000000aff3454fce5edbc8cca8697c15331677e6ebccc"]]}]})");  // NOLINT
 }
 

--- a/components/brave_wallet/browser/ethereum_provider_impl.h
+++ b/components/brave_wallet/browser/ethereum_provider_impl.h
@@ -88,7 +88,7 @@ class EthereumProviderImpl final
                       RequestCallback callback,
                       base::Value id);
 
-  void EthSubscribe(const std::string& event_type,
+  void EthSubscribe(const base::Value& params,
                     RequestCallback callback,
                     base::Value id);
   void EthUnsubscribe(const std::string& subscription_id,
@@ -173,6 +173,8 @@ class EthereumProviderImpl final
                            RequestEthereumPermissionsWithAccounts);
   FRIEND_TEST_ALL_PREFIXES(EthereumProviderImplUnitTest, EthSubscribe);
   FRIEND_TEST_ALL_PREFIXES(EthereumProviderImplUnitTest, EthSubscribeLogs);
+  FRIEND_TEST_ALL_PREFIXES(EthereumProviderImplUnitTest,
+                           EthSubscribeLogsFiltered);
   friend class EthereumProviderImplUnitTest;
 
   // mojom::BraveWalletProvider:
@@ -378,7 +380,8 @@ class EthereumProviderImpl final
   bool UnsubscribeBlockObserver(const std::string& subscription_id);
 
   // EthLogsTracker::Observer:
-  void OnLogsReceived(base::Value rawlogs) override;
+  void OnLogsReceived(const std::string& subscription,
+                      base::Value rawlogs) override;
   bool UnsubscribeLogObserver(const std::string& subscription_id);
 
   raw_ptr<HostContentSettingsMap> host_content_settings_map_ = nullptr;

--- a/components/brave_wallet/browser/ethereum_provider_impl.h
+++ b/components/brave_wallet/browser/ethereum_provider_impl.h
@@ -88,7 +88,8 @@ class EthereumProviderImpl final
                       RequestCallback callback,
                       base::Value id);
 
-  void EthSubscribe(const base::Value& params,
+  void EthSubscribe(const std::string& event_type,
+                    absl::optional<base::Value::Dict> filter,
                     RequestCallback callback,
                     base::Value id);
   void EthUnsubscribe(const std::string& subscription_id,

--- a/components/brave_wallet/browser/json_rpc_service.cc
+++ b/components/brave_wallet/browser/json_rpc_service.cc
@@ -2168,7 +2168,7 @@ void JsonRpcService::GetERC1155TokenBalance(
 }
 
 void JsonRpcService::EthGetLogs(const std::string& chain_id,
-                                const base::Value& params,
+                                base::Value::Dict filter_options,
                                 EthGetLogsCallback callback) {
   auto network_url = GetNetworkURL(prefs_, chain_id, mojom::CoinType::ETH);
   if (!network_url.is_valid()) {
@@ -2178,57 +2178,11 @@ void JsonRpcService::EthGetLogs(const std::string& chain_id,
     return;
   }
 
-  const auto load_params = [&](std::string& from_block, std::string& to_block,
-                               std::string& block_hash,
-                               base::Value::List* address,
-                               base::Value::List* topics) {
-    auto* filtering_opts = params.GetIfDict();
-    if (filtering_opts == nullptr) {
-      return;
-    }
-
-    const base::Value* from_block_val = filtering_opts->Find("fromBlock");
-    if (from_block_val != nullptr && from_block_val->is_string()) {
-      from_block = from_block_val->GetString();
-    }
-
-    const base::Value* to_block_val = filtering_opts->Find("toBlock");
-    if (to_block_val != nullptr && to_block_val->is_string()) {
-      to_block = *(to_block_val->GetIfString());
-    }
-
-    const base::Value* block_hash_val = filtering_opts->Find("blockHash");
-    if (block_hash_val != nullptr && block_hash_val->is_string()) {
-      block_hash = *(block_hash_val->GetIfString());
-    }
-
-    const auto* contract_addresses_str = filtering_opts->FindString("address");
-    if (contract_addresses_str != nullptr) {
-      address->Append(*contract_addresses_str);
-    }
-
-    const base::Value::List* contract_addresses =
-        filtering_opts->FindList("address");
-    if (contract_addresses != nullptr) {
-      *address = contract_addresses->Clone();
-    }
-
-    const base::Value::List* topics_list = filtering_opts->FindList("topics");
-    if (topics_list != nullptr) {
-      *topics = topics_list->Clone();
-    }
-  };
-
-  std::string from_block, to_block, block_hash;
-  base::Value::List contract_addresses, topics;
-  load_params(from_block, to_block, block_hash, &contract_addresses, &topics);
   auto internal_callback =
       base::BindOnce(&JsonRpcService::OnEthGetLogs,
                      weak_ptr_factory_.GetWeakPtr(), std::move(callback));
-  RequestInternal(
-      eth::eth_getLogs(from_block, to_block, std::move(contract_addresses),
-                       std::move(topics), block_hash),
-      true, network_url, std::move(internal_callback));
+  RequestInternal(eth::eth_getLogs(std::move(filter_options)), true,
+                  network_url, std::move(internal_callback));
 }
 
 void JsonRpcService::OnEthGetLogs(EthGetLogsCallback callback,

--- a/components/brave_wallet/browser/json_rpc_service.h
+++ b/components/brave_wallet/browser/json_rpc_service.h
@@ -330,10 +330,7 @@ class JsonRpcService : public KeyedService, public mojom::JsonRpcService {
                       GetEthTokenUriCallback callback);
 
   void EthGetLogs(const std::string& chain_id,
-                  const std::string& from_block,
-                  const std::string& to_block,
-                  base::Value::List addresses,
-                  base::Value::List topics,
+                  const base::Value& params,
                   EthGetLogsCallback callback);
 
   void OnEthGetLogs(EthGetLogsCallback callback,

--- a/components/brave_wallet/browser/json_rpc_service.h
+++ b/components/brave_wallet/browser/json_rpc_service.h
@@ -330,7 +330,7 @@ class JsonRpcService : public KeyedService, public mojom::JsonRpcService {
                       GetEthTokenUriCallback callback);
 
   void EthGetLogs(const std::string& chain_id,
-                  const base::Value& params,
+                  base::Value::Dict filter_options,
                   EthGetLogsCallback callback);
 
   void OnEthGetLogs(EthGetLogsCallback callback,

--- a/components/brave_wallet/browser/json_rpc_service_unittest.cc
+++ b/components/brave_wallet/browser/json_rpc_service_unittest.cc
@@ -1166,7 +1166,7 @@ class JsonRpcServiceUnitTest : public testing::Test {
     params.Set("address", std::move(contract_addresses));
     params.Set("topics", std::move(topics));
     json_rpc_service_->EthGetLogs(
-        chain_id, base::Value(std::move(params)),
+        chain_id, std::move(params),
         base::BindLambdaForTesting(
             [&](const std::vector<Log>& logs, base::Value rawlogs,
                 mojom::ProviderError error, const std::string& error_message) {

--- a/components/brave_wallet/browser/json_rpc_service_unittest.cc
+++ b/components/brave_wallet/browser/json_rpc_service_unittest.cc
@@ -1160,9 +1160,13 @@ class JsonRpcServiceUnitTest : public testing::Test {
                       mojom::ProviderError expected_error,
                       const std::string& expected_error_message) {
     base::RunLoop run_loop;
+    base::Value::Dict params;
+    params.Set("fromBlock", from_block);
+    params.Set("toBlock", to_block);
+    params.Set("address", std::move(contract_addresses));
+    params.Set("topics", std::move(topics));
     json_rpc_service_->EthGetLogs(
-        chain_id, from_block, to_block, std::move(contract_addresses),
-        std::move(topics),
+        chain_id, base::Value(std::move(params)),
         base::BindLambdaForTesting(
             [&](const std::vector<Log>& logs, base::Value rawlogs,
                 mojom::ProviderError error, const std::string& error_message) {

--- a/components/brave_wallet/common/eth_request_helper.cc
+++ b/components/brave_wallet/common/eth_request_helper.cc
@@ -677,19 +677,18 @@ bool ParseEthSendRawTransactionParams(const std::string& json,
   return true;
 }
 
-bool ParseEthSubscribeParams(const std::string& json, std::string* event_type) {
-  if (!event_type)
+bool ParseEthSubscribeParams(const std::string& json, base::Value* params) {
+  if (params == nullptr) {
     return false;
+  }
 
-  auto list = GetParamsList(json);
-  if (!list || list->size() != 1)
+  auto params_value = GetParamsList(json);
+  if (!params_value) {
     return false;
+  }
 
-  const std::string* event_type_str = (*list)[0].GetIfString();
-  if (!event_type_str)
-    return false;
+  *params = base::Value(std::move(*params_value));
 
-  *event_type = *event_type_str;
   return true;
 }
 

--- a/components/brave_wallet/common/eth_request_helper.cc
+++ b/components/brave_wallet/common/eth_request_helper.cc
@@ -677,17 +677,31 @@ bool ParseEthSendRawTransactionParams(const std::string& json,
   return true;
 }
 
-bool ParseEthSubscribeParams(const std::string& json, base::Value* params) {
-  if (params == nullptr) {
+bool ParseEthSubscribeParams(const std::string& json,
+                             std::string* event_type,
+                             base::Value::Dict* filter) {
+  if (filter == nullptr) {
     return false;
   }
 
-  auto params_value = GetParamsList(json);
-  if (!params_value) {
+  auto list = GetParamsList(json);
+  if (!list || list->empty() || list->size() > 2) {
     return false;
   }
 
-  *params = base::Value(std::move(*params_value));
+  if (!(*list)[0].is_string()) {
+    return false;
+  }
+
+  *event_type = (*list)[0].GetString();
+
+  if (list->size() == 2) {
+    if (!(*list)[1].is_dict()) {
+      return false;
+    }
+
+    *filter = std::move((*list)[1].GetDict());
+  }
 
   return true;
 }

--- a/components/brave_wallet/common/eth_request_helper.h
+++ b/components/brave_wallet/common/eth_request_helper.h
@@ -74,7 +74,9 @@ bool ParseRequestPermissionsParams(
 
 bool ParseEthSendRawTransactionParams(const std::string& json,
                                       std::string* signed_transaction);
-bool ParseEthSubscribeParams(const std::string& json, base::Value* params);
+bool ParseEthSubscribeParams(const std::string& json,
+                             std::string* event_type,
+                             base::Value::Dict* filter);
 bool ParseEthUnsubscribeParams(const std::string& json,
                                std::string* subscription_id);
 

--- a/components/brave_wallet/common/eth_request_helper.h
+++ b/components/brave_wallet/common/eth_request_helper.h
@@ -74,7 +74,7 @@ bool ParseRequestPermissionsParams(
 
 bool ParseEthSendRawTransactionParams(const std::string& json,
                                       std::string* signed_transaction);
-bool ParseEthSubscribeParams(const std::string& json, std::string* event_type);
+bool ParseEthSubscribeParams(const std::string& json, base::Value* params);
 bool ParseEthUnsubscribeParams(const std::string& json,
                                std::string* subscription_id);
 


### PR DESCRIPTION
PR represents the implementation of advanced functionality for log subscription. It provides filtering options for retrieving logs

For example, the next JS code illustrates new approach:
```
window.ethereum.on('message', (x, y, z) => console.log('message event: ', x, y, z))
window.ethereum.send({ id:1, method: 'eth_subscribe', params:['logs', {"address":  ["0xdac17f958d2ee523a2206206994597c13d831ec7", "0x51fe8e8fa3f9f10288fa8c2aff1400f887d21c42"]}]}, console.log)
```
As you can see, only the logs for the next two addresses will be retrieved each time:
```
"0xdac17f958d2ee523a2206206994597c13d831ec7", 
"0x51fe8e8fa3f9f10288fa8c2aff1400f887d21c42"
```
Full list of supported filtering options described here: [https://www.quicknode.com/docs/ethereum/eth_getLogs](https://www.quicknode.com/docs/ethereum/eth_getLogs)

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves [brave/brave-browser/issues/27842](https://github.com/brave/brave-browser/issues/27842)

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues/27842) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

1. Subscribe for logs with additional filtering options
```
window.ethereum.on('message', (x, y, z) => console.log('message event: ', x, y, z))
window.ethereum.send({ id:1, method: 'eth_subscribe', params:['logs', {"address":  ["0xdac17f958d2ee523a2206206994597c13d831ec7", "0x51fe8e8fa3f9f10288fa8c2aff1400f887d21c42"]}]}, console.log)
```
Response:
```
{
    "id": 1,
    "jsonrpc": "2.0",
    "result": "0xac2fa41a9975eeac8a2ef8f8ae1c97e8"
}
```
2. Receiving logs only for specified address (or another filtering options):  `0xdac17f958d2ee523a2206206994597c13d831ec7`

3.  Unsubscribe with using subscription id:

```
window.ethereum.on('message', (x, y, z) => console.log('message event: ', x, y, z))
window.ethereum.send({ id:5, method: 'eth_unsubscribe', params:['0xac2fa41a9975eeac8a2ef8f8ae1c97e8']}, console.log)
```
4. Logging is stopped
