### PR TITLE
Disable upstream's WarmupManager.initializeViewHierarchy

### DIFF
--- a/android/brave_java_sources.gni
+++ b/android/brave_java_sources.gni
@@ -39,6 +39,7 @@ brave_java_sources = [
   "../../brave/android/java/org/chromium/chrome/browser/BraveSyncInformers.java",
   "../../brave/android/java/org/chromium/chrome/browser/BraveSyncWorker.java",
   "../../brave/android/java/org/chromium/chrome/browser/BraveWalletProvider.java",
+  "../../brave/android/java/org/chromium/chrome/browser/BraveWarmupManager.java",
   "../../brave/android/java/org/chromium/chrome/browser/CrossPromotionalModalDialogFragment.java",
   "../../brave/android/java/org/chromium/chrome/browser/DormantUsersEngagementDialogFragment.java",
   "../../brave/android/java/org/chromium/chrome/browser/InternetConnection.java",

--- a/android/java/apk_for_test.flags
+++ b/android/java/apk_for_test.flags
@@ -214,6 +214,10 @@
     *** getInstance(...);
 }
 
+-keep class org.chromium.chrome.browser.WarmupManager {
+    *** initializeViewHierarchy(...);
+}
+
 -keep class org.chromium.chrome.browser.toolbar.BraveToolbarManager {
     public <init>(...);
 }

--- a/android/java/org/chromium/chrome/browser/BraveWarmupManager.java
+++ b/android/java/org/chromium/chrome/browser/BraveWarmupManager.java
@@ -1,0 +1,13 @@
+/* Copyright (c) 2023 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+package org.chromium.chrome.browser;
+
+import android.content.Context;
+
+public class BraveWarmupManager {
+    public void initializeViewHierarchy(
+            Context baseContext, int toolbarContainerId, int toolbarId) {}
+}

--- a/android/javatests/org/chromium/chrome/browser/BytecodeTest.java
+++ b/android/javatests/org/chromium/chrome/browser/BytecodeTest.java
@@ -307,6 +307,7 @@ public class BytecodeTest {
                 classExists("org/chromium/chrome/browser/settings/BravePreferenceFragment"));
         Assert.assertTrue(
                 classExists("org/chromium/chrome/browser/preferences/ChromePreferenceKeyChecker"));
+        Assert.assertTrue(classExists("org/chromium/chrome/browser/WarmupManager"));
     }
 
     @Test
@@ -466,6 +467,10 @@ public class BytecodeTest {
         Assert.assertTrue(
                 methodExists("org/chromium/chrome/browser/preferences/ChromePreferenceKeyChecker",
                         "getInstance", false, null));
+        // We expect Chromium's WarmupManager.initializeViewHierarchy to be removed by the bytecode
+        // patching and BraveWarmupManager.initializeViewHierarchy to be used instead
+        Assert.assertFalse(methodExists("org/chromium/chrome/browser/WarmupManager",
+                "initializeViewHierarchy", false, null));
     }
 
     @Test

--- a/build/android/bytecode/BUILD.gn
+++ b/build/android/bytecode/BUILD.gn
@@ -88,6 +88,7 @@ java_binary("java_bytecode_rewriter") {
     "//brave/build/android/bytecode/java/org/brave/bytecode/BraveTopToolbarCoordinatorClassAdapter.java",
     "//brave/build/android/bytecode/java/org/brave/bytecode/BraveTranslateCompactInfoBarBaseClassAdapter.java",
     "//brave/build/android/bytecode/java/org/brave/bytecode/BraveVariationsSeedFetcherClassAdapter.java",
+    "//brave/build/android/bytecode/java/org/brave/bytecode/BraveWarmupManagerClassAdapter.java",
     "//brave/build/android/bytecode/java/org/brave/bytecode/BraveWebsiteClassAdapter.java",
     "//brave/build/android/bytecode/java/org/brave/bytecode/BraveWebsitePermissionsFetcherClassAdapter.java",
     "//brave/build/android/bytecode/java/org/brave/bytecode/ByteCodeProcessor.java",

--- a/build/android/bytecode/java/org/brave/bytecode/BraveClassAdapter.java
+++ b/build/android/bytecode/java/org/brave/bytecode/BraveClassAdapter.java
@@ -86,6 +86,7 @@ public class BraveClassAdapter {
         chain = new BraveToolbarManagerClassAdapter(chain);
         chain = new BraveTopToolbarCoordinatorClassAdapter(chain);
         chain = new BraveVariationsSeedFetcherClassAdapter(chain);
+        chain = new BraveWarmupManagerClassAdapter(chain);
         chain = new BraveWebsiteClassAdapter(chain);
         chain = new BraveWebsitePermissionsFetcherClassAdapter(chain);
         return chain;

--- a/build/android/bytecode/java/org/brave/bytecode/BraveWarmupManagerClassAdapter.java
+++ b/build/android/bytecode/java/org/brave/bytecode/BraveWarmupManagerClassAdapter.java
@@ -1,0 +1,24 @@
+/* Copyright (c) 2023 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+package org.brave.bytecode;
+
+import org.objectweb.asm.ClassVisitor;
+
+public class BraveWarmupManagerClassAdapter extends BraveClassVisitor {
+    static String sChromeWarmupManagerClassName = "org/chromium/chrome/browser/WarmupManager";
+
+    static String sBraveWarmupManagerClassName = "org/chromium/chrome/browser/BraveWarmupManager";
+
+    public BraveWarmupManagerClassAdapter(ClassVisitor visitor) {
+        super(visitor);
+
+        changeSuperName(sChromeWarmupManagerClassName, sBraveWarmupManagerClassName);
+        changeMethodOwner(sChromeWarmupManagerClassName, "initializeViewHierarchy",
+                sBraveWarmupManagerClassName);
+
+        deleteMethod(sChromeWarmupManagerClassName, "initializeViewHierarchy");
+    }
+}


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/28805

Issue happens because when custom tabs are used for the first time, at `BraveShieldsHandler` `mContext` is null, because it is not inherited from `Activity`, but it is just `Context`. So `mHardwareButtonMenuAnchor` also is not initialized, and methods `BraveShieldsHandler.show` / `BraveShieldsHandler.showPopupMenu` don't perform any work.

This PR cuts `WarmupManager.initializeViewHierarchy`, so at `CustomTabsConnection.warmupInternal` only `(1), (2) and (4)` steps are executed. I didn't found visual slowdown after this, and Brave menu is shown without issues.

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux, CI/skip-android, CI/skip-macos, CI/skip-ios, CI/skip-windows, CI/skip-windows-x86 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
1. Ensure the Brave browser of proper channel is set as a default browser;
2. Swipe out from the carousel both Slack and Brave Browser
3. Launch Slack and open some link in custom tab
4. Press Brave shields button - the menu must  be open just right at the time.
5. Buttons Share and TWEET must be also pressed instantly - but I could not verify because I could not reproduce issue with them.



