### PR TITLE
feat(wallet): Implemented show all networks assets

### DIFF
--- a/android/java/org/chromium/chrome/browser/app/BraveActivity.java
+++ b/android/java/org/chromium/chrome/browser/app/BraveActivity.java
@@ -6,6 +6,7 @@
 package org.chromium.chrome.browser.app;
 
 import static org.chromium.chrome.browser.app.domain.NetworkSelectorModel.Mode.DEFAULT_WALLET_NETWORK;
+import static org.chromium.chrome.browser.crypto_wallet.activities.NetworkSelectorActivity.NETWORK_SELECTOR_KEY;
 import static org.chromium.chrome.browser.crypto_wallet.activities.NetworkSelectorActivity.NETWORK_SELECTOR_MODE;
 import static org.chromium.ui.base.ViewUtils.dpToPx;
 
@@ -1245,15 +1246,28 @@ public abstract class BraveActivity<C extends ChromeActivityComponent> extends C
 
     // should only be called if the wallet is setup and unlocked
     public void openNetworkSelection() {
-        openNetworkSelection(DEFAULT_WALLET_NETWORK);
+        openNetworkSelection(DEFAULT_WALLET_NETWORK, null);
     }
 
-    // should only be called if the wallet is setup and unlocked
-    public void openNetworkSelection(NetworkSelectorModel.Mode mode) {
+    /**
+     * Open the network selector activity with key as an identifier to show the previously selected
+     * local network (if available otherwise All Networks as default) on {@link
+     * NetworkSelectorActivity}.
+     * @param mode Whether to open network selection for default/global network mode or
+     *          in local network selection mode i.e.
+     *          View <=> NetworkSelection state only with All Networks option.
+     * @param key as identifier to bind local state of NetworkSelection with the view. If null then
+     *         use global/default network selection mode.
+     ^ IMP: Should only be called if the wallet is setup and unlocked
+     */
+    public void openNetworkSelection(NetworkSelectorModel.Mode mode, String key) {
         Intent braveNetworkSelectionIntent = new Intent(this, NetworkSelectorActivity.class);
         braveNetworkSelectionIntent.setFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP);
         // Either in global or local network selection mode
         braveNetworkSelectionIntent.putExtra(NETWORK_SELECTOR_MODE, mode);
+        // To bind selection between the caller and NetworkSelection Activity for local state of
+        // network selection
+        braveNetworkSelectionIntent.putExtra(NETWORK_SELECTOR_KEY, key);
         startActivity(braveNetworkSelectionIntent);
     }
 

