### PR TITLE
[POC] Introduce "Shared pinned tab" features

### DIFF
--- a/browser/about_flags.cc
+++ b/browser/about_flags.cc
@@ -331,12 +331,10 @@
 #endif  // BUILDFLAG(IS_ANDROID)
 
 #if !BUILDFLAG(IS_ANDROID)
-#define BRAVE_SHARED_PINNED_TABS \
-    {"brave-shared-pinned-tabs",                                 \
-     "Shared pinned tab",                                        \
-     "Pinned tabs are shared across windows",                    \
-     kOsWin | kOsMac | kOsLinux,                                 \
-     FEATURE_VALUE_TYPE(tabs::features::kBraveSharedPinnedTabs)},
+#define BRAVE_SHARED_PINNED_TABS                                        \
+  {"brave-shared-pinned-tabs", "Shared pinned tab",                     \
+   "Pinned tabs are shared across windows", kOsWin | kOsMac | kOsLinux, \
+   FEATURE_VALUE_TYPE(tabs::features::kBraveSharedPinnedTabs)},
 #else
 #define BRAVE_SHARED_PINNED_TABS
 #endif

--- a/browser/about_flags.cc
+++ b/browser/about_flags.cc
@@ -330,6 +330,17 @@
 #define BRAVE_SAFE_BROWSING_ANDROID
 #endif  // BUILDFLAG(IS_ANDROID)
 
+#if !BUILDFLAG(IS_ANDROID)
+#define BRAVE_SHARED_PINNED_TABS \
+    {"brave-shared-pinned-tabs",                                 \
+     "Shared pinned tab",                                        \
+     "Pinned tabs are shared across windows",                    \
+     kOsWin | kOsMac | kOsLinux,                                 \
+     FEATURE_VALUE_TYPE(tabs::features::kBraveSharedPinnedTabs)},
+#else
+#define BRAVE_SHARED_PINNED_TABS
+#endif
+
 // Keep the last item empty.
 #define LAST_BRAVE_FEATURE_ENTRIES_ITEM
 
@@ -706,6 +717,7 @@
   BRAVE_BACKGROUND_VIDEO_PLAYBACK_ANDROID                                      \
   BRAVE_SAFE_BROWSING_ANDROID                                                  \
   BRAVE_CHANGE_ACTIVE_TAB_ON_SCROLL_EVENT_FEATURE_ENTRIES                      \
+  BRAVE_SHARED_PINNED_TABS                                                     \
   LAST_BRAVE_FEATURE_ENTRIES_ITEM  // Keep it as the last item.
 
 namespace flags_ui {

--- a/browser/browser_context_keyed_service_factories.cc
+++ b/browser/browser_context_keyed_service_factories.cc
@@ -44,6 +44,8 @@
 
 #if !BUILDFLAG(IS_ANDROID)
 #include "brave/browser/ui/bookmark/bookmark_prefs_service_factory.h"
+#include "brave/browser/ui/tabs/features.h"
+#include "brave/browser/ui/tabs/shared_pinned_tab_service_factory.h"
 #else
 #include "brave/browser/ntp_background/android/ntp_background_images_bridge.h"
 #endif
@@ -132,6 +134,12 @@ void EnsureBrowserContextKeyedServiceFactoriesBuilt() {
 #endif
 
   BraveSyncAlertsServiceFactory::GetInstance();
+
+#if !BUILDFLAG(IS_ANDROID)
+  if (base::FeatureList::IsEnabled(tabs::features::kBraveSharedPinnedTabs)) {
+    SharedPinnedTabServiceFactory::GetInstance();
+  }
+#endif
 }
 
 }  // namespace brave

