### PR TITLE
fix(wallet): signed transaction status text

### DIFF
--- a/components/brave_wallet_ui/components/desktop/portfolio-transaction-item/index.tsx
+++ b/components/brave_wallet_ui/components/desktop/portfolio-transaction-item/index.tsx
@@ -23,7 +23,7 @@ import { getLocale } from '../../../../common/locale'
 import { WalletActions } from '../../../common/actions'
 import {
   getGasFeeFiatValue,
-  getLocaleKeyForTxStatus,
+  getTransactionStatusString,
   ParsedTransactionWithoutFiatValues
 } from '../../../utils/tx-utils'
 import { findTokenBySymbol } from '../../../utils/asset-utils'
@@ -503,7 +503,7 @@ export const PortfolioTransactionItem = React.forwardRef<HTMLDivElement, Props>(
         <StatusRow>
           <StatusBubble status={transaction.status} />
           <DetailTextDarkBold>
-            {getLocale(getLocaleKeyForTxStatus(transaction.status))}
+            {getTransactionStatusString(transaction.status)}
           </DetailTextDarkBold>
         </StatusRow>
 

--- a/components/brave_wallet_ui/utils/tx-utils.ts
+++ b/components/brave_wallet_ui/utils/tx-utils.ts
@@ -164,27 +164,33 @@ export const sortTransactionByDate = <
   return [...transactions].sort(transactionSortByDateComparer<T>(order))
 }
 
-export const getTransactionStatusString = (statusId: number) => {
-  switch (statusId) {
+export const getLocaleKeyForTxStatus = (
+  status: BraveWallet.TransactionStatus
+) => {
+  switch (status) {
     case BraveWallet.TransactionStatus.Unapproved:
-      return getLocale('braveWalletTransactionStatusUnapproved')
+      return 'braveWalletTransactionStatusUnapproved'
     case BraveWallet.TransactionStatus.Approved:
-      return getLocale('braveWalletTransactionStatusApproved')
+      return 'braveWalletTransactionStatusApproved'
     case BraveWallet.TransactionStatus.Rejected:
-      return getLocale('braveWalletTransactionStatusRejected')
+      return 'braveWalletTransactionStatusRejected'
     case BraveWallet.TransactionStatus.Submitted:
-      return getLocale('braveWalletTransactionStatusSubmitted')
+      return 'braveWalletTransactionStatusSubmitted'
     case BraveWallet.TransactionStatus.Confirmed:
-      return getLocale('braveWalletTransactionStatusConfirmed')
+      return 'braveWalletTransactionStatusConfirmed'
     case BraveWallet.TransactionStatus.Error:
-      return getLocale('braveWalletTransactionStatusError')
+      return 'braveWalletTransactionStatusError'
     case BraveWallet.TransactionStatus.Dropped:
-      return getLocale('braveWalletTransactionStatusDropped')
+      return 'braveWalletTransactionStatusDropped'
     case BraveWallet.TransactionStatus.Signed:
-      return getLocale('braveWalletTransactionStatusSigned')
+      return 'braveWalletTransactionStatusSigned'
     default:
       return ''
   }
+}
+
+export const getTransactionStatusString = (statusId: number) => {
+  return getLocale(getLocaleKeyForTxStatus(statusId))
 }
 
 export const transactionSortByDateComparer = <
@@ -1422,29 +1428,6 @@ export const getTransactionFiatValues = ({
       .plus(sendAmountFiat)
       .toNumber()
       .toString()
-  }
-}
-
-export const getLocaleKeyForTxStatus = (
-  status: BraveWallet.TransactionStatus
-) => {
-  switch (status) {
-    case BraveWallet.TransactionStatus.Unapproved:
-      return 'braveWalletTransactionStatusUnapproved'
-    case BraveWallet.TransactionStatus.Approved:
-      return 'braveWalletTransactionStatusApproved'
-    case BraveWallet.TransactionStatus.Rejected:
-      return 'braveWalletTransactionStatusRejected'
-    case BraveWallet.TransactionStatus.Submitted:
-      return 'braveWalletTransactionStatusSubmitted'
-    case BraveWallet.TransactionStatus.Confirmed:
-      return 'braveWalletTransactionStatusConfirmed'
-    case BraveWallet.TransactionStatus.Error:
-      return 'braveWalletTransactionStatusError'
-    case BraveWallet.TransactionStatus.Dropped:
-      return 'braveWalletTransactionStatusDropped'
-    default:
-      return ''
   }
 }
 


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/28205

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
### Normal flow
1. Setup wallet
2. Setup https://github.com/bbondy/eth-manual-tests 
3. Change to any test network and visit http://localhost:8081/request.html
4. Click `ethereum.enable` and grant permission
5. Fill to address next to `eth_signTransaction` and click it
6. Check transactions on brave://wallet/crypto/portfolio/ETH and there should be a "Signed" transaction
7. Go back to the console of http://localhost:8081/request.html
8. Paste the return signed transaction in console to `eth_sendRawTransaction` and click
9. Check transactions on brave://wallet/crypto/portfolio/ETH and previously "Signed" transaction should be "Confirmed" after a while

### Nonce drop
1. Setup wallet
2. Setup https://github.com/bbondy/eth-manual-tests 
3. Change to any test network and visit http://localhost:8081/request.html
4. Click `ethereum.enable` and grant permission
5. Fill to address next to `eth_signTransaction` and click it
6. Fill to address next to `eth_signTransaction (1559)` and click it
7. Check transactions on brave://wallet/crypto/portfolio/ETH and there should be TWO "Signed" transactions
8. Go back to the console of http://localhost:8081/request.html
9. Paste one of the return signed transactions in console to `eth_sendRawTransaction` and click
10. Check transactions on brave://wallet/crypto/portfolio/ETH and previously one "Signed" transaction should be "Confirmed" and one "Signed" transaction should be deleted after a while
