### PR TITLE
Show alert icon in download button when insecure download is in-progress

### DIFF
--- a/chromium_src/chrome/browser/ui/views/download/bubble/download_toolbar_button_view.h
+++ b/chromium_src/chrome/browser/ui/views/download/bubble/download_toolbar_button_view.h
@@ -6,25 +6,26 @@
 #ifndef BRAVE_CHROMIUM_SRC_CHROME_BROWSER_UI_VIEWS_DOWNLOAD_BUBBLE_DOWNLOAD_TOOLBAR_BUTTON_VIEW_H_
 #define BRAVE_CHROMIUM_SRC_CHROME_BROWSER_UI_VIEWS_DOWNLOAD_BUBBLE_DOWNLOAD_TOOLBAR_BUTTON_VIEW_H_
 
+#include "chrome/browser/download/bubble/download_bubble_controller.h"
 #include "chrome/browser/download/bubble/download_display_controller.h"
+#include "chrome/browser/ui/views/toolbar/toolbar_button.h"
 
 #define DownloadToolbarButtonView DownloadToolbarButtonViewChromium
-#define GetIconColor                                        \
-  UnUsed() {                                                \
-    return SK_ColorTRANSPARENT;                             \
-  }                                                         \
+#define PaintButtonContents                                 \
+  PaintButtonContents_UnUsed() {}                           \
                                                             \
  protected:                                                 \
   DownloadDisplayController::IconInfo GetIconInfo() const { \
     return controller_->GetIconInfo();                      \
   }                                                         \
-                                                            \
- public:                                                    \
-  virtual SkColor GetIconColor
+  void PaintButtonContents
+
+#define GetIconColor virtual GetIconColor
 
 #include "src/chrome/browser/ui/views/download/bubble/download_toolbar_button_view.h"  // IWYU pragma: export
 
 #undef GetIconColor
+#undef PaintButtonContents
 #undef DownloadToolbarButtonView
 
 class DownloadToolbarButtonView : public DownloadToolbarButtonViewChromium {
@@ -33,6 +34,12 @@ class DownloadToolbarButtonView : public DownloadToolbarButtonViewChromium {
 
   // DownloadToolbarButtonViewChromium overrides:
   SkColor GetIconColor() const override;
+  void PaintButtonContents(gfx::Canvas* canvas) override;
+  void UpdateIcon() override;
+
+ private:
+  bool HasInsecureDownloads(
+      const std::vector<DownloadUIModelPtr>& models) const;
 };
 
 #endif  // BRAVE_CHROMIUM_SRC_CHROME_BROWSER_UI_VIEWS_DOWNLOAD_BUBBLE_DOWNLOAD_TOOLBAR_BUTTON_VIEW_H_

--- a/chromium_src/ui/color/core_default_color_mixer.cc
+++ b/chromium_src/ui/color/core_default_color_mixer.cc
@@ -1,0 +1,30 @@
+/* Copyright (c) 2023 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#define AddCoreDefaultColorMixer AddCoreDefaultColorMixer_Chromium
+#include "src/ui/color/core_default_color_mixer.cc"
+#undef AddCoreDefaultColorMixer
+
+namespace ui {
+
+void AddBraveCoreDefaultColorMixer(ColorProvider* provider,
+                                   const ColorProviderManager::Key& key) {
+  ColorMixer& mixer = provider->AddMixer();
+
+  const bool dark_mode =
+      key.color_mode == ColorProviderManager::ColorMode::kDark;
+
+  mixer[kColorAlertMediumSeverity] = {dark_mode
+                                          ? SkColorSetRGB(0xBB, 0x88, 0x00)
+                                          : SkColorSetRGB(0xE2, 0xA5, 0x00)};
+}
+
+void AddCoreDefaultColorMixer(ColorProvider* provider,
+                              const ColorProviderManager::Key& key) {
+  AddCoreDefaultColorMixer_Chromium(provider, key);
+  AddBraveCoreDefaultColorMixer(provider, key);
+}
+
+}  // namespace ui

--- a/vector_icons/components/vector_icons/not_secure_warning.icon
+++ b/vector_icons/components/vector_icons/not_secure_warning.icon
@@ -1,0 +1,25 @@
+// Copyright (c) 2023 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+CANVAS_DIMENSIONS, 16,
+MOVE_TO, 9.67f, 2.97f,
+R_CUBIC_TO, -0.74f, -1.29f, -2.6f, -1.29f, -3.34f, 0,
+LINE_TO, 1.6f, 11.17f,
+R_CUBIC_TO, -0.74f, 1.29f, 0.19f, 2.9f, 1.67f, 2.9f,
+R_H_LINE_TO, 9.47f,
+R_CUBIC_TO, 1.49f, 0, 2.42f, -1.61f, 1.67f, -2.89f,
+LINE_TO, 9.67f, 2.97f,
+CLOSE,
+MOVE_TO, 8, 5.43f,
+R_CUBIC_TO, 0.28f, 0, 0.51f, 0.23f, 0.51f, 0.51f,
+R_V_LINE_TO, 2.56f,
+R_ARC_TO, 0.51f, 0.51f, 0, 0, 1, -1.03f, 0,
+V_LINE_TO, 5.95f,
+R_CUBIC_TO, 0, -0.28f, 0.23f, -0.51f, 0.51f, -0.51f,
+CLOSE,
+R_MOVE_TO, 0.73f, 5.3f,
+R_ARC_TO, 0.73f, 0.73f, 0, 1, 1, -1.47f, 0,
+R_ARC_TO, 0.73f, 0.73f, 0, 0, 1, 1.47f, 0,
+CLOSE


### PR DESCRIPTION
fix https://github.com/brave/brave-browser/issues/29376
<img width="90" alt="Screenshot 2023-03-31 at 11 32 19 AM" src="https://user-images.githubusercontent.com/6786187/229035177-4884b77a-e054-43e8-b6e1-bd5aa9fc1d06.png">
<img width="79" alt="Screenshot 2023-03-31 at 11 32 40 AM" src="https://user-images.githubusercontent.com/6786187/229035194-a6955a81-dbb5-467f-82cf-cd267b53242c.png">




<!-- Add brave-browser issue below that this PR will resolve -->
Resolves 

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-arm64, CI/skip-linux-x64, CI/skip-android, CI/skip-macos, CI/skip-ios, CI/skip-windows-arm64, CI/skip-windows-x64, CI/skip-windows-x86 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [ ] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

