### PR TITLE
Poll device list during long initial commits procedure

### DIFF
--- a/chromium_src/components/sync/engine/syncer.cc
+++ b/chromium_src/components/sync/engine/syncer.cc
@@ -1,0 +1,32 @@
+/* Copyright (c) 2023 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "brave/components/sync/engine/brave_syncer_device_poll.h"
+// Forward include to avoid redefine CommitProcessor at upstream header
+#include "components/sync/engine/commit_processor.h"
+
+// CommitProcessor is occurred just once in upstream syncer.cc
+// so we can use it to redefine and introduce own variable.
+#define CommitProcessor                           \
+  BraveSyncerDevicePoll brave_syncer_device_poll; \
+  CommitProcessor
+
+#define BRAVE_SYNCER_BUILD_AND_POST_COMMITS_POLLER_CHECK                    \
+  brave_syncer_device_poll.CheckIntervalAndPoll(base::BindOnce(             \
+      [](Syncer* the_syncer, SyncCycle* cycle, NudgeTracker* nudge_tracker, \
+         BraveSyncerDevicePoll* the_brave_syncer_device_poll) {             \
+        VLOG(1) << "Forced poll of device info during long commit. Passed " \
+                   "time since begin of commit operation is "               \
+                << the_brave_syncer_device_poll->SinceBegin();              \
+        ModelTypeSet device_only(ModelType::DEVICE_INFO);                   \
+        the_syncer->DownloadAndApplyUpdates(                                \
+            &device_only, cycle, NormalGetUpdatesDelegate(*nudge_tracker)); \
+      },                                                                    \
+      this, cycle, nudge_tracker, &brave_syncer_device_poll));
+
+#include "src/components/sync/engine/syncer.cc"
+
+#undef BRAVE_SYNCER_BUILD_AND_POST_COMMITS_POLLER_CHECK
+#undef CommitProcessor

--- a/components/sync/engine/BUILD.gn
+++ b/components/sync/engine/BUILD.gn
@@ -6,8 +6,10 @@
 source_set("unit_tests") {
   testonly = true
 
-  sources =
-      [ "//brave/components/sync/engine/brave_model_type_worker_unittest.cc" ]
+  sources = [
+    "//brave/components/sync/engine/brave_model_type_worker_unittest.cc",
+    "//brave/components/sync/engine/brave_syncer_device_poll_unittest.cc",
+  ]
 
   deps = [
     "//base",

--- a/components/sync/engine/brave_syncer_device_poll.cc
+++ b/components/sync/engine/brave_syncer_device_poll.cc
@@ -1,0 +1,42 @@
+/* Copyright (c) 2023 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "brave/components/sync/engine/brave_syncer_device_poll.h"
+
+#include <utility>
+
+#include "base/functional/callback.h"
+#include "base/time/time.h"
+
+using base::TimeTicks;
+
+namespace syncer {
+
+namespace {
+constexpr base::TimeDelta kDelayBeforeForcedPoll = base::Seconds(15);
+}
+
+BraveSyncerDevicePoll::BraveSyncerDevicePoll()
+    : ticks_at_begin_(TimeTicks::Now()), ticks_(ticks_at_begin_) {}
+
+void BraveSyncerDevicePoll::CheckIntervalAndPoll(
+    base::OnceClosure poll_devices) {
+  auto now = TimeTicks::Now();
+  if (now - ticks_ > kDelayBeforeForcedPoll) {
+    std::move(poll_devices).Run();
+    ticks_ = now;
+  }
+}
+
+/* static */
+base::TimeDelta BraveSyncerDevicePoll::GetDelayBeforeForcedPollForTesting() {
+  return kDelayBeforeForcedPoll;
+}
+
+base::TimeDelta BraveSyncerDevicePoll::SinceBegin() {
+  return TimeTicks::Now() - ticks_at_begin_;
+}
+
+}  // namespace syncer

