### PR TITLE
Add P3A metrics for capturing rewards/ads conversion

### DIFF
--- a/browser/extensions/api/brave_rewards_api.h
+++ b/browser/extensions/api/brave_rewards_api.h
@@ -50,6 +50,16 @@ class BraveRewardsGetLocaleFunction : public ExtensionFunction {
   ResponseAction Run() override;
 };
 
+class BraveRewardsRecordNTPPanelTriggerFunction : public ExtensionFunction {
+ public:
+  DECLARE_EXTENSION_FUNCTION("braveRewards.recordNTPPanelTrigger", UNKNOWN)
+
+ protected:
+  ~BraveRewardsRecordNTPPanelTriggerFunction() override;
+
+  ResponseAction Run() override;
+};
+
 class BraveRewardsOpenRewardsPanelFunction : public ExtensionFunction {
  public:
   DECLARE_EXTENSION_FUNCTION("braveRewards.openRewardsPanel", UNKNOWN)

--- a/browser/ui/views/brave_actions/brave_rewards_action_view.cc
+++ b/browser/ui/views/brave_actions/brave_rewards_action_view.cc
@@ -14,6 +14,7 @@
 #include "brave/browser/brave_rewards/rewards_service_factory.h"
 #include "brave/browser/ui/brave_icon_with_badge_image_source.h"
 #include "brave/browser/ui/webui/brave_rewards/rewards_panel_ui.h"
+#include "brave/components/brave_rewards/browser/rewards_p3a.h"
 #include "brave/components/brave_rewards/browser/rewards_service.h"
 #include "brave/components/brave_rewards/common/pref_names.h"
 #include "brave/components/constants/webui_url_constants.h"
@@ -281,6 +282,14 @@ void BraveRewardsActionView::OnNotificationDeleted(
 }
 
 void BraveRewardsActionView::OnButtonPressed() {
+  brave_rewards::RewardsService* rewards_service = GetRewardsService();
+  if (rewards_service != nullptr) {
+    auto* prefs = browser_->profile()->GetPrefs();
+    if (!prefs->GetBoolean(brave_rewards::prefs::kEnabled)) {
+      rewards_service->GetP3AConversionMonitor()->RecordPanelTrigger(
+          ::brave_rewards::p3a::PanelTrigger::kToolbarButton);
+    }
+  }
   // If we are opening the Rewards panel, use `RewardsPanelCoordinator` to open
   // it so that the panel arguments will be correctly set.
   if (!IsPanelOpen() && panel_coordinator_) {

--- a/common/extensions/api/brave_rewards.json
+++ b/common/extensions/api/brave_rewards.json
@@ -380,6 +380,12 @@
         ]
       },
       {
+        "name": "recordNTPPanelTrigger",
+        "type": "function",
+        "description": "Records an NTP Rewards card 'Start using Brave Rewards' click.",
+        "parameters": []
+      },
+      {
         "name": "openRewardsPanel",
         "type": "function",
         "description": "Opens the Rewards panel in the active window.",

--- a/components/brave_new_tab_ui/components/default/rewards/index.tsx
+++ b/components/brave_new_tab_ui/components/default/rewards/index.tsx
@@ -125,6 +125,7 @@ export const RewardsWidget = createWidget((props: RewardsProps) => {
   }
 
   const openRewardsPanel = () => {
+    chrome.braveRewards.recordNTPPanelTrigger();
     chrome.braveRewards.openRewardsPanel()
   }
 

--- a/components/brave_rewards/browser/rewards_p3a.h
+++ b/components/brave_rewards/browser/rewards_p3a.h
@@ -8,16 +8,30 @@
 
 #include <string>
 
+#include "base/time/time.h"
+#include "third_party/abseil-cpp/absl/types/optional.h"
+
 class PrefService;
 
 namespace brave_rewards {
 namespace p3a {
+
+extern const char kEnabledSourceHistogramName[];
+extern const char kInlineTipTriggerHistogramName[];
+extern const char kToolbarButtonTriggerHistogramName[];
 
 enum class AutoContributionsState {
   kNoWallet,
   kRewardsDisabled,
   kWalletCreatedAutoContributeOff,
   kAutoContributeOn,
+};
+
+enum class PanelTrigger {
+  kInlineTip = 0,
+  kToolbarButton = 1,
+  kNTP = 2,
+  kMaxValue = kNTP
 };
 
 void RecordAutoContributionsState(AutoContributionsState state, int count);
@@ -62,6 +76,27 @@ enum class AdsEnabledDuration {
 };
 
 void RecordAdsEnabledDuration(PrefService* prefs, bool ads_enabled);
+
+class ConversionMonitor {
+ public:
+  ConversionMonitor();
+  ~ConversionMonitor();
+
+  ConversionMonitor(const ConversionMonitor&) = delete;
+  ConversionMonitor& operator=(const ConversionMonitor&) = delete;
+
+  // Record trigger of an action that could potentially trigger opening the
+  // Rewards panel. Will immediately record the action (if applicable).
+  void RecordPanelTrigger(PanelTrigger trigger);
+
+  // Record the enabled of rewards, which may record a metric containing the
+  // source of user conversion a.k.a. the action that opened the Rewards panel.
+  void RecordRewardsEnable();
+
+ private:
+  absl::optional<PanelTrigger> last_trigger_;
+  base::Time last_trigger_time_;
+};
 
 }  // namespace p3a
 }  // namespace brave_rewards

--- a/components/brave_rewards/browser/rewards_service.h
+++ b/components/brave_rewards/browser/rewards_service.h
@@ -32,6 +32,10 @@ class NavigationHandle;
 
 namespace brave_rewards {
 
+namespace p3a {
+class ConversionMonitor;
+}  // namespace p3a
+
 class RewardsNotificationService;
 class RewardsServiceObserver;
 
@@ -370,6 +374,8 @@ class RewardsService : public KeyedService {
   virtual void SetExternalWalletType(const std::string& wallet_type) = 0;
 
   virtual void GetEnvironment(GetEnvironmentCallback callback) = 0;
+
+  virtual p3a::ConversionMonitor* GetP3AConversionMonitor() = 0;
 
  protected:
   base::ObserverList<RewardsServiceObserver> observers_;

--- a/components/brave_rewards/browser/rewards_service_impl.cc
+++ b/components/brave_rewards/browser/rewards_service_impl.cc
@@ -553,6 +553,8 @@ void RewardsServiceImpl::CreateRewardsWallet(
         observer.OnRewardsWalletUpdated();
       }
 
+      self->conversion_monitor_.RecordRewardsEnable();
+
       std::move(callback).Run(CreateRewardsWalletResult::kSuccess);
     };
 
@@ -2277,6 +2279,10 @@ void RewardsServiceImpl::GetEnvironment(GetEnvironmentCallback callback) {
                          GetDefaultServerEnvironment());
   }
   ledger_->GetEnvironment(std::move(callback));
+}
+
+p3a::ConversionMonitor* RewardsServiceImpl::GetP3AConversionMonitor() {
+  return &conversion_monitor_;
 }
 
 void RewardsServiceImpl::GetDebug(GetDebugCallback callback) {

--- a/components/brave_rewards/browser/rewards_service_impl.h
+++ b/components/brave_rewards/browser/rewards_service_impl.h
@@ -26,6 +26,7 @@
 #include "base/time/time.h"
 #include "base/values.h"
 #include "brave/components/brave_rewards/browser/diagnostic_log.h"
+#include "brave/components/brave_rewards/browser/rewards_p3a.h"
 #include "brave/components/brave_rewards/browser/rewards_service.h"
 #include "brave/components/brave_rewards/common/mojom/bat_ledger.mojom.h"
 #include "brave/components/brave_rewards/common/rewards_flags.h"
@@ -197,6 +198,8 @@ class RewardsServiceImpl : public RewardsService,
   void GetRewardsInternalsInfo(
       GetRewardsInternalsInfoCallback callback) override;
   void GetEnvironment(GetEnvironmentCallback callback) override;
+
+  p3a::ConversionMonitor* GetP3AConversionMonitor() override;
 
   void HandleFlags(const RewardsFlags& flags);
   void SetEnvironment(ledger::mojom::Environment environment);
@@ -661,6 +664,8 @@ class RewardsServiceImpl : public RewardsService,
   int persist_log_level_ = 0;
 
   GetTestResponseCallback test_response_callback_;
+
+  p3a::ConversionMonitor conversion_monitor_;
 
   SEQUENCE_CHECKER(sequence_checker_);
 };

--- a/components/brave_rewards/browser/test/rewards_p3a_browsertest.cc
+++ b/components/brave_rewards/browser/test/rewards_p3a_browsertest.cc
@@ -224,4 +224,45 @@ IN_PROC_BROWSER_TEST_F(RewardsP3ABrowserTest, Duration) {
                                        AdsEnabledDuration::kQuarters, 1);
 }
 
+#if !BUILDFLAG(IS_ANDROID)
+IN_PROC_BROWSER_TEST_F(RewardsP3ABrowserTest, Conversion) {
+  brave_rewards::p3a::ConversionMonitor conversion_monitor;
+  conversion_monitor.RecordPanelTrigger(
+      brave_rewards::p3a::PanelTrigger::kInlineTip);
+
+  histogram_tester_->ExpectTotalCount(
+      brave_rewards::p3a::kEnabledSourceHistogramName, 0);
+  histogram_tester_->ExpectUniqueSample(
+      brave_rewards::p3a::kInlineTipTriggerHistogramName, 1, 1);
+
+  conversion_monitor.RecordRewardsEnable();
+
+  histogram_tester_->ExpectUniqueSample(
+      brave_rewards::p3a::kEnabledSourceHistogramName, 0, 1);
+
+  conversion_monitor.RecordPanelTrigger(
+      brave_rewards::p3a::PanelTrigger::kToolbarButton);
+
+  histogram_tester_->ExpectBucketCount(
+      brave_rewards::p3a::kToolbarButtonTriggerHistogramName, 1, 1);
+
+  conversion_monitor.RecordRewardsEnable();
+
+  histogram_tester_->ExpectBucketCount(
+      brave_rewards::p3a::kEnabledSourceHistogramName, 1, 1);
+
+  conversion_monitor.RecordPanelTrigger(brave_rewards::p3a::PanelTrigger::kNTP);
+
+  histogram_tester_->ExpectBucketCount(
+      brave_rewards::p3a::kToolbarButtonTriggerHistogramName, 1, 1);
+  histogram_tester_->ExpectBucketCount(
+      brave_rewards::p3a::kInlineTipTriggerHistogramName, 1, 1);
+
+  conversion_monitor.RecordRewardsEnable();
+
+  histogram_tester_->ExpectBucketCount(
+      brave_rewards::p3a::kEnabledSourceHistogramName, 2, 1);
+}
+#endif  // !BUILDFLAG(IS_ANDROID)
+
 }  // namespace rewards_browsertest

