### PR TITLE
Fix Tab search bubble position bugs

### DIFF
--- a/browser/ui/views/brave_tab_search_bubble_host.cc
+++ b/browser/ui/views/brave_tab_search_bubble_host.cc
@@ -5,18 +5,28 @@
 
 #include "brave/browser/ui/views/brave_tab_search_bubble_host.h"
 
+#include "brave/browser/ui/tabs/features.h"
+#include "brave/browser/ui/views/tabs/vertical_tab_utils.h"
+#include "chrome/browser/ui/layout_constants.h"
+#include "chrome/browser/ui/views/frame/browser_view.h"
 #include "ui/views/bubble/bubble_dialog_delegate_view.h"
 
 void BraveTabSearchBubbleHost::SetBubbleArrow(
     views::BubbleBorder::Arrow arrow) {
+  DCHECK(base::FeatureList::IsEnabled(tabs::features::kBraveVerticalTabs))
+      << "Should be called only when the vertical tab feature is enabled.";
   arrow_ = arrow;
 }
 
 bool BraveTabSearchBubbleHost::ShowTabSearchBubble(
     bool triggered_by_keyboard_shortcut) {
+  if (!base::FeatureList::IsEnabled(tabs::features::kBraveVerticalTabs)) {
+    return TabSearchBubbleHost::ShowTabSearchBubble(
+        triggered_by_keyboard_shortcut);
+  }
+
   bool result =
       TabSearchBubbleHost::ShowTabSearchBubble(triggered_by_keyboard_shortcut);
-
   if (!arrow_ || !result) {
     return result;
   }
@@ -27,6 +37,37 @@ bool BraveTabSearchBubbleHost::ShowTabSearchBubble(
   auto* bubble_delegate = widget->widget_delegate()->AsBubbleDialogDelegate();
   DCHECK(bubble_delegate);
 
+  auto* anchor_widget = button_->GetWidget();
+  DCHECK(anchor_widget);
+  anchor_widget = anchor_widget->GetTopLevelWidget();
+  DCHECK(anchor_widget);
+
+#if DCHECK_IS_ON()
+  // This path is reachable only when it's vertical tabs.
+  auto* browser_view = BrowserView::GetBrowserViewForNativeWindow(
+      anchor_widget->GetNativeWindow());
+  DCHECK(browser_view);
+  DCHECK(tabs::utils::ShouldShowVerticalTabs(browser_view->browser()));
+#endif
+
   bubble_delegate->SetArrow(*arrow_);
+
+  if (anchor_widget->IsFullscreen() && !button_->IsDrawn()) {
+    // In this case, anchor bubble on to the screen edge. In this case, we
+    // should also reparent native widget, as vertical tab's widget could be
+    // hidden.
+    gfx::Rect bounds = anchor_widget->GetWorkAreaBoundsInScreen();
+    int offset = GetLayoutConstant(TABSTRIP_REGION_VIEW_CONTROL_PADDING);
+    bubble_delegate->SetAnchorView(nullptr);
+    bubble_delegate->set_parent_window(anchor_widget->GetNativeView());
+    bubble_delegate->SetAnchorRect(
+        gfx::Rect(bounds.x() + offset, bounds.y() + offset, 0, 0));
+
+    views::Widget::ReparentNativeView(widget->GetNativeView(),
+                                      anchor_widget->GetNativeView());
+    bubble_delegate->SizeToContents();
+  }
+
+  widget->Show();
   return result;
 }

--- a/browser/ui/views/frame/brave_browser_view.cc
+++ b/browser/ui/views/frame/brave_browser_view.cc
@@ -585,6 +585,20 @@ void BraveBrowserView::OnThemeChanged() {
   }
 }
 
+TabSearchBubbleHost* BraveBrowserView::GetTabSearchBubbleHost() {
+  if (!base::FeatureList::IsEnabled(tabs::features::kBraveVerticalTabs)) {
+    return BrowserView::GetTabSearchBubbleHost();
+  }
+
+  if (tabs::utils::ShouldShowVerticalTabs(browser())) {
+    return vertical_tab_strip_widget_delegate_view_
+        ->vertical_tab_strip_region_view()
+        ->GetTabSearchBubbleHost();
+  }
+
+  return BrowserView::GetTabSearchBubbleHost();
+}
+
 bool BraveBrowserView::IsSidebarVisible() const {
   return sidebar_container_view_ && sidebar_container_view_->IsSidebarVisible();
 }

