### PR TITLE
Add Blob URL support to the Playlist Downloader

### DIFF
--- a/components/playlist/browser/playlist_download_request_manager.cc
+++ b/components/playlist/browser/playlist_download_request_manager.cc
@@ -86,8 +86,9 @@ void PlaylistDownloadRequestManager::GetMediaFilesFromPage(Request request) {
 }
 
 void PlaylistDownloadRequestManager::FetchPendingRequest() {
-  if (pending_requests_.empty() || !ReadyToRunMediaDetectorScript())
+  if (pending_requests_.empty() || !ReadyToRunMediaDetectorScript()) {
     return;
+  }
 
   auto request = std::move(pending_requests_.front());
   pending_requests_.pop_front();
@@ -129,11 +130,13 @@ bool PlaylistDownloadRequestManager::ReadyToRunMediaDetectorScript() const {
 void PlaylistDownloadRequestManager::DidFinishLoad(
     content::RenderFrameHost* render_frame_host,
     const GURL& validated_url) {
-  if (render_frame_host != web_contents_->GetPrimaryMainFrame())
+  if (render_frame_host != web_contents_->GetPrimaryMainFrame()) {
     return;
+  }
 
-  if (in_progress_urls_count_ == 0 || callback_for_current_request_.is_null())
+  if (in_progress_urls_count_ == 0 || callback_for_current_request_.is_null()) {
     return;
+  }
 
   GetMedia(web_contents_.get());
 }
@@ -181,8 +184,9 @@ void PlaylistDownloadRequestManager::OnGetMedia(
 void PlaylistDownloadRequestManager::ProcessFoundMedia(
     base::WeakPtr<content::WebContents> contents,
     base::Value value) {
-  if (!contents)
+  if (!contents) {
     return;
+  }
 
   DCHECK(!callback_for_current_request_.is_null()) << " callback already ran";
   auto callback = std::move(callback_for_current_request_);
@@ -204,8 +208,9 @@ void PlaylistDownloadRequestManager::ProcessFoundMedia(
     ]
   */
 
-  if (in_progress_urls_count_ == 0)
+  if (in_progress_urls_count_ == 0) {
     ScheduleWebContentsDestroying();
+  }
   Observe(nullptr);
 
   if (value.is_dict() && value.GetDict().empty()) {
@@ -247,8 +252,10 @@ void PlaylistDownloadRequestManager::ProcessFoundMedia(
     item->id = base::Token::CreateRandom().ToString();
     item->page_source = GURL(*page_source);
     item->name = *name;
+
     // URL data
-    if (GURL media_url(*src); !media_url.SchemeIsHTTPOrHTTPS()) {
+    if (GURL media_url(*src);
+        !media_url.SchemeIsHTTPOrHTTPS() && !media_url.SchemeIsBlob()) {
       LOG(ERROR) << __func__ << "media scheme";
       continue;
     }
@@ -271,8 +278,9 @@ void PlaylistDownloadRequestManager::ProcessFoundMedia(
     }
     item->media_source = GURL(*src);
     item->media_path = GURL(*src);
-    if (author)
+    if (author) {
       item->author = *author;
+    }
 
     items.push_back(std::move(item));
   }

--- a/components/playlist/browser/playlist_media_file_downloader.h
+++ b/components/playlist/browser/playlist_media_file_downloader.h
@@ -106,7 +106,6 @@ class PlaylistMediaFileDownloader
 
   raw_ptr<Delegate> delegate_ = nullptr;
 
-  scoped_refptr<network::SharedURLLoaderFactory> url_loader_factory_;
   std::unique_ptr<download::InProgressDownloadManager> download_manager_;
   std::vector<std::unique_ptr<download::DownloadItemImpl>>
       download_items_to_be_detached_;
@@ -128,6 +127,7 @@ class PlaylistMediaFileDownloader
   bool in_progress_ = false;
 
   scoped_refptr<base::SequencedTaskRunner> task_runner_;
+  raw_ptr<content::BrowserContext> context_;
 
   base::WeakPtrFactory<PlaylistMediaFileDownloader> weak_factory_{this};
 };


### PR DESCRIPTION
Test site, with a Video which sets it's source to a `blob:` url:
https://wistful-insidious-cuckoo.glitch.me/

Not working test site, with a `MediaSource` `blob:` url
https://wistful-insidious-cuckoo.glitch.me/mediaSource.html