### PR TITLE
Launch what's new page at major version update

### DIFF
--- a/browser/brave_local_state_prefs.cc
+++ b/browser/brave_local_state_prefs.cc
@@ -46,6 +46,7 @@
 
 #if !BUILDFLAG(IS_ANDROID)
 #include "brave/browser/p3a/p3a_core_metrics.h"
+#include "brave/browser/ui/whats_new/whats_new_util.h"
 #include "chrome/browser/first_run/first_run.h"
 #endif  // !BUILDFLAG(IS_ANDROID)
 
@@ -107,6 +108,7 @@ void RegisterLocalStatePrefs(PrefRegistrySimple* registry) {
   BraveWindowTracker::RegisterPrefs(registry);
   BraveUptimeTracker::RegisterPrefs(registry);
   dark_mode::RegisterBraveDarkModeLocalStatePrefs(registry);
+  whats_new::RegisterLocalStatePrefs(registry);
 #endif
 
 #if BUILDFLAG(ENABLE_CRASH_DIALOG)

--- a/browser/ui/BUILD.gn
+++ b/browser/ui/BUILD.gn
@@ -176,6 +176,9 @@ source_set("ui") {
       "webui/welcome_page/brave_welcome_ui.h",
       "webui/welcome_page/welcome_dom_handler.cc",
       "webui/welcome_page/welcome_dom_handler.h",
+      "whats_new/pref_names.h",
+      "whats_new/whats_new_util.cc",
+      "whats_new/whats_new_util.h",
     ]
 
     if (enable_pin_shortcut) {

--- a/browser/ui/whats_new/BUILD.gn
+++ b/browser/ui/whats_new/BUILD.gn
@@ -1,0 +1,37 @@
+# Copyright (c) 2023 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+
+assert(!is_android)
+
+source_set("browser_test") {
+  testonly = true
+  defines = [ "HAS_OUT_OF_PROC_TEST_RUNNER" ]
+
+  sources = [ "whats_new_browsertest.cc" ]
+
+  deps = [
+    "//brave/components/l10n/common",
+    "//brave/components/l10n/common:test_support",
+    "//chrome/browser:browser_process",
+    "//chrome/browser/ui",
+    "//chrome/test:test_support_ui",
+    "//components/prefs",
+  ]
+}
+
+source_set("unit_test") {
+  testonly = true
+
+  sources = [ "whats_new_unittest.cc" ]
+
+  deps = [
+    "//base",
+    "//brave/components/l10n/common:test_support",
+    "//chrome/browser/ui",
+    "//components/prefs",
+    "//components/prefs:test_support",
+    "//testing/gtest",
+  ]
+}

--- a/browser/ui/whats_new/pref_names.h
+++ b/browser/ui/whats_new/pref_names.h
@@ -1,0 +1,17 @@
+/* Copyright (c) 2023 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_BROWSER_UI_WHATS_NEW_PREF_NAMES_H_
+#define BRAVE_BROWSER_UI_WHATS_NEW_PREF_NAMES_H_
+
+namespace whats_new::prefs {
+
+// Store lastly shown whats-new version - major version.
+// Ex, "1.50" means browser launched whats-new page for v1.50 update already.
+constexpr char kWhatsNewLastVersion[] = "brave.whats_new.last_version";
+
+}  // namespace whats_new::prefs
+
+#endif  // BRAVE_BROWSER_UI_WHATS_NEW_PREF_NAMES_H_

--- a/browser/ui/whats_new/whats_new_browsertest.cc
+++ b/browser/ui/whats_new/whats_new_browsertest.cc
@@ -1,0 +1,74 @@
+/* Copyright (c) 2023 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "base/command_line.h"
+#include "base/metrics/field_trial.h"
+#include "base/metrics/field_trial_param_associator.h"
+#include "brave/browser/ui/whats_new/pref_names.h"
+#include "brave/browser/ui/whats_new/whats_new_util.h"
+#include "brave/components/l10n/common/test/scoped_default_locale.h"
+#include "chrome/browser/browser_process.h"
+#include "chrome/browser/ui/browser.h"
+#include "chrome/browser/ui/tabs/tab_strip_model.h"
+#include "chrome/test/base/in_process_browser_test.h"
+#include "components/prefs/pref_service.h"
+#include "content/public/browser/web_contents.h"
+#include "content/public/test/browser_test.h"
+
+namespace whats_new {
+
+class BraveWhatsNewBrowserTest : public InProcessBrowserTest {
+ public:
+  BraveWhatsNewBrowserTest() {
+    scoped_default_locale_ =
+        std::make_unique<brave_l10n::test::ScopedDefaultLocale>("en_US");
+    PrepareValidFieldTrialParams();
+    SetCurrentVersionForTesting(1.51);
+
+    // To disable tab presets for startup.
+    // When preset tabs are used, whats-new page is not launched.
+    set_open_about_blank_on_browser_launch(false);
+  }
+
+  ~BraveWhatsNewBrowserTest() override = default;
+
+  void PrepareValidFieldTrialParams() {
+    constexpr char kWhatsNewTrial[] = "WhatsNewStudy";
+    std::map<std::string, std::string> params;
+    params["target_major_version"] = "1.51";
+    ASSERT_TRUE(
+        base::AssociateFieldTrialParams(kWhatsNewTrial, "Enabled", params));
+    base::FieldTrialList::CreateFieldTrial(kWhatsNewTrial, "Enabled");
+  }
+
+  TabStripModel* tab_model() const { return browser()->tab_strip_model(); }
+  PrefService* local_state() const { return g_browser_process->local_state(); }
+
+  std::unique_ptr<brave_l10n::test::ScopedDefaultLocale> scoped_default_locale_;
+};
+
+IN_PROC_BROWSER_TEST_F(BraveWhatsNewBrowserTest, PRE_WhatsNewPageLaunchTest) {
+  // Whats-new page is not shown with onboarding page together.
+  // It's upstream logic - see the comments of
+  // StartupBrowserCreatorImpl::DetermineStartupTabs().
+  EXPECT_EQ(1, tab_model()->count());
+  EXPECT_EQ(GURL(" chrome://welcome/"),
+            tab_model()->GetActiveWebContents()->GetVisibleURL());
+
+  // In production, fresh user doesn't see whats-new for that version.
+  // For testing purpose, clear cache to test whether whats-new is launched in
+  // another launch.
+  local_state()->SetDouble(prefs::kWhatsNewLastVersion, 0);
+}
+
+IN_PROC_BROWSER_TEST_F(BraveWhatsNewBrowserTest, WhatsNewPageLaunchTest) {
+  // Two tabs - first one is whats-new and another one is welcome
+  EXPECT_EQ(2, tab_model()->count());
+  EXPECT_EQ(GURL("https://brave.com/whats-new/"),
+            tab_model()->GetActiveWebContents()->GetVisibleURL());
+  EXPECT_EQ(1.51, local_state()->GetDouble(prefs::kWhatsNewLastVersion));
+}
+
+}  // namespace whats_new

--- a/browser/ui/whats_new/whats_new_unittest.cc
+++ b/browser/ui/whats_new/whats_new_unittest.cc
@@ -1,0 +1,115 @@
+/* Copyright (c) 2023 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "base/metrics/field_trial.h"
+#include "base/metrics/field_trial_param_associator.h"
+#include "brave/browser/ui/whats_new/pref_names.h"
+#include "brave/browser/ui/whats_new/whats_new_util.h"
+#include "brave/components/l10n/common/test/scoped_default_locale.h"
+#include "components/prefs/testing_pref_service.h"
+#include "testing/gtest/include/gtest/gtest.h"
+
+namespace whats_new {
+
+namespace {
+
+constexpr char kWhatsNewTrial[] = "WhatsNewStudy";
+
+}  // namespace
+
+class BraveWhatsNewTest : public testing::Test {
+ public:
+  BraveWhatsNewTest() = default;
+  ~BraveWhatsNewTest() override = default;
+
+  void SetUp() override {
+    RegisterLocalStatePrefs(local_state_.registry());
+    PrepareValidFieldTrialParams();
+  }
+
+  void PrepareValidFieldTrialParams() {
+    std::map<std::string, std::string> params;
+    params["target_major_version"] = "1.51";
+    ASSERT_TRUE(
+        base::AssociateFieldTrialParams(kWhatsNewTrial, "Enabled", params));
+  }
+
+  TestingPrefServiceSimple local_state_;
+};
+
+TEST_F(BraveWhatsNewTest, SupportedLangTest) {
+  // Prepare all other factors to show brave whats-new except lang.
+  // Set current version with field trial's target major version(1.51)
+  SetCurrentVersionForTesting(1.51);
+  base::FieldTrialList::CreateFieldTrial(kWhatsNewTrial, "Enabled");
+
+  // Italy is not supported yet.
+  {
+    const brave_l10n::test::ScopedDefaultLocale scoped_default_locale("it_IT");
+    EXPECT_FALSE(ShouldShowBraveWhatsNewForState(&local_state_));
+  }
+
+  // South korea is supported.
+  {
+    const brave_l10n::test::ScopedDefaultLocale scoped_default_locale("ko_KR");
+    EXPECT_TRUE(ShouldShowBraveWhatsNewForState(&local_state_));
+  }
+}
+
+// Test when field trial is not available.
+// base::FieldTrialList::CreateFieldTrial(kWhatsNewTrial, "Enabled") is not
+// called.
+TEST_F(BraveWhatsNewTest, FieldTrialNotAvailableTest) {
+  // Set supported lang.
+  const brave_l10n::test::ScopedDefaultLocale scoped_default_locale("en_US");
+
+  // Set current version with field trial's target major version(1.51)
+  SetCurrentVersionForTesting(1.51);
+
+  EXPECT_FALSE(ShouldShowBraveWhatsNewForState(&local_state_));
+}
+
+// Test when current version and target version is matched.
+TEST_F(BraveWhatsNewTest, MatchedCurrentVersionTest) {
+  // Set supported lang.
+  const brave_l10n::test::ScopedDefaultLocale scoped_default_locale("en_US");
+
+  // Set current version with field trial's target major version(1.51)
+  SetCurrentVersionForTesting(1.51);
+  base::FieldTrialList::CreateFieldTrial(kWhatsNewTrial, "Enabled");
+
+  EXPECT_NE(1.51, local_state_.GetDouble(prefs::kWhatsNewLastVersion));
+  EXPECT_TRUE(ShouldShowBraveWhatsNewForState(&local_state_));
+  EXPECT_EQ(1.51, local_state_.GetDouble(prefs::kWhatsNewLastVersion));
+}
+
+// Test when current version and target version is not matched.
+TEST_F(BraveWhatsNewTest, NotMatchedCurrentVersionTest) {
+  // Set supported lang.
+  const brave_l10n::test::ScopedDefaultLocale scoped_default_locale("en_US");
+
+  // Set different version as current version. field trial's target major
+  // version is 1.51
+  SetCurrentVersionForTesting(1.52);
+  base::FieldTrialList::CreateFieldTrial(kWhatsNewTrial, "Enabled");
+
+  EXPECT_FALSE(ShouldShowBraveWhatsNewForState(&local_state_));
+}
+
+// Test whats-new is already shown by setting 1.51 to prefs in advance.
+TEST_F(BraveWhatsNewTest, NotWhatsNewIsAlreadyShown) {
+  // Set supported lang.
+  const brave_l10n::test::ScopedDefaultLocale scoped_default_locale("en_US");
+
+  // Set different version as current version. field trial's target major
+  // version is 1.51
+  SetCurrentVersionForTesting(1.51);
+  base::FieldTrialList::CreateFieldTrial(kWhatsNewTrial, "Enabled");
+
+  local_state_.SetDouble(prefs::kWhatsNewLastVersion, 1.51);
+  EXPECT_FALSE(ShouldShowBraveWhatsNewForState(&local_state_));
+}
+
+}  // namespace whats_new

--- a/browser/ui/whats_new/whats_new_util.h
+++ b/browser/ui/whats_new/whats_new_util.h
@@ -1,0 +1,23 @@
+/* Copyright (c) 2023 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_BROWSER_UI_WHATS_NEW_WHATS_NEW_UTIL_H_
+#define BRAVE_BROWSER_UI_WHATS_NEW_WHATS_NEW_UTIL_H_
+
+class PrefRegistrySimple;
+class PrefService;
+class Browser;
+
+namespace whats_new {
+
+// Returns true when we want to show whats-new page in foreground tab.
+bool ShouldShowBraveWhatsNewForState(PrefService* local_state);
+void RegisterLocalStatePrefs(PrefRegistrySimple* registry);
+void StartBraveWhatsNew(Browser* browser);
+void SetCurrentVersionForTesting(double major_version);
+
+}  // namespace whats_new
+
+#endif  // BRAVE_BROWSER_UI_WHATS_NEW_WHATS_NEW_UTIL_H_

--- a/chromium_src/chrome/browser/ui/webui/whats_new/whats_new_util.cc
+++ b/chromium_src/chrome/browser/ui/webui/whats_new/whats_new_util.cc
@@ -1,0 +1,29 @@
+/* Copyright (c) 2023 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "chrome/browser/ui/webui/whats_new/whats_new_util.h"
+
+#include "brave/browser/ui/whats_new/whats_new_util.h"
+
+#define ShouldShowForState ShouldShowForState_UnUsed
+#define StartWhatsNewFetch StartWhatsNewFetch_UnUsed
+
+#include "src/chrome/browser/ui/webui/whats_new/whats_new_util.cc"
+
+#undef StartWhatsNewFetch
+#undef ShouldShowForState
+
+namespace whats_new {
+
+bool ShouldShowForState(PrefService* local_state,
+                        bool promotional_tabs_enabled) {
+  return ShouldShowBraveWhatsNewForState(local_state);
+}
+
+void StartWhatsNewFetch(Browser* browser) {
+  StartBraveWhatsNew(browser);
+}
+
+}  // namespace whats_new

--- a/test/BUILD.gn
+++ b/test/BUILD.gn
@@ -409,6 +409,7 @@ test("brave_unit_tests") {
       "//brave/browser/ui/color:unit_tests",
       "//brave/browser/ui/toolbar:brave_app_menu_unit_test",
       "//brave/browser/ui/webui/settings:unittests",
+      "//brave/browser/ui/whats_new:unit_test",
       "//brave/components/brave_shields/common:mojom",
       "//brave/components/brave_wallet/browser:pref_names",
       "//brave/components/brave_wallet/browser:utils",
@@ -1089,6 +1090,7 @@ test("brave_browser_tests") {
     sources += [ "//brave/browser/ui/views/toolbar/wallet_button_notification_source_browsertest.cc" ]
     deps += [
       "//brave/browser/sharing_hub:browser_tests",
+      "//brave/browser/ui/whats_new:browser_test",
       "//chrome/browser/apps/app_service:app_service",
       "//chrome/browser/apps/app_service:constants",
     ]


### PR DESCRIPTION
fix https://github.com/brave/brave-browser/issues/28947

If griffin's target version is same with browser's current version,
browser will load whats-new url in the first foreground tab once per major version up.

Griffin will provide `target_major_version` params - https://github.com/brave/brave-variations/blob/main/seed/seed.json#L1843

When `whats_new::ShouldShowBraveWhatsNewForState()` returns `true`,
`chrome://whats-new/` url is added to startup tabs list.
For that loading that url, browser runs `whats_new::StartBraveWhatsNew()`
instead of loading it directly. And `whats_new::StartBraveWhatsNew()` loads
https://www.brave.com/whats-new/ in foreground first tab.

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves 

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-arm64, CI/skip-linux-x64, CI/skip-android, CI/skip-macos, CI/skip-ios, CI/skip-windows-arm64, CI/skip-windows-x64, CI/skip-windows-x86 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

`BraveWhatsNewTest.*`
`BraveWhatsNewBrowserTest.*`

Manual test
1. Set current version as target version in griffin (ex, 1.51).
2. Install 1.50 or earlier and use it
3. Update to 1.51 and check whats-new url is loaded in the first tab afater launching.
   Note: Maybe need some relaunching to `1.51` as it need to get trial data from griffin