### PR TITLE
fix: display 'unlimited' for max approval amount

### DIFF
--- a/components/brave_wallet_ui/common/hooks/use-pending-transaction.ts
+++ b/components/brave_wallet_ui/common/hooks/use-pending-transaction.ts
@@ -4,7 +4,7 @@
 // you can obtain one at https://mozilla.org/MPL/2.0/.
 
 import * as React from 'react'
-import { useDispatch, useSelector } from 'react-redux'
+import { useDispatch } from 'react-redux'
 import { create } from 'ethereum-blockies'
 
 // actions
@@ -23,31 +23,42 @@ import { useTransactionParser } from './transaction-parser'
 import usePricing from './pricing'
 import useTokenInfo from './token'
 import { useLib } from './useLib'
-import { useSafeWalletSelector } from './use-safe-selector'
+import { useSafeWalletSelector, useUnsafeWalletSelector } from './use-safe-selector'
 
 // Constants
-import { WalletState, BraveWallet } from '../../constants/types'
+import { BraveWallet } from '../../constants/types'
 import {
   UpdateUnapprovedTransactionGasFieldsType,
   UpdateUnapprovedTransactionNonceType
 } from '../constants/action_types'
 import { isSolanaTransaction, sortTransactionByDate } from '../../utils/tx-utils'
+import { MAX_UINT256 } from '../constants/magics'
 
 export const usePendingTransactions = () => {
   // redux
   const dispatch = useDispatch()
-  const {
-    accounts,
-    transactions,
-    selectedNetwork,
-    selectedPendingTransaction: transactionInfo,
-    userVisibleTokensInfo: visibleTokens,
-    transactionSpotPrices,
-    gasEstimates,
-    fullTokenList,
-    pendingTransactions,
-    defaultNetworks
-  } = useSelector((state: { wallet: WalletState }) => state.wallet)
+  const accounts = useUnsafeWalletSelector(WalletSelectors.accounts)
+  const transactions = useUnsafeWalletSelector(WalletSelectors.transactions)
+  const selectedNetwork = useUnsafeWalletSelector(
+    WalletSelectors.selectedNetwork
+  )
+  const transactionInfo = useUnsafeWalletSelector(
+    WalletSelectors.selectedPendingTransaction
+  )
+  const visibleTokens = useUnsafeWalletSelector(
+    WalletSelectors.userVisibleTokensInfo
+  )
+  const transactionSpotPrices = useUnsafeWalletSelector(
+    WalletSelectors.transactionSpotPrices
+  )
+  const gasEstimates = useUnsafeWalletSelector(WalletSelectors.gasEstimates)
+  const fullTokenList = useUnsafeWalletSelector(WalletSelectors.fullTokenList)
+  const pendingTransactions = useUnsafeWalletSelector(
+    WalletSelectors.pendingTransactions
+  )
+  const defaultNetworks = useUnsafeWalletSelector(
+    WalletSelectors.defaultNetworks
+  )
   const hasFeeEstimatesError = useSafeWalletSelector(
     WalletSelectors.hasFeeEstimatesError
   )
@@ -77,7 +88,9 @@ export const usePendingTransactions = () => {
     transactionGasEstimates?.fastMaxPriorityFeePerGas || '0'
   ])
   const [baseFeePerGas, setBaseFeePerGas] = React.useState<string>(transactionGasEstimates?.baseFeePerGas || '')
-  const [currentTokenAllowance, setCurrentTokenAllowance] = React.useState<string>('')
+  const [erc20AllowanceResult, setERC20AllowanceResult] = React.useState<
+    string | undefined
+  >(undefined)
 
   // computed state
   const transactionDetails = transactionInfo ? parseTransaction(transactionInfo) : undefined
@@ -206,6 +219,29 @@ export const usePendingTransactions = () => {
     )
   }, [transactionDetails, hasFeeEstimatesError, isLoadingGasFee])
 
