### PR TITLE
fix(wallet): Testnetwork Fiat Balances

### DIFF
--- a/components/brave_wallet_ui/utils/pricing-utils.ts
+++ b/components/brave_wallet_ui/utils/pricing-utils.ts
@@ -3,7 +3,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this file,
 // you can obtain one at https://mozilla.org/MPL/2.0/.
 
-import { AssetPriceWithContractAndChainId } from '../constants/types'
+import { AssetPriceWithContractAndChainId, SupportedTestNetworks } from '../constants/types'
 import Amount from './amount'
 
 export const findAssetPrice = (
@@ -12,6 +12,12 @@ export const findAssetPrice = (
   contractAddress: string,
   chainId: string
 ) => {
+  if (SupportedTestNetworks.includes(chainId)) {
+    return spotPrices.find(
+      (token) => token.fromAsset.toLowerCase() === symbol.toLowerCase() &&
+        token.contractAddress === contractAddress
+    )?.price ?? ''
+  }
   return spotPrices.find(
     (token) => token.fromAsset.toLowerCase() === symbol.toLowerCase() &&
       token.contractAddress === contractAddress &&


### PR DESCRIPTION
## Description 
Fixes a bug where `Fiat` balances were not loading for testnetworks.

<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves <https://github.com/brave/brave-browser/issues/28806>

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
1. Enable a test network in settings
2. Go to the portfolio page and filter by that test network
3. The Fiat balance should load.

Before:

![Before1](https://user-images.githubusercontent.com/40611140/221946311-6e94a322-bb4f-431b-bcf2-788edf5273a5.png)

![Before2](https://user-images.githubusercontent.com/40611140/221946328-6b328786-6e49-4e3a-b698-bd5799a448f3.png)

After:

![Screenshot 4](https://user-images.githubusercontent.com/40611140/221946369-6f406b4c-1699-4456-a90a-9bcd323a249c.png)

![Screenshot 3](https://user-images.githubusercontent.com/40611140/221946391-1ab979fe-4db5-4207-bd93-6853b860c340.png)
