### PR TITLE
Use BalanceScanner contracts for ETH asset discovery

### DIFF
--- a/browser/brave_wallet/asset_discovery_manager_unittest.cc
+++ b/browser/brave_wallet/asset_discovery_manager_unittest.cc
@@ -45,20 +45,27 @@ namespace brave_wallet {
 
 namespace {
 
+// JSON RPC responses for eth_call to the BalanceScanner contract
+const char eth_balance_detected_response[] = R"({
+      "jsonrpc":"2.0",
+      "id":1,
+      "result":"0x000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000000100000000000000000000000000000000000000000000000000000000000000400000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000006e83695ab1f893c00"
+  })";
+const char eth_balance_not_detected_response[] = R"({
+      "jsonrpc":"2.0",
+      "id":1,
+      "result":"0x0000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000000100000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000001000000000000000000000000000000000000000000000000000000000000004000000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000000"
+  })";
+const char eth_error_fetching_balance_response[] = R"({
+      "jsonrpc":"2.0",
+      "id":1,
+      "result":"0x000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000400000000000000000000000000000000000000000000000000000000000000000"
+  })";
+
 const char kMnemonic1[] =
     "divide cruise upon flag harsh carbon filter merit once advice bright "
     "drive";
 const char kPasswordBrave[] = "brave";
