### PR TITLE
[Abandoned] Enlarge favicon size for pinned tabs

### DIFF
--- a/browser/ui/BUILD.gn
+++ b/browser/ui/BUILD.gn
@@ -293,6 +293,8 @@ source_set("ui") {
       "views/tabs/brave_tab_group_underline.h",
       "views/tabs/brave_tab_hover_card_controller.cc",
       "views/tabs/brave_tab_hover_card_controller.h",
+      "views/tabs/brave_tab_icon.cc",
+      "views/tabs/brave_tab_icon.h",
       "views/tabs/brave_tab_strip.cc",
       "views/tabs/brave_tab_strip.h",
       "views/tabs/brave_tab_strip_layout_helper.cc",

--- a/browser/ui/views/tabs/brave_tab_icon.cc
+++ b/browser/ui/views/tabs/brave_tab_icon.cc
@@ -1,0 +1,52 @@
+/* Copyright (c) 2023 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "brave/browser/ui/views/tabs/brave_tab_icon.h"
+
+#include "brave/browser/ui/tabs/features.h"
+#include "brave/browser/ui/views/tabs/brave_tab.h"
+#include "brave/browser/ui/views/tabs/vertical_tab_utils.h"
+#include "chrome/browser/ui/views/tabs/fake_tab_slot_controller.h"
+#include "ui/base/metadata/metadata_impl_macros.h"
+#include "ui/gfx/favicon_size.h"
+#include "ui/gfx/scoped_canvas.h"
+
+BraveTabIcon::BraveTabIcon(Tab* tab) : tab_(tab) {
+  CHECK(base::FeatureList::IsEnabled(tabs::features::kBraveVerticalTabs))
+      << "This class is used only for vertical tab strip";
+}
+
+void BraveTabIcon::OnPaint(gfx::Canvas* canvas) {
+  CHECK(tab_->controller()->GetBrowser());
+  if (!tabs::utils::ShouldShowVerticalTabs(tab_->controller()->GetBrowser())) {
+    TabIcon::OnPaint(canvas);
+    return;
+  }
+
+  if (!tab_->data().pinned) {
+    TabIcon::OnPaint(canvas);
+    return;
+  }
+
+  // Enlarge tab icon if it's pinned tab in vertical tab strip.
+  const auto center_point = GetLocalBounds().CenterPoint();
+  constexpr auto kFaviconSizeForPinnedTab = 18.f;
+  const auto scale = kFaviconSizeForPinnedTab / gfx::kFaviconSize;
+
+  gfx::ScopedCanvas scoped_canvas(canvas);
+  // Scale to desired size
+  canvas->Translate({center_point.x(), center_point.y()});
+  canvas->Scale(scale, scale);
+
+  // Set back canvas to the lef top and adjust insets by the enlarged size.
+  const auto delta =
+      static_cast<int>(kFaviconSizeForPinnedTab - gfx::kFaviconSize);
+  canvas->Translate({-center_point.x() + delta, -center_point.y() + delta});
+
+  TabIcon::OnPaint(canvas);
+}
+
+BEGIN_METADATA(BraveTabIcon, TabIcon)
+END_METADATA

--- a/browser/ui/views/tabs/brave_tab_icon.h
+++ b/browser/ui/views/tabs/brave_tab_icon.h
@@ -1,0 +1,27 @@
+/* Copyright (c) 2023 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_BROWSER_UI_VIEWS_TABS_BRAVE_TAB_ICON_H_
+#define BRAVE_BROWSER_UI_VIEWS_TABS_BRAVE_TAB_ICON_H_
+
+#include "chrome/browser/ui/views/tabs/tab_icon.h"
+
+class Tab;
+
+class BraveTabIcon : public TabIcon {
+ public:
+  METADATA_HEADER(BraveTabIcon);
+
+  explicit BraveTabIcon(Tab* tab);
+  ~BraveTabIcon() override = default;
+
+  // TabIcon:
+  void OnPaint(gfx::Canvas* canvas) override;
+
+ private:
+  raw_ptr<Tab> tab_;
+};
+
+#endif  // BRAVE_BROWSER_UI_VIEWS_TABS_BRAVE_TAB_ICON_H_

--- a/chromium_src/chrome/browser/ui/views/tabs/tab_icon.h
+++ b/chromium_src/chrome/browser/ui/views/tabs/tab_icon.h
@@ -1,0 +1,17 @@
+/* Copyright (c) 2023 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_CHROMIUM_SRC_CHROME_BROWSER_UI_VIEWS_TABS_TAB_ICON_H_
+#define BRAVE_CHROMIUM_SRC_CHROME_BROWSER_UI_VIEWS_TABS_TAB_ICON_H_
+
+#define TabTest \
+  TabTest;      \
+  friend class BraveTabIcon
+
+#include "src/chrome/browser/ui/views/tabs/tab_icon.h"  // IWYU: pragma: export
+
+#undef TabTest
+
+#endif  // BRAVE_CHROMIUM_SRC_CHROME_BROWSER_UI_VIEWS_TABS_TAB_ICON_H_


### PR DESCRIPTION
Upload for the record. Favicon quality is not that good. 

![image](https://user-images.githubusercontent.com/5474642/228244492-ce149e38-13df-400e-af14-a3f2b68b397a.png)

* TabIcon can have its own layer, so we have to override TabIcon::OnPaint.
* TabIcon paints not only favicon, but also spinner and other indicators. Thus translating and scaling canvas would be easier approach.

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves 

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-arm64, CI/skip-linux-x64, CI/skip-android, CI/skip-macos, CI/skip-ios, CI/skip-windows-arm64, CI/skip-windows-x64, CI/skip-windows-x86 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [ ] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

