### PR TITLE
Added runtime check for service launch and fallback to DoH

### DIFF
--- a/browser/brave_vpn/dns/brave_vpn_dns_observer_service_win.cc
+++ b/browser/brave_vpn/dns/brave_vpn_dns_observer_service_win.cc
@@ -9,6 +9,7 @@
 
 #include "base/strings/string_util.h"
 #include "brave/browser/ui/views/brave_vpn/brave_vpn_dns_settings_notificiation_dialog_view.h"
+#include "brave/components/brave_vpn/browser/connection/win/brave_vpn_helper/brave_vpn_helper_constants.h"
 #include "brave/components/brave_vpn/browser/connection/win/brave_vpn_helper/brave_vpn_helper_state.h"
 #include "brave/components/brave_vpn/common/brave_vpn_utils.h"
 #include "brave/components/brave_vpn/common/pref_names.h"
@@ -24,6 +25,8 @@
 #include "chrome/grit/chromium_strings.h"
 #include "components/grit/brave_components_strings.h"
 #include "components/prefs/pref_service.h"
+#include "content/public/browser/browser_task_traits.h"
+#include "content/public/browser/browser_thread.h"
 #include "ui/base/l10n/l10n_util.h"
 
 namespace brave_vpn {
@@ -31,6 +34,10 @@ namespace brave_vpn {
 namespace {
 const char kCloudflareDnsProviderURL[] =
     "https://chrome.cloudflare-dns.com/dns-query";
+
+// Timer to recheck the service launch after some time and fallback to DoH if
+// the service was not launched.
+const int kHelperServiceStartTimeoutSec = 3;
 
 void SkipDNSDialog(PrefService* prefs, bool checked) {
   if (!prefs)
@@ -99,15 +106,65 @@ bool BraveVpnDnsObserverService::IsDNSHelperLive() {
   if (dns_helper_live_for_testing_.has_value()) {
     return dns_helper_live_for_testing_.value();
   }
-  // If BraveVpnHelper is live we should not override DNS because it will be
+  // If the service is not installed we should override DNS because it will be
   // handled by the service.
-  return brave_vpn::IsBraveVPNHelperServiceLive();
+
+  if (!IsBraveVPNHelperServiceInstalled()) {
+    return false;
+  }
+  if (!IsBraveVPNHelperServiceRunning()) {
+    content::GetUIThreadTaskRunner({})->PostDelayedTask(
+        FROM_HERE,
+        base::BindOnce(&BraveVpnDnsObserverService::OnCheckIfServiceStarted,
+                       weak_ptr_factory_.GetWeakPtr()),
+        base::Seconds(kHelperServiceStartTimeoutSec));
+    // The service can be stopped and this is valid state, not started yet,
+    // crashed once and restarting and so on.
+    return true;
+  }
+  RunServiceWatcher();
+  return IsNetworkFiltersInstalled();
+}
+
+void BraveVpnDnsObserverService::RunServiceWatcher() {
+  service_watcher_.reset(new ServiceWatcher());
+  if (!service_watcher_->Subscribe(
+          brave_vpn::GetVpnServiceName(), SERVICE_NOTIFY_STOPPED,
+          base::BindOnce(&BraveVpnDnsObserverService::OnServiceStopped,
+                         weak_ptr_factory_.GetWeakPtr()))) {
+    VLOG(1) << "Unable to set service watcher";
+  }
+}
+
+void BraveVpnDnsObserverService::OnServiceStopped() {
+  // Postpone check because the service can be restarted by the system due to
+  // configured failure actions.
+  content::GetUIThreadTaskRunner({})->PostDelayedTask(
+      FROM_HERE,
+      base::BindOnce(&BraveVpnDnsObserverService::OnCheckIfServiceStarted,
+                     weak_ptr_factory_.GetWeakPtr()),
+      base::Seconds(kHelperServiceStartTimeoutSec));
+}
+
+bool BraveVpnDnsObserverService::IsVPNConnected() const {
+  return connection_state_.has_value() &&
+         connection_state_.value() ==
+             brave_vpn::mojom::ConnectionState::CONNECTED;
+}
+
+void BraveVpnDnsObserverService::OnCheckIfServiceStarted() {
+  if (!IsVPNConnected()) {
+    return;
+  }
+  // Checking if the service was not launched or filters were not set.
+  if (!IsNetworkFiltersInstalled() || !IsBraveVPNHelperServiceRunning()) {
+    LockDNS();
+    return;
+  }
+  RunServiceWatcher();
 }
 
 void BraveVpnDnsObserverService::LockDNS() {
-  if (IsDNSHelperLive()) {
-    return;
-  }
   auto old_dns_config =
       SystemNetworkContextManager::GetStubResolverConfigReader()
           ->GetSecureDnsConfiguration(false);
@@ -134,7 +191,11 @@ void BraveVpnDnsObserverService::LockDNS() {
 
 void BraveVpnDnsObserverService::OnConnectionStateChanged(
     brave_vpn::mojom::ConnectionState state) {
+  connection_state_ = state;
   if (state == brave_vpn::mojom::ConnectionState::CONNECTED) {
+    if (IsDNSHelperLive()) {
+      return;
+    }
     LockDNS();
   } else if (state == brave_vpn::mojom::ConnectionState::DISCONNECTED) {
     UnlockDNS();

--- a/browser/brave_vpn/dns/brave_vpn_dns_observer_service_win.cc
+++ b/browser/brave_vpn/dns/brave_vpn_dns_observer_service_win.cc
@@ -32,12 +32,12 @@
 namespace brave_vpn {
 
 namespace {
-const char kCloudflareDnsProviderURL[] =
+constexpr char kCloudflareDnsProviderURL[] =
     "https://chrome.cloudflare-dns.com/dns-query";
 
 // Timer to recheck the service launch after some time and fallback to DoH if
 // the service was not launched.
-const int kHelperServiceStartTimeoutSec = 3;
+constexpr int kHelperServiceStartTimeoutSec = 3;
 
 void SkipDNSDialog(PrefService* prefs, bool checked) {
   if (!prefs)

--- a/browser/brave_vpn/dns/brave_vpn_dns_observer_service_win.h
+++ b/browser/brave_vpn/dns/brave_vpn_dns_observer_service_win.h
@@ -11,9 +11,9 @@
 #include <utility>
 
 #include "base/memory/weak_ptr.h"
+#include "brave/browser/brave_vpn/dns/brave_vpn_helper_watcher_win.h"
 #include "brave/components/brave_vpn/browser/brave_vpn_service_observer.h"
 #include "components/keyed_service/core/keyed_service.h"
-#include "components/prefs/pref_change_registrar.h"
 #include "third_party/abseil-cpp/absl/types/optional.h"
 
 class PrefService;
@@ -44,10 +44,13 @@ class BraveVpnDnsObserverService : public brave_vpn::BraveVPNServiceObserver,
   void SetDNSHelperLiveForTesting(bool value) {
     dns_helper_live_for_testing_ = value;
   }
+  bool IsVPNConnected() const;
 
  private:
   friend class BraveVpnDnsObserverServiceUnitTest;
 
+  void OnServiceStopped();
+  void RunServiceWatcher();
   void OnPrefChanged();
   bool IsDNSHelperLive();
   void LockDNS();
@@ -56,13 +59,16 @@ class BraveVpnDnsObserverService : public brave_vpn::BraveVPNServiceObserver,
   void ShowVpnDnsSettingsNotificationDialog();
   void OnDnsModePrefChanged();
 
+  void OnCheckIfServiceStarted();
+
+  absl::optional<brave_vpn::mojom::ConnectionState> connection_state_;
+  std::unique_ptr<ServiceWatcher> service_watcher_;
   absl::optional<bool> dns_helper_live_for_testing_;
   base::OnceClosure policy_callback_;
   base::RepeatingClosure dialog_callback_;
   bool skip_notification_dialog_for_testing_ = false;
   raw_ptr<PrefService> local_state_;
   raw_ptr<PrefService> profile_prefs_;
-
   base::WeakPtrFactory<BraveVpnDnsObserverService> weak_ptr_factory_{this};
 };
 

--- a/browser/brave_vpn/dns/brave_vpn_helper_watcher_win.cc
+++ b/browser/brave_vpn/dns/brave_vpn_helper_watcher_win.cc
@@ -1,0 +1,85 @@
+/* Copyright (c) 2022 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "brave/browser/brave_vpn/dns/brave_vpn_helper_watcher_win.h"
+
+#include <utility>
+
+#include "base/logging.h"
+#include "base/task/task_traits.h"
+#include "base/task/thread_pool.h"
+#include "brave/components/brave_vpn/browser/connection/win/brave_vpn_helper/scoped_sc_handle.h"
+#include "content/public/browser/browser_task_traits.h"
+#include "content/public/browser/browser_thread.h"
+
+namespace {
+
+VOID CALLBACK OnServiceStoppedCallback(PVOID pParameter) {
+  SERVICE_NOTIFY* service_notfiy =
+      reinterpret_cast<SERVICE_NOTIFY*>(pParameter);
+  if (!service_notfiy || !service_notfiy->pContext) {
+    return;
+  }
+  SetEvent(service_notfiy->pContext);
+}
+
+void WaitForEvent(HANDLE event,
+                  SC_HANDLE service,
+                  SERVICE_NOTIFY* service_notify) {
+  if (NotifyServiceStatusChange(service, SERVICE_NOTIFY_STOPPED,
+                                service_notify) != ERROR_SUCCESS) {
+    return;
+  }
+
+  ::WaitForSingleObjectEx(event, INFINITE, TRUE);
+}
+
+}  // namespace
+
+ServiceWatcher::ServiceWatcher()
+    : task_runner_(base::ThreadPool::CreateSequencedTaskRunner(
+          {base::MayBlock(), base::TaskPriority::BEST_EFFORT,
+           base::TaskShutdownBehavior::SKIP_ON_SHUTDOWN})) {}
+ServiceWatcher::~ServiceWatcher() = default;
+
+void ServiceWatcher::OnServiceSignaled(base::OnceClosure callback,
+                                       base::WaitableEvent* service_event) {
+  if (callback) {
+    std::move(callback).Run();
+  }
+}
+
+bool ServiceWatcher::Subscribe(const std::wstring& service_name,
+                               int state,
+                               base::OnceClosure callback) {
+  scm_.Set(::OpenSCManager(
+      nullptr, nullptr, SERVICE_QUERY_STATUS | SC_MANAGER_ENUMERATE_SERVICE));
+  if (!scm_.IsValid()) {
+    return false;
+  }
+  service_.Set(
+      ::OpenService(scm_.Get(), service_name.c_str(), SERVICE_QUERY_STATUS));
+
+  if (!service_.IsValid()) {
+    return false;
+  }
+
+  service_notify_ = {
+      .dwVersion = SERVICE_NOTIFY_STATUS_CHANGE,
+      .pfnNotifyCallback = (PFN_SC_NOTIFY_CALLBACK)&OnServiceStoppedCallback,
+      .pContext = service_stoped_event_.handle()};
+
+  task_runner_->PostTask(
+      FROM_HERE, base::BindOnce(&WaitForEvent, service_stoped_event_.handle(),
+                                service_.get(), &service_notify_));
+
+  service_watcher_.StartWatching(
+      &service_stoped_event_,
+      base::BindOnce(&ServiceWatcher::OnServiceSignaled,
+                     weak_ptr_factory_.GetWeakPtr(), std::move(callback)),
+      task_runner_);
+
+  return true;
+}

--- a/browser/brave_vpn/dns/brave_vpn_helper_watcher_win.cc
+++ b/browser/brave_vpn/dns/brave_vpn_helper_watcher_win.cc
@@ -30,6 +30,9 @@ void WaitForEvent(HANDLE event,
                   SERVICE_NOTIFY* service_notify) {
   if (NotifyServiceStatusChange(service, SERVICE_NOTIFY_STOPPED,
                                 service_notify) != ERROR_SUCCESS) {
+    // Assuming the service is not in good state if we are unable to subscribe
+    // and fire the stop event to make fallback.
+    SetEvent(event);
     return;
   }
 

--- a/browser/brave_vpn/dns/brave_vpn_helper_watcher_win.cc
+++ b/browser/brave_vpn/dns/brave_vpn_helper_watcher_win.cc
@@ -28,8 +28,11 @@ VOID CALLBACK OnServiceStoppedCallback(PVOID pParameter) {
 void WaitForEvent(HANDLE event,
                   SC_HANDLE service,
                   SERVICE_NOTIFY* service_notify) {
-  if (NotifyServiceStatusChange(service, SERVICE_NOTIFY_STOPPED,
-                                service_notify) != ERROR_SUCCESS) {
+  auto result = NotifyServiceStatusChange(service, SERVICE_NOTIFY_STOPPED,
+                                          service_notify);
+  if (result != ERROR_SUCCESS) {
+    VLOG(1) << "Unable to subscribe for service notifications:"
+            << logging::SystemErrorCodeToString(result);
     // If we're unable to subscribe to status changes for this service,
     // the service may be in a bad state.
     // We can immediately signal to trigger the DoH fallback behavior.

--- a/browser/brave_vpn/dns/brave_vpn_helper_watcher_win.cc
+++ b/browser/brave_vpn/dns/brave_vpn_helper_watcher_win.cc
@@ -1,4 +1,4 @@
-/* Copyright (c) 2022 The Brave Authors. All rights reserved.
+/* Copyright (c) 2023 The Brave Authors. All rights reserved.
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at https://mozilla.org/MPL/2.0/. */

--- a/browser/brave_vpn/dns/brave_vpn_helper_watcher_win.h
+++ b/browser/brave_vpn/dns/brave_vpn_helper_watcher_win.h
@@ -1,0 +1,40 @@
+/* Copyright (c) 2022 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_BROWSER_BRAVE_VPN_DNS_BRAVE_VPN_HELPER_WATCHER_WIN_H_
+#define BRAVE_BROWSER_BRAVE_VPN_DNS_BRAVE_VPN_HELPER_WATCHER_WIN_H_
+
+#include <windows.h>
+#include <string>
+
+#include "base/memory/weak_ptr.h"
+#include "base/synchronization/waitable_event.h"
+#include "base/synchronization/waitable_event_watcher.h"
+#include "brave/components/brave_vpn/browser/connection/win/brave_vpn_helper/scoped_sc_handle.h"
+
+class ServiceWatcher {
+ public:
+  ServiceWatcher();
+  virtual ~ServiceWatcher();
+
+  bool Subscribe(const std::wstring& service_name,
+                 int state,
+                 base::OnceClosure callback);
+
+ protected:
+  void OnServiceSignaled(base::OnceClosure callback,
+                         base::WaitableEvent* service_event);
+
+ private:
+  ScopedScHandle scm_;
+  ScopedScHandle service_;
+  SERVICE_NOTIFY service_notify_{0};
+  base::WaitableEvent service_stoped_event_;
+  base::WaitableEventWatcher service_watcher_;
+  scoped_refptr<base::SequencedTaskRunner> task_runner_;
+  base::WeakPtrFactory<ServiceWatcher> weak_ptr_factory_{this};
+};
+
+#endif  // BRAVE_BROWSER_BRAVE_VPN_DNS_BRAVE_VPN_HELPER_WATCHER_WIN_H_

--- a/browser/brave_vpn/dns/brave_vpn_helper_watcher_win.h
+++ b/browser/brave_vpn/dns/brave_vpn_helper_watcher_win.h
@@ -31,7 +31,7 @@ class ServiceWatcher {
   ScopedScHandle scm_;
   ScopedScHandle service_;
   SERVICE_NOTIFY service_notify_{0};
-  base::WaitableEvent service_stoped_event_;
+  base::WaitableEvent service_stopped_event_;
   base::WaitableEventWatcher service_watcher_;
   scoped_refptr<base::SequencedTaskRunner> task_runner_;
   base::WeakPtrFactory<ServiceWatcher> weak_ptr_factory_{this};

--- a/browser/brave_vpn/dns/brave_vpn_helper_watcher_win.h
+++ b/browser/brave_vpn/dns/brave_vpn_helper_watcher_win.h
@@ -1,4 +1,4 @@
-/* Copyright (c) 2022 The Brave Authors. All rights reserved.
+/* Copyright (c) 2023 The Brave Authors. All rights reserved.
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at https://mozilla.org/MPL/2.0/. */

--- a/browser/brave_vpn/sources.gni
+++ b/browser/brave_vpn/sources.gni
@@ -21,7 +21,10 @@ if (enable_brave_vpn) {
       "//brave/browser/brave_vpn/dns/brave_vpn_dns_observer_factory_win.h",
       "//brave/browser/brave_vpn/dns/brave_vpn_dns_observer_service_win.cc",
       "//brave/browser/brave_vpn/dns/brave_vpn_dns_observer_service_win.h",
+      "//brave/browser/brave_vpn/dns/brave_vpn_helper_watcher_win.cc",
+      "//brave/browser/brave_vpn/dns/brave_vpn_helper_watcher_win.h",
     ]
+
     brave_browser_brave_vpn_deps += [
       "//brave/app:brave_generated_resources_grit",
       "//brave/browser:browser_process",

--- a/components/brave_vpn/browser/connection/win/brave_vpn_helper/BUILD.gn
+++ b/components/brave_vpn/browser/connection/win/brave_vpn_helper/BUILD.gn
@@ -24,11 +24,25 @@ source_set("common") {
     "brave_vpn_helper_state.h",
     "scoped_sc_handle.h",
   ]
+  public_configs = [ ":brave_vpn_helper_config" ]
   deps = [
     "//base",
     "//brave/components/brave_vpn/common",
     "//chrome/install_static:install_static_util",
   ]
+}
+
+config("brave_vpn_helper_config") {
+  defines = []
+  if (brave_channel == "nightly") {
+    defines += [ "CHANNEL_NIGHTLY" ]
+  } else if (brave_channel == "beta") {
+    defines += [ "CHANNEL_BETA" ]
+  } else if (brave_channel == "dev") {
+    defines += [ "CHANNEL_DEV" ]
+  } else if (brave_channel == "development") {
+    defines += [ "CHANNEL_DEVELOPMENT" ]
+  }
 }
 
 source_set("lib") {
@@ -51,18 +65,6 @@ source_set("lib") {
     "//brave//components/brave_vpn/common",
     "//third_party/abseil-cpp:absl",
   ]
-
-  defines = []
-
-  if (brave_channel == "nightly") {
-    defines += [ "CHANNEL_NIGHTLY" ]
-  } else if (brave_channel == "beta") {
-    defines += [ "CHANNEL_BETA" ]
-  } else if (brave_channel == "dev") {
-    defines += [ "CHANNEL_DEV" ]
-  } else if (brave_channel == "development") {
-    defines += [ "CHANNEL_DEVELOPMENT" ]
-  }
 
   libs = [
     "Fwpuclnt.lib",

--- a/components/brave_vpn/browser/connection/win/brave_vpn_helper/brave_vpn_helper_constants.h
+++ b/components/brave_vpn/browser/connection/win/brave_vpn_helper/brave_vpn_helper_constants.h
@@ -12,7 +12,7 @@ namespace brave_vpn {
 
 constexpr char kBraveVpnHelperInstall[] = "install";
 constexpr wchar_t kBraveVPNHelperExecutable[] = L"brave_vpn_helper.exe";
-constexpr wchar_t kBraveVpnHelperLaunchCounterValue[] = L"launched";
+constexpr wchar_t kBraveVpnHelperFiltersInstalledValue[] = L"filters";
 // Repeating interval to check the connection is live.
 constexpr int kCheckConnectionIntervalInSeconds = 3;
 

--- a/components/brave_vpn/browser/connection/win/brave_vpn_helper/brave_vpn_helper_state.cc
+++ b/components/brave_vpn/browser/connection/win/brave_vpn_helper/brave_vpn_helper_state.cc
@@ -82,6 +82,7 @@ std::wstring GetVpnServiceDisplayName() {
 }
 
 bool IsNetworkFiltersInstalled() {
+  DCHECK(IsBraveVPNHelperServiceInstalled());
   base::win::RegKey service_storage_key(
       HKEY_LOCAL_MACHINE, brave_vpn::kBraveVpnHelperRegistryStoragePath,
       KEY_READ);

--- a/components/brave_vpn/browser/connection/win/brave_vpn_helper/brave_vpn_helper_state.h
+++ b/components/brave_vpn/browser/connection/win/brave_vpn_helper/brave_vpn_helper_state.h
@@ -6,12 +6,10 @@
 #ifndef BRAVE_COMPONENTS_BRAVE_VPN_BROWSER_CONNECTION_WIN_BRAVE_VPN_HELPER_BRAVE_VPN_HELPER_STATE_H_
 #define BRAVE_COMPONENTS_BRAVE_VPN_BROWSER_CONNECTION_WIN_BRAVE_VPN_HELPER_BRAVE_VPN_HELPER_STATE_H_
 
-#include <windows.h>
 #include <string>
 
 namespace brave_vpn {
 
-bool SubscribeForServiceStop(HANDLE event);
 bool IsBraveVPNHelperServiceInstalled();
 bool IsBraveVPNHelperServiceRunning();
 bool IsNetworkFiltersInstalled();

--- a/components/brave_vpn/browser/connection/win/brave_vpn_helper/brave_vpn_helper_state.h
+++ b/components/brave_vpn/browser/connection/win/brave_vpn_helper/brave_vpn_helper_state.h
@@ -6,11 +6,15 @@
 #ifndef BRAVE_COMPONENTS_BRAVE_VPN_BROWSER_CONNECTION_WIN_BRAVE_VPN_HELPER_BRAVE_VPN_HELPER_STATE_H_
 #define BRAVE_COMPONENTS_BRAVE_VPN_BROWSER_CONNECTION_WIN_BRAVE_VPN_HELPER_BRAVE_VPN_HELPER_STATE_H_
 
+#include <windows.h>
 #include <string>
 
 namespace brave_vpn {
 
-bool IsBraveVPNHelperServiceLive();
+bool SubscribeForServiceStop(HANDLE event);
+bool IsBraveVPNHelperServiceInstalled();
+bool IsBraveVPNHelperServiceRunning();
+bool IsNetworkFiltersInstalled();
 std::wstring GetBraveVPNConnectionName();
 std::wstring GetVpnServiceName();
 std::wstring GetVpnServiceDisplayName();

--- a/components/brave_vpn/browser/connection/win/brave_vpn_helper/main.cc
+++ b/components/brave_vpn/browser/connection/win/brave_vpn_helper/main.cc
@@ -26,20 +26,25 @@
 namespace {
 const char kUserDataDir[] = "user-data-dir";
 const char kProcessType[] = "type";
+const char kLogFile[] = "log-file";
 }  // namespace
 
 int main(int argc, char* argv[]) {
   // Initialize the CommandLine singleton from the environment.
-  base::CommandLine::Init(0, nullptr);
-
+  base::CommandLine::Init(argc, argv);
+  auto* command_line = base::CommandLine::ForCurrentProcess();
   logging::LoggingSettings settings;
   settings.logging_dest =
       logging::LOG_TO_SYSTEM_DEBUG_LOG | logging::LOG_TO_STDERR;
+  base::FilePath log_file_path;
+  if (command_line->HasSwitch(kLogFile)) {
+    settings.logging_dest |= logging::LOG_TO_FILE;
+    log_file_path = command_line->GetSwitchValuePath(kLogFile);
+    settings.log_file_path = log_file_path.value().c_str();
+  }
   logging::InitLogging(settings);
-
   // The exit manager is in charge of calling the dtors of singletons.
   base::AtExitManager exit_manager;
-  auto* command_line = base::CommandLine::ForCurrentProcess();
   std::string process_type = command_line->GetSwitchValueASCII(kProcessType);
 
   BraveVPNHelperCrashReporterClient::InitializeCrashReportingForProcess(

--- a/components/brave_vpn/browser/connection/win/brave_vpn_helper/service_main.cc
+++ b/components/brave_vpn/browser/connection/win/brave_vpn_helper/service_main.cc
@@ -18,7 +18,6 @@
 #include "base/threading/thread_restrictions.h"
 #include "brave/components/brave_vpn/browser/connection/win/brave_vpn_helper/brave_vpn_helper_constants.h"
 #include "brave/components/brave_vpn/browser/connection/win/brave_vpn_helper/brave_vpn_helper_state.h"
-#include "brave/components/brave_vpn/browser/connection/win/brave_vpn_helper/vpn_utils.h"
 
 namespace brave_vpn {
 namespace {
@@ -88,7 +87,6 @@ void ServiceMain::ServiceMainImpl() {
     return;
   }
   SetServiceStatus(SERVICE_RUNNING);
-  CountSuccessfulLaunch();
   service_status_.dwWin32ExitCode = ERROR_SUCCESS;
   service_status_.dwCheckPoint = 0;
   service_status_.dwWaitHint = 0;

--- a/components/brave_vpn/browser/connection/win/brave_vpn_helper/vpn_dns_handler.cc
+++ b/components/brave_vpn/browser/connection/win/brave_vpn_helper/vpn_dns_handler.cc
@@ -34,6 +34,7 @@ VpnDnsHandler::VpnDnsHandler(BraveVpnDnsDelegate* delegate)
     : delegate_(delegate) {
   DCHECK(delegate_);
 }
+
 VpnDnsHandler::~VpnDnsHandler() {
   CloseWatchers();
 }
@@ -142,6 +143,7 @@ void VpnDnsHandler::UpdateFiltersState() {
         ScheduleExit();
         return;
       }
+      SetFiltersInstalledFlag();
       break;
     case internal::CheckConnectionResult::DISCONNECTED:
       VLOG(1) << "BraveVPN Disconnected, remove filters";
@@ -151,7 +153,7 @@ void VpnDnsHandler::UpdateFiltersState() {
         break;
       }
       // Reset service launch counter if dns filters successfully removed.
-      ResetLaunchCounter();
+      ResetFiltersInstalledFlag();
       ScheduleExit();
       break;
     default:

--- a/components/brave_vpn/browser/connection/win/brave_vpn_helper/vpn_utils.cc
+++ b/components/brave_vpn/browser/connection/win/brave_vpn_helper/vpn_utils.cc
@@ -354,27 +354,25 @@ bool ConfigureServiceAutoRestart(const std::wstring& service_name,
   return true;
 }
 
-void CountSuccessfulLaunch() {
+void SetFiltersInstalledFlag() {
   base::win::RegKey key(HKEY_LOCAL_MACHINE, kBraveVpnHelperRegistryStoragePath,
                         KEY_ALL_ACCESS);
   if (!key.Valid()) {
-    LOG(ERROR) << "Failed to write successful launch counter";
+    VLOG(1) << "Failed to open vpn service storage";
     return;
   }
-  DWORD launch = 0;
-  key.ReadValueDW(kBraveVpnHelperLaunchCounterValue, &launch);
-  launch++;
-  key.WriteValue(kBraveVpnHelperLaunchCounterValue, launch);
+  DWORD launch = 1;
+  key.WriteValue(kBraveVpnHelperFiltersInstalledValue, launch);
 }
 
-void ResetLaunchCounter() {
+void ResetFiltersInstalledFlag() {
   base::win::RegKey key(HKEY_LOCAL_MACHINE, kBraveVpnHelperRegistryStoragePath,
                         KEY_ALL_ACCESS);
   if (!key.Valid()) {
-    LOG(ERROR) << "Failed to reset successful launch counter";
+    VLOG(1) << "Failed to open vpn service storage";
     return;
   }
-  key.DeleteValue(kBraveVpnHelperLaunchCounterValue);
+  key.DeleteValue(kBraveVpnHelperFiltersInstalledValue);
 }
 
 }  // namespace brave_vpn

--- a/components/brave_vpn/browser/connection/win/brave_vpn_helper/vpn_utils.h
+++ b/components/brave_vpn/browser/connection/win/brave_vpn_helper/vpn_utils.h
@@ -10,10 +10,10 @@
 #include <string>
 
 namespace brave_vpn {
-// Increases helper's launch counter in the registry.
-void CountSuccessfulLaunch();
-// Resets helper's launch counter in the registry.
-void ResetLaunchCounter();
+// Sets helper's flag to indicate filters successfully installed.
+void SetFiltersInstalledFlag();
+// Resets helper's filters installed flag.
+void ResetFiltersInstalledFlag();
 // Register and setup DNS filters layer to the system, if the layer is already
 // registered reuses existing.
 bool AddWpmFilters(HANDLE engine_handle, const std::string& name);


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/28195

- Replaced the service startup counter with an indication that the filters were successfully installed. Unfortunately, checking filters directly from fwpm requires administrator privileges, so I added a flag to the registry to be able to read it from the browser in user space.
- Added a check that the service is alive, running, and has successfully installed filters when the vpn is connected.
- Added subscription for service's stop if it was started. If the service is stopped, rechecks the status and enables DoH if the service is no longer running.

https://user-images.githubusercontent.com/2965009/216957208-e39bd44a-1b56-428c-bd9f-947ef328ef97.mp4

https://user-images.githubusercontent.com/2965009/216957215-b8fe8140-6991-4ef9-a3e0-3f077f383047.mp4

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [x] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [x] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

- Enable vpn try to kill service many times, pay attention if service restarated fallback will not happen, otherwise should happen fallback to DoH solution.
- Enable vpn and stop the service manually, check that browser will fallback to DoH overriding.