### PR TITLE
Enabled onDemand rule to brave vpn

### DIFF
--- a/browser/ui/webui/brave_vpn/brave_vpn_localized_string_provider.cc
+++ b/browser/ui/webui/brave_vpn/brave_vpn_localized_string_provider.cc
@@ -34,6 +34,7 @@ void AddLocalizedStrings(content::WebUIDataSource* html_source) {
       {"braveVpnStatus", IDS_BRAVE_VPN_STATUS},
       {"braveVpnExpires", IDS_BRAVE_VPN_EXPIRES},
       {"braveVpnManageSubscription", IDS_BRAVE_VPN_MANAGE_SUBSCRIPTION},
+      {"braveVpnReconnectAutomatically", IDS_BRAVE_VPN_RECONNECT_AUTOMATICALLY},
       {"braveVpnContactSupport", IDS_BRAVE_VPN_CONTACT_SUPPORT},
       {"braveVpnAbout", IDS_BRAVE_VPN_ABOUT},
       {"braveVpnFeature1", IDS_BRAVE_VPN_FEATURE_1},

--- a/components/brave_vpn/browser/brave_vpn_service.cc
+++ b/components/brave_vpn/browser/brave_vpn_service.cc
@@ -297,6 +297,23 @@ void BraveVpnService::ResetConnectionState() {
   connection_manager_->ResetConnectionState();
 }
 
+void BraveVpnService::EnableOnDemand(bool enable) {
+#if BUILDFLAG(IS_MAC)
+  VLOG(2) << __func__ << ": enabled" << enable;
+  local_prefs_->SetBoolean(prefs::kBraveVPNOnDemandEnabled, enable);
+#endif
+}
+
+void BraveVpnService::GetOnDemandState(GetOnDemandStateCallback callback) {
+#if BUILDFLAG(IS_MAC)
+  std::move(callback).Run(
+      /*available*/ true,
+      /*enabled*/ local_prefs_->GetBoolean(prefs::kBraveVPNOnDemandEnabled));
+#else
+  std::move(callback).Run(false, false);
+#endif
+}
+
 // NOTE(bsclifton): Desktop uses API to create a ticket.
 // Android and iOS directly send an email.
 void BraveVpnService::OnCreateSupportTicket(

--- a/components/brave_vpn/browser/brave_vpn_service.cc
+++ b/components/brave_vpn/browser/brave_vpn_service.cc
@@ -299,8 +299,16 @@ void BraveVpnService::ResetConnectionState() {
 
 void BraveVpnService::EnableOnDemand(bool enable) {
 #if BUILDFLAG(IS_MAC)
-  VLOG(2) << __func__ << ": enabled" << enable;
   local_prefs_->SetBoolean(prefs::kBraveVPNOnDemandEnabled, enable);
+
+  // If not connected, do nothing because on-demand bit will
+  // be applied when new connection starts. Whenever new connection starts,
+  // we create os vpn entry.
+  if (IsConnected()) {
+    VLOG(2) << __func__ << " : reconnect to apply on-demand config(" << enable
+            << "> to current connection";
+    Connect();
+  }
 #endif
 }
 

--- a/components/brave_vpn/browser/brave_vpn_service.h
+++ b/components/brave_vpn/browser/brave_vpn_service.h
@@ -105,6 +105,8 @@ class BraveVpnService :
                            CreateSupportTicketCallback callback) override;
   void GetSupportData(GetSupportDataCallback callback) override;
   void ResetConnectionState() override;
+  void EnableOnDemand(bool enable) override;
+  void GetOnDemandState(GetOnDemandStateCallback callback) override;
 #else
   // mojom::vpn::ServiceHandler
   void GetPurchaseToken(GetPurchaseTokenCallback callback) override;

--- a/components/brave_vpn/browser/connection/ikev2/mac/BUILD.gn
+++ b/components/brave_vpn/browser/connection/ikev2/mac/BUILD.gn
@@ -16,10 +16,12 @@ source_set("mac") {
 
   deps = [
     "//base",
+    "//brave/components/brave_vpn/browser/connection:api",
     "//brave/components/brave_vpn/browser/connection:common",
     "//brave/components/brave_vpn/browser/connection/ikev2",
     "//brave/components/brave_vpn/common",
     "//brave/components/brave_vpn/common/mojom",
+    "//components/prefs",
     "//net",
     "//services/network/public/cpp",
   ]

--- a/components/brave_vpn/browser/connection/ikev2/mac/ikev2_connection_api_impl_mac.h
+++ b/components/brave_vpn/browser/connection/ikev2/mac/ikev2_connection_api_impl_mac.h
@@ -28,6 +28,7 @@ class IKEv2ConnectionAPIImplMac : public SystemVPNConnectionAPIImplBase {
   bool IsPlatformNetworkAvailable() override;
 
   void ObserveVPNConnectionChange();
+  bool IsOnDemandEnabled() const;
 
   id vpn_observer_ = nil;
 };

--- a/components/brave_vpn/browser/connection/ikev2/mac/ikev2_connection_api_impl_mac.mm
+++ b/components/brave_vpn/browser/connection/ikev2/mac/ikev2_connection_api_impl_mac.mm
@@ -18,6 +18,9 @@
 #include "base/files/file_util.h"
 #include "base/notreached.h"
 #include "base/strings/sys_string_conversions.h"
+#include "brave/components/brave_vpn/browser/connection/brave_vpn_connection_manager.h"
+#include "brave/components/brave_vpn/common/pref_names.h"
+#include "components/prefs/pref_service.h"
 #include "services/network/public/cpp/shared_url_loader_factory.h"
 
 // Referenced GuardianConnect implementation.
@@ -188,6 +191,19 @@ void IKEv2ConnectionAPIImplMac::CreateVPNConnectionImpl(
     [vpn_manager setProtocolConfiguration:CreateProtocolConfig(info)];
     [vpn_manager setLocalizedDescription:base::SysUTF8ToNSString(
                                              info.connection_name())];
+    if (IsOnDemandEnabled()) {
+      [vpn_manager setOnDemandEnabled:YES];
+      NEOnDemandRuleConnect* vpn_server_connect_rule =
+          [[NEOnDemandRuleConnect alloc] init];
+      vpn_server_connect_rule.interfaceTypeMatch =
+          NEOnDemandRuleInterfaceTypeAny;
+      vpn_server_connect_rule.probeURL = [NSURL
+          URLWithString:
+              [NSString
+                  stringWithFormat:@"https://%@/vpnsrv/api/server-status",
+                                   base::SysUTF8ToNSString(info.hostname())]];
+      [vpn_manager setOnDemandRules:@[ vpn_server_connect_rule ]];
+    }
 
     [vpn_manager saveToPreferencesWithCompletionHandler:^(NSError* save_error) {
       if (save_error) {
@@ -278,7 +294,17 @@ void IKEv2ConnectionAPIImplMac::DisconnectImpl(const std::string& name) {
       return;
     }
 
-    [[vpn_manager connection] stopVPNTunnel];
+    // Always clear on-demand bit when user disconnect vpn connection.
+    [vpn_manager setOnDemandEnabled:NO];
+    [vpn_manager saveToPreferencesWithCompletionHandler:^(NSError* save_error) {
+      if (save_error) {
+        SetLastConnectionError(
+            base::SysNSStringToUTF8([save_error localizedDescription]));
+        LOG(ERROR) << "Create - saveToPrefs error: "
+                   << GetLastConnectionError();
+      }
+      [[vpn_manager connection] stopVPNTunnel];
+    }];
   }];
 }
 
@@ -342,6 +368,10 @@ bool IKEv2ConnectionAPIImplMac::IsPlatformNetworkAvailable() {
   BOOL isReachable = flags & kSCNetworkReachabilityFlagsReachable;
   BOOL needsConnection = flags & kSCNetworkReachabilityFlagsConnectionRequired;
   return isReachable && !needsConnection;
+}
+
+bool IKEv2ConnectionAPIImplMac::IsOnDemandEnabled() const {
+  return manager_->local_prefs()->GetBoolean(prefs::kBraveVPNOnDemandEnabled);
 }
 
 }  // namespace brave_vpn

--- a/components/brave_vpn/common/brave_vpn_utils.cc
+++ b/components/brave_vpn/common/brave_vpn_utils.cc
@@ -44,6 +44,9 @@ void RegisterVPNLocalStatePrefs(PrefRegistrySimple* registry) {
 #if BUILDFLAG(ENABLE_BRAVE_VPN_WIREGUARD)
   registry->RegisterBooleanPref(prefs::kBraveVPNWireguardEnabled, false);
 #endif
+#if BUILDFLAG(IS_MAC)
+  registry->RegisterBooleanPref(prefs::kBraveVPNOnDemandEnabled, false);
+#endif
 }
 
 }  // namespace

--- a/components/brave_vpn/common/brave_vpn_utils_unittest.cc
+++ b/components/brave_vpn/common/brave_vpn_utils_unittest.cc
@@ -225,6 +225,15 @@ TEST(BraveVPNUtilsUnitTest, FeatureTest) {
 }
 
 #if BUILDFLAG(IS_MAC)
+TEST(BraveVPNUtilsUnitTest, DefaultPrefsTest) {
+  TestingPrefServiceSimple local_state_pref_service;
+  brave_vpn::RegisterLocalStatePrefs(local_state_pref_service.registry());
+
+  // Off by default.
+  EXPECT_FALSE(local_state_pref_service.GetBoolean(
+      brave_vpn::prefs::kBraveVPNOnDemandEnabled));
+}
+
 TEST(BraveVPNUtilsUnitTest, IsBraveVPNWireguardEnabledMac) {
   {
     TestingPrefServiceSimple local_state_pref_service;

--- a/components/brave_vpn/common/mojom/brave_vpn.mojom
+++ b/components/brave_vpn/common/mojom/brave_vpn.mojom
@@ -73,6 +73,16 @@ interface ServiceHandler {
   [EnableIfNot=is_android]
   ResetConnectionState();
 
+  // on demand and automatic reconnect both have same meaning.
+  // When on demand is enabled, vpn is connected(automatically) at anytime when network request is made.
+  [EnableIfNot=is_android]
+  EnableOnDemand(bool enable);
+
+  // true to |available| when on demand feature is supported.
+  // |enabled| is only valid when |available| is true.
+  [EnableIfNot=is_android]
+  GetOnDemandState() => (bool available, bool enabled);
+
   [EnableIf=is_android]
   GetPurchaseToken() => (string token);
 };

--- a/components/brave_vpn/common/pref_names.h
+++ b/components/brave_vpn/common/pref_names.h
@@ -37,6 +37,12 @@ inline constexpr char kBraveVPNWireguardFallbackDialog[] =
 inline constexpr char kBraveVPNWireguardEnabled[] =
     "brave.brave_vpn.wireguard_enabled";
 #endif
+
+#if BUILDFLAG(IS_MAC)
+inline constexpr char kBraveVPNOnDemandEnabled[] =
+    "brave.brave_vpn.on_demand_enabled";
+#endif
+
 inline constexpr char kBraveVPNWireguardProfileCredentials[] =
     "brave.brave_vpn.wireguard.profile_credentials";
 inline constexpr char kBraveVPNEnvironment[] = "brave.brave_vpn.env";

--- a/components/brave_vpn/resources/panel/components/settings-panel/index.tsx
+++ b/components/brave_vpn/resources/panel/components/settings-panel/index.tsx
@@ -8,6 +8,7 @@ import { getLocale } from '../../../../../common/locale'
 import * as S from './style'
 import { CaratStrongLeftIcon } from 'brave-ui/components/icons'
 import getPanelBrowserAPI from '../../api/panel_browser_api'
+import Toggle from '$web-components/toggle'
 
 interface Props {
   closeSettingsPanel: React.MouseEventHandler<HTMLButtonElement>
@@ -15,6 +16,11 @@ interface Props {
 }
 
 function SettingsPanel (props: Props) {
+  const [onDemand, setOnDemand] =
+    React.useState({ available: false, enabled: false})
+
+  getPanelBrowserAPI().serviceHandler.getOnDemandState().then(setOnDemand)
+
   const handleClick = (entry: string) => {
     getPanelBrowserAPI().panelHandler.openVpnUI(entry)
   }
@@ -26,6 +32,10 @@ function SettingsPanel (props: Props) {
     }
     handleClick(entry)
   }
+  const handleToggleChange = (isOn: boolean) => {
+    getPanelBrowserAPI().serviceHandler.enableOnDemand(isOn)
+  }
+
   return (
     <S.Box>
       <S.PanelContent>
@@ -40,6 +50,20 @@ function SettingsPanel (props: Props) {
           </S.BackButton>
         </S.PanelHeader>
         <S.List>
+          {onDemand.available && <li>
+            <S.ReconnectBox>
+              <span>
+                {getLocale('braveVpnReconnectAutomatically')}
+              </span>
+              <Toggle
+                isOn={onDemand.enabled}
+                onChange={handleToggleChange}
+                brand='vpn'
+                size='sm'
+                aria-label='Reconnect automatically'
+              />
+            </S.ReconnectBox>
+          </li>}
           <li>
             <a href="#" onClick={handleClick.bind(this, 'manage')} onKeyDown={handleKeyDown.bind(this, 'manage')}>
               {getLocale('braveVpnManageSubscription')}

--- a/components/brave_vpn/resources/panel/components/settings-panel/index.tsx
+++ b/components/brave_vpn/resources/panel/components/settings-panel/index.tsx
@@ -19,7 +19,9 @@ function SettingsPanel (props: Props) {
   const [onDemand, setOnDemand] =
     React.useState({ available: false, enabled: false})
 
-  getPanelBrowserAPI().serviceHandler.getOnDemandState().then(setOnDemand)
+  React.useEffect(() => {
+    getPanelBrowserAPI().serviceHandler.getOnDemandState().then(setOnDemand)
+  }, [])
 
   const handleClick = (entry: string) => {
     getPanelBrowserAPI().panelHandler.openVpnUI(entry)

--- a/components/brave_vpn/resources/panel/components/settings-panel/style.ts
+++ b/components/brave_vpn/resources/panel/components/settings-panel/style.ts
@@ -14,8 +14,8 @@ export const Box = styled.div`
 export const List = styled.ul`
   list-style-type: none;
   padding: 0;
-  margin: 0;
-  text-align: center;
+  margin: 8px;
+  text-align: left;
 
   li {
     margin-bottom: 28px;
@@ -76,5 +76,20 @@ export const BackButton = styled.button`
 
   svg {
     fill: ${(p) => p.theme.color.interactive05};
+  }
+`
+
+export const ReconnectBox = styled.div`
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  justify-content: space-between;
+  width: 100%;
+
+  span {
+    font-family: ${(p) => p.theme.fontFamily.heading};
+    font-size: 13px;
+    font-weight: 600;
+    color: ${(p) => p.theme.color.interactive05};
   }
 `

--- a/components/brave_vpn/resources/panel/components/settings-panel/style.ts
+++ b/components/brave_vpn/resources/panel/components/settings-panel/style.ts
@@ -15,7 +15,7 @@ export const List = styled.ul`
   list-style-type: none;
   padding: 0;
   margin: 8px;
-  text-align: left;
+  text-align: start;
 
   li {
     margin-bottom: 28px;

--- a/components/brave_vpn/resources/panel/stories/locale.ts
+++ b/components/brave_vpn/resources/panel/stories/locale.ts
@@ -23,6 +23,7 @@ provideStrings({
   braveVpnStatus: 'Status',
   braveVpnExpires: 'Expires',
   braveVpnManageSubscription: 'Manage subscription',
+  braveVpnReconnectAutomatically: 'Reconnect automatically',
   braveVpnContactSupport: 'Contact technical support',
   braveVpnAbout: 'About',
   braveVpnErrorPanelHeader: 'Brave VPN',

--- a/components/brave_vpn/resources/panel/stories/locale.ts
+++ b/components/brave_vpn/resources/panel/stories/locale.ts
@@ -20,6 +20,7 @@ provideStrings({
   braveVpnPurchased: 'Already purchased VPN?',
   braveVpnPoweredBy: 'Powered by',
   braveVpnSettings: 'Settings',
+  braveVpnSettingsPanelHeader: 'Settings',
   braveVpnStatus: 'Status',
   braveVpnExpires: 'Expires',
   braveVpnManageSubscription: 'Manage subscription',

--- a/components/brave_vpn/resources/panel/stories/mock-data/api.ts
+++ b/components/brave_vpn/resources/panel/stories/mock-data/api.ts
@@ -46,6 +46,11 @@ BraveVPN.setPanelBrowserApiForTesting({
     createSupportTicket: (email: string, subject: string, body: string) => Promise.resolve({
       success: true,
       response: 'OK'
-    })
+    }),
+    getOnDemandState: () => Promise.resolve({
+      available: false,
+      enabled: false
+    }),
+    enableOnDemand: (enable: boolean) => {}
   }
 })

--- a/components/brave_vpn/resources/panel/stories/mock-data/api.ts
+++ b/components/brave_vpn/resources/panel/stories/mock-data/api.ts
@@ -48,7 +48,7 @@ BraveVPN.setPanelBrowserApiForTesting({
       response: 'OK'
     }),
     getOnDemandState: () => Promise.resolve({
-      available: false,
+      available: true,
       enabled: false
     }),
     enableOnDemand: (enable: boolean) => {}

--- a/components/resources/brave_vpn_strings.grdp
+++ b/components/resources/brave_vpn_strings.grdp
@@ -80,6 +80,10 @@
     Expires
   </message>
 
+  <message name="IDS_BRAVE_VPN_RECONNECT_AUTOMATICALLY" desc="Label to toggle reconnect toggle">
+    Reconnect automatically
+  </message>
+
   <message name="IDS_BRAVE_VPN_MANAGE_SUBSCRIPTION" desc="Link text to redirect user to manage account page">
     Manage subscription
   </message>


### PR DESCRIPTION
fix https://github.com/brave/brave-browser/issues/29406

<img width="343" alt="Screenshot 2024-03-07 at 8 52 48 PM" src="https://github.com/brave/brave-core/assets/6786187/5ea5c6b0-c231-47ba-bb10-d23cd064a453">

NOTE: This panel's design is outdated but not updated as this PR is only for adding toggle button.

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves 

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-arm64, CI/skip-linux-x64, CI/skip-android, CI/skip-macos, CI/skip-ios, CI/skip-windows-arm64, CI/skip-windows-x64, CI/skip-windows-x86 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

1. Set purchased state
2. Turn on on-demand from vpn panel's setting
3. Connect to VPN
4. Get some sleep or restart
5. Wake computer up and check it's connected
6. Turn off on-demand from vpn panel's setting
7. Check VPN is still connected
8. Turn on on-demand and check it's connected
9. Get some sleep or restart
10. Wake computer up and check it's still connected

NOTE: When vpn is on with on-demand, user can't disconnect via menubar.
User can only control vpn state with menubar when on-demand is not used.
When on-demand is used, only vpn panel can disconnect.
Or user can disconnect with Preferences > Network. After unchecking on-demand option and save, it's disconnected.