### PR TITLE
Fix BraveCompoundTabContainer layout for vertical tab strip

### DIFF
--- a/browser/ui/views/tabs/brave_compound_tab_container.cc
+++ b/browser/ui/views/tabs/brave_compound_tab_container.cc
@@ -36,15 +36,19 @@ void BraveCompoundTabContainer::SetAvailableWidthCallback(
   if (!base::FeatureList::IsEnabled(tabs::features::kBraveVerticalTabs))
     return;
 
-  if (!available_width_callback || tabs::features::ShouldShowVerticalTabs(
-                                       tab_slot_controller_->GetBrowser())) {
-    // Unlike Chromium Impl, Just pass the `available_width_callback` to
-    // child containers when it's vertical tabs or we're trying to clear
-    // the callback.
-    pinned_tab_container_->SetAvailableWidthCallback(available_width_callback_);
+  if (tabs::features::ShouldShowVerticalTabs(
+          tab_slot_controller_->GetBrowser()) &&
+      available_width_callback) {
+    pinned_tab_container_->SetAvailableWidthCallback(
+        base::BindRepeating(&views::View::width, base::Unretained(this)));
     unpinned_tab_container_->SetAvailableWidthCallback(
-        available_width_callback_);
+        base::BindRepeating(&views::View::width, base::Unretained(this)));
+    return;
   }
+
+  // Upstream's compound tab container doesn't use this.
+  pinned_tab_container_->SetAvailableWidthCallback(base::NullCallback());
+  unpinned_tab_container_->SetAvailableWidthCallback(base::NullCallback());
 }
 
 BraveCompoundTabContainer::~BraveCompoundTabContainer() = default;
@@ -72,6 +76,13 @@ void BraveCompoundTabContainer::TransferTabBetweenContainers(
   const bool was_pinned = to_model_index < NumPinnedTabs();
   CompoundTabContainer::TransferTabBetweenContainers(from_model_index,
                                                      to_model_index);
+  if (!ShouldShowVerticalTabs()) {
+    return;
+  }
+
+  // Override transfer animation so that it goes well with vertical tab strip.
+  CompleteAnimationAndLayout();
+
   const bool is_pinned = to_model_index < NumPinnedTabs();
   bool layout_dirty = false;
   if (is_pinned && !pinned_tab_container_->GetVisible()) {
@@ -80,6 +91,13 @@ void BraveCompoundTabContainer::TransferTabBetweenContainers(
     pinned_tab_container_->SetVisible(true);
     layout_dirty = true;
   }
+
+  // Animate tab from left to right.
+  Tab* tab = GetTabAtModelIndex(to_model_index);
+  tab->SetPosition({-tab->width(), 0});
+  TabContainer& to_container =
+      *(is_pinned ? pinned_tab_container_ : unpinned_tab_container_);
+  to_container.AnimateToIdealBounds();
 
   if (was_pinned != is_pinned) {
     // After transferring a tab from one to another container, we should layout
@@ -93,6 +111,52 @@ void BraveCompoundTabContainer::TransferTabBetweenContainers(
 
   if (layout_dirty)
     Layout();
+}
+
+void BraveCompoundTabContainer::Layout() {
+  if (!ShouldShowVerticalTabs()) {
+    CompoundTabContainer::Layout();
+    return;
+  }
+
+  // We use flex layout manager so let it do its job.
+  views::View::Layout();
+}
+
+gfx::Size BraveCompoundTabContainer::CalculatePreferredSize() const {
+  if (!ShouldShowVerticalTabs()) {
+    return CompoundTabContainer::CalculatePreferredSize();
+  }
+
+  // We use flex layout manager so let it do its job.
+  return views::View::CalculatePreferredSize();
+}
+
+gfx::Size BraveCompoundTabContainer::GetMinimumSize() const {
+  if (!ShouldShowVerticalTabs()) {
+    return CompoundTabContainer::GetMinimumSize();
+  }
+
+  // We use flex layout manager so let it do its job.
+  return views::View::GetMinimumSize();
+}
+
+views::SizeBounds BraveCompoundTabContainer::GetAvailableSize(
+    const views::View* child) const {
+  if (!base::FeatureList::IsEnabled(tabs::features::kBraveVerticalTabs) ||
+      !tabs::features::ShouldShowVerticalTabs(
+          tab_slot_controller_->GetBrowser())) {
+    return CompoundTabContainer::GetAvailableSize(child);
+  }
+
+  return views::SizeBounds(views::SizeBound(width()),
+                           /*height=*/views::SizeBound());
+}
+
+bool BraveCompoundTabContainer::ShouldShowVerticalTabs() const {
+  return base::FeatureList::IsEnabled(tabs::features::kBraveVerticalTabs) &&
+         tabs::features::ShouldShowVerticalTabs(
+             tab_slot_controller_->GetBrowser());
 }
 
 BEGIN_METADATA(BraveCompoundTabContainer, CompoundTabContainer)

--- a/browser/ui/views/tabs/brave_compound_tab_container.h
+++ b/browser/ui/views/tabs/brave_compound_tab_container.h
@@ -28,9 +28,13 @@ class BraveCompoundTabContainer : public CompoundTabContainer {
       base::RepeatingCallback<int()> available_width_callback) override;
   void TransferTabBetweenContainers(int from_model_index,
                                     int to_model_index) override;
+  void Layout() override;
+  gfx::Size CalculatePreferredSize() const override;
+  gfx::Size GetMinimumSize() const override;
+  views::SizeBounds GetAvailableSize(const views::View* child) const override;
 
  private:
-  void UpdateLayout();
+  bool ShouldShowVerticalTabs() const;
 
   base::raw_ref<TabSlotController> tab_slot_controller_;
 };

--- a/browser/ui/views/tabs/brave_tab_strip.cc
+++ b/browser/ui/views/tabs/brave_tab_strip.cc
@@ -288,8 +288,8 @@ void BraveTabStrip::UpdateTabContainer() {
     }
 
     if (should_use_compound_tab_container) {
-      tab_container_->SetLayoutManager(std::make_unique<views::FlexLayout>())
-          ->SetOrientation(views::LayoutOrientation::kVertical);
+      // Upstream's compound tab container lay out its sub containers manually.
+      tab_container_->SetLayoutManager(nullptr);
     }
   }
 }

--- a/components/brave_shields/browser/ad_block_engine.cc
+++ b/components/brave_shields/browser/ad_block_engine.cc
@@ -254,8 +254,9 @@ void AdBlockEngine::UpdateAdBlockClient(
     const std::string& resources_json) {
   DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
   ad_block_client_ = std::move(ad_block_client);
-  if (regex_discard_policy_)
+  if (regex_discard_policy_) {
     ad_block_client_->setupDiscardPolicy(*regex_discard_policy_);
+  }
   UseResources(resources_json);
   AddKnownTagsToAdBlockInstance();
   if (test_observer_) {


### PR DESCRIPTION
In the latest Chromium, CompoundTabContainer doesn't use FlexLayout. But in our use case, FlexLayout does good so make things work based on the FlexLayout.

Related upstream changes:
https://chromium-review.googlesource.com/c/chromium/src/+/4081180 
https://chromium-review.googlesource.com/c/chromium/src/+/3956548

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/28084

Many thanks to @antonok-edm for reporting this!

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
None
