### PR TITLE
Revert default search provider list in SK

### DIFF
--- a/chromium_src/components/search_engines/brave_template_url_prepopulate_data_unittest.cc
+++ b/chromium_src/components/search_engines/brave_template_url_prepopulate_data_unittest.cc
@@ -258,5 +258,5 @@ TEST_F(BraveTemplateURLPrepopulateDataTest,
 
 TEST_F(BraveTemplateURLPrepopulateDataTest,
        DefaultSearchProvidersForSouthKorea) {
-  CheckForCountry('K', 'R', PREPOPULATED_ENGINE_ID_NAVER);
+  CheckForCountry('K', 'R', PREPOPULATED_ENGINE_ID_GOOGLE);
 }

--- a/chromium_src/components/search_engines/template_url_prepopulate_data.cc
+++ b/chromium_src/components/search_engines/template_url_prepopulate_data.cc
@@ -81,13 +81,6 @@ constexpr BravePrepopulatedEngineID kBraveEnginesAUIE[] = {
     PREPOPULATED_ENGINE_ID_ECOSIA,
 };
 
-constexpr BravePrepopulatedEngineID kBraveEnginesKR[] = {
-    PREPOPULATED_ENGINE_ID_BRAVE,
-    PREPOPULATED_ENGINE_ID_NAVER,
-    PREPOPULATED_ENGINE_ID_DAUM,
-    PREPOPULATED_ENGINE_ID_GOOGLE,
-};
-
 constexpr BravePrepopulatedEngineID kBraveEnginesNZ[] = {
     PREPOPULATED_ENGINE_ID_BRAVE,  PREPOPULATED_ENGINE_ID_DUCKDUCKGO_AU_NZ_IE,
     PREPOPULATED_ENGINE_ID_GOOGLE, PREPOPULATED_ENGINE_ID_QWANT,
@@ -132,7 +125,6 @@ constexpr auto kDefaultEnginesByCountryIdMap =
           kBraveEnginesWithEcosia},
          {country_codes::CountryCharsToCountryID('K', 'G'),
           kBraveEnginesWithYandex},
-         {country_codes::CountryCharsToCountryID('K', 'R'), kBraveEnginesKR},
          {country_codes::CountryCharsToCountryID('K', 'Z'),
           kBraveEnginesWithYandex},
          {country_codes::CountryCharsToCountryID('L', 'U'),
@@ -398,62 +390,8 @@ BravePrepopulatedEngineID GetDefaultSearchEngine(int country_id, int version) {
           {country_codes::CountryCharsToCountryID('I', 'N'),
            PREPOPULATED_ENGINE_ID_BRAVE},
       });
-  static constexpr auto kContentV23 =
-      base::MakeFixedFlatMap<int, BravePrepopulatedEngineID>({
-          {country_codes::CountryCharsToCountryID('A', 'M'),
-           PREPOPULATED_ENGINE_ID_YANDEX},
-          {country_codes::CountryCharsToCountryID('A', 'Z'),
-           PREPOPULATED_ENGINE_ID_YANDEX},
-          {country_codes::CountryCharsToCountryID('B', 'Y'),
-           PREPOPULATED_ENGINE_ID_YANDEX},
-          {country_codes::CountryCharsToCountryID('C', 'A'),
-           PREPOPULATED_ENGINE_ID_BRAVE},
-          {country_codes::CountryCharsToCountryID('D', 'E'),
-           PREPOPULATED_ENGINE_ID_BRAVE},
-          {country_codes::CountryCharsToCountryID('F', 'R'),
-           PREPOPULATED_ENGINE_ID_BRAVE},
-          {country_codes::CountryCharsToCountryID('G', 'B'),
-           PREPOPULATED_ENGINE_ID_BRAVE},
-          {country_codes::CountryCharsToCountryID('K', 'G'),
-           PREPOPULATED_ENGINE_ID_YANDEX},
-          {country_codes::CountryCharsToCountryID('K', 'Z'),
-           PREPOPULATED_ENGINE_ID_YANDEX},
-          {country_codes::CountryCharsToCountryID('M', 'D'),
-           PREPOPULATED_ENGINE_ID_YANDEX},
-          {country_codes::CountryCharsToCountryID('R', 'U'),
-           PREPOPULATED_ENGINE_ID_YANDEX},
-          {country_codes::CountryCharsToCountryID('T', 'J'),
-           PREPOPULATED_ENGINE_ID_YANDEX},
-          {country_codes::CountryCharsToCountryID('T', 'M'),
-           PREPOPULATED_ENGINE_ID_YANDEX},
-          {country_codes::CountryCharsToCountryID('U', 'S'),
-           PREPOPULATED_ENGINE_ID_BRAVE},
-          {country_codes::CountryCharsToCountryID('U', 'Z'),
-           PREPOPULATED_ENGINE_ID_YANDEX},
-          {country_codes::CountryCharsToCountryID('A', 'T'),
-           PREPOPULATED_ENGINE_ID_BRAVE},
-          {country_codes::CountryCharsToCountryID('E', 'S'),
-           PREPOPULATED_ENGINE_ID_BRAVE},
-          {country_codes::CountryCharsToCountryID('M', 'X'),
-           PREPOPULATED_ENGINE_ID_BRAVE},
-          {country_codes::CountryCharsToCountryID('A', 'R'),
-           PREPOPULATED_ENGINE_ID_BRAVE},
-          {country_codes::CountryCharsToCountryID('B', 'R'),
-           PREPOPULATED_ENGINE_ID_BRAVE},
-          {country_codes::CountryCharsToCountryID('I', 'N'),
-           PREPOPULATED_ENGINE_ID_BRAVE},
-          // Added values in this version bellow
-          {country_codes::CountryCharsToCountryID('K', 'R'),
-           PREPOPULATED_ENGINE_ID_NAVER},
-      });
 
-  if (version > 22) {
-    auto* it = kContentV23.find(country_id);
-    if (it == kContentV23.end()) {
-      return default_v6;
-    }
-    return it->second;
-  } else if (version > 21) {
+  if (version > 21) {
     auto* it = kContentV22.find(country_id);
     if (it == kContentV22.end()) {
       return default_v6;

--- a/components/search_engines/brave_prepopulated_engines.cc
+++ b/components/search_engines/brave_prepopulated_engines.cc
@@ -13,7 +13,7 @@ namespace TemplateURLPrepopulateData {
 
 // IMPORTANT! Make sure to bump this value if you make changes to the
 // engines below or add/remove engines.
-const int kBraveCurrentDataVersion = 23;
+const int kBraveCurrentDataVersion = 24;
 // DO NOT CHANGE THIS ONE. Used for backfilling kBraveDefaultSearchVersion.
 const int kBraveFirstTrackedDataVersion = 6;
 


### PR DESCRIPTION
re-open https://github.com/brave/brave-browser/issues/18855

Private search provider setting is not ready for default search provider list update.
When previous default private search provider is not in default list,
default provider is back to Brave on desktop(https://github.com/brave/brave-browser/issues/28235) instead of using previous default provider.
On android, there is another issue when default list is upated(https://github.com/brave/brave-browser/issues/28232).

We should update default provider list when default private search provider is handled properly.

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves 

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