-
-void UpdateCustomNetworks(PrefService* prefs,
-                          std::vector<base::Value::Dict>* values) {
-  ScopedDictPrefUpdate update(prefs, kBraveWalletCustomNetworks);
-  base::Value::List* list = update->EnsureList(kEthereumPrefKey);
-  list->clear();
-  for (auto& it : *values) {
-    list->Append(std::move(it));
-  }
-}
 
 const std::vector<std::string>& GetAssetDiscoverySupportedEthChainsForTest() {
   static base::NoDestructor<std::vector<std::string>>
@@ -175,7 +182,7 @@ class AssetDiscoveryManagerUnitTest : public testing::Test {
   // SetInterceptorForDiscoverSolAssets takes a map of addresses to responses
   // and adds the response if the address if found in the request string
   void SetInterceptorForDiscoverSolAssets(
-      GURL& intended_url,
+      const GURL& intended_url,
       const std::map<std::string, std::string>& requests) {
     url_loader_factory_.SetInterceptor(base::BindLambdaForTesting(
         [&, intended_url, requests](const network::ResourceRequest& request) {
@@ -199,6 +206,41 @@ class AssetDiscoveryManagerUnitTest : public testing::Test {
         }));
   }
 
+  // Interceptor that takes a mapping of URLs to a mapping of addresses
+  // (std::strings) to responses (std::strings). If the requested URL is one in
+  // the map and the requested address is one in the map, the response is
+  // returned.
+  void SetInterceptorForDiscoverEthAssets(
+      const std::map<GURL, std::map<std::string, std::string>>& requests) {
+    url_loader_factory_.SetInterceptor(base::BindLambdaForTesting(
+        [&, requests](const network::ResourceRequest& request) {
+          for (auto const& [url, address_response_map] : requests) {
+            if (request.url.spec() == url.spec()) {
+              base::StringPiece request_string(
+                  request.request_body->elements()
+                      ->at(0)
+                      .As<network::DataElementBytes>()
+                      .AsStringPiece());
+              std::string response;
+              for (auto const& [address, potential_response] :
+                   address_response_map) {
+                // Trim leading "0x" from address before searching for it in the
+                // it in the request string since it's not included in the
+                // calldata
+                if (request_string.find(address.substr(2)) !=
+                    std::string::npos) {
+                  response = potential_response;
+                  break;
+                }
+              }
+              ASSERT_FALSE(response.empty());
+              url_loader_factory_.ClearResponses();
+              url_loader_factory_.AddResponse(request.url.spec(), response);
+            }
+          }
+        }));
+  }
+
   void SetLimitExceededJsonErrorResponse() {
     url_loader_factory_.SetInterceptor(base::BindLambdaForTesting(
         [&](const network::ResourceRequest& request) {
@@ -215,149 +257,54 @@ class AssetDiscoveryManagerUnitTest : public testing::Test {
         }));
   }
 
-  // SetDiscoverAssetsOnAllSupportedChainsInterceptor sets the response
-  // based on the requested URL and verifies the from / to blocks
-  // specified in the eth_getLogs query is expected for each URL/chain ID
-  // requested.
-  void SetDiscoverAssetsOnAllSupportedChainsInterceptor(
-      const std::map<std::string, std::string> responses,
-      const std::map<std::string, std::string> expected_from_blocks,
-      const std::map<std::string, std::string> expected_to_blocks) {
-    url_loader_factory_.SetInterceptor(base::BindLambdaForTesting(
-        [&, responses, expected_from_blocks,
-         expected_to_blocks](const network::ResourceRequest& request) {
-          base::StringPiece request_string(request.request_body->elements()
-                                               ->at(0)
-                                               .As<network::DataElementBytes>()
-                                               .AsStringPiece());
-
-          // Verify fromBlock and toBlock's requested match expected for ETH
-          // chains
-          auto it = expected_from_blocks.find(request.url.spec());
-          if (it != expected_from_blocks.end()) {
-            const auto& expected_from_block = it->second;
-            EXPECT_NE(request_string.find(base::StringPrintf(
-                          "\"fromBlock\":\"%s\"", expected_from_block.c_str())),
-                      std::string::npos);
-          }
-          // Same for toBlock
-          it = expected_to_blocks.find(request.url.spec());
-          if (it != expected_to_blocks.end()) {
-            const auto& expected_to_block = it->second;
-            EXPECT_NE(request_string.find(base::StringPrintf(
-                          "\"toBlock\":\"%s\"", expected_to_block.c_str())),
-                      std::string::npos);
-          }
-          url_loader_factory_.ClearResponses();
-          for (const auto& kv : responses) {
-            url_loader_factory_.AddResponse(kv.first, kv.second);
-          }
-          return;
-        }));
-  }
-
   void TestDiscoverSolAssets(
       const std::vector<std::string>& account_addresses,
-      const std::vector<std::string>& expected_contract_addresses) {
-    asset_discovery_manager_->SetDiscoverAssetsCompletedCallbackForTesting(
-        base::BindLambdaForTesting(
-            [&](const std::string& chain_id,
-                const std::vector<mojom::BlockchainTokenPtr> discovered_assets,
-                absl::optional<mojom::ProviderError> error,
-                const std::string& error_message) {
-              ASSERT_FALSE(error);
-              ASSERT_EQ(discovered_assets.size(),
-                        expected_contract_addresses.size());
-              for (size_t i = 0; i < discovered_assets.size(); i++) {
-                EXPECT_EQ(discovered_assets[i]->contract_address,
-                          expected_contract_addresses[i]);
-              }
-            }));
+      const std::vector<std::string>& expected_token_contract_addresses) {
+    asset_discovery_manager_->remaining_buckets_ = 1;
     asset_discovery_manager_->DiscoverSolAssets(account_addresses, false);
-    base::RunLoop().RunUntilIdle();
-  }
-
-  void TestDiscoverAssets(
-      const std::string& chain_id,
-      mojom::CoinType coin,
-      const std::vector<std::string>& account_addresses,
-      const std::vector<std::string>& expected_token_contract_addresses,
-      mojom::ProviderError expected_error,
-      const std::string& expected_error_message,
-      const std::string& expected_next_asset_discovery_from_block) {
-    // Set remaining chains to 1 in order since this value needs to end at
-    // 0 by the end of the DiscoverEthAssets call in order to trigger the
-    // event and it will not be set by an outer
-    // DiscoverAssetsOnAllSupportedChains* call in this unit test.
-    asset_discovery_manager_->remaining_chains_ = 1;
-    asset_discovery_manager_->SetDiscoverAssetsCompletedCallbackForTesting(
-        base::BindLambdaForTesting(
-            [&](const std::string& chain_id,
-                const std::vector<mojom::BlockchainTokenPtr> discovered_assets,
-                absl::optional<mojom::ProviderError> error,
-                const std::string& error_message) {
-              EXPECT_EQ(chain_id, chain_id);
-              ASSERT_TRUE(error);
-              EXPECT_EQ(*error, expected_error);
-              EXPECT_EQ(expected_error_message, error_message);
-              ASSERT_EQ(expected_token_contract_addresses.size(),
-                        discovered_assets.size());
-              for (size_t i = 0; i < discovered_assets.size(); i++) {
-                EXPECT_EQ(expected_token_contract_addresses[i],
-                          discovered_assets[i]->contract_address);
-              }
-            }));
-    asset_discovery_manager_->DiscoverEthAssets(
-        chain_id, mojom::CoinType::ETH, account_addresses, false,
-        kEthereumBlockTagEarliest, kEthereumBlockTagLatest);
     wallet_service_observer_->WaitForOnDiscoverAssetsCompleted(
         expected_token_contract_addresses);
-    auto next_asset_discovery_from_blocks =
-        GetPrefs()->GetDict(kBraveWalletNextAssetDiscoveryFromBlocks).Clone();
-    const auto path = base::StrCat({kEthereumPrefKey, ".", chain_id});
-    const std::string* next_asset_discovery_from_block =
-        next_asset_discovery_from_blocks.FindStringByDottedPath(path);
-    if (next_asset_discovery_from_block) {
-      EXPECT_EQ(*next_asset_discovery_from_block,
-                expected_next_asset_discovery_from_block);
-    } else {
-      ASSERT_EQ(expected_next_asset_discovery_from_block, "");
-    }
     wallet_service_observer_->Reset();
   }
 
-  void TestDiscoverAssetsOnAllSupportedChainsAccountsAdded(
+  void TestDiscoverEthAssets(
+      const std::vector<std::string>& account_addresses,
+      bool triggered_by_accounts_added,
+      const std::vector<std::string>& expected_token_contract_addresses) {
+    asset_discovery_manager_->remaining_buckets_ = 1;
+    asset_discovery_manager_->DiscoverEthAssets(account_addresses,
+                                                triggered_by_accounts_added);
+    wallet_service_observer_->WaitForOnDiscoverAssetsCompleted(
+        expected_token_contract_addresses);
+    wallet_service_observer_->Reset();
+  }
+
+  void TestDiscoverAssetsOnAllSupportedChainsAccountsAddedV2(
       mojom::CoinType coin,
       const std::vector<std::string>& account_addresses,
-      const base::Time expected_assets_last_discovered_at_pref,
-      const base::Value::Dict& expected_next_asset_discovery_from_blocks,
-      const std::vector<std::string>& expected_token_contract_addresses = {}) {
-    std::vector<std::string> expected_chain_ids_remaining;
-    if (coin == mojom::CoinType::ETH) {
-      expected_chain_ids_remaining =
-          GetAssetDiscoverySupportedEthChainsForTest();
-    } else {
-      expected_chain_ids_remaining = {mojom::kSolanaMainnet};
-    }
+      const std::vector<std::string>& expected_token_contract_addresses) {
+    base::Time last_discovered_assets_at =
+        GetPrefs()->GetTime(kBraveWalletLastDiscoveredAssetsAt);
     asset_discovery_manager_->SetDiscoverAssetsCompletedCallbackForTesting(
         base::BindLambdaForTesting(
-            [&](const std::string& chain_id,
-                const std::vector<mojom::BlockchainTokenPtr> discovered_assets,
-                absl::optional<mojom::ProviderError> error,
-                const std::string& error_message) {
-              expected_chain_ids_remaining.erase(
-                  std::remove(expected_chain_ids_remaining.begin(),
-                              expected_chain_ids_remaining.end(), chain_id),
-                  expected_chain_ids_remaining.end());
+            [&](const std::vector<mojom::BlockchainTokenPtr>
+                    discovered_assets) {
+              ASSERT_EQ(discovered_assets.size(),
+                        expected_token_contract_addresses.size());
+              for (size_t i = 0; i < discovered_assets.size(); i++) {
+                EXPECT_EQ(discovered_assets[i]->contract_address,
+                          expected_token_contract_addresses[i]);
+              }
             }));
     asset_discovery_manager_->DiscoverAssetsOnAllSupportedChainsAccountsAdded(
         coin, account_addresses);
     base::RunLoop().RunUntilIdle();
-    EXPECT_EQ(expected_chain_ids_remaining.size(), 0u);
-    EXPECT_EQ(GetPrefs()->GetTime(kBraveWalletLastDiscoveredAssetsAt),
-              expected_assets_last_discovered_at_pref);
-    EXPECT_EQ(GetPrefs()->GetDict(kBraveWalletNextAssetDiscoveryFromBlocks),
-              expected_next_asset_discovery_from_blocks);
+
+    // Verify kBraveWalletLastDiscoveredAssetsAt prefs are not updated
+    EXPECT_EQ(last_discovered_assets_at,
+              GetPrefs()->GetTime(kBraveWalletLastDiscoveredAssetsAt));
+
+    // Verify observer event not fired
     EXPECT_FALSE(wallet_service_observer_->OnDiscoverAssetsCompletedFired());
     wallet_service_observer_->Reset();
   }
@@ -366,38 +313,29 @@ class AssetDiscoveryManagerUnitTest : public testing::Test {
       std::map<mojom::CoinType, std::vector<std::string>>& addresses,
       base::OnceCallback<void(base::Time previous, base::Time current)>
           assets_last_discovered_at_test_fn,
-      const base::Value::Dict& expected_next_asset_discovery_from_blocks,
-      const std::vector<std::string>& expected_token_contract_addresses,
-      std::vector<std::string> expected_chain_ids_remaining =
-          GetAssetDiscoverySupportedEthChainsForTest()) {
+      const std::vector<std::string>& expected_token_contract_addresses) {
+    // Capture the previous value for kBraveWalletLastDiscoveredAssetsAt before
+    // calling DiscoverAssetsOnAllSupportedChains
     const base::Time previous_assets_last_discovered_at =
         GetPrefs()->GetTime(kBraveWalletLastDiscoveredAssetsAt);
-    asset_discovery_manager_->SetDiscoverAssetsCompletedCallbackForTesting(
-        base::BindLambdaForTesting(
-            [&](const std::string& chain_id,
-                const std::vector<mojom::BlockchainTokenPtr> discovered_assets,
-                absl::optional<mojom::ProviderError> error,
-                const std::string& error_message) {
-              expected_chain_ids_remaining.erase(
-                  std::remove(expected_chain_ids_remaining.begin(),
-                              expected_chain_ids_remaining.end(), chain_id),
-                  expected_chain_ids_remaining.end());
-            }));
+
+    // Call DiscoverAssetsOnAllSupportedChains
     asset_discovery_manager_->DiscoverAssetsOnAllSupportedChainsRefresh(
         addresses);
+
+    // Wait for the the wallet service event to be emitted (meaning asset
+    // discovery has totally completed)
     wallet_service_observer_->WaitForOnDiscoverAssetsCompleted(
         expected_token_contract_addresses);
-    EXPECT_EQ(expected_chain_ids_remaining.size(), 0u);
+
+    // Fetch the current value for kBraveWalletLastDiscoveredAssetsAt after
+    // calling DiscoverAssetsOnAllSupportedChains and compare it against the
+    // previous value using the provided test function
     base::Time current_assets_last_discovered_at =
         GetPrefs()->GetTime(kBraveWalletLastDiscoveredAssetsAt);
     std::move(assets_last_discovered_at_test_fn)
         .Run(previous_assets_last_discovered_at,
              current_assets_last_discovered_at);
-    const base::Value::Dict current_next_asset_discovery_from_blocks =
-        GetPrefs()->GetDict(kBraveWalletNextAssetDiscoveryFromBlocks).Clone();
-    EXPECT_EQ(expected_next_asset_discovery_from_blocks,
-              current_next_asset_discovery_from_blocks);
-    wallet_service_observer_->Reset();
   }
 
   PrefService* GetPrefs() { return profile_->GetPrefs(); }
@@ -422,370 +360,239 @@ class AssetDiscoveryManagerUnitTest : public testing::Test {
   data_decoder::test::InProcessDataDecoder in_process_data_decoder_;
 };
 
-TEST_F(AssetDiscoveryManagerUnitTest, DiscoverEthAssets) {
+TEST_F(AssetDiscoveryManagerUnitTest,
+       DiscoverAssetsOnAllSupportedChainsAccountsAddedV2) {
   auto* blockchain_registry = BlockchainRegistry::GetInstance();
   TokenListMap token_list_map;
-  std::string response;
 
-  // Unsupported chainId is not supported
-  TestDiscoverAssets(
-      mojom::kBinanceSmartChainMainnetChainId, mojom::CoinType::ETH,
-      {"0xB4B2802129071b2B9eBb8cBB01EA1E4D14B34961"}, {},
-      mojom::ProviderError::kMethodNotSupported,
-      l10n_util::GetStringUTF8(IDS_WALLET_METHOD_NOT_SUPPORTED_ERROR), "");
-
-  // Empty address is invalid
-  TestDiscoverAssets(mojom::kMainnetChainId, mojom::CoinType::ETH, {}, {},
-                     mojom::ProviderError::kInvalidParams,
-                     l10n_util::GetStringUTF8(IDS_WALLET_INVALID_PARAMETERS),
-                     "");
-
-  // Invalid address is invalid
-  TestDiscoverAssets(mojom::kMainnetChainId, mojom::CoinType::ETH,
-                     {"0xinvalid"}, {}, mojom::ProviderError::kInvalidParams,
-                     l10n_util::GetStringUTF8(IDS_WALLET_INVALID_PARAMETERS),
-                     "");
-
-  // Invalid RPC response json response triggers parsing error
-  auto expected_network =
-      GetNetwork(mojom::kMainnetChainId, mojom::CoinType::ETH);
+  // Ethereum
+  asset_discovery_manager_->SetSupportedChainsForTesting(
+      {mojom::kMainnetChainId, mojom::kPolygonMainnetChainId});
   std::string token_list_json = R"({
-     "0x0d8775f648430679a709e98d2b0cb6250d2887ef": {
-       "name": "Basic Attention Token",
-       "logo": "bat.svg",
-       "erc20": true,
-       "symbol": "BAT",
-       "decimals": 18
-     }
-    })";
-  ASSERT_TRUE(
-      ParseTokenList(token_list_json, &token_list_map, mojom::CoinType::ETH));
-  blockchain_registry->UpdateTokenList(std::move(token_list_map));
-  SetInterceptor(expected_network, "invalid eth_getLogs response");
-  TestDiscoverAssets(mojom::kMainnetChainId, mojom::CoinType::ETH,
-                     {"0xB4B2802129071b2B9eBb8cBB01EA1E4D14B34961"}, {},
-                     mojom::ProviderError::kParsingError,
-                     l10n_util::GetStringUTF8(IDS_WALLET_PARSING_ERROR), "");
-
-  // Invalid limit exceeded response triggers parsing error
-  SetLimitExceededJsonErrorResponse();
-  TestDiscoverAssets(mojom::kMainnetChainId, mojom::CoinType::ETH,
-                     {"0xB4B2802129071b2B9eBb8cBB01EA1E4D14B34961"}, {},
-                     mojom::ProviderError::kParsingError,
-                     l10n_util::GetStringUTF8(IDS_WALLET_PARSING_ERROR), "");
-
-  // Invalid logs (missing addresses) triggers parsing error
-  response = R"({
-    "jsonrpc": "2.0",
-    "id": 1,
-    "result": [
-      {
-        "blockHash": "0xaefb023131aa58e533c09c0eae29c280460d3976f5235a1ff53159ef37f73073",
-        "blockNumber": "0xa72603",
-        "data": "0x000000000000000000000000000000000000000000000006e83695ab1f893c00",
-        "logIndex": "0x14",
-        "removed": false,
-        "topics": [
-          "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef",
-          "0x000000000000000000000000897bb1e945f5aa7ed7f81646e7991eaba63aa4b0",
-          "0x000000000000000000000000b4b2802129071b2b9ebb8cbb01ea1e4d14b34961"
-        ],
-        "transactionHash": "0x5c655301d386f45af116a4aef418491ee27b71ac30be70a593ccffa3754797d4",
-        "transactionIndex": "0xa"
-      },
-    ]
-  })";
-  SetInterceptor(expected_network, response);
-  TestDiscoverAssets(mojom::kMainnetChainId, mojom::CoinType::ETH,
-                     {"0xB4B2802129071b2B9eBb8cBB01EA1E4D14B34961"}, {},
-                     mojom::ProviderError::kParsingError,
-                     l10n_util::GetStringUTF8(IDS_WALLET_PARSING_ERROR), "");
-
-  // Valid registry token DAI is discovered and added.
-  // Valid registry token WETH is discovered and added (tests insensitivity to
-  // lower case addresses in provider logs response).
-  // Valid BAT is not added because it is already a user asset.
-  // Invalid LilNoun is not added because it is an ERC721.
-  token_list_json = R"(
-     {
-      "0x0d8775f648430679a709e98d2b0cb6250d2887ef": {
-        "name": "Basic Attention Token",
-        "logo": "bat.svg",
+      "0x3333333333333333333333333333333333333333": {
+        "name": "3333",
+        "logo": "333.svg",
         "erc20": true,
-        "symbol": "BAT",
-        "decimals": 18
-      },
-      "0x6B175474E89094C44Da98b954EedeAC495271d0F": {
-        "name": "Dai Stablecoin",
-        "logo": "dai.svg",
-        "erc20": true,
-        "symbol": "DAI",
-        "decimals": 18
-      },
-      "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2": {
-        "name": "Wrapped Eth",
-        "logo": "weth.svg",
-        "erc20": true,
-        "symbol": "WETH",
+        "symbol": "333",
         "decimals": 18,
         "chainId": "0x1"
       },
-      "0x4b10701Bfd7BFEdc47d50562b76b436fbB5BdB3B": {
-        "name": "Lil Nouns",
-        "logo": "lilnouns.svg",
-        "erc20": false,
-        "erc721": true,
-        "symbol": "LilNouns",
+      "0x4444444444444444444444444444444444444444": {
+        "name": "44444444444",
+        "logo": "4444.svg",
+        "erc20": true,
+        "symbol": "4444",
+        "decimals": 18,
+        "chainId": "0x89"
+      }
+     })";
+  ASSERT_TRUE(
+      ParseTokenList(token_list_json, &token_list_map, mojom::CoinType::ETH));
+  blockchain_registry->UpdateTokenList(std::move(token_list_map));
+  std::map<GURL, std::map<std::string, std::string>> requests = {
+      {GetNetwork(mojom::kMainnetChainId, mojom::CoinType::ETH),
+       {
+           {"0xBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB",
+            eth_balance_detected_response},
+           {"0xCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC",
+            eth_balance_not_detected_response},
+       }},
+      {GetNetwork(mojom::kPolygonMainnetChainId, mojom::CoinType::ETH),
+       {
+           {"0xBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB",
+            eth_balance_not_detected_response},
+           {"0xCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC",
+            eth_balance_detected_response},
+       }},
+  };
+  SetInterceptorForDiscoverEthAssets(requests);
+  TestDiscoverAssetsOnAllSupportedChainsAccountsAddedV2(
+      mojom::CoinType::ETH,
+      {
+          "0xBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB",
+          "0xCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC",
+      },
+      {
+          "0x3333333333333333333333333333333333333333",
+          "0x4444444444444444444444444444444444444444",
+      });
+
+  // Solana
+  const std::string first_response = R"({
+    "jsonrpc": "2.0",
+    "result": {
+      "context": {
+        "apiVersion": "1.13.5",
+        "slot": 166895942
+      },
+      "value": [
+        {
+          "account": {
+            "data": [
+              "l/QUsV2gleWOBK7DT7McygX06DWutQjr6AinX510aVU2kEWUG3BArj8SJRSnd1faFt2Tm0Ey/qtGnPdOOlQluoAsOSueAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+              "base64"
+            ],
+            "executable": false,
+            "lamports": 2039280,
+            "owner": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA",
+            "rentEpoch": 0
+          },
+          "pubkey": "BhZnyGAe58uHHdFQgej8ShuDGy9JL1tbs29Bqx3FRgy1"
+        },
+        {
+          "account": {
+            "data": [
+              "iOBUDkpieWsUu53IBhROGzPicXkIYV2OIGUzsFvIlvU2kEWUG3BArj8SJRSnd1faFt2Tm0Ey/qtGnPdOOlQlugDkC1QCAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+              "base64"
+            ],
+            "executable": false,
+            "lamports": 2039280,
+            "owner": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA",
+            "rentEpoch": 0
+          },
+          "pubkey": "3Ra8B4XsnumedGgKvfussaTLxrhyxFAqMkGmst8UqX3k"
+        }
+      ]
+    },
+    "id": 1
+  })";
+
+  // Owner 8RFACUfst117ARQLezvK4cKVR8ZHvW2xUfdUoqWnTuEB has mints
+  // 7vfCXTUXx5WJV5JADk17DUJ4ksgau7utNKj4b963voxs and
+  // 4zLh7YPr8NfrNP4bzTXaYaE72QQc3A8mptbtqUspRz5g
+  const std::string second_response = R"({
+    "jsonrpc": "2.0",
+    "result": {
+      "context": {
+        "apiVersion": "1.13.5",
+        "slot": 166895942
+      },
+      "value": [
+        {
+          "account": {
+            "data": [
+              "O0NuqIea7HUvvwtwGehJ95pVsBSH6xpS3rvbymg9TMNuN8HO+P8En+NLC+JfUEsxJnxEYiI50JuYlZKuo/DnTAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+              "base64"
+            ],
+            "executable": false,
+            "lamports": 2039280,
+            "owner": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA",
+            "rentEpoch": 361
+          },
+          "pubkey": "56iYTYcGgVj3kQ1eTApSp9BJRAvjNfZ7AFbdyeKfGPLK"
+        },
+        {
+          "account": {
+            "data": [
+              "ZuUYihMIoduQttMfP73KjD3yZ4yBEt/dPRksWjzEV6huN8HO+P8En+NLC+JfUEsxJnxEYiI50JuYlZKuo/DnTCeWHwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+              "base64"
+            ],
+            "executable": false,
+            "lamports": 2039280,
+            "owner": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA",
+            "rentEpoch": 361
+          },
+          "pubkey": "dUomT6JpMrZioLeLgtLfcUQpqHsA2jiH9vvz8HDsbyZ"
+        }
+      ]
+    },
+    "id": 1
+  })";
+
+  const std::map<std::string, std::string> solana_requests = {
+      {"4fzcQKyGFuk55uJaBZtvTHh42RBxbrZMuXzsGQvBJbwF", first_response},
+      {"8RFACUfst117ARQLezvK4cKVR8ZHvW2xUfdUoqWnTuEB", second_response},
+  };
+  SetInterceptorForDiscoverSolAssets(
+      GetNetwork(mojom::kSolanaMainnet, mojom::CoinType::SOL), solana_requests);
+  // Add BEARs6toGY6fRGsmz2Se8NDuR2NVPRmJuLPpeF8YxCq2,
+  // ADJqxHJRfFBpyxVQ2YS8nBhfW6dumdDYGU21B4AmYLZJ,
+  // 7vfCXTUXx5WJV5JADk17DUJ4ksgau7utNKj4b963voxs, and
+  // 4zLh7YPr8NfrNP4bzTXaYaE72QQc3A8mptbtqUspRz5g to token list
+  token_list_json = R"({
+    "BEARs6toGY6fRGsmz2Se8NDuR2NVPRmJuLPpeF8YxCq2": {
+      "name": "Tesla Inc.",
+      "logo": "2inRoG4DuMRRzZxAt913CCdNZCu2eGsDD9kZTrsj2DAZ.png",
+      "erc20": false,
+      "symbol": "TSLA",
+      "decimals": 8,
+      "chainId": "0x65"
+    },
+    "ADJqxHJRfFBpyxVQ2YS8nBhfW6dumdDYGU21B4AmYLZJ": {
+      "name": "Apple Inc.",
+      "logo": "8bpRdBGPt354VfABL5xugP3pmYZ2tQjzRcqjg2kmwfbF.png",
+      "erc20": false,
+      "symbol": "AAPL",
+      "decimals": 8,
+      "chainId": "0x65"
+    },
+    "7vfCXTUXx5WJV5JADk17DUJ4ksgau7utNKj4b963voxs": {
+      "name": "Microsoft Corporation",
+      "logo": "3vhcrQfEn8ashuBfE82F3MtEDFcBCEFfFw1ZgM3xj1s8.png",
+      "erc20": false,
+      "symbol": "MSFT",
+      "decimals": 8,
+      "chainId": "0x65"
+    },
+    "4zLh7YPr8NfrNP4bzTXaYaE72QQc3A8mptbtqUspRz5g": {
+      "name": "MicroStrategy Incorporated.",
+      "logo": "ASwYCbLedk85mRdPnkzrUXbbYbwe26m71af9rzrhC2Qz.png",
+      "erc20": false,
+      "symbol": "MSTR",
+      "decimals": 8,
+      "chainId": "0x65"
+    }
+  })";
+  ASSERT_TRUE(
+      ParseTokenList(token_list_json, &token_list_map, mojom::CoinType::SOL));
+  blockchain_registry->UpdateTokenList(std::move(token_list_map));
+  TestDiscoverAssetsOnAllSupportedChainsAccountsAddedV2(
+      mojom::CoinType::SOL,
+      {"4fzcQKyGFuk55uJaBZtvTHh42RBxbrZMuXzsGQvBJbwF",
+       "8RFACUfst117ARQLezvK4cKVR8ZHvW2xUfdUoqWnTuEB"},
+      {"4zLh7YPr8NfrNP4bzTXaYaE72QQc3A8mptbtqUspRz5g",
+       "7vfCXTUXx5WJV5JADk17DUJ4ksgau7utNKj4b963voxs",
+       "ADJqxHJRfFBpyxVQ2YS8nBhfW6dumdDYGU21B4AmYLZJ",
+       "BEARs6toGY6fRGsmz2Se8NDuR2NVPRmJuLPpeF8YxCq2"});
+}
+
+TEST_F(AssetDiscoveryManagerUnitTest,
+       DiscoverAssetsOnAllSupportedChainsRefresh) {
+  std::string token_list_json;
+  std::map<mojom::CoinType, std::vector<std::string>> addresses;
+  auto* blockchain_registry = BlockchainRegistry::GetInstance();
+  TokenListMap token_list_map;
+  std::map<GURL, std::map<std::string, std::string>> requests;
+
+  // Verify that in a single call, we can discover assets on multiple Ethereum
+  // chains as well as Solana. Rate limit pref is updated.
+  asset_discovery_manager_->SetSupportedChainsForTesting(
+      {mojom::kMainnetChainId, mojom::kPolygonMainnetChainId});
+  // Parse the ETH token list
+  token_list_json = R"({
+      "0x3333333333333333333333333333333333333333": {
+        "name": "3333",
+        "logo": "333.svg",
+        "erc20": true,
+        "symbol": "333",
+        "decimals": 18,
         "chainId": "0x1"
+      },
+      "0x4444444444444444444444444444444444444444": {
+        "name": "44444444444",
+        "logo": "4444.svg",
+        "erc20": true,
+        "symbol": "4444",
+        "decimals": 18,
+        "chainId": "0x89"
       }
      })";
   ASSERT_TRUE(
       ParseTokenList(token_list_json, &token_list_map, mojom::CoinType::ETH));
   blockchain_registry->UpdateTokenList(std::move(token_list_map));
 
