### PR TITLE
Enable NFT Pinning by default (uplift to 1.51.x)

### DIFF
--- a/components/brave_wallet/common/features.cc
+++ b/components/brave_wallet/common/features.cc
@@ -50,7 +50,12 @@ BASE_FEATURE(kBraveWalletSnsFeature,
 
 BASE_FEATURE(kBraveWalletNftPinningFeature,
              "BraveWalletNftPinning",
-             base::FEATURE_DISABLED_BY_DEFAULT);
+#if BUILDFLAG(IS_ANDROID)
+             base::FEATURE_DISABLED_BY_DEFAULT
+#else
+             base::FEATURE_ENABLED_BY_DEFAULT
+#endif
+);
 
 BASE_FEATURE(kBraveWalletPanelV2Feature,
              "BraveWalletPanelV2",


### PR DESCRIPTION
Uplift of #17758
Resolves https://github.com/brave/brave-browser/issues/29017

Pre-approval checklist: 
- [ ] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [ ] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [ ] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [ ] The associated issue milestone is set to the smallest version that the changes is landed on.