### PR TITLE
[Android] Fix Adblock settings are not selected under Shields (uplift to 1.49.x)

### DIFF
--- a/android/java/org/chromium/chrome/browser/preferences/website/BraveShieldsContentSettings.java
+++ b/android/java/org/chromium/chrome/browser/preferences/website/BraveShieldsContentSettings.java
@@ -97,7 +97,9 @@ public class BraveShieldsContentSettings {
             BraveShieldsContentSettingsJni.get().setCosmeticFilteringControlType(
                     DEFAULT.equals(settingOption) ? BLOCK_THIRDPARTY_RESOURCE : settingOption, host,
                     profile);
-            BraveShieldsContentSettingsJni.get().setAdControlType(settingOption, host, profile);
+            BraveShieldsContentSettingsJni.get().setAdControlType(
+                    BLOCK_THIRDPARTY_RESOURCE.equals(settingOption) ? DEFAULT : settingOption, host,
+                    profile);
         }
     }
 

--- a/android/java/org/chromium/chrome/browser/shields/BraveShieldsHandler.java
+++ b/android/java/org/chromium/chrome/browser/shields/BraveShieldsHandler.java
@@ -675,14 +675,25 @@ public class BraveShieldsHandler implements BraveRewardsHelper.LargeIconReadyCal
                     BraveShieldsContentSettings.getShieldsValue(mProfile, mHost, layout);
             if (settingOption.equals(BraveShieldsContentSettings.BLOCK_RESOURCE)) {
                 mBlockShieldsOption1.setChecked(true);
-            } else if (settingOption.equals(
-                               layout.equals(BraveShieldsContentSettings
-                                                     .RESOURCE_IDENTIFIER_FINGERPRINTING)
-                                       ? BraveShieldsContentSettings.DEFAULT
-                                       : BraveShieldsContentSettings.BLOCK_THIRDPARTY_RESOURCE)) {
-                mBlockShieldsOption2.setChecked(true);
             } else if (settingOption.equals(BraveShieldsContentSettings.ALLOW_RESOURCE)) {
                 mBlockShieldsOption3.setChecked(true);
+            } else {
+                boolean checkOption2 = false;
+                switch (layout) {
+                    case BraveShieldsContentSettings.RESOURCE_IDENTIFIER_TRACKERS:
+                        checkOption2 = settingOption.equals(BraveShieldsContentSettings.DEFAULT)
+                                || settingOption.equals(
+                                        BraveShieldsContentSettings.BLOCK_THIRDPARTY_RESOURCE);
+                        break;
+                    case BraveShieldsContentSettings.RESOURCE_IDENTIFIER_FINGERPRINTING:
+                        checkOption2 = settingOption.equals(BraveShieldsContentSettings.DEFAULT);
+                        break;
+                    case BraveShieldsContentSettings.RESOURCE_IDENTIFIER_COOKIES:
+                        checkOption2 = settingOption.equals(
+                                BraveShieldsContentSettings.BLOCK_THIRDPARTY_RESOURCE);
+                        break;
+                }
+                if (checkOption2) mBlockShieldsOption2.setChecked(true);
             }
 
             RadioGroup mBlockShieldsOptionGroup =


### PR DESCRIPTION
Uplift of #17543
Resolves brave/brave-browser/issues/28975

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.