### PR TITLE
1.49.x  Disable copy-clean-link-by-default for osx (uplift #17752)

### DIFF
--- a/browser/brave_app_controller_mac_browsertest.mm
+++ b/browser/brave_app_controller_mac_browsertest.mm
@@ -32,7 +32,16 @@ namespace {
 
 const char kTestingPage[] = "/empty.html";
 
-using BraveAppControllerBrowserTest = InProcessBrowserTest;
+class BraveAppControllerBrowserTest : public InProcessBrowserTest {
+ public:
+  BraveAppControllerBrowserTest() {
+    features_.InitWithFeatureState(features::kBraveCopyCleanLinkByDefault,
+                                   true);
+  }
+
+ private:
+  base::test::ScopedFeatureList features_;
+};
 
 class BraveAppControllerCleanLinkFeatureDisabledBrowserTest
     : public InProcessBrowserTest {

--- a/browser/brave_browser_features.cc
+++ b/browser/brave_browser_features.cc
@@ -4,12 +4,18 @@
  * You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 #include "brave/browser/brave_browser_features.h"
+#include "build/build_config.h"
 
 namespace features {
 
 // Sanitize url before copying, replaces default ctrl+c hotkey for urls.
 BASE_FEATURE(kBraveCopyCleanLinkByDefault,
              "brave-copy-clean-link-by-default",
-             base::FEATURE_ENABLED_BY_DEFAULT);
+#if BUILDFLAG(IS_MAC)
+             base::FEATURE_DISABLED_BY_DEFAULT
+#else
+             base::FEATURE_ENABLED_BY_DEFAULT
+#endif
+);
 
 }  // namespace features


### PR DESCRIPTION
Uplift of #17752 
Resolves https://github.com/brave/brave-browser/issues/29303

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.