### PR TITLE
fix(wallet): Clear State on Selecting Send Token

### DIFF
--- a/components/brave_wallet_ui/common/hooks/send.ts
+++ b/components/brave_wallet_ui/common/hooks/send.ts
@@ -72,6 +72,12 @@ export default function useSend (isSendTab?: boolean) {
     } else {
       setSendAmount('')
     }
+    setToAddress('')
+    setToAddressOrUrl('')
+    setAddressError(undefined)
+    setAddressWarning(undefined)
+    setShowEnsOffchainWarning(false)
+    setSearchingForDomain(false)
     setSelectedSendAsset(asset)
   }
 


### PR DESCRIPTION
## Description 
Fixes a bug where the new `Send` page would allow you to try and send a `Solana` token to an `Ethereum` address and vice versa. Causing a broken transaction which would prevent you from opening the wallet `Panel`.

<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves <https://github.com/brave/brave-browser/issues/28151>

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
   1. Go to the send tab, select an `Ethereum` token to send and past in a `Ethereum` address
   2. Switch the send token to any other token.
   3. The `To Address` field should be cleared out and all other `Send` state reset.
   
Before:

https://user-images.githubusercontent.com/40611140/215631146-164041a7-96f3-4656-9848-95cf3825f7fd.mov

After:

https://user-images.githubusercontent.com/40611140/215631180-a186e715-e172-4d9a-ad4e-e6de0677f1c8.mov
