### PR TITLE
Fix crash due to empty pointer on rust adblock FFI (uplift to 1.48.x)

### DIFF
--- a/components/adblock_rust_ffi/src/lib.rs
+++ b/components/adblock_rust_ffi/src/lib.rs
@@ -3,6 +3,7 @@ use adblock::lists::FilterListMetadata;
 use adblock::resources::{MimeType, Resource, ResourceType};
 use core::ptr;
 use libc::size_t;
+use std::collections::HashSet;
 use std::ffi::CStr;
 use std::ffi::CString;
 use std::os::raw::c_char;
@@ -375,18 +376,35 @@ pub unsafe extern "C" fn engine_hidden_class_id_selectors(
     exceptions: *const *const c_char,
     exceptions_size: size_t,
 ) -> *mut c_char {
-    let classes = std::slice::from_raw_parts(classes, classes_size);
-    let classes: Vec<String> = (0..classes_size)
-        .map(|index| CStr::from_ptr(classes[index]).to_str().unwrap().to_owned())
-        .collect();
-    let ids = std::slice::from_raw_parts(ids, ids_size);
-    let ids: Vec<String> = (0..ids_size)
-        .map(|index| CStr::from_ptr(ids[index]).to_str().unwrap().to_owned())
-        .collect();
-    let exceptions = std::slice::from_raw_parts(exceptions, exceptions_size);
-    let exceptions: std::collections::HashSet<String> = (0..exceptions_size)
-        .map(|index| CStr::from_ptr(exceptions[index]).to_str().unwrap().to_owned())
-        .collect();
+    // Note checks for `size == 0` - `std::vector<T>::data()`'s return value when empty is
+    // undefined behavior and should never be used.
+    let classes = if classes_size == 0 {
+        Vec::new()
+    } else {
+        let classes = std::slice::from_raw_parts(classes, classes_size);
+        (0..classes_size)
+            .map(|index| CStr::from_ptr(classes[index]).to_str().unwrap().to_owned())
+            .collect()
+    };
+
+    let ids = if ids_size == 0 {
+        Vec::new()
+    } else {
+        let ids = std::slice::from_raw_parts(ids, ids_size);
+        (0..ids_size)
+            .map(|index| CStr::from_ptr(ids[index]).to_str().unwrap().to_owned())
+            .collect()
+    };
+    
+    let exceptions = if exceptions_size == 0 {
+        HashSet::new()
+    } else {
+        let exceptions = std::slice::from_raw_parts(exceptions, exceptions_size);
+        (0..exceptions_size)
+            .map(|index| CStr::from_ptr(exceptions[index]).to_str().unwrap().to_owned())
+            .collect()
+    };
+
     assert!(!engine.is_null());
     let engine = Box::leak(Box::from_raw(engine));
     let stylesheet = engine.hidden_class_id_selectors(&classes, &ids, &exceptions);


### PR DESCRIPTION
Uplift of #17243
Resolves https://github.com/brave/brave-browser/issues/28556

Pre-approval checklist: 
- [ ] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.