### PR TITLE
fix(wallet): Remove Fiat from Offramp Flow

### DIFF
--- a/components/brave_wallet/browser/asset_ratio_service.cc
+++ b/components/brave_wallet/browser/asset_ratio_service.cc
@@ -259,9 +259,11 @@ void AssetRatioService::GetSellUrl(mojom::OffRampProvider provider,
                                              kOffRampEnabledFlows);
     off_ramp_url = net::AppendQueryParameter(off_ramp_url, "defaultFlow",
                                              kOffRampDefaultFlow);
+    off_ramp_url = net::AppendQueryParameter(off_ramp_url, "swapAsset", symbol);
     off_ramp_url =
         net::AppendQueryParameter(off_ramp_url, "offrampAsset", symbol);
-    off_ramp_url = net::AppendQueryParameter(off_ramp_url, "fiatValue", amount);
+    off_ramp_url =
+        net::AppendQueryParameter(off_ramp_url, "swapAmount", amount);
     off_ramp_url =
         net::AppendQueryParameter(off_ramp_url, "fiatCurrency", currency_code);
     off_ramp_url =

--- a/components/brave_wallet/browser/asset_ratio_service_unittest.cc
+++ b/components/brave_wallet/browser/asset_ratio_service_unittest.cc
@@ -195,7 +195,8 @@ TEST_F(AssetRatioServiceUnitTest, GetSellUrl) {
                  "0xdeadbeef", "ETH_BAT", "250", "USD",
                  "https://buy.ramp.network/"
                  "?userAddress=0xdeadbeef&enabledFlows=ONRAMP%2COFFRAMP"
-                 "&defaultFlow=OFFRAMP&offrampAsset=ETH_BAT&fiatValue=250"
+                 "&defaultFlow=OFFRAMP&swapAsset=ETH_BAT&offrampAsset=ETH_BAT"
+                 "&swapAmount=250"
                  "&fiatCurrency=USD&hostApiKey="
                  "8yxja8782as5essk2myz3bmh4az6gpq4nte9n2gf",
                  absl::nullopt);

