### PR TITLE
Change tab context menu string for vertical tabs

### DIFF
--- a/app/brave_generated_resources.grd
+++ b/app/brave_generated_resources.grd
@@ -898,6 +898,12 @@ Or change later at <ph name="SETTINGS_EXTENIONS_LINK">$2<ex>brave://settings/ext
         <message name="IDS_TAB_CXMENU_SOUND_UNMUTE_TAB" desc="The label of the tab context menu item for unmuting one or more tabs. NOTE: If having no explicit # makes the phrasing awkward, feel free to add a # as necessary. [ICU Syntax]">
           {NUM_TABS, plural, =1 {Unmute tab} other {Unmute tabs}}
         </message>
+        <message name="IDS_TAB_CXMENU_NEWTABTORIGHT_VERTICAL_TABS" desc="The label of the 'New Tab below' Tab context menu item for vertical tabs.">
+          New tab below
+        </message>
+        <message name="IDS_TAB_CXMENU_CLOSETABSTORIGHT_VERTICAL_TABS" desc="The label of the 'Close Tabs below' Tab context menu item for vertical tabs.">
+          Close tabs below
+        </message>
       </if>
       <if expr="use_titlecase">
         <message name="IDS_TAB_CXMENU_BOOKMARK_ALL_TABS" desc="In Title Case: The label of the tab context menu item for creating a bookmark folder containing an entry for each open tab.">
@@ -917,6 +923,12 @@ Or change later at <ph name="SETTINGS_EXTENIONS_LINK">$2<ex>brave://settings/ext
         </message>
         <message name="IDS_TAB_CXMENU_SOUND_UNMUTE_TAB" desc="The label of the tab context menu item for unmuting one or more tabs. NOTE: If having no explicit # makes the phrasing awkward, feel free to add a # as necessary. [ICU Syntax]">
           {NUM_TABS, plural, =1 {Unmute Tab} other {Unmute Tabs}}
+        </message>
+        <message name="IDS_TAB_CXMENU_NEWTABTORIGHT_VERTICAL_TABS" desc="The label of the 'New Tab below' Tab context menu item for vertical tabs.">
+          New Tab Below
+        </message>
+        <message name="IDS_TAB_CXMENU_CLOSETABSTORIGHT_VERTICAL_TABS" desc="The label of the 'Close Tabs below' Tab context menu item for vertical tabs.">
+          Close Tabs Below
         </message>
       </if>
 

--- a/browser/ui/tabs/brave_tab_menu_model.cc
+++ b/browser/ui/tabs/brave_tab_menu_model.cc
@@ -24,8 +24,10 @@ BraveTabMenuModel::BraveTabMenuModel(
     ui::SimpleMenuModel::Delegate* delegate,
     TabMenuModelDelegate* tab_menu_model_delegate,
     TabStripModel* tab_strip_model,
-    int index)
-    : TabMenuModel(delegate, tab_menu_model_delegate, tab_strip_model, index) {
+    int index,
+    bool is_vertical_tab)
+    : TabMenuModel(delegate, tab_menu_model_delegate, tab_strip_model, index),
+      is_vertical_tab_(is_vertical_tab) {
   web_contents_ = tab_strip_model->GetWebContentsAt(index);
   if (web_contents_) {
     Browser* browser = chrome::FindBrowserWithWebContents(web_contents_);
@@ -62,6 +64,23 @@ int BraveTabMenuModel::GetRestoreTabCommandStringId() const {
   }
 
   return id;
+}
+
+std::u16string BraveTabMenuModel::GetLabelAt(size_t index) const {
+  if (!is_vertical_tab_) {
+    return TabMenuModel::GetLabelAt(index);
+  }
+
+  if (auto command_id = GetCommandIdAt(index);
+      command_id == TabStripModel::CommandNewTabToRight) {
+    return l10n_util::GetStringUTF16(
+        IDS_TAB_CXMENU_NEWTABTORIGHT_VERTICAL_TABS);
+  } else if (command_id == TabStripModel::CommandCloseTabsToRight) {
+    return l10n_util::GetStringUTF16(
+        IDS_TAB_CXMENU_CLOSETABSTORIGHT_VERTICAL_TABS);
+  }
+
+  return TabMenuModel::GetLabelAt(index);
 }
 
 void BraveTabMenuModel::Build(int selected_tab_count) {

--- a/browser/ui/tabs/brave_tab_menu_model.h
+++ b/browser/ui/tabs/brave_tab_menu_model.h
@@ -34,12 +34,16 @@ class BraveTabMenuModel : public TabMenuModel {
   BraveTabMenuModel(ui::SimpleMenuModel::Delegate* delegate,
                     TabMenuModelDelegate* tab_menu_model_delegate,
                     TabStripModel* tab_strip_model,
-                    int index);
+                    int index,
+                    bool is_vertical_tab);
   BraveTabMenuModel(const BraveTabMenuModel&) = delete;
   BraveTabMenuModel& operator=(const BraveTabMenuModel&) = delete;
   ~BraveTabMenuModel() override;
 
   bool all_muted() const { return all_muted_; }
+
+  // TabMenuModel:
+  std::u16string GetLabelAt(size_t index) const override;
 
  private:
   void Build(int selected_tab_count);
@@ -48,6 +52,8 @@ class BraveTabMenuModel : public TabMenuModel {
   raw_ptr<content::WebContents> web_contents_ = nullptr;
   sessions::TabRestoreService* restore_service_ = nullptr;
   bool all_muted_;
+
+  bool is_vertical_tab_ = false;
 };
 
 #endif  // BRAVE_BROWSER_UI_TABS_BRAVE_TAB_MENU_MODEL_H_

--- a/browser/ui/views/tabs/brave_tab_context_menu_contents.h
+++ b/browser/ui/views/tabs/brave_tab_context_menu_contents.h
@@ -52,6 +52,9 @@ class BraveTabContextMenuContents : public ui::SimpleMenuModel::Delegate {
   void ExecuteCommand(int command_id, int event_flags) override;
 
  private:
+  FRIEND_TEST_ALL_PREFIXES(VerticalTabStripStringBrowserTest,
+                           ContextMenuString);
+
   bool IsBraveCommandIdEnabled(int command_id) const;
   void ExecuteBraveCommand(int command_id);
   bool IsBraveCommandId(int command_id) const;


### PR DESCRIPTION
As vertical tabs are laid out vertically, "Below" is better than "Right"

<img width="231" alt="image" src="https://user-images.githubusercontent.com/5474642/226493544-b48992db-e642-4a07-b167-b5d66deb24fe.png">

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/29192

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-arm64, CI/skip-linux-x64, CI/skip-android, CI/skip-macos, CI/skip-ios, CI/skip-windows-arm64, CI/skip-windows-x64, CI/skip-windows-x86 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [ ] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
### Manual
* Trigger context menu on vertical tabs
* There shouldn't be "Right" in labels. Instead, "Below" should be used.

### Automated
* VerticalTabStripStringBrowserTest.ContextMenuString
