### PR TITLE
RequestTracker refactor to use WTF strings

### DIFF
--- a/third_party/blink/renderer/core/brave_page_graph/graph_item/edge/request/edge_request_complete.cc
+++ b/third_party/blink/renderer/core/brave_page_graph/graph_item/edge/request/edge_request_complete.cc
@@ -5,8 +5,6 @@
 
 #include "brave/third_party/blink/renderer/core/brave_page_graph/graph_item/edge/request/edge_request_complete.h"
 
-#include <string>
-
 #include "brave/third_party/blink/renderer/core/brave_page_graph/graph_item/node/node_resource.h"
 #include "brave/third_party/blink/renderer/core/brave_page_graph/graphml.h"
 #include "brave/third_party/blink/renderer/core/brave_page_graph/utilities/response_metadata.h"
@@ -18,9 +16,9 @@ EdgeRequestComplete::EdgeRequestComplete(GraphItemContext* context,
                                          NodeResource* out_node,
                                          GraphNode* in_node,
                                          const InspectorId request_id,
-                                         const std::string& resource_type,
+                                         const String& resource_type,
                                          const ResponseMetadata& metadata,
-                                         const std::string& hash)
+                                         const String& hash)
     : EdgeRequestResponse(context,
                           out_node,
                           in_node,
@@ -37,7 +35,8 @@ ItemName EdgeRequestComplete::GetItemName() const {
 }
 
 ItemDesc EdgeRequestComplete::GetItemDesc() const {
-  return EdgeRequestResponse::GetItemDesc() + " [" + resource_type_ + "]";
+  return EdgeRequestResponse::GetItemDesc() + " [" + resource_type_.Utf8() +
+         "]";
 }
 
 void EdgeRequestComplete::AddGraphMLAttributes(xmlDocPtr doc,

--- a/third_party/blink/renderer/core/brave_page_graph/graph_item/edge/request/edge_request_complete.h
+++ b/third_party/blink/renderer/core/brave_page_graph/graph_item/edge/request/edge_request_complete.h
@@ -6,11 +6,10 @@
 #ifndef BRAVE_THIRD_PARTY_BLINK_RENDERER_CORE_BRAVE_PAGE_GRAPH_GRAPH_ITEM_EDGE_REQUEST_EDGE_REQUEST_COMPLETE_H_
 #define BRAVE_THIRD_PARTY_BLINK_RENDERER_CORE_BRAVE_PAGE_GRAPH_GRAPH_ITEM_EDGE_REQUEST_EDGE_REQUEST_COMPLETE_H_
 
-#include <string>
-
 #include "brave/third_party/blink/renderer/core/brave_page_graph/graph_item/edge/request/edge_request_response.h"
 #include "brave/third_party/blink/renderer/core/brave_page_graph/utilities/response_metadata.h"
 #include "third_party/blink/renderer/platform/wtf/casting.h"
+#include "third_party/blink/renderer/platform/wtf/text/wtf_string.h"
 
 namespace brave_page_graph {
 
@@ -23,13 +22,13 @@ class EdgeRequestComplete final : public EdgeRequestResponse {
                       NodeResource* out_node,
                       GraphNode* in_node,
                       const InspectorId request_id,
-                      const std::string& resource_type,
+                      const String& resource_type,
                       const ResponseMetadata& metadata,
-                      const std::string& hash);
+                      const String& hash);
 
   ~EdgeRequestComplete() override;
 
-  const std::string& GetResourceType() const { return resource_type_; }
+  const String& GetResourceType() const { return resource_type_; }
 
   ItemName GetItemName() const override;
   ItemDesc GetItemDesc() const override;
@@ -40,8 +39,8 @@ class EdgeRequestComplete final : public EdgeRequestResponse {
   bool IsEdgeRequestComplete() const override;
 
  private:
-  const std::string resource_type_;
-  const std::string hash_;
+  const String resource_type_;
+  const String hash_;
 };
 
 }  // namespace brave_page_graph

--- a/third_party/blink/renderer/core/brave_page_graph/graph_item/edge/request/edge_request_start.cc
+++ b/third_party/blink/renderer/core/brave_page_graph/graph_item/edge/request/edge_request_start.cc
@@ -14,7 +14,7 @@ EdgeRequestStart::EdgeRequestStart(GraphItemContext* context,
                                    GraphNode* out_node,
                                    NodeResource* in_node,
                                    const InspectorId request_id,
-                                   const std::string& resource_type)
+                                   const String& resource_type)
     : EdgeRequest(context, out_node, in_node, request_id, kRequestStatusStart),
       resource_type_(resource_type) {}
 