--- a/browser/ui/BUILD.gn
+++ b/browser/ui/BUILD.gn
@@ -94,6 +94,8 @@ source_set("ui") {
       "brave_pages.h",
       "brave_shields_data_controller.cc",
       "brave_shields_data_controller.h",
+      "brave_tab_strip_model_delegate.cc",
+      "brave_tab_strip_model_delegate.h",
       "brave_view_ids.h",
       "browser_commands.cc",
       "browser_commands.h",

--- a/browser/ui/brave_tab_strip_model_delegate.cc
+++ b/browser/ui/brave_tab_strip_model_delegate.cc
@@ -1,0 +1,41 @@
+/* Copyright (c) 2023 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "brave/browser/ui/brave_tab_strip_model_delegate.h"
+
+#include "brave/browser/ui/tabs/features.h"
+#include "brave/browser/ui/tabs/shared_pinned_tab_service.h"
+#include "brave/browser/ui/tabs/shared_pinned_tab_service_factory.h"
+#include "chrome/browser/ui/browser.h"
+
+namespace chrome {
+
+bool BraveTabStripModelDelegate::CanMoveTabsToWindow(
+    const std::vector<int>& indices) {
+  if (!base::FeatureList::IsEnabled(tabs::features::kBraveSharedPinnedTabs)) {
+    return BrowserTabStripModelDelegate::CanMoveTabsToWindow(indices);
+  }
+
+  // Shared pinned tabs shouldn't be moved.
+  return base::ranges::none_of(indices, [this](const auto& index) {
+    return browser_->tab_strip_model()->IsTabPinned(index);
+  });
+}
+
+void BraveTabStripModelDelegate::CacheWebContents(
+    const std::vector<std::unique_ptr<TabStripModel::DetachedWebContents>>&
+        web_contents) {
+  BrowserTabStripModelDelegate::CacheWebContents(web_contents);
+  if (!base::FeatureList::IsEnabled(tabs::features::kBraveSharedPinnedTabs)) {
+    return;
+  }
+
+  auto* shared_pinned_tab_service =
+      SharedPinnedTabServiceFactory::GetForProfile(browser_->profile());
+  DCHECK(shared_pinned_tab_service);
+  shared_pinned_tab_service->CacheWebContentsIfNeeded(browser_, web_contents);
+}
+
+}  // namespace chrome

--- a/browser/ui/brave_tab_strip_model_delegate.h
+++ b/browser/ui/brave_tab_strip_model_delegate.h
@@ -18,6 +18,12 @@ namespace chrome {
 class BraveTabStripModelDelegate : public BrowserTabStripModelDelegate {
  public:
   using BrowserTabStripModelDelegate::BrowserTabStripModelDelegate;
+  BraveTabStripModelDelegate(const BraveTabStripModelDelegate&) = delete;
+  BraveTabStripModelDelegate& operator=(const BraveTabStripModelDelegate&) =
+      delete;
+  BraveTabStripModelDelegate(BraveTabStripModelDelegate&&) noexcept = delete;
+  BraveTabStripModelDelegate& operator=(BraveTabStripModelDelegate&&) noexcept =
+      delete;
   ~BraveTabStripModelDelegate() override = default;
 
   // BrowserTabStripModelDelegate:

--- a/browser/ui/brave_tab_strip_model_delegate.h
+++ b/browser/ui/brave_tab_strip_model_delegate.h
@@ -1,0 +1,32 @@
+/* Copyright (c) 2023 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_BROWSER_UI_BRAVE_TAB_STRIP_MODEL_DELEGATE_H_
+#define BRAVE_BROWSER_UI_BRAVE_TAB_STRIP_MODEL_DELEGATE_H_
+
+#include <memory>
+#include <vector>
+
+#include "chrome/browser/ui/browser_tab_strip_model_delegate.h"
+
+// In order to make it easy to replace BrowserTabStripModelDelegate with our
+// BraveTabStripModelDelegate, wrap this class with chrome namespace.
+namespace chrome {
+
+class BraveTabStripModelDelegate : public BrowserTabStripModelDelegate {
+ public:
+  using BrowserTabStripModelDelegate::BrowserTabStripModelDelegate;
+  ~BraveTabStripModelDelegate() override = default;
+
+  // BrowserTabStripModelDelegate:
+  bool CanMoveTabsToWindow(const std::vector<int>& indices) override;
+  void CacheWebContents(
+      const std::vector<std::unique_ptr<TabStripModel::DetachedWebContents>>&
+          web_contents) override;
+};
+
+}  // namespace chrome
+
+#endif  // BRAVE_BROWSER_UI_BRAVE_TAB_STRIP_MODEL_DELEGATE_H_

--- a/browser/ui/brave_tab_strip_model_delegate.h
+++ b/browser/ui/brave_tab_strip_model_delegate.h
@@ -21,9 +21,6 @@ class BraveTabStripModelDelegate : public BrowserTabStripModelDelegate {
   BraveTabStripModelDelegate(const BraveTabStripModelDelegate&) = delete;
   BraveTabStripModelDelegate& operator=(const BraveTabStripModelDelegate&) =
       delete;
-  BraveTabStripModelDelegate(BraveTabStripModelDelegate&&) noexcept = delete;
-  BraveTabStripModelDelegate& operator=(BraveTabStripModelDelegate&&) noexcept =
-      delete;
   ~BraveTabStripModelDelegate() override = default;
 
   // BrowserTabStripModelDelegate:

--- a/browser/ui/tabs/BUILD.gn
+++ b/browser/ui/tabs/BUILD.gn
@@ -19,6 +19,10 @@ source_set("tabs") {
       "brave_vertical_tab_color_mixer.h",
       "features.cc",
       "features.h",
+      "shared_pinned_tab_service.cc",
+      "shared_pinned_tab_service.h",
+      "shared_pinned_tab_service_factory.cc",
+      "shared_pinned_tab_service_factory.h",
     ]
 
     deps = [

--- a/browser/ui/tabs/features.cc
+++ b/browser/ui/tabs/features.cc
@@ -17,4 +17,8 @@ BASE_FEATURE(kBraveChangeActiveTabOnScrollEvent,
              base::FEATURE_ENABLED_BY_DEFAULT);
 #endif  // BUILDFLAG(IS_LINUX)
 
+BASE_FEATURE(kBraveSharedPinnedTabs,
+             "BraveSharedPinnedTabs",
+             base::FEATURE_DISABLED_BY_DEFAULT);
+
 }  // namespace tabs::features

--- a/browser/ui/tabs/features.h
+++ b/browser/ui/tabs/features.h
@@ -17,6 +17,8 @@ BASE_DECLARE_FEATURE(kBraveVerticalTabs);
 BASE_DECLARE_FEATURE(kBraveChangeActiveTabOnScrollEvent);
 #endif  // BUILDFLAG(IS_LINUX)
 
+BASE_DECLARE_FEATURE(kBraveSharedPinnedTabs);
+
 }  // namespace tabs::features
 
 #endif  // BRAVE_BROWSER_UI_TABS_FEATURES_H_

--- a/browser/ui/tabs/shared_pinned_tab_service.cc
+++ b/browser/ui/tabs/shared_pinned_tab_service.cc
@@ -30,6 +30,8 @@ namespace {
 class SharedContentsData
     : public content::WebContentsUserData<SharedContentsData> {
  public:
+  SharedContentsData(const SharedContentsData&) = delete;
+  SharedContentsData& operator=(const SharedContentsData&) = delete;
   ~SharedContentsData() override = default;
 
   static void RemoveFromWebContents(content::WebContents* contents) {
@@ -56,6 +58,8 @@ WEB_CONTENTS_USER_DATA_KEY_IMPL(SharedContentsData);
 class DummyContentsData
     : public content::WebContentsUserData<DummyContentsData> {
  public:
+  DummyContentsData(const DummyContentsData&) = delete;
+  DummyContentsData& operator=(const DummyContentsData&) = delete;
   ~DummyContentsData() override = default;
 
   static void RemoveFromWebContents(content::WebContents* contents) {
@@ -290,11 +294,11 @@ void SharedPinnedTabService::TabPinnedStateChanged(
                              .contents_owner_model = tab_strip_model});
     SynchronizeNewPinnedTab(index);
   } else {
-    // TODO(sko) Check lifecycle, remove Unretained.
     base::SequencedTaskRunner::GetCurrentDefault()->PostTask(
-        FROM_HERE, base::BindOnce(&SharedPinnedTabService::OnTabUnpinned,
-                                  base::Unretained(this), tab_strip_model,
-                                  contents->GetWeakPtr(), index));
+        FROM_HERE,
+        base::BindOnce(&SharedPinnedTabService::OnTabUnpinned,
+                       weak_ptr_factory_.GetWeakPtr(), tab_strip_model,
+                       contents->GetWeakPtr(), index));
   }
 }
 
@@ -481,12 +485,11 @@ void SharedPinnedTabService::OnActiveTabChanged(
     return;
   }
 
-  // TODO(sko) Check lifecycle, remove Unretained.
   base::SequencedTaskRunner::GetCurrentDefault()->PostTask(
       FROM_HERE,
       base::BindOnce(
           &SharedPinnedTabService::MoveSharedWebContentsToActiveBrowser,
-          base::Unretained(this), active_index));
+          weak_ptr_factory_.GetWeakPtr(), active_index));
 }
 
 void SharedPinnedTabService::OnTabUnpinned(

--- a/browser/ui/tabs/shared_pinned_tab_service.cc
+++ b/browser/ui/tabs/shared_pinned_tab_service.cc
@@ -25,7 +25,7 @@ namespace {
 
 ////////////////////////////////////////////////////////////////////////////////
 // SharedContentsData is a WebContentsUserData attached to pinned tab's web
-// contentses that could be movable between multiple windows.
+// contents that could be movable between multiple windows.
 //
 class SharedContentsData
     : public content::WebContentsUserData<SharedContentsData> {
@@ -50,7 +50,7 @@ class SharedContentsData
 WEB_CONTENTS_USER_DATA_KEY_IMPL(SharedContentsData);
 
 ////////////////////////////////////////////////////////////////////////////////
-// DummyContentsData is a WebContentsUserData attached to dummy web contentses
+// DummyContentsData is a WebContentsUserData attached to a dummy web contents
 // we create for inactive pinned tabs.
 //
 class DummyContentsData

--- a/browser/ui/tabs/shared_pinned_tab_service.cc
+++ b/browser/ui/tabs/shared_pinned_tab_service.cc
@@ -243,7 +243,6 @@ void SharedPinnedTabService::OnBrowserClosing(Browser* browser) {
 
 void SharedPinnedTabService::OnBrowserRemoved(Browser* browser) {
   DVLOG(2) << __FUNCTION__;
-  DCHECK(base::Contains(closing_browsers_, browser));
   closing_browsers_.erase(browser);
 }
 

--- a/browser/ui/tabs/shared_pinned_tab_service.cc
+++ b/browser/ui/tabs/shared_pinned_tab_service.cc
@@ -162,6 +162,15 @@ void SharedPinnedTabService::CacheWebContentsIfNeeded(
 void SharedPinnedTabService::Shutdown() {
   DCHECK(cached_shared_contentses_from_closing_browser_.empty())
       << " There're dangled web contentses";
+
+  profile_ = nullptr;
+  browsers_.clear();
+  last_active_browser_ = nullptr;
+  closing_browsers_.clear();
+  pinned_tab_data_.clear();
+  change_source_model_ = nullptr;
+  profile_observation_.Reset();
+  browser_list_observation_.Reset();
 }
 
 void SharedPinnedTabService::OnBrowserAdded(Browser* browser) {
@@ -617,7 +626,7 @@ void SharedPinnedTabService::SynchronizeNewBrowser(Browser* browser) {
     return;
   }
 
-  // Add shared pinned tabs to |browser first.
+  // Add shared pinned tabs to |browser| first.
   LOCK_REENTRANCE(model);
 
   for (auto i = 0u; i < pinned_tab_data_.size(); i++) {

--- a/browser/ui/tabs/shared_pinned_tab_service.cc
+++ b/browser/ui/tabs/shared_pinned_tab_service.cc
@@ -1,0 +1,680 @@
+/* Copyright (c) 2023 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "brave/browser/ui/tabs/shared_pinned_tab_service.h"
+
+#include <utility>
+
+#include "brave/browser/ui/tabs/features.h"
+#include "chrome/browser/profiles/profile.h"
+#include "chrome/browser/ui/browser.h"
+#include "chrome/browser/ui/browser_list.h"
+#include "chrome/browser/ui/browser_tabrestore.h"
+#include "chrome/browser/ui/browser_tabstrip.h"
+#include "content/public/browser/navigation_entry.h"
+#include "content/public/browser/web_contents_user_data.h"
+
+#define LOCK_REENTRANCE(tab_strip_model)                                  \
+  DCHECK(!change_source_model_) << "Already locked";                      \
+  base::AutoReset<raw_ptr<TabStripModel>> resetter(&change_source_model_, \
+                                                   raw_ptr(tab_strip_model))
+
+namespace {
+
+////////////////////////////////////////////////////////////////////////////////
+// SharedContentsData is a WebContentsUserData attached to pinned tab's web
+// contentses that could be movable between multiple windows.
+//
+class SharedContentsData
+    : public content::WebContentsUserData<SharedContentsData> {
+ public:
+  ~SharedContentsData() override = default;
+
+  static void RemoveFromWebContents(content::WebContents* contents) {
+    DCHECK(contents);
+    if (FromWebContents(contents)) {
+      contents->SetUserData(UserDataKey(), {});
+    }
+  }
+
+ private:
+  explicit SharedContentsData(content::WebContents* contents)
+      : WebContentsUserData(*contents) {}
+
+  friend WebContentsUserData;
+  WEB_CONTENTS_USER_DATA_KEY_DECL();
+};
+
+WEB_CONTENTS_USER_DATA_KEY_IMPL(SharedContentsData);
+
+////////////////////////////////////////////////////////////////////////////////
+// DummyContentsData is a WebContentsUserData attached to dummy web contentses
+// we creates for inactive pinned tabs.
+//
+class DummyContentsData
+    : public content::WebContentsUserData<DummyContentsData> {
+ public:
+  ~DummyContentsData() override = default;
+
+  static void RemoveFromWebContents(content::WebContents* contents) {
+    DCHECK(contents);
+    if (FromWebContents(contents)) {
+      contents->SetUserData(UserDataKey(), {});
+    }
+  }
+
+  content::WebContents* shared_contents() { return shared_contents_; }
+
+  void stop_propagation() { stop_propagation_ = true; }
+  bool propagation_stopped() const { return stop_propagation_; }
+
+ private:
+  DummyContentsData(content::WebContents* dummy_contents,
+                    content::WebContents* shared_contents)
+      : WebContentsUserData(*dummy_contents),
+        shared_contents_(shared_contents) {
+    DCHECK(SharedContentsData::FromWebContents(shared_contents_));
+  }
+
+  friend WebContentsUserData;
+  WEB_CONTENTS_USER_DATA_KEY_DECL();
+
+  raw_ptr<content::WebContents> shared_contents_ = nullptr;
+
+  bool stop_propagation_ = false;
+};
+
+WEB_CONTENTS_USER_DATA_KEY_IMPL(DummyContentsData);
+
+}  // namespace
+
+SharedPinnedTabService::SharedPinnedTabService(Profile* profile)
+    : profile_(profile) {
+  DCHECK(base::FeatureList::IsEnabled(tabs::features::kBraveSharedPinnedTabs));
+  profile_observation_.Observe(profile_);
+  browser_list_observation_.Observe(BrowserList::GetInstance());
+}
+
+SharedPinnedTabService::~SharedPinnedTabService() = default;
+
+bool SharedPinnedTabService::IsSharedContents(
+    content::WebContents* contents) const {
+  return !!SharedContentsData::FromWebContents(contents);
+}
+
+bool SharedPinnedTabService::IsDummyContents(
+    content::WebContents* contents) const {
+  return !!DummyContentsData::FromWebContents(contents);
+}
+
+const TabRendererData*
+SharedPinnedTabService::GetTabRendererDataForDummyContents(
+    int index,
+    content::WebContents* maybe_dummy_contents) {
+  auto* dummy_contents_data =
+      DummyContentsData::FromWebContents(maybe_dummy_contents);
+  DCHECK(dummy_contents_data);
+
+  const auto& pinned_tab_data = pinned_tab_data_.at(index);
+  DCHECK_EQ(dummy_contents_data->shared_contents(),
+            pinned_tab_data.shared_contents);
+
+  return &pinned_tab_data.renderer_data;
+}
+
+void SharedPinnedTabService::CacheWebContentsIfNeeded(
+    Browser* browser,
+    const std::vector<std::unique_ptr<TabStripModel::DetachedWebContents>>&
+        web_contents) {
+  DVLOG(2) << __FUNCTION__;
+  DCHECK(!profile_will_be_destroyed_);
+
+  // Caches shared contents from closing browser so that we can extend the
+  // lifetime of the contents.
+  if (!base::Contains(closing_browsers_, browser)) {
+    return;
+  }
+
+  // Check if there's any browser can host web contents.
+  if (browsers_.empty()) {
+    return;
+  }
+
+  for (auto& detached_web_contents : web_contents) {
+    if (!detached_web_contents->owned_contents) {
+      // Could be already cached by another component.
+      continue;
+    }
+
+    if (!SharedContentsData::FromWebContents(detached_web_contents->contents)) {
+      continue;
+    }
+
+    cached_shared_contentses_from_closing_browser_.insert(
+        std::move(detached_web_contents->owned_contents));
+    detached_web_contents->remove_reason =
+        TabStripModelChange::RemoveReason::kCached;
+  }
+}
+
+void SharedPinnedTabService::Shutdown() {
+  DCHECK(cached_shared_contentses_from_closing_browser_.empty())
+      << " There're dangled web contentses";
+}
+
+void SharedPinnedTabService::OnBrowserAdded(Browser* browser) {
+  if (profile_ != browser->profile()) {
+    return;
+  }
+
+  if (!browser->is_type_normal()) {
+    return;
+  }
+
+  DVLOG(2) << __FUNCTION__ << " " << browser->tab_strip_model()->count();
+
+  browser->tab_strip_model()->AddObserver(this);
+  DCHECK_EQ(0, browser->tab_strip_model()->count())
+      << "We're assuming that browser doesn't have any tabs at this point.";
+  browsers_.insert(browser);
+}
+
+void SharedPinnedTabService::OnBrowserSetLastActive(Browser* browser) {
+  if (profile_ != browser->profile()) {
+    return;
+  }
+
+  auto* model = browser->tab_strip_model();
+  DVLOG(2) << __FUNCTION__ << " " << model->count();
+  DCHECK(base::Contains(browsers_, browser))
+      << "We expect a browser created first and then activated";
+  DCHECK_LT(0, model->count()) << "We're assuming that browser has tabs";
+
+  SynchronizeNewBrowser(browser);
+
+  if (last_active_browser_ != browser) {
+    last_active_browser_ = browser;
+    OnActiveTabChanged(last_active_browser_->tab_strip_model());
+  }
+}
+
+void SharedPinnedTabService::OnBrowserClosing(Browser* browser) {
+  DVLOG(2) << __FUNCTION__;
+  if (!base::Contains(browsers_, browser)) {
+    // This could be called multiple times for the same |browser|
+    return;
+  }
+
+  browsers_.erase(browser);
+  closing_browsers_.insert(browser);
+  if (last_active_browser_ == browser) {
+    last_active_browser_ = nullptr;
+  }
+
+  if (browsers_.empty()) {
+    if (cached_shared_contentses_from_closing_browser_.size()) {
+      // This was the last browser and there's a dangling contentses. We should
+      // attach them to this |browser| so that they could be cleaned up.
+      for (auto i = 0u; i < pinned_tab_data_.size(); i++) {
+        if (!pinned_tab_data_.at(i).contents_owner_model) {
+          MoveSharedWebContentsToBrowser(browser, i);
+        }
+      }
+    }
+  } else {
+    for (auto& pinned_tab_data : pinned_tab_data_) {
+      if (pinned_tab_data.contents_owner_model == browser->tab_strip_model()) {
+        pinned_tab_data.contents_owner_model = nullptr;
+      }
+    }
+  }
+}
+
+void SharedPinnedTabService::OnBrowserRemoved(Browser* browser) {
+  DVLOG(2) << __FUNCTION__;
+  DCHECK(base::Contains(closing_browsers_, browser));
+  closing_browsers_.erase(browser);
+}
+
+void SharedPinnedTabService::OnTabStripModelChanged(
+    TabStripModel* tab_strip_model,
+    const TabStripModelChange& change,
+    const TabStripSelectionChange& selection) {
+  if (change_source_model_) {
+    return;
+  }
+
+  if (change.type() == TabStripModelChange::Type::kInserted) {
+    OnTabAdded(tab_strip_model, change.GetInsert());
+  } else if (change.type() == TabStripModelChange::Type::kRemoved) {
+    OnTabRemoved(tab_strip_model, change.GetRemove());
+  } else if (change.type() == TabStripModelChange::Type::kMoved) {
+    OnTabMoved(tab_strip_model, change.GetMove());
+  }
+  // TODO(sko) Replace and move should be handled.
+
+  if (selection.active_tab_changed()) {
+    OnActiveTabChanged(tab_strip_model);
+  }
+}
+
+void SharedPinnedTabService::TabPinnedStateChanged(
+    TabStripModel* tab_strip_model,
+    content::WebContents* contents,
+    int index) {
+  if (change_source_model_) {
+    return;
+  }
+
+  LOCK_REENTRANCE(tab_strip_model);
+
+  DVLOG(2) << __FUNCTION__ << " index: " << index << " pinned? "
+           << tab_strip_model->IsTabPinned(index);
+  if (tab_strip_model->IsTabPinned(index)) {
+    SharedContentsData::CreateForWebContents(contents);
+    auto tab_renderer_data =
+        TabRendererData::FromTabInModel(tab_strip_model, index);
+    DCHECK_LE(index, static_cast<int>(pinned_tab_data_.size()));
+    pinned_tab_data_.insert(pinned_tab_data_.begin() + index,
+                            {.renderer_data = tab_renderer_data,
+                             .shared_contents = contents,
+                             .contents_owner_model = tab_strip_model});
+    SynchronizeNewPinnedTab(index);
+  } else {
+    // We shouldn't count on |index| in this case. The previous index could be
+    // different from |index|.
+    if (auto* dummy_contents_data =
+            DummyContentsData::FromWebContents(contents)) {
+      contents = dummy_contents_data->shared_contents();
+    }
+    auto iter = base::ranges::find(pinned_tab_data_, contents,
+                                   &PinnedTabData::shared_contents);
+    DCHECK(iter != pinned_tab_data_.end());
+
+    const auto previous_index = std::distance(pinned_tab_data_.begin(), iter);
+    pinned_tab_data_.erase(iter);
+
+    SharedContentsData::RemoveFromWebContents(contents);
+    DummyContentsData::RemoveFromWebContents(contents);
+
+    SynchronizeDeletedPinnedTab(previous_index);
+  }
+}
+
+void SharedPinnedTabService::TabChangedAt(content::WebContents* contents,
+                                          int index,
+                                          TabChangeType change_type) {
+  if (change_source_model_) {
+    return;
+  }
+
+  if (DummyContentsData::FromWebContents(contents)) {
+    // We don't need to propagate changes from dummy contentses.
+    return;
+  }
+
+  auto iter = base::ranges::find(pinned_tab_data_, contents,
+                                 &PinnedTabData::shared_contents);
+  if (iter == pinned_tab_data_.end()) {
+    return;
+  }
+
+  LOCK_REENTRANCE(iter->contents_owner_model);
+
+  iter->renderer_data =
+      TabRendererData::FromTabInModel(iter->contents_owner_model, index);
+  for (auto* browser : browsers_) {
+    auto* tab_strip_model = browser->tab_strip_model();
+    if (tab_strip_model == change_source_model_) {
+      continue;
+    }
+
+    tab_strip_model->UpdateWebContentsStateAt(index, change_type);
+  }
+}
+
+void SharedPinnedTabService::OnProfileWillBeDestroyed(Profile* profile) {
+  profile_will_be_destroyed_ = true;
+}
+
+void SharedPinnedTabService::OnTabAdded(
+    TabStripModel* tab_strip_model,
+    const TabStripModelChange::Insert* insert) {
+  DVLOG(2) << __FUNCTION__;
+  LOCK_REENTRANCE(tab_strip_model);
+  DCHECK(insert);
+
+  for (const auto& contents_with_index : insert->contents) {
+    auto current_index =
+        tab_strip_model->GetIndexOfWebContents(contents_with_index.contents);
+    if (!tab_strip_model->IsTabPinned(current_index)) {
+      continue;
+    }
+
+    auto tab_renderer_data =
+        TabRendererData::FromTabInModel(tab_strip_model, current_index);
+    if (static_cast<int>(pinned_tab_data_.size()) > current_index &&
+        pinned_tab_data_.at(current_index).renderer_data.last_committed_url ==
+            tab_renderer_data.last_committed_url) {
+      DummyContentsData::CreateForWebContents(
+          /* dummy_contents= */ contents_with_index.contents,
+          /* shared_contents= */ pinned_tab_data_.at(current_index)
+              .shared_contents);
+      continue;
+    }
+
+    SharedContentsData::CreateForWebContents(contents_with_index.contents);
+    DCHECK_LE(contents_with_index.index,
+              static_cast<int>(pinned_tab_data_.size()));
+    pinned_tab_data_.insert(
+        pinned_tab_data_.begin() + contents_with_index.index,
+        {.renderer_data = tab_renderer_data,
+         .shared_contents = contents_with_index.contents,
+         .contents_owner_model = tab_strip_model});
+
+    SynchronizeNewPinnedTab(contents_with_index.index);
+  }
+}
+
+void SharedPinnedTabService::OnTabMoved(TabStripModel* tab_strip_model,
+                                        const TabStripModelChange::Move* move) {
+  if (!tab_strip_model->IsTabPinned(move->to_index)) {
+    return;
+  }
+
+  if (static_cast<int>(pinned_tab_data_.size()) <= move->from_index) {
+    // This case is where a tab is newly pinned. This case will be dealt in
+    // TabPinnedStateChanged().
+    return;
+  }
+
+  DVLOG(2) << __FUNCTION__;
+
+  LOCK_REENTRANCE(tab_strip_model);
+
+  // Now we're handling a pinned tab's was moved while remaining pinned.
+  if (move->from_index < move->to_index) {
+    std::rotate(pinned_tab_data_.begin() + move->from_index,
+                pinned_tab_data_.begin() + move->from_index + 1,
+                pinned_tab_data_.begin() + move->to_index + 1);
+  } else {
+    std::rotate(pinned_tab_data_.begin() + move->to_index,
+                pinned_tab_data_.begin() + move->from_index,
+                pinned_tab_data_.begin() + move->from_index + 1);
+  }
+
+  SynchronizeMovedPinnedTab(move->from_index, move->to_index);
+}
+
+void SharedPinnedTabService::OnTabRemoved(
+    TabStripModel* tab_strip_model,
+    const TabStripModelChange::Remove* remove) {
+  if (last_active_browser_ &&
+      last_active_browser_->tab_strip_model() != tab_strip_model) {
+    // We filters removal events from inactive browsers. Otherwise, unpinning
+    // a tab could delete wrong tabs.
+    return;
+  }
+
+  DVLOG(2) << __FUNCTION__;
+  DCHECK(remove);
+
+  if (base::Contains(closing_browsers_, tab_strip_model,
+                     &Browser::tab_strip_model)) {
+    // We don't close pinned tabs if this browser is being closed.
+    return;
+  }
+
+  LOCK_REENTRANCE(tab_strip_model);
+
+  for (const auto& removed_tab : remove->contents) {
+    if (removed_tab.index >= static_cast<int>(pinned_tab_data_.size())) {
+      // This was non pinned tab
+      continue;
+    }
+
+    if (auto* dummy_contents_data =
+            DummyContentsData::FromWebContents(removed_tab.contents);
+        dummy_contents_data && dummy_contents_data->propagation_stopped()) {
+      // Restoring from cached contents removes dummy pinned tabs. In this case,
+      // we shouldn't touch data.
+      continue;
+    }
+
+    pinned_tab_data_.erase(pinned_tab_data_.begin() + removed_tab.index);
+    SynchronizeDeletedPinnedTab(removed_tab.index);
+  }
+}
+
+void SharedPinnedTabService::OnActiveTabChanged(
+    TabStripModel* tab_strip_model) {
+  if (change_source_model_) {
+    return;
+  }
+
+  DVLOG(2) << __FUNCTION__;
+
+  // Swap the pinned active web contents with the shared web contents if needed
+  if (!last_active_browser_ ||
+      last_active_browser_->tab_strip_model() != tab_strip_model) {
+    return;
+  }
+
+  if (base::Contains(closing_browsers_, tab_strip_model,
+                     &Browser::tab_strip_model)) {
+    return;
+  }
+
+  const auto active_index = tab_strip_model->active_index();
+  if (active_index == TabStripModel::kNoTab) {
+    // The browser could be in the middle of shutdown
+    return;
+  }
+
+  if (!tab_strip_model->IsTabPinned(active_index)) {
+    return;
+  }
+
+  if (pinned_tab_data_.at(active_index).contents_owner_model ==
+      tab_strip_model) {
+    // this pinned tab already has the shared contents.
+    DCHECK_EQ(pinned_tab_data_.at(active_index).shared_contents,
+              tab_strip_model->GetWebContentsAt(active_index));
+    return;
+  }
+
+  base::SequencedTaskRunner::GetCurrentDefault()->PostTask(
+      FROM_HERE,
+      base::BindOnce(
+          &SharedPinnedTabService::MoveSharedWebContentsToActiveBrowser,
+          base::Unretained(this), active_index));
+}
+
+void SharedPinnedTabService::SynchronizeNewPinnedTab(int index) {
+  DVLOG(2) << __FUNCTION__;
+  DCHECK_LT(index, static_cast<int>(pinned_tab_data_.size()));
+  DCHECK(change_source_model_);
+
+  for (auto* browser : browsers_) {
+    auto* model = browser->tab_strip_model();
+    if (model == change_source_model_) {
+      continue;
+    }
+
+    model->InsertWebContentsAt(
+        index,
+        CreateDummyWebContents(pinned_tab_data_.at(index).shared_contents),
+        ADD_PINNED | ADD_FORCE_INDEX);
+  }
+}
+
+void SharedPinnedTabService::SynchronizeDeletedPinnedTab(int index) {
+  DVLOG(2) << __FUNCTION__;
+  DCHECK(change_source_model_);
+
+  for (auto* browser : browsers_) {
+    auto* model = browser->tab_strip_model();
+    if (model == change_source_model_) {
+      continue;
+    }
+
+    // We may not want to keep history for dummy pinned tabs, so pass 0 for
+    // |close_type|.
+    model->CloseWebContentsAt(index, /* close_type */ 0);
+  }
+}
+
+void SharedPinnedTabService::SynchronizeMovedPinnedTab(int from, int to) {
+  DVLOG(2) << __FUNCTION__;
+  DCHECK(change_source_model_);
+
+  for (auto* browser : browsers_) {
+    auto* model = browser->tab_strip_model();
+    if (model == change_source_model_) {
+      continue;
+    }
+
+    model->MoveWebContentsAt(from, to, /* select_after_move= */ false);
+  }
+}
+
+void SharedPinnedTabService::SynchronizeNewBrowser(Browser* browser) {
+  auto* model = browser->tab_strip_model();
+  std::vector<PinnedTabData> new_pinned_tabs;
+  for (auto i = 0; i < model->IndexOfFirstNonPinnedTab(); i++) {
+    new_pinned_tabs.push_back(
+        {.renderer_data = TabRendererData::FromTabInModel(model, i),
+         .shared_contents = model->GetWebContentsAt(i),
+         .contents_owner_model = model});
+  }
+
+  if (base::ranges::equal(
+          new_pinned_tabs, pinned_tab_data_,
+          [&](const auto& new_pin_tab, const auto& old_pin_tab) {
+            return new_pin_tab.renderer_data.last_committed_url ==
+                   old_pin_tab.renderer_data.last_committed_url;
+          })) {
+    DVLOG(2) << __FUNCTION__ << " Shared pinned tabs in sync";
+    // Tabs are already in sync. Check web contents data is attached properly
+    // in case they were restored from a session.
+    for (auto i = 0u; i < pinned_tab_data_.size(); i++) {
+      content::WebContents* contents = new_pinned_tabs.at(i).shared_contents;
+      if (IsSharedContents(contents)) {
+        continue;
+      }
+
+      if (!IsDummyContents(contents)) {
+        DummyContentsData::CreateForWebContents(
+            /* dummy_contents= */ new_pinned_tabs.at(i).shared_contents,
+            /* shared_contents= */ pinned_tab_data_.at(i).shared_contents);
+      }
+    }
+    return;
+  }
+
+  // Add shared pinned tabs to |browser first.
+  LOCK_REENTRANCE(model);
+
+  for (auto i = 0u; i < pinned_tab_data_.size(); i++) {
+    model->InsertWebContentsAt(
+        i, CreateDummyWebContents(pinned_tab_data_[i].shared_contents),
+        ADD_PINNED | ADD_FORCE_INDEX);
+  }
+
+  if (new_pinned_tabs.empty()) {
+    return;
+  }
+
+  DVLOG(2) << __FUNCTION__ << " Append new shared pinned tabs";
+  // If the |browser| has pinned tabs out of sync, append them to other browsers
+  const auto offset = pinned_tab_data_.size();
+  for (auto i = 0u; i < new_pinned_tabs.size(); i++) {
+    SharedContentsData::CreateForWebContents(
+        new_pinned_tabs.at(i).shared_contents);
+    pinned_tab_data_.push_back(std::move(new_pinned_tabs.at(i)));
+    SynchronizeNewPinnedTab(offset + i);
+  }
+}
+
+void SharedPinnedTabService::MoveSharedWebContentsToActiveBrowser(int index) {
+  if (!last_active_browser_) {
+    DVLOG(2)
+        << "Failed to attach contents to active browser: No active browser";
+    return;
+  }
+
+  MoveSharedWebContentsToBrowser(last_active_browser_, index);
+}
+
+void SharedPinnedTabService::MoveSharedWebContentsToBrowser(Browser* browser,
+                                                            int index) {
+  auto* tab_strip_model = browser->tab_strip_model();
+  DCHECK_LT(index, tab_strip_model->count());
+
+  LOCK_REENTRANCE(tab_strip_model);
+
+  auto& pinned_tab_data = pinned_tab_data_.at(index);
+  if (pinned_tab_data.contents_owner_model) {
+    std::unique_ptr<content::WebContents> unique_shared_contents;
+    unique_shared_contents =
+        pinned_tab_data.contents_owner_model->ReplaceWebContentsAt(
+            index, CreateDummyWebContents(pinned_tab_data.shared_contents));
+    DCHECK_EQ(pinned_tab_data.shared_contents, unique_shared_contents.get());
+    pinned_tab_data.contents_owner_model = tab_strip_model;
+
+    auto* dummy_contents =
+        pinned_tab_data.contents_owner_model->GetWebContentsAt(index);
+    auto* dummy_contents_data =
+        DummyContentsData::FromWebContents(dummy_contents);
+    DCHECK(dummy_contents_data);
+    dummy_contents_data->stop_propagation();
+
+    pinned_tab_data.contents_owner_model->ReplaceWebContentsAt(
+        index, std::move(unique_shared_contents));
+  } else {
+    // Restore a shared pinned tab from a closed browser.
+    auto iter =
+        base::ranges::find(cached_shared_contentses_from_closing_browser_,
+                           pinned_tab_data.shared_contents,
+                           &std::unique_ptr<content::WebContents>::get);
+    DCHECK(iter != cached_shared_contentses_from_closing_browser_.end());
+    auto unique_shared_contents = std::move(*iter);
+    DCHECK(unique_shared_contents);
+
+    cached_shared_contentses_from_closing_browser_.erase(iter);
+
+    pinned_tab_data.contents_owner_model = tab_strip_model;
+
+    auto* dummy_contents_data = DummyContentsData::FromWebContents(
+        tab_strip_model->GetWebContentsAt(index));
+    DCHECK(dummy_contents_data);
+    dummy_contents_data->stop_propagation();
+
+    // Unfortunately, We can't replace existing tab contents with cached web
+    // contents. We should use restore method.
+    chrome::AddRestoredTabFromCache(
+        std::move(unique_shared_contents), browser, index,
+        /* group= */ {},
+        /* select */ true, /* pin= */ true, /* user_agent_override= */ {},
+        /* extra_data= */ {});
+
+    // In order to prevent browser from being closed, we should close the dummy
+    // contents after we restore the tab.
+    tab_strip_model->CloseWebContentsAt(index + 1, /* close_type */ 0);
+  }
+}
+
+std::unique_ptr<content::WebContents>
+SharedPinnedTabService::CreateDummyWebContents(
+    content::WebContents* shared_contents) {
+  content::WebContents::CreateParams create_params(profile_);
+  create_params.initially_hidden = true;
+  create_params.desired_renderer_state =
+      content::WebContents::CreateParams::kNoRendererProcess;
+  auto dummy_contents = content::WebContents::Create(create_params);
+  DummyContentsData::CreateForWebContents(dummy_contents.get(),
+                                          shared_contents);
+  return dummy_contents;
+}

