### PR TITLE
Support permission duration in Brave Wallet permissions

### DIFF
--- a/browser/brave_wallet/brave_wallet_sign_message_browsertest.cc
+++ b/browser/brave_wallet/brave_wallet_sign_message_browsertest.cc
@@ -114,13 +114,14 @@ class BraveWalletSignMessageBrowserTest : public InProcessBrowserTest {
     run_loop.Run();
   }
   void UserGrantPermission(bool granted) {
-    if (granted)
+    if (granted) {
       permissions::BraveWalletPermissionContext::AcceptOrCancel(
           std::vector<std::string>{
               "0x084DCb94038af1715963F149079cE011C4B22961"},
-          web_contents());
-    else
+          mojom::PermissionLifetimeOption::kForever, web_contents());
+    } else {
       permissions::BraveWalletPermissionContext::Cancel(web_contents());
+    }
     ASSERT_EQ(EvalJs(web_contents(), "getPermissionGranted()",
                      content::EXECUTE_SCRIPT_USE_MANUAL_REPLY)
                   .ExtractBool(),

--- a/browser/brave_wallet/send_or_sign_transaction_browsertest.cc
+++ b/browser/brave_wallet/send_or_sign_transaction_browsertest.cc
@@ -273,7 +273,8 @@ class SendOrSignTransactionBrowserTest : public InProcessBrowserTest {
     std::string expected_address = "undefined";
     if (granted) {
       permissions::BraveWalletPermissionContext::AcceptOrCancel(
-          std::vector<std::string>{from()}, web_contents());
+          std::vector<std::string>{from()},
+          mojom::PermissionLifetimeOption::kForever, web_contents());
       expected_address = from();
     } else {
       permissions::BraveWalletPermissionContext::Cancel(web_contents());
@@ -354,8 +355,9 @@ class SendOrSignTransactionBrowserTest : public InProcessBrowserTest {
                         const std::string& test_method,
                         const std::string& data = "",
                         bool skip_restore = false) {
-    if (!skip_restore)
+    if (!skip_restore) {
       RestoreWallet();
+    }
     bool sign_only = expected_signed_tx.has_value();
     GURL url = https_server_for_files()->GetURL(
         "a.com", "/send_or_sign_transaction.html");

--- a/browser/brave_wallet/solana_provider_browsertest.cc
+++ b/browser/brave_wallet/solana_provider_browsertest.cc
@@ -398,7 +398,8 @@ class SolanaProviderTest : public InProcessBrowserTest {
   void UserGrantPermission(bool granted) {
     if (granted) {
       permissions::BraveWalletPermissionContext::AcceptOrCancel(
-          std::vector<std::string>{kFirstAccount}, web_contents());
+          std::vector<std::string>{kFirstAccount},
+          mojom::PermissionLifetimeOption::kForever, web_contents());
     } else {
       permissions::BraveWalletPermissionContext::Cancel(web_contents());
     }
@@ -671,7 +672,8 @@ IN_PROC_BROWSER_TEST_F(SolanaProviderTest, ConnectedStatusInIframes) {
 
   CallSolanaConnect(ChildFrameAt(main_frame, 0), true);
   permissions::BraveWalletPermissionContext::AcceptOrCancel(
-      std::vector<std::string>{kFirstAccount}, web_contents());
+      std::vector<std::string>{kFirstAccount},
+      mojom::PermissionLifetimeOption::kForever, web_contents());
   // First iframe is now connected.
   EXPECT_TRUE(IsSolanaConnected(ChildFrameAt(main_frame, 0)));
   // Second iframe is still disconnected
@@ -1077,7 +1079,8 @@ IN_PROC_BROWSER_TEST_F(SolanaProviderTest, Request) {
   CallSolanaRequest(R"({method: "connect"})");
   EXPECT_TRUE(WaitForWalletBubble(web_contents()));
   permissions::BraveWalletPermissionContext::AcceptOrCancel(
-      std::vector<std::string>{kFirstAccount}, web_contents());
+      std::vector<std::string>{kFirstAccount},
+      mojom::PermissionLifetimeOption::kForever, web_contents());
   WaitForResultReady();
   EXPECT_EQ(GetRequestResult(), kFirstAccount);
   ASSERT_TRUE(IsSolanaConnected(web_contents()));

--- a/browser/permissions/brave_wallet_permission_prompt_android.cc
+++ b/browser/permissions/brave_wallet_permission_prompt_android.cc
@@ -30,8 +30,11 @@ void BraveWalletPermissionPrompt::ConnectToSite(
     const std::vector<std::string>& accounts) {
   has_interacted_with_dialog_ = true;
   dialog_controller_.reset();
-  permissions::BraveWalletPermissionContext::AcceptOrCancel(accounts,
-                                                            web_contents_);
+  // TODO(SergeyZhukovsky): Use the real option that the user chooses, using
+  // `kForever` here is for landing new API changes separately.
+  permissions::BraveWalletPermissionContext::AcceptOrCancel(
+      accounts, brave_wallet::mojom::PermissionLifetimeOption::kForever,
+      web_contents_);
 }
 
 void BraveWalletPermissionPrompt::CancelConnectToSite() {
@@ -54,8 +57,9 @@ void BraveWalletPermissionPrompt::OnDialogDismissed() {
 }
 
 void BraveWalletPermissionPrompt::Delegate::Closing() {
-  if (!permission_prompt_)
+  if (!permission_prompt_) {
     return;
+  }
   permission_prompt_->Closing();
 }
 

--- a/browser/permissions/permission_manager_browsertest.cc
+++ b/browser/permissions/permission_manager_browsertest.cc
@@ -229,7 +229,9 @@ IN_PROC_BROWSER_TEST_F(PermissionManagerBrowserTest, RequestPermissions) {
 
     // Test accepting request with one of the address.
     permissions::BraveWalletPermissionContext::AcceptOrCancel(
-        std::vector<std::string>{addresses[1]}, web_contents());
+        std::vector<std::string>{addresses[1]},
+        brave_wallet::mojom::PermissionLifetimeOption::kForever,
+        web_contents());
     std::vector<ContentSetting> expected_settings(
         {ContentSetting::CONTENT_SETTING_ASK,
          ContentSetting::CONTENT_SETTING_ALLOW});

--- a/browser/ui/webui/brave_wallet/panel_handler/wallet_panel_handler.cc
+++ b/browser/ui/webui/brave_wallet/panel_handler/wallet_panel_handler.cc
@@ -44,9 +44,10 @@ void WalletPanelHandler::CloseUI() {
 }
 
 void WalletPanelHandler::ConnectToSite(
-    const std::vector<std::string>& accounts) {
+    const std::vector<std::string>& accounts,
+    brave_wallet::mojom::PermissionLifetimeOption option) {
   permissions::BraveWalletPermissionContext::AcceptOrCancel(
-      accounts, active_web_contents_);
+      accounts, option, active_web_contents_);
 }
 
 void WalletPanelHandler::CancelConnectToSite() {
@@ -54,8 +55,9 @@ void WalletPanelHandler::CancelConnectToSite() {
 }
 
 void WalletPanelHandler::SetCloseOnDeactivate(bool close) {
-  if (close_on_deactivation_)
+  if (close_on_deactivation_) {
     close_on_deactivation_.Run(close);
+  }
 }
 
 void WalletPanelHandler::Focus() {

--- a/browser/ui/webui/brave_wallet/panel_handler/wallet_panel_handler.h
+++ b/browser/ui/webui/brave_wallet/panel_handler/wallet_panel_handler.h
@@ -35,7 +35,9 @@ class WalletPanelHandler : public brave_wallet::mojom::PanelHandler {
   void ShowUI() override;
   void CloseUI() override;
   void SetCloseOnDeactivate(bool close) override;
-  void ConnectToSite(const std::vector<std::string>& accounts) override;
+  void ConnectToSite(
+      const std::vector<std::string>& accounts,
+      brave_wallet::mojom::PermissionLifetimeOption option) override;
   void CancelConnectToSite() override;
   void Focus() override;
   void IsSolanaAccountConnected(

--- a/chromium_src/components/permissions/permission_context_base.h
+++ b/chromium_src/components/permissions/permission_context_base.h
@@ -72,16 +72,20 @@ class PermissionContextBase : public PermissionContextBase_ChromiumImpl {
     GroupedPermissionRequests();
     ~GroupedPermissionRequests();
 
+    using GroupedRequests =
+        std::vector<std::pair<std::unique_ptr<PermissionRequest>,
+                              BrowserPermissionCallback>>;
+
     bool IsDone() const;
     void AddRequest(std::pair<std::unique_ptr<PermissionRequest>,
                               BrowserPermissionCallback> request);
     BrowserPermissionCallback GetNextCallback();
     void RequestFinished();
 
+    const GroupedRequests& Requests() const { return requests_; }
+
    private:
-    std::vector<std::pair<std::unique_ptr<PermissionRequest>,
-                          BrowserPermissionCallback>>
-        requests_;
+    GroupedRequests requests_;
     size_t finished_request_count_ = 0;
     size_t next_callback_index_ = 0;
   };

--- a/chromium_src/components/permissions/request_type.cc
+++ b/chromium_src/components/permissions/request_type.cc
@@ -98,6 +98,10 @@ absl::optional<ContentSettingsType> RequestTypeToContentSettingsType(
   switch (request_type) {
     case RequestType::kBraveGoogleSignInPermission:
       return ContentSettingsType::BRAVE_GOOGLE_SIGN_IN;
+    case RequestType::kBraveEthereum:
+      return ContentSettingsType::BRAVE_ETHEREUM;
+    case RequestType::kBraveSolana:
+      return ContentSettingsType::BRAVE_SOLANA;
     default:
       return RequestTypeToContentSettingsType_ChromiumImpl(request_type);
   }
@@ -106,6 +110,8 @@ absl::optional<ContentSettingsType> RequestTypeToContentSettingsType(
 bool IsRequestablePermissionType(ContentSettingsType content_settings_type) {
   switch (content_settings_type) {
     case ContentSettingsType::BRAVE_GOOGLE_SIGN_IN:
+    case ContentSettingsType::BRAVE_ETHEREUM:
+    case ContentSettingsType::BRAVE_SOLANA:
       return true;
     default:
       return IsRequestablePermissionType_ChromiumImpl(content_settings_type);

--- a/components/brave_wallet/browser/permission_utils_unittest.cc
+++ b/components/brave_wallet/browser/permission_utils_unittest.cc
@@ -7,7 +7,10 @@
 #include <vector>
 
 #include "base/strings/string_util.h"
+#include "base/time/time.h"
 #include "brave/components/brave_wallet/browser/permission_utils.h"
+#include "brave/components/brave_wallet/common/brave_wallet.mojom.h"
+#include "brave/components/permissions/permission_lifetime_utils.h"
 #include "testing/gtest/include/gtest/gtest.h"
 #include "url/gurl.h"
 #include "url/origin.h"
@@ -338,6 +341,38 @@ TEST(PermissionUtilsUnitTest, GetConnectWithSiteWebUIURL) {
     GURL url_out = GetConnectWithSiteWebUIURL(base_url, cases[i].addrs, origin);
     EXPECT_EQ(url_out.spec(), cases[i].expected_out_url) << "case: " << i;
   }
+}
+
+TEST(PermissionUtilsUnitTest, SyncingWithCreatePermissionLifetimeOptions) {
+  const auto options = permissions::CreatePermissionLifetimeOptions();
+  ASSERT_EQ(
+      options.size(),
+      static_cast<size_t>(mojom::PermissionLifetimeOption::kMaxValue) + 1);
+  ASSERT_EQ(mojom::PermissionLifetimeOption::kPageClosed,
+            mojom::PermissionLifetimeOption::kMinValue);
+  ASSERT_EQ(mojom::PermissionLifetimeOption::kForever,
+            mojom::PermissionLifetimeOption::kMaxValue);
+
+  for (size_t i = 0; i < options.size(); ++i) {
+    EXPECT_TRUE(mojom::IsKnownEnumValue(
+        static_cast<mojom::PermissionLifetimeOption>(i)));
+  }
+  EXPECT_EQ(
+      options[static_cast<size_t>(mojom::PermissionLifetimeOption::kPageClosed)]
+          .lifetime,
+      base::TimeDelta());
+  EXPECT_EQ(
+      options[static_cast<size_t>(mojom::PermissionLifetimeOption::k24Hours)]
+          .lifetime,
+      base::Hours(24));
+  EXPECT_EQ(
+      options[static_cast<size_t>(mojom::PermissionLifetimeOption::k7Days)]
+          .lifetime,
+      base::Days(7));
+  EXPECT_EQ(
+      options[static_cast<size_t>(mojom::PermissionLifetimeOption::kForever)]
+          .lifetime,
+      absl::nullopt);
 }
 
 }  // namespace brave_wallet

--- a/components/brave_wallet/browser/test/BUILD.gn
+++ b/components/brave_wallet/browser/test/BUILD.gn
@@ -106,6 +106,7 @@ source_set("brave_wallet_unit_tests") {
     "//brave/components/filecoin/rs:cxx",
     "//brave/components/ipfs",
     "//brave/components/resources:strings_grit",
+    "//components/permissions",
     "//components/prefs",
     "//components/prefs:test_support",
     "//components/sync_preferences:test_support",

--- a/components/brave_wallet/common/brave_wallet.mojom
+++ b/components/brave_wallet/common/brave_wallet.mojom
@@ -340,6 +340,14 @@ interface PageHandlerFactory {
                         brave_wallet_auto_pin_service);
 };
 
+// Lifetime option in sync with CreatePermissionLifetimeOptions()
+enum PermissionLifetimeOption {
+  kPageClosed = 0,
+  k24Hours = 1,
+  k7Days = 2,
+  kForever = 3
+};
+
 // Browser-side handler for requests from WebUI page.
 interface PanelHandler {
   // Notify the backend that the UI is ready to be shown.
@@ -348,7 +356,7 @@ interface PanelHandler {
   // Notify the backend that the dialog should be closed.
   CloseUI();
 
-  ConnectToSite(array<string> accounts);
+  ConnectToSite(array<string> accounts, PermissionLifetimeOption option);
   CancelConnectToSite();
   SetCloseOnDeactivate(bool close);
   Focus();

--- a/components/brave_wallet_ui/panel/async/wallet_panel_async_handler.ts
+++ b/components/brave_wallet_ui/panel/async/wallet_panel_async_handler.ts
@@ -293,7 +293,10 @@ handler.on(PanelActions.connectToSite.type, async (store: Store, payload: Accoun
   const apiProxy = getWalletPanelApiProxy()
   let accounts: string[] = []
   payload.selectedAccounts.forEach((account) => { accounts.push(account.address) })
-  apiProxy.panelHandler.connectToSite(accounts)
+  // TODO(muliswilliam): Use the real option that the user chooses, using
+  // `kForever` here is for landing new API changes separately.
+  apiProxy.panelHandler.connectToSite(
+    accounts, BraveWallet.PermissionLifetimeOption.kForever)
   apiProxy.panelHandler.closeUI()
 })
 

--- a/components/permissions/contexts/brave_wallet_permission_context.h
+++ b/components/permissions/contexts/brave_wallet_permission_context.h
@@ -11,6 +11,7 @@
 #include <string>
 #include <vector>
 
+#include "brave/components/brave_wallet/common/brave_wallet.mojom.h"
 #include "components/permissions/permission_context_base.h"
 #include "components/permissions/permission_request_id.h"
 #include "components/permissions/request_type.h"
@@ -58,9 +59,10 @@ class BraveWalletPermissionContext : public PermissionContextBase {
           void(const std::vector<blink::mojom::PermissionStatus>&)> callback);
   static bool HasRequestsInProgress(content::RenderFrameHost* rfh,
                                     permissions::RequestType request_type);
-
-  static void AcceptOrCancel(const std::vector<std::string>& accounts,
-                             content::WebContents* web_contents);
+  static void AcceptOrCancel(
+      const std::vector<std::string>& accounts,
+      brave_wallet::mojom::PermissionLifetimeOption option,
+      content::WebContents* web_contents);
   static void Cancel(content::WebContents* web_contents);
 
   static void GetAllowedAccounts(

--- a/components/permissions/permission_lifetime_utils.cc
+++ b/components/permissions/permission_lifetime_utils.cc
@@ -90,15 +90,21 @@ bool ShouldShowLifetimeOptions(PermissionPrompt::Delegate* delegate) {
 void SetRequestsLifetime(const std::vector<PermissionLifetimeOption>& options,
                          size_t index,
                          PermissionPrompt::Delegate* delegate) {
+  for (auto* request : delegate->Requests()) {
+    SetRequestLifetime(options, index, request);
+  }
+}
+
+void SetRequestLifetime(const std::vector<PermissionLifetimeOption>& options,
+                        size_t index,
+                        PermissionRequest* request) {
   DCHECK(base::FeatureList::IsEnabled(features::kPermissionLifetime));
   DCHECK(!options.empty());
   DCHECK(index < options.size());
   const auto& lifetime = options[index].lifetime;
   DLOG(INFO) << "Set permission lifetime "
              << (lifetime ? lifetime->InSeconds() : -1);
-  for (auto* request : delegate->Requests()) {
-    request->SetLifetime(lifetime);
-  }
+  request->SetLifetime(lifetime);
 }
 
 }  // namespace permissions

--- a/components/permissions/permission_lifetime_utils.h
+++ b/components/permissions/permission_lifetime_utils.h
@@ -25,6 +25,10 @@ bool ShouldShowLifetimeOptions(PermissionPrompt::Delegate* delegate);
 void SetRequestsLifetime(const std::vector<PermissionLifetimeOption>& options,
                          size_t index,
                          PermissionPrompt::Delegate* delegate);
+// Sets selected liftime for a request.
+void SetRequestLifetime(const std::vector<PermissionLifetimeOption>& options,
+                        size_t index,
+                        PermissionRequest* request);
 
 }  // namespace permissions
 

--- a/components/permissions/sources.gni
+++ b/components/permissions/sources.gni
@@ -26,6 +26,7 @@ brave_components_permissions_sources = [
 brave_components_permissions_deps = [
   "//base",
   "//brave/components/brave_wallet/browser:permission_utils",
+  "//brave/components/brave_wallet/common:mojom",
   "//brave/components/l10n/common",
   "//brave/components/resources:strings_grit",
   "//components/content_settings/core/browser",


### PR DESCRIPTION
1. mojo `PanelHandler::ConnectToSite` now requires PermissionLifetimeOption which is in synced with `CreatePermissionLifetimeOptions()` we use in native permission prompt.
2. We set request lifetime in `BraveWalletPermissionContext::AcceptOrCancel` which is also updated to require lifetime index.
3. Based on 1 and 2,Desktop and Android choose Forever liftime option by default until UI can pass correct options for backward compatibility.
4. Initiate permission lifetime monitoring for wallet permissions in `PermissionContextBase::PermissionDecided` because wallet permission is stored in `pending_grouped_requests_` instead of upstream `pending_requests_` to handle origin X account permission binding.
5. Since origin wallet permission is embedded with account info and different format between Ethereum and Solana, we need to convert it back to the original requesting origin so we can observe tab closed behavior correctly.
6. Update permission lifetime tests to be wallet permission patterns aware.

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/28840

## Submitter Checklist:

- [ ] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

