### PR TITLE
Prevents a crash on Android when a system setting of show everything in Bold is turned on (uplift to 1.51.x)

### DIFF
--- a/patches/chrome-browser-password_entry_edit-android-java-res-layout-credential_edit_view.xml.patch
+++ b/patches/chrome-browser-password_entry_edit-android-java-res-layout-credential_edit_view.xml.patch
@@ -1,0 +1,22 @@
+diff --git a/chrome/browser/password_entry_edit/android/java/res/layout/credential_edit_view.xml b/chrome/browser/password_entry_edit/android/java/res/layout/credential_edit_view.xml
+index 3d482cbedf7ed9e9b868e913d5cf265071731ed0..b7df538e669bd9af3284686cc182034e543436c9 100644
+--- a/chrome/browser/password_entry_edit/android/java/res/layout/credential_edit_view.xml
++++ b/chrome/browser/password_entry_edit/android/java/res/layout/credential_edit_view.xml
+@@ -44,7 +44,7 @@ found in the LICENSE file.
+                     android:imeOptions="flagNoExtractUi"
+                     android:importantForAutofill="noExcludeDescendants"
+                     android:inputType="textMultiLine"
+-                    android:textAppearance="@style/TextAppearance.TextLarge.Primary"/>
++                    />
+             </com.google.android.material.textfield.TextInputLayout>
+ 
+             <org.chromium.ui.widget.ChromeImageButton
+@@ -84,7 +84,7 @@ found in the LICENSE file.
+                     android:imeOptions="flagNoExtractUi"
+                     android:importantForAutofill="noExcludeDescendants"
+                     android:inputType="textVisiblePassword"
+-                    android:textAppearance="@style/TextAppearance.TextLarge.Primary"/>
++                    />
+             </com.google.android.material.textfield.TextInputLayout>
+ 
+             <LinearLayout


### PR DESCRIPTION
Uplift of #17804
Resolves https://github.com/brave/brave-browser/issues/29344

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.