### PR TITLE
Redirect cc fixes

### DIFF
--- a/build/commands/lib/util.js
+++ b/build/commands/lib/util.js
@@ -552,11 +552,6 @@ const util = {
       goma_dir: config.realGomaDir,
       real_gomacc: path.join(config.realGomaDir, 'gomacc'),
     }
-    // Temprorary workaround for VS2022 lld-link PDB issue. Should be resolved
-    // in May 2022 update.
-    if (process.platform === 'win32') {
-      gnArgs = {...gnArgs, is_component_build: true}
-    }
 
     const buildArgsStr = util.buildArgsToString(gnArgs)
     util.run('gn', ['gen', config.nativeRedirectCCDir, '--args="' + buildArgsStr + '"'], options)

--- a/tools/redirect_cc/redirect_cc.cc
+++ b/tools/redirect_cc/redirect_cc.cc
@@ -108,15 +108,20 @@ class RedirectCC {
       if (!compile_file_found && base::Contains(kCompileFileFlags, arg_piece)) {
         compile_file_found = true;
         if (arg_idx + 1 >= argc_) {
-          LOG(ERROR) << "No arg after compile flag";
+          LOG(ERROR) << "No arg after compile flag " << arg_piece;
           return -1;
         }
 
         // Trim a file path to look for a similar file in
         // brave/chromium_src.
         base::FilePath::StringPieceType path_cc = argv_[arg_idx + 1];
-        // Most common case - a file is located directly in src/...
-        if (base::StartsWith(path_cc, chromium_src_dir_with_slash)) {
+        if (!path_cc.empty() && path_cc[0] == arg_piece[0]) {
+          // That's not a file path, but another compiler parameter. This syntax
+          // is used by asm compiler. We can safely ignore this, becaused we
+          // don't redirect asm files.
+          path_cc = base::FilePath::StringPieceType();
+        } else if (base::StartsWith(path_cc, chromium_src_dir_with_slash)) {
+          // Most common case - a file is located directly in src/...
           path_cc.remove_prefix(chromium_src_dir_with_slash.size());
         } else {
           // Less common case - a file is generated and located in the `out`


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Remove VS2022 workaround and fix warning on Windows ARM builds:
```
[0405/160445.636080:WARNING:redirect_cc.cc(138)] unhandled path: -oobj/third_party/ffmpeg/ffmpeg_internal/autorename_libavcodec_aarch64_h264cmc_neon.obj
```

Windows ARM command line for `.S` files is built here:
https://github.com/chromium/chromium/blob/39354ccb106a7d348875d99664f85180b802e7a0/build/toolchain/win/toolchain.gni#L254

Resolves https://github.com/brave/brave-browser/issues/29522

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-arm64, CI/skip-linux-x64, CI/skip-android, CI/skip-macos, CI/skip-ios, CI/skip-windows-arm64, CI/skip-windows-x64, CI/skip-windows-x86 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

