### PR TITLE
Remove ScopedClosureRunner from DetectUncertainFuture. (uplift to 1.51.x)

### DIFF
--- a/browser/brave_stats/brave_stats_updater.cc
+++ b/browser/brave_stats/brave_stats_updater.cc
@@ -322,7 +322,7 @@ void BraveStatsUpdater::QueueServerPing() {
   stats_preconditions_barrier_ = base::BarrierClosure(
       num_closures,
       base::BindOnce(&BraveStatsUpdater::StartServerPingStartupTimer,
-                     base::Unretained(this)));
+                     weak_ptr_factory_.GetWeakPtr()));
   if (!referrals_initialized) {
     pref_change_registrar_ = std::make_unique<PrefChangeRegistrar>();
     pref_change_registrar_->Init(pref_service_);
@@ -338,9 +338,9 @@ void BraveStatsUpdater::QueueServerPing() {
 }
 
 void BraveStatsUpdater::DetectUncertainFuture() {
-  auto callback = base::BindOnce(&BraveStatsUpdater::OnDetectUncertainFuture,
-                                 base::Unretained(this));
-  brave_rpill::DetectUncertainFuture(base::BindOnce(std::move(callback)));
+  brave_rpill::DetectUncertainFuture(
+      base::BindOnce(&BraveStatsUpdater::OnDetectUncertainFuture,
+                     weak_ptr_factory_.GetWeakPtr()));
 }
 
 void BraveStatsUpdater::OnReferralInitialization() {

--- a/browser/brave_stats/brave_stats_updater.h
+++ b/browser/brave_stats/brave_stats_updater.h
@@ -12,6 +12,7 @@
 #include "base/functional/callback.h"
 #include "base/memory/raw_ptr.h"
 #include "base/memory/scoped_refptr.h"
+#include "base/memory/weak_ptr.h"
 #include "base/scoped_observation.h"
 #include "brave/components/brave_stats/browser/brave_stats_updater_util.h"
 #include "services/network/public/cpp/shared_url_loader_factory.h"
@@ -111,6 +112,7 @@ class BraveStatsUpdater {
   scoped_refptr<network::SharedURLLoaderFactory> testing_url_loader_factory_;
 
   std::unique_ptr<misc_metrics::GeneralBrowserUsage> general_browser_usage_p3a_;
+  base::WeakPtrFactory<BraveStatsUpdater> weak_ptr_factory_{this};
 };
 
 // Registers the preferences used by BraveStatsUpdater


### PR DESCRIPTION
Uplift of #17837
Resolves https://github.com/brave/brave-browser/issues/29254

Pre-approval checklist: 
- [ ] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.