@@ -33,7 +33,7 @@ ItemName EdgeRequestStart::GetItemName() const {
 }
 
 ItemDesc EdgeRequestStart::GetItemDesc() const {
-  return EdgeRequest::GetItemDesc() + " [" + resource_type_ + "]";
+  return EdgeRequest::GetItemDesc() + " [" + resource_type_.Utf8() + "]";
 }
 
 void EdgeRequestStart::AddGraphMLAttributes(xmlDocPtr doc,

--- a/third_party/blink/renderer/core/brave_page_graph/graph_item/edge/request/edge_request_start.h
+++ b/third_party/blink/renderer/core/brave_page_graph/graph_item/edge/request/edge_request_start.h
@@ -6,10 +6,9 @@
 #ifndef BRAVE_THIRD_PARTY_BLINK_RENDERER_CORE_BRAVE_PAGE_GRAPH_GRAPH_ITEM_EDGE_REQUEST_EDGE_REQUEST_START_H_
 #define BRAVE_THIRD_PARTY_BLINK_RENDERER_CORE_BRAVE_PAGE_GRAPH_GRAPH_ITEM_EDGE_REQUEST_EDGE_REQUEST_START_H_
 
-#include <string>
-
 #include "brave/third_party/blink/renderer/core/brave_page_graph/graph_item/edge/request/edge_request.h"
 #include "third_party/blink/renderer/platform/wtf/casting.h"
+#include "third_party/blink/renderer/platform/wtf/text/wtf_string.h"
 
 namespace brave_page_graph {
 
@@ -22,11 +21,11 @@ class EdgeRequestStart final : public EdgeRequest {
                    GraphNode* out_node,
                    NodeResource* in_node,
                    const InspectorId request_id,
-                   const std::string& resource_type);
+                   const String& resource_type);
 
   ~EdgeRequestStart() override;
 
-  const std::string& GetResourceType() const { return resource_type_; }
+  const String& GetResourceType() const { return resource_type_; }
 
   NodeResource* GetResourceNode() const override;
   GraphNode* GetRequestingNode() const override;
@@ -40,7 +39,7 @@ class EdgeRequestStart final : public EdgeRequest {
   bool IsEdgeRequestStart() const override;
 
  private:
-  const std::string resource_type_;
+  const String resource_type_;
 };
 
 }  // namespace brave_page_graph

