### PR TITLE
Use opaque color for tab background in dark mode tab strip

### DIFF
--- a/browser/ui/tabs/brave_vertical_tab_color_mixer.cc
+++ b/browser/ui/tabs/brave_vertical_tab_color_mixer.cc
@@ -38,7 +38,7 @@ ChromeColorIds GetMappedChromeColorId(BraveColorIds brave_color_id) {
   return kChromiumColorMap.at(brave_color_id);
 }
 
-ui::ColorRecipe GetCustomColorOrDefaultColor(
+ui::ColorTransform GetCustomColorOrDefaultColor(
     const scoped_refptr<ui::ColorProviderManager::ThemeInitializerSupplier>&
         custom_theme,
     BraveColorIds color_id,
@@ -110,8 +110,16 @@ void AddBraveVerticalTabDarkThemeColorMixer(
            SkColorSetRGB(0x68, 0x6D, 0x7D)},
       });
   for (const auto& [color_id, default_color] : kDefaultColorMap) {
-    mixer[color_id] =
+    auto color =
         GetCustomColorOrDefaultColor(key.custom_theme, color_id, default_color);
+    if (color_id == kColorBraveVerticalTabActiveBackground ||
+        color_id == kColorBraveVerticalTabInactiveBackground) {
+      mixer[color_id] = ui::GetResultingPaintColor(
+          /* foreground_transform= */ color,
+          /* background_transform= */ kColorToolbar);
+    } else {
+      mixer[color_id] = color;
+    }
   }
 }
 


### PR DESCRIPTION
When the color has opacity, the hover glow effect's color will be multiplied, which ends up with too strong effect. In order to avoid that use opaque color by blending tab's background and tab strip background color.

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/29436

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-arm64, CI/skip-linux-x64, CI/skip-android, CI/skip-macos, CI/skip-ios, CI/skip-windows-arm64, CI/skip-windows-x64, CI/skip-windows-x86 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [ ] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

