### PR TITLE
fix(wallet): Generic Error for Invalid Addresses

### DIFF
--- a/components/brave_wallet/browser/brave_wallet_constants.h
+++ b/components/brave_wallet/browser/brave_wallet_constants.h
@@ -658,6 +658,8 @@ constexpr webui::LocalizedString kLocalizedStrings[] = {
     {"braveWalletZeroBalanceError", IDS_BRAVE_WALLET_ZERO_BALANCE_ERROR},
     {"braveWalletAddressRequiredError",
      IDS_BRAVE_WALLET_ADDRESS_REQUIRED_ERROR},
+    {"braveWalletInvalidRecipientAddress",
+     IDS_BRAVE_WALLET_INVALID_RECIPIENT_ADDRESS},
     {"braveWalletQueueOf", IDS_BRAVE_WALLET_QUEUE_OF},
     {"braveWalletQueueNext", IDS_BRAVE_WALLET_QUEUE_NEXT},
     {"braveWalletQueueFirst", IDS_BRAVE_WALLET_QUEUE_FIRST},

--- a/components/brave_wallet_ui/common/hooks/send.test.tsx
+++ b/components/brave_wallet_ui/common/hooks/send.test.tsx
@@ -300,8 +300,8 @@ describe('useSend hook', () => {
   describe('check for address errors', () => {
     describe.each([
       [mockAccountWithAddress.address, 'braveWalletSameAddressError'],
-      ['0x8b52c24d6e2600bdb8dbb6e8da849ed', 'braveWalletNotValidAddress'],
-      ['0x0D8775F648430679A709E98d2b0Cb6250d2887EF', 'braveWalletContractAddressError']
+      ['0x8b52c24d6e2600bdb8dbb6e8da849ed', 'braveWalletInvalidRecipientAddress'],
+      ['0x0D8775F648430679A709E98d2b0Cb6250d2887EF', 'braveWalletInvalidRecipientAddress']
     ])('%s', (toAddress, addressError) => {
       it(`Should return a ${addressError}`, async () => {
         let sendTransactionSpy = jest.fn()

--- a/components/brave_wallet_ui/common/hooks/send.ts
+++ b/components/brave_wallet_ui/common/hooks/send.ts
@@ -146,7 +146,7 @@ export default function useSend (isSendTab?: boolean) {
     if (fullTokenList.some(token => token.contractAddress.toLowerCase() === valueToLowerCase)) {
       setToAddress(addressOrUrl)
       setAddressWarning('')
-      setAddressError(getLocale('braveWalletContractAddressError'))
+      setAddressError(getLocale('braveWalletInvalidRecipientAddress'))
       return
     }
 
@@ -155,7 +155,7 @@ export default function useSend (isSendTab?: boolean) {
       setToAddress(addressOrUrl)
       if (!isValidAddress(addressOrUrl, 20)) {
         setAddressWarning('')
-        setAddressError(getLocale('braveWalletNotValidAddress'))
+        setAddressError(getLocale('braveWalletInvalidRecipientAddress'))
         return
       }
 
@@ -189,7 +189,7 @@ export default function useSend (isSendTab?: boolean) {
 
     // Fallback error state
     setAddressWarning('')
-    setAddressError(getLocale('braveWalletNotValidAddress'))
+    setAddressError(getLocale('braveWalletInvalidRecipientAddress'))
   }, [selectedAccount?.address, handleUDAddressLookUp, handleDomainLookupResponse, setShowEnsOffchainWarning])
 
   const processFilecoinAddress = React.useCallback((addressOrUrl: string) => {
@@ -220,7 +220,7 @@ export default function useSend (isSendTab?: boolean) {
     setToAddress(valueToLowerCase)
     if (!isValidFilAddress(valueToLowerCase)) {
       setAddressWarning('')
-      setAddressError(getLocale('braveWalletNotValidFilAddress'))
+      setAddressError(getLocale('braveWalletInvalidRecipientAddress'))
       return
     }
 
@@ -268,7 +268,7 @@ export default function useSend (isSendTab?: boolean) {
 
     // Check if value is a Tokens Contract Address
     if (fullTokenList.some(token => token.contractAddress.toLowerCase() === addressOrUrl.toLowerCase())) {
-      setAddressError(getLocale('braveWalletContractAddressError'))
+      setAddressError(getLocale('braveWalletInvalidRecipientAddress'))
       setAddressWarning('')
       return
     }
@@ -280,7 +280,7 @@ export default function useSend (isSendTab?: boolean) {
       // If result is false we show address error
       if (!result) {
         setAddressWarning('')
-        setAddressError(getLocale('braveWalletNotValidSolAddress'))
+        setAddressError(getLocale('braveWalletInvalidRecipientAddress'))
         return
       }
       setAddressWarning('')

--- a/components/brave_wallet_ui/stories/locale.ts
+++ b/components/brave_wallet_ui/stories/locale.ts
@@ -624,6 +624,7 @@ provideStrings({
   braveWalletMissingGasLimitError: 'Missing gas limit',
   braveWalletZeroBalanceError: 'Amount must be greater than 0',
   braveWalletAddressRequiredError: 'To address is required',
+  braveWalletInvalidRecipientAddress: 'Invalid recipient address',
 
   // Transaction Queue Strings
   braveWalletQueueOf: 'of',

--- a/components/resources/wallet_strings.grdp
+++ b/components/resources/wallet_strings.grdp
@@ -426,6 +426,7 @@
   <message name="IDS_BRAVE_WALLET_MISSING_GAS_LIMIT_ERROR" desc="Transaction has missing gas limit information">Missing gas limit</message>
   <message name="IDS_BRAVE_WALLET_ZERO_BALANCE_ERROR" desc="Send amount must be greater than 0 error">Amount must be greater than 0</message>
   <message name="IDS_BRAVE_WALLET_ADDRESS_REQUIRED_ERROR" desc="Address field is required error">To address is required</message>
+  <message name="IDS_BRAVE_WALLET_INVALID_RECIPIENT_ADDRESS" desc="Invalid recipient address error">Invalid recipient address</message>
   <message name="IDS_BRAVE_WALLET_QUEUE_OF" desc="Confirm Transaction Queue of">of</message>
   <message name="IDS_BRAVE_WALLET_QUEUE_NEXT" desc="Confirm Transaction Queue next">next</message>
   <message name="IDS_BRAVE_WALLET_QUEUE_FIRST" desc="Confirm Transaction Queue first">first</message>


### PR DESCRIPTION
## Description 
We now show a generic error message `Invalid recipient address` for all invalid addresses in the `Send` tab.

<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves <https://github.com/brave/brave-browser/issues/28050>

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
1. Go to the `Send` tab and type in a invalid address for either `Ethereum, Solana or Filecoin`.
2. You should see the `Invalid recipient address` error.
3. Paste in a tokens `Contract Address`.
4. You should see the `Invalid recipient address` error.

![Screenshot 2023-01-30 at 1 57 40 PM](https://user-images.githubusercontent.com/40611140/215586379-eff9d7e1-5abc-499b-8f6a-0a45a5d93391.png)