--- a/components/definitions/chromel.d.ts
+++ b/components/definitions/chromel.d.ts
@@ -164,6 +164,8 @@ declare namespace chrome.braveRewards {
     addListener: (callback: () => void) => void
   }
 
+  const recordNTPPanelTrigger: () => void
+
   const openRewardsPanel: () => void
 
   const showRewardsTour: () => void

--- a/components/p3a/metric_names.h
+++ b/components/p3a/metric_names.h
@@ -42,10 +42,13 @@ constexpr inline auto kCollectedTypicalHistograms =
     "Brave.NTP.SponsoredNewTabsCreated",
     "Brave.Omnibox.SearchCount",
     "Brave.P3A.SentAnswersCount",
+    "Brave.Rewards.AdsEnabledDuration",
     "Brave.Rewards.AdsState.2",
     "Brave.Rewards.AutoContributionsState.2",
+    "Brave.Rewards.EnabledSource",
+    "Brave.Rewards.InlineTipTrigger",
     "Brave.Rewards.TipsState.2",
-    "Brave.Rewards.AdsEnabledDuration",
+    "Brave.Rewards.ToolbarButtonTrigger",
     "Brave.Rewards.WalletBalance.3",
     "Brave.Rewards.WalletState",
     "Brave.Savings.BandwidthSavingsMB",
