### PR TITLE
[Uplift] [1.50] Don't show zero suggest results when autocomplete is disabled (#17587)

### DIFF
--- a/components/omnibox/browser/brave_local_history_zero_suggest_provider.cc
+++ b/components/omnibox/browser/brave_local_history_zero_suggest_provider.cc
@@ -24,7 +24,8 @@ BraveLocalHistoryZeroSuggestProvider::~BraveLocalHistoryZeroSuggestProvider() =
 
 void BraveLocalHistoryZeroSuggestProvider::Start(const AutocompleteInput& input,
                                                  bool minimal_changes) {
-  if (!client_->GetPrefs()->GetBoolean(omnibox::kHistorySuggestionsEnabled)) {
+  if (!client_->GetPrefs()->GetBoolean(omnibox::kHistorySuggestionsEnabled) ||
+      !client_->GetPrefs()->GetBoolean(omnibox::kAutocompleteEnabled)) {
     matches_.clear();
     return;
   }


### PR DESCRIPTION
Uplift of https://github.com/brave/brave-core/pull/17587 which fixes https://github.com/brave/brave-browser/issues/29043