### PR TITLE
Revert "Add wallet-standard-brave to register Solana wallet-standard (Reland) (uplift to 1.47.x)"

### DIFF
--- a/browser/speedreader/speedreader_browsertest.cc
+++ b/browser/speedreader/speedreader_browsertest.cc
@@ -14,7 +14,6 @@
 #include "brave/browser/speedreader/speedreader_service_factory.h"
 #include "brave/browser/speedreader/speedreader_tab_helper.h"
 #include "brave/browser/ui/webui/speedreader/speedreader_panel_data_handler_impl.h"
-#include "brave/components/brave_wallet/browser/brave_wallet_utils.h"
 #include "brave/components/constants/brave_paths.h"
 #include "brave/components/speedreader/common/constants.h"
 #include "brave/components/speedreader/common/features.h"
@@ -184,10 +183,6 @@ IN_PROC_BROWSER_TEST_F(SpeedReaderBrowserTest, DisableSiteWorks) {
 }
 
 IN_PROC_BROWSER_TEST_F(SpeedReaderBrowserTest, SmokeTest) {
-  // Solana web3.js console warning will interfere with console observer
-  brave_wallet::SetDefaultSolanaWallet(
-      browser()->profile()->GetPrefs(),
-      brave_wallet::mojom::DefaultWallet::None);
   ToggleSpeedreader();
   NavigateToPageSynchronously(kTestPageReadable);
   const std::string kGetStyleLength =

--- a/components/brave_wallet/resources/solana_provider.js
+++ b/components/brave_wallet/resources/solana_provider.js
@@ -31,8 +31,4 @@
       writable: false
     }
   })
-
-  const WalletStandard = require('@brave/wallet-standard-brave')
-
-  WalletStandard.initialize(window.braveSolana);
 })()

--- a/components/webpack/webpack.config.js
+++ b/components/webpack/webpack.config.js
@@ -157,23 +157,6 @@ module.exports = async function (env, argv) {
             },
           ],
         },
-        {
-          test: (input) => {
-            // Handle both Windows and Linux/Mac paths formats
-            return (
-              input.endsWith('/wallet-standard-brave/lib/esm/wallet.js') ||
-              input.endsWith('\\wallet-standard-brave\\lib\\esm\\wallet.js')
-            );
-          },
-          use: [
-            {
-              loader: 'babel-loader', // This should be the last loader of course
-              options: {
-                plugins: ['@babel/plugin-proposal-optional-chaining'],
-              },
-            },
-          ],
-        },
       ]
     },
     node: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,6 @@
       "license": "MPL-2.0",
       "dependencies": {
         "@brave/react-virtualized-auto-sizer": "^1.0.4",
-        "@brave/wallet-standard-brave": "~0.0.5",
         "@dnd-kit/core": "6.0.5",
         "@dnd-kit/sortable": "7.0.1",
         "@glif/filecoin-wallet-provider": "2.0.0-beta.12",
@@ -2076,21 +2075,6 @@
         "react-dom": "^15.3.0 || ^16.0.0-alpha"
       }
     },
-    "node_modules/@brave/wallet-standard-brave": {
-      "version": "0.0.5",
-      "resolved": "https://registry.npmjs.org/@brave/wallet-standard-brave/-/wallet-standard-brave-0.0.5.tgz",
-      "integrity": "sha512-gXiQZgAx0mis9arHzZatCR8D7QXt7IR4oUsSTT3XAp7ua0hqlvAsFJwBxsL+p+hRGD1Ruzmt7l2ai7m7gV41ww==",
-      "dependencies": {
-        "@solana/wallet-standard-features": "^1.0.0",
-        "@solana/web3.js": "1.58.0",
-        "@wallet-standard/base": "^1.0.0",
-        "@wallet-standard/features": "^1.0.0",
-        "bs58": "^4.0.1"
-      },
-      "engines": {
-        "node": ">=16"
-      }
-    },
     "node_modules/@chainsafe/filsnap-types": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/@chainsafe/filsnap-types/-/filsnap-types-2.1.2.tgz",
