### PR TITLE
Brave News sometimes picks the wrong language in the Subscribe Button

### DIFF
--- a/components/brave_today/browser/publishers_controller_unittest.cc
+++ b/components/brave_today/browser/publishers_controller_unittest.cc
@@ -278,7 +278,8 @@ TEST_F(PublishersControllerTest, CanGetPublisherByFeedUrl) {
   EXPECT_EQ("555", publisher->publisher_id);
 }
 
-TEST_F(PublishersControllerTest, PublisherInDefaultLocaleIsPreferred_PreferredFirst) {
+TEST_F(PublishersControllerTest,
+       PublisherInDefaultLocaleIsPreferred_PreferredFirst) {
   test_url_loader_factory_.AddResponse(GetSourcesUrl(), R"([
     {
         "publisher_id": "111",
@@ -333,7 +334,8 @@ TEST_F(PublishersControllerTest, PublisherInDefaultLocaleIsPreferred_PreferredFi
   EXPECT_EQ("111", publisher->publisher_id);
 }
 
-TEST_F(PublishersControllerTest, PublisherInDefaultLocaleIsPreferred_PreferredLast) {
+TEST_F(PublishersControllerTest,
+       PublisherInDefaultLocaleIsPreferred_PreferredLast) {
   test_url_loader_factory_.AddResponse(GetSourcesUrl(), R"([
     {
         "publisher_id": "111",
@@ -381,8 +383,8 @@ TEST_F(PublishersControllerTest, PublisherInDefaultLocaleIsPreferred_PreferredLa
 
   auto* publisher = publishers_controller_.GetPublisherForSite(
       GURL("https://tp1.example.com/"));
-  EXPECT_EQ("222", publisher->publisher_id); 
-  
+  EXPECT_EQ("222", publisher->publisher_id);
+
   publisher = publishers_controller_.GetPublisherForFeed(
       GURL("https://tp1.example.com/feed"));
   EXPECT_EQ("222", publisher->publisher_id);
@@ -480,7 +482,7 @@ TEST_F(PublishersControllerTest, LocaleDefaultsToENUS) {
         "cover_url": "https://tp1.example.com/favicon",
         "background_color": "#FF0000",
         "channels": ["One", "Tech"],
-        "locales": ["not_LOCALE"],
+        "locales": [{ "locale": "not_LOCALE", "channels": [] }],
         "enabled": false
     }])",
                                        net::HTTP_OK);

--- a/components/brave_today/browser/publishers_parsing.cc
+++ b/components/brave_today/browser/publishers_parsing.cc
@@ -22,23 +22,6 @@ mojom::LocaleInfoPtr ParseLocaleInfo(const base::Value::Dict& publisher_dict,
                                      const base::Value& locale_entry) {
   auto result = mojom::LocaleInfo::New();
 
-  // TODO(fallaciousreasoining): Remove this branch after sources.global.json
-  // has been updated. https://github.com/brave/brave-browser/issues/26307
-  if (locale_entry.is_string()) {
-    result->locale = locale_entry.GetString();
-
-    // We consider '0' to be unranked, as mojo doesn't support nullable
-    // primitives.
-    result->rank = publisher_dict.FindInt("rank").value_or(0);
-    auto* channels_raw = publisher_dict.FindList("channels");
-    if (channels_raw) {
-      for (const auto& channel : *channels_raw)
-        result->channels.push_back(channel.GetString());
-    }
-
-    return result;
-  }
-
   const auto& locale_dict = locale_entry.GetDict();
   result->locale = *locale_dict.FindString("locale");
   result->rank = locale_dict.FindInt("rank").value_or(0);


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/28064
Resolves https://github.com/brave/brave-browser/issues/26092
Resolves https://github.com/brave/brave-browser/issues/26307

## Submitter Checklist:

- [ ] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

1. Navigate to https://brave.com/blog
2. Click the subscribe button in the location bar.
3. The feed should be "Brave Blog" not "Brave Blog Português"
