### PR TITLE
[Android] remove grey border from brave news onboarding card in ntp (uplift to 1.48.x)

### DIFF
--- a/android/java/res/drawable/card_bg.xml
+++ b/android/java/res/drawable/card_bg.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <shape xmlns:android="http://schemas.android.com/apk/res/android">
     <solid android:color="@color/card_background"/>
-    <stroke android:width="3dp" android:color="@color/card_background" />
     <corners android:radius="10dp"/>
-    <padding android:left="0dp" android:top="0dp" android:right="0dp" android:bottom="0dp" />
 </shape>


### PR DESCRIPTION
Uplift of #16824
Resolves https://github.com/brave/brave-browser/issues/27992

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.