### PR TITLE
fix(wallet): Allow Wallet Wrapper to Scroll

### DIFF
--- a/components/brave_wallet_ui/components/desktop/views/market/index.tsx
+++ b/components/brave_wallet_ui/components/desktop/views/market/index.tsx
@@ -18,7 +18,7 @@ import { BraveWallet, WalletRoutes, WalletState } from '../../../../constants/ty
 import { WalletActions } from '../../../../common/actions'
 
 // Styled Components
-import { LoadIcon, LoadIconWrapper, MarketDataIframe, StyledWrapper } from './style'
+import { LoadIcon, LoadIconWrapper, MarketDataIframe } from './style'
 
 // Utils
 import { WalletPageActions } from '../../../../page/actions'
@@ -155,7 +155,7 @@ export const MarketView = () => {
   }, [])
 
   return (
-    <StyledWrapper>
+    <>
       {isLoadingCoinMarketData
         ? <LoadIconWrapper>
           <LoadIcon />
@@ -167,6 +167,6 @@ export const MarketView = () => {
           sandbox="allow-scripts allow-same-origin"
         />
       }
-    </StyledWrapper>
+    </>
   )
 }

--- a/components/brave_wallet_ui/components/desktop/views/market/style.ts
+++ b/components/brave_wallet_ui/components/desktop/views/market/style.ts
@@ -10,15 +10,6 @@ export interface StyleProps {
   alignment: 'right' | 'left'
 }
 
-export const StyledWrapper = styled.div`
-  display: flex;
-  flex-direction: column;
-  align-items: flex-start;
-  justify-content: flex-start;
-  width: 100%;
-  margin-bottom: 24px;
-`
-
 export const TopRow = styled.div`
   display: flex;
   flex-direction: row;
@@ -77,6 +68,7 @@ export const LoadIconWrapper = styled.div`
 `
 export const MarketDataIframe = styled.iframe`
   width: 100%;
+  height: 100%;
   min-height: calc(100vh - 172px);
   border: none;
 `

--- a/components/brave_wallet_ui/components/desktop/wallet-nav/wallet-nav.style.ts
+++ b/components/brave_wallet_ui/components/desktop/wallet-nav/wallet-nav.style.ts
@@ -15,7 +15,7 @@ export const Wrapper = styled.div`
   background-color: var(--nav-background);
   border-radius: 12px;
   border: 1px solid var(--nav-border);
-  position: fixed;
+  position: absolute;
   top: 100px;
   left: 32px;
   overflow: visible;

--- a/components/brave_wallet_ui/components/desktop/wallet-page-wrapper/wallet-page-wrapper.style.ts
+++ b/components/brave_wallet_ui/components/desktop/wallet-page-wrapper/wallet-page-wrapper.style.ts
@@ -6,24 +6,22 @@
 import styled from 'styled-components'
 import * as leo from '@brave/leo/tokens/css'
 
+const minCardHeight = 595
+
 export const Wrapper = styled.div<{ noPadding?: boolean }>`
   position: fixed;
-  top: 0;
-  bottom: 0;
-  left: 0;
-  right: 0;
+  top: 0px;
+  bottom: 0px;
+  left: 0px;
+  right: 0px;
   display: flex;
   flex-direction: column;
   align-items: center;
   justify-content: flex-start;
-  background-color: ${leo.color.container.highlight};
   overflow: hidden;
+  overflow-y: auto;
   z-index: 10;
   padding: ${(p) => p.noPadding ? '0px' : '100px 0px'};
-  @media (prefers-color-scheme: dark) {
-    /* #17171F does not exist in design system */
-    background-color: #17171F;
-  }
 `
 
 export const LayoutCardWrapper = styled.div<{
@@ -55,7 +53,7 @@ export const ContainerCard = styled.div<
   align-items: center;
   padding: 20px;
   width: 100%;
-  min-height: 500px;
+  min-height: ${minCardHeight}px;
   max-height: calc(100vh - 132px);
   overflow-y: ${(p) => p.cardOverflow ?? 'hidden'};
   position: relative;
@@ -64,12 +62,25 @@ export const ContainerCard = styled.div<
   }
 `
 
-export const BackgroundWrapper = styled.div`
+export const StaticBackground = styled.div`
   position: fixed;
-  top: 0;
-  bottom: 0;
-  left: 0;
-  right: 0;
+  top: 0px;
+  bottom: 0px;
+  left: 0px;
+  right: 0px;
+  background-color: ${leo.color.container.highlight};
+  @media (prefers-color-scheme: dark) {
+    /* #17171F does not exist in design system */
+    background-color: #17171F;
+  }
+`
+
+export const BackgroundGradientWrapper = styled.div`
+  position: fixed;
+  top: 0px;
+  bottom: 0px;
+  left: 0px;
+  right: 0px;
   opacity: 0.5;
   background-color: ${(p) => p.theme.color.background01};
 `
