### PR TITLE
Makes a workaround to avoid crash on Android 8 with windowIsTranslucent attr (uplift to 1.50.x)

### DIFF
--- a/android/brave_java_resources.gni
+++ b/android/brave_java_resources.gni
@@ -970,6 +970,7 @@ brave_java_resources = [
   "java/res/values-night/brave_styles.xml",
   "java/res/values-sw600dp/brave_dimens.xml",
   "java/res/values-v21/brave_styles.xml",
+  "java/res/values-v26/brave_styles.xml",
   "java/res/values/array.xml",
   "java/res/values/brave_attrs.xml",
   "java/res/values/brave_colors.xml",

--- a/android/java/res/values-v26/brave_styles.xml
+++ b/android/java/res/values-v26/brave_styles.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright (c) 2023 The Brave Authors. All rights reserved.
+     This Source Code Form is subject to the terms of the Mozilla Public
+     License, v. 2.0. If a copy of the MPL was not distributed with this file,
+     You can obtain one at https://mozilla.org/MPL/2.0/.
+-->
+
+<resources>
+    <style name="BraveTranslucentMaterial" parent="Theme.MaterialComponents.Light.NoActionBar">
+        <item name="android:windowIsTranslucent">false</item>
+        <item name="android:windowBackground">@color/translucent_activity_background_color</item>
+        <item name="android:windowContentOverlay">@null</item>
+        <item name="android:windowNoTitle">true</item>
+        <item name="android:backgroundDimEnabled">false</item>
+    </style>
+</resources>


### PR DESCRIPTION
Uplift of #17950
Resolves https://github.com/brave/brave-browser/issues/29538

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.