### PR TITLE
Use closest frame with filled WebContentSettingsClient instead of top frame. (uplift to 1.50.x)

### DIFF
--- a/browser/ephemeral_storage/blob_url_browsertest.cc
+++ b/browser/ephemeral_storage/blob_url_browsertest.cc
@@ -10,6 +10,7 @@
 #include "chrome/browser/ui/tabs/tab_enums.h"
 #include "chrome/browser/ui/tabs/tab_strip_model.h"
 #include "chrome/test/base/ui_test_utils.h"
+#include "content/public/common/content_switches.h"
 #include "content/public/common/url_constants.h"
 #include "content/public/test/browser_test.h"
 #include "content/public/test/browser_test_utils.h"
@@ -297,6 +298,22 @@ class BlobUrlPartitionEnabledBrowserTest : public BlobUrlBrowserTestBase {
 };
 
 IN_PROC_BROWSER_TEST_F(BlobUrlPartitionEnabledBrowserTest,
+                       BlobsArePartitioned) {
+  TestBlobsArePartitioned();
+}
+
+class BlobUrlPartitionEnabledWithoutSiteIsolationBrowserTest
+    : public BlobUrlPartitionEnabledBrowserTest {
+ public:
+  BlobUrlPartitionEnabledWithoutSiteIsolationBrowserTest() = default;
+
+  void SetUpCommandLine(base::CommandLine* command_line) override {
+    BlobUrlPartitionEnabledBrowserTest::SetUpCommandLine(command_line);
+    command_line->AppendSwitch(switches::kDisableSiteIsolation);
+  }
+};
+
+IN_PROC_BROWSER_TEST_F(BlobUrlPartitionEnabledWithoutSiteIsolationBrowserTest,
                        BlobsArePartitioned) {
   TestBlobsArePartitioned();
 }

--- a/chromium_src/chrome/renderer/worker_content_settings_client.cc
+++ b/chromium_src/chrome/renderer/worker_content_settings_client.cc
@@ -70,4 +70,8 @@ WorkerContentSettingsClient::GetEphemeralStorageOriginSync() {
           : blink::WebSecurityOrigin());
 }
 
+bool WorkerContentSettingsClient::HasContentSettingsRules() const {
+  return content_setting_rules_.get();
+}
+
 #include "src/chrome/renderer/worker_content_settings_client.cc"

--- a/chromium_src/chrome/renderer/worker_content_settings_client.h
+++ b/chromium_src/chrome/renderer/worker_content_settings_client.h
@@ -6,9 +6,10 @@
 #ifndef BRAVE_CHROMIUM_SRC_CHROME_RENDERER_WORKER_CONTENT_SETTINGS_CLIENT_H_
 #define BRAVE_CHROMIUM_SRC_CHROME_RENDERER_WORKER_CONTENT_SETTINGS_CLIENT_H_
 
-#define BRAVE_WORKER_CONTENT_SETTINGS_CLIENT_H         \
-  BraveFarblingLevel GetBraveFarblingLevel() override; \
-  blink::WebSecurityOrigin GetEphemeralStorageOriginSync() override;
+#define BRAVE_WORKER_CONTENT_SETTINGS_CLIENT_H                       \
+  BraveFarblingLevel GetBraveFarblingLevel() override;               \
+  blink::WebSecurityOrigin GetEphemeralStorageOriginSync() override; \
+  bool HasContentSettingsRules() const override;
 
 #include "src/chrome/renderer/worker_content_settings_client.h"  // IWYU pragma: export
 

--- a/chromium_src/components/content_settings/renderer/content_settings_agent_impl.cc
+++ b/chromium_src/components/content_settings/renderer/content_settings_agent_impl.cc
@@ -24,4 +24,8 @@ ContentSetting GetContentSettingFromRulesImpl(
   return GetContentSettingFromRules(rules, secondary_url);
 }
 
+bool ContentSettingsAgentImpl::HasContentSettingsRules() const {
+  return content_setting_rules_.get();
+}
+
 }  // namespace content_settings

--- a/chromium_src/components/content_settings/renderer/content_settings_agent_impl.h
+++ b/chromium_src/components/content_settings/renderer/content_settings_agent_impl.h
@@ -7,11 +7,12 @@
 #define BRAVE_CHROMIUM_SRC_COMPONENTS_CONTENT_SETTINGS_RENDERER_CONTENT_SETTINGS_AGENT_IMPL_H_
 
 #define BRAVE_CONTENT_SETTINGS_AGENT_IMPL_H_ \