@@ -120,4 +131,13 @@ export const BackgroundGradientBottomLayer = styled.div`
   @media (prefers-color-scheme: dark) {
     background: #141C38;
   }
+`
+
+export const BlockForHeight = styled.div`
+  top: 100px;
+  width: 1px;
+  height: calc(${minCardHeight}px + 30px);
+  display: flex;
+  position: absolute;
+  left: 0px;
 `

--- a/components/brave_wallet_ui/components/desktop/wallet-page-wrapper/wallet-page-wrapper.tsx
+++ b/components/brave_wallet_ui/components/desktop/wallet-page-wrapper/wallet-page-wrapper.tsx
@@ -32,10 +32,12 @@ import {
   Wrapper,
   LayoutCardWrapper,
   ContainerCard,
-  BackgroundWrapper,
+  StaticBackground,
+  BackgroundGradientWrapper,
   BackgroundGradientTopLayer,
   BackgroundGradientMiddleLayer,
-  BackgroundGradientBottomLayer
+  BackgroundGradientBottomLayer,
+  BlockForHeight
 } from './wallet-page-wrapper.style'
 
 export interface Props {
@@ -83,37 +85,41 @@ export const WalletPageWrapper = (props: Props) => {
     walletLocation.includes(option.route))?.name ?? ''
 
   return (
-    <Wrapper noPadding={noPadding}>
-      {showNavigationAndHeader && walletLocation !== WalletRoutes.Swap &&
-        <TabHeader title={headerTitle} />
-      }
-      {showNavigationAndHeader &&
-        <WalletNav isSwap={walletLocation === WalletRoutes.Swap} />
-      }
-      {!isWalletLocked &&
-        <FeatureRequestButton />
-      }
+    <>
+      <StaticBackground />
       {!hideBackground &&
-        <BackgroundWrapper>
+        <BackgroundGradientWrapper>
           <BackgroundGradientTopLayer />
           <BackgroundGradientMiddleLayer />
           <BackgroundGradientBottomLayer />
-        </BackgroundWrapper>
+        </BackgroundGradientWrapper>
       }
-      {wrapContentInBox ? (
-        <LayoutCardWrapper
-          maxWidth={cardWidth}
-        >
-          <ContainerCard
-            cardOverflow={cardOverflow}
+      <Wrapper noPadding={noPadding}>
+        {showNavigationAndHeader && walletLocation !== WalletRoutes.Swap &&
+          <TabHeader title={headerTitle} />
+        }
+        {showNavigationAndHeader &&
+          <WalletNav isSwap={walletLocation === WalletRoutes.Swap} />
+        }
+        {!isWalletLocked &&
+          <FeatureRequestButton />
+        }
+        <BlockForHeight />
+        {wrapContentInBox ? (
+          <LayoutCardWrapper
+            maxWidth={cardWidth}
           >
-            {children}
-          </ContainerCard>
-        </LayoutCardWrapper>
-      ) : (
-        children
-      )}
-    </Wrapper>
+            <ContainerCard
+              cardOverflow={cardOverflow}
+            >
+              {children}
+            </ContainerCard>
+          </LayoutCardWrapper>
+        ) : (
+          children
+        )}
+      </Wrapper>
+    </>
   )
 }
 

--- a/components/brave_wallet_ui/page/screens/shared-screen-components/tab-header/tab-header.style.ts
+++ b/components/brave_wallet_ui/page/screens/shared-screen-components/tab-header/tab-header.style.ts
@@ -26,7 +26,7 @@ export const HeaderWrapper = styled.div`
   right: 0;
   width: 100vw;
   box-sizing: border-box;
-  position: fixed;
+  position: absolute;
   z-index: 10;
 `
 


### PR DESCRIPTION
## Description 
Allows the `Wallet Wrapper` to scroll when the `browser window height` is shorter than the `min-height` of the `nav` and `card`

<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves <https://github.com/brave/brave-browser/issues/29564>

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-arm64, CI/skip-linux-x64, CI/skip-android, CI/skip-macos, CI/skip-ios, CI/skip-windows-arm64, CI/skip-windows-x64, CI/skip-windows-x86 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
1. Go to the `Wallet` and collapse the `browser window height` until it is smaller than the `nav` and `card
2. You should be able to scroll up or down to see everything.

Before:

https://user-images.githubusercontent.com/40611140/230498375-f99e3cac-f4cc-4b80-9dd0-497c9c0d5060.mov

After:

https://user-images.githubusercontent.com/40611140/230498387-062bd661-8d13-47a6-bf5b-3657b3eb9236.mov
