### PR TITLE
26327 allow for revocation of token allowances back end work

### DIFF
--- a/browser/brave_wallet/BUILD.gn
+++ b/browser/brave_wallet/BUILD.gn
@@ -172,6 +172,7 @@ source_set("unit_tests") {
     "brave_wallet_p3a_unittest.cc",
     "brave_wallet_prefs_unittest.cc",
     "brave_wallet_service_unittest.cc",
+    "eth_allowance_manager_unittest.cc",
     "eth_pending_tx_tracker_unittest.cc",
     "filecoin_keyring_unittest.cc",
     "keyring_service_unittest.cc",

--- a/browser/brave_wallet/eth_allowance_manager_unittest.cc
+++ b/browser/brave_wallet/eth_allowance_manager_unittest.cc
@@ -1,0 +1,947 @@
+/* Copyright (c) 2023 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "brave/components/brave_wallet/browser/eth_allowance_manager.h"
+
+#include <map>
+#include <memory>
+#include <utility>
+
+#include "base/json/json_reader.h"
+#include "base/memory/raw_ptr.h"
+#include "base/test/bind.h"
+#include "base/test/scoped_feature_list.h"
+#include "base/time/time.h"
+#include "brave/browser/brave_wallet/json_rpc_service_factory.h"
+#include "brave/browser/brave_wallet/keyring_service_factory.h"
+#include "brave/browser/brave_wallet/tx_service_factory.h"
+#include "brave/components/brave_wallet/browser/blockchain_registry.h"
+#include "brave/components/brave_wallet/browser/brave_wallet_service.h"
+#include "brave/components/brave_wallet/browser/brave_wallet_service_delegate.h"
+#include "brave/components/brave_wallet/browser/brave_wallet_service_observer_base.h"
+#include "brave/components/brave_wallet/browser/brave_wallet_utils.h"
+#include "brave/components/brave_wallet/browser/json_rpc_service.h"
+#include "brave/components/brave_wallet/browser/keyring_service.h"
+#include "brave/components/brave_wallet/browser/pref_names.h"
+#include "brave/components/brave_wallet/browser/tx_service.h"
+#include "brave/components/brave_wallet/common/features.h"
+#include "brave/components/brave_wallet/common/hex_utils.h"
+#include "brave/components/brave_wallet/common/test_utils.h"
+#include "chrome/browser/prefs/browser_prefs.h"
+#include "chrome/test/base/scoped_testing_local_state.h"
+#include "chrome/test/base/testing_browser_process.h"
+#include "chrome/test/base/testing_profile.h"
+#include "components/prefs/pref_service.h"
+#include "components/prefs/scoped_user_pref_update.h"
+#include "components/sync_preferences/testing_pref_service_syncable.h"
+#include "content/public/test/browser_task_environment.h"
+#include "services/data_decoder/public/cpp/test_support/in_process_data_decoder.h"
+#include "services/network/public/cpp/weak_wrapper_shared_url_loader_factory.h"
+#include "services/network/test/test_url_loader_factory.h"
+#include "testing/gtest/include/gtest/gtest.h"
+#include "ui/base/l10n/l10n_util.h"
+namespace brave_wallet {
+
+namespace {
+
+constexpr base::StringPiece eth_allowance_detected_response = R"({
+    "jsonrpc": "2.0",
+    "id": 1,
+    "result": [
+        {
+            "address": "$1",
+            "blockHash": "0xaff41c269d9f87f9d71e826ccc612bec9eff33fe5f01a0c9b6f54bfaa8178686",
+            "blockNumber": "0x101a7f1",
+            "data": "0x0000000000000000000000000000000000000000000000000000000000000001",
+            "logIndex": "0x92",
+            "removed": false,
+            "topics": [
+                "0x8c5be1e5ebec7d5bd14f71427d1e84f3dd0314c0f7b2291e5b200ac8c7c3b925",
+                "$2",
+                "0x000000000000000000000000dac308312e195710467ce36effe51ac7a4ecbf01"
+            ],
+            "transactionHash": "0x32132b285e95d82a9b81e3f25ea8290756f36c9fedd92af8290d4ee8cd1d7f98",
+            "transactionIndex": "0x38"
+        }
+    ]
+})";
+
+constexpr base::StringPiece eth_allowance_error_response = R"({
+                  "error": {
+                    "code": -32000,
+"message": "requested too many blocks from 0
+ to 27842567, maximum is set to 2048"
+                  },
+                  "id": 1,
+                  "jsonrpc": "2.0"
+                })";
+
+constexpr char token_list_json[] = R"({
+      "0x3333333333333333333333333333333333333333": {
+        "name": "3333",
+        "logo": "333.svg",
+        "erc20": true,
+        "symbol": "333",
+        "decimals": 18,
+        "chainId": "0x1"
+      }
+    })";
+
+constexpr char allowance_chache_json[] = R"({
+            "0x1": {
+               "allowances_found": [ {
+                  "amount":
+         "0x0000000000000000000000000000000000000000000000000000000000000001",
+                  "approver_address":
+         "0x00000000000000000000000091272b2c4990927d1fe28201cf0a6ce288a221d6",
+                  "contract_address":
+         "0x0c10bf8fcb7bf5412187a595ab97a3609160b5c6",
+                  "spender_address":
+         "0x000000000000000000000000dac308312e195710467ce36effe51ac7a4ecbf01"
+               } ],
+               "last_block_number": "0x1054bfe"
+            },
+            "0xa4b1": {
+               "allowances_found": [ {
+                  "amount":
+         "0x0000000000000000000000000000000000000000000000000000000000000001",
+                  "approver_address":
+         "0x00000000000000000000000091272b2c4990927d1fe28201cf0a6ce288a221d6",
+                  "contract_address":
+         "0xfd086bc7cd5c481dcc9c85ebe478a1c0b69fcbb9",
+                  "spender_address":
+         "0x000000000000000000000000dac308312e195710467ce36effe51ac7a4ecbf01"
+               } ],
+               "last_block_number": "0x504d1a3"
+            }
+         })";
+
+constexpr char incorrect_allowance_chache_data_json[] = R"({
+            "0x1": {
+               "allowances_found": [ {
+                  "amount":
+         "0x0000000000000000000000000000000000000000000000000000000000000001",
+                  "approver_address":
+         "0x00000000000000000000000091272b2c4990927d1fe28201cf0a6ce288a221d6",
+                  "spender_address":
+         "0x000000000000000000000000dac308312e195710467ce36effe51ac7a4ecbf01"
+               } ],
+               "last_block_number": "0x1054bfe"
+            }
+         })";
+
+constexpr char incorrect_allowance_chache_block_number_json[] = R"({
+            "0x1": {
+               "allowances_found": [ {
+                  "amount":
+         "0x0000000000000000000000000000000000000000000000000000000000000001",
+                  "approver_address":
+         "0x00000000000000000000000091272b2c4990927d1fe28201cf0a6ce288a221d6",
+                  "contract_address":
+         "0x0c10bf8fcb7bf5412187a595ab97a3609160b5c6",
+                  "spender_address":
+         "0x000000000000000000000000dac308312e195710467ce36effe51ac7a4ecbf01"
+               } ],
+               "last_block_number": "123456"
+            }
+         })";
+
+constexpr char kMnemonic1[] =
+    "divide cruise upon flag harsh carbon filter merit once advice bright "
+    "drive";
+constexpr char kPasswordBrave[] = "brave";
+
+using AllowancesMap =
+    std::map<std::string, std::tuple<uint256_t, mojom::AllowanceInfoPtr>>;
+using AllowancesMapCallback = base::OnceCallback<void(const AllowancesMap&)>;
+using OnDiscoverEthAllowancesCompletedValidation =
+    base::RepeatingCallback<void(const std::vector<mojom::AllowanceInfoPtr>&)>;
+
+base::Value::Dict ParseTestJson(const base::StringPiece& json) {
+  absl::optional<base::Value> potential_response_dict_val =
+      base::JSONReader::Read(json, base::JSON_PARSE_CHROMIUM_EXTENSIONS |
+                                       base::JSONParserOptions::JSON_PARSE_RFC);
+  return std::move(potential_response_dict_val.value().GetDict());
+}
+
+void FillAllowanceLogItem(base::Value::Dict& current_item,
+                          const std::string& contract_address,
+                          const uint256_t& log_index,
+                          const std::string& approver_address,
+                          const uint256_t& amount,
+                          const std::string& block_number = "") {
+  current_item.Set("address", contract_address);
+  current_item.Set("logIndex", Uint256ValueToHex(log_index));
+
+  auto* pr_topics_ptr = current_item.FindList("topics");
+  DCHECK(pr_topics_ptr);
+  (*pr_topics_ptr)[1] = base::Value(approver_address);
+
+  std::string hex_amount;
+  if (PadHexEncodedParameter(Uint256ValueToHex(amount), &hex_amount)) {
+    current_item.Set("data", hex_amount);
+  }
+
+  if (!block_number.empty()) {
+    current_item.Set("blockNumber", block_number);
+  }
+}
+
+mojom::AllowanceInfoPtr GetAllowanceInfo(const base::Value::Dict& current_item,
+                                         const std::string& chain_id) {
+  const auto* contract_addr_ptr = current_item.FindString("address");
+  DCHECK(contract_addr_ptr);
+  const auto* pr_topics_ptr = current_item.FindList("topics");
+  DCHECK(pr_topics_ptr);
+  const auto* data_ptr = current_item.FindString("data");
+  DCHECK(data_ptr);
+  return mojom::AllowanceInfo::New(chain_id, *contract_addr_ptr,
+                                   (*pr_topics_ptr)[1].GetString(),
+                                   (*pr_topics_ptr)[2].GetString(), *data_ptr);
+}
+
+}  // namespace
+class EthAllowanceManagerUnitTest : public testing::Test {
+ public:
+  EthAllowanceManagerUnitTest()
+      : shared_url_loader_factory_(
+            base::MakeRefCounted<network::WeakWrapperSharedURLLoaderFactory>(
+                &url_loader_factory_)),
+        task_environment_(base::test::TaskEnvironment::TimeSource::MOCK_TIME) {}
+  ~EthAllowanceManagerUnitTest() override = default;
+
+ protected:
+  void SetUp() override {
+    scoped_feature_list_.InitAndEnableFeature(
+        features::kNativeBraveWalletFeature);
+
+    TestingProfile::Builder builder;
+    auto prefs =
+        std::make_unique<sync_preferences::TestingPrefServiceSyncable>();
+    RegisterUserProfilePrefs(prefs->registry());
+    builder.SetPrefService(std::move(prefs));
+    profile_ = builder.Build();
+    local_state_ = std::make_unique<ScopedTestingLocalState>(
+        TestingBrowserProcess::GetGlobal());
+    keyring_service_ =
+        KeyringServiceFactory::GetServiceForContext(profile_.get());
+    json_rpc_service_ =
+        JsonRpcServiceFactory::GetServiceForContext(profile_.get());
+    json_rpc_service_->SetAPIRequestHelperForTesting(
+        shared_url_loader_factory_);
+    tx_service = TxServiceFactory::GetServiceForContext(profile_.get());
+    wallet_service_ = std::make_unique<BraveWalletService>(
+        shared_url_loader_factory_,
+        BraveWalletServiceDelegate::Create(profile_.get()), keyring_service_,
+        json_rpc_service_, tx_service, GetPrefs(), GetLocalState());
+    eth_allowance_manager_ = std::make_unique<EthAllowanceManager>(
+        wallet_service_.get(), json_rpc_service_, keyring_service_, GetPrefs());
+  }
+
+  void CreateCachedAllowancesPrefs(const std::string& json) {
+    absl::optional<base::Value> allowance_chache_json_value =
+        base::JSONReader::Read(json,
+                               base::JSON_PARSE_CHROMIUM_EXTENSIONS |
+                                   base::JSONParserOptions::JSON_PARSE_RFC);
+
+    if (allowance_chache_json_value.has_value()) {
+      GetPrefs()->SetDict(
+          kBraveWalletEthAllowancesCache,
+          allowance_chache_json_value.value().GetDict().Clone());
+    }
+  }
+
+  absl::optional<std::string> GetSelectedAccount(mojom::CoinType coin) {
+    absl::optional<std::string> account;
+    base::RunLoop run_loop;
+    keyring_service_->GetSelectedAccount(
+        coin,
+        base::BindLambdaForTesting([&](const absl::optional<std::string>& v) {
+          account = v;
+          run_loop.Quit();
+        }));
+    run_loop.Run();
+    return account;
+  }
+
+  void AddEthAccount(const std::string& account_name) {
+    base::RunLoop run_loop;
+    keyring_service_->AddAccount(
+        account_name, mojom::CoinType::ETH,
+        base::BindLambdaForTesting([&run_loop](bool success) {
+          EXPECT_TRUE(success);
+          run_loop.Quit();
+        }));
+    run_loop.Run();
+  }
+
+  void CreateWallet() {
+    base::RunLoop run_loop;
+    keyring_service_->CreateWallet(
+        "brave",
+        base::BindLambdaForTesting([&run_loop](const std::string& mnemonic) {
+          EXPECT_FALSE(mnemonic.empty());
+          run_loop.Quit();
+        }));
+    run_loop.Run();
+  }
+
+  void TestAllowancesLoading(
+      const std::string& current_token_list_json,
+      base::OnceCallback<std::map<GURL, std::map<std::string, std::string>>(
+          const std::vector<std::string>&,
+          const TokenListMap&)> get_responses,
+      const int& eth_account_count,
+      const std::size_t& eth_allowance_completed_call_count,
+      OnDiscoverEthAllowancesCompletedValidation allowances_validation,
+      const std::size_t& call_reset_on_pos =
+          std::numeric_limits<std::size_t>::max()) {
+    auto* blockchain_registry = BlockchainRegistry::GetInstance();
+
+    TokenListMap token_list_map;
+    ASSERT_TRUE(ParseTokenList(current_token_list_json, &token_list_map,
+                               mojom::CoinType::ETH));
+
+    std::vector<std::string> contract_addresses;
+    for (auto const& [contract_addr, token_info] : token_list_map) {
+      for (auto const& tkn : token_info) {
+        contract_addresses.push_back(tkn->contract_address);
+      }
+    }
+    keyring_service_->RestoreWallet(kMnemonic1, kPasswordBrave, false,
+                                    base::DoNothing());
+    for (int i = 0; i < (eth_account_count - 1); i++) {
+      AddEthAccount("additonal eth account");
+    }
+
+    const auto keyring_info = keyring_service_->GetKeyringInfoSync(
+        brave_wallet::mojom::kDefaultKeyringId);
+    std::vector<std::string> account_addresses;
+    for (const auto& account_info : keyring_info->account_infos) {
+      std::string hex_account_address;
+      if (!PadHexEncodedParameter(account_info->address,
+                                  &hex_account_address)) {
+        ASSERT_TRUE(false);
+      }
+      account_addresses.push_back(hex_account_address);
+    }
+    auto responses =
+        std::move(get_responses).Run(account_addresses, token_list_map);
+    blockchain_registry->UpdateTokenList(std::move(token_list_map));
+
+    url_loader_factory_.SetInterceptor(base::BindLambdaForTesting(
+        [&, responses](const network::ResourceRequest& request) {
+          for (auto const& [url, address_response_map] : responses) {
+            if (request.url.spec().find("nfts") != std::string::npos) {
+              continue;
+            }
+            std::string header_value;
+            EXPECT_TRUE(
+                request.headers.GetHeader("X-Eth-Method", &header_value));
+            if (request.url.spec() == url.spec() &&
+                header_value == "eth_getLogs") {
+              absl::optional<base::Value> request_dict_val =
+                  base::JSONReader::Read(
+                      request.request_body->elements()
+                          ->at(0)
+                          .As<network::DataElementBytes>()
+                          .AsStringPiece(),
+                      base::JSON_PARSE_CHROMIUM_EXTENSIONS |
+                          base::JSONParserOptions::JSON_PARSE_RFC);
+              std::string response;
+              for (auto const& [address, potential_response] :
+                   address_response_map) {
+                const auto* params_ptr =
+                    request_dict_val.value().GetDict().FindList("params");
+                if (!params_ptr) {
+                  continue;
+                }
+
+                const auto* address_ptr =
+                    (*params_ptr)[0].GetDict().FindList("address");
+                const auto* topics_ptr =
+                    (*params_ptr)[0].GetDict().FindList("topics");
+
+                if (!address_ptr || !topics_ptr) {
+                  continue;
+                }
+
+                const auto request_addresses = (*address_ptr)[0].GetString();
+                const auto request_approver_address =
+                    (*topics_ptr)[1].GetString();
+
+                absl::optional<base::Value> potential_response_dict_val =
+                    base::JSONReader::Read(
+                        potential_response,
+                        base::JSON_PARSE_CHROMIUM_EXTENSIONS |
+                            base::JSONParserOptions::JSON_PARSE_RFC);
+
+                const auto* pr_error_ptr =
+                    potential_response_dict_val.value().GetDict().FindDict(
+                        "error");
+
+                if (pr_error_ptr) {
+                  response = potential_response;
+                  continue;
+                }
+
+                const auto* pr_result_ptr =
+                    potential_response_dict_val.value().GetDict().FindList(
+                        "result");
+
+                if (!pr_result_ptr) {
+                  continue;
+                }
+
+                if (pr_result_ptr->empty()) {
+                  response = potential_response;
+                  continue;
+                }
+
+                for (const auto& curr_result : *pr_result_ptr) {
+                  const auto* pr_topics_ptr =
+                      curr_result.GetDict().FindList("topics");
+                  if (!pr_topics_ptr) {
+                    continue;
+                  }
+
+                  const auto* pr_contract_address_ptr =
+                      curr_result.GetDict().FindString("address");
+                  const auto pr_approver_address =
+                      (*pr_topics_ptr)[1].GetString();
+
+                  if (std::find(address_ptr->begin(), address_ptr->end(),
+                                *pr_contract_address_ptr) !=
+                          address_ptr->end() &&
+                      request_approver_address == pr_approver_address) {
+                    auto pr_dict =
+                        potential_response_dict_val.value().GetDict().Clone();
+
+                    auto* pr_dict_result_ptr = pr_dict.FindList("result");
+
+                    if (!pr_dict_result_ptr) {
+                      continue;
+                    }
+                    pr_dict_result_ptr->EraseIf([&](const base::Value& item) {
+                      auto* contract_address_value =
+                          item.GetDict().FindString("address");
+                      if (!contract_address_value) {
+                        return true;
+                      }
+                      const auto* topics_list =
+                          item.GetDict().FindList("topics");
+                      if (!topics_list) {
+                        return true;
+                      }
+                      return *contract_address_value !=
+                                 *pr_contract_address_ptr ||
+                             (*topics_list)[1].GetString() !=
+                                 request_approver_address;
+                    });
+                    response = pr_dict.DebugString();
+                    break;
+                  }
+                }
+                if (!response.empty()) {
+                  break;
+                }
+              }
+              ASSERT_FALSE(response.empty());
+              url_loader_factory_.ClearResponses();
+              url_loader_factory_.AddResponse(request.url.spec(), response);
+            }
+          }
+        }));
+
+    base::RunLoop run_loop;
+    std::size_t call_count{0};
+    std::size_t callback_count{0};
+    while (eth_allowance_completed_call_count > call_count) {
+      if (call_reset_on_pos == call_count) {
+        eth_allowance_manager_->Reset();
+      } else {
+        eth_allowance_manager_->DiscoverEthAllowancesOnAllSupportedChains(
+            base::BindLambdaForTesting(
+                [&](std::vector<mojom::AllowanceInfoPtr> allowances) {
+                  callback_count++;
+                  allowances_validation.Run(allowances);
+                  if (callback_count ==
+                      (eth_allowance_completed_call_count -
+                       (call_reset_on_pos !=
+                                std::numeric_limits<std::size_t>::max()
+                            ? 1
+                            : 0))) {
+                    run_loop.Quit();
+                  }
+                }));
+      }
+      call_count++;
+    }
+    run_loop.Run();
+  }
+
+  void TestLoadCachedAllowances(const std::string& chain_id,
+                                const std::string& hex_account_address,
+                                AllowancesMapCallback test_validation) {
+    AllowancesMap allowance_map;
+    eth_allowance_manager_->LoadCachedAllowances(chain_id, hex_account_address,
+                                                 allowance_map);
+    std::move(test_validation).Run(allowance_map);
+  }
+
+  std::map<GURL, std::map<std::string, std::string>> PrepareResponses(
+      const base::StringPiece& response_json,
+      const std::vector<std::string>& eth_account_address,
+      const TokenListMap& token_list_map,
+      base::RepeatingCallback<void(base::Value::Dict,
+                                   const mojom::BlockchainTokenPtr&,
+                                   uint256_t&,
+                                   const std::string&,
+                                   const std::string&,
+                                   base::Value::List*)> per_addr_action) {
+    std::map<GURL, std::map<std::string, std::string>> result;
+    for (auto const& [key, token_info] : token_list_map) {
+      std::string chain_id;
+      std::map<std::string, std::string> resp_jsns_map;
+      for (auto const& tkn : token_info) {
+        chain_id = tkn->chain_id;
+        auto dict = ParseTestJson(response_json);
+        if (!dict.FindList("error")) {
+          auto* pr_result_ptr = dict.FindList("result");
+          DCHECK(pr_result_ptr);
+          auto& result_item = (*pr_result_ptr)[0].GetDict();
+          auto temp_item = result_item.Clone();
+          pr_result_ptr->clear();
+          uint256_t log_index(0);
+          for (const auto& addr : eth_account_address) {
+            auto allovance_item = temp_item.Clone();
+            per_addr_action.Run(std::move(allovance_item), tkn, log_index, addr,
+                                chain_id, pr_result_ptr);
+          }
+          resp_jsns_map.insert({tkn->contract_address, dict.DebugString()});
+        }
+      }
+      result.insert(
+          {GetNetwork(chain_id, mojom::CoinType::ETH), resp_jsns_map});
+    }
+    return result;
+  }
+
+  PrefService* GetPrefs() { return profile_->GetPrefs(); }
+  TestingPrefServiceSimple* GetLocalState() { return local_state_->Get(); }
+  GURL GetNetwork(const std::string& chain_id, mojom::CoinType coin) {
+    return brave_wallet::GetNetworkURL(GetPrefs(), chain_id, coin);
+  }
+
+  network::TestURLLoaderFactory url_loader_factory_;
+  scoped_refptr<network::SharedURLLoaderFactory> shared_url_loader_factory_;
+  content::BrowserTaskEnvironment task_environment_;
+  std::unique_ptr<ScopedTestingLocalState> local_state_;
+  std::unique_ptr<TestingProfile> profile_;
+  std::unique_ptr<BraveWalletService> wallet_service_;
+  std::unique_ptr<EthAllowanceManager> eth_allowance_manager_;
+  raw_ptr<KeyringService> keyring_service_ = nullptr;
+  raw_ptr<JsonRpcService> json_rpc_service_;
+  raw_ptr<TxService> tx_service;
+  base::test::ScopedFeatureList scoped_feature_list_;
+  data_decoder::test::InProcessDataDecoder in_process_data_decoder_;
+};
+
+TEST_F(EthAllowanceManagerUnitTest, LoadCachedAllowances) {
+  CreateCachedAllowancesPrefs(allowance_chache_json);
+  TestLoadCachedAllowances(
+      "0x1",
+      "0x00000000000000000000000091272b2c4990927d1fe28201cf0a6ce288a221d6",
+      base::BindLambdaForTesting([](const AllowancesMap& allowance_map) {
+        EXPECT_EQ(allowance_map.size(), 1u);
+        const auto map_key =
+            base::JoinString({"0x0c10bf8fcb7bf5412187a595ab97a3609160b5c6",
+                              "0x00000000000000000000000091272b2c4990927d1fe282"
+                              "01cf0a6ce288a221d6",
+                              "0x000000000000000000000000dac308312e195710467ce3"
+                              "6effe51ac7a4ecbf01"},
+                             "_");
+
+        auto allowance_iter = allowance_map.find(map_key);
+        EXPECT_TRUE(allowance_map.end() != allowance_iter);
+        EXPECT_EQ(std::get<0>(allowance_iter->second), uint256_t(17124350));
+        const auto allowance = std::get<1>(allowance_iter->second).Clone();
+        EXPECT_EQ(allowance->contract_address,
+                  "0x0c10bf8fcb7bf5412187a595ab97a3609160b5c6");
+        EXPECT_EQ(allowance->approver_address,
+                  "0x00000000000000000000000091272b2c4990927d1fe28201cf0a6ce288"
+                  "a221d6");
+        EXPECT_EQ(allowance->spender_address,
+                  "0x000000000000000000000000dac308312e195710467ce36effe51ac7a4"
+                  "ecbf01");
+        EXPECT_EQ(allowance->amount,
+                  "0x0000000000000000000000000000000000000000000000000000000000"
+                  "000001");
+      }));
+}
+
+TEST_F(EthAllowanceManagerUnitTest, CouldNotLoadCachedAllowancesPrefsEmpty) {
+  TestLoadCachedAllowances(
+      "0x1",
+      "0x00000000000000000000000091272b2c4990927d1fe28201cf0a6ce288a221d6",
+      base::BindLambdaForTesting([](const AllowancesMap& allowance_map) {
+        EXPECT_TRUE(allowance_map.empty());
+      }));
+}
+
+TEST_F(EthAllowanceManagerUnitTest, CouldNotLoadCachedAllowancesByAddress) {
+  CreateCachedAllowancesPrefs(allowance_chache_json);
+  TestLoadCachedAllowances(
+      "0x1",
+      "0x000000000000000000000000000000000000000000000000000000000000AAAA",
+      base::BindLambdaForTesting([](const AllowancesMap& allowance_map) {
+        EXPECT_TRUE(allowance_map.empty());
+      }));
+
+  TestLoadCachedAllowances(
+      "0x99",
+      "0x00000000000000000000000091272b2c4990927d1fe28201cf0a6ce288a221d6",
+      base::BindLambdaForTesting([](const AllowancesMap& allowance_map) {
+        EXPECT_TRUE(allowance_map.empty());
+      }));
+}
+
+TEST_F(EthAllowanceManagerUnitTest,
+       CouldNotLoadCachedAllowancesIncorrectCacheData) {
+  CreateCachedAllowancesPrefs(incorrect_allowance_chache_data_json);
+  TestLoadCachedAllowances(
+      "0x1",
+      "0x00000000000000000000000091272b2c4990927d1fe28201cf0a6ce288a221d6",
+      base::BindLambdaForTesting([](const AllowancesMap& allowance_map) {
+        EXPECT_TRUE(allowance_map.empty());
+      }));
+}
+
+TEST_F(EthAllowanceManagerUnitTest,
+       CouldNotLoadCachedAllowancesIncorrectCacheBlockNumber) {
+  CreateCachedAllowancesPrefs(incorrect_allowance_chache_block_number_json);
+  TestLoadCachedAllowances(
+      "0x1",
+      "0x00000000000000000000000091272b2c4990927d1fe28201cf0a6ce288a221d6",
+      base::BindLambdaForTesting([](const AllowancesMap& allowance_map) {
+        EXPECT_TRUE(allowance_map.empty());
+      }));
+}
+
+TEST_F(EthAllowanceManagerUnitTest, BreakAllowanceDiscoveringIfTokenListEmpty) {
+  CreateWallet();
+  TokenListMap token_list_map;
+  BlockchainRegistry::GetInstance()->UpdateTokenList(std::move(token_list_map));
+  int on_completed_call_counter(0);
+
+  eth_allowance_manager_->DiscoverEthAllowancesOnAllSupportedChains(
+      base::BindLambdaForTesting(
+          [&](std::vector<mojom::AllowanceInfoPtr> allowances) {
+            ASSERT_TRUE((++on_completed_call_counter == 1) &&
+                        allowances.empty());
+          }));
+}
+
+TEST_F(EthAllowanceManagerUnitTest, AllowancesLoading) {
+  std::vector<mojom::AllowanceInfoPtr> expected_allowances;
+  // Generates one allowance log per ETH account address.
+  auto generate_responses = base::BindLambdaForTesting(
+      [&](const std::vector<std::string>& eth_account_address,
+          const TokenListMap& token_list_map) {
+        return PrepareResponses(
+            eth_allowance_detected_response, eth_account_address,
+            token_list_map,
+            base::BindLambdaForTesting(
+                [&](base::Value::Dict allovance_item,
+                    const mojom::BlockchainTokenPtr& tkn, uint256_t& log_index,
+                    const std::string& addr, const std::string& chain_id,
+                    base::Value::List* pr_result_ptr) {
+                  FillAllowanceLogItem(allovance_item, tkn->contract_address,
+                                       ++log_index, addr, 1);
+                  expected_allowances.push_back(
+                      GetAllowanceInfo(allovance_item, chain_id));
+                  pr_result_ptr->Append(std::move(allovance_item));
+                }));
+      });
+
+  auto allowances_validation = base::BindLambdaForTesting(
+      [&expected_allowances](
+          const std::vector<mojom::AllowanceInfoPtr>& allowances) {
+        ASSERT_EQ(allowances.size(), expected_allowances.size());
+        for (const auto& expected_allowance : expected_allowances) {
+          const auto& allowance_iter = std::find_if(
+              allowances.begin(), allowances.end(),
+              [&expected_allowance](const auto& item) {
+                return expected_allowance->amount == item->amount &&
+                       expected_allowance->contract_address ==
+                           item->contract_address &&
+                       expected_allowance->approver_address ==
+                           item->approver_address &&
+                       expected_allowance->spender_address ==
+                           item->spender_address;
+              });
+
+          ASSERT_FALSE(allowance_iter == allowances.end());
+        }
+      });
+  TestAllowancesLoading(token_list_json, generate_responses, 2, 3,
+                        allowances_validation);
+
+  const auto& allowance_cashe_dict =
+      GetPrefs()->GetDict(kBraveWalletEthAllowancesCache);
+  const auto* chain_id_dict = allowance_cashe_dict.FindDict("0x1");
+  ASSERT_TRUE(nullptr != chain_id_dict);
+  const auto* last_block_number_ptr =
+      chain_id_dict->FindString("last_block_number");
+  ASSERT_TRUE(nullptr != last_block_number_ptr);
+  EXPECT_EQ(*last_block_number_ptr, "0x101a7f1");
+  const auto* allowances_found_ptr =
+      chain_id_dict->FindList("allowances_found");
+  ASSERT_TRUE(nullptr != allowances_found_ptr);
+  EXPECT_EQ(allowances_found_ptr->size(), (size_t)1);
+}
+
+TEST_F(EthAllowanceManagerUnitTest, AllowancesRevoked) {
+  // Generates an allowance and revokation logs per account address.
+  auto generate_revoked_responses = base::BindLambdaForTesting(
+      [&](const std::vector<std::string>& eth_account_address,
+          const TokenListMap& token_list_map) {
+        return PrepareResponses(
+            eth_allowance_detected_response, eth_account_address,
+            token_list_map,
+            base::BindLambdaForTesting(
+                [&](base::Value::Dict allovance_item,
+                    const mojom::BlockchainTokenPtr& tkn, uint256_t& log_index,
+                    const std::string& addr, const std::string& chain_id,
+                    base::Value::List* pr_result_ptr) {
+                  FillAllowanceLogItem(allovance_item, tkn->contract_address,
+                                       ++log_index, addr, 1);
+                  auto revoke_item = allovance_item.Clone();
+                  FillAllowanceLogItem(revoke_item, tkn->contract_address,
+                                       ++log_index, addr, 0);
+                  // Add allowance record.
+                  pr_result_ptr->Append(std::move(allovance_item));
+                  // Add revocation record.
+                  pr_result_ptr->Append(std::move(revoke_item));
+                }));
+      });
+
+  auto allowances_validation = base::BindLambdaForTesting(
+      [](const std::vector<mojom::AllowanceInfoPtr>& allowances) {
+        ASSERT_TRUE(allowances.empty());
+      });
+
+  TestAllowancesLoading(token_list_json, generate_revoked_responses, 2, 3,
+                        allowances_validation);
+
+  const auto& allowance_cashe_dict =
+      GetPrefs()->GetDict(kBraveWalletEthAllowancesCache);
+  ASSERT_TRUE(allowance_cashe_dict.empty());
+}
+
+TEST_F(EthAllowanceManagerUnitTest, AllowancesIgnorePendingBlocks) {
+  // Generates an logs with block in the pending state.
+  auto generate_pending_responses = base::BindLambdaForTesting(
+      [&](const std::vector<std::string>& eth_account_address,
+          const TokenListMap& token_list_map) {
+        return PrepareResponses(
+            eth_allowance_detected_response, eth_account_address,
+            token_list_map,
+            base::BindLambdaForTesting(
+                [&](base::Value::Dict allovance_item,
+                    const mojom::BlockchainTokenPtr& tkn, uint256_t& log_index,
+                    const std::string& addr, const std::string& chain_id,
+                    base::Value::List* pr_result_ptr) {
+                  // Mark block number as 0x0 like for pending state.
+                  FillAllowanceLogItem(allovance_item, tkn->contract_address,
+                                       ++log_index, addr, 1, "0x0");
+                  // Add allowance record.
+                  pr_result_ptr->Append(std::move(allovance_item));
+                }));
+      });
+
+  auto allowances_validation = base::BindLambdaForTesting(
+      [](const std::vector<mojom::AllowanceInfoPtr>& allowances) {
+        // There are no any allowances found.
+        ASSERT_TRUE(allowances.empty());
+      });
+
+  TestAllowancesLoading(token_list_json, generate_pending_responses, 1, 1,
+                        allowances_validation);
+
+  const auto& allowance_cashe_dict =
+      GetPrefs()->GetDict(kBraveWalletEthAllowancesCache);
+  ASSERT_TRUE(allowance_cashe_dict.empty());
+}
+
+TEST_F(EthAllowanceManagerUnitTest, AllowancesIgnoreWrongTopicsData) {
+  // Generates logs with wrong topics data (one item is missing).
+  auto generate_pending_responses = base::BindLambdaForTesting(
+      [&](const std::vector<std::string>& eth_account_address,
+          const TokenListMap& token_list_map) {
+        return PrepareResponses(
+            eth_allowance_detected_response, eth_account_address,
+            token_list_map,
+            base::BindLambdaForTesting(
+                [&](base::Value::Dict allovance_item,
+                    const mojom::BlockchainTokenPtr& tkn, uint256_t& log_index,
+                    const std::string& addr, const std::string& chain_id,
+                    base::Value::List* pr_result_ptr) {
+                  FillAllowanceLogItem(allovance_item, tkn->contract_address,
+                                       ++log_index, addr, 1);
+                  auto* topics_ptr = allovance_item.FindList("topics");
+                  DCHECK(topics_ptr);
+                  // Remove spender topics data.
+                  topics_ptr->EraseValue(topics_ptr->back());
+                  // Add allowance record.
+                  pr_result_ptr->Append(std::move(allovance_item));
+                }));
+      });
+
+  auto allowances_validation = base::BindLambdaForTesting(
+      [](const std::vector<mojom::AllowanceInfoPtr>& allowances) {
+        // There are no any allowances found.
+        ASSERT_TRUE(allowances.empty());
+      });
+
+  TestAllowancesLoading(token_list_json, generate_pending_responses, 1, 1,
+                        allowances_validation);
+
+  const auto& allowance_cashe_dict =
+      GetPrefs()->GetDict(kBraveWalletEthAllowancesCache);
+  ASSERT_TRUE(allowance_cashe_dict.empty());
+}
+
+TEST_F(EthAllowanceManagerUnitTest, AllowancesIgnoreWrongAmountData) {
+  // Generates logs with wrong amount format.
+  auto generate_wrong_amount_responses = base::BindLambdaForTesting(
+      [&](const std::vector<std::string>& eth_account_address,
+          const TokenListMap& token_list_map) {
+        return PrepareResponses(
+            eth_allowance_detected_response, eth_account_address,
+            token_list_map,
+            base::BindLambdaForTesting(
+                [&](base::Value::Dict allovance_item,
+                    const mojom::BlockchainTokenPtr& tkn, uint256_t& log_index,
+                    const std::string& addr, const std::string& chain_id,
+                    base::Value::List* pr_result_ptr) {
+                  FillAllowanceLogItem(allovance_item, tkn->contract_address,
+                                       ++log_index, addr, 1);
+                  // Set amount to wrong format.
+                  allovance_item.Set("data", "0");
+                  // Add allowance record.
+                  pr_result_ptr->Append(std::move(allovance_item));
+                }));
+      });
+
+  auto allowances_validation = base::BindLambdaForTesting(
+      [](const std::vector<mojom::AllowanceInfoPtr>& allowances) {
+        // There are no any allowances found.
+        ASSERT_TRUE(allowances.empty());
+      });
+
+  TestAllowancesLoading(token_list_json, generate_wrong_amount_responses, 1, 1,
+                        allowances_validation);
+
+  const auto& allowance_cashe_dict =
+      GetPrefs()->GetDict(kBraveWalletEthAllowancesCache);
+  ASSERT_TRUE(allowance_cashe_dict.empty());
+}
+
+TEST_F(EthAllowanceManagerUnitTest, NoAllowancesLoaded) {
+  // Generates empty logs response.
+  auto generate_empty_response = base::BindLambdaForTesting(
+      [&](const std::vector<std::string>& eth_account_address,
+          const TokenListMap& token_list_map) {
+        return PrepareResponses(
+            eth_allowance_detected_response, eth_account_address,
+            token_list_map,
+            base::BindLambdaForTesting(
+                [&](base::Value::Dict allovance_item,
+                    const mojom::BlockchainTokenPtr& tkn, uint256_t& log_index,
+                    const std::string& addr, const std::string& chain_id,
+                    base::Value::List* pr_result_ptr) {
+                  // Do nothing
+                }));
+      });
+
+  auto allowances_validation = base::BindLambdaForTesting(
+      [](const std::vector<mojom::AllowanceInfoPtr>& allowances) {
+        // There are no any allowances found.
+        ASSERT_TRUE(allowances.empty());
+      });
+
+  TestAllowancesLoading(token_list_json, generate_empty_response, 1, 1,
+                        allowances_validation);
+
+  ASSERT_TRUE(GetPrefs()->HasPrefPath(kBraveWalletEthAllowancesCache));
+  EXPECT_EQ(GetPrefs()->GetDict(kBraveWalletEthAllowancesCache).size(),
+            (size_t)0);
+}
+
+TEST_F(EthAllowanceManagerUnitTest, NoAllowancesLoadedForSkippedNetwork) {
+  // Generates logs response with response.
+  auto generate_error_response = base::BindLambdaForTesting(
+      [&](const std::vector<std::string>& eth_account_address,
+          const TokenListMap& token_list_map) {
+        return std::map<GURL, std::map<std::string, std::string>>({
+            {GetNetwork(mojom::kMainnetChainId, mojom::CoinType::ETH),
+             {{"0x3333333333333333333333333333333333333333",
+               std::string(eth_allowance_error_response)}}},
+        });
+      });
+
+  auto allowances_validation = base::BindLambdaForTesting(
+      [](const std::vector<mojom::AllowanceInfoPtr>& allowances) {
+        // There are no any allowances found.
+        ASSERT_TRUE(allowances.empty());
+      });
+
+  TestAllowancesLoading(token_list_json, generate_error_response, 0, 5,
+                        allowances_validation);
+
+  ASSERT_TRUE(GetPrefs()->HasPrefPath(kBraveWalletEthAllowancesCache));
+  EXPECT_EQ(GetPrefs()->GetDict(kBraveWalletEthAllowancesCache).size(),
+            (size_t)0);
+}
+
+TEST_F(EthAllowanceManagerUnitTest, AllowancesLoadingReset) {
+  std::vector<mojom::AllowanceInfoPtr> expected_allowances;
+  // Generates one allowance log per ETH account address.
+  auto generate_responses = base::BindLambdaForTesting(
+      [&](const std::vector<std::string>& eth_account_address,
+          const TokenListMap& token_list_map) {
+        return PrepareResponses(
+            eth_allowance_detected_response, eth_account_address,
+            token_list_map,
+            base::BindLambdaForTesting(
+                [&](base::Value::Dict allovance_item,
+                    const mojom::BlockchainTokenPtr& tkn, uint256_t& log_index,
+                    const std::string& addr, const std::string& chain_id,
+                    base::Value::List* pr_result_ptr) {
+                  FillAllowanceLogItem(allovance_item, tkn->contract_address,
+                                       ++log_index, addr, 1);
+                  expected_allowances.push_back(
+                      GetAllowanceInfo(allovance_item, chain_id));
+                  pr_result_ptr->Append(std::move(allovance_item));
+                }));
+      });
+
+  auto allowances_validation = base::BindLambdaForTesting(
+      [&expected_allowances](
+          const std::vector<mojom::AllowanceInfoPtr>& allowances) {
+        ASSERT_EQ(expected_allowances.size(), 2UL);
+        ASSERT_TRUE(allowances.empty());
+      });
+  TestAllowancesLoading(token_list_json, generate_responses, 2, 2,
+                        allowances_validation, 1);
+
+  const auto& allowance_cashe_dict =
+      GetPrefs()->GetDict(kBraveWalletEthAllowancesCache);
+  const auto* chain_id_dict = allowance_cashe_dict.FindDict("0x1");
+  ASSERT_TRUE(nullptr == chain_id_dict);
+}
+
+}  // namespace brave_wallet

--- a/components/brave_wallet/browser/BUILD.gn
+++ b/components/brave_wallet/browser/BUILD.gn
@@ -71,6 +71,8 @@ static_library("browser") {
     "ens_resolver_task.h",
     "eth_abi_decoder.cc",
     "eth_abi_decoder.h",
+    "eth_allowance_manager.cc",
+    "eth_allowance_manager.h",
     "eth_block_tracker.cc",
     "eth_block_tracker.h",
     "eth_data_builder.cc",

--- a/components/brave_wallet/browser/brave_wallet_prefs.cc
+++ b/components/brave_wallet/browser/brave_wallet_prefs.cc
@@ -126,6 +126,7 @@ void RegisterProfilePrefs(user_prefs::PrefRegistrySyncable* registry) {
                                    GetDefaultUserAssets());
   registry->RegisterIntegerPref(kBraveWalletAutoLockMinutes,
                                 kDefaultWalletAutoLockMinutes);
+  registry->RegisterDictionaryPref(kBraveWalletEthAllowancesCache);
   registry->RegisterStringPref(kBraveWalletSelectedAccount, "");
   registry->RegisterBooleanPref(kSupportEip1559OnLocalhostChain, false);
   registry->RegisterDictionaryPref(kBraveWalletLastTransactionSentTimeDict);
@@ -235,6 +236,7 @@ void ClearBraveWalletServicePrefs(PrefService* prefs) {
   prefs->ClearPref(kBraveWalletUserAssets);
   prefs->ClearPref(kDefaultBaseCurrency);
   prefs->ClearPref(kDefaultBaseCryptocurrency);
+  prefs->ClearPref(kBraveWalletEthAllowancesCache);
 }
 
 void MigrateObsoleteProfilePrefs(PrefService* prefs) {

--- a/components/brave_wallet/browser/brave_wallet_service.cc
+++ b/components/brave_wallet/browser/brave_wallet_service.cc
@@ -17,6 +17,7 @@
 #include "brave/components/brave_wallet/browser/blockchain_registry.h"
 #include "brave/components/brave_wallet/browser/brave_wallet_prefs.h"
 #include "brave/components/brave_wallet/browser/brave_wallet_utils.h"
+#include "brave/components/brave_wallet/browser/eth_allowance_manager.h"
 #include "brave/components/brave_wallet/browser/json_rpc_service.h"
 #include "brave/components/brave_wallet/browser/keyring_service.h"
 #include "brave/components/brave_wallet/browser/pref_names.h"
@@ -179,6 +180,11 @@ BraveWalletService::BraveWalletService(
                                                   json_rpc_service,
                                                   keyring_service,
                                                   profile_prefs)),
+      eth_allowance_manager_(
+          std::make_unique<EthAllowanceManager>(this,
+                                                json_rpc_service,
+                                                keyring_service,
+                                                profile_prefs)),
       weak_ptr_factory_(this) {
   if (delegate_) {
     delegate_->AddObserver(this);
@@ -1768,6 +1774,10 @@ void BraveWalletService::OnNetworkChanged() {
 void BraveWalletService::Reset() {
   delegate_->ClearWalletUIStoragePartition();
 
+  if (eth_allowance_manager_) {
+    eth_allowance_manager_->Reset();
+  }
+
   if (tx_service_) {
     tx_service_->Reset();
   }
@@ -1791,6 +1801,12 @@ void BraveWalletService::Reset() {
   for (const auto& observer : observers_) {
     observer->OnResetWallet();
   }
+}
+
+void BraveWalletService::DiscoverEthAllowances(
+    DiscoverEthAllowancesCallback callback) {
+  eth_allowance_manager_->DiscoverEthAllowancesOnAllSupportedChains(
+      std::move(callback));
 }
 
 }  // namespace brave_wallet

--- a/components/brave_wallet/browser/brave_wallet_service.cc
+++ b/components/brave_wallet/browser/brave_wallet_service.cc
@@ -181,8 +181,7 @@ BraveWalletService::BraveWalletService(
                                                   keyring_service,
                                                   profile_prefs)),
       eth_allowance_manager_(
-          std::make_unique<EthAllowanceManager>(this,
-                                                json_rpc_service,
+          std::make_unique<EthAllowanceManager>(json_rpc_service,
                                                 keyring_service,
                                                 profile_prefs)),
       weak_ptr_factory_(this) {

--- a/components/brave_wallet/browser/brave_wallet_service.h
+++ b/components/brave_wallet/browser/brave_wallet_service.h
@@ -44,6 +44,7 @@ extern const char kBraveWalletLastUsageTimeHistogramName[];
 class KeyringService;
 class JsonRpcService;
 class TxService;
+class EthAllowanceManager;
 
 class BraveWalletService : public KeyedService,
                            public mojom::BraveWalletService,
@@ -240,6 +241,8 @@ class BraveWalletService : public KeyedService,
   // To be used when the Wallet is reset / erased
   void Reset() override;
 
+  void DiscoverEthAllowances(DiscoverEthAllowancesCallback callback) override;
+
   void AddSignMessageRequest(mojom::SignMessageRequestPtr request,
                              SignMessageRequestCallback callback);
   void AddSuggestTokenRequest(mojom::AddSuggestTokenRequestPtr request,
@@ -367,6 +370,7 @@ class BraveWalletService : public KeyedService,
   raw_ptr<PrefService> profile_prefs_ = nullptr;
   BraveWalletP3A brave_wallet_p3a_;
   std::unique_ptr<AssetDiscoveryManager> asset_discovery_manager_;
+  std::unique_ptr<EthAllowanceManager> eth_allowance_manager_;
   mojo::ReceiverSet<mojom::BraveWalletService> receivers_;
   PrefChangeRegistrar pref_change_registrar_;
   base::WeakPtrFactory<BraveWalletService> weak_ptr_factory_;

--- a/components/brave_wallet/browser/eth_allowance_manager.cc
+++ b/components/brave_wallet/browser/eth_allowance_manager.cc
@@ -1,0 +1,416 @@
+/* Copyright (c) 2023 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "brave/components/brave_wallet/browser/eth_allowance_manager.h"
+
+#include <algorithm>
+#include <utility>
+
+#include "brave/components/brave_wallet/browser/blockchain_registry.h"
+#include "brave/components/brave_wallet/browser/brave_wallet_utils.h"
+#include "brave/components/brave_wallet/browser/json_rpc_service.h"
+#include "brave/components/brave_wallet/browser/keyring_service.h"
+#include "brave/components/brave_wallet/browser/pref_names.h"
+#include "brave/components/brave_wallet/common/brave_wallet.mojom.h"
+#include "brave/components/brave_wallet/common/hash_utils.h"
+#include "brave/components/brave_wallet/common/hex_utils.h"
+#include "components/prefs/pref_service.h"
+#include "components/prefs/scoped_user_pref_update.h"
+#include "ui/base/l10n/l10n_util.h"
+
+namespace {
+static const int kTopicElementsCountToCheck = 3;
+constexpr char kLastBlockNumber[] = "last_block_number";
+constexpr char kAllowanceFound[] = "allowances_found";
+constexpr char kApproverAddress[] = "approver_address";
+constexpr char kContractAddress[] = "contract_address";
+constexpr char kSpenderAddress[] = "spender_address";
+constexpr char kAmount[] = "amount";
+
+constexpr char kAddress[] = "address";
+constexpr char kTopics[] = "topics";
+constexpr char kFromBlock[] = "fromBlock";
+constexpr char kToBlock[] = "toBlock";
+constexpr char kEarliestBlock[] = "earliest";
+constexpr char kLatestBlock[] = "latest";
+
+constexpr char kApprovalTopicHash[] = "Approval(address,address,uint256)";
+
+// Returns vector of chain_ids supported by allowance discovering.
+const std::vector<std::string>& GetChainIdsForAlowanceDiscovering() {
+  static base::NoDestructor<std::vector<std::string>> supported_chain_ids(
+      {brave_wallet::mojom::kMainnetChainId,
+       brave_wallet::mojom::kPolygonMainnetChainId,
+       brave_wallet::mojom::kAvalancheMainnetChainId,
+       brave_wallet::mojom::kCeloMainnetChainId,
+       brave_wallet::mojom::kArbitrumMainnetChainId,
+       brave_wallet::mojom::kOptimismMainnetChainId});
+  return *supported_chain_ids;
+}
+static std::string GetAllowanceMapKey(const std::string& contract_address,
+                                      const std::string& approver_addr,
+                                      const std::string& spender_address) {
+  return base::JoinString({contract_address, approver_addr, spender_address},
+                          "_");
+}
+
+}  // namespace
+
+namespace brave_wallet {
+EthAllowanceManager::EthAllowanceTask::EthAllowanceTask(const int& taskid)
+    : task_id(taskid), is_completed(false) {}
+EthAllowanceManager::EthAllowanceTask::~EthAllowanceTask() = default;
+void EthAllowanceManager::EthAllowanceTask::SetResults(
+    const std::string& chain_id,
+    const uint256_t& max_block_number,
+    std::vector<mojom::AllowanceInfoPtr>&& alwns) {
+  allowances.insert_or_assign(
+      chain_id, std::make_tuple(max_block_number, std::move(alwns)));
+  MarkComplete();
+}
+void EthAllowanceManager::EthAllowanceTask::MarkComplete() {
+  is_completed = true;
+}
+
+EthAllowanceManager::EthAllowanceManager(BraveWalletService* wallet_service,
+                                         JsonRpcService* json_rpc_service,
+                                         KeyringService* keyring_service,
+                                         PrefService* prefs)
+    : wallet_service_(wallet_service),
+      json_rpc_service_(json_rpc_service),
+      keyring_service_(keyring_service),
+      prefs_(prefs) {}
+
+EthAllowanceManager::~EthAllowanceManager() = default;
+
+/**
+ * @brief Represents start of the allowance discovering operation
+ *
+ * @param callback callback to front end, to pass allowances list, error code
+ * and description
+ */
+void EthAllowanceManager::DiscoverEthAllowancesOnAllSupportedChains(
+    BraveWalletService::DiscoverEthAllowancesCallback callback) {
+  if (!discover_eth_allowance_callback_.empty()) {
+    discover_eth_allowance_callback_.push_back(std::move(callback));
+    MergeAllResultsAnCallBack();
+    return;
+  }
+  discover_eth_allowance_callback_.push_back(std::move(callback));
+
+  const auto keyring_info = keyring_service_->GetKeyringInfoSync(
+      brave_wallet::mojom::kDefaultKeyringId);
+  std::vector<std::string> account_addresses;
+  for (const auto& account_info : keyring_info->account_infos) {
+    account_addresses.push_back(account_info->address);
+  }
+
+  if (account_addresses.empty()) {
+    OnDiscoverEthAllowancesCompleted({});
+    return;
+  }
+
+  const auto token_list_map =
+      BlockchainRegistry::GetInstance()->GetEthTokenListMap(
+          GetChainIdsForAlowanceDiscovering());
+
+  base::flat_map<std::string, base::Value::List> chain_id_to_contract_addresses;
+
+  for (const auto& [chain_id, token_list] : token_list_map) {
+    for (const auto& token : token_list) {
+      chain_id_to_contract_addresses[chain_id].Append(token->contract_address);
+    }
+  }
+
+  if (chain_id_to_contract_addresses.empty()) {
+    OnDiscoverEthAllowancesCompleted({});
+    return;
+  }
+
+  const auto& allowance_cache_dict =
+      prefs_->GetDict(kBraveWalletEthAllowancesCache);
+
+  if (!tasks.empty()) {
+    tasks.clear();
+  }
+
+  int task_id(0);
+  const auto approval_topic_hash = KeccakHash(kApprovalTopicHash);
+  for (const auto& account_address : account_addresses) {
+    for (const auto& [chain_id, contract_addresses] :
+         chain_id_to_contract_addresses) {
+      const auto* chain_cached_data = allowance_cache_dict.FindDict(chain_id);
+
+      const auto* last_block_number_ptr =
+          chain_cached_data ? chain_cached_data->FindString(kLastBlockNumber)
+                            : nullptr;
+      const std::string last_block_number =
+          last_block_number_ptr != nullptr ? *last_block_number_ptr : "";
+
+      std::string hex_account_address;
+      if (!PadHexEncodedParameter(account_address, &hex_account_address)) {
+        continue;
+      }
+      auto internal_callback = base::BindOnce(
+          &EthAllowanceManager::OnGetAllowances, weak_ptr_factory_.GetWeakPtr(),
+          task_id, chain_id, hex_account_address);
+      tasks.insert_or_assign(task_id,
+                             std::make_unique<EthAllowanceTask>(task_id));
+
+      base::Value::List topics;
+      topics.Append(approval_topic_hash);
+      topics.Append(std::move(hex_account_address));
+
+      base::Value::Dict filter_options;
+      filter_options.Set(kAddress, contract_addresses.Clone());
+      filter_options.Set(kTopics, std::move(topics));
+      uint256_t block_number{0};
+      if (!last_block_number.empty() &&
+          HexValueToUint256(last_block_number, &block_number)) {
+        filter_options.Set(kFromBlock, Uint256ValueToHex(++block_number));
+      } else {
+        filter_options.Set(kFromBlock, kEarliestBlock);
+      }
+      filter_options.Set(kToBlock, kLatestBlock);
+      json_rpc_service_->EthGetLogs(chain_id, std::move(filter_options),
+                                    std::move(internal_callback));
+      task_id++;
+    }
+  }
+}
+
+void EthAllowanceManager::Reset() {
+  tasks.clear();
+  OnDiscoverEthAllowancesCompleted({});
+}
+
+/**
+ * @brief Represents loading cached data from the preferences.
+ * Cached data, always must be loaded first as we loading retrieved from the
+ * logs "fresh" data
+ *
+ * Path of the new preferences key is: "brave.wallet.eth_allowances_cache"
+ * "eth_allowances_cache": {
+ *    "<chain_id>": {
+ *      "allowances_found": [{
+ *          "amount": "<hex encoded (with padding) value allowed to be spent>",
+ *          "approver_address": "<approver address (with padding)>",
+ *          "contract_address": "<address of the contract>",
+ *          "spender_address": "<approver address (with padding)>"
+ *      }],
+ *      "last_block_number": "<number of the last processed block (hex
+ * encoded)>"
+ *    }
+ *  }
+ *
+ * @param chain_id - Id of the chain you want to load.
+ * @param hex_account_address  - account address (with padding) you want to
+ * filter by.
+ * @param [out] allowance_map - Loaded from the preferences allowances cached
+ * data represented as map. Key of the map is the unique combination of the next
+ * values: <contract_address>_<approver_addr>_<spender_address>. The value of
+ * the map is a std::tuple which contains <uint256_t> - block number and
+ * <mojom::AllowanceInfoPtr> allowance info data.
+ */
+void EthAllowanceManager::LoadCachedAllowances(
+    const std::string& chain_id,
+    const std::string& hex_account_address,
+    std::map<std::string, std::tuple<uint256_t, mojom::AllowanceInfoPtr>>&
+        allowance_map) {
+  const auto& allowance_cache_dict =
+      prefs_->GetDict(kBraveWalletEthAllowancesCache);
+
+  const auto* chain_cached_data = allowance_cache_dict.FindDict(chain_id);
+  if (!chain_cached_data) {
+    return;
+  }
+
+  const auto* cached_allowances_ptr =
+      chain_cached_data->FindList(kAllowanceFound);
+  if (!cached_allowances_ptr) {
+    return;
+  }
+
+  const auto* block_number_ptr =
+      chain_cached_data->FindString(kLastBlockNumber);
+
+  uint256_t block_number{0};
+  if (!block_number_ptr ||
+      !HexValueToUint256(*block_number_ptr, &block_number)) {
+    return;
+  }
+
+  for (const auto& ca_item : *cached_allowances_ptr) {
+    const auto* ca_dict = ca_item.GetIfDict();
+    if (!ca_dict) {
+      continue;
+    }
+    const auto* approver_address = ca_dict->FindString(kApproverAddress);
+    const auto* contract_address = ca_dict->FindString(kContractAddress);
+    const auto* spender_address = ca_dict->FindString(kSpenderAddress);
+    const auto* amount = ca_dict->FindString(kAmount);
+
+    if (!approver_address || !contract_address || !spender_address || !amount ||
+        base::ToUpperASCII(*approver_address) !=
+            base::ToUpperASCII(hex_account_address)) {
+      continue;
+    }
+
+    allowance_map.insert_or_assign(
+        GetAllowanceMapKey(*contract_address, *approver_address,
+                           *spender_address),
+        std::make_tuple(block_number,
+                        mojom::AllowanceInfo::New(chain_id, *contract_address,
+                                                  *approver_address,
+                                                  *spender_address, *amount)));
+  }
+}
+
+/**
+ * @brief Represents callback which processes data portions
+ * retrieved from logs and calls the DiscoverEthAllowancesCallback with
+ * last processed portion of data
+ *
+ * @param task_id - Id of the processing task
+ * @param chain_id - Id of the Chain, which the current data portion belongs to
+ * @param hex_account_address - Account address (whith padding), which the
+ * current data portion belongs to
+ * @param logs - chain_id and account address related Log data portion
+ * @param rawlogs - chain_id and account address related Log data portion
+ * @param error - error code
+ * @param error_message - error message
+ */
+void EthAllowanceManager::OnGetAllowances(
+    const int& task_id,
+    const std::string& chain_id,
+    const std::string& hex_account_address,
+    const std::vector<Log>& logs,
+    base::Value rawlogs,
+    mojom::ProviderError error,
+    const std::string& error_message) {
+  if (error != mojom::ProviderError::kSuccess) {
+    if (tasks.find(task_id) != tasks.end()) {
+      tasks[task_id]->MarkComplete();
+      MergeAllResultsAnCallBack();
+    }
+    return;
+  }
+
+  std::vector<Log> logs_tmp{logs};
+  std::sort(logs_tmp.begin(), logs_tmp.end(),
+            [](const Log& first, const Log& second) -> bool {
+              return std::tie(first.block_number, first.log_index) <
+                     std::tie(second.block_number, second.log_index);
+            });
+
+  // Collection of the latest allowances per contract & spender & approver.
+  std::map<std::string, std::tuple<uint256_t, mojom::AllowanceInfoPtr>>
+      allowance_map;
+  // Put cached data into the map first if available.
+  LoadCachedAllowances(chain_id, hex_account_address, allowance_map);
+  for (const auto& log_item : logs_tmp) {
+    // Skip pending logs.
+    if (log_item.block_number == 0) {
+      continue;
+    }
+
+    if (log_item.topics.size() < kTopicElementsCountToCheck) {
+      continue;
+    }
+    const auto current_map_key = GetAllowanceMapKey(
+        log_item.address, log_item.topics[1], log_item.topics[2]);
+
+    uint256_t parsed_amount{0};
+    if (!HexValueToUint256(log_item.data, &parsed_amount)) {
+      continue;
+    }
+
+    if (parsed_amount > 0) {
+      // Replace if same key exists by the fresh allowance data.
+      allowance_map.insert_or_assign(
+          current_map_key,
+          std::make_tuple(log_item.block_number,
+                          mojom::AllowanceInfo::New(
+                              chain_id, log_item.address, log_item.topics[1],
+                              log_item.topics[2], log_item.data)));
+    } else if (allowance_map.find(current_map_key) != allowance_map.end()) {
+      allowance_map.erase(current_map_key);
+    }
+  }
+  std::vector<mojom::AllowanceInfoPtr> allowances_found;
+  uint256_t max_block_number{0};
+  for (const auto& [allowance_map_key, allowance_tuple] : allowance_map) {
+    allowances_found.push_back(std::get<1>(allowance_tuple).Clone());
+    if (std::get<0>(allowance_tuple) > max_block_number) {
+      max_block_number = std::get<0>(allowance_tuple);
+    }
+  }
+  if (tasks.find(task_id) != tasks.end()) {
+    tasks[task_id]->SetResults(chain_id, max_block_number,
+                               std::move(allowances_found));
+    MergeAllResultsAnCallBack();
+  }
+}
+
+bool EthAllowanceManager::IsAllTasksCompleted() {
+  return !discover_eth_allowance_callback_.empty() &&
+         tasks.end() ==
+             std::find_if(
+                 tasks.begin(), tasks.end(),
+                 [](std::pair<
+                     const int,
+                     std::unique_ptr<EthAllowanceManager::EthAllowanceTask>>&
+                        item) { return !(item.second->is_completed); });
+}
+
+void EthAllowanceManager::MergeAllResultsAnCallBack() {
+  if (IsAllTasksCompleted()) {
+    std::vector<mojom::AllowanceInfoPtr> result;
+    ScopedDictPrefUpdate allowance_cache_update(prefs_,
+                                                kBraveWalletEthAllowancesCache);
+    auto& allowance_cache = allowance_cache_update.Get();
+
+    for (const auto& [tid, allowance_task_info] : tasks) {
+      for (const auto& [cid, allowances] : allowance_task_info->allowances) {
+        base::Value::List allw_list;
+        for (const auto& allowance : std::get<1>(allowances)) {
+          base::Value::Dict allw_dict_item;
+          allw_dict_item.Set(kContractAddress, allowance->contract_address);
+          allw_dict_item.Set(kApproverAddress, allowance->approver_address);
+          allw_dict_item.Set(kSpenderAddress, allowance->spender_address);
+          allw_dict_item.Set(kAmount, allowance->amount);
+          allw_list.Append(std::move(allw_dict_item));
+          result.push_back(allowance.Clone());
+        }
+
+        if (allw_list.empty()) {
+          continue;
+        }
+        auto* chain_section = allowance_cache.EnsureDict(cid);
+        chain_section->Set(kLastBlockNumber,
+                           Uint256ValueToHex(std::get<0>(allowances)));
+        chain_section->Set(kAllowanceFound, std::move(allw_list));
+      }
+    }
+    OnDiscoverEthAllowancesCompleted(std::move(result));
+  }
+}
+
+void EthAllowanceManager::OnDiscoverEthAllowancesCompleted(
+    std::vector<mojom::AllowanceInfoPtr> result) {
+  auto clone_results = [&](std::vector<mojom::AllowanceInfoPtr>& results) {
+    for (const auto& allowance_info : result) {
+      results.push_back(allowance_info.Clone());
+    }
+  };
+  for (auto& callback : discover_eth_allowance_callback_) {
+    std::vector<mojom::AllowanceInfoPtr> results;
+    clone_results(results);
+    std::move(callback).Run(std::move(results));
+  }
+  discover_eth_allowance_callback_.clear();
+}
+
+}  // namespace brave_wallet

