### PR TITLE
Cache skus credential till we get valid subs credential

### DIFF
--- a/components/brave_vpn/browser/brave_vpn_service.cc
+++ b/components/brave_vpn/browser/brave_vpn_service.cc
@@ -813,7 +813,7 @@ void BraveVpnService::OnGetSubscriberCredentialV12(
     if (subscriber_credential == kTokenNoLongerValid) {
       SetPurchasedState(GetCurrentEnvironment(), PurchasedState::INVALID);
     } else {
-      SetPurchasedState(GetCurrentEnvironment(), PurchasedState::NOT_PURCHASED);
+      SetPurchasedState(GetCurrentEnvironment(), PurchasedState::FAILED);
     }
 #endif
     return;

--- a/components/brave_vpn/browser/brave_vpn_service.cc
+++ b/components/brave_vpn/browser/brave_vpn_service.cc
@@ -89,6 +89,10 @@ void BraveVpnService::CheckInitialState() {
 
     ScheduleBackgroundRegionDataFetch();
 #endif
+  } else if (HasValidSkusCredential(local_prefs_)) {
+    // If we have valid skus creds during the startup, we can try to get subs
+    // credential in advance.
+    ReloadPurchasedState();
   } else {
     // Try to reload purchased state if cached credential is not valid because
     // it could be invalidated when not running.
@@ -643,9 +647,28 @@ void BraveVpnService::LoadPurchasedState(const std::string& domain) {
     return;
   }
 
+  if (HasValidSkusCredential(local_prefs_)) {
+    // We can reach here if we fail to get subscriber credential from guardian.
+    VLOG(2) << __func__
+            << " Try to get subscriber credential with valid cached skus "
+               "credential.";
+
+    if (GetCurrentEnvironment() != requested_env) {
+      SetCurrentEnvironment(requested_env);
+    }
+
+    api_request_.GetSubscriberCredentialV12(
+        base::BindOnce(&BraveVpnService::OnGetSubscriberCredentialV12,
+                       base::Unretained(this),
+                       GetExpirationTimeForSkusCredential(local_prefs_)),
+        GetSkusCredential(local_prefs_),
+        GetBraveVPNPaymentsEnv(GetCurrentEnvironment()));
+    return;
+  }
+
   VLOG(2) << __func__
-          << ": Checking purchased state as we doesn't have valid subscriber "
-             "credentials";
+          << ": Checking purchased state as we doesn't have valid skus or "
+             "subscriber credentials";
   ClearSubscriberCredential(local_prefs_);
 
   EnsureMojoConnected();
@@ -765,6 +788,8 @@ void BraveVpnService::OnPrepareCredentialsPresentation(
     return;
   }
 
+  SetSkusCredential(local_prefs_, credential, time);
+
   if (GetCurrentEnvironment() != env) {
     // Change environment because we have successfully authorized with new one.
     SetCurrentEnvironment(env);
@@ -794,6 +819,8 @@ void BraveVpnService::OnGetSubscriberCredentialV12(
     return;
   }
 
+  // Previously cached skus credential is cleared and fetched subscriber
+  // credential is cached.
   SetSubscriberCredential(local_prefs_, subscriber_credential, expiration_time);
 
   // Launch one-shot timer for refreshing subscriber_credential before it's

--- a/components/brave_vpn/browser/brave_vpn_service_helper.cc
+++ b/components/brave_vpn/browser/brave_vpn_service_helper.cc
@@ -151,4 +151,28 @@ void ClearSubscriberCredential(PrefService* local_prefs) {
   local_prefs->ClearPref(prefs::kBraveVPNSubscriberCredential);
 }
 
+void SetSkusCredential(PrefService* local_prefs,
+                       const std::string& skus_credential,
+                       const base::Time& expiration_time) {
+  base::Value::Dict cred_dict;
+  cred_dict.Set(kSkusCredentialKey, skus_credential);
+  cred_dict.Set(kSubscriberCredentialExpirationKey,
+                base::TimeToValue(expiration_time));
+  local_prefs->SetDict(prefs::kBraveVPNSubscriberCredential,
+                       std::move(cred_dict));
+}
+
+base::Time GetExpirationTimeForSkusCredential(PrefService* local_prefs) {
+  CHECK(HasValidSkusCredential(local_prefs));
+
+  const base::Value::Dict& sub_cred_dict =
+      local_prefs->GetDict(prefs::kBraveVPNSubscriberCredential);
+
+  const base::Value* expiration_time_value =
+      sub_cred_dict.Find(kSubscriberCredentialExpirationKey);
+
+  CHECK(expiration_time_value);
+  return *base::ValueToTime(expiration_time_value);
+}
+
 }  // namespace brave_vpn

--- a/components/brave_vpn/browser/brave_vpn_service_helper.h
+++ b/components/brave_vpn/browser/brave_vpn_service_helper.h
@@ -40,6 +40,10 @@ void SetSubscriberCredential(PrefService* local_prefs,
                              const std::string& subscriber_credential,
                              const base::Time& expiration_time);
 void ClearSubscriberCredential(PrefService* local_prefs);
+void SetSkusCredential(PrefService* local_prefs,
+                       const std::string& skus_credential,
+                       const base::Time& expiration_time);
+base::Time GetExpirationTimeForSkusCredential(PrefService* local_prefs);
 
 }  // namespace brave_vpn
 

--- a/components/brave_vpn/common/brave_vpn_constants.h
+++ b/components/brave_vpn/common/brave_vpn_constants.h
@@ -43,6 +43,7 @@ constexpr char kCreateSubscriberCredentialV12[] =
 constexpr int kP3AIntervalHours = 24;
 
 constexpr char kSubscriberCredentialKey[] = "credential";
+constexpr char kSkusCredentialKey[] = "skus_credential";
 constexpr char kSubscriberCredentialExpirationKey[] = "expiration";
 
 #if !BUILDFLAG(IS_ANDROID)

--- a/components/brave_vpn/common/brave_vpn_utils.cc
+++ b/components/brave_vpn/common/brave_vpn_utils.cc
@@ -182,4 +182,42 @@ std::string GetSubscriberCredential(PrefService* local_prefs) {
   return *cred;
 }
 
+bool HasValidSkusCredential(PrefService* local_prefs) {
+  const base::Value::Dict& sub_cred_dict =
+      local_prefs->GetDict(prefs::kBraveVPNSubscriberCredential);
+  if (sub_cred_dict.empty()) {
+    return false;
+  }
+
+  const std::string* skus_cred = sub_cred_dict.FindString(kSkusCredentialKey);
+  const base::Value* expiration_time_value =
+      sub_cred_dict.Find(kSubscriberCredentialExpirationKey);
+
+  if (!skus_cred || !expiration_time_value) {
+    return false;
+  }
+
+  if (skus_cred->empty()) {
+    return false;
+  }
+
+  auto expiration_time = base::ValueToTime(expiration_time_value);
+  if (!expiration_time || expiration_time < base::Time::Now()) {
+    return false;
+  }
+
+  return true;
+}
+
+std::string GetSkusCredential(PrefService* local_prefs) {
+  CHECK(HasValidSkusCredential(local_prefs))
+      << "Don't call when there is no valid skus credential.";
+
+  const base::Value::Dict& sub_cred_dict =
+      local_prefs->GetDict(prefs::kBraveVPNSubscriberCredential);
+  const std::string* skus_cred = sub_cred_dict.FindString(kSkusCredentialKey);
+  DCHECK(skus_cred);
+  return *skus_cred;
+}
+
 }  // namespace brave_vpn

--- a/components/brave_vpn/common/brave_vpn_utils.h
+++ b/components/brave_vpn/common/brave_vpn_utils.h
@@ -32,6 +32,8 @@ void RegisterProfilePrefs(user_prefs::PrefRegistrySyncable* registry);
 void RegisterAndroidProfilePrefs(PrefRegistrySimple* registry);
 bool HasValidSubscriberCredential(PrefService* local_prefs);
 std::string GetSubscriberCredential(PrefService* local_prefs);
+bool HasValidSkusCredential(PrefService* local_prefs);
+std::string GetSkusCredential(PrefService* local_prefs);
 
 }  // namespace brave_vpn
 


### PR DESCRIPTION
fix https://github.com/brave/brave-browser/issues/29345

If we fail to get subs credential from guardian, we should keep skus credential till it's expired.

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves 

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-arm64, CI/skip-linux-x64, CI/skip-android, CI/skip-macos, CI/skip-ios, CI/skip-windows-arm64, CI/skip-windows-x64, CI/skip-windows-x86 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [ ] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

`BraveVPNServiceTest.SkusCredentialCacheTest`