### PR TITLE
Use Brave-specific identifiers for MPRIS

### DIFF
--- a/patches/components-system_media_controls-linux-system_media_controls_linux.cc.patch
+++ b/patches/components-system_media_controls-linux-system_media_controls_linux.cc.patch
@@ -1,0 +1,19 @@
+diff --git a/components/system_media_controls/linux/system_media_controls_linux.cc b/components/system_media_controls/linux/system_media_controls_linux.cc
+index 46b9488bfc0d83060748b7d58d389124e09cb521..448b9a670fd9faf641cebed02bb020627d8653ea 100644
+--- a/components/system_media_controls/linux/system_media_controls_linux.cc
++++ b/components/system_media_controls/linux/system_media_controls_linux.cc
+@@ -46,12 +46,12 @@ constexpr base::TimeDelta kUpdatePositionInterval = base::Milliseconds(100);
+ const char kMprisAPINoTrackPath[] = "/org/mpris/MediaPlayer2/TrackList/NoTrack";
+ 
+ const char kMprisAPICurrentTrackPathFormatString[] =
+-    "/org/chromium/MediaPlayer2/TrackList/Track%s";
++    "/com/brave/MediaPlayer2/TrackList/Track%s";
+ 
+ }  // namespace
+ 
+ const char kMprisAPIServiceNameFormatString[] =
+-    "org.mpris.MediaPlayer2.chromium.instance%i";
++    "org.mpris.MediaPlayer2.brave.instance%i";
+ const char kMprisAPIObjectPath[] = "/org/mpris/MediaPlayer2";
+ const char kMprisAPIInterfaceName[] = "org.mpris.MediaPlayer2";
+ const char kMprisAPIPlayerInterfaceName[] = "org.mpris.MediaPlayer2.Player";


### PR DESCRIPTION
Fixes brave/brave-browser#16187

To be compliant with the MPRIS specification, we need to [use a unique service name](https://specifications.freedesktop.org/mpris-spec/latest/#Bus-Name-Policy) and not re-use Chromium's one.

The Track ID is [defined in the same spec](https://specifications.freedesktop.org/mpris-spec/latest/Player_Interface.html#Simple-Type:Track_Id).

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

1. Dowload the shell script at https://gitlab.com/axdsop/nix-dotfiles/-/blob/master/Configs/polybar/scripts/mpris_player/mpris_player_control
2. Start Brave and start playing [this YouTube video](https://www.youtube.com/watch?v=G1IbRujko-A).
3. Run these commands and confirm the output matches this:
```
$ bash ./mpris_player_control -l
brave.instance1211788
$ bash ./mpris_player_control -c
Playing
Brave
```
Note: the instance number is random and instead of "Brave", you might see "Brave Browser" or something similar.