### PR TITLE
Show pinned tab container when adding pinned tabs

### DIFF
--- a/browser/ui/views/tabs/brave_compound_tab_container.cc
+++ b/browser/ui/views/tabs/brave_compound_tab_container.cc
@@ -153,6 +153,25 @@ views::SizeBounds BraveCompoundTabContainer::GetAvailableSize(
                            /*height=*/views::SizeBound());
 }
 
+Tab* BraveCompoundTabContainer::AddTab(std::unique_ptr<Tab> tab,
+                                       int model_index,
+                                       TabPinned pinned) {
+  auto* result =
+      CompoundTabContainer::AddTab(std::move(tab), model_index, pinned);
+  if (!base::FeatureList::IsEnabled(tabs::features::kBraveVerticalTabs) ||
+      !tabs::utils::ShouldShowVerticalTabs(
+          tab_slot_controller_->GetBrowser())) {
+    return result;
+  }
+
+  if (pinned == TabPinned::kPinned && !pinned_tab_container_->GetVisible()) {
+    // When the browser was initialized without any pinned tabs, pinned tabs
+    // could be hidden initially by the FlexLayout.
+    pinned_tab_container_->SetVisible(true);
+  }
+  return result;
+}
+
 bool BraveCompoundTabContainer::ShouldShowVerticalTabs() const {
   return base::FeatureList::IsEnabled(tabs::features::kBraveVerticalTabs) &&
          tabs::utils::ShouldShowVerticalTabs(

--- a/browser/ui/views/tabs/brave_compound_tab_container.h
+++ b/browser/ui/views/tabs/brave_compound_tab_container.h
@@ -6,6 +6,8 @@
 #ifndef BRAVE_BROWSER_UI_VIEWS_TABS_BRAVE_COMPOUND_TAB_CONTAINER_H_
 #define BRAVE_BROWSER_UI_VIEWS_TABS_BRAVE_COMPOUND_TAB_CONTAINER_H_
 
+#include <memory>
+
 #include "chrome/browser/ui/views/tabs/compound_tab_container.h"
 
 class BraveCompoundTabContainer : public CompoundTabContainer {
@@ -32,6 +34,9 @@ class BraveCompoundTabContainer : public CompoundTabContainer {
   gfx::Size CalculatePreferredSize() const override;
   gfx::Size GetMinimumSize() const override;
   views::SizeBounds GetAvailableSize(const views::View* child) const override;
+  Tab* AddTab(std::unique_ptr<Tab> tab,
+              int model_index,
+              TabPinned pinned) override;
 
  private:
   bool ShouldShowVerticalTabs() const;


### PR DESCRIPTION
The container could be initially hidden. We should show up the container when adding pinned tabs.

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/28682

## Submitter Checklist:

- [ ] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
When recovering browser with pinned tabs, pinned tabs should be visible
