### PR TITLE
Fixes a crash on Android bottom toolbar when LayoutManager is null (uplift to 1.49.x)

### DIFF
--- a/android/java/org/chromium/chrome/browser/toolbar/bottom/BottomToolbarCoordinator.java
+++ b/android/java/org/chromium/chrome/browser/toolbar/bottom/BottomToolbarCoordinator.java
@@ -30,6 +30,7 @@ import org.chromium.chrome.browser.app.BraveActivity;
 import org.chromium.chrome.browser.app.ChromeActivity;
 import org.chromium.chrome.browser.bookmarks.BookmarkModel;
 import org.chromium.chrome.browser.compositor.CompositorViewHolder;
+import org.chromium.chrome.browser.compositor.layouts.LayoutManagerImpl;
 import org.chromium.chrome.browser.feature_engagement.TrackerFactory;
 import org.chromium.chrome.browser.homepage.HomepageManager;
 import org.chromium.chrome.browser.layouts.LayoutStateProvider;
@@ -266,8 +267,10 @@ class BottomToolbarCoordinator implements View.OnLongClickListener {
 
         if (mScrollingBottomView != null && activity != null) {
             Supplier<CompositorViewHolder> cvh = activity.getCompositorViewHolderSupplier();
-            mScrollingBottomView.setSwipeDetector(
-                    cvh.get().getLayoutManager().getToolbarSwipeHandler());
+            LayoutManagerImpl layoutManager = cvh.get().getLayoutManager();
+            if (layoutManager != null) {
+                mScrollingBottomView.setSwipeDetector(layoutManager.getToolbarSwipeHandler());
+            }
         }
     }
 


### PR DESCRIPTION
Uplift of #17678
Resolves https://github.com/brave/brave-browser/issues/29184

Pre-approval checklist: 
- [ ] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.