### PR TITLE
Mitigate perf degradation cause by loading wallet-standard

### DIFF
--- a/browser/brave_wallet/solana_provider_renderer_browsertest.cc
+++ b/browser/brave_wallet/solana_provider_renderer_browsertest.cc
@@ -116,8 +116,9 @@ std::string VectorToArrayString(const std::vector<uint8_t>& vec) {
   std::string result;
   for (size_t i = 0; i < vec.size(); ++i) {
     base::StrAppend(&result, {base::NumberToString(vec[i])});
-    if (i != vec.size() - 1)
+    if (i != vec.size() - 1) {
       base::StrAppend(&result, {", "});
+    }
   }
   return result;
 }
@@ -305,10 +306,11 @@ class TestSolanaProvider final : public brave_wallet::mojom::SolanaProvider {
   }
   void Disconnect() override {
     // Used to test onAccountChanged
-    if (emit_empty_account_changed_)
+    if (emit_empty_account_changed_) {
       events_listener_->AccountChangedEvent(absl::nullopt);
-    else
+    } else {
       events_listener_->AccountChangedEvent(kTestPublicKey);
+    }
   }
   void IsConnected(IsConnectedCallback callback) override {
     if (error_ == SolanaProviderError::kSuccess) {
@@ -335,9 +337,10 @@ class TestSolanaProvider final : public brave_wallet::mojom::SolanaProvider {
   void SignAllTransactions(
       std::vector<brave_wallet::mojom::SolanaSignTransactionParamPtr> params,
       SignAllTransactionsCallback callback) override {
-    for (const auto& param : params)
+    for (const auto& param : params) {
       EXPECT_EQ(param->encoded_serialized_msg,
                 brave_wallet::Base58Encode(kSerializedMessage));
+    }
     if (error_ == SolanaProviderError::kSuccess) {
       std::move(callback).Run(SolanaProviderError::kSuccess, "",
                               {kSignedTx, kSignedTx});
@@ -400,6 +403,11 @@ class TestSolanaProvider final : public brave_wallet::mojom::SolanaProvider {
     }
   }
 
+  void IsSolanaKeyringCreated(
+      IsSolanaKeyringCreatedCallback callback) override {
+    std::move(callback).Run(true);
+  }
+
   void SetError(SolanaProviderError error, const std::string& error_message) {
     error_ = error;
     error_message_ = error_message;
@@ -445,15 +453,17 @@ class TestBraveContentBrowserClient : public BraveContentBrowserClient {
   }
 
   TestSolanaProvider* GetProvider(content::RenderFrameHost* frame_host) {
-    if (!provider_map_.contains(frame_host))
+    if (!provider_map_.contains(frame_host)) {
       return nullptr;
+    }
     return static_cast<TestSolanaProvider*>(
         provider_map_.at(frame_host)->impl());
   }
   bool WaitForBinding(content::RenderFrameHost* render_frame_host,
                       base::OnceClosure callback) {
-    if (IsBound(render_frame_host))
+    if (IsBound(render_frame_host)) {
       return false;
+    }
     quit_on_binding_ = std::move(callback);
     return true;
   }
@@ -471,8 +481,9 @@ class TestBraveContentBrowserClient : public BraveContentBrowserClient {
         base::BindOnce(&TestBraveContentBrowserClient::OnDisconnect,
                        weak_ptr_factory_.GetWeakPtr(), frame_host));
     provider_map_[frame_host] = provider;
-    if (quit_on_binding_)
+    if (quit_on_binding_) {
       std::move(quit_on_binding_).Run();
+    }
   }
   void OnDisconnect(content::RenderFrameHost* frame_host) {
     provider_map_.erase(frame_host);

--- a/components/brave_wallet/browser/solana_provider_impl.cc
+++ b/components/brave_wallet/browser/solana_provider_impl.cc
@@ -600,6 +600,13 @@ void SolanaProviderImpl::Request(base::Value::Dict arg,
   }
 }
 
+void SolanaProviderImpl::IsSolanaKeyringCreated(
+    IsSolanaKeyringCreatedCallback callback) {
+  DCHECK(keyring_service_);
+  std::move(callback).Run(
+      !!keyring_service_->GetSelectedAccount(mojom::CoinType::SOL));
+}
+
 bool SolanaProviderImpl::IsAccountConnected(const std::string& account) {
   return delegate_->IsSolanaAccountConnected(account);
 }

--- a/components/brave_wallet/browser/solana_provider_impl.h
+++ b/components/brave_wallet/browser/solana_provider_impl.h
@@ -62,6 +62,8 @@ class SolanaProviderImpl final : public mojom::SolanaProvider,
                    SignMessageCallback callback) override;
   void Request(base::Value::Dict arg, RequestCallback callback) override;
 
+  void IsSolanaKeyringCreated(IsSolanaKeyringCreatedCallback callback) override;
+
  private:
   FRIEND_TEST_ALL_PREFIXES(SolanaProviderImplUnitTest, GetDeserializedMessage);
 

--- a/components/brave_wallet/common/brave_wallet.mojom
+++ b/components/brave_wallet/common/brave_wallet.mojom
@@ -211,6 +211,9 @@ interface SolanaProvider {
     => (SolanaProviderError error, string error_message,
         mojo_base.mojom.DictionaryValue result);
 
+  // DO NOT USE: This is supposed to be a temporary solution for us to decide
+  // whether to load wallet-standard js module
+  IsSolanaKeyringCreated() => (bool created);
 };
 
 enum WalletPinServiceErrorCode {

--- a/components/brave_wallet/renderer/js_ethereum_provider.cc
+++ b/components/brave_wallet/renderer/js_ethereum_provider.cc
@@ -35,8 +35,6 @@
 
 namespace {
 
-static base::NoDestructor<std::string> g_provider_script("");
-
 constexpr char kEthereum[] = "ethereum";
 constexpr char kEmit[] = "emit";
 constexpr char kIsBraveWallet[] = "isBraveWallet";
@@ -74,8 +72,9 @@ void JSEthereumProvider::SendResponse(
     bool force_json_response,
     base::Value formed_response,
     bool success) {
-  if (!render_frame())
+  if (!render_frame()) {
     return;
+  }
   v8::HandleScope handle_scope(isolate);
   v8::Local<v8::Context> context = global_context.Get(isolate);
   v8::Context::Scope context_scope(context);
@@ -112,10 +111,6 @@ void JSEthereumProvider::SendResponse(
 
 JSEthereumProvider::JSEthereumProvider(content::RenderFrame* render_frame)
     : RenderFrameObserver(render_frame) {
-  if (g_provider_script->empty()) {
-    *g_provider_script = LoadDataResource(
-        IDR_BRAVE_WALLET_SCRIPT_ETHEREUM_PROVIDER_SCRIPT_BUNDLE_JS);
-  }
   EnsureConnected();
 }
 
@@ -125,22 +120,25 @@ gin::WrapperInfo JSEthereumProvider::kWrapperInfo = {gin::kEmbedderNativeGin};
 
 void JSEthereumProvider::WillReleaseScriptContext(v8::Local<v8::Context>,
                                                   int32_t world_id) {
-  if (world_id != content::ISOLATED_WORLD_ID_GLOBAL)
+  if (world_id != content::ISOLATED_WORLD_ID_GLOBAL) {
     return;
+  }
   // Close mojo connection from browser to renderer.
   receiver_.reset();
   script_context_released_ = true;
 }
 
 void JSEthereumProvider::DidDispatchDOMContentLoadedEvent() {
-  if (script_context_released_)
+  if (script_context_released_) {
     return;
+  }
   ConnectEvent();
 }
 
 bool JSEthereumProvider::EnsureConnected() {
-  if (!render_frame())
+  if (!render_frame()) {
     return false;
+  }
 
   if (!ethereum_provider_.is_bound()) {
     render_frame()->GetBrowserInterfaceBroker()->GetInterface(
@@ -160,8 +158,9 @@ void JSEthereumProvider::Install(bool allow_overwrite_window_ethereum_provider,
   v8::HandleScope handle_scope(isolate);
   v8::Local<v8::Context> context =
       render_frame->GetWebFrame()->MainWorldScriptContext();
-  if (context.IsEmpty())
+  if (context.IsEmpty()) {
     return;
+  }
   v8::Context::Scope context_scope(context);
 
   // Check window.ethereum existence.
@@ -169,13 +168,15 @@ void JSEthereumProvider::Install(bool allow_overwrite_window_ethereum_provider,
   v8::Local<v8::Value> ethereum_value =
       global->Get(context, gin::StringToV8(isolate, kEthereum))
           .ToLocalChecked();
-  if (!ethereum_value->IsUndefined())
+  if (!ethereum_value->IsUndefined()) {
     return;
+  }
 
   gin::Handle<JSEthereumProvider> provider =
       gin::CreateHandle(isolate, new JSEthereumProvider(render_frame));
-  if (provider.IsEmpty())
+  if (provider.IsEmpty()) {
     return;
+  }
   v8::Local<v8::Value> provider_value = provider.ToV8();
 
   if (!allow_overwrite_window_ethereum_provider) {
@@ -226,7 +227,10 @@ void JSEthereumProvider::Install(bool allow_overwrite_window_ethereum_provider,
                          gin::StringToV8(isolate, kIsUnlocked), false);
 
   blink::WebLocalFrame* web_frame = render_frame->GetWebFrame();
-  ExecuteScript(web_frame, *g_provider_script, kEthereumProviderScript);
+  ExecuteScript(web_frame,
+                LoadDataResource(
+                    IDR_BRAVE_WALLET_SCRIPT_ETHEREUM_PROVIDER_SCRIPT_BUNDLE_JS),
+                kEthereumProviderScript);
 }
 
 bool JSEthereumProvider::GetIsBraveWallet() {
@@ -260,8 +264,9 @@ v8::Local<v8::Value> JSEthereumProvider::GetSelectedAddress(
     v8::Isolate* isolate) {
   // Note this does not return the selected account, but it returns the first
   // connected account that was given permissions.
-  if (first_allowed_account_.empty())
+  if (first_allowed_account_.empty()) {
     return v8::Undefined(isolate);
+  }
   return gin::StringToV8(isolate, first_allowed_account_);
 }
 
@@ -296,8 +301,9 @@ const char* JSEthereumProvider::GetTypeName() {
 // 3) ethereum.send(payload: JsonRpcRequest): unknown;
 // Only valid for: eth_accounts, eth_coinbase, eth_uninstallFilter, etc.
 v8::Local<v8::Promise> JSEthereumProvider::SendMethod(gin::Arguments* args) {
-  if (!EnsureConnected())
+  if (!EnsureConnected()) {
     return v8::Local<v8::Promise>();
+  }
   v8::Isolate* isolate = args->isolate();
   if (args->Length() == 0) {
     args->ThrowError();
@@ -363,8 +369,9 @@ v8::Local<v8::Promise> JSEthereumProvider::SendMethod(gin::Arguments* args) {
     params = std::make_unique<base::Value>(base::Value::Type::LIST);
   }
 
-  if (!EnsureConnected())
+  if (!EnsureConnected()) {
     return v8::Local<v8::Promise>();
+  }
 
   v8::MaybeLocal<v8::Promise::Resolver> resolver =
       v8::Promise::Resolver::New(isolate->GetCurrentContext());
@@ -387,8 +394,9 @@ v8::Local<v8::Promise> JSEthereumProvider::SendMethod(gin::Arguments* args) {
 }
 
 void JSEthereumProvider::SendAsync(gin::Arguments* args) {
-  if (!EnsureConnected())
+  if (!EnsureConnected()) {
     return;
+  }
   v8::Isolate* isolate = args->isolate();
   v8::Local<v8::Value> input;
   v8::Local<v8::Function> callback;
@@ -420,14 +428,16 @@ bool JSEthereumProvider::IsConnected() {
 
 v8::Local<v8::Promise> JSEthereumProvider::Request(v8::Isolate* isolate,
                                                    v8::Local<v8::Value> input) {
-  if (!input->IsObject())
+  if (!input->IsObject()) {
     return v8::Local<v8::Promise>();
+  }
   std::unique_ptr<base::Value> input_value =
       content::V8ValueConverter::Create()->FromV8Value(
           input, isolate->GetCurrentContext());
 
-  if (!EnsureConnected())
+  if (!EnsureConnected()) {
     return v8::Local<v8::Promise>();
+  }
 
   v8::MaybeLocal<v8::Promise::Resolver> resolver =
       v8::Promise::Resolver::New(isolate->GetCurrentContext());
@@ -469,8 +479,9 @@ void JSEthereumProvider::OnRequestOrSendAsync(
 }
 
 v8::Local<v8::Promise> JSEthereumProvider::Enable(v8::Isolate* isolate) {
-  if (!EnsureConnected())
+  if (!EnsureConnected()) {
     return v8::Local<v8::Promise>();
+  }
 
   v8::MaybeLocal<v8::Promise::Resolver> resolver =
       v8::Promise::Resolver::New(isolate->GetCurrentContext());
@@ -493,8 +504,9 @@ v8::Local<v8::Promise> JSEthereumProvider::Enable(v8::Isolate* isolate) {
 }
 
 v8::Local<v8::Promise> JSEthereumProvider::IsUnlocked(v8::Isolate* isolate) {
-  if (!EnsureConnected())
+  if (!EnsureConnected()) {
     return v8::Local<v8::Promise>();
+  }
 
   v8::MaybeLocal<v8::Promise::Resolver> resolver =
       v8::Promise::Resolver::New(isolate->GetCurrentContext());
@@ -516,8 +528,9 @@ v8::Local<v8::Promise> JSEthereumProvider::IsUnlocked(v8::Isolate* isolate) {
 
 void JSEthereumProvider::FireEvent(const std::string& event,
                                    base::ValueView event_args) {
-  if (!render_frame())
+  if (!render_frame()) {
     return;
+  }
   base::Value event_name(event);
   base::ValueView args_list[] = {event_name, event_args};
 
@@ -536,8 +549,9 @@ void JSEthereumProvider::FireEvent(const std::string& event,
 }
 
 void JSEthereumProvider::ConnectEvent() {
-  if (!EnsureConnected())
+  if (!EnsureConnected()) {
     return;
+  }
 
   ethereum_provider_->GetChainId(base::BindOnce(
       &JSEthereumProvider::OnGetChainId, weak_ptr_factory_.GetWeakPtr()));
@@ -556,8 +570,9 @@ void JSEthereumProvider::DisconnectEvent(const std::string& message) {
 }
 
 void JSEthereumProvider::ChainChangedEvent(const std::string& chain_id) {
-  if (chain_id_ == chain_id)
+  if (chain_id_ == chain_id) {
     return;
+  }
 
   FireEvent(ethereum::kChainChangedEvent, base::Value(chain_id));
   chain_id_ = chain_id;

--- a/components/brave_wallet/renderer/js_solana_provider.cc
+++ b/components/brave_wallet/renderer/js_solana_provider.cc
@@ -39,10 +39,6 @@ namespace brave_wallet {
 
 namespace {
 
-static base::NoDestructor<std::string> g_provider_script("");
-static base::NoDestructor<std::string> g_provider_solana_web3_script("");
-static base::NoDestructor<std::string> g_wallet_standard_script("");
-
 constexpr char kBraveSolana[] = "braveSolana";
 constexpr char kPublicKeyModule[] = "PublicKey";
 constexpr char kTransactionModule[] = "Transaction";
@@ -62,18 +58,6 @@ constexpr char kWalletStandardScript[] = "wallet_standard.js";
 JSSolanaProvider::JSSolanaProvider(content::RenderFrame* render_frame)
     : RenderFrameObserver(render_frame),
       v8_value_converter_(content::V8ValueConverter::Create()) {
-  if (g_provider_script->empty()) {
-    *g_provider_script = LoadDataResource(
-        IDR_BRAVE_WALLET_SCRIPT_SOLANA_PROVIDER_SCRIPT_BUNDLE_JS);
-  }
-  if (g_provider_solana_web3_script->empty()) {
-    *g_provider_solana_web3_script =
-        LoadDataResource(IDR_BRAVE_WALLET_SOLANA_WEB3_JS);
-  }
-  if (g_wallet_standard_script->empty()) {
-    *g_wallet_standard_script = LoadDataResource(
-        IDR_BRAVE_WALLET_SCRIPT_WALLET_STANDARD_SCRIPT_BUNDLE_JS);
-  }
   EnsureConnected();
   v8_value_converter_->SetStrategy(&strategy_);
 }
@@ -99,8 +83,9 @@ bool JSSolanaProvider::V8ConverterStrategy::FromV8ArrayBuffer(
     data_length = view.num_bytes();
     bytes.assign(data, data + data_length);
   }
-  if (!bytes.size())
+  if (!bytes.size()) {
     return false;
+  }
   std::unique_ptr<base::Value> new_value = std::make_unique<base::Value>(bytes);
   *out = std::move(new_value);
 
@@ -116,8 +101,9 @@ void JSSolanaProvider::Install(bool allow_overwrite_window_solana,
   v8::HandleScope handle_scope(isolate);
   v8::Local<v8::Context> context =
       render_frame->GetWebFrame()->MainWorldScriptContext();
-  if (context.IsEmpty())
+  if (context.IsEmpty()) {
     return;
+  }
   v8::Context::Scope context_scope(context);
 
   // check window.braveSolana existence
@@ -125,14 +111,16 @@ void JSSolanaProvider::Install(bool allow_overwrite_window_solana,
   v8::Local<v8::Value> brave_solana_value =
       global->Get(context, gin::StringToV8(isolate, kBraveSolana))
           .ToLocalChecked();
-  if (!brave_solana_value->IsUndefined())
+  if (!brave_solana_value->IsUndefined()) {
     return;
+  }
 
   // v8 will manage the lifetime of JSSolanaProvider
   gin::Handle<JSSolanaProvider> provider =
       gin::CreateHandle(isolate, new JSSolanaProvider(render_frame));
-  if (provider.IsEmpty())
+  if (provider.IsEmpty()) {
     return;
+  }
   v8::Local<v8::Value> provider_value = provider.ToV8();
 
   SetProviderNonWritable(context, global, provider_value,
@@ -158,7 +146,11 @@ void JSSolanaProvider::Install(bool allow_overwrite_window_solana,
   }
 
   blink::WebLocalFrame* web_frame = render_frame->GetWebFrame();
-  ExecuteScript(web_frame, *g_provider_script, kSolanaProviderScript);
+
+  ExecuteScript(web_frame,
+                LoadDataResource(
+                    IDR_BRAVE_WALLET_SCRIPT_SOLANA_PROVIDER_SCRIPT_BUNDLE_JS),
+                kSolanaProviderScript);
 }
 
 gin::ObjectTemplateBuilder JSSolanaProvider::GetObjectTemplateBuilder(
@@ -186,8 +178,9 @@ const char* JSSolanaProvider::GetTypeName() {
 
 void JSSolanaProvider::AccountChangedEvent(
     const absl::optional<std::string>& account) {
-  if (!render_frame())
+  if (!render_frame()) {
     return;
+  }
   v8::Isolate* isolate = blink::MainThreadIsolate();
   v8::HandleScope handle_scope(isolate);
   v8::Local<v8::Context> context =
@@ -216,15 +209,17 @@ void JSSolanaProvider::DidFinishLoad() {
 
 void JSSolanaProvider::WillReleaseScriptContext(v8::Local<v8::Context>,
                                                 int32_t world_id) {
-  if (world_id != content::ISOLATED_WORLD_ID_GLOBAL)
+  if (world_id != content::ISOLATED_WORLD_ID_GLOBAL) {
     return;
+  }
   // Close mojo connection from browser to renderer
   receiver_.reset();
 }
 
 bool JSSolanaProvider::EnsureConnected() {
-  if (!render_frame())
+  if (!render_frame()) {
     return false;
+  }
   if (!solana_provider_.is_bound()) {
     render_frame()->GetBrowserInterfaceBroker()->GetInterface(
         solana_provider_.BindNewPipeAndPassReceiver());
@@ -254,15 +249,17 @@ v8::Local<v8::Value> JSSolanaProvider::GetPublicKey(gin::Arguments* arguments) {
   v8::Isolate* isolate = arguments->isolate();
   v8::Local<v8::Context> context = isolate->GetCurrentContext();
   std::string public_key;
-  if (!solana_provider_->GetPublicKey(&public_key) || public_key.empty())
+  if (!solana_provider_->GetPublicKey(&public_key) || public_key.empty()) {
     return v8::Null(isolate);
+  }
 
   return CreatePublicKey(context, public_key);
 }
 
 v8::Local<v8::Promise> JSSolanaProvider::Connect(gin::Arguments* arguments) {
-  if (!EnsureConnected())
+  if (!EnsureConnected()) {
     return v8::Local<v8::Promise>();
+  }
 
   v8::Isolate* isolate = arguments->isolate();
   v8::MaybeLocal<v8::Promise::Resolver> resolver =
@@ -305,8 +302,9 @@ v8::Local<v8::Promise> JSSolanaProvider::Connect(gin::Arguments* arguments) {
 }
 
 v8::Local<v8::Promise> JSSolanaProvider::Disconnect(gin::Arguments* arguments) {
-  if (!EnsureConnected())
+  if (!EnsureConnected()) {
     return v8::Local<v8::Promise>();
+  }
   v8::Isolate* isolate = arguments->isolate();
   v8::MaybeLocal<v8::Promise::Resolver> resolver =
       v8::Promise::Resolver::New(isolate->GetCurrentContext());
@@ -325,8 +323,9 @@ v8::Local<v8::Promise> JSSolanaProvider::Disconnect(gin::Arguments* arguments) {
 
 v8::Local<v8::Promise> JSSolanaProvider::SignAndSendTransaction(
     gin::Arguments* arguments) {
-  if (!EnsureConnected())
+  if (!EnsureConnected()) {
     return v8::Local<v8::Promise>();
+  }
   v8::Isolate* isolate = arguments->isolate();
   v8::MaybeLocal<v8::Promise::Resolver> resolver =
       v8::Promise::Resolver::New(isolate->GetCurrentContext());
@@ -381,8 +380,9 @@ v8::Local<v8::Promise> JSSolanaProvider::SignAndSendTransaction(
 
 v8::Local<v8::Promise> JSSolanaProvider::SignMessage(
     gin::Arguments* arguments) {
-  if (!EnsureConnected())
+  if (!EnsureConnected()) {
     return v8::Local<v8::Promise>();
+  }
   v8::Isolate* isolate = arguments->isolate();
   v8::MaybeLocal<v8::Promise::Resolver> resolver =
       v8::Promise::Resolver::New(isolate->GetCurrentContext());
@@ -409,8 +409,9 @@ v8::Local<v8::Promise> JSSolanaProvider::SignMessage(
   if (arguments->GetNext(&display)) {
     std::unique_ptr<base::Value> display_value =
         v8_value_converter_->FromV8Value(display, isolate->GetCurrentContext());
-    if (display_value->is_string())
+    if (display_value->is_string()) {
       display_str = display_value->GetString();
+    }
   }
 
   auto global_context(
@@ -427,8 +428,9 @@ v8::Local<v8::Promise> JSSolanaProvider::SignMessage(
 }
 
 v8::Local<v8::Promise> JSSolanaProvider::Request(gin::Arguments* arguments) {
-  if (!EnsureConnected())
+  if (!EnsureConnected()) {
     return v8::Local<v8::Promise>();
+  }
   v8::Isolate* isolate = arguments->isolate();
   v8::MaybeLocal<v8::Promise::Resolver> resolver =
       v8::Promise::Resolver::New(isolate->GetCurrentContext());
@@ -476,8 +478,9 @@ v8::Local<v8::Promise> JSSolanaProvider::Request(gin::Arguments* arguments) {
 // Deprecated
 v8::Local<v8::Promise> JSSolanaProvider::SignTransaction(
     gin::Arguments* arguments) {
-  if (!EnsureConnected())
+  if (!EnsureConnected()) {
     return v8::Local<v8::Promise>();
+  }
   v8::Isolate* isolate = arguments->isolate();
   v8::MaybeLocal<v8::Promise::Resolver> resolver =
       v8::Promise::Resolver::New(isolate->GetCurrentContext());
@@ -514,8 +517,9 @@ v8::Local<v8::Promise> JSSolanaProvider::SignTransaction(
 // Deprecated
 v8::Local<v8::Promise> JSSolanaProvider::SignAllTransactions(
     gin::Arguments* arguments) {
-  if (!EnsureConnected())
+  if (!EnsureConnected()) {
     return v8::Local<v8::Promise>();
+  }
   v8::Isolate* isolate = arguments->isolate();
   v8::Local<v8::Context> context = isolate->GetCurrentContext();
   v8::MaybeLocal<v8::Promise::Resolver> resolver =
@@ -561,8 +565,9 @@ v8::Local<v8::Promise> JSSolanaProvider::SignAllTransactions(
 void JSSolanaProvider::FireEvent(
     const std::string& event,
     std::vector<v8::Local<v8::Value>>&& event_args) {
-  if (!render_frame())
+  if (!render_frame()) {
     return;
+  }
   v8::Local<v8::Context> context =
       render_frame()->GetWebFrame()->MainWorldScriptContext();
   std::vector<v8::Local<v8::Value>> args;
@@ -801,27 +806,31 @@ void JSSolanaProvider::SendResponse(
 
 absl::optional<std::string> JSSolanaProvider::GetSerializedMessage(
     v8::Local<v8::Value> transaction) {
-  if (!render_frame())
+  if (!render_frame()) {
     return absl::nullopt;
+  }
   v8::Isolate* isolate = blink::MainThreadIsolate();
 
   v8::MaybeLocal<v8::Value> serialized_msg = CallMethodOfObject(
       render_frame()->GetWebFrame(), transaction, kSerializeMessage,
       std::vector<v8::Local<v8::Value>>());
-  if (serialized_msg.IsEmpty())
+  if (serialized_msg.IsEmpty()) {
     return absl::nullopt;
+  }
   std::unique_ptr<base::Value> blob_value = v8_value_converter_->FromV8Value(
       serialized_msg.ToLocalChecked(), isolate->GetCurrentContext());
-  if (!blob_value->is_blob())
+  if (!blob_value->is_blob()) {
     return absl::nullopt;
+  }
 
   return Base58Encode(blob_value->GetBlob());
 }
 
 absl::optional<std::vector<mojom::SignaturePubkeyPairPtr>>
 JSSolanaProvider::GetSignatures(v8::Local<v8::Value> transaction) {
-  if (!render_frame())
+  if (!render_frame()) {
     return absl::nullopt;
+  }
   v8::Isolate* isolate = blink::MainThreadIsolate();
   v8::Local<v8::Context> context = isolate->GetCurrentContext();
 
@@ -844,8 +853,9 @@ JSSolanaProvider::GetSignatures(v8::Local<v8::Value> transaction) {
     if (!v8_signature->IsNullOrUndefined()) {
       std::unique_ptr<base::Value> blob_value =
           v8_value_converter_->FromV8Value(v8_signature, context);
-      if (!blob_value || !blob_value->is_blob())
+      if (!blob_value || !blob_value->is_blob()) {
         return absl::nullopt;
+      }
       signature = blob_value->GetBlob();
     }
 
@@ -855,13 +865,15 @@ JSSolanaProvider::GetSignatures(v8::Local<v8::Value> transaction) {
     v8::MaybeLocal<v8::Value> v8_pubkey =
         CallMethodOfObject(render_frame()->GetWebFrame(), v8_pubkey_object,
                            kToString, std::vector<v8::Local<v8::Value>>());
-    if (v8_pubkey.IsEmpty())
+    if (v8_pubkey.IsEmpty()) {
       return absl::nullopt;
+    }
 
     std::unique_ptr<base::Value> pubkey_value =
         v8_value_converter_->FromV8Value(v8_pubkey.ToLocalChecked(), context);
-    if (!pubkey_value || !pubkey_value->is_string())
+    if (!pubkey_value || !pubkey_value->is_string()) {
       return absl::nullopt;
+    }
 
     sig_pubkey_pairs.push_back(
         mojom::SignaturePubkeyPair::New(signature, pubkey_value->GetString()));
@@ -874,33 +886,38 @@ mojom::SolanaSignTransactionParamPtr JSSolanaProvider::GetSignTransactionParam(
     v8::Local<v8::Value> transaction) {
   absl::optional<std::string> serialized_message =
       GetSerializedMessage(transaction);
-  if (!serialized_message)
+  if (!serialized_message) {
     return nullptr;
+  }
   absl::optional<std::vector<mojom::SignaturePubkeyPairPtr>> signatures =
       GetSignatures(transaction);
-  if (!signatures)
+  if (!signatures) {
     return nullptr;
+  }
   return mojom::SolanaSignTransactionParam::New(*serialized_message,
                                                 std::move(*signatures));
 }
 
 bool JSSolanaProvider::LoadSolanaWeb3ModuleIfNeeded(v8::Isolate* isolate) {
-  if (!render_frame())
+  if (!render_frame()) {
     return false;
-  if (!solana_web3_module_.IsEmpty())
+  }
+  if (!solana_web3_module_.IsEmpty()) {
     return true;
+  }
 
-  std::string solana_web3_module_str =
-      base::StrCat({"(function() {", *g_provider_solana_web3_script,
-                    "return solanaWeb3; })()"});
+  std::string solana_web3_module_str = base::StrCat(
+      {"(function() {", LoadDataResource(IDR_BRAVE_WALLET_SOLANA_WEB3_JS),
+       "return solanaWeb3; })()"});
 
   solana_web3_module_.Reset(isolate,
                             ExecuteScript(render_frame()->GetWebFrame(),
                                           solana_web3_module_str, "solana_web3")
                                 .ToLocalChecked());
   // loading SolanaWeb3 module failed
-  if (solana_web3_module_.IsEmpty())
+  if (solana_web3_module_.IsEmpty()) {
     return false;
+  }
   return true;
 }
 
@@ -939,8 +956,9 @@ v8::Local<v8::Value> JSSolanaProvider::CreateTransaction(
     v8::Local<v8::Context> context,
     const std::vector<uint8_t> serialized_tx) {
   v8::Isolate* isolate = context->GetIsolate();
-  if (!render_frame())
+  if (!render_frame()) {
     return v8::Undefined(isolate);
+  }
 
   v8::MicrotasksScope microtasks(isolate,
                                  v8::MicrotasksScope::kDoNotRunMicrotasks);
@@ -981,7 +999,10 @@ void JSSolanaProvider::OnIsSolanaKeyringCreated(bool created) {
   v8::Isolate* isolate = blink::MainThreadIsolate();
   v8::HandleScope handle_scope(isolate);
   blink::WebLocalFrame* web_frame = render_frame()->GetWebFrame();
-  ExecuteScript(web_frame, *g_wallet_standard_script, kWalletStandardScript);
+  ExecuteScript(web_frame,
+                LoadDataResource(
+                    IDR_BRAVE_WALLET_SCRIPT_WALLET_STANDARD_SCRIPT_BUNDLE_JS),
+                kWalletStandardScript);
   wallet_standard_loaded_ = true;
 }
 

--- a/components/brave_wallet/renderer/js_solana_provider.h
+++ b/components/brave_wallet/renderer/js_solana_provider.h
@@ -177,6 +177,9 @@ class JSSolanaProvider final : public gin::Wrappable<JSSolanaProvider>,
       v8::Local<v8::Context> context,
       const std::vector<uint8_t> serialized_tx);
 
+  void OnIsSolanaKeyringCreated(bool created);
+
+  bool wallet_standard_loaded_ = false;
   v8::Global<v8::Value> solana_web3_module_;
   std::unique_ptr<content::V8ValueConverter> v8_value_converter_;
   V8ConverterStrategy strategy_;

--- a/components/brave_wallet/renderer/js_solana_provider.h
+++ b/components/brave_wallet/renderer/js_solana_provider.h
@@ -57,6 +57,7 @@ class JSSolanaProvider final : public gin::Wrappable<JSSolanaProvider>,
 
   // RenderFrameObserver implementation.
   void OnDestruct() override {}
+  void DidFinishLoad() override;
   void WillReleaseScriptContext(v8::Local<v8::Context>,
                                 int32_t world_id) override;
 

--- a/components/brave_wallet/renderer/v8_helper.cc
+++ b/components/brave_wallet/renderer/v8_helper.cc
@@ -46,7 +46,7 @@ v8::MaybeLocal<v8::Value> CallMethodOfObject(
     return v8::Local<v8::Value>();
   v8::Isolate* isolate = v8::Isolate::GetCurrent();
   v8::Local<v8::Context> context = web_frame->MainWorldScriptContext();
-  v8::MicrotasksScope microtasks(isolate,
+  v8::MicrotasksScope microtasks(isolate, context->GetMicrotaskQueue(),
                                  v8::MicrotasksScope::kDoNotRunMicrotasks);
   v8::Local<v8::Value> object;
   if (!GetProperty(context, context->Global(), object_name).ToLocal(&object)) {
@@ -66,7 +66,7 @@ v8::MaybeLocal<v8::Value> CallMethodOfObject(
   v8::Local<v8::Context> context = web_frame->MainWorldScriptContext();
   v8::Isolate* isolate = v8::Isolate::GetCurrent();
   v8::Context::Scope context_scope(context);
-  v8::MicrotasksScope microtasks(isolate,
+  v8::MicrotasksScope microtasks(isolate, context->GetMicrotaskQueue(),
                                  v8::MicrotasksScope::kDoNotRunMicrotasks);
   v8::Local<v8::Value> method;
   if (!GetProperty(context, object, method_name).ToLocal(&method)) {

--- a/components/brave_wallet/resources/BUILD.gn
+++ b/components/brave_wallet/resources/BUILD.gn
@@ -12,6 +12,10 @@ transpile_web_ui("brave_wallet_script_resources") {
       "solana_provider_script",
       rebase_path("solana_provider.js"),
     ],
+    [
+      "wallet_standard_script",
+      rebase_path("wallet_standard.js"),
+    ],
   ]
 
   resource_name = "brave_wallet_script"

--- a/components/brave_wallet/resources/solana_provider.js
+++ b/components/brave_wallet/resources/solana_provider.js
@@ -31,8 +31,4 @@
       writable: false
     }
   })
-
-  const WalletStandard = require('@brave/wallet-standard-brave')
-
-  WalletStandard.initialize(window.braveSolana);
 })()

--- a/components/brave_wallet/resources/wallet_standard.js
+++ b/components/brave_wallet/resources/wallet_standard.js
@@ -1,7 +1,7 @@
 // Copyright (c) 2023 The Brave Authors. All rights reserved.
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this file,
-// you can obtain one at https://mozilla.org/MPL/2.0/.
+// You can obtain one at https://mozilla.org/MPL/2.0/.
 
 (function () {
   if (!window.braveSolana) {

--- a/components/brave_wallet/resources/wallet_standard.js
+++ b/components/brave_wallet/resources/wallet_standard.js
@@ -1,0 +1,14 @@
+// Copyright (c) 2023 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// you can obtain one at https://mozilla.org/MPL/2.0/.
+
+(function () {
+  if (!window.braveSolana) {
+    return
+  }
+
+  const WalletStandard = require('@brave/wallet-standard-brave')
+  WalletStandard.initialize(window.braveSolana);
+})()
+

--- a/components/safe_builtins/renderer/safe_builtins_helpers.cc
+++ b/components/safe_builtins/renderer/safe_builtins_helpers.cc
@@ -67,6 +67,7 @@ v8::Local<v8::Value> RunScript(v8::Local<v8::Context> context,
   v8::Context::Scope context_scope(context);
 
   v8::MicrotasksScope microtasks(context->GetIsolate(),
+                                 context->GetMicrotaskQueue(),
                                  v8::MicrotasksScope::kDoNotRunMicrotasks);
   v8::TryCatch try_catch(context->GetIsolate());
   try_catch.SetCaptureMessage(true);
@@ -107,6 +108,7 @@ v8::MaybeLocal<v8::Value> SafeCallFunction(
   v8::EscapableHandleScope handle_scope(context->GetIsolate());
   v8::Context::Scope scope(context);
   v8::MicrotasksScope microtasks(context->GetIsolate(),
+                                 context->GetMicrotaskQueue(),
                                  v8::MicrotasksScope::kDoNotRunMicrotasks);
   v8::Local<v8::Object> global = context->Global();
   if (web_frame) {

--- a/ios/browser/api/brave_wallet/brave_wallet_api.h
+++ b/ios/browser/api/brave_wallet/brave_wallet_api.h
@@ -24,6 +24,8 @@ OBJC_EXPORT BraveWalletProviderScriptKey const
     BraveWalletProviderScriptKeySolana;
 OBJC_EXPORT BraveWalletProviderScriptKey const
     BraveWalletProviderScriptKeySolanaWeb3;
+OBJC_EXPORT BraveWalletProviderScriptKey const
+    BraveWalletProviderScriptKeyWalletStandard;
 
 OBJC_EXPORT
 @interface BraveWalletAPI : NSObject

--- a/ios/browser/api/brave_wallet/brave_wallet_api.mm
+++ b/ios/browser/api/brave_wallet/brave_wallet_api.mm
@@ -29,6 +29,8 @@ BraveWalletProviderScriptKey const BraveWalletProviderScriptKeySolana =
     @"solana_provider.js";
 BraveWalletProviderScriptKey const BraveWalletProviderScriptKeySolanaWeb3 =
     @"solana_web3.js";
+BraveWalletProviderScriptKey const BraveWalletProviderScriptKeyWalletStandard =
+    @"wallet_standard.js";
 
 #if !defined(__has_feature) || !__has_feature(objc_arc)
 #error "This file requires ARC support."
@@ -163,7 +165,10 @@ BraveWalletProviderScriptKey const BraveWalletProviderScriptKeySolanaWeb3 =
                     BraveWalletProviderScriptKeySolana,
                     IDR_BRAVE_WALLET_SCRIPT_SOLANA_PROVIDER_SCRIPT_BUNDLE_JS),
                 std::make_pair(BraveWalletProviderScriptKeySolanaWeb3,
-                               IDR_BRAVE_WALLET_SOLANA_WEB3_JS)};
+                               IDR_BRAVE_WALLET_SOLANA_WEB3_JS),
+                std::make_pair(
+                    BraveWalletProviderScriptKeyWalletStandard,
+                    IDR_BRAVE_WALLET_SCRIPT_WALLET_STANDARD_SCRIPT_BUNDLE_JS)};
       case BraveWalletCoinTypeFil:
         // Currently not supported
         return {std::make_pair(@"", 0)};


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/27997

We now load wallet-standard script separately in `OnFinishLoad` and only when Solana keyring is created.
follow-up issue created: https://github.com/brave/brave-browser/issues/28082

iOS now needs to load new script `IDR_BRAVE_WALLET_SCRIPT_WALLET_STANDARD_SCRIPT_BUNDLE_JS` in order to get wallet-standard compatibility and also call `IsSolanaKeyringCreated` to decide whether to load wallet-standard

Release build comparison on example.com: (Reland: v1.49.56, No wallet-standard: v1.48.110) 
<img width="2560" alt="Screen Shot 2023-01-25 at 14 52 18" src="https://user-images.githubusercontent.com/11330831/214724817-dba523aa-bc94-429c-9180-da88816a7487.png">
<img width="2548" alt="Screen Shot 2023-01-25 at 17 03 32" src="https://user-images.githubusercontent.com/11330831/214731896-bc06da77-9a15-4966-991d-8855f7554c7a.png">


task (compile time + function call) is delayed after first paint

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
### Fresh profile
1. Get the nightly version with this fix (ex. v1.49.56) and with this fix
2. Open them with fresh profiles and navigate to https://example.com (`--user-data-dir` can be used so you can open them simultaneously)
3. Open dev console and switch to performance page
4. Click "Start profiling and reload page" and wait for it to stop on each of them
5. There shouldn't be any Function call (`Function(anonymous) @ wallet_standard.js:1:10`) + Compile time  appeared after FP and FCP

### With Solana account created
1. Get the nightly version with this fix (ex. v1.49.56) and with this fix
2. Open them with fresh profiles and navigate to https://example.com (`--user-data-dir` can be used so you can open them simultaneously)
4. Setup wallet on both profiles.
7. Open dev console and switch to performance page
8. Click "Start profiling and reload page" and wait for it to stop on each of them
9. Function call (`Function(anonymous) @ wallet_standard.js:1:10`) + Compile time ahead of it should be similar to previous version of `Function(anonymous) @ solana_provider.js:1:10`
10. Also fixed version's Function call should be after FP and FCP
11. Make sure https://github.com/brave/brave-browser/issues/27340#issuecomment-1400494916 still passed in new version.