### PR TITLE
Shows spinner if balance (vBAT/custodian) cannot be fetched.

### DIFF
--- a/browser/extensions/api/brave_rewards_api.h
+++ b/browser/extensions/api/brave_rewards_api.h
@@ -467,8 +467,13 @@ class BraveRewardsFetchBalanceFunction : public ExtensionFunction {
   ResponseAction Run() override;
 
  private:
-  void OnBalance(const ledger::mojom::Result result,
-                 ledger::mojom::BalancePtr balance);
+  void OnGetExternalWallet(
+      base::expected<ledger::mojom::ExternalWalletPtr,
+                     ledger::mojom::GetExternalWalletError> result);
+
+  void OnFetchBalance(const std::string& connected_wallet_type,
+                      ledger::mojom::Result result,
+                      ledger::mojom::BalancePtr balance);
 };
 
 class BraveRewardsGetExternalWalletProvidersFunction

--- a/browser/ui/webui/brave_rewards/rewards_panel_ui.cc
+++ b/browser/ui/webui/brave_rewards/rewards_panel_ui.cc
@@ -63,6 +63,7 @@ static constexpr webui::LocalizedString kStrings[] = {
     {"includeInAutoContribute", IDS_REWARDS_PANEL_INCLUDE_IN_AUTO_CONTRIBUTE},
     {"learnMore", IDS_REWARDS_LEARN_MORE},
     {"learnMoreAboutBAT", IDS_REWARDS_PANEL_LEARN_MORE_ABOUT_BAT},
+    {"loading", IDS_BRAVE_REWARDS_LOADING_LABEL},
     {"monthlyTip", IDS_REWARDS_PANEL_MONTHLY_TIP},
     {"notificationAdGrantAmount", IDS_REWARDS_NOTIFICATION_AD_GRANT_AMOUNT},
     {"notificationAdGrantTitle", IDS_REWARDS_NOTIFICATION_AD_GRANT_TITLE},

--- a/browser/ui/webui/brave_rewards_internals_ui.cc
+++ b/browser/ui/webui/brave_rewards_internals_ui.cc
@@ -53,7 +53,7 @@ class RewardsInternalsDOMHandler : public content::WebUIMessageHandler {
   void HandleGetRewardsInternalsInfo(const base::Value::List& args);
   void OnGetRewardsInternalsInfo(ledger::mojom::RewardsInternalsInfoPtr info);
   void GetBalance(const base::Value::List& args);
-  void OnGetBalance(const ledger::mojom::Result result,
+  void OnGetBalance(ledger::mojom::Result result,
                     ledger::mojom::BalancePtr balance);
   void GetContributions(const base::Value::List& args);
   void OnGetContributions(
@@ -204,7 +204,7 @@ void RewardsInternalsDOMHandler::GetBalance(const base::Value::List& args) {
 }
 
 void RewardsInternalsDOMHandler::OnGetBalance(
-    const ledger::mojom::Result result,
+    ledger::mojom::Result,
     ledger::mojom::BalancePtr balance) {
   if (!IsJavascriptAllowed()) {
     return;
@@ -212,17 +212,21 @@ void RewardsInternalsDOMHandler::OnGetBalance(
 
   base::Value::Dict balance_value;
 
-  if (result == ledger::mojom::Result::LEDGER_OK && balance) {
+  if (balance) {
     balance_value.Set("total", balance->total);
 
     base::Value::Dict wallets;
-    for (auto const& wallet : balance->wallets) {
+    for (const auto& wallet : balance->wallets) {
       wallets.Set(wallet.first, wallet.second);
     }
     balance_value.Set("wallets", std::move(wallets));
+  } else {
+    balance_value.Set("total", 0.0);
+    balance_value.Set("wallets", base::Value::Dict());
   }
 
-  CallJavascriptFunction("brave_rewards_internals.balance", balance_value);
+  CallJavascriptFunction("brave_rewards_internals.balance",
+                         std::move(balance_value));
 }
 
 void RewardsInternalsDOMHandler::GetContributions(

--- a/browser/ui/webui/brave_webui_source.cc
+++ b/browser/ui/webui/brave_webui_source.cc
@@ -350,6 +350,8 @@ void CustomizeWebUIHTMLSource(content::WebUI* web_ui,
         {"rewardsVBATNoticeTitle1", IDS_REWARDS_VBAT_NOTICE_TITLE1},
         {"rewardsVBATNoticeTitle2", IDS_REWARDS_VBAT_NOTICE_TITLE2},
 
+        { "loading", IDS_BRAVE_REWARDS_LOADING_LABEL },
+
         // Brave Talk  Widget
         { "braveTalkWidgetTitle", IDS_BRAVE_TALK_WIDGET_TITLE },
         { "braveTalkWidgetWelcomeTitle", IDS_BRAVE_TALK_WIDGET_WELCOME_TITLE },
@@ -689,6 +691,8 @@ void CustomizeWebUIHTMLSource(content::WebUI* web_ui,
         { "walletViewStatement", IDS_REWARDS_WALLET_VIEW_STATEMENT },
         { "walletVerified", IDS_REWARDS_WALLET_VERIFIED },
         { "walletYourBalance", IDS_REWARDS_WALLET_YOUR_BALANCE },
+
+        { "loading", IDS_BRAVE_REWARDS_LOADING_LABEL },
       }
     }, {
       std::string("adblock"), {
@@ -898,6 +902,8 @@ void CustomizeWebUIHTMLSource(content::WebUI* web_ui,
         { "walletStatusDisconnectedVerified", IDS_BRAVE_REWARDS_INTERNALS_WALLET_STATUS_DISCONNECTED_VERIFIED },    // NOLINT
         { "walletCreationEnvironment", IDS_BRAVE_REWARDS_INTERNALS_WALLET_CREATION_ENVIRONMENT },    // NOLINT
         { "currentEnvironment", IDS_BRAVE_REWARDS_INTERNALS_CURRENT_ENVIRONMENT},    // NOLINT
+
+        { "loading", IDS_BRAVE_REWARDS_LOADING_LABEL },
       }
     }, {
 #if BUILDFLAG(ENABLE_TOR)

--- a/common/extensions/api/brave_rewards.json
+++ b/common/extensions/api/brave_rewards.json
@@ -1368,15 +1368,8 @@
             "parameters": [
               {
                 "name": "balance",
-                "type": "object",
-                "properties": {
-                  "total": {
-                    "type": "any"
-                  },
-                  "wallets": {
-                    "type": "any"
-                  }
-                }
+                "type": "number",
+                "optional": true
               }
             ]
           }

--- a/components/brave_new_tab_ui/components/default/rewards/index.tsx
+++ b/components/brave_new_tab_ui/components/default/rewards/index.tsx
@@ -1,4 +1,5 @@
-/* This Source Code Form is subject to the terms of the Mozilla Public
+/* Copyright (c) 2023 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at https://mozilla.org/MPL/2.0/. */
 
@@ -13,6 +14,9 @@ import { getProviderPayoutStatus } from '../../../../brave_rewards/resources/sha
 import { WithThemeVariables } from '../../../../brave_rewards/resources/shared/components/with_theme_variables'
 import { GrantInfo } from '../../../../brave_rewards/resources/shared/lib/grant_info'
 import { userTypeFromString } from '../../../../brave_rewards/resources/shared/lib/user_type'
+import {
+  optional
+} from '../../../../brave_rewards/resources/shared/lib/optional'
 
 import {
   externalWalletFromExtensionData,
@@ -138,7 +142,7 @@ export const RewardsWidget = createWidget((props: RewardsProps) => {
       adsEnabled={props.enabledAds}
       adsSupported={Boolean(props.adsSupported)}
       needsBrowserUpgradeToServeAds={props.needsBrowserUpgradeToServeAds}
-      rewardsBalance={props.balance.total}
+      rewardsBalance={optional(props.balance)}
       exchangeCurrency='USD'
       exchangeRate={props.parameters.rate}
       providerPayoutStatus={providerPayoutStatus()}

--- a/components/brave_new_tab_ui/storage/new_tab_storage.ts
+++ b/components/brave_new_tab_ui/storage/new_tab_storage.ts
@@ -61,10 +61,7 @@ export const defaultState: NewTab.State = {
       earningsThisMonth: 0,
       earningsLastMonth: 0
     },
-    balance: {
-      total: 0,
-      wallets: {}
-    },
+    balance: undefined,
     externalWallet: undefined,
     externalWalletProviders: [],
     dismissedNotifications: [],

--- a/components/brave_rewards/resources/internals/components/balance.tsx
+++ b/components/brave_rewards/resources/internals/components/balance.tsx
@@ -1,4 +1,5 @@
-/* This Source Code Form is subject to the terms of the Mozilla Public
+/* Copyright (c) 2023 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at https://mozilla.org/MPL/2.0/. */
 
@@ -6,9 +7,12 @@ import * as React from 'react'
 
 // Utils
 import { getLocale } from '../../../../common/locale'
+import { LoadingIcon } from '../../shared/components/icons/loading_icon'
+import * as mojom from '../../shared/lib/mojom'
 
 interface Props {
-  info: RewardsInternals.Balance
+  balance: RewardsInternals.Balance
+  externalWallet: RewardsInternals.ExternalWallet
 }
 
 const getWalletName = (walletKey: string) => {
@@ -30,17 +34,31 @@ const getWalletName = (walletKey: string) => {
   return 'Missing wallet'
 }
 
-const getWalletBalance = (wallets: Record<string, number>) => {
+const getBalances = (
+  balances: Record<string, number>,
+  externalWallet: RewardsInternals.ExternalWallet
+) => {
+  const walletKeys = Object.keys(balances)
+
+  const getBalance = (wallet: string) => {
+    return <div key={'wallet-' + wallet}>
+      {getWalletName(wallet)}: {walletKeys.includes(wallet)
+        ? balances[wallet] + ' ' + getLocale('bat')
+        : <><LoadingIcon />{getLocale('loading')}</>}
+    </div>
+  }
+
   let items = []
-  for (const key in wallets) {
-    items.push(<div key={'wallet-' + key}> {getWalletName(key)}: {wallets[key]} {getLocale('bat')} </div>)
+  items.push(getBalance('blinded'))
+  if (externalWallet.status === mojom.WalletStatus.kConnected) {
+    items.push(getBalance(externalWallet.type))
   }
 
   return items
 }
 
 export const Balance = (props: Props) => {
-  if (!props.info) {
+  if (!props.balance) {
     return null
   }
 
@@ -48,8 +66,8 @@ export const Balance = (props: Props) => {
     <>
       <h3>{getLocale('balanceInfo')}</h3>
       <div>
-        {getLocale('totalBalance')} {props.info.total} {getLocale('bat')}
+        {getLocale('totalBalance')} {props.balance.total} {getLocale('bat')}
       </div>
-      {getWalletBalance(props.info.wallets)}
+      {getBalances(props.balance.wallets, props.externalWallet)}
     </>)
 }

--- a/components/brave_rewards/resources/internals/components/general.tsx
+++ b/components/brave_rewards/resources/internals/components/general.tsx
@@ -1,4 +1,5 @@
-/* This Source Code Form is subject to the terms of the Mozilla Public
+/* Copyright (c) 2023 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at https://mozilla.org/MPL/2.0/. */
 
@@ -9,7 +10,7 @@ import { WalletHistory } from './walletHistory'
 import { Balance } from './balance'
 import { ExternalWallet } from './externalWallet'
 import { Button } from 'brave-ui/components'
-import { ButtonWrapper } from '../style'
+import { BalanceWrapper, ButtonWrapper } from '../style'
 
 // Utils
 import { getLocale } from '../../../../common/locale'
@@ -36,7 +37,11 @@ export class General extends React.Component<Props, {}> {
           paymentId={this.props.data.info.walletPaymentId}
           logEntries={this.props.data.eventLogs}
         />
-        <Balance info={this.props.data.balance} />
+        <BalanceWrapper>
+          <Balance
+            balance={this.props.data.balance}
+            externalWallet={this.props.data.externalWallet} />
+        </BalanceWrapper>
         <ExternalWallet info={this.props.data.externalWallet} />
       </>
     )

--- a/components/brave_rewards/resources/internals/style.ts
+++ b/components/brave_rewards/resources/internals/style.ts
@@ -1,4 +1,5 @@
-/* This Source Code Form is subject to the terms of the Mozilla Public
+/* Copyright (c) 2023 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at https://mozilla.org/MPL/2.0/. */
 
@@ -103,4 +104,12 @@ export const Input = styled.input`
 
 export const DiagnosticsHeader = styled.h3`
   margin: 20px 0px 10px;
+`
+
+export const BalanceWrapper = styled('div')<{}>`
+  .icon {
+    height: 16px;
+    vertical-align: bottom;
+    margin-right: 2px;
+  }
 `

--- a/components/brave_rewards/resources/page/components/pageWallet.tsx
+++ b/components/brave_rewards/resources/page/components/pageWallet.tsx
@@ -33,6 +33,7 @@ import { PendingContributionsModal } from './pending_contributions_modal'
 
 import * as mojom from '../../shared/lib/mojom'
 import { isPublisherVerified } from '../../shared/lib/publisher_status'
+import { optional } from '../../shared/lib/optional'
 
 interface State {
   modalActivity: boolean
@@ -530,7 +531,6 @@ class PageWallet extends React.Component<Props, State> {
       pendingContributions,
       userType
     } = this.props.rewardsData
-    const { total } = balance
     const { modalReset, modalConnect } = ui
 
     let externalWalletInfo: ExternalWallet | null = null
@@ -553,12 +553,20 @@ class PageWallet extends React.Component<Props, State> {
       pendingTips: pendingContributionTotal || 0
     }
 
+    const walletKeys = Object.keys(balance.wallets)
+    const totalBalance =
+      !walletKeys.includes('blinded')
+        ? undefined
+        : externalWallet && !walletKeys.includes(externalWallet.type)
+          ? undefined
+          : balance.total
+
     return (
       <>
         {
           userType !== 'unconnected' &&
             <WalletCard
-              balance={total}
+              balance={optional(totalBalance)}
               externalWallet={externalWalletInfo}
               providerPayoutStatus={'off'}
               earningsThisMonth={adsData.adsEarningsThisMonth || 0}

--- a/components/brave_rewards/resources/rewards_panel/components/panel.tsx
+++ b/components/brave_rewards/resources/rewards_panel/components/panel.tsx
@@ -1,4 +1,5 @@
-/* This Source Code Form is subject to the terms of the Mozilla Public
+/* Copyright (c) 2023 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at https://mozilla.org/MPL/2.0/. */
 

--- a/components/brave_rewards/resources/rewards_panel/lib/extension_api_adapter.ts
+++ b/components/brave_rewards/resources/rewards_panel/lib/extension_api_adapter.ts
@@ -26,14 +26,16 @@ import {
   Settings
 } from './interfaces'
 
+import { optional, Optional } from '../../shared/lib/optional'
+
 // The functions exported from this module wrap the existing |braveRewards|
 // and |rewardsNotifications| extension API functions in order to reduce the
 // amount of mapping/adapter code found in |extension_host|. As the extension
 // APIs are improved, the need for this adapter will diminish.
 
 export function getRewardsBalance () {
-  return new Promise<number>((resolve) => {
-    chrome.braveRewards.fetchBalance((balance) => { resolve(balance.total) })
+  return new Promise<Optional<number>>((resolve) => {
+    chrome.braveRewards.fetchBalance((balance) => { resolve(optional(balance)) })
   })
 }
 

--- a/components/brave_rewards/resources/rewards_panel/lib/initial_state.ts
+++ b/components/brave_rewards/resources/rewards_panel/lib/initial_state.ts
@@ -1,8 +1,10 @@
-/* This Source Code Form is subject to the terms of the Mozilla Public
+/* Copyright (c) 2023 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 import { HostState } from './interfaces'
+import { optional } from '../../shared/lib/optional'
 
 export function getInitialState (): HostState {
   return {
@@ -10,7 +12,7 @@ export function getInitialState (): HostState {
     loading: true,
     requestedView: null,
     rewardsEnabled: false,
-    balance: 0,
+    balance: optional<number>(),
     settings: {
       adsEnabled: false,
       adsPerHour: 0,

--- a/components/brave_rewards/resources/rewards_panel/lib/interfaces.ts
+++ b/components/brave_rewards/resources/rewards_panel/lib/interfaces.ts
@@ -16,6 +16,7 @@ import { PublisherPlatform } from '../../shared/lib/publisher_platform'
 import { OnboardingResult } from '../../shared/components/onboarding'
 import { ExternalWalletAction, RewardsSummaryData } from '../../shared/components/wallet_card'
 import { Notification, NotificationAction } from '../../shared/components/notifications'
+import { Optional } from '../../shared/lib/optional'
 
 export interface ExchangeInfo {
   currency: string
@@ -83,7 +84,7 @@ export interface HostState {
   loading: boolean
   rewardsEnabled: boolean
   requestedView: RequestedView | null
-  balance: number
+  balance: Optional<number>
   settings: Settings
   options: Options
   grantCaptchaInfo: GrantCaptchaInfo | null

--- a/components/brave_rewards/resources/rewards_panel/stories/index.tsx
+++ b/components/brave_rewards/resources/rewards_panel/stories/index.tsx
@@ -1,4 +1,5 @@
-/* This Source Code Form is subject to the terms of the Mozilla Public
+/* Copyright (c) 2023 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at https://mozilla.org/MPL/2.0/. */
 
@@ -18,6 +19,7 @@ import { App } from '../components/app'
 
 import grantCaptchaImageURL from './grant_captcha_image.png'
 import * as mojom from '../../shared/lib/mojom'
+import { optional } from '../../shared/lib/optional'
 
 export default {
   title: 'Rewards/Panel'
@@ -72,7 +74,7 @@ function createHost (): Host {
       status: 'pending'
     },
     externalWalletProviders: ['uphold', 'gemini'],
-    balance: 10.2,
+    balance: optional(10.2),
     exchangeInfo: {
       rate: 0.75,
       currency: 'USD'

--- a/components/brave_rewards/resources/shared/components/newtab/rewards_card.style.ts
+++ b/components/brave_rewards/resources/shared/components/newtab/rewards_card.style.ts
@@ -1,4 +1,5 @@
-/* This Source Code Form is subject to the terms of the Mozilla Public
+/* Copyright (c) 2023 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at https://mozilla.org/MPL/2.0/. */
 
@@ -110,13 +111,32 @@ export const disconnectedArrow = styled.div`
 
 export const balance = styled.div`
   margin-top: 16px;
+  margin-bottom: 16px;
   font-size: 12px;
   line-height: 18px;
+
+  &.flat {
+    margin-bottom: 6px;
+  }
 `
 
 export const balanceTitle = styled.div`
   color: rgba(255, 255, 255, 0.8);
   letter-spacing: 0.01em;
+`
+
+export const balanceSpinner = styled.div`
+  .icon {
+    height: 36px;
+    vertical-align: middle;
+    margin-right: 4px;
+  }
+`
+
+export const loading = styled.span`
+  font-size: 12px;
+  line-height: 18px;
+  vertical-align: middle;
 `
 
 export const balanceAmount = styled.div`
@@ -213,7 +233,6 @@ export const needsBrowserUpdateContentBody = styled.div`
 `
 
 export const progressHeader = styled.div`
-  margin-top: 16px;
   display: flex;
   align-items: center;
   gap: 11px;

--- a/components/brave_rewards/resources/shared/components/newtab/rewards_card.tsx
+++ b/components/brave_rewards/resources/shared/components/newtab/rewards_card.tsx
@@ -1,4 +1,5 @@
-/* This Source Code Form is subject to the terms of the Mozilla Public
+/* Copyright (c) 2023 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at https://mozilla.org/MPL/2.0/. */
 
@@ -23,6 +24,8 @@ import { SelectCountryCard } from './select_country_card'
 import { PaymentStatusView } from '../payment_status_view'
 import { UnsupportedRegionCard } from './unsupported_region_card'
 import { VBATNotice, shouldShowVBATNotice } from '../vbat_notice'
+import { LoadingIcon } from '../../../shared/components/icons/loading_icon'
+import { Optional } from '../../../shared/lib/optional'
 
 import * as urls from '../../lib/rewards_urls'
 
@@ -76,7 +79,7 @@ interface Props {
   adsEnabled: boolean
   adsSupported: boolean
   needsBrowserUpgradeToServeAds: boolean
-  rewardsBalance: number
+  rewardsBalance: Optional<number>
   exchangeRate: number
   exchangeCurrency: string
   providerPayoutStatus: ProviderPayoutStatus
@@ -166,29 +169,38 @@ export function RewardsCard (props: Props) {
     }
 
     return (
-      <style.balance>
+      <style.balance
+        className={!props.rewardsBalance.hasValue() ? 'flat' : ''}>
         <style.balanceTitle>
           {getString('rewardsTokenBalance')}
         </style.balanceTitle>
-        <style.balanceAmount>
-          <TokenAmount amount={props.rewardsBalance} />
-        </style.balanceAmount>
-        <style.balanceExchange>
-          <style.balanceExchangeAmount>
-            ≈&nbsp;
-            <ExchangeAmount
-              amount={props.rewardsBalance}
-              rate={props.exchangeRate}
-              currency={props.exchangeCurrency}
-            />
-          </style.balanceExchangeAmount>
-          {
-            props.rewardsBalance > 0 &&
-              <style.balanceExchangeNote>
-                {getString('rewardsExchangeValueNote')}
-              </style.balanceExchangeNote>
-          }
-        </style.balanceExchange>
+        {
+          !props.rewardsBalance.hasValue()
+            ? <style.balanceSpinner>
+              <LoadingIcon />
+              <style.loading>{getString('loading')}</style.loading>
+            </style.balanceSpinner>
+            : <>
+              <style.balanceAmount>
+                <TokenAmount amount={props.rewardsBalance.value()} />
+              </style.balanceAmount>
+              <style.balanceExchange>
+                <style.balanceExchangeAmount>
+                  ≈&nbsp;
+                  <ExchangeAmount
+                    amount={props.rewardsBalance.value()}
+                    rate={props.exchangeRate}
+                    currency={props.exchangeCurrency} />
+                </style.balanceExchangeAmount>
+                {
+                  props.rewardsBalance.value() > 0 &&
+                  <style.balanceExchangeNote>
+                    {getString('rewardsExchangeValueNote')}
+                  </style.balanceExchangeNote>
+                }
+              </style.balanceExchange>
+            </>
+        }
         <style.pendingRewards>
           <PaymentStatusView
             earningsLastMonth={props.earningsLastMonth}

--- a/components/brave_rewards/resources/shared/components/newtab/stories/index.tsx
+++ b/components/brave_rewards/resources/shared/components/newtab/stories/index.tsx
@@ -12,6 +12,7 @@ import { SponsoredImageTooltip } from '../sponsored_image_tooltip'
 
 import { localeStrings } from './locale_strings'
 import * as mojom from '../../../../shared/lib/mojom'
+import { optional } from '../../../../shared/lib/optional'
 
 const localeContext = createLocaleContextForTesting(localeStrings)
 
@@ -42,7 +43,7 @@ export function Card () {
             adsEnabled={true}
             adsSupported={true}
             needsBrowserUpgradeToServeAds={false}
-            rewardsBalance={91.5812}
+            rewardsBalance={optional(91.5812)}
             exchangeCurrency='USD'
             exchangeRate={0.82}
             providerPayoutStatus={'complete'}

--- a/components/brave_rewards/resources/shared/components/wallet_card/stories/index.tsx
+++ b/components/brave_rewards/resources/shared/components/wallet_card/stories/index.tsx
@@ -12,6 +12,7 @@ import { WalletCard } from '../'
 
 import { localeStrings } from './locale_strings'
 import * as mojom from '../../../../shared/lib/mojom'
+import { optional } from '../../../../shared/lib/optional'
 
 const locale = createLocaleContextForTesting(localeStrings)
 
@@ -56,7 +57,7 @@ export function Wallet () {
       <WithThemeVariables>
         <div style={{ width: '375px' }}>
           <WalletCard
-            balance={0}
+            balance={optional(0)}
             externalWallet={externalWallet}
             providerPayoutStatus={'complete'}
             earningsThisMonth={0}

--- a/components/brave_rewards/resources/shared/components/wallet_card/wallet_card.style.ts
+++ b/components/brave_rewards/resources/shared/components/wallet_card/wallet_card.style.ts
@@ -1,4 +1,5 @@
-/* This Source Code Form is subject to the terms of the Mozilla Public
+/* Copyright (c) 2023 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at https://mozilla.org/MPL/2.0/. */
 
@@ -94,10 +95,28 @@ export const batAmount = styled.div`
   }
 `
 
+export const balanceSpinner = styled.div`
+  .icon {
+    height: 24px;
+    vertical-align: middle;
+    margin-right: 4px;
+  }
+`
+
+export const loading = styled.span`
+  font-size: 14px;
+  line-height: 18px;
+  vertical-align: middle;
+`
+
 export const exchangeAmount = styled.div`
   font-size: 12px;
   line-height: 14px;
   opacity: 0.66;
+
+  &.hidden {
+    visibility: hidden;
+  }
 `
 
 export const earningsPanel = styled.div`

--- a/components/brave_rewards/resources/shared/components/wallet_card/wallet_card.tsx
+++ b/components/brave_rewards/resources/shared/components/wallet_card/wallet_card.tsx
@@ -1,4 +1,5 @@
-/* This Source Code Form is subject to the terms of the Mozilla Public
+/* Copyright (c) 2023 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at https://mozilla.org/MPL/2.0/. */
 
@@ -17,6 +18,8 @@ import { RewardsSummary, RewardsSummaryData } from './rewards_summary'
 import { PendingRewardsView } from './pending_rewards_view'
 import { WalletInfoIcon } from './icons/wallet_info_icon'
 import { ArrowCircleIcon } from '../icons/arrow_circle_icon'
+import { LoadingIcon } from '../../../shared/components/icons/loading_icon'
+import { Optional } from '../../../shared/lib/optional'
 
 import * as urls from '../../lib/rewards_urls'
 
@@ -30,7 +33,7 @@ const rangeFormatter = new Intl.DateTimeFormat(undefined, {
 })
 
 interface Props {
-  balance: number
+  balance: Optional<number>
   externalWallet: ExternalWallet | null
   providerPayoutStatus: ProviderPayoutStatus
   earningsThisMonth: number
@@ -94,10 +97,20 @@ export function WalletCard (props: Props) {
           {getString('walletYourBalance')}
         </style.balanceHeader>
         <style.batAmount data-test-id='rewards-balance-text'>
-          <TokenAmount amount={props.balance} />
+          {
+            !props.balance.hasValue()
+              ? <style.balanceSpinner>
+                <LoadingIcon />
+                <style.loading>{getString('loading')}</style.loading>
+              </style.balanceSpinner>
+              : <TokenAmount amount={props.balance.value()} />
+          }
         </style.batAmount>
-        <style.exchangeAmount>
-          <ExchangeAmount amount={props.balance} rate={props.exchangeRate} />
+        <style.exchangeAmount
+          className={!props.balance.hasValue() ? 'hidden' : ''}>
+          <ExchangeAmount
+            amount={props.balance.valueOr(0)}
+            rate={props.exchangeRate} />
         </style.exchangeAmount>
       </style.rewardsBalance>
     )

--- a/components/brave_rewards/resources/shared/lib/optional.ts
+++ b/components/brave_rewards/resources/shared/lib/optional.ts
@@ -1,0 +1,31 @@
+/* Copyright (c) 2023 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+export class Optional<T> {
+  value_: T | undefined
+
+  constructor (value?: T) {
+    this.value_ = value
+  }
+
+  hasValue () {
+    return this.value_ !== undefined
+  }
+
+  value () {
+    if (this.value_ === undefined) {
+      throw new Error('Cannot get value of empty optional')
+    }
+    return this.value_
+  }
+
+  valueOr<U> (fallback: U) {
+    return this.value_ === undefined ? fallback : this.value_
+  }
+}
+
+export function optional<T> (value?: T) {
+  return new Optional<T>(value)
+}

--- a/components/definitions/newTab.d.ts
+++ b/components/definitions/newTab.d.ts
@@ -220,10 +220,7 @@ declare namespace NewTab {
     amount: number
   }
 
-  export interface RewardsBalance {
-    total: number
-    wallets: Record<string, number>
-  }
+  export type RewardsBalance = number | undefined
 
   export interface AdsAccountStatement {
     nextPaymentDate: number

--- a/components/definitions/rewardsExtensions.d.ts
+++ b/components/definitions/rewardsExtensions.d.ts
@@ -175,10 +175,7 @@ declare namespace RewardsExtension {
 
   export type TipDialogEntryPoint = 'one-time' | 'set-monthly' | 'clear-monthly'
 
-  export interface Balance {
-    total: number
-    wallets: Record<string, number>
-  }
+  export type Balance = number | undefined
 
   type WalletStatus = import('gen/brave/vendor/bat-native-ledger/include/bat/ledger/public/interfaces/ledger_types.mojom.m.js').WalletStatus
 

--- a/components/resources/rewards_strings.grdp
+++ b/components/resources/rewards_strings.grdp
@@ -528,4 +528,9 @@
     You can still browse privately!
   </message>
 
+  <!-- Rewards common strings -->
+  <message name="IDS_BRAVE_REWARDS_LOADING_LABEL" desc="">
+    Loading...
+  </message>
+
 </grit-part>


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/28549.

Rewards page:
![rewards_page_0](https://user-images.githubusercontent.com/5390451/220428674-1531dd03-98e6-4780-9ea0-5e9737753f64.png)

![rewards_page_1](https://user-images.githubusercontent.com/5390451/220428707-5b9ebc1f-cb42-46de-9705-d03e6fc6f4aa.png)

Rewards panel:
![rewards_panel_0](https://user-images.githubusercontent.com/5390451/220428746-2b3310c9-5dce-4940-8749-3f3ad67be86f.png)

![rewards_panel_1](https://user-images.githubusercontent.com/5390451/220428772-a945f2f6-492a-46ff-86ed-06f5cf3819a2.png)

Rewards Internals page:
![rewards_internals_0](https://user-images.githubusercontent.com/5390451/220428882-a0742a75-cfc6-46e1-8eff-80db25690c57.png)

![rewards_internals_1](https://user-images.githubusercontent.com/5390451/220428907-6b923d10-86be-437e-890e-904f02d29084.png)

![rewards_internals_2](https://user-images.githubusercontent.com/5390451/220428933-94406810-368a-4b75-a021-f113d4774a88.png)

NTP Rewards widget:
![ntp_0](https://user-images.githubusercontent.com/5390451/220428985-c3324d4e-4f23-4670-92ef-ef2552435d51.png)

![ntp_1](https://user-images.githubusercontent.com/5390451/220429003-999c90ec-9b46-4dec-af68-fde687e7f776.png)

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
Use Charles proxy to fail the fetch balance request:
- bitFlyer: `/api/link/v1/account/inventory`
- Gemini: `/v1/balances`
- Uphold: `/v0/me/cards/:card-id`