### PR TITLE
Wrap clean link to a feature flag

### DIFF
--- a/browser/about_flags.cc
+++ b/browser/about_flags.cc
@@ -7,6 +7,7 @@
 
 #include <initializer_list>
 
+#include "brave/browser/brave_browser_features.h"
 #include "brave/browser/brave_features_internal_names.h"
 #include "brave/browser/ethereum_remote_client/buildflags/buildflags.h"
 #include "brave/browser/ethereum_remote_client/features.h"
@@ -703,6 +704,14 @@
           "server including transitions of link, bookmark, reload, etc",       \
           kOsAll,                                                              \
           FEATURE_VALUE_TYPE(brave_sync::features::kBraveSyncSendAllHistory),  \
+      },                                                                       \
+      {                                                                        \
+          "brave-copy-clean-link-by-default",                                  \
+          "Override default copy hotkey with copy clean link",                 \
+          "Sanitize url before copying, replaces default ctrl+c hotkey for "   \
+          "url ",                                                              \
+          kOsWin | kOsLinux | kOsMac,                                          \
+          FEATURE_VALUE_TYPE(features::kBraveCopyCleanLinkByDefault),          \
       },                                                                       \
       {                                                                        \
           "https-by-default",                                                  \

--- a/browser/brave_app_controller_mac.mm
+++ b/browser/brave_app_controller_mac.mm
@@ -6,6 +6,7 @@
 #import "brave/browser/brave_app_controller_mac.h"
 
 #include "brave/app/brave_command_ids.h"
+#include "brave/browser/brave_browser_features.h"
 #include "brave/browser/ui/browser_commands.h"
 #include "chrome/app/chrome_command_ids.h"
 #include "chrome/browser/ui/browser.h"
@@ -60,7 +61,11 @@
   }
   if ([self shouldShowCleanLinkItem]) {
     [_copyCleanLinkMenuItem setHidden:NO];
-    [self setKeyEquivalentToItem:_copyCleanLinkMenuItem];
+    if (base::FeatureList::IsEnabled(features::kBraveCopyCleanLinkByDefault)) {
+      [self setKeyEquivalentToItem:_copyCleanLinkMenuItem];
+    } else {
+      [self setKeyEquivalentToItem:_copyMenuItem];
+    }
   } else {
     [_copyCleanLinkMenuItem setHidden:YES];
     [self setKeyEquivalentToItem:_copyMenuItem];

--- a/browser/brave_app_controller_mac_browsertest.mm
+++ b/browser/brave_app_controller_mac_browsertest.mm
@@ -13,8 +13,10 @@
 #include "base/mac/foundation_util.h"
 #include "base/mac/scoped_nsobject.h"
 #include "base/mac/scoped_objc_class_swizzler.h"
+#include "base/test/scoped_feature_list.h"
 #include "brave/app/brave_command_ids.h"
 #include "brave/browser/brave_app_controller_mac.h"
+#include "brave/browser/brave_browser_features.h"
 #include "brave/browser/ui/views/frame/brave_browser_view.h"
 #include "chrome/app/chrome_command_ids.h"
 #include "chrome/browser/ui/browser.h"
@@ -31,6 +33,58 @@ namespace {
 const char kTestingPage[] = "/empty.html";
 
 using BraveAppControllerBrowserTest = InProcessBrowserTest;
+
+class BraveAppControllerCleanLinkFeatureDisabledBrowserTest
+    : public InProcessBrowserTest {
+ public:
+  BraveAppControllerCleanLinkFeatureDisabledBrowserTest() {
+    features_.InitWithFeatureState(features::kBraveCopyCleanLinkByDefault,
+                                   false);
+  }
+
+ private:
+  base::test::ScopedFeatureList features_;
+};
+
+IN_PROC_BROWSER_TEST_F(BraveAppControllerCleanLinkFeatureDisabledBrowserTest,
+                       CopyLinkItemVisible) {
+  ASSERT_TRUE(embedded_test_server()->Start());
+  GURL url = embedded_test_server()->GetURL(kTestingPage);
+  ASSERT_TRUE(ui_test_utils::NavigateToURL(browser(), url));
+  EXPECT_EQ(1u, chrome::GetTotalBrowserCount());
+
+  BraveBrowserView* browser_view = static_cast<BraveBrowserView*>(
+      BraveBrowserView::GetBrowserViewForBrowser(browser()));
+  OmniboxView* omnibox_view = browser_view->GetLocationBar()->GetOmniboxView();
+  omnibox_view->SetFocus(true);
+  omnibox_view->SelectAll(false);
+  EXPECT_TRUE(omnibox_view->IsSelectAll());
+  EXPECT_TRUE(BraveBrowserWindow::From(browser()->window())->HasSelectedURL());
+
+  BraveAppController* ac = base::mac::ObjCCastStrict<BraveAppController>(
+      [[NSApplication sharedApplication] delegate]);
+  ASSERT_TRUE(ac);
+  base::scoped_nsobject<NSMenu> edit_submenu(
+      [[[NSApp mainMenu] itemWithTag:IDC_EDIT_MENU] submenu],
+      base::scoped_policy::RETAIN);
+
+  base::scoped_nsobject<NSMenuItem> copy_item(
+      [edit_submenu itemWithTag:IDC_CONTENT_CONTEXT_COPY],
+      base::scoped_policy::RETAIN);
+
+  base::scoped_nsobject<NSMenuItem> clean_link_menu_item(
+      [edit_submenu itemWithTag:IDC_COPY_CLEAN_LINK],
+      base::scoped_policy::RETAIN);
+
+  [ac menuNeedsUpdate:[clean_link_menu_item menu]];
+  base::RunLoop().RunUntilIdle();
+  EXPECT_FALSE([clean_link_menu_item isHidden]);
+
+  EXPECT_TRUE([[clean_link_menu_item keyEquivalent] isEqualToString:@""]);
+
+  EXPECT_TRUE([[copy_item keyEquivalent] isEqualToString:@"c"]);
+  EXPECT_EQ([copy_item keyEquivalentModifierMask], NSEventModifierFlagCommand);
+}
 
 IN_PROC_BROWSER_TEST_F(BraveAppControllerBrowserTest, CopyLinkItemVisible) {
   ASSERT_TRUE(embedded_test_server()->Start());

--- a/browser/brave_browser_features.cc
+++ b/browser/brave_browser_features.cc
@@ -12,4 +12,9 @@ BASE_FEATURE(kBraveCleanupSessionCookiesOnSessionRestore,
              "BraveCleanupSessionCookiesOnSessionRestore",
              base::FEATURE_ENABLED_BY_DEFAULT);
 
+// Sanitize url before copying, replaces default ctrl+c hotkey for urls.
+BASE_FEATURE(kBraveCopyCleanLinkByDefault,
+             "brave-copy-clean-link-by-default",
+             base::FEATURE_ENABLED_BY_DEFAULT);
+
 }  // namespace features

--- a/browser/brave_browser_features.h
+++ b/browser/brave_browser_features.h
@@ -11,6 +11,7 @@
 namespace features {
 
 BASE_DECLARE_FEATURE(kBraveCleanupSessionCookiesOnSessionRestore);
+BASE_DECLARE_FEATURE(kBraveCopyCleanLinkByDefault);
 
 }  // namespace features
 


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/29177

- Enabled flag means we replace default `Ctrl+C` hotkey and it copies sanitized url.
- Disabled flag means we DO NOT replace default `Ctrl+C` hotkey and it copies url as usual.

![image](https://user-images.githubusercontent.com/2965009/226406917-058609e5-fc28-4406-8d47-828f750d193d.png)

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-arm64, CI/skip-linux-x64, CI/skip-android, CI/skip-macos, CI/skip-ios, CI/skip-windows-arm64, CI/skip-windows-x64, CI/skip-windows-x86 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
- Enable feature and check that we replace `Ctrl+C` default hotkey
- Disable feature and check that we do not replcae default `Ctrl+C` hotkey
