### PR TITLE
Extend Recover API so that we can update media source for items

### DIFF
--- a/components/playlist/browser/playlist_download_request_manager.h
+++ b/components/playlist/browser/playlist_download_request_manager.h
@@ -66,7 +66,7 @@ class PlaylistDownloadRequestManager : public content::WebContentsObserver {
       const PlaylistDownloadRequestManager&) = delete;
 
   // Request::callback will be called with generated param.
-  void GetMediaFilesFromPage(Request request);
+  virtual void GetMediaFilesFromPage(Request request);
 
   // Update |web_prefs| if we want for |web_contents|.
   void ConfigureWebPrefsForBackgroundWebContents(

--- a/components/playlist/browser/playlist_media_file_download_manager.cc
+++ b/components/playlist/browser/playlist_media_file_download_manager.cc
@@ -15,11 +15,24 @@
 
 namespace playlist {
 
+// DownloadJob -----------------------------------------------------------------
+
+PlaylistMediaFileDownloadManager::DownloadJob::DownloadJob() = default;
+PlaylistMediaFileDownloadManager::DownloadJob::DownloadJob(
+    PlaylistMediaFileDownloadManager::DownloadJob&&) noexcept = default;
+PlaylistMediaFileDownloadManager::DownloadJob&
+PlaylistMediaFileDownloadManager::DownloadJob::operator=(
+    PlaylistMediaFileDownloadManager::DownloadJob&&) noexcept = default;
+PlaylistMediaFileDownloadManager::DownloadJob::~DownloadJob() = default;
+
+// PlaylistMediaFileDownloadManager --------------------------------------------
+
 PlaylistMediaFileDownloadManager::PlaylistMediaFileDownloadManager(
     content::BrowserContext* context,
     Delegate* delegate,
     const base::FilePath& base_dir)
     : base_dir_(base_dir), delegate_(delegate) {
+  DCHECK(delegate_) << "We don't consider where |delegate| is null";
   // TODO(pilgrim) dynamically set file extensions based on format.
   media_file_downloader_ = std::make_unique<PlaylistMediaFileDownloader>(
       this, context, kMediaFileName);
@@ -28,8 +41,11 @@ PlaylistMediaFileDownloadManager::PlaylistMediaFileDownloadManager(
 PlaylistMediaFileDownloadManager::~PlaylistMediaFileDownloadManager() = default;
 
 void PlaylistMediaFileDownloadManager::DownloadMediaFile(
-    const mojom::PlaylistItemPtr& playlist_item) {
-  pending_media_file_creation_jobs_.push(playlist_item.Clone());
+    std::unique_ptr<DownloadJob> request) {
+  DCHECK(request);
+  DCHECK(request->item);
+
+  pending_media_file_creation_jobs_.push(std::move(request));
 
   // If either media file controller is generating a playlist media file,
   // delay the next playlist generation. It will be triggered when the current
@@ -63,26 +79,32 @@ void PlaylistMediaFileDownloadManager::TryStartingDownloadTask() {
   if (pending_media_file_creation_jobs_.empty())
     return;
 
-  current_item_ = GetNextPlaylistItemTarget();
-  if (!current_item_)
+  current_job_ = PopNextJob();
+  if (!current_job_) {
     return;
+  }
 
-  VLOG(2) << __func__ << ": " << current_item_->name;
+  DCHECK(current_job_->item);
 
   if (!pause_download_for_testing_) {
-    media_file_downloader_->DownloadMediaFileForPlaylistItem(current_item_,
+    VLOG(2) << __func__ << ": " << current_job_->item->name;
+    media_file_downloader_->DownloadMediaFileForPlaylistItem(current_job_->item,
                                                              base_dir_);
   }
 }
 
-mojom::PlaylistItemPtr
-PlaylistMediaFileDownloadManager::GetNextPlaylistItemTarget() {
+std::unique_ptr<PlaylistMediaFileDownloadManager::DownloadJob>
+PlaylistMediaFileDownloadManager::PopNextJob() {
   while (!pending_media_file_creation_jobs_.empty()) {
-    auto playlist_item(std::move(pending_media_file_creation_jobs_.front()));
+    auto request = std::move(pending_media_file_creation_jobs_.front());
+    DCHECK(request);
+    DCHECK(request->item);
+
     pending_media_file_creation_jobs_.pop();
 
-    if (delegate_->IsValidPlaylistItem(playlist_item->id))
-      return playlist_item;
+    if (delegate_->IsValidPlaylistItem(request->item->id)) {
+      return request;
+    }
   }
 
   return {};
@@ -98,7 +120,7 @@ PlaylistMediaFileDownloadManager::GetCurrentDownloadingPlaylistItemID() const {
 
 void PlaylistMediaFileDownloadManager::CancelCurrentDownloadingPlaylistItem() {
   media_file_downloader_->RequestCancelCurrentPlaylistGeneration();
-  current_item_.reset();
+  current_job_.reset();
 }
 
 bool PlaylistMediaFileDownloadManager::IsCurrentDownloadingInProgress() const {
@@ -111,18 +133,38 @@ void PlaylistMediaFileDownloadManager::OnMediaFileDownloadProgressed(
     int64_t received_bytes,
     int percent_complete,
     base::TimeDelta time_remaining) {
-  delegate_->OnMediaFileDownloadProgressed(id, total_bytes, received_bytes,
-                                           percent_complete, time_remaining);
+  if (!current_job_ || !current_job_->item) {
+    return;
+  }
+
+  if (current_job_->item->id != id) {
+    return;
+  }
+
+  if (current_job_->on_progress_callback) {
+    current_job_->on_progress_callback.Run(current_job_->item, total_bytes,
+                                           received_bytes, percent_complete,
+                                           time_remaining);
+  }
 }
 
 void PlaylistMediaFileDownloadManager::OnMediaFileReady(
     const std::string& id,
     const std::string& media_file_path) {
   VLOG(2) << __func__ << ": " << id << " is ready.";
+  if (!current_job_ || !current_job_->item) {
+    return;
+  }
 
-  delegate_->OnMediaFileReady(id, media_file_path);
+  if (current_job_->item->id != id) {
+    return;
+  }
 
-  current_item_.reset();
+  if (current_job_->on_finish_callback) {
+    std::move(current_job_->on_finish_callback)
+        .Run(std::move(current_job_->item), media_file_path);
+  }
+  current_job_.reset();
 
   base::SequencedTaskRunner::GetCurrentDefault()->PostTask(
       FROM_HERE,
@@ -133,9 +175,19 @@ void PlaylistMediaFileDownloadManager::OnMediaFileReady(
 void PlaylistMediaFileDownloadManager::OnMediaFileGenerationFailed(
     const std::string& id) {
   VLOG(2) << __func__ << ": " << id;
+  if (!current_job_ || !current_job_->item) {
+    return;
+  }
 
-  delegate_->OnMediaFileGenerationFailed(id);
+  if (current_job_->item && current_job_->item->id != id) {
+    return;
+  }
 
+  if (current_job_->on_finish_callback) {
+    std::move(current_job_->on_finish_callback)
+        .Run(std::move(current_job_->item), {});
+  }
+  current_job_.reset();
   CancelCurrentDownloadingPlaylistItem();
 
   base::SequencedTaskRunner::GetCurrentDefault()->PostTask(

--- a/components/playlist/browser/playlist_service.cc
+++ b/components/playlist/browser/playlist_service.cc
@@ -812,8 +812,9 @@ void PlaylistService::OnMediaFileDownloadFinished(
   VLOG(2) << __func__ << ": " << item->id << " result path" << media_file_path;
 
   if (media_file_path.empty() && update_media_src_and_retry_on_fail) {
-    VLOG(2) << __func__ << ": " << item->id
-            << " try updating media src and download";
+    VLOG(2) << __func__ << ": downloading " << item->id << " from "
+            << item->media_source.spec()
+            << " failed. Try updating media src and download";
 
     base::SequencedTaskRunner::GetCurrentDefault()->PostTask(
         FROM_HERE, base::BindOnce(&PlaylistService::RecoverLocalDataForItem,

--- a/components/playlist/browser/resources/api/api.ts
+++ b/components/playlist/browser/resources/api/api.ts
@@ -57,7 +57,7 @@ class API {
   }
 
   recoverLocalData (playlistItemId: string) {
-    this.#pageHandler.recoverLocalDataForItem(playlistItemId)
+    this.#pageHandler.recoverLocalDataForItem(playlistItemId, /* updatePageUrlBeforeRecovery= */false)
   }
 
   removeLocalData (playlistItemId: string) {

--- a/components/playlist/common/mojom/playlist.mojom
+++ b/components/playlist/common/mojom/playlist.mojom
@@ -79,7 +79,7 @@ interface PlaylistService {
   UpdateItem(PlaylistItem item);
 
   // Try downloading media files again
-  RecoverLocalDataForItem(string id);
+  RecoverLocalDataForItem(string id, bool update_media_src_before_recovery);
 
   // Removes media files for a item stored in local directory.
   RemoveLocalDataForItem(string id);


### PR DESCRIPTION
The media source url could be easily expired. So we might have got to update media source url before we try recovering the media file. In case we can notice that the url would be expired from url, we can update media source first. But mostly we can't infer if its expired or not. So when we fail to recover media file, we try updating media source by default.

In order to implement this new behavior, also refactored PlaylistMediaFileDownloadManager. The delegate pattern is extracted out to callbacks so that we can remember |update_media_src_and_retry_on_failure| param,

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/28291

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
### Automated
PlaylistServiceUnitTest.MediaRecoverTest
