### PR TITLE
Overlap window caption button on toolbar on linux 

### DIFF
--- a/browser/ui/BUILD.gn
+++ b/browser/ui/BUILD.gn
@@ -333,6 +333,13 @@ source_set("ui") {
       ]
     }
 
+    if (is_linux) {
+      sources += [
+        "views/frame/brave_browser_frame_view_linux_native.cc",
+        "views/frame/brave_browser_frame_view_linux_native.h",
+      ]
+    }
+
     if (is_mac) {
       sources += [
         "views/frame/brave_browser_frame_mac.h",

--- a/browser/ui/views/frame/brave_browser_frame_view_linux_native.cc
+++ b/browser/ui/views/frame/brave_browser_frame_view_linux_native.cc
@@ -1,0 +1,206 @@
+/* Copyright (c) 2023 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "brave/browser/ui/views/frame/brave_browser_frame_view_linux_native.h"
+
+#include <numeric>
+#include <string>
+
+#include "brave/browser/ui/tabs/features.h"
+#include "brave/browser/ui/views/tabs/vertical_tab_utils.h"
+#include "brave/browser/ui/views/toolbar/brave_toolbar_view.h"
+#include "chrome/browser/ui/layout_constants.h"
+#include "chrome/browser/ui/views/frame/browser_view.h"
+#include "chrome/common/pref_names.h"
+#include "ui/base/metadata/metadata_impl_macros.h"
+#include "ui/views/controls/button/image_button.h"
+#include "ui/views/window/caption_button_layout_constants.h"
+#include "ui/views/window/window_button_order_provider.h"
+
+namespace {
+
+ui::NavButtonProvider::ButtonState ButtonStateToNavButtonProviderState(
+    views::Button::ButtonState state) {
+  switch (state) {
+    case views::Button::STATE_NORMAL:
+      return ui::NavButtonProvider::ButtonState::kNormal;
+    case views::Button::STATE_HOVERED:
+      return ui::NavButtonProvider::ButtonState::kHovered;
+    case views::Button::STATE_PRESSED:
+      return ui::NavButtonProvider::ButtonState::kPressed;
+    case views::Button::STATE_DISABLED:
+      return ui::NavButtonProvider::ButtonState::kDisabled;
+
+    case views::Button::STATE_COUNT:
+    default:
+      NOTREACHED();
+      return ui::NavButtonProvider::ButtonState::kNormal;
+  }
+}
+
+}  // namespace
+
+BraveBrowserFrameViewLinuxNative::BraveBrowserFrameViewLinuxNative(
+    BrowserFrame* frame,
+    BrowserView* browser_view,
+    BrowserFrameViewLayoutLinux* layout,
+    std::unique_ptr<ui::NavButtonProvider> nav_button_provider,
+    ui::WindowFrameProvider* window_frame_provider)
+    : BrowserFrameViewLinuxNative(frame,
+                                  browser_view,
+                                  layout,
+                                  std::move(nav_button_provider),
+                                  window_frame_provider) {}
+
+BraveBrowserFrameViewLinuxNative::~BraveBrowserFrameViewLinuxNative() = default;
+
+void BraveBrowserFrameViewLinuxNative::MaybeUpdateCachedFrameButtonImages() {
+  if (!base::FeatureList::IsEnabled(tabs::features::kBraveVerticalTabs)) {
+    BrowserFrameViewLinuxNative::MaybeUpdateCachedFrameButtonImages();
+    return;
+  }
+
+  auto* browser = browser_view()->browser();
+  DCHECK(browser);
+
+  if (!tabs::utils::ShouldShowVerticalTabs(browser) ||
+      tabs::utils::ShouldShowWindowTitleForVerticalTabs(browser)) {
+    BrowserFrameViewLinuxNative::MaybeUpdateCachedFrameButtonImages();
+    UpdateLeadingTrailingCaptionButtonWidth();
+    return;
+  }
+
+  // In order to lay out window caption buttons over toolbar, we should set
+  // height as tall as button's on toolbar
+  DrawFrameButtonParams params{
+      .top_area_height = GetLayoutConstant(TOOLBAR_BUTTON_HEIGHT) +
+                         GetLayoutInsets(TOOLBAR_BUTTON).height() +
+                         GetTopAreaHeight() -
+                         layout()->FrameEdgeInsets(!IsMaximized()).top(),
+      .maximized = IsMaximized(),
+      .active = ShouldPaintAsActive()};
+
+  if (cache_ == params) {
+    return;
+  }
+
+  cache_ = params;
+  nav_button_provider_->RedrawImages(cache_.top_area_height, cache_.maximized,
+                                     cache_.active);
+
+  for (auto type : {
+           ui::NavButtonProvider::FrameButtonDisplayType::kMinimize,
+           IsMaximized()
+               ? ui::NavButtonProvider::FrameButtonDisplayType::kRestore
+               : ui::NavButtonProvider::FrameButtonDisplayType::kMaximize,
+           ui::NavButtonProvider::FrameButtonDisplayType::kClose,
+       }) {
+    for (size_t state = 0; state < views::Button::STATE_COUNT; state++) {
+      views::Button::ButtonState button_state =
+          static_cast<views::Button::ButtonState>(state);
+      views::Button* button = GetButtonFromDisplayType(type);
+      DCHECK_EQ(std::string(views::ImageButton::kViewClassName),
+                button->GetClassName());
+      static_cast<views::ImageButton*>(button)->SetImage(
+          button_state,
+          nav_button_provider_->GetImage(
+              type, ButtonStateToNavButtonProviderState(button_state)));
+    }
+  }
+
+  UpdateLeadingTrailingCaptionButtonWidth();
+}
+
+void BraveBrowserFrameViewLinuxNative::Layout() {
+  BrowserFrameViewLinuxNative::Layout();
+
+  if (base::FeatureList::IsEnabled(tabs::features::kBraveVerticalTabs)) {
+    UpdateLeadingTrailingCaptionButtonWidth();
+  }
+}
+
+views::Button* BraveBrowserFrameViewLinuxNative::FrameButtonToButton(
+    views::FrameButton frame_button) {
+  switch (frame_button) {
+    case views::FrameButton::kMinimize:
+      return minimize_button();
+    case views::FrameButton::kMaximize:
+      return IsMaximized() ? restore_button() : maximize_button();
+    case views::FrameButton::kClose:
+      return close_button();
+  }
+  NOTREACHED();
+  return nullptr;
+}
+
+void BraveBrowserFrameViewLinuxNative::
+    UpdateLeadingTrailingCaptionButtonWidth() {
+  DCHECK(base::FeatureList::IsEnabled(tabs::features::kBraveVerticalTabs));
+
+  auto* browser = browser_view()->browser();
+  DCHECK(browser);
+  std::pair<int, int> new_leading_trailing_caption_button_width;
+  if (tabs::utils::ShouldShowVerticalTabs(browser) &&
+      !tabs::utils::ShouldShowWindowTitleForVerticalTabs(browser)) {
+    auto* window_order_provider =
+        views::WindowButtonOrderProvider::GetInstance();
+    const auto leading_buttons = window_order_provider->leading_buttons();
+    const auto trailing_buttons = window_order_provider->trailing_buttons();
+
+    const auto leading_button_width = std::accumulate(
+        leading_buttons.begin(), leading_buttons.end(), 0,
+        [this](int max_right, auto frame_button) {
+          auto* button = FrameButtonToButton(frame_button);
+          if (!button || !button->GetVisible() || button->bounds().IsEmpty()) {
+            return max_right;
+          }
+
+          if (auto current_right = button->bounds().right();
+              current_right > max_right) {
+            return current_right;
+          }
+
+          return max_right;
+        });
+
+    const auto trailing_button_width =
+        width() -
+        std::accumulate(trailing_buttons.begin(), trailing_buttons.end(),
+                        width(), [this](int min_left, auto frame_button) {
+                          auto* button = FrameButtonToButton(frame_button);
+                          if (!button || !button->GetVisible() ||
+                              button->bounds().IsEmpty()) {
+                            return min_left;
+                          }
+
+                          if (int current_left = button->bounds().x();
+                              current_left < min_left) {
+                            return current_left;
+                          }
+
+                          return min_left;
+                        });
+    new_leading_trailing_caption_button_width = {leading_button_width,
+                                                 trailing_button_width};
+  }
+
+  if (leading_trailing_caption_button_width_ ==
+      new_leading_trailing_caption_button_width) {
+    return;
+  }
+
+  leading_trailing_caption_button_width_ =
+      new_leading_trailing_caption_button_width;
+
+  // Notify toolbar view that caption button's width changed so that it can
+  // make space for caption buttons.
+  static_cast<BraveToolbarView*>(browser_view()->toolbar())
+      ->UpdateHorizontalPadding();
+}
+
+// Unfortunately, BrowserFrameViewLinux(Native) doesn't declare metadata.
+// OpaqueBrowserFrameView is the nearest ancestor.
+BEGIN_METADATA(BraveBrowserFrameViewLinuxNative, OpaqueBrowserFrameView)
+END_METADATA

--- a/browser/ui/views/frame/brave_browser_frame_view_linux_native.h
+++ b/browser/ui/views/frame/brave_browser_frame_view_linux_native.h
@@ -1,0 +1,45 @@
+/* Copyright (c) 2023 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_BROWSER_UI_VIEWS_FRAME_BRAVE_BROWSER_FRAME_VIEW_LINUX_NATIVE_H_
+#define BRAVE_BROWSER_UI_VIEWS_FRAME_BRAVE_BROWSER_FRAME_VIEW_LINUX_NATIVE_H_
+
+#include <memory>
+#include <utility>
+
+#include "chrome/browser/ui/views/frame/browser_frame_view_linux_native.h"
+
+class BraveBrowserFrameViewLinuxNative : public BrowserFrameViewLinuxNative {
+ public:
+  METADATA_HEADER(BraveBrowserFrameViewLinuxNative);
+
+  BraveBrowserFrameViewLinuxNative(
+      BrowserFrame* frame,
+      BrowserView* browser_view,
+      BrowserFrameViewLayoutLinux* layout,
+      std::unique_ptr<ui::NavButtonProvider> nav_button_provider,
+      ui::WindowFrameProvider* window_frame_provider
+
+  );
+  ~BraveBrowserFrameViewLinuxNative() override;
+
+  // Returns caption buttons width provided by GTK.
+  std::pair<int, int> leading_trailing_caption_button_width() const {
+    return leading_trailing_caption_button_width_;
+  }
+
+  // BrowserFrameViewLinuxNative:
+  void MaybeUpdateCachedFrameButtonImages() override;
+  void Layout() override;
+
+ private:
+  views::Button* FrameButtonToButton(views::FrameButton frame_button);
+
+  void UpdateLeadingTrailingCaptionButtonWidth();
+
+  std::pair<int, int> leading_trailing_caption_button_width_;
+};
+
+#endif  // BRAVE_BROWSER_UI_VIEWS_FRAME_BRAVE_BROWSER_FRAME_VIEW_LINUX_NATIVE_H_

--- a/browser/ui/views/frame/brave_browser_view_layout.cc
+++ b/browser/ui/views/frame/brave_browser_view_layout.cc
@@ -42,10 +42,12 @@ void BraveBrowserViewLayout::Layout(views::View* host) {
   gfx::Rect vertical_tab_strip_bounds = vertical_layout_rect_;
   vertical_tab_strip_bounds.set_y(views_next_to_vertical_tabs.front()->y());
   gfx::Insets insets;
+#if !BUILDFLAG(IS_LINUX)
   if (contents_separator_ &&
       views_next_to_vertical_tabs.front() == bookmark_bar_) {
     insets.set_top(contents_separator_->GetPreferredSize().height());
   }
+#endif  // BUILDFLAG(IS_LINUX)
 
 #if BUILDFLAG(IS_MAC)
   // for frame border drawn by OS. Vertical tabstrip's widget shouldn't cover

--- a/browser/ui/views/frame/brave_opaque_browser_frame_view.cc
+++ b/browser/ui/views/frame/brave_opaque_browser_frame_view.cc
@@ -1,18 +1,23 @@
-/* Copyright 2020 The Brave Authors. All rights reserved.
+/* Copyright (c) 2020 The Brave Authors. All rights reserved.
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
- * You can obtain one at http://mozilla.org/MPL/2.0/. */
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 #include "brave/browser/ui/views/frame/brave_opaque_browser_frame_view.h"
 
 #include <memory>
 
+#include "brave/browser/ui/tabs/features.h"
 #include "brave/browser/ui/views/frame/brave_non_client_hit_test_helper.h"
 #include "brave/browser/ui/views/frame/brave_window_frame_graphic.h"
+#include "brave/browser/ui/views/tabs/vertical_tab_utils.h"
+#include "brave/browser/ui/views/toolbar/brave_toolbar_view.h"
 #include "chrome/browser/ui/browser.h"
+#include "chrome/browser/ui/color/chrome_color_id.h"
 #include "chrome/browser/ui/views/frame/browser_view.h"
 #include "chrome/browser/ui/views/frame/opaque_browser_frame_view_layout.h"
 #include "ui/base/hit_test.h"
+#include "ui/compositor/layer.h"
 #include "ui/gfx/geometry/insets.h"
 #include "ui/gfx/geometry/rect.h"
 #include "ui/gfx/scoped_canvas.h"
@@ -44,10 +49,88 @@ void BraveOpaqueBrowserFrameView::OnPaint(gfx::Canvas* canvas) {
 }
 
 int BraveOpaqueBrowserFrameView::NonClientHitTest(const gfx::Point& point) {
+  if (base::FeatureList::IsEnabled(tabs::features::kBraveVerticalTabs) &&
+      tabs::utils::ShouldShowVerticalTabs(browser_view()->browser())) {
+    auto hit_test_caption_button = [](views::Button* button,
+                                      const gfx::Point& point) {
+      return button && button->GetVisible() &&
+             button->GetMirroredBounds().Contains(point);
+    };
+
+    if (hit_test_caption_button(close_button_, point)) {
+      return HTCLOSE;
+    }
+    if (hit_test_caption_button(restore_button_, point)) {
+      return HTMAXBUTTON;
+    }
+    if (hit_test_caption_button(maximize_button_, point)) {
+      return HTMAXBUTTON;
+    }
+    if (hit_test_caption_button(minimize_button_, point)) {
+      return HTMINBUTTON;
+    }
+  }
+
   if (auto res = brave::NonClientHitTest(browser_view(), point);
       res != HTNOWHERE) {
     return res;
   }
 
   return OpaqueBrowserFrameView::NonClientHitTest(point);
+}
+
+void BraveOpaqueBrowserFrameView::
+    UpdateCaptionButtonPlaceholderContainerBackground() {
+  OpaqueBrowserFrameView::UpdateCaptionButtonPlaceholderContainerBackground();
+  if (!base::FeatureList::IsEnabled(tabs::features::kBraveVerticalTabs)) {
+    return;
+  }
+
+  DCHECK(browser_view());
+  auto* browser = browser_view()->browser();
+  DCHECK(browser);
+  const bool should_window_caption_buttons_overlap_toolbar =
+      tabs::utils::ShouldShowVerticalTabs(browser) &&
+      !tabs::utils::ShouldShowWindowTitleForVerticalTabs(browser);
+
+  for (auto& button :
+       {close_button_, restore_button_, maximize_button_, minimize_button_}) {
+    if (!button) {
+      continue;
+    }
+
+    if (should_window_caption_buttons_overlap_toolbar) {
+      auto* cp = GetColorProvider();
+      DCHECK(cp);
+
+      button->SetPaintToLayer();
+      button->layer()->SetFillsBoundsOpaquely(false);
+    } else {
+      if (button->layer()) {
+        button->DestroyLayer();
+      }
+    }
+  }
+
+  // Notify toolbar view that caption button's width changed so that it can
+  // make space for caption buttons.
+  static_cast<BraveToolbarView*>(browser_view()->toolbar())
+      ->UpdateHorizontalPadding();
+}
+
+void BraveOpaqueBrowserFrameView::PaintClientEdge(gfx::Canvas* canvas) const {
+  if (!base::FeatureList::IsEnabled(tabs::features::kBraveVerticalTabs)) {
+    OpaqueBrowserFrameView::PaintClientEdge(canvas);
+    return;
+  }
+
+  // Don't draw client edge next to toolbar when it's in vertical tab stirp mode
+  DCHECK(browser_view());
+  auto* browser = browser_view()->browser();
+  DCHECK(browser);
+  if (tabs::utils::ShouldShowVerticalTabs(browser)) {
+    return;
+  }
+
+  OpaqueBrowserFrameView::PaintClientEdge(canvas);
 }

--- a/browser/ui/views/frame/brave_opaque_browser_frame_view.h
+++ b/browser/ui/views/frame/brave_opaque_browser_frame_view.h
@@ -1,7 +1,7 @@
-/* Copyright 2020 The Brave Authors. All rights reserved.
+/* Copyright (c) 2020 The Brave Authors. All rights reserved.
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
- * You can obtain one at http://mozilla.org/MPL/2.0/. */
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 #ifndef BRAVE_BROWSER_UI_VIEWS_FRAME_BRAVE_OPAQUE_BROWSER_FRAME_VIEW_H_
 #define BRAVE_BROWSER_UI_VIEWS_FRAME_BRAVE_OPAQUE_BROWSER_FRAME_VIEW_H_
@@ -26,6 +26,8 @@ class BraveOpaqueBrowserFrameView : public OpaqueBrowserFrameView {
   // OpaqueBrowserFrameView overrides:
   void OnPaint(gfx::Canvas* canvas) override;
   int NonClientHitTest(const gfx::Point& point) override;
+  void UpdateCaptionButtonPlaceholderContainerBackground() override;
+  void PaintClientEdge(gfx::Canvas* canvas) const override;
 
  private:
   std::unique_ptr<BraveWindowFrameGraphic> frame_graphic_;

--- a/browser/ui/views/toolbar/brave_toolbar_view.cc
+++ b/browser/ui/views/toolbar/brave_toolbar_view.cc
@@ -42,6 +42,10 @@
 #include "brave/components/brave_vpn/common/pref_names.h"
 #endif
 
+#if BUILDFLAG(IS_LINUX)
+#include "chrome/common/pref_names.h"
+#endif
+
 namespace {
 constexpr int kLocationBarMaxWidth = 1080;
 
@@ -163,6 +167,12 @@ void BraveToolbarView::Init() {
         profile->GetOriginalProfile()->GetPrefs(),
         base::BindRepeating(&BraveToolbarView::UpdateHorizontalPadding,
                             base::Unretained(this)));
+#if BUILDFLAG(IS_LINUX)
+    use_custom_chrome_frame_.Init(
+        prefs::kUseCustomChromeFrame, profile->GetOriginalProfile()->GetPrefs(),
+        base::BindRepeating(&BraveToolbarView::UpdateHorizontalPadding,
+                            base::Unretained(this)));
+#endif  // BUILDFLAG(IS_LINUX)
     UpdateHorizontalPadding();
   }
 

--- a/browser/ui/views/toolbar/brave_toolbar_view.h
+++ b/browser/ui/views/toolbar/brave_toolbar_view.h
@@ -34,6 +34,8 @@ class BraveToolbarView : public ToolbarView,
   void OnVPNButtonVisibilityChanged();
 #endif
 
+  void UpdateHorizontalPadding();
+
   void Init() override;
   void Layout() override;
   void Update(content::WebContents* tab) override;
@@ -52,7 +54,6 @@ class BraveToolbarView : public ToolbarView,
   void ResetLocationBarBounds();
   void ResetButtonBounds();
   void UpdateBookmarkVisibility();
-  void UpdateHorizontalPadding();
 
   // ProfileAttributesStorage::Observer:
   void OnProfileAdded(const base::FilePath& profile_path) override;
@@ -76,6 +77,9 @@ class BraveToolbarView : public ToolbarView,
 
   BooleanPrefMember show_vertical_tabs_;
   BooleanPrefMember show_title_bar_on_vertical_tabs_;
+#if BUILDFLAG(IS_LINUX)
+  BooleanPrefMember use_custom_chrome_frame_;
+#endif  // BUILDFLAG(IS_LINUX)
 
   // Whether this toolbar has been initialized.
   bool brave_initialized_ = false;

--- a/chromium_src/chrome/browser/ui/views/frame/browser_frame_view_layout_linux.cc
+++ b/chromium_src/chrome/browser/ui/views/frame/browser_frame_view_layout_linux.cc
@@ -3,50 +3,53 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+#include "src/chrome/browser/ui/views/frame/browser_frame_view_layout_linux.cc"
+
 #include "base/check_is_test.h"
 #include "brave/browser/ui/tabs/features.h"
 #include "brave/browser/ui/views/tabs/vertical_tab_utils.h"
 #include "chrome/browser/ui/views/frame/browser_view.h"
+#include "chrome/browser/ui/views/toolbar/toolbar_view.h"
 #include "ui/views/window/caption_button_layout_constants.h"
+#include "ui/views/window/frame_caption_button.h"
 
-#include "src/chrome/browser/ui/views/frame/browser_frame_view_layout_linux.cc"
-
-int BrowserFrameViewLayoutLinux::NonClientTopHeight(bool restored) const {
-  if (!base::FeatureList::IsEnabled(tabs::features::kBraveVerticalTabs))
-    return OpaqueBrowserFrameViewLayout::NonClientTopHeight(restored);
+void BrowserFrameViewLayoutLinux::SetBoundsForButton(
+    views::FrameButton button_id,
+    views::Button* button,
+    ButtonAlignment align) {
+  OpaqueBrowserFrameViewLayout::SetBoundsForButton(button_id, button, align);
+  if (!base::FeatureList::IsEnabled(tabs::features::kBraveVerticalTabs)) {
+    return;
+  }
 
   if (!view_) {
     CHECK_IS_TEST();
-    return OpaqueBrowserFrameViewLayout::NonClientTopHeight(restored);
+    return;
   }
 
-  if (tabs::utils::ShouldShowVerticalTabs(view_->browser_view()->browser())) {
-    if (!view_->ShouldShowCaptionButtons()) {
-      // In this case, the window manager might be forcibly providing system
-      // window title or it's in fullscreen mode. We shouldn't show title bar
-      // in this case.
-      return OpaqueBrowserFrameViewLayout::NonClientTopHeight(restored);
-    }
+  auto* browser = view_->browser_view()->browser();
+  DCHECK(browser);
 
-    // TODO(sko) For now, I couldn't find a way to overlay caption buttons
-    // on toolbar. Once it gets possible, we shouldn't reserve non client top
-    // height when window title isn't visible.
-
-    // Adding 2px of vertical padding puts at least 1 px of space on the top and
-    // bottom of the element.
-    constexpr int kVerticalPadding = 2;
-    // delegate_->GetIconSize() also considers the default font's height so
-    // title will be visible.
-    const int icon_height = FrameEdgeInsets(restored).top() +
-                            delegate_->GetIconSize() + kVerticalPadding;
-
-    const int caption_button_height =
-        DefaultCaptionButtonY(restored) +
-        18 /*kCaptionButtonHeight in OpaqueBrowserFrameView*/ +
-        kCaptionButtonBottomPadding;
-    return std::max(icon_height, caption_button_height) +
-           kCaptionButtonBottomPadding;
+  const bool should_window_caption_buttons_overlap_toolbar =
+      tabs::utils::ShouldShowVerticalTabs(browser) &&
+      !tabs::utils::ShouldShowWindowTitleForVerticalTabs(browser);
+  if (!should_window_caption_buttons_overlap_toolbar) {
+    return;
   }
 
-  return OpaqueBrowserFrameViewLayout::NonClientTopHeight(restored);
+  // Sets fixed heights for |button| regardless of non client top height.
+  if (delegate_->GetFrameButtonStyle() ==
+      OpaqueBrowserFrameViewLayoutDelegate::FrameButtonStyle::kMdButton) {
+    gfx::Size size = button->GetPreferredSize();
+    DCHECK_LT(0, size.width());
+    size.set_height(size.width());
+    button->SetPreferredSize(size);
+    button->SetSize(size);
+    const auto toolbar_height =
+        view_->browser_view()->toolbar()->GetPreferredSize().height();
+    button->SetY(view_->GetTopAreaHeight() +
+                 (toolbar_height - size.height()) / 2);
+    static_cast<views::FrameCaptionButton*>(button)->SetInkDropCornerRadius(
+        views::kCaptionButtonInkDropDefaultCornerRadius);
+  }
 }

--- a/chromium_src/chrome/browser/ui/views/frame/browser_frame_view_layout_linux.h
+++ b/chromium_src/chrome/browser/ui/views/frame/browser_frame_view_layout_linux.h
@@ -8,9 +8,10 @@
 
 #include "chrome/browser/ui/views/frame/opaque_browser_frame_view_layout.h"
 
-#define GetInputInsets                                  \
-  Unused() { return {}; }                               \
-  int NonClientTopHeight(bool restored) const override; \
+#define GetInputInsets                                                         \
+  GetInputInsets_Unused();                                                     \
+  void SetBoundsForButton(views::FrameButton button_id, views::Button* button, \
+                          ButtonAlignment align) override;                     \
   gfx::Insets GetInputInsets
 
 #include "src/chrome/browser/ui/views/frame/browser_frame_view_layout_linux.h"  // IWYU pragma: export

--- a/chromium_src/chrome/browser/ui/views/frame/browser_frame_view_linux_native.h
+++ b/chromium_src/chrome/browser/ui/views/frame/browser_frame_view_linux_native.h
@@ -1,0 +1,18 @@
+/* Copyright (c) 2023 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_CHROMIUM_SRC_CHROME_BROWSER_UI_VIEWS_FRAME_BROWSER_FRAME_VIEW_LINUX_NATIVE_H_
+#define BRAVE_CHROMIUM_SRC_CHROME_BROWSER_UI_VIEWS_FRAME_BROWSER_FRAME_VIEW_LINUX_NATIVE_H_
+
+#define MaybeUpdateCachedFrameButtonImages       \
+  MaybeUpdateCachedFrameButtonImages_Unused() {} \
+  friend class BraveBrowserFrameViewLinuxNative; \
+  virtual void MaybeUpdateCachedFrameButtonImages
+
+#include "src/chrome/browser/ui/views/frame/browser_frame_view_linux_native.h"  // IWYU pragma: export
+
+#undef MaybeUpdateCachedFrameButtonImages
+
+#endif  // BRAVE_CHROMIUM_SRC_CHROME_BROWSER_UI_VIEWS_FRAME_BROWSER_FRAME_VIEW_LINUX_NATIVE_H_

--- a/chromium_src/chrome/browser/ui/views/frame/browser_non_client_frame_view_factory_views.cc
+++ b/chromium_src/chrome/browser/ui/views/frame/browser_non_client_frame_view_factory_views.cc
@@ -1,7 +1,7 @@
-/* Copyright 2020 The Brave Authors. All rights reserved.
+/* Copyright (c) 2020 The Brave Authors. All rights reserved.
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
- * You can obtain one at http://mozilla.org/MPL/2.0/. */
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 #include <functional>
 #include <type_traits>
@@ -20,7 +20,16 @@
 #include "brave/browser/ui/views/frame/brave_opaque_browser_frame_view.h"
 #define OpaqueBrowserFrameView BraveOpaqueBrowserFrameView
 
+#if BUILDFLAG(IS_LINUX)
+#include "brave/browser/ui/views/frame/brave_browser_frame_view_linux_native.h"
+#define BrowserFrameViewLinuxNative BraveBrowserFrameViewLinuxNative
+#endif  // BUILDFLAG(IS_LINUX)
+
 #include "src/chrome/browser/ui/views/frame/browser_non_client_frame_view_factory_views.cc"
+
+#if BUILDFLAG(IS_LINUX)
+#undef BrowserFrameViewLinuxNative
+#endif  // BUILDFLAG(IS_LINUX)
 
 #undef OpaqueBrowserFrameView
 

--- a/chromium_src/chrome/browser/ui/views/frame/opaque_browser_frame_view.h
+++ b/chromium_src/chrome/browser/ui/views/frame/opaque_browser_frame_view.h
@@ -1,0 +1,22 @@
+/* Copyright (c) 2023 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_CHROMIUM_SRC_CHROME_BROWSER_UI_VIEWS_FRAME_OPAQUE_BROWSER_FRAME_VIEW_H_
+#define BRAVE_CHROMIUM_SRC_CHROME_BROWSER_UI_VIEWS_FRAME_OPAQUE_BROWSER_FRAME_VIEW_H_
+
+#define WebAppOpaqueBrowserFrameViewWindowControlsOverlayTest \
+  WebAppOpaqueBrowserFrameViewWindowControlsOverlayTest;      \
+  friend class BraveOpaqueBrowserFrameView
+#define UpdateCaptionButtonPlaceholderContainerBackground \
+  virtual UpdateCaptionButtonPlaceholderContainerBackground
+#define PaintClientEdge virtual PaintClientEdge
+
+#include "src/chrome/browser/ui/views/frame/opaque_browser_frame_view.h"  // IWYU pragma: export
+
+#undef PaintClientEdge
+#undef UpdateCaptionButtonPlaceholderContainerBackground
+#undef WebAppOpaqueBrowserFrameViewWindowControlsOverlayTest
+
+#endif  // BRAVE_CHROMIUM_SRC_CHROME_BROWSER_UI_VIEWS_FRAME_OPAQUE_BROWSER_FRAME_VIEW_H_

--- a/chromium_src/chrome/browser/ui/views/frame/opaque_browser_frame_view_layout.h
+++ b/chromium_src/chrome/browser/ui/views/frame/opaque_browser_frame_view_layout.h
@@ -6,8 +6,11 @@
 #ifndef BRAVE_CHROMIUM_SRC_CHROME_BROWSER_UI_VIEWS_FRAME_OPAQUE_BROWSER_FRAME_VIEW_LAYOUT_H_
 #define BRAVE_CHROMIUM_SRC_CHROME_BROWSER_UI_VIEWS_FRAME_OPAQUE_BROWSER_FRAME_VIEW_LAYOUT_H_
 
-#define NonClientTopHeight virtual NonClientTopHeight
+#define SetBoundsForButton                  \
+  SetBoundsForButton_Unused();              \
+  friend class BrowserFrameViewLayoutLinux; \
+  virtual void SetBoundsForButton
 #include "src/chrome/browser/ui/views/frame/opaque_browser_frame_view_layout.h"  // IWYU pragma: export
-#undef NonClientTopHeight
+#undef SetBoundsForButton
 
 #endif  // BRAVE_CHROMIUM_SRC_CHROME_BROWSER_UI_VIEWS_FRAME_OPAQUE_BROWSER_FRAME_VIEW_LAYOUT_H_


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/26233

When it's in vertical tab strip mode and there's no title visible,
we should overlap caption buttons on toolbar

Also this patch fixes 2 things together
* Don't draw stroke next to toolbar
* Don't make gap between vertical tab strip and toolbar on linux

> Show title
<img width="981" alt="image" src="https://user-images.githubusercontent.com/5474642/218443192-14603baf-741a-499f-a86d-01d136ad0ced.png">

> Hide title : overlap toolbar, ink drop
<img width="190" alt="image" src="https://user-images.githubusercontent.com/5474642/218447222-0836808b-e133-440a-88ad-8733c3d0cb2b.png">


## Submitter Checklist:

- [ ] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
### Manual
* Enable vertical tabs (brave://flags > vertical tabs and then open up context menu on tabs and click 'Use vertical tabs')
* When "Show window title" menu is false, caption buttons should be overlapped over toolbar and fully functional.
