### PR TITLE
[Android] fix crash enable brave news when no internet connection (uplift to 1.48.x)

### DIFF
--- a/android/java/org/chromium/chrome/browser/ntp/BraveNtpAdapter.java
+++ b/android/java/org/chromium/chrome/browser/ntp/BraveNtpAdapter.java
@@ -328,7 +328,6 @@ public class BraveNtpAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolde
         int statsCount = getStatsCount();
         int topSitesCount = getTopSitesCount();
         int newsLoadingCount = shouldDisplayNewsLoading() ? 1 : 0;
-
         if (mIsDisplayNewsOptin) {
             return statsCount + topSitesCount + TWO_ITEMS_SPACE + newsLoadingCount;
         } else if (mIsDisplayNews) {
@@ -468,6 +467,11 @@ public class BraveNtpAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolde
 
     public void setNewsLoading(boolean isNewsLoading) {
         mIsNewsLoading = isNewsLoading;
+        if (isNewsLoading) {
+            notifyItemInserted(getStatsCount() + getTopSitesCount() + ONE_ITEM_SPACE);
+        } else {
+            notifyItemRemoved(getStatsCount() + getTopSitesCount() + ONE_ITEM_SPACE);
+        }
         notifyItemRangeChanged(getStatsCount() + getTopSitesCount(), TWO_ITEMS_SPACE);
     }
 


### PR DESCRIPTION
Uplift of #17012
Resolves https://github.com/brave/brave-browser/issues/28197

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.