-  // Note: the matching transfer log for WETH uses an all lowercase address
-  // while the token registry uses checksum address (contains uppercase)
-  response = R"({
-    "jsonrpc":"2.0",
-    "id":1,
-    "result":[
-      {
-        "address":"0x6B175474E89094C44Da98b954EedeAC495271d0F",
-        "blockHash":"0x2961ceb6c16bab72a55f79e394a35f2bf1c62b30446e3537280f7c22c3115e6e",
-        "blockNumber":"0xd6464a",
-        "data":"0x00000000000000000000000000000000000000000000000555aff1f0fae8c000",
-        "logIndex":"0x159",
-        "removed":false,
-        "topics":[
-          "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef",
-          "0x000000000000000000000000503828976d22510aad0201ac7ec88293211d23da",
-          "0x000000000000000000000000b4b2802129071b2b9ebb8cbb01ea1e4d14b34961"
-        ],
-        "transactionHash":"0x2e652b70966c6a05f4b3e68f20d6540b7a5ab712385464a7ccf62774d39b7066",
-        "transactionIndex":"0x9f"
-      },
-      {
-        "address":"0x4b10701Bfd7BFEdc47d50562b76b436fbB5BdB3B",
-        "blockHash":"0x2961ceb6c16bab72a55f79e394a35f2bf1c62b30446e3537280f7c22c3115e6e",
-        "blockNumber":"0xd6464b",
-        "data":"0x00000000000000000000000000000000000000000000000555aff1f0fae8c000",
-        "logIndex":"0x159",
-        "removed":false,
-        "topics":[
-          "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef",
-          "0x000000000000000000000000503828976d22510aad0201ac7ec88293211d23da",
-          "0x000000000000000000000000b4b2802129071b2b9ebb8cbb01ea1e4d14b34961"
-        ],
-        "transactionHash":"0x2e652b70966c6a05f4b3e68f20d6540b7a5ab712385464a7ccf62774d39b7066",
-        "transactionIndex":"0x9f"
-      },
-      {
-        "address":"0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
-        "blockHash":"0x2961ceb6c16bab72a55f79e394a35f2bf1c62b30446e3537280f7c22c3115e6e",
-        "blockNumber":"0xd6464c",
-        "data":"0x00000000000000000000000000000000000000000000000555aff1f0fae8c000",
-        "logIndex":"0x159",
-        "removed":false,
-        "topics":[
-          "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef",
-          "0x000000000000000000000000503828976d22510aad0201ac7ec88293211d23da",
-          "0x000000000000000000000000b4b2802129071b2b9ebb8cbb01ea1e4d14b34961"
-        ],
-        "transactionHash":"0x2e652b70966c6a05f4b3e68f20d6540b7a5ab712385464a7ccf62774d39b7066",
-        "transactionIndex":"0x9f"
-      }
-    ]
-  })";
-
-  SetInterceptor(expected_network, response);
-  TestDiscoverAssets(mojom::kMainnetChainId, mojom::CoinType::ETH,
-                     {"0xB4B2802129071b2B9eBb8cBB01EA1E4D14B34961"},
-                     {"0x6B175474E89094C44Da98b954EedeAC495271d0F",
-                      "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2"},
-                     mojom::ProviderError::kSuccess, "", "0xd6464d");
-
-  // Discover assets should not run unless using Infura proxy
-  std::vector<base::Value::Dict> values;
-  mojom::NetworkInfo chain = GetTestNetworkInfo1("0x1");
-  values.push_back(brave_wallet::NetworkInfoToValue(chain));
-  UpdateCustomNetworks(GetPrefs(), &values);
-  TestDiscoverAssets(
-      mojom::kMainnetChainId, mojom::CoinType::ETH,
-      {"0xB4B2802129071b2B9eBb8cBB01EA1E4D14B34961"}, {},
-      mojom::ProviderError::kMethodNotSupported,
-      l10n_util::GetStringUTF8(IDS_WALLET_METHOD_NOT_SUPPORTED_ERROR),
-      "0xd6464d");
-
-  // Discover assets should be supported on Polygon
-  token_list_json = R"(
-    {
-      "0x6B175474E89094C44Da98b954EedeAC495271d0F": {
-        "name": "Dai Stablecoin",
-        "logo": "dai.svg",
-        "erc20": true,
-        "symbol": "DAI",
-        "chainId": "0x89",
-        "decimals": 18
-      }
-  })";
-  ASSERT_TRUE(
-      ParseTokenList(token_list_json, &token_list_map, mojom::CoinType::ETH));
-  blockchain_registry->UpdateTokenList(std::move(token_list_map));
-  response = R"({
-    "jsonrpc":"2.0",
-    "id":1,
-    "result":[
-      {
-        "address":"0x6B175474E89094C44Da98b954EedeAC495271d0F",
-        "blockHash":"0x2961ceb6c16bab72a55f79e394a35f2bf1c62b30446e3537280f7c22c3115e6e",
-        "blockNumber":"0xd6464c",
-        "data":"0x00000000000000000000000000000000000000000000000555aff1f0fae8c000",
-        "logIndex":"0x159",
-        "removed":false,
-        "topics":[
-          "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef",
-          "0x000000000000000000000000503828976d22510aad0201ac7ec88293211d23da",
-          "0x000000000000000000000000b4b2802129071b2b9ebb8cbb01ea1e4d14b34961"
-        ],
-        "transactionHash":"0x2e652b70966c6a05f4b3e68f20d6540b7a5ab712385464a7ccf62774d39b7066",
-        "transactionIndex":"0x9f"
-      }
-    ]
-  })";
-  expected_network =
-      GetNetwork(mojom::kPolygonMainnetChainId, mojom::CoinType::ETH);
-  SetInterceptor(expected_network, response);
-  TestDiscoverAssets(mojom::kPolygonMainnetChainId, mojom::CoinType::ETH,
-                     {"0xB4B2802129071b2B9eBb8cBB01EA1E4D14B34961"},
-                     {"0x6B175474E89094C44Da98b954EedeAC495271d0F"},
-                     mojom::ProviderError::kSuccess, "", "0xd6464d");
-
-  // Discover assets should be supported on Optimism
+  // Now parse the SOL token list
   token_list_json = R"({
-      "0x6B175474E89094C44Da98b954EedeAC495271d0F": {
-        "name": "Dai Stablecoin",
-        "logo": "dai.svg",
-        "erc20": true,
-        "symbol": "DAI",
-        "chainId": "0xa",
-        "decimals": 18
-      },
-      "0x4200000000000000000000000000000000000006": {
-        "name": "WETH optimism",
-        "logo": "eth.svg",
-        "erc20": true,
-        "symbol": "WETH",
-        "chainId": "0xa",
-        "decimals": 18
-      }
-  })";
-  ASSERT_TRUE(
-      ParseTokenList(token_list_json, &token_list_map, mojom::CoinType::ETH));
-  blockchain_registry->UpdateTokenList(std::move(token_list_map));
-  response = R"({
-    "jsonrpc":"2.0",
-    "id":1,
-    "result":[
-      {
-        "address":"0x6B175474E89094C44Da98b954EedeAC495271d0F",
-        "blockHash":"0x2961ceb6c16bab72a55f79e394a35f2bf1c62b30446e3537280f7c22c3115e6e",
-        "blockNumber":"0xd6464c",
-        "data":"0x00000000000000000000000000000000000000000000000555aff1f0fae8c000",
-        "logIndex":"0x159",
-        "removed":false,
-        "topics":[
-          "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef",
-          "0x000000000000000000000000503828976d22510aad0201ac7ec88293211d23da",
-          "0x000000000000000000000000b4b2802129071b2b9ebb8cbb01ea1e4d14b34961"
-        ],
-        "transactionHash":"0x2e652b70966c6a05f4b3e68f20d6540b7a5ab712385464a7ccf62774d39b7066",
-        "transactionIndex":"0x9f"
-      }
-    ]
-  })";
-  expected_network =
-      GetNetwork(mojom::kOptimismMainnetChainId, mojom::CoinType::ETH);
-  SetInterceptor(expected_network, response);
-  TestDiscoverAssets(mojom::kOptimismMainnetChainId, mojom::CoinType::ETH,
-                     {"0xB4B2802129071b2B9eBb8cBB01EA1E4D14B34961"},
-                     {"0x6B175474E89094C44Da98b954EedeAC495271d0F"},
-                     mojom::ProviderError::kSuccess, "", "0xd6464d");
-
-  // Another Optimism asset discovered at later block
-  // Asset discovered through block pref should update when newer transfers
-  // for a given network are found
-  response = R"({
-    "jsonrpc":"2.0",
-    "id":1,
-    "result":[
-      {
-        "address":"0x4200000000000000000000000000000000000006",
-        "blockHash":"0x2961ceb6c16bab72a55f79e394a35f2bf1c62b30446e3537280f7c22c3115e6e",
-        "blockNumber":"0xd6464d",
-        "data":"0x00000000000000000000000000000000000000000000000555aff1f0fae8c000",
-        "logIndex":"0x159",
-        "removed":false,
-        "topics":[
-          "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef",
-          "0x000000000000000000000000503828976d22510aad0201ac7ec88293211d23da",
-          "0x000000000000000000000000b4b2802129071b2b9ebb8cbb01ea1e4d14b34961"
-        ],
-        "transactionHash":"0x2e652b70966c6a05f4b3e68f20d6540b7a5ab712385464a7ccf62774d39b7066",
-        "transactionIndex":"0x9f"
-      }
-    ]
-  })";
-  SetInterceptor(expected_network, response);
-  TestDiscoverAssets(mojom::kOptimismMainnetChainId, mojom::CoinType::ETH,
-                     {"0xB4B2802129071b2B9eBb8cBB01EA1E4D14B34961"},
-                     {"0x4200000000000000000000000000000000000006"},
-                     mojom::ProviderError::kSuccess, "", "0xd6464e");
-}
-
-TEST_F(AssetDiscoveryManagerUnitTest,
-       DiscoverAssetsOnAllSupportedChainsAccountsAdded) {
-  // Ethereum
-  // Send valid requests that yield no results and verify
-  // 1. OnDiscoverAssetsCompleted is called exactly once for each supported
-  // chain
-  // 2. All eth_getLogs requests specify all block ranges (earliest to latest)
-  // 3. kBraveWalletNextAssetDiscoveryFromBlocks &
-  // kBraveWalletAssetsLastDiscoveredAt prefs are not updated
-  std::map<std::string, std::string> responses;
-  std::map<std::string, std::string> expected_from_blocks;
-  std::map<std::string, std::string> expected_to_blocks;
-  const std::string default_response =
-      R"({ "jsonrpc":"2.0", "id":1, "result":[] })";
-  for (const std::string& supported_chain_id :
-       GetAssetDiscoverySupportedEthChainsForTest()) {
-    GURL network_url = GetNetwork(supported_chain_id, mojom::CoinType::ETH);
-    responses[network_url.spec()] = default_response;
-    expected_from_blocks[network_url.spec()] = kEthereumBlockTagEarliest;
-    expected_to_blocks[network_url.spec()] = kEthereumBlockTagLatest;
-  }
-  const base::Time assets_last_discovered_at =
-      GetPrefs()->GetTime(kBraveWalletLastDiscoveredAssetsAt);
-  auto expected_next_asset_discovery_from_blocks =
-      GetPrefs()->GetDict(kBraveWalletNextAssetDiscoveryFromBlocks).Clone();
-  SetDiscoverAssetsOnAllSupportedChainsInterceptor(
-      responses, expected_from_blocks, expected_to_blocks);
-  TestDiscoverAssetsOnAllSupportedChainsAccountsAdded(
-      mojom::CoinType::ETH, {"0xB4B2802129071b2B9eBb8cBB01EA1E4D14B34961"},
-      assets_last_discovered_at, expected_next_asset_discovery_from_blocks);
-
-  // Solana
-  auto* blockchain_registry = BlockchainRegistry::GetInstance();
-  TokenListMap token_list_map;
-  std::string token_list_json = R"({
-    "88j24JNwWLmJCjn2tZQ5jJzyaFtnusS2qsKup9NeDnd8": {
-      "name": "Wrapped SOL",
-      "logo": "So11111111111111111111111111111111111111112.png",
-      "erc20": false,
-      "symbol": "SOL",
-      "decimals": 9,
-      "chainId": "0x65",
-      "coingeckoId": "solana"
-    },
     "EybFzCH4nBYEr7FD4wLWBvNZbEGgjy4kh584bGQntr1b": {
       "name": "USD Coin",
       "logo": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v.png",
@@ -798,10 +605,12 @@ TEST_F(AssetDiscoveryManagerUnitTest,
   })";
   ASSERT_TRUE(
       ParseTokenList(token_list_json, &token_list_map, mojom::CoinType::SOL));
-  blockchain_registry->UpdateTokenList(std::move(token_list_map));
-  auto expected_network_url =
-      GetNetwork(mojom::kSolanaMainnet, mojom::CoinType::SOL);
-  SetInterceptor(expected_network_url, R"({
+  for (auto& list_pair : token_list_map) {
+    blockchain_registry->UpdateTokenList(list_pair.first,
+                                         std::move(list_pair.second));
+  }
+
+  std::string sol_response = R"({
     "jsonrpc": "2.0",
     "result": {
       "context": {
@@ -821,355 +630,65 @@ TEST_F(AssetDiscoveryManagerUnitTest,
             "rentEpoch": 361
           },
           "pubkey": "5gjGaTE41sPVS1Dzwg43ipdj9NTtApZLcK55ihRuVb6Y"
-        },
-        {
-          "account": {
-            "data": [
-              "afxiYbRCtH5HgLYFzytARQOXmFT6HhvNzk2Baxua+lM2kEWUG3BArj8SJRSnd1faFt2Tm0Ey/qtGnPdOOlQlugEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
-              "base64"
-            ],
-            "executable": false,
-            "lamports": 2039280,
-            "owner": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA",
-            "rentEpoch": 361
-          },
-          "pubkey": "81ZdQjbr7FhEPmcyGJtG8BAUyWxAjb2iSiWFEQn8i8Da"
         }
       ]
     },
     "id": 1
-  })");
-  TestDiscoverAssetsOnAllSupportedChainsAccountsAdded(
-      mojom::CoinType::SOL, {"4fzcQKyGFuk55uJaBZtvTHh42RBxbrZMuXzsGQvBJbwF"},
-      assets_last_discovered_at, expected_next_asset_discovery_from_blocks);
-}
+  })";
 