--- a/browser/ui/tabs/shared_pinned_tab_service.cc
+++ b/browser/ui/tabs/shared_pinned_tab_service.cc
@@ -51,7 +51,7 @@ WEB_CONTENTS_USER_DATA_KEY_IMPL(SharedContentsData);
 
 ////////////////////////////////////////////////////////////////////////////////
 // DummyContentsData is a WebContentsUserData attached to dummy web contentses
-// we creates for inactive pinned tabs.
+// we create for inactive pinned tabs.
 //
 class DummyContentsData
     : public content::WebContentsUserData<DummyContentsData> {
@@ -253,7 +253,7 @@ void SharedPinnedTabService::OnTabStripModelChanged(
   } else if (change.type() == TabStripModelChange::Type::kMoved) {
     OnTabMoved(tab_strip_model, change.GetMove());
   }
-  // TODO(sko) Replace and move should be handled.
+  // TODO(sko) Replace should be handled.
 
   if (selection.active_tab_changed()) {
     OnActiveTabChanged(tab_strip_model);

--- a/browser/ui/tabs/shared_pinned_tab_service.h
+++ b/browser/ui/tabs/shared_pinned_tab_service.h
@@ -89,6 +89,10 @@ class SharedPinnedTabService : public KeyedService,
                     const TabStripModelChange::Remove* remove);
   void OnActiveTabChanged(TabStripModel* tab_strip_model);
 
+  void OnTabUnpinned(TabStripModel* tab_strip_model,
+                     base::WeakPtr<content::WebContents> contents,
+                     int index);
+
   void SynchronizeNewPinnedTab(int index);
   void SynchronizeDeletedPinnedTab(int index);
   void SynchronizeMovedPinnedTab(int from, int to);

--- a/browser/ui/tabs/shared_pinned_tab_service.h
+++ b/browser/ui/tabs/shared_pinned_tab_service.h
@@ -43,6 +43,10 @@ class SharedPinnedTabService : public KeyedService,
   SharedPinnedTabService& operator=(const SharedPinnedTabService&) = delete;
   ~SharedPinnedTabService() override;
 
+  // There are two types of contents for pinned tabs. "Shared contents" is a
+  // single instance contents for a pinned tab shared across multiple windows.
+  // "Dummy contents" is a empty contents used as a placeholder for inactive
+  // windows.
   bool IsSharedContents(content::WebContents* contents) const;
   bool IsDummyContents(content::WebContents* contents) const;
 

--- a/browser/ui/tabs/shared_pinned_tab_service.h
+++ b/browser/ui/tabs/shared_pinned_tab_service.h
@@ -124,6 +124,8 @@ class SharedPinnedTabService : public KeyedService,
 
   base::ScopedObservation<BrowserList, BrowserListObserver>
       browser_list_observation_{this};
+
+  base::WeakPtrFactory<SharedPinnedTabService> weak_ptr_factory_{this};
 };
 
 #endif  // BRAVE_BROWSER_UI_TABS_SHARED_PINNED_TAB_SERVICE_H_

