### PR TITLE
Note: text is displayed twice

### DIFF
--- a/android/java/org/chromium/chrome/browser/rewards/BraveRewardsCreatorPanelFragment.java
+++ b/android/java/org/chromium/chrome/browser/rewards/BraveRewardsCreatorPanelFragment.java
@@ -275,6 +275,26 @@ public class BraveRewardsCreatorPanelFragment extends Fragment
         setPublisherNoteText(pubStatus, walletStatus);
     }
 
+    private String getWalletStringFromType(String walletType) {
+        if (walletType.equals(BraveWalletProvider.UPHOLD)) {
+            return getResources().getString(R.string.uphold);
+        } else if (walletType.equals(BraveWalletProvider.GEMINI)) {
+            return getResources().getString(R.string.gemini);
+        } else {
+            return getResources().getString(R.string.bitflyer);
+        }
+    }
+
+    private String getWalletStringFromStatus(int pubStatus) {
+        if (pubStatus == PublisherStatus.UPHOLD_VERIFIED) {
+            return getResources().getString(R.string.uphold);
+        } else if (pubStatus == PublisherStatus.GEMINI_VERIFIED) {
+            return getResources().getString(R.string.gemini);
+        } else {
+            return getResources().getString(R.string.bitflyer);
+        }
+    }
+
     @SuppressLint("ClickableViewAccessibility")
     private void setPublisherNoteText(int pubStatus, int walletStatus) {
         String notePart1 = "";
@@ -300,10 +320,9 @@ public class BraveRewardsCreatorPanelFragment extends Fragment
                             && !walletType.equals(BraveWalletProvider.BITFLYER))
                     || (pubStatus == PublisherStatus.GEMINI_VERIFIED
                             && !walletType.equals(BraveWalletProvider.GEMINI))) {
-                notePart1 = getResources().getString(
-                        R.string.brave_ui_site_banner_different_verified_notice_text);
-                Log.d(TAG,
-                        "User is verified and publisher is verified but not with the same provider");
+                notePart1 = String.format(
+                        getString(R.string.brave_ui_site_banner_different_verified_notice_text1),
+                        getWalletStringFromType(walletType), getWalletStringFromStatus(pubStatus));
             }
         }
 

--- a/browser/ui/android/strings/android_brave_strings.grd
+++ b/browser/ui/android/strings/android_brave_strings.grd
@@ -838,8 +838,8 @@ This file contains all "about" strings.  It is set to NOT be translated, in tran
       <message name="IDS_BRAVE_UI_SITE_BANNER_UNVERIFIED_NOTICE_TEXT" desc="A message on tipping page when a creator is not verified yet">
         This creator has not yet signed up to receive contributions from Brave users. We'll keep trying to contribute until they verify, or until 90 days have passed.
       </message>
-      <message name="IDS_BRAVE_UI_SITE_BANNER_DIFFERENT_VERIFIED_NOTICE_TEXT" desc="A message on tipping page when a creator is not verified yet">
-        NOTE: This creator is currently not configured to receive tips from your Rewards custodial wallet service. Any tip you make will remain pending and retry automatically for 90 days.
+      <message name="IDS_BRAVE_UI_SITE_BANNER_DIFFERENT_VERIFIED_NOTICE_TEXT1" desc="A message on tipping page when a creator is not verified yet">
+        You're connected to <ph name="WALLET_PROVIDER">%1$s</ph>, but this creator is connected to <ph name="SUPPORTED_WALLET_PROVIDER">%2$s</ph>. This means your tip can't reach this creator. For now, any tip you make will remain pending and retry automatically for 90 days.
       </message>
       <message name="IDS_BRAVE_UI_SITE_BANNER_WELCOME" desc="Tipping page title">
         Welcome!


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/29081  
Resolves https://github.com/brave/brave-browser/issues/29080



<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-arm64, CI/skip-linux-x64, CI/skip-android, CI/skip-macos, CI/skip-ios, CI/skip-windows-arm64, CI/skip-windows-x64, CI/skip-windows-x86 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
In this PR not resolved the Reward panel tool tip because it's new implementation will resolve this in rewards 3.0

In this PR resolves two issues
1. Note: text is displayed twice
2. Tipping banner text is updated based on creator wallettype connected and wallettype already verified
https://user-images.githubusercontent.com/32419898/228364534-03f02471-5a1c-4ef1-a620-22727687ac3a.mp4


