### PR TITLE
Align TabHoverCard and TabSearchBubble to the right side of tab/button

### DIFF
--- a/browser/ui/BUILD.gn
+++ b/browser/ui/BUILD.gn
@@ -235,6 +235,8 @@ source_set("ui") {
       "views/brave_news/brave_news_feeds_container_view.h",
       "views/brave_shields/cookie_list_opt_in_bubble_host.cc",
       "views/brave_shields/cookie_list_opt_in_bubble_host.h",
+      "views/brave_tab_search_bubble_host.cc",
+      "views/brave_tab_search_bubble_host.h",
       "views/crash_report_permission_ask_dialog_view.cc",
       "views/crash_report_permission_ask_dialog_view.h",
       "views/download/brave_download_item_view.cc",

--- a/browser/ui/views/brave_tab_search_bubble_host.cc
+++ b/browser/ui/views/brave_tab_search_bubble_host.cc
@@ -1,0 +1,32 @@
+/* Copyright (c) 2023 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "brave/browser/ui/views/brave_tab_search_bubble_host.h"
+
+#include "ui/views/bubble/bubble_dialog_delegate_view.h"
+
+void BraveTabSearchBubbleHost::SetBubbleArrow(
+    views::BubbleBorder::Arrow arrow) {
+  arrow_ = arrow;
+}
+
+bool BraveTabSearchBubbleHost::ShowTabSearchBubble(
+    bool triggered_by_keyboard_shortcut) {
+  bool result =
+      TabSearchBubbleHost::ShowTabSearchBubble(triggered_by_keyboard_shortcut);
+
+  if (!arrow_ || !result) {
+    return result;
+  }
+
+  auto* widget = webui_bubble_manager_.GetBubbleWidget();
+  DCHECK(widget && widget->widget_delegate());
+
+  auto* bubble_delegate = widget->widget_delegate()->AsBubbleDialogDelegate();
+  DCHECK(bubble_delegate);
+
+  bubble_delegate->SetArrow(*arrow_);
+  return result;
+}

--- a/browser/ui/views/brave_tab_search_bubble_host.h
+++ b/browser/ui/views/brave_tab_search_bubble_host.h
@@ -1,0 +1,26 @@
+/* Copyright (c) 2023 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_BROWSER_UI_VIEWS_BRAVE_TAB_SEARCH_BUBBLE_HOST_H_
+#define BRAVE_BROWSER_UI_VIEWS_BRAVE_TAB_SEARCH_BUBBLE_HOST_H_
+
+#include "chrome/browser/ui/views/tab_search_bubble_host.h"
+
+class BraveTabSearchBubbleHost : public TabSearchBubbleHost {
+ public:
+  using TabSearchBubbleHost::TabSearchBubbleHost;
+  ~BraveTabSearchBubbleHost() override = default;
+
+  void SetBubbleArrow(views::BubbleBorder::Arrow arrow);
+
+  // TabSearchBubbleHost:
+  bool ShowTabSearchBubble(
+      bool triggered_by_keyboard_shortcut = false) override;
+
+ private:
+  absl::optional<views::BubbleBorder::Arrow> arrow_;
+};
+
+#endif  // BRAVE_BROWSER_UI_VIEWS_BRAVE_TAB_SEARCH_BUBBLE_HOST_H_

--- a/browser/ui/views/frame/vertical_tab_strip_region_view.cc
+++ b/browser/ui/views/frame/vertical_tab_strip_region_view.cc
@@ -208,6 +208,7 @@ class VerticalTabStripRegionView::ScrollHeaderView : public views::View {
     tab_search_button_->SetAccessibleName(
         l10n_util::GetStringUTF16(IDS_ACCNAME_TAB_SEARCH));
     tab_search_button_->set_fill_color_disabled();
+    tab_search_button_->SetBubbleArrow(views::BubbleBorder::LEFT_TOP);
 
     UpdateTabSearchButtonVisibility();
   }

--- a/browser/ui/views/tabs/brave_tab_hover_card_controller.cc
+++ b/browser/ui/views/tabs/brave_tab_hover_card_controller.cc
@@ -1,7 +1,7 @@
 // Copyright (c) 2022 The Brave Authors. All rights reserved.
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this file,
-// you can obtain one at http://mozilla.org/MPL/2.0/.
+// You can obtain one at https://mozilla.org/MPL/2.0/.
 
 #include "brave/browser/ui/views/tabs/brave_tab_hover_card_controller.h"
 
@@ -12,10 +12,27 @@
 #include "chrome/browser/profiles/profile.h"
 #include "chrome/browser/ui/browser.h"
 #include "chrome/browser/ui/views/tabs/tab.h"
+#include "chrome/browser/ui/views/tabs/tab_hover_card_bubble_view.h"
 #include "chrome/browser/ui/views/tabs/tab_hover_card_controller.h"
 #include "chrome/browser/ui/views/tabs/tab_hover_card_thumbnail_observer.h"
+#include "ui/views/bubble/bubble_border.h"
 
 BraveTabHoverCardController::~BraveTabHoverCardController() = default;
+
+void BraveTabHoverCardController::SetIsVerticalTabs(bool is_vertical_tabs) {
+  if (std::exchange(is_vertical_tabs_, is_vertical_tabs) == is_vertical_tabs) {
+    return;
+  }
+
+  UpdateHoverCardArrow();
+}
+
+void BraveTabHoverCardController::UpdateHoverCardArrow() {
+  if (hover_card_) {
+    hover_card_->SetArrow(is_vertical_tabs_ ? views::BubbleBorder::LEFT_TOP
+                                            : views::BubbleBorder::TOP_CENTER);
+  }
+}
 
 void BraveTabHoverCardController::CreateHoverCard(Tab* tab) {
   TabHoverCardController::CreateHoverCard(tab);
@@ -28,4 +45,6 @@ void BraveTabHoverCardController::CreateHoverCard(Tab* tab) {
         base::BindRepeating(&TabHoverCardController::OnPreviewImageAvaialble,
                             weak_ptr_factory_.GetWeakPtr()));
   }
+
+  UpdateHoverCardArrow();
 }

--- a/browser/ui/views/tabs/brave_tab_hover_card_controller.h
+++ b/browser/ui/views/tabs/brave_tab_hover_card_controller.h
@@ -1,7 +1,7 @@
 // Copyright (c) 2022 The Brave Authors. All rights reserved.
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this file,
-// you can obtain one at http://mozilla.org/MPL/2.0/.
+// You can obtain one at https://mozilla.org/MPL/2.0/.
 
 #ifndef BRAVE_BROWSER_UI_VIEWS_TABS_BRAVE_TAB_HOVER_CARD_CONTROLLER_H_
 #define BRAVE_BROWSER_UI_VIEWS_TABS_BRAVE_TAB_HOVER_CARD_CONTROLLER_H_
@@ -15,8 +15,15 @@ class BraveTabHoverCardController : public TabHoverCardController {
   using TabHoverCardController::TabHoverCardController;
   ~BraveTabHoverCardController() override;
 
+  void SetIsVerticalTabs(bool is_vertical_tabs);
+
  protected:
+  void UpdateHoverCardArrow();
+
+  // TabHoverCardController:
   void CreateHoverCard(Tab* tab) override;
+
+  bool is_vertical_tabs_ = false;
 };
 
 #endif  // BRAVE_BROWSER_UI_VIEWS_TABS_BRAVE_TAB_HOVER_CARD_CONTROLLER_H_

--- a/browser/ui/views/tabs/brave_tab_search_button.cc
+++ b/browser/ui/views/tabs/brave_tab_search_button.cc
@@ -7,14 +7,23 @@
 
 #include <algorithm>
 
+#include "brave/browser/ui/views/brave_tab_search_bubble_host.h"
 #include "brave/browser/ui/views/tabs/brave_new_tab_button.h"
 #include "chrome/browser/ui/views/chrome_layout_provider.h"
 #include "chrome/browser/ui/views/tabs/new_tab_button.h"
+#include "chrome/browser/ui/views/tabs/tab_strip_controller.h"
+#include "ui/base/metadata/metadata_impl_macros.h"
 #include "ui/gfx/geometry/point_f.h"
 #include "ui/gfx/geometry/rect.h"
 #include "ui/gfx/geometry/size.h"
 #include "ui/gfx/geometry/skia_conversions.h"
 #include "ui/views/layout/layout_provider.h"
+
+BraveTabSearchButton::BraveTabSearchButton(TabStrip* tab_strip)
+    : TabSearchButton(tab_strip),
+      tab_search_bubble_host_(std::make_unique<BraveTabSearchBubbleHost>(
+          this,
+          tab_strip->controller()->GetProfile())) {}
 
 BraveTabSearchButton::~BraveTabSearchButton() = default;
 
@@ -33,7 +42,14 @@ SkPath BraveTabSearchButton::GetBorderPath(const gfx::Point& origin,
                                           GetContentsBounds().size());
 }
 
+void BraveTabSearchButton::SetBubbleArrow(views::BubbleBorder::Arrow arrow) {
+  tab_search_bubble_host_->SetBubbleArrow(arrow);
+}
+
 int BraveTabSearchButton::GetCornerRadius() const {
   return ChromeLayoutProvider::Get()->GetCornerRadiusMetric(
       views::Emphasis::kMaximum, GetContentsBounds().size());
 }
+
+BEGIN_METADATA(BraveTabSearchButton, TabSearchButton)
+END_METADATA

--- a/browser/ui/views/tabs/brave_tab_search_button.cc
+++ b/browser/ui/views/tabs/brave_tab_search_button.cc
@@ -6,6 +6,7 @@
 #include "brave/browser/ui/views/tabs/brave_tab_search_button.h"
 
 #include <algorithm>
+#include <memory>
 
 #include "brave/browser/ui/views/brave_tab_search_bubble_host.h"
 #include "brave/browser/ui/views/tabs/brave_new_tab_button.h"
@@ -20,10 +21,10 @@
 #include "ui/views/layout/layout_provider.h"
 
 BraveTabSearchButton::BraveTabSearchButton(TabStrip* tab_strip)
-    : TabSearchButton(tab_strip),
-      tab_search_bubble_host_(std::make_unique<BraveTabSearchBubbleHost>(
-          this,
-          tab_strip->controller()->GetProfile())) {}
+    : TabSearchButton(tab_strip) {
+  tab_search_bubble_host_ = std::make_unique<BraveTabSearchBubbleHost>(
+      this, tab_strip->controller()->GetProfile());
+}
 
 BraveTabSearchButton::~BraveTabSearchButton() = default;
 
@@ -43,7 +44,8 @@ SkPath BraveTabSearchButton::GetBorderPath(const gfx::Point& origin,
 }
 
 void BraveTabSearchButton::SetBubbleArrow(views::BubbleBorder::Arrow arrow) {
-  tab_search_bubble_host_->SetBubbleArrow(arrow);
+  static_cast<BraveTabSearchBubbleHost*>(tab_search_bubble_host_.get())
+      ->SetBubbleArrow(arrow);
 }
 
 int BraveTabSearchButton::GetCornerRadius() const {

--- a/browser/ui/views/tabs/brave_tab_search_button.h
+++ b/browser/ui/views/tabs/brave_tab_search_button.h
@@ -6,13 +6,9 @@
 #ifndef BRAVE_BROWSER_UI_VIEWS_TABS_BRAVE_TAB_SEARCH_BUTTON_H_
 #define BRAVE_BROWSER_UI_VIEWS_TABS_BRAVE_TAB_SEARCH_BUTTON_H_
 
-#include <memory>
-
 #include "chrome/browser/ui/views/tabs/tab_search_button.h"
 #include "third_party/skia/include/core/SkPath.h"
 #include "ui/gfx/geometry/size.h"
-
-class BraveTabSearchBubbleHost;
 
 class BraveTabSearchButton : public TabSearchButton {
  public:
@@ -36,9 +32,6 @@ class BraveTabSearchButton : public TabSearchButton {
 
  private:
   bool fill_color_disabled_ = false;
-
-  // This hides the same member in the base class
-  std::unique_ptr<BraveTabSearchBubbleHost> tab_search_bubble_host_;
 };
 
 #endif  // BRAVE_BROWSER_UI_VIEWS_TABS_BRAVE_TAB_SEARCH_BUTTON_H_

--- a/browser/ui/views/tabs/brave_tab_search_button.h
+++ b/browser/ui/views/tabs/brave_tab_search_button.h
@@ -6,18 +6,26 @@
 #ifndef BRAVE_BROWSER_UI_VIEWS_TABS_BRAVE_TAB_SEARCH_BUTTON_H_
 #define BRAVE_BROWSER_UI_VIEWS_TABS_BRAVE_TAB_SEARCH_BUTTON_H_
 
+#include <memory>
+
 #include "chrome/browser/ui/views/tabs/tab_search_button.h"
 #include "third_party/skia/include/core/SkPath.h"
 #include "ui/gfx/geometry/size.h"
 
+class BraveTabSearchBubbleHost;
+
 class BraveTabSearchButton : public TabSearchButton {
  public:
-  using TabSearchButton::TabSearchButton;
+  METADATA_HEADER(BraveTabSearchButton);
+
+  explicit BraveTabSearchButton(TabStrip* tab_strip);
   ~BraveTabSearchButton() override;
   BraveTabSearchButton(const BraveTabSearchButton&) = delete;
   BraveTabSearchButton& operator=(const BraveTabSearchButton&) = delete;
 
   void set_fill_color_disabled() { fill_color_disabled_ = true; }
+
+  void SetBubbleArrow(views::BubbleBorder::Arrow arrow);
 
   // TabSearchButton overrides:
   SkPath GetBorderPath(const gfx::Point& origin,
@@ -28,6 +36,9 @@ class BraveTabSearchButton : public TabSearchButton {
 
  private:
   bool fill_color_disabled_ = false;
+
+  // This hides the same member in the base class
+  std::unique_ptr<BraveTabSearchBubbleHost> tab_search_bubble_host_;
 };
 
 #endif  // BRAVE_BROWSER_UI_VIEWS_TABS_BRAVE_TAB_SEARCH_BUTTON_H_

--- a/browser/ui/views/tabs/brave_tab_strip.cc
+++ b/browser/ui/views/tabs/brave_tab_strip.cc
@@ -293,6 +293,8 @@ void BraveTabStrip::UpdateTabContainer() {
       tab_container_->SetLayoutManager(nullptr);
     }
   }
+
+  hover_card_controller_->SetIsVerticalTabs(using_vertical_tabs);
 }
 
 bool BraveTabStrip::ShouldShowVerticalTabs() const {

--- a/chromium_src/chrome/browser/ui/views/tab_search_bubble_host.h
+++ b/chromium_src/chrome/browser/ui/views/tab_search_bubble_host.h
@@ -1,0 +1,18 @@
+/* Copyright (c) 2023 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_CHROMIUM_SRC_CHROME_BROWSER_UI_VIEWS_TAB_SEARCH_BUBBLE_HOST_H_
+#define BRAVE_CHROMIUM_SRC_CHROME_BROWSER_UI_VIEWS_TAB_SEARCH_BUBBLE_HOST_H_
+
+#define ShowTabSearchBubble              \
+  ShowTabSearchBubble_Unused();          \
+  friend class BraveTabSearchBubbleHost; \
+  virtual bool ShowTabSearchBubble
+
+#include "src/chrome/browser/ui/views/tab_search_bubble_host.h"  // IWYU pragma: export
+
+#undef ShowTabSearchBubble
+
+#endif  // BRAVE_CHROMIUM_SRC_CHROME_BROWSER_UI_VIEWS_TAB_SEARCH_BUBBLE_HOST_H_

--- a/chromium_src/chrome/browser/ui/views/tabs/tab_search_button.h
+++ b/chromium_src/chrome/browser/ui/views/tabs/tab_search_button.h
@@ -1,0 +1,20 @@
+/* Copyright (c) 2023 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_CHROMIUM_SRC_CHROME_BROWSER_UI_VIEWS_TABS_TAB_SEARCH_BUTTON_H_
+#define BRAVE_CHROMIUM_SRC_CHROME_BROWSER_UI_VIEWS_TABS_TAB_SEARCH_BUTTON_H_
+
+#include "chrome/browser/ui/views/tabs/new_tab_button.h"
+
+#define FrameColorsChanged           \
+  FrameColorsChanged_Unused();       \
+  friend class BraveTabSearchButton; \
+  void FrameColorsChanged
+
+#include "src/chrome/browser/ui/views/tabs/tab_search_button.h"  // IWYU pragma: export
+
+#undef FrameColorsChanged
+
+#endif  // BRAVE_CHROMIUM_SRC_CHROME_BROWSER_UI_VIEWS_TABS_TAB_SEARCH_BUTTON_H_


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/28594

### Hover card
<img width="539" alt="image" src="https://user-images.githubusercontent.com/5474642/220611141-7227040e-f537-4886-acba-14751a22cec6.png">

### Search bubble
<img width="592" alt="image" src="https://user-images.githubusercontent.com/5474642/220611178-d8637e13-0a0d-41af-8651-3da3af10e6f9.png">


## Submitter Checklist:

- [ ] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
Each of UI should appear on the right side when they are for vertical tab strip
