### PR TITLE
Perform download safety check even when user is prompted for save location. (uplift to 1.48.x)

### DIFF
--- a/chromium_src/chrome/browser/download/download_target_determiner.cc
+++ b/chromium_src/chrome/browser/download/download_target_determiner.cc
@@ -1,0 +1,13 @@
+/* Copyright (c) 2023 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+// Prompting the user for download location shouldn't be a factor in determining
+// the download's danger level.
+#define BRAVE_DOWNLOAD_TARGET_DETERMINER_GET_DANGER_LEVEL \
+  true) {}                                                \
+  if (
+
+#include "src/chrome/browser/download/download_target_determiner.cc"
+#undef BRAVE_DOWNLOAD_TARGET_DETERMINER_GET_DANGER_LEVEL

--- a/patches/chrome-browser-download-download_target_determiner.cc.patch
+++ b/patches/chrome-browser-download-download_target_determiner.cc.patch
@@ -1,0 +1,12 @@
+diff --git a/chrome/browser/download/download_target_determiner.cc b/chrome/browser/download/download_target_determiner.cc
+index 6e2ece915f5b00068b804607d24a0eb39bce8ffd..19a3ed5111d24613941f5c5505694cedabe42884 100644
+--- a/chrome/browser/download/download_target_determiner.cc
++++ b/chrome/browser/download/download_target_determiner.cc
+@@ -1253,6 +1253,7 @@ DownloadFileType::DangerLevel DownloadTargetDeterminer::GetDangerLevel(
+   // contains malware.
+   if (HasPromptedForPath() ||
+       confirmation_reason_ != DownloadConfirmationReason::NONE ||
++      BRAVE_DOWNLOAD_TARGET_DETERMINER_GET_DANGER_LEVEL
+       !download_->GetForcedFilePath().empty())
+     return DownloadFileType::NOT_DANGEROUS;
+ 


### PR DESCRIPTION
Uplift of #16969
Resolves https://github.com/brave/brave-browser/issues/28079

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.