### PR TITLE
[Android] fix retention notification gps crash (uplift to 1.49.x)

### DIFF
--- a/android/java/org/chromium/chrome/browser/notifications/retention/RetentionNotificationPublisher.java
+++ b/android/java/org/chromium/chrome/browser/notifications/retention/RetentionNotificationPublisher.java
@@ -152,7 +152,7 @@ public class RetentionNotificationPublisher extends BroadcastReceiver {
                     break;
                 }
             }
-        } catch (NullPointerException exc) {
+        } catch (Exception exc) {
             // There could be uninitialized parts on early stages. Just ignore it the exception,
             // it's better comparing to crashing
         }


### PR DESCRIPTION
Uplift of #17158
Resolves https://github.com/brave/brave-browser/issues/28317

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.