### PR TITLE
fix(wallet): Portfolio Asset Routing

### DIFF
--- a/components/brave_wallet_ui/components/desktop/portfolio-transaction-item/index.tsx
+++ b/components/brave_wallet_ui/components/desktop/portfolio-transaction-item/index.tsx
@@ -289,10 +289,10 @@ export const PortfolioTransactionItem = React.forwardRef<HTMLDivElement, Props>(
 
   const onSelectAsset = React.useCallback((asset: BraveWallet.BlockchainToken) => {
     if (asset.contractAddress === '') {
-      history.push(`${WalletRoutes.Portfolio}/${asset.symbol}`)
+      history.push(`${WalletRoutes.Portfolio}/${asset.chainId}/${asset.symbol}`)
       return
     }
-    history.push(`${WalletRoutes.Portfolio}/${asset.contractAddress}`)
+    history.push(`${WalletRoutes.Portfolio}/${asset.chainId}/${asset.contractAddress}/${asset.tokenId}`)
   }, [history])
 
   const onAssetClick = React.useCallback((symbol?: string) =>

--- a/components/brave_wallet_ui/components/desktop/views/nfts/components/nfts.tsx
+++ b/components/brave_wallet_ui/components/desktop/views/nfts/components/nfts.tsx
@@ -74,7 +74,7 @@ export const Nfts = (props: Props) => {
   }, [])
 
   const onSelectAsset = React.useCallback((asset: BraveWallet.BlockchainToken) => {
-    history.push(`${WalletRoutes.Portfolio}/${asset.contractAddress}/${asset.tokenId}`)
+    history.push(`${WalletRoutes.Portfolio}/${asset.chainId}/${asset.contractAddress}/${asset.tokenId}`)
     // reset nft metadata
     dispatch(WalletPageActions.updateNFTMetadata(undefined))
   }, [dispatch])

--- a/components/brave_wallet_ui/components/desktop/views/portfolio/portfolio-overview.tsx
+++ b/components/brave_wallet_ui/components/desktop/views/portfolio/portfolio-overview.tsx
@@ -193,14 +193,10 @@ export const PortfolioOverview = () => {
 
   const onSelectAsset = React.useCallback((asset: BraveWallet.BlockchainToken) => {
     if (asset.contractAddress === '') {
-      history.push(`${WalletRoutes.Portfolio}/${asset.symbol}`)
+      history.push(`${WalletRoutes.Portfolio}/${asset.chainId}/${asset.symbol}`)
       return
-    } else if (asset.isErc721) {
-       history.push(`${WalletRoutes.Portfolio}/${asset.contractAddress}/${asset.tokenId}`)
-    } else {
-      history.push(`${WalletRoutes.Portfolio}/${asset.contractAddress}`)
     }
-
+    history.push(`${WalletRoutes.Portfolio}/${asset.chainId}/${asset.contractAddress}/${asset.tokenId}`)
     dispatch(WalletPageActions.selectAsset({ asset, timeFrame: selectedTimeline }))
     if ((asset.isErc721 || asset.isNft) && nftMetadata) {
       // reset nft metadata

--- a/components/brave_wallet_ui/components/extension/assets-panel/index.tsx
+++ b/components/brave_wallet_ui/components/extension/assets-panel/index.tsx
@@ -36,14 +36,27 @@ const AssetsPanel = (props: Props) => {
     onAddAsset
   } = props
 
-  const onClickAsset = (symbol: string) => () => {
-    const url = `brave://wallet${WalletRoutes.Portfolio}/${symbol}`
+  const routeToAssetDetails = (url: string) => {
     chrome.tabs.create({ url: url }, () => {
       if (chrome.runtime.lastError) {
         console.error('tabs.create failed: ' + chrome.runtime.lastError.message)
       }
     })
   }
+
+  const onClickAsset = React.useCallback(
+    (
+      contractAddress: string,
+      symbol: string,
+      tokenId: string,
+      chainId: string
+    ) => () => {
+      if (contractAddress === '') {
+        routeToAssetDetails(`brave://wallet${WalletRoutes.Portfolio}/${chainId}/${symbol}`)
+        return
+      }
+      routeToAssetDetails(`brave://wallet${WalletRoutes.Portfolio}/${chainId}/${contractAddress}/${tokenId}`)
+    }, [routeToAssetDetails])
 
   return (
     <StyledWrapper>
@@ -54,7 +67,12 @@ const AssetsPanel = (props: Props) => {
       </AddAssetButton>
       {userAssetList?.map((asset) =>
         <PortfolioAssetItem
-          action={onClickAsset(asset.symbol)}
+          action={onClickAsset(
+            asset.contractAddress,
+            asset.symbol,
+            asset.tokenId,
+            asset.chainId
+          )}
           key={getAssetIdKey(asset)}
           assetBalance={getBalance(selectedAccount, asset)}
           token={asset}

--- a/components/brave_wallet_ui/constants/types.ts
+++ b/components/brave_wallet_ui/constants/types.ts
@@ -514,7 +514,7 @@ export type SerializableSolanaTxData = Omit<
   | 'lamports'
   | 'amount'
   | 'sendOptions'
-  > & {
+> & {
   lastValidBlockHeight: string
   lamports: string
   amount: string
@@ -524,14 +524,14 @@ export type SerializableSolanaTxData = Omit<
 export type SerializableOrigin = Omit<
   BraveWallet.OriginInfo['origin'],
   | 'nonceIfOpaque'
-  > & {
+> & {
   nonceIfOpaque: SerializableUnguessableToken | undefined
 }
 
 export type SerializableOriginInfo = Omit<
   BraveWallet.OriginInfo,
   | 'origin'
-  > & {
+> & {
   origin: SerializableOrigin
 }
 
@@ -747,7 +747,7 @@ export enum WalletRoutes {
 
   // market
   Market = '/crypto/market',
-  MarketSub = '/crypto/market/:id?',
+  MarketSub = '/crypto/market/:chainIdOrMarketSymbol?',
 
   // accounts
   Accounts = '/crypto/accounts',
@@ -781,8 +781,8 @@ export enum WalletRoutes {
 
   // portfolio
   Portfolio = '/crypto/portfolio',
-  PortfolioAsset = '/crypto/portfolio/:id/:tokenId?',
-  PortfolioSub = '/crypto/portfolio/:id?',
+  PortfolioAsset = '/crypto/portfolio/:chainIdOrMarketSymbol/:contractOrSymbol?/:tokenId?',
+  PortfolioSub = '/crypto/portfolio/:chainIdOrMarketSymbol?',
 
   // portfolio asset modals
   AddAssetModal = '/crypto/portfolio/add-asset',


### PR DESCRIPTION
## Description 
We will now include `chainId` as a `param` when selecting `any` assets from the `Portfolio` page.

- Fixes a bug where selecting `Ethereum` on `Optimism` or `Aurora` would select `Ethereum` on `Ethereum Mainnet`
- Fixes a bug where when selecting a tokens from the panel was only passing the `Symbol` as a `Param`

`Routes` are now normalized for the following situations

- Native Assets: `crypto/portfolio/chainId/symbol`
- Fungible Tokens: `crypto/portfolio/chainId/contractAddress`
- Non-Fungible Tokens: `crypto/portfolio/chaindId/contractAddress/tokenId`
- Market Data: `crypto/market/symbol` (chainId and contractAddress are not available in this situation.)

<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves <https://github.com/brave/brave-browser/issues/28976>

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-arm64, CI/skip-linux-x64, CI/skip-android, CI/skip-macos, CI/skip-ios, CI/skip-windows-arm64, CI/skip-windows-x64, CI/skip-windows-x86 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
1. Go to the `Portfolio` page and select `ETH on Optimism`, it should load `ETH on Optimism` on the asset details page.
2. Go to the `Portfolio` page and select `ETH on Aurora`, it should load `ETH on Aurora` on the asset details page.
3. Open the `Panel` and click `View account assets`, select a token. It route correctly to the assets details page.

Before:

https://user-images.githubusercontent.com/40611140/224129440-bb09dcde-e3f7-44f9-b25b-9f7242d6efec.mov

After:

https://user-images.githubusercontent.com/40611140/224366650-35464e76-0915-4573-9a4a-e216b2781fb1.mov
