### PR TITLE
To field should be optional in Transaction params

### DIFF
--- a/components/brave_wallet/common/eth_request_helper.cc
+++ b/components/brave_wallet/common/eth_request_helper.cc
@@ -70,7 +70,9 @@ brave_wallet::mojom::TxDataPtr ValueToTxData(
   auto tx_data = brave_wallet::mojom::TxData::New();
 
   *from_out = tx->from;
-  tx_data->to = tx->to;
+  if (tx->to) {
+    tx_data->to = *tx->to;
+  }
   if (tx->gas)
     tx_data->gas_limit = *tx->gas;
   if (tx->gas_price)

--- a/components/brave_wallet/common/eth_request_helper_unittest.cc
+++ b/components/brave_wallet/common/eth_request_helper_unittest.cc
@@ -72,6 +72,25 @@ TEST(EthRequestHelperUnitTest, ParseEthTransactionParams) {
   EXPECT_EQ(tx_data->value, "0x25F38E9E0000000");
   EXPECT_EQ(tx_data->data, (std::vector<uint8_t>{1, 2, 3}));
   EXPECT_TRUE(tx_data->nonce.empty());  // Should be ignored.
+
+  // deploying contract
+  json =
+      R"({
+        "params": [{
+          "from": "0x7f84E0DfF3ffd0af78770cF86c1b1DdFF99d51C8",
+          "gas": "0x146",
+          "data": "0x010203",
+        }]
+      })";
+  tx_data = ParseEthTransactionParams(json, &from);
+  ASSERT_TRUE(tx_data);
+  EXPECT_EQ(from, "0x7f84E0DfF3ffd0af78770cF86c1b1DdFF99d51C8");
+  EXPECT_TRUE(tx_data->to.empty());
+  EXPECT_EQ(tx_data->gas_limit, "0x146");
+  EXPECT_TRUE(tx_data->gas_price.empty());
+  EXPECT_TRUE(tx_data->value.empty());
+  EXPECT_EQ(tx_data->data, (std::vector<uint8_t>{1, 2, 3}));
+  EXPECT_TRUE(tx_data->nonce.empty());  // Should be ignored.
 }
 
 TEST(EthResponseHelperUnitTest, ParseEthTransaction1559Params) {
@@ -95,7 +114,7 @@ TEST(EthResponseHelperUnitTest, ParseEthTransaction1559Params) {
   EXPECT_EQ(tx_data->base_data->to,
             "0x7f84E0DfF3ffd0af78770cF86c1b1DdFF99d51C7");
   EXPECT_EQ(tx_data->base_data->gas_limit, "0x146");
-  EXPECT_EQ(tx_data->base_data->gas_price.empty(), true);
+  EXPECT_TRUE(tx_data->base_data->gas_price.empty());
   EXPECT_EQ(tx_data->base_data->value, "0x25F38E9E0000000");
   EXPECT_EQ(tx_data->base_data->data, (std::vector<uint8_t>{1, 2, 3}));
   EXPECT_EQ(tx_data->max_priority_fee_per_gas, "0x1");
@@ -123,6 +142,26 @@ TEST(EthResponseHelperUnitTest, ParseEthTransaction1559Params) {
   EXPECT_EQ(tx_data->base_data->data, (std::vector<uint8_t>{1, 2, 3}));
   // Allowed to parse without these fields, the client should determine
   // reasonable values in this case.
+  EXPECT_TRUE(tx_data->max_priority_fee_per_gas.empty());
+  EXPECT_TRUE(tx_data->max_fee_per_gas.empty());
+
+  // deploying contract
+  json =
+      R"({
+        "params": [{
+          "from": "0x7f84E0DfF3ffd0af78770cF86c1b1DdFF99d51C8",
+          "gas": "0x146",
+          "data": "0x010203"
+        }]
+      })";
+  tx_data = ParseEthTransaction1559Params(json, &from);
+  ASSERT_TRUE(tx_data);
+  EXPECT_EQ(from, "0x7f84E0DfF3ffd0af78770cF86c1b1DdFF99d51C8");
+  EXPECT_TRUE(tx_data->base_data->to.empty());
+  EXPECT_EQ(tx_data->base_data->gas_limit, "0x146");
+  EXPECT_TRUE(tx_data->base_data->gas_price.empty());
+  EXPECT_TRUE(tx_data->base_data->value.empty());
+  EXPECT_EQ(tx_data->base_data->data, (std::vector<uint8_t>{1, 2, 3}));
   EXPECT_TRUE(tx_data->max_priority_fee_per_gas.empty());
   EXPECT_TRUE(tx_data->max_fee_per_gas.empty());
 }

--- a/components/brave_wallet/common/json_rpc_requests.idl
+++ b/components/brave_wallet/common/json_rpc_requests.idl
@@ -6,7 +6,7 @@
 namespace json_rpc_requests {
   dictionary Transaction {
     DOMString from;
-    DOMString to;
+    DOMString? to;
     DOMString? gas;
     DOMString? gasPrice;
     DOMString? value;


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/29252

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-arm64, CI/skip-linux-x64, CI/skip-android, CI/skip-macos, CI/skip-ios, CI/skip-windows-arm64, CI/skip-windows-x64, CI/skip-windows-x86 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
1. Setup wallet
2. Navigate to https://metamask.github.io/test-dapp/
3. Connect and approve
4. Click "Deploy Contract"
5. Prompt should show up for users to sign a transaction instead of responding with internal error
6. Switch network to Goerli and fund the account through faucet
7. Repeat step 4-5 and approve transaction
8. Transaction should be sent and should be able to track its status on etherscan.io 
