### PR TITLE
Fix error message: Brave needs Windows 10, not 7/8 (uplift to 1.49.x)

### DIFF
--- a/app/brave_strings.grd
+++ b/app/brave_strings.grd
@@ -577,7 +577,7 @@ Permissions you've already given to websites and apps may apply to this account.
           Installation failed due to unspecified error. Please download Brave again.
         </message>
         <message name="IDS_INSTALL_OS_NOT_SUPPORTED" desc="Error displayed if OS is not supported">
-          Brave requires Windows 7 or higher.
+          Brave requires Windows 10 or higher.
         </message>
         <message name="IDS_INSTALL_OS_ERROR" desc="Error displayed when any Windows API call fails and we do not have more specific information.">
           An operating system error occurred during installation. Please download Brave again.

--- a/app/resources/chromium_strings_af.xtb
+++ b/app/resources/chromium_strings_af.xtb
@@ -184,7 +184,7 @@ Sommige kenmerke kan dalk nie beskikbaar wees nie en veranderings aan voorkeure 
 <translation id="232381795826373334">Maak PDF's in Brave oop</translation>
 <translation id="5381032481466106256">Wanneer dit aan is, sal jy ook by Brave afgemeld word</translation>
 <translation id="1026406809507858026">{0,plural, =0{'n Brave-opdatering is beskikbaar}=1{'n Brave-opdatering is beskikbaar}other{'n Brave-opdatering is al # dae lank beskikbaar}}</translation>
-<translation id="95624393026532554">Brave vereis Windows 7 of nuwer.</translation>
+<translation id="4378573854226202617">Brave vereis Windows 10 of nuwer.</translation>
 <translation id="5646769069113654257">Herbegin Brave asseblief nou</translation>
 <translation id="2335583906071111058">Wys Brave in hierdie taal</translation>
 <translation id="7207456302801184289">Welkom by Brave</translation>

--- a/app/resources/chromium_strings_am.xtb
+++ b/app/resources/chromium_strings_am.xtb
@@ -184,7 +184,7 @@
 <translation id="232381795826373334">PDFዎችን በBrave ውስጥ ክፈት</translation>
 <translation id="5381032481466106256">ሲበራ ከBrave ዘግተው እንዲወጡ ይደረጋሉ</translation>
 <translation id="1026406809507858026">{0,plural, =0{የBrave ዝማኔ ይገኛል}=1{የBrave ዝማኔ ይገኛል}one{አንድ የBrave ዝማኔ ለ# ቀኖች ነበር}other{አንድ የBrave ዝማኔ ለ# ቀኖች ነበር}}</translation>
-<translation id="95624393026532554">Brave Windows 7 ወይም ከዚያ በላይ ያስፈልገዋል።</translation>
+<translation id="4378573854226202617">Brave Windows 10 ወይም ከዚያ በላይ ያስፈልገዋል።</translation>
 <translation id="5646769069113654257">እባክዎ Brave ን አህን ዳግም ያስጀምሩ</translation>
 <translation id="2335583906071111058">Braveን በዚህ ቋንቋ አሳይ</translation>
 <translation id="7207456302801184289">ወደ Brave እንኳን በደህና መጡ</translation>

--- a/app/resources/chromium_strings_ar.xtb
+++ b/app/resources/chromium_strings_ar.xtb
@@ -182,7 +182,7 @@
 <translation id="232381795826373334">‏فتح ملفات PDF في Brave</translation>
 <translation id="5381032481466106256">‏عند تفعيل هذا الخيار، سيتم تسجيل خروجك أيضًا من Brave.</translation>
 <translation id="1026406809507858026">{0,plural, =0{‏يتوفر تحديث لمتصفح Brave}=1{‏يتوفر تحديث لمتصفح Brave}two{‏يتوفر تحديث لمتصفح Brave منذ يومين}few{‏يتوفر تحديث لمتصفح Brave منذ # أيام}many{‏يتوفر تحديث لمتصفح Brave منذ # يومًا}other{‏يتوفر تحديث لمتصفح Brave منذ # يوم}}</translation>
-<translation id="95624393026532554">‏يتطلب Brave نظام التشغيل Windows 7 أو إصدارًا أحدث.</translation>
+<translation id="4378573854226202617">‏يتطلب Brave نظام التشغيل Windows 10 أو إصدارًا أحدث.</translation>
 <translation id="5646769069113654257">‏يُرجى إعادة تشغيل Brave الآن</translation>
 <translation id="2335583906071111058">‏عرض Brave بهذه اللغة</translation>
 <translation id="7207456302801184289">‏مرحبًا بك في Brave</translation>

--- a/app/resources/chromium_strings_as.xtb
+++ b/app/resources/chromium_strings_as.xtb
@@ -184,7 +184,7 @@
 <translation id="232381795826373334">Braveত PDF খোলক</translation>
 <translation id="5381032481466106256">অন হৈ থাকিলে, আপোনাক Braveৰ পৰাও ছাইন আউট কৰোৱা হ'ব</translation>
 <translation id="1026406809507858026">{0,plural, =0{Braveৰ এটা আপডে'ট আছে}=1{Braveৰ এটা আপডে'ট আছে}one{Braveৰ এটা আপডে’ট # দিনৰ বাবে উপলব্ধ}other{Braveৰ এটা আপডে’ট # দিনৰ বাবে উপলব্ধ}}</translation>
-<translation id="95624393026532554">Braveৰ বাবে Windows 7 বা তাতোকৈ উন্নত সংস্কৰণৰ আৱশ্যক।</translation>
+<translation id="4378573854226202617">Braveৰ বাবে Windows 10 বা তাতোকৈ উন্নত সংস্কৰণৰ আৱশ্যক।</translation>
 <translation id="5646769069113654257">অনুগ্ৰহ কৰি এতিয়া Brave ৰিষ্টাৰ্ট কৰক</translation>
 <translation id="2335583906071111058">এই ভাষাত Brave প্ৰদর্শন কৰক</translation>
 <translation id="7207456302801184289">Brave লৈ স্বাগতম</translation>

--- a/app/resources/chromium_strings_az.xtb
+++ b/app/resources/chromium_strings_az.xtb
@@ -196,7 +196,7 @@ Hazırda veb saytlar və tətbiqlərə verdiyiniz icazələr bu hesaba tətbiq o
 <translation id="232381795826373334">PDF-ləri Brave'da açın</translation>
 <translation id="5381032481466106256">Aktiv olduqda, Brave'dan da çıxacaqsınız</translation>
 <translation id="1026406809507858026">{0,plural, =0{Brave güncəlləməsi əlçatandır}=1{Brave güncəlləməsi əlçatandır}other{Brave güncəlləməsi # gün ərzində əlçatan olub}}</translation>
-<translation id="95624393026532554">Brave Windows 7 və ya daha yeni versiya tələb edir.</translation>
+<translation id="4378573854226202617">Brave Windows 10 və ya daha yeni versiya tələb edir.</translation>
 <translation id="5646769069113654257">Brave'u indi başladın</translation>
 <translation id="2335583906071111058">Brave'u bu dildə görüntüləyin</translation>
 <translation id="7207456302801184289">Brave'a xoş gəlmisiniz</translation>

--- a/app/resources/chromium_strings_be.xtb
+++ b/app/resources/chromium_strings_be.xtb
@@ -184,7 +184,7 @@
 <translation id="232381795826373334">Адкрываць PDF-файлы ў Brave</translation>
 <translation id="5381032481466106256">Калі гэты параметр уключаны, будзе выконвацца таксама выхад з вашага ўліковага запісу ў Brave</translation>
 <translation id="1026406809507858026">{0,plural, =0{Ёсць абнаўленне Brave}=1{Ёсць абнаўленне Brave}one{Абнаўленне Brave выйшла # дзень таму}few{Абнаўленне Brave выйшла # дні таму}many{Абнаўленне Brave выйшла # дзён таму}other{Абнаўленне Brave выйшла # дня таму}}</translation>
-<translation id="95624393026532554">Для браўзера Brave патрабуецца Windows 7 або навейшая версія.</translation>
+<translation id="4378573854226202617">Для браўзера Brave патрабуецца Windows 10 або навейшая версія.</translation>
 <translation id="5646769069113654257">Перазапусціце Brave</translation>
 <translation id="2335583906071111058">Паказваць інтэрфейс браўзера Brave на гэтай мове</translation>
 <translation id="7207456302801184289">Вас вітае Brave</translation>

--- a/app/resources/chromium_strings_bg.xtb
+++ b/app/resources/chromium_strings_bg.xtb
@@ -180,7 +180,7 @@
 <translation id="232381795826373334">Отваряне на PDF файловете в Brave</translation>
 <translation id="5381032481466106256">Когато е включено, ще излезете и от Brave</translation>
 <translation id="1026406809507858026">{0,plural, =0{Налице е актуализация за Brave}=1{Налице е актуализация за Brave}other{Налице е актуализация за Brave от # дни}}</translation>
-<translation id="95624393026532554">За Brave се изисква Windows 7 или по-нова версия.</translation>
+<translation id="4378573854226202617">За Brave се изисква Windows 10 или по-нова версия.</translation>
 <translation id="5646769069113654257">Моля, рестартирайте Brave сега</translation>
 <translation id="2335583906071111058">Показване на Brave на този език</translation>
 <translation id="7207456302801184289">Добре дошли в Brave</translation>

--- a/app/resources/chromium_strings_bn.xtb
+++ b/app/resources/chromium_strings_bn.xtb
@@ -182,7 +182,7 @@
 <translation id="232381795826373334">Brave-এ পিডিএফ ফাইল খুলুন</translation>
 <translation id="5381032481466106256">চালু হলে, আপনি Brave থেকেও সাইন-আউট হয়ে যাবেন</translation>
 <translation id="1026406809507858026">{0,plural, =0{Brave-এর একটি আপডেট উপলভ্য আছে}=1{Brave-এর একটি আপডেট উপলভ্য আছে}one{Brave-এর একটি আপডেট # দিন ধরে উপলভ্য আছে}other{Brave-এর একটি আপডেট # দিন ধরে উপলভ্য আছে}}</translation>
-<translation id="95624393026532554">Brave এর জন্য Windows 7 বা উচ্চতর সংস্করণ প্রয়োজন।</translation>
+<translation id="4378573854226202617">Brave এর জন্য Windows 10 বা উচ্চতর সংস্করণ প্রয়োজন।</translation>
 <translation id="5646769069113654257">এখনই Brave রিস্টার্ট করুন</translation>
 <translation id="2335583906071111058">এই ভাষায় Brave প্রদর্শন করুন</translation>
 <translation id="7207456302801184289">Brave-এ স্বাগতম</translation>

--- a/app/resources/chromium_strings_bs.xtb
+++ b/app/resources/chromium_strings_bs.xtb
@@ -184,7 +184,7 @@ Neke funkcije možda neće biti dostupne i promjene postavki se neće sačuvati.
 <translation id="232381795826373334">Otvaraj PDF-ove u Braveu</translation>
 <translation id="5381032481466106256">Kada je uključeno, također ćete biti odjavljeni iz Bravea</translation>
 <translation id="1026406809507858026">{0,plural, =0{Ažuriranje za Brave je dostupno}=1{Ažuriranje za Brave je dostupno}one{Ažuriranje za Brave je dostupno # dan}few{Ažuriranje za Brave je dostupno # dana}other{Ažuriranje za Brave je dostupno # dana}}</translation>
-<translation id="95624393026532554">Za Brave je potreban Windows 7 ili noviji operativni sistem.</translation>
+<translation id="4378573854226202617">Za Brave je potreban Windows 10 ili noviji operativni sistem.</translation>
 <translation id="5646769069113654257">Ponovo pokrenite Brave sada</translation>
 <translation id="2335583906071111058">Prikaži Brave na ovom jeziku.</translation>
 <translation id="7207456302801184289">Dobro došli u Brave</translation>

--- a/app/resources/chromium_strings_ca.xtb
+++ b/app/resources/chromium_strings_ca.xtb
@@ -182,7 +182,7 @@
 <translation id="232381795826373334">Obre els fitxers PDF a Brave</translation>
 <translation id="5381032481466106256">Si aquesta opció està activada, també se't tancarà la sessió de Brave</translation>
 <translation id="1026406809507858026">{0,plural, =0{Hi ha una actualització de Brave disponible}=1{Hi ha una actualització de Brave disponible}other{Fa # dies que hi ha una actualització de Brave disponible}}</translation>
-<translation id="95624393026532554">Brave requereix Windows 7 o una versió posterior.</translation>
+<translation id="4378573854226202617">Brave requereix Windows 10 o una versió posterior.</translation>
 <translation id="5646769069113654257">Reinicia Brave ara</translation>
 <translation id="2335583906071111058">Mostra Brave en aquest idioma</translation>
 <translation id="7207456302801184289">Us donem la benvinguda a Brave</translation>

--- a/app/resources/chromium_strings_cs.xtb
+++ b/app/resources/chromium_strings_cs.xtb
@@ -184,7 +184,7 @@ Některé funkce možná nebudou k dispozici a změny nastavení se neuloží.</
 <translation id="232381795826373334">Otevírat soubory PDF v Chromiu</translation>
 <translation id="5381032481466106256">Když zapnete tuto možnost, budete také odhlášeni z Chromia</translation>
 <translation id="1026406809507858026">{0,plural, =0{Je k dispozici aktualizace prohlížeče Brave}=1{Je k dispozici aktualizace prohlížeče Brave}few{Již # dny je k dispozici aktualizace prohlížeče Brave}many{Již # dne je k dispozici aktualizace prohlížeče Brave}other{Již # dní je k dispozici aktualizace prohlížeče Brave}}</translation>
-<translation id="95624393026532554">Brave vyžaduje systém Windows 7 nebo vyšší.</translation>
+<translation id="4378573854226202617">Brave vyžaduje systém Windows 10 nebo vyšší.</translation>
 <translation id="5646769069113654257">Restartujte Brave</translation>
 <translation id="2335583906071111058">Zobrazit Brave v tomto jazyce</translation>
 <translation id="7207456302801184289">Vítejte v prohlížeči Brave</translation>

--- a/app/resources/chromium_strings_cy.xtb
+++ b/app/resources/chromium_strings_cy.xtb
@@ -184,7 +184,7 @@ Mae'n bosib na fydd rhai nodweddion ar gael ac ni fydd newidiadau o ran dewisiad
 <translation id="232381795826373334">Agor ffeiliau PDF yn Brave</translation>
 <translation id="5381032481466106256">Pan fydd ymlaen, byddwch hefyd yn cael eich allgofnodi o Brave</translation>
 <translation id="1026406809507858026">{0,plural, =0{Mae diweddariad Cromiwm ar gael}=1{Mae diweddariad Cromiwm ar gael}two{Mae diweddariad Brave wedi bod ar gael ers # ddiwrnod}few{Mae diweddariad Brave wedi bod ar gael ers # diwrnod}many{Mae diweddariad Brave wedi bod ar gael ers # diwrnod}other{Mae diweddariad Brave wedi bod ar gael ers # diwrnod}}</translation>
-<translation id="95624393026532554">Mae Brave yn gofyn am Windows 7 neu uwch.</translation>
+<translation id="4378573854226202617">Mae Brave yn gofyn am Windows 10 neu uwch.</translation>
 <translation id="5646769069113654257">Ailgychwynnwch Brave nawr</translation>
 <translation id="2335583906071111058">Dangos Brave yn yr iaith hon</translation>
 <translation id="7207456302801184289">Croeso i Brave</translation>

--- a/app/resources/chromium_strings_da.xtb
+++ b/app/resources/chromium_strings_da.xtb
@@ -182,7 +182,7 @@
 <translation id="232381795826373334">Åbn PDF-filer i Brave</translation>
 <translation id="5381032481466106256">Når den er slået til, bliver du også logget ud af Brave</translation>
 <translation id="1026406809507858026">{0,plural, =0{Der er en tilgængelig Brave-opdatering}=1{Der er en tilgængelig Brave-opdatering}one{En Brave-opdatering har været tilgængelig i # dag}other{En Brave-opdatering har været tilgængelig i # dage}}</translation>
-<translation id="95624393026532554">Brave kræver Windows 7 eller nyere.</translation>
+<translation id="4378573854226202617">Brave kræver Windows 10 eller nyere.</translation>
 <translation id="5646769069113654257">Genstart Brave nu</translation>
 <translation id="2335583906071111058">Vis Brave på dette sprog</translation>
 <translation id="7207456302801184289">Velkommen til Brave</translation>

--- a/app/resources/chromium_strings_de.xtb
+++ b/app/resources/chromium_strings_de.xtb
@@ -182,7 +182,7 @@
 <translation id="232381795826373334">PDFs in Brave öffnen</translation>
 <translation id="5381032481466106256">Wenn aktiviert, wirst du auch aus Brave abgemeldet</translation>
 <translation id="1026406809507858026">{0,plural, =0{Ein Brave-Update ist verfügbar}=1{Ein Brave-Update ist verfügbar}other{Ein Brave-Update ist seit # Tagen verfügbar}}</translation>
-<translation id="95624393026532554">Für Brave ist Windows 7 oder höher erforderlich.</translation>
+<translation id="4378573854226202617">Für Brave ist Windows 10 oder höher erforderlich.</translation>
 <translation id="5646769069113654257">Starte Brave jetzt neu</translation>
 <translation id="2335583906071111058">Brave in dieser Sprache anzeigen</translation>
 <translation id="7207456302801184289">Willkommen bei Brave</translation>

--- a/app/resources/chromium_strings_el.xtb
+++ b/app/resources/chromium_strings_el.xtb
@@ -182,7 +182,7 @@
 <translation id="232381795826373334">Άνοιγμα PDF στο Brave</translation>
 <translation id="5381032481466106256">Όταν είναι ενεργή η επιλογή, θα αποσυνδεθείτε και από το Brave</translation>
 <translation id="1026406809507858026">{0,plural, =0{Υπάρχει μια διαθέσιμη ενημέρωση του Brave}=1{Υπάρχει μια διαθέσιμη ενημέρωση του Brave}other{Υπάρχει μια διαθέσιμη ενημέρωση του Brave για # ημέρες}}</translation>
-<translation id="95624393026532554">Το Brave απαιτεί Windows 7 ή νεότερη έκδοση.</translation>
+<translation id="4378573854226202617">Το Brave απαιτεί Windows 10 ή νεότερη έκδοση.</translation>
 <translation id="5646769069113654257">Επανεκκινήστε το Brave τώρα</translation>
 <translation id="2335583906071111058">Να εμφανίζεται το Brave σε αυτήν τη γλώσσα</translation>
 <translation id="7207456302801184289">Καλώς ήρθατε στο Brave</translation>

--- a/app/resources/chromium_strings_en-GB.xtb
+++ b/app/resources/chromium_strings_en-GB.xtb
@@ -184,7 +184,7 @@ Some features may be unavailable and changes to preferences won't be saved.</tra
 <translation id="232381795826373334">Open PDFs in Brave</translation>
 <translation id="5381032481466106256">When on, you'll also be signed out of Brave</translation>
 <translation id="1026406809507858026">{0,plural, =0{A Brave update is available}=1{A Brave update is available}other{A Brave update has been available for # days}}</translation>
-<translation id="95624393026532554">Brave requires Windows 7 or higher.</translation>
+<translation id="4378573854226202617">Brave requires Windows 10 or higher.</translation>
 <translation id="5646769069113654257">Please restart Brave now</translation>
 <translation id="2335583906071111058">Display Brave in this language</translation>
 <translation id="7207456302801184289">Welcome to Brave</translation>

--- a/app/resources/chromium_strings_es-419.xtb
+++ b/app/resources/chromium_strings_es-419.xtb
@@ -180,7 +180,7 @@
 <translation id="232381795826373334">Abrir archivos PDF en Brave</translation>
 <translation id="5381032481466106256">Si activas esta opción, saldrás de Brave</translation>
 <translation id="1026406809507858026">{0,plural, =0{Hay una actualización de Brave disponible}=1{Hay una actualización de Brave disponible}other{Hay una actualización de Brave disponible hace # días}}</translation>
-<translation id="95624393026532554">Para usar Brave, se requiere Windows 7 o versiones posteriores.</translation>
+<translation id="4378573854226202617">Para usar Brave, se requiere Windows 10 o versiones posteriores.</translation>
 <translation id="5646769069113654257">Reinicia Brave ahora</translation>
 <translation id="2335583906071111058">Mostrar Brave en este idioma</translation>
 <translation id="7207456302801184289">Bienvenido a Brave</translation>

--- a/app/resources/chromium_strings_es.xtb
+++ b/app/resources/chromium_strings_es.xtb
@@ -184,7 +184,7 @@ Es posible que algunas funciones no estén disponibles y que no se guarden los c
 <translation id="232381795826373334">Abrir archivos PDF en Brave</translation>
 <translation id="5381032481466106256">Si activas esta opción, también se cerrará tu sesión en Brave</translation>
 <translation id="1026406809507858026">{0,plural, =0{Hay una actualización de Brave disponible}=1{Hay una actualización de Brave disponible}other{Hay una actualización de Brave disponible desde hace # días}}</translation>
-<translation id="95624393026532554">Brave requiere Windows 7 o una versión posterior.</translation>
+<translation id="4378573854226202617">Brave requiere Windows 10 o una versión posterior.</translation>
 <translation id="5646769069113654257">Reinicia Brave ahora</translation>
 <translation id="2335583906071111058">Mostrar Brave en este idioma</translation>
 <translation id="7207456302801184289">Te damos la bienvenida a Brave</translation>

--- a/app/resources/chromium_strings_et.xtb
+++ b/app/resources/chromium_strings_et.xtb
@@ -182,7 +182,7 @@
 <translation id="232381795826373334">Ava PDF-id Braveis</translation>
 <translation id="5381032481466106256">Kui see on sisse lülitatud, logitakse teid ka Braveist välja</translation>
 <translation id="1026406809507858026">{0,plural, =0{Bravei värskendus on saadaval}=1{Bravei värskendus on saadaval}other{Bravei värskendus on # päeva saadaval olnud}}</translation>
-<translation id="95624393026532554">Brave vajab operatsioonisüsteemi Windows 7 või uuemat versiooni.</translation>
+<translation id="4378573854226202617">Brave vajab operatsioonisüsteemi Windows 10 või uuemat versiooni.</translation>
 <translation id="5646769069113654257">Käivitage Brave kohe uuesti</translation>
 <translation id="2335583906071111058">Kuva Brave selles keeles</translation>
 <translation id="7207456302801184289">Tere tulemast Bravei</translation>

--- a/app/resources/chromium_strings_eu.xtb
+++ b/app/resources/chromium_strings_eu.xtb
@@ -184,7 +184,7 @@ Eginbide batzuk agian dira erabilgarri egongo eta hobespenei egindako aldaketak 
 <translation id="232381795826373334">Ireki PDFak Brave-en</translation>
 <translation id="5381032481466106256">Aktibatuta dagoenean, Brave-eko saioa ere amaituko da</translation>
 <translation id="1026406809507858026">{0,plural, =0{Brave arakatzailearen eguneratze bat dago erabilgarri}=1{Brave arakatzailearen eguneratze bat dago erabilgarri}other{Brave arakatzailearen eguneratze batek # egun daramatza erabilgarri}}</translation>
-<translation id="95624393026532554">Windows 7 edo sistema berriagoa behar da Brave erabiltzeko.</translation>
+<translation id="4378573854226202617">Windows 10 edo sistema berriagoa behar da Brave erabiltzeko.</translation>
 <translation id="5646769069113654257">Berrabiarazi Brave</translation>
 <translation id="2335583906071111058">Bistaratu Brave hizkuntza honetan</translation>
 <translation id="7207456302801184289">Ongi etorri Brave-era</translation>

--- a/app/resources/chromium_strings_fa.xtb
+++ b/app/resources/chromium_strings_fa.xtb
@@ -181,7 +181,7 @@
 <translation id="232381795826373334">‏باز کردن فایل‌های PDF در Brave</translation>
 <translation id="5381032481466106256">‏وقتی روشن باشد، از سیستم Brave نیز خارج خواهید شد</translation>
 <translation id="1026406809507858026">{0,plural, =0{‏به‌روزرسانی Brave دردسترس است}=1{‏به‌روزرسانی Brave دردسترس است}one{‏به‌روزرسانی Brave از # روز پیش دردسترس است}other{‏به‌روزرسانی Brave از # روز پیش دردسترس است}}</translation>
-<translation id="95624393026532554">‏Brave به Windows 7 یا بالاتر نیاز دارد.</translation>
+<translation id="4378573854226202617">‏Brave به Windows 10 یا بالاتر نیاز دارد.</translation>
 <translation id="5646769069113654257">‏لطفاً اکنون Brave را بازراه‌اندازی کنید</translation>
 <translation id="2335583906071111058">‏نمایش Brave به این زبان</translation>
 <translation id="7207456302801184289">‏به Brave خوش آمدید</translation>

--- a/app/resources/chromium_strings_fi.xtb
+++ b/app/resources/chromium_strings_fi.xtb
@@ -182,7 +182,7 @@
 <translation id="232381795826373334">Avaa PDF-tiedostot Braveissa</translation>
 <translation id="5381032481466106256">Kun tämä on päällä, sinut kirjataan ulos myös Braveista</translation>
 <translation id="1026406809507858026">{0,plural, =0{Brave-päivitys on saatavilla}=1{Brave-päivitys on saatavilla}other{Brave-päivitys on ollut saatavilla # vuorokauden ajan}}</translation>
-<translation id="95624393026532554">Brave edellyttää Windows 7:ää tai uudempaa versiota.</translation>
+<translation id="4378573854226202617">Brave edellyttää Windows 10:ää tai uudempaa versiota.</translation>
 <translation id="5646769069113654257">Käynnistä Brave uudelleen nyt</translation>
 <translation id="2335583906071111058">Näytä Brave tällä kielellä</translation>
 <translation id="7207456302801184289">Tervetuloa Braveiin</translation>

--- a/app/resources/chromium_strings_fil.xtb
+++ b/app/resources/chromium_strings_fil.xtb
@@ -184,7 +184,7 @@ Maaaring hindi available ang ilang tampok at hindi mase-save ang mga pagbabago s
 <translation id="232381795826373334">Magbukas ng mga PDF sa Brave</translation>
 <translation id="5381032481466106256">Kapag naka-on, masa-sign out ka rin sa Brave</translation>
 <translation id="1026406809507858026">{0,plural, =0{May available na update sa Brave}=1{May available na update sa Brave}one{# araw nang may available na update sa Brave}other{# na araw nang may available na update sa Brave}}</translation>
-<translation id="95624393026532554">Kailangan ng Brave ng Windows 7 o mas bago.</translation>
+<translation id="4378573854226202617">Kailangan ng Brave ng Windows 10 o mas bago.</translation>
 <translation id="5646769069113654257">Paki-restart ang Brave ngayon</translation>
 <translation id="2335583906071111058">Ipakita ang Brave sa wikang ito</translation>
 <translation id="7207456302801184289">Maligayang Pagdating sa Brave</translation>

--- a/app/resources/chromium_strings_fr-CA.xtb
+++ b/app/resources/chromium_strings_fr-CA.xtb
@@ -184,7 +184,7 @@ Certaines fonctionnalités ne seront peut-être pas disponibles et les modificat
 <translation id="232381795826373334">Ouvrir les PDF dans Brave</translation>
 <translation id="5381032481466106256">Si ce paramètre est activé, vous serez aussi déconnecté de Brave</translation>
 <translation id="1026406809507858026">{0,plural, =0{Une mise à jour de Brave est proposée}=1{Une mise à jour de Brave est proposée}one{Une mise à jour de Brave est proposée depuis # jour}other{Une mise à jour de Brave est proposée depuis # jours}}</translation>
-<translation id="95624393026532554">Brave requiert Windows 7 ou une version ultérieure.</translation>
+<translation id="4378573854226202617">Brave requiert Windows 10 ou une version ultérieure.</translation>
 <translation id="5646769069113654257">Veuillez redémarrer Brave maintenant</translation>
 <translation id="2335583906071111058">Afficher Brave dans cette langue</translation>
 <translation id="7207456302801184289">Bienvenue dans Brave</translation>

--- a/app/resources/chromium_strings_fr.xtb
+++ b/app/resources/chromium_strings_fr.xtb
@@ -183,7 +183,7 @@ Certaines fonctionnalités ne seront peut-être pas disponibles, et les modifica
 <translation id="232381795826373334">Ouvrir les PDF dans Brave</translation>
 <translation id="5381032481466106256">Si l'option est activée, vous serez également déconnecté de Brave</translation>
 <translation id="1026406809507858026">{0,plural, =0{Une mise à jour de Brave est disponible}=1{Une mise à jour de Brave est disponible}one{Une mise à jour de Brave est disponible depuis # jour}other{Une mise à jour de Brave est disponible depuis # jours}}</translation>
-<translation id="95624393026532554">Vous devez disposer de Windows 7 ou version ultérieure pour utiliser Brave.</translation>
+<translation id="4378573854226202617">Vous devez disposer de Windows 10 ou version ultérieure pour utiliser Brave.</translation>
 <translation id="5646769069113654257">Veuillez redémarrer Brave maintenant</translation>
 <translation id="2335583906071111058">Afficher Brave dans cette langue</translation>
 <translation id="7207456302801184289">Bienvenue dans Brave</translation>

--- a/app/resources/chromium_strings_gl.xtb
+++ b/app/resources/chromium_strings_gl.xtb
@@ -184,7 +184,7 @@
 <translation id="232381795826373334">Abrir PDF en Brave</translation>
 <translation id="5381032481466106256">Se activas esta opción, tamén se pechará a túa sesión en Brave</translation>
 <translation id="1026406809507858026">{0,plural, =0{Hai unha actualización de Brave dispoñible}=1{Hai unha actualización de Brave dispoñible}other{Hai unha actualización de Brave que leva dispoñible # días}}</translation>
-<translation id="95624393026532554">Brave require Windows 7 ou unha versión posterior.</translation>
+<translation id="4378573854226202617">Brave require Windows 10 ou unha versión posterior.</translation>
 <translation id="5646769069113654257">Reinicia Brave agora</translation>
 <translation id="2335583906071111058">Mostrar Brave neste idioma</translation>
 <translation id="7207456302801184289">Dámosche a benvida a Brave</translation>

--- a/app/resources/chromium_strings_gu.xtb
+++ b/app/resources/chromium_strings_gu.xtb
@@ -184,7 +184,7 @@
 <translation id="232381795826373334">Braveમાં PDFs ખોલો</translation>
 <translation id="5381032481466106256">જ્યારે ચાલુ હોય, ત્યારે તમે Braveમાંથી પણ સાઇન આઉટ થશો</translation>
 <translation id="1026406809507858026">{0,plural, =0{Brave અપડેટ ઉપલબ્ધ છે}=1{Brave અપડેટ ઉપલબ્ધ છે}one{Brave અપડેટ # દિવસ માટે ઉપલબ્ધ છે}other{Brave અપડેટ # દિવસ માટે ઉપલબ્ધ છે}}</translation>
-<translation id="95624393026532554">Brave માટે Windows 7 અથવા તે પછીનું સંસ્કરણ આવશ્યક છે.</translation>
+<translation id="4378573854226202617">Brave માટે Windows 10 અથવા તે પછીનું સંસ્કરણ આવશ્યક છે.</translation>
 <translation id="5646769069113654257">કૃપા કરીને હવે Brave ફરી શરૂ કરો</translation>
 <translation id="2335583906071111058">આ ભાષામાં Brave બતાવો</translation>
 <translation id="7207456302801184289">Brave માં સ્વાગત છે</translation>

--- a/app/resources/chromium_strings_hi.xtb
+++ b/app/resources/chromium_strings_hi.xtb
@@ -182,7 +182,7 @@
 <translation id="232381795826373334">Brave में पीडीएफ़ खोलें</translation>
 <translation id="5381032481466106256">इसके चालू होने पर, आपको Brave से भी साइन आउट कर दिया जाएगा</translation>
 <translation id="1026406809507858026">{0,plural, =0{Brave का एक अपडेट उपलब्ध है}=1{Brave का एक अपडेट उपलब्ध है}one{Brave का एक अपडेट # दिनों से उपलब्ध है}other{Brave का एक अपडेट # दिनों से उपलब्ध है}}</translation>
-<translation id="95624393026532554">Brave के लिए Windows 7 या उसके बाद के वर्शन की आवश्यकता होती है.</translation>
+<translation id="4378573854226202617">Brave के लिए Windows 10 या उसके बाद के वर्शन की आवश्यकता होती है.</translation>
 <translation id="5646769069113654257">कृपया 'Brave' को अभी रीस्टार्ट करें</translation>
 <translation id="2335583906071111058">Brave को इस भाषा में दिखाएं</translation>
 <translation id="7207456302801184289">Brave में आपका स्वागत है</translation>

--- a/app/resources/chromium_strings_hr.xtb
+++ b/app/resources/chromium_strings_hr.xtb
@@ -182,7 +182,7 @@
 <translation id="232381795826373334">Otvori PDF-ove u Braveu</translation>
 <translation id="5381032481466106256">Kad uključite tu opciju, odjavit ćete se i s Bravea</translation>
 <translation id="1026406809507858026">{0,plural, =0{Dostupno je ažuriranje Bravea}=1{Dostupno je ažuriranje Bravea}one{Ažuriranje Bravea dostupno je već # dan}few{Ažuriranje Bravea dostupno je već # dana}other{Ažuriranje Bravea dostupno je već # dana}}</translation>
-<translation id="95624393026532554">Brave zahtijeva Windows 7 ili noviju verziju.</translation>
+<translation id="4378573854226202617">Brave zahtijeva Windows 10 ili noviju verziju.</translation>
 <translation id="5646769069113654257">Sada ponovo pokrenite Brave</translation>
 <translation id="2335583906071111058">Prikaži Brave na tom jeziku</translation>
 <translation id="7207456302801184289">Dobro došli u Brave</translation>

--- a/app/resources/chromium_strings_hu.xtb
+++ b/app/resources/chromium_strings_hu.xtb
@@ -182,7 +182,7 @@
 <translation id="232381795826373334">PDF-fájlok megnyitása a Braveban</translation>
 <translation id="5381032481466106256">Amikor be van kapcsolva, a Braveból is kijelentkezteti Önt a rendszer</translation>
 <translation id="1026406809507858026">{0,plural, =0{Rendelkezésre áll egy Brave-frissítés}=1{Rendelkezésre áll egy Brave-frissítés}other{# napja rendelkezésre áll egy Brave-frissítés}}</translation>
-<translation id="95624393026532554">A Brave futtatásához Windows 7 vagy újabb verzió szükséges.</translation>
+<translation id="4378573854226202617">A Brave futtatásához Windows 10 vagy újabb verzió szükséges.</translation>
 <translation id="5646769069113654257">Indítsa újra a Braveot most</translation>
 <translation id="2335583906071111058">A Brave megjelenítése ezen a nyelven</translation>
 <translation id="7207456302801184289">Üdvözli a Brave!</translation>

--- a/app/resources/chromium_strings_hy.xtb
+++ b/app/resources/chromium_strings_hy.xtb
@@ -184,7 +184,7 @@
 <translation id="232381795826373334">Բացել PDF ֆայլեր Brave-ում</translation>
 <translation id="5381032481466106256">Երբ այս կարգավորումը միացված է, դուք նաև դուրս կգրվեք Brave-ից</translation>
 <translation id="1026406809507858026">{0,plural, =0{Հասանելի է Brave-ի նոր տարբերակը}=1{Հասանելի է Brave-ի նոր տարբերակը}one{Brave-ի նոր տարբերակը # օր է հասանելի է}other{Brave-ի նոր տարբերակը # օր է հասանելի է}}</translation>
-<translation id="95624393026532554">Brave-ի համար հարկավոր է Windows 7 կամ ավելի նոր տարբերակ:</translation>
+<translation id="4378573854226202617">Brave-ի համար հարկավոր է Windows 10 կամ ավելի նոր տարբերակ:</translation>
 <translation id="5646769069113654257">Վերագործարկեք Brave-ը</translation>
 <translation id="2335583906071111058">Brave-ը ցուցադրել այս լեզվով</translation>
 <translation id="7207456302801184289">Բարի գալուստ Brave</translation>

--- a/app/resources/chromium_strings_id.xtb
+++ b/app/resources/chromium_strings_id.xtb
@@ -182,7 +182,7 @@
 <translation id="232381795826373334">Buka PDF di Brave</translation>
 <translation id="5381032481466106256">Jika aktif, Anda juga akan logout dari Brave</translation>
 <translation id="1026406809507858026">{0,plural, =0{Update Brave tersedia}=1{Update Brave tersedia}other{Update Brave telah tersedia selama # hari}}</translation>
-<translation id="95624393026532554">Brave memerlukan Windows 7 atau lebih tinggi.</translation>
+<translation id="4378573854226202617">Brave memerlukan Windows 10 atau lebih tinggi.</translation>
 <translation id="5646769069113654257">Mulai ulang Brave sekarang</translation>
 <translation id="2335583906071111058">Tampilkan Brave dalam bahasa ini</translation>
 <translation id="7207456302801184289">Selamat Datang di Brave</translation>

--- a/app/resources/chromium_strings_is.xtb
+++ b/app/resources/chromium_strings_is.xtb
@@ -198,7 +198,7 @@ Heimildir sem þú hefur þegar veitt vefsvæðum og forritum kunna að gilda á
 <translation id="232381795826373334">Opna PDF-skjöl í Brave</translation>
 <translation id="5381032481466106256">Þegar þetta er virkt verður þú einnig skráð(ur) út úr Brave</translation>
 <translation id="1026406809507858026">{0,plural, =0{Uppfærsla er í boði fyrir Brave}=1{Uppfærsla er í boði fyrir Brave}one{Uppfærsla hefur verið í boði fyrir Brave í # dag}other{Uppfærsla hefur verið í boði fyrir Brave í # daga}}</translation>
-<translation id="95624393026532554">Brave krefst Windows 7 eða nýrri útgáfu.</translation>
+<translation id="4378573854226202617">Brave krefst Windows 10 eða nýrri útgáfu.</translation>
 <translation id="5646769069113654257">Endurræstu Brave núna</translation>
 <translation id="2335583906071111058">Birta Brave á þessu tungumáli</translation>
 <translation id="7207456302801184289">Velkomin(n) í Brave</translation>

--- a/app/resources/chromium_strings_it.xtb
+++ b/app/resources/chromium_strings_it.xtb
@@ -182,7 +182,7 @@
 <translation id="232381795826373334">Apri PDF in Brave</translation>
 <translation id="5381032481466106256">Se attivi l'opzione, uscirai anche da Brave</translation>
 <translation id="1026406809507858026">{0,plural, =0{È disponibile un aggiornamento di Brave}=1{È disponibile un aggiornamento di Brave}other{È disponibile un aggiornamento di Brave da # giorni}}</translation>
-<translation id="95624393026532554">Brave richiede Windows 7 o versioni successive.</translation>
+<translation id="4378573854226202617">Brave richiede Windows 10 o versioni successive.</translation>
 <translation id="5646769069113654257">Riavvia subito Brave</translation>
 <translation id="2335583906071111058">Visualizza Brave in questa lingua</translation>
 <translation id="7207456302801184289">Benvenuto in Brave</translation>

--- a/app/resources/chromium_strings_iw.xtb
+++ b/app/resources/chromium_strings_iw.xtb
@@ -180,7 +180,7 @@
 <translation id="232381795826373334">‏פתיחה של קובצי PDF ב-Brave</translation>
 <translation id="5381032481466106256">‏כשההגדרה מופעלת, תתבצע יציאה גם מ-Brave</translation>
 <translation id="1026406809507858026">{0,plural, =0{‏יש עדכון ל-Brave}=1{‏יש עדכון ל-Brave}one{‏עדכון של Brave זמין כבר # ימים}two{‏עדכון של Brave זמין כבר # ימים}other{‏עדכון של Brave זמין כבר # ימים}}</translation>
-<translation id="95624393026532554">‏כדי להשתמש ב-Brave יש צורך ב-Windows מגרסה 7 ואילך.</translation>
+<translation id="4378573854226202617">‏כדי להשתמש ב-Brave יש צורך ב-Windows מגרסה 10 ואילך.</translation>
 <translation id="5646769069113654257">‏יש להפעיל מחדש את Brave</translation>
 <translation id="2335583906071111058">‏הצגת Brave בשפה זו</translation>
 <translation id="7207456302801184289">‏ברוכים הבאים ל-Brave‏</translation>

--- a/app/resources/chromium_strings_ja.xtb
+++ b/app/resources/chromium_strings_ja.xtb
@@ -182,7 +182,7 @@
 <translation id="232381795826373334">Brave で PDF を開く</translation>
 <translation id="5381032481466106256">オンにすると、Brave からもログアウトします</translation>
 <translation id="1026406809507858026">{0,plural, =0{Brave のアップデートが利用可能です}=1{Brave のアップデートが利用可能です}other{Brave のアップデートが利用可能になってから # 日経過しています}}</translation>
-<translation id="95624393026532554">Brave のご利用には Windows 7 以上が必要です。</translation>
+<translation id="4378573854226202617">Brave のご利用には Windows 10 以上が必要です。</translation>
 <translation id="5646769069113654257">今すぐ Brave を再起動してください</translation>
 <translation id="2335583906071111058">Brave をこの言語で表示</translation>
 <translation id="7207456302801184289">Brave へようこそ</translation>

--- a/app/resources/chromium_strings_ka.xtb
+++ b/app/resources/chromium_strings_ka.xtb
@@ -184,7 +184,7 @@
 <translation id="232381795826373334">PDF-ების გახსნა Brave-ში</translation>
 <translation id="5381032481466106256">როცა ეს ფუნქცია ჩართულია, თქვენ, ასევე, გახვალთ Brave-იდან</translation>
 <translation id="1026406809507858026">{0,plural, =0{ხელმისაწვდომია Brave-ის განახლება}=1{ხელმისაწვდომია Brave-ის განახლება}other{უკვე # დღეა, რაც ხელმისაწვდომია Brave-ის განახლება}}</translation>
-<translation id="95624393026532554">Brave-ის მუშაობისთვის საჭიროა Windows 7 ან უფრო ახალი ვერსია.</translation>
+<translation id="4378573854226202617">Brave-ის მუშაობისთვის საჭიროა Windows 10 ან უფრო ახალი ვერსია.</translation>
 <translation id="5646769069113654257">გთხოვთ, ახლავე გადატვირთოთ Brave</translation>
 <translation id="2335583906071111058">Brave-ის ამ ენაზე ჩვენება</translation>
 <translation id="7207456302801184289">მოგესალმებათ Brave!</translation>

--- a/app/resources/chromium_strings_kk.xtb
+++ b/app/resources/chromium_strings_kk.xtb
@@ -198,7 +198,7 @@
 <translation id="232381795826373334">PDF-терді Brave-де ашу</translation>
 <translation id="5381032481466106256">Қосылған кезде, Brave браузерінен шығарыласыз.</translation>
 <translation id="1026406809507858026">{0,plural, =0{Brave браузерінің жаңартылған нұсқасы қолжетімді}=1{Brave браузерінің жаңартылған нұсқасы қолжетімді}other{Brave браузерінің жаңартылған нұсқасы # күннен бері қолжетімді}}</translation>
-<translation id="95624393026532554">Brave браузері Windows 7 жүйесін не одан кейінгі нұсқасын қажет етеді.</translation>
+<translation id="4378573854226202617">Brave браузері Windows 10 жүйесін не одан кейінгі нұсқасын қажет етеді.</translation>
 <translation id="5646769069113654257">Brave браузерін қайта іске қосыңыз</translation>
 <translation id="2335583906071111058">Brave жүйесін осы тілде көрсету</translation>
 <translation id="7207456302801184289">Brave жүйесіне қош келдіңіз</translation>

--- a/app/resources/chromium_strings_km.xtb
+++ b/app/resources/chromium_strings_km.xtb
@@ -185,7 +185,7 @@
 <translation id="232381795826373334">បើក PDF នៅក្នុង Brave</translation>
 <translation id="5381032481466106256">នៅពេលបើក អ្នកក៏នឹងត្រូវចេញពី Brave ផងដែរ</translation>
 <translation id="1026406809507858026">{0,plural, =0{មាន​កំណែថ្មីរបស់ Brave ហើយ}=1{មាន​កំណែថ្មីរបស់ Brave ហើយ}other{មាន​កំណែថ្មីរបស់ Brave រយៈពេល # ថ្ងៃហើយ}}</translation>
-<translation id="95624393026532554">Brave តម្រូវឲ្យមានប្រព័ន្ធប្រតិបត្តិការ Windows 7 ឬខ្ពស់ជាងនេះ។</translation>
+<translation id="4378573854226202617">Brave តម្រូវឲ្យមានប្រព័ន្ធប្រតិបត្តិការ Windows 10 ឬខ្ពស់ជាងនេះ។</translation>
 <translation id="5646769069113654257">សូមចាប់ផ្ដើម Brave ឡើងវិញ​ឥឡូវនេះ</translation>
 <translation id="2335583906071111058">បង្ហាញ Brave ជាភាសានេះ</translation>
 <translation id="7207456302801184289">ស្វាគមន៍មកកាន់ Brave</translation>

--- a/app/resources/chromium_strings_kn.xtb
+++ b/app/resources/chromium_strings_kn.xtb
@@ -180,7 +180,7 @@
 <translation id="232381795826373334">Brave ನಲ್ಲಿ PDF ಗಳನ್ನು ತೆರೆಯಿರಿ</translation>
 <translation id="5381032481466106256">ಇದನ್ನು ಆನ್ ಮಾಡಿದಾಗ, Brave ನಿಂದಲೂ ನಿಮ್ಮನ್ನು ಸೈನ್ ಔಟ್ ಮಾಡಲಾಗುತ್ತದೆ</translation>
 <translation id="1026406809507858026">{0,plural, =0{Brave ಅಪ್‌ಡೇಟ್ ಲಭ್ಯವಿದೆ}=1{Brave ಅಪ್‌ಡೇಟ್ ಲಭ್ಯವಿದೆ}one{# ದಿನಗಳ ಮಟ್ಟಿಗೆ Brave ಅಪ್‌ಡೇಟ್ ಲಭ್ಯವಿದೆ}other{# ದಿನಗಳ ಮಟ್ಟಿಗೆ Brave ಅಪ್‌ಡೇಟ್ ಲಭ್ಯವಿದೆ}}</translation>
-<translation id="95624393026532554">Brave ಗೆ Windows 7 ಅಥವಾ ಹೆಚ್ಚಿನ ಆವೃತ್ತಿ ಅಗತ್ಯವಿರುತ್ತದೆ.</translation>
+<translation id="4378573854226202617">Brave ಗೆ Windows 10 ಅಥವಾ ಹೆಚ್ಚಿನ ಆವೃತ್ತಿ ಅಗತ್ಯವಿರುತ್ತದೆ.</translation>
 <translation id="5646769069113654257">ಇದೀಗ Brave ಅನ್ನು ಮರುಪ್ರಾರಂಭಿಸಿ</translation>
 <translation id="2335583906071111058">ಈ ಭಾಷೆಯಲ್ಲಿ Brave ಪ್ರದರ್ಶಿಸು</translation>
 <translation id="7207456302801184289">Brave ಗೆ ಸುಸ್ವಾಗತ</translation>

--- a/app/resources/chromium_strings_ko.xtb
+++ b/app/resources/chromium_strings_ko.xtb
@@ -184,7 +184,7 @@
 <translation id="232381795826373334">Brave에서 PDF 열기</translation>
 <translation id="5381032481466106256">사용하게 되면 Brave에서도 로그아웃됩니다.</translation>
 <translation id="1026406809507858026">{0,plural, =0{Brave 업데이트 출시}=1{Brave 업데이트 출시}other{Brave 업데이트가 출시된 지 #일 지남}}</translation>
-<translation id="95624393026532554">Brave은 Windows 7 이상 버전에서 사용할 수 있습니다.</translation>
+<translation id="4378573854226202617">Brave은 Windows 10 이상 버전에서 사용할 수 있습니다.</translation>
 <translation id="5646769069113654257">지금 Brave을 다시 시작하세요</translation>
 <translation id="2335583906071111058">이 언어로 Brave 표시</translation>
 <translation id="7207456302801184289">Brave에 오신 것을 환영합니다.</translation>

--- a/app/resources/chromium_strings_ky.xtb
+++ b/app/resources/chromium_strings_ky.xtb
@@ -198,7 +198,7 @@
 <translation id="232381795826373334">PDF файлдарын Brave'да ачуу</translation>
 <translation id="5381032481466106256">Күйгүзүлсө, Brave'дан да чыгарыласыз</translation>
 <translation id="1026406809507858026">{0,plural, =0{Brave'дун жаңы версиясы жеткиликтүү}=1{Brave'дун жаңы версиясы жеткиликтүү}other{Brave'дун жаңы версиясы # күндөн бери жеткиликтүү}}</translation>
-<translation id="95624393026532554">Brave'га Windows 7 же жаңыраак версиясы талап кылынат.</translation>
+<translation id="4378573854226202617">Brave'га Windows 10 же жаңыраак версиясы талап кылынат.</translation>
 <translation id="5646769069113654257">Brave'ду азыр өчүрүп күйгүзүңүз</translation>
 <translation id="2335583906071111058">Brave ушул тилде көрүнсүн</translation>
 <translation id="7207456302801184289">Brave'га кош келиңиз</translation>

--- a/app/resources/chromium_strings_lo.xtb
+++ b/app/resources/chromium_strings_lo.xtb
@@ -198,7 +198,7 @@
 <translation id="232381795826373334">ເປີດ PDF ໃນ Brave</translation>
 <translation id="5381032481466106256">ເມື່ອເປີດໃຊ້, ທ່ານຈະອອກຈາກລະບົບ Brave ນຳ</translation>
 <translation id="1026406809507858026">{0,plural, =0{ມີການອັບເດດ Brave}=1{ມີການອັບເດດ Brave}other{ມີການອັບເດດ Brave ເປັນເວລາ # ມື້ແລ້ວ}}</translation>
-<translation id="95624393026532554">Brave ຕ້ອງໃຊ້ Windows 7 ຫຼື ສູງກວ່າ.</translation>
+<translation id="4378573854226202617">Brave ຕ້ອງໃຊ້ Windows 10 ຫຼື ສູງກວ່າ.</translation>
 <translation id="5646769069113654257">ກະລຸນາປິດເປີດ Brave ຄືນໃໝ່ຕອນນີ້</translation>
 <translation id="2335583906071111058">ສະ​ແດງ Brave ເປັນພາສານີ້</translation>
 <translation id="7207456302801184289">ຍິນ​ດີ​ຕ້ອນ​ຮັບສູ່ Brave</translation>

--- a/app/resources/chromium_strings_lt.xtb
+++ b/app/resources/chromium_strings_lt.xtb
@@ -184,7 +184,7 @@ Kai kurios funkcijos gali būti nepasiekiamos ir nuostatų pakeitimai nebus išs
 <translation id="232381795826373334">Atidaryti PDF failus naudojant „Brave“</translation>
 <translation id="5381032481466106256">Kai tai bus įjungta, taip pat būsite atjungti nuo „Brave“</translation>
 <translation id="1026406809507858026">{0,plural, =0{Pasiekiamas „Brave“ naujinys}=1{Pasiekiamas „Brave“ naujinys}one{„Brave“ naujinys pasiekiamas # dieną}few{„Brave“ naujinys pasiekiamas # dienas}many{„Brave“ naujinys pasiekiamas # dienos}other{„Brave“ naujinys pasiekiamas # dienų}}</translation>
-<translation id="95624393026532554">Kad būtų galima naudoti „Brave“, reikalinga 7 ar naujesnės versijos „Windows“.</translation>
+<translation id="4378573854226202617">Kad būtų galima naudoti „Brave“, reikalinga 10 ar naujesnės versijos „Windows“.</translation>
 <translation id="5646769069113654257">Dabar iš naujo paleiskite „Brave“</translation>
 <translation id="2335583906071111058">Pateikti „Brave“ šia kalba</translation>
 <translation id="7207456302801184289">Sveiki, tai „Brave“</translation>

--- a/app/resources/chromium_strings_lv.xtb
+++ b/app/resources/chromium_strings_lv.xtb
@@ -182,7 +182,7 @@
 <translation id="232381795826373334">Atvērt PDF failus pārlūkā Brave</translation>
 <translation id="5381032481466106256">Iestatījumam esot ieslēgtam, jūs tiksiet izrakstīts arī no pārlūka Brave.</translation>
 <translation id="1026406809507858026">{0,plural, =0{Ir pieejams Brave atjauninājums}=1{Ir pieejams Brave atjauninājums}zero{Brave atjauninājums ir pieejams jau # dienu}one{Brave atjauninājums ir pieejams jau # dienu}other{Brave atjauninājums ir pieejams jau # dienas}}</translation>
-<translation id="95624393026532554">Pārlūka Brave izmantošanai nepieciešama operētājsistēma Windows 7 vai jaunāka versija.</translation>
+<translation id="4378573854226202617">Pārlūka Brave izmantošanai nepieciešama operētājsistēma Windows 10 vai jaunāka versija.</translation>
 <translation id="5646769069113654257">Lūdzu, nekavējoties restartējiet pārlūku Brave</translation>
 <translation id="2335583906071111058">Rādīt Brave šajā valodā</translation>
 <translation id="7207456302801184289">Laipni lūdzam pārlūkā Brave!</translation>

--- a/app/resources/chromium_strings_mk.xtb
+++ b/app/resources/chromium_strings_mk.xtb
@@ -198,7 +198,7 @@
 <translation id="232381795826373334">Отворај PDF-формат во Brave</translation>
 <translation id="5381032481466106256">Кога е вклучено, ќе се одјавите и од Brave</translation>
 <translation id="1026406809507858026">{0,plural, =0{Достапно е ажурирање за Brave}=1{Достапно е ажурирање за Brave}one{Достапно е ажурирање за Brave веќе # ден}other{Достапно е ажурирање за Brave веќе # дена}}</translation>
-<translation id="95624393026532554">Brave бара Windows 7 или понова верзија.</translation>
+<translation id="4378573854226202617">Brave бара Windows 10 или понова верзија.</translation>
 <translation id="5646769069113654257">Рестартирајте го Brave сега</translation>
 <translation id="2335583906071111058">Прикажи го Brave на овој јазик</translation>
 <translation id="7207456302801184289">Добре дојдовте во Brave</translation>

--- a/app/resources/chromium_strings_ml.xtb
+++ b/app/resources/chromium_strings_ml.xtb
@@ -184,7 +184,7 @@
 <translation id="232381795826373334">Brave-ൽ PDF-കൾ തുറക്കുക</translation>
 <translation id="5381032481466106256">ഓണായിരിക്കുമ്പോൾ, Brave-ൽ നിന്ന് നിങ്ങളും സൈൻ ഔട്ട് ആകും</translation>
 <translation id="1026406809507858026">{0,plural, =0{Brave-ത്തിനൊരു അപ്‌ഡേറ്റ് ലഭ്യമാണ്}=1{Brave-ത്തിനൊരു അപ്‌ഡേറ്റ് ലഭ്യമാണ്}other{# ദിവസമായി Brave-ത്തിനൊരു അപ്‌ഡേറ്റ് ലഭ്യമാണ്}}</translation>
-<translation id="95624393026532554">Brave-ത്തിന് Windows 7 അല്ലെങ്കിൽ അതിനുശേഷമുള്ള പതിപ്പ് ആവശ്യമാണ്.</translation>
+<translation id="4378573854226202617">Brave-ത്തിന് Windows 10 അല്ലെങ്കിൽ അതിനുശേഷമുള്ള പതിപ്പ് ആവശ്യമാണ്.</translation>
 <translation id="5646769069113654257">Brave ഇപ്പോൾ റീസ്‌റ്റാർട്ട് ചെയ്യുക</translation>
 <translation id="2335583906071111058">ഈ ഭാഷയിൽ Brave പ്രദർശിപ്പിക്കുക</translation>
 <translation id="7207456302801184289">Brave-ത്തിലേക്ക് സ്വാഗതം</translation>

--- a/app/resources/chromium_strings_mn.xtb
+++ b/app/resources/chromium_strings_mn.xtb
@@ -182,7 +182,7 @@
 <translation id="232381795826373334">PDF-г Brave-д нээх</translation>
 <translation id="5381032481466106256">Асаалттай үед таныг мөн Brave-с гаргана</translation>
 <translation id="1026406809507858026">{0,plural, =0{Brave-н шинэчлэлт боломжтой байна}=1{Brave-н шинэчлэлт боломжтой байна}other{Brave-н шинэчлэлт # хоногийн турш боломжтой байсаар байна}}</translation>
-<translation id="95624393026532554">Brave-д Windows 7 болон үүнээс дээших хувилбарууд шаардлагатай.</translation>
+<translation id="4378573854226202617">Brave-д Windows 10 болон үүнээс дээших хувилбарууд шаардлагатай.</translation>
 <translation id="5646769069113654257">Brave-г одоо дахин эхлүүлнэ үү</translation>
 <translation id="2335583906071111058">Brave-г энэ хэлээр харуулах</translation>
 <translation id="7207456302801184289">Brave-д тавтай морил</translation>

--- a/app/resources/chromium_strings_mr.xtb
+++ b/app/resources/chromium_strings_mr.xtb
@@ -183,7 +183,7 @@
 <translation id="232381795826373334">Brave मध्ये PDF उघडा</translation>
 <translation id="5381032481466106256">सुरू केलेले असेल, तेव्हा तुम्हाला Brave मधूनदेखील साइन आउट केले जाईल</translation>
 <translation id="1026406809507858026">{0,plural, =0{Brave अपडेट उपलब्ध आहे}=1{Brave अपडेट उपलब्ध आहे}other{Brave अपडेट # दिवसांसाठी उपलब्ध आहे}}</translation>
-<translation id="95624393026532554">Brave साठी Windows 7 किंवा नंतरची आवृत्ती आवश्यक आहे.</translation>
+<translation id="4378573854226202617">Brave साठी Windows 10 किंवा नंतरची आवृत्ती आवश्यक आहे.</translation>
 <translation id="5646769069113654257">कृपया आता Brave रीस्टार्ट करा</translation>
 <translation id="2335583906071111058">Brave या भाषेत डिस्प्ले करा</translation>
 <translation id="7207456302801184289">Brave वर तुमचे स्‍वागत आहे</translation>

--- a/app/resources/chromium_strings_ms.xtb
+++ b/app/resources/chromium_strings_ms.xtb
@@ -182,7 +182,7 @@
 <translation id="232381795826373334">Buka PDF dalam Brave</translation>
 <translation id="5381032481466106256">Apabila dihidupkan, anda juga akan dilog keluar daripada Brave</translation>
 <translation id="1026406809507858026">{0,plural, =0{Kemas kini Brave tersedia}=1{Kemas kini Brave tersedia}other{Kemas kini Brave telah tersedia selama # hari}}</translation>
-<translation id="95624393026532554">Brave memerlukan Windows 7 atau lebih tinggi.</translation>
+<translation id="4378573854226202617">Brave memerlukan Windows 10 atau lebih tinggi.</translation>
 <translation id="5646769069113654257">Sila mulakan semula Brave sekarang</translation>
 <translation id="2335583906071111058">Paparkan Brave dalam bahasa ini</translation>
 <translation id="7207456302801184289">Selamat datang ke Brave</translation>

--- a/app/resources/chromium_strings_my.xtb
+++ b/app/resources/chromium_strings_my.xtb
@@ -200,7 +200,7 @@
 <translation id="232381795826373334">Brave တွင် PDF များ ဖွင့်ရန်</translation>
 <translation id="5381032481466106256">ဖွင့်ထားပါက Brave မှလည်း သင်ထွက်သွားပါမည်</translation>
 <translation id="1026406809507858026">{0,plural, =0{Brave အပ်ဒိတ်တစ်ခု ရနိုင်ပါသည်}=1{Brave အပ်ဒိတ်တစ်ခု ရနိုင်ပါသည်}other{Brave အပ်ဒိတ်တစ်ခု ရနိုင်သည်မှာ # ရက် ရှိပါပြီ}}</translation>
-<translation id="95624393026532554">Brave ကိုထည့်သွင်းရန် Windows 7 နှင့်အထက်လိုအပ်ပါသည်။</translation>
+<translation id="4378573854226202617">Brave ကိုထည့်သွင်းရန် Windows 10 နှင့်အထက်လိုအပ်ပါသည်။</translation>
 <translation id="5646769069113654257">Brave ကို ယခု ပြန်စပါ</translation>
 <translation id="2335583906071111058">Brave ကို ဤဘာသာစကားဖြင့် ပြသပါ</translation>
 <translation id="7207456302801184289">Brave က ကြိုဆိုပါ၏</translation>

--- a/app/resources/chromium_strings_ne.xtb
+++ b/app/resources/chromium_strings_ne.xtb
@@ -196,7 +196,7 @@
 <translation id="232381795826373334">PDF फाइलहरू Brave मा खोलियोस्</translation>
 <translation id="5381032481466106256">टगल अन गरिएका खण्डमा तपाईंलाई Brave बाट साइन आउट पनि गरिने छ</translation>
 <translation id="1026406809507858026">{0,plural, =0{Brave को अद्यावधिक उपलब्ध छ}=1{Brave को अद्यावधिक उपलब्ध छ}other{Brave को अद्यावधिक # दिनदेखि उपलब्ध भएको छ}}</translation>
-<translation id="95624393026532554">Brave लाई Windows 7 वा सो भन्दा पछाडिका संस्करणको आवश्यकता पर्छ।</translation>
+<translation id="4378573854226202617">Brave लाई Windows 10 वा सो भन्दा पछाडिका संस्करणको आवश्यकता पर्छ।</translation>
 <translation id="5646769069113654257">अहिले नै Brave पुनः सुरु गर्नुहोस्</translation>
 <translation id="2335583906071111058">यो भाषामा Brave प्रदर्शित गर्नुहोस्</translation>
 <translation id="7207456302801184289">Brave मा स्वागतम्</translation>

--- a/app/resources/chromium_strings_nl.xtb
+++ b/app/resources/chromium_strings_nl.xtb
@@ -184,7 +184,7 @@ Sommige functies zijn wellicht niet beschikbaar en wijzigingen in voorkeuren wor
 <translation id="232381795826373334">Pdf's openen in Brave</translation>
 <translation id="5381032481466106256">Als de schakelaar aanstaat, word je ook uitgelogd van Brave</translation>
 <translation id="1026406809507858026">{0,plural, =0{Er is een Brave-update beschikbaar}=1{Er is een Brave-update beschikbaar}other{Er is al # dagen een Brave-update beschikbaar}}</translation>
-<translation id="95624393026532554">Voor Brave is Windows 7 of hoger vereist.</translation>
+<translation id="4378573854226202617">Voor Brave is Windows 10 of hoger vereist.</translation>
 <translation id="5646769069113654257">Brave nu opnieuw opstarten</translation>
 <translation id="2335583906071111058">Brave bekijken in deze taal</translation>
 <translation id="7207456302801184289">Welkom bij Brave</translation>

--- a/app/resources/chromium_strings_no.xtb
+++ b/app/resources/chromium_strings_no.xtb
@@ -182,7 +182,7 @@
 <translation id="232381795826373334">Åpne PDF-filer i Brave</translation>
 <translation id="5381032481466106256">Når dette er på, blir du også logget av Brave</translation>
 <translation id="1026406809507858026">{0,plural, =0{En Brave-oppdatering er tilgjengelig}=1{En Brave-oppdatering er tilgjengelig}other{En Brave-oppdatering har vært tilgjengelig i # dager}}</translation>
-<translation id="95624393026532554">Brave krever Windows 7 eller nyere.</translation>
+<translation id="4378573854226202617">Brave krever Windows 10 eller nyere.</translation>
 <translation id="5646769069113654257">Start Brave på nytt nå</translation>
 <translation id="2335583906071111058">Vis Brave på dette språket</translation>
 <translation id="7207456302801184289">Velkommen til Brave</translation>

--- a/app/resources/chromium_strings_or.xtb
+++ b/app/resources/chromium_strings_or.xtb
@@ -184,7 +184,7 @@
 <translation id="232381795826373334">Braveରେ PDFଗୁଡ଼ିକୁ ଖୋଲନ୍ତୁ</translation>
 <translation id="5381032481466106256">ଚାଲୁ ଥିବା ସମୟରେ, ଆପଣ Braveରୁ ମଧ୍ୟ ସାଇନ ଆଉଟ ହୋଇଯିବେ</translation>
 <translation id="1026406809507858026">{0,plural, =0{ଏକ Brave ଅପ୍‌ଡେଟ୍‍ ଉପଲବ୍ଧ ଅଛି}=1{ଏକ Brave ଅପ୍‌ଡେଟ୍‍ ଉପଲବ୍ଧ ଅଛି}other{# ଦିନ ପାଇଁ ଏକ Brave ଅପ୍‌ଡେଟ୍‌ ଉପଲବ୍ଧ ଅଛି}}</translation>
-<translation id="95624393026532554">Brave ପାଇଁ Windows 7 କିମ୍ବା ଏହାଠାରୁ ଉଚ୍ଚତର ସଂସ୍କରଣ ଆବଶ୍ୟକତା ହୋ‍ଇଥାଏ।</translation>
+<translation id="4378573854226202617">Brave ପାଇଁ Windows 10 କିମ୍ବା ଏହାଠାରୁ ଉଚ୍ଚତର ସଂସ୍କରଣ ଆବଶ୍ୟକତା ହୋ‍ଇଥାଏ।</translation>
 <translation id="5646769069113654257">ଦୟାକରି ବର୍ତ୍ତମାନ Brave ରିଷ୍ଟାର୍ଟ କରନ୍ତୁ</translation>
 <translation id="2335583906071111058">Braveକୁ ଏହି ଭାଷାରେ ପ୍ରଦର୍ଶନ କରନ୍ତୁ</translation>
 <translation id="7207456302801184289">Braveକୁ ସ୍ଵାଗତ</translation>

--- a/app/resources/chromium_strings_pa.xtb
+++ b/app/resources/chromium_strings_pa.xtb
@@ -184,7 +184,7 @@
 <translation id="232381795826373334">Brave ਵਿੱਚ PDF ਖੋਲ੍ਹੋ</translation>
 <translation id="5381032481466106256">ਚਾਲੂ ਹੋਣ 'ਤੇ, ਤੁਹਾਨੂੰ Brave ਤੋਂ ਵੀ ਸਾਈਨ-ਆਊਟ ਕਰ ਦਿੱਤਾ ਜਾਵੇਗਾ</translation>
 <translation id="1026406809507858026">{0,plural, =0{Brave ਅੱਪਡੇਟ ਉਪਲਬਧ ਹੈ}=1{Brave ਅੱਪਡੇਟ ਉਪਲਬਧ ਹੈ}other{Brave ਅੱਪਡੇਟ # ਦਿਨਾਂ ਤੋਂ ਉਪਲਬਧ ਹੈ}}</translation>
-<translation id="95624393026532554">Brave ਨੂੰ Windows 7 ਜਾਂ ਇਸ ਤੋਂ ਬਾਅਦ ਵਾਲੇ ਵਰਜਨ ਦੀ ਲੋੜ ਹੈ।</translation>
+<translation id="4378573854226202617">Brave ਨੂੰ Windows 10 ਜਾਂ ਇਸ ਤੋਂ ਬਾਅਦ ਵਾਲੇ ਵਰਜਨ ਦੀ ਲੋੜ ਹੈ।</translation>
 <translation id="5646769069113654257">ਕਿਰਪਾ ਕਰਕੇ ਹੁਣੇ Brave ਨੂੰ ਮੁੜ-ਸ਼ੁਰੂ ਕਰੋ</translation>
 <translation id="2335583906071111058">Brave ਨੂੰ ਇਸ ਭਾਸ਼ਾ ਵਿੱਚ  ਦਿਖਾਓ ।</translation>
 <translation id="7207456302801184289">Brave ਵਿੱਚ ਸੁਆਗਤ ਹੈ</translation>

--- a/app/resources/chromium_strings_pl.xtb
+++ b/app/resources/chromium_strings_pl.xtb
@@ -180,7 +180,7 @@
 <translation id="232381795826373334">Otwieranie plików PDF w Brave</translation>
 <translation id="5381032481466106256">Jeśli ta opcja jest włączona, zostaniesz też wylogowany(-a) z Brave</translation>
 <translation id="1026406809507858026">{0,plural, =0{Dostępna jest aktualizacja Brave}=1{Dostępna jest aktualizacja Brave}few{Aktualizacja Brave jest dostępna od # dni}many{Aktualizacja Brave jest dostępna od # dni}other{Aktualizacja Brave jest dostępna od # dnia}}</translation>
-<translation id="95624393026532554">Brave wymaga systemu Windows 7 lub nowszego.</translation>
+<translation id="4378573854226202617">Brave wymaga systemu Windows 10 lub nowszego.</translation>
 <translation id="5646769069113654257">Uruchom Brave ponownie</translation>
 <translation id="2335583906071111058">Wyświetlaj Brave w tym języku</translation>
 <translation id="7207456302801184289">Brave – witamy!</translation>

--- a/app/resources/chromium_strings_pt-BR.xtb
+++ b/app/resources/chromium_strings_pt-BR.xtb
@@ -180,7 +180,7 @@
 <translation id="232381795826373334">Abrir PDFs no Brave</translation>
 <translation id="5381032481466106256">Quando essa opção for ativada, sua conta será desconectada do Brave</translation>
 <translation id="1026406809507858026">{0,plural, =0{Uma atualização do Brave está disponível}=1{Uma atualização do Brave está disponível}one{Uma atualização do Brave está disponível há # dia}other{Uma atualização do Brave está disponível há # dias}}</translation>
-<translation id="95624393026532554">O Brave requer o Windows 7 ou versão superior.</translation>
+<translation id="4378573854226202617">O Brave requer o Windows 10 ou versão superior.</translation>
 <translation id="5646769069113654257">Reinicie o Brave agora</translation>
 <translation id="2335583906071111058">Exibir Brave neste idioma</translation>
 <translation id="7207456302801184289">Bem-vindo ao Brave</translation>

--- a/app/resources/chromium_strings_pt-PT.xtb
+++ b/app/resources/chromium_strings_pt-PT.xtb
@@ -182,7 +182,7 @@
 <translation id="232381795826373334">Abrir PDFs no Brave</translation>
 <translation id="5381032481466106256">Quando está ativado, a sua sessão também é terminada no Brave</translation>
 <translation id="1026406809507858026">{0,plural, =0{Está disponível uma atualização do Brave}=1{Está disponível uma atualização do Brave}other{Está disponível uma atualização do Brave há # dias}}</translation>
-<translation id="95624393026532554">O Brave requer o Windows 7 ou superior.</translation>
+<translation id="4378573854226202617">O Brave requer o Windows 10 ou superior.</translation>
 <translation id="5646769069113654257">Reinicie o Brave agora</translation>
 <translation id="2335583906071111058">Apresentar o Brave neste idioma</translation>
 <translation id="7207456302801184289">Bem-vindo ao Brave</translation>

--- a/app/resources/chromium_strings_ro.xtb
+++ b/app/resources/chromium_strings_ro.xtb
@@ -182,7 +182,7 @@
 <translation id="232381795826373334">Deschide fișierele PDF în Brave</translation>
 <translation id="5381032481466106256">Când opțiunea este activată, te vei deconecta de la Brave</translation>
 <translation id="1026406809507858026">{0,plural, =0{Este disponibilă o actualizare Brave}=1{Este disponibilă o actualizare Brave}few{O actualizare Brave este disponibilă de # zile}other{O actualizare Brave este disponibilă de # de zile}}</translation>
-<translation id="95624393026532554">Brave necesită Windows 7 sau o versiune ulterioară.</translation>
+<translation id="4378573854226202617">Brave necesită Windows 10 sau o versiune ulterioară.</translation>
 <translation id="5646769069113654257">Repornește Brave acum</translation>
 <translation id="2335583906071111058">Afișează Brave în această limbă</translation>
 <translation id="7207456302801184289">Bun venit la Brave</translation>

--- a/app/resources/chromium_strings_ru.xtb
+++ b/app/resources/chromium_strings_ru.xtb
@@ -180,7 +180,7 @@
 <translation id="232381795826373334">Открывать PDF-файлы в Brave</translation>
 <translation id="5381032481466106256">Также выполняется выход из Brave</translation>
 <translation id="1026406809507858026">{0,plural, =0{Доступно обновление Brave}=1{Доступно обновление Brave}one{Обновление Brave доступно # день}few{Обновление Brave доступно # дня}many{Обновление Brave доступно # дней}other{Обновление Brave доступно # дня}}</translation>
-<translation id="95624393026532554">Для работы Brave необходима ОС Windows 7 или более поздней версии.</translation>
+<translation id="4378573854226202617">Для работы Brave необходима ОС Windows 10 или более поздней версии.</translation>
 <translation id="5646769069113654257">Перезапустите Brave</translation>
 <translation id="2335583906071111058">Отображать Brave на этом языке</translation>
 <translation id="7207456302801184289">Добро пожаловать в Brave</translation>

--- a/app/resources/chromium_strings_si.xtb
+++ b/app/resources/chromium_strings_si.xtb
@@ -184,7 +184,7 @@
 <translation id="232381795826373334">Brave හි PDF විවෘත කරන්න</translation>
 <translation id="5381032481466106256">ක්‍රියාත්මක විට, ඔබව Brave වෙතින්ද වරනු ඇත</translation>
 <translation id="1026406809507858026">{0,plural, =0{Brave යාවත්කාලීනයක් තිබේ}=1{Brave යාවත්කාලීනයක් තිබේ}one{දින # ක් තුළ Brave යාවත්කාලීනයක් ලැබී ඇත}other{දින # ක් තුළ Brave යාවත්කාලීනයක් ලැබී ඇත}}</translation>
-<translation id="95624393026532554">Brave හට Windows 7 හෝ ඊට ඉහළ අනුවාදයක් අවශ්‍යයි.</translation>
+<translation id="4378573854226202617">Brave හට Windows 10 හෝ ඊට ඉහළ අනුවාදයක් අවශ්‍යයි.</translation>
 <translation id="5646769069113654257">දැන් Brave යළි අරඹන්න</translation>
 <translation id="2335583906071111058">මෙම භාෂාවෙන් Brave දර්ශනය කරන්න</translation>
 <translation id="7207456302801184289">Brave වෙත සාදරයෙන් පිළිගනිමු</translation>

--- a/app/resources/chromium_strings_sk.xtb
+++ b/app/resources/chromium_strings_sk.xtb
@@ -184,7 +184,7 @@ Niektoré funkcie nemusia byť k dispozícii a zmeny vykonané v predvoľbách s
 <translation id="232381795826373334">Otvoriť súbory PDF v prehliadači Brave</translation>
 <translation id="5381032481466106256">Keď zapnete túto možnosť, systém vás odhlási aj z prehliadača Brave</translation>
 <translation id="1026406809507858026">{0,plural, =0{Je k dispozícii aktualizácia prehliadača Brave}=1{Je k dispozícii aktualizácia prehliadača Brave}few{Aktualizácia prehliadača Brave je k dispozícii už # dni}many{Aktualizácia prehliadača Brave je k dispozícii už # dňa}other{Aktualizácia prehliadača Brave je k dispozícii už # dní}}</translation>
-<translation id="95624393026532554">Brave vyžaduje Windows 7 alebo vyšší.</translation>
+<translation id="4378573854226202617">Brave vyžaduje Windows 10 alebo vyšší.</translation>
 <translation id="5646769069113654257">Reštartujte Brave</translation>
 <translation id="2335583906071111058">Zobraziť Brave v tomto jazyku</translation>
 <translation id="7207456302801184289">Vitajte v prehliadači Brave</translation>

--- a/app/resources/chromium_strings_sl.xtb
+++ b/app/resources/chromium_strings_sl.xtb
@@ -184,7 +184,7 @@ Nekatere funkcije morda niso na voljo in spremembe nastavitev ne bodo shranjene.
 <translation id="232381795826373334">Odpri datoteke PDF v Braveu</translation>
 <translation id="5381032481466106256">Če je to vklopljeno, boste odjavljeni tudi iz Bravea.</translation>
 <translation id="1026406809507858026">{0,plural, =0{Posodobitev za Brave je na voljo}=1{Posodobitev za Brave je na voljo}one{Posodobitev za Brave je na voljo že # dan}two{Posodobitev za Brave je na voljo že # dneva}few{Posodobitev za Brave je na voljo že # dni}other{Posodobitev za Brave je na voljo že # dni}}</translation>
-<translation id="95624393026532554">Za Brave potrebujete Windows 7 ali novejši.</translation>
+<translation id="4378573854226202617">Za Brave potrebujete Windows 10 ali novejši.</translation>
 <translation id="5646769069113654257">Znova zaženite Brave</translation>
 <translation id="2335583906071111058">Prikaži Brave v tem jeziku</translation>
 <translation id="7207456302801184289">Pozdravljeni v Braveu</translation>

--- a/app/resources/chromium_strings_sq.xtb
+++ b/app/resources/chromium_strings_sq.xtb
@@ -184,7 +184,7 @@ Disa funksione mund të mos ofrohen dhe ndryshimet në preferenca nuk do të ruh
 <translation id="232381795826373334">Hap PDF-të në Brave</translation>
 <translation id="5381032481466106256">Kur opsioni është aktiv, do të dalësh po ashtu nga Brave</translation>
 <translation id="1026406809507858026">{0,plural, =0{Ofrohet një përditësim i Brave}=1{Ofrohet një përditësim i Brave}other{Një përditësim i Brave ofrohet prej # ditësh}}</translation>
-<translation id="95624393026532554">Brave kërkon Windows 7 ose një version më të lartë.</translation>
+<translation id="4378573854226202617">Brave kërkon Windows 10 ose një version më të lartë.</translation>
 <translation id="5646769069113654257">Rinise Brave tani</translation>
 <translation id="2335583906071111058">Shfaqe Brave në këtë gjuhë</translation>
 <translation id="7207456302801184289">Mirë se vjen në Brave</translation>

--- a/app/resources/chromium_strings_sr-Latn.xtb
+++ b/app/resources/chromium_strings_sr-Latn.xtb
@@ -184,7 +184,7 @@ Neke funkcije su možda nedostupne i promene podešavanja neće biti sačuvane.
 <translation id="232381795826373334">Otvarajte PDF-ove u Brave-u</translation>
 <translation id="5381032481466106256">Kada je ovo uključeno, bićete i odjavljeni iz Brave-a</translation>
 <translation id="1026406809507858026">{0,plural, =0{Ažuriranje za Brave je dostupno}=1{Ažuriranje za Brave je dostupno}one{Ažuriranje za Brave je dostupno već # dan}few{Ažuriranje za Brave je dostupno već # dana}other{Ažuriranje za Brave je dostupno već # dana}}</translation>
-<translation id="95624393026532554">Za Brave je potreban Windows 7 ili novija verzija.</translation>
+<translation id="4378573854226202617">Za Brave je potreban Windows 10 ili novija verzija.</translation>
 <translation id="5646769069113654257">Restartujte Brave</translation>
 <translation id="2335583906071111058">Prikazuj Brave na ovom jeziku</translation>
 <translation id="7207456302801184289">Dobro došli u Brave</translation>

--- a/app/resources/chromium_strings_sr.xtb
+++ b/app/resources/chromium_strings_sr.xtb
@@ -184,7 +184,7 @@
 <translation id="232381795826373334">Отварајте PDF-ове у Brave-у</translation>
 <translation id="5381032481466106256">Када је ово укључено, бићете и одјављени из Brave-а</translation>
 <translation id="1026406809507858026">{0,plural, =0{Ажурирање за Brave је доступно}=1{Ажурирање за Brave је доступно}one{Ажурирање за Brave је доступно већ # дан}few{Ажурирање за Brave је доступно већ # дана}other{Ажурирање за Brave је доступно већ # дана}}</translation>
-<translation id="95624393026532554">За Brave је потребан Windows 7 или новија верзија.</translation>
+<translation id="4378573854226202617">За Brave је потребан Windows 10 или новија верзија.</translation>
 <translation id="5646769069113654257">Рестартујте Brave</translation>
 <translation id="2335583906071111058">Приказуј Brave на овом језику</translation>
 <translation id="7207456302801184289">Добро дошли у Brave</translation>

--- a/app/resources/chromium_strings_sv.xtb
+++ b/app/resources/chromium_strings_sv.xtb
@@ -184,7 +184,7 @@ Vissa funktioner kanske inte är tillgängliga och ändringar i inställningarna
 <translation id="232381795826373334">Öppna PDF-filer i Brave</translation>
 <translation id="5381032481466106256">När inställningen är aktiverad loggas du också ut från Brave</translation>
 <translation id="1026406809507858026">{0,plural, =0{Det finns en uppdatering för Brave}=1{Det finns en uppdatering för Brave}other{Det finns en uppdatering för Brave sedan # dagar}}</translation>
-<translation id="95624393026532554">För Brave krävs Windows 7 eller senare.</translation>
+<translation id="4378573854226202617">För Brave krävs Windows 10 eller senare.</translation>
 <translation id="5646769069113654257">Starta om Brave nu</translation>
 <translation id="2335583906071111058">Visa Brave på det här språket</translation>
 <translation id="7207456302801184289">Välkommen till Brave</translation>

--- a/app/resources/chromium_strings_sw.xtb
+++ b/app/resources/chromium_strings_sw.xtb
@@ -184,7 +184,7 @@ Baadhi ya vipengele huenda visipatikane na mabadiliko katika mapendeleo hayatahi
 <translation id="232381795826373334">Fungua PDF katika Brave</translation>
 <translation id="5381032481466106256">Kinapokuwa kimewashwa, utaondolewa pia katika akaunti ya Brave</translation>
 <translation id="1026406809507858026">{0,plural, =0{Sasisho la Brave linapatikana}=1{Sasisho la Brave linapatikana}other{Sasisho la Brave limekuwepo kwa siku #}}</translation>
-<translation id="95624393026532554">Brave inahitaji Windows 7 au toleo jipya zaidi.</translation>
+<translation id="4378573854226202617">Brave inahitaji Windows 10 au toleo jipya zaidi.</translation>
 <translation id="5646769069113654257">Tafadhali zima kisha uwashe Brave sasa</translation>
 <translation id="2335583906071111058">Onyesha Brave katika lugha hii</translation>
 <translation id="7207456302801184289">Karibu kwenye Brave</translation>

--- a/app/resources/chromium_strings_ta.xtb
+++ b/app/resources/chromium_strings_ta.xtb
@@ -182,7 +182,7 @@
 <translation id="232381795826373334">PDFகளை Braveமில் திற</translation>
 <translation id="5381032481466106256">இயக்கினால் Braveமில் இருந்தும் வெளியேறுவீர்கள்</translation>
 <translation id="1026406809507858026">{0,plural, =0{Braveமிற்கான புதுப்பிப்பு உள்ளது}=1{Braveமிற்கான புதுப்பிப்பு உள்ளது}other{Braveமிற்கான புதுப்பிப்பு வந்து # நாட்களாகிறது}}</translation>
-<translation id="95624393026532554">Windows 7 அல்லது அதற்குப் பிந்தைய பதிப்புகளில் மட்டுமே Brave இயங்கும்.</translation>
+<translation id="4378573854226202617">Windows 10 அல்லது அதற்குப் பிந்தைய பதிப்புகளில் மட்டுமே Brave இயங்கும்.</translation>
 <translation id="5646769069113654257">Braveமை இப்போது மீண்டும் தொடங்கவும்</translation>
 <translation id="2335583906071111058">Braveமை இந்த மொழியில் காட்டு</translation>
 <translation id="7207456302801184289">Brave க்கு வரவேற்கிறோம்</translation>

--- a/app/resources/chromium_strings_te.xtb
+++ b/app/resources/chromium_strings_te.xtb
@@ -180,7 +180,7 @@
 <translation id="232381795826373334">Braveలో PDFలను తెరవండి</translation>
 <translation id="5381032481466106256">దీన్ని ఆన్ చేసినప్పుడు, మీరు Brave నుండి కూడా సైన్ అవుట్ చేయబడతారు</translation>
 <translation id="1026406809507858026">{0,plural, =0{ఒక Brave అప్‌డేట్ అందుబాటులో ఉంది}=1{ఒక Brave అప్‌డేట్ అందుబాటులో ఉంది}other{ఒక Brave అప్‌డేట్ # రోజులుగా అందుబాటులో ఉంది}}</translation>
-<translation id="95624393026532554">Braveకి Windows 7 లేదా అంతకంటే ఆధునికమైనది ఉండటం ఆవశ్యకం.</translation>
+<translation id="4378573854226202617">Braveకి Windows 10 లేదా అంతకంటే ఆధునికమైనది ఉండటం ఆవశ్యకం.</translation>
 <translation id="5646769069113654257">దయచేసి ఇప్పుడు Braveను మళ్ళీ ప్రారంభించండి</translation>
 <translation id="2335583906071111058">Braveను ఈ భాషలో ప్రదర్శించు</translation>
 <translation id="7207456302801184289">Braveకు స్వాగతం</translation>

--- a/app/resources/chromium_strings_th.xtb
+++ b/app/resources/chromium_strings_th.xtb
@@ -182,7 +182,7 @@
 <translation id="232381795826373334">เปิด PDF ใน Brave</translation>
 <translation id="5381032481466106256">หากเปิดใช้ คุณจะออกจากระบบของ Brave ด้วย</translation>
 <translation id="1026406809507858026">{0,plural, =0{มีอัปเดต Brave พร้อมให้ใช้งาน}=1{มีอัปเดต Brave พร้อมให้ใช้งาน}other{อัปเดต Brave พร้อมให้ใช้งานมาแล้ว # วัน}}</translation>
-<translation id="95624393026532554">Brave ต้องใช้ Windows 7 ขึ้นไป</translation>
+<translation id="4378573854226202617">Brave ต้องใช้ Windows 10 ขึ้นไป</translation>
 <translation id="5646769069113654257">โปรดรีสตาร์ท Brave ตอนนี้เลย</translation>
 <translation id="2335583906071111058">แสดง Brave ในภาษานี้</translation>
 <translation id="7207456302801184289">ยินดีต้อนรับสู่ Brave</translation>

--- a/app/resources/chromium_strings_tr.xtb
+++ b/app/resources/chromium_strings_tr.xtb
@@ -180,7 +180,7 @@
 <translation id="232381795826373334">PDF'leri Brave'da aç</translation>
 <translation id="5381032481466106256">Etkin durumdayken Brave oturumunuz da kapatılır</translation>
 <translation id="1026406809507858026">{0,plural, =0{Bir Brave güncellemesi var}=1{Bir Brave güncellemesi var}other{# gün önce kullanıma sunulmuş bir Brave güncellemesi var}}</translation>
-<translation id="95624393026532554">Brave, Windows 7 veya daha sonraki bir sürümü gerektirir.</translation>
+<translation id="4378573854226202617">Brave, Windows 10 veya daha sonraki bir sürümü gerektirir.</translation>
 <translation id="5646769069113654257">Lütfen Brave'u şimdi yeniden başlatın</translation>
 <translation id="2335583906071111058">Brave'u bu dilde görüntüle</translation>
 <translation id="7207456302801184289">Brave'a Hoş Geldiniz</translation>

--- a/app/resources/chromium_strings_uk.xtb
+++ b/app/resources/chromium_strings_uk.xtb
@@ -182,7 +182,7 @@
 <translation id="232381795826373334">Відкривати файли PDF у Brave</translation>
 <translation id="5381032481466106256">Якщо перемикач увімкнено, ви також автоматично вийдете зі свого облікового запису в Brave</translation>
 <translation id="1026406809507858026">{0,plural, =0{Доступне оновлення Brave}=1{Доступне оновлення Brave}one{Оновлення Brave доступне вже # день}few{Оновлення Brave доступне вже # дні}many{Оновлення Brave доступне вже # днів}other{Оновлення Brave доступне вже # дня}}</translation>
-<translation id="95624393026532554">Для роботи Brave потрібно мати ОС Windows 7 або новішої версії.</translation>
+<translation id="4378573854226202617">Для роботи Brave потрібно мати ОС Windows 10 або новішої версії.</translation>
 <translation id="5646769069113654257">Перезапустіть Brave</translation>
 <translation id="2335583906071111058">Вибрати цю мову для Brave</translation>
 <translation id="7207456302801184289">Вітаємо в Brave</translation>

--- a/app/resources/chromium_strings_ur.xtb
+++ b/app/resources/chromium_strings_ur.xtb
@@ -198,7 +198,7 @@
 <translation id="232381795826373334">‏Brave میں PDFs کھولیں</translation>
 <translation id="5381032481466106256">‏آن ہونے پر، آپ Brave سے بھی سائن آؤٹ ہو جائیں گے</translation>
 <translation id="1026406809507858026">{0,plural, =0{‏Brave کا اپ ڈیٹ دستیاب ہے}=1{‏Brave کا اپ ڈیٹ دستیاب ہے}other{‏Brave کا اپ ڈیٹ # دن سے دستیاب ہے}}</translation>
-<translation id="95624393026532554">‏Brave کیلئے Windows 7 یا اس کے بعد کا ورژن درکار ہے۔</translation>
+<translation id="4378573854226202617">‏Brave کیلئے Windows 10 یا اس کے بعد کا ورژن درکار ہے۔</translation>
 <translation id="5646769069113654257">‏براہ کرم ابھی Brave کو ری اسٹارٹ کریں</translation>
 <translation id="2335583906071111058">‏Brave کو اس زبان میں ڈسپلے کریں</translation>
 <translation id="7207456302801184289">‏Brave میں خوش آمدید</translation>

--- a/app/resources/chromium_strings_uz.xtb
+++ b/app/resources/chromium_strings_uz.xtb
@@ -194,7 +194,7 @@ Sayt va ilovalarga berilgan ruxsatlar bu hisobga tatbiq etilishi mumkin. Brave h
 <translation id="232381795826373334">PDF fayllarni Brave bilan ochish</translation>
 <translation id="5381032481466106256">Bu yoqilsa, Brave dasturida ham hisobingizdan chiqasiz</translation>
 <translation id="1026406809507858026">{0,plural, =0{Brave uchun yangilanish mavjud}=1{Brave uchun yangilanish mavjud}other{Brave uchun yangilanish mavjud (# kun)}}</translation>
-<translation id="95624393026532554">Brave brauzeri ishlashi uchun kompyuterda Windows 7 yoki undan yangiroq versiyadagi operatsion tizim o‘rnatilgan bo‘lishi lozim.</translation>
+<translation id="4378573854226202617">Brave brauzeri ishlashi uchun kompyuterda Windows 10 yoki undan yangiroq versiyadagi operatsion tizim o‘rnatilgan bo‘lishi lozim.</translation>
 <translation id="5646769069113654257">Braveni hozir qayta ishga tushiring</translation>
 <translation id="2335583906071111058">Brave shu tilda ko‘rsatilsin</translation>
 <translation id="7207456302801184289">Brave brauzeriga xush kelibsiz</translation>

--- a/app/resources/chromium_strings_vi.xtb
+++ b/app/resources/chromium_strings_vi.xtb
@@ -182,7 +182,7 @@
 <translation id="232381795826373334">Mở tệp PDF trong Brave</translation>
 <translation id="5381032481466106256">Khi bật, bạn cũng sẽ đăng xuất khỏi Brave</translation>
 <translation id="1026406809507858026">{0,plural, =0{Đã có bản cập nhật Brave}=1{Đã có bản cập nhật Brave}other{Đã có bản cập nhật Brave từ # ngày trước}}</translation>
-<translation id="95624393026532554">Brave yêu cầu Windows 7 trở lên.</translation>
+<translation id="4378573854226202617">Brave yêu cầu Windows 10 trở lên.</translation>
 <translation id="5646769069113654257">Vui lòng khởi động lại Brave ngay bây giờ</translation>
 <translation id="2335583906071111058">Hiển thị Brave bằng ngôn ngữ này</translation>
 <translation id="7207456302801184289">Chào mừng bạn đến với Brave</translation>

--- a/app/resources/chromium_strings_zh-CN.xtb
+++ b/app/resources/chromium_strings_zh-CN.xtb
@@ -182,7 +182,7 @@
 <translation id="232381795826373334">在 Brave 中打开 PDF 文件</translation>
 <translation id="5381032481466106256">当此设置处于开启状态时，关闭所有窗口的操作也会致使您退出 Brave</translation>
 <translation id="1026406809507858026">{0,plural, =0{有一项可用的 Brave 更新}=1{有一项可用的 Brave 更新}other{有一项可用的 Brave 更新（已发布 # 天）}}</translation>
-<translation id="95624393026532554">Brave 仅支持 Windows 7 或更高版本的操作系统。</translation>
+<translation id="4378573854226202617">Brave 仅支持 Windows 10 或更高版本的操作系统。</translation>
 <translation id="5646769069113654257">请立即重启 Brave</translation>
 <translation id="2335583906071111058">以这种语言显示 Brave</translation>
 <translation id="7207456302801184289">欢迎使用 Brave</translation>

--- a/app/resources/chromium_strings_zh-HK.xtb
+++ b/app/resources/chromium_strings_zh-HK.xtb
@@ -198,7 +198,7 @@
 <translation id="232381795826373334">在 Brave 中開啟 PDF</translation>
 <translation id="5381032481466106256">開啟時，您亦將會從 Brave 登出</translation>
 <translation id="1026406809507858026">{0,plural, =0{有可用的 Brave 更新}=1{有可用的 Brave 更新}other{Brave 更新已發佈 # 天}}</translation>
-<translation id="95624393026532554">Brave 只能在 Windows 7 或以上作業系統中執行。</translation>
+<translation id="4378573854226202617">Brave 只能在 Windows 10 或以上作業系統中執行。</translation>
 <translation id="5646769069113654257">請立即重新啟動 Brave</translation>
 <translation id="2335583906071111058">以此語言顯示 Brave</translation>
 <translation id="7207456302801184289">歡迎使用 Brave</translation>

--- a/app/resources/chromium_strings_zh-TW.xtb
+++ b/app/resources/chromium_strings_zh-TW.xtb
@@ -182,7 +182,7 @@
 <translation id="232381795826373334">在 Brave 中開啟 PDF</translation>
 <translation id="5381032481466106256">如果啟用此選項，系統也會將你從 Brave 登出</translation>
 <translation id="1026406809507858026">{0,plural, =0{有可用的 Brave 更新}=1{有可用的 Brave 更新}other{Brave 更新已發布 # 天}}</translation>
-<translation id="95624393026532554">Brave 僅支援 Windows 7 以上版本的作業系統。</translation>
+<translation id="4378573854226202617">Brave 僅支援 Windows 10 以上版本的作業系統。</translation>
 <translation id="5646769069113654257">請立即重新啟動 Brave</translation>
 <translation id="2335583906071111058">將 Brave 的介面文字設為這種語言</translation>
 <translation id="7207456302801184289">歡迎使用 Brave</translation>

--- a/app/resources/chromium_strings_zu.xtb
+++ b/app/resources/chromium_strings_zu.xtb
@@ -198,7 +198,7 @@ Izimvume ozinikezile kakade amawebhusayithi nama-app zingase zisebenze kule akha
 <translation id="232381795826373334">Vula ama-PDF ku-Brave</translation>
 <translation id="5381032481466106256">Lapho ivuliwe, uzophinde futhi uphume ngemvume ku-Brave</translation>
 <translation id="1026406809507858026">{0,plural, =0{Isibuyekezo se-Brave siyatholakala}=1{Isibuyekezo se-Brave siyatholakala}one{Isibuyekezo se-Brave sitholakala ngezinsuku ezingu-#}other{Isibuyekezo se-Brave sitholakala ngezinsuku ezingu-#}}</translation>
-<translation id="95624393026532554">I-Brave idinga i-Windows 7 noma ngaphezulu.</translation>
+<translation id="4378573854226202617">I-Brave idinga i-Windows 10 noma ngaphezulu.</translation>
 <translation id="5646769069113654257">Sicela uqalise kabusha i-Brave manje</translation>
 <translation id="2335583906071111058">Veza i-Brave ngalolu limi</translation>
 <translation id="7207456302801184289">Siyakwamukela ku-Brave</translation>

--- a/script/chromium-rebase-l10n.py
+++ b/script/chromium-rebase-l10n.py
@@ -160,6 +160,9 @@ def main():
         elem1 = xml_tree.xpath(
             '//part[@file="settings_chromium_strings.grdp"]')[0]
         elem1.set('file', 'settings_brave_strings.grdp')
+        elem1 = xml_tree.xpath(
+            '//message[@name="IDS_INSTALL_OS_NOT_SUPPORTED"]')[0]
+        elem1.text = elem1.text.replace('Windows 7', 'Windows 10')
 
     grit_root = xml_tree.xpath(
         '//grit' if extension == '.grd' else '//grit-part')[0]


### PR DESCRIPTION
Uplift of https://github.com/brave/brave-core/pull/17234
Resolves https://github.com/brave/brave-browser/issues/28511

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.