### PR TITLE
fix(wallet): Long Account Names in Filter

### DIFF
--- a/components/brave_wallet_ui/components/desktop/account-filter-selector/account-filter-selector.style.ts
+++ b/components/brave_wallet_ui/components/desktop/account-filter-selector/account-filter-selector.style.ts
@@ -9,6 +9,7 @@ export const AccountCircle = styled.div<{
   orb: string
 }>`
   width: 20px;
+  min-width: 20px;
   height: 20px;
   border-radius: 100%;
   background-image: url(${(p) => p.orb});

--- a/components/brave_wallet_ui/components/desktop/network-filter-selector/style.ts
+++ b/components/brave_wallet_ui/components/desktop/network-filter-selector/style.ts
@@ -86,7 +86,7 @@ export const NetworkItemButton = styled(WalletButton)`
   border: none;
   margin: 0px;
   padding: 8px 8px 8px 12px;
-  height: 40px;
+  min-height: 40px;
   box-sizing: border-box;
   border-radius: 6px;
   &:hover {
@@ -99,6 +99,7 @@ export const LeftSide = styled.div`
   align-items: center;
   justify-content: flex-start;
   flex-direction: row;
+  max-width: 90%;
 `
 
 export const SelectorLeftSide = styled(LeftSide)`


### PR DESCRIPTION
## Description 
Fixes a bug where long `Account` names were getting squished in the portfolio `Account Filter`

<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves <https://github.com/brave/brave-browser/issues/29129>

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-arm64, CI/skip-linux-x64, CI/skip-android, CI/skip-macos, CI/skip-ios, CI/skip-windows-arm64, CI/skip-windows-x64, CI/skip-windows-x86 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
1. Create an account with a really long name.
2. Go to the `Portfolio` page and click on the `Account` filter.
3. The account `Name` and `Icon` should not be squished.

Before:

![Screenshot 44](https://user-images.githubusercontent.com/40611140/227248188-6695f1b9-7485-4016-bfe8-0da96dc4511b.png)

After:

![Screenshot](https://user-images.githubusercontent.com/40611140/227248814-53a618f8-d6a0-4525-939b-ad42876fec97.png)


