### PR TITLE
Support multiple ninja target builds at once.

### DIFF
--- a/build/commands/lib/config.js
+++ b/build/commands/lib/config.js
@@ -932,7 +932,7 @@ Config.prototype.update = function (options) {
     this.extraNinjaOpts.push('--offline')
   }
 
-  if (options.target) {
+  if (options.target?.length) {
     this.buildTarget = options.target
   }
 

--- a/build/commands/lib/util.js
+++ b/build/commands/lib/util.js
@@ -612,8 +612,9 @@ const util = {
     if (config.ignore_compile_failure)
       num_compile_failure = 0
 
+    const targets = Array.isArray(target) ? target : [target]
     let ninjaOpts = [
-      '-C', options.outputDir || config.outputDir, target,
+      '-C', options.outputDir || config.outputDir, ...targets,
       '-k', num_compile_failure,
       ...config.extraNinjaOpts
     ]

--- a/build/commands/scripts/commands.js
+++ b/build/commands/scripts/commands.js
@@ -130,7 +130,7 @@ program
   .option('--use_goma [arg]', 'whether to use Goma for building', JSON.parse)
   .option('--goma_offline', 'use offline mode for goma')
   .option('--force_gn_gen', 'always run gn gen')
-  .option('--target <target>', 'Custom target to build, instead of the default browser target')
+  .option('--target <target>', 'Custom targets to build, instead of the default browser target', collect, [])
   .option('--build_sparkle', 'Build the Sparkle macOS update framework from source')
   .option('--no_gn_gen', 'Build without running gn gen')
   .arguments('[build_config]')


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
This PR allows such construct:
```
npm run build -- --target brave --target brave_tests
```
which is converted to this `autoninja` call:
```
autoninja -C C:\brave\5\src\out\Component brave brave_tests -k 1
```

Resolves https://github.com/brave/brave-browser/issues/28240

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

