### PR TITLE
Fix LocalCredentialManagementMac::HasCredentials crash. (uplift to 1.49.x)

### DIFF
--- a/patches/chrome-browser-webauthn-local_credential_management_mac.cc.patch
+++ b/patches/chrome-browser-webauthn-local_credential_management_mac.cc.patch
@@ -1,0 +1,23 @@
+diff --git a/chrome/browser/webauthn/local_credential_management_mac.cc b/chrome/browser/webauthn/local_credential_management_mac.cc
+index fba2f18674bd16e044cebef25b96f0290eb23dad..d011f6cd476812979045417e5fe5ca4b60137a08 100644
+--- a/chrome/browser/webauthn/local_credential_management_mac.cc
++++ b/chrome/browser/webauthn/local_credential_management_mac.cc
+@@ -31,7 +31,7 @@ void LocalCredentialManagementMac::HasCredentials(
+   Enumerate(
+       base::BindOnce(
+           [](absl::optional<std::vector<device::DiscoverableCredentialMetadata>>
+-                 metadata) { return !metadata->empty(); })
++                 metadata) { return metadata ? !metadata->empty() : false; })
+           .Then(std::move(callback)));
+ }
+ 
+@@ -44,7 +44,8 @@ void LocalCredentialManagementMac::Enumerate(
+       credential_store.FindResidentCredentials(/*rp_id=*/absl::nullopt);
+ 
+   if (!credentials) {
+-    std::move(callback).Run(/*credentials=*/{});
++    // FindResidentCredentials() encountered an error.
++    std::move(callback).Run(absl::nullopt);
+     return;
+   }
+   std::vector<device::DiscoverableCredentialMetadata> credential_metadata;


### PR DESCRIPTION
Uplift of #17206
Resolves https://github.com/brave/brave-browser/issues/28512

Pre-approval checklist: 
- [ ] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.