### PR TITLE
Fix Twitter's redirector (fixes brave/brave-browser#28184)

### DIFF
--- a/browser/net/brave_query_filter.cc
+++ b/browser/net/brave_query_filter.cc
@@ -69,8 +69,6 @@ static constexpr auto kScopedQueryStringTrackers =
     base::MakeFixedFlatMap<base::StringPiece, base::StringPiece>({
         // https://github.com/brave/brave-browser/issues/11580
         {"igshid", "instagram.com"},
-        // https://github.com/brave/brave-browser/issues/26756
-        {"t", "twitter.com"},
         // https://github.com/brave/brave-browser/issues/26966
         {"ref_src", "twitter.com"},
         {"ref_url", "twitter.com"},


### PR DESCRIPTION
The `t` parameter is required for the Twitter redirector to work.

This reverts commit 2c2afa6abf58ff64decfd2c4c4d818a6f705455e added to fix https://github.com/brave/brave-browser/issues/26756.

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/28184

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

In a new profile in which **you have never visited Twitter**:

1. Open <https://twitter.com/i/redirect?url=https%3A%2F%2Ftwitter.com%2Fmask_3dcg%2Fstatus%2F1617094871818596354%3Fcn%3DZmxleGlibGVfcmVjcw%253D%253D%26refsrc%3Demail&t=1+1674400145805&cn=ZmxleGlibGVfcmVjcw%3D%3D&sig=5d71ce9ef69b11a9f5e9ad0489166c17e89947ce&iid=93b0f359fc6f4fe795753cb5475c6801&uid=1360753837754048512&nid=244+276893697> in a new tab.
2. Confirm that it loads <https://twitter.com/mask_3dcg/status/1617094871818596354?cn=ZmxleGlibGVfcmVjcw%3D%3D&refsrc=email> instead of an error page.