### PR TITLE
Get global accelerators on Mac for brave://commands

### DIFF
--- a/app/command_utils.cc.template
+++ b/app/command_utils.cc.template
@@ -45,7 +45,7 @@ base::StringPiece GetCommandName(int command_id) {
   CHECK(it != kCommandInfos.end())
       << "Unknown command " << command_id
       << ". This function should only be used for known "
-         "commands (i.e. commands in |GetCommandInfo|). "
+         "commands (i.e. commands in |GetCommands()|). "
          "This command should probably be added.";
   return it->second.data();
 }

--- a/app/command_utils_unittest.cc
+++ b/app/command_utils_unittest.cc
@@ -14,7 +14,7 @@
 #include "testing/gtest/include/gtest/gtest.h"
 
 // Note: If this test fails because an accelerated command isn't present just
-// add the missing command to |commands::GetCommandInfo| in command_utils.h.
+// add the missing command to |commands::GetCommands| in command_utils.h.
 TEST(CommandUtilsUnitTest, AllAcceleratedCommandsShouldBeAvailable) {
   base::flat_set<int> excluded_commands = {
       IDC_RUN_SCREEN_AI_VISUAL_ANNOTATIONS};

--- a/browser/ui/BUILD.gn
+++ b/browser/ui/BUILD.gn
@@ -359,6 +359,8 @@ source_set("ui") {
 
     if (is_mac) {
       sources += [
+        "views/commands/default_accelerators_mac.h",
+        "views/commands/default_accelerators_mac.mm",
         "views/frame/brave_browser_frame_mac.h",
         "views/frame/brave_browser_frame_mac.mm",
         "views/frame/brave_browser_non_client_frame_view_mac.h",

--- a/browser/ui/views/commands/default_accelerators_mac.h
+++ b/browser/ui/views/commands/default_accelerators_mac.h
@@ -1,0 +1,22 @@
+/* Copyright (c) 2023 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_BROWSER_UI_VIEWS_COMMANDS_DEFAULT_ACCELERATORS_MAC_H_
+#define BRAVE_BROWSER_UI_VIEWS_COMMANDS_DEFAULT_ACCELERATORS_MAC_H_
+
+#include <vector>
+
+#include "chrome/browser/ui/views/accelerator_table.h"
+
+namespace commands {
+
+// Returns shortcuts mapped to global menu, which can be changed dynamically
+// by the OS too. This is why we don't have a static table for these.
+// (System Preference > Keyboard > Keyboard Shortcuts > App shortcuts)
+std::vector<AcceleratorMapping> GetGlobalAccelerators();
+
+}  // namespace commands
+
+#endif  // BRAVE_BROWSER_UI_VIEWS_COMMANDS_DEFAULT_ACCELERATORS_MAC_H_

--- a/browser/ui/views/commands/default_accelerators_mac.mm
+++ b/browser/ui/views/commands/default_accelerators_mac.mm
@@ -28,14 +28,18 @@ namespace commands {
 namespace {
 
 bool CanConvertToAcceleratorMapping(int command_id) {
-  if (!command_id) {
-    return command_id;
+  if (command_id == 0) {
+    return false;
   }
 
   return base::Contains(commands::GetCommands(), command_id);
 }
 
 bool CanConvertToAcceleratorMapping(NSMenuItem* item) {
+  if (item.hasSubmenu) {
+    return false;
+  }
+
   if (auto command_id = static_cast<int>(item.tag);
       !CanConvertToAcceleratorMapping(command_id)) {
     return false;

--- a/browser/ui/views/commands/default_accelerators_views.cc
+++ b/browser/ui/views/commands/default_accelerators_views.cc
@@ -8,14 +8,25 @@
 #include "brave/browser/ui/commands/accelerator_service.h"
 #include "chrome/browser/ui/views/accelerator_table.h"
 
+#if BUILDFLAG(IS_MAC)
+#include "brave/browser/ui/views/commands/default_accelerators_mac.h"
+#endif  // BUILDFLAG(IS_MAC)
+
 namespace commands {
 
 Accelerators GetDefaultAccelerators() {
   Accelerators defaults;
-  for (const auto& accelerator_info : GetAcceleratorList()) {
-    defaults[accelerator_info.command_id].push_back(
-        ui::Accelerator(accelerator_info.keycode, accelerator_info.modifiers));
-  }
+  auto add_to_accelerators = [&defaults](const AcceleratorMapping& mapping) {
+    defaults[mapping.command_id].push_back(
+        ui::Accelerator(mapping.keycode, mapping.modifiers));
+  };
+
+  base::ranges::for_each(GetAcceleratorList(), add_to_accelerators);
+#if BUILDFLAG(IS_MAC)
+  // TODO(sko) These accelerators should be flagged as unmodifiable unless we
+  // can modify the OS settings. See the comment in default_accelerator_mac.h
+  base::ranges::for_each(GetGlobalAccelerators(), add_to_accelerators);
+#endif  // BUILDFLAG(IS_MAC)
   return defaults;
 }
 

--- a/browser/ui/views/frame/vertical_tab_strip_region_view_mac.mm
+++ b/browser/ui/views/frame/vertical_tab_strip_region_view_mac.mm
@@ -60,10 +60,8 @@ std::u16string VerticalTabStripRegionView::GetShortcutTextForNewTabButton(
   // So we should look into main menus in order to get the accurate accelerator
   // for new tab command.
 
-  //   auto* menu = [NSApp mainMenu];
   NSMenuItem* item =
       findMenuItemWithCommandRecursively([NSApp mainMenu], IDC_NEW_TAB);
-  //   NSMenuItem* item = [[NSApp mainMenu] itemWithTag:IDC_NEW_TAB];
   DCHECK(item);
 
   return base::SysNSStringToUTF16(keyCombinationForMenuItem(item));

--- a/components/commands/browser/accelerator_pref_manager.cc
+++ b/components/commands/browser/accelerator_pref_manager.cc
@@ -8,6 +8,7 @@
 #include <string>
 #include <vector>
 
+#include "base/check.h"
 #include "base/containers/flat_map.h"
 #include "base/notreached.h"
 #include "base/strings/string_number_conversions.h"
@@ -74,7 +75,9 @@ void AcceleratorPrefManager::AddAccelerator(
     const ui::Accelerator& accelerator) {
   ScopedDictPrefUpdate update(prefs_, kAcceleratorsPrefs);
   auto* list = update->EnsureList(base::NumberToString(command_id));
-  list->Append(ToCodesString(accelerator));
+  auto accelerator_string = ToCodesString(accelerator);
+  DCHECK(!accelerator_string.empty());
+  list->Append(accelerator_string);
 }
 
 void AcceleratorPrefManager::RemoveAccelerator(


### PR DESCRIPTION

On Mac, accelerator mechanism is different from that of other platforms.
Make a shim to fill the accelerators properly.


* Refactor modifier and name mapping
With a single table, we can avoid changing multiple places in order to
add or remove modifier names.

<img width="631" alt="image" src="https://user-images.githubusercontent.com/5474642/229398595-ac41338d-ee64-4436-9eda-04fbb62be96f.png">


<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/29373

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-arm64, CI/skip-linux-x64, CI/skip-android, CI/skip-macos, CI/skip-ios, CI/skip-windows-arm64, CI/skip-windows-x64, CI/skip-windows-x86 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [ ] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
* Go to brave://commands with the feature flag is enabled.
* Default accelerators on Mac should appear.