-TEST_F(AssetDiscoveryManagerUnitTest,
-       DiscoverAssetsOnAllSupportedChainsRefresh) {
-  // Send valid requests that yield no results and verify
-  // 1. OnDiscoverAssetsCompleted is called exactly once for each supported
-  // chain
-  // 2. kBraveWalletAssetsLastDiscoveredAt pref is updated
-  // 3. kBraveWalletNextAssetDiscoveryFromBlocks pref is not updated
-  const std::vector<std::string>& supported_chain_ids =
-      GetAssetDiscoverySupportedEthChainsForTest();
-  std::map<std::string, std::string> responses;
-  std::map<std::string, std::string> expected_from_blocks;
-  std::map<std::string, std::string> expected_to_blocks;
-  std::string default_response = R"({ "jsonrpc":"2.0", "id":1, "result":[] })";
-  for (const std::string& chain_id : supported_chain_ids) {
-    GURL network_url = GetNetwork(chain_id, mojom::CoinType::ETH);
-    responses[network_url.spec()] = default_response;
-    expected_from_blocks[network_url.spec()] = kEthereumBlockTagEarliest;
-    expected_to_blocks[network_url.spec()] = kEthereumBlockTagLatest;
-  }
-
-  std::map<mojom::CoinType, std::vector<std::string>> addresses = {
-      {mojom::CoinType::ETH, {"0xB4B2802129071b2B9eBb8cBB01EA1E4D14B34961"}},
-      {mojom::CoinType::SOL, {}}};
-
-  base::Value::Dict expected_next_asset_discovery_from_blocks;  // Expect empty
-  SetDiscoverAssetsOnAllSupportedChainsInterceptor(
-      responses, expected_from_blocks, expected_to_blocks);
+  requests = {
+      {GetNetwork(mojom::kMainnetChainId, mojom::CoinType::ETH),
+       {
+           {"0xBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB",
+            eth_balance_detected_response},
+           {"0xCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC",
+            eth_balance_not_detected_response},
+       }},
+      {GetNetwork(mojom::kPolygonMainnetChainId, mojom::CoinType::ETH),
+       {
+           {"0xBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB",
+            eth_balance_not_detected_response},
+           {"0xCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC",
+            eth_balance_detected_response},
+       }},
+      {GetNetwork(mojom::kSolanaMainnet, mojom::CoinType::SOL),
+       {
+           {"4fzcQKyGFuk55uJaBZtvTHh42RBxbrZMuXzsGQvBJbwF", sol_response},
+       }},
+  };
+  SetInterceptorForDiscoverEthAssets(requests);
+  addresses = {
+      {mojom::CoinType::ETH,
+       {"0xBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB",
+        "0xCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC"}},
+      {mojom::CoinType::SOL, {"4fzcQKyGFuk55uJaBZtvTHh42RBxbrZMuXzsGQvBJbwF"}},
+  };
   TestDiscoverAssetsOnAllSupportedChainsRefresh(
       addresses,
       base::BindLambdaForTesting([&](base::Time previous, base::Time current) {
-        EXPECT_TRUE(previous < current);
+        EXPECT_GT(current, previous);
       }),
-      expected_next_asset_discovery_from_blocks, {});
+      {"EybFzCH4nBYEr7FD4wLWBvNZbEGgjy4kh584bGQntr1b",
+       "0x3333333333333333333333333333333333333333",
+       "0x4444444444444444444444444444444444444444"});
 
-  // Send valid requests that yield no results that are aborted because of rate
-  // limiting rules and verify
-  // 1. OnDiscoverAssetsCompleted is called exactly once for each supported
-  // chain
-  // 2. kBraveWalletLastDiscoveredAssetsAt stays the same
-  // 3. kBraveWalletNextAssetDiscoveryFromBlocks stays the same (not
-  // actually tested since the value is null...)
-  expected_next_asset_discovery_from_blocks.clear();
-  TestDiscoverAssetsOnAllSupportedChainsRefresh(
-      addresses,
-      base::BindLambdaForTesting([&](base::Time previous, base::Time current) {
-        EXPECT_EQ(previous, current);
-      }),
-      expected_next_asset_discovery_from_blocks, {}, {});
-
-  // Send valid requests that yield new assets on multiple chains and verify
-  // 1. OnDiscoverAssetsCompleted is called exactly once for each supported
-  // chain
-  // 2. Rate limit pref is updated
-  // 3. Dict pref is is updated
-  expected_next_asset_discovery_from_blocks.clear();
-  responses.clear();
-  task_environment_.FastForwardBy(
-      base::Minutes(kAssetDiscoveryMinutesPerRequest));
-
-  std::string token_list_json = R"({
-      "0x0d8775f648430679a709e98d2b0cb6250d2887ef": {
-        "name": "Basic Attention Token",
-        "logo": "bat.svg",
+  // Verify that subsequent calls are rate limited.
+  // Need to adds some new assets to the token list first though
+  token_list_json = R"({
+      "0x5555555555555555555555555555555555555555": {
+        "name": "3333",
+        "logo": "333.svg",
         "erc20": true,
-        "symbol": "BAT",
-        "chainId": "0x1",
-        "decimals": 18
-      },
-      "0x6B175474E89094C44Da98b954EedeAC495271d0F": {
-        "name": "Dai Stablecoin",
-        "logo": "dai.svg",
-        "erc20": true,
-        "symbol": "DAI",
-        "chainId": "0x1",
-        "decimals": 18
-      },
-      "0x4200000000000000000000000000000000000006": {
-        "name": "WETH Optimism",
-        "logo": "weth.svg",
-        "erc20": true,
-        "symbol": "WETH",
-        "chainId": "0xa",
-        "decimals": 18
-      },
-      "0x0000000000000000000000000000000000001010": {
-        "name": "MATIC Polygon",
-        "logo": "matic.svg",
-        "erc20": true,
-        "symbol": "WETH",
-        "chainId": "0x89",
-        "decimals": 18
-      }})";
-
-  auto* blockchain_registry = BlockchainRegistry::GetInstance();
-  TokenListMap token_list_map;
-
+        "symbol": "333",
+        "decimals": 18,
+        "chainId": "0x1"
+      }
+     })";
   ASSERT_TRUE(
       ParseTokenList(token_list_json, &token_list_map, mojom::CoinType::ETH));
   blockchain_registry->UpdateTokenList(std::move(token_list_map));
-
-  // Add responses for mainnet Ethereum, Optimism, then Polygon
-  // Mainnet Ethereum
-  GURL network_url = GetNetwork(mojom::kMainnetChainId, mojom::CoinType::ETH);
-  responses[network_url.spec()] = R"({
-    "jsonrpc":"2.0",
-    "id":1,
-    "result":[
-      {
-        "address":"0x0d8775f648430679a709e98d2b0cb6250d2887ef",
-        "blockHash":"0x2961ceb6c16bab72a55f79e394a35f2bf1c62b30446e3537280f7c22c3115e6e",
-        "blockNumber":"0xd6464d",
-        "data":"0x00000000000000000000000000000000000000000000000555aff1f0fae8c000",
-        "logIndex":"0x159",
-        "removed":false,
-        "topics":[
-          "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef",
-          "0x000000000000000000000000503828976d22510aad0201ac7ec88293211d23da",
-          "0x000000000000000000000000b4b2802129071b2b9ebb8cbb01ea1e4d14b34961"
-        ],
-        "transactionHash":"0x2e652b70966c6a05f4b3e68f20d6540b7a5ab712385464a7ccf62774d39b7066",
-        "transactionIndex":"0x9f"
-      }
-    ]
-  })";
-  expected_from_blocks[network_url.spec()] = kEthereumBlockTagEarliest;
-  expected_next_asset_discovery_from_blocks.SetByDottedPath(
-      base::StrCat({kEthereumPrefKey, ".", mojom::kMainnetChainId}),
-      "0xd6464e");
-
-  // Optimism
-  network_url =
-      GetNetwork(mojom::kOptimismMainnetChainId, mojom::CoinType::ETH);
-  responses[network_url.spec()] = R"({
-    "jsonrpc":"2.0",
-    "id":1,
-    "result":[
-      {
-        "address":"0x4200000000000000000000000000000000000006",
-        "blockHash":"0x2961ceb6c16bab72a55f79e394a35f2bf1c62b30446e3537280f7c22c3115e6e",
-        "blockNumber":"0xd6464d",
-        "data":"0x00000000000000000000000000000000000000000000000555aff1f0fae8c000",
-        "logIndex":"0x159",
-        "removed":false,
-        "topics":[
-          "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef",
-          "0x000000000000000000000000503828976d22510aad0201ac7ec88293211d23da",
-          "0x000000000000000000000000b4b2802129071b2b9ebb8cbb01ea1e4d14b34961"
-        ],
-        "transactionHash":"0x2e652b70966c6a05f4b3e68f20d6540b7a5ab712385464a7ccf62774d39b7066",
-        "transactionIndex":"0x9f"
-      }
-    ]
-  })";
-  expected_from_blocks[network_url.spec()] = kEthereumBlockTagEarliest;
-  expected_next_asset_discovery_from_blocks.SetByDottedPath(
-      base::StrCat({kEthereumPrefKey, ".", mojom::kOptimismMainnetChainId}),
-      "0xd6464e");
-
-  // Polygon
-  network_url = GetNetwork(mojom::kPolygonMainnetChainId, mojom::CoinType::ETH);
-  responses[network_url.spec()] = R"({
-    "jsonrpc":"2.0",
-    "id":1,
-    "result":[
-      {
-        "address":"0x0000000000000000000000000000000000001010",
-        "blockHash":"0x2961ceb6c16bab72a55f79e394a35f2bf1c62b30446e3537280f7c22c3115e6e",
-        "blockNumber":"0xd6464d",
-        "data":"0x00000000000000000000000000000000000000000000000555aff1f0fae8c000",
-        "logIndex":"0x159",
-        "removed":false,
-        "topics":[
-          "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef",
-          "0x000000000000000000000000503828976d22510aad0201ac7ec88293211d23da",
-          "0x000000000000000000000000b4b2802129071b2b9ebb8cbb01ea1e4d14b34961"
-        ],
-        "transactionHash":"0x2e652b70966c6a05f4b3e68f20d6540b7a5ab712385464a7ccf62774d39b7066",
-        "transactionIndex":"0x9f"
-      }
-    ]
-  })";
-  expected_from_blocks[network_url.spec()] = kEthereumBlockTagEarliest;
-  expected_next_asset_discovery_from_blocks.SetByDottedPath(
-      base::StrCat({kEthereumPrefKey, ".", mojom::kPolygonMainnetChainId}),
-      "0xd6464e");
-  SetDiscoverAssetsOnAllSupportedChainsInterceptor(
-      responses, expected_from_blocks, expected_to_blocks);
-  TestDiscoverAssetsOnAllSupportedChainsRefresh(
-      addresses,
-      base::BindLambdaForTesting([&](base::Time previous, base::Time current) {
-        EXPECT_TRUE(previous < current);
-      }),
-      expected_next_asset_discovery_from_blocks,
-      {"0x0000000000000000000000000000000000001010",
-       "0x4200000000000000000000000000000000000006"});
-
-  // Send valid request that for Ethereum mainnet (not rate limited) that yields
-  // new assets at blocks after the previous largest block and verify
-  // 1. from_block in eth_getLogs request is the
-  // kBraveWalletNextAssetDiscoveryFromBlocks set from the previous
-  // request Ethereum mainnet
-  // 2. kBraveWalletNextAssetDiscoveryFromBlocks is incremented for
-  // Ethereum mainnet
-  expected_next_asset_discovery_from_blocks.clear();
-  responses.clear();
-  expected_from_blocks.clear();
-  task_environment_.FastForwardBy(
-      base::Minutes(kAssetDiscoveryMinutesPerRequest));
-  GetPrefs()->GetTime(kBraveWalletLastDiscoveredAssetsAt);
-
-  network_url = GetNetwork(mojom::kMainnetChainId, mojom::CoinType::ETH);
-  responses[network_url.spec()] = R"({
-    "jsonrpc":"2.0",
-    "id":1,
-    "result":[
-      {
-        "address":"0x6B175474E89094C44Da98b954EedeAC495271d0F",
-        "blockHash":"0x2961ceb6c16bab72a55f79e394a35f2bf1c62b30446e3537280f7c22c3115e6e",
-        "blockNumber":"0xd6464e",
-        "data":"0x00000000000000000000000000000000000000000000000555aff1f0fae8c000",
-        "logIndex":"0x159",
-        "removed":false,
-        "topics":[
-          "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef",
-          "0x000000000000000000000000503828976d22510aad0201ac7ec88293211d23da",
-          "0x000000000000000000000000b4b2802129071b2b9ebb8cbb01ea1e4d14b34961"
-        ],
-        "transactionHash":"0x2e652b70966c6a05f4b3e68f20d6540b7a5ab712385464a7ccf62774d39b7066",
-        "transactionIndex":"0x9f"
-      }
-    ]
-  })";
-  expected_from_blocks[network_url.spec()] = "0xd6464e";
-  expected_next_asset_discovery_from_blocks.SetByDottedPath(
-      base::StrCat({kEthereumPrefKey, ".", mojom::kMainnetChainId}),
-      "0xd6464f");
-  expected_next_asset_discovery_from_blocks.SetByDottedPath(
-      base::StrCat({kEthereumPrefKey, ".", mojom::kOptimismMainnetChainId}),
-      "0xd6464e");
-  expected_next_asset_discovery_from_blocks.SetByDottedPath(
-      base::StrCat({kEthereumPrefKey, ".", mojom::kPolygonMainnetChainId}),
-      "0xd6464e");
-
-  SetDiscoverAssetsOnAllSupportedChainsInterceptor(
-      responses, expected_from_blocks, expected_to_blocks);
-  TestDiscoverAssetsOnAllSupportedChainsRefresh(
-      addresses,
-      base::BindLambdaForTesting([&](base::Time previous, base::Time current) {
-        EXPECT_TRUE(previous < current);
-      }),
-      expected_next_asset_discovery_from_blocks,
-      {"0x6B175474E89094C44Da98b954EedeAC495271d0F"});
-}
-
-TEST_F(AssetDiscoveryManagerUnitTest,
-       MultiChainDiscoverAssetsOnAllSupportedChainsRefresh) {
-  // Add ETH assets to registry
-  std::string eth_token_list = R"({
-      "0x0d8775f648430679a709e98d2b0cb6250d2887ef": {
-        "name": "Basic Attention Token",
-        "logo": "bat.svg",
-        "erc20": true,
-        "symbol": "BAT",
-        "chainId": "0x1",
-        "decimals": 18
-      },
-      "0x6B175474E89094C44Da98b954EedeAC495271d0F": {
-        "name": "Dai Stablecoin",
-        "logo": "dai.svg",
-        "erc20": true,
-        "symbol": "DAI",
-        "chainId": "0x1",
-        "decimals": 18
-      }})";
-  auto* blockchain_registry = BlockchainRegistry::GetInstance();
-  TokenListMap token_list_map;
-  ASSERT_TRUE(
-      ParseTokenList(eth_token_list, &token_list_map, mojom::CoinType::ETH));
-  blockchain_registry->UpdateTokenList(std::move(token_list_map));
-
-  // Set up mock RPC responses with a map from chain_id -> mock response  (ETH
-  // only)
-  std::map<std::string, std::string> responses;
-  std::map<std::string, std::string> expected_from_blocks;
-  std::map<std::string, std::string> expected_to_blocks;
-  const std::string default_response =
-      R"({ "jsonrpc":"2.0", "id":1, "result":[] })";
-  for (const std::string& supported_chain_id :
-       GetAssetDiscoverySupportedEthChainsForTest()) {
-    GURL network_url = GetNetwork(supported_chain_id, mojom::CoinType::ETH);
-    responses[network_url.spec()] = default_response;
-    expected_from_blocks[network_url.spec()] = kEthereumBlockTagEarliest;
-    expected_to_blocks[network_url.spec()] = kEthereumBlockTagLatest;
-  }
-
-  // Create response for Ethereum eth_getLogs request
-  GURL network_url = GetNetwork(mojom::kMainnetChainId, mojom::CoinType::ETH);
-  responses[network_url.spec()] = R"({
-    "jsonrpc":"2.0",
-    "id":1,
-    "result":[
-      {
-        "address":"0x6B175474E89094C44Da98b954EedeAC495271d0F",
-        "blockHash":"0x2961ceb6c16bab72a55f79e394a35f2bf1c62b30446e3537280f7c22c3115e6e",
-        "blockNumber":"0xd6464d",
-        "data":"0x00000000000000000000000000000000000000000000000555aff1f0fae8c000",
-        "logIndex":"0x159",
-        "removed":false,
-        "topics":[
-          "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef",
-          "0x000000000000000000000000503828976d22510aad0201ac7ec88293211d23da",
-          "0x000000000000000000000000b4b2802129071b2b9ebb8cbb01ea1e4d14b34961"
-        ],
-        "transactionHash":"0x2e652b70966c6a05f4b3e68f20d6540b7a5ab712385464a7ccf62774d39b7066",
-        "transactionIndex":"0x9f"
-      }
-    ]
-  })";
-  auto expected_next_asset_discovery_from_blocks =
-      GetPrefs()->GetDict(kBraveWalletNextAssetDiscoveryFromBlocks).Clone();
-  expected_next_asset_discovery_from_blocks.SetByDottedPath(
-      base::StrCat({kEthereumPrefKey, ".", mojom::kMainnetChainId}),
-      "0xd6464e");
-
-  // Add SOL assets to registry
-  std::string sol_token_list_json = R"({
+  // Now parse the SOL token list
+  token_list_json = R"({
     "88j24JNwWLmJCjn2tZQ5jJzyaFtnusS2qsKup9NeDnd8": {
       "name": "Wrapped SOL",
       "logo": "So11111111111111111111111111111111111111112.png",
@@ -1178,27 +697,16 @@ TEST_F(AssetDiscoveryManagerUnitTest,
       "decimals": 9,
       "chainId": "0x65",
       "coingeckoId": "solana"
-    },
-    "EybFzCH4nBYEr7FD4wLWBvNZbEGgjy4kh584bGQntr1b": {
-      "name": "USD Coin",
-      "logo": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v.png",
-      "erc20": false,
-      "symbol": "USDC",
-      "decimals": 6,
-      "chainId": "0x65",
-      "coingeckoId": "usd-coin"
     }
   })";
