### PR TITLE
Allow adblock to work without Brave services key

### DIFF
--- a/browser/resources/settings/default_brave_shields_page/brave_adblock_subpage.html
+++ b/browser/resources/settings/default_brave_shields_page/brave_adblock_subpage.html
@@ -159,40 +159,42 @@
 </style>
 
 <div id="adblock-section">
-  <div class="settings-box">
-    <div class="flex">
-        <div class="label shields-primary-title">$i18n{adblockTrackingFiltersLabel}</div>
-        <div class="label secondary shields-secondary-title">
-          $i18n{adblockTrackingFiltersDesc}
-        </div>
-        <cr-input
-          type="text"
-          placeholder="$i18n{adblockFilterListsInputPlaceHolder}"
-          min="1"
-          max="100"
-          value="{{filterListTitle}}"
-        >
-          <span id="search-box" slot="inline-suffix">
-            <iron-icon icon="brave_leo:magnifying-glass"></iron-icon>
-          </span>
-        </cr-input>
-        <div class$="filter-list-box expanded-[[hasListExpanded_]]">
-          <template is="dom-repeat" items="[[filterList_]]"
-          filter="{{searchListBy_(filterListTitle)}}" observe="val" initial-count="10">
-            <div class$="filter-list-item selected-[[item.enabled]]">
-              <cr-checkbox checked="{{item.enabled}}" on-change="handleFilterListItemToggle_">
-                <div>[[item.title]]</div>
-              </cr-checkbox>
+  <template is="dom-if" if="[[filterList_.length]]">
+    <div class="settings-box">
+      <div class="flex">
+          <div class="label shields-primary-title">$i18n{adblockTrackingFiltersLabel}</div>
+          <div class="label secondary shields-secondary-title">
+            $i18n{adblockTrackingFiltersDesc}
+          </div>
+          <cr-input
+            type="text"
+            placeholder="$i18n{adblockFilterListsInputPlaceHolder}"
+            min="1"
+            max="100"
+            value="{{filterListTitle}}"
+          >
+            <span id="search-box" slot="inline-suffix">
+              <iron-icon icon="brave_leo:magnifying-glass"></iron-icon>
+            </span>
+          </cr-input>
+          <div class$="filter-list-box expanded-[[hasListExpanded_]]">
+            <template is="dom-repeat" items="[[filterList_]]"
+            filter="{{searchListBy_(filterListTitle)}}" observe="val" initial-count="10">
+              <div class$="filter-list-item selected-[[item.enabled]]">
+                <cr-checkbox checked="{{item.enabled}}" on-change="handleFilterListItemToggle_">
+                  <div>[[item.title]]</div>
+                </cr-checkbox>
+              </div>
+            </template>
+          </div>
+          <template is="dom-if" if="[[!hasListExpanded_]]">
+            <div class="show-list-button-box">
+              <cr-button on-click="handleShowList_">$i18n{adblockShowFullListsButtonLabel}</cr-button>
             </div>
           </template>
-        </div>
-        <template is="dom-if" if="[[!hasListExpanded_]]">
-          <div class="show-list-button-box">
-            <cr-button on-click="handleShowList_">$i18n{adblockShowFullListsButtonLabel}</cr-button>
-          </div>
-        </template>
+      </div>
     </div>
-  </div>
+  </template>
   <div class="settings-box">
     <div class="flex">
       <div class="label shields-primary-title">

--- a/components/brave_shields/browser/BUILD.gn
+++ b/components/brave_shields/browser/BUILD.gn
@@ -75,6 +75,7 @@ if (!is_ios) {
       "//brave/components/brave_shields/common",
       "//brave/components/brave_shields/common:mojom",
       "//brave/components/constants",
+      "//brave/components/constants:brave_service_key_helper",
       "//brave/components/content_settings/core/common",
       "//brave/components/debounce/common",
       "//brave/components/ephemeral_storage",

--- a/components/brave_shields/browser/ad_block_subscription_service_manager.h
+++ b/components/brave_shields/browser/ad_block_subscription_service_manager.h
@@ -113,7 +113,6 @@ class AdBlockSubscriptionServiceManager {
 
   void StartDownload(const GURL& sub_url, bool from_ui);
 
-  bool initialized_;
   void LoadSubscriptionServices();
   void UpdateSubscriptionPrefs(const GURL& sub_url,
                                const SubscriptionInfo& info);

--- a/components/constants/brave_services_key_helper.cc
+++ b/components/constants/brave_services_key_helper.cc
@@ -16,8 +16,8 @@ bool ShouldAddBraveServicesKeyHeader(const GURL& url) {
                                         kBraveProxyPattern);
   static URLPattern bravesoftware_proxy_pattern(URLPattern::SCHEME_HTTPS,
                                                 kBraveSoftwareProxyPattern);
-  return brave_proxy_pattern.MatchesURL(url) ||
-         bravesoftware_proxy_pattern.MatchesURL(url);
+  return CanUseBraveServices() && (brave_proxy_pattern.MatchesURL(url) ||
+                                   bravesoftware_proxy_pattern.MatchesURL(url));
 }
 
 }  // namespace brave

--- a/components/constants/brave_services_key_helper.h
+++ b/components/constants/brave_services_key_helper.h
@@ -6,9 +6,16 @@
 #ifndef BRAVE_COMPONENTS_CONSTANTS_BRAVE_SERVICES_KEY_HELPER_H_
 #define BRAVE_COMPONENTS_CONSTANTS_BRAVE_SERVICES_KEY_HELPER_H_
 
+#include "base/strings/string_piece.h"
+#include "brave/components/constants/brave_services_key.h"
+
 class GURL;
 
 namespace brave {
+
+constexpr bool CanUseBraveServices() {
+  return !base::StringPiece(BUILDFLAG(BRAVE_SERVICES_KEY)).empty();
+}
 
 bool ShouldAddBraveServicesKeyHeader(const GURL& url);
 


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/26143

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [x] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [x] New files have MPL-2.0 license header
- [x] Adequate test coverage exists to prevent regressions
- [x] Major classes, functions and non-trivial code blocks are well-commented
- [x] Changes in component dependencies are properly reflected in `gn`
- [x] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [x] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

**NOTE**: the changes in this PR should have no effect on official Brave builds; it must be tested on a service-keyless build. These are available (Linux-only) as per  https://github.com/brave/devops/pull/8926#issuecomment-1442746719

- Start the browser for the first time, then visit brave://settings/shields/filters.
- The `Filter lists` section, normally containing regional filter list options, should not be visible at all
- The `Add custom filter lists` section should be prefilled<sup>1</sup> with 19 entries corresponding to those listed in https://github.com/brave/adblock-resources/blob/master/filter_lists/default.json
- Most<sup>2</sup> of the lists should be downloaded successfully

1: If you're quick enough, they may _all_ appear with a `Download failed` status at first. This is okay; it should automatically be resolved within a minute or so.
2: I've noticed while testing that a random set of 4 lists would fail to download. I suspect that this is due to a maximum download queue length in the Chromium code. Manually retriggering the downloads will work correctly. I think we could investigate it properly in a followup.