### PR TITLE
Add a flag to use fake UA for playlist

### DIFF
--- a/browser/about_flags.cc
+++ b/browser/about_flags.cc
@@ -254,15 +254,24 @@
                                  kCryptoWalletsForNewInstallsFeature),      \
       }))
 
-#define PLAYLIST_FEATURE_ENTRIES                                      \
-  IF_BUILDFLAG(ENABLE_PLAYLIST,                                       \
-               EXPAND_FEATURE_ENTRIES({                               \
-                   kPlaylistFeatureInternalName,                      \
-                   "Playlist",                                        \
-                   "Enables Playlist",                                \
-                   kOsMac | kOsWin | kOsLinux | kOsAndroid,           \
-                   FEATURE_VALUE_TYPE(playlist::features::kPlaylist), \
-               }))
+#define PLAYLIST_FEATURE_ENTRIES                                       \
+  IF_BUILDFLAG(                                                        \
+      ENABLE_PLAYLIST,                                                 \
+      EXPAND_FEATURE_ENTRIES(                                          \
+          {                                                            \
+              kPlaylistFeatureInternalName,                            \
+              "Playlist",                                              \
+              "Enables Playlist",                                      \
+              kOsMac | kOsWin | kOsLinux | kOsAndroid,                 \
+              FEATURE_VALUE_TYPE(playlist::features::kPlaylist),       \
+          },                                                           \
+          {                                                            \
+              kPlaylistFakeUAFeatureInternalName,                      \
+              "PlaylistFakeUA",                                        \
+              "Use fake UA for playlist",                              \
+              kOsMac | kOsWin | kOsLinux | kOsAndroid,                 \
+              FEATURE_VALUE_TYPE(playlist::features::kPlaylistFakeUA), \
+          }))
 
 #if !BUILDFLAG(IS_ANDROID)
 #define BRAVE_COMMANDS_FEATURE_ENTRIES                                        \

--- a/browser/about_flags.cc
+++ b/browser/about_flags.cc
@@ -340,11 +340,14 @@
 #endif  // BUILDFLAG(IS_ANDROID)
 
 #if !BUILDFLAG(IS_ANDROID)
-#define BRAVE_SHARED_PINNED_TABS                                            \
-  EXPAND_FEATURE_ENTRIES(                                                   \
-      {"brave-shared-pinned-tabs", "Shared pinned tab",                     \
-       "Pinned tabs are shared across windows", kOsWin | kOsMac | kOsLinux, \
-       FEATURE_VALUE_TYPE(tabs::features::kBraveSharedPinnedTabs)}),
+#define BRAVE_SHARED_PINNED_TABS                                  \
+  EXPAND_FEATURE_ENTRIES({                                        \
+      "brave-shared-pinned-tabs",                                 \
+      "Shared pinned tab",                                        \
+      "Pinned tabs are shared across windows",                    \
+      kOsWin | kOsMac | kOsLinux,                                 \
+      FEATURE_VALUE_TYPE(tabs::features::kBraveSharedPinnedTabs), \
+  })
 #else
 #define BRAVE_SHARED_PINNED_TABS
 #endif

--- a/browser/about_flags.cc
+++ b/browser/about_flags.cc
@@ -340,10 +340,11 @@
 #endif  // BUILDFLAG(IS_ANDROID)
 
 #if !BUILDFLAG(IS_ANDROID)
-#define BRAVE_SHARED_PINNED_TABS                                        \
-  {"brave-shared-pinned-tabs", "Shared pinned tab",                     \
-   "Pinned tabs are shared across windows", kOsWin | kOsMac | kOsLinux, \
-   FEATURE_VALUE_TYPE(tabs::features::kBraveSharedPinnedTabs)},
+#define BRAVE_SHARED_PINNED_TABS                                            \
+  EXPAND_FEATURE_ENTRIES(                                                   \
+      {"brave-shared-pinned-tabs", "Shared pinned tab",                     \
+       "Pinned tabs are shared across windows", kOsWin | kOsMac | kOsLinux, \
+       FEATURE_VALUE_TYPE(tabs::features::kBraveSharedPinnedTabs)}),
 #else
 #define BRAVE_SHARED_PINNED_TABS
 #endif