--- a/components/brave_wallet/browser/brave_wallet_constants.h
+++ b/components/brave_wallet/browser/brave_wallet_constants.h
@@ -770,7 +770,6 @@ constexpr webui::LocalizedString kLocalizedStrings[] = {
     {"braveWalletNotValidFilAddress", IDS_BRAVE_WALLET_NOT_VALID_FIL_ADDRESS},
     {"braveWalletBuyWithRamp", IDS_BRAVE_WALLET_BUY_WITH_RAMP},
     {"braveWalletSellWithProvider", IDS_BRAVE_WALLET_SELL_WITH_PROVIDER},
-    {"braveWalletSellMinimumAmount", IDS_BRAVE_WALLET_SELL_MINIMUM_AMOUNT},
     {"braveWalletBuyWithSardine", IDS_BRAVE_WALLET_BUY_WITH_SARDINE},
     {"braveWalletBuyWithTransak", IDS_BRAVE_WALLET_BUY_WITH_TRANSAK},
     {"braveWalletBuyRampNetworkName", IDS_BRAVE_WALLET_BUY_RAMP_NETWORK_NAME},

--- a/components/brave_wallet_ui/common/hooks/select-preset.ts
+++ b/components/brave_wallet_ui/common/hooks/select-preset.ts
@@ -3,7 +3,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this file,
 // you can obtain one at https://mozilla.org/MPL/2.0/.
 
-import { BraveWallet } from '../../constants/types'
+import { BraveWallet, WalletAccountType } from '../../constants/types'
 
 // Utils
 import Amount from '../../utils/amount'
@@ -15,14 +15,16 @@ import { useUnsafeWalletSelector } from './use-safe-selector'
 export default function usePreset (
   {
     asset,
-    onSetAmount
+    onSetAmount,
+    account
   }: {
     onSetAmount?: (value: string) => void
     asset?: BraveWallet.BlockchainToken
+    account?: WalletAccountType
   }
 ) {
   // redux
-  const selectedAccount = useUnsafeWalletSelector(WalletSelectors.selectedAccount)
+  const selectedAccount = account ?? useUnsafeWalletSelector(WalletSelectors.selectedAccount)
 
   return (percent: number) => {
     if (!asset) {

--- a/components/brave_wallet_ui/common/hooks/use-multi-chain-sell-assets.ts
+++ b/components/brave_wallet_ui/common/hooks/use-multi-chain-sell-assets.ts
@@ -10,6 +10,7 @@ import { getNetworkInfo } from '../../utils/network-utils'
 import {
   getRampAssetSymbol
 } from '../../utils/asset-utils'
+import Amount from '../../utils/amount'
 
 // Types
 import {
@@ -87,7 +88,9 @@ export const useMultiChainSellAssets = () => {
       offRampProvider: BraveWallet.OffRampProvider.kRamp,
       chainId: sellAsset.chainId,
       address: sellAddress,
-      amount: sellAmount,
+      amount: sellAsset.coin === BraveWallet.CoinType.SOL
+        ? new Amount(sellAmount).multiplyByDecimals(sellAsset?.decimals ?? 18).toNumber().toString()
+        : new Amount(sellAmount).multiplyByDecimals(sellAsset?.decimals ?? 18).toHex(),
       currencyCode: defaultCurrencies.fiat
     })
       .then(url => {

--- a/components/brave_wallet_ui/components/desktop/popup-modals/sell-asset-modal/sell-asset-modal.style.ts
+++ b/components/brave_wallet_ui/components/desktop/popup-modals/sell-asset-modal/sell-asset-modal.style.ts
@@ -67,7 +67,6 @@ export const AmountInput = styled.input`
   line-height: 48px;
   text-align: left;
   width: 100%;
-  padding-left: 16px;
   outline: none;
   background-image: none;
   box-shadow: none;

--- a/components/brave_wallet_ui/components/desktop/views/accounts/account.tsx
+++ b/components/brave_wallet_ui/components/desktop/views/accounts/account.tsx
@@ -368,6 +368,7 @@ export const Account = ({
           setSellAmount={setSellAmount}
           openSellAssetLink={onOpenSellAssetLink}
           showSellModal={showSellModal}
+          account={selectedAccount}
           sellAssetBalance={getBalance(selectedAccount, selectedSellAsset)}
         />
       }

--- a/components/brave_wallet_ui/components/desktop/views/portfolio/components/accounts-and-transctions-list/index.tsx
+++ b/components/brave_wallet_ui/components/desktop/views/portfolio/components/accounts-and-transctions-list/index.tsx
@@ -212,6 +212,7 @@ export const AccountsAndTransactionsList = ({
           setSellAmount={setSellAmount}
           openSellAssetLink={onOpenSellAssetLink}
           showSellModal={showSellModal}
+          account={selectedSellAccount}
           sellAssetBalance={getBalance(selectedSellAccount, selectedAsset)}
         />
       }

--- a/components/brave_wallet_ui/stories/locale.ts
+++ b/components/brave_wallet_ui/stories/locale.ts
@@ -439,7 +439,6 @@ provideStrings({
   braveWalletBuyWithSardine: 'Buy with Sardine',
   braveWalletBuyWithTransak: 'Buy with Transak',
   braveWalletSellWithProvider: 'Sell with $1',
-  braveWalletSellMinimumAmount: 'The minimum amount must be $1 or more.',
 
   // Fund Wallet Screen
   braveWalletFundWalletTitle: 'To finish your $1 purchase, select one of our partners',

--- a/components/resources/wallet_strings.grdp
+++ b/components/resources/wallet_strings.grdp
@@ -524,7 +524,6 @@
   <message name="IDS_BRAVE_WALLET_NOT_VALID_FIL_ADDRESS" desc="Send input not valid FIL address error">Not a valid FIL address</message>
   <message name="IDS_BRAVE_WALLET_BUY_WITH_RAMP" desc="Buy with Ramp option label">Buy with Ramp</message>
   <message name="IDS_BRAVE_WALLET_SELL_WITH_PROVIDER" desc="Sell with Provider option label">Sell with <ph name="OFFRAMP_PROVIDER">$1<ex>Ramp</ex></ph></message>
-  <message name="IDS_BRAVE_WALLET_SELL_MINIMUM_AMOUNT" desc="Sell minimum amount alert">The minimum amount must be <ph name="FIAT_AMOUNT">$1<ex>$50</ex></ph> or more.</message>
   <message name="IDS_BRAVE_WALLET_BUY_WITH_SARDINE" desc="Buy with Sardine option label">Buy with Sardine</message>
   <message name="IDS_BRAVE_WALLET_BUY_WITH_TRANSAK" desc="Buy with Transak option label">Buy with Transak</message>
   <message name="IDS_BRAVE_WALLET_BUY_RAMP_NETWORK_NAME" desc="Ramp.Network onramp provider name">Ramp.Network</message>


### PR DESCRIPTION
## Description 
Updates the `Offramp` flow to have the users enter the `Token` amount they want to sell instead of `Fiat` amount

Additional Changes:
- Remove fiat balances
- Remove the minimum threshold of `$50` for entered amount

<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves <https://github.com/brave/brave-browser/issues/28960>

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
1. Select a `Token` to sell
2. The input amount should be for the `Token` amount and not `Fiat` amount.
3. There should not be any `Fiat` balances or values on the popup modal
4. The minimum $50 sell amount should no longer exist
5. Enter in the `Token` amount you want to sell and click `Sell with Ramp`.
6. You should be directed to the `Ramp` sell widget and the `Sell` amount should reflect the `Amount` you entered.

https://user-images.githubusercontent.com/40611140/223862336-d7343eb3-e3bb-4a4d-95cb-0a5c47285485.mov