--- a/android/java/org/chromium/chrome/browser/app/domain/CryptoModel.java
+++ b/android/java/org/chromium/chrome/browser/app/domain/CryptoModel.java
@@ -51,6 +51,7 @@ import org.chromium.url.internal.mojom.Origin;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.stream.Collectors;
 
 public class CryptoModel {
     private TxService mTxService;
@@ -385,6 +386,14 @@ public class CryptoModel {
         @Override
         public List<CryptoAccountTypeInfo> getSupportedCryptoAccountTypes() {
             return CryptoModel.this.getSupportedCryptoAccountTypes();
+        }
+
+        @Override
+        public List<Integer> getSupportedCryptoCoins() {
+            return getSupportedCryptoAccountTypes()
+                    .stream()
+                    .map(CryptoAccountTypeInfo::getCoinType)
+                    .collect(Collectors.toList());
         }
 
         @Override

--- a/android/java/org/chromium/chrome/browser/app/domain/CryptoSharedData.java
+++ b/android/java/org/chromium/chrome/browser/app/domain/CryptoSharedData.java
@@ -1,3 +1,8 @@
+/* Copyright (c) 2023 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
 package org.chromium.chrome.browser.app.domain;
 
 import android.content.Context;
@@ -16,5 +21,6 @@ public interface CryptoSharedData {
     LiveData<Integer> getCoinTypeLd();
     String[] getEnabledKeyrings();
     List<CryptoAccountTypeInfo> getSupportedCryptoAccountTypes();
+    List<Integer> getSupportedCryptoCoins();
     LiveData<List<AccountInfo>> getAccounts();
 }

--- a/android/java/org/chromium/chrome/browser/app/domain/NetworkModel.java
+++ b/android/java/org/chromium/chrome/browser/app/domain/NetworkModel.java
@@ -10,6 +10,10 @@ import android.content.pm.ApplicationInfo;
 import android.text.TextUtils;
 import android.util.Pair;
 
+import androidx.annotation.NonNull;
+import androidx.lifecycle.DefaultLifecycleObserver;
+import androidx.lifecycle.Lifecycle;
+import androidx.lifecycle.LifecycleOwner;
 import androidx.lifecycle.LiveData;
 import androidx.lifecycle.MediatorLiveData;
 import androidx.lifecycle.MutableLiveData;
@@ -24,6 +28,7 @@ import org.chromium.chrome.browser.crypto_wallet.activities.BuySendSwapActivity;
 import org.chromium.chrome.browser.crypto_wallet.model.CryptoAccountTypeInfo;
 import org.chromium.chrome.browser.crypto_wallet.util.JavaUtils;
 import org.chromium.chrome.browser.crypto_wallet.util.NetworkResponsesCollector;
+import org.chromium.chrome.browser.crypto_wallet.util.NetworkUtils;
 import org.chromium.chrome.browser.crypto_wallet.util.Utils;
 import org.chromium.chrome.browser.crypto_wallet.util.WalletConstants;
 import org.chromium.chrome.browser.util.Triple;
@@ -31,34 +36,39 @@ import org.chromium.mojo.bindings.Callbacks;
 import org.chromium.mojo.system.MojoException;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 public class NetworkModel implements JsonRpcServiceObserver {
     private JsonRpcService mJsonRpcService;
     private final Object mLock = new Object();
     private final MediatorLiveData<String> _mChainId;
     private final MediatorLiveData<NetworkInfo[]> _mDefaultCoinCryptoNetworks;
-    private final MutableLiveData<NetworkInfo[]> _mCryptoNetworks;
+    private final MutableLiveData<List<NetworkInfo>> _mCryptoNetworks;
     private final CryptoSharedData mSharedData;
     private final CryptoSharedActions mCryptoActions;
     private final MediatorLiveData<Pair<String, NetworkInfo[]>> _mPairChainAndNetwork;
     private final MediatorLiveData<NetworkInfo> _mNeedToCreateAccountForNetwork;
     private final MediatorLiveData<NetworkInfo> _mDefaultNetwork;
-    private final MediatorLiveData<Triple<String, NetworkInfo, NetworkInfo[]>>
+    private final MediatorLiveData<Triple<String, NetworkInfo, List<NetworkInfo>>>
             _mChainNetworkAllNetwork;
     private final Context mContext;
     private final MediatorLiveData<String[]> _mCustomNetworkIds;
     private final MediatorLiveData<List<NetworkInfo>> _mPrimaryNetworks;
     private final MediatorLiveData<List<NetworkInfo>> _mSecondaryNetworks;
-    private NetworkSelectorModel mNetworkSelectorModel;
+    private Map<String, NetworkSelectorModel> mNetworkSelectorMap;
     public final LiveData<String[]> mCustomNetworkIds;
     public LiveData<NetworkInfo> mNeedToCreateAccountForNetwork;
-    public final LiveData<Triple<String, NetworkInfo, NetworkInfo[]>> mChainNetworkAllNetwork;
+    public final LiveData<Triple<String, NetworkInfo, List<NetworkInfo>>> mChainNetworkAllNetwork;
     public final LiveData<Pair<String, NetworkInfo[]>> mPairChainAndNetwork;
     public final LiveData<String> mChainId;
     public final LiveData<NetworkInfo[]> mDefaultCoinCryptoNetworks;
-    public final LiveData<NetworkInfo[]> mCryptoNetworks;
+    public final LiveData<List<NetworkInfo>> mCryptoNetworks;
     public final LiveData<NetworkInfo> mDefaultNetwork;
     public final LiveData<List<NetworkInfo>> mPrimaryNetworks;
     public final LiveData<List<NetworkInfo>> mSecondaryNetworks;
@@ -74,7 +84,7 @@ public class NetworkModel implements JsonRpcServiceObserver {
         _mDefaultCoinCryptoNetworks = new MediatorLiveData<>();
         mChainId = _mChainId;
         mDefaultCoinCryptoNetworks = _mDefaultCoinCryptoNetworks;
-        _mCryptoNetworks = new MutableLiveData<>(new NetworkInfo[0]);
+        _mCryptoNetworks = new MutableLiveData<>(Collections.emptyList());
         mCryptoNetworks = _mCryptoNetworks;
         _mPairChainAndNetwork = new MediatorLiveData<>();
         mPairChainAndNetwork = _mPairChainAndNetwork;
@@ -92,7 +102,7 @@ public class NetworkModel implements JsonRpcServiceObserver {
         _mSecondaryNetworks = new MediatorLiveData<>();
         mSecondaryNetworks = _mSecondaryNetworks;
         jsonRpcService.addObserver(this);
-        mNetworkSelectorModel = new NetworkSelectorModel(this, mContext);
+        mNetworkSelectorMap = new HashMap<>();
         _mPairChainAndNetwork.setValue(Pair.create("", new NetworkInfo[] {}));
         _mPairChainAndNetwork.addSource(_mChainId, chainId -> {
             _mPairChainAndNetwork.setValue(
@@ -106,8 +116,7 @@ public class NetworkModel implements JsonRpcServiceObserver {
             NetworkInfo[] cryptoNetworks = chainIdAndInfosPair.second;
             if (chainId == null || cryptoNetworks == null) return;
             for (NetworkInfo networkInfo : cryptoNetworks) {
-                if (networkInfo.chainId.equals(chainId)
-                        && sharedData.getCoinType() == networkInfo.coin) {
+                if (networkInfo.chainId.equals(chainId)) {
                     _mDefaultNetwork.postValue(networkInfo);
                     break;
                 }
@@ -131,11 +140,19 @@ public class NetworkModel implements JsonRpcServiceObserver {
         });
 
         _mChainNetworkAllNetwork.addSource(_mDefaultNetwork, networkInfo -> {
+            NetworkInfo currNetwork = null;
+            if (_mChainNetworkAllNetwork.getValue() != null) {
+                currNetwork = _mChainNetworkAllNetwork.getValue().second;
+            }
+            if (currNetwork != null && networkInfo != null
+                    && NetworkUtils.Filters.isSameNetwork(currNetwork, networkInfo)) {
+                return;
+            }
             _mChainNetworkAllNetwork.postValue(
                     Triple.create(networkInfo.chainId, networkInfo, _mCryptoNetworks.getValue()));
         });
         _mChainNetworkAllNetwork.addSource(_mCryptoNetworks, networkInfos -> {
-            String chainId = _mChainId.getValue();
+            String chainId = null;
             NetworkInfo networkInfo = _mDefaultNetwork.getValue();
             if (networkInfo != null) {
                 chainId = networkInfo.chainId;
@@ -172,12 +189,43 @@ public class NetworkModel implements JsonRpcServiceObserver {
      * @return mNetworkSelectorModel object in DEFAULT_WALLET_NETWORK mode
      */
     public NetworkSelectorModel openNetworkSelectorModel() {
-        return openNetworkSelectorModel(NetworkSelectorModel.Mode.DEFAULT_WALLET_NETWORK);
+        return new NetworkSelectorModel(this, mContext);
     }
 
-    public NetworkSelectorModel openNetworkSelectorModel(NetworkSelectorModel.Mode mode) {
-        mNetworkSelectorModel.updateSelectorMode(mode);
-        return mNetworkSelectorModel;
+    /**
+     * Create a network model to handle either default or local state (onscreen e.g. {@link
+     * org.chromium.chrome.browser.crypto_wallet.fragments.PortfolioFragment}). Local network
+     * selection can be used by many views so make sure to use the same key which acts as a contract
+     * between the view and the selection activity.
+     * @param key acts as a binding key between caller and selection activity.
+     * @param mode to handle network selection event globally or locally.
+     * @param lifecycle to auto remove network-selection objects.
+     * @return NetworkSelectorModel object.
+     */
+    public NetworkSelectorModel openNetworkSelectorModel(
+            String key, NetworkSelectorModel.Mode mode, Lifecycle lifecycle) {
+        NetworkSelectorModel networkSelectorModel;
+        if (key == null) {
+            return new NetworkSelectorModel(mode, this, mContext);
+        } else if (mNetworkSelectorMap.containsKey(key)) {
+            // Use existing NetworkSelector object to show the previously selected network
+            networkSelectorModel = mNetworkSelectorMap.get(key);
+            if (networkSelectorModel != null && mode != networkSelectorModel.getMode()) {
+                networkSelectorModel.updateSelectorMode(mode);
+            }
+        } else {
+            networkSelectorModel = new NetworkSelectorModel(mode, this, mContext);
+            mNetworkSelectorMap.put(key, networkSelectorModel);
+        }
+        if (lifecycle != null) {
+            lifecycle.addObserver(new DefaultLifecycleObserver() {
+                @Override
+                public void onDestroy(@NonNull LifecycleOwner owner) {
+                    mNetworkSelectorMap.remove(key);
+                }
+            });
+        }
+        return networkSelectorModel;
     }
 
     public void setAccountInfosFromKeyRingModel(
@@ -212,22 +260,27 @@ public class NetworkModel implements JsonRpcServiceObserver {
         init();
     }
 
+    static void getAllNetworks(JsonRpcService jsonRpcService, List<Integer> supportedCoins,
+            Callbacks.Callback1<Set<NetworkInfo>> callback) {
+        if (jsonRpcService == null) {
+            callback.call(Collections.emptySet());
+            return;
+        }
+
+        NetworkResponsesCollector networkResponsesCollector =
+                new NetworkResponsesCollector(jsonRpcService, supportedCoins);
+        networkResponsesCollector.getNetworks(networkInfos -> { callback.call(networkInfos); });
+    }
+
     public void init() {
         synchronized (mLock) {
             if (mJsonRpcService == null) {
                 return;
             }
 
-            List<Integer> coins = new ArrayList<>();
-            for (CryptoAccountTypeInfo cryptoAccountTypeInfo :
-                    mSharedData.getSupportedCryptoAccountTypes()) {
-                coins.add(cryptoAccountTypeInfo.getCoinType());
-            }
-            NetworkResponsesCollector networkResponsesCollector =
-                    new NetworkResponsesCollector(mJsonRpcService, coins);
-            networkResponsesCollector.getNetworks(networkInfos -> {
-                _mCryptoNetworks.postValue(
-                        stripDebugNetwork(mContext, networkInfos.toArray(new NetworkInfo[0])));
+            getAllNetworks(mJsonRpcService, mSharedData.getSupportedCryptoCoins(), allNetworks -> {
+                _mCryptoNetworks.postValue(Arrays.asList(
+                        stripDebugNetwork(mContext, allNetworks.toArray(new NetworkInfo[0]))));
             });
         }
     }
@@ -250,6 +303,11 @@ public class NetworkModel implements JsonRpcServiceObserver {
         }
     }
 
+    public void setNetworkWithAccountCheck(String chainId, Callbacks.Callback1<Boolean> callback) {
+        NetworkInfo networkToBeSetAsSelected = getNetwork(chainId);
+        setNetworkWithAccountCheck(networkToBeSetAsSelected, callback);
+    }
+
     public void setNetwork(
             NetworkInfo networkToBeSetAsSelected, Callbacks.Callback1<Boolean> callback) {
         mJsonRpcService.setNetwork(
@@ -268,8 +326,8 @@ public class NetworkModel implements JsonRpcServiceObserver {
         _mNeedToCreateAccountForNetwork.postValue(null);
     }
 
-    public NetworkInfo[] stripNoBuySwapNetworks(
-            NetworkInfo[] networkInfos, BuySendSwapActivity.ActivityType type) {
+    public List<NetworkInfo> stripNoBuySwapNetworks(
+            List<NetworkInfo> networkInfos, BuySendSwapActivity.ActivityType type) {
         List<NetworkInfo> networkInfosFiltered = new ArrayList<>();
         for (NetworkInfo networkInfo : networkInfos) {
             if (type == BuySendSwapActivity.ActivityType.BUY && Utils.allowBuy(networkInfo.chainId)
@@ -279,7 +337,18 @@ public class NetworkModel implements JsonRpcServiceObserver {
             }
         }
 
-        return networkInfosFiltered.toArray(new NetworkInfo[networkInfosFiltered.size()]);
+        return networkInfosFiltered;
+    }
+
+    public NetworkInfo getNetwork(String chainId) {
+        if (TextUtils.isEmpty(chainId)) return null;
+        List<NetworkInfo> cryptoNws = JavaUtils.safeVal(_mCryptoNetworks.getValue());
+        for (NetworkInfo info : cryptoNws) {
+            if (info.chainId.equals(chainId)) {
+                return info;
+            }
+        }
+        return null;
     }
 
     private NetworkInfo[] stripDebugNetwork(Context context, NetworkInfo[] networkInfos) {
@@ -298,8 +367,8 @@ public class NetworkModel implements JsonRpcServiceObserver {
     }
 
     List<NetworkInfo> getSubTestNetworks(NetworkInfo networkInfo) {
-        NetworkInfo[] cryptoNws = _mCryptoNetworks.getValue();
-        if (cryptoNws == null || cryptoNws.length == 0
+        List<NetworkInfo> cryptoNws = _mCryptoNetworks.getValue();
+        if (cryptoNws == null || cryptoNws.size() == 0
                 || !WalletConstants.SUPPORTED_TOP_LEVEL_CHAIN_IDS.contains(networkInfo.chainId))
             return Collections.emptyList();
         List<NetworkInfo> list = new ArrayList<>();

--- a/android/java/org/chromium/chrome/browser/app/domain/PortfolioModel.java
+++ b/android/java/org/chromium/chrome/browser/app/domain/PortfolioModel.java
@@ -14,6 +14,7 @@ import androidx.lifecycle.MutableLiveData;
 import org.json.JSONException;
 import org.json.JSONObject;
 
+import org.chromium.brave_wallet.mojom.AccountInfo;
 import org.chromium.brave_wallet.mojom.AssetRatioService;
 import org.chromium.brave_wallet.mojom.BlockchainRegistry;
 import org.chromium.brave_wallet.mojom.BlockchainToken;
@@ -25,24 +26,29 @@ import org.chromium.brave_wallet.mojom.KeyringService;
 import org.chromium.brave_wallet.mojom.NetworkInfo;
 import org.chromium.brave_wallet.mojom.SolanaTxManagerProxy;
 import org.chromium.brave_wallet.mojom.TxService;
+import org.chromium.chrome.browser.crypto_wallet.activities.BraveWalletBaseActivity;
 import org.chromium.chrome.browser.crypto_wallet.observers.BraveWalletServiceObserverImpl;
 import org.chromium.chrome.browser.crypto_wallet.observers.BraveWalletServiceObserverImpl.BraveWalletServiceObserverImplDelegate;
+import org.chromium.chrome.browser.crypto_wallet.observers.KeyringServiceObserverImpl;
 import org.chromium.chrome.browser.crypto_wallet.util.AssetUtils;
 import org.chromium.chrome.browser.crypto_wallet.util.AsyncUtils;
 import org.chromium.chrome.browser.crypto_wallet.util.JavaUtils;
+import org.chromium.chrome.browser.crypto_wallet.util.NetworkUtils;
 import org.chromium.chrome.browser.crypto_wallet.util.PortfolioHelper;
+import org.chromium.chrome.browser.crypto_wallet.util.WalletConstants;
+import org.chromium.chrome.browser.crypto_wallet.util.WalletUtils;
+import org.chromium.mojo.bindings.Callbacks;
 
 import java.io.Serializable;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
 public class PortfolioModel implements BraveWalletServiceObserverImplDelegate {
     public final LiveData<List<NftDataModel>> mNftModels;
     private final CryptoSharedData mSharedData;
-    private final MutableLiveData<List<NftDataModel>> _mNftModels;
     private final Object mLock = new Object();
-    public PortfolioHelper mPortfolioHelper;
     private TxService mTxService;
     private KeyringService mKeyringService;
     private BlockchainRegistry mBlockchainRegistry;
@@ -52,8 +58,11 @@ public class PortfolioModel implements BraveWalletServiceObserverImplDelegate {
     private BraveWalletService mBraveWalletService;
     private AssetRatioService mAssetRatioService;
     private Context mContext;
+    private final MutableLiveData<List<NftDataModel>> _mNftModels;
     private MutableLiveData<Boolean> _mIsDiscoveringUserAssets;
     public LiveData<Boolean> mIsDiscoveringUserAssets;
+    private List<NetworkInfo> mAllNetworkInfos;
+    public PortfolioHelper mPortfolioHelper;
 
     public PortfolioModel(Context context, TxService txService, KeyringService keyringService,
             BlockchainRegistry blockchainRegistry, JsonRpcService jsonRpcService,
@@ -132,6 +141,63 @@ public class PortfolioModel implements BraveWalletServiceObserverImplDelegate {
         mBraveWalletService.discoverAssetsOnAllSupportedChains();
     }
 
+    public void fetchAssets(NetworkInfo selectedNetwork,
+            BraveWalletBaseActivity braveWalletBaseActivity,
+            Callbacks.Callback1<PortfolioHelper> callback) {
+        synchronized (mLock) {
+            clear();
+            if (mJsonRpcService == null) {
+                return;
+            }
+            NetworkModel.getAllNetworks(
+                    mJsonRpcService, mSharedData.getSupportedCryptoCoins(), allNetworks -> {
+                        mAllNetworkInfos = new ArrayList<>(allNetworks);
+                        if (selectedNetwork.chainId.equals(
+                                    NetworkUtils.getAllNetworkOption(mContext).chainId)) {
+                            mKeyringService.getKeyringsInfo(
+                                    mSharedData.getEnabledKeyrings(), keyringInfos -> {
+                                        AccountInfo[] accountInfos =
+                                                WalletUtils
+                                                        .getAccountInfosFromKeyrings(keyringInfos)
+                                                        .toArray(new AccountInfo[0]);
+                                        mPortfolioHelper =
+                                                new PortfolioHelper(braveWalletBaseActivity,
+                                                        mAllNetworkInfos, accountInfos);
+                                        mPortfolioHelper.setSelectedNetworks(
+                                                NetworkUtils.nonTestNetwork(mAllNetworkInfos));
+                                        fetchUserAssetsAndDetails(mPortfolioHelper, callback);
+                                    });
+                        } else {
+                            mKeyringService.getKeyringInfo(
+                                    AssetUtils.getKeyringForCoinType(selectedNetwork.coin),
+                                    keyringInfo -> {
+                                        mPortfolioHelper =
+                                                new PortfolioHelper(braveWalletBaseActivity,
+                                                        mAllNetworkInfos, keyringInfo.accountInfos);
+                                        mPortfolioHelper.setSelectedNetworks(
+                                                Arrays.asList(selectedNetwork));
+                                        fetchUserAssetsAndDetails(mPortfolioHelper, callback);
+                                    });
+                        }
+                    });
+        }
+    }
+
+    @Override
+    public void onDiscoverAssetsCompleted(BlockchainToken[] discoveredAssets) {
+        _mIsDiscoveringUserAssets.postValue(false);
+    }
+
+    // Clear state
+    public void clear() {
+        _mNftModels.postValue(Collections.emptyList());
+    }
+
+    private void fetchUserAssetsAndDetails(
+            PortfolioHelper portfolioHelper, Callbacks.Callback1<PortfolioHelper> callback) {
+        portfolioHelper.fetchAllAssetsAndDetails(callback);
+    }
+
     private void addServiceObservers() {
         if (mBraveWalletService != null) {
             BraveWalletServiceObserverImpl walletServiceObserver =
@@ -204,10 +270,5 @@ public class PortfolioModel implements BraveWalletServiceObserverImplDelegate {
             else
                 return AssetUtils.httpifyIpfsUrl(url);
         }
-    }
-
-    @Override
-    public void onDiscoverAssetsCompleted(BlockchainToken[] discoveredAssets) {
-        _mIsDiscoveringUserAssets.postValue(false);
     }
 }

--- a/android/java/org/chromium/chrome/browser/crypto_wallet/activities/AccountDetailActivity.java
+++ b/android/java/org/chromium/chrome/browser/crypto_wallet/activities/AccountDetailActivity.java
@@ -152,7 +152,7 @@ public class AccountDetailActivity
                     portfolioHelper.calculateBalances(() -> {
                         RecyclerView rvAssets = findViewById(R.id.rv_assets);
 
-                        BlockchainToken[] userAssets = portfolioHelper.getUserAssets();
+                        List<BlockchainToken> userAssets = portfolioHelper.getUserAssetList();
                         HashMap<String, Double> perTokenCryptoSum =
                                 portfolioHelper.getPerTokenCryptoSum();
                         HashMap<String, Double> perTokenFiatSum =
@@ -161,8 +161,9 @@ public class AccountDetailActivity
                         String tokensPath =
                                 BlockchainRegistryFactory.getInstance().getTokensIconsLocation();
 
-                        WalletCoinAdapter walletCoinAdapter = Utils.setupVisibleAssetList(
-                                userAssets, perTokenCryptoSum, perTokenFiatSum, tokensPath);
+                        WalletCoinAdapter walletCoinAdapter =
+                                Utils.setupVisibleAssetList(userAssets, perTokenCryptoSum,
+                                        perTokenFiatSum, tokensPath, getResources(), allNetworks);
                         walletCoinAdapter.setOnWalletListItemClick(AccountDetailActivity.this);
                         rvAssets.setAdapter(walletCoinAdapter);
                         rvAssets.setLayoutManager(new LinearLayoutManager(this));

--- a/android/java/org/chromium/chrome/browser/crypto_wallet/activities/BraveWalletBaseActivity.java
+++ b/android/java/org/chromium/chrome/browser/crypto_wallet/activities/BraveWalletBaseActivity.java
@@ -58,7 +58,6 @@ public abstract class BraveWalletBaseActivity extends AsyncInitializationActivit
     public void onConnectionError(MojoException e) {
         if (mKeyringServiceObserver != null) {
             mKeyringServiceObserver.close();
-            mKeyringServiceObserver.destroy();
             mKeyringServiceObserver = null;
         }
         if (mTxServiceObserver != null) {
@@ -236,7 +235,6 @@ public abstract class BraveWalletBaseActivity extends AsyncInitializationActivit
     public void onDestroy() {
         if (mKeyringServiceObserver != null) {
             mKeyringServiceObserver.close();
-            mKeyringServiceObserver.destroy();
         }
         if (mTxServiceObserver != null) {
             mTxServiceObserver.close();

--- a/android/java/org/chromium/chrome/browser/crypto_wallet/activities/NetworkSelectorActivity.java
+++ b/android/java/org/chromium/chrome/browser/crypto_wallet/activities/NetworkSelectorActivity.java
@@ -38,6 +38,7 @@ import java.util.ArrayList;
 public class NetworkSelectorActivity
         extends BraveWalletBaseActivity implements NetworkSelectorAdapter.NetworkClickListener {
     public static String NETWORK_SELECTOR_MODE = "network_selector_mode";
+    public static String NETWORK_SELECTOR_KEY = "network_selector_key";
     private static final String TAG = "NetworkSelector";
     private NetworkSelectorModel.Mode mMode;
     private RecyclerView mRVNetworkSelector;
@@ -45,6 +46,7 @@ public class NetworkSelectorActivity
     private MaterialToolbar mToolbar;
     private String mSelectedNetwork;
     private SettingsLauncher mSettingsLauncher;
+    private String mKey;
     private WalletModel mWalletModel;
     private NetworkSelectorModel mNetworkSelectorModel;
 
@@ -62,6 +64,9 @@ public class NetworkSelectorActivity
         mMode = JavaUtils.safeVal(
                 (NetworkSelectorModel.Mode) intent.getSerializableExtra(NETWORK_SELECTOR_MODE),
                 NetworkSelectorModel.Mode.DEFAULT_WALLET_NETWORK);
+        // Key acts as a binding contract between the caller and network selection activity to share
+        // local network selection actions in LOCAL_NETWORK_FILTER mode
+        mKey = intent.getStringExtra(NETWORK_SELECTOR_KEY);
         mRVNetworkSelector = findViewById(R.id.rv_network_activity);
         onInitialLayoutInflationComplete();
     }
@@ -82,7 +87,8 @@ public class NetworkSelectorActivity
 
         mSettingsLauncher = new BraveSettingsLauncherImpl();
         mNetworkSelectorModel =
-                mWalletModel.getCryptoModel().getNetworkModel().openNetworkSelectorModel(mMode);
+                mWalletModel.getCryptoModel().getNetworkModel().openNetworkSelectorModel(
+                        mKey, mMode, null);
         networkSelectorAdapter = new NetworkSelectorAdapter(this, new ArrayList<>());
         mRVNetworkSelector.setAdapter(networkSelectorAdapter);
         networkSelectorAdapter.setOnNetworkItemSelected(this);
@@ -110,14 +116,13 @@ public class NetworkSelectorActivity
                     mWalletModel.getCryptoModel().getNetworkModel().mDefaultNetwork,
                     networkInfo -> { updateNetworkSelection(networkInfo); });
         } else if (mMode == NetworkSelectorModel.Mode.LOCAL_NETWORK_FILTER) {
-            mNetworkSelectorModel.mSelectedNetwork.observe(
+            mNetworkSelectorModel.getSelectedNetwork().observe(
                     this, networkInfo -> { updateNetworkSelection(networkInfo); });
         }
     }
 
     private void updateNetworkSelection(NetworkInfo networkInfo) {
         if (networkInfo != null) {
-            mSelectedNetwork = Utils.getShortNameOfNetwork(networkInfo.chainName);
             networkSelectorAdapter.setSelectedNetwork(networkInfo.chainName);
         }
     }

--- a/android/java/org/chromium/chrome/browser/crypto_wallet/adapters/NetworkSpinnerAdapter.java
+++ b/android/java/org/chromium/chrome/browser/crypto_wallet/adapters/NetworkSpinnerAdapter.java
@@ -21,18 +21,18 @@ import org.chromium.brave_wallet.mojom.NetworkInfo;
 import org.chromium.chrome.R;
 import org.chromium.chrome.browser.crypto_wallet.util.Utils;
 
-import java.util.ArrayList;
+import java.util.List;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
 public class NetworkSpinnerAdapter extends BaseAdapter implements SpinnerAdapter {
     private Context context;
     private LayoutInflater inflater;
-    private NetworkInfo[] mNetworkInfos;
+    private List<NetworkInfo> mNetworkInfos;
     private ExecutorService mExecutor;
     private Handler mHandler;
 
-    public NetworkSpinnerAdapter(Context applicationContext, NetworkInfo[] networkInfos) {
+    public NetworkSpinnerAdapter(Context applicationContext, List<NetworkInfo> networkInfos) {
         this.context = applicationContext;
         inflater = (LayoutInflater.from(applicationContext));
         mNetworkInfos = networkInfos;
@@ -41,17 +41,17 @@ public class NetworkSpinnerAdapter extends BaseAdapter implements SpinnerAdapter
     }
 
     public NetworkInfo getNetwork(int position) {
-        return mNetworkInfos[position];
+        return mNetworkInfos.get(position);
     }
 
     @Override
     public int getCount() {
-        return mNetworkInfos.length;
+        return mNetworkInfos.size();
     }
 
     @Override
     public Object getItem(int position) {
-        return mNetworkInfos[position];
+        return mNetworkInfos.get(position);
     }
 
     @Override
@@ -68,7 +68,7 @@ public class NetworkSpinnerAdapter extends BaseAdapter implements SpinnerAdapter
     public View getView(int position, View view, ViewGroup viewGroup) {
         view = inflater.inflate(R.layout.network_spinner_items, null);
         TextView name = view.findViewById(R.id.network_name_text);
-        name.setText(Utils.getShortNameOfNetwork(mNetworkInfos[position].chainName));
+        name.setText(Utils.getShortNameOfNetwork(mNetworkInfos.get(position).chainName));
         ImageView networkPicture = view.findViewById(R.id.network_picture);
         networkPicture.setVisibility(View.GONE);
         name.setCompoundDrawablesRelativeWithIntrinsicBounds(null, null, null, null);
@@ -79,15 +79,15 @@ public class NetworkSpinnerAdapter extends BaseAdapter implements SpinnerAdapter
     public View getDropDownView(int position, View view, ViewGroup viewGroup) {
         view = inflater.inflate(R.layout.network_spinner_items, null);
         TextView name = (TextView) view.findViewById(R.id.network_name_text);
-        name.setText(mNetworkInfos[position].chainName);
+        name.setText(mNetworkInfos.get(position).chainName);
         ImageView networkPicture = view.findViewById(R.id.network_picture);
         Utils.setBlockiesBitmapResource(
-                mExecutor, mHandler, networkPicture, mNetworkInfos[position].chainName, false);
+                mExecutor, mHandler, networkPicture, mNetworkInfos.get(position).chainName, false);
 
         return view;
     }
 
-    public void setNetworks(NetworkInfo[] networkInfos) {
+    public void setNetworks(List<NetworkInfo> networkInfos) {
         mNetworkInfos = networkInfos;
         notifyDataSetChanged();
     }

--- a/android/java/org/chromium/chrome/browser/crypto_wallet/adapters/WalletCoinAdapter.java
+++ b/android/java/org/chromium/chrome/browser/crypto_wallet/adapters/WalletCoinAdapter.java
@@ -29,6 +29,7 @@ import org.chromium.chrome.R;
 import org.chromium.chrome.browser.app.domain.PortfolioModel;
 import org.chromium.chrome.browser.crypto_wallet.listeners.OnWalletListItemClick;
 import org.chromium.chrome.browser.crypto_wallet.model.WalletListItemModel;
+import org.chromium.chrome.browser.crypto_wallet.util.AndroidUtils;
 import org.chromium.chrome.browser.crypto_wallet.util.ImageLoader;
 import org.chromium.chrome.browser.crypto_wallet.util.Utils;
 
@@ -147,9 +148,18 @@ public class WalletCoinAdapter extends RecyclerView.Adapter<WalletCoinAdapter.Vi
             }
         }
 
-        if (mType == AdapterType.EDIT_VISIBLE_ASSETS_LIST || mType == AdapterType.BUY_ASSETS_LIST
-                || mType == AdapterType.SEND_ASSETS_LIST || mType == AdapterType.SWAP_TO_ASSETS_LIST
-                || mType == AdapterType.SWAP_FROM_ASSETS_LIST) {
+        if (isAssetSelectionType() || mType == AdapterType.VISIBLE_ASSETS_LIST) {
+            if (walletListItemModel.isNativeAsset()) {
+                AndroidUtils.gone(holder.ivNetworkImage);
+            } else {
+                AndroidUtils.show(holder.ivNetworkImage);
+                Utils.setBitmapResource(mExecutor, mHandler, context,
+                        walletListItemModel.getNetworkIcon(), walletListItemModel.getIcon(),
+                        holder.ivNetworkImage, null, true);
+            }
+        }
+
+        if (isAssetSelectionType()) {
             holder.text1Text.setVisibility(View.GONE);
             holder.text2Text.setVisibility(View.GONE);
             if (mType == AdapterType.EDIT_VISIBLE_ASSETS_LIST) {
@@ -231,6 +241,12 @@ public class WalletCoinAdapter extends RecyclerView.Adapter<WalletCoinAdapter.Vi
         }
     }
 
+    private boolean isAssetSelectionType() {
+        return mType == AdapterType.EDIT_VISIBLE_ASSETS_LIST || mType == AdapterType.BUY_ASSETS_LIST
+                || mType == AdapterType.SEND_ASSETS_LIST || mType == AdapterType.SWAP_TO_ASSETS_LIST
+                || mType == AdapterType.SWAP_FROM_ASSETS_LIST;
+    }
+
     @Override
     public int getItemCount() {
         return walletListItemModelList.size();
@@ -241,10 +257,8 @@ public class WalletCoinAdapter extends RecyclerView.Adapter<WalletCoinAdapter.Vi
     }
 
     public void setWalletListItemModelList(List<WalletListItemModel> walletListItemModelList) {
-        this.walletListItemModelList = removeDuplicates(walletListItemModelList);
-        if (mType == AdapterType.EDIT_VISIBLE_ASSETS_LIST || mType == AdapterType.BUY_ASSETS_LIST
-                || mType == AdapterType.SEND_ASSETS_LIST || mType == AdapterType.SWAP_TO_ASSETS_LIST
-                || mType == AdapterType.SWAP_FROM_ASSETS_LIST) {
+        this.walletListItemModelList = walletListItemModelList;
+        if (isAssetSelectionType()) {
             walletListItemModelListCopy.addAll(this.walletListItemModelList);
             mCheckedPositions.clear();
         }
@@ -305,43 +319,6 @@ public class WalletCoinAdapter extends RecyclerView.Adapter<WalletCoinAdapter.Vi
         }
     }
 
-    // Removing duplicates will allow the recycler viewer to render a clean list without showing the
-    // same assets multiple times. Currently, the list of available assets is fetched from Core
-    // API the returns a merged list containing the available assets <b>per ramp provider</b>.
-    // It's not unusual to have the same asset multiple times with the same contract address all
-    // upper case from a ramp provider and all lower case from another one. Thus it's important to
-    // compare the contract addresses ignoring case.
-    private List<WalletListItemModel> removeDuplicates(
-            List<WalletListItemModel> walletListItemModelList) {
-        List<WalletListItemModel> result = new ArrayList<>();
-        for (WalletListItemModel item : walletListItemModelList) {
-            if (item.getBlockchainToken() == null) {
-                // If blockchain token is null the item can be safely added without any risk
-                // of duplication.
-                result.add(item);
-                continue;
-            }
-            String contractAddress = item.getBlockchainToken().contractAddress;
-            boolean duplicate = false;
-            for (WalletListItemModel itemResult : result) {
-                // IMPORTANT: use `equalsIgnoreCase` to detect two contract addresses with different
-                // capitalization.
-                if (contractAddress.equalsIgnoreCase(
-                            itemResult.getBlockchainToken().contractAddress)) {
-                    // Duplicated item detected!
-                    duplicate = true;
-                    break;
-                }
-            }
-            // Do not add duplicated item.
-            if (!duplicate) {
-                result.add(item);
-            }
-        }
-
-        return result;
-    }
-
     private void updateSelectedNetwork(int selectedAccountPosition) {
         walletListItemModelList.get(previousSelectedPos).setIsUserSelected(false);
         notifyItemChanged(previousSelectedPos);
@@ -352,30 +329,31 @@ public class WalletCoinAdapter extends RecyclerView.Adapter<WalletCoinAdapter.Vi
     }
 
     public static class ViewHolder extends RecyclerView.ViewHolder {
-        public ImageView iconImg;
-        public TextView titleText;
-        public TextView subTitleText;
-        public TextView txStatus;
-        public TextView text1Text;
-        public TextView text2Text;
-        public CheckBox assetCheck;
-        public LinearLayout feeLayout;
-        public TextView feeText;
-        public ImageView iconTrash;
-        public ImageView ivSelected;
+        private final ImageView iconImg;
+        private final TextView titleText;
+        private final TextView subTitleText;
+        private final TextView txStatus;
+        private final TextView text1Text;
+        private final TextView text2Text;
+        private final CheckBox assetCheck;
+        private final TextView feeText;
+        private final ImageView iconTrash;
+        private final ImageView ivSelected;
+        private final ImageView ivNetworkImage;
 
         public ViewHolder(View itemView) {
             super(itemView);
-            this.iconImg = itemView.findViewById(R.id.icon);
-            this.titleText = itemView.findViewById(R.id.title);
-            this.txStatus = itemView.findViewById(R.id.status);
-            this.subTitleText = itemView.findViewById(R.id.sub_title);
-            this.text1Text = itemView.findViewById(R.id.text1);
-            this.text2Text = itemView.findViewById(R.id.text2);
-            this.assetCheck = itemView.findViewById(R.id.assetCheck);
-            this.feeText = itemView.findViewById(R.id.fee_text);
-            this.iconTrash = itemView.findViewById(R.id.icon_trash);
-            this.ivSelected = itemView.findViewById(R.id.iv_selected);
+            iconImg = itemView.findViewById(R.id.icon);
+            titleText = itemView.findViewById(R.id.title);
+            txStatus = itemView.findViewById(R.id.status);
+            subTitleText = itemView.findViewById(R.id.sub_title);
+            text1Text = itemView.findViewById(R.id.text1);
+            text2Text = itemView.findViewById(R.id.text2);
+            assetCheck = itemView.findViewById(R.id.assetCheck);
+            feeText = itemView.findViewById(R.id.fee_text);
+            iconTrash = itemView.findViewById(R.id.icon_trash);
+            ivSelected = itemView.findViewById(R.id.iv_selected);
+            ivNetworkImage = itemView.findViewById(R.id.iv_network_Icon);
         }
 
         public void resetObservers() {

--- a/android/java/org/chromium/chrome/browser/crypto_wallet/model/WalletListItemModel.java
+++ b/android/java/org/chromium/chrome/browser/crypto_wallet/model/WalletListItemModel.java
@@ -10,6 +10,7 @@ import android.text.TextUtils;
 
 import org.chromium.brave_wallet.mojom.AccountInfo;
 import org.chromium.brave_wallet.mojom.BlockchainToken;
+import org.chromium.brave_wallet.mojom.NetworkInfo;
 import org.chromium.brave_wallet.mojom.TransactionInfo;
 import org.chromium.chrome.browser.app.domain.PortfolioModel;
 import org.chromium.chrome.browser.crypto_wallet.util.Utils;
@@ -36,6 +37,8 @@ public class WalletListItemModel {
     private String mChainSymbol;
     private int mChainDecimals;
     private PortfolioModel.NftDataModel mNftDataModel;
+    private NetworkInfo mAssetNetwork;
+    private String mBrowserResPath;
 
     public WalletListItemModel(
             int icon, String title, String subTitle, String id, String text1, String text2) {
@@ -206,5 +209,31 @@ public class WalletListItemModel {
 
     public void setNftDataModel(PortfolioModel.NftDataModel mNftDataModel) {
         this.mNftDataModel = mNftDataModel;
+    }
+
+    public NetworkInfo getAssetNetwork() {
+        return mAssetNetwork;
+    }
+
+    public void setAssetNetwork(NetworkInfo mAssetNetwork) {
+        this.mAssetNetwork = mAssetNetwork;
+    }
+
+    public boolean isNativeAsset() {
+        if (mAssetNetwork == null || mBlockchainToken == null) return false;
+        return Utils.isNativeToken(mAssetNetwork, mBlockchainToken);
+    }
+
+    public void setBrowserResourcePath(String resPath) {
+        mBrowserResPath = resPath;
+    }
+
+    public String getBrowserResourcePath() {
+        return mBrowserResPath;
+    }
+
+    public String getNetworkIcon() {
+        if (mAssetNetwork == null || TextUtils.isEmpty(getBrowserResourcePath())) return "";
+        return "file://" + getBrowserResourcePath() + "/" + Utils.getNetworkIconName(mAssetNetwork);
     }
 }

--- a/android/java/org/chromium/chrome/browser/crypto_wallet/observers/KeyringServiceObserverImpl.java
+++ b/android/java/org/chromium/chrome/browser/crypto_wallet/observers/KeyringServiceObserverImpl.java
@@ -8,6 +8,8 @@ package org.chromium.chrome.browser.crypto_wallet.observers;
 import org.chromium.brave_wallet.mojom.KeyringServiceObserver;
 import org.chromium.mojo.system.MojoException;
 
+import java.lang.ref.WeakReference;
+
 public class KeyringServiceObserverImpl implements KeyringServiceObserver {
     public interface KeyringServiceObserverImplDelegate {
         default void locked() {}
@@ -22,80 +24,60 @@ public class KeyringServiceObserverImpl implements KeyringServiceObserver {
         default void selectedAccountChanged(int coin) {}
     }
 
-    private KeyringServiceObserverImplDelegate mDelegate;
+    private WeakReference<KeyringServiceObserverImplDelegate> mDelegate;
 
     public KeyringServiceObserverImpl(KeyringServiceObserverImplDelegate delegate) {
-        mDelegate = delegate;
+        mDelegate = new WeakReference<>(delegate);
     }
 
     @Override
     public void keyringCreated(String keyringId) {
-        if (mDelegate == null) return;
-
-        mDelegate.keyringCreated(keyringId);
+        if (isActive()) getRef().keyringCreated(keyringId);
     }
 
     @Override
     public void keyringRestored(String keyringId) {
-        if (mDelegate == null) return;
-
-        mDelegate.keyringRestored(keyringId);
+        if (isActive()) getRef().keyringRestored(keyringId);
     }
 
     @Override
     public void keyringReset() {
-        if (mDelegate == null) return;
-
-        mDelegate.keyringReset();
+        if (isActive()) getRef().keyringReset();
     }
 
     @Override
     public void locked() {
-        if (mDelegate == null) return;
-
-        mDelegate.locked();
+        if (isActive()) getRef().locked();
     }
 
     @Override
     public void unlocked() {
-        if (mDelegate == null) return;
-
-        mDelegate.unlocked();
+        if (isActive()) getRef().unlocked();
     }
 
     @Override
     public void backedUp() {
-        if (mDelegate == null) return;
-
-        mDelegate.backedUp();
+        if (isActive()) getRef().backedUp();
     }
 
     @Override
     public void accountsChanged() {
-        if (mDelegate == null) return;
-
-        mDelegate.accountsChanged();
+        if (isActive()) getRef().accountsChanged();
     }
 
     @Override
     public void accountsAdded(int coin, String[] addresses) {
-        if (mDelegate == null) return;
-
-        mDelegate.accountsAdded(coin, addresses);
+        if (isActive()) getRef().accountsAdded(coin, addresses);
     }
 
     @Override
     public void autoLockMinutesChanged() {
-        if (mDelegate == null) return;
-
-        mDelegate.autoLockMinutesChanged();
+        if (isActive()) getRef().autoLockMinutesChanged();
     }
 
     @Override
     public void selectedAccountChanged(int coin) {
-        if (mDelegate == null) return;
-
-        mDelegate.selectedAccountChanged(coin);
+        if (isActive()) getRef().selectedAccountChanged(coin);
     }
 
     @Override
@@ -106,7 +88,11 @@ public class KeyringServiceObserverImpl implements KeyringServiceObserver {
     @Override
     public void onConnectionError(MojoException e) {}
 
-    public void destroy() {
-        mDelegate = null;
+    private KeyringServiceObserverImplDelegate getRef() {
+        return mDelegate.get();
+    }
+
+    private boolean isActive() {
+        return mDelegate != null && mDelegate.get() != null;
     }
 }

--- a/android/java/org/chromium/chrome/browser/crypto_wallet/util/AndroidUtils.java
+++ b/android/java/org/chromium/chrome/browser/crypto_wallet/util/AndroidUtils.java
@@ -16,6 +16,7 @@ import android.view.View;
 import android.widget.TextView;
 
 import androidx.annotation.IdRes;
+import androidx.fragment.app.Fragment;
 
 import org.chromium.chrome.R;
 
@@ -97,5 +98,15 @@ public class AndroidUtils {
      */
     public static int getScreenHeight() {
         return Resources.getSystem().getDisplayMetrics().heightPixels;
+    }
+
+    /**
+     * Check if the fragment is safe to update its UI
+     * @param frag instance
+     * @return true if Fragment UI can be updated otherwise false
+     */
+    public static boolean canUpdateFragmentUi(Fragment frag) {
+        return !(frag.isRemoving() || frag.getActivity() == null || frag.isDetached()
+                || !frag.isAdded() || frag.getView() == null);
     }
 }

--- a/android/java/org/chromium/chrome/browser/crypto_wallet/util/AssetUtils.java
+++ b/android/java/org/chromium/chrome/browser/crypto_wallet/util/AssetUtils.java
@@ -198,6 +198,11 @@ public class AssetUtils {
             put(BraveWalletConstants.SOLANA_MAINNET, Arrays.asList("sol"));
             put(BraveWalletConstants.FILECOIN_MAINNET, Arrays.asList("fil"));
             put(BraveWalletConstants.AVALANCHE_MAINNET_CHAIN_ID, Arrays.asList("avax", "avaxc"));
+            // Test Net
+            put(BraveWalletConstants.GOERLI_CHAIN_ID, Arrays.asList("eth"));
+            put(BraveWalletConstants.SEPOLIA_CHAIN_ID, Arrays.asList("eth"));
+            put(BraveWalletConstants.SOLANA_TESTNET, Arrays.asList("sol"));
+            put(BraveWalletConstants.SOLANA_DEVNET, Arrays.asList("sol"));
         }
     };
     public static String httpifyIpfsUrl(String url) {
@@ -206,5 +211,13 @@ public class AssetUtils {
         return trimedUrl.startsWith("ipfs://")
                 ? trimedUrl.replace("ipfs://", "https://ipfs.io/ipfs/")
                 : trimedUrl;
+    }
+
+    public static String assetRatioId(BlockchainToken token) {
+        if (!TextUtils.isEmpty(token.coingeckoId)) return token.coingeckoId;
+        if (BraveWalletConstants.MAINNET_CHAIN_ID.equals(token.chainId)
+                || TextUtils.isEmpty(token.contractAddress))
+            return token.symbol;
+        return token.contractAddress;
     }
 }

--- a/android/java/org/chromium/chrome/browser/crypto_wallet/util/BalanceHelper.java
+++ b/android/java/org/chromium/chrome/browser/crypto_wallet/util/BalanceHelper.java
@@ -185,7 +185,7 @@ public class BalanceHelper {
     }
 
     public static void getP3ABalances(WeakReference<BraveWalletBaseActivity> activityRef,
-            NetworkInfo[] allNetworks, NetworkInfo selectedNetwork,
+            List<NetworkInfo> allNetworks, NetworkInfo selectedNetwork,
             Callbacks.Callback1<HashMap<Integer, HashSet<String>>> callback) {
         BraveWalletBaseActivity activity = activityRef.get();
         if (activity == null || activity.isFinishing()) return;

--- a/android/java/org/chromium/chrome/browser/crypto_wallet/util/JavaUtils.java
+++ b/android/java/org/chromium/chrome/browser/crypto_wallet/util/JavaUtils.java
@@ -5,7 +5,10 @@
 
 package org.chromium.chrome.browser.crypto_wallet.util;
 
+import android.text.TextUtils;
+
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.function.Predicate;
@@ -35,6 +38,10 @@ public class JavaUtils {
             }
         }
         return filteredList;
+    }
+
+    public static <T> List<T> filter(T[] items, Predicate<T> filter) {
+        return filter(Arrays.asList(items), filter);
     }
 
     public static <T> T find(List<T> list, Predicate<T> predicate) {
@@ -69,5 +76,30 @@ public class JavaUtils {
             if (item == null) return true;
         }
         return false;
+    }
+
+    @SafeVarargs
+    public static <T> T[] asArray(T... items) {
+        return items;
+    }
+
+    /**
+     * Returns a combined string with a separator or an empty string. Empty and null values are
+     * ignored.
+     * @param separator to append after each string. Pass null for no separator
+     * @param items of string values.
+     * @return a combined or empty string.
+     */
+    public static String concatStrings(char separator, String... items) {
+        if (items == null) return "";
+        StringBuilder builder = new StringBuilder();
+        for (int i = 0; i < items.length; i++) {
+            String item = items[i];
+            if (TextUtils.isEmpty(item)) continue;
+            builder.append(item).append(separator);
+        }
+        // Delete separator after the last value
+        builder.deleteCharAt(builder.length() - 1);
+        return builder.toString();
     }
 }

--- a/android/java/org/chromium/chrome/browser/crypto_wallet/util/NetworkUtils.java
+++ b/android/java/org/chromium/chrome/browser/crypto_wallet/util/NetworkUtils.java
@@ -6,13 +6,28 @@
 package org.chromium.chrome.browser.crypto_wallet.util;
 
 import android.content.Context;
+import android.text.TextUtils;
 
 import org.chromium.brave_wallet.mojom.NetworkInfo;
 import org.chromium.chrome.R;
 import org.chromium.url.mojom.Url;
 
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+
 public class NetworkUtils {
     private static NetworkInfo sAllNetworksOption;
+
+    public static class Filters {
+        public static boolean isSameNetwork(NetworkInfo network, String chainId, int coin) {
+            return network.chainId.equals(chainId) && network.coin == coin;
+        }
+
+        public static boolean isSameNetwork(NetworkInfo network1, NetworkInfo network2) {
+            return isSameNetwork(network1, network2.chainId, network2.coin);
+        }
+    }
 
     public static NetworkInfo getAllNetworkOption(Context context) {
         if (sAllNetworksOption == null) {
@@ -31,5 +46,23 @@ public class NetworkUtils {
             sAllNetworksOption = allNetworkInfo;
         }
         return sAllNetworksOption;
+    }
+
+    public static List<NetworkInfo> nonTestNetwork(List<NetworkInfo> networkInfos) {
+        if (networkInfos == null) return Collections.emptyList();
+        return networkInfos.stream()
+                .filter(network -> !WalletConstants.KNOWN_TEST_CHAIN_IDS.contains(network.chainId))
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * Get the NetworkInfo object of given chainId
+     * @param networkInfos all networks
+     * @param chainId of network to be found
+     * @return found network or null
+     */
+    public static NetworkInfo findNetwork(List<NetworkInfo> networkInfos, String chainId) {
+        if (networkInfos.isEmpty() || TextUtils.isEmpty(chainId)) return null;
+        return JavaUtils.find(networkInfos, networkInfo -> networkInfo.chainId.equals(chainId));
     }
 }

--- a/android/java/org/chromium/chrome/browser/crypto_wallet/util/Utils.java
+++ b/android/java/org/chromium/chrome/browser/crypto_wallet/util/Utils.java
@@ -73,7 +73,6 @@ import org.chromium.brave_wallet.mojom.BraveWalletP3a;
 import org.chromium.brave_wallet.mojom.BraveWalletService;
 import org.chromium.brave_wallet.mojom.CoinType;
 import org.chromium.brave_wallet.mojom.JsonRpcService;
-import org.chromium.brave_wallet.mojom.KeyringService;
 import org.chromium.brave_wallet.mojom.NetworkInfo;
 import org.chromium.brave_wallet.mojom.ProviderError;
 import org.chromium.brave_wallet.mojom.TransactionInfo;
@@ -88,7 +87,6 @@ import org.chromium.chrome.browser.app.domain.PortfolioModel;
 import org.chromium.chrome.browser.crypto_wallet.activities.AssetDetailActivity;
 import org.chromium.chrome.browser.crypto_wallet.activities.BraveWalletBaseActivity;
 import org.chromium.chrome.browser.crypto_wallet.activities.BuySendSwapActivity;
-import org.chromium.chrome.browser.crypto_wallet.activities.NftDetailActivity;
 import org.chromium.chrome.browser.crypto_wallet.adapters.WalletCoinAdapter;
 import org.chromium.chrome.browser.crypto_wallet.fragments.ApproveTxBottomSheetDialogFragment;
 import org.chromium.chrome.browser.crypto_wallet.listeners.OnWalletListItemClick;
@@ -250,18 +248,21 @@ public class Utils {
         if (focusedView != null) imm.hideSoftInputFromWindow(focusedView.getWindowToken(), 0);
     }
 
-    public static void openBuySendSwapActivity(Activity activity,
-            BuySendSwapActivity.ActivityType activityType, String swapFromAssetSymbol) {
-        assert activity != null;
-        Intent buySendSwapActivityIntent = new Intent(activity, BuySendSwapActivity.class);
-        buySendSwapActivityIntent.putExtra("activityType", activityType.getValue());
-        buySendSwapActivityIntent.putExtra("swapFromAssetSymbol", swapFromAssetSymbol);
-        activity.startActivity(buySendSwapActivityIntent);
-    }
-
     public static void openBuySendSwapActivity(
             Activity activity, BuySendSwapActivity.ActivityType activityType) {
-        openBuySendSwapActivity(activity, activityType, null);
+        openBuySendSwapActivity(activity, activityType, null, null);
+    }
+
+    public static void openBuySendSwapActivity(Activity activity,
+            BuySendSwapActivity.ActivityType activityType, String swapFromAssetSymbol,
+            String chainId) {
+        assert activity != null;
+        Intent buySendSwapActivityIntent = new Intent(activity, BuySendSwapActivity.class);
+        buySendSwapActivityIntent.putExtra(
+                BuySendSwapActivity.ACTIVITY_TYPE, activityType.getValue());
+        buySendSwapActivityIntent.putExtra(BuySendSwapActivity.ASSET_SYMBOL, swapFromAssetSymbol);
+        buySendSwapActivityIntent.putExtra(BuySendSwapActivity.ASSET_CHAIN_ID, chainId);
+        activity.startActivity(buySendSwapActivityIntent);
     }
 
     public static void openAssetDetailsActivity(
@@ -286,6 +287,7 @@ public class Utils {
      */
     public static String getShortNameOfNetwork(String networkName) {
         if (!TextUtils.isEmpty(networkName)) {
+            if (networkName.length() < 14) return networkName;
             String firstWord = networkName.split(" ")[0];
             if (firstWord.length() > 18) {
                 return firstWord.substring(0, 16) + "..";
@@ -968,39 +970,7 @@ public class Utils {
     public static BlockchainToken makeNetworkAsset(NetworkInfo network) {
         String logo;
 
-        // TODO: Add missing logos
-        //             case "SOL":
-        //                 logo = "sol.png";
-        //                 break;
-        //             case "FIL":
-        //                 logo = "fil.png";
-        //                 break;
-        //             case network.chainId === BraveWallet.OPTIMISM_MAINNET_CHAIN_ID:
-        //                 logo = "optimism.png";
-        //                 break;
-        //             case network.chainId === BraveWallet.AVALANCHE_MAINNET_CHAIN_ID:
-        //                 logo = "avax.png";
-        //                 break;
-        //             case network.chainId === BraveWallet.FANTOM_MAINNET_CHAIN_ID:
-        //                 logo = "fantom.png";
-        //                 break;
-        //             case network.chainId === BraveWallet.CELO_MAINNET_CHAIN_ID:
-        //                 logo = "celo.png";
-        //                 break;
-        if (network.chainId.equals(BraveWalletConstants.MAINNET_CHAIN_ID)) {
-            logo = "eth.png";
-        } else if (network.chainId.equals(BraveWalletConstants.POLYGON_MAINNET_CHAIN_ID)) {
-            logo = "matic.png";
-        } else if (network.chainId.equals(
-                           BraveWalletConstants.BINANCE_SMART_CHAIN_MAINNET_CHAIN_ID)) {
-            logo = "bnb.png";
-        } else if (network.chainId.equals(BraveWalletConstants.SOLANA_MAINNET)
-                || network.chainId.equals(BraveWalletConstants.SOLANA_TESTNET)
-                || network.chainId.equals(BraveWalletConstants.SOLANA_DEVNET)) {
-            logo = "sol.png";
-        } else {
-            logo = "eth.png";
-        }
+        logo = getNetworkIconName(network);
 
         BlockchainToken asset = new BlockchainToken();
         asset.name = network.symbolName;
@@ -1015,6 +985,36 @@ public class Utils {
         asset.chainId = network.chainId;
         asset.coin = network.coin;
         return asset;
+    }
+
+    @NonNull
+    public static String getNetworkIconName(NetworkInfo network) {
+        String logo;
+        switch (network.chainId) {
+            case BraveWalletConstants.MAINNET_CHAIN_ID:
+                logo = "eth.png";
+                break;
+            case BraveWalletConstants.POLYGON_MAINNET_CHAIN_ID:
+                logo = "matic.png";
+                break;
+            case BraveWalletConstants.BINANCE_SMART_CHAIN_MAINNET_CHAIN_ID:
+                logo = "bnb.png";
+                break;
+            case BraveWalletConstants.SOLANA_MAINNET:
+            case BraveWalletConstants.SOLANA_TESTNET:
+            case BraveWalletConstants.SOLANA_DEVNET:
+                logo = "sol.png";
+                break;
+            case BraveWalletConstants.AVALANCHE_MAINNET_CHAIN_ID:
+                logo = "avax.png";
+                break;
+            case BraveWalletConstants.CELO_MAINNET_CHAIN_ID:
+                logo = "celo.png";
+                break;
+            default:
+                logo = "eth.png";
+        }
+        return logo;
     }
 
     // Replace USDC and DAI contract addresses for Goerli network
@@ -1434,16 +1434,16 @@ public class Utils {
         return hostOrigin;
     }
 
-    public static WalletCoinAdapter setupVisibleAssetList(BlockchainToken[] userAssets,
+    public static WalletCoinAdapter setupVisibleAssetList(List<BlockchainToken> userAssets,
             HashMap<String, Double> perTokenCryptoSum, HashMap<String, Double> perTokenFiatSum,
-            String tokensPath) {
+            String tokensPath, Resources resources, List<NetworkInfo> allNetworkInfos) {
         WalletCoinAdapter walletCoinAdapter =
                 new WalletCoinAdapter(WalletCoinAdapter.AdapterType.VISIBLE_ASSETS_LIST);
         List<WalletListItemModel> walletListItemModelList = new ArrayList<>();
 
         for (BlockchainToken userAsset : userAssets) {
-            WalletListItemModel walletListItemModel = mapToWalletListItemModel(
-                    perTokenCryptoSum, perTokenFiatSum, tokensPath, userAsset);
+            WalletListItemModel walletListItemModel = mapToWalletListItemModel(perTokenCryptoSum,
+                    perTokenFiatSum, tokensPath, userAsset, resources, allNetworkInfos);
             walletListItemModelList.add(walletListItemModel);
         }
 
@@ -1455,14 +1455,15 @@ public class Utils {
 
     public static WalletCoinAdapter setupVisibleNftAssetList(
             List<PortfolioModel.NftDataModel> userAssets, HashMap<String, Double> perTokenCryptoSum,
-            HashMap<String, Double> perTokenFiatSum, String tokensPath) {
+            HashMap<String, Double> perTokenFiatSum, String tokensPath, Resources resources,
+            List<NetworkInfo> allNetworkInfos) {
         WalletCoinAdapter walletCoinAdapter =
                 new WalletCoinAdapter(WalletCoinAdapter.AdapterType.VISIBLE_ASSETS_LIST);
         List<WalletListItemModel> walletListItemModelList = new ArrayList<>();
 
         for (PortfolioModel.NftDataModel userAsset : userAssets) {
-            WalletListItemModel walletListItemModel = mapToWalletListItemModel(
-                    perTokenCryptoSum, perTokenFiatSum, tokensPath, userAsset.token);
+            WalletListItemModel walletListItemModel = mapToWalletListItemModel(perTokenCryptoSum,
+                    perTokenFiatSum, tokensPath, userAsset.token, resources, allNetworkInfos);
             walletListItemModel.setNftDataModel(userAsset);
             walletListItemModelList.add(walletListItemModel);
         }
@@ -1476,22 +1477,29 @@ public class Utils {
     @NonNull
     private static WalletListItemModel mapToWalletListItemModel(
             HashMap<String, Double> perTokenCryptoSum, HashMap<String, Double> perTokenFiatSum,
-            String tokensPath, BlockchainToken userAsset) {
+            String tokensPath, BlockchainToken userAsset, Resources resources,
+            List<NetworkInfo> allNetworkInfos) {
         String currentAssetKey = Utils.tokenToString(userAsset);
         Double fiatBalance = Utils.getOrDefault(perTokenFiatSum, currentAssetKey, 0.0d);
         String fiatBalanceString = String.format(Locale.getDefault(), "$%,.2f", fiatBalance);
         Double cryptoBalance = Utils.getOrDefault(perTokenCryptoSum, currentAssetKey, 0.0d);
+        NetworkInfo assetNetwork = NetworkUtils.findNetwork(allNetworkInfos, userAsset.chainId);
+        String subtitle = assetNetwork == null
+                ? userAsset.symbol
+                : resources.getString(R.string.brave_wallet_portfolio_asset_network_description,
+                        userAsset.symbol, assetNetwork.chainName);
         String cryptoBalanceString =
                 String.format(Locale.getDefault(), "%.4f %s", cryptoBalance, userAsset.symbol);
 
-        WalletListItemModel walletListItemModel =
-                new WalletListItemModel(Utils.getCoinIcon(userAsset.coin), userAsset.name,
-                        userAsset.symbol, userAsset.tokenId,
-                        // Amount in USD
-                        fiatBalanceString,
-                        // Amount in current crypto currency/token
-                        cryptoBalanceString);
+        WalletListItemModel walletListItemModel = new WalletListItemModel(
+                Utils.getCoinIcon(userAsset.coin), userAsset.name, subtitle, userAsset.tokenId,
+                // Amount in USD
+                fiatBalanceString,
+                // Amount in current crypto currency/token
+                cryptoBalanceString);
 
+        walletListItemModel.setBrowserResourcePath(tokensPath);
+        walletListItemModel.setAssetNetwork(assetNetwork);
         walletListItemModel.setIconPath("file://" + tokensPath + "/" + userAsset.logo);
         walletListItemModel.setBlockchainToken(userAsset);
         return walletListItemModel;
@@ -1511,15 +1519,16 @@ public class Utils {
     public static String tokenToString(BlockchainToken token) {
         if (token == null) return "";
 
-        final String symbolLowerCase = token.symbol.toLowerCase(Locale.getDefault());
-        return token.isErc721 ? Utils.formatErc721TokenTitle(symbolLowerCase, token.tokenId)
-                              : symbolLowerCase;
+        final String symbolLowerCase = token.symbol.toLowerCase(Locale.ENGLISH);
+        final String contractAddress = token.contractAddress.toLowerCase(Locale.ENGLISH);
+        return JavaUtils.concatStrings(
+                '#', symbolLowerCase, contractAddress, token.tokenId, token.chainId);
     }
 
     // Please only use this function when you need all the info (tokens, prices and balances) at the
     // same time!
     public static void getTxExtraInfo(WeakReference<BraveWalletBaseActivity> activityRef,
-            NetworkInfo[] allNetworks, NetworkInfo selectedNetwork, AccountInfo[] accountInfos,
+            List<NetworkInfo> allNetworks, NetworkInfo selectedNetwork, AccountInfo[] accountInfos,
             BlockchainToken[] filterByTokens, boolean userAssetsOnly,
             Callbacks.Callback4<HashMap<String, Double>, BlockchainToken[], HashMap<String, Double>,
                     HashMap<String, HashMap<String, Double>>> callback) {
@@ -1529,16 +1538,14 @@ public class Utils {
         BlockchainRegistry blockchainRegistry = activity.getBlockchainRegistry();
         AssetRatioService assetRatioService = activity.getAssetRatioService();
         JsonRpcService jsonRpcService = activity.getJsonRpcService();
-        BraveWalletP3a braveWalletP3A = activity.getBraveWalletP3A();
         assert braveWalletService != null && blockchainRegistry != null && assetRatioService != null
-                && jsonRpcService != null
-                && braveWalletP3A != null : "Invalid service initialization";
+                && jsonRpcService != null : "Invalid service initialization";
 
-        if (JavaUtils.anyNull(braveWalletService, blockchainRegistry, assetRatioService,
-                    jsonRpcService, braveWalletP3A))
+        if (JavaUtils.anyNull(
+                    braveWalletService, blockchainRegistry, assetRatioService, jsonRpcService))
             return;
 
-        AsyncUtils.MultiResponseHandler multiResponse = new AsyncUtils.MultiResponseHandler(4);
+        AsyncUtils.MultiResponseHandler multiResponse = new AsyncUtils.MultiResponseHandler(3);
 
         TokenUtils.getUserOrAllTokensFiltered(braveWalletService, blockchainRegistry,
                 selectedNetwork, selectedNetwork.coin, TokenUtils.TokenType.ALL, userAssetsOnly,
@@ -1570,36 +1577,19 @@ public class Utils {
                     BalanceHelper.getBlockchainTokensBalances(jsonRpcService, selectedNetwork,
                             accountInfos, tokens, getBlockchainTokensBalancesContext);
 
-                    AsyncUtils.GetP3ABalancesContext getP3ABalancesContext =
-                            new AsyncUtils.GetP3ABalancesContext(
-                                    multiResponse.singleResponseComplete);
-                    BalanceHelper.getP3ABalances(
-                            activityRef, allNetworks, selectedNetwork, getP3ABalancesContext);
-
                     multiResponse.setWhenAllCompletedAction(() -> {
-                        // P3A active accounts
-                        HashMap<Integer, HashSet<String>> activeAddresses =
-                                getP3ABalancesContext.activeAddresses;
-                        BalanceHelper.updateActiveAddresses(
-                                new AsyncUtils.GetNativeAssetsBalancesResponseContext[] {
-                                        getNativeAssetsBalancesContext},
-                                new AsyncUtils.GetBlockchainTokensBalancesResponseContext[] {
-                                        getBlockchainTokensBalancesContext},
-                                activeAddresses);
-                        for (int coinType : P3ACoinTypes) {
-                            braveWalletP3A.recordActiveWalletCount(
-                                    activeAddresses.get(coinType).size(), coinType);
-                        }
-
                         callback.call(fetchPricesContext.assetPrices, fullTokenList,
                                 getNativeAssetsBalancesContext.nativeAssetsBalances,
                                 getBlockchainTokensBalancesContext.blockchainTokensBalances);
+                        logP3ARecords(JavaUtils.asArray(getNativeAssetsBalancesContext),
+                                JavaUtils.asArray(getBlockchainTokensBalancesContext), activityRef,
+                                allNetworks, selectedNetwork);
                     });
                 });
     }
 
     public static void getP3ANetworks(
-            NetworkInfo[] allNetworks, Callbacks.Callback1<NetworkInfo[]> callback) {
+            List<NetworkInfo> allNetworks, Callbacks.Callback1<NetworkInfo[]> callback) {
         ArrayList<NetworkInfo> relevantNetworks = new ArrayList<NetworkInfo>();
         boolean countTestNetworks = CommandLine.getInstance().hasSwitch(
                 BraveWalletConstants.P3A_COUNT_TEST_NETWORKS_SWITCH);
@@ -1705,5 +1695,37 @@ public class Utils {
         }
 
         return num.doubleValue();
+    }
+
+    private static void logP3ARecords(
+            AsyncUtils.GetNativeAssetsBalancesResponseContext[] nativeAssetsBalancesResponses,
+            AsyncUtils
+                    .GetBlockchainTokensBalancesResponseContext[] blockchainTokensBalancesResponses,
+            WeakReference<BraveWalletBaseActivity> activityRef, List<NetworkInfo> allNetworks,
+            NetworkInfo selectedNetwork) {
+        BraveWalletBaseActivity activity = activityRef.get();
+        if (activity == null || activity.isFinishing()
+                || JavaUtils.anyNull(activity.getBraveWalletP3A()))
+            return;
+        BraveWalletP3a braveWalletP3A = activity.getBraveWalletP3A();
+
+        AsyncUtils.MultiResponseHandler multiResponse = new AsyncUtils.MultiResponseHandler(1);
+
+        AsyncUtils.GetP3ABalancesContext getP3ABalancesContext =
+                new AsyncUtils.GetP3ABalancesContext(multiResponse.singleResponseComplete);
+        BalanceHelper.getP3ABalances(
+                activityRef, allNetworks, selectedNetwork, getP3ABalancesContext);
+
+        multiResponse.setWhenAllCompletedAction(() -> {
+            HashMap<Integer, HashSet<String>> activeAddresses =
+                    getP3ABalancesContext.activeAddresses;
+            // P3A active accounts
+            BalanceHelper.updateActiveAddresses(nativeAssetsBalancesResponses,
+                    blockchainTokensBalancesResponses, activeAddresses);
+            for (int coinType : P3ACoinTypes) {
+                braveWalletP3A.recordActiveWalletCount(
+                        activeAddresses.get(coinType).size(), coinType);
+            }
+        });
     }
 }

--- a/android/java/res/layout/edit_visible_assets_bottom_sheet.xml
+++ b/android/java/res/layout/edit_visible_assets_bottom_sheet.xml
@@ -1,36 +1,57 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    tools:ignore="RtlSymmetry"
     android:background="@color/wallet_bg"
-    android:orientation="vertical">
+    android:orientation="vertical"
+    tools:ignore="RtlSymmetry">
 
     <androidx.appcompat.widget.SearchView
         android:id="@+id/searchView"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:inputType="textFilter"
         android:layout_marginStart="21dp"
         android:layout_marginTop="32dp"
-        android:layout_marginEnd="27dp"/>
+        android:layout_marginEnd="27dp"
+        android:inputType="textFilter" />
 
-    <TextView
-        android:id="@+id/add_custom_asset"
-        android:layout_width="wrap_content"
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:text="@string/wallet_add_custom_asset"
-        android:textColor="@color/brave_action_color"
-        android:gravity="center"
-        android:textSize="14sp"
-        android:paddingTop="8dp"
-        android:paddingBottom="8dp"
-        android:paddingStart="16dp"
-        android:paddingEnd="16dp"
-        android:layout_marginStart="21dp"
-        android:layout_marginTop="8dp"
-        android:layout_marginBottom="8dp"/>
+        android:layout_marginVertical="4dp"
+        android:layout_marginHorizontal="20dp">
+
+        <TextView
+            android:id="@+id/add_custom_asset"
+            style="@style/BraveWalletTextView"
+            android:layout_width="0dp"
+            android:paddingVertical="8dp"
+            android:text="@string/wallet_add_custom_asset"
+            android:textColor="@color/brave_action_color"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toStartOf="@id/edit_visible_tv_network"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
+
+        <TextView
+            android:id="@+id/edit_visible_tv_network"
+            style="@style/BraveWalletTextView"
+            android:background="@drawable/crypto_wallet_hollow_button"
+            android:gravity="center"
+            android:paddingHorizontal="8dp"
+            android:paddingVertical="2dp"
+            android:textStyle="bold"
+            android:visibility="gone"
+            app:autoSizeTextType="uniform"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toEndOf="@id/add_custom_asset"
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintWidth_min="80dp" />
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
 
     <androidx.recyclerview.widget.RecyclerView
         android:id="@+id/rvAssets"

--- a/android/java/res/layout/wallet_coin_list_item.xml
+++ b/android/java/res/layout/wallet_coin_list_item.xml
@@ -3,19 +3,37 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
+    android:layout_marginVertical="8dp"
     android:background="?android:attr/selectableItemBackground"
     android:clickable="true"
     android:focusable="true"
-    android:layout_marginTop="8dp"
-    android:layout_marginBottom="8dp"
     android:orientation="horizontal">
 
-    <ImageView
-        android:id="@+id/icon"
-        android:layout_width="50dp"
-        android:layout_height="50dp"
-        android:layout_gravity="center_vertical"
-        android:contentDescription="@null"/>
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content">
+
+        <ImageView
+            android:id="@+id/icon"
+            android:layout_width="50dp"
+            android:layout_height="50dp"
+            android:layout_gravity="center_vertical"
+            android:contentDescription="@null"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
+
+        <ImageView
+            android:id="@+id/iv_network_Icon"
+            android:layout_width="18dp"
+            android:layout_height="18dp"
+            android:layout_gravity="center_vertical"
+            android:contentDescription="@null"
+            android:visibility="gone"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent" />
+    </androidx.constraintlayout.widget.ConstraintLayout>
 
     <LinearLayout
         android:layout_width="0dp"

--- a/browser/ui/android/strings/android_brave_strings.grd
+++ b/browser/ui/android/strings/android_brave_strings.grd
@@ -3575,6 +3575,9 @@ If you don't accept this request, VPN will not reconnect and your internet conne
     <message name="IDS_ENABLE_SPEEDREADER_SUMMARY" desc="Summary for preference that enables or disables Speedreader">
       Automatically loads eligible articles in reader mode
     </message>
+    <message name="IDS_BRAVE_WALLET_PORTFOLIO_ASSET_NETWORK_DESCRIPTION" desc="Portfolio asset item network description">
+      <ph name="SYMBOL"><ex>BAT</ex>%1$s</ph> on <ph name="NETWORK"><ex>Ethereum Mainnet</ex>%2$s</ph>
+    </message>
   </messages>
   </release>
 </grit>


### PR DESCRIPTION
- Implementing multi chain show balance (#27333)
- Refactor network selector screen to show new "All network" (#27074)
- Implemented multi-chain price and asset data collection (#27333)
- Show overlapping network icon on Portfolio and Asset selection screens (#27333)
- Show asset graph data for different networks and assets (#28748)
- Fixed unwanted duplicate removal from list (#28506)
- Fix balance issue for incoming asset
- Reduce latency by separating P3A calls
- Fixed edit visible asset to select assets
- Fixed edit visible assets list for all network to show default assets in "edit visible assets" when all networks is selected (until all network is supported)
- Updated portfolio, edit, view assets list UI list to show asset and network details from "All network" view
- Fix AssetDetails activity to use passed network
- Fixed AccountDetails activity issue with network
- Tested and added available icons for networks/native assets, logged issue for missing assets (#28798)
- Fix account list on asset details on AssetDetails screen
- Fixed cached NFTs after unlock wallet (#28301)
- Fixing asset graph data when multiple assets are shown
- Fix nested network list is instantly closed after selection (click) and improve selection (#27614)
- ERC721 NFTs with different token identifiers may show incorrect balance (#28627)
- Implement All networks list sort order
- Fix Buy, Send, Swap flows for selected multi-chain view token
- Fix crash with test network with new flow
- Ux: Show full network name on click on Edit visible via click popup
- Clear balance with network switching
- Clean up and refactoring to reuse

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/27074
Resolves https://github.com/brave/brave-browser/issues/27333
Resolves https://github.com/brave/brave-browser/issues/28506
Resolves https://github.com/brave/brave-browser/issues/28748
Resolves https://github.com/brave/brave-browser/issues/28627
Resolves https://github.com/brave/brave-browser/issues/28301
Resolves https://github.com/brave/brave-browser/issues/27614

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-arm64, CI/skip-linux-x64, CI/skip-android, CI/skip-macos, CI/skip-ios, CI/skip-windows-arm64, CI/skip-windows-x64, CI/skip-windows-x86 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

[multi-chain.webm](https://user-images.githubusercontent.com/11755381/225301245-e26457d1-64ce-45f2-a163-7d0b69ec6387.webm)

### Additional:
- Not all network overlapping icons are show because they are unavailable: https://github.com/brave/brave-browser/issues/28561#issuecomment-1448109555
- Selected asset is preserved for long enough to work with incoming asset and single selection. Ideally will be showing no asset like desktop to avoid complication and extra calls to show the selected asset.