--- a/browser/brave_features_internal_names.h
+++ b/browser/brave_features_internal_names.h
@@ -10,6 +10,7 @@
 #include "build/build_config.h"
 
 constexpr char kPlaylistFeatureInternalName[] = "playlist";
+constexpr char kPlaylistFakeUAFeatureInternalName[] = "playlist-fake-ua";
 #if BUILDFLAG(ENABLE_BRAVE_VPN)
 constexpr char kBraveVPNFeatureInternalName[] = "brave-vpn";
 #if BUILDFLAG(IS_WIN)

--- a/browser/playlist/test/playlist_download_request_manager_browsertests.cc
+++ b/browser/playlist/test/playlist_download_request_manager_browsertests.cc
@@ -7,6 +7,7 @@
 
 #include "base/ranges/algorithm.h"
 #include "brave/components/playlist/browser/media_detector_component_manager.h"
+#include "brave/components/playlist/common/features.h"
 #include "brave/components/playlist/common/mojom/playlist.mojom.h"
 #include "chrome/browser/profiles/profile.h"
 #include "chrome/common/chrome_isolated_world_ids.h"
@@ -295,4 +296,26 @@ IN_PROC_BROWSER_TEST_F(PlaylistDownloadRequestManagerBrowserTest,
 
   ASSERT_EQ(net::SchemefulSite(GURL("https://m.youtube.com")),
             net::SchemefulSite(https_server()->GetURL("m.youtube.com", "/")));
+}
+
+class PlaylistDownloadRequestManagerWithFakeUABrowserTest
+    : public PlaylistDownloadRequestManagerBrowserTest {
+ public:
+  PlaylistDownloadRequestManagerWithFakeUABrowserTest()
+      : scoped_feature_list_(playlist::features::kPlaylistFakeUA) {}
+  ~PlaylistDownloadRequestManagerWithFakeUABrowserTest() override = default;
+
+ private:
+  base::test::ScopedFeatureList scoped_feature_list_;
+};
+
+IN_PROC_BROWSER_TEST_F(PlaylistDownloadRequestManagerWithFakeUABrowserTest,
+                       FakeUAStringContainsIPhone) {
+  const auto user_agent_string = request_manager()
+                                     ->GetBackgroundWebContentsForTesting()
+                                     ->GetUserAgentOverride()
+                                     .ua_string_override;
+
+  EXPECT_TRUE(base::Contains(user_agent_string, "iPhone"));
+  EXPECT_FALSE(base::Contains(user_agent_string, "Chrome"));
 }

--- a/browser/playlist/test/playlist_render_frame_observer_browsertest.cc
+++ b/browser/playlist/test/playlist_render_frame_observer_browsertest.cc
@@ -67,9 +67,9 @@ class PlaylistRenderFrameObserverBrowserTest : public PlatformBrowserTest {
 
     // Instead, we should download contents on backgrounds when we should hide
     // the API.
-    EXPECT_EQ(
-        visibility == APIVisibility::kHidden,
-        playlist_service->ShouldDownloadOnBackground(active_web_contents));
+    EXPECT_EQ(visibility == APIVisibility::kHidden,
+              playlist_service->ShouldGetMediaFromBackgroundWebContents(
+                  active_web_contents));
 
     // Then, the WebContents used for background download always hides the API.
     auto* background_web_contents = playlist_service->download_request_manager_

--- a/browser/playlist/test/playlist_service_unittest.cc
+++ b/browser/playlist/test/playlist_service_unittest.cc
@@ -1340,4 +1340,22 @@ TEST_F(PlaylistServiceUnitTest, CleanUpOrphanedPlaylistItemDirs) {
       service->GetPlaylistItemDirPath(item.id)));
 }
 
