### PR TITLE
[Uplift] [1.49] Fix placement of image attribution & customize button when showing the NTP SI Clickbox 

### DIFF
--- a/components/brave_new_tab_ui/components/default/page/index.tsx
+++ b/components/brave_new_tab_ui/components/default/page/index.tsx
@@ -190,7 +190,7 @@ export const GridItemTopSites = styled('section')`
 
 export const GridItemSponsoredImageClickArea = styled.section<{ otherWidgetsHidden: boolean }>`
   grid-column: 2;
-  grid-row: 2 / span 3;
+  grid-row: 2 / span calc(var(--ntp-page-rows) - 1);
   height: calc(100% - 200px);
   width: 100%;
   position: relative;


### PR DESCRIPTION
Uplift of https://github.com/brave/brave-core/pull/17764 which fixes https://github.com/brave/brave-browser/issues/29246 to 1.49.x