### PR TITLE
fix(wallet): Updated Fund Screens With Nav

### DIFF
--- a/components/brave_wallet_ui/components/desktop/centered-page-layout/centered-page-layout.style.ts
+++ b/components/brave_wallet_ui/components/desktop/centered-page-layout/centered-page-layout.style.ts
@@ -18,12 +18,12 @@ export const StyledWrapper = styled('div')`
   overflow-y: auto;
  `
 
-export const StyledContent = styled('div')`
+export const StyledContent = styled('div') <{ isTabView?: boolean }>`
   width: 456px;
   display: flex;
   flex-direction: column;
   align-items: flex-start;
   justify-content: flex-start;
-  padding-top: 32px;
+  padding-top: ${(p) => p.isTabView ? 0 : 32}px;
   padding-bottom: 0px;
  `

--- a/components/brave_wallet_ui/components/desktop/centered-page-layout/centered-page-layout.tsx
+++ b/components/brave_wallet_ui/components/desktop/centered-page-layout/centered-page-layout.tsx
@@ -6,12 +6,13 @@
 import * as React from 'react'
 import { StyledWrapper, StyledContent } from './centered-page-layout.style'
 
-export const CenteredPageLayout = React.memo<React.PropsWithChildren<{}>>(({
-  children
+export const CenteredPageLayout = React.memo<React.PropsWithChildren<{ isTabView?: boolean }>>(({
+  children,
+  isTabView
 }) => {
   return (
     <StyledWrapper>
-      <StyledContent>
+      <StyledContent isTabView={isTabView}>
         {children}
       </StyledContent>
     </StyledWrapper>

--- a/components/brave_wallet_ui/page/container.tsx
+++ b/components/brave_wallet_ui/page/container.tsx
@@ -139,15 +139,15 @@ export const Container = () => {
     if (
       walletLocation.includes(WalletRoutes.Accounts) ||
       walletLocation.includes(WalletRoutes.Backup) ||
-      walletLocation.includes(WalletRoutes.DepositFundsPage) ||
-      walletLocation.includes(WalletRoutes.FundWalletPage) ||
+      walletLocation.includes(WalletRoutes.DepositFundsPageStart) ||
+      walletLocation.includes(WalletRoutes.FundWalletPageStart) ||
       walletLocation.includes(WalletRoutes.Portfolio) ||
       walletLocation.includes(WalletRoutes.Market) ||
       walletLocation.includes(WalletRoutes.Nfts) ||
       walletLocation.includes(WalletRoutes.Swap) ||
       walletLocation.includes(WalletRoutes.Send) ||
       walletLocation.includes(WalletRoutes.LocalIpfsNode ||
-      walletLocation.includes(WalletRoutes.InspectNfts))
+        walletLocation.includes(WalletRoutes.InspectNfts))
     ) {
       setSessionRoute(walletLocation)
     }
@@ -209,13 +209,17 @@ export const Container = () => {
                 <OnboardingSuccess />
               </Route>
 
-              <Route path={WalletRoutes.FundWalletPage} exact>
-                <FundWalletScreen />
-              </Route>
+              {!isWalletLocked &&
+                <Route path={WalletRoutes.FundWalletPage} exact>
+                  <FundWalletScreen />
+                </Route>
+              }
 
-              <Route path={WalletRoutes.DepositFundsPage} exact>
-                <DepositFundsScreen />
-              </Route>
+              {!isWalletLocked &&
+                <Route path={WalletRoutes.DepositFundsPage} exact>
+                  <DepositFundsScreen />
+                </Route>
+              }
 
               <Route path={WalletRoutes.Restore} exact={true}>
                 <SimplePageWrapper>

--- a/components/brave_wallet_ui/page/screens/fund-wallet/deposit-funds.tsx
+++ b/components/brave_wallet_ui/page/screens/fund-wallet/deposit-funds.tsx
@@ -22,7 +22,6 @@ import {
   SupportedTestNetworks,
   UserAssetInfoType,
   WalletAccountType,
-  WalletRoutes,
   WalletState
 } from '../../../constants/types'
 
@@ -62,6 +61,8 @@ import { NavButton } from '../../../components/extension/buttons/nav-button/inde
 import CreateAccountTab from '../../../components/buy-send-swap/create-account/index'
 import SelectHeader from '../../../components/buy-send-swap/select-header/index'
 import { getBatTokensFromList } from '../../../utils/asset-utils'
+import { BuySendSwapDepositNav } from '../../../components/desktop/buy-send-swap-deposit-nav/buy-send-swap-deposit-nav'
+import { TabHeader } from '../shared-screen-components/tab-header/tab-header'
 
 export const DepositFundsScreen = () => {
   // routing
@@ -183,14 +184,6 @@ export const DepositFundsScreen = () => {
   const closeAccountSearch = React.useCallback(() => setShowAccountSearch(false), [])
   const onSearchTextChanged = React.useCallback((e: React.ChangeEvent<HTMLInputElement>) => setAccountSearchText(e.target.value), [])
 
-  const goToPortfolio = React.useCallback(() => {
-    if (tokenId !== undefined) {
-      history.goBack()
-      return
-    }
-    history.push(WalletRoutes.Portfolio)
-  }, [history, tokenId])
-
   const onSelectAccountFromSearch = React.useCallback((account: WalletAccountType) => () => {
     closeAccountSearch()
     setSelectedAccount(account)
@@ -311,8 +304,10 @@ export const DepositFundsScreen = () => {
 
   // render
   return (
-    <CenteredPageLayout>
-      <MainWrapper>
+    <CenteredPageLayout isTabView={true}>
+      <TabHeader title='braveWalletDepositCryptoButton' />
+      <BuySendSwapDepositNav isTab={true} />
+      <MainWrapper isTabView={true}>
         <StyledWrapper>
 
           {/* Hide nav when creating or searching accounts */}
@@ -321,10 +316,9 @@ export const DepositFundsScreen = () => {
           ) &&
             <StepsNavigation
               goBack={onBack}
-              onSkip={goToPortfolio}
-              skipButtonText={getLocale('braveWalletButtonDone')}
               steps={[]}
               currentStep=''
+              preventGoBack={!showDepositAddress}
             />
           }
 

--- a/components/brave_wallet_ui/page/screens/fund-wallet/fund-wallet.tsx
+++ b/components/brave_wallet_ui/page/screens/fund-wallet/fund-wallet.tsx
@@ -19,7 +19,6 @@ import {
   BraveWallet,
   UserAssetInfoType,
   WalletAccountType,
-  WalletRoutes,
   WalletState
 } from '../../../constants/types'
 import { RenderTokenFunc } from '../../../components/desktop/views/portfolio/components/token-lists/virtualized-tokens-list'
@@ -55,6 +54,8 @@ import CreateAccountTab from '../../../components/buy-send-swap/create-account'
 import SwapInputComponent from '../../../components/buy-send-swap/swap-input-component'
 import SelectHeader from '../../../components/buy-send-swap/select-header'
 import { SelectCurrency } from '../../../components/buy-send-swap/select-currency/select-currency'
+import { BuySendSwapDepositNav } from '../../../components/desktop/buy-send-swap-deposit-nav/buy-send-swap-deposit-nav'
+import { TabHeader } from '../shared-screen-components/tab-header/tab-header'
 
 export const FundWalletScreen = () => {
   // routing
@@ -99,8 +100,8 @@ export const FundWalletScreen = () => {
     const assets = selectedNetworkFilter.chainId === AllNetworksOption.chainId
       ? allBuyAssetOptions
       : allBuyAssetOptions.filter(({ chainId }) =>
-          selectedNetworkFilter.chainId === chainId
-        )
+        selectedNetworkFilter.chainId === chainId
+      )
 
     return assets.map(asset => ({ asset, assetBalance: '1' }))
   }, [selectedNetworkFilter.chainId, allBuyAssetOptions])
@@ -133,14 +134,6 @@ export const FundWalletScreen = () => {
   const openAccountSearch = React.useCallback(() => setShowAccountSearch(true), [])
   const closeAccountSearch = React.useCallback(() => setShowAccountSearch(false), [])
   const onSearchTextChanged = React.useCallback((e: React.ChangeEvent<HTMLInputElement>) => setAccountSearchText(e.target.value), [])
-
-  const goToPortfolio = React.useCallback(() => {
-    if (tokenId !== undefined) {
-      history.goBack()
-      return
-    }
-    history.push(WalletRoutes.Portfolio)
-  }, [history, tokenId])
 
   const onSelectAccountFromSearch = React.useCallback((account: WalletAccountType) => () => {
     closeAccountSearch()
@@ -265,8 +258,10 @@ export const FundWalletScreen = () => {
 
   // render
   return (
-    <CenteredPageLayout>
-      <MainWrapper>
+    <CenteredPageLayout isTabView={true}>
+      <TabHeader title='braveWalletBuy' />
+      <BuySendSwapDepositNav isTab={true} />
+      <MainWrapper isTabView={true}>
         <StyledWrapper>
 
           {/* Hide nav when creating or searching accounts */}
@@ -275,10 +270,9 @@ export const FundWalletScreen = () => {
           ) &&
             <StepsNavigation
               goBack={onBack}
-              onSkip={goToPortfolio}
-              skipButtonText={getLocale('braveWalletButtonDone')}
               steps={[]}
               currentStep=''
+              preventGoBack={!showBuyOptions}
             />
           }
 
@@ -426,7 +420,6 @@ export const FundWalletScreen = () => {
               }
             </>
           }
-
         </StyledWrapper>
       </MainWrapper>
     </CenteredPageLayout>

--- a/components/brave_wallet_ui/page/screens/onboarding/onboarding.style.ts
+++ b/components/brave_wallet_ui/page/screens/onboarding/onboarding.style.ts
@@ -28,7 +28,7 @@ export const NextButtonRow = styled.div`
   margin-bottom: 28px;
 `
 
-export const MainWrapper = styled.div`
+export const MainWrapper = styled.div<{ isTabView?: boolean }>`
   align-self: center;
   width: 100%;
   max-width: 456px;
@@ -38,8 +38,9 @@ export const MainWrapper = styled.div`
   justify-content: center;
   background-color: ${(p) => p.theme.color.background02};
   padding: 30px;
