### PR TITLE
Add eth_getCode support for getting address bytecode

### DIFF
--- a/components/brave_wallet/browser/json_rpc_service.h
+++ b/components/brave_wallet/browser/json_rpc_service.h
@@ -112,6 +112,10 @@ class JsonRpcService : public KeyedService, public mojom::JsonRpcService {
                   mojom::CoinType coin,
                   const std::string& chaind_id,
                   GetBalanceCallback callback) override;
+  void GetCode(const std::string& address,
+               mojom::CoinType coin,
+               const std::string& chain_id,
+               GetCodeCallback callback) override;
   using GetFilBlockHeightCallback =
       base::OnceCallback<void(uint64_t height,
                               mojom::FilecoinProviderError error,
@@ -446,6 +450,7 @@ class JsonRpcService : public KeyedService, public mojom::JsonRpcService {
                        APIRequestResult api_request_result);
   void OnFilGetBalance(GetBalanceCallback callback,
                        APIRequestResult api_request_result);
+  void OnGetCode(GetCodeCallback callback, APIRequestResult api_request_result);
   void OnEthGetTransactionCount(GetTxCountCallback callback,
                                 APIRequestResult api_request_result);
   void OnFilGetTransactionCount(GetFilTxCountCallback callback,

--- a/components/brave_wallet/common/brave_wallet.mojom
+++ b/components/brave_wallet/common/brave_wallet.mojom
@@ -1030,6 +1030,9 @@ interface JsonRpcService {
   // Obtains the native balance (e.g. ETH for Ethereum) for the address
   GetBalance(string address, CoinType coin, string chain_id) => (string balance, ProviderError error, string error_message);
 
+  // Obtains the associated bytecode for the contract
+  GetCode(string address, CoinType coin, string chain_id) => (string bytecode, ProviderError error, string error_message);
+
   // Obtains the contract's ERC20 compatible balance for an address
   // Supported by all EVM chains.
   GetERC20TokenBalance(string contract,


### PR DESCRIPTION
Resolves https://github.com/brave/brave-browser/issues/28518

This is intended to be used to check if an address is an EOA or a contract

You can query
```js
const apiProxy = getWalletPanelApiProxy()
const jsonRpcService = apiProxy.jsonRpcService
console.log('BAT rpc service get code: ', await jsonRpcService.getCode('0x0d8775f648430679a709e98d2b0cb6250d2887ef', BraveWallet.CoinType.ETH, '0x1'))
console.log('EOA rpc service get code: ', await jsonRpcService.getCode('0x...', BraveWallet.CoinType.ETH, '0x1'))
```

This would output the bytecode in hex format for the BAT price and the string 0x for the EOA address.

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

