### PR TITLE
Fix infobar inset on NTP with bookmarks bar visible

### DIFF
--- a/browser/ui/views/frame/brave_browser_view_layout.cc
+++ b/browser/ui/views/frame/brave_browser_view_layout.cc
@@ -106,6 +106,11 @@ int BraveBrowserViewLayout::LayoutInfoBar(int top) {
   if (!vertical_tab_strip_host_)
     return BrowserViewLayout::LayoutInfoBar(top);
 
+  if (ShouldPushBookmarkBarForVerticalTabs()) {
+    // Inserts are already applied from LayoutBookmarkAndInfoBar().
+    return BrowserViewLayout::LayoutInfoBar(top);
+  }
+
   auto new_rect = vertical_layout_rect_;
   new_rect.Inset(GetInsetsConsideringVerticalTabHost());
   base::AutoReset resetter(&vertical_layout_rect_, new_rect);

--- a/browser/ui/views/frame/brave_browser_view_layout.cc
+++ b/browser/ui/views/frame/brave_browser_view_layout.cc
@@ -107,7 +107,7 @@ int BraveBrowserViewLayout::LayoutInfoBar(int top) {
     return BrowserViewLayout::LayoutInfoBar(top);
 
   if (ShouldPushBookmarkBarForVerticalTabs()) {
-    // Inserts are already applied from LayoutBookmarkAndInfoBar().
+    // Insets are already applied from LayoutBookmarkAndInfoBar().
     return BrowserViewLayout::LayoutInfoBar(top);
   }
 


### PR DESCRIPTION
We were adding insets twice

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/28899


### Before
<img width="1275" alt="image" src="https://user-images.githubusercontent.com/5474642/222935123-5d4e04f9-f858-4008-9161-a32a1d9d7462.png">

### After
<img width="450" alt="image" src="https://user-images.githubusercontent.com/5474642/222995888-542ba077-82f3-4f07-9cd5-fa8d1fbc9300.png">


<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-draft - run CI builds on a draft PR (otherwise only on non-draft PRs)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux, CI/skip-android, CI/skip-macos, CI/skip-ios, CI/skip-windows, CI/skip-windows-x86 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [ ] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
* Brave shouldn't be default browser
* Bookmark bar visibility option should be "only on NTP"
* Then, "Set Default" infobar should be laid out properly.
