### PR TITLE
delete ad_block_service on its TaskRunner

### DIFF
--- a/browser/brave_browser_process_impl.h
+++ b/browser/brave_browser_process_impl.h
@@ -161,7 +161,8 @@ class BraveBrowserProcessImpl : public BraveBrowserProcess,
       local_data_files_service_;
   std::unique_ptr<brave_component_updater::BraveComponent::Delegate>
       brave_component_updater_delegate_;
-  std::unique_ptr<brave_shields::AdBlockService> ad_block_service_;
+  std::unique_ptr<brave_shields::AdBlockService, base::OnTaskRunnerDeleter>
+      ad_block_service_;
   std::unique_ptr<https_upgrade_exceptions::HttpsUpgradeExceptionsService>
       https_upgrade_exceptions_service_;
 #if BUILDFLAG(ENABLE_GREASELION)

--- a/components/brave_shields/browser/ad_block_engine.cc
+++ b/components/brave_shields/browser/ad_block_engine.cc
@@ -102,7 +102,9 @@ AdBlockEngine::AdBlockEngine() : ad_block_client_(new adblock::Engine()) {
   DETACH_FROM_SEQUENCE(sequence_checker_);
 }
 
-AdBlockEngine::~AdBlockEngine() = default;
+AdBlockEngine::~AdBlockEngine() {
+  DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
+}
 
 void AdBlockEngine::ShouldStartRequest(const GURL& url,
                                        blink::mojom::ResourceType resource_type,

--- a/components/brave_shields/browser/ad_block_service.h
+++ b/components/brave_shields/browser/ad_block_service.h
@@ -120,6 +120,8 @@ class AdBlockService {
 
   void EnableTag(const std::string& tag, bool enabled);
 
+  void Shutdown();
+
   // Methods for brave://adblock-internals.
   using GetDebugInfoCallback =
       base::OnceCallback<void(base::Value::Dict, base::Value::Dict)>;
@@ -178,9 +180,8 @@ class AdBlockService {
   std::unique_ptr<AdBlockRegionalServiceManager> regional_service_manager_
       GUARDED_BY_CONTEXT(sequence_checker_);
 
-  std::unique_ptr<AdBlockEngine, base::OnTaskRunnerDeleter> default_engine_;
-  std::unique_ptr<AdBlockEngine, base::OnTaskRunnerDeleter>
-      additional_filters_engine_;
+  std::unique_ptr<AdBlockEngine> default_engine_;
+  std::unique_ptr<AdBlockEngine> additional_filters_engine_;
 
   std::unique_ptr<SourceProviderObserver> default_service_observer_
       GUARDED_BY_CONTEXT(sequence_checker_);


### PR DESCRIPTION
The problem - `ad_block_service` is used on its `TaskRunner` possible after resetting in `BraveBrowserProcessImpl::StartTearDown()` (because `TaskRunner` is `RefCounted` it continues living after `ad_block_service_` is resetting). Flag `SKIP_ON_SHUTDOWN` doesn't guarantee that a task isn't executing during shutting down, that's why risk of using an invalid pointer exists. 

I changed a thread where  `ad_block_service` will be destructed, that allows to access the `|ad_block_service|` during shutting down without a crash. Perhaps you need to refactor all usage of `ad_block_service` via `g_brave_browser_process->ad_block_service()` on `TaskRunner`, but it is huge diff  and I think my fix is enough for now.

I checked `brave_browser_tests --gtest_filter=AdBlockService*`, everything is green.