### PR TITLE
Use opaque color for tab background in dark mode tab strip (uplift to 1.51.x)

### DIFF
--- a/browser/ui/tabs/brave_vertical_tab_color_mixer.cc
+++ b/browser/ui/tabs/brave_vertical_tab_color_mixer.cc
@@ -38,7 +38,7 @@ ChromeColorIds GetMappedChromeColorId(BraveColorIds brave_color_id) {
   return kChromiumColorMap.at(brave_color_id);
 }
 
-ui::ColorRecipe GetCustomColorOrDefaultColor(
+ui::ColorTransform GetCustomColorOrDefaultColor(
     const scoped_refptr<ui::ColorProviderManager::ThemeInitializerSupplier>&
         custom_theme,
     BraveColorIds color_id,
@@ -110,8 +110,16 @@ void AddBraveVerticalTabDarkThemeColorMixer(
            SkColorSetRGB(0x68, 0x6D, 0x7D)},
       });
   for (const auto& [color_id, default_color] : kDefaultColorMap) {
-    mixer[color_id] =
+    auto color =
         GetCustomColorOrDefaultColor(key.custom_theme, color_id, default_color);
+    if (color_id == kColorBraveVerticalTabActiveBackground ||
+        color_id == kColorBraveVerticalTabInactiveBackground) {
+      mixer[color_id] = ui::GetResultingPaintColor(
+          /* foreground_transform= */ color,
+          /* background_transform= */ kColorToolbar);
+    } else {
+      mixer[color_id] = color;
+    }
   }
 }
 


### PR DESCRIPTION
Uplift of #17846
Resolves https://github.com/brave/brave-browser/issues/29436

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.