### PR TITLE
Use buildflag instead of defines gn var (uplift to 1.50.x)

### DIFF
--- a/components/brave_vpn/browser/connection/win/brave_vpn_helper/BUILD.gn
+++ b/components/brave_vpn/browser/connection/win/brave_vpn_helper/BUILD.gn
@@ -24,25 +24,14 @@ source_set("common") {
     "brave_vpn_helper_state.h",
     "scoped_sc_handle.h",
   ]
-  public_configs = [ ":brave_vpn_helper_config" ]
+
+  public_deps = [ "//brave/components/brave_vpn/common/buildflags" ]
+
   deps = [
     "//base",
     "//brave/components/brave_vpn/common",
     "//chrome/install_static:install_static_util",
   ]
-}
-
-config("brave_vpn_helper_config") {
-  defines = []
-  if (brave_channel == "nightly") {
-    defines += [ "CHANNEL_NIGHTLY" ]
-  } else if (brave_channel == "beta") {
-    defines += [ "CHANNEL_BETA" ]
-  } else if (brave_channel == "dev") {
-    defines += [ "CHANNEL_DEV" ]
-  } else if (brave_channel == "development") {
-    defines += [ "CHANNEL_DEVELOPMENT" ]
-  }
 }
 
 source_set("lib") {

--- a/components/brave_vpn/browser/connection/win/brave_vpn_helper/brave_vpn_helper_constants.h
+++ b/components/brave_vpn/browser/connection/win/brave_vpn_helper/brave_vpn_helper_constants.h
@@ -8,6 +8,8 @@
 
 #include <guiddef.h>
 
+#include "brave/components/brave_vpn/common/buildflags/buildflags.h"
+
 namespace brave_vpn {
 
 constexpr char kBraveVpnHelperInstall[] = "install";
@@ -18,7 +20,7 @@ constexpr wchar_t kBraveVpnHelperFiltersInstalledValue[] = L"filters";
 constexpr int kCheckConnectionIntervalInSeconds = 3;
 
 /* UUID of WFP sublayer used by all instances */
-#if defined(CHANNEL_NIGHTLY)
+#if BUILDFLAG(CHANNEL_NIGHTLY)
 constexpr wchar_t kBraveVPNServiceFilter[] =
     L"Brave VPN Nightly Service DNS Filter";
 constexpr wchar_t kBraveVpnHelperRegistryStoragePath[] =
@@ -30,7 +32,7 @@ constexpr GUID kVpnDnsSublayerGUID = {
     0xeb83,
     0x4d2c,
     {0x9d, 0x77, 0xf6, 0xe9, 0xb5, 0x47, 0xf3, 0x9c}};
-#elif defined(CHANNEL_BETA)
+#elif BUILDFLAG(CHANNEL_BETA)
 constexpr wchar_t kBraveVPNServiceFilter[] =
     L"Brave VPN Beta Service DNS Filter";
 constexpr wchar_t kBraveVpnHelperRegistryStoragePath[] =
@@ -42,7 +44,7 @@ constexpr GUID kVpnDnsSublayerGUID = {
     0xe313,
     0x4f5e,
     {0x80, 0x52, 0xfe, 0x8b, 0x15, 0x0f, 0x7d, 0xe0}};
-#elif defined(CHANNEL_DEV)
+#elif BUILDFLAG(CHANNEL_DEV)
 constexpr wchar_t kBraveVPNServiceFilter[] =
     L"Brave VPN Dev Service DNS Filter";
 constexpr wchar_t kBraveVpnHelperRegistryStoragePath[] =
@@ -53,7 +55,7 @@ constexpr GUID kVpnDnsSublayerGUID = {
     0x729d,
     0x4a89,
     {0x87, 0x9b, 0x1c, 0xf0, 0xcd, 0x24, 0x60, 0xc0}};
-#elif defined(CHANNEL_DEVELOPMENT)
+#elif BUILDFLAG(CHANNEL_DEVELOPMENT)
 constexpr wchar_t kBraveVPNServiceFilter[] =
     L"Brave VPN Development Service DNS Filter";
 constexpr wchar_t kBraveVpnHelperRegistryStoragePath[] =

--- a/components/brave_vpn/common/buildflags/BUILD.gn
+++ b/components/brave_vpn/common/buildflags/BUILD.gn
@@ -3,10 +3,50 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this file,
 # You can obtain one at https://mozilla.org/MPL/2.0/.
 
+import("//brave/build/config.gni")
 import("//build/buildflag_header.gni")
 import("buildflags.gni")
 
 buildflag_header("buildflags") {
   header = "buildflags.h"
   flags = [ "ENABLE_BRAVE_VPN=$enable_brave_vpn" ]
+
+  if (is_win) {
+    if (brave_channel == "development") {
+      flags += [
+        "CHANNEL_NIGHTLY=0",
+        "CHANNEL_BETA=0",
+        "CHANNEL_DEV=0",
+        "CHANNEL_DEVELOPMENT=1",
+      ]
+    } else if (brave_channel == "nightly") {
+      flags += [
+        "CHANNEL_NIGHTLY=1",
+        "CHANNEL_BETA=0",
+        "CHANNEL_DEV=0",
+        "CHANNEL_DEVELOPMENT=0",
+      ]
+    } else if (brave_channel == "dev") {
+      flags += [
+        "CHANNEL_NIGHTLY=0",
+        "CHANNEL_BETA=0",
+        "CHANNEL_DEV=1",
+        "CHANNEL_DEVELOPMENT=0",
+      ]
+    } else if (brave_channel == "beta") {
+      flags += [
+        "CHANNEL_NIGHTLY=0",
+        "CHANNEL_BETA=1",
+        "CHANNEL_DEV=0",
+        "CHANNEL_DEVELOPMENT=0",
+      ]
+    } else {  # stable
+      flags += [
+        "CHANNEL_NIGHTLY=0",
+        "CHANNEL_BETA=0",
+        "CHANNEL_DEV=0",
+        "CHANNEL_DEVELOPMENT=0",
+      ]
+    }
+  }
 }


### PR DESCRIPTION
Uplift of #17443
Resolves https://github.com/brave/brave-browser/issues/28848

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.