### PR TITLE
Desktop NTP: prevent image bg loading observer getting destroyed and not getting onload event (uplift to 1.49.x)

### DIFF
--- a/components/brave_new_tab_ui/containers/newTab/index.tsx
+++ b/components/brave_new_tab_ui/containers/newTab/index.tsx
@@ -123,6 +123,7 @@ class NewTabPage extends React.Component<Props, State> {
     forceToHideWidget: false
   }
 
+  imgCache: HTMLImageElement
   braveNewsPromptTimerId: number
   hasInitBraveToday: boolean = false
   imageSource?: string = undefined
@@ -168,6 +169,7 @@ class NewTabPage extends React.Component<Props, State> {
     if (oldImageSource &&
       !newImageSource) {
       // reset loaded state
+      console.debug('reset image loaded state due to removing image source')
       this.setState({ backgroundHasLoaded: false })
     }
     if (!GetShouldShowBrandedWallpaperNotification(prevProps) &&
@@ -216,19 +218,26 @@ class NewTabPage extends React.Component<Props, State> {
   }
 
   trackCachedImage () {
+    console.debug('trackCachedImage')
     if (this.state.backgroundHasLoaded) {
+      console.debug('Resetting to new image')
       this.setState({ backgroundHasLoaded: false })
     }
     if (this.imageSource) {
       const imgCache = new Image()
+      // Store Image in class so it doesn't go out of scope
+      this.imgCache = imgCache
       imgCache.src = this.imageSource
-      console.timeStamp('image start loading...')
-      imgCache.onload = () => {
-        console.timeStamp('image loaded')
+      console.debug('image start loading...')
+      imgCache.addEventListener('load', () => {
+        console.debug('image loaded')
         this.setState({
           backgroundHasLoaded: true
         })
-      }
+      })
+      imgCache.addEventListener('error', (e) => {
+        console.debug('image error', e)
+      })
     }
   }
 


### PR DESCRIPTION
Uplift of https://github.com/brave/brave-core/pull/17251
fix https://github.com/brave/brave-browser/issues/28493

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.