### PR TITLE
Keep pinned tabs in vertically positioned in floating mode

### DIFF
--- a/browser/ui/views/frame/vertical_tab_strip_region_view.cc
+++ b/browser/ui/views/frame/vertical_tab_strip_region_view.cc
@@ -607,6 +607,7 @@ int VerticalTabStripRegionView::GetPreferredWidthForState(
       << "If a new state was added, " << __FUNCTION__
       << " should be revisited.";
   return tabs::kVerticalTabMinWidth +
+         tabs::kMarginForVerticalTabContainers * 2 +
          (include_border ? GetInsets().width() : 0);
 }
 

--- a/browser/ui/views/tabs/brave_compound_tab_container.cc
+++ b/browser/ui/views/tabs/brave_compound_tab_container.cc
@@ -9,6 +9,7 @@
 #include <utility>
 #include <vector>
 
+#include "brave/browser/ui/color/brave_color_id.h"
 #include "brave/browser/ui/tabs/brave_tab_prefs.h"
 #include "brave/browser/ui/tabs/features.h"
 #include "brave/browser/ui/views/tabs/brave_tab_container.h"
@@ -192,6 +193,18 @@ BrowserRootView::DropTarget* BraveCompoundTabContainer::GetDropTarget(
   }
 
   return GetTabContainerAt(loc_in_local_coords);
