### PR TITLE
Added back button to vpn error panel

### DIFF
--- a/browser/ui/webui/brave_vpn/brave_vpn_localized_string_provider.cc
+++ b/browser/ui/webui/brave_vpn/brave_vpn_localized_string_provider.cc
@@ -30,6 +30,7 @@ void AddLocalizedStrings(content::WebUIDataSource* html_source) {
       {"braveVpnPurchased", IDS_BRAVE_VPN_HAS_PURCHASED},
       {"braveVpnPoweredBy", IDS_BRAVE_VPN_POWERED_BY},
       {"braveVpnSettingsPanelHeader", IDS_BRAVE_VPN_SETTINGS_PANEL_HEADER},
+      {"braveVpnErrorPanelHeader", IDS_BRAVE_VPN_ERROR_PANEL_HEADER},
       {"braveVpnStatus", IDS_BRAVE_VPN_STATUS},
       {"braveVpnExpires", IDS_BRAVE_VPN_EXPIRES},
       {"braveVpnManageSubscription", IDS_BRAVE_VPN_MANAGE_SUBSCRIPTION},

--- a/components/brave_vpn/browser/brave_vpn_service.cc
+++ b/components/brave_vpn/browser/brave_vpn_service.cc
@@ -467,6 +467,10 @@ void BraveVpnService::GetSupportData(GetSupportDataCallback callback) {
                           GetTimeZoneName());
 }
 
+void BraveVpnService::ResetConnectionState() {
+  GetBraveVPNConnectionAPI()->ResetConnectionState();
+}
+
 BraveVPNOSConnectionAPI* BraveVpnService::GetBraveVPNConnectionAPI() const {
   DCHECK(connection_api_);
   return connection_api_;

--- a/components/brave_vpn/browser/brave_vpn_service.h
+++ b/components/brave_vpn/browser/brave_vpn_service.h
@@ -98,6 +98,7 @@ class BraveVpnService :
                            const std::string& body,
                            CreateSupportTicketCallback callback) override;
   void GetSupportData(GetSupportDataCallback callback) override;
+  void ResetConnectionState() override;
 #else
   // mojom::vpn::ServiceHandler
   void GetPurchaseToken(GetPurchaseTokenCallback callback) override;

--- a/components/brave_vpn/browser/brave_vpn_service_unittest.cc
+++ b/components/brave_vpn/browser/brave_vpn_service_unittest.cc
@@ -598,6 +598,29 @@ TEST_F(BraveVPNServiceTest, LoadPurchasedStateTest) {
   EXPECT_EQ(PurchasedState::FAILED, GetPurchasedStateSync());
 }
 
