### PR TITLE
Pass "production" as vpn payment env value in prod env (uplift to 1.49.x)

### DIFF
--- a/components/brave_vpn/common/BUILD.gn
+++ b/components/brave_vpn/common/BUILD.gn
@@ -38,6 +38,7 @@ source_set("unit_tests") {
   deps = [
     ":common",
     "//base",
+    "//brave/components/skus/browser",
     "//components/prefs",
     "//components/prefs:test_support",
     "//components/sync_preferences:test_support",

--- a/components/brave_vpn/common/brave_vpn_utils.cc
+++ b/components/brave_vpn/common/brave_vpn_utils.cc
@@ -122,19 +122,8 @@ std::string GetManageUrl(const std::string& env) {
 // When the vendor receives a credential from us during auth, it also includes
 // the environment. The vendor then can do a lookup using Payment Service.
 std::string GetBraveVPNPaymentsEnv(const std::string& env) {
-  if (env == skus::kEnvProduction)
-    return "";
-  // Use same value.
-  if (env == skus::kEnvStaging || env == skus::kEnvDevelopment)
-    return env;
-
-  NOTREACHED();
-
-#if defined(OFFICIAL_BUILD)
-  return "";
-#else
-  return "development";
-#endif
+  // Use same string as payment env.
+  return env;
 }
 
 void RegisterProfilePrefs(user_prefs::PrefRegistrySyncable* registry) {

--- a/components/brave_vpn/common/brave_vpn_utils_unittest.cc
+++ b/components/brave_vpn/common/brave_vpn_utils_unittest.cc
@@ -10,6 +10,7 @@
 #include "brave/components/brave_vpn/common/pref_names.h"
 #include "components/prefs/pref_service.h"
 #include "components/prefs/testing_pref_service.h"
+#include "components/skus/browser/skus_utils.h"
 #include "components/sync_preferences/testing_pref_service_syncable.h"
 #include "testing/gmock/include/gmock/gmock.h"
 #include "testing/gtest/include/gtest/gtest.h"
@@ -186,4 +187,10 @@ TEST(BraveVPNUtilsUnitTest, AlreadyMigrated) {
       *p3a_settings);
   EXPECT_TRUE(local_state_pref_service.HasPrefPath(
       brave_vpn::prefs::kBraveVPNLocalStateMigrated));
+}
+
+TEST(BraveVPNUtilsUnitTest, VPNPaymentsEnv) {
+  EXPECT_EQ("production", GetBraveVPNPaymentsEnv(skus::kEnvProduction));
+  EXPECT_EQ("staging", GetBraveVPNPaymentsEnv(skus::kEnvStaging));
+  EXPECT_EQ("development", GetBraveVPNPaymentsEnv(skus::kEnvDevelopment));
 }


### PR DESCRIPTION
Uplift of #17244
fix https://github.com/brave/brave-browser/issues/28554

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.