+}
+
+void BraveCompoundTabContainer::OnThemeChanged() {
+  CompoundTabContainer::OnThemeChanged();
+
+  if (ShouldShowVerticalTabs()) {
+    pinned_tab_container_->SetBorder(views::CreateSolidSidedBorder(
+        gfx::Insets().set_bottom(1),
+        GetColorProvider()->GetColor(kColorBraveVerticalTabSeparator)));
+  } else {
+    pinned_tab_container_->SetBorder(nullptr);
+  }
 }
 
 TabContainer* BraveCompoundTabContainer::GetTabContainerAt(

--- a/browser/ui/views/tabs/brave_compound_tab_container.h
+++ b/browser/ui/views/tabs/brave_compound_tab_container.h
@@ -43,6 +43,7 @@ class BraveCompoundTabContainer : public CompoundTabContainer {
       gfx::Rect ideal_bounds) const override;
   BrowserRootView::DropTarget* GetDropTarget(
       gfx::Point loc_in_local_coords) override;
+  void OnThemeChanged() override;
 
   bool ShouldShowVerticalTabs() const;
 

--- a/browser/ui/views/tabs/brave_new_tab_button.cc
+++ b/browser/ui/views/tabs/brave_new_tab_button.cc
@@ -28,7 +28,7 @@
 // static
 const gfx::Size BraveNewTabButton::kButtonSize{24, 24};
 
-constexpr int kInsetForVerticalTab = 14;
+constexpr int kInsetForVerticalTab = 22;
 
 // static
 SkPath BraveNewTabButton::GetBorderPath(const gfx::Point& origin,
@@ -208,10 +208,10 @@ void BraveNewTabButton::Layout() {
   if (!text_->GetVisible())
     return;
 
-  constexpr int kTextLeftMargin = 20;
+  constexpr int kTextLeftMargin = 20 + kInsetForVerticalTab;
   gfx::Rect text_bounds = GetLocalBounds();
-  text_bounds.Inset(gfx::Insets(kInsetForVerticalTab));
-  text_bounds.Inset(gfx::Insets().set_left(kTextLeftMargin));
+  text_bounds.Inset(
+      gfx::Insets().set_left(kTextLeftMargin).set_right(kInsetForVerticalTab));
   text_->SetBoundsRect(text_bounds);
   shortcut_text_->SetBoundsRect(text_bounds);
 }

--- a/browser/ui/views/tabs/brave_tab_container.h
+++ b/browser/ui/views/tabs/brave_tab_container.h
@@ -52,6 +52,8 @@ class BraveTabContainer : public TabContainerImpl {
   raw_ptr<TabDragContext> drag_context_;
 
   BooleanPrefMember show_vertical_tabs_;
+  BooleanPrefMember vertical_tabs_floating_mode_enabled_;
+  BooleanPrefMember vertical_tabs_collapsed_;
 
   bool layout_locked_ = false;
 };

--- a/browser/ui/views/tabs/brave_tab_strip.cc
+++ b/browser/ui/views/tabs/brave_tab_strip.cc
@@ -43,6 +43,15 @@ BraveTabStrip::BraveTabStrip(std::unique_ptr<TabStripController> controller)
 
 BraveTabStrip::~BraveTabStrip() = default;
 
+bool BraveTabStrip::IsVerticalTabsFloating() const {
+  DCHECK(ShouldShowVerticalTabs())
+      << "This method should be called when vertical tab strip is enabled";
+
+  const auto* prefs = controller_->GetProfile()->GetPrefs();
+  return prefs->GetBoolean(brave_tabs::kVerticalTabsFloatingEnabled) &&
+         prefs->GetBoolean(brave_tabs::kVerticalTabsCollapsed);
+}
+
 bool BraveTabStrip::ShouldDrawStrokes() const {
   if (ShouldShowVerticalTabs()) {
     // Prevent root view from drawing lines. For tabs, we're overriding

--- a/browser/ui/views/tabs/brave_tab_strip.h
+++ b/browser/ui/views/tabs/brave_tab_strip.h
@@ -20,6 +20,8 @@ class BraveTabStrip : public TabStrip {
   BraveTabStrip(const BraveTabStrip&) = delete;
   BraveTabStrip& operator=(const BraveTabStrip&) = delete;
 
+  bool IsVerticalTabsFloating() const;
+
   // TabStrip:
   void UpdateHoverCard(Tab* tab, HoverCardUpdateType update_type) override;
   void MaybeStartDrag(

--- a/browser/ui/views/tabs/brave_tab_strip_layout_helper.cc
+++ b/browser/ui/views/tabs/brave_tab_strip_layout_helper.cc
@@ -8,6 +8,7 @@
 #include <limits>
 
 #include "brave/browser/ui/views/tabs/brave_tab_group_header.h"
+#include "brave/browser/ui/views/tabs/brave_tab_strip.h"
 #include "chrome/browser/ui/layout_constants.h"
 #include "chrome/browser/ui/tabs/tab_style.h"
 #include "chrome/browser/ui/tabs/tab_types.h"
@@ -19,66 +20,113 @@
 
 namespace tabs {
 
-constexpr int kVerticalMarginForTabs = 4;
+namespace {
+
+void CalculatePinnedTabsBoundsInGrid(
+    const TabLayoutConstants& layout_constants,
+    const std::vector<TabWidthConstraints>& tabs,
+    absl::optional<int> width,
+    bool is_floating_mode,
+    std::vector<gfx::Rect>* result) {
+  DCHECK(tabs.size());
+  DCHECK(result);
+
+  if (is_floating_mode) {
+    // In floating mode, we should lay out pinned tabs vertically so that tabs
+    // underneath the mouse cursor wouldn't move.
+    return;
+  }
+
+  gfx::Rect rect(/* x= */ kMarginForVerticalTabContainers,
+                 /* y= */ kMarginForVerticalTabContainers,
+                 /* width= */ kVerticalTabMinWidth,
+                 /* height= */ kVerticalTabHeight);
+  for (const auto& tab : tabs) {
+    if (tab.state().pinned() != TabPinned::kPinned) {
+      break;
+    }
+
+    result->push_back(rect);
+
+    // Update rect for the next pinned tabs. If overflowed, break into new line
+    if (rect.right() + kVerticalTabMinWidth + kVerticalTabsSpacing <
+        width.value_or(TabStyle::GetStandardWidth())) {
+      rect.set_x(rect.right() + kVerticalTabsSpacing);
+    } else {
+      // New line
+      rect.set_x(kMarginForVerticalTabContainers);
+      rect.set_y(result->back().bottom() + kVerticalTabsSpacing);
+    }
+  }
+}
+
+void CalculateVerticalLayout(const TabLayoutConstants& layout_constants,
+                             const std::vector<TabWidthConstraints>& tabs,
+                             absl::optional<int> width,
+                             std::vector<gfx::Rect>* result) {
+  DCHECK(tabs.size());
+  DCHECK(result);
+
+  if (result->size() == tabs.size()) {
+    // No tabs to lay out vertically.
+    return;
+  }
+
+  if (!result->empty()) {
+    // Usually this shouldn't happen, as pinned tabs and unpinned tabs belong to
+    // separated containers. But this could happen on start-up. In this case,
+    // fills bounds for unpinned tabs with empty rects.
+    while (result->size() < tabs.size()) {
+      result->push_back({});
+    }
+    return;
+  }
+
+  gfx::Rect rect;
+  rect.set_y(kMarginForVerticalTabContainers);
+  for (auto iter = tabs.begin() + result->size(); iter != tabs.end(); iter++) {
+    auto& tab = *iter;
+    rect.set_x(
+        kMarginForVerticalTabContainers +
+        (tab.is_tab_in_group() ? BraveTabGroupHeader::kPaddingForGroup : 0));
+    rect.set_width(width.value_or(tab.GetPreferredWidth()) - rect.x() * 2);
+    rect.set_height(tab.state().open() == TabOpen::kOpen ? kVerticalTabHeight
+                                                         : 0);
+    result->push_back(rect);
+
+    // Update rect for the next tab.
+    if (tab.state().open() == TabOpen::kOpen) {
+      rect.set_y(rect.bottom() + kVerticalTabsSpacing);
+    }
+  }
+}
+
+}  // namespace
 
 std::vector<gfx::Rect> CalculateVerticalTabBounds(
     const TabLayoutConstants& layout_constants,
     const std::vector<TabWidthConstraints>& tabs,
-    absl::optional<int> width) {
-  if (tabs.empty())
+    absl::optional<int> width,
+    bool is_floating_mode) {
+  if (tabs.empty()) {
     return std::vector<gfx::Rect>();
+  }
 
   std::vector<gfx::Rect> bounds;
-  gfx::Rect rect;
-  bool last_tab_was_pinned = false;
+  CalculatePinnedTabsBoundsInGrid(layout_constants, tabs, width,
+                                  is_floating_mode, &bounds);
+  CalculateVerticalLayout(layout_constants, tabs, width, &bounds);
 
-  for (const auto& tab : tabs) {
-    if (tab.state().pinned() == TabPinned::kPinned) {
-      rect.set_width(kVerticalTabMinWidth);
-      rect.set_height(kVerticalTabHeight);
-      bounds.push_back(rect);
-
-      if (tab.state().open() == TabOpen::kOpen) {
-        if (rect.right() + tab.GetMinimumWidth() <
-            width.value_or(TabStyle::GetStandardWidth())) {
-          rect.set_x(rect.right());
-        } else {
-          // New line
-          rect.set_x(0);
-          rect.set_y(bounds.back().bottom());
-        }
-      }
-
-      last_tab_was_pinned = true;
-      continue;
-    }
-
-    if (last_tab_was_pinned) {
-      // This could happen on start-up.
-      gfx::Rect empty_rect;
-      empty_rect.set_y(bounds.back().bottom());
-      bounds.push_back(empty_rect);
-      continue;
-    }
-
-    // This method is called by two separated containers. One contains only
-    // pinned tabs and the other contains only non-pinned tabs. So we don't need
-    // to consider the last pinned tab's bottom coordinate here.
-    rect.set_x(tab.is_tab_in_group() ? BraveTabGroupHeader::kPaddingForGroup
-                                     : 0);
-    rect.set_width(width.value_or(tab.GetPreferredWidth()) - rect.x() * 2);
-    rect.set_height(tab.state().open() == TabOpen::kOpen ? kVerticalTabHeight
-                                                         : 0);
-    bounds.push_back(rect);
-
-    if (tab.state().open() == TabOpen::kOpen)
-      rect.set_y(rect.bottom() + kVerticalMarginForTabs);
-  }
+  DCHECK_EQ(tabs.size(), bounds.size());
   return bounds;
 }
 
 std::vector<gfx::Rect> CalculateBoundsForVerticalDraggedViews(
-    const std::vector<TabSlotView*>& views) {
+    const std::vector<TabSlotView*>& views,
+    TabStrip* tab_strip) {
+  const bool is_vertical_tabs_floating =
+      static_cast<BraveTabStrip*>(tab_strip)->IsVerticalTabsFloating();
+
   std::vector<gfx::Rect> bounds;
   int x = 0;
   int y = 0;
@@ -86,13 +134,15 @@ std::vector<gfx::Rect> CalculateBoundsForVerticalDraggedViews(
     auto width = TabStyle::GetStandardWidth();
     const int height = view->height();
     if (view->GetTabSlotViewType() == TabSlotView::ViewType::kTab) {
-      if (const Tab* tab = static_cast<const Tab*>(view); tab->data().pinned) {
+      if (!is_vertical_tabs_floating &&
+          static_cast<const Tab*>(view)->data().pinned) {
         // In case it's a pinned tab, lay out them horizontally
         bounds.emplace_back(x, y, tabs::kVerticalTabMinWidth, height);
         constexpr int kStackedOffset = 4;
         x += kStackedOffset;
         continue;
       }
+
       if (view->group().has_value()) {
         // In case it's a tab in a group, set left padding
         x = BraveTabGroupHeader::kPaddingForGroup;
@@ -101,7 +151,7 @@ std::vector<gfx::Rect> CalculateBoundsForVerticalDraggedViews(
     }
     bounds.emplace_back(x, y, width, height);
     // unpinned dragged tabs are laid out vertically
-    y += height + kVerticalMarginForTabs;
+    y += height + kVerticalTabsSpacing;
   }
   return bounds;
 }
@@ -115,17 +165,22 @@ void UpdateInsertionIndexForVerticalTabs(
     TabStripController* tab_strip_controller,
     TabContainer* tab_container,
     int& min_distance,
-    int& min_distance_index) {
+    int& min_distance_index,
+    TabStrip* tab_strip) {
   // We don't allow tab groups to be dragged over pinned tabs area.
   if (dragged_group.has_value() && candidate_index != 0 &&
       tab_strip_controller->IsTabPinned(candidate_index - 1))
     return;
 
+  const bool is_vertical_tabs_floating =
+      static_cast<BraveTabStrip*>(tab_strip)->IsVerticalTabsFloating();
+
   int distance = std::numeric_limits<int>::max();
   const gfx::Rect candidate_bounds =
       candidate_index == 0 ? gfx::Rect()
                            : tab_container->GetIdealBounds(candidate_index - 1);
-  if (tab_strip_controller->IsTabPinned(first_dragged_tab_index)) {
+  if (!is_vertical_tabs_floating &&
+      tab_strip_controller->IsTabPinned(first_dragged_tab_index)) {
     // Pinned tabs are laid out in a grid.
     distance = std::sqrt(
         std::pow(dragged_bounds.x() - candidate_bounds.CenterPoint().x(), 2) +

--- a/browser/ui/views/tabs/brave_tab_strip_layout_helper.h
+++ b/browser/ui/views/tabs/brave_tab_strip_layout_helper.h
@@ -21,20 +21,25 @@ class TabWidthConstraints;
 class TabStripController;
 class TabContainer;
 class TabSlotView;
+class TabStrip;
 struct TabLayoutConstants;
 
 namespace tabs {
 
-constexpr int kVerticalTabMinWidth = 48;
-constexpr int kVerticalTabHeight = 38;
+constexpr int kVerticalTabHeight = 36;
+constexpr int kVerticalTabMinWidth = kVerticalTabHeight;
+constexpr int kVerticalTabsSpacing = 4;
+constexpr int kMarginForVerticalTabContainers = kVerticalTabsSpacing * 2;
 
 std::vector<gfx::Rect> CalculateVerticalTabBounds(
     const TabLayoutConstants& layout_constants,
     const std::vector<TabWidthConstraints>& tabs,
-    absl::optional<int> width);
+    absl::optional<int> width,
+    bool is_floating_mode);
 
 std::vector<gfx::Rect> CalculateBoundsForVerticalDraggedViews(
-    const std::vector<TabSlotView*>& views);
+    const std::vector<TabSlotView*>& views,
+    TabStrip* tab_strip);
 
 void UpdateInsertionIndexForVerticalTabs(
     const gfx::Rect& dragged_bounds,
@@ -45,7 +50,8 @@ void UpdateInsertionIndexForVerticalTabs(
     TabStripController* tab_strip_controller,
     TabContainer* tab_container,
     int& min_distance,
-    int& min_distance_index);
+    int& min_distance_index,
+    TabStrip* tab_strip);
 
 }  // namespace tabs
 

--- a/chromium_src/chrome/browser/ui/views/tabs/tab_strip.cc
+++ b/chromium_src/chrome/browser/ui/views/tabs/tab_strip.cc
@@ -28,20 +28,21 @@
 #define CompoundTabContainer BraveCompoundTabContainer
 #define TabContainerImpl BraveTabContainer
 #define TabHoverCardController BraveTabHoverCardController
-#define BRAVE_CALCULATE_INSERTION_INDEX                                       \
-  if (base::FeatureList::IsEnabled(tabs::features::kBraveVerticalTabs) &&     \
-      tabs::utils::ShouldShowVerticalTabs(tab_strip_->GetBrowser())) {        \
-    tabs::UpdateInsertionIndexForVerticalTabs(                                \
-        dragged_bounds, first_dragged_tab_index, num_dragged_tabs,            \
-        dragged_group, candidate_index, tab_strip_->controller_.get(),        \
-        &tab_strip_->tab_container_.get(), min_distance, min_distance_index); \
-    continue;                                                                 \
+#define BRAVE_CALCULATE_INSERTION_INDEX                                      \
+  if (base::FeatureList::IsEnabled(tabs::features::kBraveVerticalTabs) &&    \
+      tabs::utils::ShouldShowVerticalTabs(tab_strip_->GetBrowser())) {       \
+    tabs::UpdateInsertionIndexForVerticalTabs(                               \
+        dragged_bounds, first_dragged_tab_index, num_dragged_tabs,           \
+        dragged_group, candidate_index, tab_strip_->controller_.get(),       \
+        &tab_strip_->tab_container_.get(), min_distance, min_distance_index, \
+        tab_strip_);                                                         \
+    continue;                                                                \
   }
 
-#define BRAVE_CALCULATE_BOUNDS_FOR_DRAGGED_VIEWS                          \
-  if (base::FeatureList::IsEnabled(tabs::features::kBraveVerticalTabs) && \
-      tabs::utils::ShouldShowVerticalTabs(tab_strip_->GetBrowser())) {    \
-    return tabs::CalculateBoundsForVerticalDraggedViews(views);           \
+#define BRAVE_CALCULATE_BOUNDS_FOR_DRAGGED_VIEWS                            \
+  if (base::FeatureList::IsEnabled(tabs::features::kBraveVerticalTabs) &&   \
+      tabs::utils::ShouldShowVerticalTabs(tab_strip_->GetBrowser())) {      \
+    return tabs::CalculateBoundsForVerticalDraggedViews(views, tab_strip_); \
   }
 
 #include "src/chrome/browser/ui/views/tabs/tab_strip.cc"

--- a/chromium_src/chrome/browser/ui/views/tabs/tab_strip_layout_helper.cc
+++ b/chromium_src/chrome/browser/ui/views/tabs/tab_strip_layout_helper.cc
@@ -5,18 +5,23 @@
 
 #include "chrome/browser/ui/views/tabs/tab_strip_layout_helper.h"
 
-#define CalculateTabBounds                                             \
-  use_vertical_tabs_&& FillGroupInfo(tab_widths)                       \
-      ? tabs::CalculateVerticalTabBounds(layout_constants, tab_widths, \
-                                         tabstrip_width)               \
+#define CalculateTabBounds                                               \
+  use_vertical_tabs_&& FillGroupInfo(tab_widths)                         \
+      ? tabs::CalculateVerticalTabBounds(layout_constants, tab_widths,   \
+                                         tabstrip_width, floating_mode_) \
       : CalculateTabBounds
 
 #include "src/chrome/browser/ui/views/tabs/tab_strip_layout_helper.cc"
 
 #undef CalculateTabBounds
 
+// Unfortunately, TabStripLayout::TabSlot is declared and defined in the .cc
+// file, we can't move this method out of this file.
 bool TabStripLayoutHelper::FillGroupInfo(
     std::vector<TabWidthConstraints>& tab_widths) {
+  DCHECK(use_vertical_tabs_)
+      << "Must be called only when |use_vertical_tabs_| is true";
+
   for (auto i = 0u; i < tab_widths.size(); i++) {
     auto& tab_width_constraints = tab_widths.at(i);
     tab_width_constraints.set_is_tab_in_group(

--- a/chromium_src/chrome/browser/ui/views/tabs/tab_strip_layout_helper.h
+++ b/chromium_src/chrome/browser/ui/views/tabs/tab_strip_layout_helper.h
@@ -8,16 +8,26 @@
 
 #include "brave/browser/ui/views/tabs/brave_tab_strip_layout_helper.h"
 
-#define UpdateIdealBounds                                                      \
-  UnUsed() { return {}; }                                                      \
-  void set_use_vertical_tabs(bool vertical) { use_vertical_tabs_ = vertical; } \
-                                                                               \
- private:                                                                      \
-  friend class BraveTabContainer;                                              \
-  bool FillGroupInfo(std::vector<TabWidthConstraints>& tab_widths);            \
-  bool use_vertical_tabs_ = false;                                             \
-                                                                               \
- public:                                                                       \
+// As TabStripLayoutHelper's destructor is not virtual, it'd be safer not to
+// make virtual methods and child class of it
+#define UpdateIdealBounds                                           \
+  UnUsed() {                                                        \
+    return {};                                                      \
+  }                                                                 \
+  void set_use_vertical_tabs(bool vertical) {                       \
+    use_vertical_tabs_ = vertical;                                  \
+  }                                                                 \
+  void set_floating_mode(bool floating) {                           \
+    floating_mode_ = floating;                                      \
+  }                                                                 \
+                                                                    \
+ private:                                                           \
+  friend class BraveTabContainer;                                   \
+  bool FillGroupInfo(std::vector<TabWidthConstraints>& tab_widths); \
+  bool use_vertical_tabs_ = false;                                  \
+  bool floating_mode_ = false;                                      \
+                                                                    \
+ public:                                                            \
   int UpdateIdealBounds
 
 #include "src/chrome/browser/ui/views/tabs/tab_strip_layout_helper.h"  // IWYU pragma: export

--- a/chromium_src/chrome/browser/ui/views/tabs/tab_style_views.cc
+++ b/chromium_src/chrome/browser/ui/views/tabs/tab_style_views.cc
@@ -113,12 +113,10 @@ SkPath BraveVerticalTabStyle::GetPath(PathType path_type,
   gfx::RectF aligned_bounds =
       ScaleAndAlignBounds(tab()->bounds(), scale, stroke_thickness);
 
-  constexpr int kHorizontalInset = BraveTabGroupHeader::kPaddingForGroup;
-
   // Calculate the bounds of the actual path.
   float tab_top = aligned_bounds.y();
-  float tab_left = aligned_bounds.x() + kHorizontalInset * scale;
-  float tab_right = aligned_bounds.right() - kHorizontalInset * scale;
+  float tab_left = aligned_bounds.x();
+  float tab_right = aligned_bounds.right();
   float tab_bottom = aligned_bounds.bottom();
 
   const float stroke_adjustment = stroke_thickness * scale;
@@ -135,9 +133,10 @@ SkPath BraveVerticalTabStyle::GetPath(PathType path_type,
     tab_bottom -= 0.5f * stroke_adjustment;
   }
 
+  constexpr int kRadius = 8;
   SkPath path;
-  path.addRoundRect({tab_left, tab_top, tab_right, tab_bottom},
-                    kHorizontalInset * scale, kHorizontalInset * scale);
+  path.addRoundRect({tab_left, tab_top, tab_right, tab_bottom}, kRadius * scale,
+                    kRadius * scale);
 
   // Convert path to be relative to the tab origin.
   gfx::PointF origin(tab()->origin());
@@ -161,13 +160,16 @@ TabStyle::SeparatorBounds BraveVerticalTabStyle::GetSeparatorBounds(
 
 void BraveVerticalTabStyle::PaintTab(gfx::Canvas* canvas) const {
   BraveGM2TabStyle::PaintTab(canvas);
-  if (ShouldShowVerticalTabs() && (tab()->IsActive() || IsHoverActive())) {
+  if (!ShouldShowVerticalTabs()) {
+    return;
+  }
+
+  if (tab()->IsActive() || IsHoverActive() || tab()->data().pinned) {
     const auto* widget = tab()->GetWidget();
     DCHECK(widget);
     const SkColor tab_stroke_color =
         widget->GetColorProvider()->GetColor(kColorBraveVerticalTabSeparator);
     PaintBackgroundStroke(canvas, TabActive::kActive, tab_stroke_color);
-    return;
   }
 }
 


### PR DESCRIPTION
If we change the layout to grid style, the tab underneath the cursor would move around, which distracts users. In order to prevent that, we should keep them in vertical layout when tab strip is temporarily expanded in floating mode.

### Demo

https://user-images.githubusercontent.com/5474642/223106457-5354b37a-7a04-43da-add8-ec61da8440fe.mov


<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/28810

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-draft - run CI builds on a draft PR (otherwise only on non-draft PRs)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux, CI/skip-android, CI/skip-macos, CI/skip-ios, CI/skip-windows, CI/skip-windows-x86 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [ ] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

