### PR TITLE
fix(wallet): Show correct balance and asset

### DIFF
--- a/android/java/org/chromium/chrome/browser/app/domain/NetworkModel.java
+++ b/android/java/org/chromium/chrome/browser/app/domain/NetworkModel.java
@@ -135,8 +135,12 @@ public class NetworkModel implements JsonRpcServiceObserver {
                     Triple.create(networkInfo.chainId, networkInfo, _mCryptoNetworks.getValue()));
         });
         _mChainNetworkAllNetwork.addSource(_mCryptoNetworks, networkInfos -> {
-            _mChainNetworkAllNetwork.postValue(
-                    Triple.create(_mChainId.getValue(), _mDefaultNetwork.getValue(), networkInfos));
+            String chainId = _mChainId.getValue();
+            NetworkInfo networkInfo = _mDefaultNetwork.getValue();
+            if (networkInfo != null) {
+                chainId = networkInfo.chainId;
+            }
+            _mChainNetworkAllNetwork.postValue(Triple.create(chainId, networkInfo, networkInfos));
         });
         _mCustomNetworkIds.addSource(mSharedData.getCoinTypeLd(), coinType -> {
             mJsonRpcService.getCustomNetworks(

--- a/android/java/org/chromium/chrome/browser/crypto_wallet/activities/AssetDetailActivity.java
+++ b/android/java/org/chromium/chrome/browser/crypto_wallet/activities/AssetDetailActivity.java
@@ -1,7 +1,7 @@
 /* Copyright (c) 2021 The Brave Authors. All rights reserved.
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
- * You can obtain one at http://mozilla.org/MPL/2.0/. */
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 package org.chromium.chrome.browser.crypto_wallet.activities;
 
@@ -231,11 +231,10 @@ public class AssetDetailActivity
                     TabUtils.openLinkWithFocus(this, WalletConstants.URL_RAINBOW_AURORA);
                 }
             });
-        } else {
-            mBtnSwap.setOnClickListener(v
-                    -> Utils.openBuySendSwapActivity(AssetDetailActivity.this,
-                            BuySendSwapActivity.ActivityType.SWAP, mAssetSymbol));
         }
+        mBtnSwap.setOnClickListener(v
+                -> Utils.openBuySendSwapActivity(AssetDetailActivity.this,
+                        BuySendSwapActivity.ActivityType.SWAP, mAssetSymbol));
 
         adjustButtonsVisibilities();
 