--- a/components/brave_wallet/browser/eth_allowance_manager.h
+++ b/components/brave_wallet/browser/eth_allowance_manager.h
@@ -1,0 +1,120 @@
+/* Copyright (c) 2023 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_COMPONENTS_BRAVE_WALLET_BROWSER_ETH_ALLOWANCE_MANAGER_H_
+#define BRAVE_COMPONENTS_BRAVE_WALLET_BROWSER_ETH_ALLOWANCE_MANAGER_H_
+
+#include <map>
+#include <memory>
+#include <string>
+#include <tuple>
+#include <vector>
+
+#include "base/barrier_callback.h"
+#include "base/memory/raw_ptr.h"
+#include "base/memory/weak_ptr.h"
+#include "brave/components/brave_wallet/browser/brave_wallet_service.h"
+#include "brave/components/brave_wallet/common/brave_wallet.mojom.h"
+#include "brave/components/brave_wallet/common/brave_wallet_types.h"
+
+class PrefService;
+
+namespace brave_wallet {
+
+class JsonRpcService;
+class KeyringService;
+class EthAllowanceManager {
+ public:
+  EthAllowanceManager(BraveWalletService* wallet_service,
+                      JsonRpcService* json_rpc_service,
+                      KeyringService* keyring_service,
+                      PrefService* prefs);
+  EthAllowanceManager(const EthAllowanceManager&) = delete;
+  EthAllowanceManager& operator=(const EthAllowanceManager&) = delete;
+  EthAllowanceManager(const EthAllowanceManager&&) = delete;
+  EthAllowanceManager& operator=(const EthAllowanceManager&&) = delete;
+
+  ~EthAllowanceManager();
+
+  void DiscoverEthAllowancesOnAllSupportedChains(
+      BraveWalletService::DiscoverEthAllowancesCallback callback);
+  void Reset();
+
+ private:
+  friend class EthAllowanceManagerUnitTest;
+  FRIEND_TEST_ALL_PREFIXES(EthAllowanceManagerUnitTest, LoadCachedAllowances);
+  FRIEND_TEST_ALL_PREFIXES(EthAllowanceManagerUnitTest,
+                           CouldNotLoadCachedAllowancesPrefsEmpty);
+  FRIEND_TEST_ALL_PREFIXES(EthAllowanceManagerUnitTest,
+                           CouldNotLoadCachedAllowancesByAddress);
+  FRIEND_TEST_ALL_PREFIXES(EthAllowanceManagerUnitTest,
+                           CouldNotLoadCachedAllowancesIncorrectCacheData);
+  FRIEND_TEST_ALL_PREFIXES(EthAllowanceManagerUnitTest,
+                           BreakAllowanceDiscoveringIfTokenListEmpty);
+  FRIEND_TEST_ALL_PREFIXES(EthAllowanceManagerUnitTest, AllowancesLoading);
+  FRIEND_TEST_ALL_PREFIXES(EthAllowanceManagerUnitTest, AllowancesRevoked);
+  FRIEND_TEST_ALL_PREFIXES(EthAllowanceManagerUnitTest,
+                           AllowancesIgnorePendingBlocks);
+  FRIEND_TEST_ALL_PREFIXES(EthAllowanceManagerUnitTest,
+                           AllowancesIgnoreWrongTopicsData);
+  FRIEND_TEST_ALL_PREFIXES(EthAllowanceManagerUnitTest,
+                           AllowancesIgnoreWrongAmountData);
+  FRIEND_TEST_ALL_PREFIXES(EthAllowanceManagerUnitTest, NoAllowancesLoaded);
+  FRIEND_TEST_ALL_PREFIXES(EthAllowanceManagerUnitTest,
+                           NoAllowancesLoadedForSkippedNetwork);
+  FRIEND_TEST_ALL_PREFIXES(EthAllowanceManagerUnitTest, AllowancesLoadingReset);
+
+  void OnGetAllowances(const int& task_id,
+                       const std::string& chain_id,
+                       const std::string& hex_account_address,
+                       [[maybe_unused]] const std::vector<Log>& logs,
+                       base::Value rawlogs,
+                       mojom::ProviderError error,
+                       const std::string& error_message);
+
+  void LoadCachedAllowances(
+      const std::string& chain_id,
+      const std::string& hex_account_address,
+      std::map<std::string, std::tuple<uint256_t, mojom::AllowanceInfoPtr>>&
+          allowances_map);
+  using EthAllowanceCollection =
+      base::flat_map<std::string,
+                     std::tuple<brave_wallet::uint256_t,
+                                std::vector<mojom::AllowanceInfoPtr>>>;
+  struct EthAllowanceTask {
+    explicit EthAllowanceTask(const int& taskid);
+    EthAllowanceTask(const EthAllowanceTask&) = delete;
+    EthAllowanceTask& operator=(const EthAllowanceTask&) = delete;
+    EthAllowanceTask(const EthAllowanceTask&&) = delete;
+    EthAllowanceTask& operator=(const EthAllowanceTask&&) = delete;
+    ~EthAllowanceTask();
+
+    void SetResults(const std::string& chain_id,
+                    const uint256_t& max_block_number,
+                    std::vector<mojom::AllowanceInfoPtr>&& alwns);
+    void MarkComplete();
+    int task_id;
+    EthAllowanceCollection allowances;
+    bool is_completed;
+  };
+  bool IsAllTasksCompleted();
+  void MergeAllResultsAnCallBack();
+  void OnDiscoverEthAllowancesCompleted(
+      std::vector<mojom::AllowanceInfoPtr> result);
+
+  std::map<int, std::unique_ptr<EthAllowanceTask>> tasks;
+  std::vector<BraveWalletService::DiscoverEthAllowancesCallback>
+      discover_eth_allowance_callback_;
+  raw_ptr<BraveWalletService> wallet_service_;
+  raw_ptr<JsonRpcService> json_rpc_service_;
+  raw_ptr<KeyringService> keyring_service_;
+  raw_ptr<PrefService> prefs_;
+
+  base::WeakPtrFactory<EthAllowanceManager> weak_ptr_factory_{this};
+};
+
+}  // namespace brave_wallet
+
+#endif  // BRAVE_COMPONENTS_BRAVE_WALLET_BROWSER_ETH_ALLOWANCE_MANAGER_H_

--- a/components/brave_wallet/browser/eth_allowance_manager.h
+++ b/components/brave_wallet/browser/eth_allowance_manager.h
@@ -67,8 +67,6 @@ class EthAllowanceManager {
   FRIEND_TEST_ALL_PREFIXES(EthAllowanceManagerUnitTest, AllowancesLoadingReset);
 
   void OnGetAllowances(const int& task_id,
-                       const std::string& chain_id,
-                       const std::string& hex_account_address,
                        const std::vector<Log>& logs,
                        base::Value rawlogs,
                        mojom::ProviderError error,
@@ -77,25 +75,24 @@ class EthAllowanceManager {
   void LoadCachedAllowances(
       const std::string& chain_id,
       const std::string& hex_account_address,
-      uint256_t& block_number,
       std::map<std::string, mojom::AllowanceInfoPtr>& allowance_map);
   struct EthAllowanceTask {
     explicit EthAllowanceTask(const int& taskid,
                               const std::string& chain_id,
-                              const std::string& account_address);
+                              const std::string& account_address,
+                              const uint256_t& latest_block_number);
     EthAllowanceTask(const EthAllowanceTask&) = delete;
     EthAllowanceTask& operator=(const EthAllowanceTask&) = delete;
     EthAllowanceTask(const EthAllowanceTask&&) = delete;
     EthAllowanceTask& operator=(const EthAllowanceTask&&) = delete;
     ~EthAllowanceTask();
 
-    void SetResults(const uint256_t& latest_block_number,
-                    std::vector<mojom::AllowanceInfoPtr> alwns);
+    void SetResults(std::vector<mojom::AllowanceInfoPtr> alwns);
     void MarkComplete();
     int task_id;
     std::vector<mojom::AllowanceInfoPtr> allowances_;
     std::string account_address_;
-    brave_wallet::uint256_t latest_block_number_{0};
+    brave_wallet::uint256_t latest_block_number_;
     std::string chain_id_;
     bool is_completed_{false};
   };
@@ -106,7 +103,7 @@ class EthAllowanceManager {
                          mojom::ProviderError error,
                          const std::string& error_message);
   bool IsAllTasksCompleted() const;
-  void MergeAllResultsAnCallBack();
+  void MaybeMergeAllResultsAndCallBack();
   void OnDiscoverEthAllowancesCompleted(
       const std::vector<mojom::AllowanceInfoPtr>& result);
 

--- a/components/brave_wallet/browser/pref_names.cc
+++ b/components/brave_wallet/browser/pref_names.cc
@@ -37,6 +37,8 @@ const char kBraveWalletSelectedNetworksPerOrigin[] =
     "brave.wallet.selected_networks_origin";
 const char kBraveWalletKeyrings[] = "brave.wallet.keyrings";
 const char kBraveWalletUserAssets[] = "brave.wallet.wallet_user_assets";
+const char kBraveWalletEthAllowancesCache[] =
+    "brave.wallet.eth_allowances_cache";
 const char kBraveWalletUserAssetEthContractAddressMigrated[] =
     "brave.wallet.user.asset.eth_contract_address_migrated";
 const char kBraveWalletUserAssetsAddPreloadingNetworksMigrated[] =

--- a/components/brave_wallet/browser/pref_names.h
+++ b/components/brave_wallet/browser/pref_names.h
@@ -25,6 +25,7 @@ extern const char kBraveWalletHiddenNetworks[];
 extern const char kBraveWalletSelectedNetworks[];
 extern const char kBraveWalletSelectedNetworksPerOrigin[];
 extern const char kBraveWalletUserAssets[];
+extern const char kBraveWalletEthAllowancesCache[];
 // Added 10/2021 to migrate contract address to an empty string for ETH.
 extern const char kBraveWalletUserAssetEthContractAddressMigrated[];
 // Added 06/2022 to add native assets of preloading networks to user assets.

--- a/components/brave_wallet/common/brave_wallet.mojom
+++ b/components/brave_wallet/common/brave_wallet.mojom
@@ -678,6 +678,14 @@ struct BlockchainToken {
   CoinType coin;
 };
 
+struct AllowanceInfo {
+  string chain_id;
+  string contract_address;
+  string approver_address;
+  string spender_address;
+  string amount;
+};
+
 // WebUI-side handler for requests from the browser.
 interface Page {
 };
@@ -1741,6 +1749,9 @@ interface BraveWalletService {
 
   // Resets the keyring and the related preferences
   Reset();
+
+  // Used for UI to trigger the allowance discovery
+  DiscoverEthAllowances() => (array<AllowanceInfo> allowances);
 };
 
 // For reporting wallet related P3A metrics.


### PR DESCRIPTION
I implemented an ability to discover the allowances. It starts at the same moment when discovering of assets runs.
In result we have new handler here: [components/brave_wallet_ui/common/wallet_api_proxy.ts](https://github.com/brave/brave-core/pull/17807/files#diff-b05ef78fd07ac143d6f515ab63c1f657eb79261044a35f48bb57fb86f9ee0577R134)

If some allowances have been found (I'm talking only about allowances with amount > 0) mentioned above handler called and allowances data passed as array of objects.
Object definition is here: [AllowanceInfo](https://github.com/brave/brave-core/pull/17807/files#diff-9f2cf11d57c8efee5461b92cdb38fa327b70c25fd8d009f7692049e8e88944a8R627)
In result we can represent that data on the front-end side.

In case we need to revoke some allowance. It means that we have to approve allowance with the same parameters but with "0" amount.
To do that we should do something like this: 
``` TS
handler.on(WalletActions.approveERC20Allowance.type, async (store: Store, payload: ApproveERC20Params) => {
  const apiProxy = getAPIProxy()
  const { data, success } = await apiProxy.ethTxManagerProxy.makeERC20ApproveData(payload.spenderAddress, payload.allowance)
  if (!success) {
    console.log(
      'Failed making ERC20 approve data, contract: ',
      payload.contractAddress,
      ', spender: ', payload.spenderAddress,
      ', allowance: ', payload.allowance
    )
    return
  }

  await store.dispatch(WalletActions.sendTransaction({
    from: payload.from,
    to: payload.contractAddress,
    value: '0x0',
    data,
    coin: BraveWallet.CoinType.ETH
  }))
})
```

There are several networks (Fantom, BinanceSmartChain, Aurora) that have limitations for the `eth_getLogs` RPC call. They don't allow us to select logs through the whole block range. 
They are added to ignore list here:
[https://github.com/brave/brave-core/pull/17807/files#diff-8b312b4db97f727f9ab53dcec66c099de6f277ab694a7cddae9f7df570268ee3R1056](https://github.com/brave/brave-core/pull/17807/files#diff-8b312b4db97f727f9ab53dcec66c099de6f277ab694a7cddae9f7df570268ee3R1056)
Later If we resolve the problem with limits, or may be we will decide to implement 1-time scan of the block ranges in chunks up to point X (then only incremental from there).

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves [26327](https://github.com/brave/brave-browser/issues/26327)

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-arm64, CI/skip-linux-x64, CI/skip-android, CI/skip-macos, CI/skip-ios, CI/skip-windows-arm64, CI/skip-windows-x64, CI/skip-windows-x86 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues/26327) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

<!-- ## Test Plan:-->