-  ASSERT_TRUE(ParseTokenList(sol_token_list_json, &token_list_map,
-                             mojom::CoinType::SOL));
+  ASSERT_TRUE(
+      ParseTokenList(token_list_json, &token_list_map, mojom::CoinType::SOL));
   for (auto& list_pair : token_list_map) {
     blockchain_registry->UpdateTokenList(list_pair.first,
                                          std::move(list_pair.second));
   }
 
-  // Create response for Solana getTokenAccountsByOwner RPC request
-  network_url = GetNetwork(mojom::kSolanaMainnet, mojom::CoinType::SOL);
-  responses[network_url.spec()] = R"({
+  sol_response = R"({
     "jsonrpc": "2.0",
     "result": {
       "context": {
@@ -1206,19 +714,6 @@ TEST_F(AssetDiscoveryManagerUnitTest,
         "slot": 166895942
       },
       "value": [
-        {
-          "account": {
-            "data": [
-              "z6cxAUoRHIupvmezOL4EAsTLlwKTgwxzCg/xcNWSEu42kEWUG3BArj8SJRSnd1faFt2Tm0Ey/qtGnPdOOlQlugEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
-              "base64"
-            ],
-            "executable": false,
-            "lamports": 2039280,
-            "owner": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA",
-            "rentEpoch": 361
-          },
-          "pubkey": "5gjGaTE41sPVS1Dzwg43ipdj9NTtApZLcK55ihRuVb6Y"
-        },
         {
           "account": {
             "data": [
@@ -1237,24 +732,44 @@ TEST_F(AssetDiscoveryManagerUnitTest,
     "id": 1
   })";
 
-  // Queue the responses for ETH and SOL
-  std::map<mojom::CoinType, std::vector<std::string>> addresses = {
-      {mojom::CoinType::ETH, {"0xB4B2802129071b2B9eBb8cBB01EA1E4D14B34961"}},
-      {mojom::CoinType::SOL, {"4fzcQKyGFuk55uJaBZtvTHh42RBxbrZMuXzsGQvBJbwF"}}};
-  SetDiscoverAssetsOnAllSupportedChainsInterceptor(
-      responses, expected_from_blocks, expected_to_blocks);
-
-  // Verify all three addresses (1 ETH and 2 SOL are discovered)
-  // and that the next asset discovery from block is updated
+  requests = {
+      {GetNetwork(mojom::kMainnetChainId, mojom::CoinType::ETH),
+       {
+           {"0xBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB",
+            eth_balance_detected_response},
+           {"0xCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC",
+            eth_balance_not_detected_response},
+       }},
+      {GetNetwork(mojom::kPolygonMainnetChainId, mojom::CoinType::ETH),
+       {
+           {"0xBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB",
+            eth_balance_not_detected_response},
+           {"0xCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC",
+            eth_balance_detected_response},
+       }},
+      {GetNetwork(mojom::kSolanaMainnet, mojom::CoinType::SOL),
+       {
+           {"4fzcQKyGFuk55uJaBZtvTHh42RBxbrZMuXzsGQvBJbwF", sol_response},
+       }},
+  };
+  SetInterceptorForDiscoverEthAssets(requests);
   TestDiscoverAssetsOnAllSupportedChainsRefresh(
       addresses,
       base::BindLambdaForTesting([&](base::Time previous, base::Time current) {
-        EXPECT_TRUE(previous < current);
+        EXPECT_EQ(current, previous);
       }),
-      expected_next_asset_discovery_from_blocks,
+      {});
+
+  // Verify that after fast forwarding, we can discover assets again
+  task_environment_.FastForwardBy(
+      base::Minutes(kAssetDiscoveryMinutesPerRequest));
+  TestDiscoverAssetsOnAllSupportedChainsRefresh(
+      addresses,
+      base::BindLambdaForTesting([&](base::Time previous, base::Time current) {
+        EXPECT_GT(current, previous);
+      }),
       {"88j24JNwWLmJCjn2tZQ5jJzyaFtnusS2qsKup9NeDnd8",
-       "EybFzCH4nBYEr7FD4wLWBvNZbEGgjy4kh584bGQntr1b",
-       "0x6B175474E89094C44Da98b954EedeAC495271d0F"});
+       "0x5555555555555555555555555555555555555555"});
 }
 
 TEST_F(AssetDiscoveryManagerUnitTest, KeyringServiceObserver) {
@@ -1270,234 +785,31 @@ TEST_F(AssetDiscoveryManagerUnitTest, KeyringServiceObserver) {
       "symbol":"DAI",
       "decimals":18,
       "chainId":"0x1"
-    },
-    "0x4b10701Bfd7BFEdc47d50562b76b436fbB5BdB3B":{
-      "name":"Lil Nouns",
-      "logo":"lilnouns.svg",
-      "erc20":false,
-      "erc721":true,
-      "symbol":"LilNouns",
-      "chainId":"0x1"
-    }, "0x6e84a6216eA6dACC71eE8E6b0a5B7322EEbC0fDd":{
-      "name":"JoeToken",
-      "logo":"joe.svg",
-      "erc20":true,
-      "symbol":"JOE",
-      "decimals":18,
-      "chainId":"0xa86a"
-    },
-    "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48":{
-      "name":"USD Coin",
-      "logo":"usdc.svg",
-      "erc20":true,
-      "symbol":"USDC",
-      "decimals":18,
-      "chainId":"0x1"
-    },
-    "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2":{
-      "name":"Wrapped Eth",
-      "logo":"weth.svg",
-      "erc20":true,
-      "symbol":"WETH",
-      "decimals":18,
-      "chainId":"0x1"
-    },
-    "0x03ab458634910aad20ef5f1c8ee96f1d6ac54919":{
-      "name":"Rai Reflex Index",
-      "logo":"rai.svg",
-      "erc20":true,
-      "symbol":"RAI",
-      "decimals":18,
-      "chainId":"0x1"
     }
   })";
   ASSERT_TRUE(
       ParseTokenList(token_list_json, &token_list_map, mojom::CoinType::ETH));
   blockchain_registry->UpdateTokenList(std::move(token_list_map));
 
-  // RestoreWallet
-  // Mock an eth_getLogs response that includes
-  //  * DAI transfers to next account,
-  //  0xf81229FE54D8a20fBc1e1e2a3451D1c7489437Db (valid)
-  //  * JOE transfers to next account (invalid, wrong network)
-  //  * LilNouns transfers to next account (invalid, not an ERC20 token)
-  std::string response = R"({
-    "jsonrpc":"2.0",
-    "id":1,
-    "result":[
-      {
-        "address":"0x6b175474e89094c44da98b954eedeac495271d0f",
-        "blockHash":"0x2961ceb6c16bab72a55f79e394a35f2bf1c62b30446e3537280f7c22c3115e6e",
-        "blockNumber":"0xd6464c",
-        "data":"0x00000000000000000000000000000000000000000000000555aff1f0fae8c000",
-        "logIndex":"0x159",
-        "removed":false,
-        "topics":[
-          "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef",
-          "0x000000000000000000000000503828976d22510aad0201ac7ec88293211d23da",
-          "0x000000000000000000000000f81229FE54D8a20fBc1e1e2a3451D1c7489437Db"
-        ],
-        "transactionHash":"0x2e652b70966c6a05f4b3e68f20d6540b7a5ab712385464a7ccf62774d39b7066",
-        "transactionIndex":"0x9f"
-      },
-      {
-        "address":"0x6e84a6216eA6dACC71eE8E6b0a5B7322EEbC0fDd",
-        "blockHash":"0x2961ceb6c16bab72a55f79e394a35f2bf1c62b30446e3537280f7c22c3115e6e",
-        "blockNumber":"0xd6464c",
-        "data":"0x00000000000000000000000000000000000000000000000555aff1f0fae8c000",
-        "logIndex":"0x159",
-        "removed":false,
-        "topics":[
-          "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef",
-          "0x000000000000000000000000503828976d22510aad0201ac7ec88293211d23da",
-          "0x000000000000000000000000f81229FE54D8a20fBc1e1e2a3451D1c7489437Db"
-        ],
-        "transactionHash":"0x2e652b70966c6a05f4b3e68f20d6540b7a5ab712385464a7ccf62774d39b7066",
-        "transactionIndex":"0x9f"
-      },
-      {
-        "address":"0x4b10701Bfd7BFEdc47d50562b76b436fbB5BdB3B",
-        "blockHash":"0x2961ceb6c16bab72a55f79e394a35f2bf1c62b30446e3537280f7c22c3115e6e",
-        "blockNumber":"0xd6464c",
-        "data":"0x00000000000000000000000000000000000000000000000555aff1f0fae8c000",
-        "logIndex":"0x159",
-        "removed":false,
-        "topics":[
-          "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef",
-          "0x000000000000000000000000503828976d22510aad0201ac7ec88293211d23da",
-          "0x000000000000000000000000f81229FE54D8a20fBc1e1e2a3451D1c7489437Db"
-        ],
-        "transactionHash":"0x2e652b70966c6a05f4b3e68f20d6540b7a5ab712385464a7ccf62774d39b7066",
-        "transactionIndex":"0x9f"
-      }
-    ]
-  })";
-  auto intended_network =
-      GetNetwork(mojom::kMainnetChainId, mojom::CoinType::ETH);
-  SetInterceptor(intended_network, response);
-  keyring_service_->RestoreWallet(
-      kMnemonic1, kPasswordBrave, false,
-      base::DoNothing());  // Creates account
-                           // 0xf81229FE54D8a20fBc1e1e2a3451D1c7489437Db
+  // RestoreWallet (restores 0xf81229FE54D8a20fBc1e1e2a3451D1c7489437Db)
+  asset_discovery_manager_->SetSupportedChainsForTesting(
+      {mojom::kMainnetChainId});
+  std::vector<mojom::BlockchainTokenPtr> user_assets_before =
+      BraveWalletService::GetUserAssets(mojom::kMainnetChainId,
+                                        mojom::CoinType::ETH, GetPrefs());
+  SetInterceptor(GetNetwork(mojom::kMainnetChainId, mojom::CoinType::ETH),
+                 eth_balance_detected_response);
+  keyring_service_->RestoreWallet(kMnemonic1, kPasswordBrave, false,
+                                  base::DoNothing());
   base::RunLoop().RunUntilIdle();
   std::vector<mojom::AccountInfoPtr> account_infos =
       keyring_service_->GetAccountInfosForKeyring(mojom::kDefaultKeyringId);
   EXPECT_EQ(account_infos.size(), 1u);
-  std::vector<mojom::BlockchainTokenPtr> user_assets =
+  std::vector<mojom::BlockchainTokenPtr> user_assets_after =
       BraveWalletService::GetUserAssets(mojom::kMainnetChainId,
                                         mojom::CoinType::ETH, GetPrefs());
