### PR TITLE
Fix missing Privacy and Security section in brave://settings/privacy

### DIFF
--- a/browser/resources/settings/brave_overrides/privacy_page.ts
+++ b/browser/resources/settings/brave_overrides/privacy_page.ts
@@ -10,70 +10,6 @@ import {I18nBehavior} from 'chrome://resources/i18n_behavior.js'
 import {loadTimeData} from 'chrome://resources/js/load_time_data.js';
 import {getTrustedHTML} from 'chrome://resources/js/static_types.js'
 
-function InsertGoogleSignInSubpage (
-  templateContent: DocumentFragment,
-  pages: Element)
-{
-  pages.insertAdjacentHTML(
-    'beforeend',
-    getTrustedHTML`
-      <template is="dom-if" route-path="/content/googleSignIn" no-search>
-        <settings-subpage>
-          <category-default-setting
-            id="googleSignInDefault"
-            category="[[contentSettingsTypesEnum_.GOOGLE_SIGN_IN]]">
-          </category-default-setting>
-          <category-setting-exceptions
-            id="googleSignInExceptions"
-            category="[[contentSettingsTypesEnum_.GOOGLE_SIGN_IN]]">
-          </category-setting-exceptions>
-        </settings-subpage>
-      </template>
-    `)
-  const googleSignInTemplate = templateContent.
-    querySelector('[route-path="/content/googleSignIn"]')
-  if (!googleSignInTemplate) {
-    console.error(
-      '[Brave Settings Overrides] Couldn\'t find Google signin template')
-  } else {
-    const googleSignInSubpage =
-      googleSignInTemplate.content.querySelector('settings-subpage')
-    if (!googleSignInSubpage) {
-      console.error(
-        '[Brave Settings Overrides] Couldn\'t find Google signin subpage')
-    } else {
-      googleSignInSubpage.setAttribute('page-title',
-        I18nBehavior.i18n('siteSettingsCategoryGoogleSignIn'))
-      const googleSignInDefault =
-        googleSignInTemplate.content.getElementById('googleSignInDefault')
-      if (!googleSignInDefault) {
-        console.error(
-          '[Brave Settings Overrides] Couldn\'t find Google signin default')
-      } else {
-        googleSignInDefault.setAttribute(
-          'toggle-off-label',
-          I18nBehavior.i18n('siteSettingsGoogleSignInBlock'))
-        googleSignInDefault.setAttribute(
-          'toggle-on-label',
-          I18nBehavior.i18n('siteSettingsGoogleSignInAllow'))
-      }
-      const googleSignInExceptions =
-        googleSignInTemplate.content.getElementById('googleSignInExceptions')
-      if (!googleSignInExceptions) {
-        console.error(
-          '[Brave Settings Overrides] Couldn\'t find Google signin exceptions')
-      } else {
-        googleSignInExceptions.setAttribute(
-          'block-header',
-          I18nBehavior.i18n('siteSettingsGoogleSignInBlock'))
-        googleSignInExceptions.setAttribute(
-          'allow-header',
-          I18nBehavior.i18n('siteSettingsGoogleSignInAllow'))
-      }
-    }
-  }
-}
-
 function InsertAutoplaySubpage (
   templateContent: DocumentFragment,
   pages: Element)
@@ -324,11 +260,6 @@ RegisterPolymerTemplateModifications({
         } else {
           idleDetection.content.firstElementChild.hidden = true
         }
-      }
-      const isGoogleSignInFeatureEnabled =
-        loadTimeData.getBoolean('isGoogleSignInFeatureEnabled')
-      if (isGoogleSignInFeatureEnabled) {
-        InsertGoogleSignInSubpage(templateContent, pages)
       }
       InsertAutoplaySubpage(templateContent, pages)
       const isNativeBraveWalletEnabled = loadTimeData.getBoolean('isNativeBraveWalletFeatureEnabled')


### PR DESCRIPTION
Due to a faulty rebase, Google SignIn code was added to brave://settings/privacy without its corresponding feature. This PR removes that setting from brave://settings/privacy.

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/28261

## Submitter Checklist:

- [ ] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

