### PR TITLE
Fix asset discovery for cUSDT

### DIFF
--- a/browser/brave_wallet/asset_discovery_manager_unittest.cc
+++ b/browser/brave_wallet/asset_discovery_manager_unittest.cc
@@ -1125,6 +1125,25 @@ TEST_F(AssetDiscoveryManagerUnitTest, DiscoverEthAssets) {
   TestDiscoverEthAssets({"0xB4B2802129071b2B9eBb8cBB01EA1E4D14B34961"}, false,
                         {});
 
+  // One account returns the cUSDT token response for no balance detected
+  // (successful), yields no discovered contract addresses
+  const char cusdt_balance_not_detected_response[] = R"({
+        "jsonrpc":"2.0",
+        "id":1,
+        "result":"0x000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000000100000000000000000000000000000000000000000000000000000000000000400000000000000000000000000000000000000000000000000000000000000060000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"
+    })";
+
+  requests = {
+      {GetNetwork(mojom::kMainnetChainId, mojom::CoinType::ETH),
+       {
+           {"0xB4B2802129071b2B9eBb8cBB01EA1E4D14B34961",
+            cusdt_balance_not_detected_response},
+       }},
+  };
+  SetInterceptorForDiscoverEthAssets(requests);
+  TestDiscoverEthAssets({"0xB4B2802129071b2B9eBb8cBB01EA1E4D14B34961"}, false,
+                        {});
+
   // One account, with a balance, yields discovered contract address
   requests = {
       {GetNetwork(mojom::kMainnetChainId, mojom::CoinType::ETH),

--- a/components/brave_wallet/browser/asset_discovery_manager.cc
+++ b/components/brave_wallet/browser/asset_discovery_manager.cc
@@ -279,12 +279,13 @@ void AssetDiscoveryManager::OnGetERC20TokenBalances(
 
   // Populate the map using the balance_results
   for (size_t i = 0; i < balance_results.size(); i++) {
-    if (balance_results[i]->balance.has_value() &&
-        balance_results[i]->balance !=
-            "0x000000000000000000000000000000000000000000000000000000000000000"
-            "0") {
-      chain_id_to_contract_addresses_with_balance[chain_id].push_back(
-          contract_addresses[i]);
+    if (balance_results[i]->balance.has_value()) {
+      uint256_t balance_uint;
+      HexValueToUint256(balance_results[i]->balance.value(), &balance_uint);
+      if (balance_uint > 0) {
+        chain_id_to_contract_addresses_with_balance[chain_id].push_back(
+            contract_addresses[i]);
+      }
     }
   }
 

--- a/components/brave_wallet/browser/asset_discovery_manager.cc
+++ b/components/brave_wallet/browser/asset_discovery_manager.cc
@@ -281,8 +281,9 @@ void AssetDiscoveryManager::OnGetERC20TokenBalances(
   for (size_t i = 0; i < balance_results.size(); i++) {
     if (balance_results[i]->balance.has_value()) {
       uint256_t balance_uint;
-      HexValueToUint256(balance_results[i]->balance.value(), &balance_uint);
-      if (balance_uint > 0) {
+      bool success =
+          HexValueToUint256(balance_results[i]->balance.value(), &balance_uint);
+      if (success && balance_uint > 0) {
         chain_id_to_contract_addresses_with_balance[chain_id].push_back(
             contract_addresses[i]);
       }


### PR DESCRIPTION
When checking if a BalanceScanner result is > 0 for asset discovery, convert the balance to an integer instead of doing a string comparison.

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/28752

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
Verify Compound Tether should is not discovered automatically unless you actually own that asset.  Other assets should still be discovered.
