### PR TITLE
Prevents a crash on Android when Activity is not foreground and there is an attempt to set a default browser dialog (uplift to 1.50.x)

### DIFF
--- a/android/java/org/chromium/chrome/browser/set_default_browser/BraveSetDefaultBrowserUtils.java
+++ b/android/java/org/chromium/chrome/browser/set_default_browser/BraveSetDefaultBrowserUtils.java
@@ -25,6 +25,7 @@ import androidx.appcompat.app.AppCompatActivity;
 
 import org.chromium.base.BravePreferenceKeys;
 import org.chromium.base.ContextUtils;
+import org.chromium.base.Log;
 import org.chromium.chrome.R;
 import org.chromium.chrome.browser.onboarding.OnboardingPrefManager;
 import org.chromium.chrome.browser.preferences.SharedPreferencesManager;
@@ -33,6 +34,7 @@ import org.chromium.components.embedder_support.util.UrlConstants;
 import org.chromium.ui.widget.Toast;
 
 public class BraveSetDefaultBrowserUtils {
+    private static final String TAG = "BSDBrowserUtils";
     public static final String ANDROID_SETUPWIZARD_PACKAGE_NAME = "com.google.android.setupwizard";
     public static final String ANDROID_PACKAGE_NAME = "android";
     public static final String BRAVE_BLOG_URL = "https://brave.com/privacy-features/";
@@ -98,6 +100,18 @@ public class BraveSetDefaultBrowserUtils {
         if (!isBottomSheetVisible) {
             isBottomSheetVisible = true;
 
+            try {
+                SetDefaultBrowserBottomSheetFragment bottomSheetDialog =
+                        SetDefaultBrowserBottomSheetFragment.newInstance(isFromMenu);
+
+                bottomSheetDialog.show(activity.getSupportFragmentManager(),
+                        "SetDefaultBrowserBottomSheetFragment");
+            } catch (IllegalStateException e) {
+                // That exception could be thrown when Activity is not in the foreground.
+                Log.e(TAG, "showBraveSetDefaultBrowserDialog error: " + e.getMessage());
+                return;
+            }
+
             if (!isFromMenu) {
                 int braveDefaultModalCount = SharedPreferencesManager.getInstance().readInt(
                         BravePreferenceKeys.BRAVE_SET_DEFAULT_BOTTOM_SHEET_COUNT);
@@ -105,12 +119,6 @@ public class BraveSetDefaultBrowserUtils {
                         BravePreferenceKeys.BRAVE_SET_DEFAULT_BOTTOM_SHEET_COUNT,
                         braveDefaultModalCount + 1);
             }
-
-            SetDefaultBrowserBottomSheetFragment bottomSheetDialog =
-                    SetDefaultBrowserBottomSheetFragment.newInstance(isFromMenu);
-
-            bottomSheetDialog.show(
-                    activity.getSupportFragmentManager(), "SetDefaultBrowserBottomSheetFragment");
         }
     }
 


### PR DESCRIPTION
Uplift of #17916
Resolves https://github.com/brave/brave-browser/issues/29428

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.