### PR TITLE
Don't reuse background web contents

### DIFF
--- a/components/playlist/browser/playlist_download_request_manager.cc
+++ b/components/playlist/browser/playlist_download_request_manager.cc
@@ -27,8 +27,6 @@ namespace playlist {
 
 namespace {
 
-constexpr base::TimeDelta kWebContentDestroyDelay = base::Minutes(5);
-
 const int32_t kInvalidWorldID = -1;
 
 int32_t g_playlist_javascript_world_id = kInvalidWorldID;
@@ -75,10 +73,21 @@ void PlaylistDownloadRequestManager::CreateWebContents() {
 }
 
 void PlaylistDownloadRequestManager::GetMediaFilesFromPage(Request request) {
-  web_contents_destroy_timer_.reset();
-
+  DVLOG(2) << __func__;
   if (!ReadyToRunMediaDetectorScript()) {
+    if (!request_start_time_.is_null()) {
+      // See if the last job is stuck.
+#if DCHECK_IS_ON()
+      DCHECK(base::Time::Now() - request_start_time_ <= base::Minutes(1));
+#else
+      if (base::Time::Now() - request_start_time_ > base::Minutes(1)) {
+        LOG(ERROR) << "The previous job is pending longer than 1 min";
+      }
+#endif
+    }
+
     pending_requests_.push_back(std::move(request));
+    DVLOG(2) << "Queued request";
     return;
   }
 
@@ -95,6 +104,7 @@ void PlaylistDownloadRequestManager::FetchPendingRequest() {
 }
 
 void PlaylistDownloadRequestManager::RunMediaDetector(Request request) {
+  DVLOG(2) << __func__;
   CHECK(PlaylistJavaScriptWorldIdIsSet());
 
   DCHECK_GE(in_progress_urls_count_, 0);
@@ -102,9 +112,16 @@ void PlaylistDownloadRequestManager::RunMediaDetector(Request request) {
 
   DCHECK(callback_for_current_request_.is_null());
   callback_for_current_request_ = std::move(request.callback);
+  DCHECK(callback_for_current_request_)
+      << "Empty callback shouldn't be requested";
+  request_start_time_ = base::Time::Now();
 
   if (absl::holds_alternative<std::string>(request.url_or_contents)) {
+    // Start to request on clean slate, so that result won't be affected by
+    // previous page.
+    web_contents_.reset();
     CreateWebContents();
+
     GURL url(absl::get<std::string>(request.url_or_contents));
     DCHECK(url.is_valid());
     DCHECK(web_contents_);
@@ -114,6 +131,10 @@ void PlaylistDownloadRequestManager::RunMediaDetector(Request request) {
     auto weak_contents =
         absl::get<base::WeakPtr<content::WebContents>>(request.url_or_contents);
     if (!weak_contents) {
+      // While the request was in queue, the tab was deleted. Proceed to the
+      // next request.
+      in_progress_urls_count_--;
+
       FetchPendingRequest();
       return;
     }
@@ -132,9 +153,13 @@ void PlaylistDownloadRequestManager::DidFinishLoad(
   if (render_frame_host != web_contents_->GetPrimaryMainFrame())
     return;
 
-  if (in_progress_urls_count_ == 0 || callback_for_current_request_.is_null())
+  if (in_progress_urls_count_ == 0 || callback_for_current_request_.is_null()) {
+    // As we don't support canceling at this moment, this shouldn't happen.
+    CHECK_IS_TEST();
     return;
+  }
 
+  DVLOG(2) << __func__;
   GetMedia(web_contents_.get());
 }
 
@@ -181,14 +206,17 @@ void PlaylistDownloadRequestManager::OnGetMedia(
 void PlaylistDownloadRequestManager::ProcessFoundMedia(
     base::WeakPtr<content::WebContents> contents,
     base::Value value) {
-  if (!contents)
-    return;
-
   DCHECK(!callback_for_current_request_.is_null()) << " callback already ran";
   auto callback = std::move(callback_for_current_request_);
 
   DCHECK_GT(in_progress_urls_count_, 0);
   in_progress_urls_count_--;
+  Observe(nullptr);
+  if (!contents) {
+    return;
+  }
+
+  web_contents_.reset();
 
   /* Expected output:
     [
@@ -203,10 +231,6 @@ void PlaylistDownloadRequestManager::ProcessFoundMedia(
       }
     ]
   */
-
-  if (in_progress_urls_count_ == 0)
-    ScheduleWebContentsDestroying();
-  Observe(nullptr);
 
   if (value.is_dict() && value.GetDict().empty()) {
     DVLOG(2) << "No media was detected";
@@ -278,20 +302,6 @@ void PlaylistDownloadRequestManager::ProcessFoundMedia(
   }
 
   std::move(callback).Run(std::move(items));
-}
-
-void PlaylistDownloadRequestManager::ScheduleWebContentsDestroying() {
-  if (!web_contents_destroy_timer_) {
-    web_contents_destroy_timer_ = std::make_unique<base::RetainingOneShotTimer>(
-        FROM_HERE, kWebContentDestroyDelay,
-        base::BindRepeating(&PlaylistDownloadRequestManager::DestroyWebContents,
-                            base::Unretained(this)));
-  }
-  web_contents_destroy_timer_->Reset();
-}
-
-void PlaylistDownloadRequestManager::DestroyWebContents() {
-  web_contents_.reset();
 }
 
 void PlaylistDownloadRequestManager::SetRunScriptOnMainWorldForTest() {

--- a/components/playlist/browser/playlist_download_request_manager.cc
+++ b/components/playlist/browser/playlist_download_request_manager.cc
@@ -63,11 +63,10 @@ PlaylistDownloadRequestManager::PlaylistDownloadRequestManager(
 PlaylistDownloadRequestManager::~PlaylistDownloadRequestManager() = default;
 
 void PlaylistDownloadRequestManager::CreateWebContents() {
-  if (!web_contents_) {
-    // |web_contents_| is created on demand.
-    content::WebContents::CreateParams create_params(context_, nullptr);
-    web_contents_ = content::WebContents::Create(create_params);
-  }
+  DCHECK(!web_contents_);
+
+  content::WebContents::CreateParams create_params(context_, nullptr);
+  web_contents_ = content::WebContents::Create(create_params);
 
   Observe(web_contents_.get());
 }
@@ -119,7 +118,6 @@ void PlaylistDownloadRequestManager::RunMediaDetector(Request request) {
   if (absl::holds_alternative<std::string>(request.url_or_contents)) {
     // Start to request on clean slate, so that result won't be affected by
     // previous page.
-    web_contents_.reset();
     CreateWebContents();
 
     GURL url(absl::get<std::string>(request.url_or_contents));
@@ -320,7 +318,10 @@ void PlaylistDownloadRequestManager::ConfigureWebPrefsForBackgroundWebContents(
 
 content::WebContents*
 PlaylistDownloadRequestManager::GetBackgroundWebContentsForTesting() {
-  CreateWebContents();
+  if (!web_contents_) {
+    CreateWebContents();
+  }
+
   return web_contents_.get();
 }
 

--- a/components/playlist/browser/playlist_download_request_manager.h
+++ b/components/playlist/browser/playlist_download_request_manager.h
@@ -99,9 +99,6 @@ class PlaylistDownloadRequestManager : public content::WebContentsObserver {
   // Pop a task from queue and detect media from the page if any.
   void FetchPendingRequest();
 
-  void ScheduleWebContentsDestroying();
-  void DestroyWebContents();
-
   // content::WebContentsObserver overrides:
   void DidFinishLoad(content::RenderFrameHost* render_frame_host,
                      const GURL& validated_url) override;
@@ -121,11 +118,11 @@ class PlaylistDownloadRequestManager : public content::WebContentsObserver {
   // destroying task will be scheduled.
   int in_progress_urls_count_ = 0;
   Request::Callback callback_for_current_request_ = base::NullCallback();
+  base::Time request_start_time_;
 
   raw_ptr<content::BrowserContext> context_;
 
   raw_ptr<MediaDetectorComponentManager> media_detector_component_manager_;
-  std::unique_ptr<base::RetainingOneShotTimer> web_contents_destroy_timer_;
 
   bool run_script_on_main_world_ = false;
 


### PR DESCRIPTION
Reusing contents could make DidFinishLoad() not called.

e.g.
  * https://youtube.com was loaded on the contents
  * Make a new request for http://youtube.com#searching
  * As the youtube.com was already loaded, it just moves scroll to #searching fragment and doesn't reload. As a result, we can't get DidFinishLoad() callback.
  * This make the request never ends.

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/28944

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-draft - run CI builds on a draft PR (otherwise only on non-draft PRs)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux, CI/skip-android, CI/skip-macos, CI/skip-ios, CI/skip-windows, CI/skip-windows-x86 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [ ] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

