### PR TITLE
Update @brave/leo dependency to include fixes as detailed:

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.51.56",
       "license": "MPL-2.0",
       "dependencies": {
-        "@brave/leo": "github:brave/leo#342a641",
+        "@brave/leo": "github:brave/leo#fa7ffcd446e6ef23dd8ab7b549861d4668ca46a8",
         "@brave/react-virtualized-auto-sizer": "^1.0.4",
         "@brave/wallet-standard-brave": "~0.0.6",
         "@dnd-kit/core": "6.0.5",
@@ -2071,7 +2071,8 @@
     },
     "node_modules/@brave/leo": {
       "version": "0.0.1",
-      "resolved": "git+ssh://git@github.com/brave/leo.git#342a641d9dc780a5cb4a1a2f12fb969643571a13",
+      "resolved": "git+ssh://git@github.com/brave/leo.git#fa7ffcd446e6ef23dd8ab7b549861d4668ca46a8",
+      "integrity": "sha512-n7bBneIuMA4u+8F2UgGb/o11WNwjgZQN9p/WQ+RtpAnTZfXrA3MGlIJLD7O8b86q8Rj8Nw66eX/6+ta5Y0/JOQ==",
       "license": "MIT",
       "dependencies": {
         "@ctrl/tinycolor": "3.5.1",
@@ -2079,7 +2080,7 @@
         "lodash.camelcase": "4.3.0",
         "lodash.merge": "4.6.2",
         "style-dictionary": "3.7.2",
-        "svelte": "github:brave/svelte",
+        "svelte": "3.56.0",
         "svelte-check": "3.0.3",
         "svelte-preprocess": "5.0.1",
         "svelte2tsx": "0.6.1",
@@ -25663,9 +25664,9 @@
       }
     },
     "node_modules/svelte": {
-      "version": "3.55.1",
-      "resolved": "git+ssh://git@github.com/brave/svelte.git#18a68115e0092a1c515e352097c51618c6b841a1",
-      "license": "MIT",
+      "version": "3.56.0",
+      "resolved": "https://registry.npmjs.org/svelte/-/svelte-3.56.0.tgz",
+      "integrity": "sha512-LvXiJbjdvJKwB/0CQyYpDX0q+hFqCyWmybzC2G6eK1tJJA/RSRCytTfNmjHv+RHlLuA70vWG7nXp6gbeErYvRA==",
       "engines": {
         "node": ">= 8"
       }
@@ -31136,15 +31137,16 @@
       "dev": true
     },
     "@brave/leo": {
-      "version": "git+ssh://git@github.com/brave/leo.git#342a641d9dc780a5cb4a1a2f12fb969643571a13",
-      "from": "@brave/leo@github:brave/leo#342a641",
+      "version": "git+ssh://git@github.com/brave/leo.git#fa7ffcd446e6ef23dd8ab7b549861d4668ca46a8",
+      "integrity": "sha512-n7bBneIuMA4u+8F2UgGb/o11WNwjgZQN9p/WQ+RtpAnTZfXrA3MGlIJLD7O8b86q8Rj8Nw66eX/6+ta5Y0/JOQ==",
+      "from": "@brave/leo@github:brave/leo#fa7ffcd446e6ef23dd8ab7b549861d4668ca46a8",
       "requires": {
         "@ctrl/tinycolor": "3.5.1",
         "@tsconfig/svelte": "3.0.0",
         "lodash.camelcase": "4.3.0",
         "lodash.merge": "4.6.2",
         "style-dictionary": "3.7.2",
-        "svelte": "github:brave/svelte",
+        "svelte": "3.56.0",
         "svelte-check": "3.0.3",
         "svelte-preprocess": "5.0.1",
         "svelte2tsx": "0.6.1",
@@ -49290,8 +49292,9 @@
       "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w=="
     },
     "svelte": {
-      "version": "git+ssh://git@github.com/brave/svelte.git#18a68115e0092a1c515e352097c51618c6b841a1",
-      "from": "svelte@github:brave/svelte"
+      "version": "3.56.0",
+      "resolved": "https://registry.npmjs.org/svelte/-/svelte-3.56.0.tgz",
+      "integrity": "sha512-LvXiJbjdvJKwB/0CQyYpDX0q+hFqCyWmybzC2G6eK1tJJA/RSRCytTfNmjHv+RHlLuA70vWG7nXp6gbeErYvRA=="
     },
     "svelte-check": {
       "version": "3.0.3",

--- a/package.json
+++ b/package.json
@@ -351,7 +351,7 @@
     "webpack-cli": "3.3.12"
   },
   "dependencies": {
-    "@brave/leo": "github:brave/leo#342a641",
+    "@brave/leo": "github:brave/leo#fa7ffcd446e6ef23dd8ab7b549861d4668ca46a8",
     "@brave/react-virtualized-auto-sizer": "^1.0.4",
     "@brave/wallet-standard-brave": "~0.0.6",
     "@dnd-kit/core": "6.0.5",


### PR DESCRIPTION
https://github.com/brave/leo/compare/342a641...fa7ffcd446e6ef23dd8ab7b549861d4668ca46a8
- Added browser tokens file
- Improves skia output
- Update icons
- Fix bug in WebComponent @theme
- Use upstream svelte
- Button is inline-block by default
- Use custom WebComponent wrapper for Svelte to bypass svelte's WebComponent issues

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/29257

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-arm64, CI/skip-linux-x64, CI/skip-android, CI/skip-macos, CI/skip-ios, CI/skip-windows-arm64, CI/skip-windows-x64, CI/skip-windows-x86 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