--- a/browser/ui/tabs/shared_pinned_tab_service.h
+++ b/browser/ui/tabs/shared_pinned_tab_service.h
@@ -1,0 +1,125 @@
+/* Copyright (c) 2023 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_BROWSER_UI_TABS_SHARED_PINNED_TAB_SERVICE_H_
+#define BRAVE_BROWSER_UI_TABS_SHARED_PINNED_TAB_SERVICE_H_
+
+#include <memory>
+#include <vector>
+
+#include "base/scoped_observation.h"
+#include "chrome/browser/profiles/profile_observer.h"
+#include "chrome/browser/ui/browser_list_observer.h"
+#include "chrome/browser/ui/tabs/tab_renderer_data.h"
+#include "chrome/browser/ui/tabs/tab_strip_model.h"
+#include "chrome/browser/ui/tabs/tab_strip_model_observer.h"
+#include "components/keyed_service/core/keyed_service.h"
+
+class Profile;
+class BrowserList;
+
+// SharedPinnedTabService observes pinned tabs and synchronizes it to all
+// windows with the same profile. When a pinned tab in a window is activated,
+// the pinned tab's web contents could be replaced with a web contents that
+// user was interacting with in another window. i.e. This service will make
+// pinned tabs to share a single web contents instance.
+// This service will be created when profile is created, so we don't have to
+// create this explicitly.
+class SharedPinnedTabService : public KeyedService,
+                               public BrowserListObserver,
+                               public TabStripModelObserver,
+                               public ProfileObserver {
+ public:
+  struct PinnedTabData {
+    TabRendererData renderer_data;
+    raw_ptr<content::WebContents> shared_contents = nullptr;
+    raw_ptr<TabStripModel> contents_owner_model = nullptr;
+  };
+
+  explicit SharedPinnedTabService(Profile* profile);
+  SharedPinnedTabService(const SharedPinnedTabService&) = delete;
+  SharedPinnedTabService& operator=(const SharedPinnedTabService&) = delete;
+  ~SharedPinnedTabService() override;
+
+  bool IsSharedContents(content::WebContents* contents) const;
+  bool IsDummyContents(content::WebContents* contents) const;
+
+  // Returns nullptr if it's not dummy contents or the data isn't ready yet.
+  const TabRendererData* GetTabRendererDataForDummyContents(
+      int index,
+      content::WebContents* maybe_dummy_contents);
+
+  void CacheWebContentsIfNeeded(
+      Browser* browser,
+      const std::vector<std::unique_ptr<TabStripModel::DetachedWebContents>>&
+          web_contents);
+
+  // KeyedService:
+  void Shutdown() override;
+
+  // BrowserListObserver:
+  void OnBrowserAdded(Browser* browser) override;
+  void OnBrowserSetLastActive(Browser* browser) override;
+  void OnBrowserClosing(Browser* browser) override;
+  void OnBrowserRemoved(Browser* browser) override;
+
+  // TabStripModelObserver:
+  void OnTabStripModelChanged(
+      TabStripModel* tab_strip_model,
+      const TabStripModelChange& change,
+      const TabStripSelectionChange& selection) override;
+  void TabPinnedStateChanged(TabStripModel* tab_strip_model,
+                             content::WebContents* contents,
+                             int index) override;
+  void TabChangedAt(content::WebContents* contents,
+                    int index,
+                    TabChangeType change_type) override;
+
+  // ProfileWillBeDestroyed;
+  void OnProfileWillBeDestroyed(Profile* profile) override;
+
+ private:
+  void OnTabAdded(TabStripModel* tab_strip_model,
+                  const TabStripModelChange::Insert* insert);
+  void OnTabMoved(TabStripModel* tab_strip_model,
+                  const TabStripModelChange::Move* move);
+  void OnTabRemoved(TabStripModel* tab_strip_model,
+                    const TabStripModelChange::Remove* remove);
+  void OnActiveTabChanged(TabStripModel* tab_strip_model);
+
+  void SynchronizeNewPinnedTab(int index);
+  void SynchronizeDeletedPinnedTab(int index);
+  void SynchronizeMovedPinnedTab(int from, int to);
+  void SynchronizeNewBrowser(Browser* browser);
+
+  void MoveSharedWebContentsToActiveBrowser(int index);
+  void MoveSharedWebContentsToBrowser(Browser* browser, int index);
+
+  std::unique_ptr<content::WebContents> CreateDummyWebContents(
+      content::WebContents* shared_contents);
+
+  raw_ptr<Profile> profile_;
+
+  base::flat_set<Browser*> browsers_;
+  raw_ptr<Browser> last_active_browser_ = nullptr;
+
+  base::flat_set<Browser*> closing_browsers_;
+  base::flat_set<std::unique_ptr<content::WebContents>>
+      cached_shared_contentses_from_closing_browser_;
+
+  // This data is ordered in the actual pinned tab order.
+  std::vector<PinnedTabData> pinned_tab_data_;
+
+  raw_ptr<TabStripModel> change_source_model_ = nullptr;
+
+  bool profile_will_be_destroyed_ = false;
+
+  base::ScopedObservation<Profile, ProfileObserver> profile_observation_{this};
+
+  base::ScopedObservation<BrowserList, BrowserListObserver>
+      browser_list_observation_{this};
+};
+
+#endif  // BRAVE_BROWSER_UI_TABS_SHARED_PINNED_TAB_SERVICE_H_

--- a/browser/ui/tabs/shared_pinned_tab_service_factory.cc
+++ b/browser/ui/tabs/shared_pinned_tab_service_factory.cc
@@ -21,20 +21,16 @@ SharedPinnedTabServiceFactory* SharedPinnedTabServiceFactory::GetInstance() {
 }
 
 SharedPinnedTabServiceFactory::SharedPinnedTabServiceFactory()
-    : ProfileKeyedServiceFactory("PinnedTabService") {}
+    : ProfileKeyedServiceFactory("SharedPinnedTabService",
+                                 ProfileSelections::BuildForAllProfiles()) {}
 
 SharedPinnedTabServiceFactory::~SharedPinnedTabServiceFactory() {}
 
 KeyedService* SharedPinnedTabServiceFactory::BuildServiceInstanceFor(
-    content::BrowserContext* profile) const {
-  return new SharedPinnedTabService(static_cast<Profile*>(profile));
+    content::BrowserContext* context) const {
+  return new SharedPinnedTabService(Profile::FromBrowserContext(context));
 }
 
 bool SharedPinnedTabServiceFactory::ServiceIsCreatedWithBrowserContext() const {
   return true;
-}
-
-content::BrowserContext* SharedPinnedTabServiceFactory::GetBrowserContextToUse(
-    content::BrowserContext* context) const {
-  return chrome::GetBrowserContextOwnInstanceInIncognito(context);
 }

--- a/browser/ui/tabs/shared_pinned_tab_service_factory.cc
+++ b/browser/ui/tabs/shared_pinned_tab_service_factory.cc
@@ -1,0 +1,40 @@
+/* Copyright (c) 2023 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "brave/browser/ui/tabs/shared_pinned_tab_service_factory.h"
+
+#include "brave/browser/ui/tabs/shared_pinned_tab_service.h"
+#include "chrome/browser/profiles/incognito_helpers.h"
+#include "chrome/browser/profiles/profile.h"
+
+// static
+SharedPinnedTabService* SharedPinnedTabServiceFactory::GetForProfile(
+    Profile* profile) {
+  return static_cast<SharedPinnedTabService*>(
+      GetInstance()->GetServiceForBrowserContext(profile, true));
+}
+
+SharedPinnedTabServiceFactory* SharedPinnedTabServiceFactory::GetInstance() {
+  return base::Singleton<SharedPinnedTabServiceFactory>::get();
+}
+
+SharedPinnedTabServiceFactory::SharedPinnedTabServiceFactory()
+    : ProfileKeyedServiceFactory("PinnedTabService") {}
+
+SharedPinnedTabServiceFactory::~SharedPinnedTabServiceFactory() {}
+
+KeyedService* SharedPinnedTabServiceFactory::BuildServiceInstanceFor(
+    content::BrowserContext* profile) const {
+  return new SharedPinnedTabService(static_cast<Profile*>(profile));
+}
+
+bool SharedPinnedTabServiceFactory::ServiceIsCreatedWithBrowserContext() const {
+  return true;
+}
+
+content::BrowserContext* SharedPinnedTabServiceFactory::GetBrowserContextToUse(
+    content::BrowserContext* context) const {
+  return chrome::GetBrowserContextOwnInstanceInIncognito(context);
+}

--- a/browser/ui/tabs/shared_pinned_tab_service_factory.h
+++ b/browser/ui/tabs/shared_pinned_tab_service_factory.h
@@ -1,0 +1,34 @@
+/* Copyright (c) 2023 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_BROWSER_UI_TABS_SHARED_PINNED_TAB_SERVICE_FACTORY_H_
+#define BRAVE_BROWSER_UI_TABS_SHARED_PINNED_TAB_SERVICE_FACTORY_H_
+
+#include "base/memory/singleton.h"
+#include "chrome/browser/profiles/profile_keyed_service_factory.h"
+
+class SharedPinnedTabService;
+
+class SharedPinnedTabServiceFactory : public ProfileKeyedServiceFactory {
+ public:
+  static SharedPinnedTabService* GetForProfile(Profile* profile);
+
+  static SharedPinnedTabServiceFactory* GetInstance();
+
+ private:
+  friend struct base::DefaultSingletonTraits<SharedPinnedTabServiceFactory>;
+
+  SharedPinnedTabServiceFactory();
+  ~SharedPinnedTabServiceFactory() override;
+
+  // BrowserContextKeyedServiceFactory:
+  KeyedService* BuildServiceInstanceFor(
+      content::BrowserContext* profile) const override;
+  bool ServiceIsCreatedWithBrowserContext() const override;
+  content::BrowserContext* GetBrowserContextToUse(
+      content::BrowserContext* context) const override;
+};
+
+#endif  // BRAVE_BROWSER_UI_TABS_SHARED_PINNED_TAB_SERVICE_FACTORY_H_

--- a/browser/ui/tabs/shared_pinned_tab_service_factory.h
+++ b/browser/ui/tabs/shared_pinned_tab_service_factory.h
@@ -25,10 +25,8 @@ class SharedPinnedTabServiceFactory : public ProfileKeyedServiceFactory {
 
   // BrowserContextKeyedServiceFactory:
   KeyedService* BuildServiceInstanceFor(
-      content::BrowserContext* profile) const override;
-  bool ServiceIsCreatedWithBrowserContext() const override;
-  content::BrowserContext* GetBrowserContextToUse(
       content::BrowserContext* context) const override;
+  bool ServiceIsCreatedWithBrowserContext() const override;
 };
 
 #endif  // BRAVE_BROWSER_UI_TABS_SHARED_PINNED_TAB_SERVICE_FACTORY_H_

--- a/browser/ui/tabs/test/BUILD.gn
+++ b/browser/ui/tabs/test/BUILD.gn
@@ -13,6 +13,7 @@ source_set("browser_tests") {
   ]
 
   deps = [
+    "//brave/browser/ui/tabs:tabs",
     "//brave/components/constants",
     "//chrome/app:command_ids",
     "//chrome/browser",

--- a/browser/ui/tabs/test/BUILD.gn
+++ b/browser/ui/tabs/test/BUILD.gn
@@ -7,7 +7,10 @@ source_set("browser_tests") {
   testonly = true
   defines = [ "HAS_OUT_OF_PROC_TEST_RUNNER" ]
 
-  sources = [ "brave_tab_strip_model_browsertest.cc" ]
+  sources = [
+    "brave_tab_strip_model_browsertest.cc",
+    "shared_pinned_tab_service_browsertest.cc",
+  ]
 
   deps = [
     "//brave/components/constants",

--- a/browser/ui/tabs/test/shared_pinned_tab_service_browsertest.cc
+++ b/browser/ui/tabs/test/shared_pinned_tab_service_browsertest.cc
@@ -109,14 +109,19 @@ IN_PROC_BROWSER_TEST_F(SharedPinnedTabServiceBrowserTest, PinAndUnpinTabs) {
       tab_strip_model_2->GetWebContentsAt(0)));
 
   // Test: Unpin the tab and see if it's synchronized
+  browser_1->window()->Show();
   tab_strip_model_1->SetTabPinned(0, /* pinned= */ false);
   EXPECT_FALSE(tab_strip_model_1->IsTabPinned(0));
