### PR TITLE
Fixes build of desktop sync tests (uplift to 1.49.x)

### DIFF
--- a/components/sync/driver/brave_sync_service_impl_unittest.cc
+++ b/components/sync/driver/brave_sync_service_impl_unittest.cc
@@ -424,7 +424,7 @@ TEST_F(BraveSyncServiceImplTest, JoinActiveOrNewChain) {
   bool join_chain_callback_invoked = false;
 
   brave_sync_service_impl()->SetJoinChainResultCallback(base::BindOnce(
-      [](bool* join_chain_callback_invoked, const bool& join_succeeded) {
+      [](bool* join_chain_callback_invoked, bool join_succeeded) {
         *join_chain_callback_invoked = true;
         EXPECT_TRUE(join_succeeded);
       },
@@ -450,7 +450,7 @@ TEST_F(BraveSyncServiceImplTest, JoinDeletedChain) {
   bool join_chain_callback_invoked = false;
 
   brave_sync_service_impl()->SetJoinChainResultCallback(base::BindOnce(
-      [](bool* join_chain_callback_invoked, const bool& join_succeeded) {
+      [](bool* join_chain_callback_invoked, bool join_succeeded) {
         *join_chain_callback_invoked = true;
         EXPECT_FALSE(join_succeeded);
       },


### PR DESCRIPTION
Uplift of #17409
Resolves https://github.com/brave/brave-browser/issues/28796

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.