### PR TITLE
feat(wallet): Add Label Reveal to Wallet Nav

### DIFF
--- a/components/brave_wallet_ui/components/desktop/wallet-nav/wallet-nav-button/wallet-nav-button.style.ts
+++ b/components/brave_wallet_ui/components/desktop/wallet-nav/wallet-nav-button/wallet-nav-button.style.ts
@@ -5,7 +5,7 @@
 
 import styled from 'styled-components'
 import Icon from '@brave/leo/react/icon'
-import { WalletButton } from '../../../shared/style'
+import { WalletButton, Text } from '../../../shared/style'
 
 export const StyledButton = styled(WalletButton) <{ isSelected?: boolean }>`
   display: flex;
@@ -32,9 +32,18 @@ export const StyledButton = styled(WalletButton) <{ isSelected?: boolean }>`
   &:last-child {
     margin-bottom: 0px;
   }
+  transition-duration: inherit;
 `
 
 export const ButtonIcon = styled(Icon)`
   --leo-icon-size: 24px;
   color: var(--nav-button-color);
+  margin-right: var(--icon-margin-right);
+  transition-duration: inherit;
+`
+
+export const ButtonText = styled(Text)`
+  color: var(--nav-button-color);
+  display: var(--display-text);
+  transition-duration: inherit;
 `

--- a/components/brave_wallet_ui/components/desktop/wallet-nav/wallet-nav-button/wallet-nav-button.tsx
+++ b/components/brave_wallet_ui/components/desktop/wallet-nav/wallet-nav-button/wallet-nav-button.tsx
@@ -12,22 +12,15 @@ import { getLocale } from '../../../../../common/locale'
 // Types
 import { NavOption } from '../../../../constants/types'
 
-// Components
-import { NavTooltip } from '../../../shared/nav-tooltip/nav-tooltip'
-
 // Styled Components
-import { StyledButton, ButtonIcon } from './wallet-nav-button.style'
+import { StyledButton, ButtonIcon, ButtonText } from './wallet-nav-button.style'
 
 export interface Props {
   option: NavOption
-  isSwap?: boolean
 }
 
 export const WalletNavButton = (props: Props) => {
-  const { option, isSwap } = props
-
-  // State
-  const [active, setActive] = React.useState(false)
+  const { option } = props
 
   // Routing
   const history = useHistory()
@@ -38,29 +31,18 @@ export const WalletNavButton = (props: Props) => {
     history.push(option.route)
   }, [option.route])
 
-  const showTip = React.useCallback(() => {
-    setActive(true)
-  }, [])
-
-  const hideTip = React.useCallback(() => {
-    setActive(false)
-  }, [])
-
   return (
     <StyledButton
-      onMouseEnter={showTip}
-      onMouseLeave={hideTip}
       onClick={onClick}
       isSelected={walletLocation.includes(option.route)}
     >
       <ButtonIcon name={option.icon} />
-      <NavTooltip
-        text={getLocale(option.name)}
-        orientation='right'
-        distance={60}
-        showTip={active}
-        isSwap={isSwap}
-      />
+      <ButtonText
+        textSize='14px'
+        isBold={true}
+      >
+        {getLocale(option.name)}
+      </ButtonText>
     </StyledButton>
   )
 }

--- a/components/brave_wallet_ui/components/desktop/wallet-nav/wallet-nav.style.ts
+++ b/components/brave_wallet_ui/components/desktop/wallet-nav/wallet-nav.style.ts
@@ -6,6 +6,8 @@
 import styled from 'styled-components'
 
 export const Wrapper = styled.div`
+  --display-text: none;
+  --icon-margin-right: 0px;
   display: flex;
   align-items: center;
   justify-content: center;
@@ -19,6 +21,11 @@ export const Wrapper = styled.div`
   overflow: visible;
   z-index: 10;
   padding: 0px 8px;
+  transition-duration: 0.1s;
+  &:hover {
+    --display-text: flex;
+    --icon-margin-right: 16px;
+  }
 `
 
 export const Section = styled.div<{ showBorder?: boolean }>`
@@ -26,7 +33,9 @@ export const Section = styled.div<{ showBorder?: boolean }>`
   align-items: center;
   justify-content: center;
   flex-direction: column;
+  width: 100%;
   padding: 8px 0px;
+  transition-duration: inherit;
   border-bottom: ${(p) => p.showBorder
     ? `1px solid var(--nav-border)`
     : 'none'};

--- a/components/brave_wallet_ui/components/desktop/wallet-nav/wallet-nav.tsx
+++ b/components/brave_wallet_ui/components/desktop/wallet-nav/wallet-nav.tsx
@@ -48,12 +48,12 @@ export const WalletNav = (props: Props) => {
     <Wrapper>
       <Section showBorder={true}>
         {NavOptions.map((option) =>
-          <WalletNavButton isSwap={isSwap} option={option} key={option.id} />
+          <WalletNavButton option={option} key={option.id} />
         )}
       </Section>
       <Section>
         {BuySendSwapDepositOptions.map((option) =>
-          <WalletNavButton isSwap={isSwap} option={option} key={option.id} />
+          <WalletNavButton option={option} key={option.id} />
         )}
       </Section>
     </Wrapper>


### PR DESCRIPTION
## Description 
Adds a `Label` reveal to the `Wallet Nav` on hovering the nav.

<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves <https://github.com/brave/brave-browser/issues/29529>

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-arm64, CI/skip-linux-x64, CI/skip-android, CI/skip-macos, CI/skip-ios, CI/skip-windows-arm64, CI/skip-windows-x64, CI/skip-windows-x86 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
1. Move your mouse over the `Wallet Nav`, it should expand and reveal the button labels.
2. Move your mouse out of the `Wallet Nav`, it should collapse back down and hide the button labels.

https://user-images.githubusercontent.com/40611140/230130880-98cc5c13-f44d-40ab-9160-f240b497f2e6.mov
