### PR TITLE
Attempt to fix crash in cosmetic filters

### DIFF
--- a/build/rust/Cargo.lock
+++ b/build/rust/Cargo.lock
@@ -34,6 +34,7 @@ version = "0.1.0"
 dependencies = [
  "adblock",
  "libc",
+ "serde",
  "serde_json",
 ]
 

--- a/components/adblock_rust_ffi/Cargo.toml
+++ b/components/adblock_rust_ffi/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2018"
 
 [dependencies]
 adblock = { version = "0.7.3", default-features = false, features = ["full-regex-handling", "debug-info", "css-validation"] }
+serde = "1.0"
 serde_json = "1.0"
 libc = "0.2"
 

--- a/components/adblock_rust_ffi/src/lib.h
+++ b/components/adblock_rust_ffi/src/lib.h
@@ -229,12 +229,7 @@ char* engine_url_cosmetic_resources(struct C_Engine* engine, const char* url);
  * The leading '.' or '#' character should not be provided
  */
 char* engine_hidden_class_id_selectors(struct C_Engine* engine,
-                                       const char* const* classes,
-                                       size_t classes_size,
-                                       const char* const* ids,
-                                       size_t ids_size,
-                                       const char* const* exceptions,
-                                       size_t exceptions_size);
+                                       const char* json);
 
 #if BUILDFLAG(IS_IOS)
 char* convert_rules_to_content_blocking(const char* rules);

--- a/components/adblock_rust_ffi/src/wrapper.cc
+++ b/components/adblock_rust_ffi/src/wrapper.cc
@@ -164,31 +164,8 @@ const std::string Engine::urlCosmeticResources(const std::string& url) {
   return resources_json;
 }
 
-const std::string Engine::hiddenClassIdSelectors(
-    const std::vector<std::string>& classes,
-    const std::vector<std::string>& ids,
-    const std::vector<std::string>& exceptions) {
-  std::vector<const char*> classes_raw;
-  classes_raw.reserve(classes.size());
-  for (const auto& classe : classes) {
-    classes_raw.push_back(classe.c_str());
-  }
-
-  std::vector<const char*> ids_raw;
-  ids_raw.reserve(ids.size());
-  for (const auto& id : ids) {
-    ids_raw.push_back(id.c_str());
-  }
-
-  std::vector<const char*> exceptions_raw;
-  exceptions_raw.reserve(exceptions.size());
-  for (const auto& exception : exceptions) {
-    exceptions_raw.push_back(exception.c_str());
-  }
-
-  char* stylesheet_raw = engine_hidden_class_id_selectors(
-      raw, classes_raw.data(), classes.size(), ids_raw.data(), ids.size(),
-      exceptions_raw.data(), exceptions.size());
+const std::string Engine::hiddenClassIdSelectors(const std::string& json) {
+  char* stylesheet_raw = engine_hidden_class_id_selectors(raw, json.c_str());
   const std::string stylesheet = std::string(stylesheet_raw);
 
   c_char_buffer_destroy(stylesheet_raw);

--- a/components/adblock_rust_ffi/src/wrapper.h
+++ b/components/adblock_rust_ffi/src/wrapper.h
@@ -116,10 +116,7 @@ class ADBLOCK_EXPORT Engine {
   void removeTag(const std::string& tag);
   bool tagExists(const std::string& tag);
   const std::string urlCosmeticResources(const std::string& url);
-  const std::string hiddenClassIdSelectors(
-      const std::vector<std::string>& classes,
-      const std::vector<std::string>& ids,
-      const std::vector<std::string>& exceptions);
+  const std::string hiddenClassIdSelectors(const std::string& json);
   AdblockDebugInfo getAdblockDebugInfo();
   void discardRegex(uint64_t regex_id);
   void setupDiscardPolicy(const RegexManagerDiscardPolicy& policy);

--- a/ios/browser/api/brave_shields/adblock_engine.h
+++ b/ios/browser/api/brave_shields/adblock_engine.h
@@ -85,10 +85,8 @@ OBJC_EXPORT
 ///
 /// The leading '.' or '#' character should not be provided
 - (NSString*)
-    stylesheetForCosmeticRulesIncludingClasses:(NSArray<NSString*>*)classes
-                                           ids:(NSArray<NSString*>*)ids
-                                    exceptions:(NSArray<NSString*>*)exceptions
-    NS_SWIFT_NAME(stylesheetForCosmeticRulesIncluding(classes:ids:exceptions:));
+    stylesheetForCosmeticRulesFromJSON:(NSString*)json
+    NS_SWIFT_NAME(stylesheetForCosmeticRules(fromJSON:));
 
 /// Passes a callback to the adblock library, allowing it to be used for domain
 /// resolution.

--- a/ios/browser/api/brave_shields/adblock_engine.mm
+++ b/ios/browser/api/brave_shields/adblock_engine.mm
@@ -118,13 +118,9 @@
 }
 
 - (NSString*)
-    stylesheetForCosmeticRulesIncludingClasses:(NSArray<NSString*>*)classes
-                                           ids:(NSArray<NSString*>*)ids
-                                    exceptions:(NSArray<NSString*>*)exceptions {
-  return base::SysUTF8ToNSString(adblock_engine->hiddenClassIdSelectors(
-      brave::ns_to_vector<std::string>(classes),
-      brave::ns_to_vector<std::string>(ids),
-      brave::ns_to_vector<std::string>(exceptions)));
+    stylesheetForCosmeticRulesFromJSON:(NSString*)json {
+  return base::SysUTF8ToNSString(
+      adblock_engine->hiddenClassIdSelectors(base::SysNSStringToUTF8(json)));
 }
 
 + (bool)setDomainResolver:(DomainResolverCallback)domainResolver {


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Fixes a crash in cosmetic filters. This is not necessarily a fix but more of an example of one way to fix the issue. Here instead of passing arrays/hashes from iOS, I pass a json encoded string and decode the data using serde. Perhaps the issue has to do with how we pass the arrays (Vecotrs) from iOS to rust

## Submitter Checklist:

- [ ] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

