### PR TITLE
[CodeHealth] Remove deprecated uses of base::Value

### DIFF
--- a/browser/brave_vpn/dns/brave_vpn_dns_observer_service_win_unittest.cc
+++ b/browser/brave_vpn/dns/brave_vpn_dns_observer_service_win_unittest.cc
@@ -139,8 +139,7 @@ class BraveVpnDnsObserverServiceUnitTest : public testing::Test {
   }
 
   void SetManagedMode(const std::string& value) {
-    local_state_.SetManagedPref(::prefs::kDnsOverHttpsMode,
-                                std::make_unique<base::Value>(value));
+    local_state_.SetManagedPref(::prefs::kDnsOverHttpsMode, base::Value(value));
   }
 
  private:

--- a/browser/brave_wallet/brave_wallet_service_unittest.cc
+++ b/browser/brave_wallet/brave_wallet_service_unittest.cc
@@ -1225,7 +1225,7 @@ TEST_F(BraveWalletServiceUnitTest, NetworkListChangedEvent) {
     ScopedDictPrefUpdate update(GetPrefs(), kBraveWalletCustomNetworks);
     base::Value::List* list = update->FindList(kEthereumPrefKey);
     list->EraseIf([&](const base::Value& v) {
-      auto* chain_id_value = v.FindStringKey("chainId");
+      auto* chain_id_value = v.GetDict().FindString("chainId");
       if (!chain_id_value)
         return false;
       return *chain_id_value == "0x5566";

--- a/browser/brave_wallet/keyring_service_unittest.cc
+++ b/browser/brave_wallet/keyring_service_unittest.cc
@@ -1829,15 +1829,13 @@ TEST_F(KeyringServiceUnitTest, ImportedAccounts) {
       KeyringService::GetPrefForKeyring(*GetPrefs(), kImportedAccounts,
                                         mojom::kDefaultKeyringId);
   ASSERT_TRUE(imported_accounts_value);
-  EXPECT_EQ(imported_accounts_value->GetList()[0]
-                .FindKey(kAccountAddress)
-                ->GetString(),
+  EXPECT_EQ(*imported_accounts_value->GetList()[0].GetDict().FindString(
+                kAccountAddress),
             imported_accounts[0].address);
   // private key is encrypted
   const std::string encrypted_private_key =
-      imported_accounts_value->GetList()[0]
-          .FindKey(kEncryptedPrivateKey)
-          ->GetString();
+      *imported_accounts_value->GetList()[0].GetDict().FindString(
+          kEncryptedPrivateKey);
   EXPECT_FALSE(encrypted_private_key.empty());
 
   std::vector<uint8_t> private_key0;
@@ -1905,9 +1903,8 @@ TEST_F(KeyringServiceUnitTest, ImportedAccountFromJson) {
                                         mojom::kDefaultKeyringId);
   ASSERT_TRUE(imported_accounts_value);
   const std::string encrypted_private_key =
-      imported_accounts_value->GetList()[0]
-          .FindKey(kEncryptedPrivateKey)
-          ->GetString();
+      *imported_accounts_value->GetList()[0].GetDict().FindString(
+          kEncryptedPrivateKey);
   EXPECT_FALSE(encrypted_private_key.empty());
 
   std::vector<uint8_t> private_key_bytes;
@@ -3906,7 +3903,8 @@ class KeyringServiceAccountDiscoveryUnitTest : public KeyringServiceUnitTest {
                                          .AsStringPiece());
     absl::optional<base::Value> request_value =
         base::JSONReader::Read(request_string);
-    if (*request_value->FindStringKey("method") == "eth_getTransactionCount") {
+    if (*request_value->GetDict().FindString("method") ==
+        "eth_getTransactionCount") {
       base::Value* params = request_value->FindListKey("params");
       EXPECT_TRUE(params);
       std::string* address = params->GetList()[0].GetIfString();

--- a/browser/ntp_background/ntp_background_prefs.cc
+++ b/browser/ntp_background/ntp_background_prefs.cc
@@ -62,8 +62,7 @@ void NTPBackgroundPrefs::RegisterPref(
   dict.Set(kSelectedValueKey, "");
   registry->RegisterDictionaryPref(kPrefName, base::Value(std::move(dict)));
 
-  registry->RegisterListPref(kCustomImageListPrefName,
-                             base::Value(base::Value::Type::LIST));
+  registry->RegisterListPref(kCustomImageListPrefName);
 }
 
 void NTPBackgroundPrefs::MigrateOldPref() {

--- a/browser/search_engines/search_engine_provider_service_factory.cc
+++ b/browser/search_engines/search_engine_provider_service_factory.cc
@@ -108,7 +108,6 @@ void SearchEngineProviderServiceFactory::RegisterProfilePrefs(
 #endif
 
   registry->RegisterDictionaryPref(
-      prefs::kSyncedDefaultPrivateSearchProviderData,
-      base::Value(base::Value::Type::DICT),
+      prefs::kSyncedDefaultPrivateSearchProviderData, base::Value::Dict(),
       user_prefs::PrefRegistrySyncable::SYNCABLE_PREF);
 }

--- a/browser/ui/toolbar/brave_bookmark_context_menu_controller_unittest.cc
+++ b/browser/ui/toolbar/brave_bookmark_context_menu_controller_unittest.cc
@@ -76,14 +76,14 @@ TEST_F(BraveBookmarkContextMenuControllerTest,
 
   // Disabling the shorcut by policy doesn't cause the command to be added.
   prefs->SetManagedPref(bookmarks::prefs::kShowAppsShortcutInBookmarkBar,
-                        std::make_unique<base::Value>(false));
+                        base::Value(false));
   EXPECT_FALSE(controller.menu_model()
                    ->GetIndexOfCommandId(IDC_BOOKMARK_BAR_SHOW_APPS_SHORTCUT)
                    .has_value());
 
   // And enabling the shortcut by policy doesn't cause the command to be added.
   prefs->SetManagedPref(bookmarks::prefs::kShowAppsShortcutInBookmarkBar,
-                        std::make_unique<base::Value>(true));
+                        base::Value(true));
   EXPECT_FALSE(controller.menu_model()
                    ->GetIndexOfCommandId(IDC_BOOKMARK_BAR_SHOW_APPS_SHORTCUT)
                    .has_value());
@@ -91,7 +91,7 @@ TEST_F(BraveBookmarkContextMenuControllerTest,
   // And enabling the shortcut by user doesn't cause the command to be added.
   prefs->RemoveManagedPref(bookmarks::prefs::kShowAppsShortcutInBookmarkBar);
   prefs->SetUserPref(bookmarks::prefs::kShowAppsShortcutInBookmarkBar,
-                     std::make_unique<base::Value>(true));
+                     base::Value(true));
   EXPECT_FALSE(controller.menu_model()
                    ->GetIndexOfCommandId(IDC_BOOKMARK_BAR_SHOW_APPS_SHORTCUT)
                    .has_value());

--- a/browser/ui/webui/ipfs_dom_handler_unittest.cc
+++ b/browser/ui/webui/ipfs_dom_handler_unittest.cc
@@ -47,9 +47,9 @@ TEST(TestIPFSDomHandler, AddComponentVersion) {
   handler.OnGetNodeInfo(true, info);
   const auto& data = *handler.web_ui()->call_data()[0];
   ASSERT_TRUE(data.arg1()->is_dict());
-  EXPECT_EQ(*data.arg1()->FindStringKey("id"), info.id);
-  EXPECT_EQ(*data.arg1()->FindStringKey("version"), info.version);
-  EXPECT_EQ(*data.arg1()->FindStringKey("component_version"), component);
+  EXPECT_EQ(*data.arg1()->GetDict().FindString("id"), info.id);
+  EXPECT_EQ(*data.arg1()->GetDict().FindString("version"), info.version);
+  EXPECT_EQ(*data.arg1()->GetDict().FindString("component_version"), component);
 }
 
 TEST(TestIPFSDomHandler, ComponentNotRegistered) {
@@ -60,7 +60,7 @@ TEST(TestIPFSDomHandler, ComponentNotRegistered) {
   handler.OnGetNodeInfo(true, info);
   const auto& data = *handler.web_ui()->call_data()[0];
   ASSERT_TRUE(data.arg1()->is_dict());
-  EXPECT_EQ(*data.arg1()->FindStringKey("id"), info.id);
-  EXPECT_EQ(*data.arg1()->FindStringKey("version"), info.version);
-  ASSERT_FALSE(data.arg1()->FindStringKey("component_version"));
+  EXPECT_EQ(*data.arg1()->GetDict().FindString("id"), info.id);
+  EXPECT_EQ(*data.arg1()->GetDict().FindString("version"), info.version);
+  ASSERT_FALSE(data.arg1()->GetDict().FindString("component_version"));
 }

--- a/browser/ui/webui/new_tab_page/brave_new_tab_message_handler.cc
+++ b/browser/ui/webui/new_tab_page/brave_new_tab_message_handler.cc
@@ -462,12 +462,13 @@ void BraveNewTabMessageHandler::HandleBrandedWallpaperLogoClicked(
   }
 
   if (auto* service = ViewCounterServiceFactory::GetForProfile(profile_)) {
+    const auto& arg = args[0].GetDict();
     auto* creative_instance_id =
-        args[0].FindStringKey(ntp_background_images::kCreativeInstanceIDKey);
-    auto* destination_url =
-        args[0].FindStringPath(ntp_background_images::kLogoDestinationURLPath);
+        arg.FindString(ntp_background_images::kCreativeInstanceIDKey);
+    auto* destination_url = arg.FindStringByDottedPath(
+        ntp_background_images::kLogoDestinationURLPath);
     auto* wallpaper_id =
-        args[0].FindStringPath(ntp_background_images::kWallpaperIDKey);
+        arg.FindStringByDottedPath(ntp_background_images::kWallpaperIDKey);
 
     DCHECK(creative_instance_id);
     DCHECK(destination_url);

--- a/build/ios/mojom/public/base/base_values+private.h
+++ b/build/ios/mojom/public/base/base_values+private.h
@@ -19,7 +19,7 @@ namespace brave {
 NSArray<MojoBaseValue*>* NSArrayFromBaseValue(const base::Value);
 
 // Clone the contents of a `base::Value` whos type is
-// `base::Value::Type::DICTIONARY`.  Any types found within the `base::Value`
+// `base::Value::Type::DICT`.  Any types found within the `base::Value`
 // that are unsupported or `NONE` will become `NSNull`
 NSDictionary<NSString*, MojoBaseValue*>* NSDictionaryFromBaseValue(
     const base::Value);
@@ -29,7 +29,7 @@ NSDictionary<NSString*, MojoBaseValue*>* NSDictionaryFromBaseValue(
 base::Value BaseValueFromNSArray(NSArray<MojoBaseValue*>*);
 
 // Clone the contents of an NSDictionary into a `base::Value` with the type
-// `base::Value::Type::DICTIONARY`
+// `base::Value::Type::DICT`
 base::Value BaseValueFromNSDictionary(NSDictionary<NSString*, MojoBaseValue*>*);
 
 NSDictionary<NSString*, MojoBaseValue*>* NSDictionaryFromBaseValueDict(

--- a/build/ios/mojom/public/base/base_values.mm
+++ b/build/ios/mojom/public/base/base_values.mm
@@ -213,7 +213,7 @@
           return a;
         }();
         break;
-      case base::Value::Type::DICTIONARY:
+      case base::Value::Type::DICT:
         self.dictionaryValue = brave::NSDictionaryFromBaseValue(value.Clone());
         break;
       case base::Value::Type::LIST:
@@ -334,12 +334,13 @@ base::Value BaseValueFromNSArray(NSArray<MojoBaseValue*>* array) {
 
 base::Value BaseValueFromNSDictionary(
     NSDictionary<NSString*, MojoBaseValue*>* dictionary) {
-  base::Value dict(base::Value::Type::DICTIONARY);
+  base::Value result(base::Value::Type::DICT);
+  base::Value::Dict& dict = result.GetDict();
   for (NSString* key in dictionary) {
     MojoBaseValue* value = dictionary[key];
-    dict.SetKey(base::SysNSStringToUTF8(key), value.cppObjPtr);
+    dict.Set(base::SysNSStringToUTF8(key), value.cppObjPtr);
   }
-  return dict;
+  return result;
 }
 
 NSDictionary<NSString*, MojoBaseValue*>* NSDictionaryFromBaseValueDict(

--- a/chromium_src/components/privacy_sandbox/privacy_sandbox_settings_unittest.cc
+++ b/chromium_src/components/privacy_sandbox/privacy_sandbox_settings_unittest.cc
@@ -522,8 +522,7 @@ class PrivacySandboxSettingsTestCookiesClearOnExitTurnedOff
  public:
   void InitializePrefsBeforeStart() override {
     prefs()->SetUserPref(prefs::kPrivacySandboxTopicsDataAccessibleSince,
-                         std::make_unique<base::Value>(::base::TimeToValue(
-                             base::Time::FromTimeT(12345))));
+                         base::TimeToValue(base::Time::FromTimeT(12345)));
   }
 };
 
@@ -542,8 +541,7 @@ class PrivacySandboxSettingsTestCookiesClearOnExitTurnedOn
         ContentSetting::CONTENT_SETTING_SESSION_ONLY);
 
     prefs()->SetUserPref(prefs::kPrivacySandboxTopicsDataAccessibleSince,
-                         std::make_unique<base::Value>(::base::TimeToValue(
-                             base::Time::FromTimeT(12345))));
+                         base::TimeToValue(base::Time::FromTimeT(12345)));
   }
 };
 

--- a/components/brave_shields/browser/brave_shields_util_unittest.cc
+++ b/components/brave_shields/browser/brave_shields_util_unittest.cc
@@ -183,18 +183,16 @@ TEST_F(BraveShieldsUtilTest, SetBraveShieldsEnabled_ForOrigin) {
   EXPECT_EQ(CONTENT_SETTING_ALLOW, setting);
 
   // Set policy to disable shields for specific domain.
-  auto disabled_list = base::Value(base::Value::Type::LIST);
+  base::Value::List disabled_list;
   disabled_list.Append("[*.]host2.com");
   disabled_list.Append("*.*");
   profile()->GetTestingPrefService()->SetManagedPref(
-      kManagedBraveShieldsDisabledForUrls,
-      base::Value::ToUniquePtrValue(std::move(disabled_list)));
+      kManagedBraveShieldsDisabledForUrls, std::move(disabled_list));
 
-  auto enabled_list = base::Value(base::Value::Type::LIST);
+  base::Value::List enabled_list;
   enabled_list.Append("[*.]host1.com");
   profile()->GetTestingPrefService()->SetManagedPref(
-      kManagedBraveShieldsEnabledForUrls,
-      base::Value::ToUniquePtrValue(std::move(enabled_list)));
+      kManagedBraveShieldsEnabledForUrls, std::move(enabled_list));
 
   // setting should apply block to origin.
   setting =
@@ -222,11 +220,10 @@ TEST_F(BraveShieldsUtilTest, IsBraveShieldsManaged) {
   EXPECT_FALSE(brave_shields::IsBraveShieldsManaged(
       profile()->GetTestingPrefService(), map, host2));
 
-  auto disabled_list = base::Value(base::Value::Type::LIST);
+  base::Value::List disabled_list;
   disabled_list.Append("[*.]host2.com");
   profile()->GetTestingPrefService()->SetManagedPref(
-      kManagedBraveShieldsDisabledForUrls,
-      base::Value::ToUniquePtrValue(std::move(disabled_list)));
+      kManagedBraveShieldsDisabledForUrls, std::move(disabled_list));
   // only disabled pref set
   EXPECT_TRUE(brave_shields::IsBraveShieldsManaged(
       profile()->GetTestingPrefService(), map, host2));
@@ -234,11 +231,10 @@ TEST_F(BraveShieldsUtilTest, IsBraveShieldsManaged) {
   EXPECT_FALSE(brave_shields::IsBraveShieldsManaged(
       profile()->GetTestingPrefService(), map, GURL("http://host1.com")));
 
-  auto enabled_list = base::Value(base::Value::Type::LIST);
+  base::Value::List enabled_list;
   enabled_list.Append("[*.]host1.com");
   profile()->GetTestingPrefService()->SetManagedPref(
-      kManagedBraveShieldsEnabledForUrls,
-      base::Value::ToUniquePtrValue(std::move(enabled_list)));
+      kManagedBraveShieldsEnabledForUrls, std::move(enabled_list));
 
   // both disabled/enabled prefs set
   EXPECT_TRUE(brave_shields::IsBraveShieldsManaged(

--- a/components/brave_vpn/browser/brave_vpn_service_unittest.cc
+++ b/components/brave_vpn/browser/brave_vpn_service_unittest.cc
@@ -451,9 +451,9 @@ class BraveVPNServiceTest : public testing::Test {
                                       bool active_subscription = true) {
     std::string domain = skus::GetDomain("vpn", env);
     auto testing_payload = GenerateTestingCreds(domain, active_subscription);
-    base::Value state(base::Value::Type::DICT);
-    state.SetStringKey("skus:" + env, testing_payload);
-    local_pref_service_.Set(skus::prefs::kSkusState, std::move(state));
+    base::Value::Dict state;
+    state.Set("skus:" + env, testing_payload);
+    local_pref_service_.SetDict(skus::prefs::kSkusState, std::move(state));
     SetInterceptorResponse(GetRegionsData());
     return domain;
   }

--- a/components/brave_wallet/browser/fil_transaction_unittest.cc
+++ b/components/brave_wallet/browser/fil_transaction_unittest.cc
@@ -193,7 +193,7 @@ TEST(FilTransactionUnitTest, GetMessageToSignSecp) {
   ASSERT_TRUE(signature.has_value());
   auto signature_value = base::JSONReader::Read(*signature);
   EXPECT_TRUE(signature_value);
-  auto* message = signature_value->FindKey("Message");
+  auto* message = signature_value->GetDict().Find("Message");
   auto* signature_data = signature_value->FindStringPath("Signature.Data");
   EXPECT_TRUE(message);
   EXPECT_TRUE(signature_data);
@@ -246,7 +246,7 @@ TEST(FilTransactionUnitTest, GetMessageToSignBLS) {
   ASSERT_TRUE(signature.has_value());
   auto signature_value = base::JSONReader::Read(*signature);
   EXPECT_TRUE(signature_value);
-  auto* message = signature_value->FindKey("Message");
+  auto* message = signature_value->GetDict().Find("Message");
   auto* signature_data = signature_value->FindStringPath("Signature.Data");
   EXPECT_TRUE(message);
   EXPECT_TRUE(signature_data);

--- a/components/skus/browser/skus_service_unittest.cc
+++ b/components/skus/browser/skus_service_unittest.cc
@@ -296,12 +296,12 @@ class SkusServiceTestUnitTest : public testing::Test {
 };
 
 TEST_F(SkusServiceTestUnitTest, CredentialSummarySuccess) {
-  base::Value state(base::Value::Type::DICT);
+  base::Value::Dict state;
   auto env = skus::GetDefaultEnvironment();
   auto domain = skus::GetDomain("vpn", env);
   auto testing_payload = GenerateTestingCreds(domain);
-  state.SetStringKey("skus:" + env, testing_payload);
-  prefs()->Set(skus::prefs::kSkusState, std::move(state));
+  state.Set("skus:" + env, testing_payload);
+  prefs()->SetDict(skus::prefs::kSkusState, std::move(state));
   auto credentials = GetCredentialsSummary(domain);
   EXPECT_FALSE(credentials.empty());
   auto credentials_json = base::JSONReader::Read(credentials);
@@ -312,7 +312,7 @@ TEST_F(SkusServiceTestUnitTest, CredentialSummarySuccess) {
 }
 
 TEST_F(SkusServiceTestUnitTest, CredentialSummaryFailed) {
-  base::Value state(base::Value::Type::DICT);
+  base::Value::Dict state;
   auto env = skus::GetDefaultEnvironment();
   auto domain = skus::GetDomain("vpn", env);
   auto testing_payload = GenerateTestingCreds(domain);
@@ -325,18 +325,18 @@ TEST_F(SkusServiceTestUnitTest, CredentialSummaryFailed) {
   base::JSONWriter::WriteWithOptions(
       payload_value.value(), base::JSONWriter::OPTIONS_PRETTY_PRINT, &json);
   // Save prefs with expired prefs only
-  state.SetStringKey("skus:" + env, json);
+  state.Set("skus:" + env, json);
 
-  prefs()->Set(skus::prefs::kSkusState, std::move(state));
+  prefs()->SetDict(skus::prefs::kSkusState, std::move(state));
   auto credentials = GetCredentialsSummary(domain);
   EXPECT_EQ(credentials, "{}");
 }
 
 TEST_F(SkusServiceTestUnitTest, CredentialSummaryWrongEnv) {
-  base::Value state(base::Value::Type::DICT);
+  base::Value::Dict state;
   auto testing_payload = GenerateTestingCreds("vpn.brave.software");
-  state.SetStringKey("skus:staging", testing_payload);
-  prefs()->Set(skus::prefs::kSkusState, std::move(state));
+  state.Set("skus:staging", testing_payload);
+  prefs()->SetDict(skus::prefs::kSkusState, std::move(state));
   auto credentials = GetCredentialsSummary("vpn.brave.software");
   EXPECT_EQ(credentials, "{}");
 }

--- a/ios/browser/api/sync/brave_sync_api.mm
+++ b/ios/browser/api/sync/brave_sync_api.mm
@@ -264,7 +264,7 @@ OBJC_EXPORT BraveSyncAPIWordsValidationStatus const
   auto device_list = _worker->GetDeviceList();
   auto* local_device_info = _worker->GetLocalDeviceInfo();
 
-  base::Value device_list_value(base::Value::Type::LIST);
+  base::Value::List device_list_value;
 
   for (const auto& device : device_list) {
     auto device_value = device->ToValue();


### PR DESCRIPTION
A number of base::Value functions have been marked as deprecated. This PR removes some of those cases in favour of the new interfaces, as these function will soon be removed upstream.

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/28648

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [x] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [x] New files have MPL-2.0 license header
- [x] Adequate test coverage exists to prevent regressions
- [x] Major classes, functions and non-trivial code blocks are well-commented
- [x] Changes in component dependencies are properly reflected in `gn`
- [x] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [x] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

