### PR TITLE
fix(wallet): NFTs Tab Layout Bugs

### DIFF
--- a/components/brave_wallet_ui/components/desktop/views/nfts/components/nfts.styles.tsx
+++ b/components/brave_wallet_ui/components/desktop/views/nfts/components/nfts.styles.tsx
@@ -8,14 +8,6 @@ import { WalletButton } from '../../../../shared/style'
 import Ipfs from '../../../../../assets/svg-icons/nft-ipfs/ipfs.svg'
 import PlusIcon from '../../../../../assets/svg-icons/plus-icon.svg'
 
-export const StyledWrapper = styled.div`
-  display: flex;
-  flex-direction: column;
-  width: 100%;
-  justify-content: flex-start;
-  height: 100%;
-`
-
 export const FilterTokenRow = styled.div`
   display: flex;
   align-items: center;

--- a/components/brave_wallet_ui/components/desktop/views/nfts/components/nfts.tsx
+++ b/components/brave_wallet_ui/components/desktop/views/nfts/components/nfts.tsx
@@ -33,7 +33,6 @@ import { NFTGridViewItem } from '../../portfolio/components/nft-grid-view/nft-gr
 
 // styles
 import {
-  StyledWrapper,
   FilterTokenRow,
   IpfsButton,
   IpfsIcon,
@@ -113,7 +112,7 @@ export const Nfts = (props: Props) => {
   }, [filteredNfts])
 
   return (
-    <StyledWrapper>
+    <>
       <FilterTokenRow>
         <SearchBar
           placeholder={getLocale('braveWalletSearchText')}
@@ -150,6 +149,6 @@ export const Nfts = (props: Props) => {
           onHideForm={toggleShowAddNftModal}
         />
       }
-    </StyledWrapper>
+    </>
   )
 }

--- a/components/brave_wallet_ui/components/desktop/wallet-page-wrapper/wallet-page-wrapper.tsx
+++ b/components/brave_wallet_ui/components/desktop/wallet-page-wrapper/wallet-page-wrapper.tsx
@@ -76,9 +76,7 @@ export const WalletPageWrapper = (props: Props) => {
       walletLocation.includes(WalletRoutes.Send) ||
       walletLocation.includes(WalletRoutes.Swap) ||
       walletLocation.includes(WalletRoutes.FundWalletPageStart) ||
-      walletLocation.includes(WalletRoutes.DepositFundsPageStart) ||
-      walletLocation.includes(WalletRoutes.LocalIpfsNode) ||
-      walletLocation.includes(WalletRoutes.InspectNfts)
+      walletLocation.includes(WalletRoutes.DepositFundsPageStart)
     )
 
   const headerTitle = AllNavOptions.find((option) =>


### PR DESCRIPTION
## Description 
- Fixes a bug where NFTs were overflowing the wallet card on scroll
- Fixes a bug where the `NFT Pinning` page was showing the `Header` and `Navigation`

<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves <https://github.com/brave/brave-browser/issues/29478>

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-arm64, CI/skip-linux-x64, CI/skip-android, CI/skip-macos, CI/skip-ios, CI/skip-windows-arm64, CI/skip-windows-x64, CI/skip-windows-x86 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
1. Add a bunch of NFTs and then go to the NFTs tab
2. The NFTs should not overflow the wallet card on scroll.
3. Click on `Learn More` on the `NFT Pinning` banner. 
4. There should not be a `Header` and `Navigation` on this page.


Before:

https://user-images.githubusercontent.com/40611140/229683110-064d5684-5ea5-46b0-aaad-c902f9f6702c.mov

After:

https://user-images.githubusercontent.com/40611140/229683304-face8ef0-5ec5-4b0b-b376-af1a7c6af9c3.mov