@@ -3859,18 +3843,6 @@
       },
       "engines": {
         "node": ">=5.10"
-      }
-    },
-    "node_modules/@solana/wallet-standard-features": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@solana/wallet-standard-features/-/wallet-standard-features-1.0.0.tgz",
-      "integrity": "sha512-cZKUm2w67MQOAzbfdZCGAbePWuqSwpvpbWA2K2D0UcHX30I8ry8YEeHlqwqULIOTeY8lRCHu8WMxZwC9iMEqHQ==",
-      "dependencies": {
-        "@wallet-standard/base": "^1.0.0",
-        "@wallet-standard/features": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=16"
       }
     },
     "node_modules/@solana/web3.js": {
@@ -7252,25 +7224,6 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
-      }
-    },
-    "node_modules/@wallet-standard/base": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@wallet-standard/base/-/base-1.0.1.tgz",
-      "integrity": "sha512-1To3ekMfzhYxe0Yhkpri+Fedq0SYcfrOfJi3vbLjMwF2qiKPjTGLwZkf2C9ftdQmxES+hmxhBzTwF4KgcOwf8w==",
-      "engines": {
-        "node": ">=16"
-      }
-    },
-    "node_modules/@wallet-standard/features": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@wallet-standard/features/-/features-1.0.1.tgz",
-      "integrity": "sha512-B/WzRpoEiGQ+kwL/AuzqzNjrGvdL5J2OXiXHkDGONsNbKdtTpExU+ttZKQwSP/EvPl8+ZZ/4OO/Bz4YkigtQDg==",
-      "dependencies": {
-        "@wallet-standard/base": "^1.0.1"
-      },
-      "engines": {
-        "node": ">=16"
       }
     },
     "node_modules/@webassemblyjs/ast": {
@@ -29883,18 +29836,6 @@
       "integrity": "sha512-l2fzRUYGqmkZnJbatw9NIjwauXAbiglQeP2BY/pI1B/Y3+sdElGq0nMBmuLH5/Fbuf7AOxvGVQAonT68x9uRRw==",
       "requires": {}
     },
-    "@brave/wallet-standard-brave": {
-      "version": "0.0.5",
-      "resolved": "https://registry.npmjs.org/@brave/wallet-standard-brave/-/wallet-standard-brave-0.0.5.tgz",
-      "integrity": "sha512-gXiQZgAx0mis9arHzZatCR8D7QXt7IR4oUsSTT3XAp7ua0hqlvAsFJwBxsL+p+hRGD1Ruzmt7l2ai7m7gV41ww==",
-      "requires": {
-        "@solana/wallet-standard-features": "^1.0.0",
-        "@solana/web3.js": "1.58.0",
-        "@wallet-standard/base": "^1.0.0",
-        "@wallet-standard/features": "^1.0.0",
-        "bs58": "^4.0.1"
-      }
-    },
     "@chainsafe/filsnap-types": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/@chainsafe/filsnap-types/-/filsnap-types-2.1.2.tgz",
@@ -30864,7 +30805,7 @@
       "requires": {
         "@mdx-js/mdx": "1.6.22",
         "@mdx-js/react": "1.6.22",
-        "loader-utils": "2.0.0"
+        "loader-utils": "2.0.3"
       }
     },
     "@mdx-js/mdx": {
@@ -30911,7 +30852,7 @@
             "convert-source-map": "^1.7.0",
             "debug": "^4.1.0",
             "gensync": "^1.0.0-beta.1",
-            "json5": "^2.1.2",
+            "json5": "2.2.2",
             "lodash": "^4.17.19",
             "resolve": "^1.3.2",
             "semver": "^5.4.1",
@@ -31063,7 +31004,7 @@
         "error-stack-parser": "^2.0.6",
         "find-up": "^5.0.0",
         "html-entities": "^2.1.0",
-        "loader-utils": "^2.0.0",
+        "loader-utils": "2.0.3",
         "schema-utils": "^3.0.0",
         "source-map": "^0.7.3"
       },
@@ -31231,15 +31172,6 @@
         "buffer": "~6.0.3"
       }
     },