-  EXPECT_FALSE(shared_pinned_tab_service->IsSharedContents(
-      tab_strip_model_1->GetWebContentsAt(0)));
+  WaitUntil(base::BindLambdaForTesting([&]() {
+    return shared_pinned_tab_service->IsSharedContents(
+        tab_strip_model_1->GetWebContentsAt(0));
+  }));
   EXPECT_FALSE(shared_pinned_tab_service->IsDummyContents(
       tab_strip_model_1->GetWebContentsAt(0)));
 
-  EXPECT_EQ(1, tab_strip_model_2->count());
+  WaitUntil(base::BindLambdaForTesting(
+      [&]() { return tab_strip_model_2->count() == 1; }));
+
   EXPECT_FALSE(tab_strip_model_2->IsTabPinned(0));
   EXPECT_FALSE(shared_pinned_tab_service->IsSharedContents(
       tab_strip_model_2->GetWebContentsAt(0)));

--- a/browser/ui/tabs/test/shared_pinned_tab_service_browsertest.cc
+++ b/browser/ui/tabs/test/shared_pinned_tab_service_browsertest.cc
@@ -1,0 +1,193 @@
+/* Copyright (c) 2023 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "brave/browser/ui/tabs/shared_pinned_tab_service.h"
+
+#include "base/test/bind.h"
+#include "base/test/scoped_feature_list.h"
+#include "brave/browser/ui/tabs/features.h"
+#include "brave/browser/ui/tabs/shared_pinned_tab_service_factory.h"
+#include "chrome/browser/ui/browser.h"
+#include "chrome/browser/ui/browser_commands.h"
+#include "chrome/browser/ui/browser_window.h"
+#include "chrome/browser/ui/tabs/tab_strip_model.h"
+#include "chrome/test/base/in_process_browser_test.h"
+#include "content/public/test/browser_test.h"
+
+class SharedPinnedTabServiceBrowserTest : public InProcessBrowserTest {
+ public:
+  SharedPinnedTabServiceBrowserTest()
+      : feature_list_(tabs::features::kBraveSharedPinnedTabs) {}
+
+  ~SharedPinnedTabServiceBrowserTest() override = default;
+
+  Browser* CreateNewBrowser() {
+    auto* new_browser =
+        chrome::OpenEmptyWindow(browser()->profile(),
+                                /*should_trigger_session_restore= */ false);
+    browsers_.push_back(new_browser->AsWeakPtr());
+    return new_browser;
+  }
+
+  SharedPinnedTabService* GetForBrowser(Browser* browser) {
+    return SharedPinnedTabServiceFactory::GetForProfile(browser->profile());
+  }
+
+  void WaitUntil(base::RepeatingCallback<bool()> condition) {
+    if (condition.Run()) {
+      return;
+    }
+
+    base::RepeatingTimer scheduler;
+    scheduler.Start(FROM_HERE, base::Milliseconds(100),
+                    base::BindLambdaForTesting([this, &condition]() {
+                      if (condition.Run()) {
+                        run_loop_->Quit();
+                      }
+                    }));
+    Run();
+  }
+
+  void Run() {
+    run_loop_ = std::make_unique<base::RunLoop>();
+    run_loop_->Run();
+  }
+
+  // InProcessBrowserTest:
+  void TearDownOnMainThread() override {
+    for (auto& browser : browsers_) {
+      if (browser) {
+        browser->window()->Close();
+      }
+    }
+
+    WaitUntil(base::BindLambdaForTesting([&]() {
+      return base::ranges::none_of(browsers_, [](const auto& b) { return b; });
+    }));
+
+    InProcessBrowserTest::TearDownOnMainThread();
+  }
+
+ private:
+  base::test::ScopedFeatureList feature_list_;
+
+  std::vector<base::WeakPtr<Browser>> browsers_;
+
+  std::unique_ptr<base::RunLoop> run_loop_;
+};
+
+IN_PROC_BROWSER_TEST_F(SharedPinnedTabServiceBrowserTest, PinAndUnpinTabs) {
+  // Precondition
+  auto* browser_1 = browser();
+  auto* tab_strip_model_1 = browser_1->tab_strip_model();
+  ASSERT_EQ(1, tab_strip_model_1->count());
+  ASSERT_FALSE(tab_strip_model_1->IsTabPinned(0));
+
+  auto* browser_2 = CreateNewBrowser();
+  auto* tab_strip_model_2 = browser_2->tab_strip_model();
+  ASSERT_EQ(1, tab_strip_model_2->count());
+  ASSERT_FALSE(tab_strip_model_2->IsTabPinned(0));
+
+  auto* shared_pinned_tab_service = GetForBrowser(browser_1);
+  ASSERT_TRUE(shared_pinned_tab_service);
+
+  // Test: set a tab pinned and see if it's synchronized
+  tab_strip_model_1->SetTabPinned(0, /* pinned= */ true);
+  EXPECT_TRUE(tab_strip_model_1->IsTabPinned(0));
+  EXPECT_TRUE(shared_pinned_tab_service->IsSharedContents(
+      tab_strip_model_1->GetWebContentsAt(0)));
+  EXPECT_FALSE(shared_pinned_tab_service->IsDummyContents(
+      tab_strip_model_1->GetWebContentsAt(0)));
+
+  EXPECT_EQ(2, tab_strip_model_2->count());
+  EXPECT_TRUE(tab_strip_model_2->IsTabPinned(0));
+  EXPECT_FALSE(shared_pinned_tab_service->IsSharedContents(
+      tab_strip_model_2->GetWebContentsAt(0)));
+  EXPECT_TRUE(shared_pinned_tab_service->IsDummyContents(
+      tab_strip_model_2->GetWebContentsAt(0)));
+
+  // Test: Unpin the tab and see if it's synchronized
+  tab_strip_model_1->SetTabPinned(0, /* pinned= */ false);
+  EXPECT_FALSE(tab_strip_model_1->IsTabPinned(0));
+  EXPECT_FALSE(shared_pinned_tab_service->IsSharedContents(
+      tab_strip_model_1->GetWebContentsAt(0)));
+  EXPECT_FALSE(shared_pinned_tab_service->IsDummyContents(
+      tab_strip_model_1->GetWebContentsAt(0)));
+
+  EXPECT_EQ(1, tab_strip_model_2->count());
+  EXPECT_FALSE(tab_strip_model_2->IsTabPinned(0));
+  EXPECT_FALSE(shared_pinned_tab_service->IsSharedContents(
+      tab_strip_model_2->GetWebContentsAt(0)));
+  EXPECT_FALSE(shared_pinned_tab_service->IsDummyContents(
+      tab_strip_model_2->GetWebContentsAt(0)));
+}
+
+IN_PROC_BROWSER_TEST_F(SharedPinnedTabServiceBrowserTest, ActivatePinnedTab) {
+  // Precondition
+  auto* browser_1 = browser();
+  auto* tab_strip_model_1 = browser_1->tab_strip_model();
+
+  auto* browser_2 = CreateNewBrowser();
+  auto* tab_strip_model_2 = browser_2->tab_strip_model();
+
+  auto* shared_pinned_tab_service = GetForBrowser(browser_1);
+  ASSERT_TRUE(shared_pinned_tab_service);
+
+  tab_strip_model_1->SetTabPinned(0, /* pinned= */ true);
+  ASSERT_TRUE(tab_strip_model_1->IsTabPinned(0));
+  ASSERT_TRUE(shared_pinned_tab_service->IsSharedContents(
+      tab_strip_model_1->GetWebContentsAt(0)));
+  ASSERT_FALSE(shared_pinned_tab_service->IsDummyContents(
+      tab_strip_model_1->GetWebContentsAt(0)));
+
+  ASSERT_TRUE(tab_strip_model_2->IsTabPinned(0));
+  ASSERT_FALSE(shared_pinned_tab_service->IsSharedContents(
+      tab_strip_model_2->GetWebContentsAt(0)));
+  ASSERT_TRUE(shared_pinned_tab_service->IsDummyContents(
+      tab_strip_model_2->GetWebContentsAt(0)));
+
+  // Test: Activating a pinned tab in other browser(2) should bring the contents
+  // from the browser(1).
+  browser_2->window()->Show();
+  ui::ListSelectionModel selection;
+  selection.set_active(0);
+  tab_strip_model_2->SetSelectionFromModel(selection);
+
+  WaitUntil(base::BindLambdaForTesting([&]() {
+    return shared_pinned_tab_service->IsSharedContents(
+        tab_strip_model_2->GetWebContentsAt(0));
+  }));
+  EXPECT_FALSE(shared_pinned_tab_service->IsDummyContents(
+      tab_strip_model_2->GetWebContentsAt(0)));
+
+  EXPECT_FALSE(shared_pinned_tab_service->IsSharedContents(
+      tab_strip_model_1->GetWebContentsAt(0)));
+  EXPECT_TRUE(shared_pinned_tab_service->IsDummyContents(
+      tab_strip_model_1->GetWebContentsAt(0)));
+}
+
+IN_PROC_BROWSER_TEST_F(SharedPinnedTabServiceBrowserTest, NewBrowser) {
+  // Precondition
+  auto* browser_1 = browser();
+  auto* tab_strip_model_1 = browser_1->tab_strip_model();
+  tab_strip_model_1->SetTabPinned(0, /* pinned= */ true);
+  auto* shared_pinned_tab_service = GetForBrowser(browser_1);
+  ASSERT_TRUE(shared_pinned_tab_service);
+  ASSERT_TRUE(shared_pinned_tab_service->IsSharedContents(
+      tab_strip_model_1->GetWebContentsAt(0)));
+
+  // Test: Creates a new browser while there are tabs already pinned. The new
+  // browser should have pinned tabs.
+  auto* browser_2 = CreateNewBrowser();
+  auto* tab_strip_model_2 = browser_2->tab_strip_model();
+  WaitUntil(base::BindLambdaForTesting(
+      [&]() { return tab_strip_model_2->count() > 1; }));
+  EXPECT_TRUE(tab_strip_model_2->IsTabPinned(0));
+
+  EXPECT_TRUE(shared_pinned_tab_service->IsDummyContents(
+      tab_strip_model_2->GetWebContentsAt(0)));
+  EXPECT_FALSE(shared_pinned_tab_service->IsSharedContents(
+      tab_strip_model_2->GetWebContentsAt(0)));
+}