-  EXPECT_EQ(user_assets.size(), 3u);
-  EXPECT_EQ(user_assets[user_assets.size() - 1]->symbol, "DAI");
-
-  // AddAccount
-  // Mock an eth_getLogs response that includes logs for WETH transfers to the
-  // account to be added, 0x00c0f72E601C31DEb7890612cB92Ac0Fb7090EB0
-  response = R"({
-    "jsonrpc":"2.0",
-    "id":1,
-    "result":[
-      {
-        "address":"0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2",
-        "blockHash":"0x2961ceb6c16bab72a55f79e394a35f2bf1c62b30446e3537280f7c22c3115e6e",
-        "blockNumber":"0xd6464c",
-        "data":"0x00000000000000000000000000000000000000000000000555aff1f0fae8c000",
-        "logIndex":"0x159",
-        "removed":false,
-        "topics":[
-          "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef",
-          "0x000000000000000000000000503828976d22510aad0201ac7ec88293211d23da",
-          "0x00000000000000000000000000c0f72E601C31DEb7890612cB92Ac0Fb7090EB0"
-        ],
-        "transactionHash":"0x2e652b70966c6a05f4b3e68f20d6540b7a5ab712385464a7ccf62774d39b7066",
-        "transactionIndex":"0x9f"
-      }
-    ]
-  })";
-  SetInterceptor(intended_network, response);
-  keyring_service_->AddAccount(
-      "Account", mojom::CoinType::ETH,
-      base::DoNothing());  // Creates account
-                           // 0x00c0f72E601C31DEb7890612cB92Ac0Fb7090EB0
-  base::RunLoop().RunUntilIdle();
-  user_assets = BraveWalletService::GetUserAssets(
-      mojom::kMainnetChainId, mojom::CoinType::ETH, GetPrefs());
-  EXPECT_EQ(user_assets.size(), 4u);
-  EXPECT_EQ(user_assets[user_assets.size() - 1]->symbol, "WETH");
-
-  // AddHardwareAccounts
-  // Mock an eth_getLogs response that includes logs for USDC transfers to the
-  // hardware account to be added, 0x595a0583621FDe81A935021707e81343f75F9324
-  response = R"({
-    "jsonrpc":"2.0",
-    "id":1,
-    "result":[
-      {
-        "address":"0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
-        "blockHash":"0x2961ceb6c16bab72a55f79e394a35f2bf1c62b30446e3537280f7c22c3115e6e",
-        "blockNumber":"0xd6464c",
-        "data":"0x00000000000000000000000000000000000000000000000555aff1f0fae8c000",
-        "logIndex":"0x159",
-        "removed":false,
-        "topics":[
-          "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef",
-          "0x000000000000000000000000503828976d22510aad0201ac7ec88293211d23da",
-          "0x000000000000000000000000595a0583621FDe81A935021707e81343f75F9324"
-        ],
-        "transactionHash":"0x2e652b70966c6a05f4b3e68f20d6540b7a5ab712385464a7ccf62774d39b7066",
-        "transactionIndex":"0x9f"
-      }
-    ]
-  })";
-  SetInterceptor(intended_network, response);
-  std::vector<mojom::HardwareWalletAccountPtr> hardware_accounts;
-  hardware_accounts.push_back(mojom::HardwareWalletAccount::New(
-      "0x595a0583621FDe81A935021707e81343f75F9324", "m/44'/60'/1'/0/0",
-      "name 1", "Ledger", "device1", mojom::CoinType::ETH, absl::nullopt));
-  keyring_service_->AddHardwareAccounts(std::move(hardware_accounts));
-  base::RunLoop().RunUntilIdle();
-  account_infos =
-      keyring_service_->GetAccountInfosForKeyring(mojom::kDefaultKeyringId);
-  user_assets = BraveWalletService::GetUserAssets(
-      mojom::kMainnetChainId, mojom::CoinType::ETH, GetPrefs());
-  EXPECT_EQ(user_assets[user_assets.size() - 1]->symbol, "USDC");
-  EXPECT_EQ(user_assets.size(), 5u);
-
-  // ImportAccountForKeyring
-  // Mock an eth_getLogs response that includes logs for RAI transfers to the
-  // account to be imported, 0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266
-  response = R"({
-    "jsonrpc":"2.0",
-    "id":1,
-    "result":[
-      {
-        "address":"0x03ab458634910aad20ef5f1c8ee96f1d6ac54919",
-        "blockHash":"0x2961ceb6c16bab72a55f79e394a35f2bf1c62b30446e3537280f7c22c3115e6e",
-        "blockNumber":"0xd6464c",
-        "data":"0x00000000000000000000000000000000000000000000000555aff1f0fae8c000",
-        "logIndex":"0x159",
-        "removed":false,
-        "topics":[
-          "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef",
-          "0x000000000000000000000000503828976d22510aad0201ac7ec88293211d23da",
-          "0x000000000000000000000000f39Fd6e51aad88F6F4ce6aB8827279cffFb92266"
-        ],
-        "transactionHash":"0x2e652b70966c6a05f4b3e68f20d6540b7a5ab712385464a7ccf62774d39b7066",
-        "transactionIndex":"0x9f"
-      }
-    ]
-  })";
-  SetInterceptor(intended_network, response);
-  const std::string private_key_str =
-      "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80";
-  std::vector<uint8_t> private_key_bytes;
-  ASSERT_TRUE(PrefixedHexStringToBytes(private_key_str, &private_key_bytes));
-  ASSERT_TRUE(keyring_service_->ImportAccountForKeyring(
-      mojom::kDefaultKeyringId, "Imported Account", private_key_bytes));
-  base::RunLoop().RunUntilIdle();
-  user_assets = BraveWalletService::GetUserAssets(
-      mojom::kMainnetChainId, mojom::CoinType::ETH, GetPrefs());
-  EXPECT_EQ(user_assets[user_assets.size() - 1]->symbol, "RAI");
-  EXPECT_EQ(user_assets.size(), 6u);
+  EXPECT_EQ(user_assets_after.size(), user_assets_before.size() + 1);
+  EXPECT_EQ(user_assets_after[user_assets_after.size() - 1]->symbol, "DAI");
 }
 
 TEST_F(AssetDiscoveryManagerUnitTest, DecodeMintAddress) {
@@ -1762,6 +1074,215 @@ TEST_F(AssetDiscoveryManagerUnitTest, DiscoverSolAssets) {
                          "7vfCXTUXx5WJV5JADk17DUJ4ksgau7utNKj4b963voxs",
                          "ADJqxHJRfFBpyxVQ2YS8nBhfW6dumdDYGU21B4AmYLZJ",
                          "BEARs6toGY6fRGsmz2Se8NDuR2NVPRmJuLPpeF8YxCq2"});
+}
+
+TEST_F(AssetDiscoveryManagerUnitTest, DiscoverEthAssets) {
+  // Supplying no addresses should end early but still trigger an
+  // OnDiscoverAssetsCompleted event
+  TestDiscoverEthAssets({}, false, {});
+
+  // Add token to the registry for upcoming tests
+  auto* blockchain_registry = BlockchainRegistry::GetInstance();
+  TokenListMap token_list_map;
+  std::string token_list_json = R"({
+     "0x6B175474E89094C44Da98b954EedeAC495271d0F": {
+       "name": "Dai Stablecoin",
+       "logo": "dai.svg",
+       "erc20": true,
+       "symbol": "DAI",
+       "chainId": "0x1",
+       "decimals": 18
+     }
+    })";
+  ASSERT_TRUE(
+      ParseTokenList(token_list_json, &token_list_map, mojom::CoinType::ETH));
+  blockchain_registry->UpdateTokenList(std::move(token_list_map));
+
+  // One account, no balances, yields empty token_contract_addresses
+  asset_discovery_manager_->SetSupportedChainsForTesting(
+      {mojom::kMainnetChainId});
+  std::map<GURL, std::map<std::string, std::string>> requests = {
+      {GetNetwork(mojom::kMainnetChainId, mojom::CoinType::ETH),
+       {
+           {"0xB4B2802129071b2B9eBb8cBB01EA1E4D14B34961",
+            eth_balance_not_detected_response},
+       }},
+  };
+  SetInterceptorForDiscoverEthAssets(requests);
+  TestDiscoverEthAssets({"0xB4B2802129071b2B9eBb8cBB01EA1E4D14B34961"}, false,
+                        {});
+
+  // One account, BalanceScanner reports failure to fetch (successfull), yields
+  // no discovered contract addresses
+  requests = {
+      {GetNetwork(mojom::kMainnetChainId, mojom::CoinType::ETH),
+       {
+           {"0xB4B2802129071b2B9eBb8cBB01EA1E4D14B34961",
+            eth_error_fetching_balance_response},
+       }},
+  };
+  SetInterceptorForDiscoverEthAssets(requests);
+  TestDiscoverEthAssets({"0xB4B2802129071b2B9eBb8cBB01EA1E4D14B34961"}, false,
+                        {});
+
+  // One account, with a balance, yields discovered contract address
+  requests = {
+      {GetNetwork(mojom::kMainnetChainId, mojom::CoinType::ETH),
+       {
+           {"0xB4B2802129071b2B9eBb8cBB01EA1E4D14B34961",
+            eth_balance_detected_response},
+       }},
+  };
+  SetInterceptorForDiscoverEthAssets(requests);
+  TestDiscoverEthAssets({"0xB4B2802129071b2B9eBb8cBB01EA1E4D14B34961"}, false,
+                        {"0x6B175474E89094C44Da98b954EedeAC495271d0F"});
+
+  // One account, with a balance, yields no discovered contract addresseses
+  // (already in user asset list)
+  requests = {
+      {GetNetwork(mojom::kMainnetChainId, mojom::CoinType::ETH),
+       {
+           {"0xB4B2802129071b2B9eBb8cBB01EA1E4D14B34961",
+            eth_balance_detected_response},
+       }},
+  };
+  SetInterceptorForDiscoverEthAssets(requests);
+  TestDiscoverEthAssets({"0xB4B2802129071b2B9eBb8cBB01EA1E4D14B34961"}, false,
+                        {});
+
+  // Reset token list with a fresh token not in user assets
+  token_list_json = R"({
+    "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2": {
+      "name": "Wrapped Eth",
+      "logo": "weth.svg",
+      "erc20": true,
+      "symbol": "WETH",
+      "decimals": 18,
+      "chainId": "0x1"
+    }
+  })";
+  ASSERT_TRUE(
+      ParseTokenList(token_list_json, &token_list_map, mojom::CoinType::ETH));
+  blockchain_registry->UpdateTokenList(std::move(token_list_map));
+
+  // Two accounts, each with the same balance, yields just one discovered
+  // contract address
+  requests = {
+      {GetNetwork(mojom::kMainnetChainId, mojom::CoinType::ETH),
+       {
+           {"0xB4B2802129071b2B9eBb8cBB01EA1E4D14B34961",
+            eth_balance_detected_response},
+           {"0x2B5AD5c4795c026514f8317c7a215E218DcCD6cF",
+            eth_balance_detected_response},
+       }},
+  };
+  SetInterceptorForDiscoverEthAssets(requests);
+  TestDiscoverEthAssets({"0xB4B2802129071b2B9eBb8cBB01EA1E4D14B34961",
+                         "0x2B5AD5c4795c026514f8317c7a215E218DcCD6cF"},
+                        false, {"0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2"});
+
+  // Single account on multiple chains discovers two assets
+  asset_discovery_manager_->SetSupportedChainsForTesting(
+      {mojom::kMainnetChainId, mojom::kPolygonMainnetChainId});
+  token_list_json = R"({
+      "0x1111111111111111111111111111111111111111": {
+        "name": "1111",
+        "logo": "111.svg",
+        "erc20": true,
+        "symbol": "111",
+        "decimals": 18,
+        "chainId": "0x1"
+      },
+      "0x2222222222222222222222222222222222222222": {
+        "name": "22222222222",
+        "logo": "2222.svg",
+        "erc20": true,
+        "symbol": "2222",
+        "decimals": 18,
+        "chainId": "0x89"
+      }
+     })";
+  ASSERT_TRUE(
+      ParseTokenList(token_list_json, &token_list_map, mojom::CoinType::ETH));
+  blockchain_registry->UpdateTokenList(std::move(token_list_map));
+  requests = {
+      {GetNetwork(mojom::kMainnetChainId, mojom::CoinType::ETH),
+       {
+           {"0xB4B2802129071b2B9eBb8cBB01EA1E4D14B34961",
+            eth_balance_detected_response},
+       }},
+      {GetNetwork(mojom::kPolygonMainnetChainId, mojom::CoinType::ETH),
+       {
+           {"0xB4B2802129071b2B9eBb8cBB01EA1E4D14B34961",
+            eth_balance_detected_response},
+       }},
+  };
+  SetInterceptorForDiscoverEthAssets(requests);
+  TestDiscoverEthAssets({"0xB4B2802129071b2B9eBb8cBB01EA1E4D14B34961"}, false,
+                        {"0x1111111111111111111111111111111111111111",
+                         "0x2222222222222222222222222222222222222222"});
+
+  // Multiple accounts with different balances, yields multiple discovered
+  // contract addresses Reset token list with a fresh token not in user assets
+  token_list_json = R"({
+      "0x3333333333333333333333333333333333333333": {
+        "name": "3333",
+        "logo": "333.svg",
+        "erc20": true,
+        "symbol": "333",
+        "decimals": 18,
+        "chainId": "0x1"
+      },
+      "0x4444444444444444444444444444444444444444": {
+        "name": "44444444444",
+        "logo": "4444.svg",
+        "erc20": true,
+        "symbol": "4444",
+        "decimals": 18,
+        "chainId": "0x89"
+      }
+     })";
+  ASSERT_TRUE(
+      ParseTokenList(token_list_json, &token_list_map, mojom::CoinType::ETH));
+  blockchain_registry->UpdateTokenList(std::move(token_list_map));
+  requests = {
+      {GetNetwork(mojom::kMainnetChainId, mojom::CoinType::ETH),
+       {
+           {"0xBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB",
+            eth_balance_detected_response},
+           {"0xCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC",
+            eth_balance_not_detected_response},
+       }},
+      {GetNetwork(mojom::kPolygonMainnetChainId, mojom::CoinType::ETH),
+       {
+           {"0xBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB",
+            eth_balance_not_detected_response},
+           {"0xCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC",
+            eth_balance_detected_response},
+       }},
+  };
+  SetInterceptorForDiscoverEthAssets(requests);
+  TestDiscoverEthAssets({"0xBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB",
+                         "0xCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC"},
+                        false,
+                        {"0x3333333333333333333333333333333333333333",
+                         "0x4444444444444444444444444444444444444444"});
+}
+
+TEST_F(AssetDiscoveryManagerUnitTest, GetAssetDiscoverySupportedEthChains) {
+  // Bypass SetSupportedChainsForTesting by setting to empty list
+  asset_discovery_manager_->SetSupportedChainsForTesting({});
+  // GetAssetDiscoverySupportedEthChains should return a list of the same size
+  // every time
+  const std::vector<std::string> chains1 =
+      asset_discovery_manager_->GetAssetDiscoverySupportedEthChains();
+  const std::vector<std::string> chains2 =
+      asset_discovery_manager_->GetAssetDiscoverySupportedEthChains();
+  const std::vector<std::string> chains3 =
+      asset_discovery_manager_->GetAssetDiscoverySupportedEthChains();
+  EXPECT_GT(chains1.size(), 0u);
+  EXPECT_EQ(chains1.size(), chains2.size());
+  EXPECT_EQ(chains2.size(), chains3.size());
 }
 
 }  // namespace brave_wallet

