### PR TITLE
Always Show Full URLs option appears twice -> fixed (uplift to 1.49.x)

### DIFF
--- a/browser/resources/settings/brave_appearance_page/toolbar.html
+++ b/browser/resources/settings/brave_appearance_page/toolbar.html
@@ -60,11 +60,6 @@
   </template>
 </if>
 <settings-toggle-button
-  pref="{{prefs.omnibox.prevent_url_elisions}}"
-  class="cr-row"
-  label="$i18n{showFullUrls}">
-</settings-toggle-button>
-<settings-toggle-button
   pref="{{prefs.brave.tabs_search_show}}"
   class="cr-row"
   label="$i18n{showSearchTabsBtn}">


### PR DESCRIPTION
Uplift of #17286
Resolves https://github.com/brave/brave-browser/issues/28589

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.