--- a/chromium_src/chrome/browser/ui/browser.cc
+++ b/chromium_src/chrome/browser/ui/browser.cc
@@ -23,8 +23,11 @@
 #if !BUILDFLAG(IS_ANDROID)
 #define BookmarkTabHelper BraveBookmarkTabHelper
 #endif
+#define BrowserTabStripModelDelegate BraveTabStripModelDelegate
 
 #include "src/chrome/browser/ui/browser.cc"
+
+#undef BrowserTabStripModelDelegate
 #undef BrowserLocationBarModelDelegate
 #undef BrowserContentSettingBubbleModelDelegate
 #undef BrowserCommandController

--- a/chromium_src/chrome/browser/ui/browser.cc
+++ b/chromium_src/chrome/browser/ui/browser.cc
@@ -6,6 +6,7 @@
 #include "brave/browser/ui/brave_browser.h"
 #include "brave/browser/ui/brave_browser_command_controller.h"
 #include "brave/browser/ui/brave_browser_content_setting_bubble_model_delegate.h"
+#include "brave/browser/ui/brave_tab_strip_model_delegate.h"
 #include "brave/browser/ui/tabs/brave_tab_strip_model.h"
 #include "brave/browser/ui/toolbar/brave_location_bar_model_delegate.h"
 #include "chrome/browser/ui/browser_command_controller.h"

