### PR TITLE
Add P3A core usage ping metrics for daily & monthly cadences, create …

### DIFF
--- a/browser/brave_local_state_prefs.cc
+++ b/browser/brave_local_state_prefs.cc
@@ -69,6 +69,8 @@ void RegisterLocalStatePrefsForMigration(PrefRegistrySimple* registry) {
   // Added 10/2022
   registry->RegisterBooleanPref(kDefaultBrowserPromptEnabled, true);
 #endif
+
+  brave_wallet::RegisterLocalStatePrefsForMigration(registry);
 }
 
 void RegisterLocalStatePrefs(PrefRegistrySimple* registry) {

--- a/browser/brave_stats/brave_stats_updater.cc
+++ b/browser/brave_stats/brave_stats_updater.cc
@@ -10,6 +10,7 @@
 
 #include "base/barrier_closure.h"
 #include "base/command_line.h"
+#include "base/metrics/histogram_macros.h"
 #include "base/system/sys_info.h"
 #include "brave/browser/brave_stats/brave_stats_updater_params.h"
 #include "brave/browser/brave_stats/buildflags.h"
@@ -40,6 +41,9 @@
 #include "services/network/public/mojom/fetch_api.mojom-shared.h"
 
 namespace brave_stats {
+
+const char kP3AMonthlyPingHistogramName[] = "Brave.Core.UsageMonthly";
+const char kP3ADailyPingHistogramName[] = "Brave.Core.UsageDaily";
 
 namespace {
 
@@ -89,6 +93,7 @@ net::NetworkTrafficAnnotationTag AnonymousStatsAnnotation() {
         "Not implemented."
     })");
 }
+
 }  // anonymous namespace
 
 BraveStatsUpdater::BraveStatsUpdater(PrefService* pref_service)
