### PR TITLE
Fixes NTP Settings rewards description button. (uplift to 1.51.x)

### DIFF
--- a/components/brave_new_tab_ui/containers/newTab/index.tsx
+++ b/components/brave_new_tab_ui/containers/newTab/index.tsx
@@ -319,7 +319,7 @@ class NewTabPage extends React.Component<Props, State> {
   startRewards = () => {
     const { rewardsState } = this.props.newTabData
     if (!rewardsState.rewardsEnabled ||
-      rewardsState.externalWallet?.status === mojom.WalletStatus.kConnected) {
+      rewardsState.externalWallet?.status === mojom.WalletStatus.kNotConnected) {
       chrome.braveRewards.openRewardsPanel()
     } else {
       chrome.braveRewards.enableAds()


### PR DESCRIPTION
Fixes https://github.com/brave/brave-browser/issues/29389
Uplift of #17924

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.