@@ -195,6 +198,9 @@ constexpr inline auto kCollectedExpressHistograms =
 constexpr inline auto kEphemeralHistograms =
   base::MakeFixedFlatSet<base::StringPiece>({
     "Brave.Rewards.EnabledInstallationTime",
+    "Brave.Rewards.EnabledSource",
+    "Brave.Rewards.InlineTipTrigger",
+    "Brave.Rewards.ToolbarButtonTrigger",
     "Brave.Wallet.UsageDaily",
     "Brave.Wallet.UsageMonthly",
     "Brave.Wallet.UsageWeekly"


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/28597

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-arm64, CI/skip-linux-x64, CI/skip-android, CI/skip-macos, CI/skip-ios, CI/skip-windows-arm64, CI/skip-windows-x64, CI/skip-windows-x86 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [ ] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

0. Start with fresh profile.
1. Click on inline tip button on any publisher page, ensure `Brave.Rewards.InlineTipTrigger` is recorded with 1 on local state page.
2. Click on toolbar BAT button, ensure `Brave.Rewards.ToolbarButtonTrigger` is recorded with 1 on local state page.
3. Click on "start using brave rewards" on NTP, enable rewards. Ensure the above metrics disappear, and `Brave.Rewards.EnabledSource` is recorded with answer 2.
4. Reset rewards and repeat step 3 - 4 with the inline tip and BAT toolbar button. Ensure the enabled source metric reports the correct result.