@@ -126,6 +131,10 @@ void BraveStatsUpdater::Start() {
   server_ping_periodic_timer_->Start(
       FROM_HERE, base::Seconds(kUpdateServerPeriodicPingFrequencySeconds), this,
       &BraveStatsUpdater::OnServerPingTimerFired);
+
+  // Record ping for P3A.
+  UMA_HISTOGRAM_BOOLEAN(kP3AMonthlyPingHistogramName, true);
+  UMA_HISTOGRAM_BOOLEAN(kP3ADailyPingHistogramName, true);
 }
 
 void BraveStatsUpdater::Stop() {

--- a/browser/brave_stats/brave_stats_updater.h
+++ b/browser/brave_stats/brave_stats_updater.h
@@ -42,6 +42,9 @@ class GeneralBrowserUsage;
 
 namespace brave_stats {
 
+extern const char kP3AMonthlyPingHistogramName[];
+extern const char kP3ADailyPingHistogramName[];
+
 class BraveStatsUpdaterParams;
 
 class BraveStatsUpdater {
@@ -66,6 +69,7 @@ class BraveStatsUpdater {
   void SetUsageServerForTesting(const std::string& usage_server);
 
  private:
+  void RecordP3APing();
   GURL BuildStatsEndpoint(const std::string& path);
   void OnThresholdLoaderComplete(scoped_refptr<net::HttpResponseHeaders>);
   // Invoked from SimpleURLLoader after download is complete.

--- a/browser/brave_wallet/brave_wallet_service_unittest.cc
+++ b/browser/brave_wallet/brave_wallet_service_unittest.cc
@@ -1990,81 +1990,6 @@ TEST_F(BraveWalletServiceUnitTest, MigrateUserAssetsAddIsERC1155) {
       GetPrefs()->GetBoolean(kBraveWalletUserAssetsAddIsERC1155Migrated));
 }
 
-TEST_F(BraveWalletServiceUnitTest, RecordWalletNoUse) {
-  EXPECT_EQ(GetLocalState()->GetTime(kBraveWalletP3ALastReportTime),
-            base::Time::Now());
-  EXPECT_EQ(GetLocalState()->GetTime(kBraveWalletP3AFirstReportTime),
-            base::Time::Now());
-
-  task_environment_.FastForwardBy(base::Days(3));
-  // Still in the one week "no report" period, we should not see any reporting
-  histogram_tester_->ExpectTotalCount(kBraveWalletWeeklyHistogramName, 0);
-  histogram_tester_->ExpectTotalCount(kBraveWalletMonthlyHistogramName, 0);
-
-  task_environment_.FastForwardBy(base::Days(4));
-  // Just exited the "no report" period, we should have one report
-  histogram_tester_->ExpectBucketCount(kBraveWalletWeeklyHistogramName, 0, 1);
-  histogram_tester_->ExpectTotalCount(kBraveWalletMonthlyHistogramName, 0);
-}
-
-TEST_F(BraveWalletServiceUnitTest, RecordWalletWeekly) {
-  service_->RemovePrefListenersForTests();
-  // skipping one week "no report" period
-  task_environment_.FastForwardBy(base::Days(8) + base::Seconds(2));
-
-  // unlocked wallet on day 1
-  GetLocalState()->SetTime(kBraveWalletLastUnlockTime, base::Time::Now());
-  task_environment_.RunUntilIdle();
-  histogram_tester_->ExpectBucketCount(kBraveWalletWeeklyHistogramName, 1, 1);
-
-  task_environment_.FastForwardBy(base::Days(2));
-  // day 3
-  histogram_tester_->ExpectBucketCount(kBraveWalletWeeklyHistogramName, 1, 3);
-
-  // unlocked wallet on day 4
-  GetLocalState()->SetTime(kBraveWalletLastUnlockTime, base::Time::Now());
-  task_environment_.RunUntilIdle();
-  task_environment_.FastForwardBy(base::Days(1));
-  // day 5
-  histogram_tester_->ExpectBucketCount(kBraveWalletWeeklyHistogramName, 1, 3);
-  histogram_tester_->ExpectBucketCount(kBraveWalletWeeklyHistogramName, 2, 2);
-
-  task_environment_.FastForwardBy(base::Days(2));
-  // day 7
-  histogram_tester_->ExpectBucketCount(kBraveWalletWeeklyHistogramName, 1, 3);
-  histogram_tester_->ExpectBucketCount(kBraveWalletWeeklyHistogramName, 2, 4);
-
-  task_environment_.FastForwardBy(base::Days(2));
-  // day 9, first use is no longer in weekly lookback
-  histogram_tester_->ExpectBucketCount(kBraveWalletWeeklyHistogramName, 1, 4);
-}
-
-TEST_F(BraveWalletServiceUnitTest, RecordWalletMonthly) {
-  service_->RemovePrefListenersForTests();
-  // skipping one week "no report" period
-  task_environment_.AdvanceClock(base::Days(8));
-  task_environment_.FastForwardBy(base::Minutes(1));
-  histogram_tester_->ExpectBucketCount(kBraveWalletMonthlyHistogramName, 0, 0);
-
-  // unlocked wallet for first time during current month
-  GetLocalState()->SetTime(kBraveWalletLastUnlockTime,
-                           base::Time::Now() + base::Minutes(1));
-  task_environment_.AdvanceClock(base::Days(1));
-  task_environment_.FastForwardBy(base::Minutes(1));
-  // we do not report the monthly use until the next month
-  histogram_tester_->ExpectBucketCount(kBraveWalletMonthlyHistogramName, 0, 0);
-
-  // skipping ahead to new month, should report monthly use
-  task_environment_.AdvanceClock(base::Days(31));
-  task_environment_.FastForwardBy(base::Minutes(1));
-  histogram_tester_->ExpectBucketCount(kBraveWalletMonthlyHistogramName, 1, 1);
-
-  // skipping ahead another month without using wallet
-  task_environment_.AdvanceClock(base::Days(31));
-  task_environment_.FastForwardBy(base::Minutes(1));
-  histogram_tester_->ExpectBucketCount(kBraveWalletMonthlyHistogramName, 0, 1);
-}
-
 TEST_F(BraveWalletServiceUnitTest, OnGetImportInfo) {
   const char* new_password = "brave1234!";
   bool success;
@@ -2579,7 +2504,7 @@ TEST_F(BraveWalletServiceUnitTest, LastUsageTimeMetric) {
   histogram_tester_->ExpectTotalCount(kBraveWalletLastUsageTimeHistogramName,
                                       0);
 
-  GetPrefs()->SetTime(kBraveWalletLastUnlockTime, base::Time::Now());
+  GetLocalState()->SetTime(kBraveWalletLastUnlockTime, base::Time::Now());
   task_environment_.RunUntilIdle();
 
   histogram_tester_->ExpectUniqueSample(kBraveWalletLastUsageTimeHistogramName,
@@ -2597,7 +2522,7 @@ TEST_F(BraveWalletServiceUnitTest, LastUsageTimeMetric) {
   histogram_tester_->ExpectBucketCount(kBraveWalletLastUsageTimeHistogramName,
                                        1, 7);
 
-  GetPrefs()->SetTime(kBraveWalletLastUnlockTime, base::Time::Now());
+  GetLocalState()->SetTime(kBraveWalletLastUnlockTime, base::Time::Now());
   task_environment_.RunUntilIdle();
 
   histogram_tester_->ExpectBucketCount(kBraveWalletLastUsageTimeHistogramName,
@@ -2628,6 +2553,32 @@ TEST_F(BraveWalletServiceUnitTest, SetNftDiscoveryEnabled) {
   // And then back to false
   service_->SetNftDiscoveryEnabled(false);
   EXPECT_FALSE(GetPrefs()->GetBoolean(kBraveWalletNftDiscoveryEnabled));
+}
+
+TEST_F(BraveWalletServiceUnitTest, RecordGeneralUsageMetrics) {
+  histogram_tester_->ExpectTotalCount(kBraveWalletMonthlyHistogramName, 0);
+  histogram_tester_->ExpectTotalCount(kBraveWalletWeeklyHistogramName, 0);
+  histogram_tester_->ExpectTotalCount(kBraveWalletDailyHistogramName, 0);
+
+  GetLocalState()->SetTime(kBraveWalletLastUnlockTime, base::Time::Now());
+  task_environment_.RunUntilIdle();
+
+  histogram_tester_->ExpectUniqueSample(kBraveWalletMonthlyHistogramName, 1, 1);
+  histogram_tester_->ExpectUniqueSample(kBraveWalletWeeklyHistogramName, 1, 1);
+  histogram_tester_->ExpectUniqueSample(kBraveWalletDailyHistogramName, 1, 1);
+
+  task_environment_.FastForwardBy(base::Days(7));
+
+  histogram_tester_->ExpectUniqueSample(kBraveWalletMonthlyHistogramName, 1, 1);
+  histogram_tester_->ExpectUniqueSample(kBraveWalletWeeklyHistogramName, 1, 1);
+  histogram_tester_->ExpectUniqueSample(kBraveWalletDailyHistogramName, 1, 1);
+
+  GetLocalState()->SetTime(kBraveWalletLastUnlockTime, base::Time::Now());
+  task_environment_.RunUntilIdle();
+
+  histogram_tester_->ExpectUniqueSample(kBraveWalletMonthlyHistogramName, 1, 2);
+  histogram_tester_->ExpectUniqueSample(kBraveWalletWeeklyHistogramName, 1, 2);
+  histogram_tester_->ExpectUniqueSample(kBraveWalletDailyHistogramName, 1, 2);
 }
 
 }  // namespace brave_wallet

--- a/components/brave_wallet/browser/BUILD.gn
+++ b/components/brave_wallet/browser/BUILD.gn
@@ -193,7 +193,6 @@ static_library("browser") {
     "//brave/components/json/rs:cxx",
     "//brave/components/p3a_utils",
     "//brave/components/resources:strings_grit",
-    "//brave/components/time_period_storage",
     "//components/component_updater",
     "//components/content_settings/core/browser",
     "//components/keyed_service/core",

--- a/components/brave_wallet/browser/brave_wallet_p3a.cc
+++ b/components/brave_wallet/browser/brave_wallet_p3a.cc
@@ -17,7 +17,6 @@
 #include "brave/components/brave_wallet/common/brave_wallet.mojom-forward.h"
 #include "brave/components/p3a_utils/bucket.h"
 #include "brave/components/p3a_utils/feature_usage.h"
-#include "brave/components/time_period_storage/weekly_storage.h"
 #include "components/prefs/pref_service.h"
 #include "components/prefs/scoped_user_pref_update.h"
 
@@ -40,8 +39,9 @@ const char kFilTransactionSentHistogramName[] =
 const char kEthActiveAccountHistogramName[] = "Brave.Wallet.ActiveEthAccounts";
 const char kSolActiveAccountHistogramName[] = "Brave.Wallet.ActiveSolAccounts";
 const char kFilActiveAccountHistogramName[] = "Brave.Wallet.ActiveFilAccounts";
-const char kBraveWalletWeeklyHistogramName[] = "Brave.Wallet.UsageDaysInWeek";
-const char kBraveWalletMonthlyHistogramName[] = "Brave.Wallet.UsageMonthly.2";
+const char kBraveWalletDailyHistogramName[] = "Brave.Wallet.UsageDaily";
+const char kBraveWalletWeeklyHistogramName[] = "Brave.Wallet.UsageWeekly";
+const char kBraveWalletMonthlyHistogramName[] = "Brave.Wallet.UsageMonthly";
 const char kBraveWalletNewUserReturningHistogramName[] =
     "Brave.Wallet.NewUserReturning";
 const char kBraveWalletLastUsageTimeHistogramName[] =
@@ -51,10 +51,11 @@ namespace {
 
 constexpr int kRefreshP3AFrequencyHours = 24;
 constexpr int kActiveAccountBuckets[] = {0, 1, 2, 3, 7};
-const char* kTimePrefsToMigrateToLocalState[] = {
-    kBraveWalletLastUnlockTime, kBraveWalletP3AFirstReportTime,
-    kBraveWalletP3ALastReportTime, kBraveWalletP3AFirstUnlockTime,
-    kBraveWalletP3ALastUnlockTime};
+const char* kTimePrefsToMigrateToLocalState[] = {kBraveWalletLastUnlockTime,
+                                                 kBraveWalletP3AFirstUnlockTime,
+                                                 kBraveWalletP3ALastUnlockTime};
+const char* kTimePrefsToRemove[] = {kBraveWalletP3AFirstReportTime,
+                                    kBraveWalletP3ALastReportTime};
 
 // Has the Wallet keyring been created?
 // 0) No, 1) Yes
@@ -138,31 +139,11 @@ void BraveWalletP3A::ReportUsage(bool unlocked) {
   VLOG(1) << "Wallet P3A: starting report";
   base::Time wallet_last_used =
       local_state_->GetTime(kBraveWalletLastUnlockTime);
-  base::Time first_p3a_report =
-      local_state_->GetTime(kBraveWalletP3AFirstReportTime);
-  base::Time last_p3a_report =
-      local_state_->GetTime(kBraveWalletP3ALastReportTime);
-
-  VLOG(1) << "Wallet P3A: first report: " << first_p3a_report
-          << " last_report: " << last_p3a_report;
-
-  WeeklyStorage weekly_store(local_state_, kBraveWalletP3AWeeklyStorage);
-  if (wallet_last_used > last_p3a_report) {
-    weekly_store.ReplaceTodaysValueIfGreater(1);
-    VLOG(1) << "Wallet P3A: Reporting day in week, curr days in week val: "
-            << weekly_store.GetWeeklySum();
-  }
-
-  WriteUsageStatsToHistogram(wallet_last_used, first_p3a_report,
-                             last_p3a_report, weekly_store.GetWeeklySum());
-
-  local_state_->SetTime(kBraveWalletP3ALastReportTime, base::Time::Now());
-  if (first_p3a_report.is_null())
-    local_state_->SetTime(kBraveWalletP3AFirstReportTime, base::Time::Now());
 
   if (unlocked) {
     p3a_utils::RecordFeatureUsage(local_state_, kBraveWalletP3AFirstUnlockTime,
                                   kBraveWalletP3ALastUnlockTime);
+    WriteUsageStatsToHistogram();
   } else {
     // Maybe record existing timestamp in case the user is not new.
     p3a_utils::MaybeRecordFeatureExistingUsageTimestamp(
@@ -329,7 +310,7 @@ void BraveWalletP3A::RecordActiveWalletCount(int count,
                                      count);
 }
 
-// TODO(djandries): remove pref migration after a few months have passed
+// TODO(djandries): remove pref migration around November 2023
 void BraveWalletP3A::MigrateUsageProfilePrefsToLocalState() {
   for (const char* pref_name : kTimePrefsToMigrateToLocalState) {
     if (local_state_->GetTime(pref_name).is_null()) {
@@ -340,6 +321,10 @@ void BraveWalletP3A::MigrateUsageProfilePrefsToLocalState() {
       }
     }
   }
+  for (const char* pref_name : kTimePrefsToRemove) {
+    local_state_->ClearPref(pref_name);
+    profile_prefs_->ClearPref(pref_name);
+  }
   if (!local_state_->GetBoolean(kBraveWalletP3AUsedSecondDay)) {
     bool profile_used_second_day =
         profile_prefs_->GetBoolean(kBraveWalletP3AUsedSecondDay);
@@ -348,15 +333,8 @@ void BraveWalletP3A::MigrateUsageProfilePrefsToLocalState() {
       profile_prefs_->ClearPref(kBraveWalletP3AUsedSecondDay);
     }
   }
-  if (local_state_->GetList(kBraveWalletP3AWeeklyStorage).empty()) {
-    const base::Value::List& profile_weekly_list =
-        profile_prefs_->GetList(kBraveWalletP3AWeeklyStorage);
-    if (!profile_weekly_list.empty()) {
-      local_state_->SetList(kBraveWalletP3AWeeklyStorage,
-                            profile_weekly_list.Clone());
-      profile_prefs_->ClearPref(kBraveWalletP3AWeeklyStorage);
-    }
-  }
+  local_state_->ClearPref(kBraveWalletP3AWeeklyStorage);
+  profile_prefs_->ClearPref(kBraveWalletP3AWeeklyStorage);
 }
 
 void BraveWalletP3A::OnUpdateTimerFired() {
@@ -366,42 +344,11 @@ void BraveWalletP3A::OnUpdateTimerFired() {
   ReportTransactionSent(mojom::CoinType::SOL, false);
 }
 
-void BraveWalletP3A::WriteUsageStatsToHistogram(base::Time wallet_last_used,
-                                                base::Time first_p3a_report,
-                                                base::Time last_p3a_report,
-                                                unsigned use_days_in_week) {
-  base::Time::Exploded now_exp;
-  base::Time::Exploded last_report_exp;
-  base::Time::Exploded last_used_exp;
-  base::Time::Now().LocalExplode(&now_exp);
-  last_p3a_report.LocalExplode(&last_report_exp);
-  wallet_last_used.LocalExplode(&last_used_exp);
-
-  bool new_month_detected =
-      !last_p3a_report.is_null() && (now_exp.year != last_report_exp.year ||
-                                     now_exp.month != last_report_exp.month);
-
-  if (new_month_detected) {
-    bool used_last_month = !wallet_last_used.is_null() &&
-                           last_report_exp.month == last_used_exp.month &&
-                           last_report_exp.year == last_used_exp.year;
-    VLOG(1) << "Wallet P3A: New month detected. used last month: "
-            << used_last_month;
-    UMA_HISTOGRAM_BOOLEAN(kBraveWalletMonthlyHistogramName, used_last_month);
-  }
-
-  bool week_passed_since_install =
-      !first_p3a_report.is_null() &&
-      (base::Time::Now() - first_p3a_report).InDays() >= 7;
-  if (week_passed_since_install) {
-    VLOG(1) << "Wallet P3A: recording daily/weekly. weekly_sum: "
-            << use_days_in_week;
-    UMA_HISTOGRAM_EXACT_LINEAR(kBraveWalletWeeklyHistogramName,
-                               use_days_in_week, 8);
-  } else {
-    VLOG(1) << "Wallet P3A: Need 7 days of reports before recording "
-               "daily/weekly, skipping";
-  }
+void BraveWalletP3A::WriteUsageStatsToHistogram() {
+  VLOG(1) << "Wallet P3A: Recording usage";
+  UMA_HISTOGRAM_BOOLEAN(kBraveWalletMonthlyHistogramName, true);
+  UMA_HISTOGRAM_BOOLEAN(kBraveWalletWeeklyHistogramName, true);
+  UMA_HISTOGRAM_BOOLEAN(kBraveWalletDailyHistogramName, true);
 }
 
 void BraveWalletP3A::RecordInitialBraveWalletP3AState() {

--- a/components/brave_wallet/browser/brave_wallet_p3a.h
+++ b/components/brave_wallet/browser/brave_wallet_p3a.h
@@ -32,6 +32,7 @@ extern const char kFilTransactionSentHistogramName[];
 extern const char kEthActiveAccountHistogramName[];
 extern const char kSolActiveAccountHistogramName[];
 extern const char kFilActiveAccountHistogramName[];
+extern const char kBraveWalletDailyHistogramName[];
 extern const char kBraveWalletWeeklyHistogramName[];
 extern const char kBraveWalletMonthlyHistogramName[];
 extern const char kBraveWalletNewUserReturningHistogramName[];
@@ -103,10 +104,7 @@ class BraveWalletP3A : public mojom::KeyringServiceObserver,
  private:
   void MigrateUsageProfilePrefsToLocalState();
   void OnUpdateTimerFired();
-  void WriteUsageStatsToHistogram(base::Time wallet_last_used,
-                                  base::Time first_p3a_used,
-                                  base::Time last_p3a_report,
-                                  unsigned use_days_in_week);
+  void WriteUsageStatsToHistogram();
   void RecordInitialBraveWalletP3AState();
   raw_ptr<BraveWalletService> wallet_service_;
   raw_ptr<KeyringService> keyring_service_;

--- a/components/brave_wallet/browser/brave_wallet_prefs.cc
+++ b/components/brave_wallet/browser/brave_wallet_prefs.cc
@@ -76,9 +76,6 @@ base::Value::Dict GetDefaultHiddenNetworks() {
 
 void RegisterLocalStatePrefs(PrefRegistrySimple* registry) {
   registry->RegisterTimePref(kBraveWalletLastUnlockTime, base::Time());
-  registry->RegisterTimePref(kBraveWalletP3ALastReportTime, base::Time());
-  registry->RegisterTimePref(kBraveWalletP3AFirstReportTime, base::Time());
-  registry->RegisterListPref(kBraveWalletP3AWeeklyStorage);
   p3a_utils::RegisterFeatureUsagePrefs(registry, kBraveWalletP3AFirstUnlockTime,
                                        kBraveWalletP3ALastUnlockTime,
                                        kBraveWalletP3AUsedSecondDay, nullptr);
@@ -118,19 +115,17 @@ void RegisterProfilePrefs(user_prefs::PrefRegistrySyncable* registry) {
   registry->RegisterDictionaryPref(kBraveWalletLastTransactionSentTimeDict);
   registry->RegisterTimePref(kBraveWalletLastDiscoveredAssetsAt, base::Time());
 
-  // TODO(djandries): remove the following prefs at some point,
-  //                  since they're now maintained in local state
-  p3a_utils::RegisterFeatureUsagePrefs(registry, kBraveWalletP3AFirstUnlockTime,
-                                       kBraveWalletP3ALastUnlockTime,
-                                       kBraveWalletP3AUsedSecondDay, nullptr);
-  registry->RegisterTimePref(kBraveWalletLastUnlockTime, base::Time());
-  registry->RegisterTimePref(kBraveWalletP3ALastReportTime, base::Time());
-  registry->RegisterTimePref(kBraveWalletP3AFirstReportTime, base::Time());
-  registry->RegisterListPref(kBraveWalletP3AWeeklyStorage);
   registry->RegisterDictionaryPref(kPinnedNFTAssets);
   registry->RegisterBooleanPref(kAutoPinEnabled, false);
   registry->RegisterBooleanPref(kShouldShowWalletSuggestionBadge, true);
   registry->RegisterBooleanPref(kBraveWalletNftDiscoveryEnabled, false);
+}
+
+void RegisterLocalStatePrefsForMigration(PrefRegistrySimple* registry) {
+  // Added 04/2023
+  registry->RegisterTimePref(kBraveWalletP3ALastReportTime, base::Time());
+  registry->RegisterTimePref(kBraveWalletP3AFirstReportTime, base::Time());
+  registry->RegisterListPref(kBraveWalletP3AWeeklyStorage);
 }
 
 void RegisterProfilePrefsForMigration(
@@ -170,6 +165,15 @@ void RegisterProfilePrefsForMigration(
 
   // Added 10/2022
   registry->RegisterBooleanPref(kBraveWalletUserAssetsAddIsNFTMigrated, false);
+
+  // Added 11/2022
+  p3a_utils::RegisterFeatureUsagePrefs(registry, kBraveWalletP3AFirstUnlockTime,
+                                       kBraveWalletP3ALastUnlockTime,
+                                       kBraveWalletP3AUsedSecondDay, nullptr);
+  registry->RegisterTimePref(kBraveWalletLastUnlockTime, base::Time());
+  registry->RegisterTimePref(kBraveWalletP3ALastReportTime, base::Time());
+  registry->RegisterTimePref(kBraveWalletP3AFirstReportTime, base::Time());
+  registry->RegisterListPref(kBraveWalletP3AWeeklyStorage);
 
   // Added 12/2022
   registry->RegisterBooleanPref(kShowWalletTestNetworksDeprecated, false);

--- a/components/brave_wallet/browser/brave_wallet_prefs.h
+++ b/components/brave_wallet/browser/brave_wallet_prefs.h
@@ -17,6 +17,7 @@ namespace brave_wallet {
 
 void RegisterLocalStatePrefs(PrefRegistrySimple* registry);
 void RegisterProfilePrefs(user_prefs::PrefRegistrySyncable* registry);
+void RegisterLocalStatePrefsForMigration(PrefRegistrySimple* registry);
 void RegisterProfilePrefsForMigration(
     user_prefs::PrefRegistrySyncable* registry);
 void ClearJsonRpcServiceProfilePrefs(PrefService* prefs);

--- a/components/p3a/metric_names.h
+++ b/components/p3a/metric_names.h
@@ -99,8 +99,7 @@ constexpr inline auto kCollectedTypicalHistograms =
     "Brave.Wallet.OnboardingConversion.2",
     "Brave.Wallet.SolProvider",
     "Brave.Wallet.SolTransactionSent",
-    "Brave.Wallet.UsageDaysInWeek",
-    "Brave.Wallet.UsageMonthly.2",
+    "Brave.Wallet.UsageWeekly",
     "Brave.Welcome.InteractionStatus",
 
     // IPFS
@@ -177,24 +176,26 @@ constexpr inline auto kCollectedTypicalHistograms =
 
 constexpr inline auto kCollectedSlowHistograms =
   base::MakeFixedFlatSet<base::StringPiece>({
-    // Please remove following placeholder metric once
-    // static slow metrics are added
+    "Brave.Core.UsageMonthly",
     "Brave.P3A.TestSlowMetric",
+    "Brave.Wallet.UsageMonthly"
 });
 
 constexpr inline auto kCollectedExpressHistograms =
   base::MakeFixedFlatSet<base::StringPiece>({
-    // Keep the top metric for the express unit test
-    // Remove it when there are other non ephemeral metrics at the beginning of the set
-    "Brave.P3A.TestExpressMetric",
-    "Brave.Rewards.EnabledInstallationTime"
+    "Brave.Core.UsageDaily",
+    "Brave.Rewards.EnabledInstallationTime",
+    "Brave.Wallet.UsageDaily"
 });
 
 // List of metrics that should only be sent once per latest histogram update.
 // Once the metric value has been sent, the value will be removed from the log store.
 constexpr inline auto kEphemeralHistograms =
   base::MakeFixedFlatSet<base::StringPiece>({
-    "Brave.Rewards.EnabledInstallationTime"
+    "Brave.Rewards.EnabledInstallationTime",
+    "Brave.Wallet.UsageDaily",
+    "Brave.Wallet.UsageMonthly",
+    "Brave.Wallet.UsageWeekly"
 });
 
 // clang-format on


### PR DESCRIPTION
…new wallet ping metrics for all cadences

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves brave/brave-browser#29122
Resolves brave/brave-browser#29123

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-arm64, CI/skip-linux-x64, CI/skip-android, CI/skip-macos, CI/skip-ios, CI/skip-windows-arm64, CI/skip-windows-x64, CI/skip-windows-x86 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [ ] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

For brave/brave-browser#29122:

Ensure `1` is sent for `Brave.Core.UsageMonthly` and `Brave.Core.UsageDaily` once for month/day.

For brave/brave-browser#29123:

Ensure `1` is sent for `Brave.Wallet.UsageMonthly`, `Brave.Wallet.UsageWeekly` and `Brave.Wallet.UsageDaily` when the wallet is unlocked. Advance the system time by one day/week/month, launch browser and ensure each metric has been deleted, depending on the cadence. Ensure the metrics appear and are sent again when the wallet is unlocked again.