### PR TITLE
[Leo]: Update to latest

### DIFF
--- a/components/brave_wallet_ui/components/extension/connect-with-site-panel/connect-with-site-header/connect-with-site-header.style.ts
+++ b/components/brave_wallet_ui/components/extension/connect-with-site-panel/connect-with-site-header/connect-with-site-header.style.ts
@@ -109,7 +109,7 @@ export const BackButton = styled(WalletButton)`
 
 export const BackIcon = styled(Icon)`
   --leo-icon-size: 24px;
-  color: ${leo.color.icon};
+  color: ${leo.color.iconTint};
 `
 
 export const GradientLine = styled.div`

--- a/components/brave_wallet_ui/components/extension/connect-with-site-panel/connect-with-site-panel.tsx
+++ b/components/brave_wallet_ui/components/extension/connect-with-site-panel/connect-with-site-panel.tsx
@@ -264,13 +264,13 @@ export const ConnectWithSite = (props: Props) => {
         )}
       </ScrollContainer>
       <ButtonRow padding={16} isReadyToConnect={isReadyToConnect}>
-        <NavButton size="large" kind="secondary" onClick={onCancel}>
+        <NavButton size="large" kind="outline" onClick={onCancel}>
           {getLocale('braveWalletButtonCancel')}
         </NavButton>
         <HorizontalSpace space="16px" />
         <NavButton
           size="large"
-          kind="primary"
+          kind="filled"
           isDisabled={!addressToConnect}
           onClick={onNext}
         >

--- a/components/brave_wallet_ui/components/extension/connect-with-site-panel/permission-duration-dropdown/permission-duration-dropdown.style.ts
+++ b/components/brave_wallet_ui/components/extension/connect-with-site-panel/permission-duration-dropdown/permission-duration-dropdown.style.ts
@@ -41,7 +41,7 @@ export const DropDownButton = styled(WalletButton)`
 
 export const DropDownIcon = styled(Icon)<{ isOpen: boolean }>`
   --leo-icon-size: 20px;
-  color: ${leo.color.icon};
+  color: ${leo.color.iconTint};
   transition-duration: 0.3s;
   transform: ${(p) => (p.isOpen ? 'rotate(180deg)' : 'unset')};
 `

--- a/components/brave_wallet_ui/components/extension/connect-with-site-panel/select-account-item/select-account-item.style.ts
+++ b/components/brave_wallet_ui/components/extension/connect-with-site-panel/select-account-item/select-account-item.style.ts
@@ -82,5 +82,5 @@ export const BalanceText = styled.span`
 export const SelectedIcon = styled(Icon)<{ isSelected: boolean }>`
   --leo-icon-size: 20px;
   color: ${(p) =>
-    p.isSelected ? leo.color.primary[40] : leo.color.icon};
+    p.isSelected ? leo.color.primary[40] : leo.color.icon.default};
 `

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.52.3",
       "license": "MPL-2.0",
       "dependencies": {
-        "@brave/leo": "github:brave/leo#fa7ffcd446e6ef23dd8ab7b549861d4668ca46a8",
+        "@brave/leo": "github:brave/leo#16eb3a3",
         "@brave/react-virtualized-auto-sizer": "^1.0.4",
         "@brave/wallet-standard-brave": "~0.0.6",
         "@dnd-kit/core": "6.0.5",
@@ -2071,8 +2071,7 @@
     },
     "node_modules/@brave/leo": {
       "version": "0.0.1",
-      "resolved": "git+ssh://git@github.com/brave/leo.git#fa7ffcd446e6ef23dd8ab7b549861d4668ca46a8",
-      "integrity": "sha512-n7bBneIuMA4u+8F2UgGb/o11WNwjgZQN9p/WQ+RtpAnTZfXrA3MGlIJLD7O8b86q8Rj8Nw66eX/6+ta5Y0/JOQ==",
+      "resolved": "git+ssh://git@github.com/brave/leo.git#16eb3a3bc50fd40aa0eadef952e5d1902ded81c6",
       "license": "MIT",
       "dependencies": {
         "@ctrl/tinycolor": "3.5.1",
@@ -31061,9 +31060,8 @@
       "dev": true
     },
     "@brave/leo": {
-      "version": "git+ssh://git@github.com/brave/leo.git#fa7ffcd446e6ef23dd8ab7b549861d4668ca46a8",
-      "integrity": "sha512-n7bBneIuMA4u+8F2UgGb/o11WNwjgZQN9p/WQ+RtpAnTZfXrA3MGlIJLD7O8b86q8Rj8Nw66eX/6+ta5Y0/JOQ==",
-      "from": "@brave/leo@github:brave/leo#fa7ffcd446e6ef23dd8ab7b549861d4668ca46a8",
+      "version": "git+ssh://git@github.com/brave/leo.git#16eb3a3bc50fd40aa0eadef952e5d1902ded81c6",
+      "from": "@brave/leo@github:brave/leo#16eb3a3",
       "requires": {
         "@ctrl/tinycolor": "3.5.1",
         "@tsconfig/svelte": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -351,7 +351,7 @@
     "webpack-cli": "3.3.12"
   },
   "dependencies": {
-    "@brave/leo": "github:brave/leo#fa7ffcd446e6ef23dd8ab7b549861d4668ca46a8",
+    "@brave/leo": "github:brave/leo#16eb3a3",
     "@brave/react-virtualized-auto-sizer": "^1.0.4",
     "@brave/wallet-standard-brave": "~0.0.6",
     "@dnd-kit/core": "6.0.5",


### PR DESCRIPTION
Updates Leo to current ToT. A list of changes is available at
https://github.com/brave/leo/compare/fa7ffcd446e6ef23dd8ab7b549861d4668ca46a8...16eb3a3

- [Meta] Updates Rennovate Schedule (no change for Brave Core)
- Adds new button variants
    - Adds `jumbo` size
    - Adds `tiny` size
    - Renames `kind`s to match the Figma files
        - `primary` ==> `filled`
        - `secondary` ==> `outline`
        - `tertiary` ==> `plain`
    - Adds `plain-faint` variant
- [Meta] Documents component creation
- Updates tokens (fixes a bug where there was a clash between browser and universal tokens)
    - `leo.color.icon` ==> `leo.color.iconTint`
- Fix tap highlights on mobile

This is a reland of https://github.com/brave/brave-core/pull/17568 after it was reverted by https://github.com/brave/brave-core/pull/17838 (not sure why the build went green)