### PR TITLE
Reduce apk size with disable_compression parameter=false for certain files

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -123,10 +123,8 @@ group("resources") {
 }
 
 if (is_android) {
-  android_assets("brave_pak_assets") {
+  android_assets("brave_file_assets") {
     sources = [
-      "$root_out_dir/brave_100_percent.pak",
-      "$root_out_dir/brave_resources.pak",
       "//brave/LICENSE.html",
       "//brave/android/java/org/chromium/chrome/browser/ntp/ntp_news_optin_icon_animation.json",
       "//brave/android/java/org/chromium/chrome/browser/onboarding/animations/onboarding_ads.json",
@@ -138,9 +136,17 @@ if (is_android) {
       "//brave/android/java/org/chromium/chrome/browser/shields/disconnect_entitylist.json",
       "//brave/android/java/org/chromium/chrome/browser/vpn/brave_vpn_confirm.json",
     ]
+    disable_compression = false
+  }
+
+  android_assets("brave_pak_assets") {
+    sources = [
+      "$root_out_dir/brave_100_percent.pak",
+      "$root_out_dir/brave_resources.pak",
+    ]
 
     deps = [
-      "//brave:browser_dependencies",
+      "//brave:brave_file_assets",
       "//brave:packed_resources_100_percent",
       "//brave:packed_resources_extra",
     ]


### PR DESCRIPTION
This PR enables compressions for the assets which:
1) can be compressed with a good ratio;
2) are not opened with [AssetManager.openFd](https://developer.android.com/reference/android/content/res/AssetManager#openFd(java.lang.String))

The reason why in Chromium `disable_compression = true` is used explained at [issue 394502](https://bugs.chromium.org/p/chromium/issues/detail?id=394502).
Currently this is implemented in `ApkAssets.java`. 
When I applied compression to whole `brave_pak_assets` target, I got the exception `Error while loading asset assets/brave_100_percent.pak: java.io.FileNotFoundException: This file can not be opened as a file descriptor; it is probably compressed`  for `assets/brave_resources.pak` and `assets/brave_100_percent.pak`, however, the app was loaded normally.

Here is the result

Size | before | after | diff
-- | -- | -- | --
apk | 158571663 | 157719470 | -852193
aab | 86625723 | 86625655 | -68


For aab packages this doesn't have any effect, because it was already compressed. 

<details>
<summary><b>Details from zipinfo</b></summary>

```
$ zipinfo -hm  00-BraveMonoarm-initial.apk  | grep -E "(\.json|resources\.pak|percent\.pak)"
?rw-r--r--  2.0 unx    16301 bx  0% stor 01-Jan-01 00:00 assets/brave_100_percent.pak
?rw-r--r--  2.0 unx  3567381 bx  0% stor 01-Jan-01 00:00 assets/brave_resources.pak
?rw-r--r--  2.0 unx     9334 b-  0% stor 01-Jan-01 00:00 assets/brave_vpn_confirm.json
?rw-r--r--  2.0 unx    98112 bx  0% stor 01-Jan-01 00:00 assets/chrome_100_percent.pak
?rw-r--r--  2.0 unx   249360 bx  0% stor 01-Jan-01 00:00 assets/disconnect_entitylist.json
?rw-r--r--  2.0 unx    15991 bx  0% stor 01-Jan-01 00:00 assets/ntp_news_optin_icon_animation.json
?rw-r--r--  2.0 unx     3042 bx  0% stor 01-Jan-01 00:00 assets/onboarding_ads.json
?rw-r--r--  2.0 unx   120062 bx  0% stor 01-Jan-01 00:00 assets/onboarding_ads_notification.json
?rw-r--r--  2.0 unx    93333 bx  0% stor 01-Jan-01 00:00 assets/onboarding_rewards.json
?rw-r--r--  2.0 unx   143738 bx  0% stor 01-Jan-01 00:00 assets/privacy_protection.json
?rw-r--r--  2.0 unx  2424786 b-  0% stor 01-Jan-01 00:00 assets/resources.pak
?rw-r--r--  2.0 unx   191874 bx  0% stor 01-Jan-01 00:00 assets/save_data_and_battery.json
?rw-r--r--  2.0 unx   136503 bx  0% stor 01-Jan-01 00:00 assets/website_loads_faster.json
$ zipinfo -hm  00-BraveMonoarm-initial.aab  | grep -E "(\.json|resources\.pak|percent\.pak)"
-rw----     2.0 fat    16301 bX  7% defN 70-Jan-01 03:00 base/assets/brave_100_percent.pak
-rw----     2.0 fat  3567381 bX  1% defN 70-Jan-01 03:00 base/assets/brave_resources.pak
-rw----     2.0 fat     9334 bX 83% defN 70-Jan-01 03:00 base/assets/brave_vpn_confirm.json
-rw----     2.0 fat    98112 bX  3% defN 70-Jan-01 03:00 base/assets/chrome_100_percent.pak
-rw----     2.0 fat   249360 bX 87% defN 70-Jan-01 03:00 base/assets/disconnect_entitylist.json
-rw----     2.0 fat    15991 bX 88% defN 70-Jan-01 03:00 base/assets/ntp_news_optin_icon_animation.json
-rw----     2.0 fat     3042 bX 76% defN 70-Jan-01 03:00 base/assets/onboarding_ads.json
-rw----     2.0 fat   120062 bX 88% defN 70-Jan-01 03:00 base/assets/onboarding_ads_notification.json
-rw----     2.0 fat    93333 bX 87% defN 70-Jan-01 03:00 base/assets/onboarding_rewards.json
-rw----     2.0 fat   143738 bX 86% defN 70-Jan-01 03:00 base/assets/privacy_protection.json
-rw----     2.0 fat  2170801 bX  3% defN 70-Jan-01 03:00 base/assets/resources.pak
-rw----     2.0 fat   191874 bX 86% defN 70-Jan-01 03:00 base/assets/save_data_and_battery.json
-rw----     2.0 fat   136503 bX 89% defN 70-Jan-01 03:00 base/assets/website_loads_faster.json
-rw----     2.0 fat       37 bX 22% defN 70-Jan-01 03:00 test_dummy/assets/test_dummy_resources.pak
-rw----     2.0 fat   262396 bX  1% defN 70-Jan-01 03:00 dev_ui/assets/dev_ui_resources.pak
$ zipinfo -hm  03-BraveMonoarm-selectionable_compression.apk  | grep -E "(\.json|resources\.pak|percent\.pak)"
?rw-r--r--  2.0 unx     9334 b- 83% defN 01-Jan-01 00:00 assets/brave_vpn_confirm.json
?rw-r--r--  2.0 unx   249360 b- 87% defN 01-Jan-01 00:00 assets/disconnect_entitylist.json
?rw-r--r--  2.0 unx    15991 b- 88% defN 01-Jan-01 00:00 assets/ntp_news_optin_icon_animation.json
?rw-r--r--  2.0 unx     3042 b- 76% defN 01-Jan-01 00:00 assets/onboarding_ads.json
?rw-r--r--  2.0 unx   120062 b- 89% defN 01-Jan-01 00:00 assets/onboarding_ads_notification.json
?rw-r--r--  2.0 unx    93333 b- 88% defN 01-Jan-01 00:00 assets/onboarding_rewards.json
?rw-r--r--  2.0 unx   143738 b- 87% defN 01-Jan-01 00:00 assets/privacy_protection.json
?rw-r--r--  2.0 unx   191874 b- 86% defN 01-Jan-01 00:00 assets/save_data_and_battery.json
?rw-r--r--  2.0 unx   136503 b- 89% defN 01-Jan-01 00:00 assets/website_loads_faster.json
?rw-r--r--  2.0 unx    16301 bx  0% stor 01-Jan-01 00:00 assets/brave_100_percent.pak
?rw-r--r--  2.0 unx  3567381 bx  0% stor 01-Jan-01 00:00 assets/brave_resources.pak
?rw-r--r--  2.0 unx    98112 b-  0% stor 01-Jan-01 00:00 assets/chrome_100_percent.pak
?rw-r--r--  2.0 unx  2424786 bx  0% stor 01-Jan-01 00:00 assets/resources.pak
$ zipinfo -hm  03-BraveMonoarm-selectionable_compression.aab  | grep -E "(\.json|resources\.pak|percent\.pak)"
-rw----     2.0 fat     9334 bX 83% defN 70-Jan-01 03:00 base/assets/brave_vpn_confirm.json
-rw----     2.0 fat   249360 bX 87% defN 70-Jan-01 03:00 base/assets/disconnect_entitylist.json
-rw----     2.0 fat    15991 bX 88% defN 70-Jan-01 03:00 base/assets/ntp_news_optin_icon_animation.json
-rw----     2.0 fat     3042 bX 76% defN 70-Jan-01 03:00 base/assets/onboarding_ads.json
-rw----     2.0 fat   120062 bX 88% defN 70-Jan-01 03:00 base/assets/onboarding_ads_notification.json
-rw----     2.0 fat    93333 bX 87% defN 70-Jan-01 03:00 base/assets/onboarding_rewards.json
-rw----     2.0 fat   143738 bX 86% defN 70-Jan-01 03:00 base/assets/privacy_protection.json
-rw----     2.0 fat   191874 bX 86% defN 70-Jan-01 03:00 base/assets/save_data_and_battery.json
-rw----     2.0 fat   136503 bX 89% defN 70-Jan-01 03:00 base/assets/website_loads_faster.json
-rw----     2.0 fat    16301 bX  7% defN 70-Jan-01 03:00 base/assets/brave_100_percent.pak
-rw----     2.0 fat  3567381 bX  1% defN 70-Jan-01 03:00 base/assets/brave_resources.pak
-rw----     2.0 fat    98112 bX  3% defN 70-Jan-01 03:00 base/assets/chrome_100_percent.pak
-rw----     2.0 fat  2170801 bX  3% defN 70-Jan-01 03:00 base/assets/resources.pak
-rw----     2.0 fat       37 bX 22% defN 70-Jan-01 03:00 test_dummy/assets/test_dummy_resources.pak
-rw----     2.0 fat   262396 bX  1% defN 70-Jan-01 03:00 dev_ui/assets/dev_ui_resources.pak
```


</details>

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/29390

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-arm64, CI/skip-linux-x64, CI/skip-android, CI/skip-macos, CI/skip-ios, CI/skip-windows-arm64, CI/skip-windows-x64, CI/skip-windows-x86 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
There are no dedicated test plan, just ensure that apk still can be built and app launches well.
