### PR TITLE
Restore ActiveScriptWrappable Nodes post construction callback.

### DIFF
--- a/chromium_src/third_party/blink/renderer/bindings/core/v8/active_script_wrappable.h
+++ b/chromium_src/third_party/blink/renderer/bindings/core/v8/active_script_wrappable.h
@@ -30,10 +30,10 @@ template <typename T, typename>
 struct PostConstructionCallbackTrait;
 
 template <class, class = void>
-struct is_post_construction_callback : std::false_type {};
+struct HasActiveScriptWrappableBaseConstructed : std::false_type {};
 
 template <class T>
-struct is_post_construction_callback<
+struct HasActiveScriptWrappableBaseConstructed<
     T,
     std::void_t<
         decltype(std::declval<T>().ActiveScriptWrappableBaseConstructed())>>
@@ -43,7 +43,7 @@ struct is_post_construction_callback<
 template <typename T>
 struct PostConstructionCallbackTrait<
     T,
-    typename std::enable_if<is_post_construction_callback<T>::value &&
+    typename std::enable_if<HasActiveScriptWrappableBaseConstructed<T>::value &&
                                 !std::is_base_of<blink::Node, T>::value,
                             void>::type> {
   static void Call(T* object) {

--- a/chromium_src/third_party/blink/renderer/core/dom/node.h
+++ b/chromium_src/third_party/blink/renderer/core/dom/node.h
@@ -9,7 +9,7 @@
 #include <type_traits>
 
 #include "brave/components/brave_page_graph/common/buildflags.h"
-#include "third_party/blink/renderer/platform/bindings/active_script_wrappable_base.h"
+#include "third_party/blink/renderer/bindings/core/v8/active_script_wrappable.h"
 
 #define MarkAncestorsWithChildNeedsStyleInvalidation             \
   NotUsed();                                                     \
@@ -39,23 +39,22 @@ struct PostConstructionCallbackTrait<
     T,
     typename std::enable_if<
         std::is_base_of<blink::Node, T>::value &&
-            !std::is_base_of<blink::ActiveScriptWrappableBase, T>::value,
+            !HasActiveScriptWrappableBaseConstructed<T>::value,
         void>::type> {
   static void Call(blink::Node* object) { object->NodeConstructed(); }
 };
 
-// If Node is derived from ActiveScriptWrappableBase we need to call both
+// If Node is derived from ActiveScriptWrappable we need to call both
 // PostConstructionCallbacks.
 template <typename T>
 struct PostConstructionCallbackTrait<
     T,
     typename std::enable_if<
         std::is_base_of<blink::Node, T>::value &&
-            std::is_base_of<blink::ActiveScriptWrappableBase, T>::value,
+            HasActiveScriptWrappableBaseConstructed<T>::value,
         void>::type> {
   static void Call(T* object) {
-    PostConstructionCallbackTrait<blink::ActiveScriptWrappableBase>::Call(
-        object);
+    PostConstructionCallbackTrait_ChromiumImpl<T, void>::Call(object);
     PostConstructionCallbackTrait<blink::Node>::Call(object);
   }
 };


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
`blink::Node` derived from `blink::ActiveScriptWrappable` should be registered in v8 to not being cleaned-up during GC. [cr110 changed](https://chromium.googlesource.com/chromium/src/+/995f951511ca7df63b38d05b93a05d98bfde1584) `ActiveScriptWrappableBase` post construction callback which we modify to support Node tracking for PageGraph.

Instead of `PostConstructionCallbackTrait<blink::ActiveScriptWrappableBase>::Call()` we need to call `PostConstructionCallbackTrait<blink::ActiveScriptWrappable<T>>::Call()`, because `ActiveScriptWrappable<T>` now contains method to register the class in v8.

Resolves https://github.com/brave/brave-browser/issues/28428

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

