### PR TITLE
[Android] [C112] Fix for mapping file check

### DIFF
--- a/patches/build-android-gyp-proguard.py.patch
+++ b/patches/build-android-gyp-proguard.py.patch
@@ -1,0 +1,12 @@
+diff --git a/build/android/gyp/proguard.py b/build/android/gyp/proguard.py
+index 9ab674c6a83db13d9982bd5f2924d191df3b053e..de8c88739394266c6fd3ace59f481a7cd8e4009a 100755
+--- a/build/android/gyp/proguard.py
++++ b/build/android/gyp/proguard.py
+@@ -275,6 +275,7 @@ def _OptimizeWithR8(options,
+         '--pg-map-output',
+         tmp_mapping_path,
+     ]
++    cmd.remove('--map-id-template'); cmd.remove(f'{options.source_file} ({options.package_name})') # required to omit package check for mapping file
+ 
+     if options.disable_checks:
+       cmd += ['--map-diagnostics:CheckDiscardDiagnostic', 'error', 'none']


### PR DESCRIPTION
Chromium change:
https://github.com/chromium/chromium/commit/278cce40eb2c6ee4c04ab40febb120e563186e7e

Reland "Android: Add package identifier to proguard .mapping files" This reverts commit 8bdad33.

Reason for reland: R8 failures fixed by separate CL:

https://chromium-review.googlesource.com/c/chromium/src/+/4279444

Original change's description:
> Revert "Android: Add package identifier to proguard .mapping files"
>
> This reverts commit b49fa79.
>
> Reason for revert: R8 failing in many bots
>
> Original change's description:
> > Android: Add package identifier to proguard .mapping files
> >
> > This moves from using -renamesourcefileattribute to change the source
> > file string of stack frames to using R8's --source-file-template.
> >
> > It also uses R8's --map-id-template to add a comment to the top of
> > .mapping files with the package_name and version_code of the apk/bundle.
> >
> > Both of these flags are new since we originally started using
> > -renamesourcefileattribute, and they are a better fit for doing what we
> > want.
> >
> > This also stops pass -ignorewarnings, as I believe it's been redundant
> > since we started passing --map-diagnostics error warning.
> >
> > Example mapping file comment:
> > # pg_map_id: chromium-Monochrome.apk-dev-560200020 (com.chrome.dev)
> >
> > Bug: 1417308
> > Change-Id: Ia1c6e8fd08c0f97fb07d6f8af15c48b37ec701dc
> > Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/4265535
> > Commit-Queue: Andrew Grieve <agrieve@chromium.org>
> > Reviewed-by: Sam Maier <smaier@chromium.org>
> > Cr-Commit-Position: refs/heads/main@{#1108132}
>
> Bug: 1417308, 1418350
> Change-Id: Ie1a5907ac759ec81172061643df2aabedc59fe08
> No-Presubmit: true
> No-Tree-Checks: true
> No-Try: true
> Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/4281798
> Commit-Queue: Sam Maier <smaier@chromium.org>
> Auto-Submit: Andrew Grieve <agrieve@chromium.org>
> Reviewed-by: Sam Maier <smaier@chromium.org>
> Cr-Commit-Position: refs/heads/main@{#1108344}

Bug: 1417308, 1418350

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/29180

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-arm64, CI/skip-linux-x64, CI/skip-android, CI/skip-macos, CI/skip-ios, CI/skip-windows-arm64, CI/skip-windows-x64, CI/skip-windows-x86 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [ ] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

