### PR TITLE
Plug and play hardware support (Core)

### DIFF
--- a/browser/brave_wallet/brave_wallet_service_unittest.cc
+++ b/browser/brave_wallet/brave_wallet_service_unittest.cc
@@ -569,24 +569,16 @@ class BraveWalletServiceUnitTest : public testing::Test {
     ASSERT_NE(valid_password, nullptr);
     ASSERT_NE(valid_mnemonic, nullptr);
 
-    keyring_service_->Lock();
-    // Check new password
-    base::RunLoop run_loop;
-    keyring_service_->Unlock(new_password,
-                             base::BindLambdaForTesting([&](bool success) {
-                               *valid_password = success;
-                               run_loop.Quit();
-                             }));
-    run_loop.Run();
+    *valid_password = keyring_service_->ValidatePasswordInternal(new_password);
 
-    base::RunLoop run_loop2;
+    base::RunLoop run_loop;
     keyring_service_->GetMnemonicForDefaultKeyring(
         new_password,
         base::BindLambdaForTesting([&](const std::string& mnemonic) {
           *valid_mnemonic = (mnemonic == in_mnemonic);
-          run_loop2.Quit();
+          run_loop.Quit();
         }));
-    run_loop2.Run();
+    run_loop.Run();
   }
 
   void CheckAddresses(const std::vector<std::string>& addresses,

--- a/browser/brave_wallet/ethereum_provider_impl_unittest.cc
+++ b/browser/brave_wallet/ethereum_provider_impl_unittest.cc
@@ -419,9 +419,9 @@ class EthereumProviderImplUnitTest : public testing::Test {
   KeyringService* keyring_service() { return keyring_service_; }
   EthereumProviderImpl* provider() { return provider_.get(); }
   std::string from(size_t from_index = 0) {
-    CHECK(!keyring_service_->IsLocked());
+    CHECK(!keyring_service_->IsLockedSync());
     return keyring_service()
-        ->GetHDKeyringById(brave_wallet::mojom::kDefaultKeyringId)
+        ->GetHDKeyringById(mojom::kDefaultKeyringId)
         ->GetAddress(from_index);
   }
   std::string from_lower(size_t from_index = 0) {

--- a/browser/brave_wallet/solana_provider_impl_unittest.cc
+++ b/browser/brave_wallet/solana_provider_impl_unittest.cc
@@ -207,7 +207,7 @@ class SolanaProviderImplUnitTest : public testing::Test {
   std::string GetAddressByIndex(
       size_t index,
       const std::string& id = mojom::kSolanaKeyringId) {
-    CHECK(!keyring_service_->IsLocked());
+    CHECK(!keyring_service_->IsLockedSync());
     return keyring_service_->GetHDKeyringById(id)->GetAddress(index);
   }
 
@@ -228,13 +228,11 @@ class SolanaProviderImplUnitTest : public testing::Test {
     run_loop.Run();
   }
 
-  bool RemoveHardwareAccount(const std::string& address,
-                             const std::string& password) {
+  bool RemoveHardwareAccount(const std::string& address) {
     bool success;
     base::RunLoop run_loop;
     keyring_service_->RemoveHardwareAccount(
-        address, password, mojom::CoinType::SOL,
-        base::BindLambdaForTesting([&](bool v) {
+        address, mojom::CoinType::SOL, base::BindLambdaForTesting([&](bool v) {
           success = v;
           run_loop.Quit();
         }));
@@ -644,7 +642,7 @@ TEST_F(SolanaProviderImplUnitTest,
   ASSERT_TRUE(IsConnected());
 
   // Remove selected hardware account.
-  EXPECT_TRUE(RemoveHardwareAccount(kHardwareAccountAddr, "brave"));
+  EXPECT_TRUE(RemoveHardwareAccount(kHardwareAccountAddr));
   EXPECT_TRUE(observer_->AccountChangedFired());
   // Account is empty because GetSelectedAccount returns absl::nullopt.
   EXPECT_TRUE(observer_->GetAccount().empty());

--- a/components/brave_wallet/browser/eth_tx_manager.cc
+++ b/components/brave_wallet/browser/eth_tx_manager.cc
@@ -546,7 +546,7 @@ void EthTxManager::OnGetNextNonce(std::unique_ptr<EthTxMeta> meta,
     return;
   }
   meta->tx()->set_nonce(nonce);
-  DCHECK(!keyring_service_->IsLocked());
+  DCHECK(!keyring_service_->IsLocked(mojom::kDefaultKeyringId));
   keyring_service_->SignTransactionByDefaultKeyring(meta->from(), meta->tx(),
                                                     chain_id);
   meta->set_status(mojom::TransactionStatus::Approved);

--- a/components/brave_wallet/browser/keyring_service.h
+++ b/components/brave_wallet/browser/keyring_service.h
@@ -124,7 +124,6 @@ class KeyringService : public KeyedService, public mojom::KeyringService {
   void AddHardwareAccounts(
       std::vector<mojom::HardwareWalletAccountPtr> info) override;
   void RemoveHardwareAccount(const std::string& address,
-                             const std::string& password,
                              mojom::CoinType coin,
                              RemoveHardwareAccountCallback callback) override;
   void RemoveImportedAccount(const std::string& address,
@@ -198,7 +197,8 @@ class KeyringService : public KeyedService, public mojom::KeyringService {
 
   void AddAccountsWithDefaultName(size_t number);
 
-  bool IsLocked(const std::string& keyring_id = mojom::kDefaultKeyringId) const;
+  bool IsLocked(const std::string& keyring_id) const;
+  bool IsLockedSync() const;
   bool HasPendingUnlockRequest() const;
   void RequestUnlock();
   absl::optional<std::string> GetSelectedAccount(mojom::CoinType coin) const;
@@ -269,6 +269,7 @@ class KeyringService : public KeyedService, public mojom::KeyringService {
   FRIEND_TEST_ALL_PREFIXES(AssetDiscoveryManagerUnitTest,
                            KeyringServiceObserver);
 
+  friend class BraveWalletServiceUnitTest;
   friend class EthereumProviderImplUnitTest;
   friend class SolanaProviderImplUnitTest;
   friend class KeyringServiceAccountDiscoveryUnitTest;

--- a/components/brave_wallet/browser/tx_manager.cc
+++ b/components/brave_wallet/browser/tx_manager.cc
@@ -91,9 +91,12 @@ void TxManager::RejectTransaction(const std::string& tx_meta_id,
 }
 
 void TxManager::CheckIfBlockTrackerShouldRun() {
-  bool locked = keyring_service_->IsLocked();
+  // TODO(darkdh): each keyring should have their own block tracker check.
+  bool keyring_created =
+      keyring_service_->IsKeyringCreated(mojom::kDefaultKeyringId);
+  bool locked = keyring_service_->IsLockedSync();
   bool running = block_tracker_->IsRunning();
-  if (!locked && !running) {
+  if (keyring_created && !locked && !running) {
     block_tracker_->Start(base::Seconds(kBlockTrackerDefaultTimeInSeconds));
   } else if ((locked || known_no_pending_tx_) && running) {
     block_tracker_->Stop();

--- a/components/brave_wallet/common/brave_wallet.mojom
+++ b/components/brave_wallet/common/brave_wallet.mojom
@@ -770,7 +770,7 @@ interface KeyringService {
   AddHardwareAccounts(array<HardwareWalletAccount> info);
 
   // Removes a hardware account
-  RemoveHardwareAccount(string address, string password, CoinType coin) => (bool success);
+  RemoveHardwareAccount(string address, CoinType coin) => (bool success);
 
   // Informs the user that user interaction occurred so auto-lock doesn't occur
   NotifyUserInteraction();

--- a/components/brave_wallet_ui/components/desktop/popup-modals/confirm-password-modal/confirm-password-modal.tsx
+++ b/components/brave_wallet_ui/components/desktop/popup-modals/confirm-password-modal/confirm-password-modal.tsx
@@ -55,7 +55,7 @@ export const ConfirmPasswordModal = () => {
     const { address, coin, hardware } = accountToRemove
 
     if (hardware) {
-      dispatch(WalletPageActions.removeHardwareAccount({ address, coin, password }))
+      dispatch(WalletPageActions.removeHardwareAccount({ address, coin }))
     }
 
     if (!hardware) {

--- a/components/brave_wallet_ui/page/async/wallet_page_async_handler.ts
+++ b/components/brave_wallet_ui/page/async/wallet_page_async_handler.ts
@@ -225,7 +225,6 @@ handler.on(WalletPageActions.removeHardwareAccount.type, async (store: Store, pa
   const { keyringService } = getWalletPageApiProxy()
   const { success } = await keyringService.removeHardwareAccount(
     payload.address,
-    payload.password,
     payload.coin
   )
 

--- a/components/brave_wallet_ui/page/constants/action_types.ts
+++ b/components/brave_wallet_ui/page/constants/action_types.ts
@@ -50,7 +50,6 @@ export type RemoveImportedAccountPayloadType = {
 export type RemoveHardwareAccountPayloadType = {
   address: string
   coin: BraveWallet.CoinType
-  password: string
 }
 
 export type RestoreWalletPayloadType = {


### PR DESCRIPTION
Decouple hardware mojo API from encryptor requirement because hardware
wallets prefs doesn't need to be encrypted. Also fix a bug in
`AddHardwareAccounts` that mixing keyring ids will select only one
account for first keyring id. Private `IsLocked` now requires mandatory keyring
id and it will return false the users has no derived accounts or imported accounts.

Global wallet lock state works like this
1. If a user has both software and hardware wallets, leaning on always require password despite hardware doesn’t need it.
2. If a user has only software wallet, same as above.
3. If a user has only hardware wallet, no password needed.

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/28362

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

