### PR TITLE
Autoupload vpn helper service crash dumps

### DIFF
--- a/components/brave_vpn/browser/connection/win/brave_vpn_helper/brave_vpn_helper_constants.h
+++ b/components/brave_vpn/browser/connection/win/brave_vpn_helper/brave_vpn_helper_constants.h
@@ -11,6 +11,7 @@
 namespace brave_vpn {
 
 constexpr char kBraveVpnHelperInstall[] = "install";
+constexpr char kBraveVpnHelperCrashMe[] = "crash-me";
 constexpr wchar_t kBraveVPNHelperExecutable[] = L"brave_vpn_helper.exe";
 constexpr wchar_t kBraveVpnHelperFiltersInstalledValue[] = L"filters";
 // Repeating interval to check the connection is live.

--- a/components/brave_vpn/browser/connection/win/brave_vpn_helper/brave_vpn_helper_crash_reporter_client.cc
+++ b/components/brave_vpn/browser/connection/win/brave_vpn_helper/brave_vpn_helper_crash_reporter_client.cc
@@ -12,7 +12,6 @@
 #include "base/file_version_info.h"
 #include "base/logging.h"
 #include "base/notreached.h"
-#include "base/path_service.h"
 #include "base/strings/string_util.h"
 #include "base/strings/utf_string_conversions.h"
 #include "brave/components/brave_vpn/browser/connection/win/brave_vpn_helper/brave_vpn_helper_constants.h"
@@ -55,11 +54,11 @@ void BraveVPNHelperCrashReporterClient::InitializeCrashReportingForProcess(
   }
   install_static::InitializeProductDetailsForPrimaryModule();
   crash_reporter::SetCrashReporterClient(instance);
-  std::wstring vpn_data_dir = brave_vpn::GetVpnServiceProfileDir().value();
 
   crash_reporter::InitializeCrashpadWithEmbeddedHandler(
       true, kBraveVPNHelperProcessType,
-      install_static::WideToUTF8(vpn_data_dir), base::FilePath());
+      install_static::WideToUTF8(brave_vpn::GetVpnServiceProfileDir().value()),
+      base::FilePath());
 }
 
 bool BraveVPNHelperCrashReporterClient::ShouldCreatePipeName(

--- a/components/brave_vpn/browser/connection/win/brave_vpn_helper/brave_vpn_helper_crash_reporter_client.cc
+++ b/components/brave_vpn/browser/connection/win/brave_vpn_helper/brave_vpn_helper_crash_reporter_client.cc
@@ -8,10 +8,11 @@
 #include <memory>
 #include <string>
 
-#include "base/check.h"
 #include "base/debug/leak_annotations.h"
 #include "base/file_version_info.h"
+#include "base/logging.h"
 #include "base/notreached.h"
+#include "base/path_service.h"
 #include "base/strings/string_util.h"
 #include "base/strings/utf_string_conversions.h"
 #include "brave/components/brave_vpn/browser/connection/win/brave_vpn_helper/brave_vpn_helper_constants.h"
@@ -54,12 +55,11 @@ void BraveVPNHelperCrashReporterClient::InitializeCrashReportingForProcess(
   }
   install_static::InitializeProductDetailsForPrimaryModule();
   crash_reporter::SetCrashReporterClient(instance);
-  std::wstring user_data_dir;
-  install_static::GetUserDataDirectory(&user_data_dir, nullptr);
+  std::wstring vpn_data_dir = brave_vpn::GetVpnServiceProfileDir().value();
 
   crash_reporter::InitializeCrashpadWithEmbeddedHandler(
       true, kBraveVPNHelperProcessType,
-      install_static::WideToUTF8(user_data_dir), base::FilePath());
+      install_static::WideToUTF8(vpn_data_dir), base::FilePath());
 }
 
 bool BraveVPNHelperCrashReporterClient::ShouldCreatePipeName(
@@ -124,18 +124,19 @@ int BraveVPNHelperCrashReporterClient::GetResultCodeRespawnFailed() {
 
 bool BraveVPNHelperCrashReporterClient::GetCrashDumpLocation(
     std::wstring* crash_dir) {
-  *crash_dir = install_static::GetCrashDumpLocation();
-  return !crash_dir->empty();
+  auto profile_dir = brave_vpn::GetVpnServiceProfileDir();
+  *crash_dir = (profile_dir.Append(L"Crashpad")).value();
+  return !profile_dir.empty();
 }
 
 bool BraveVPNHelperCrashReporterClient::GetCrashMetricsLocation(
     std::wstring* metrics_dir) {
-  install_static::GetUserDataDirectory(metrics_dir, nullptr);
+  *metrics_dir = brave_vpn::GetVpnServiceProfileDir().value();
   return !metrics_dir->empty();
 }
 
 bool BraveVPNHelperCrashReporterClient::IsRunningUnattended() {
-  return true;
+  return false;
 }
 
 bool BraveVPNHelperCrashReporterClient::GetCollectStatsConsent() {

--- a/components/brave_vpn/browser/connection/win/brave_vpn_helper/brave_vpn_helper_state.cc
+++ b/components/brave_vpn/browser/connection/win/brave_vpn_helper/brave_vpn_helper_state.cc
@@ -107,10 +107,9 @@ base::FilePath GetVpnServiceProfileDir() {
   if (program_data.empty()) {
     return base::FilePath();
   }
-  base::FilePath common_app_data(base::UTF8ToWide(program_data));
-  common_app_data = common_app_data.Append(install_static::kCompanyPathName);
-  common_app_data = common_app_data.Append(brave_vpn::GetVpnServiceName());
-  return common_app_data;
+  return base::FilePath(base::UTF8ToWide(program_data))
+      .Append(install_static::kCompanyPathName)
+      .Append(brave_vpn::GetVpnServiceName());
 }
 
 }  // namespace brave_vpn

--- a/components/brave_vpn/browser/connection/win/brave_vpn_helper/brave_vpn_helper_state.cc
+++ b/components/brave_vpn/browser/connection/win/brave_vpn_helper/brave_vpn_helper_state.cc
@@ -7,12 +7,14 @@
 
 #include <windows.h>
 
+#include "base/files/file_path.h"
 #include "base/logging.h"
 #include "base/strings/utf_string_conversions.h"
 #include "base/win/registry.h"
 #include "brave/components/brave_vpn/browser/connection/win/brave_vpn_helper/brave_vpn_helper_constants.h"
 #include "brave/components/brave_vpn/browser/connection/win/brave_vpn_helper/scoped_sc_handle.h"
 #include "brave/components/brave_vpn/common/brave_vpn_utils.h"
+#include "chrome/install_static/install_modes.h"
 #include "chrome/install_static/install_util.h"
 
 namespace brave_vpn {
@@ -96,6 +98,19 @@ bool IsNetworkFiltersInstalled() {
     return false;
   }
   return current > 0;
+}
+
+// The service starts under sytem user so we save crashes to
+// %PROGRAMDATA%\BraveSoftware\{service name}\Crashpad
+base::FilePath GetVpnServiceProfileDir() {
+  auto program_data = install_static::GetEnvironmentString("PROGRAMDATA");
+  if (program_data.empty()) {
+    return base::FilePath();
+  }
+  base::FilePath common_app_data(base::UTF8ToWide(program_data));
+  common_app_data = common_app_data.Append(install_static::kCompanyPathName);
+  common_app_data = common_app_data.Append(brave_vpn::GetVpnServiceName());
+  return common_app_data;
 }
 
 }  // namespace brave_vpn

--- a/components/brave_vpn/browser/connection/win/brave_vpn_helper/brave_vpn_helper_state.h
+++ b/components/brave_vpn/browser/connection/win/brave_vpn_helper/brave_vpn_helper_state.h
@@ -8,6 +8,10 @@
 
 #include <string>
 
+namespace base {
+class FilePath;
+}  // namespace base
+
 namespace brave_vpn {
 
 bool IsBraveVPNHelperServiceInstalled();
@@ -16,7 +20,7 @@ bool IsNetworkFiltersInstalled();
 std::wstring GetBraveVPNConnectionName();
 std::wstring GetVpnServiceName();
 std::wstring GetVpnServiceDisplayName();
-
+base::FilePath GetVpnServiceProfileDir();
 }  // namespace brave_vpn
 
 #endif  // BRAVE_COMPONENTS_BRAVE_VPN_BROWSER_CONNECTION_WIN_BRAVE_VPN_HELPER_BRAVE_VPN_HELPER_STATE_H_

--- a/components/brave_vpn/browser/connection/win/brave_vpn_helper/service_main.cc
+++ b/components/brave_vpn/browser/connection/win/brave_vpn_helper/service_main.cc
@@ -37,6 +37,13 @@ bool ServiceMain::InitWithCommandLine(const base::CommandLine* command_line) {
     LOG(ERROR) << "No positional parameters expected.";
     return false;
   }
+
+  // Crash itself if crash-me was used.
+  if (command_line->HasSwitch(kBraveVpnHelperCrashMe)) {
+    CHECK(!command_line->HasSwitch(kBraveVpnHelperCrashMe))
+        << "--crash-me was used.";
+  }
+
   // Run interactively if needed.
   if (command_line->HasSwitch(kConsoleSwitchName)) {
     run_routine_ = &ServiceMain::RunInteractive;


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/28343

- Saving dumps to `%PROGRAMDATA%\BraveSoftware\{service name}\Crashpad`

- Added flag `--crash-me` to make service crash for testing like  in updater https://source.chromium.org/chromium/chromium/src/+/main:chrome/updater/updater.cc;l=138?q=crash-me&ss=chromium
This flag can be added to the service path in registry `HKEY_LOCAL_MACHINE\SYSTEM\ControlSet001\Services\Brave{Channel}VpnService` -> `ImagePath`
- Configured crashpad client parameters to enable crash dumps autoupload

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
- In order to make a crash need to add `--crash-me` flag to the service command line in registry `HKEY_LOCAL_MACHINE\SYSTEM\ControlSet001\Services\Brave{Channel}VpnService` -> `ImagePath`
- Crash reports from the service are expected to be inside `%PROGRAMDATA%\BraveSoftware\{service name}\Crashpad` 
- Crashes will be autouploaded if we have usage stats consent, `HKLM -> Software\BraveSoftware\Update\ClientState\.. -> usagestats -> 1`
- Uploaded crashes can be found on server with url `https://brave.sp.backtrace.io/p/brave/debug?time=year&filters=(upload_file_minidump%3D%22{crash_filename}%22)&debug=(%22455a622%22,0,0)` replace `{crash_filename}` by a crash filename.