--- a/third_party/blink/renderer/core/brave_page_graph/graphml.cc
+++ b/third_party/blink/renderer/core/brave_page_graph/graphml.cc
@@ -62,6 +62,18 @@ void GraphMLAttr::AddValueNode(xmlDocPtr doc,
 
 void GraphMLAttr::AddValueNode(xmlDocPtr doc,
                                xmlNodePtr parent_node,
+                               const String& value) const {
+  CHECK(type_ == kGraphMLAttrTypeString);
+  xmlChar* encoded_content =
+      xmlEncodeEntitiesReentrant(doc, BAD_CAST value.Characters8());
+  xmlNodePtr new_node =
+      xmlNewChild(parent_node, nullptr, BAD_CAST "data", encoded_content);
+  xmlSetProp(new_node, BAD_CAST "key", BAD_CAST GetGraphMLId().c_str());
+  xmlFree(encoded_content);
+}
+
+void GraphMLAttr::AddValueNode(xmlDocPtr doc,
+                               xmlNodePtr parent_node,
                                const int value) const {
   CHECK(type_ == kGraphMLAttrTypeInt);
   xmlNodePtr new_node =

--- a/third_party/blink/renderer/core/brave_page_graph/graphml.h
+++ b/third_party/blink/renderer/core/brave_page_graph/graphml.h
@@ -13,6 +13,7 @@
 #include "base/containers/flat_map.h"
 #include "base/time/time.h"
 #include "brave/third_party/blink/renderer/core/brave_page_graph/types.h"
+#include "third_party/blink/renderer/platform/wtf/text/wtf_string.h"
 
 namespace brave_page_graph {
 
@@ -30,6 +31,9 @@ class GraphMLAttr {
   void AddValueNode(xmlDocPtr doc,
                     xmlNodePtr parent_node,
                     const std::string& value) const;
+  void AddValueNode(xmlDocPtr doc,
+                    xmlNodePtr parent_node,
+                    const String& value) const;
   void AddValueNode(xmlDocPtr doc,
                     xmlNodePtr parent_node,
                     const int value) const;

--- a/third_party/blink/renderer/core/brave_page_graph/page_graph.cc
+++ b/third_party/blink/renderer/core/brave_page_graph/page_graph.cc
@@ -443,9 +443,8 @@ void PageGraph::WillSendRequest(
   blink::ExecutionContext* execution_context =
       loader->GetFrame()->GetDocument()->GetExecutionContext();
 
-  const std::string page_graph_resource_type =
-      blink::Resource::ResourceTypeToString(resource_type,
-                                            options.initiator_info.name);
+  const String page_graph_resource_type = blink::Resource::ResourceTypeToString(
+      resource_type, options.initiator_info.name);
 
   if (options.initiator_info.dom_node_id != blink::kInvalidDOMNodeId) {
     RegisterRequestStartFromElm(options.initiator_info.dom_node_id,
@@ -1339,7 +1338,7 @@ void PageGraph::RegisterTextNodeChange(blink::Node* node,
 void PageGraph::DoRegisterRequestStart(const InspectorId request_id,
                                        GraphNode* requesting_node,
                                        const std::string& local_url,
-                                       const std::string& resource_type) {
+                                       const String& resource_type) {
   NodeResource* const requested_node = GetResourceNodeForUrl(local_url);
 
   scoped_refptr<const TrackedRequestRecord> request_record =
@@ -1364,7 +1363,7 @@ void PageGraph::PossiblyWriteRequestsIntoGraph(
 
   NodeResource* const resource = request->GetResource();
   const bool was_error = request->GetIsError();
-  const std::string& resource_type = request->GetResourceType();
+  const String& resource_type = request->GetResourceType();
   const InspectorId request_id = request->GetRequestId();
 
   if (was_error) {
@@ -1388,7 +1387,7 @@ void PageGraph::PossiblyWriteRequestsIntoGraph(
 void PageGraph::RegisterRequestStartFromElm(const DOMNodeId node_id,
                                             const InspectorId request_id,
                                             const KURL& url,
-                                            const std::string& resource_type) {
+                                            const String& resource_type) {
   const KURL normalized_url = NormalizeUrl(url);
   const std::string local_url(normalized_url.GetString().Utf8());
 
@@ -1407,7 +1406,7 @@ void PageGraph::RegisterRequestStartFromCurrentScript(
     blink::ExecutionContext* execution_context,
     const InspectorId request_id,
     const KURL& url,
-    const std::string& resource_type) {
+    const String& resource_type) {
   VLOG(1) << "RegisterRequestStartFromCurrentScript)";
   const ScriptId script_id = GetExecutingScriptId(execution_context);
   RegisterRequestStartFromScript(execution_context, script_id, request_id, url,
@@ -1419,7 +1418,7 @@ void PageGraph::RegisterRequestStartFromScript(
     const ScriptId script_id,
     const InspectorId request_id,
     const blink::KURL& url,
-    const std::string& resource_type) {
+    const String& resource_type) {
   const KURL normalized_url = NormalizeUrl(url);
   const std::string local_url(normalized_url.GetString().Utf8());
 
@@ -1435,11 +1434,10 @@ void PageGraph::RegisterRequestStartFromScript(
 // This is basically the same as |RegisterRequestStartFromCurrentScript|,
 // except we don't require the acting node to be a script (CSS fetches
 // can be initiated by the parser).
-void PageGraph::RegisterRequestStartFromCSSOrLink(
-    blink::DocumentLoader* loader,
-    const InspectorId request_id,
-    const blink::KURL& url,
-    const std::string& resource_type) {
+void PageGraph::RegisterRequestStartFromCSSOrLink(blink::DocumentLoader* loader,
+                                                  const InspectorId request_id,
+                                                  const blink::KURL& url,
+                                                  const String& resource_type) {
   NodeActor* const acting_node = GetCurrentActingNode(
       loader->GetFrame()->GetDocument()->GetExecutionContext());
   const KURL normalized_url = NormalizeUrl(url);

--- a/third_party/blink/renderer/core/brave_page_graph/page_graph.h
+++ b/third_party/blink/renderer/core/brave_page_graph/page_graph.h
@@ -320,28 +320,28 @@ class CORE_EXPORT PageGraph : public GarbageCollected<PageGraph>,
   void DoRegisterRequestStart(const InspectorId request_id,
                               GraphNode* requesting_node,
                               const std::string& local_url,
-                              const std::string& resource_type);
+                              const String& resource_type);
   void PossiblyWriteRequestsIntoGraph(
       scoped_refptr<const TrackedRequestRecord> record);
   void RegisterRequestStartFromElm(const blink::DOMNodeId node_id,
                                    const InspectorId request_id,
                                    const blink::KURL& url,
-                                   const std::string& resource_type);
+                                   const String& resource_type);
   void RegisterRequestStartFromCurrentScript(
       blink::ExecutionContext* execution_context,
       const InspectorId request_id,
       const blink::KURL& url,
-      const std::string& resource_type);
+      const String& resource_type);
   void RegisterRequestStartFromScript(
       blink::ExecutionContext* execution_context,
       const ScriptId script_id,
       const InspectorId request_id,
       const blink::KURL& url,
-      const std::string& resource_type);
+      const String& resource_type);
   void RegisterRequestStartFromCSSOrLink(blink::DocumentLoader* loader,
                                          const InspectorId request_id,
                                          const blink::KURL& url,
-                                         const std::string& resource_type);
+                                         const String& resource_type);
   void RegisterRequestStartForDocument(blink::Document* document,
                                        const InspectorId request_id,
                                        const blink::KURL& url,

--- a/third_party/blink/renderer/core/brave_page_graph/requests/request_tracker.cc
+++ b/third_party/blink/renderer/core/brave_page_graph/requests/request_tracker.cc
@@ -27,7 +27,7 @@ scoped_refptr<const TrackedRequestRecord> RequestTracker::RegisterRequestStart(
     const InspectorId request_id,
     GraphNode* requester,
     NodeResource* resource,
-    const std::string& resource_type) {
+    const String& resource_type) {
   auto item = tracked_requests_.find(request_id);
   if (item == tracked_requests_.end()) {
     auto request_record = std::make_unique<TrackedRequest>(

--- a/third_party/blink/renderer/core/brave_page_graph/requests/request_tracker.h
+++ b/third_party/blink/renderer/core/brave_page_graph/requests/request_tracker.h
@@ -53,7 +53,7 @@ class RequestTracker {
       const InspectorId request_id,
       GraphNode* requester,
       NodeResource* resource,
-      const std::string& resource_type);
+      const String& resource_type);
   scoped_refptr<const TrackedRequestRecord> RegisterRequestComplete(
       const InspectorId request_id,
       int64_t encoded_data_length);

--- a/third_party/blink/renderer/core/brave_page_graph/requests/tracked_request.cc
+++ b/third_party/blink/renderer/core/brave_page_graph/requests/tracked_request.cc
@@ -5,8 +5,6 @@
 
 #include "brave/third_party/blink/renderer/core/brave_page_graph/requests/tracked_request.h"
 
-#include <string>
-
 #include "brave/third_party/blink/renderer/core/brave_page_graph/graph_item/node/graph_node.h"
 #include "brave/third_party/blink/renderer/core/brave_page_graph/graph_item/node/node_resource.h"
 #include "brave/third_party/blink/renderer/core/brave_page_graph/utilities/response_metadata.h"
@@ -21,7 +19,7 @@ TrackedRequest::~TrackedRequest() = default;
 TrackedRequest::TrackedRequest(const InspectorId request_id,
                                GraphNode* requester,
                                NodeResource* resource,
-                               const std::string& resource_type)
+                               const String& resource_type)
     : request_id_(request_id),
       resource_type_(resource_type),
       resource_(resource) {
@@ -60,13 +58,13 @@ bool TrackedRequest::GetIsError() const {
   return request_status_ == RequestStatus::kError;
 }
 
-const std::string& TrackedRequest::GetResourceType() const {
+const String& TrackedRequest::GetResourceType() const {
   return resource_type_;
 }
 
 void TrackedRequest::AddRequest(GraphNode* requester,
                                 NodeResource* resource,
-                                const std::string& resource_type) {
+                                const String& resource_type) {
   CHECK(requester != nullptr);
   CHECK(resource != nullptr);
   CHECK(!resource_type.empty());
@@ -112,7 +110,7 @@ const ResponseMetadata& TrackedRequest::GetResponseMetadata() const {
   return response_metadata_;
 }
 
-const std::string& TrackedRequest::GetResponseBodyHash() const {
+const String& TrackedRequest::GetResponseBodyHash() const {
   CHECK(request_status_ == RequestStatus::kSuccess);
   CHECK(!hash_.empty());
   return hash_;
@@ -132,7 +130,7 @@ void TrackedRequest::FinishResponseBodyHash() {
   CHECK(hash_.empty());
   blink::DigestValue digest;
   CHECK(body_digestor_.Finish(digest));
-  hash_ = WTF::Base64Encode(digest).Utf8();
+  hash_ = WTF::Base64Encode(digest);
 }
 
 }  // namespace brave_page_graph

--- a/third_party/blink/renderer/core/brave_page_graph/requests/tracked_request.h
+++ b/third_party/blink/renderer/core/brave_page_graph/requests/tracked_request.h
@@ -6,8 +6,6 @@
 #ifndef BRAVE_THIRD_PARTY_BLINK_RENDERER_CORE_BRAVE_PAGE_GRAPH_REQUESTS_TRACKED_REQUEST_H_
 #define BRAVE_THIRD_PARTY_BLINK_RENDERER_CORE_BRAVE_PAGE_GRAPH_REQUESTS_TRACKED_REQUEST_H_
 
-#include <string>
-
 #include "base/containers/span.h"
 #include "brave/third_party/blink/renderer/core/brave_page_graph/types.h"
 #include "brave/third_party/blink/renderer/core/brave_page_graph/utilities/response_metadata.h"
@@ -27,27 +25,27 @@ class TrackedRequest {
   TrackedRequest(const InspectorId request_id,
                  GraphNode* requester,
                  NodeResource* resource,
-                 const std::string& resource_type);
+                 const String& resource_type);
   ~TrackedRequest();
 
   bool IsComplete() const;
 
   InspectorId GetRequestId() const;
   const Vector<GraphNode*>& GetRequesters() const;
-  const std::string& GetResourceType() const;
+  const String& GetResourceType() const;
   NodeResource* GetResource() const;
   bool GetIsError() const;
 
   void AddRequest(GraphNode* requester,
                   NodeResource* resource,
-                  const std::string& request_type);
+                  const String& request_type);
   void SetIsError();
   void SetCompleted();
 
   ResponseMetadata& GetResponseMetadata();
   const ResponseMetadata& GetResponseMetadata() const;
 
-  const std::string& GetResponseBodyHash() const;
+  const String& GetResponseBodyHash() const;
   void UpdateResponseBodyHash(base::span<const char> data);
 
  protected:
@@ -58,7 +56,7 @@ class TrackedRequest {
   const InspectorId request_id_;
 
   Vector<GraphNode*> requesters_;
-  std::string resource_type_;
+  String resource_type_;
 
   NodeResource* resource_ = nullptr;
 
@@ -69,7 +67,7 @@ class TrackedRequest {
   ResponseMetadata response_metadata_;
   int64_t size_ = -1;
   blink::Digestor body_digestor_{blink::kHashAlgorithmSha256};
-  std::string hash_;
+  String hash_;
 };
 
 }  // namespace brave_page_graph


### PR DESCRIPTION
This refactor remove the use of std::string from code aroudn RequestTracker, replacing it with the WTF equivalent. This is in line with upstream policies to ban the use of std types in blink code.

Chromium change:
https://chromium.googlesource.com/chromium/src/+/52472aba170b71f97ae9ab17f429ff494537adae

commit 52472aba170b71f97ae9ab17f429ff494537adae
Author: Xianzhu Wang <wangxianzhu@chromium.org>
Date:   Mon Jan 9 20:26:58 2023 +0000

    Enable discouraged type check for data members under blink/renderer

    For existing usages of discouraged type:
    - Simple cases are changed to use blink types;
    - For other cases, ALLOW_DISCOURAGED_TYPE(reason) is added.

    Rules audit_non_blink_usages.py checking such usages are removed.
    We'll use the clang plugin from now on.

    Bug: 1363780

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/28185

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