--- a/components/sync/engine/brave_syncer_device_poll.h
+++ b/components/sync/engine/brave_syncer_device_poll.h
@@ -1,0 +1,36 @@
+/* Copyright (c) 2023 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_COMPONENTS_SYNC_ENGINE_BRAVE_SYNCER_DEVICE_POLL_H_
+#define BRAVE_COMPONENTS_SYNC_ENGINE_BRAVE_SYNCER_DEVICE_POLL_H_
+
+#include "base/functional/callback_forward.h"
+#include "base/gtest_prod_util.h"
+#include "base/time/time.h"
+
+namespace syncer {
+
+FORWARD_DECLARE_TEST(BraveSyncerDevicePoll, ForcedPolling);
+
+class BraveSyncerDevicePoll {
+ public:
+  BraveSyncerDevicePoll(const BraveSyncerDevicePoll&) = delete;
+  BraveSyncerDevicePoll& operator=(const BraveSyncerDevicePoll&) = delete;
+  BraveSyncerDevicePoll();
+
+  void CheckIntervalAndPoll(base::OnceClosure poll_devices);
+  base::TimeDelta SinceBegin();
+
+ private:
+  FRIEND_TEST_ALL_PREFIXES(BraveSyncerDevicePoll, ForcedPolling);
+  static base::TimeDelta GetDelayBeforeForcedPollForTesting();
+
+  const base::TimeTicks ticks_at_begin_;
+  base::TimeTicks ticks_;
+};
+
+}  // namespace syncer
+
+#endif  // BRAVE_COMPONENTS_SYNC_ENGINE_BRAVE_SYNCER_DEVICE_POLL_H_

--- a/components/sync/engine/brave_syncer_device_poll_unittest.cc
+++ b/components/sync/engine/brave_syncer_device_poll_unittest.cc
@@ -1,0 +1,49 @@
+/* Copyright (c) 2023 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "brave/components/sync/engine/brave_syncer_device_poll.h"
+
+#include <memory>
+
+#include "base/functional/callback.h"
+#include "base/test/mock_callback.h"
+#include "base/test/scoped_mock_clock_override.h"
+#include "testing/gtest/include/gtest/gtest.h"
+
+namespace syncer {
+
+TEST(BraveSyncerDevicePoll, ForcedPolling) {
+  base::ScopedMockClockOverride clock;
+  BraveSyncerDevicePoll brave_syncer_device_poll;
+  const auto kDelayBeforeForcedPoll =
+      BraveSyncerDevicePoll::GetDelayBeforeForcedPollForTesting();
+
+  base::MockCallback<base::OnceClosure> mock_callback;
+  EXPECT_CALL(mock_callback, Run).Times(0);
+  brave_syncer_device_poll.CheckIntervalAndPoll(mock_callback.Get());
+  testing::Mock::VerifyAndClearExpectations(&mock_callback);
+
+  clock.Advance(kDelayBeforeForcedPoll - base::Seconds(1));
+  EXPECT_CALL(mock_callback, Run).Times(0);
+  brave_syncer_device_poll.CheckIntervalAndPoll(mock_callback.Get());
+  testing::Mock::VerifyAndClearExpectations(&mock_callback);
+
+  clock.Advance(base::Seconds(2));
+  EXPECT_CALL(mock_callback, Run).Times(1);
+  brave_syncer_device_poll.CheckIntervalAndPoll(mock_callback.Get());
+  testing::Mock::VerifyAndClearExpectations(&mock_callback);
+
+  clock.Advance(kDelayBeforeForcedPoll - base::Seconds(2));
+  EXPECT_CALL(mock_callback, Run).Times(0);
+  brave_syncer_device_poll.CheckIntervalAndPoll(mock_callback.Get());
+  testing::Mock::VerifyAndClearExpectations(&mock_callback);
+
+  clock.Advance(base::Seconds(3));
+  EXPECT_CALL(mock_callback, Run).Times(1);
+  brave_syncer_device_poll.CheckIntervalAndPoll(mock_callback.Get());
+  testing::Mock::VerifyAndClearExpectations(&mock_callback);
+}
+
+}  // namespace syncer

--- a/components/sync/engine/sources.gni
+++ b/components/sync/engine/sources.gni
@@ -10,4 +10,6 @@ brave_components_sync_engine_sources = [
   "//brave/components/sync/engine/brave_sync_manager_impl.h",
   "//brave/components/sync/engine/brave_sync_server_commands.cc",
   "//brave/components/sync/engine/brave_sync_server_commands.h",
+  "//brave/components/sync/engine/brave_syncer_device_poll.cc",
+  "//brave/components/sync/engine/brave_syncer_device_poll.h",
 ]

--- a/patches/components-sync-engine-syncer.cc.patch
+++ b/patches/components-sync-engine-syncer.cc.patch
@@ -1,0 +1,12 @@
+diff --git a/components/sync/engine/syncer.cc b/components/sync/engine/syncer.cc
+index c927a5e12fcb709761f6d3c04d89f55f35a902ec..6079d94ab56761587c1b305e02e1689b6830f606 100644
+--- a/components/sync/engine/syncer.cc
++++ b/components/sync/engine/syncer.cc
+@@ -188,6 +188,7 @@ SyncerError Syncer::BuildAndPostCommits(const ModelTypeSet& request_types,
+     }
+     nudge_tracker->RecordSuccessfulCommitMessage(
+         commit->GetContributingDataTypes());
++    BRAVE_SYNCER_BUILD_AND_POST_COMMITS_POLLER_CHECK
+   }
+ 
+   return SyncerError(SyncerError::SYNCER_OK);


### PR DESCRIPTION
Issue happens because at [Syncer::BuildAndPostCommits](https://source.chromium.org/chromium/chromium/src/+/main:components/sync/engine/syncer.cc;l=152;drc=0c4306fc554c80506eb0f9b833a5d2a5fdd452d5?q=Syncer::BuildAndPostCommits&sq=&ss=chromium%2Fchromium%2Fsrc) loop is executed till all the records will be sent. It can take significant amount of time, ~10 minutes for 20k records, and during this time device can't receive updates. 

This PR adds forced get updates only of device type to get the updates if large commit initial happens.

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/27931

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
[import_20k.zip](https://github.com/brave/brave-core/files/10678936/import_20k.zip)

Test plan
1. For device1 import bookmarks from `import_20k/import1` folder from attached zip. Similar for device2 => `import_20k/import1`;
2. On device1 create the sync chain;
3. Connect device2 to the sync chain, expected ti see device1 in devices list;
4. Expected to see on device1's list the device2 in approx ~15..35 seconds
5. Connect device3 to the sync chain, expected to see `device1;device2;device3` on each device list in approx ~15..35 seconds.



