### PR TITLE
feat(wallet): Add NFT properties(attributes)

### DIFF
--- a/components/brave_wallet_ui/constants/types.ts
+++ b/components/brave_wallet_ui/constants/types.ts
@@ -814,6 +814,11 @@ export interface CreateAccountOptionsType {
   icon: string
 }
 
+export interface NFTAtrribute {
+  traitType: string
+  value: string
+} 
+
 export interface NFTMetadataReturnType {
   chainName: string
   tokenType: string
@@ -832,7 +837,8 @@ export interface NFTMetadataReturnType {
     twitter: string
     facebook: string
     logo: string
-  }
+  },
+  attributes?: NFTAtrribute[] 
 }
 
 export interface TransactionProviderError {

--- a/components/brave_wallet_ui/nft/components/nft-attribute/nft-attribute.styles.ts
+++ b/components/brave_wallet_ui/nft/components/nft-attribute/nft-attribute.styles.ts
@@ -1,0 +1,33 @@
+// Copyright (c) 2023 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+import styled from 'styled-components'
+
+export const StyledWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-start;
+  padding: 12px;
+  border: 1px solid ${p => p.theme.color.divider01};
+  margin-bottom: 8px;
+  border-radius: 8px;
+`
+
+export const TraitType = styled.span`
+  font-family: Poppins;
+  font-size: 12px;
+  line-height: 18px;
+  letter-spacing: 0.01em;
+  color: ${(p) => p.theme.color.text02};
+  margin-bottom: 10px;
+`
+
+export const TraitValue = styled.span`
+  font-family: Poppins;
+  font-size: 15px;
+  line-height: 20px;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  color: ${(p) => p.theme.color.text01};
+`

--- a/components/brave_wallet_ui/nft/components/nft-attribute/nft-attribute.styles.ts
+++ b/components/brave_wallet_ui/nft/components/nft-attribute/nft-attribute.styles.ts
@@ -12,6 +12,7 @@ export const StyledWrapper = styled.div`
   border: 1px solid ${p => p.theme.color.divider01};
   margin-bottom: 8px;
   border-radius: 8px;
+  text-align: center;
 `
 
 export const TraitType = styled.span`

--- a/components/brave_wallet_ui/nft/components/nft-attribute/nft-attribute.tsx
+++ b/components/brave_wallet_ui/nft/components/nft-attribute/nft-attribute.tsx
@@ -1,0 +1,23 @@
+// Copyright (c) 2023 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+import * as React from 'react'
+import { NFTAtrribute } from '../../../constants/types'
+
+import { StyledWrapper, TraitType, TraitValue } from './nft-attribute.styles'
+
+interface Props {
+  attribute: NFTAtrribute
+}
+
+export const NftAttribute = ({ attribute }: Props) => {
+  const { traitType, value } = attribute
+
+  return (
+    <StyledWrapper>
+      <TraitType>{traitType}</TraitType>
+      <TraitValue>{value}</TraitValue>
+    </StyledWrapper>
+  )
+}

--- a/components/brave_wallet_ui/nft/components/nft-details/nft-details-styles.ts
+++ b/components/brave_wallet_ui/nft/components/nft-details/nft-details-styles.ts
@@ -114,6 +114,7 @@ export const ProjectDetailName = styled.span`
   font-weight: 500;
   color: ${(p) => p.theme.color.text01};
   margin-right: 12px;
+  margin-bottom: 10px;
 `
 
 export const ProjectDetailDescription = styled.span`
@@ -124,6 +125,7 @@ export const ProjectDetailDescription = styled.span`
   color: ${(p) => p.theme.color.text02};
   margin-right: 12px;
   max-width: 80%;
+  margin-bottom: 10px;
 `
 
 export const ProjectDetailImage = styled.img`
@@ -279,4 +281,11 @@ export const Subdivider = styled.div`
   background-color: ${p => p.theme.color.divider01};
   margin-bottom: 16px;
   margin-top: 16px;
+`
+
+export const AttributesWrapper = styled.div`
+  display: grid;
+  grid-template-columns: 1fr 1fr 1fr 1fr;
+  grid-gap: 8px;
+  margin-bottom: 10px;
 `

--- a/components/brave_wallet_ui/nft/components/nft-details/nft-details-styles.ts
+++ b/components/brave_wallet_ui/nft/components/nft-details/nft-details-styles.ts
@@ -285,7 +285,7 @@ export const Subdivider = styled.div`
 
 export const AttributesWrapper = styled.div`
   display: grid;
-  grid-template-columns: 1fr 1fr 1fr 1fr;
+  grid-template-columns: 1fr 1fr 1fr;
   grid-gap: 8px;
   margin-bottom: 10px;
 `

--- a/components/brave_wallet_ui/nft/components/nft-details/nft-details.tsx
+++ b/components/brave_wallet_ui/nft/components/nft-details/nft-details.tsx
@@ -44,7 +44,8 @@ import {
   TokenName,
   HighlightedDetailSectionValue,
   Subdivider,
-  ProjectDetailName
+  ProjectDetailName,
+  AttributesWrapper
 } from './nft-details-styles'
 import { NftMultimedia } from '../nft-multimedia/nft-multimedia'
 import { MultimediaWrapper } from '../nft-content/nft-content-styles'
@@ -53,6 +54,7 @@ import { Row } from '../../../components/shared/style'
 import CopyTooltip from '../../../components/shared/copy-tooltip/copy-tooltip'
 import { NftPinningStatus } from '../../../components/desktop/nft-pinning-status/nft-pinning-status'
 import { PinningStatusType } from '../../../page/constants/action_types'
+import { NftAttribute } from '../nft-attribute/nft-attribute'
 
 interface Props {
   isLoading?: boolean
@@ -196,6 +198,14 @@ export const NftDetails = ({ selectedAsset, nftMetadata, nftMetadataError, token
                   <DetailSectionTitle>{getLocale('braveWalletNFTDetailDescription')}</DetailSectionTitle>
                   <ProjectDetailDescription>{nftMetadata.contractInformation.description}</ProjectDetailDescription>
                 </DetailSectionColumn>
+                {nftMetadata?.attributes &&
+                  <DetailSectionColumn>
+                    <DetailSectionTitle>Properties</DetailSectionTitle>
+                    <AttributesWrapper>
+                      {nftMetadata?.attributes?.map((attribute, idx) => (<NftAttribute key={idx} attribute={attribute} />))}
+                    </AttributesWrapper>
+                  </DetailSectionColumn>
+                }
                 {nftPinningStatus?.code === BraveWallet.TokenPinStatusCode.STATUS_PINNED &&
                   <>
                     <Subdivider />

--- a/components/brave_wallet_ui/page/async/wallet_page_async_handler.ts
+++ b/components/brave_wallet_ui/page/async/wallet_page_async_handler.ts
@@ -296,6 +296,9 @@ handler.on(WalletPageActions.getNFTMetadata.type, async (store, payload: BraveWa
   const result = await getNFTMetadata(payload)
   if (!result?.error) {
     const response = result?.response && JSON.parse(result.response)
+    const attributes = Array.isArray(response.attributes)
+      ? response.attributes.map((attr: { trait_type: string; value: string }) => ({ traitType: attr.trait_type, value: attr.value }))
+      : []
     const tokenNetwork = getTokensNetwork(getWalletState(store).networkList, payload)
     const nftMetadata: NFTMetadataReturnType = {
       chainName: tokenNetwork.chainName,
@@ -317,11 +320,13 @@ handler.on(WalletPageActions.getNFTMetadata.type, async (store, payload: BraveWa
         facebook: '',
         logo: '',
         twitter: ''
-      }
+      },
+      attributes 
     }
     store.dispatch(WalletPageActions.updateNFTMetadata(nftMetadata))
     store.dispatch(WalletPageActions.updateNftMetadataError(undefined))
   } else {
+    console.error(result)
     store.dispatch(WalletPageActions.updateNftMetadataError(result.errorMessage))
   }
   store.dispatch(WalletPageActions.setIsFetchingNFTMetadata(false))


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/28920

### There may be some design changes before this PR is merged

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-draft - run CI builds on a draft PR (otherwise only on non-draft PRs)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux, CI/skip-android, CI/skip-macos, CI/skip-ios, CI/skip-windows, CI/skip-windows-x86 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
<img width="1512" alt="Light Theme" src="https://user-images.githubusercontent.com/48117473/223192644-59e5ee2c-e0e1-4884-800a-9d38098fbbf2.png">
<img width="1512" alt="Dark Theme" src="https://user-images.githubusercontent.com/48117473/223192654-a6954015-7320-45a2-94cf-ac7873c4dd49.png">
