### PR TITLE
Removing std::vector from blink code

### DIFF
--- a/third_party/blink/renderer/core/brave_page_graph/graph_item/node/html/node_html_element.cc
+++ b/third_party/blink/renderer/core/brave_page_graph/graph_item/node/html/node_html_element.cc
@@ -101,21 +101,20 @@ void NodeHTMLElement::PlaceChildNodeAfterSiblingNode(NodeHTML* child,
   // Or, if sibling is null, then insert the child in the first position
   // in the child nodes.
   if (sibling == nullptr) {
-    child_nodes_.insert(child_nodes_.begin(), child);
+    child_nodes_.insert(0, child);
     return;
   }
 
   // Otherwise, figure out where the sibling is in the child node set.
-  const auto sib_pos = find(child_nodes_.begin(), child_nodes_.end(), sibling);
-  CHECK(sib_pos != child_nodes_.end());
+  const auto sib_pos = child_nodes_.Find(sibling);
+  CHECK_NE(sib_pos, WTF::kNotFound);
   child_nodes_.insert(sib_pos + 1, child);
 }
 
 void NodeHTMLElement::RemoveChildNode(NodeHTML* child_node) {
-  const auto child_pos =
-      find(child_nodes_.begin(), child_nodes_.end(), child_node);
-  CHECK(child_pos != child_nodes_.end());
-  child_nodes_.erase(child_pos);
+  const auto child_pos = child_nodes_.Find(child_node);
+  CHECK_NE(child_pos, WTF::kNotFound);
+  child_nodes_.EraseAt(child_pos);
 }
 
 void NodeHTMLElement::MarkDeleted() {

--- a/third_party/blink/renderer/core/brave_page_graph/types.h
+++ b/third_party/blink/renderer/core/brave_page_graph/types.h
@@ -10,7 +10,6 @@
 #include <memory>
 #include <string>
 #include <utility>
-#include <vector>
 
 #include "brave/third_party/blink/renderer/core/brave_page_graph/blink_probe_types.h"
 #include "third_party/blink/renderer/bindings/core/v8/script_source_location_type.h"
@@ -18,6 +17,7 @@
 #include "third_party/blink/renderer/platform/graphics/dom_node_id.h"
 #include "third_party/blink/renderer/platform/weborigin/kurl.h"
 #include "third_party/blink/renderer/platform/wtf/text/wtf_string.h"
+#include "third_party/blink/renderer/platform/wtf/vector.h"
 
 namespace brave_page_graph {
 
@@ -42,10 +42,10 @@ using MethodName = std::string;
 using RequestURL = std::string;
 using InspectorId = uint64_t;
 
-using GraphItemUniquePtrList = std::vector<std::unique_ptr<GraphItem>>;
-using EdgeList = std::vector<const GraphEdge*>;
-using NodeList = std::vector<GraphNode*>;
-using HTMLNodeList = std::vector<NodeHTML*>;
+using GraphItemUniquePtrList = Vector<std::unique_ptr<GraphItem>>;
+using EdgeList = Vector<const GraphEdge*>;
+using NodeList = Vector<GraphNode*>;
+using HTMLNodeList = Vector<NodeHTML*>;
 using AttributeMap = std::map<const std::string, const std::string>;
 
 struct CORE_EXPORT FingerprintingRule {


### PR DESCRIPTION
This change removes all uses of `std::vector` from brave's blink code, and replaces it with its WTF equivalent.

    Chromium change:
    https://chromium.googlesource.com/chromium/src/+/52472aba170b71f97ae9ab17f429ff494537adae
    
    commit 52472aba170b71f97ae9ab17f429ff494537adae
    Author: Xianzhu Wang <wangxianzhu@chromium.org>
    Date:   Mon Jan 9 20:26:58 2023 +0000
    
        Enable discouraged type check for data members under blink/renderer
    
        For existing usages of discouraged type:
        - Simple cases are changed to use blink types;
        - For other cases, ALLOW_DISCOURAGED_TYPE(reason) is added.
    
        Rules audit_non_blink_usages.py checking such usages are removed.
        We'll use the clang plugin from now on.
    
        Bug: 1363780

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/28200

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

