### PR TITLE
Added fallback to the chrome's page distilled feature.

### DIFF
--- a/browser/speedreader/speedreader_browsertest.cc
+++ b/browser/speedreader/speedreader_browsertest.cc
@@ -24,6 +24,7 @@
 #include "brave/components/speedreader/common/speedreader_panel.mojom.h"
 #include "brave/components/speedreader/speedreader_service.h"
 #include "brave/components/speedreader/speedreader_util.h"
+#include "chrome/app/chrome_command_ids.h"
 #include "chrome/browser/profiles/keep_alive/profile_keep_alive_types.h"
 #include "chrome/browser/profiles/keep_alive/scoped_profile_keep_alive.h"
 #include "chrome/browser/ui/browser.h"
@@ -125,8 +126,7 @@ class SpeedReaderBrowserTest : public InProcessBrowserTest {
   }
 
   void ClickReaderButton() {
-    browser()->command_controller()->ExecuteCommand(
-        IDC_SPEEDREADER_ICON_ONCLICK);
+    browser()->command_controller()->ExecuteCommand(IDC_DISTILL_PAGE);
     content::WaitForLoadStop(ActiveWebContents());
   }
 

--- a/browser/speedreader/speedreader_tab_helper.h
+++ b/browser/speedreader/speedreader_tab_helper.h
@@ -67,7 +67,7 @@ class SpeedreaderTabHelper
   bool IsEnabledForSite();
 
   // In Speedreader mode shows bubble. In Reader mode toggles state.
-  void ProcessIconClick();
+  bool ProcessIconClick();
 
   DistillState PageDistillState() const { return distill_state_; }
 
@@ -160,7 +160,7 @@ class SpeedreaderTabHelper
 
   // SpeedreaderThrottleDelegate:
   bool IsPageDistillationAllowed() override;
-  void OnDistillComplete() override;
+  void OnDistillComplete(speedreader::DistillationStatus status) override;
 
   void SetDocumentAttribute(const std::string& attribute,
                             const std::string& value);

--- a/browser/ui/brave_browser_command_controller.cc
+++ b/browser/ui/brave_browser_command_controller.cc
@@ -49,10 +49,11 @@ bool IsBraveCommands(int id) {
 }
 
 bool IsBraveOverrideCommands(int id) {
-  static std::vector<int> override_commands({
+  constexpr const int override_commands[] = {
       IDC_NEW_WINDOW,
       IDC_NEW_INCOGNITO_WINDOW,
-  });
+      IDC_DISTILL_PAGE,
+  };
   return base::Contains(override_commands, id);
 }
 
