### PR TITLE
Rotate Windows update key

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -5,7 +5,7 @@ deps = {
   "vendor/boto": "https://github.com/boto/boto@f7574aa6cc2c819430c1f05e9a1a1a666ef8169b",
   "vendor/python-patch": "https://github.com/brave/python-patch@d8880110be6554686bc08261766538c2926d4e82",
   "vendor/omaha": {
-    "url": "https://github.com/brave/omaha.git@aefae2f29e433edbace3f41687048d7842e6f54d",
+    "url": "https://github.com/brave/omaha.git@bb0df2033b66d1611708e4b248aff17622f14bae",
     "condition": "checkout_win",
   },
   "vendor/sparkle": {

--- a/DEPS
+++ b/DEPS
@@ -5,7 +5,7 @@ deps = {
   "vendor/boto": "https://github.com/boto/boto@f7574aa6cc2c819430c1f05e9a1a1a666ef8169b",
   "vendor/python-patch": "https://github.com/brave/python-patch@d8880110be6554686bc08261766538c2926d4e82",
   "vendor/omaha": {
-    "url": "https://github.com/brave/omaha.git@bb0df2033b66d1611708e4b248aff17622f14bae",
+    "url": "https://github.com/brave/omaha.git@7e78687ac8d8188c70089e96a172c2d6cfe3a3e4",
     "condition": "checkout_win",
   },
   "vendor/sparkle": {


### PR DESCRIPTION
Resolves https://github.com/brave/brave-browser/issues/28091.

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] **Upload the new version of Brave Update to the update server, so existing users receive it. Only do this once the new implementation has been tested to work. Otherwise, we risk bricking the update fleet.**
- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

This change affects Brave's auto-updater (Brave Update) on Windows. We need to test the following things:

### Brave's online installer

Brave's 1MB online installer is generated with Brave Update. It pulls the latest version of Brave from the update server. If we can show that this installer still works, then we can be confident that Brave Update is still able to talk to the update server and thus that the changes in this PR didn't break anything.

1. Uninstall all copies of Brave from your system.
2. Uninstall Brave Update. This can usually be done by running the command line `"C:\Program Files (x86)\BraveSoftware\Update\BraveUpdate.exe" /uninstall` in an **Administrator** command prompt.
3. Make sure that 1. & 2. were successful by verifying that the registry key `HKEY_LOCAL_MACHINE\SOFTWARE\WOW6432Node\BraveSoftware\Update` is empty or does not exist.
4. Run `BraveBrowserSetup.exe`  (the 1 MB online installer) as admin. This should be from a release that contains the changes in this PR.
5. Check that Brave gets installed correctly.
6. Verify that the new version of Brave Update was actually used: Check that the registry entry `HKEY_LOCAL_MACHINE\SOFTWARE\WOW6432Node\BraveSoftware\Update\Clients\{B131C935-9BE6-41DA-9599-1F776BEB8019}\pv` shows the value `1.3.361.137`.

If you run into any problems, especially with uninstalling Brave Update, please see "Cleaning up after a test" in https://github.com/brave/brave-core/pull/11096.

### Updating the updater

We want to roll out the changes to Brave Update to existing users. To do this, we will upload a new version of Brave Update (not Brave) to the update server. We want to test that this works, and also that the new version of Brave Update can update itself to future versions.

To test that updating the current version of Brave Update (.135) to the new version (.137) works, uninstall Brave and Brave Update per steps 1. - 3. above. Then install an old version of Brave via a standalone installer. Check that the registry value `...\{B131C935-...}\pv` above end in `.135`. Make sure that the registry value `...\BraveUpdate\LastChecked` does not exist. If it does, delete it. Set the registry value `HKEY_LOCAL_MACHINE\SOFTWARE\WOW6432Node\BraveSoftware\UpdateDev\url` to `https://updates-panel.brave.com/service/update2` to use the staging update server. Then open the Windows Task Scheduler. You should see a task `BraveSoftwareUpdateTaskMachineUA{...}`. Run it by right-clicking. Refresh with <kbd>F5</kbd> until the status changes from _Running_ back to _Ready_. Then look at `...\pv` again. It should have changed to `.137`.

To test that updating Brave Update .137 to a potential future version .139 works, get in touch with @mherrmann after the steps in the previous paragraph. He will enable .139 on the staging update server. Then you can delete `LastChecked` and run the Windows Task again to test that you will receive .139.