--- a/chromium_src/chrome/browser/ui/browser.h
+++ b/chromium_src/chrome/browser/ui/browser.h
@@ -6,7 +6,6 @@
 #ifndef BRAVE_CHROMIUM_SRC_CHROME_BROWSER_UI_BROWSER_H_
 #define BRAVE_CHROMIUM_SRC_CHROME_BROWSER_UI_BROWSER_H_
 
-#include "brave/browser/ui/brave_tab_strip_model_delegate.h"
 #include "chrome/browser/ui/tabs/tab_strip_model_observer.h"
 #include "chrome/browser/ui/unload_controller.h"
 

--- a/chromium_src/chrome/browser/ui/browser.h
+++ b/chromium_src/chrome/browser/ui/browser.h
@@ -6,6 +6,7 @@
 #ifndef BRAVE_CHROMIUM_SRC_CHROME_BROWSER_UI_BROWSER_H_
 #define BRAVE_CHROMIUM_SRC_CHROME_BROWSER_UI_BROWSER_H_
 
+#include "brave/browser/ui/brave_tab_strip_model_delegate.h"
 #include "chrome/browser/ui/tabs/tab_strip_model_observer.h"
 #include "chrome/browser/ui/unload_controller.h"
 

--- a/chromium_src/chrome/browser/ui/browser_tab_strip_model_delegate.h
+++ b/chromium_src/chrome/browser/ui/browser_tab_strip_model_delegate.h
@@ -1,0 +1,18 @@
+/* Copyright (c) 2023 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_CHROMIUM_SRC_CHROME_BROWSER_UI_BROWSER_TAB_STRIP_MODEL_DELEGATE_H_
+#define BRAVE_CHROMIUM_SRC_CHROME_BROWSER_UI_BROWSER_TAB_STRIP_MODEL_DELEGATE_H_
+
+#define CloseFrame                         \
+  CloseFrame_Unused();                     \
+  friend class BraveTabStripModelDelegate; \
+  void CloseFrame
+
+#include "src/chrome/browser/ui/browser_tab_strip_model_delegate.h"  // IWYU pragma: export
+
+#undef CloseFrame
+
+#endif  // BRAVE_CHROMIUM_SRC_CHROME_BROWSER_UI_BROWSER_TAB_STRIP_MODEL_DELEGATE_H_


### PR DESCRIPTION
When this feature is enabled, a pinned tab will be shared across all windows. i.e. there's only one shared single instance for pinned tab contents. When users switches window, the shared pinned tab will be swapped so that users can keep doing interacting with the contents.

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/28532


https://user-images.githubusercontent.com/5474642/220217272-1903032f-cfdc-4f2a-8e9e-3095bcb75f46.mov


## Submitter Checklist:

- [ ] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
SharedPinnedTabServiceBrowserTest.*