### PR TITLE
Adjust icon's left position in floating mode

### DIFF
--- a/browser/ui/views/tabs/brave_tab.cc
+++ b/browser/ui/views/tabs/brave_tab.cc
@@ -9,6 +9,9 @@
 
 #include "brave/browser/ui/tabs/brave_tab_prefs.h"
 #include "brave/browser/ui/tabs/features.h"
+#include "brave/browser/ui/views/frame/brave_browser_view.h"
+#include "brave/browser/ui/views/frame/vertical_tab_strip_region_view.h"
+#include "brave/browser/ui/views/frame/vertical_tab_strip_widget_delegate_view.h"
 #include "brave/browser/ui/views/tabs/vertical_tab_utils.h"
 #include "chrome/browser/profiles/profile.h"
 #include "chrome/browser/ui/browser.h"
@@ -17,6 +20,7 @@
 #include "chrome/browser/ui/views/tabs/tab_slot_controller.h"
 #include "ui/compositor/layer.h"
 #include "ui/compositor/paint_recorder.h"
+#include "ui/gfx/favicon_size.h"
 #include "ui/gfx/skia_paint_util.h"
 
 namespace {
@@ -177,6 +181,43 @@ void BraveTab::OnBoundsChanged(const gfx::Rect& previous_bounds) {
   if (shadow_layer_ && shadow_layer_->parent()) {
     LayoutShadowLayer();
   }
+}
+
+void BraveTab::MaybeAdjustLeftForPinnedTab(gfx::Rect* bounds,
+                                           int visual_width) const {
+  if (!base::FeatureList::IsEnabled(tabs::features::kBraveVerticalTabs) ||
+      !tabs::utils::ShouldShowVerticalTabs(controller()->GetBrowser())) {
+    Tab::MaybeAdjustLeftForPinnedTab(bounds, visual_width);
+    return;
+  }
+
+  if (!ShouldRenderAsNormalTab()) {
+    // In case it's pinned tab, use the same calculation with the upstream.
+    Tab::MaybeAdjustLeftForPinnedTab(bounds, visual_width);
+    return;
+  }
+
+  auto* browser_view =
+      BrowserView::GetBrowserViewForBrowser(controller_->GetBrowser());
+  if (!browser_view) {
+    Tab::MaybeAdjustLeftForPinnedTab(bounds, visual_width);
+    return;
+  }
+
+  auto* widget_delegate_view = static_cast<BraveBrowserView*>(browser_view)
+                                   ->vertical_tab_strip_widget_delegate_view();
+  DCHECK(widget_delegate_view);
+  auto* region_view = widget_delegate_view->vertical_tab_strip_region_view();
+  DCHECK(region_view);
+
+  if (region_view->state() == VerticalTabStripRegionView::State::kFloating) {
+    // In case we're in floating mode, set the same left padding with the one
+    // we use for the collapsed state, so that the favicon doesn't moves left
+    // and right.
+    bounds->set_x((tabs::kVerticalTabMinWidth - gfx::kFaviconSize) / 2);
+  }
+
+  // For else cases(non-pinned tabs), we don't do anything just like upstream.
 }
 
 bool BraveTab::ShouldRenderAsNormalTab() const {

--- a/browser/ui/views/tabs/brave_tab.h
+++ b/browser/ui/views/tabs/brave_tab.h
@@ -36,6 +36,8 @@ class BraveTab : public Tab {
   void Layout() override;
   void ReorderChildLayers(ui::Layer* parent_layer) override;
   void OnBoundsChanged(const gfx::Rect& previous_bounds) override;
+  void MaybeAdjustLeftForPinnedTab(gfx::Rect* bounds,
+                                   int visual_width) const override;
 
  private:
   bool IsAtMinWidthForVerticalTabStrip() const;

--- a/chromium_src/chrome/browser/ui/views/tabs/tab.h
+++ b/chromium_src/chrome/browser/ui/views/tabs/tab.h
@@ -22,9 +22,11 @@ class BraveTab;
 #define GetGroupColor virtual GetGroupColor
 #define UpdateIconVisibility virtual UpdateIconVisibility
 #define ShouldRenderAsNormalTab virtual ShouldRenderAsNormalTab
+#define MaybeAdjustLeftForPinnedTab virtual MaybeAdjustLeftForPinnedTab
 
 #include "src/chrome/browser/ui/views/tabs/tab.h"  // IWYU pragma: export
 
+#undef MaybeAdjustLeftForPinnedTab
 #undef ShouldRenderAsNormalTab
 #undef UpdateIconVisibility
 #undef GetGroupColor


### PR DESCRIPTION
In floating mode, we should adjust icon's left position so that favicons doesn't move

### Demo

https://user-images.githubusercontent.com/5474642/226282281-782b3e2c-e45e-4fe1-9853-26661644beb3.mov

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/29164

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-arm64, CI/skip-linux-x64, CI/skip-android, CI/skip-macos, CI/skip-ios, CI/skip-windows-arm64, CI/skip-windows-x64, CI/skip-windows-x86 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [ ] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
### Manual
* Enable vertical tab strip
* Navigate to other sites so that we have a favicon.
* Move mouse over tab strip area
* Favicon shouldn't move

