### PR TITLE
Removing bug-prone base::WriteFile calls

### DIFF
--- a/browser/component_updater/brave_component_installer.cc
+++ b/browser/component_updater/brave_component_installer.cc
@@ -48,8 +48,7 @@ bool RewriteManifestFile(const base::FilePath& extension_root,
 
   base::FilePath manifest_path =
       extension_root.Append(FILE_PATH_LITERAL("manifest.json"));
-  int size = base::checked_cast<int>(manifest_json.size());
-  if (base::WriteFile(manifest_path, manifest_json.data(), size) != size) {
+  if (!base::WriteFile(manifest_path, manifest_json)) {
     return false;
   }
   return true;

--- a/browser/extensions/api/ipfs_api.cc
+++ b/browser/extensions/api/ipfs_api.cc
@@ -80,7 +80,7 @@ std::string MakePeersResponseFromVector(
 
 bool WriteFileOnFileThread(const base::FilePath& path,
                            const std::string& value) {
-  return base::WriteFile(path, value.c_str(), value.size());
+  return base::WriteFile(path, value);
 }
 
 }  // namespace

--- a/chromium_src/chrome/installer/setup/setup_main.cc
+++ b/chromium_src/chrome/installer/setup/setup_main.cc
@@ -23,8 +23,7 @@ int WINAPI wWinMain(HINSTANCE instance, HINSTANCE prev_instance,
         base::PathService::Get(chrome::DIR_USER_DATA, &user_data_dir);
         base::FilePath referral_code_path =
             user_data_dir.AppendASCII("promoCode");
-        if (!base::WriteFile(referral_code_path, referral_code.c_str(),
-                             referral_code.size())) {
+        if (!base::WriteFile(referral_code_path, referral_code)) {
           LOG(ERROR) << "Failed to write referral code " << referral_code
                      << " to " << referral_code_path;
         }


### PR DESCRIPTION
This PR removes the use of the overload in upstream chromium for base::WriteFile, which happens to be bug prone, due to the way the return logic has to be checked.

For instance, the check for base::WriteFile in the installer code was wrong, as the failure sentinel for the bug-prone version is -1.

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves 

## Submitter Checklist:

- [ ] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