+TEST_F(BraveVPNServiceTest, ResetConnectionStateTest) {
+  // Prepare valid connection info.
+  auto* test_api = static_cast<BraveVPNOSConnectionAPISim*>(GetConnectionAPI());
+
+  // Set failed state before setting observer.
+  test_api->SetConnectionState(ConnectionState::CONNECT_FAILED);
+
+  TestBraveVPNServiceObserver observer;
+  AddObserver(observer.GetReceiver());
+  std::string env = skus::GetDefaultEnvironment();
+  SetPurchasedState(env, PurchasedState::PURCHASED);
+
+  service_->ResetConnectionState();
+
+  base::RunLoop loop;
+  observer.WaitConnectionStateChange(loop.QuitClosure());
+  loop.Run();
+
+  // Check state is changed to disconnected after reset connection state.
+  EXPECT_EQ(ConnectionState::DISCONNECTED, test_api->GetConnectionState());
+  EXPECT_EQ(ConnectionState::DISCONNECTED, observer.GetConnectionState());
+}
+
 TEST_F(BraveVPNServiceTest, ConnectionStateUpdateWithPurchasedStateTest) {
   // Prepare valid connection info.
   auto* test_api = static_cast<BraveVPNOSConnectionAPISim*>(GetConnectionAPI());

--- a/components/brave_vpn/browser/connection/brave_vpn_os_connection_api.h
+++ b/components/brave_vpn/browser/connection/brave_vpn_os_connection_api.h
@@ -38,6 +38,7 @@ class BraveVPNOSConnectionAPI {
   };
 
   virtual mojom::ConnectionState GetConnectionState() const = 0;
+  virtual void ResetConnectionState() = 0;
   virtual void RemoveVPNConnection() = 0;
   virtual void Connect() = 0;
   virtual void Disconnect() = 0;

--- a/components/brave_vpn/browser/connection/brave_vpn_os_connection_api_base.cc
+++ b/components/brave_vpn/browser/connection/brave_vpn_os_connection_api_base.cc
@@ -52,6 +52,16 @@ void BraveVPNOSConnectionAPIBase::SetConnectionState(
   UpdateAndNotifyConnectionStateChange(state);
 }
 
+void BraveVPNOSConnectionAPIBase::ResetConnectionState() {
+  // Don't use UpdateAndNotifyConnectionStateChange() to update connection state
+  // and set state directly because we have a logic to ignore disconnected state
+  // when connect failed.
+  connection_state_ = ConnectionState::DISCONNECTED;
+  for (auto& obs : observers_) {
+    obs.OnConnectionStateChanged(connection_state_);
+  }
+}
+
 std::string BraveVPNOSConnectionAPIBase::GetLastConnectionError() const {
   return last_connection_error_;
 }

--- a/components/brave_vpn/browser/connection/brave_vpn_os_connection_api_base.h
+++ b/components/brave_vpn/browser/connection/brave_vpn_os_connection_api_base.h
@@ -42,6 +42,7 @@ class BraveVPNOSConnectionAPIBase
 
   // BraveVPNOSConnectionAPI
   mojom::ConnectionState GetConnectionState() const override;
+  void ResetConnectionState() override;
   void Connect() override;
   void Disconnect() override;
   void ToggleConnection() override;

--- a/components/brave_vpn/browser/connection/brave_vpn_os_connection_api_sim.h
+++ b/components/brave_vpn/browser/connection/brave_vpn_os_connection_api_sim.h
@@ -57,6 +57,7 @@ class BraveVPNOSConnectionAPISim : public BraveVPNOSConnectionAPIBase {
                            CreateOSVPNEntryWithInvalidInfoTest);
   FRIEND_TEST_ALL_PREFIXES(BraveVPNServiceTest,
                            ConnectionStateUpdateWithPurchasedStateTest);
+  FRIEND_TEST_ALL_PREFIXES(BraveVPNServiceTest, ResetConnectionStateTest);
 
   void OnCreated(const std::string& name, bool success);
   void OnConnected(const std::string& name, bool success);

--- a/components/brave_vpn/common/mojom/brave_vpn.mojom
+++ b/components/brave_vpn/common/mojom/brave_vpn.mojom
@@ -70,6 +70,9 @@ interface ServiceHandler {
   CreateSupportTicket(string email, string subject, string body) =>
     (bool success, string response);
 
+  [EnableIfNot=is_android]
+  ResetConnectionState();
+
   [EnableIf=is_android]
   GetPurchaseToken() => (string token);
 };

--- a/components/brave_vpn/resources/panel/components/error-panel/index.tsx
+++ b/components/brave_vpn/resources/panel/components/error-panel/index.tsx
@@ -7,7 +7,7 @@ import Button from '$web-components/button'
 
 import * as S from './style'
 import { ButtonText, IconBox } from '../general'
-import { AlertCircleIcon } from 'brave-ui/components/icons'
+import { AlertCircleIcon, CaratStrongLeftIcon } from 'brave-ui/components/icons'
 import { getLocale } from '../../../../../common/locale'
 import { useSelector, useDispatch } from '../../state/hooks'
 import * as Actions from '../../state/actions'
@@ -19,6 +19,10 @@ interface Props {
 function ErrorPanel (props: Props) {
   const dispatch = useDispatch()
   const currentRegion = useSelector(state => state.currentRegion)
+
+  const handleShowMainView = () => {
+    dispatch(Actions.resetConnectionState())
+  }
 
   const handleTryAgain = () => {
     dispatch(Actions.connect())
@@ -36,6 +40,16 @@ function ErrorPanel (props: Props) {
   return (
     <S.Box>
       <S.PanelContent>
+        <S.PanelHeader>
+          <S.BackButton
+            type='button'
+            onClick={handleShowMainView}
+            aria-label='Go to main'
+          >
+            <i><CaratStrongLeftIcon /></i>
+            <span>{getLocale('braveVpnErrorPanelHeader')}</span>
+          </S.BackButton>
+        </S.PanelHeader>
         <IconBox>
           <AlertCircleIcon color='#84889C' />
         </IconBox>

--- a/components/brave_vpn/resources/panel/components/error-panel/style.ts
+++ b/components/brave_vpn/resources/panel/components/error-panel/style.ts
@@ -17,7 +17,7 @@ export const PanelContent = styled.section`
   display: flex;
   flex-direction: column;
   align-items: center;
-  padding: 48px 24px 16px 24px;
+  padding: 28px 24px 16px 24px;
   position: relative;
   z-index: 2;
 `
@@ -52,5 +52,39 @@ export const ActionArea = styled.div`
     &:first-child {
       margin-bottom: 10px;
     }
+  }
+`
+
+export const PanelHeader = styled.section`
+  display: flex;
+  align-items: center;
+  width: 100%;
+  margin-bottom: 10px;
+  box-sizing: border-box;
+`
+
+export const BackButton = styled.button`
+  background-color: transparent;
+  border: 0;
+  padding: 0;
+  display: flex;
+  align-items: center;
+  cursor: pointer;
+
+  span {
+    font-family: ${(p) => p.theme.fontFamily.heading};
+    font-size: 13px;
+    font-weight: 600;
+    color: ${(p) => p.theme.color.interactive05};
+  }
+
+  i {
+    width: 18px;
+    height: 18px;
+    margin-right: 5px;
+  }
+
+  svg {
+    fill: ${(p) => p.theme.color.interactive05};
   }
 `

--- a/components/brave_vpn/resources/panel/state/actions.ts
+++ b/components/brave_vpn/resources/panel/state/actions.ts
@@ -42,6 +42,7 @@ export const purchaseFailed = createAction('purchaseFailed')
 export const showSellView = createAction('showSellView')
 export const showLoadingView = createAction('showLoadingView')
 export const showSubscriptionExpiredView = createAction('showSubscriptionExpiredView')
+export const resetConnectionState = createAction('resetConnectionState')
 
 export const initialized = createAction<initializedPayload>('initialized')
 export const showMainView = createAction<showMainViewPayload>('showMainView')

--- a/components/brave_vpn/resources/panel/state/async.ts
+++ b/components/brave_vpn/resources/panel/state/async.ts
@@ -21,6 +21,10 @@ handler.on(Actions.disconnect.getType(), async () => {
   getPanelBrowserAPI().serviceHandler.disconnect()
 })
 
+handler.on(Actions.resetConnectionState.getType(), async () => {
+  getPanelBrowserAPI().serviceHandler.resetConnectionState()
+})
+
 handler.on(Actions.connectToNewRegion.getType(), async (store) => {
   const state = getState(store)
 

--- a/components/brave_vpn/resources/panel/state/reducer.ts
+++ b/components/brave_vpn/resources/panel/state/reducer.ts
@@ -127,6 +127,15 @@ reducer.on(Actions.initialized, (state, payload): RootState => {
   }
 })
 
+reducer.on(Actions.resetConnectionState, (state): RootState => {
+  return {
+    ...state,
+    hasError: false,
+    connectionStatus: ConnectionState.DISCONNECTED,
+    currentView: ViewType.Main
+  }
+})
+
 // TODO(nullhook): The handler doesnt throw an error unless if explicitly
 // defined. Update the type internally so it can be infered.
 reducer.on(Actions.showMainView, (state, payload): RootState => {

--- a/components/brave_vpn/resources/panel/stories/locale.ts
+++ b/components/brave_vpn/resources/panel/stories/locale.ts
@@ -25,6 +25,7 @@ provideStrings({
   braveVpnManageSubscription: 'Manage subscription',
   braveVpnContactSupport: 'Contact technical support',
   braveVpnAbout: 'About',
+  braveVpnErrorPanelHeader: 'Brave VPN',
   braveVpnFeature1: 'Block trackers & ads across all apps',
   braveVpnFeature2: 'Protects you from unwanted network connections',
   braveVpnFeature3: 'Choose your VPN location',

--- a/components/brave_vpn/resources/panel/stories/mock-data/api.ts
+++ b/components/brave_vpn/resources/panel/stories/mock-data/api.ts
@@ -19,6 +19,7 @@ BraveVPN.setPanelBrowserApiForTesting({
     addObserver: doNothing,
     getPurchasedState: () => Promise.resolve({ state: BraveVPN.PurchasedState.LOADING }),
     getConnectionState: () => Promise.resolve({ state: BraveVPN.ConnectionState.CONNECTED }),
+    resetConnectionState: doNothing,
     connect: doNothing,
     disconnect: doNothing,
     loadPurchasedState: doNothing,

--- a/components/resources/brave_vpn_strings.grdp
+++ b/components/resources/brave_vpn_strings.grdp
@@ -68,6 +68,10 @@
     Settings
   </message>
 
+  <message name="IDS_BRAVE_VPN_ERROR_PANEL_HEADER" desc="Text shown in header for error panel">
+    Brave VPN
+  </message>
+
   <message name="IDS_BRAVE_VPN_STATUS" desc="Label to show the status of the user's subscription">
     Status
   </message>


### PR DESCRIPTION
fix https://github.com/brave/brave-browser/issues/21732

State.hasError is cleared to show main panel
and requested to service to clear connection state.

![스크린샷 2023-03-07 145909](https://user-images.githubusercontent.com/6786187/223336554-a6bc5aa1-dd51-40c9-83ee-148e89c11311.png)
![스크린샷 2023-03-07 152106](https://user-images.githubusercontent.com/6786187/223337698-34853197-9208-458c-8043-032280331466.png)


<!-- Add brave-browser issue below that this PR will resolve -->
Resolves 

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-draft - run CI builds on a draft PR (otherwise only on non-draft PRs)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux, CI/skip-android, CI/skip-macos, CI/skip-ios, CI/skip-windows, CI/skip-windows-x86 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

`BraveVPNServiceTest.ResetConnectionStateTest`

1. Set VPN purchased state
2. Open vpn panel and check main panel is shown
3. Disconnect os network connection
4. Connect vpn via panel
5. Error panel is shown and back button is visible
6. Click back button and check panel goes to main view