### PR TITLE
Trap and report error when hostname is null/empty (uplift to 1.51.x)

### DIFF
--- a/components/brave_vpn/browser/connection/win/utils.cc
+++ b/components/brave_vpn/browser/connection/win/utils.cc
@@ -329,6 +329,14 @@ RasOperationResult CreateEntry(const std::wstring& entry_name,
                                const std::wstring& hostname,
                                const std::wstring& username,
                                const std::wstring& password) {
+  // `RasSetEntryProperties` can have problems if fields are empty.
+  // Specifically, it will crash if `hostname` is NULL. Entry name
+  // is already validated.
+  if (hostname.empty()) {
+    VLOG(2) << __func__ << " Can't create entry with empty `hostname`";
+    return GetRasErrorResult("`hostname` is empty");
+  }
+
   auto connection_result = CheckConnection(entry_name);
   if (connection_result == CheckConnectionResult::CONNECTING ||
       connection_result == CheckConnectionResult::CONNECTED) {


### PR DESCRIPTION
Manual uplift of https://github.com/brave/brave-core/pull/17917
Fixes https://github.com/brave/brave-browser/issues/28940
Fixes https://github.com/brave/brave-browser/issues/29502
Fixes https://github.com/brave/brave-browser/issues/29477

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.