### PR TITLE
[Uplift] Top Sites Alignment 1.49

### DIFF
--- a/components/brave_new_tab_ui/components/default/gridSites/index.ts
+++ b/components/brave_new_tab_ui/components/default/gridSites/index.ts
@@ -111,6 +111,7 @@ export const GridPagesContainer = styled('div')<{ customLinksEnabled: boolean }>
   display: flex;
   flex-direction: row;
 
+  margin-left: 24px;
   padding: 24px 24px 0 24px;
   max-width: calc((var(--grid-columns) + 1) * var(--grid-column-width));
   overflow-x: ${p => p.customLinksEnabled ? 'auto' : 'hidden'};


### PR DESCRIPTION
Uplift of https://github.com/brave/brave-core/pull/17044 which fixes https://github.com/brave/brave-browser/issues/28071 into 1.49.x