-  border-radius: 8px;
-  margin-top: 10vh;
+  border-radius: ${(p) => p.isTabView ? 24 : 8}px;
+  margin-top: ${(p) => p.isTabView ? '100px' : '10vh'};
+  box-shadow: ${(p) => p.isTabView ? '0px 4px 20px rgba(0, 0, 0, 0.1)' : 'none'};
 `
 
 export const StyledWrapper = styled.div`
@@ -123,7 +124,7 @@ export const PhraseCardBody = styled.div`
   border-radius: 4px;
 `
 
-export const PhraseCardBottomRow = styled(PhraseCardTopRow)<{
+export const PhraseCardBottomRow = styled(PhraseCardTopRow) <{
   centered?: boolean
 }>`
   justify-content: ${(p) => p.centered ? 'center' : 'flex-start'};

--- a/components/brave_wallet_ui/page/screens/send/send-page/send-screen.tsx
+++ b/components/brave_wallet_ui/page/screens/send/send-page/send-screen.tsx
@@ -15,7 +15,7 @@ import { useOnClickOutside } from '../../../../common/hooks/useOnClickOutside'
 import { SendScreenWrapper } from './send-screen.style'
 
 // Components
-import { SendHeader } from '../components/header/header'
+import { TabHeader } from '../../shared-screen-components/tab-header/tab-header'
 import { Send } from '../send/send'
 import { BuySendSwapDepositNav } from '../../../../components/desktop/buy-send-swap-deposit-nav/buy-send-swap-deposit-nav'
 import { FeatureRequestButton } from '../../../../components/shared/feature-request-button/feature-request-button'
@@ -38,7 +38,7 @@ export const SendScreen = () => {
   // render
   return (
     <SendScreenWrapper>
-      <SendHeader />
+      <TabHeader title='braveWalletSend' />
       <BuySendSwapDepositNav isTab={true} />
       <Send
         onShowSelectTokenModal={() => setShowSelectTokenModal(true)}

--- a/components/brave_wallet_ui/page/screens/shared-screen-components/tab-header/tab-header.style.ts
+++ b/components/brave_wallet_ui/page/screens/shared-screen-components/tab-header/tab-header.style.ts
@@ -1,16 +1,16 @@
-// Copyright (c) 2022 The Brave Authors. All rights reserved.
+// Copyright (c) 2023 The Brave Authors. All rights reserved.
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this file,
-// you can obtain one at https://mozilla.org/MPL/2.0/.
+// You can obtain one at https://mozilla.org/MPL/2.0/.
 
 import styled from 'styled-components'
 
 // Assets
-import BraveLogoLight from '../../assets/brave-logo-light.svg'
-import BraveLogoDark from '../../assets/brave-logo-dark.svg'
+import BraveLogoLight from '../../send/assets/brave-logo-light.svg'
+import BraveLogoDark from '../../send/assets/brave-logo-dark.svg'
 
 // Shared Styles
-import { StyledDiv } from '../../shared.styles'
+import { StyledDiv } from '../../send/shared.styles'
 
 export const HeaderWrapper = styled.div`
   display: flex;
@@ -20,7 +20,9 @@ export const HeaderWrapper = styled.div`
   padding: 16px 32px 0px 32px;
   margin-bottom: 45px;
   top: 0;
-  width: 100%;
+  left: 0;
+  right: 0;
+  width: 100vw;
   box-sizing: border-box;
   position: fixed;
   z-index: 10;

--- a/components/brave_wallet_ui/page/screens/shared-screen-components/tab-header/tab-header.tsx
+++ b/components/brave_wallet_ui/page/screens/shared-screen-components/tab-header/tab-header.tsx
@@ -1,21 +1,27 @@
-// Copyright (c) 2022 The Brave Authors. All rights reserved.
+// Copyright (c) 2023 The Brave Authors. All rights reserved.
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this file,
-// you can obtain one at https://mozilla.org/MPL/2.0/.
+// You can obtain one at https://mozilla.org/MPL/2.0/.
 
 import * as React from 'react'
 
 // Utils
-import { getLocale } from '../../../../../../common/locale'
+import { getLocale } from '../../../../../common/locale'
 
 // Styled Components
-import { HeaderWrapper, BraveLogo } from './header.style'
-import { HorizontalDivider, Row, Text } from '../../shared.styles'
+import { HeaderWrapper, BraveLogo } from './tab-header.style'
+import { HorizontalDivider, Row, Text } from '../../send/shared.styles'
 
 // Components
 // import { ToggleThemeButton } from './toggle-theme-button/toggle-theme-button'
 
-export const SendHeader = () => {
+interface Props {
+  title: string
+}
+
+export const TabHeader = (props: Props) => {
+  const { title } = props
+
   // render
   return (
     <HeaderWrapper>
@@ -23,7 +29,7 @@ export const SendHeader = () => {
         <BraveLogo />
         <HorizontalDivider height={22} marginRight={12} />
         <Text textSize='18px' textColor='text02' isBold={true}>
-          {getLocale('braveWalletSend')}
+          {getLocale(title)}
         </Text>
       </Row>
       {/* Disabling Theme Toggle until we can make it work correctly with brave-core */}
@@ -32,4 +38,4 @@ export const SendHeader = () => {
   )
 }
 
-export default SendHeader
+export default TabHeader

--- a/components/brave_wallet_ui/page/screens/shared-screen-components/tab-header/toggle-theme-button/toggle-theme-button.style.ts
+++ b/components/brave_wallet_ui/page/screens/shared-screen-components/tab-header/toggle-theme-button/toggle-theme-button.style.ts
@@ -1,16 +1,16 @@
-// Copyright (c) 2022 The Brave Authors. All rights reserved.
+// Copyright (c) 2023 The Brave Authors. All rights reserved.
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this file,
-// you can obtain one at https://mozilla.org/MPL/2.0/.
+// You can obtain one at https://mozilla.org/MPL/2.0/.
 
 import styled from 'styled-components'
 
 // Assets
-import DayIcon from '../../../assets/day-icon.svg'
-import NightIcon from '../../../assets/night-icon.svg'
+import DayIcon from '../../../send/assets/assets/day-icon.svg'
+import NightIcon from '../../../send/assets/assets/night-icon.svg'
 
 // Shared Styles
-import { StyledButton, StyledDiv } from '../../../shared.styles'
+import { StyledButton, StyledDiv } from '../../../send/shared.styles'
 
 export const Button = styled(StyledButton)`
   background-color: ${(p) => p.theme.color.background01};

--- a/components/brave_wallet_ui/page/screens/shared-screen-components/tab-header/toggle-theme-button/toggle-theme-button.tsx
+++ b/components/brave_wallet_ui/page/screens/shared-screen-components/tab-header/toggle-theme-button/toggle-theme-button.tsx
@@ -1,7 +1,7 @@
-// Copyright (c) 2022 The Brave Authors. All rights reserved.
+// Copyright (c) 2023 The Brave Authors. All rights reserved.
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this file,
-// you can obtain one at https://mozilla.org/MPL/2.0/.
+// You can obtain one at https://mozilla.org/MPL/2.0/.
 
 import * as React from 'react'
 


### PR DESCRIPTION
## Description 
Updates to the `Fund Wallet` and `Deposit Funds` screens to be similar to the `Send`/`Swap` screens:

- Added the new `Side Nav`
- Added the tab `Header`
- Updated the `border-radius` and added a `drop-shadow` 
- Removed the `Done` buttons
- Now only shows the `back` button if selecting a `Buy option`, `Account` or `Create account`.
- Makes the `Fund Wallet` and `Deposit Funds` screens a private route.

<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves <https://github.com/brave/brave-browser/issues/28490>
Resolves <https://github.com/brave/brave-browser/issues/28402>

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

### Testing Fund Wallet
1. Create a new wallet and skip the `Wallet Backup`
2. Click on the `Buy crypto` button
3. It should route to the `fund-wallet` page
4. There should be a header with the `BraveLogo | Buy`
5. There should be the new `Nav` on the left side of the screen
6. You should not see a `Done` button
7. You should only see a back button for `Selecting a Buy Option`, `Switching Accounts` or `Creating a new account`

Before:

<img width="1310" alt="19" src="https://user-images.githubusercontent.com/40611140/218597006-1891ec25-e6d6-451c-ab02-01e0aa21ea32.png">

After:

![17](https://user-images.githubusercontent.com/40611140/218597064-d85342ed-0bb9-4ab7-8cfa-ce7e4717e03f.png)

### Testing Deposit Funds
1. Create a new wallet and skip the `Wallet Backup`
2. Click on the `Deposit` button
3. It should route to the `deposit-funds` page
4. There should be a header with the `BraveLogo | Deposit`
5. There should be the new `Nav` on the left side of the screen
6. You should not see a `Done` button
7. You should only see a back button for `Deposit view (QR code screen)`, `Switching Accounts` or `Creating a new account`

Before:

![20](https://user-images.githubusercontent.com/40611140/218597107-616d5bba-227e-42dd-aeca-59be23ac6797.png)

After:

![18](https://user-images.githubusercontent.com/40611140/218597148-2fbd729c-66e1-4ab4-b559-295171fe37b2.png)
