### PR TITLE
fix(wallet): Pre-Fill Search on Fund Screens

### DIFF
--- a/components/brave_wallet_ui/components/desktop/views/portfolio/components/token-lists/token-list.tsx
+++ b/components/brave_wallet_ui/components/desktop/views/portfolio/components/token-lists/token-list.tsx
@@ -4,7 +4,7 @@
 // you can obtain one at https://mozilla.org/MPL/2.0/.
 
 import * as React from 'react'
-import { useHistory } from 'react-router'
+import { useHistory, useParams } from 'react-router'
 
 // Selectors
 import { useSafeWalletSelector, useUnsafeWalletSelector } from '../../../../../../common/hooks/use-safe-selector'
@@ -71,6 +71,7 @@ export const TokenLists = ({
                            }: Props) => {
   // routing
   const history = useHistory()
+  const { tokenId } = useParams<{ tokenId?: string }>()
 
   // unsafe selectors
   const tokenSpotPrices = useUnsafeWalletSelector(WalletSelectors.transactionSpotPrices)
@@ -83,7 +84,7 @@ export const TokenLists = ({
   const { computeFiatAmount } = usePricing(tokenSpotPrices)
 
   // state
-  const [searchValue, setSearchValue] = React.useState<string>('')
+  const [searchValue, setSearchValue] = React.useState<string>(tokenId ?? '')
 
   // methods
 
@@ -199,10 +200,10 @@ export const TokenLists = ({
   // effects
   React.useEffect(() => {
     // reset search field on list update
-    if (userAssetList) {
+    if (userAssetList && !tokenId) {
       setSearchValue('')
     }
-  }, [userAssetList])
+  }, [userAssetList, tokenId])
 
   // render
   return (

--- a/components/brave_wallet_ui/page/screens/fund-wallet/deposit-funds.tsx
+++ b/components/brave_wallet_ui/page/screens/fund-wallet/deposit-funds.tsx
@@ -4,7 +4,7 @@
 // you can obtain one at https://mozilla.org/MPL/2.0/.
 
 import * as React from 'react'
-import { useHistory, useParams } from 'react-router'
+import { useHistory } from 'react-router'
 import {
   useDispatch,
   useSelector
@@ -67,7 +67,6 @@ import { TabHeader } from '../shared-screen-components/tab-header/tab-header'
 export const DepositFundsScreen = () => {
   // routing
   const history = useHistory()
-  const { tokenId } = useParams<{ tokenId?: string }>()
 
   // redux
   const dispatch = useDispatch()
@@ -174,10 +173,6 @@ export const DepositFundsScreen = () => {
 
     return ''
   }, [selectedAsset])
-
-  const nativeAssets: BraveWallet.BlockchainToken[] = React.useMemo(() => {
-    return networkList.map((network) => makeNetworkAsset(network))
-  }, [networkList])
 
   // methods
   const openAccountSearch = React.useCallback(() => setShowAccountSearch(true), [])
@@ -289,18 +284,6 @@ export const DepositFundsScreen = () => {
       dispatch(WalletActions.getAllTokensList())
     }
   }, [fullTokenList])
-
-  React.useEffect(() => {
-    if (tokenId !== undefined) {
-      if (nativeAssets.some((asset) => asset.symbol.toLowerCase() === tokenId.toLocaleLowerCase())) {
-        const foundNativeAsset = nativeAssets.find((asset) => asset.symbol.toLowerCase() === tokenId.toLowerCase())
-        setSelectedAsset(foundNativeAsset)
-        return
-      }
-      const foundDepositableAsset = fullTokenList.find((asset) => asset.symbol.toLowerCase() === tokenId.toLowerCase())
-      setSelectedAsset(foundDepositableAsset)
-    }
-  }, [tokenId, fullTokenList, nativeAssets])
 
   // render
   return (

--- a/components/brave_wallet_ui/page/screens/fund-wallet/fund-wallet.tsx
+++ b/components/brave_wallet_ui/page/screens/fund-wallet/fund-wallet.tsx
@@ -4,7 +4,7 @@
 // you can obtain one at https://mozilla.org/MPL/2.0/.
 
 import * as React from 'react'
-import { useHistory, useParams } from 'react-router'
+import { useHistory } from 'react-router'
 import {
   useSelector
 } from 'react-redux'
@@ -60,7 +60,6 @@ import { TabHeader } from '../shared-screen-components/tab-header/tab-header'
 export const FundWalletScreen = () => {
   // routing
   const history = useHistory()
-  const { tokenId } = useParams<{ tokenId?: string }>()
 
   // redux
   const accounts = useSelector(({ wallet }: { wallet: WalletState }) => wallet.accounts)
@@ -246,15 +245,6 @@ export const FundWalletScreen = () => {
     accountsForSelectedAssetNetwork,
     selectedAccount
   ])
-
-  React.useEffect(() => {
-    if (tokenId !== undefined) {
-      const foundBuyAsset = allBuyAssetOptions.find((asset) => asset.symbol.toLowerCase() === tokenId.toLowerCase())
-      if (foundBuyAsset) {
-        setSelectedAsset(foundBuyAsset)
-      }
-    }
-  }, [tokenId, allBuyAssetOptions])
 
   // render
   return (


### PR DESCRIPTION
## Description 
Rather than pre-selecting and trying to guess which chain a user wants to `Buy` or `Deposit` a token on,
we now just pre-fill the search value on the `FundWallet` and `DepositFunds` screens and let the user decide.

<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves <https://github.com/brave/brave-browser/issues/28829>
Resolves <https://github.com/brave/brave-browser/issues/26246>

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

### Testing from Market Tab
1. Go to the `Market` tab and select a token to `Buy`
2. The `FundWallet` screen should pre-fill the search value with that tokens `Symbol` rather than making a selection for them.

https://user-images.githubusercontent.com/40611140/223928635-8ddddee2-e7ac-4667-908c-3e22cd450ff4.mov

3. Go to the `Market` tab and select a token to `Deposit`
4. The `DepositFunds` screen should pre-fill the search value with that tokens `Symbol` rather than making a selection for them.

https://user-images.githubusercontent.com/40611140/223929117-59586ebf-e928-4162-b52b-2aa838a68537.mov

### Testing from Asset Details Screen
1. Select a token from your portfolio and click `Buy`
2. The `FundWallet` screen should pre-fill the search value with that tokens `Symbol` rather than making a selection for them.

https://user-images.githubusercontent.com/40611140/223928975-011c2008-af8b-4789-ad9b-6d51dea7f4f9.mov

3. Select a token from your portfolio and click `Deposit`
4. The `DepositFunds` screen should pre-fill the search value with that tokens `Symbol` rather than making a selection for them.

https://user-images.githubusercontent.com/40611140/223929010-f2ead5a1-543e-4d36-afaf-252cb45d13ca.mov