--- a/browser/ui/views/frame/brave_browser_view.h
+++ b/browser/ui/views/frame/brave_browser_view.h
@@ -78,6 +78,7 @@ class BraveBrowserView : public BrowserView {
 #endif
   bool ShouldShowWindowTitle() const override;
   void OnThemeChanged() override;
+  TabSearchBubbleHost* GetTabSearchBubbleHost() override;
 
   views::View* sidebar_host_view() { return sidebar_host_view_; }
   bool IsSidebarVisible() const;

--- a/browser/ui/views/frame/vertical_tab_strip_region_view.cc
+++ b/browser/ui/views/frame/vertical_tab_strip_region_view.cc
@@ -215,6 +215,8 @@ class VerticalTabStripRegionView::ScrollHeaderView : public views::View {
   }
   ~ScrollHeaderView() override = default;
 
+  BraveTabSearchButton* tab_search_button() { return tab_search_button_; }
+
   void UpdateTabSearchButtonVisibility() {
     tab_search_button_->SetVisible(
         !WindowFrameUtil::IsWin10TabSearchCaptionButtonEnabled(
@@ -539,6 +541,10 @@ void VerticalTabStripRegionView::OnBoundsChanged(
     ScrollActiveTabToBeVisible();
 }
 
+bool VerticalTabStripRegionView::IsDrawn() const {
+  return View::IsDrawn() && !IsTabFullscreen();
+}
+
 void VerticalTabStripRegionView::OnTabStripModelChanged(
     TabStripModel* tab_strip_model,
     const TabStripModelChange& change,
@@ -554,6 +560,10 @@ void VerticalTabStripRegionView::UpdateNewTabButtonVisibility() {
   auto* original_ntb = region_view_->new_tab_button();
   original_ntb->SetVisible(!is_vertical_tabs);
   new_tab_button_->SetVisible(is_vertical_tabs);
+}
+
+TabSearchBubbleHost* VerticalTabStripRegionView::GetTabSearchBubbleHost() {
+  return scroll_view_header_->tab_search_button()->tab_search_bubble_host();
 }
 
 void VerticalTabStripRegionView::UpdateTabSearchButtonVisibility() {

--- a/browser/ui/views/frame/vertical_tab_strip_region_view.h
+++ b/browser/ui/views/frame/vertical_tab_strip_region_view.h
@@ -67,6 +67,8 @@ class VerticalTabStripRegionView : public views::View,
   // This should be called when height of this view or tab strip changes.
   void UpdateNewTabButtonVisibility();
 
+  TabSearchBubbleHost* GetTabSearchBubbleHost();
+
   // views::View:
   gfx::Size CalculatePreferredSize() const override;
   gfx::Size GetMinimumSize() const override;
@@ -75,6 +77,7 @@ class VerticalTabStripRegionView : public views::View,
   void OnMouseExited(const ui::MouseEvent& event) override;
   void OnMouseEntered(const ui::MouseEvent& event) override;
   void OnBoundsChanged(const gfx::Rect& previous_bounds) override;
+  bool IsDrawn() const override;
 
   // TabStripModelObserver:
   void OnTabStripModelChanged(

--- a/chromium_src/chrome/browser/ui/views/frame/browser_view.h
+++ b/chromium_src/chrome/browser/ui/views/frame/browser_view.h
@@ -29,6 +29,10 @@
 #define GetTabStripVisible virtual GetTabStripVisible
 #define BrowserViewLayout BraveBrowserViewLayout
 
+#define GetTabSearchBubbleHost     \
+  GetTabSearchBubbleHost_Unused(); \
+  virtual TabSearchBubbleHost* GetTabSearchBubbleHost
+
 #if BUILDFLAG(IS_WIN)
 #define GetSupportsTitle virtual GetSupportsTitle
 #endif
@@ -39,6 +43,7 @@
 #undef GetSupportsTitle
 #endif
 
+#undef GetTabSearchBubbleHost
 #undef BrowserViewLayout
 #undef GetTabStripVisible
 #undef BrowserViewLayoutDelegateImpl


### PR DESCRIPTION
* Show bubble on the right even when it's triggered from shortcut.
  * This is fixed by returning proper button from BraveBrowserView

* Show bubble when it's tab fullscreen too.
  * The bubble should be anchored to screen.
  * <img width="821" alt="image" src="https://user-images.githubusercontent.com/5474642/221560642-07513bb5-5211-417a-a083-9c89d3589e51.png">

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/28768

## Submitter Checklist:

- [ ] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

