### PR TITLE
Added BraveVPNDisable policy

### DIFF
--- a/browser/brave_content_browser_client.cc
+++ b/browser/brave_content_browser_client.cc
@@ -486,7 +486,7 @@ void BraveContentBrowserClient::RegisterWebUIInterfaceBrokers(
     content::WebUIBrowserInterfaceBrokerRegistry& registry) {
   ChromeContentBrowserClient::RegisterWebUIInterfaceBrokers(registry);
 #if BUILDFLAG(ENABLE_BRAVE_VPN) && !BUILDFLAG(IS_ANDROID)
-  if (brave_vpn::IsBraveVPNEnabled()) {
+  if (brave_vpn::IsBraveVPNFeatureEnabled()) {
     registry.ForWebUI<VPNPanelUI>()
         .Add<brave_vpn::mojom::PanelHandlerFactory>();
   }

--- a/browser/brave_vpn/brave_vpn_service_factory.cc
+++ b/browser/brave_vpn/brave_vpn_service_factory.cc
@@ -9,6 +9,7 @@
 
 #include "base/feature_list.h"
 #include "brave/browser/brave_browser_process.h"
+#include "brave/browser/brave_vpn/vpn_utils.h"
 #include "brave/browser/profiles/profile_util.h"
 #include "brave/browser/skus/skus_service_factory.h"
 #include "brave/components/brave_vpn/browser/brave_vpn_service.h"
@@ -67,8 +68,9 @@ BraveVpnServiceFactory::~BraveVpnServiceFactory() = default;
 
 KeyedService* BraveVpnServiceFactory::BuildServiceInstanceFor(
     content::BrowserContext* context) const {
-  if (!IsBraveVPNEnabled())
+  if (!brave_vpn::IsAllowedForContext(context)) {
     return nullptr;
+  }
 
   auto* default_storage_partition = context->GetDefaultStoragePartition();
   auto shared_url_loader_factory =

--- a/browser/brave_vpn/dns/brave_vpn_dns_observer_factory_win.cc
+++ b/browser/brave_vpn/dns/brave_vpn_dns_observer_factory_win.cc
@@ -11,6 +11,7 @@
 
 #include "base/feature_list.h"
 #include "brave/browser/brave_vpn/dns/brave_vpn_dns_observer_service_win.h"
+#include "brave/browser/brave_vpn/vpn_utils.h"
 #include "brave/components/brave_vpn/common/brave_vpn_utils.h"
 #include "brave/components/brave_vpn/common/features.h"
 #include "brave/components/brave_vpn/common/pref_names.h"
@@ -47,7 +48,7 @@ BraveVpnDnsObserverService* BraveVpnDnsObserverFactory::GetServiceForContext(
           brave_vpn::features::kBraveVPNDnsProtection)) {
     return nullptr;
   }
-  DCHECK(IsBraveVPNEnabled());
+  DCHECK(brave_vpn::IsAllowedForContext(context));
   return static_cast<BraveVpnDnsObserverService*>(
       GetInstance()->GetServiceForBrowserContext(context, true));
 }

--- a/browser/brave_vpn/vpn_utils.cc
+++ b/browser/brave_vpn/vpn_utils.cc
@@ -25,7 +25,7 @@ bool IsBraveVPNEnabled(content::BrowserContext* context) {
   return brave_vpn::IsBraveVPNEnabled(user_prefs::UserPrefs::Get(context)) &&
          IsAllowedForContext(context);
 #else
-  return IsAllowedForContext(context);
+  return brave::IsRegularProfile(context);
 #endif
 }
 

--- a/browser/brave_vpn/vpn_utils.cc
+++ b/browser/brave_vpn/vpn_utils.cc
@@ -8,17 +8,24 @@
 #include "brave/browser/profiles/profile_util.h"
 #include "brave/components/brave_vpn/common/brave_vpn_utils.h"
 #include "build/build_config.h"
+#include "components/user_prefs/user_prefs.h"
 
 namespace brave_vpn {
+
+bool IsAllowedForContext(content::BrowserContext* context) {
+  return brave::IsRegularProfile(context) &&
+         brave_vpn::IsBraveVPNFeatureEnabled();
+}
 
 bool IsBraveVPNEnabled(content::BrowserContext* context) {
   // TODO(simonhong): Can we use this check for android?
   // For now, vpn is disabled by default on desktop but not sure on
   // android.
 #if BUILDFLAG(IS_WIN) || BUILDFLAG(IS_MAC)
-  return brave_vpn::IsBraveVPNEnabled() && brave::IsRegularProfile(context);
+  return brave_vpn::IsBraveVPNEnabled(user_prefs::UserPrefs::Get(context)) &&
+         IsAllowedForContext(context);
 #else
-  return brave::IsRegularProfile(context);
+  return IsAllowedForContext(context);
 #endif
 }
 

--- a/browser/brave_vpn/vpn_utils.h
+++ b/browser/brave_vpn/vpn_utils.h
@@ -13,6 +13,7 @@ class BrowserContext;
 namespace brave_vpn {
 
 bool IsBraveVPNEnabled(content::BrowserContext* context);
+bool IsAllowedForContext(content::BrowserContext* context);
 
 }  // namespace brave_vpn
 

--- a/browser/ui/brave_browser_command_controller.cc
+++ b/browser/ui/brave_browser_command_controller.cc
@@ -36,6 +36,7 @@
 #include "brave/browser/brave_vpn/brave_vpn_service_factory.h"
 #include "brave/browser/brave_vpn/vpn_utils.h"
 #include "brave/components/brave_vpn/browser/brave_vpn_service.h"
+#include "brave/components/brave_vpn/common/pref_names.h"
 #endif
 
 #if BUILDFLAG(ENABLE_SPEEDREADER)
@@ -146,6 +147,16 @@ void BraveBrowserCommandController::InitBraveCommandState() {
 #endif
   UpdateCommandForSidebar();
   UpdateCommandForBraveVPN();
+#if BUILDFLAG(ENABLE_BRAVE_VPN)
+  if (brave_vpn::IsAllowedForContext(browser_->profile())) {
+    brave_vpn_pref_change_registrar_.Init(browser_->profile()->GetPrefs());
+    brave_vpn_pref_change_registrar_.Add(
+        brave_vpn::prefs::kManagedBraveVPNDisabled,
+        base::BindRepeating(
+            &BraveBrowserCommandController::UpdateCommandForBraveVPN,
+            base::Unretained(this)));
+  }
+#endif
   bool add_new_profile_enabled = !is_guest_session;
   bool open_guest_profile_enabled = !is_guest_session;
   if (!is_guest_session) {

--- a/browser/ui/brave_browser_command_controller.h
+++ b/browser/ui/brave_browser_command_controller.h
@@ -7,13 +7,9 @@
 #define BRAVE_BROWSER_UI_BRAVE_BROWSER_COMMAND_CONTROLLER_H_
 
 #include "brave/components/brave_vpn/common/buildflags/buildflags.h"
-#include "brave/components/ipfs/buildflags/buildflags.h"
 #include "brave/components/tor/buildflags/buildflags.h"
 #include "chrome/browser/ui/browser_command_controller.h"
-
-#if BUILDFLAG(ENABLE_IPFS)
 #include "components/prefs/pref_change_registrar.h"
-#endif
 
 #if BUILDFLAG(ENABLE_BRAVE_VPN)
 #include "brave/components/brave_vpn/browser/brave_vpn_service_observer.h"
@@ -73,7 +69,9 @@ class BraveBrowserCommandController : public chrome::BrowserCommandController
   bool ExecuteBraveCommandWithDisposition(int id,
                                           WindowOpenDisposition disposition,
                                           base::TimeTicks time_stamp);
-
+#if BUILDFLAG(ENABLE_BRAVE_VPN)
+  PrefChangeRegistrar brave_vpn_pref_change_registrar_;
+#endif
   Browser* const browser_;
 
   CommandUpdaterImpl brave_command_updater_;

--- a/browser/ui/views/toolbar/brave_toolbar_view.cc
+++ b/browser/ui/views/toolbar/brave_toolbar_view.cc
@@ -39,6 +39,7 @@
 #if BUILDFLAG(ENABLE_BRAVE_VPN)
 #include "brave/browser/brave_vpn/vpn_utils.h"
 #include "brave/browser/ui/views/toolbar/brave_vpn_button.h"
+#include "brave/components/brave_vpn/common/brave_vpn_utils.h"
 #include "brave/components/brave_vpn/common/pref_names.h"
 #endif
 
@@ -202,14 +203,18 @@ void BraveToolbarView::Init() {
   }
 
 #if BUILDFLAG(ENABLE_BRAVE_VPN)
-  if (brave_vpn::IsBraveVPNEnabled(profile)) {
+  if (brave_vpn::IsAllowedForContext(profile)) {
+    brave_vpn_ = AddChildViewAt(std::make_unique<BraveVPNButton>(browser()),
+                                *GetIndexOf(GetAppMenuButton()) - 1);
     show_brave_vpn_button_.Init(
         brave_vpn::prefs::kBraveVPNShowButton, profile->GetPrefs(),
         base::BindRepeating(&BraveToolbarView::OnVPNButtonVisibilityChanged,
                             base::Unretained(this)));
-    brave_vpn_ = AddChildViewAt(std::make_unique<BraveVPNButton>(browser()),
-                                *GetIndexOf(GetAppMenuButton()) - 1);
-    brave_vpn_->SetVisible(show_brave_vpn_button_.GetValue());
+    hide_brave_vpn_button_by_policy_.Init(
+        brave_vpn::prefs::kManagedBraveVPNDisabled, profile->GetPrefs(),
+        base::BindRepeating(&BraveToolbarView::OnVPNButtonVisibilityChanged,
+                            base::Unretained(this)));
+    brave_vpn_->SetVisible(IsBraveVPNButtonVisible());
   }
 #endif
 
@@ -217,9 +222,13 @@ void BraveToolbarView::Init() {
 }
 
 #if BUILDFLAG(ENABLE_BRAVE_VPN)
+bool BraveToolbarView::IsBraveVPNButtonVisible() const {
+  return show_brave_vpn_button_.GetValue() &&
+         !hide_brave_vpn_button_by_policy_.GetValue();
+}
 void BraveToolbarView::OnVPNButtonVisibilityChanged() {
   DCHECK(brave_vpn_);
-  brave_vpn_->SetVisible(show_brave_vpn_button_.GetValue());
+  brave_vpn_->SetVisible(IsBraveVPNButtonVisible());
 }
 #endif
 

--- a/browser/ui/views/toolbar/brave_toolbar_view.h
+++ b/browser/ui/views/toolbar/brave_toolbar_view.h
@@ -31,6 +31,7 @@ class BraveToolbarView : public ToolbarView,
 
 #if BUILDFLAG(ENABLE_BRAVE_VPN)
   BraveVPNButton* brave_vpn_button() const { return brave_vpn_; }
+  bool IsBraveVPNButtonVisible() const;
   void OnVPNButtonVisibilityChanged();
 #endif
 
@@ -67,6 +68,7 @@ class BraveToolbarView : public ToolbarView,
 #if BUILDFLAG(ENABLE_BRAVE_VPN)
   raw_ptr<BraveVPNButton> brave_vpn_ = nullptr;
   BooleanPrefMember show_brave_vpn_button_;
+  BooleanPrefMember hide_brave_vpn_button_by_policy_;
 #endif
 
   BooleanPrefMember show_bookmarks_button_;

--- a/chromium_src/chrome/browser/policy/configuration_policy_handler_list_factory.cc
+++ b/chromium_src/chrome/browser/policy/configuration_policy_handler_list_factory.cc
@@ -5,6 +5,7 @@
 
 #include "chrome/browser/policy/configuration_policy_handler_list_factory.h"
 
+#include "brave/components/brave_vpn/common/buildflags/buildflags.h"
 #include "brave/components/constants/pref_names.h"
 #include "brave/components/ipfs/buildflags/buildflags.h"
 #include "brave/components/tor/buildflags/buildflags.h"
@@ -23,6 +24,10 @@
 
 #if BUILDFLAG(ENABLE_IPFS)
 #include "brave/components/ipfs/pref_names.h"
+#endif
+
+#if BUILDFLAG(ENABLE_BRAVE_VPN)
+#include "brave/components/brave_vpn/common/pref_names.h"
 #endif
 
 namespace {
@@ -44,6 +49,10 @@ const policy::PolicyToPreferenceMapEntry kBraveSimplePolicyMap[] = {
 #endif
 #if BUILDFLAG(ENABLE_IPFS)
     {policy::key::kIPFSEnabled, kIPFSEnabled, base::Value::Type::BOOLEAN},
+#endif
+#if BUILDFLAG(ENABLE_BRAVE_VPN)
+    {policy::key::kBraveVPNDisabled, brave_vpn::prefs::kManagedBraveVPNDisabled,
+     base::Value::Type::BOOLEAN},
 #endif
 };
 

--- a/chromium_src/chrome/browser/ui/webui/chrome_untrusted_web_ui_configs.cc
+++ b/chromium_src/chrome/browser/ui/webui/chrome_untrusted_web_ui_configs.cc
@@ -46,7 +46,7 @@ void RegisterChromeUntrustedWebUIConfigs() {
   content::WebUIConfigMap::GetInstance().AddUntrustedWebUIConfig(
       std::make_unique<nft::UntrustedNftUIConfig>());
 #if BUILDFLAG(ENABLE_BRAVE_VPN)
-  if (brave_vpn::IsBraveVPNEnabled()) {
+  if (brave_vpn::IsBraveVPNFeatureEnabled()) {
     content::WebUIConfigMap::GetInstance().AddUntrustedWebUIConfig(
         std::make_unique<UntrustedVPNPanelUIConfig>());
   }

--- a/components/brave_vpn/browser/brave_vpn_service.cc
+++ b/components/brave_vpn/browser/brave_vpn_service.cc
@@ -156,7 +156,7 @@ void BraveVpnService::OnConnectionStateChanged(mojom::ConnectionState state) {
   if (state == ConnectionState::CONNECTED) {
     // If user connected vpn from the system and launched the browser
     // we detected it was disabled by policies and disabling it.
-    if (IsConnected() && IsBraveVPNDisabledByPolicy(profile_prefs_)) {
+    if (IsBraveVPNDisabledByPolicy(profile_prefs_)) {
       GetBraveVPNConnectionAPI()->Disconnect();
       return;
     }
@@ -527,7 +527,7 @@ void BraveVpnService::OnPreferenceChanged(const std::string& pref_name) {
     return;
   }
   if (pref_name == prefs::kManagedBraveVPNDisabled) {
-    if (IsConnected() && IsBraveVPNDisabledByPolicy(profile_prefs_)) {
+    if (IsBraveVPNDisabledByPolicy(profile_prefs_)) {
       GetBraveVPNConnectionAPI()->Disconnect();
     }
     return;

--- a/components/brave_vpn/browser/brave_vpn_service.h
+++ b/components/brave_vpn/browser/brave_vpn_service.h
@@ -78,7 +78,7 @@ class BraveVpnService :
   }
   void BindInterface(mojo::PendingReceiver<mojom::ServiceHandler> receiver);
   void ReloadPurchasedState();
-
+  bool IsBraveVPNEnabled() const;
 #if !BUILDFLAG(IS_ANDROID)
   void ToggleConnection();
   void RemoveVPNConnection();
@@ -233,6 +233,7 @@ class BraveVpnService :
   raw_ptr<BraveVPNOSConnectionAPI> connection_api_ = nullptr;
 
   PrefChangeRegistrar pref_change_registrar_;
+  PrefChangeRegistrar policy_pref_change_registrar_;
 #endif  // !BUILDFLAG(IS_ANDROID)
 
   SEQUENCE_CHECKER(sequence_checker_);

--- a/components/brave_vpn/browser/brave_vpn_service_observer.cc
+++ b/components/brave_vpn/browser/brave_vpn_service_observer.cc
@@ -20,7 +20,7 @@ void BraveVPNServiceObserver::Observe(BraveVpnService* service) {
   if (!service)
     return;
 
-  if (IsBraveVPNEnabled()) {
+  if (service->IsBraveVPNEnabled()) {
     mojo::PendingRemote<mojom::ServiceObserver> listener;
     receiver_.Bind(listener.InitWithNewPipeAndPassReceiver());
     service->AddObserver(std::move(listener));

--- a/components/brave_vpn/browser/brave_vpn_service_unittest.cc
+++ b/components/brave_vpn/browser/brave_vpn_service_unittest.cc
@@ -482,14 +482,6 @@ class BraveVPNServiceTest : public testing::Test {
   base::HistogramTester histogram_tester_;
 };
 
-TEST(BraveVPNFeatureTest, FeatureTest) {
-#if BUILDFLAG(IS_ANDROID) || BUILDFLAG(IS_IOS)
-  EXPECT_TRUE(IsBraveVPNEnabled());
-#else
-  EXPECT_FALSE(IsBraveVPNEnabled());
-#endif
-}
-
 TEST_F(BraveVPNServiceTest, ResponseSanitizingTest) {
   // Give invalid json data as a server response and check sanitized(empty
   // string) result is returned.

--- a/components/brave_vpn/browser/connection/brave_vpn_os_connection_api_sim.h
+++ b/components/brave_vpn/browser/connection/brave_vpn_os_connection_api_sim.h
@@ -58,6 +58,7 @@ class BraveVPNOSConnectionAPISim : public BraveVPNOSConnectionAPIBase {
   FRIEND_TEST_ALL_PREFIXES(BraveVPNServiceTest,
                            ConnectionStateUpdateWithPurchasedStateTest);
   FRIEND_TEST_ALL_PREFIXES(BraveVPNServiceTest, ResetConnectionStateTest);
+  FRIEND_TEST_ALL_PREFIXES(BraveVPNServiceTest, DisconnectedIfDisabledByPolicy);
 
   void OnCreated(const std::string& name, bool success);
   void OnConnected(const std::string& name, bool success);

--- a/components/brave_vpn/common/BUILD.gn
+++ b/components/brave_vpn/common/BUILD.gn
@@ -38,7 +38,9 @@ source_set("unit_tests") {
   deps = [
     ":common",
     "//base",
+    "//base/test:test_support",
     "//brave/components/skus/browser",
+    "//brave/components/skus/common",
     "//components/prefs",
     "//components/prefs:test_support",
     "//components/sync_preferences:test_support",

--- a/components/brave_vpn/common/brave_vpn_utils.cc
+++ b/components/brave_vpn/common/brave_vpn_utils.cc
@@ -81,9 +81,20 @@ void MigrateVPNSettings(PrefService* profile_prefs, PrefService* local_prefs) {
   profile_prefs->SetBoolean(brave_vpn::prefs::kBraveVPNShowButton, show_button);
 }
 
-bool IsBraveVPNEnabled() {
+bool IsBraveVPNDisabledByPolicy(PrefService* prefs) {
+  DCHECK(prefs);
+  return prefs->FindPreference(prefs::kManagedBraveVPNDisabled) &&
+         prefs->IsManagedPreference(prefs::kManagedBraveVPNDisabled) &&
+         prefs->GetBoolean(prefs::kManagedBraveVPNDisabled);
+}
+
+bool IsBraveVPNFeatureEnabled() {
   return base::FeatureList::IsEnabled(brave_vpn::features::kBraveVPN) &&
          base::FeatureList::IsEnabled(skus::features::kSkusFeature);
+}
+
+bool IsBraveVPNEnabled(PrefService* prefs) {
+  return !IsBraveVPNDisabledByPolicy(prefs) && IsBraveVPNFeatureEnabled();
 }
 
 std::string GetBraveVPNEntryName(version_info::Channel channel) {
@@ -130,6 +141,7 @@ std::string GetBraveVPNPaymentsEnv(const std::string& env) {
 }
 
 void RegisterProfilePrefs(user_prefs::PrefRegistrySyncable* registry) {
+  registry->RegisterBooleanPref(prefs::kManagedBraveVPNDisabled, false);
   registry->RegisterDictionaryPref(prefs::kBraveVPNRootPref);
   registry->RegisterBooleanPref(prefs::kBraveVPNShowButton, true);
 #if BUILDFLAG(IS_WIN)

--- a/components/brave_vpn/common/brave_vpn_utils.h
+++ b/components/brave_vpn/common/brave_vpn_utils.h
@@ -23,7 +23,9 @@ enum class Channel;
 namespace brave_vpn {
 
 std::string GetBraveVPNEntryName(version_info::Channel channel);
-bool IsBraveVPNEnabled();
+bool IsBraveVPNEnabled(PrefService* prefs);
+bool IsBraveVPNFeatureEnabled();
+bool IsBraveVPNDisabledByPolicy(PrefService* prefs);
 std::string GetBraveVPNPaymentsEnv(const std::string& env);
 std::string GetManageUrl(const std::string& env);
 void MigrateVPNSettings(PrefService* profile_prefs, PrefService* local_prefs);

--- a/components/brave_vpn/common/pref_names.h
+++ b/components/brave_vpn/common/pref_names.h
@@ -10,7 +10,8 @@
 
 namespace brave_vpn {
 namespace prefs {
-constexpr char kManagedBraveVPNDisabled[] = "brave.brave_vpn.diabled_by_policy";
+constexpr char kManagedBraveVPNDisabled[] =
+    "brave.brave_vpn.disabled_by_policy";
 constexpr char kBraveVPNLocalStateMigrated[] = "brave.brave_vpn.migrated";
 constexpr char kBraveVPNRootPref[] = "brave.brave_vpn";
 constexpr char kBraveVPNShowButton[] = "brave.brave_vpn.show_button";

--- a/components/brave_vpn/common/pref_names.h
+++ b/components/brave_vpn/common/pref_names.h
@@ -10,7 +10,7 @@
 
 namespace brave_vpn {
 namespace prefs {
-
+constexpr char kManagedBraveVPNDisabled[] = "brave.brave_vpn.diabled_by_policy";
 constexpr char kBraveVPNLocalStateMigrated[] = "brave.brave_vpn.migrated";
 constexpr char kBraveVPNRootPref[] = "brave.brave_vpn";
 constexpr char kBraveVPNShowButton[] = "brave.brave_vpn.show_button";

--- a/components/brave_vpn/renderer/android/vpn_render_frame_observer.cc
+++ b/components/brave_vpn/renderer/android/vpn_render_frame_observer.cc
@@ -119,7 +119,7 @@ bool VpnRenderFrameObserver::IsValueAllowed(
 }
 
 bool VpnRenderFrameObserver::IsAllowed() {
-  DCHECK(brave_vpn::IsBraveVPNEnabled());
+  DCHECK(brave_vpn::IsBraveVPNFeatureEnabled());
 
   if (!skus::IsSafeOrigin(render_frame()->GetWebFrame()->GetSecurityOrigin())) {
     return false;

--- a/renderer/brave_content_renderer_client.cc
+++ b/renderer/brave_content_renderer_client.cc
@@ -115,7 +115,7 @@ void BraveContentRendererClient::RenderFrameCreated(
   }
 
 #if BUILDFLAG(IS_ANDROID)
-  if (brave_vpn::IsBraveVPNEnabled()) {
+  if (brave_vpn::IsBraveVPNFeatureEnabled()) {
     new brave_vpn::VpnRenderFrameObserver(render_frame,
                                           content::ISOLATED_WORLD_ID_GLOBAL);
   }

--- a/script/policy_source_helper.py
+++ b/script/policy_source_helper.py
@@ -15,10 +15,12 @@ def AddBravePolicies(template_file_contents):
         {
             'name': 'TorDisabled',
             'type': 'main',
-            'schema': {'type': 'boolean'},
-            'supported_on': ['chrome.win:78-',
-                             'chrome.mac:93-',
-                             'chrome.linux:93-'],
+            'schema': {
+                'type': 'boolean'
+            },
+            'supported_on': [
+                'chrome.win:78-', 'chrome.mac:93-', 'chrome.linux:93-'
+            ],
             'features': {
                 'dynamic_refresh': False,
                 'per_profile': False,
@@ -35,7 +37,9 @@ def AddBravePolicies(template_file_contents):
         {
             'name': 'IPFSEnabled',
             'type': 'main',
-            'schema': {'type': 'boolean'},
+            'schema': {
+                'type': 'boolean'
+            },
             'supported_on': ['chrome.*:87-'],
             'future_on': ['android'],
             'features': {
@@ -54,7 +58,9 @@ def AddBravePolicies(template_file_contents):
         {
             'name': 'BraveRewardsDisabled',
             'type': 'main',
-            'schema': {'type': 'boolean'},
+            'schema': {
+                'type': 'boolean'
+            },
             'supported_on': ['chrome.*:105-'],
             'features': {
                 'dynamic_refresh': False,
@@ -72,7 +78,9 @@ def AddBravePolicies(template_file_contents):
         {
             'name': 'BraveWalletDisabled',
             'type': 'main',
-            'schema': {'type': 'boolean'},
+            'schema': {
+                'type': 'boolean'
+            },
             'supported_on': ['chrome.*:106-'],
             'features': {
                 'dynamic_refresh': False,
@@ -91,8 +99,10 @@ def AddBravePolicies(template_file_contents):
             'name': 'BraveShieldsDisabledForUrls',
             'type': 'main',
             'schema': {
-              'type': 'array',
-              'items': { 'type': 'string' },
+                'type': 'array',
+                'items': {
+                    'type': 'string'
+                },
             },
             'supported_on': ['chrome.*:107-'],
             'features': {
@@ -112,8 +122,10 @@ def AddBravePolicies(template_file_contents):
             'name': 'BraveShieldsEnabledForUrls',
             'type': 'main',
             'schema': {
-              'type': 'array',
-              'items': { 'type': 'string' },
+                'type': 'array',
+                'items': {
+                    'type': 'string'
+                },
             },
             'supported_on': ['chrome.*:107-'],
             'features': {
@@ -128,6 +140,27 @@ def AddBravePolicies(template_file_contents):
             'tags': [],
             'desc': ('''This policy allows an admin to specify that Brave '''
                      '''Shields enabled.'''),
+        },
+        {
+            'name': 'BraveVPNDisabled',
+            'type': 'main',
+            'schema': {
+                'type': 'boolean'
+            },
+            'supported_on': ['chrome.*:112-'],
+            'future_on': ['android'],
+            'features': {
+                'dynamic_refresh': False,
+                'per_profile': True,
+                'can_be_recommended': False,
+                'can_be_mandatory': True
+            },
+            'example_value': True,
+            'id': 6,
+            'caption': '''Disable Brave VPN feature.''',
+            'tags': [],
+            'desc': ('''This policy allows an admin to specify that Brave '''
+                     '''VPN feature will be disabled.'''),
         },
     ]
 

--- a/test/BUILD.gn
+++ b/test/BUILD.gn
@@ -325,6 +325,7 @@ test("brave_unit_tests") {
   if (enable_brave_vpn) {
     deps += [
       "//brave/components/brave_vpn/browser:unit_tests",
+      "//brave/components/brave_vpn/common:unit_tests",
       "//brave/components/skus/browser:unit_tests",
     ]
     if (is_win) {


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/29397

In order to add `BraveVPNDisabled` policy additionaly to `IsBraveVPNEnabled` added few functions `IsBraveVPNFeatureEnabled`, `IsAllowedForContext` and `IsBraveVPNDisabledByPolicy`. The policy can be added in runtime so we have to be able to apply it in runtime as well. 
If policy enabled in connected state the service disconnects vpn, this works as well for cases when user enabled policy when the browser is closed and vpn connected.
Added few watchers for the managed pref in command controller and toolbar view to be able to re-enable UI back when policy applied.


https://user-images.githubusercontent.com/2965009/229149623-39090f0a-6758-4939-95d0-648355e33242.mp4



<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-arm64, CI/skip-linux-x64, CI/skip-android, CI/skip-macos, CI/skip-ios, CI/skip-windows-arm64, CI/skip-windows-x64, CI/skip-windows-x86 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
- In order to disable vpn by policy need to add to `Computer\HKEY_LOCAL_MACHINE\SOFTWARE\Policies\BraveSoftware\Brave` a key `BraveVPNDisable` as 1 for windows, or here you can find how to do same on other OS https://support.brave.com/hc/en-us/articles/360039248271-Group-Policy
- Play with key to enable/disable it in different states, when vpn connected/disconnected/purchased or not. Use `brave://policy` for runtime policy reload.
- Check cases when the browser is closed and user connected vpn in the system and launched the browser, the vpn should be disconnected if policy is on.