@@ -161,12 +162,6 @@ void BraveBrowserCommandController::InitBraveCommandState() {
   UpdateCommandEnabled(IDC_COPY_CLEAN_LINK, true);
   UpdateCommandEnabled(IDC_TOGGLE_TAB_MUTE, true);
 
-#if BUILDFLAG(ENABLE_SPEEDREADER)
-  if (base::FeatureList::IsEnabled(speedreader::kSpeedreaderFeature)) {
-    UpdateCommandEnabled(IDC_SPEEDREADER_ICON_ONCLICK, true);
-    UpdateCommandEnabled(IDC_DISTILL_PAGE, false);
-  }
-#endif
 #if BUILDFLAG(ENABLE_IPFS_LOCAL_NODE)
   UpdateCommandEnabled(IDC_APP_MENU_IPFS_OPEN_FILES, true);
 #endif
@@ -288,8 +283,11 @@ bool BraveBrowserCommandController::ExecuteBraveCommandWithDisposition(
     case IDC_OPEN_GUEST_PROFILE:
       brave::OpenGuestProfile();
       break;
-    case IDC_SPEEDREADER_ICON_ONCLICK:
-      brave::MaybeDistillAndShowSpeedreaderBubble(browser_);
+    case IDC_DISTILL_PAGE:
+      if (!brave::MaybeDistillAndShowSpeedreaderBubble(browser_)) {
+        BrowserCommandController::ExecuteCommandWithDisposition(id, disposition,
+                                                                time_stamp);
+      }
       break;
     case IDC_SHOW_BRAVE_WALLET_PANEL:
       brave::ShowWalletBubble(browser_);

--- a/browser/ui/browser_commands.cc
+++ b/browser/ui/browser_commands.cc
@@ -112,16 +112,17 @@ void OpenGuestProfile() {
   profiles::SwitchToGuestProfile(base::DoNothing());
 }
 
-void MaybeDistillAndShowSpeedreaderBubble(Browser* browser) {
+bool MaybeDistillAndShowSpeedreaderBubble(Browser* browser) {
 #if BUILDFLAG(ENABLE_SPEEDREADER)
   WebContents* contents = browser->tab_strip_model()->GetActiveWebContents();
   if (!contents)
-    return;
+    return false;
   if (auto* tab_helper =
           speedreader::SpeedreaderTabHelper::FromWebContents(contents)) {
-    tab_helper->ProcessIconClick();
+    return tab_helper->ProcessIconClick();
   }
 #endif  // BUILDFLAG(ENABLE_SPEEDREADER)
+  return false;
 }
 
 void ShowBraveVPNBubble(Browser* browser) {

--- a/browser/ui/browser_commands.h
+++ b/browser/ui/browser_commands.h
@@ -18,7 +18,7 @@ void OpenGuestProfile();
 void ShowWalletBubble(Browser* browser);
 void ShowApproveWalletBubble(Browser* browser);
 void CloseWalletBubble(Browser* browser);
-void MaybeDistillAndShowSpeedreaderBubble(Browser* browser);
+bool MaybeDistillAndShowSpeedreaderBubble(Browser* browser);
 void ShowBraveVPNBubble(Browser* browser);
 void ToggleBraveVPNButton(Browser* browser);
 void OpenBraveVPNUrls(Browser* browser, int command_id);

--- a/browser/ui/views/speedreader/speedreader_icon_view.cc
+++ b/browser/ui/views/speedreader/speedreader_icon_view.cc
@@ -48,8 +48,9 @@ void SpeedreaderIconView::UpdateImpl() {
       !speedreader::PageSupportsDistillation(state)) {
     if (base::FeatureList::IsEnabled(speedreader::kSpeedreaderFallback)) {
       ReaderModeIconView::UpdateImpl();
-      if (!GetVisible())
+      if (!GetVisible()) {
         return;
+      }
     } else {
       return;
     }

--- a/browser/ui/views/speedreader/speedreader_icon_view.h
+++ b/browser/ui/views/speedreader/speedreader_icon_view.h
@@ -8,13 +8,13 @@
 
 #include "brave/browser/speedreader/speedreader_tab_helper.h"
 #include "chrome/browser/ui/views/page_action/page_action_icon_view.h"
+#include "chrome/browser/ui/views/reader_mode/reader_mode_icon_view.h"
 #include "ui/base/metadata/metadata_header_macros.h"
 
 class PrefService;
 
-class SpeedreaderIconView : public PageActionIconView {
+class SpeedreaderIconView : public ReaderModeIconView {
  public:
-  METADATA_HEADER(SpeedreaderIconView);
   SpeedreaderIconView(CommandUpdater* command_updater,
                       IconLabelBubbleView::Delegate* icon_label_bubble_delegate,
                       PageActionIconView::Delegate* page_action_icon_delegate,
@@ -24,7 +24,7 @@ class SpeedreaderIconView : public PageActionIconView {
   ~SpeedreaderIconView() override;
 
  protected:
-  // PageActionIconView:
+  // ReaderModeIconView:
   const gfx::VectorIcon& GetVectorIcon() const override;
   void OnExecuting(PageActionIconView::ExecuteSource execute_source) override;
   views::BubbleDialogDelegate* GetBubble() const override;

--- a/components/speedreader/common/features.cc
+++ b/components/speedreader/common/features.cc
@@ -18,4 +18,8 @@ BASE_FEATURE(kSpeedreaderPanelV2,
 const base::FeatureParam<int> kSpeedreaderMinOutLengthParam{
     &kSpeedreaderFeature, "min_out_length", 1000};
 
+BASE_FEATURE(kSpeedreaderFallback,
+             "SpeedreaderFallback",
+             base::FEATURE_DISABLED_BY_DEFAULT);
+
 }  // namespace speedreader

--- a/components/speedreader/common/features.h
+++ b/components/speedreader/common/features.h
@@ -13,6 +13,7 @@ namespace speedreader {
 BASE_DECLARE_FEATURE(kSpeedreaderFeature);
 extern const base::FeatureParam<int> kSpeedreaderMinOutLengthParam;
 BASE_DECLARE_FEATURE(kSpeedreaderPanelV2);
+BASE_DECLARE_FEATURE(kSpeedreaderFallback);
 }  // namespace speedreader
 
 #endif  // BRAVE_COMPONENTS_SPEEDREADER_COMMON_FEATURES_H_

--- a/components/speedreader/speedreader_throttle_delegate.h
+++ b/components/speedreader/speedreader_throttle_delegate.h
@@ -8,12 +8,18 @@
 
 namespace speedreader {
 
+enum class DistillationStatus : int {
+  kNone,
+  kSucceess,
+  kFail,
+};
+
 // SpeedreaderThrottleDelegate is an interface for the speedreader component to
 // notify a tab_helper.
 class SpeedreaderThrottleDelegate {
  public:
   virtual bool IsPageDistillationAllowed() = 0;
-  virtual void OnDistillComplete() = 0;
+  virtual void OnDistillComplete(DistillationStatus status) = 0;
 
  protected:
   virtual ~SpeedreaderThrottleDelegate() = default;

--- a/components/speedreader/speedreader_throttle_unittest.cc
+++ b/components/speedreader/speedreader_throttle_unittest.cc
@@ -36,7 +36,7 @@ class TestSpeedreaderThrottleDelegate
  public:
   ~TestSpeedreaderThrottleDelegate() override = default;
   bool IsPageDistillationAllowed() override { return true; }
-  void OnDistillComplete() override {}
+  void OnDistillComplete(DistillationStatus status) override {}
 };
 
 }  // anonymous namespace

--- a/components/speedreader/speedreader_url_loader.cc
+++ b/components/speedreader/speedreader_url_loader.cc
@@ -143,7 +143,7 @@ void SpeedReaderURLLoader::CompleteLoading(std::string body) {
         base::BindOnce(
             [](const GURL& response_url, std::string data,
                std::unique_ptr<Rewriter> rewriter,
-               const std::string& stylesheet) -> auto{
+               const std::string& stylesheet) -> auto {
               SCOPED_UMA_HISTOGRAM_TIMER("Brave.Speedreader.Distill");
               int written = rewriter->Write(data.c_str(), data.length());
               // Error occurred

--- a/components/speedreader/speedreader_url_loader.h
+++ b/components/speedreader/speedreader_url_loader.h
@@ -1,7 +1,7 @@
-/* Copyright 2020 The Brave Authors. All rights reserved.
+/* Copyright (c) 2020 The Brave Authors. All rights reserved.
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
- * You can obtain one at http://mozilla.org/MPL/2.0/. */
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 #ifndef BRAVE_COMPONENTS_SPEEDREADER_SPEEDREADER_URL_LOADER_H_
 #define BRAVE_COMPONENTS_SPEEDREADER_SPEEDREADER_URL_LOADER_H_
@@ -29,6 +29,7 @@ class SpeedreaderRewriterService;
 class SpeedreaderService;
 class SpeedReaderThrottle;
 class SpeedreaderThrottleDelegate;
+enum class DistillationStatus : int;
 
 // Loads the whole response body and tries to Speedreader-distill it.
 // Cargoculted from |`SniffingURLLoader|.
@@ -88,6 +89,7 @@ class SpeedReaderURLLoader : public body_sniffer::BodySnifferURLLoader {
   base::WeakPtr<SpeedreaderThrottleDelegate> delegate_;
 
   GURL response_url_;
+  DistillationStatus distillation_status_;
 
   // Not Owned
   raw_ptr<SpeedreaderRewriterService> rewriter_service_ = nullptr;

--- a/test/BUILD.gn
+++ b/test/BUILD.gn
@@ -1019,6 +1019,7 @@ test("brave_browser_tests") {
     deps += [
       "//brave/components/speedreader",
       "//brave/components/speedreader/common:mojom",
+      "//components/dom_distiller/content/browser",
     ]
   }
 


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves 

https://user-images.githubusercontent.com/73575789/214614182-f0927774-c0d8-4cb8-a563-6698665aafb9.mp4

When the ```SpeedreaderFallback``` feature and chrome://flags/#enable-reader-mode are enabled the fallback to chrome's reader mode is enabled. There is no changes for css/html of reader mode in this PR. We can override the distiller's resources to make the reader mode looks like speedreader and be controllable by our controls as well.

## Submitter Checklist:

- [ ] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