-friend class BraveContentSettingsAgentImpl;
+  friend class BraveContentSettingsAgentImpl;
 
 #define IsAllowlistedForContentSettings                                     \
   IsAllowlistedForContentSettings(const blink::WebSecurityOrigin& origin,   \
                                   const blink::WebURL& document_url) const; \
+  bool HasContentSettingsRules() const override;                            \
   bool IsAllowlistedForContentSettings
 
 #include "src/components/content_settings/renderer/content_settings_agent_impl.h"  // IWYU pragma: export

--- a/chromium_src/third_party/blink/public/platform/web_content_settings_client.h
+++ b/chromium_src/third_party/blink/public/platform/web_content_settings_client.h
@@ -11,19 +11,28 @@
 
 class GURL;
 
-#define AllowStorageAccessSync                                               \
-  AllowAutoplay(bool play_requested) { return true; }                        \
-  virtual bool IsCosmeticFilteringEnabled(const GURL& url) { return false; } \
-  virtual bool IsFirstPartyCosmeticFilteringEnabled(const GURL& url) {       \
-    return false;                                                            \
-  }                                                                          \
-  virtual BraveFarblingLevel GetBraveFarblingLevel() {                       \
-    return BraveFarblingLevel::OFF;                                          \
-  }                                                                          \
-  virtual bool IsReduceLanguageEnabled() { return false; }                   \
-  virtual blink::WebSecurityOrigin GetEphemeralStorageOriginSync() {         \
-    return blink::WebSecurityOrigin();                                       \
-  }                                                                          \
+#define AllowStorageAccessSync                                         \
+  AllowAutoplay(bool play_requested) {                                 \
+    return true;                                                       \
+  }                                                                    \
+  virtual bool IsCosmeticFilteringEnabled(const GURL& url) {           \
+    return false;                                                      \
+  }                                                                    \
+  virtual bool IsFirstPartyCosmeticFilteringEnabled(const GURL& url) { \
+    return false;                                                      \
+  }                                                                    \
+  virtual BraveFarblingLevel GetBraveFarblingLevel() {                 \
+    return BraveFarblingLevel::OFF;                                    \
+  }                                                                    \
+  virtual bool IsReduceLanguageEnabled() {                             \
+    return false;                                                      \
+  }                                                                    \
+  virtual blink::WebSecurityOrigin GetEphemeralStorageOriginSync() {   \
+    return blink::WebSecurityOrigin();                                 \
+  }                                                                    \
+  virtual bool HasContentSettingsRules() const {                       \
+    return false;                                                      \
+  }                                                                    \
   virtual bool AllowStorageAccessSync
 
 #include "src/third_party/blink/public/platform/web_content_settings_client.h"  // IWYU pragma: export

--- a/third_party/blink/renderer/core/farbling/brave_session_cache.cc
+++ b/third_party/blink/renderer/core/farbling/brave_session_cache.cc
@@ -8,7 +8,6 @@
 #include "base/command_line.h"
 #include "base/feature_list.h"
 #include "base/numerics/safe_conversions.h"
-#include "base/sequence_checker.h"
 #include "base/strings/string_number_conversions.h"
 #include "brave/third_party/blink/renderer/brave_farbling_constants.h"
 #include "brave/third_party/blink/renderer/brave_font_whitelist.h"
@@ -16,16 +15,11 @@
 #include "crypto/hmac.h"
 #include "third_party/blink/public/common/features.h"
 #include "third_party/blink/public/platform/web_content_settings_client.h"
-#include "third_party/blink/renderer/core/dom/document.h"
 #include "third_party/blink/renderer/core/execution_context/execution_context.h"
 #include "third_party/blink/renderer/core/frame/local_dom_window.h"
 #include "third_party/blink/renderer/core/frame/local_frame.h"
-#include "third_party/blink/renderer/core/workers/worker_global_scope.h"
-#include "third_party/blink/renderer/platform/bindings/script_state.h"
+#include "third_party/blink/renderer/core/workers/worker_or_worklet_global_scope.h"
 #include "third_party/blink/renderer/platform/fonts/font_fallback_list.h"
