### PR TITLE
Prevents a crash on Android when a system setting of show everything in Bold is turned on

### DIFF
--- a/patches/chrome-browser-password_entry_edit-android-java-res-layout-credential_edit_view.xml.patch
+++ b/patches/chrome-browser-password_entry_edit-android-java-res-layout-credential_edit_view.xml.patch
@@ -1,0 +1,22 @@
+diff --git a/chrome/browser/password_entry_edit/android/java/res/layout/credential_edit_view.xml b/chrome/browser/password_entry_edit/android/java/res/layout/credential_edit_view.xml
+index 3d482cbedf7ed9e9b868e913d5cf265071731ed0..b7df538e669bd9af3284686cc182034e543436c9 100644
+--- a/chrome/browser/password_entry_edit/android/java/res/layout/credential_edit_view.xml
++++ b/chrome/browser/password_entry_edit/android/java/res/layout/credential_edit_view.xml
+@@ -44,7 +44,7 @@ found in the LICENSE file.
+                     android:imeOptions="flagNoExtractUi"
+                     android:importantForAutofill="noExcludeDescendants"
+                     android:inputType="textMultiLine"
+-                    android:textAppearance="@style/TextAppearance.TextLarge.Primary"/>
++                    />
+             </com.google.android.material.textfield.TextInputLayout>
+ 
+             <org.chromium.ui.widget.ChromeImageButton
+@@ -84,7 +84,7 @@ found in the LICENSE file.
+                     android:imeOptions="flagNoExtractUi"
+                     android:importantForAutofill="noExcludeDescendants"
+                     android:inputType="textVisiblePassword"
+-                    android:textAppearance="@style/TextAppearance.TextLarge.Primary"/>
++                    />
+             </com.google.android.material.textfield.TextInputLayout>
+ 
+             <LinearLayout


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/29344

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-arm64, CI/skip-linux-x64, CI/skip-android, CI/skip-macos, CI/skip-ios, CI/skip-windows-arm64, CI/skip-windows-x64, CI/skip-windows-x86 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [ ] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
It's described in the original issue. In short, I had to remove a style applied to EditText in the Edit password layout as they caused a crash when `Bold text` is select on Android OS level. There are pictures how did it look before and after when `Bold text` is off:

Before:
![Screenshot_20230327-172228](https://user-images.githubusercontent.com/12011303/228330864-ade0f640-666d-46f9-8a7f-ecb71d0c3fd9.png)

After:
![Screenshot_20230327-171914](https://user-images.githubusercontent.com/12011303/228330962-c76a4841-2b21-440f-a2c1-b36139864610.png)
