### PR TITLE
fix(wallet): Remove Local Storage When Hiding Network

### DIFF
--- a/components/brave_wallet_ui/common/async/handlers.ts
+++ b/components/brave_wallet_ui/common/async/handlers.ts
@@ -55,6 +55,7 @@ import {
   refreshBalances,
   refreshVisibleTokenInfo,
   refreshPrices,
+  refreshPortfolioFilterOptions,
   sendEthTransaction,
   sendFilTransaction,
   sendSolTransaction,
@@ -160,6 +161,7 @@ handler.on(WalletActions.refreshNetworksAndTokens.type, async (store: Store) => 
   await store.dispatch(refreshVisibleTokenInfo())
   await store.dispatch(refreshBalances())
   await store.dispatch(refreshPrices())
+  await store.dispatch(refreshPortfolioFilterOptions())
 })
 
 handler.on(WalletActions.initialize.type, async (store) => {
@@ -281,6 +283,7 @@ handler.on(WalletActions.initialized.type, async (store: Store, payload: WalletI
     await store.dispatch(refreshNetworkInfo())
     await store.dispatch(refreshVisibleTokenInfo())
     await store.dispatch(refreshBalances())
+    await store.dispatch(refreshPortfolioFilterOptions())
     await store.dispatch(refreshPrices())
     await store.dispatch(refreshTokenPriceHistory(state.selectedPortfolioTimeline))
     await braveWalletService.discoverAssetsOnAllSupportedChains()

--- a/components/brave_wallet_ui/common/async/lib.ts
+++ b/components/brave_wallet_ui/common/async/lib.ts
@@ -41,12 +41,13 @@ import { getHardwareKeyring } from '../api/hardware_keyrings'
 import { GetAccountsHardwareOperationResult, SolDerivationPaths } from '../hardware/types'
 import EthereumLedgerBridgeKeyring from '../hardware/ledgerjs/eth_ledger_bridge_keyring'
 import TrezorBridgeKeyring from '../hardware/trezor/trezor_bridge_keyring'
-import { AllNetworksOption } from '../../options/network-filter-options'
+import { AllNetworksOption, AllNetworksOptionDefault } from '../../options/network-filter-options'
 import { AllAccountsOption } from '../../options/account-filter-options'
 import SolanaLedgerBridgeKeyring from '../hardware/ledgerjs/sol_ledger_bridge_keyring'
 import FilecoinLedgerBridgeKeyring from '../hardware/ledgerjs/fil_ledger_bridge_keyring'
 import { deserializeOrigin, makeSerializableTransaction } from '../../utils/model-serialization-utils'
 import { WalletPageActions } from '../../page/actions'
+import { LOCAL_STORAGE_KEYS } from '../../common/constants/local-storage-keys'
 
 export const getERC20Allowance = (
   contractAddress: string,
@@ -1107,4 +1108,27 @@ export async function getNFTMetadata (token: BraveWallet.BlockchainToken) {
 export async function isTokenPinningSupported (token: BraveWallet.BlockchainToken) {
   const { braveWalletPinService } = getAPIProxy()
   return await braveWalletPinService.isTokenSupported(token)
+}
+
+
+export function refreshPortfolioFilterOptions () {
+  return async (dispatch: Dispatch, getState: () => State) => {
+    const { wallet: { accounts, networkList, selectedAccountFilter, selectedNetworkFilter } } = getState()
+
+    if (
+      !networkList.some(network => network.chainId === selectedNetworkFilter.chainId) &&
+      selectedNetworkFilter.chainId !== AllNetworksOption.chainId
+    ) {
+      dispatch(WalletActions.setSelectedNetworkFilter(AllNetworksOptionDefault))
+      window.localStorage.removeItem(LOCAL_STORAGE_KEYS.PORTFOLIO_NETWORK_FILTER_OPTION)
+    }
+
+    if (
+      !accounts.some(account => account.id === selectedAccountFilter) &&
+      selectedAccountFilter !== AllAccountsOption.id
+    ) {
+      dispatch(WalletActions.setSelectedAccountFilterItem(AllAccountsOption.id))
+      window.localStorage.removeItem(LOCAL_STORAGE_KEYS.PORTFOLIO_ACCOUNT_FILTER_OPTION)
+    }
+  }
 }


### PR DESCRIPTION
## Description 
Will now reset the users `Network Filter` and `Account Filter` local storage pref if they hide that network in settings.

<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves <https://github.com/brave/brave-browser/issues/28570>

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
1. Go to the `Portfolio` page and select a `Network` to filter by.
2. Go to brave://settings/wallet/networks and hide that network
3. Go back to the `Portfolio` page, your selected `Network` filter should reset back to `All networks`

Before:

https://user-images.githubusercontent.com/40611140/219524573-953c53b3-daf0-4c14-8ed7-279c4a3a447f.mov

After:

https://user-images.githubusercontent.com/40611140/219524605-be7e201e-8d0b-4ed2-97f6-e3574990c072.mov