+  const {
+    currentTokenAllowance,
+    isCurrentAllowanceUnlimited
+  } = React.useMemo(() => {
+    if (!transactionDetails || erc20AllowanceResult === undefined) {
+      return {
+        currentTokenAllowance: undefined,
+        isCurrentAllowanceUnlimited: false
+      }
+    }
+    
+    const currentTokenAllowance = new Amount(erc20AllowanceResult)
+      .divideByDecimals(transactionDetails.decimals)
+      .format()
+
+    const isCurrentAllowanceUnlimited = erc20AllowanceResult === MAX_UINT256
+
+    return {
+      currentTokenAllowance,
+      isCurrentAllowanceUnlimited
+    }
+  }, [erc20AllowanceResult])
+
   // effects
   React.useEffect(() => {
     const interval = setInterval(() => {
@@ -235,6 +271,7 @@ export const usePendingTransactions = () => {
   )
 
   React.useEffect(() => {
+    let subscribed = true
     if (transactionInfo?.txType !== BraveWallet.TransactionType.ERC20Approve) {
       return
     }
@@ -248,11 +285,13 @@ export const usePendingTransactions = () => {
       transactionDetails.sender,
       transactionDetails.approvalTarget
     ).then(result => {
-      const allowance = new Amount(result)
-        .divideByDecimals(transactionDetails.decimals)
-        .format()
-      setCurrentTokenAllowance(allowance)
+      subscribed && setERC20AllowanceResult(result)
     }).catch(e => console.error(e))
+
+    // cleanup
+    return () => {
+      subscribed = false
+    }
   }, [transactionInfo?.txType, transactionDetails, getERC20Allowance])
 
   React.useEffect(() => {
@@ -267,6 +306,7 @@ export const usePendingTransactions = () => {
   return {
     baseFeePerGas,
     currentTokenAllowance,
+    isCurrentAllowanceUnlimited,
     findAssetPrice,
     foundTokenInfoByContractAddress,
     fromAccountName,

--- a/components/brave_wallet_ui/components/desktop/portfolio-transaction-item/index.tsx
+++ b/components/brave_wallet_ui/components/desktop/portfolio-transaction-item/index.tsx
@@ -465,7 +465,11 @@ export const PortfolioTransactionItem = React.forwardRef<HTMLDivElement, Props>(
 
   // render
   return (
-    <PortfolioTransactionItemWrapper ref={forwardedRef} isFocused={isFocused} onClick={onHideTransactionPopup}>
+    <PortfolioTransactionItemWrapper
+      ref={forwardedRef}
+      isFocused={isFocused}
+      onClick={onHideTransactionPopup}
+    >
       <OrbAndTxDescriptionContainer>
         <OrbWrapper>
           <FromCircle orb={fromOrb} />
@@ -474,16 +478,16 @@ export const PortfolioTransactionItem = React.forwardRef<HTMLDivElement, Props>(
 
         <DetailColumn>
           <DetailRow>
-
             {/* Display account name only if rendered under Portfolio view */}
-            {displayAccountName && account?.name &&
+            {displayAccountName && account?.name && (
               <DetailTextLight>
-                {isLoadingAccountInfos
-                  ? <Skeleton {...skeletonProps} />
-                  : account.name
-                }
+                {isLoadingAccountInfos ? (
+                  <Skeleton {...skeletonProps} />
+                ) : (
+                  account.name
+                )}
               </DetailTextLight>
-            }
+            )}
 
             <DetailTextDark>{transactionActionLocale}</DetailTextDark>
             <DetailTextLight>-</DetailTextLight>
@@ -491,21 +495,22 @@ export const PortfolioTransactionItem = React.forwardRef<HTMLDivElement, Props>(
             <TransactionTimestampTooltip
               text={
                 <TransactionFeeTooltipBody>
-                  {serializedTimeDeltaToJSDate(transaction.createdTime).toUTCString()}
+                  {serializedTimeDeltaToJSDate(
+                    transaction.createdTime
+                  ).toUTCString()}
                 </TransactionFeeTooltipBody>
               }
             >
               <DetailTextDarkBold>
-                {formatDateAsRelative(serializedTimeDeltaToJSDate(transaction.createdTime))}
+                {formatDateAsRelative(
+                  serializedTimeDeltaToJSDate(transaction.createdTime)
+                )}
               </DetailTextDarkBold>
             </TransactionTimestampTooltip>
-
           </DetailRow>
 
           {transactionIntentDescription}
-
         </DetailColumn>
-
       </OrbAndTxDescriptionContainer>
 
       <StatusBalanceAndMoreContainer>
@@ -519,35 +524,49 @@ export const PortfolioTransactionItem = React.forwardRef<HTMLDivElement, Props>(
         {/* Balance & more */}
         <DetailRow>
           <BalanceColumn>
-            <DetailTextDark>
-              {/* We need to return a Transaction Time Stamp to calculate Fiat value here */}
-              {(isLoadingTokenSpotPrice || isLoadingDefaultFiatCurrency)
-                ? <Skeleton {...skeletonProps} />
-                : formattedTransactionFiatValue || 'NOT FOUND!'
-              }
-            </DetailTextDark>
-            <DetailTextLight>{formattedSendCurrencyTotal}</DetailTextLight>
+            {transaction.txType !==
+              BraveWallet.TransactionType.ERC20Approve && (
+              <>
+                <DetailTextDark>
+                  {/*
+                    We need to return a Transaction Time Stamp
+                    to calculate Fiat value here
+                  */}
+                  {isLoadingTokenSpotPrice || isLoadingDefaultFiatCurrency ? (
+                    <Skeleton {...skeletonProps} />
+                  ) : (
+                    formattedTransactionFiatValue || 'NOT FOUND!'
+                  )}
+                </DetailTextDark>
+                <DetailTextLight>{formattedSendCurrencyTotal}</DetailTextLight>
+              </>
+            )}
           </BalanceColumn>
 
           {/* Will remove this conditional for solana once https://github.com/brave/brave-browser/issues/22040 is implemented. */}
-          {!isSolanaTransaction && !!txNetwork &&
+          {!isSolanaTransaction && !!txNetwork && (
             <TransactionFeesTooltip
               text={
                 <>
-                  <TransactionFeeTooltipTitle>{getLocale('braveWalletAllowSpendTransactionFee')}</TransactionFeeTooltipTitle>
+                  <TransactionFeeTooltipTitle>
+                    {getLocale('braveWalletAllowSpendTransactionFee')}
+                  </TransactionFeeTooltipTitle>
                   <TransactionFeeTooltipBody>
-                    {isLoadingAllNetworks
-                      ? <Skeleton {...skeletonProps} />
-                      : txNetwork && new Amount(transaction.gasFee)
-                          .divideByDecimals(txNetwork.decimals)
-                          .formatAsAsset(6, txNetwork.symbol)
-                    }
+                    {isLoadingAllNetworks ? (
+                      <Skeleton {...skeletonProps} />
+                    ) : (
+                      txNetwork &&
+                      new Amount(transaction.gasFee)
+                        .divideByDecimals(txNetwork.decimals)
+                        .formatAsAsset(6, txNetwork.symbol)
+                    )}
                   </TransactionFeeTooltipBody>
                   <TransactionFeeTooltipBody>
-                    {(isLoadingDefaultFiatCurrency || isLoadingGasAssetPrice)
-                      ? <Skeleton {...skeletonProps} />
-                      : formattedGasFeeFiatValue
-                    }
+                    {isLoadingDefaultFiatCurrency || isLoadingGasAssetPrice ? (
+                      <Skeleton {...skeletonProps} />
+                    ) : (
+                      formattedGasFeeFiatValue
+                    )}
                   </TransactionFeeTooltipBody>
                 </>
               }
@@ -556,23 +575,24 @@ export const PortfolioTransactionItem = React.forwardRef<HTMLDivElement, Props>(
                 <CoinsIcon />
               </CoinsButton>
             </TransactionFeesTooltip>
-          }
+          )}
 
-          {wasTxRejected
-            ? <MoreButton onClick={onShowTransactionPopup}>
+          {wasTxRejected ? (
+            <MoreButton onClick={onShowTransactionPopup}>
               <MoreIcon />
             </MoreButton>
-            : <RejectedTransactionSpacer />
-          }
+          ) : (
+            <RejectedTransactionSpacer />
+          )}
 
-          {showTransactionPopup &&
+          {showTransactionPopup && (
             <TransactionPopup>
               {[
                 BraveWallet.TransactionStatus.Approved,
                 BraveWallet.TransactionStatus.Submitted,
                 BraveWallet.TransactionStatus.Confirmed,
                 BraveWallet.TransactionStatus.Dropped
-              ].includes(transaction.status) &&
+              ].includes(transaction.status) && (
                 <>
                   <TransactionPopupItem
                     onClick={onClickViewOnBlockExplorer('tx', transaction.hash)}
@@ -583,39 +603,38 @@ export const PortfolioTransactionItem = React.forwardRef<HTMLDivElement, Props>(
                     text={getLocale('braveWalletTransactionCopyHash')}
                   />
                 </>
-              }
+              )}
 
               {[
                 BraveWallet.TransactionStatus.Submitted,
                 BraveWallet.TransactionStatus.Approved
               ].includes(transaction.status) &&
                 !isSolanaTransaction &&
-                !isFilecoinTransaction &&
-                <>
-                  <TransactionPopupItem
-                    onClick={onClickSpeedupTransaction}
-                    text={getLocale('braveWalletTransactionSpeedup')}
-                  />
-                  <TransactionPopupItem
-                    onClick={onClickCancelTransaction}
-                    text={getLocale('braveWalletTransactionCancel')}
-                  />
-                </>
-              }
+                !isFilecoinTransaction && (
+                  <>
+                    <TransactionPopupItem
+                      onClick={onClickSpeedupTransaction}
+                      text={getLocale('braveWalletTransactionSpeedup')}
+                    />
+                    <TransactionPopupItem
+                      onClick={onClickCancelTransaction}
+                      text={getLocale('braveWalletTransactionCancel')}
+                    />
+                  </>
+                )}
 
               {BraveWallet.TransactionStatus.Error === transaction.status &&
                 !isSolanaTransaction &&
-                !isFilecoinTransaction &&
-                <TransactionPopupItem
-                  onClick={onClickRetryTransaction}
-                  text={getLocale('braveWalletTransactionRetry')}
-                />
-              }
+                !isFilecoinTransaction && (
+                  <TransactionPopupItem
+                    onClick={onClickRetryTransaction}
+                    text={getLocale('braveWalletTransactionRetry')}
+                  />
+                )}
             </TransactionPopup>
-          }
+          )}
         </DetailRow>
       </StatusBalanceAndMoreContainer>
-
     </PortfolioTransactionItemWrapper>
   )
 }


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/23666

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-arm64, CI/skip-linux-x64, CI/skip-android, CI/skip-macos, CI/skip-ios, CI/skip-windows-arm64, CI/skip-windows-x64, CI/skip-windows-x86 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
It should instead read "Unlimited ". For any other amount less than MAX_UNINT256, it should rendered as usual.

Before:

https://user-images.githubusercontent.com/30185185/224166437-ba66a8cf-e679-4eba-b20a-a4943568b68e.mov

After:


https://user-images.githubusercontent.com/30185185/224170843-792f9efa-44c0-4d15-9c07-ef3ac52e6cd8.mov