--- a/components/brave_wallet/browser/asset_discovery_manager.cc
+++ b/components/brave_wallet/browser/asset_discovery_manager.cc
@@ -13,6 +13,7 @@
 #include "base/threading/platform_thread.h"
 #include "base/time/time.h"
 #include "brave/components/brave_wallet/browser/blockchain_registry.h"
+#include "brave/components/brave_wallet/browser/brave_wallet_constants.h"
 #include "brave/components/brave_wallet/browser/brave_wallet_service.h"
 #include "brave/components/brave_wallet/browser/brave_wallet_utils.h"
 #include "brave/components/brave_wallet/browser/eth_topics_builder.h"
@@ -48,8 +49,17 @@ AssetDiscoveryManager::GetAssetDiscoverySupportedEthChains() {
   if (supported_chains_for_testing_.size() > 0) {
     return supported_chains_for_testing_;
   }
-  static base::NoDestructor<std::vector<std::string>>
-      asset_discovery_supported_chains({mojom::kMainnetChainId});
+
+  // Use the hardcoded list of BalanceScanner contract addresses to determine
+  // which chains are supported.
+  static const base::NoDestructor<std::vector<std::string>>
+      asset_discovery_supported_chains([] {
+        std::vector<std::string> supported_chains;
+        for (const auto& entry : GetEthBalanceScannerContractAddresses()) {
+          supported_chains.push_back(entry.first);
+        }
+        return supported_chains;
+      }());
   return *asset_discovery_supported_chains;
 }
 
@@ -71,10 +81,8 @@ void AssetDiscoveryManager::DiscoverSolAssets(
   }
 
   if (solana_addresses.empty()) {
-    CompleteDiscoverAssets(
-        mojom::kSolanaMainnet, std::vector<mojom::BlockchainTokenPtr>(),
-        absl::nullopt, l10n_util::GetStringUTF8(IDS_WALLET_INVALID_PARAMETERS),
-        triggered_by_accounts_added);
+    CompleteDiscoverAssets(std::vector<mojom::BlockchainTokenPtr>(),
+                           triggered_by_accounts_added);
     return;
   }
 
@@ -170,228 +178,167 @@ void AssetDiscoveryManager::OnGetSolanaTokenRegistry(
     }
   }
 
