### PR TITLE
Add PlaylistService::CopyItemToPlaylist API

### DIFF
--- a/browser/playlist/test/playlist_service_unittest.cc
+++ b/browser/playlist/test/playlist_service_unittest.cc
@@ -756,8 +756,8 @@ TEST_F(PlaylistServiceUnitTest, AddItemsToList) {
   for (const auto& item_id : item_ids) {
     service->GetPlaylistItem(
         item_id, base::BindLambdaForTesting([](mojom::PlaylistItemPtr item) {
-          ASSERT_EQ(item->parent_lists.size(), 1u);
-          EXPECT_TRUE(base::Contains(item->parent_lists, kDefaultPlaylistID));
+          ASSERT_EQ(item->parents.size(), 1u);
+          EXPECT_TRUE(base::Contains(item->parents, kDefaultPlaylistID));
         }));
   }
 
@@ -778,9 +778,9 @@ TEST_F(PlaylistServiceUnitTest, AddItemsToList) {
   for (const auto& id : item_ids) {
     service->GetPlaylistItem(
         id, base::BindLambdaForTesting([&](mojom::PlaylistItemPtr item) {
-          EXPECT_EQ(item->parent_lists.size(), 2u);
-          EXPECT_TRUE(base::Contains(item->parent_lists, kDefaultPlaylistID));
-          EXPECT_TRUE(base::Contains(item->parent_lists, another_playlist_id));
+          EXPECT_EQ(item->parents.size(), 2u);
+          EXPECT_TRUE(base::Contains(item->parents, kDefaultPlaylistID));
+          EXPECT_TRUE(base::Contains(item->parents, another_playlist_id));
         }));
   }
 }
@@ -813,8 +813,8 @@ TEST_F(PlaylistServiceUnitTest, MoveItem) {
   for (const auto& item_id : item_ids) {
     service->GetPlaylistItem(
         item_id, base::BindLambdaForTesting([](mojom::PlaylistItemPtr item) {
-          ASSERT_EQ(item->parent_lists.size(), 1u);
-          ASSERT_TRUE(base::Contains(item->parent_lists, kDefaultPlaylistID));
+          ASSERT_EQ(item->parents.size(), 1u);
+          ASSERT_TRUE(base::Contains(item->parents, kDefaultPlaylistID));
         }));
   }
 
@@ -846,8 +846,8 @@ TEST_F(PlaylistServiceUnitTest, MoveItem) {
   for (const auto& item_id : item_ids) {
     service->GetPlaylistItem(
         item_id, base::BindLambdaForTesting([&](mojom::PlaylistItemPtr item) {
-          ASSERT_EQ(item->parent_lists.size(), 1u);
-          ASSERT_TRUE(base::Contains(item->parent_lists, another_playlist_id));
+          ASSERT_EQ(item->parents.size(), 1u);
+          ASSERT_TRUE(base::Contains(item->parents, another_playlist_id));
         }));
   }
 
@@ -1111,8 +1111,8 @@ TEST_F(PlaylistServiceUnitTest, RemoveItemFromPlaylist) {
 
     service->GetPlaylistItem(
         id, base::BindLambdaForTesting([&](mojom::PlaylistItemPtr item) {
-          EXPECT_EQ(item->parent_lists.size(), 1u);
-          EXPECT_TRUE(base::Contains(item->parent_lists, another_playlist_id));
+          EXPECT_EQ(item->parents.size(), 1u);
+          EXPECT_TRUE(base::Contains(item->parents, another_playlist_id));
         }));
   }
 }

--- a/browser/playlist/test/playlist_service_unittest.cc
+++ b/browser/playlist/test/playlist_service_unittest.cc
@@ -997,17 +997,12 @@ TEST_F(PlaylistServiceUnitTest, ReorderItemFromPlaylist) {
     auto item = prototype_item.Clone();
     item->id = base::Token::CreateRandom().ToString();
     item->name = base::NumberToString(i + 1);
-
-    playlist_service()->UpdatePlaylistItemValue(
-        item->id, base::Value(ConvertPlaylistItemToValue(item->Clone())));
     items.push_back(std::move(item));
   }
 
   auto target = prototype_item.Clone();
   target->id = base::Token::CreateRandom().ToString();
   target->name = "target";
-  playlist_service()->UpdatePlaylistItemValue(
-      target->id, base::Value(ConvertPlaylistItemToValue(target->Clone())));
   items.push_back(target->Clone());
 
   auto* service = playlist_service();

--- a/components/playlist/browser/playlist_service.cc
+++ b/components/playlist/browser/playlist_service.cc
@@ -284,15 +284,15 @@ void PlaylistService::AddMediaFilesFromItems(
   if (items.empty())
     return;
 
+  base::ranges::for_each(items, [this, cache](const auto& item) {
+    CreatePlaylistItem(item, cache);
+  });
+
   std::vector<std::string> ids;
   base::ranges::transform(items, std::back_inserter(ids),
                           [](const auto& item) { return item->id; });
   AddItemsToPlaylist(
       playlist_id.empty() ? GetDefaultSaveTargetListID() : playlist_id, ids);
-
-  base::ranges::for_each(items, [this, cache](const auto& item) {
-    CreatePlaylistItem(item, cache);
-  });
 }
 
 void PlaylistService::NotifyPlaylistChanged(

--- a/components/playlist/browser/playlist_service.h
+++ b/components/playlist/browser/playlist_service.h
@@ -131,6 +131,8 @@ class PlaylistService : public KeyedService,
       FindMediaFilesFromActiveTabCallback callback) override;
   void AddMediaFiles(std::vector<mojom::PlaylistItemPtr> items,
                      const std::string& playlist_id) override;
+  void CopyItemToPlaylist(const std::vector<std::string>& item_ids,
+                          const std::string& playlist_id) override;
   void RemoveItemFromPlaylist(const std::string& playlist_id,
                               const std::string& item_id) override;
   void MoveItem(const std::string& from_playlist_id,
@@ -168,6 +170,7 @@ class PlaylistService : public KeyedService,
   FRIEND_TEST_ALL_PREFIXES(PlaylistServiceUnitTest, UpdateItem);
   FRIEND_TEST_ALL_PREFIXES(PlaylistServiceUnitTest, CreateAndRemovePlaylist);
   FRIEND_TEST_ALL_PREFIXES(PlaylistServiceUnitTest, ReorderItemFromPlaylist);
+  FRIEND_TEST_ALL_PREFIXES(PlaylistServiceUnitTest, RemoveItemFromPlaylist);
 
   void AddObserverForTest(PlaylistServiceObserver* observer);
   void RemoveObserverForTest(PlaylistServiceObserver* observer);
@@ -243,11 +246,12 @@ class PlaylistService : public KeyedService,
 
   std::string GetDefaultSaveTargetListID();
 
-  // Remove a item from a list. When |remove_item| is true, the item preference
-  // and local data will be removed together.
+  // Remove a item from a list. When |delete_item| is true, the item preference
+  // and local data will be removed if there's no other playlists referencing
+  // the item.
   bool RemoveItemFromPlaylist(const PlaylistId& playlist_id,
                               const PlaylistItemId& item_id,
-                              bool remove_item = true);
+                              bool delete_item);
 
   bool MoveItem(const PlaylistId& from,
                 const PlaylistId& to,

--- a/components/playlist/browser/type_converter.cc
+++ b/components/playlist/browser/type_converter.cc
@@ -41,6 +41,7 @@ constexpr char kPlaylistItemTitleKey[] = "title";
 constexpr char kPlaylistItemAuthorKey[] = "author";
 constexpr char kPlaylistItemDurationKey[] = "duration";
 constexpr char kPlaylistItemLastPlayedPositionKey[] = "lastPlayedPosition";
+constexpr char kPlaylistItemParentListsKey[] = "parentPlaylists";
 
 }  // namespace
 
@@ -54,10 +55,12 @@ bool IsItemValueMalformed(const base::Value::Dict& dict) {
          !dict.contains(kPlaylistItemMediaSrcKey) ||
          !dict.contains(kPlaylistItemThumbnailSrcKey) ||
          !dict.contains(kPlaylistItemMediaFilePathKey) ||
-         // Added 2022, dec.
+         // Added 2022. Dec.
          !dict.contains(kPlaylistItemDurationKey) ||
          !dict.contains(kPlaylistItemAuthorKey) ||
-         !dict.contains(kPlaylistItemLastPlayedPositionKey);
+         !dict.contains(kPlaylistItemLastPlayedPositionKey) ||
+         // Added 2023. Jan.
+         !dict.contains(kPlaylistItemParentListsKey);
 }
 
 mojom::PlaylistItemPtr ConvertValueToPlaylistItem(
@@ -77,6 +80,15 @@ mojom::PlaylistItemPtr ConvertValueToPlaylistItem(
   item->author = *dict.FindString(kPlaylistItemAuthorKey);
   item->last_played_position =
       *dict.FindInt(kPlaylistItemLastPlayedPositionKey);
+
+  const auto* parents_lists = dict.FindList(kPlaylistItemParentListsKey);
+  for (const auto& id_value : *parents_lists) {
+    DCHECK(id_value.is_string());
+    const auto& id = id_value.GetString();
+    DCHECK(!id.empty());
+    item->parent_lists.push_back(id);
+  }
+
   return item;
 }
 
@@ -97,6 +109,14 @@ base::Value::Dict ConvertPlaylistItemToValue(
   playlist_value.Set(kPlaylistItemDurationKey, item->duration);
   playlist_value.Set(kPlaylistItemLastPlayedPositionKey,
                      item->last_played_position);
+
+  base::Value::List parent_lists;
+  for (const auto& parent_playlist_id : item->parent_lists) {
+    parent_lists.Append(base::Value(parent_playlist_id));
+  }
+
+  playlist_value.Set(kPlaylistItemParentListsKey, std::move(parent_lists));
+
   return playlist_value;
 }
 

--- a/components/playlist/browser/type_converter.cc
+++ b/components/playlist/browser/type_converter.cc
@@ -41,7 +41,7 @@ constexpr char kPlaylistItemTitleKey[] = "title";
 constexpr char kPlaylistItemAuthorKey[] = "author";
 constexpr char kPlaylistItemDurationKey[] = "duration";
 constexpr char kPlaylistItemLastPlayedPositionKey[] = "lastPlayedPosition";
-constexpr char kPlaylistItemParentListsKey[] = "parentPlaylists";
+constexpr char kPlaylistItemParentKey[] = "parent";
 
 }  // namespace
 
@@ -60,7 +60,7 @@ bool IsItemValueMalformed(const base::Value::Dict& dict) {
          !dict.contains(kPlaylistItemAuthorKey) ||
          !dict.contains(kPlaylistItemLastPlayedPositionKey) ||
          // Added 2023. Jan.
-         !dict.contains(kPlaylistItemParentListsKey);
+         !dict.contains(kPlaylistItemParentKey);
 }
 
 mojom::PlaylistItemPtr ConvertValueToPlaylistItem(
@@ -81,12 +81,12 @@ mojom::PlaylistItemPtr ConvertValueToPlaylistItem(
   item->last_played_position =
       *dict.FindInt(kPlaylistItemLastPlayedPositionKey);
 
-  const auto* parents_lists = dict.FindList(kPlaylistItemParentListsKey);
-  for (const auto& id_value : *parents_lists) {
+  const auto* parents = dict.FindList(kPlaylistItemParentKey);
+  for (const auto& id_value : *parents) {
     DCHECK(id_value.is_string());
     const auto& id = id_value.GetString();
     DCHECK(!id.empty());
-    item->parent_lists.push_back(id);
+    item->parents.push_back(id);
   }
 
   return item;
@@ -110,12 +110,12 @@ base::Value::Dict ConvertPlaylistItemToValue(
   playlist_value.Set(kPlaylistItemLastPlayedPositionKey,
                      item->last_played_position);
 
-  base::Value::List parent_lists;
-  for (const auto& parent_playlist_id : item->parent_lists) {
-    parent_lists.Append(base::Value(parent_playlist_id));
+  base::Value::List parent;
+  for (const auto& parent_playlist_id : item->parents) {
+    parent.Append(base::Value(parent_playlist_id));
   }
 
-  playlist_value.Set(kPlaylistItemParentListsKey, std::move(parent_lists));
+  playlist_value.Set(kPlaylistItemParentKey, std::move(parent));
 
   return playlist_value;
 }

--- a/components/playlist/common/mojom/playlist.mojom
+++ b/components/playlist/common/mojom/playlist.mojom
@@ -37,6 +37,10 @@ struct PlaylistItem {
   string author;
   string duration;
   int32 last_played_position;
+
+  // Playlists that contain this item. Could have multiple |Playlist| in case
+  // user copied this item to another list.
+  array<string> parent_lists;
 };
 
 // Used by the web UI to bootstrap bidirectional communication.
@@ -65,6 +69,8 @@ interface PlaylistService {
   FindMediaFilesFromActiveTab() => (array<PlaylistItem> items);
 
   AddMediaFiles(array<PlaylistItem> items, string playlist_id);
+
+  CopyItemToPlaylist(array<string> item_ids, string playlist_id);
 
   RemoveItemFromPlaylist(string playlist_id, string item_id);
   MoveItem(string from_playlist_id, string to_playlist_id, string item_id);

--- a/components/playlist/common/mojom/playlist.mojom
+++ b/components/playlist/common/mojom/playlist.mojom
@@ -40,7 +40,7 @@ struct PlaylistItem {
 
   // Playlists that contain this item. Could have multiple |Playlist| in case
   // user copied this item to another list.
-  array<string> parent_lists;
+  array<string> parents;
 };
 
 // Used by the web UI to bootstrap bidirectional communication.


### PR DESCRIPTION
When this API is called, we add an item's id to another playlist. We don't copy the item deeply so that we can avoid caching again.

For this,
* Store parent playlists data in mojom::PlaylistItem
* Add / Remove / Move operation consider cases where multiple playlists share the same item.

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/28170

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

