### PR TITLE
Hide rewards menu for unsupported countries (uplift to 1.50.x)

### DIFF
--- a/android/java/org/chromium/chrome/browser/appmenu/BraveTabbedAppMenuPropertiesDelegate.java
+++ b/android/java/org/chromium/chrome/browser/appmenu/BraveTabbedAppMenuPropertiesDelegate.java
@@ -123,8 +123,7 @@ public class BraveTabbedAppMenuPropertiesDelegate extends TabbedAppMenuPropertie
         }
 
         BraveRewardsNativeWorker braveRewardsNativeWorker = BraveRewardsNativeWorker.getInstance();
-        if (braveRewardsNativeWorker != null
-                && braveRewardsNativeWorker.IsSupportedSkipRegionCheck()
+        if (braveRewardsNativeWorker != null && braveRewardsNativeWorker.IsSupported()
                 && !BravePrefServiceBridge.getInstance().getSafetynetCheckFailed()) {
             MenuItem rewards =
                     menu.add(Menu.NONE, R.id.brave_rewards_id, 0, R.string.menu_brave_rewards);


### PR DESCRIPTION
Uplift of #17482
Resolves https://github.com/brave/brave-browser/issues/28908

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.