### PR TITLE
Expand BraveCompoundTabContainer to fill scroll view

### DIFF
--- a/browser/ui/views/frame/vertical_tab_strip_region_view.cc
+++ b/browser/ui/views/frame/vertical_tab_strip_region_view.cc
@@ -5,6 +5,7 @@
 
 #include "brave/browser/ui/views/frame/vertical_tab_strip_region_view.h"
 
+#include <algorithm>
 #include <memory>
 #include <utility>
 #include <vector>
@@ -403,7 +404,7 @@ gfx::Size VerticalTabStripRegionView::GetMinimumSize() const {
 
 void VerticalTabStripRegionView::Layout() {
   // As we have to update ScrollView's viewport size and its contents size,
-  // layouting children manually will be more handy.
+  // laying out children manually will be more handy.
 
   // 1. New tab should be fixed at the bottom of container.
   auto contents_bounds = GetContentsBounds();
@@ -439,7 +440,8 @@ void VerticalTabStripRegionView::Layout() {
   } else {
     scroll_contents_view_->SetSize(
         {scroll_view_->width(),
-         scroll_contents_view_->GetPreferredSize().height()});
+         std::max(scroll_viewport_height,
+                  scroll_contents_view_->GetPreferredSize().height())});
   }
   UpdateTabSearchButtonVisibility();
 }
@@ -560,6 +562,10 @@ void VerticalTabStripRegionView::UpdateNewTabButtonVisibility() {
 
 TabSearchBubbleHost* VerticalTabStripRegionView::GetTabSearchBubbleHost() {
   return scroll_view_header_->tab_search_button()->tab_search_bubble_host();
+}
+
+int VerticalTabStripRegionView::GetScrollViewViewportHeight() const {
+  return scroll_view_->GetMaxHeight();
 }
 
 void VerticalTabStripRegionView::UpdateTabSearchButtonVisibility() {

--- a/browser/ui/views/frame/vertical_tab_strip_region_view.h
+++ b/browser/ui/views/frame/vertical_tab_strip_region_view.h
@@ -69,6 +69,8 @@ class VerticalTabStripRegionView : public views::View,
 
   TabSearchBubbleHost* GetTabSearchBubbleHost();
 
+  int GetScrollViewViewportHeight() const;
+
   // views::View:
   gfx::Size CalculatePreferredSize() const override;
   gfx::Size GetMinimumSize() const override;

--- a/browser/ui/views/tabs/brave_compound_tab_container.cc
+++ b/browser/ui/views/tabs/brave_compound_tab_container.cc
@@ -12,12 +12,14 @@
 #include "brave/browser/ui/color/brave_color_id.h"
 #include "brave/browser/ui/tabs/brave_tab_prefs.h"
 #include "brave/browser/ui/tabs/features.h"
+#include "brave/browser/ui/views/frame/vertical_tab_strip_region_view.h"
 #include "brave/browser/ui/views/tabs/brave_tab_container.h"
 #include "brave/browser/ui/views/tabs/vertical_tab_utils.h"
 #include "chrome/browser/ui/ui_features.h"
 #include "ui/base/metadata/metadata_impl_macros.h"
 #include "ui/views/layout/fill_layout.h"
 #include "ui/views/layout/flex_layout.h"
+#include "ui/views/view_utils.h"
 
 BraveCompoundTabContainer::BraveCompoundTabContainer(
     raw_ref<TabContainerController> controller,
@@ -130,7 +132,22 @@ gfx::Size BraveCompoundTabContainer::CalculatePreferredSize() const {
   }
 
   // We use flex layout manager so let it do its job.
-  return views::View::CalculatePreferredSize();
+  auto preferred_size = views::View::CalculatePreferredSize();
+
+  // Check if we can expand height to fill the entire scroll area's viewport.
+  for (auto* parent_view = parent(); parent_view;
+       parent_view = parent_view->parent()) {
+    auto* region_view =
+        views::AsViewClass<VerticalTabStripRegionView>(parent_view);
+    if (!region_view) {
+      continue;
+    }
+    preferred_size.set_height(std::max(
+        region_view->GetScrollViewViewportHeight(), preferred_size.height()));
+    break;
+  }
+
+  return preferred_size;
 }
 
 gfx::Size BraveCompoundTabContainer::GetMinimumSize() const {


### PR DESCRIPTION
In order to make dragging tabs downward to reorder easier, expand the compound container's height.

### Demo

https://user-images.githubusercontent.com/5474642/226576284-132c3b04-f3d6-4d70-a595-735cb65c224d.mov



<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/29205

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-arm64, CI/skip-linux-x64, CI/skip-android, CI/skip-macos, CI/skip-ios, CI/skip-windows-arm64, CI/skip-windows-x64, CI/skip-windows-x86 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [ ] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
### Manual
* Drag a tab in vertical tab strip downward
* The tab shouldn't be detached into a new browser until it reaches the end of tab strip.
