### PR TITLE
[Android] fix brave news scrolling gps crash android (uplift to 1.48.x)

### DIFF
--- a/android/java/org/chromium/chrome/browser/ntp/BraveNewTabPageLayout.java
+++ b/android/java/org/chromium/chrome/browser/ntp/BraveNewTabPageLayout.java
@@ -592,7 +592,8 @@ public class BraveNewTabPageLayout
                             final int visiblePercentageFinal = visiblePercentage;
 
                             int newsFeedViewPosition = viewPosition - newsFeedPosition;
-                            if (newsFeedViewPosition >= 0) {
+                            if (newsFeedViewPosition >= 0
+                                    && newsFeedViewPosition < mNewsItemsFeedCard.size()) {
                                 if (visiblePercentageFinal >= MINIMUM_VISIBLE_HEIGHT_THRESHOLD) {
                                     mVisibleCard = mNewsItemsFeedCard.get(newsFeedViewPosition);
                                     // get params for view PROMOTED_ARTICLE


### PR DESCRIPTION
Uplift of #16889
Resolves https://github.com/brave/brave-browser/issues/28086

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.