### PR TITLE
Optimize feature overrides on startup.

### DIFF
--- a/base/feature_override_unittest.cc
+++ b/base/feature_override_unittest.cc
@@ -1,7 +1,7 @@
 /* Copyright (c) 2021 The Brave Authors. All rights reserved.
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
- * You can obtain one at http://mozilla.org/MPL/2.0/. */
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 #include "base/feature_override.h"
 #include "base/feature_list.h"
@@ -15,29 +15,27 @@ using testing::_;
 namespace base {
 namespace {
 
-const Feature kTestControlEnabledFeature{"TestControlEnabledFeature",
-                                         FEATURE_ENABLED_BY_DEFAULT};
-const Feature kTestControlDisabledFeature{"TestControlDisabledFeature",
-                                          FEATURE_DISABLED_BY_DEFAULT};
+BASE_FEATURE(kTestControlEnabledFeature,
+             "TestControlEnabledFeature",
+             FEATURE_ENABLED_BY_DEFAULT);
+BASE_FEATURE(kTestControlDisabledFeature,
+             "TestControlDisabledFeature",
+             FEATURE_DISABLED_BY_DEFAULT);
 
-const Feature kTestEnabledButOverridenFeature{"TestEnabledButOverridenFeature",
-                                              FEATURE_ENABLED_BY_DEFAULT};
-const Feature kTestDisabledButOverridenFeature{
-    "TestDisabledButOverridenFeature", FEATURE_DISABLED_BY_DEFAULT};
+BASE_FEATURE(kTestEnabledButOverridenFeature,
+             "TestEnabledButOverridenFeature",
+             FEATURE_ENABLED_BY_DEFAULT);
+BASE_FEATURE(kTestDisabledButOverridenFeature,
+             "TestDisabledButOverridenFeature",
+             FEATURE_DISABLED_BY_DEFAULT);
 
-constexpr Feature kTestConstexprEnabledButOverridenFeature{
-    "TestConstexprEnabledButOverridenFeature", FEATURE_ENABLED_BY_DEFAULT};
-constexpr Feature kTestConstexprDisabledButOverridenFeature{
-    "TestConstexprDisabledButOverridenFeature", FEATURE_DISABLED_BY_DEFAULT};
-
-const Feature kTestEnabledButOverridenFeatureWithSameState{
-    "TestEnabledButOverridenFeatureWithSameState", FEATURE_ENABLED_BY_DEFAULT};
+BASE_FEATURE(kTestEnabledButOverridenFeatureWithSameState,
+             "TestEnabledButOverridenFeatureWithSameState",
+             FEATURE_ENABLED_BY_DEFAULT);
 
 OVERRIDE_FEATURE_DEFAULT_STATES({{
     {kTestEnabledButOverridenFeature, FEATURE_DISABLED_BY_DEFAULT},
     {kTestDisabledButOverridenFeature, FEATURE_ENABLED_BY_DEFAULT},
-    {kTestConstexprEnabledButOverridenFeature, FEATURE_DISABLED_BY_DEFAULT},
-    {kTestConstexprDisabledButOverridenFeature, FEATURE_ENABLED_BY_DEFAULT},
 
     // Override, but keep the same state as `default_state`. We should properly
     // return false from IsFeatureOverridden in this case.
@@ -52,7 +50,7 @@ TEST(FeatureOverrideTest, OverridesTest) {
     const bool is_enabled;
     const bool is_overridden;
   };
-  const TestCase kTestCases[] = {
+  constexpr TestCase kTestCases[] = {
       // Untouched features.
       {kTestControlEnabledFeature, true, false},
       {kTestControlDisabledFeature, false, false},
@@ -60,10 +58,6 @@ TEST(FeatureOverrideTest, OverridesTest) {
       // Overridden features.
       {kTestEnabledButOverridenFeature, false, true},
       {kTestDisabledButOverridenFeature, true, true},
-
-      // Overridden constexpr features.
-      {kTestConstexprEnabledButOverridenFeature, false, true},
-      {kTestConstexprDisabledButOverridenFeature, true, true},
 
       // Overridden but with the same state.
       {kTestEnabledButOverridenFeatureWithSameState, true, false},
@@ -79,6 +73,10 @@ TEST(FeatureOverrideTest, OverridesTest) {
 
 #if DCHECK_IS_ON()
 TEST(FeatureOverrideTest, FeatureDuplicateDChecks) {
+  // Check any feature to make sure overridden features are finalized (moved
+  // from an unsorted vector to a sorted flat_map).
+  ASSERT_FALSE(base::FeatureList::IsEnabled(kTestEnabledButOverridenFeature));
+
   base::MockCallback<logging::LogAssertHandlerFunction> mock_log_handler;
   logging::ScopedLogAssertHandler scoped_log_handler(mock_log_handler.Get());
   EXPECT_CALL(
@@ -94,6 +92,12 @@ TEST(FeatureOverrideTest, FeatureDuplicateDChecks) {
           _))
       .Times(2);
 
+  // This will add a feature to an unsorted vector of overrides.
+  internal::FeatureDefaultStateOverrider init_overrides{{
+      {kTestEnabledButOverridenFeature, FEATURE_DISABLED_BY_DEFAULT},
+  }};
+
+  // This should trigger DCHECKs.
   internal::FeatureDefaultStateOverrider test_overrider{{
       {kTestEnabledButOverridenFeature, FEATURE_DISABLED_BY_DEFAULT},
       {kTestEnabledButOverridenFeature, FEATURE_DISABLED_BY_DEFAULT},


### PR DESCRIPTION
We insert new features into `base::flat_map` on each `OVERRIDE_FEATURE_DEFAULT_STATES` instantiation, which triggers `base::flat_map::sort()`. We currently do 45 insertions, overall feature overrides count is 125, so we do unnecessary 45 sorts of 1...125 items on startup.

We can avoid this by filling `std::vector` first and then moving everything into a `base::flat_map` in a single call which will do a single `sort()`.

Resolves https://github.com/brave/brave-browser/issues/28587

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

