### PR TITLE
Fix coordinates for vertical tabs

### DIFF
--- a/browser/ui/views/tabs/brave_compound_tab_container.h
+++ b/browser/ui/views/tabs/brave_compound_tab_container.h
@@ -41,7 +41,8 @@ class BraveCompoundTabContainer : public CompoundTabContainer {
   TabContainer* GetTabContainerAt(gfx::Point point_in_local_coords) override;
   gfx::Rect ConvertUnpinnedContainerIdealBoundsToLocal(
       gfx::Rect ideal_bounds) const override;
- BrowserRootView::DropTarget* GetDropTarget(gfx::Point loc_in_local_coords) override;
+  BrowserRootView::DropTarget* GetDropTarget(
+      gfx::Point loc_in_local_coords) override;
 
   bool ShouldShowVerticalTabs() const;
 

--- a/browser/ui/views/tabs/brave_compound_tab_container.h
+++ b/browser/ui/views/tabs/brave_compound_tab_container.h
@@ -37,8 +37,12 @@ class BraveCompoundTabContainer : public CompoundTabContainer {
   Tab* AddTab(std::unique_ptr<Tab> tab,
               int model_index,
               TabPinned pinned) override;
+  int GetUnpinnedContainerIdealLeadingX() const override;
+  TabContainer* GetTabContainerAt(gfx::Point point_in_local_coords) override;
+  gfx::Rect ConvertUnpinnedContainerIdealBoundsToLocal(
+      gfx::Rect ideal_bounds) const override;
+ BrowserRootView::DropTarget* GetDropTarget(gfx::Point loc_in_local_coords) override;
 
- private:
   bool ShouldShowVerticalTabs() const;
 
   base::raw_ref<TabSlotController> tab_slot_controller_;

--- a/chromium_src/chrome/browser/ui/views/tabs/compound_tab_container.h
+++ b/chromium_src/chrome/browser/ui/views/tabs/compound_tab_container.h
@@ -13,9 +13,19 @@
   friend class BraveCompoundTabContainer; \
   int NumPinnedTabs
 #define TransferTabBetweenContainers virtual TransferTabBetweenContainers
+#define GetUnpinnedContainerIdealLeadingX \
+  virtual GetUnpinnedContainerIdealLeadingX
+#define GetTabContainerAt     \
+  GetTabContainerAt_Unused(); \
+  virtual TabContainer* GetTabContainerAt
+#define ConvertUnpinnedContainerIdealBoundsToLocal \
+  virtual ConvertUnpinnedContainerIdealBoundsToLocal
 
 #include "src/chrome/browser/ui/views/tabs/compound_tab_container.h"  // IWYU pragma: export
 
+#undef ConvertUnpinnedContainerIdealBoundsToLocal
+#undef GetTabContainerAt
+#undef GetUnpinnedContainerIdealLeadingX
 #undef TransferTabBetweenContainers
 #undef NumPinnedTabs
 


### PR DESCRIPTION
This PR fixes to things related to coordinate system conversion.

* Bugs where tab are located at wrong position when drag-and-drop ends while pinned tabs exist
* Crash that happens on drag-and-dropping url on bookmarks bar.

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/28488
Resolves https://github.com/brave/brave-browser/issues/28592

## Submitter Checklist:

- [ ] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
* After drag and drop unpinned tabs, every tab should be in the position, regardless of pinned tabs
* When you drag and drop a url or text to bookmarks bar shouldn't cause crashes.