### PR TITLE
fix(wallet): Send NFT Text Alignments

### DIFF
--- a/components/brave_wallet_ui/page/screens/send/components/select-token-button/select-token-button.style.ts
+++ b/components/brave_wallet_ui/page/screens/send/components/select-token-button/select-token-button.style.ts
@@ -53,14 +53,14 @@ export const ButtonIcon = styled(Icon)`
 `
 
 export const IconsWrapper = styled.div<{
-  marginRight?: string
+  marginRight?: number
 }>`
   display: flex;
   align-items: center;
   justify-content: center;
   flex-direction: row;
   position: relative;
-  margin-right: ${(p) => p.marginRight || '6px'};
+  margin-right: ${(p) => p.marginRight || 6}px;
 `
 
 export const ButtonText = styled(Text) <{ isNFT: boolean }>`

--- a/components/brave_wallet_ui/page/screens/send/components/select-token-button/select-token-button.tsx
+++ b/components/brave_wallet_ui/page/screens/send/components/select-token-button/select-token-button.tsx
@@ -78,7 +78,7 @@ export const SelectTokenButton = (props: Props) => {
     <Button onClick={onClick} morePadding={token !== undefined} isNFT={selectedSendOption === 'nft'}>
       <Row>
         {token && (
-          <IconsWrapper>
+          <IconsWrapper marginRight={selectedSendOption === 'nft' ? 12 : undefined}>
             <AssetIconWithPlaceholder asset={token} network={tokensNetwork} />
             {tokensNetwork && token?.contractAddress !== '' && (
               <NetworkIconWrapper>
@@ -92,6 +92,7 @@ export const SelectTokenButton = (props: Props) => {
           textColor={token !== undefined ? 'text01' : 'text03'}
           textSize={token !== undefined ? '18px' : '16px'}
           isNFT={selectedSendOption === 'nft'}
+          textAlign='left'
         >
           {buttonText}
         </ButtonText>

--- a/components/brave_wallet_ui/page/screens/send/components/token-list-item/token-list-item.style.ts
+++ b/components/brave_wallet_ui/page/screens/send/components/token-list-item/token-list-item.style.ts
@@ -6,7 +6,7 @@
 import styled from 'styled-components'
 
 // Shared Styles
-import { StyledButton, StyledDiv } from '../../shared.styles'
+import { StyledButton, StyledDiv, Row } from '../../shared.styles'
 
 import {
   AssetIconProps,
@@ -66,4 +66,10 @@ export const IconsWrapper = styled.div`
   flex-direction: row;
   position: relative;
   margin-right: 16px;
+`
+
+export const IconAndName = styled(Row)`
+  width: 80%;
+  overflow: hidden;
+  white-space: pre-line;
 `

--- a/components/brave_wallet_ui/page/screens/send/components/token-list-item/token-list-item.tsx
+++ b/components/brave_wallet_ui/page/screens/send/components/token-list-item/token-list-item.tsx
@@ -33,9 +33,10 @@ import {
   NetworkIconWrapper,
   Button,
   IconsWrapper,
-  ButtonWrapper
+  ButtonWrapper,
+  IconAndName
 } from './token-list-item.style'
-import { Row, Column, Text } from '../../shared.styles'
+import { Column, Text } from '../../shared.styles'
 
 interface Props {
   onClick: () => void
@@ -95,7 +96,7 @@ export const TokenListItem = (props: Props) => {
   return (
     <ButtonWrapper>
       <Button onClick={onClick}>
-        <Row>
+        <IconAndName horizontalAlign='flex-start'>
           <IconsWrapper>
             <AssetIconWithPlaceholder asset={token} network={tokensNetwork} />
             {tokensNetwork && token?.contractAddress !== '' && (
@@ -105,14 +106,14 @@ export const TokenListItem = (props: Props) => {
             )}
           </IconsWrapper>
           <Column horizontalAlign='flex-start'>
-            <Text textColor='text01' textSize='14px' isBold={true}>
+            <Text textColor='text01' textSize='14px' isBold={true} textAlign='left'>
               {tokenDisplayName}
             </Text>
-            <Text textColor='text03' textSize='12px' isBold={false}>
+            <Text textColor='text03' textSize='12px' isBold={false} textAlign='left'>
               {networkDescription}
             </Text>
           </Column>
-        </Row>
+        </IconAndName>
         {!token.isErc721 && !token.isNft &&
           <Column horizontalAlign='flex-end'>
             <Text textColor='text01' textSize='14px' isBold={true}>

--- a/components/brave_wallet_ui/page/screens/send/send/send.tsx
+++ b/components/brave_wallet_ui/page/screens/send/send/send.tsx
@@ -385,7 +385,7 @@ export const Send = (props: Props) => {
                 verticalAlign='flex-start'
                 horizontalAlign='flex-end'
               >
-                <Text textSize='14px' textColor='text03' maintainHeight={true} isBold={true}>
+                <Text textSize='14px' textColor='text03' maintainHeight={true} isBold={true} textAlign='right'>
                   {accountNameAndBalance}
                 </Text>
               </Column>


### PR DESCRIPTION
## Description 
Fixes text alignments for `NFT's` with a really long name on the `Send` screen.

<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves <https://github.com/brave/brave-browser/issues/28275>
Resolves <https://github.com/brave/brave-browser/issues/28277>

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
1. Add a custom NFT with a really long name (Example: NFT with a really long account name for testing)
2. Go to the `Send` page and select the `Send NFT` tab
3. Click on `Select NFT`, your NFT with a really long name should not overlap the `info` icon and text should be aligned to the left.
4. After selecting that `NFT` the text should be wrapped and aligned to the left and the `Account` name should be wrapped and aligned to the right.

Before:

![Screenshot 2023-02-03 at 1 21 50 PM](https://user-images.githubusercontent.com/40611140/216690672-5e86406d-59df-4a25-8063-ac1eac7c6470.png)

![Screenshot 2023-02-03 at 1 21 58 PM](https://user-images.githubusercontent.com/40611140/216690708-ba599a2f-17ea-48f1-9c51-f315f65fe0ca.png)

After:

![Screenshot 2023-02-03 at 1 18 19 PM](https://user-images.githubusercontent.com/40611140/216690588-08ae4156-eac8-45f4-862a-10377be9f1a5.png)

![Screenshot 2023-02-03 at 1 18 09 PM](https://user-images.githubusercontent.com/40611140/216690617-aa5368e0-bfa5-4e0f-9b91-eeb2166a4f20.png)
