### PR TITLE
Add NTP SI creative total metric

### DIFF
--- a/browser/ntp_background/ntp_p3a_helper_impl.h
+++ b/browser/ntp_background/ntp_p3a_helper_impl.h
@@ -22,12 +22,17 @@ class BraveP3AService;
 enum class MetricLogType;
 }  // namespace brave
 
+namespace brave_ads {
+class AdsService;
+}  // namespace brave_ads
+
 namespace ntp_background_images {
 
 class NTPP3AHelperImpl : public NTPP3AHelper {
  public:
   NTPP3AHelperImpl(PrefService* local_state,
-                   brave::BraveP3AService* p3a_service);
+                   brave::BraveP3AService* p3a_service,
+                   brave_ads::AdsService* ads_service);
   ~NTPP3AHelperImpl() override;
 
   static void RegisterLocalStatePrefs(PrefRegistrySimple* registry);
@@ -57,6 +62,7 @@ class NTPP3AHelperImpl : public NTPP3AHelper {
 
   raw_ptr<PrefService> local_state_;
   raw_ptr<brave::BraveP3AService> p3a_service_;
+  raw_ptr<const brave_ads::AdsService> ads_service_;
 
   absl::optional<std::string> last_tab_hostname_;
 

--- a/browser/ntp_background/view_counter_service_factory.cc
+++ b/browser/ntp_background/view_counter_service_factory.cc
@@ -85,7 +85,7 @@ KeyedService* ViewCounterServiceFactory::BuildServiceInstanceFor(
         ads_service, profile->GetPrefs(), g_browser_process->local_state(),
         std::make_unique<NTPP3AHelperImpl>(
             g_browser_process->local_state(),
-            g_brave_browser_process->brave_p3a_service()),
+            g_brave_browser_process->brave_p3a_service(), ads_service),
         is_supported_locale);
   }
 


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves brave/brave-browser#28012

## Submitter Checklist:

- [ ] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

0. Start with fresh profile, ensure ads is disabled, ensure no metrics with the prefix creativeInstanceId exist in the local state page.
1. Open new tabs until an ad is shown.
2. Ensure that metric is not sent immediately.
3. Move system time forward by one day, launch browser. Verify that the metric is sent (by using a mitm proxy), with the URL https://p3a-creative.brave.com set. Ensure the metric no longer exists on the local state page. Ensure the metric has a value of 1.
4. Close browser, advance the time by one day, open browser, ensure metric is sent with a value of 0.
5. Enable ads, close browser, advance the time by one day, open browser, ensure that the metric is not sent.