### PR TITLE
[json-schema-compiler] Support none as optional

### DIFF
--- a/components/brave_news/api/combined_feed.idl
+++ b/components/brave_news/api/combined_feed.idl
@@ -5,7 +5,7 @@
 
 // Schema types used by brave today feed.
 
-[generate_error_messages]
+[generate_error_messages, none_as_absent_optional]
 namespace combined_feed {
 
   // A dictionary with fields representing a feed item.

--- a/components/brave_news/api/publisher.idl
+++ b/components/brave_news/api/publisher.idl
@@ -5,7 +5,7 @@
 
 // Schema types used by brave today feed.
 
-[generate_error_messages]
+[generate_error_messages, none_as_absent_optional]
 namespace feed {
 
   // A dictionary with locale data

--- a/components/brave_news/browser/publishers_parsing_unittest.cc
+++ b/components/brave_news/browser/publishers_parsing_unittest.cc
@@ -62,4 +62,43 @@ TEST(BraveNewsPublisherParsing, ParsePublisherList) {
   ASSERT_FALSE(publisher_list->contains("444"));
 }
 
+TEST(BraveNewsPublisherParsing, PublisherListWithNoneValuesInOptionalFields) {
+  // Test that we parse expected remote publisher JSON
+  const char json[] = (R"(
+    [
+      {
+        "publisher_id": "111",
+        "publisher_name": "Test Publisher 1",
+        "category": "Tech",
+        "enabled": false,
+        "site_url": "https://one.example.com",
+        "feed_url": "https://one.example.com/feed"
+      },
+      {
+        "publisher_id": "222",
+        "publisher_name": "Test Publisher 2",
+        "category": "Sports",
+        "enabled": true,
+        "site_url": "https://two.example.com",
+        "feed_url": "https://two.example.com/feed",
+        "favicon_url": null,
+        "cover_url": null,
+        "background_color": null
+      },
+      {
+        "publisher_id": "333",
+        "publisher_name": "Test Publisher 3",
+        "category": "Design",
+        "enabled": true,
+        "site_url": "https://three.example.com",
+        "feed_url": "https://three.example.com/feed"
+      }
+    ]
+  )");
+  absl::optional<Publishers> publisher_list =
+      ParseCombinedPublisherList(base::test::ParseJson(json));
+  ASSERT_TRUE(publisher_list);
+  ASSERT_EQ(publisher_list->size(), 3UL);
+}
+
 }  // namespace brave_news

--- a/patches/tools-json_schema_compiler-cc_generator.py.patch
+++ b/patches/tools-json_schema_compiler-cc_generator.py.patch
@@ -1,0 +1,21 @@
+diff --git a/tools/json_schema_compiler/cc_generator.py b/tools/json_schema_compiler/cc_generator.py
+index e683040d95174b2f2b1a253b0b096c631ee3b64e..b8b4b313da2fac57fb8a8f24f75fd9c448fd4fd4 100644
+--- a/tools/json_schema_compiler/cc_generator.py
++++ b/tools/json_schema_compiler/cc_generator.py
+@@ -28,6 +28,7 @@ class _Generator(object):
+         util_cc_helper.UtilCCHelper(self._type_helper))
+     self._generate_error_messages = namespace.compiler_options.get(
+         'generate_error_messages', False)
++    self._none_as_absent_optional = namespace.compiler_options.get('none_as_absent_optional', False)
+ 
+   def Generate(self):
+     """Generates a Code object with the .cc for a single namespace.
+@@ -310,7 +311,7 @@ class _Generator(object):
+     c.Append('const base::Value* %(value_var)s = %(src)s.Find("%(key)s");')
+     if prop.optional:
+       (c.Sblock(
+-          'if (%(value_var)s) {')
++          'if ({var}{none_check}) {{'.format(var=value_var, none_check=('' if not self._none_as_absent_optional else ' && !{var}->is_none()'.format(var=value_var))))
+         .Concat(self._GeneratePopulatePropertyFromValue(
+             prop, '(*%s)' % value_var, dst, 'false')))
+       underlying_type = self._type_helper.FollowRef(prop.type_)

--- a/patches/tools-json_schema_compiler-idl_schema.py.patch
+++ b/patches/tools-json_schema_compiler-idl_schema.py.patch
@@ -1,0 +1,13 @@
+diff --git a/tools/json_schema_compiler/idl_schema.py b/tools/json_schema_compiler/idl_schema.py
+index 7491d25ab2bf6afa662e3d066b1d59ea98b2d717..5110110152116ff1d6e7cd6a04df988b4b111e3e 100755
+--- a/tools/json_schema_compiler/idl_schema.py
++++ b/tools/json_schema_compiler/idl_schema.py
+@@ -555,6 +555,8 @@ class IDLSchema(object):
+           documentation_options['namespace'] = node.value
+         elif node.name == 'documented_in':
+           documentation_options['documented_in'] = node.value
++        elif node.name == 'none_as_absent_optional':
++          compiler_options['none_as_absent_optional'] = True
+         else:
+           continue
+       else:


### PR DESCRIPTION
The introduction of the schema compiler has broken brave news, as our server-side services in some cases provide absent fields with the `null` value in json, rather than just removing the key entirely, as it is the case with WebIDL, etc.

This PR adds support to `null` values as a form of absent field marker as well. This is is being guarded behind a namespace attribute, namely, [none_as_absent_optional], to make sure chromium codegen is not affected.

This is an interim solution, to fix the issue with the brave news feed, until the schema issue is fixed both server side, and additional changes on iOS are also made to accommodate for it.

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/29064

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-arm64, CI/skip-linux-x64, CI/skip-android, CI/skip-macos, CI/skip-ios, CI/skip-windows-arm64, CI/skip-windows-x64, CI/skip-windows-x86 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