-    "@solana/wallet-standard-features": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@solana/wallet-standard-features/-/wallet-standard-features-1.0.0.tgz",
-      "integrity": "sha512-cZKUm2w67MQOAzbfdZCGAbePWuqSwpvpbWA2K2D0UcHX30I8ry8YEeHlqwqULIOTeY8lRCHu8WMxZwC9iMEqHQ==",
-      "requires": {
-        "@wallet-standard/base": "^1.0.0",
-        "@wallet-standard/features": "^1.0.0"
-      }
-    },
     "@solana/web3.js": {
       "version": "1.58.0",
       "resolved": "https://registry.npmjs.org/@solana/web3.js/-/web3.js-1.58.0.tgz",
@@ -31386,7 +31318,7 @@
         "global": "^4.4.0",
         "html-tags": "^3.1.0",
         "js-string-escape": "^1.0.1",
-        "loader-utils": "^2.0.0",
+        "loader-utils": "2.0.3",
         "lodash": "^4.17.21",
         "nanoid": "^3.1.23",
         "p-limit": "^3.1.0",
@@ -31675,7 +31607,7 @@
           "integrity": "sha512-qo3glqyTa61Ytg4u73GultjHGjdRyig3tG6lPtyX/jOEJvHif9uB0/OCI2Kif6ctF3caQTW2G5gym21oAsI4pw==",
           "dev": true,
           "requires": {
-            "loader-utils": "^2.0.0",
+            "loader-utils": "2.0.3",
             "schema-utils": "^3.0.0"
           },
           "dependencies": {
@@ -31698,7 +31630,7 @@
           "integrity": "sha512-V7TCORko8rs9rIqkSrlMfkqA63DfoGBBJmK1kKGCcSi+BWb4cqz0SRsnp4l6rU5iwOEd0/2ePv68SV22VXon4Q==",
           "dev": true,
           "requires": {
-            "loader-utils": "^2.0.0",
+            "loader-utils": "2.0.3",
             "schema-utils": "^2.7.0"
           }
         },
@@ -31708,7 +31640,7 @@
           "integrity": "sha512-3BTV812+AVHHOJQO8O5MkWgZ5aosP7GnROJwvzLS9hWDj00lZ6Z0wNak423Lp9PBZN05N+Jk/N5Si8jRAlGyWA==",
           "dev": true,
           "requires": {
-            "loader-utils": "^2.0.0",
+            "loader-utils": "2.0.3",
             "mime-types": "^2.1.27",
             "schema-utils": "^3.0.0"
           },
@@ -31919,7 +31851,7 @@
         "glob": "^7.1.6",
         "handlebars": "^4.7.7",
         "interpret": "^2.2.0",
-        "json5": "^2.1.3",
+        "json5": "2.2.2",
         "lazy-universal-dotenv": "^3.0.1",
         "picomatch": "^2.3.0",
         "pkg-dir": "^5.0.0",
@@ -32307,7 +32239,7 @@
           "integrity": "sha512-qo3glqyTa61Ytg4u73GultjHGjdRyig3tG6lPtyX/jOEJvHif9uB0/OCI2Kif6ctF3caQTW2G5gym21oAsI4pw==",
           "dev": true,
           "requires": {
-            "loader-utils": "^2.0.0",
+            "loader-utils": "2.0.3",
             "schema-utils": "^3.0.0"
           },
           "dependencies": {
@@ -32352,7 +32284,7 @@
           "integrity": "sha512-V7TCORko8rs9rIqkSrlMfkqA63DfoGBBJmK1kKGCcSi+BWb4cqz0SRsnp4l6rU5iwOEd0/2ePv68SV22VXon4Q==",
           "dev": true,
           "requires": {
-            "loader-utils": "^2.0.0",
+            "loader-utils": "2.0.3",
             "schema-utils": "^2.7.0"
           }
         },
@@ -32368,7 +32300,7 @@
           "integrity": "sha512-3BTV812+AVHHOJQO8O5MkWgZ5aosP7GnROJwvzLS9hWDj00lZ6Z0wNak423Lp9PBZN05N+Jk/N5Si8jRAlGyWA==",
           "dev": true,
           "requires": {
-            "loader-utils": "^2.0.0",
+            "loader-utils": "2.0.3",
             "mime-types": "^2.1.27",
             "schema-utils": "^3.0.0"
           },
@@ -32681,7 +32613,7 @@
         "core-js": "^3.8.2",
         "estraverse": "^5.2.0",
         "global": "^4.4.0",
-        "loader-utils": "^2.0.0",
+        "loader-utils": "2.0.3",
         "lodash": "^4.17.21",
         "prettier": "<=2.3.0",
         "regenerator-runtime": "^0.13.7"
@@ -33754,19 +33686,6 @@
       "requires": {
         "@typescript-eslint/types": "4.33.0",
         "eslint-visitor-keys": "^2.0.0"
-      }
-    },
-    "@wallet-standard/base": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@wallet-standard/base/-/base-1.0.1.tgz",
-      "integrity": "sha512-1To3ekMfzhYxe0Yhkpri+Fedq0SYcfrOfJi3vbLjMwF2qiKPjTGLwZkf2C9ftdQmxES+hmxhBzTwF4KgcOwf8w=="
-    },
-    "@wallet-standard/features": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@wallet-standard/features/-/features-1.0.1.tgz",
-      "integrity": "sha512-B/WzRpoEiGQ+kwL/AuzqzNjrGvdL5J2OXiXHkDGONsNbKdtTpExU+ttZKQwSP/EvPl8+ZZ/4OO/Bz4YkigtQDg==",
-      "requires": {
-        "@wallet-standard/base": "^1.0.1"
       }
     },
     "@webassemblyjs/ast": {
@@ -39636,7 +39555,7 @@
       "integrity": "sha512-b6OHfQuKasIKM9b6YPkX+KUj/TLBTx3B/1aT1T5F12FEuEqyFMdr59OMS53aoaSw8eVtapdqieX6lbg5opaOhA==",
       "dev": true,
       "requires": {
-        "loader-utils": "^0.2.16"
+        "loader-utils": "2.0.3"
       }
     },
     "gensync": {
@@ -40226,7 +40145,7 @@
         "@types/tapable": "^1.0.5",
         "@types/webpack": "^4.41.8",
         "html-minifier-terser": "^5.0.1",
-        "loader-utils": "^1.2.3",
+        "loader-utils": "2.0.3",
         "lodash": "^4.17.20",
         "pretty-error": "^2.1.1",
         "tapable": "^1.1.3",
@@ -44050,7 +43969,7 @@
       "requires": {
         "cosmiconfig": "^7.0.0",
         "klona": "^2.0.4",
-        "loader-utils": "^2.0.0",
+        "loader-utils": "2.0.3",
         "schema-utils": "^3.0.0",
         "semver": "^7.3.4"
       },
@@ -44564,7 +44483,7 @@
       "integrity": "sha512-ZnScIV3ag9A4wPX/ZayxL/jZH+euYb6FcUinPcgiQW0+UBtEv0O6Q3lGd3cqJ+GHH+rksEv3Pj99oxJ3u3VIKA==",
       "dev": true,
       "requires": {
-        "loader-utils": "^2.0.0",
+        "loader-utils": "2.0.3",
         "schema-utils": "^3.0.0"
       },
       "dependencies": {
@@ -45341,7 +45260,7 @@
             "convert-source-map": "^1.7.0",
             "debug": "^4.1.0",
             "gensync": "^1.0.0-beta.1",
-            "json5": "^2.1.2",
+            "json5": "2.2.2",
             "lodash": "^4.17.19",
             "resolve": "^1.3.2",
             "semver": "^5.4.1",

--- a/package.json
+++ b/package.json
@@ -345,7 +345,6 @@
   },
   "dependencies": {
     "@brave/react-virtualized-auto-sizer": "^1.0.4",
-    "@brave/wallet-standard-brave": "~0.0.5",
     "@dnd-kit/core": "6.0.5",
     "@dnd-kit/sortable": "7.0.1",
     "@glif/filecoin-wallet-provider": "2.0.0-beta.12",

--- a/third_party/npm_@brave_wallet-standard-brave/README.chromium
+++ b/third_party/npm_@brave_wallet-standard-brave/README.chromium
@@ -1,4 +1,0 @@
-Name: wallet-standard-brave
-URL: https://github.com/brave/wallet-standard-brave
-License: Apache-2.0
-License File: /brave/node_modules/@brave/wallet-standard-brave/LICENSE


### PR DESCRIPTION
Reverts brave/brave-core#16749 as per the discussion via https://bravesoftware.slack.com/archives/C3T9S9WKD/p1674560540571669. Revert was due to https://github.com/brave/brave-browser/issues/27997.