### PR TITLE
Cache private search provider's template url data

### DIFF
--- a/browser/profile_resetter/brave_profile_resetter.cc
+++ b/browser/profile_resetter/brave_profile_resetter.cc
@@ -13,8 +13,6 @@ void BraveProfileResetter::ResetDefaultSearchEngine() {
   ProfileResetter::ResetDefaultSearchEngine();
 
   if (template_url_service_->loaded()) {
-    // Reset brave default provider prefs.
-    brave::ClearDefaultPrivateSearchProvider(profile_);
-    brave::SetDefaultPrivateSearchProvider(profile_);
+    brave::ResetDefaultPrivateSearchProvider(profile_);
   }
 }

--- a/browser/search_engines/normal_window_search_engine_provider_service.cc
+++ b/browser/search_engines/normal_window_search_engine_provider_service.cc
@@ -9,15 +9,21 @@
 #include "brave/browser/search_engines/search_engine_provider_util.h"
 #include "chrome/browser/profiles/profile.h"
 #include "chrome/browser/search_engines/template_url_service_factory.h"
+#include "components/search_engines/search_engines_pref_names.h"
 #include "components/search_engines/template_url_service.h"
 
 NormalWindowSearchEngineProviderService::
-    NormalWindowSearchEngineProviderService(Profile* profile) {
-  // No-op if default provider was set to prefs.
+    NormalWindowSearchEngineProviderService(Profile* profile)
+    : profile_(profile) {
+  private_search_provider_guid_.Init(
+      prefs::kSyncedDefaultPrivateSearchProviderGUID, profile_->GetPrefs(),
+      base::BindRepeating(
+          &NormalWindowSearchEngineProviderService::OnPreferenceChanged,
+          base::Unretained(this)));
 
-  auto* service = TemplateURLServiceFactory::GetForProfile(profile);
+  auto* service = TemplateURLServiceFactory::GetForProfile(profile_);
   if (service->loaded()) {
-    brave::SetDefaultPrivateSearchProvider(profile);
+    PrepareInitialPrivateSearchProvider();
     return;
   }
 
@@ -31,8 +37,22 @@ NormalWindowSearchEngineProviderService::
 NormalWindowSearchEngineProviderService::
     ~NormalWindowSearchEngineProviderService() = default;
 
+void NormalWindowSearchEngineProviderService::Shutdown() {
+  template_url_service_subscription_ = {};
+  private_search_provider_guid_.Destroy();
+}
+
 void NormalWindowSearchEngineProviderService::OnTemplateURLServiceLoaded(
     Profile* profile) {
   template_url_service_subscription_ = {};
-  brave::SetDefaultPrivateSearchProvider(profile);
+  PrepareInitialPrivateSearchProvider();
+}
+
+void NormalWindowSearchEngineProviderService::
+    PrepareInitialPrivateSearchProvider() {
+  brave::PrepareDefaultPrivateSearchProviderDataIfNeeded(profile_);
+}
+
+void NormalWindowSearchEngineProviderService::OnPreferenceChanged() {
+  brave::UpdateDefaultPrivateSearchProviderData(profile_);
 }

--- a/browser/search_engines/normal_window_search_engine_provider_service.h
+++ b/browser/search_engines/normal_window_search_engine_provider_service.h
@@ -7,12 +7,20 @@
 #define BRAVE_BROWSER_SEARCH_ENGINES_NORMAL_WINDOW_SEARCH_ENGINE_PROVIDER_SERVICE_H_
 
 #include "base/callback_list.h"
+#include "base/memory/raw_ptr.h"
 #include "components/keyed_service/core/keyed_service.h"
+#include "components/prefs/pref_member.h"
 
 class Profile;
 
 // Set default prefs for private search provider as it's stored in normal
-// profile.
+// profile. And update TemplateURLData for private search provider whenever
+// user changes private window's search provider. This cached TemplateURLData
+// can be used when default provider list updated. When list is updated,
+// new default provider list doesn't include previous default provider.
+// In this situation, previous default provider should be default one with
+// new list. To do that, cached TemplateURLData can be added to
+// TemplateURLService.
 class NormalWindowSearchEngineProviderService : public KeyedService {
  public:
   explicit NormalWindowSearchEngineProviderService(Profile* profile);
@@ -24,8 +32,15 @@ class NormalWindowSearchEngineProviderService : public KeyedService {
       const NormalWindowSearchEngineProviderService&) = delete;
 
  private:
-  void OnTemplateURLServiceLoaded(Profile* profile);
+  // KeyedService overrides:
+  void Shutdown() override;
 
+  void OnTemplateURLServiceLoaded(Profile* profile);
+  void PrepareInitialPrivateSearchProvider();
+  void OnPreferenceChanged();
+
+  raw_ptr<Profile> profile_ = nullptr;
+  StringPrefMember private_search_provider_guid_;
   base::CallbackListSubscription template_url_service_subscription_;
 };
 

--- a/browser/search_engines/search_engine_provider_service_factory.cc
+++ b/browser/search_engines/search_engine_provider_service_factory.cc
@@ -87,4 +87,8 @@ void SearchEngineProviderServiceFactory::RegisterProfilePrefs(
   registry->RegisterStringPref(prefs::kSyncedDefaultPrivateSearchProviderGUID,
                                std::string(),
                                user_prefs::PrefRegistrySyncable::SYNCABLE_PREF);
+  registry->RegisterDictionaryPref(
+      prefs::kSyncedDefaultPrivateSearchProviderData,
+      base::Value(base::Value::Type::DICT),
+      user_prefs::PrefRegistrySyncable::SYNCABLE_PREF);
 }

--- a/browser/search_engines/search_engine_provider_util.h
+++ b/browser/search_engines/search_engine_provider_util.h
@@ -7,6 +7,7 @@
 #define BRAVE_BROWSER_SEARCH_ENGINES_SEARCH_ENGINE_PROVIDER_UTIL_H_
 
 class Profile;
+class PrefService;
 
 namespace user_prefs {
 class PrefRegistrySyncable;
@@ -15,6 +16,7 @@ class PrefRegistrySyncable;
 namespace brave {
 
 bool IsRegionForQwant(Profile* profile);
+void SetBraveAsDefaultPrivateSearchProvider(PrefService* prefs);
 
 // For prefs migration.
 void RegisterSearchEngineProviderPrefsForMigration(
@@ -22,8 +24,11 @@ void RegisterSearchEngineProviderPrefsForMigration(
 void MigrateSearchEngineProviderPrefs(Profile* profile);
 
 // Initialize default provider for private profile.
-void SetDefaultPrivateSearchProvider(Profile* profile);
-void ClearDefaultPrivateSearchProvider(Profile* profile);
+void PrepareDefaultPrivateSearchProviderDataIfNeeded(Profile* profile);
+
+// Update TemplareURLData with provider guid.
+void UpdateDefaultPrivateSearchProviderData(Profile* profile);
+void ResetDefaultPrivateSearchProvider(Profile* profile);
 
 }  // namespace brave
 

--- a/browser/ui/webui/settings/brave_search_engines_handler.cc
+++ b/browser/ui/webui/settings/brave_search_engines_handler.cc
@@ -40,9 +40,10 @@ void BraveSearchEnginesHandler::RegisterMessages() {
 void BraveSearchEnginesHandler::OnModelChanged() {
   SearchEnginesHandler::OnModelChanged();
 
-  brave::SetDefaultPrivateSearchProvider(profile_);
+  brave::UpdateDefaultPrivateSearchProviderData(profile_);
 
-  // Sync normal profile's search provider list with private profile's.
+  // Sync normal profile's search provider list with private profile
+  // for using same list on both.
   FireWebUIListener("private-search-engines-changed",
                     GetPrivateSearchEnginesList());
 }

--- a/chromium_src/components/search_engines/search_engines_pref_names.cc
+++ b/chromium_src/components/search_engines/search_engines_pref_names.cc
@@ -13,4 +13,6 @@ const char kAddOpenSearchEngines[] = "brave.other_search_engines_enabled";
 const char kBraveDefaultSearchVersion[] = "brave.search.default_version";
 const char kSyncedDefaultPrivateSearchProviderGUID[] =
     "brave.default_private_search_provider_guid";
+const char kSyncedDefaultPrivateSearchProviderData[] =
+    "brave.default_private_search_provider_data";
 }  // namespace prefs

--- a/chromium_src/components/search_engines/search_engines_pref_names.h
+++ b/chromium_src/components/search_engines/search_engines_pref_names.h
@@ -14,6 +14,7 @@ extern const char kDefaultSearchProviderByExtension[];
 extern const char kAddOpenSearchEngines[];
 extern const char kBraveDefaultSearchVersion[];
 extern const char kSyncedDefaultPrivateSearchProviderGUID[];
+extern const char kSyncedDefaultPrivateSearchProviderData[];
 
 }  // namespace prefs
 


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/28360

Cache TemplateURLData for default search provider of private window.
It could be used to add previous default provider when newly updated
provider list doesn't include it.
If we don't know it, user'll see Brave as a default provider even previous one wasn't
Brave when it's not included in default provider list.

So far Brave is set when previous default one is not included in
the default list. We should set previous one as a default
when new default list is changed and it's not included.

**_NOTE:_** To make https://github.com/brave/brave-core/pull/10590 works properly on desktop, this fix should be applied in advance.

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

`SearchEngineProviderServiceTest.CheckDefaultSearchProviderTest`

1. Launch Brave and go to brave://settings/search
2. Change private search provider
3. Load brave://prefs-internals/ and check `default_private_search_provider_data.synced_guid` and `default_private_search_provider_guid` is same