-  CompleteDiscoverAssets(mojom::kSolanaMainnet, std::move(discovered_tokens),
-                         absl::nullopt, "", triggered_by_accounts_added);
-}
-
-void AssetDiscoveryManager::DiscoverEthAssets(
-    const std::string& chain_id,
-    mojom::CoinType coin,
-    const std::vector<std::string>& account_addresses,
-    bool triggered_by_accounts_added,
-    const std::string& from_block,
-    const std::string& to_block) {
-  if (account_addresses.empty()) {
-    CompleteDiscoverAssets(
-        chain_id, std::vector<mojom::BlockchainTokenPtr>(),
-        mojom::ProviderError::kInvalidParams,
-        l10n_util::GetStringUTF8(IDS_WALLET_INVALID_PARAMETERS),
-        triggered_by_accounts_added);
-    return;
-  }
-
-  // Asset discovery only supported on select EVM chains
-  if (coin != mojom::CoinType::ETH ||
-      !base::Contains(GetAssetDiscoverySupportedEthChains(), chain_id)) {
-    CompleteDiscoverAssets(
-        chain_id, std::vector<mojom::BlockchainTokenPtr>(),
-        mojom::ProviderError::kMethodNotSupported,
-        l10n_util::GetStringUTF8(IDS_WALLET_METHOD_NOT_SUPPORTED_ERROR),
-        triggered_by_accounts_added);
-    return;
-  }
-
-  // Asset discovery only supported when using Infura proxy
-  GURL infura_url = GetInfuraURLForKnownChainId(chain_id);
-  GURL active_url = GetNetworkURL(prefs_, chain_id, coin);
-  if (infura_url.host() != active_url.host()) {
-    CompleteDiscoverAssets(
-        chain_id, std::vector<mojom::BlockchainTokenPtr>(),
-        mojom::ProviderError::kMethodNotSupported,
-        l10n_util::GetStringUTF8(IDS_WALLET_METHOD_NOT_SUPPORTED_ERROR),
-        triggered_by_accounts_added);
-    return;
-  }
-
-  for (const auto& account_address : account_addresses) {
-    if (!EthAddress::IsValidAddress(account_address)) {
-      CompleteDiscoverAssets(
-          chain_id, std::vector<mojom::BlockchainTokenPtr>(),
-          mojom::ProviderError::kInvalidParams,
-          l10n_util::GetStringUTF8(IDS_WALLET_INVALID_PARAMETERS),
-          triggered_by_accounts_added);
-      return;
-    }
-  }
-
-  std::vector<mojom::BlockchainTokenPtr> user_assets =
-      BraveWalletService::GetUserAssets(chain_id, mojom::CoinType::ETH, prefs_);
-  auto internal_callback =
-      base::BindOnce(&AssetDiscoveryManager::OnGetEthTokenRegistry,
-                     weak_ptr_factory_.GetWeakPtr(), chain_id,
-                     account_addresses, std::move(user_assets),
-                     triggered_by_accounts_added, from_block, to_block);
-
-  BlockchainRegistry::GetInstance()->GetAllTokens(
-      chain_id, mojom::CoinType::ETH, std::move(internal_callback));
-}
-
-void AssetDiscoveryManager::OnGetEthTokenRegistry(
-    const std::string& chain_id,
-    const std::vector<std::string>& account_addresses,
-    std::vector<mojom::BlockchainTokenPtr> user_assets,
-    bool triggered_by_accounts_added,
-    const std::string& from_block,
-    const std::string& to_block,
-    std::vector<mojom::BlockchainTokenPtr> token_registry) {
-  auto network_url = GetNetworkURL(prefs_, chain_id, mojom::CoinType::ETH);
-  if (!network_url.is_valid()) {
-    CompleteDiscoverAssets(
-        chain_id, std::vector<mojom::BlockchainTokenPtr>(),
-        mojom::ProviderError::kInvalidParams,
-        l10n_util::GetStringUTF8(IDS_WALLET_INVALID_PARAMETERS),
-        triggered_by_accounts_added);
-    return;
-  }
-
-  base::Value::List topics;
-  if (!MakeAssetDiscoveryTopics(account_addresses, &topics)) {
-    CompleteDiscoverAssets(
-        chain_id, std::vector<mojom::BlockchainTokenPtr>(),
-        mojom::ProviderError::kInvalidParams,
-        l10n_util::GetStringUTF8(IDS_WALLET_INVALID_PARAMETERS),
-        triggered_by_accounts_added);
-    return;
-  }
-
-  // Create set of contract addresses the user already has for easy lookups
-  base::flat_set<std::string> user_asset_contract_addresses;
-  for (const auto& user_asset : user_assets) {
-    user_asset_contract_addresses.insert(user_asset->contract_address);
-  }
-
-  // Create a list of contract addresses to search by removing
-  // all erc20s and assets the user has already added.
-  base::Value::List contract_addresses_to_search;
-  // Also create a map for addresses to blockchain tokens for easy lookup
-  // for blockchain tokens in OnGetTokenTransferLogs
-  base::flat_map<std::string, mojom::BlockchainTokenPtr> tokens_to_search;
-  for (auto& registry_token : token_registry) {
-    if (registry_token->is_erc20 && !registry_token->contract_address.empty() &&
-        !user_asset_contract_addresses.contains(
-            registry_token->contract_address)) {
-      // Use lowercase representation of hex address for comparisons
-      // because providers may return all lowercase addresses.
-      const std::string lower_case_contract_address =
-          base::ToLowerASCII(registry_token->contract_address);
-      contract_addresses_to_search.Append(lower_case_contract_address);
-      tokens_to_search[lower_case_contract_address] = std::move(registry_token);
-    }
-  }
-
-  if (contract_addresses_to_search.size() == 0) {
-    CompleteDiscoverAssets(chain_id, std::vector<mojom::BlockchainTokenPtr>(),
-                           mojom::ProviderError::kSuccess, "",
-                           triggered_by_accounts_added);
-    return;
-  }
-
-  auto callback = base::BindOnce(&AssetDiscoveryManager::OnGetTokenTransferLogs,
-                                 weak_ptr_factory_.GetWeakPtr(),
-                                 base::OwnedRef(std::move(tokens_to_search)),
-                                 triggered_by_accounts_added, chain_id);
-  base::Value::Dict filtering;
-  filtering.Set("fromBlock", from_block);
-  filtering.Set("toBlock", to_block);
-  filtering.Set("address", std::move(contract_addresses_to_search));
-  filtering.Set("topics", std::move(topics));
-  json_rpc_service_->EthGetLogs(chain_id, std::move(filtering),
-                                std::move(callback));
-}
-
-void AssetDiscoveryManager::OnGetTokenTransferLogs(
-    base::flat_map<std::string, mojom::BlockchainTokenPtr>& tokens_to_search,
-    bool triggered_by_accounts_added,
-    const std::string& chain_id,
-    const std::vector<Log>& logs,
-    base::Value rawlogs,
-    mojom::ProviderError error,
-    const std::string& error_message) {
-  if (error != mojom::ProviderError::kSuccess) {
-    CompleteDiscoverAssets(chain_id, std::vector<mojom::BlockchainTokenPtr>(),
-                           error, error_message, triggered_by_accounts_added);
-    return;
-  }
-
-  // Create unique list of addresses that matched eth_getLogs query
-  // and keep track of largest block discovered
-  base::flat_set<std::string> matching_contract_addresses;
-  uint256_t largest_block = 0;
-  for (const auto& log : logs) {
-    matching_contract_addresses.insert(base::ToLowerASCII(log.address));
-    if (log.block_number > largest_block) {
-      largest_block = log.block_number;
-    }
-  }
-
-  std::vector<mojom::BlockchainTokenPtr> discovered_assets;
-  for (const auto& contract_address : matching_contract_addresses) {
-    if (!tokens_to_search.contains(contract_address)) {
-      continue;
-    }
-    mojom::BlockchainTokenPtr token =
-        std::move(tokens_to_search.at(contract_address));
-
-    if (!BraveWalletService::AddUserAsset(token.Clone(), prefs_)) {
-      continue;
-    }
-    discovered_assets.push_back(std::move(token));
-  }
-
-  if (!triggered_by_accounts_added) {
-    // Update the last block discovered for this chain unless this
-    // was triggered by accounts being added
-    ScopedDictPrefUpdate update(prefs_,
-                                kBraveWalletNextAssetDiscoveryFromBlocks);
-    base::Value::Dict& next_asset_discovery_from_blocks = update.Get();
-    const auto path = base::StrCat({kEthereumPrefKey, ".", chain_id});
-    const std::string* current =
-        next_asset_discovery_from_blocks.FindStringByDottedPath(path);
-    uint256_t current_int = 0;
-    if (current) {
-      if (!HexValueToUint256(*current, &current_int)) {
-        CompleteDiscoverAssets(
-            chain_id, std::vector<mojom::BlockchainTokenPtr>(),
-            mojom::ProviderError::kInternalError,
-            l10n_util::GetStringUTF8(IDS_WALLET_INTERNAL_ERROR),
-            triggered_by_accounts_added);
-        return;
-      }
-    }
-    if ((!current || current_int <= largest_block) && largest_block > 0) {
-      next_asset_discovery_from_blocks.SetByDottedPath(
-          path, Uint256ValueToHex(largest_block + 1));
-    }
-  }
-  CompleteDiscoverAssets(chain_id, std::move(discovered_assets),
-                         mojom::ProviderError::kSuccess, "",
+  CompleteDiscoverAssets(std::move(discovered_tokens),
                          triggered_by_accounts_added);
 }
 
-void AssetDiscoveryManager::CompleteDiscoverAssets(
+void AssetDiscoveryManager::DiscoverEthAssets(
+    const std::vector<std::string>& account_addresses,
+    bool triggered_by_accounts_added) {
+  if (account_addresses.empty()) {
+    CompleteDiscoverAssets({}, triggered_by_accounts_added);
+    return;
+  }
+
+  std::vector<mojom::BlockchainTokenPtr> user_assets =
+      BraveWalletService::GetUserAssets(prefs_);
+  TokenListMap token_list_map =
+      BlockchainRegistry::GetInstance()->GetEthTokenListMap(
+          GetAssetDiscoverySupportedEthChains());
+
+  // Create set of all user assets per chain to use to ensure we don't
+  // include assets the user has already added in the call to the BalanceScanner
+  base::flat_map<std::string, base::flat_set<base::StringPiece>>
+      user_assets_per_chain;
+  for (const auto& user_asset : user_assets) {
+    user_assets_per_chain[user_asset->chain_id].insert(
+        user_asset->contract_address);
+  }
+
+  // Create a map of chain_id to a map contract address to BlockchainToken
+  // to easily lookup tokens by contract address when the results of the
+  // BalanceScanner calls are merged
+  base::flat_map<std::string,
+                 base::flat_map<std::string, mojom::BlockchainTokenPtr>>
+      chain_id_to_contract_address_to_token;
+
+  // Create a map of chain_id to a vector of contract addresses (strings, rather
+  // than BlockchainTokens) to pass to GetERC20TokenBalances
+  base::flat_map<std::string, std::vector<std::string>>
+      chain_id_to_contract_addresses;
+
+  // Populate the chain_id_to_contract_addresses using the token_list_map of
+  // BlockchainTokenPtrs
+  for (auto& [chain_id, token_list] : token_list_map) {
+    for (auto& token : token_list) {
+      if (!user_assets_per_chain[chain_id].contains(token->contract_address)) {
+        chain_id_to_contract_addresses[chain_id].push_back(
+            token->contract_address);
+        chain_id_to_contract_address_to_token[chain_id]
+                                             [token->contract_address] =
+                                                 std::move(token);
+      }
+    }
+  }
+
+  // Use a barrier callback to wait for all GetERC20TokenBalances calls to
+  // complete (one for each account address).
+  const auto barrier_callback =
+      base::BarrierCallback<std::map<std::string, std::vector<std::string>>>(
+          account_addresses.size() * chain_id_to_contract_addresses.size(),
+          base::BindOnce(&AssetDiscoveryManager::MergeDiscoveredEthAssets,
+                         weak_ptr_factory_.GetWeakPtr(),
+                         std::move(chain_id_to_contract_address_to_token),
+                         triggered_by_accounts_added));
+
+  // For each account address, call GetERC20TokenBalances for each chain ID
+  for (const auto& account_address : account_addresses) {
+    for (const auto& [chain_id, contract_addresses] :
+         chain_id_to_contract_addresses) {
+      auto internal_callback = base::BindOnce(
+          &AssetDiscoveryManager::OnGetERC20TokenBalances,
+          weak_ptr_factory_.GetWeakPtr(), barrier_callback, chain_id,
+          triggered_by_accounts_added, contract_addresses);
+      json_rpc_service_->GetERC20TokenBalances(contract_addresses,
+                                               account_address, chain_id,
+                                               std::move(internal_callback));
+    }
+  }
+}
+
+void AssetDiscoveryManager::OnGetERC20TokenBalances(
+    base::OnceCallback<void(std::map<std::string, std::vector<std::string>>)>
+        barrier_callback,
     const std::string& chain_id,
-    std::vector<mojom::BlockchainTokenPtr> discovered_assets_for_chain,
-    absl::optional<mojom::ProviderError> error,
-    const std::string& error_message,
+    bool triggered_by_accounts_added,
+    const std::vector<std::string>&
+        contract_addresses,  // Contract addresses queried for
+    std::vector<mojom::ERC20BalanceResultPtr> balance_results,
+    mojom::ProviderError error,
+    const std::string& error_message) {
+  // If the request failed, return an empty map
+  if (error != mojom::ProviderError::kSuccess || balance_results.empty()) {
+    std::move(barrier_callback).Run({});
+    return;
+  }
+
+  // Create a map of chain_id to a vector of contract addresses that have a
+  // balance greater than 0
+  std::map<std::string, std::vector<std::string>>
+      chain_id_to_contract_addresses_with_balance;
+
+  // Populate the map using the balance_results
+  for (size_t i = 0; i < balance_results.size(); i++) {
+    if (balance_results[i]->balance.has_value() &&
+        balance_results[i]->balance !=
+            "0x000000000000000000000000000000000000000000000000000000000000000"
+            "0") {
+      chain_id_to_contract_addresses_with_balance[chain_id].push_back(
+          contract_addresses[i]);
+    }
+  }
+
+  std::move(barrier_callback).Run(chain_id_to_contract_addresses_with_balance);
+}
+
+void AssetDiscoveryManager::MergeDiscoveredEthAssets(
+    base::flat_map<std::string,
+                   base::flat_map<std::string, mojom::BlockchainTokenPtr>>
+        chain_id_to_contract_address_to_token,
+    bool triggered_by_accounts_added,
+    const std::vector<std::map<std::string, std::vector<std::string>>>&
+        discovered_assets_results) {
+  // Create a vector of BlockchainTokenPtrs to return
+  std::vector<mojom::BlockchainTokenPtr> discovered_tokens;
+
+  // Keep track of which contract addresses have been seen per chain
+  base::flat_map<std::string, base::flat_set<base::StringPiece>>
+      seen_contract_addresses;
+  for (const auto& discovered_assets_result : discovered_assets_results) {
+    for (const auto& [chain_id, contract_addresses] :
+         discovered_assets_result) {
+      for (const auto& contract_address : contract_addresses) {
+        // Skip if seen
+        if (seen_contract_addresses[chain_id].contains(contract_address)) {
+          continue;
+        }
+
+        // Add to seen and discovered_tokens if not
+        seen_contract_addresses[chain_id].insert(contract_address);
+        auto token = std::move(
+            chain_id_to_contract_address_to_token[chain_id][contract_address]);
+        if (token && BraveWalletService::AddUserAsset(token.Clone(), prefs_)) {
+          discovered_tokens.push_back(std::move(token));
+        }
+      }
+    }
+  }
+
+  CompleteDiscoverAssets(std::move(discovered_tokens),
+                         triggered_by_accounts_added);
+}
+
+// Called when asset discovery has completed for
+void AssetDiscoveryManager::CompleteDiscoverAssets(
+    std::vector<mojom::BlockchainTokenPtr> discovered_assets_for_bucket,
     bool triggered_by_accounts_added) {
   if (discover_assets_completed_callback_for_testing_) {
-    std::vector<mojom::BlockchainTokenPtr> discovered_assets_for_chain_clone;
-    for (const auto& asset : discovered_assets_for_chain) {
-      discovered_assets_for_chain_clone.push_back(asset.Clone());
+    std::vector<mojom::BlockchainTokenPtr> discovered_assets_for_bucket_clone;
+    for (const auto& asset : discovered_assets_for_bucket) {
+      discovered_assets_for_bucket_clone.push_back(asset.Clone());
     }
     discover_assets_completed_callback_for_testing_.Run(
-        chain_id, std::move(discovered_assets_for_chain_clone),
-        std::move(error), error_message);
+        std::move(discovered_assets_for_bucket_clone));
   }
 
   // Do not emit event or modify remaining_chains_ count if
@@ -403,12 +350,12 @@ void AssetDiscoveryManager::CompleteDiscoverAssets(
   // Complete the call by decrementing remaining_chains_, storing the discovered
   // assets for later, and emitting the event if this was the final chain to
   // finish
-  remaining_chains_--;
-  for (auto& asset : discovered_assets_for_chain) {
+  remaining_buckets_--;
+  for (auto& asset : discovered_assets_for_bucket) {
     discovered_assets_.push_back(std::move(asset));
   }
 
-  if (remaining_chains_ == 0) {
+  if (remaining_buckets_ == 0) {
     wallet_service_->OnDiscoverAssetsCompleted(std::move(discovered_assets_));
     discovered_assets_.clear();
   }
@@ -418,10 +365,7 @@ void AssetDiscoveryManager::DiscoverAssetsOnAllSupportedChainsAccountsAdded(
     mojom::CoinType coin,
     const std::vector<std::string>& account_addresses) {
   if (coin == mojom::CoinType::ETH) {
-    for (const auto& chain_id : GetAssetDiscoverySupportedEthChains()) {
-      DiscoverEthAssets(chain_id, mojom::CoinType::ETH, account_addresses, true,
-                        kEthereumBlockTagEarliest, kEthereumBlockTagLatest);
-    }
+    DiscoverEthAssets(account_addresses, true);
   } else if (coin == mojom::CoinType::SOL) {
     DiscoverSolAssets(account_addresses, true);
   }
@@ -442,40 +386,13 @@ void AssetDiscoveryManager::DiscoverAssetsOnAllSupportedChainsRefresh(
 
   // Return early and do not send a notification
   // if a discover assets process is flight already
-  if (remaining_chains_ != 0) {
+  if (remaining_buckets_ != 0) {
     return;
   }
 
-  const std::vector<std::string>& supported_chain_ids =
-      GetAssetDiscoverySupportedEthChains();
-  remaining_chains_ = supported_chain_ids.size() + 1;  // + 1 for Solana mainnet
-
-  // Discover Solana assets
+  remaining_buckets_ = 2;  // 1 for ETH + 1 for SOL
   DiscoverSolAssets(account_addresses[mojom::CoinType::SOL], false);
-
-  // Discover Ethereum assets
-  // Fetch block numbers for which asset discovery has been run through
-  auto& next_asset_discovery_from_blocks =
-      prefs_->GetDict(kBraveWalletNextAssetDiscoveryFromBlocks);
-
-  std::vector<std::string>& eth_account_addresses =
-      account_addresses[mojom::CoinType::ETH];
-  for (const auto& chain_id : supported_chain_ids) {
-    // Call DiscoverEthAssets for the supported chain ID
-    // using the kBraveWalletNextAssetDiscoveryFromBlocks pref
-    // as the from_block of the eth_getLogs query.
-    std::string from_block = kEthereumBlockTagEarliest;
-    std::string to_block = kEthereumBlockTagLatest;
-    const auto path = base::StrCat({kEthereumPrefKey, ".", chain_id});
-    const std::string* next_asset_discovery_from_block =
-        next_asset_discovery_from_blocks.FindStringByDottedPath(path);
-    if (next_asset_discovery_from_block) {
-      from_block = *next_asset_discovery_from_block;
-    }
-
-    DiscoverEthAssets(chain_id, mojom::CoinType::ETH, eth_account_addresses,
-                      false, from_block, to_block);
-  }
+  DiscoverEthAssets(account_addresses[mojom::CoinType::ETH], false);
 }
 
 void AssetDiscoveryManager::AccountsAdded(

--- a/components/brave_wallet/browser/blockchain_registry.cc
+++ b/components/brave_wallet/browser/blockchain_registry.cc
@@ -144,6 +144,33 @@ std::vector<mojom::BlockchainTokenPtr> BlockchainRegistry::GetBuyTokens(
   return blockchain_buy_tokens;
 }
 
+TokenListMap BlockchainRegistry::GetEthTokenListMap(
+    const std::vector<std::string>& chain_ids) {
+  // Create a copy of token_list_map with only the chain_ids we want
+  TokenListMap token_list_map_copy;
+  for (const auto& chain_id : chain_ids) {
+    const auto key = GetTokenListKey(mojom::CoinType::ETH, chain_id);
+    // Skip if the key is not in the map.
+    if (!token_list_map_.contains(key)) {
+      continue;
+    }
+
+    // Otherwise, clone the vector of tokens.
+    const auto& tokens = token_list_map_[key];
+    std::vector<brave_wallet::mojom::BlockchainTokenPtr> tokens_copy(
+        tokens.size());
+    std::transform(
+        tokens.begin(), tokens.end(), tokens_copy.begin(),
+        [](const brave_wallet::mojom::BlockchainTokenPtr& current_token)
+            -> brave_wallet::mojom::BlockchainTokenPtr {
+          return current_token.Clone();
+        });
+    token_list_map_copy[chain_id] = std::move(tokens_copy);
+  }
+
+  return token_list_map_copy;
+}
+
 void BlockchainRegistry::GetBuyTokens(mojom::OnRampProvider provider,
                                       const std::string& chain_id,
                                       GetBuyTokensCallback callback) {

--- a/components/brave_wallet/browser/blockchain_registry.h
+++ b/components/brave_wallet/browser/blockchain_registry.h
@@ -51,6 +51,7 @@ class BlockchainRegistry : public mojom::BlockchainRegistry {
   void GetAllTokens(const std::string& chain_id,
                     mojom::CoinType coin,
                     GetAllTokensCallback callback) override;
+  TokenListMap GetEthTokenListMap(const std::vector<std::string>& chain_ids);
   void GetBuyTokens(mojom::OnRampProvider provider,
                     const std::string& chain_id,
                     GetBuyTokensCallback callback) override;

--- a/components/brave_wallet/browser/blockchain_registry_unittest.cc
+++ b/components/brave_wallet/browser/blockchain_registry_unittest.cc
@@ -608,4 +608,21 @@ TEST(BlockchainRegistryUnitTest, GetPrepopulatedNetworksKnownOnesArePreferred) {
   EXPECT_EQ(found_networks[0]->chain_name, "Ethereum Mainnet");
 }
 
+TEST(BlockchainRegistryUnitTest, GetEthTokenListMap) {
+  base::test::TaskEnvironment task_environment;
+  auto* registry = BlockchainRegistry::GetInstance();
+  TokenListMap token_list_map;
+  ASSERT_TRUE(
+      ParseTokenList(token_list_json, &token_list_map, mojom::CoinType::ETH));
+  registry->UpdateTokenList(std::move(token_list_map));
+
+  // Loop twice to make sure getting the same list twice works
+  // For example, make sure nothing is std::move'd
+  for (size_t i = 0; i < 2; i++) {
+    token_list_map = registry->GetEthTokenListMap({mojom::kMainnetChainId});
+    EXPECT_EQ(token_list_map.size(), 1UL);
+    EXPECT_EQ(token_list_map[mojom::kMainnetChainId].size(), 2UL);
+  }
+}
+
 }  // namespace brave_wallet

--- a/components/brave_wallet/browser/brave_wallet_prefs.cc
+++ b/components/brave_wallet/browser/brave_wallet_prefs.cc
@@ -114,7 +114,6 @@ void RegisterProfilePrefs(user_prefs::PrefRegistrySyncable* registry) {
   registry->RegisterStringPref(kBraveWalletSelectedAccount, "");
   registry->RegisterBooleanPref(kSupportEip1559OnLocalhostChain, false);
   registry->RegisterDictionaryPref(kBraveWalletLastTransactionSentTimeDict);
-  registry->RegisterDictionaryPref(kBraveWalletNextAssetDiscoveryFromBlocks);
   registry->RegisterTimePref(kBraveWalletLastDiscoveredAssetsAt, base::Time());
 
   // TODO(djandries): remove the following prefs at some point,

--- a/components/brave_wallet/browser/pref_names.cc
+++ b/components/brave_wallet/browser/pref_names.cc
@@ -56,8 +56,6 @@ const char kBraveWalletKeyringEncryptionKeysMigrated[] =
     "brave.wallet.keyring_encryption_keys_migrated";
 const char kBraveWalletLastTransactionSentTimeDict[] =
     "brave.wallet.last_transaction_sent_time_dict";
-const char kBraveWalletNextAssetDiscoveryFromBlocks[] =
-    "brave.wallet.next_asset_discovery_from_blocks";
 const char kBraveWalletLastDiscoveredAssetsAt[] =
     "brave.wallet.last_discovered_assets_at";
 

--- a/components/brave_wallet/browser/pref_names.h
+++ b/components/brave_wallet/browser/pref_names.h
@@ -45,7 +45,6 @@ extern const char kBraveWalletP3AUsedSecondDay[];
 
 extern const char kBraveWalletP3AActiveWalletDict[];
 extern const char kBraveWalletKeyringEncryptionKeysMigrated[];
-extern const char kBraveWalletNextAssetDiscoveryFromBlocks[];
 extern const char kBraveWalletLastDiscoveredAssetsAt[];
 
 extern const char kBraveWalletLastTransactionSentTimeDict[];


### PR DESCRIPTION
Resolves https://github.com/brave/brave-browser/issues/28203
Resolves https://github.com/brave/brave-browser/issues/27666

Note: The base branch is `get-erc20-token-balances`, not `master`.

Use the JsonRpcService::GetERC20TokenBalances API added in https://github.com/brave/brave-core/pull/16955 instead of the current approach that uses eth_getLogs to discover assets.

After the changes, one request will be made per address per chain to discover ETH assets, instead of one per chain. This reflects how it is done for Solana asset discovery.  Previously DiscoverEthAssets took a chain ID param, and made just one request for that chain.  Now DiscoverEthAssets just takes the list of addresses, and makes one request per chain, using a base::BarrierCallback to merge the results.  Consequently, CompleteDiscoverAssets is now called once per CoinType, rather than once per chain ID. 

Currently, the code makes no attempt to make these requests sequentially in batches, or spread the requests out over time.

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
1. Add an Ethereum account that has an asset in our registry.  The asset should automatically appear in the user asset list.  Repeat for a different EVM network.
2. Send an asset in our registry to an Ethereum account that does not already hold that asset.  Refresh the portfolio page (might need to wait a minute before doing this in order for the the rate limiting to expire if necessary).  The asset should appear in the user asset list.