### PR TITLE
DCHECK tests using EXPECT_DEATH

### DIFF
--- a/base/feature_override_unittest.cc
+++ b/base/feature_override_unittest.cc
@@ -4,6 +4,7 @@
  * You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 #include "base/feature_override.h"
+#include "base/debug/debugging_buildflags.h"
 #include "base/feature_list.h"
 #include "base/logging.h"
 #include "base/test/mock_callback.h"
@@ -71,26 +72,11 @@ TEST(FeatureOverrideTest, OverridesTest) {
   }
 }
 
-#if DCHECK_IS_ON()
+#if DCHECK_IS_ON() && !BUILDFLAG(DCHECK_IS_CONFIGURABLE)
 TEST(FeatureOverrideTest, FeatureDuplicateDChecks) {
   // Check any feature to make sure overridden features are finalized (moved
   // from an unsorted vector to a sorted flat_map).
   ASSERT_FALSE(base::FeatureList::IsEnabled(kTestEnabledButOverridenFeature));
-
-  base::MockCallback<logging::LogAssertHandlerFunction> mock_log_handler;
-  logging::ScopedLogAssertHandler scoped_log_handler(mock_log_handler.Get());
-  EXPECT_CALL(
-      mock_log_handler,
-      Run(_, _,
-          testing::HasSubstr("TestEnabledButOverridenFeature is duplicated"),
-          _));
-  EXPECT_CALL(
-      mock_log_handler,
-      Run(_, _,
-          testing::HasSubstr(
-              "TestEnabledButOverridenFeature has already been overridden"),
-          _))
-      .Times(2);
 
   // This will add a feature to an unsorted vector of overrides.
   internal::FeatureDefaultStateOverrider init_overrides{{
@@ -98,11 +84,14 @@ TEST(FeatureOverrideTest, FeatureDuplicateDChecks) {
   }};
 
   // This should trigger DCHECKs.
-  internal::FeatureDefaultStateOverrider test_overrider{{
-      {kTestEnabledButOverridenFeature, FEATURE_DISABLED_BY_DEFAULT},
-      {kTestEnabledButOverridenFeature, FEATURE_DISABLED_BY_DEFAULT},
-  }};
+  EXPECT_DEATH_IF_SUPPORTED(
+      internal::FeatureDefaultStateOverrider({
+          {kTestEnabledButOverridenFeature, FEATURE_DISABLED_BY_DEFAULT},
+          {kTestEnabledButOverridenFeature, FEATURE_DISABLED_BY_DEFAULT},
+      }),
+      testing::HasSubstr("Feature TestEnabledButOverridenFeature has already "
+                         "been overridden"));
 }
-#endif  // DCHECK_IS_ON()
+#endif  // DCHECK_IS_ON() && !BUILDFLAG(DCHECK_IS_CONFIGURABLE)
 
 }  // namespace base

--- a/base/feature_override_unittest.cc
+++ b/base/feature_override_unittest.cc
@@ -83,14 +83,28 @@ TEST(FeatureOverrideTest, FeatureDuplicateDChecks) {
       {kTestEnabledButOverridenFeature, FEATURE_DISABLED_BY_DEFAULT},
   }};
 
-  // This should trigger DCHECKs.
+  // This should trigger DCHECK.
+  EXPECT_DEATH_IF_SUPPORTED(
+      internal::FeatureDefaultStateOverrider({
+          {kTestEnabledButOverridenFeature, FEATURE_DISABLED_BY_DEFAULT},
+      }),
+      testing::HasSubstr("Feature TestEnabledButOverridenFeature has already "
+                         "been overridden"));
+}
+
+TEST(FeatureOverrideTest, FeatureDuplicateInSameMacroDChecks) {
+  // Check any feature to make sure overridden features are finalized (moved
+  // from an unsorted vector to a sorted flat_map).
+  ASSERT_FALSE(base::FeatureList::IsEnabled(kTestEnabledButOverridenFeature));
+
+  // This should trigger DCHECK.
   EXPECT_DEATH_IF_SUPPORTED(
       internal::FeatureDefaultStateOverrider({
           {kTestEnabledButOverridenFeature, FEATURE_DISABLED_BY_DEFAULT},
           {kTestEnabledButOverridenFeature, FEATURE_DISABLED_BY_DEFAULT},
       }),
-      testing::HasSubstr("Feature TestEnabledButOverridenFeature has already "
-                         "been overridden"));
+      testing::HasSubstr("Feature TestEnabledButOverridenFeature is duplicated "
+                         "in the current override macros"));
 }
 #endif  // DCHECK_IS_ON() && !BUILDFLAG(DCHECK_IS_CONFIGURABLE)
 


### PR DESCRIPTION
This change updates the only DCHECK test we have to rely on EXPECT_DEATH, as `logging::ScopedLogAssertHandler` will not be able to prevent termination in coming upstream updates.

Chromium change:
https://chromium.googlesource.com/chromium/src/+/2cc59dab0e60c52aa7e1aca45d97992fdfc5a6dd

commit 2cc59dab0e60c52aa7e1aca45d97992fdfc5a6dd
Author: Peter Boström <pbos@chromium.org>
Date:   Sat Feb 18 08:13:24 2023 +0000

    (Partial) Make sure CHECK() failures crash

    This partial land excludes iOS and Windows where two tests currently
    rely on aborting a LOG(FATAL). This is going in to not backslide in
    platform-agnostic code.

    This is trying to make sure that CHECK failures effectively don't
    return before LOG(FATAL) is properly [[noreturn]]. A follow-up could
    be to split out CheckError from DcheckError to make sure the
    destructor can be marked [[noreturn]].

    Note that this doesn't apply to the optimized version of CHECK which is
    already a [[noreturn]] function call, but also doesn't involve
    LOG(FATAL).

    Bug: 1409729

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves 

## Submitter Checklist:

- [ ] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

