### PR TITLE
Fixes a missing space in a l10n string in Polish. (uplift to 1.49.x)

### DIFF
--- a/components/resources/strings/brave_components_resources_pl.xtb
+++ b/components/resources/strings/brave_components_resources_pl.xtb
@@ -664,7 +664,7 @@
 <translation id="7861645265922445992">Odbierz nagrody</translation>
 <translation id="9013419433042554094">Odbierz tokeny</translation>
 <translation id="5544777623605368410">Zarabianie</translation>
-<translation id="3273637494083639780">Przetwarzanie tokenów, które zarobisz w tym miesiącu, rozpocznie się<ph name="DATE"/>.</translation>
+<translation id="3273637494083639780">Przetwarzanie tokenów, które zarobisz w tym miesiącu, rozpocznie się <ph name="DATE"/>.</translation>
 <translation id="1029300693989825319">Może się różnić w zależności od zmienności rynku.</translation>
 <translation id="8334559352278209120">Wspieranie</translation>
 <translation id="4782365133987903299">Pozostało <ph name="DAYS"/> do odebrania.</translation>


### PR DESCRIPTION
Uplift of #17159
Resolves https://github.com/brave/brave-browser/issues/28280

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.