### PR TITLE
Copy url from omnibox instead of webcontent

### DIFF
--- a/browser/brave_app_controller_mac.mm
+++ b/browser/brave_app_controller_mac.mm
@@ -78,7 +78,7 @@
 - (void)executeCommand:(id)sender withProfile:(Profile*)profile {
   NSInteger tag = [sender tag];
   if (tag == IDC_COPY_CLEAN_LINK) {
-    chrome::ExecuteCommand([self getBrowser], IDC_COPY_CLEAN_LINK);
+    brave::CleanAndCopySelectedURL([self getBrowser]);
     return;
   }
 

--- a/browser/ui/brave_browser_window.cc
+++ b/browser/ui/brave_browser_window.cc
@@ -31,4 +31,6 @@ sidebar::Sidebar* BraveBrowserWindow::InitSidebar() {
 bool BraveBrowserWindow::HasSelectedURL() const {
   return false;
 }
+void BraveBrowserWindow::CleanAndCopySelectedURL() {}
+
 #endif

--- a/browser/ui/brave_browser_window.h
+++ b/browser/ui/brave_browser_window.h
@@ -48,6 +48,7 @@ class BraveBrowserWindow : public BrowserWindow {
 #if defined(TOOLKIT_VIEWS)
   virtual sidebar::Sidebar* InitSidebar();
   virtual bool HasSelectedURL() const;
+  virtual void CleanAndCopySelectedURL();
 #endif
 
   virtual void ShowBraveVPNBubble() {}

--- a/browser/ui/browser_commands.cc
+++ b/browser/ui/browser_commands.cc
@@ -285,4 +285,13 @@ bool HasSelectedURL(Browser* browser) {
   return brave_browser_window && brave_browser_window->HasSelectedURL();
 }
 
+void CleanAndCopySelectedURL(Browser* browser) {
+  if (!browser) {
+    return;
+  }
+  auto* brave_browser_window = BraveBrowserWindow::From(browser->window());
+  if (brave_browser_window) {
+    brave_browser_window->CleanAndCopySelectedURL();
+  }
+}
 }  // namespace brave

--- a/browser/ui/browser_commands.h
+++ b/browser/ui/browser_commands.h
@@ -11,6 +11,7 @@ class GURL;
 
 namespace brave {
 bool HasSelectedURL(Browser* browser);
+void CleanAndCopySelectedURL(Browser* browser);
 void NewOffTheRecordWindowTor(Browser*);
 void NewTorConnectionForSite(Browser*);
 void AddNewProfile();

--- a/browser/ui/views/frame/brave_browser_view.cc
+++ b/browser/ui/views/frame/brave_browser_view.cc
@@ -398,6 +398,18 @@ bool BraveBrowserView::HasSelectedURL() const {
   return brave_omnibox_view && brave_omnibox_view->SelectedTextIsURL();
 }
 
+void BraveBrowserView::CleanAndCopySelectedURL() {
+  if (!GetLocationBarView()) {
+    return;
+  }
+  auto* brave_omnibox_view =
+      static_cast<BraveOmniboxViewViews*>(GetLocationBarView()->omnibox_view());
+  if (!brave_omnibox_view) {
+    return;
+  }
+  brave_omnibox_view->CleanAndCopySelectedURL();
+}
+
 WalletButton* BraveBrowserView::GetWalletButton() {
   return static_cast<BraveToolbarView*>(toolbar())->wallet_button();
 }

--- a/browser/ui/views/frame/brave_browser_view.h
+++ b/browser/ui/views/frame/brave_browser_view.h
@@ -116,6 +116,7 @@ class BraveBrowserView : public BrowserView {
 
   sidebar::Sidebar* InitSidebar() override;
   bool HasSelectedURL() const override;
+  void CleanAndCopySelectedURL() override;
   void UpdateSideBarHorizontalAlignment();
 
   bool closing_confirm_dialog_activated_ = false;

--- a/browser/ui/views/omnibox/brave_omnibox_view_views.cc
+++ b/browser/ui/views/omnibox/brave_omnibox_view_views.cc
@@ -47,6 +47,14 @@ bool BraveOmniboxViewViews::SelectedTextIsURL() {
   return GetURLToCopy().has_value();
 }
 
+void BraveOmniboxViewViews::CleanAndCopySelectedURL() {
+  auto url_to_copy = GetURLToCopy();
+  if (!url_to_copy.has_value()) {
+    return;
+  }
+  CopySanitizedURL(url_to_copy.value());
+}
+
 void BraveOmniboxViewViews::CopySanitizedURL(const GURL& url) {
   OnBeforePossibleChange();
   brave::CopySanitizedURL(chrome::FindLastActive(), url);

--- a/browser/ui/views/omnibox/brave_omnibox_view_views.h
+++ b/browser/ui/views/omnibox/brave_omnibox_view_views.h
@@ -20,6 +20,7 @@ class BraveOmniboxViewViews : public OmniboxViewViews {
   ~BraveOmniboxViewViews() override;
 
   bool SelectedTextIsURL();
+  void CleanAndCopySelectedURL();
 
  protected:
   absl::optional<GURL> GetURLToCopy();


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/28542

Mac sometimes sends command via app controlller and there is an intersection with app menu overriding feature. Fixed it by copying url from omnibox instead of webcontent in this case.

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

- steps from issue