@@ -497,9 +496,7 @@ public class AssetDetailActivity
     private void adjustButtonsVisibilities() {
         showHideBuyUi();
         if (Utils.allowSwap(mChainId)) {
-            if (!AssetUtils.isAuroraAddress(mContractAddress, mChainId)) {
-                mBtnSwap.setVisibility(View.VISIBLE);
-            }
+            mBtnSwap.setVisibility(View.VISIBLE);
         } else {
             mBtnSwap.setVisibility(View.GONE);
         }

--- a/android/java/org/chromium/chrome/browser/crypto_wallet/activities/BuySendSwapActivity.java
+++ b/android/java/org/chromium/chrome/browser/crypto_wallet/activities/BuySendSwapActivity.java
@@ -1,7 +1,7 @@
 /* Copyright (c) 2021 The Brave Authors. All rights reserved.
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
- * You can obtain one at http://mozilla.org/MPL/2.0/. */
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 package org.chromium.chrome.browser.crypto_wallet.activities;
 
@@ -57,8 +57,8 @@ import org.chromium.brave_wallet.mojom.BraveWalletConstants;
 import org.chromium.brave_wallet.mojom.CoinType;
 import org.chromium.brave_wallet.mojom.GasEstimation1559;
 import org.chromium.brave_wallet.mojom.NetworkInfo;
-import org.chromium.brave_wallet.mojom.OnRampProvider;
 import org.chromium.brave_wallet.mojom.ProviderError;
+import org.chromium.brave_wallet.mojom.SolanaProviderError;
 import org.chromium.brave_wallet.mojom.SwapErrorResponse;
 import org.chromium.brave_wallet.mojom.SwapParams;
 import org.chromium.brave_wallet.mojom.SwapResponse;
@@ -80,6 +80,7 @@ import org.chromium.chrome.browser.crypto_wallet.adapters.NetworkSpinnerAdapter;
 import org.chromium.chrome.browser.crypto_wallet.adapters.WalletCoinAdapter;
 import org.chromium.chrome.browser.crypto_wallet.fragments.ApproveTxBottomSheetDialogFragment;
 import org.chromium.chrome.browser.crypto_wallet.fragments.EditVisibleAssetsBottomSheetDialogFragment;
+import org.chromium.chrome.browser.crypto_wallet.model.WalletListItemModel;
 import org.chromium.chrome.browser.crypto_wallet.observers.ApprovedTxObserver;
 import org.chromium.chrome.browser.crypto_wallet.util.AddressUtils;
 import org.chromium.chrome.browser.crypto_wallet.util.AssetUtils;
@@ -97,6 +98,7 @@ import org.chromium.chrome.browser.qrreader.BarcodeTrackerFactory;
 import org.chromium.chrome.browser.qrreader.CameraSource;
 import org.chromium.chrome.browser.qrreader.CameraSourcePreview;
 import org.chromium.chrome.browser.util.TabUtils;
+import org.chromium.mojo.bindings.Callbacks;
 import org.chromium.mojo.system.MojoException;
 import org.chromium.ui.text.NoUnderlineClickableSpan;
 
@@ -167,6 +169,7 @@ public class BuySendSwapActivity extends BraveWalletBaseActivity
     private Handler mHandler;
     private String mAllowanceTarget;
     private String mCurrentChainId;
+    private String mToAssetSymbol;
     private NetworkInfo mSelectedNetwork;
     private AccountInfo mSelectedAccount;
     private WalletModel mWalletModel;
@@ -213,7 +216,7 @@ public class BuySendSwapActivity extends BraveWalletBaseActivity
         Intent intent = getIntent();
         mActivityType = ActivityType.valueOf(
                 intent.getIntExtra("activityType", ActivityType.BUY.getValue()));
-
+        mToAssetSymbol = getIntent().getStringExtra("swapFromAssetSymbol");
         mExecutor = Executors.newSingleThreadExecutor();
         mHandler = new Handler(Looper.getMainLooper());
 
@@ -436,9 +439,7 @@ public class BuySendSwapActivity extends BraveWalletBaseActivity
             return;
         final BlockchainToken nativeAsset = Utils.makeNetworkAsset(mSelectedNetwork);
         // Swap from
-        final String swapFromAssetSymbol = getIntent().getStringExtra("swapFromAssetSymbol") != null
-                ? getIntent().getStringExtra("swapFromAssetSymbol")
-                : nativeAsset.symbol;
+        final String swapFromAssetSymbol = JavaUtils.safeVal(mToAssetSymbol, nativeAsset.symbol);
         TokenUtils.getAllTokensFiltered(mBraveWalletService, mBlockchainRegistry, mSelectedNetwork,
                 mSelectedNetwork.coin,
                 nativeAsset.coin == CoinType.SOL ? TokenUtils.TokenType.SOL
@@ -446,16 +447,16 @@ public class BuySendSwapActivity extends BraveWalletBaseActivity
                 allTokens -> {
                     if (swapFromAssetSymbol.equals(nativeAsset.symbol)) {
                         updateBuySendSwapAsset(nativeAsset.symbol, nativeAsset, true);
-                        resetSwapToAsset(nativeAsset, allTokens, swapFromAssetSymbol);
-                        updateBalanceMaybeSwap();
+                        resetSwapToAsset(nativeAsset, allTokens, swapFromAssetSymbol,
+                                () -> { updateBalanceMaybeSwap(); });
                     } else {
                         mBlockchainRegistry.getTokenBySymbol(mSelectedNetwork.chainId,
                                 mSelectedNetwork.coin, swapFromAssetSymbol, token -> {
                                     if (token != null) {
                                         updateBuySendSwapAsset(token.symbol, token, true);
-                                        resetSwapToAsset(
-                                                nativeAsset, allTokens, swapFromAssetSymbol);
-                                        updateBalanceMaybeSwap();
+                                        resetSwapToAsset(nativeAsset, allTokens,
+                                                swapFromAssetSymbol,
+                                                () -> { updateBalanceMaybeSwap(); });
                                         return;
                                     }
                                     // We most likely have a custom token
@@ -463,9 +464,9 @@ public class BuySendSwapActivity extends BraveWalletBaseActivity
                                         if (swapFromAssetSymbol.equals(filteredToken.symbol)) {
                                             updateBuySendSwapAsset(
                                                     filteredToken.symbol, filteredToken, true);
-                                            resetSwapToAsset(
-                                                    nativeAsset, allTokens, swapFromAssetSymbol);
-                                            updateBalanceMaybeSwap();
+                                            resetSwapToAsset(nativeAsset, allTokens,
+                                                    swapFromAssetSymbol,
+                                                    () -> { updateBalanceMaybeSwap(); });
                                             break;
                                         }
                                     }
@@ -474,19 +475,24 @@ public class BuySendSwapActivity extends BraveWalletBaseActivity
                 });
     }
 
-    private void resetSwapToAsset(
-            BlockchainToken nativeAsset, BlockchainToken[] allTokens, String swapFromAssetSymbol) {
-        if (mActivityType != ActivityType.SWAP) return;
+    private void resetSwapToAsset(BlockchainToken nativeAsset, BlockchainToken[] allTokens,
+            String swapFromAssetSymbol, Callbacks.Callback0 runAfterAssetSet) {
+        if (mActivityType != ActivityType.SWAP) {
+            runAfterAssetSet.call();
+            return;
+        }
         final String defaultSwapToAsset = "BAT";
         // Swap to
         if (defaultSwapToAsset.equals(swapFromAssetSymbol)) { // swap from BAT
             updateBuySendSwapAsset(nativeAsset.symbol, nativeAsset, false);
+            runAfterAssetSet.call();
         } else {
             // Only ERC20 tokens can be swapped
             mBlockchainRegistry.getTokenBySymbol(mSelectedNetwork.chainId, mSelectedNetwork.coin,
                     defaultSwapToAsset, swapToToken -> {
                         if (swapToToken != null) {
                             updateBuySendSwapAsset(swapToToken.symbol, swapToToken, false);
+                            runAfterAssetSet.call();
                         } else {
                             // We are on a chain without BAT. Get first token that is not
                             // swapFromAsset.
@@ -498,11 +504,38 @@ public class BuySendSwapActivity extends BraveWalletBaseActivity
                                     break;
                                 }
                             }
-                            if (!success)
+                            if (!success) {
+                                clearBalance(false);
                                 updateBuySendSwapAsset(nativeAsset.symbol, nativeAsset, false);
+                            }
+                            runAfterAssetSet.call();
                         }
                     });
         }
+    }
+
+    private void clearBalance(boolean shouldClearFromOtherWiseTo) {
+        if (shouldClearFromOtherWiseTo) {
+            clearSwapFromAssetState();
+        } else {
+            clearSwapToAssetState();
+        }
+    }
+
+    private void clearSwapFromAssetState() {
+        mCurrentBlockchainToken = null;
+        clearBalanceAssetUi(mFromBalanceText, mFromAssetText);
+    }
+
+    private void clearSwapToAssetState() {
+        mCurrentSwapToBlockchainToken = null;
+        clearBalanceAssetUi(mToBalanceText, mToAssetText);
+    }
+
+    private void clearBalanceAssetUi(TextView balance, TextView asset) {
+        balance.setText("0");
+        asset.setText(null);
+        asset.setCompoundDrawablesWithIntrinsicBounds(0, 0, 0, 0);
     }
 
     private void checkBalanceShowError(
@@ -593,26 +626,30 @@ public class BuySendSwapActivity extends BraveWalletBaseActivity
         if (mJsonRpcService == null) {
             return;
         }
-        BlockchainToken blockchainToken = mCurrentBlockchainToken;
-        if (!from) {
-            blockchainToken = mCurrentSwapToBlockchainToken;
-        }
+        final BlockchainToken blockchainToken =
+                from ? mCurrentBlockchainToken : mCurrentSwapToBlockchainToken;
+        if (blockchainToken == null) return;
 
-        if (blockchainToken == null || blockchainToken.contractAddress.isEmpty()) {
+        if (blockchainToken.contractAddress.isEmpty()) {
             if (mSelectedAccount.coin == CoinType.ETH) {
                 mJsonRpcService.getBalance(address, CoinType.ETH, mSelectedNetwork.chainId,
                         (balance, error, errorMessage) -> {
                             warnWhenError(TAG, "getBalance", error, errorMessage);
-                            if (error != ProviderError.SUCCESS) {
+                            if (error != ProviderError.SUCCESS
+                                    || mSelectedNetwork.coin != CoinType.ETH
+                                    || !mSelectedAccount.address.equals(address)) {
                                 return;
                             }
                             populateBalance(balance, from, 0);
                         });
-            } else if (mSelectedNetwork.coin == CoinType.SOL) {
+            } else if (mSelectedNetwork.coin == CoinType.SOL
+                    && Utils.isNativeToken(mSelectedNetwork, blockchainToken)) {
                 mJsonRpcService.getSolanaBalance(
                         address, mSelectedNetwork.chainId, (balance, error, errorMessage) -> {
                             warnWhenError(TAG, "getSolanaBalance", error, errorMessage);
-                            if (error != ProviderError.SUCCESS) {
+                            if (error != SolanaProviderError.SUCCESS
+                                    || mSelectedNetwork.coin != CoinType.SOL
+                                    || !mSelectedAccount.address.equals(address)) {
                                 return;
                             }
                             populateBalance(String.valueOf(balance), from, 0);
@@ -623,7 +660,8 @@ public class BuySendSwapActivity extends BraveWalletBaseActivity
                     blockchainToken.tokenId, address, mSelectedNetwork.chainId,
                     (balance, error, errorMessage) -> {
                         warnWhenError(TAG, "getERC721TokenBalance", error, errorMessage);
-                        if (error != ProviderError.SUCCESS) {
+                        if (error != ProviderError.SUCCESS || !blockchainToken.isErc721
+                                || !mSelectedAccount.address.equals(address)) {
                             return;
                         }
                         populateBalance(balance, from, 0);
@@ -634,13 +672,19 @@ public class BuySendSwapActivity extends BraveWalletBaseActivity
             mJsonRpcService.getSplTokenAccountBalance(address, blockchainToken.contractAddress,
                     mSelectedNetwork.chainId,
                     (amount, decimals, uiAmountString, solanaProvideError, error_message) -> {
+                        if (solanaProvideError != SolanaProviderError.SUCCESS
+                                || mSelectedNetwork.coin != CoinType.SOL
+                                || !mSelectedAccount.address.equals(address)) {
+                            return;
+                        }
                         populateBalance(amount, from, decimals);
                     });
         } else {
             mJsonRpcService.getErc20TokenBalance(blockchainToken.contractAddress, address,
                     mSelectedNetwork.chainId, (balance, error, errorMessage) -> {
                         warnWhenError(TAG, "getErc20TokenBalance", error, errorMessage);
-                        if (error != ProviderError.SUCCESS) {
+                        if (error != ProviderError.SUCCESS || !blockchainToken.isErc20
+                                || !mSelectedAccount.address.equals(address)) {
                             return;
                         }
                         populateBalance(balance, from, 0);
@@ -675,11 +719,12 @@ public class BuySendSwapActivity extends BraveWalletBaseActivity
         try {
             int decimals = responseDecimals;
             if (decimals == 0) {
-                decimals = token != null ? token.decimals : Utils.ETH_DEFAULT_DECIMALS;
+                decimals = token.decimals;
             }
-            int tokenCoin = token != null ? token.coin : CoinType.ETH;
+            int tokenCoin = token.coin;
             fromToBalance = Utils.getBalanceForCoinType(tokenCoin, decimals, balance);
-        } catch (NumberFormatException e) {
+        } catch (NumberFormatException | NullPointerException e) {
+            clearBalance(from);
             return;
         }
 
@@ -696,7 +741,7 @@ public class BuySendSwapActivity extends BraveWalletBaseActivity
             getSendSwapQuota(true, false);
         }
     }
-    private void setSelectedNetowrk(NetworkInfo networkInfo, NetworkInfo[] networkInfos) {
+    private void setSelectedNetwork(NetworkInfo networkInfo, NetworkInfo[] networkInfos) {
         if (isSameSelectedNetwork(networkInfo)) return;
         mNetworkSpinner.setSelection(getIndexOf(networkInfo, networkInfos));
     }
@@ -760,6 +805,18 @@ public class BuySendSwapActivity extends BraveWalletBaseActivity
         mFromAssetText.setOnClickListener(v -> {
             EditVisibleAssetsBottomSheetDialogFragment bottomSheetDialogFragment =
                     EditVisibleAssetsBottomSheetDialogFragment.newInstance(fromAdapterType);
+
+            bottomSheetDialogFragment.setOnAssetClickListener(
+                    new EditVisibleAssetsBottomSheetDialogFragment
+                            .OnEditVisibleItemClickListener() {
+                                @Override
+                                public void onAssetClick(WalletListItemModel asset) {
+                                    mToAssetSymbol = asset.getBlockchainToken().symbol;
+                                    updateBuySendSwapAsset(
+                                            asset.getSubTitle(), asset.getBlockchainToken(), true);
+                                    updateBalanceMaybeSwap(getCurrentSelectedAccountAddr());
+                                }
+                            });
             bottomSheetDialogFragment.setSelectedNetwork(mSelectedNetwork);
             bottomSheetDialogFragment.show(getSupportFragmentManager(),
                     EditVisibleAssetsBottomSheetDialogFragment.TAG_FRAGMENT);
@@ -825,6 +882,16 @@ public class BuySendSwapActivity extends BraveWalletBaseActivity
                         EditVisibleAssetsBottomSheetDialogFragment.newInstance(
                                 WalletCoinAdapter.AdapterType.SWAP_TO_ASSETS_LIST);
                 bottomSheetDialogFragment.setSelectedNetwork(mSelectedNetwork);
+                bottomSheetDialogFragment.setOnAssetClickListener(
+                        new EditVisibleAssetsBottomSheetDialogFragment
+                                .OnEditVisibleItemClickListener() {
+                                    @Override
+                                    public void onAssetClick(WalletListItemModel asset) {
+                                        updateBuySendSwapAsset(asset.getSubTitle(),
+                                                asset.getBlockchainToken(), false);
+                                        updateBalanceMaybeSwap(getCurrentSelectedAccountAddr());
+                                    }
+                                });
                 bottomSheetDialogFragment.show(getSupportFragmentManager(),
                         EditVisibleAssetsBottomSheetDialogFragment.TAG_FRAGMENT);
             });
@@ -1645,6 +1712,10 @@ public class BuySendSwapActivity extends BraveWalletBaseActivity
         assert mWalletModel != null;
         mWalletModel.getCryptoModel().getNetworkModel().mChainNetworkAllNetwork.observe(
                 this, chainAllNetworksAllNetwork -> {
+                    if (mCurrentChainId != null
+                            && !mCurrentChainId.equals(chainAllNetworksAllNetwork.first)) {
+                        mToAssetSymbol = chainAllNetworksAllNetwork.second.symbol;
+                    }
                     mCurrentChainId = chainAllNetworksAllNetwork.first;
                     mSelectedNetwork = chainAllNetworksAllNetwork.second;
                     mNetworks = mActivityType != ActivityType.SEND
@@ -1655,7 +1726,7 @@ public class BuySendSwapActivity extends BraveWalletBaseActivity
                             : chainAllNetworksAllNetwork.third;
 
                     mNetworkAdapter.setNetworks(mNetworks);
-                    setSelectedNetowrk(mSelectedNetwork, mNetworks);
+                    setSelectedNetwork(mSelectedNetwork, mNetworks);
 
                     mFromAssetText.setText(mSelectedNetwork.symbol);
                     mMarketLimitPriceText.setText(String.format(
@@ -1716,7 +1787,7 @@ public class BuySendSwapActivity extends BraveWalletBaseActivity
                                     })
                             .setNegativeButton(R.string.wallet_action_no, (dialog, which) -> {
                                 // update mNetworkSpinner to current network
-                                setSelectedNetowrk(mSelectedNetwork, mNetworks);
+                                setSelectedNetwork(mSelectedNetwork, mNetworks);
 
                                 mWalletModel.getCryptoModel()
                                         .getNetworkModel()

--- a/android/java/org/chromium/chrome/browser/crypto_wallet/fragments/EditVisibleAssetsBottomSheetDialogFragment.java
+++ b/android/java/org/chromium/chrome/browser/crypto_wallet/fragments/EditVisibleAssetsBottomSheetDialogFragment.java
@@ -1,7 +1,7 @@
 /* Copyright (c) 2021 The Brave Authors. All rights reserved.
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
- * You can obtain one at http://mozilla.org/MPL/2.0/. */
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 package org.chromium.chrome.browser.crypto_wallet.fragments;
 
@@ -54,7 +54,6 @@ import org.chromium.chrome.browser.app.domain.BuyModel;
 import org.chromium.chrome.browser.app.domain.WalletModel;
 import org.chromium.chrome.browser.crypto_wallet.BlockchainRegistryFactory;
 import org.chromium.chrome.browser.crypto_wallet.activities.BraveWalletBaseActivity;
-import org.chromium.chrome.browser.crypto_wallet.activities.BuySendSwapActivity;
 import org.chromium.chrome.browser.crypto_wallet.adapters.WalletCoinAdapter;
 import org.chromium.chrome.browser.crypto_wallet.listeners.OnWalletListItemClick;
 import org.chromium.chrome.browser.crypto_wallet.model.WalletListItemModel;
@@ -79,6 +78,7 @@ public class EditVisibleAssetsBottomSheetDialogFragment extends BottomSheetDialo
     private static final String TAG = "EditVisibleAssetsBottomSheetDialogFragment";
     private WalletModel mWalletModel;
     private KeyringServiceObserverImpl mKeyringServiceObserver;
+    private OnEditVisibleItemClickListener mOnEditVisibleItemClickListener;
 
     public interface DismissListener {
         void onDismiss(Boolean isAssetsListChanged);
@@ -143,6 +143,11 @@ public class EditVisibleAssetsBottomSheetDialogFragment extends BottomSheetDialo
     public void setSelectedNetwork(NetworkInfo selectedNetwork) {
         assert selectedNetwork != null;
         mSelectedNetwork = selectedNetwork;
+    }
+
+    public void setOnAssetClickListener(
+            OnEditVisibleItemClickListener onEditVisibleItemClickListener) {
+        mOnEditVisibleItemClickListener = onEditVisibleItemClickListener;
     }
 
     public void setDismissListener(DismissListener dismissListener) {
@@ -540,22 +545,8 @@ public class EditVisibleAssetsBottomSheetDialogFragment extends BottomSheetDialo
     @Override
     public void onAssetClick(BlockchainToken token) {
         List<WalletListItemModel> checkedAssets = walletCoinAdapter.getCheckedAssets();
-        Activity activity = getActivity();
-        if (activity instanceof BuySendSwapActivity && checkedAssets.size() > 0) {
-            BuySendSwapActivity buySendSwapActivity = (BuySendSwapActivity) activity;
-            if (mType == WalletCoinAdapter.AdapterType.SEND_ASSETS_LIST
-                    || mType == WalletCoinAdapter.AdapterType.BUY_ASSETS_LIST
-                    || mType == WalletCoinAdapter.AdapterType.SWAP_FROM_ASSETS_LIST) {
-                buySendSwapActivity.updateBuySendSwapAsset(checkedAssets.get(0).getSubTitle(),
-                        checkedAssets.get(0).getBlockchainToken(), true);
-                buySendSwapActivity.updateBalanceMaybeSwap(
-                        buySendSwapActivity.getCurrentSelectedAccountAddr());
-            } else if (mType == WalletCoinAdapter.AdapterType.SWAP_TO_ASSETS_LIST) {
-                buySendSwapActivity.updateBuySendSwapAsset(checkedAssets.get(0).getSubTitle(),
-                        checkedAssets.get(0).getBlockchainToken(), false);
-                buySendSwapActivity.updateBalanceMaybeSwap(
-                        buySendSwapActivity.getCurrentSelectedAccountAddr());
-            }
+        if (mOnEditVisibleItemClickListener != null) {
+            mOnEditVisibleItemClickListener.onAssetClick(checkedAssets.get(0));
         }
         dismiss();
     }
@@ -674,5 +665,9 @@ public class EditVisibleAssetsBottomSheetDialogFragment extends BottomSheetDialo
             assetCheck.setTag("noOnClickListener");
             assetCheck.setChecked(walletListItemModel.getIsUserSelected());
         }
+    }
+
+    public interface OnEditVisibleItemClickListener {
+        default void onAssetClick(WalletListItemModel asset) {}
     }
 }

--- a/android/java/org/chromium/chrome/browser/crypto_wallet/listeners/OnWalletListItemClick.java
+++ b/android/java/org/chromium/chrome/browser/crypto_wallet/listeners/OnWalletListItemClick.java
@@ -1,7 +1,7 @@
 /* Copyright (c) 2021 The Brave Authors. All rights reserved.
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
- * You can obtain one at http://mozilla.org/MPL/2.0/. */
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 package org.chromium.chrome.browser.crypto_wallet.listeners;
 
@@ -13,12 +13,12 @@ import org.chromium.brave_wallet.mojom.TransactionInfo;
 import org.chromium.chrome.browser.crypto_wallet.model.WalletListItemModel;
 
 public interface OnWalletListItemClick {
-    default public void onAccountClick(WalletListItemModel walletListItemModel){};
-    default public void onAssetClick(BlockchainToken asset){};
-    default public void onTransactionClick(TransactionInfo txInfo){};
-    default public void onAssetCheckedChanged(
-            WalletListItemModel walletListItemModel, CheckBox assetCheck, boolean isChecked){};
-    default public void onMaybeShowTrashButton(
-            WalletListItemModel walletListItemModel, ImageView trashButton){};
-    default public void onTrashIconClick(WalletListItemModel walletListItemModel){};
+    default void onAccountClick(WalletListItemModel walletListItemModel) {}
+    default void onAssetClick(BlockchainToken asset) {}
+    default void onTransactionClick(TransactionInfo txInfo) {}
+    default void onAssetCheckedChanged(
+            WalletListItemModel walletListItemModel, CheckBox assetCheck, boolean isChecked) {}
+    default void onMaybeShowTrashButton(
+            WalletListItemModel walletListItemModel, ImageView trashButton) {}
+    default void onTrashIconClick(WalletListItemModel walletListItemModel) {}
 }

--- a/android/java/res/layout/activity_asset_detail.xml
+++ b/android/java/res/layout/activity_asset_detail.xml
@@ -235,7 +235,7 @@
             android:layout_height="wrap_content"
             android:gravity="center"
             android:layout_marginHorizontal="1dp"
-            android:layout_marginBottom="16dp"
+            android:layout_marginBottom="6dp"
             android:orientation="horizontal">
 
             <androidx.appcompat.widget.AppCompatButton
@@ -279,15 +279,16 @@
                 android:text="@string/swap"
                 android:layout_marginEnd="8dp"
                 style="@style/BraveWalletButton" />
-
-            <androidx.appcompat.widget.AppCompatButton
-                android:id="@+id/btn_aurora_bridge"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:text="@string/brave_wallet_aurora_button_text"
-                style="@style/BraveWalletButton"
-                android:visibility="gone"/>
         </LinearLayout>
+
+        <androidx.appcompat.widget.AppCompatButton
+            android:id="@+id/btn_aurora_bridge"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/brave_wallet_aurora_button_text"
+            style="@style/BraveWalletButton"
+            android:layout_gravity="center"
+            android:visibility="gone"/>
 
         <TextView
             android:layout_width="match_parent"


### PR DESCRIPTION
- Fix invalid balance state and state
- Keep the selected to asset after account switching
- Clean up

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/28879
Resolves https://github.com/brave/brave-browser/issues/28914

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-arm64, CI/skip-linux-x64, CI/skip-android, CI/skip-macos, CI/skip-ios, CI/skip-windows-arm64, CI/skip-windows-x64, CI/skip-windows-x86 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

[asset-balance.webm](https://user-images.githubusercontent.com/11755381/224033129-fa7fb6aa-8cb5-41d0-8dd0-af313b3cb6aa.webm)

![Screenshot from 2023-03-09 18-45-11](https://user-images.githubusercontent.com/11755381/224034339-90ac3312-5362-477c-af0f-dfc1daa5b063.png)

### Additional:
Swap "To" asset is not persisted after account switch. will log an issue after discussion.