### PR TITLE
Removing dependency to //components/browser_watcher

### DIFF
--- a/components/brave_vpn/browser/connection/win/brave_vpn_helper/BUILD.gn
+++ b/components/brave_vpn/browser/connection/win/brave_vpn_helper/BUILD.gn
@@ -79,7 +79,6 @@ executable("brave_vpn_helper") {
     "//brave/components/brave_vpn/common",
     "//build/win:default_exe_manifest",
     "//chrome/install_static:install_static_util",
-    "//components/browser_watcher:browser_watcher_client",
     "//components/crash/core/app",
     "//components/crash/core/app:crash_export_thunks",
     "//components/crash/core/app:run_as_crashpad_handler",

--- a/components/brave_vpn/browser/connection/win/brave_vpn_helper/main.cc
+++ b/components/brave_vpn/browser/connection/win/brave_vpn_helper/main.cc
@@ -17,7 +17,6 @@
 #include "brave/components/brave_vpn/browser/connection/win/brave_vpn_helper/brave_vpn_helper_state.h"
 #include "brave/components/brave_vpn/browser/connection/win/brave_vpn_helper/service_main.h"
 #include "brave/components/brave_vpn/browser/connection/win/brave_vpn_helper/vpn_utils.h"
-#include "components/browser_watcher/exit_code_watcher_win.h"
 #include "components/crash/core/app/crash_switches.h"
 #include "components/crash/core/app/crashpad.h"
 #include "components/crash/core/app/fallback_crash_handling_win.h"
@@ -50,9 +49,6 @@ int main(int argc, char* argv[]) {
   BraveVPNHelperCrashReporterClient::InitializeCrashReportingForProcess(
       process_type);
   if (process_type == crash_reporter::switches::kCrashpadHandler) {
-    // Check if we should monitor the exit code of this process
-    std::unique_ptr<browser_watcher::ExitCodeWatcher> exit_code_watcher;
-
     crash_reporter::SetupFallbackCrashHandling(*command_line);
     // The handler process must always be passed the user data dir on the
     // command line.
@@ -63,11 +59,6 @@ int main(int argc, char* argv[]) {
     int crashpad_status = crash_reporter::RunAsCrashpadHandler(
         *base::CommandLine::ForCurrentProcess(), user_data_dir, kProcessType,
         kUserDataDir);
-    if (crashpad_status != 0 && exit_code_watcher) {
-      // Crashpad failed to initialize, explicitly stop the exit code watcher
-      // so the crashpad-handler process can exit with an error
-      exit_code_watcher->StopWatching();
-    }
     return crashpad_status;
   }
 


### PR DESCRIPTION
The code being removed in the PR was already not in use from its introduction, as the `ExitCodeWatcher` would never be initialised in the first place.

Additionally, `//components/browser_watcher` is getting deleted upstream in `cr113`, while `ExitCodeWatcher` code is getting moved into `//chrome`, which we can't easily depend on from components.

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/28919

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-draft - run CI builds on a draft PR (otherwise only on non-draft PRs)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux, CI/skip-android, CI/skip-macos, CI/skip-ios, CI/skip-windows, CI/skip-windows-x86 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [ ] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

