### PR TITLE
fix(wallet): Allow Enabling Offchain Lookup Without Input Value

### DIFF
--- a/components/brave_wallet_ui/page/screens/send/send/send.tsx
+++ b/components/brave_wallet_ui/page/screens/send/send/send.tsx
@@ -250,14 +250,28 @@ export const Send = (props: Props) => {
   }, [insufficientFundsError, addressError, addressWarning, sendAmountValidationError, searchingForDomain, showEnsOffchainWarning])
 
   const isReviewButtonDisabled = React.useMemo(() => {
-    return searchingForDomain ||
-      toAddressOrUrl === '' ||
-      parseFloat(sendAmount) === 0 ||
-      sendAmount === '' ||
-      insufficientFundsError ||
-      (addressError !== undefined && addressError !== '') ||
-      sendAmountValidationError !== undefined
-  }, [toAddressOrUrl, sendAmount, insufficientFundsError, addressError, sendAmountValidationError, searchingForDomain])
+    // We only need to check if showEnsOffchainWarning is true here to return
+    // false early before any other checks are made. This is to allow the button
+    // to be pressed to enable offchain lookup.
+    return !showEnsOffchainWarning &&
+      (searchingForDomain ||
+        toAddressOrUrl === '' ||
+        parseFloat(sendAmount) === 0 ||
+        sendAmount === '' ||
+        insufficientFundsError ||
+        (addressError !== undefined && addressError !== '') ||
+        sendAmountValidationError !== undefined)
+  },
+    [
+      toAddressOrUrl,
+      sendAmount,
+      insufficientFundsError,
+      addressError,
+      sendAmountValidationError,
+      searchingForDomain,
+      showEnsOffchainWarning
+    ]
+  )
 
   const reviewButtonHasError = React.useMemo(() => {
     return searchingForDomain


### PR DESCRIPTION
## Description 
Fixes a bug where you were not able to `Enable` off-chain lookup permission with out entering a `Send` input value.

<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves <https://github.com/brave/brave-browser/issues/29214>

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-arm64, CI/skip-linux-x64, CI/skip-android, CI/skip-macos, CI/skip-ios, CI/skip-windows-arm64, CI/skip-windows-x64, CI/skip-windows-x86 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
1. Go to brave://settings/web3 and change `Allow ENS offchain lookup.` to `Ask`
2. Go to brave://wallet/send
3. Select a token on the `Ethereum` network
4. Do not input a `Send` input value
5. In the address field enter `offchainexample.eth`
6. The `Use ENS domain` button should be enabled, click it.
7. After it is `Enabled` the `Review order` button should be `Disabled`
8. Enter a `Send` amount in the input and it should be `Enabled`

Before:

https://user-images.githubusercontent.com/40611140/226813096-77b1350b-639d-4742-9a63-9ebfe84e2a5d.mov

After:

https://user-images.githubusercontent.com/40611140/226812808-4410edd4-7876-41c7-8e11-607348931be4.mov
