### PR TITLE
Fix git patch test. Git rm now should be called explicitly. (uplift to 1.49.x)

### DIFF
--- a/build/commands/lib/gitPatcher.test.js
+++ b/build/commands/lib/gitPatcher.test.js
@@ -137,6 +137,7 @@ describe('Apply Patches', function () {
     await fs.unlink(testFile1PatchPath)
     // remove target file
     await fs.unlink(testFile1Path)
+    await runGitAsyncWithErrorLog(repoPath, ['rm', testFile1Path])
     await runGitAsyncWithErrorLog(repoPath, ['commit', '-a', '-m', '"remove target"'])
     // apply again
     const status = await gitPatcher.applyPatches()


### PR DESCRIPTION
Uplift of #17691
Resolves https://github.com/brave/brave-browser/issues/29203

Pre-approval checklist: 
- [ ] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [ ] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [ ] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [ ] The associated issue milestone is set to the smallest version that the changes is landed on.