### PR TITLE
[iOS] Fetch wallet last unlock time from local state for usage stats (uplift to 1.50.x)

### DIFF
--- a/ios/browser/api/brave_stats/brave_stats.mm
+++ b/ios/browser/api/brave_stats/brave_stats.mm
@@ -30,8 +30,7 @@
 }
 
 - (NSDictionary<NSString*, NSString*>*)walletParams {
-  auto wallet_last_unlocked =
-      _profilePrefs->GetTime(kBraveWalletLastUnlockTime);
+  auto wallet_last_unlocked = _localPrefs->GetTime(kBraveWalletLastUnlockTime);
   auto last_reported_wallet_unlock =
       _localPrefs->GetTime(kBraveWalletPingReportedUnlockTime);
   uint8_t usage_bitset = 0;
@@ -43,8 +42,7 @@
 }
 
 - (void)notifyStatsPingSent {
-  auto wallet_last_unlocked =
-      _profilePrefs->GetTime(kBraveWalletLastUnlockTime);
+  auto wallet_last_unlocked = _localPrefs->GetTime(kBraveWalletLastUnlockTime);
   _localPrefs->SetTime(kBraveWalletPingReportedUnlockTime,
                        wallet_last_unlocked);
 }


### PR DESCRIPTION
Uplift of #17753
Resolves https://github.com/brave/brave-browser/issues/29305

Pre-approval checklist: 
- [ ] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.