### PR TITLE
NFT pinning related UI fixes

### DIFF
--- a/components/brave_wallet_ui/common/async/lib.ts
+++ b/components/brave_wallet_ui/common/async/lib.ts
@@ -1171,7 +1171,7 @@ export const translateToNftGateway = async (url: string | undefined) => {
   const testUrl =
     isIpfs(trimmedUrl) ? trimmedUrl : await extractIpfsUrl(trimmedUrl)
   return (await braveWalletIpfsService
-    .translateToNFTGatewayURL(testUrl || '')).translatedUrl || ''
+    .translateToNFTGatewayURL(testUrl || '')).translatedUrl || trimmedUrl
 }
 
 export const addLogoToToken = async (token: BraveWallet.BlockchainToken) => {

--- a/components/brave_wallet_ui/common/hooks/nft-pin.ts
+++ b/components/brave_wallet_ui/common/hooks/nft-pin.ts
@@ -10,7 +10,7 @@ import { BraveWallet } from '../../constants/types'
 // selectors
 import { PageSelectors } from '../../page/selectors'
 import { WalletSelectors } from '../selectors'
-import { useSafeWalletSelector, useUnsafePageSelector, useUnsafeWalletSelector } from './use-safe-selector'
+import { useSafePageSelector, useSafeWalletSelector, useUnsafePageSelector, useUnsafeWalletSelector } from './use-safe-selector'
 
 // utils
 import { LOCAL_STORAGE_KEYS } from '../constants/local-storage-keys'
@@ -37,6 +37,8 @@ export function useNftPin () {
   // redux
   const isNftPinningFeatureEnabled = useSafeWalletSelector(WalletSelectors.isNftPinningFeatureEnabled)
   const nftsPinningStatus = useUnsafePageSelector(PageSelectors.nftsPinningStatus)
+  const isAutoPinEnabled = useSafePageSelector(PageSelectors.isAutoPinEnabled)
+
 
   // hooks
   const { isTokenPinningSupported } = useLib()
@@ -83,8 +85,9 @@ export function useNftPin () {
 
   const isIpfsBannerVisible = React.useMemo(() => {
     return isIpfsBannerEnabled &&
-      pinningStatusSummary !== OverallPinningStatus.NO_PINNED_ITEMS
-  }, [isIpfsBannerEnabled, pinningStatusSummary])
+      (pinningStatusSummary !== OverallPinningStatus.NO_PINNED_ITEMS ||
+       !isAutoPinEnabled)
+  }, [isIpfsBannerEnabled, pinningStatusSummary, isAutoPinEnabled])
 
   // methods
   const onToggleShowIpfsBanner = React.useCallback(() => {

--- a/components/brave_wallet_ui/components/desktop/nft-ipfs-banner/nft-ipfs-banner.tsx
+++ b/components/brave_wallet_ui/components/desktop/nft-ipfs-banner/nft-ipfs-banner.tsx
@@ -7,10 +7,10 @@ import * as React from 'react'
 import { useHistory } from 'react-router'
 
 // constants
-import { BraveWallet, WalletRoutes } from '../../../constants/types'
+import { WalletRoutes } from '../../../constants/types'
 
 // utils
-import { useNftPin } from '../../../common/hooks/nft-pin'
+import { OverallPinningStatus, useNftPin } from '../../../common/hooks/nft-pin'
 import { getLocale } from '../../../../common/locale'
 
 // selectors
@@ -21,7 +21,7 @@ import { PageSelectors } from '../../../page/selectors'
 import { Row } from '../../shared/style'
 import { NftPinningStatusAnimation } from '../nft-pinning-status-animation/nft-pinning-status-animation'
 
-export type BannerStatus = 'start' | 'uploading' | 'success'
+export type BannerStatus = 'start' | 'uploading' | 'success' | 'hidden'
 
 interface Props {
   onDismiss: () => void
@@ -47,12 +47,12 @@ export const NftIpfsBanner = ({ onDismiss }: Props) => {
     if (!isAutoPinEnabled) return 'start'
 
     switch (status) {
-      case BraveWallet.TokenPinStatusCode.STATUS_PINNED:
+      case OverallPinningStatus.PINNING_FINISHED:
         return 'success'
-      case BraveWallet.TokenPinStatusCode.STATUS_PINNING_IN_PROGRESS:
+      case OverallPinningStatus.PINNING_IN_PROGRESS:
         return 'uploading'
       default:
-        return 'start'
+        return 'hidden'
     }
   }, [status, pinnableNftsCount, isAutoPinEnabled])
 

--- a/components/brave_wallet_ui/components/desktop/nft-pinning-status-animation/nft-pinning-status-animation.tsx
+++ b/components/brave_wallet_ui/components/desktop/nft-pinning-status-animation/nft-pinning-status-animation.tsx
@@ -5,11 +5,7 @@
 
 import * as React from 'react'
 
-// types
-import { BraveWallet } from '../../../constants/types'
-
-// hooks
-import { useNftPin } from '../../../common/hooks/nft-pin'
+import { OverallPinningStatus, useNftPin } from '../../../common/hooks/nft-pin'
 
 // styles
 import { GifWrapper, Ipfs, IpfsUploading, StatusGif, StyledWrapper } from './nft-pinning-status-animation.style'
@@ -18,25 +14,24 @@ import SuccessGif from '../../../assets/svg-icons/nft-ipfs/success.gif'
 
 interface Props {
   size: string | undefined
-  status: BraveWallet.TokenPinStatusCode
+  status: OverallPinningStatus
   isAutopinEnabled: boolean
 }
 
 export const NftPinningStatusAnimation = ({ size, status, isAutopinEnabled }: Props) => {
-  const { STATUS_PINNING_IN_PROGRESS, STATUS_PINNED } = BraveWallet.TokenPinStatusCode
   const { pinnableNftsCount } = useNftPin()
 
   return (
     <StyledWrapper size={size || '30px'}>
       {(!isAutopinEnabled || pinnableNftsCount === 0) ? (
         <Ipfs size={size} />
-      ) : status === STATUS_PINNING_IN_PROGRESS ? (
+      ) : status === OverallPinningStatus.PINNING_IN_PROGRESS ? (
         <GifWrapper>
           <StatusGif src={UploadingGif} />
           <IpfsUploading />
         </GifWrapper>
       ) : (
-        status === STATUS_PINNED && (
+        status === OverallPinningStatus.PINNING_FINISHED && (
           <GifWrapper>
             <StatusGif src={SuccessGif} />
           </GifWrapper>

--- a/components/brave_wallet_ui/components/desktop/views/portfolio/portfolio-asset.tsx
+++ b/components/brave_wallet_ui/components/desktop/views/portfolio/portfolio-asset.tsx
@@ -423,7 +423,7 @@ export const PortfolioAsset = (props: Props) => {
       return getNftPinningStatus(selectedAsset)
     }
     return undefined
-  }, [nftPinnable, isNftAsset, selectedAsset])
+  }, [nftPinnable, isNftAsset, selectedAsset, nftPinningStatus])
 
   // methods
   const onClickAddAccount = React.useCallback((tabId: AddAccountNavTypes) => () => {
@@ -623,7 +623,7 @@ export const PortfolioAsset = (props: Props) => {
       sendMessageToNftUiFrame(nftDetailsRef.current.contentWindow, command)
     }
 
-    if (nftPinningStatus && selectedAsset && nftDetailsRef?.current) {
+    if (currentNftPinningStatus && nftDetailsRef?.current) {
       const command: UpdateNftPinningStatus = {
         command: NftUiCommand.UpdateNftPinningStatus,
         payload: {
@@ -644,7 +644,7 @@ export const PortfolioAsset = (props: Props) => {
       }))
     }
   }, [nftIframeLoaded, nftDetailsRef, selectedAsset, nftMetadata,
-      networkList, nftMetadataError, nftPinningStatus,
+      networkList, nftMetadataError,
       currentNftPinningStatus, ipfsImageUrl])
 
   React.useEffect(() => {


### PR DESCRIPTION
Resolves https://github.com/brave/brave-browser/issues/29172
Resolves https://github.com/brave/brave-browser/issues/29486
Resolves https://github.com/brave/brave-browser/issues/29487

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-arm64, CI/skip-linux-x64, CI/skip-android, CI/skip-macos, CI/skip-ios, CI/skip-windows-arm64, CI/skip-windows-x64, CI/skip-windows-x86 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
1) Test NFT pinning banner. It should be hidden if the setting is "on" and there is no pinned\in-progress NFTs.
2) Check that NFTs with non-ipfs image url(like https://opensea.io/assets/ethereum/0x70a422c390e8c7682f36611283e8a12254346ee3/1051) are correctly displayed.
3) Test that NFT pinning status is correctly updated while staying on the NFT's detail page.