+class PlaylistServiceWithFakeUAUnitTest : public PlaylistServiceUnitTest {
+ public:
+  PlaylistServiceWithFakeUAUnitTest()
+      : scoped_feature_list_(playlist::features::kPlaylistFakeUA) {}
+  ~PlaylistServiceWithFakeUAUnitTest() override = default;
+
+ private:
+  base::test::ScopedFeatureList scoped_feature_list_;
+};
+
+TEST_F(PlaylistServiceWithFakeUAUnitTest,
+       ShouldAlwaysGetMediaFromBackgroundWebContents) {
+  // When this flag is enabled, we should get videos from background web
+  // contents regardless of web contents' state, such as URL.
+  EXPECT_TRUE(
+      playlist_service()->ShouldGetMediaFromBackgroundWebContents(nullptr));
+}
+
 }  // namespace playlist

--- a/chromium_src/chrome/browser/unexpire_flags.cc
+++ b/chromium_src/chrome/browser/unexpire_flags.cc
@@ -21,8 +21,10 @@ bool IsFlagExpired(const flags_ui::FlagsStorage* storage,
   version_info::Channel channel = chrome::GetChannel();
 
   // Enable playlist feature only for nightly/development.
-  if (base::EqualsCaseInsensitiveASCII(kPlaylistFeatureInternalName,
-                                       internal_name) &&
+  if ((base::EqualsCaseInsensitiveASCII(kPlaylistFeatureInternalName,
+                                        internal_name) ||
+       base::EqualsCaseInsensitiveASCII(kPlaylistFakeUAFeatureInternalName,
+                                        internal_name)) &&
       (channel == version_info::Channel::STABLE ||
        channel == version_info::Channel::BETA)) {
     return true;

--- a/components/playlist/browser/DEPS
+++ b/components/playlist/browser/DEPS
@@ -8,7 +8,6 @@ include_rules = [
   "+content/public/common",
   "+services/network/public/cpp",
   "+services/preferences/public/cpp",
-  "+third_party/blink/public/common/web_preferences",
-  "+third_party/blink/public/common/user_agent",
+  "+third_party/blink/public/common",
   "+third_party/re2",
 ]

--- a/components/playlist/browser/DEPS
+++ b/components/playlist/browser/DEPS
@@ -9,5 +9,6 @@ include_rules = [
   "+services/network/public/cpp",
   "+services/preferences/public/cpp",
   "+third_party/blink/public/common/web_preferences",
+  "+third_party/blink/public/common/user_agent",
   "+third_party/re2",
 ]

--- a/components/playlist/browser/playlist_download_request_manager.cc
+++ b/components/playlist/browser/playlist_download_request_manager.cc
@@ -13,12 +13,14 @@
 #include "base/strings/utf_string_conversions.h"
 #include "base/time/time.h"
 #include "base/timer/timer.h"
+#include "brave/components/playlist/common/features.h"
 #include "content/public/browser/navigation_controller.h"
 #include "content/public/browser/navigation_handle.h"
 #include "content/public/browser/render_frame_host.h"
 #include "content/public/browser/web_contents.h"
 #include "content/public/common/isolated_world_ids.h"
 #include "net/base/registry_controlled_domains/registry_controlled_domain.h"
+#include "third_party/blink/public/common/user_agent/user_agent_metadata.h"
 #include "third_party/blink/public/common/web_preferences/web_preferences.h"
 #include "third_party/re2/src/re2/re2.h"
 #include "ui/base/page_transition_types.h"
@@ -67,6 +69,16 @@ void PlaylistDownloadRequestManager::CreateWebContents() {
 
   content::WebContents::CreateParams create_params(context_, nullptr);
   web_contents_ = content::WebContents::Create(create_params);
+  if (base::FeatureList::IsEnabled(features::kPlaylistFakeUA)) {
+    blink::UserAgentOverride user_agent(
+        "Mozilla/5.0 (iPhone; CPU iPhone OS 13_2_3 like Mac OS X) "
+        "AppleWebKit/605.1.15 (KHTML, like Gecko) Version/13.0.3 "
+        "Mobile/15E148 "
+        "Safari/604.1",
+        /* user_agent_metadata */ {});
+    web_contents_->SetUserAgentOverride(user_agent,
+                                        /* override_in_new_tabs= */ true);
+  }
 
   Observe(web_contents_.get());
 }

--- a/components/playlist/browser/playlist_service.h
+++ b/components/playlist/browser/playlist_service.h
@@ -183,6 +183,8 @@ class PlaylistService : public KeyedService,
   FRIEND_TEST_ALL_PREFIXES(PlaylistServiceUnitTest, ResetAll);
   FRIEND_TEST_ALL_PREFIXES(PlaylistServiceUnitTest,
                            CleanUpOrphanedPlaylistItemDirs);
+  FRIEND_TEST_ALL_PREFIXES(PlaylistServiceWithFakeUAUnitTest,
+                           ShouldAlwaysGetMediaFromBackgroundWebContents);
 
   void AddObserverForTest(PlaylistServiceObserver* observer);
   void RemoveObserverForTest(PlaylistServiceObserver* observer);
@@ -207,7 +209,10 @@ class PlaylistService : public KeyedService,
   void OnThumbnailDownloaded(const std::string& id,
                              const base::FilePath& path) override;
 
-  bool ShouldDownloadOnBackground(content::WebContents* contents) const;
+  // Returns true when we should try getting media from a background web
+  // contents that is different from the given |contents|.
+  bool ShouldGetMediaFromBackgroundWebContents(
+      content::WebContents* contents) const;
 
   std::vector<mojom::PlaylistItemPtr> GetAllPlaylistItems();
   mojom::PlaylistItemPtr GetPlaylistItem(const std::string& id);

--- a/components/playlist/common/features.cc
+++ b/components/playlist/common/features.cc
@@ -13,7 +13,7 @@ namespace playlist::features {
 BASE_FEATURE(kPlaylist, "Playlist", base::FEATURE_DISABLED_BY_DEFAULT);
 
 BASE_FEATURE(kPlaylistFakeUA,
-             "Playlist Fake UA",
+             "PlaylistFakeUA",
              base::FEATURE_DISABLED_BY_DEFAULT);
 
 }  // namespace playlist::features

--- a/components/playlist/common/features.cc
+++ b/components/playlist/common/features.cc
@@ -12,4 +12,8 @@ namespace playlist::features {
 
 BASE_FEATURE(kPlaylist, "Playlist", base::FEATURE_DISABLED_BY_DEFAULT);
 
+BASE_FEATURE(kPlaylistFakeUA,
+             "Playlist Fake UA",
+             base::FEATURE_DISABLED_BY_DEFAULT);
+
 }  // namespace playlist::features

--- a/components/playlist/common/features.h
+++ b/components/playlist/common/features.h
@@ -12,6 +12,8 @@ namespace playlist::features {
 
 BASE_DECLARE_FEATURE(kPlaylist);
 
+BASE_DECLARE_FEATURE(kPlaylistFakeUA);
+
 }  // namespace playlist::features
 
 #endif  // BRAVE_COMPONENTS_PLAYLIST_COMMON_FEATURES_H_


### PR DESCRIPTION
When this flag is enabled, playlist will try getting video URL with fake UA, which is the same UA with iOS Safari. Sites tend to give us downloadable URL when we have iOS Safari's UA string.

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/29006

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-arm64, CI/skip-linux-x64, CI/skip-android, CI/skip-macos, CI/skip-ios, CI/skip-windows-arm64, CI/skip-windows-x64, CI/skip-windows-x86 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [ ] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
PlaylistServiceWithFakeUAUnitTest.ShouldAlwaysGetMediaFromBackgroundWebContents
PlaylistDownloadRequestManagerWithFakeUABrowserTest.FakeUAStringContainsIPhone
