### PR TITLE
Add missing return statement when NFT discovery disabled (uplift to 1.51.x)

### DIFF
--- a/components/brave_wallet/browser/asset_discovery_manager.cc
+++ b/components/brave_wallet/browser/asset_discovery_manager.cc
@@ -820,6 +820,7 @@ void AssetDiscoveryManager::DiscoverNFTsOnAllSupportedChains(
   // Users must opt-in for NFT discovery
   if (!prefs_->GetBoolean(kBraveWalletNftDiscoveryEnabled)) {
     CompleteDiscoverAssets({}, triggered_by_accounts_added);
+    return;
   }
 
   auto it_eth = account_addresses.find(mojom::CoinType::ETH);


### PR DESCRIPTION
Uplift of #17960
Resolves https://github.com/brave/brave-browser/issues/29575

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.