### PR TITLE
Fixes a crash on a biometric check when context isn't available on Android (uplift to 1.48.x)

### DIFF
--- a/android/java/org/chromium/chrome/browser/crypto_wallet/util/Utils.java
+++ b/android/java/org/chromium/chrome/browser/crypto_wallet/util/Utils.java
@@ -1336,7 +1336,7 @@ public class Utils {
     @RequiresApi(api = Build.VERSION_CODES.P)
     public static boolean isBiometricAvailable(Context context) {
         // Only Android versions 9 and above are supported.
-        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.P) {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.P || context == null) {
             return false;
         }
 


### PR DESCRIPTION
Uplift of #17053
Resolves https://github.com/brave/brave-browser/issues/28212

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.