-#include "third_party/blink/renderer/platform/graphics/image_data_buffer.h"
-#include "third_party/blink/renderer/platform/graphics/static_bitmap_image.h"
-#include "third_party/blink/renderer/platform/graphics/unaccelerated_static_bitmap_image.h"
 #include "third_party/blink/renderer/platform/heap/garbage_collected.h"
 #include "third_party/blink/renderer/platform/language.h"
 #include "third_party/blink/renderer/platform/network/network_utils.h"
@@ -61,7 +55,8 @@ const char kLettersForRandomStrings[] =
 const size_t kLettersForRandomStringsLength = 64;
 
 blink::WebContentSettingsClient* GetContentSettingsClientFor(
-    ExecutionContext* context) {
+    ExecutionContext* context,
+    bool require_filled_content_settings_rules) {
   blink::WebContentSettingsClient* settings = nullptr;
   if (!context)
     return settings;
@@ -73,19 +68,30 @@ blink::WebContentSettingsClient* GetContentSettingsClientFor(
   }
   if (auto* window = blink::DynamicTo<blink::LocalDOMWindow>(context)) {
     auto* local_frame = window->GetFrame();
-    if (!local_frame)
+    if (!local_frame) {
       local_frame = window->GetDisconnectedFrame();
-    if (local_frame) {
-      if (auto* top_local_frame =
-              blink::DynamicTo<blink::LocalFrame>(&local_frame->Tree().Top())) {
-        settings = top_local_frame->GetContentSettingsClient();
-      } else {
-        settings = local_frame->GetContentSettingsClient();
-      }
     }
-  } else if (context->IsWorkerGlobalScope()) {
-    settings =
-        blink::To<blink::WorkerGlobalScope>(context)->ContentSettingsClient();
+    while (local_frame) {
+      settings = local_frame->GetContentSettingsClient();
+      if (!require_filled_content_settings_rules) {
+        break;
+      }
+
+      if (settings && settings->HasContentSettingsRules()) {
+        break;
+      }
+
+      // Dynamic iframes without a committed navigation don't have content
+      // settings rules filled, so in this case we look for a parent frame which
+      // has required data for shields/farbling to be enabled.
+      auto* parent_frame =
+          blink::DynamicTo<blink::LocalFrame>(local_frame->Parent());
+      DCHECK(!parent_frame || parent_frame != local_frame);
+      local_frame = parent_frame;
+    }
+  } else if (auto* worker_or_worklet =
+                 blink::DynamicTo<blink::WorkerOrWorkletGlobalScope>(context)) {
+    settings = worker_or_worklet->ContentSettingsClient();
   }
   return settings;
 }
@@ -108,7 +114,7 @@ bool AllowFontFamily(ExecutionContext* context,
   if (!context)
     return true;
 
-  auto* settings = brave::GetContentSettingsClientFor(context);
+  auto* settings = brave::GetContentSettingsClientFor(context, true);
   if (!settings)
     return true;
 
@@ -199,7 +205,7 @@ BraveSessionCache::BraveSessionCache(ExecutionContext& context)
   double fudge_factor = 0.99 + ((*fudge / maxUInt64AsDouble) / 100);
   uint64_t seed = *reinterpret_cast<uint64_t*>(domain_key_);
   if (blink::WebContentSettingsClient* settings =
-          GetContentSettingsClientFor(&context)) {
+          GetContentSettingsClientFor(&context, true)) {
     farbling_level_ = settings->GetBraveFarblingLevel();
   }
   if (farbling_level_ != BraveFarblingLevel::OFF) {

--- a/third_party/blink/renderer/core/farbling/brave_session_cache.h
+++ b/third_party/blink/renderer/core/farbling/brave_session_cache.h
@@ -44,7 +44,8 @@ enum FarbleKey : uint64_t {
 typedef absl::randen_engine<uint64_t> FarblingPRNG;
 
 CORE_EXPORT blink::WebContentSettingsClient* GetContentSettingsClientFor(
-    ExecutionContext* context);
+    ExecutionContext* context,
+    bool require_filled_content_settings_rules = false);
 CORE_EXPORT BraveFarblingLevel
 GetBraveFarblingLevelFor(ExecutionContext* context,
                          BraveFarblingLevel default_value);


### PR DESCRIPTION
Uplift of #17529
Resolves https://github.com/brave/brave-browser/issues/28934

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.