### PR TITLE
Integrate multichain support for NFT grid

### DIFF
--- a/android/java/org/chromium/chrome/browser/app/domain/NetworkModel.java
+++ b/android/java/org/chromium/chrome/browser/app/domain/NetworkModel.java
@@ -194,7 +194,7 @@ public class NetworkModel implements JsonRpcServiceObserver {
     }
 
     /**
-     * Create a network model to handle either default or local state (onscreen e.g. {@link
+     * Create a network selector model to handle either default or local state (onscreen e.g. {@link
      * org.chromium.chrome.browser.crypto_wallet.fragments.PortfolioFragment}). Local network
      * selection can be used by many views so make sure to use the same key which acts as a contract
      * between the view and the selection activity.

--- a/android/java/org/chromium/chrome/browser/app/domain/PortfolioModel.java
+++ b/android/java/org/chromium/chrome/browser/app/domain/PortfolioModel.java
@@ -79,9 +79,9 @@ public class PortfolioModel implements BraveWalletServiceObserverImplDelegate {
         mBraveWalletService = braveWalletService;
         mAssetRatioService = assetRatioService;
         mSharedData = sharedData;
-        _mNftModels = new MutableLiveData<>(Collections.emptyList());
+        _mNftModels = new MutableLiveData<>();
         mNftModels = _mNftModels;
-        _mIsDiscoveringUserAssets = new MutableLiveData<>(false);
+        _mIsDiscoveringUserAssets = new MutableLiveData<>();
         mIsDiscoveringUserAssets = _mIsDiscoveringUserAssets;
         addServiceObservers();
     }
@@ -146,7 +146,6 @@ public class PortfolioModel implements BraveWalletServiceObserverImplDelegate {
             BraveWalletBaseActivity braveWalletBaseActivity,
             Callbacks.Callback1<PortfolioHelper> callback) {
         synchronized (mLock) {
-            clear();
             if (mJsonRpcService == null) {
                 return;
             }
@@ -187,11 +186,6 @@ public class PortfolioModel implements BraveWalletServiceObserverImplDelegate {
     @Override
     public void onDiscoverAssetsCompleted(BlockchainToken[] discoveredAssets) {
         _mIsDiscoveringUserAssets.postValue(false);
-    }
-
-    // Clear state
-    public void clear() {
-        _mNftModels.postValue(Collections.emptyList());
     }
 
     private void addServiceObservers() {

--- a/android/java/org/chromium/chrome/browser/app/domain/PortfolioModel.java
+++ b/android/java/org/chromium/chrome/browser/app/domain/PortfolioModel.java
@@ -142,7 +142,7 @@ public class PortfolioModel implements BraveWalletServiceObserverImplDelegate {
         mBraveWalletService.discoverAssetsOnAllSupportedChains();
     }
 
-    public void fetchAssets(NetworkInfo selectedNetwork,
+    public void fetchNonNftAssets(NetworkInfo selectedNetwork,
             BraveWalletBaseActivity braveWalletBaseActivity,
             Callbacks.Callback1<PortfolioHelper> callback) {
         synchronized (mLock) {
@@ -166,7 +166,7 @@ public class PortfolioModel implements BraveWalletServiceObserverImplDelegate {
                                                         mAllNetworkInfos, accountInfos);
                                         mPortfolioHelper.setSelectedNetworks(
                                                 NetworkUtils.nonTestNetwork(mAllNetworkInfos));
-                                        mPortfolioHelper.fetchAllAssetsAndDetails(callback);
+                                        mPortfolioHelper.fetchNonNftAssetsAndDetails(callback);
                                     });
                         } else {
                             mKeyringService.getKeyringInfo(
@@ -177,7 +177,7 @@ public class PortfolioModel implements BraveWalletServiceObserverImplDelegate {
                                                         mAllNetworkInfos, keyringInfo.accountInfos);
                                         mPortfolioHelper.setSelectedNetworks(
                                                 Arrays.asList(selectedNetwork));
-                                        mPortfolioHelper.fetchAllAssetsAndDetails(callback);
+                                        mPortfolioHelper.fetchNonNftAssetsAndDetails(callback);
                                     });
                         }
                     });

--- a/android/java/org/chromium/chrome/browser/app/domain/PortfolioModel.java
+++ b/android/java/org/chromium/chrome/browser/app/domain/PortfolioModel.java
@@ -189,6 +189,10 @@ public class PortfolioModel implements BraveWalletServiceObserverImplDelegate {
         _mIsDiscoveringUserAssets.postValue(false);
     }
 
+    public void clearNftModels() {
+        _mNftModels.postValue(Collections.emptyList());
+    }
+
     private void addServiceObservers() {
         if (mBraveWalletService != null) {
             BraveWalletServiceObserverImpl walletServiceObserver =

--- a/android/java/org/chromium/chrome/browser/app/domain/PortfolioModel.java
+++ b/android/java/org/chromium/chrome/browser/app/domain/PortfolioModel.java
@@ -35,6 +35,7 @@ import org.chromium.chrome.browser.crypto_wallet.util.AsyncUtils;
 import org.chromium.chrome.browser.crypto_wallet.util.JavaUtils;
 import org.chromium.chrome.browser.crypto_wallet.util.NetworkUtils;
 import org.chromium.chrome.browser.crypto_wallet.util.PortfolioHelper;
+import org.chromium.chrome.browser.crypto_wallet.util.TokenUtils;
 import org.chromium.chrome.browser.crypto_wallet.util.WalletConstants;
 import org.chromium.chrome.browser.crypto_wallet.util.WalletUtils;
 import org.chromium.mojo.bindings.Callbacks;
@@ -142,7 +143,7 @@ public class PortfolioModel implements BraveWalletServiceObserverImplDelegate {
         mBraveWalletService.discoverAssetsOnAllSupportedChains();
     }
 
-    public void fetchNonNftAssets(NetworkInfo selectedNetwork,
+    public void fetchAssetsByType(TokenUtils.TokenType type, NetworkInfo selectedNetwork,
             BraveWalletBaseActivity braveWalletBaseActivity,
             Callbacks.Callback1<PortfolioHelper> callback) {
         synchronized (mLock) {
@@ -165,7 +166,7 @@ public class PortfolioModel implements BraveWalletServiceObserverImplDelegate {
                                                         mAllNetworkInfos, accountInfos);
                                         mPortfolioHelper.setSelectedNetworks(
                                                 NetworkUtils.nonTestNetwork(mAllNetworkInfos));
-                                        mPortfolioHelper.fetchNonNftAssetsAndDetails(callback);
+                                        mPortfolioHelper.fetchAssetsAndDetails(type, callback);
                                     });
                         } else {
                             mKeyringService.getKeyringInfo(
@@ -176,7 +177,7 @@ public class PortfolioModel implements BraveWalletServiceObserverImplDelegate {
                                                         mAllNetworkInfos, keyringInfo.accountInfos);
                                         mPortfolioHelper.setSelectedNetworks(
                                                 Arrays.asList(selectedNetwork));
-                                        mPortfolioHelper.fetchNonNftAssetsAndDetails(callback);
+                                        mPortfolioHelper.fetchAssetsAndDetails(type, callback);
                                     });
                         }
                     });

--- a/android/java/org/chromium/chrome/browser/app/helpers/ImageLoader.java
+++ b/android/java/org/chromium/chrome/browser/app/helpers/ImageLoader.java
@@ -8,17 +8,20 @@ package org.chromium.chrome.browser.app.helpers;
 import static org.chromium.ui.base.ViewUtils.dpToPx;
 
 import android.content.Context;
+import android.content.res.Resources;
 import android.graphics.Bitmap;
 import android.graphics.Rect;
 import android.graphics.drawable.BitmapDrawable;
 import android.graphics.drawable.Drawable;
 import android.text.TextUtils;
 import android.util.Base64;
+import android.util.DisplayMetrics;
 import android.webkit.URLUtil;
 import android.widget.ImageView;
 
 import com.bumptech.glide.Glide;
 import com.bumptech.glide.Priority;
+import com.bumptech.glide.RequestManager;
 import com.bumptech.glide.load.DataSource;
 import com.bumptech.glide.load.engine.DiskCacheStrategy;
 import com.bumptech.glide.load.engine.GlideException;
@@ -36,7 +39,7 @@ import org.xmlpull.v1.XmlPullParserException;
 import org.xmlpull.v1.XmlPullParserFactory;
 import org.xmlpull.v1.XmlSerializer;
 
-import org.chromium.base.Log;
+import org.chromium.base.ContextUtils;
 import org.chromium.chrome.browser.WebContentsFactory;
 import org.chromium.chrome.browser.crypto_wallet.util.Utils;
 import org.chromium.chrome.browser.crypto_wallet.util.WalletConstants;
@@ -74,19 +77,20 @@ public class ImageLoader {
     /**
      * Downloads an image from a given URL, including support for GIF and SVG image types.
      * @param url URL of the image to download.
-     * @param context Android context used by Glide for applying transformations.
+     * @param RequestManager Glide request manager for applying transformations.
      * @param isCircular When {@code true}, a circular transformation will be applied.
      * @param imageView ImageView where the downloaded image will be set.
      * @param callback Callback used to notify if the image has been set correctly. It can be {@code
      *         null}.
      */
-    public static void downloadImage(String url, final Context context, final boolean isCircular,
-            final ImageView imageView, final Callback callback) {
+    public static void downloadImage(String url, final RequestManager requestManager,
+            final boolean isCircular, final ImageView imageView, final Callback callback) {
         if (!isValidImgUrl(url)) {
             if (callback != null) callback.onLoadFailed();
             return;
         }
 
+        Resources resources = ContextUtils.getApplicationContext().getResources();
         Profile profile = Utils.getProfile(false);
         if (isSvg(url)) {
             final String validUrl;
@@ -136,10 +140,11 @@ public class ImageLoader {
                             imageFetcherFacade = null;
                         } else {
                             BitmapDrawable bitmapDrawable =
-                                    new BitmapDrawable(context.getResources(), bestBitmap);
+                                    new BitmapDrawable(resources, bestBitmap);
                             imageFetcherFacade = new ImageFetcherFacade(bitmapDrawable);
                         }
-                        loadImage(imageFetcherFacade, context, isCircular, imageView, callback);
+                        loadImage(imageFetcherFacade, requestManager, isCircular, imageView,
+                                callback);
                     });
         } else {
             ImageFetcher imageFetcher = ImageFetcherFactory.createImageFetcher(
@@ -149,16 +154,17 @@ public class ImageLoader {
                         Params.create(new GURL(url), UNUSED_CLIENT_NAME), gifImage -> {
                             ImageFetcherFacade imageFetcherFacade =
                                     new ImageFetcherFacade(gifImage.getData());
-                            loadImage(imageFetcherFacade, context, isCircular, imageView, callback);
+                            loadImage(imageFetcherFacade, requestManager, isCircular, imageView,
+                                    callback);
                         });
             } else {
                 imageFetcher.fetchImage(
                         Params.create(new GURL(url), UNUSED_CLIENT_NAME), bitmap -> {
-                            BitmapDrawable bitmapDrawable =
-                                    new BitmapDrawable(context.getResources(), bitmap);
+                            BitmapDrawable bitmapDrawable = new BitmapDrawable(resources, bitmap);
                             ImageFetcherFacade imageFetcherFacade =
                                     new ImageFetcherFacade(bitmapDrawable);
-                            loadImage(imageFetcherFacade, context, isCircular, imageView, callback);
+                            loadImage(imageFetcherFacade, requestManager, isCircular, imageView,
+                                    callback);
                         });
             }
         }
@@ -270,17 +276,18 @@ public class ImageLoader {
         }
     }
 
-    private static void loadImage(ImageFetcherFacade imageFetcherFacade, Context context,
-            boolean isCircular, ImageView imageView, Callback callback) {
+    private static void loadImage(ImageFetcherFacade imageFetcherFacade,
+            RequestManager requestManager, boolean isCircular, ImageView imageView,
+            Callback callback) {
         if (imageFetcherFacade == null
                 || (imageFetcherFacade.data == null && imageFetcherFacade.drawable == null)) {
             if (callback != null) callback.onLoadFailed();
             return;
         }
-        Glide.with(context)
+        requestManager
                 .load(imageFetcherFacade.data != null ? imageFetcherFacade.data
                                                       : imageFetcherFacade.drawable)
-                .transform(getTransformations(context, isCircular))
+                .transform(getTransformations(isCircular))
                 .diskCacheStrategy(DiskCacheStrategy.NONE)
                 .priority(Priority.IMMEDIATE)
                 .listener(new RequestListener<Drawable>() {
@@ -304,12 +311,16 @@ public class ImageLoader {
         }
     }
 
-    private static BitmapTransformation[] getTransformations(Context context, boolean isCircular) {
+    private static BitmapTransformation[] getTransformations(boolean isCircular) {
         if (isCircular) {
             return new BitmapTransformation[] {new FitCenter(), new CircleCrop()};
         }
+
+        DisplayMetrics displayMetrics =
+                ContextUtils.getApplicationContext().getResources().getDisplayMetrics();
         return new BitmapTransformation[] {new FitCenter(),
-                new RoundedCorners(dpToPx(context, WalletConstants.RECT_ROUNDED_CORNERS_DP))};
+                new RoundedCorners(
+                        dpToPx(displayMetrics, WalletConstants.RECT_ROUNDED_CORNERS_DP))};
     }
 
     /**
@@ -402,7 +413,7 @@ public class ImageLoader {
 
     /**
      * Callback used to notify if the image has been downloaded successfully.
-     * @see #downloadImage(String, Context, boolean, ImageView, Callback) /
+     * @see #downloadImage(String, RequestManager, boolean, ImageView, Callback)
      */
     public interface Callback {
         boolean onLoadFailed();

--- a/android/java/org/chromium/chrome/browser/app/helpers/ImageLoader.java
+++ b/android/java/org/chromium/chrome/browser/app/helpers/ImageLoader.java
@@ -5,6 +5,8 @@
 
 package org.chromium.chrome.browser.app.helpers;
 
+import static org.chromium.ui.base.ViewUtils.dpToPx;
+
 import android.content.Context;
 import android.graphics.Bitmap;
 import android.graphics.Rect;
@@ -58,8 +60,6 @@ import java.util.List;
 import java.util.Locale;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-
-import static org.chromium.ui.base.ViewUtils.dpToPx;
 
 public class ImageLoader {
     private static final String TAG = "ImageLoader";
@@ -306,10 +306,10 @@ public class ImageLoader {
 
     private static BitmapTransformation[] getTransformations(Context context, boolean isCircular) {
         if (isCircular) {
-            return new BitmapTransformation[] {
-                    new FitCenter(), new CircleCrop()};
+            return new BitmapTransformation[] {new FitCenter(), new CircleCrop()};
         }
-        return new BitmapTransformation[] {new FitCenter(), new RoundedCorners(dpToPx(context, WalletConstants.RECT_ROUNDED_CORNERS_DP))};
+        return new BitmapTransformation[] {new FitCenter(),
+                new RoundedCorners(dpToPx(context, WalletConstants.RECT_ROUNDED_CORNERS_DP))};
     }
 
     /**

--- a/android/java/org/chromium/chrome/browser/app/helpers/ImageLoader.java
+++ b/android/java/org/chromium/chrome/browser/app/helpers/ImageLoader.java
@@ -59,6 +59,8 @@ import java.util.Locale;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import static org.chromium.ui.base.ViewUtils.dpToPx;
+
 public class ImageLoader {
     private static final String TAG = "ImageLoader";
     private static final List<String> ANIMATED_LIST = Arrays.asList(".gif");
@@ -275,19 +277,18 @@ public class ImageLoader {
             if (callback != null) callback.onLoadFailed();
             return;
         }
-        try {
-            Glide.with(context)
-                    .load(imageFetcherFacade.data != null ? imageFetcherFacade.data
-                                                          : imageFetcherFacade.drawable)
-                    .transform(getTransformations(isCircular))
-                    .diskCacheStrategy(DiskCacheStrategy.NONE)
-                    .priority(Priority.IMMEDIATE)
-                    .listener(new RequestListener<Drawable>() {
-                        @Override
-                        public boolean onLoadFailed(GlideException glideException, Object model,
-                                Target<Drawable> target, boolean isFirstResource) {
-                            return callback != null && callback.onLoadFailed();
-                        }
+        Glide.with(context)
+                .load(imageFetcherFacade.data != null ? imageFetcherFacade.data
+                                                      : imageFetcherFacade.drawable)
+                .transform(getTransformations(context, isCircular))
+                .diskCacheStrategy(DiskCacheStrategy.NONE)
+                .priority(Priority.IMMEDIATE)
+                .listener(new RequestListener<Drawable>() {
+                    @Override
+                    public boolean onLoadFailed(GlideException glideException, Object model,
+                            Target<Drawable> target, boolean isFirstResource) {
+                        return callback != null && callback.onLoadFailed();
+                    }
 
                         @Override
                         public boolean onResourceReady(Drawable resource, Object model,
@@ -303,12 +304,12 @@ public class ImageLoader {
         }
     }
 
-    private static BitmapTransformation[] getTransformations(boolean isCircular) {
+    private static BitmapTransformation[] getTransformations(Context context, boolean isCircular) {
         if (isCircular) {
             return new BitmapTransformation[] {
-                    new FitCenter(), new RoundedCorners(32), new CircleCrop()};
+                    new FitCenter(), new CircleCrop()};
         }
-        return new BitmapTransformation[] {new FitCenter(), new RoundedCorners(32)};
+        return new BitmapTransformation[] {new FitCenter(), new RoundedCorners(dpToPx(context, WalletConstants.RECT_ROUNDED_CORNERS_DP))};
     }
 
     /**

--- a/android/java/org/chromium/chrome/browser/app/helpers/ImageLoader.java
+++ b/android/java/org/chromium/chrome/browser/app/helpers/ImageLoader.java
@@ -352,7 +352,7 @@ public class ImageLoader {
         if (!isValidImgUrl(url)) return false;
         // Converts the URL to lowercase to make the matching case-insensitive.
         url = url.toLowerCase(Locale.ENGLISH);
-        return url.endsWith(".gif");
+        return url.endsWith(".gif") || url.endsWith("=gif");
     }
 
     private static boolean isValidImgUrl(String url) {

--- a/android/java/org/chromium/chrome/browser/app/helpers/ImageLoader.java
+++ b/android/java/org/chromium/chrome/browser/app/helpers/ImageLoader.java
@@ -300,18 +300,14 @@ public class ImageLoader {
                         return callback != null && callback.onLoadFailed();
                     }
 
-                        @Override
-                        public boolean onResourceReady(Drawable resource, Object model,
-                                Target<Drawable> target, DataSource dataSource,
-                                boolean isFirstResource) {
-                            return callback != null && callback.onResourceReady(resource, target);
-                        }
-                    })
-                    .into(imageView);
-        } catch (IllegalArgumentException e) {
-            Log.e(TAG, "loadImage error: " + e.getMessage());
-            if (callback != null) callback.onLoadFailed();
-        }
+                    @Override
+                    public boolean onResourceReady(Drawable resource, Object model,
+                            Target<Drawable> target, DataSource dataSource,
+                            boolean isFirstResource) {
+                        return callback != null && callback.onResourceReady(resource, target);
+                    }
+                })
+                .into(imageView);
     }
 
     private static BitmapTransformation[] getTransformations(

--- a/android/java/org/chromium/chrome/browser/crypto_wallet/activities/AccountDetailActivity.java
+++ b/android/java/org/chromium/chrome/browser/crypto_wallet/activities/AccountDetailActivity.java
@@ -44,6 +44,7 @@ import org.chromium.chrome.browser.crypto_wallet.model.WalletListItemModel;
 import org.chromium.chrome.browser.crypto_wallet.observers.ApprovedTxObserver;
 import org.chromium.chrome.browser.crypto_wallet.util.AssetUtils;
 import org.chromium.chrome.browser.crypto_wallet.util.PortfolioHelper;
+import org.chromium.chrome.browser.crypto_wallet.util.TokenUtils;
 import org.chromium.chrome.browser.crypto_wallet.util.Utils;
 import org.chromium.chrome.browser.init.AsyncInitializationActivity;
 import org.chromium.chrome.browser.util.LiveDataUtil;
@@ -181,8 +182,8 @@ public class AccountDetailActivity
             LiveDataUtil.observeOnce(
                     mWalletModel.getCryptoModel().getNetworkModel().mCryptoNetworks,
                     allNetworks -> {
-                        Utils.getTxExtraInfo(new WeakReference<>(this), allNetworks,
-                                selectedNetwork, accounts, null, false,
+                        Utils.getTxExtraInfo(new WeakReference<>(this), TokenUtils.TokenType.ALL,
+                                allNetworks, selectedNetwork, accounts, null, false,
                                 (assetPrices, fullTokenList, nativeAssetsBalances,
                                         blockchainTokensBalances) -> {
                                     for (AccountInfo accountInfo : accounts) {

--- a/android/java/org/chromium/chrome/browser/crypto_wallet/activities/AssetDetailActivity.java
+++ b/android/java/org/chromium/chrome/browser/crypto_wallet/activities/AssetDetailActivity.java
@@ -325,9 +325,9 @@ public class AssetDetailActivity
                             R.drawable.ic_eth, mAsset.name, mAsset.symbol, mAsset.tokenId, "", "");
                     LiveDataUtil.observeOnce(
                             mWalletModel.getNetworkModel().mCryptoNetworks, allNetworks -> {
-                                Utils.getTxExtraInfo(new WeakReference<>(this), allNetworks,
-                                        mAssetNetwork, accountInfos, new BlockchainToken[] {mAsset},
-                                        false,
+                                Utils.getTxExtraInfo(new WeakReference<>(this),
+                                        TokenUtils.TokenType.ALL, allNetworks, mAssetNetwork,
+                                        accountInfos, new BlockchainToken[] {mAsset}, false,
                                         (assetPrices, fullTokenList, nativeAssetsBalances,
                                                 blockchainTokensBalances) -> {
                                             thisAssetItemModel.setBlockchainToken(mAsset);

--- a/android/java/org/chromium/chrome/browser/crypto_wallet/activities/AssetDetailActivity.java
+++ b/android/java/org/chromium/chrome/browser/crypto_wallet/activities/AssetDetailActivity.java
@@ -144,7 +144,7 @@ public class AssetDetailActivity
         } else {
             Utils.setBlockiesBitmapCustomAsset(mExecutor, mHandler, null, mContractAddress,
                     mAssetSymbol, getResources().getDisplayMetrics().density, assetTitleText, this,
-                    false, (float) 0.5);
+                    false, (float) 0.5, true);
         }
 
         TextView assetPriceText = findViewById(R.id.asset_price_text);

--- a/android/java/org/chromium/chrome/browser/crypto_wallet/activities/AssetDetailActivity.java
+++ b/android/java/org/chromium/chrome/browser/crypto_wallet/activities/AssetDetailActivity.java
@@ -450,10 +450,6 @@ public class AssetDetailActivity
             final String cryptoBalanceString =
                     String.format(Locale.ENGLISH, "%.4f %s", thisAccountBalance, mAsset.symbol);
 
-            // If NFT, only show the account that owns
-            // it (i.e. balance = 1)
-            if (mAsset.isNft && thisAccountBalance != 1.) continue;
-
             WalletListItemModel model = new WalletListItemModel(R.drawable.ic_eth, accountInfo.name,
                     accountInfo.address, fiatBalanceString, cryptoBalanceString,
                     accountInfo.isImported);

--- a/android/java/org/chromium/chrome/browser/crypto_wallet/activities/BuySendSwapActivity.java
+++ b/android/java/org/chromium/chrome/browser/crypto_wallet/activities/BuySendSwapActivity.java
@@ -1643,7 +1643,7 @@ public class BuySendSwapActivity extends BraveWalletBaseActivity
         } else {
             Utils.setBlockiesBitmapCustomAsset(mExecutor, mHandler, null, token.contractAddress,
                     token.symbol, getResources().getDisplayMetrics().density, assetText, this, true,
-                    (float) 0.5);
+                    (float) 0.5, true);
         }
         if (buySend && (token.isErc721 || token.isNft)) {
             mFromValueBlock.setVisibility(View.GONE);
@@ -1751,7 +1751,7 @@ public class BuySendSwapActivity extends BraveWalletBaseActivity
                             getString(R.string.market_price_in), mSelectedNetwork.symbol));
                     Utils.setBlockiesBitmapCustomAsset(mExecutor, mHandler, null, "",
                             mSelectedNetwork.symbol, getResources().getDisplayMetrics().density,
-                            mFromAssetText, this, true, (float) 0.5);
+                            mFromAssetText, this, true, (float) 0.5, true);
 
                     // Before updating, make sure we are on a network with the same coin type
                     if (mSelectedAccount != null

--- a/android/java/org/chromium/chrome/browser/crypto_wallet/activities/NftDetailActivity.java
+++ b/android/java/org/chromium/chrome/browser/crypto_wallet/activities/NftDetailActivity.java
@@ -58,6 +58,7 @@ public class NftDetailActivity extends BraveWalletBaseActivity {
     private static final String CHAIN_ID = "chainId";
     private static final String ASSET_NAME = "assetName";
     private static final String ASSET_CONTRACT_ADDRESS = "assetContractAddress";
+    private static final String ASSET_SYMBOL = "assetSymbol";
     private static final String NFT_TOKEN_ID_HEX = "nftTokenIdHex";
     private static final String NFT_META_DATA = "nftMetadata";
     private static final String NFT_IS_ERC_721 = "nftIsErc721";
@@ -66,6 +67,7 @@ public class NftDetailActivity extends BraveWalletBaseActivity {
     private String mNftName;
     private String mChainId;
     private String mContractAddress;
+    private String mSymbol;
     private String mNftTokenId;
     private String mNftTokenHex;
 
@@ -99,6 +101,7 @@ public class NftDetailActivity extends BraveWalletBaseActivity {
             mChainId = intent.getStringExtra(CHAIN_ID);
             mNftName = intent.getStringExtra(ASSET_NAME);
             mContractAddress = intent.getStringExtra(ASSET_CONTRACT_ADDRESS);
+            mSymbol = intent.getStringExtra(ASSET_SYMBOL);
             mNftTokenHex = intent.getStringExtra(NFT_TOKEN_ID_HEX);
             mNftTokenId = Utils.hexToIntString(mNftTokenHex);
             mNftMetadata = (PortfolioModel.NftMetadata) intent.getSerializableExtra(NFT_META_DATA);
@@ -131,7 +134,7 @@ public class NftDetailActivity extends BraveWalletBaseActivity {
         mNftDetailTitleView.setText(Utils.formatErc721TokenTitle(mNftName, mNftTokenId));
 
         mNftNameView = findViewById(R.id.nft_name);
-        mNftNameView.setText(mNftName);
+        mNftNameView.setText(mSymbol);
 
         mNetworkNameView = findViewById(R.id.blockchain_content);
         mNftTokenStandardLayout = findViewById(R.id.nft_token_standard);
@@ -269,6 +272,7 @@ public class NftDetailActivity extends BraveWalletBaseActivity {
         intent.putExtra(CHAIN_ID, chainId);
         intent.putExtra(ASSET_NAME, asset.name);
         intent.putExtra(ASSET_CONTRACT_ADDRESS, asset.contractAddress);
+        intent.putExtra(ASSET_SYMBOL, asset.symbol);
         intent.putExtra(NFT_TOKEN_ID_HEX, asset.tokenId);
         intent.putExtra(NFT_META_DATA, nftDataModel.nftMetadata);
         intent.putExtra(NFT_IS_ERC_721, nftDataModel.token.isErc721);

--- a/android/java/org/chromium/chrome/browser/crypto_wallet/activities/NftDetailActivity.java
+++ b/android/java/org/chromium/chrome/browser/crypto_wallet/activities/NftDetailActivity.java
@@ -39,6 +39,7 @@ import org.chromium.chrome.browser.app.helpers.ImageLoader;
 import org.chromium.chrome.browser.crypto_wallet.util.AddressUtils;
 import org.chromium.chrome.browser.crypto_wallet.util.AndroidUtils;
 import org.chromium.chrome.browser.crypto_wallet.util.Utils;
+import org.chromium.chrome.browser.crypto_wallet.util.WalletConstants;
 import org.chromium.chrome.browser.util.LiveDataUtil;
 import org.chromium.chrome.browser.util.TabUtils;
 import org.chromium.ui.text.NoUnderlineClickableSpan;
@@ -241,8 +242,8 @@ public class NftDetailActivity extends BraveWalletBaseActivity {
     }
 
     private void loadNftImage(String imageUrl) {
-        ImageLoader.downloadImage(
-                imageUrl, Glide.with(this), false, mNftImageView, new ImageLoader.Callback() {
+        ImageLoader.downloadImage(imageUrl, Glide.with(this), false,
+                WalletConstants.RECT_ROUNDED_CORNERS_DP, mNftImageView, new ImageLoader.Callback() {
                     @Override
                     public boolean onLoadFailed() {
                         setNftImageAsNotAvailable();

--- a/android/java/org/chromium/chrome/browser/crypto_wallet/activities/NftDetailActivity.java
+++ b/android/java/org/chromium/chrome/browser/crypto_wallet/activities/NftDetailActivity.java
@@ -21,6 +21,7 @@ import android.widget.TextView;
 
 import androidx.appcompat.widget.Toolbar;
 
+import com.bumptech.glide.Glide;
 import com.bumptech.glide.load.DataSource;
 import com.bumptech.glide.load.engine.GlideException;
 import com.bumptech.glide.request.RequestListener;
@@ -240,18 +241,20 @@ public class NftDetailActivity extends BraveWalletBaseActivity {
     }
 
     private void loadNftImage(String imageUrl) {
-        ImageLoader.downloadImage(imageUrl, this, false, mNftImageView, new ImageLoader.Callback() {
-            @Override
-            public boolean onLoadFailed() {
-                setNftImageAsNotAvailable();
-                return false;
-            }
-            @Override
-            public boolean onResourceReady(Drawable resource, Target<Drawable> target) {
-                target.onResourceReady(resource, new DrawableCrossFadeTransition(250, true));
-                return true;
-            }
-        });
+        ImageLoader.downloadImage(
+                imageUrl, Glide.with(this), false, mNftImageView, new ImageLoader.Callback() {
+                    @Override
+                    public boolean onLoadFailed() {
+                        setNftImageAsNotAvailable();
+                        return false;
+                    }
+                    @Override
+                    public boolean onResourceReady(Drawable resource, Target<Drawable> target) {
+                        target.onResourceReady(
+                                resource, new DrawableCrossFadeTransition(250, true));
+                        return true;
+                    }
+                });
     }
 
     private void setNftImageAsNotAvailable() {

--- a/android/java/org/chromium/chrome/browser/crypto_wallet/adapters/WalletCoinAdapter.java
+++ b/android/java/org/chromium/chrome/browser/crypto_wallet/adapters/WalletCoinAdapter.java
@@ -24,6 +24,8 @@ import android.widget.TextView;
 import androidx.annotation.NonNull;
 import androidx.recyclerview.widget.RecyclerView;
 
+import com.bumptech.glide.Glide;
+
 import org.chromium.brave_wallet.mojom.TransactionInfo;
 import org.chromium.brave_wallet.mojom.TransactionStatus;
 import org.chromium.chrome.R;
@@ -209,7 +211,8 @@ public class WalletCoinAdapter extends RecyclerView.Adapter<WalletCoinAdapter.Vi
                 if (walletListItemModel.hasNftImageLink()
                         && ImageLoader.isSupported(nftDataModel.nftMetadata.mImageUrl)) {
                     String url = nftDataModel.nftMetadata.mImageUrl;
-                    ImageLoader.downloadImage(url, context, false, holder.iconImg, null);
+                    ImageLoader.downloadImage(
+                            url, Glide.with(context), false, holder.iconImg, null);
                 } else {
                     Utils.setBlockiesBitmapCustomAsset(mExecutor, mHandler, holder.iconImg,
                             walletListItemModel.getBlockchainToken().contractAddress,

--- a/android/java/org/chromium/chrome/browser/crypto_wallet/adapters/WalletCoinAdapter.java
+++ b/android/java/org/chromium/chrome/browser/crypto_wallet/adapters/WalletCoinAdapter.java
@@ -35,6 +35,7 @@ import org.chromium.chrome.browser.crypto_wallet.listeners.OnWalletListItemClick
 import org.chromium.chrome.browser.crypto_wallet.model.WalletListItemModel;
 import org.chromium.chrome.browser.crypto_wallet.util.AndroidUtils;
 import org.chromium.chrome.browser.crypto_wallet.util.Utils;
+import org.chromium.chrome.browser.crypto_wallet.util.WalletConstants;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -211,8 +212,8 @@ public class WalletCoinAdapter extends RecyclerView.Adapter<WalletCoinAdapter.Vi
                 if (walletListItemModel.hasNftImageLink()
                         && ImageLoader.isSupported(nftDataModel.nftMetadata.mImageUrl)) {
                     String url = nftDataModel.nftMetadata.mImageUrl;
-                    ImageLoader.downloadImage(
-                            url, Glide.with(context), false, holder.iconImg, null);
+                    ImageLoader.downloadImage(url, Glide.with(context), false,
+                            WalletConstants.RECT_ROUNDED_CORNERS_DP, holder.iconImg, null);
                 } else {
                     Utils.setBlockiesBitmapCustomAsset(mExecutor, mHandler, holder.iconImg,
                             walletListItemModel.getBlockchainToken().contractAddress,

--- a/android/java/org/chromium/chrome/browser/crypto_wallet/adapters/WalletCoinAdapter.java
+++ b/android/java/org/chromium/chrome/browser/crypto_wallet/adapters/WalletCoinAdapter.java
@@ -215,7 +215,7 @@ public class WalletCoinAdapter extends RecyclerView.Adapter<WalletCoinAdapter.Vi
                             walletListItemModel.getBlockchainToken().contractAddress,
                             walletListItemModel.getBlockchainToken().symbol,
                             context.getResources().getDisplayMetrics().density, null, context,
-                            false, (float) 0.9);
+                            false, (float) 0.9, true);
                 }
                 if (mType == AdapterType.EDIT_VISIBLE_ASSETS_LIST) {
                     onWalletListItemClick.onMaybeShowTrashButton(

--- a/android/java/org/chromium/chrome/browser/crypto_wallet/adapters/WalletNftAdapter.java
+++ b/android/java/org/chromium/chrome/browser/crypto_wallet/adapters/WalletNftAdapter.java
@@ -65,7 +65,7 @@ public class WalletNftAdapter extends RecyclerView.Adapter<WalletNftAdapter.View
         holder.titleText.setText(walletListItemModel.getTitle());
 
         PortfolioModel.NftDataModel nftDataModel = walletListItemModel.getNftDataModel();
-        holder.subTitleText.setText(nftDataModel.token.name);
+        holder.subTitleText.setText(nftDataModel.token.symbol);
 
         holder.itemView.setOnClickListener(v -> {
             onWalletListItemClick.onAssetClick(walletListItemModel.getBlockchainToken());

--- a/android/java/org/chromium/chrome/browser/crypto_wallet/adapters/WalletNftAdapter.java
+++ b/android/java/org/chromium/chrome/browser/crypto_wallet/adapters/WalletNftAdapter.java
@@ -70,6 +70,9 @@ public class WalletNftAdapter extends RecyclerView.Adapter<WalletNftAdapter.View
             onWalletListItemClick.onAssetClick(walletListItemModel.getBlockchainToken());
         });
 
+        Utils.setBitmapResource(mExecutor, mHandler, context, walletListItemModel.getNetworkIcon(),
+                walletListItemModel.getIcon(), holder.networkIconImage, null, true);
+
         if (walletListItemModel.getBlockchainToken() == null
                 || !walletListItemModel.getBlockchainToken().logo.isEmpty()) {
             Utils.setBitmapResource(mExecutor, mHandler, context, walletListItemModel.getIconPath(),
@@ -123,12 +126,14 @@ public class WalletNftAdapter extends RecyclerView.Adapter<WalletNftAdapter.View
 
     static class ViewHolder extends RecyclerView.ViewHolder {
         public final ImageView iconImg;
+        public final ImageView networkIconImage;
         public final TextView titleText;
         public final TextView subTitleText;
 
         public ViewHolder(View itemView) {
             super(itemView);
             iconImg = itemView.findViewById(R.id.icon);
+            networkIconImage = itemView.findViewById(R.id.network_icon);
             titleText = itemView.findViewById(R.id.title);
             subTitleText = itemView.findViewById(R.id.sub_title);
         }

--- a/android/java/org/chromium/chrome/browser/crypto_wallet/adapters/WalletNftAdapter.java
+++ b/android/java/org/chromium/chrome/browser/crypto_wallet/adapters/WalletNftAdapter.java
@@ -82,7 +82,7 @@ public class WalletNftAdapter extends RecyclerView.Adapter<WalletNftAdapter.View
                         walletListItemModel.getBlockchainToken().contractAddress,
                         walletListItemModel.getBlockchainToken().symbol,
                         context.getResources().getDisplayMetrics().density, null, context, false,
-                        (float) 0.9);
+                        (float) 0.9, false);
             }
         }
     }

--- a/android/java/org/chromium/chrome/browser/crypto_wallet/adapters/WalletNftAdapter.java
+++ b/android/java/org/chromium/chrome/browser/crypto_wallet/adapters/WalletNftAdapter.java
@@ -26,6 +26,7 @@ import org.chromium.chrome.browser.app.helpers.ImageLoader;
 import org.chromium.chrome.browser.crypto_wallet.listeners.OnWalletListItemClick;
 import org.chromium.chrome.browser.crypto_wallet.model.WalletListItemModel;
 import org.chromium.chrome.browser.crypto_wallet.util.Utils;
+import org.chromium.chrome.browser.crypto_wallet.util.WalletConstants;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -81,7 +82,8 @@ public class WalletNftAdapter extends RecyclerView.Adapter<WalletNftAdapter.View
             if (walletListItemModel.hasNftImageLink()
                     && ImageLoader.isSupported(nftDataModel.nftMetadata.mImageUrl)) {
                 String url = nftDataModel.nftMetadata.mImageUrl;
-                ImageLoader.downloadImage(url, Glide.with(context), false, holder.iconImg, null);
+                ImageLoader.downloadImage(url, Glide.with(context), false,
+                        WalletConstants.RECT_SHARP_ROUNDED_CORNERS_DP, holder.iconImg, null);
             } else {
                 Utils.setBlockiesBitmapCustomAsset(mExecutor, mHandler, holder.iconImg,
                         walletListItemModel.getBlockchainToken().contractAddress,

--- a/android/java/org/chromium/chrome/browser/crypto_wallet/adapters/WalletNftAdapter.java
+++ b/android/java/org/chromium/chrome/browser/crypto_wallet/adapters/WalletNftAdapter.java
@@ -17,6 +17,8 @@ import android.widget.TextView;
 import androidx.annotation.NonNull;
 import androidx.recyclerview.widget.RecyclerView;
 
+import com.bumptech.glide.Glide;
+
 import org.chromium.brave_wallet.mojom.BlockchainToken;
 import org.chromium.chrome.R;
 import org.chromium.chrome.browser.app.domain.PortfolioModel;
@@ -76,7 +78,7 @@ public class WalletNftAdapter extends RecyclerView.Adapter<WalletNftAdapter.View
             if (walletListItemModel.hasNftImageLink()
                     && ImageLoader.isSupported(nftDataModel.nftMetadata.mImageUrl)) {
                 String url = nftDataModel.nftMetadata.mImageUrl;
-                ImageLoader.downloadImage(url, context, false, holder.iconImg, null);
+                ImageLoader.downloadImage(url, Glide.with(context), false, holder.iconImg, null);
             } else {
                 Utils.setBlockiesBitmapCustomAsset(mExecutor, mHandler, holder.iconImg,
                         walletListItemModel.getBlockchainToken().contractAddress,

--- a/android/java/org/chromium/chrome/browser/crypto_wallet/adapters/WalletNftAdapter.java
+++ b/android/java/org/chromium/chrome/browser/crypto_wallet/adapters/WalletNftAdapter.java
@@ -39,7 +39,6 @@ public class WalletNftAdapter extends RecyclerView.Adapter<WalletNftAdapter.View
     private OnWalletListItemClick onWalletListItemClick;
     private ExecutorService mExecutor;
     private Handler mHandler;
-    private int previousSelectedPos;
 
     public WalletNftAdapter() {
         mExecutor = Executors.newSingleThreadExecutor();

--- a/android/java/org/chromium/chrome/browser/crypto_wallet/fragments/ApproveTxBottomSheetDialogFragment.java
+++ b/android/java/org/chromium/chrome/browser/crypto_wallet/fragments/ApproveTxBottomSheetDialogFragment.java
@@ -318,7 +318,8 @@ public class ApproveTxBottomSheetDialogFragment extends BottomSheetDialogFragmen
                                                             new WeakReference<>(
                                                                     (BraveWalletBaseActivity)
                                                                             getActivity()),
-                                                            allNetworks, selectedNetwork, accounts,
+                                                            TokenUtils.TokenType.ALL, allNetworks,
+                                                            selectedNetwork, accounts,
                                                             filterByTokens, false,
                                                             (assetPrices, fullTokenList,
                                                                     nativeAssetsBalances,

--- a/android/java/org/chromium/chrome/browser/crypto_wallet/fragments/EditVisibleAssetsBottomSheetDialogFragment.java
+++ b/android/java/org/chromium/chrome/browser/crypto_wallet/fragments/EditVisibleAssetsBottomSheetDialogFragment.java
@@ -374,6 +374,7 @@ public class EditVisibleAssetsBottomSheetDialogFragment extends BottomSheetDialo
         tokenContractAddressEdit.addTextChangedListener(filterAddCustomAssetTextWatcher);
         tokenSymbolEdit.addTextChangedListener(filterAddCustomAssetTextWatcher);
         tokenDecimalsEdit.addTextChangedListener(filterAddCustomAssetTextWatcher);
+        tokenIdEdit.addTextChangedListener(filterAddCustomAssetTextWatcher);
         add.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {
@@ -485,14 +486,20 @@ public class EditVisibleAssetsBottomSheetDialogFragment extends BottomSheetDialo
                                 String.valueOf(token.decimals), TextView.BufferType.EDITABLE);
                         if (!token.isErc721) tokenIdEdit.setEnabled(false);
                         selfChange = false;
-                        addButton.setEnabled(true);
+                        if (!mNftsOnly
+                                || (token.isErc721 && !tokenIdEdit.getText().toString().isEmpty())
+                                || !token.isErc721) {
+                            addButton.setEnabled(true);
+                        }
                     }
                 });
             }
 
             if (tokenName.isEmpty() || tokenSymbol.isEmpty()
-                    || mSelectedNetwork.coin == CoinType.ETH
-                            && tokenDecimalsEdit.getText().toString().isEmpty()) {
+                    || (mSelectedNetwork.coin == CoinType.ETH && mNftsOnly
+                            && tokenIdEdit.getText().toString().isEmpty())
+                    || (mSelectedNetwork.coin == CoinType.ETH
+                            && tokenDecimalsEdit.getText().toString().isEmpty())) {
                 return;
             }
 

--- a/android/java/org/chromium/chrome/browser/crypto_wallet/fragments/EditVisibleAssetsBottomSheetDialogFragment.java
+++ b/android/java/org/chromium/chrome/browser/crypto_wallet/fragments/EditVisibleAssetsBottomSheetDialogFragment.java
@@ -400,7 +400,9 @@ public class EditVisibleAssetsBottomSheetDialogFragment extends BottomSheetDialo
                 }
                 if (mSelectedNetwork.coin == CoinType.SOL) {
                     token.isNft = mNftsOnly;
-                    token.decimals = 0;
+                    if (mNftsOnly) {
+                        token.decimals = 0;
+                    }
                 }
                 token.visible = true;
 

--- a/android/java/org/chromium/chrome/browser/crypto_wallet/fragments/EditVisibleAssetsBottomSheetDialogFragment.java
+++ b/android/java/org/chromium/chrome/browser/crypto_wallet/fragments/EditVisibleAssetsBottomSheetDialogFragment.java
@@ -9,6 +9,7 @@ import android.annotation.SuppressLint;
 import android.app.Activity;
 import android.app.AlertDialog;
 import android.app.Dialog;
+import android.content.ActivityNotFoundException;
 import android.content.DialogInterface;
 import android.content.res.Resources;
 import android.os.Bundle;
@@ -188,7 +189,7 @@ public class EditVisibleAssetsBottomSheetDialogFragment extends BottomSheetDialo
         try {
             BraveActivity activity = BraveActivity.getBraveActivity();
             mWalletModel = activity.getWalletModel();
-        } catch (ActivityNotFoundException e) {
+        } catch (BraveActivity.BraveActivityNotFoundException e) {
             Log.e(TAG, "Error during dialog creation.", e);
         }
         Dialog dialog = super.onCreateDialog(savedInstanceState);

--- a/android/java/org/chromium/chrome/browser/crypto_wallet/fragments/EditVisibleAssetsBottomSheetDialogFragment.java
+++ b/android/java/org/chromium/chrome/browser/crypto_wallet/fragments/EditVisibleAssetsBottomSheetDialogFragment.java
@@ -398,7 +398,8 @@ public class EditVisibleAssetsBottomSheetDialogFragment extends BottomSheetDialo
                     token.decimals = Integer.valueOf(tokenDecimalsEdit.getText().toString());
                 } catch (NumberFormatException exc) {
                 }
-                if (mSelectedNetwork.coin == CoinType.SOL && mNftsOnly) {
+                if (mSelectedNetwork.coin == CoinType.SOL) {
+                    token.isNft = mNftsOnly;
                     token.decimals = 0;
                 }
                 token.visible = true;

--- a/android/java/org/chromium/chrome/browser/crypto_wallet/fragments/EditVisibleAssetsBottomSheetDialogFragment.java
+++ b/android/java/org/chromium/chrome/browser/crypto_wallet/fragments/EditVisibleAssetsBottomSheetDialogFragment.java
@@ -500,10 +500,9 @@ public class EditVisibleAssetsBottomSheetDialogFragment extends BottomSheetDialo
             }
 
             if (tokenName.isEmpty() || tokenSymbol.isEmpty()
-                    || (mSelectedNetwork.coin == CoinType.ETH && mNftsOnly
-                            && tokenIdEdit.getText().toString().isEmpty())
                     || (mSelectedNetwork.coin == CoinType.ETH
-                            && tokenDecimalsEdit.getText().toString().isEmpty())) {
+                            && ((mNftsOnly && tokenIdEdit.getText().toString().isEmpty())
+                                    || tokenDecimalsEdit.getText().toString().isEmpty()))) {
                 return;
             }
 

--- a/android/java/org/chromium/chrome/browser/crypto_wallet/fragments/EditVisibleAssetsBottomSheetDialogFragment.java
+++ b/android/java/org/chromium/chrome/browser/crypto_wallet/fragments/EditVisibleAssetsBottomSheetDialogFragment.java
@@ -477,7 +477,8 @@ public class EditVisibleAssetsBottomSheetDialogFragment extends BottomSheetDialo
 
             AssetRatioService assetRatioService = getAssetRatioService();
             // Do not assert here, service can be null when backed from dialog
-            if (assetRatioService != null && !contractAddress.isEmpty()) {
+            if (assetRatioService != null && !contractAddress.isEmpty()
+                    && mSelectedNetwork.coin == CoinType.ETH) {
                 assetRatioService.getTokenInfo(contractAddress, token -> {
                     if (token != null) {
                         selfChange = true;

--- a/android/java/org/chromium/chrome/browser/crypto_wallet/fragments/EditVisibleAssetsBottomSheetDialogFragment.java
+++ b/android/java/org/chromium/chrome/browser/crypto_wallet/fragments/EditVisibleAssetsBottomSheetDialogFragment.java
@@ -248,6 +248,8 @@ public class EditVisibleAssetsBottomSheetDialogFragment extends BottomSheetDialo
         ((View) parent).getLayoutParams().height = ViewGroup.LayoutParams.WRAP_CONTENT;
         Button saveAssets = view.findViewById(R.id.saveAssets);
         TextView addCustomAsset = view.findViewById(R.id.add_custom_asset);
+        addCustomAsset.setText(
+                mNftsOnly ? R.string.wallet_add_nft : R.string.wallet_add_custom_asset);
         if (mType == WalletCoinAdapter.AdapterType.EDIT_VISIBLE_ASSETS_LIST) {
             saveAssets.setOnClickListener(new View.OnClickListener() {
                 @Override
@@ -330,35 +332,26 @@ public class EditVisibleAssetsBottomSheetDialogFragment extends BottomSheetDialo
         dialog.setContentView(R.layout.brave_wallet_add_custom_asset);
         dialog.show();
 
-        TextView advancedTitle = dialog.findViewById(R.id.advanced_title);
-        CheckBox isNft = dialog.findViewById(R.id.nft_check);
+        TextView title = dialog.findViewById(R.id.add_asset_dialog_title);
+        title.setText(mNftsOnly ? R.string.wallet_add_nft : R.string.wallet_add_custom_asset);
+
         if (mSelectedNetwork.coin == CoinType.ETH) {
             LinearLayout advancedSection = dialog.findViewById(R.id.advanced_section);
-            advancedTitle.setOnClickListener(new View.OnClickListener() {
-                @Override
-                public void onClick(View v) {
-                    if (advancedSection.getVisibility() == View.GONE)
-                        advancedSection.setVisibility(View.VISIBLE);
-                    else
-                        advancedSection.setVisibility(View.GONE);
-                }
-            });
+            if (mNftsOnly) {
+                advancedSection.setVisibility(View.VISIBLE);
+            } else {
+                advancedSection.setVisibility(View.GONE);
+            }
         } else {
-            advancedTitle.setVisibility(View.GONE);
-            dialog.findViewById(R.id.advanced_section_separator).setVisibility(View.GONE);
             if (mSelectedNetwork.coin == CoinType.SOL) {
-                isNft.setVisibility(View.VISIBLE);
-                isNft.setOnClickListener(v -> {
-                    boolean isNftChecked = isNft.isChecked();
-                    dialog.findViewById(R.id.token_decimals_title)
-                            .setVisibility(isNftChecked ? View.GONE : View.VISIBLE);
-                    dialog.findViewById(R.id.token_decimals)
-                            .setVisibility(isNftChecked ? View.GONE : View.VISIBLE);
-                    ((TextView) dialog.findViewById(R.id.token_contract_address_title))
-                            .setText(getString(isNftChecked
-                                            ? R.string.wallet_add_custom_asset_token_address
-                                            : R.string.wallet_add_custom_asset_token_contract_address));
-                });
+                dialog.findViewById(R.id.token_decimals_title)
+                        .setVisibility(mNftsOnly ? View.GONE : View.VISIBLE);
+                dialog.findViewById(R.id.token_decimals)
+                        .setVisibility(mNftsOnly ? View.GONE : View.VISIBLE);
+                ((TextView) dialog.findViewById(R.id.token_contract_address_title))
+                        .setText(getString(mNftsOnly
+                                        ? R.string.wallet_add_custom_asset_token_address
+                                        : R.string.wallet_add_custom_asset_token_contract_address));
             }
         }
 
@@ -403,11 +396,8 @@ public class EditVisibleAssetsBottomSheetDialogFragment extends BottomSheetDialo
                     token.decimals = Integer.valueOf(tokenDecimalsEdit.getText().toString());
                 } catch (NumberFormatException exc) {
                 }
-                if (mSelectedNetwork.coin == CoinType.SOL) {
-                    token.isNft = isNft.isChecked();
-                    if (token.isNft) {
-                        token.decimals = 0;
-                    }
+                if (mSelectedNetwork.coin == CoinType.SOL && mNftsOnly) {
+                    token.decimals = 0;
                 }
                 token.visible = true;
 

--- a/android/java/org/chromium/chrome/browser/crypto_wallet/fragments/EditVisibleAssetsBottomSheetDialogFragment.java
+++ b/android/java/org/chromium/chrome/browser/crypto_wallet/fragments/EditVisibleAssetsBottomSheetDialogFragment.java
@@ -78,7 +78,7 @@ public class EditVisibleAssetsBottomSheetDialogFragment extends BottomSheetDialo
     private final boolean mNftsOnly;
     private NetworkInfo mSelectedNetwork;
     private DismissListener mDismissListener;
-    private Boolean mIsAssetsListChanged;
+    private boolean mIsAssetsListChanged;
     private static final String TAG = "EditVisibleAssetsBottomSheetDialogFragment";
     private WalletModel mWalletModel;
     private KeyringServiceObserverImpl mKeyringServiceObserver;
@@ -86,7 +86,7 @@ public class EditVisibleAssetsBottomSheetDialogFragment extends BottomSheetDialo
     private List<NetworkInfo> mCryptoNetworks;
 
     public interface DismissListener {
-        void onDismiss(Boolean isAssetsListChanged);
+        void onDismiss(boolean isAssetsListChanged);
     }
 
     public static EditVisibleAssetsBottomSheetDialogFragment newInstance(

--- a/android/java/org/chromium/chrome/browser/crypto_wallet/fragments/EditVisibleAssetsBottomSheetDialogFragment.java
+++ b/android/java/org/chromium/chrome/browser/crypto_wallet/fragments/EditVisibleAssetsBottomSheetDialogFragment.java
@@ -79,7 +79,7 @@ public class EditVisibleAssetsBottomSheetDialogFragment extends BottomSheetDialo
     private NetworkInfo mSelectedNetwork;
     private DismissListener mDismissListener;
     private boolean mIsAssetsListChanged;
-    private static final String TAG = "EditVisibleAssetsBottomSheetDialogFragment";
+    private static final String TAG = "EditVisibleAssetsFrag";
     private WalletModel mWalletModel;
     private KeyringServiceObserverImpl mKeyringServiceObserver;
     private OnEditVisibleItemClickListener mOnEditVisibleItemClickListener;
@@ -174,7 +174,7 @@ public class EditVisibleAssetsBottomSheetDialogFragment extends BottomSheetDialo
             transaction.add(this, tag);
             transaction.commitAllowingStateLoss();
         } catch (IllegalStateException e) {
-            Log.e("EditVisibleAssetsBottomSheetDialogFragment", e.getMessage());
+            Log.e(TAG, "Error when showing EditVisibleAssetsBottomSheetDialogFragment.", e);
         }
     }
 
@@ -188,8 +188,8 @@ public class EditVisibleAssetsBottomSheetDialogFragment extends BottomSheetDialo
         try {
             BraveActivity activity = BraveActivity.getBraveActivity();
             mWalletModel = activity.getWalletModel();
-        } catch (BraveActivity.BraveActivityNotFoundException e) {
-            Log.e(TAG, "onCreateDialog " + e);
+        } catch (ActivityNotFoundException e) {
+            Log.e(TAG, "Error during dialog creation.", e);
         }
         Dialog dialog = super.onCreateDialog(savedInstanceState);
         dialog.setOnShowListener(new DialogInterface.OnShowListener() {

--- a/android/java/org/chromium/chrome/browser/crypto_wallet/fragments/NftGridFragment.java
+++ b/android/java/org/chromium/chrome/browser/crypto_wallet/fragments/NftGridFragment.java
@@ -333,7 +333,7 @@ public class NftGridFragment extends Fragment implements OnWalletListItemClick {
         bottomSheetDialogFragment.setDismissListener(
                 new EditVisibleAssetsBottomSheetDialogFragment.DismissListener() {
                     @Override
-                    public void onDismiss(Boolean isAssetsListChanged) {
+                    public void onDismiss(boolean isAssetsListChanged) {
                         if (isAssetsListChanged != null && isAssetsListChanged) {
                             updateNftGrid();
                         }

--- a/android/java/org/chromium/chrome/browser/crypto_wallet/fragments/NftGridFragment.java
+++ b/android/java/org/chromium/chrome/browser/crypto_wallet/fragments/NftGridFragment.java
@@ -303,14 +303,26 @@ public class NftGridFragment extends Fragment implements OnWalletListItemClick {
     }
 
     private void onEditVisibleAssetsClick() {
-        NetworkInfo selectedNetwork = null;
-        if (mWalletModel != null) {
-            selectedNetwork =
-                    mWalletModel.getCryptoModel().getNetworkModel().mDefaultNetwork.getValue();
-        }
+        NetworkInfo selectedNetwork = mNetworkInfo;
         if (selectedNetwork == null) {
             return;
         }
+
+        // TODO(simone): Remove this workaround once all network option is supported by
+        // EditVisibleAssetsBottomSheetDialogFragment. This workaround is to show default network
+        // assets in EditVisibleAssetsBottomSheetDialogFragment when "All Networks" option is
+        // selected. Check also PortfolioFragment#onEditVisibleAssetsClick().
+        if (selectedNetwork.chainId.equals(
+                NetworkUtils.getAllNetworkOption(getContext()).chainId)) {
+            LiveDataUtil.observeOnce(
+                    mWalletModel.getCryptoModel().getNetworkModel().mDefaultNetwork,
+                    defaultNetwork -> { showEditVisibleAssetsDialog(defaultNetwork); });
+        } else {
+            showEditVisibleAssetsDialog(selectedNetwork);
+        }
+    }
+
+    private void showEditVisibleAssetsDialog(NetworkInfo selectedNetwork) {
         EditVisibleAssetsBottomSheetDialogFragment bottomSheetDialogFragment =
                 EditVisibleAssetsBottomSheetDialogFragment.newInstance(
                         WalletCoinAdapter.AdapterType.EDIT_VISIBLE_ASSETS_LIST, true);

--- a/android/java/org/chromium/chrome/browser/crypto_wallet/fragments/NftGridFragment.java
+++ b/android/java/org/chromium/chrome/browser/crypto_wallet/fragments/NftGridFragment.java
@@ -45,6 +45,7 @@ import org.chromium.chrome.browser.crypto_wallet.listeners.OnWalletListItemClick
 import org.chromium.chrome.browser.crypto_wallet.model.WalletListItemModel;
 import org.chromium.chrome.browser.crypto_wallet.util.AssetUtils;
 import org.chromium.chrome.browser.crypto_wallet.util.JavaUtils;
+import org.chromium.chrome.browser.crypto_wallet.util.NetworkUtils;
 import org.chromium.chrome.browser.crypto_wallet.util.PortfolioHelper;
 import org.chromium.chrome.browser.crypto_wallet.util.Utils;
 import org.chromium.chrome.browser.crypto_wallet.util.WalletUtils;

--- a/android/java/org/chromium/chrome/browser/crypto_wallet/fragments/NftGridFragment.java
+++ b/android/java/org/chromium/chrome/browser/crypto_wallet/fragments/NftGridFragment.java
@@ -251,28 +251,20 @@ public class NftGridFragment extends Fragment implements OnWalletListItemClick {
 
     @Override
     public void onAssetClick(BlockchainToken asset) {
-        NetworkInfo selectedNetwork = null;
-        if (mWalletModel != null) {
-            selectedNetwork =
-                    mWalletModel.getCryptoModel().getNetworkModel().mDefaultNetwork.getValue();
-        }
+        NetworkInfo selectedNetwork = mNetworkInfo;
         if (selectedNetwork == null) {
             return;
         }
 
-        if (asset.isErc721 || asset.isNft) {
-            PortfolioModel.NftDataModel selectedNft = JavaUtils.find(mNftDataModels,
-                    nftDataModel -> AssetUtils.Filters.isSameNFT(asset, nftDataModel.token));
-            if (selectedNft == null) {
-                return;
-            }
-
-            Intent intent = NftDetailActivity.getIntent(
-                    getContext(), selectedNetwork.chainId, asset, selectedNft);
-            startActivity(intent);
-        } else {
-            Utils.openAssetDetailsActivity(getActivity(), selectedNetwork.chainId, asset);
+        PortfolioModel.NftDataModel selectedNft = JavaUtils.find(mNftDataModels,
+                nftDataModel -> AssetUtils.Filters.isSameNFT(asset, nftDataModel.token));
+        if (selectedNft == null) {
+            return;
         }
+
+        Intent intent = NftDetailActivity.getIntent(
+                getContext(), selectedNetwork.chainId, asset, selectedNft);
+        startActivity(intent);
     }
 
     private void updateNftGrid() {

--- a/android/java/org/chromium/chrome/browser/crypto_wallet/fragments/NftGridFragment.java
+++ b/android/java/org/chromium/chrome/browser/crypto_wallet/fragments/NftGridFragment.java
@@ -133,7 +133,6 @@ public class NftGridFragment extends Fragment implements OnWalletListItemClick {
                     if (isDiscoveringUserAssets) {
                         mPbAssetDiscovery.setVisibility(View.VISIBLE);
                     } else {
-                        mPbAssetDiscovery.setVisibility(View.GONE);
                         updateNftGrid();
                     }
                 });
@@ -207,6 +206,8 @@ public class NftGridFragment extends Fragment implements OnWalletListItemClick {
         // Show empty screen layout if no NFTs have been added.
         boolean emptyList = walletListItemModelList.isEmpty();
         mAddNftsContainer.setVisibility(emptyList ? View.VISIBLE : View.GONE);
+
+        mPbAssetDiscovery.setVisibility(View.GONE);
     }
 
     private void clearAssets() {

--- a/android/java/org/chromium/chrome/browser/crypto_wallet/fragments/NftGridFragment.java
+++ b/android/java/org/chromium/chrome/browser/crypto_wallet/fragments/NftGridFragment.java
@@ -98,7 +98,7 @@ public class NftGridFragment extends Fragment implements OnWalletListItemClick {
     public View onCreateView(@NonNull LayoutInflater inflater, @Nullable ViewGroup container,
             @Nullable Bundle savedInstanceState) {
         View view = inflater.inflate(R.layout.fragment_nft_grid, container, false);
-        mPbAssetDiscovery = view.findViewById(R.id.frag_port_pb_asset_discovery);
+        mPbAssetDiscovery = view.findViewById(R.id.frag_nft_grid_pb_asset_discovery);
         mAddNftsContainer = view.findViewById(R.id.add_nfts_container);
         setUpObservers();
         return view;

--- a/android/java/org/chromium/chrome/browser/crypto_wallet/fragments/NftGridFragment.java
+++ b/android/java/org/chromium/chrome/browser/crypto_wallet/fragments/NftGridFragment.java
@@ -121,6 +121,14 @@ public class NftGridFragment extends Fragment implements OnWalletListItemClick {
         return view;
     }
 
+    @Override
+    public void onDestroyView() {
+        super.onDestroyView();
+        if (mPortfolioModel != null) {
+            mPortfolioModel.clearNftModels();
+        }
+    }
+
     private void setUpObservers() {
         if (mWalletModel == null) return;
         mWalletModel.getCryptoModel().getNetworkModel().mCryptoNetworks.observe(

--- a/android/java/org/chromium/chrome/browser/crypto_wallet/fragments/NftGridFragment.java
+++ b/android/java/org/chromium/chrome/browser/crypto_wallet/fragments/NftGridFragment.java
@@ -6,6 +6,7 @@
 package org.chromium.chrome.browser.crypto_wallet.fragments;
 
 import android.app.Activity;
+import android.content.ActivityNotFoundException;
 import android.content.DialogInterface;
 import android.content.Intent;
 import android.os.Build;
@@ -16,7 +17,6 @@ import android.view.ViewGroup;
 import android.widget.Button;
 import android.widget.ProgressBar;
 import android.widget.TextView;
-import android.widget.Toast;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
@@ -56,6 +56,7 @@ import org.chromium.chrome.browser.crypto_wallet.util.WalletUtils;
 import org.chromium.chrome.browser.custom_layout.AutoFitVerticalGridLayoutManager;
 import org.chromium.chrome.browser.util.LiveDataUtil;
 import org.chromium.content_public.browser.UiThreadTaskTraits;
+import org.chromium.ui.widget.Toast;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -195,7 +196,7 @@ public class NftGridFragment extends Fragment implements OnWalletListItemClick {
         try {
             BraveActivity activity = BraveActivity.getBraveActivity();
             activity.openNetworkSelection(NetworkSelectorModel.Mode.LOCAL_NETWORK_FILTER, TAG);
-        } catch (ActivityNotFoundException e) {
+        } catch (BraveActivity.BraveActivityNotFoundException e) {
             Log.e(TAG, "Network selection cannot be opened.", e);
         }
     }

--- a/android/java/org/chromium/chrome/browser/crypto_wallet/fragments/NftGridFragment.java
+++ b/android/java/org/chromium/chrome/browser/crypto_wallet/fragments/NftGridFragment.java
@@ -33,6 +33,7 @@ import org.chromium.brave_wallet.mojom.BlockchainToken;
 import org.chromium.brave_wallet.mojom.NetworkInfo;
 import org.chromium.chrome.R;
 import org.chromium.chrome.browser.app.BraveActivity;
+import org.chromium.chrome.browser.app.domain.NetworkSelectorModel;
 import org.chromium.chrome.browser.app.domain.PortfolioModel;
 import org.chromium.chrome.browser.app.domain.WalletModel;
 import org.chromium.chrome.browser.app.helpers.Api33AndPlusBackPressHelper;

--- a/android/java/org/chromium/chrome/browser/crypto_wallet/fragments/NftGridFragment.java
+++ b/android/java/org/chromium/chrome/browser/crypto_wallet/fragments/NftGridFragment.java
@@ -16,6 +16,7 @@ import android.view.ViewGroup;
 import android.widget.Button;
 import android.widget.ProgressBar;
 import android.widget.TextView;
+import android.widget.Toast;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
@@ -71,6 +72,7 @@ public class NftGridFragment extends Fragment implements OnWalletListItemClick {
     private WalletNftAdapter mWalletNftAdapter;
     private ProgressBar mPbAssetDiscovery;
     private ViewGroup mAddNftsContainer;
+    private Button mBtnChangeNetwork;
 
     public static NftGridFragment newInstance() {
         return new NftGridFragment();
@@ -100,6 +102,14 @@ public class NftGridFragment extends Fragment implements OnWalletListItemClick {
         View view = inflater.inflate(R.layout.fragment_nft_grid, container, false);
         mPbAssetDiscovery = view.findViewById(R.id.frag_nft_grid_pb_asset_discovery);
         mAddNftsContainer = view.findViewById(R.id.add_nfts_container);
+        mBtnChangeNetwork = view.findViewById(R.id.fragment_nft_grid_btn_change_networks);
+        mBtnChangeNetwork.setOnClickListener(v -> { openNetworkSelection(); });
+        mBtnChangeNetwork.setOnLongClickListener(v -> {
+            if (mNetworkInfo != null) {
+                Toast.makeText(requireContext(), mNetworkInfo.chainName, Toast.LENGTH_SHORT).show();
+            }
+            return true;
+        });
         setUpObservers();
         return view;
     }
@@ -165,6 +175,15 @@ public class NftGridFragment extends Fragment implements OnWalletListItemClick {
         TextView editVisibleNft = view.findViewById(R.id.edit_visible_nfts);
         mRvNft = view.findViewById(R.id.rv_nft);
         editVisibleNft.setOnClickListener(v -> { onEditVisibleAssetsClick(); });
+    }
+
+    private void openNetworkSelection() {
+        try {
+            BraveActivity activity = BraveActivity.getBraveActivity();
+            activity.openNetworkSelection(NetworkSelectorModel.Mode.LOCAL_NETWORK_FILTER, TAG);
+        } catch (ActivityNotFoundException e) {
+            Log.e(TAG, "Network selection cannot be opened.", e);
+        }
     }
 
     private void setPositiveButtonAccountCreation(NetworkInfo networkInfo) {

--- a/android/java/org/chromium/chrome/browser/crypto_wallet/fragments/NftGridFragment.java
+++ b/android/java/org/chromium/chrome/browser/crypto_wallet/fragments/NftGridFragment.java
@@ -313,7 +313,7 @@ public class NftGridFragment extends Fragment implements OnWalletListItemClick {
         // assets in EditVisibleAssetsBottomSheetDialogFragment when "All Networks" option is
         // selected. Check also PortfolioFragment#onEditVisibleAssetsClick().
         if (selectedNetwork.chainId.equals(
-                NetworkUtils.getAllNetworkOption(getContext()).chainId)) {
+                    NetworkUtils.getAllNetworkOption(getContext()).chainId)) {
             LiveDataUtil.observeOnce(
                     mWalletModel.getCryptoModel().getNetworkModel().mDefaultNetwork,
                     defaultNetwork -> { showEditVisibleAssetsDialog(defaultNetwork); });

--- a/android/java/org/chromium/chrome/browser/crypto_wallet/fragments/PortfolioFragment.java
+++ b/android/java/org/chromium/chrome/browser/crypto_wallet/fragments/PortfolioFragment.java
@@ -179,14 +179,6 @@ public class PortfolioFragment
         return view;
     }
 
-    @Override
-    public void onDestroyView() {
-        super.onDestroyView();
-        if (mPortfolioModel != null) {
-            mPortfolioModel.clear();
-        }
-    }
-
     private void setUpObservers() {
         mWalletModel.getCryptoModel().getNetworkModel().mCryptoNetworks.observe(
                 getViewLifecycleOwner(),

--- a/android/java/org/chromium/chrome/browser/crypto_wallet/fragments/PortfolioFragment.java
+++ b/android/java/org/chromium/chrome/browser/crypto_wallet/fragments/PortfolioFragment.java
@@ -61,6 +61,7 @@ import org.chromium.chrome.browser.crypto_wallet.util.NetworkUtils;
 import org.chromium.chrome.browser.crypto_wallet.util.PendingTxHelper;
 import org.chromium.chrome.browser.crypto_wallet.util.PortfolioHelper;
 import org.chromium.chrome.browser.crypto_wallet.util.SmoothLineChartEquallySpaced;
+import org.chromium.chrome.browser.crypto_wallet.util.TokenUtils;
 import org.chromium.chrome.browser.crypto_wallet.util.TransactionUtils;
 import org.chromium.chrome.browser.crypto_wallet.util.Utils;
 import org.chromium.chrome.browser.crypto_wallet.util.WalletUtils;
@@ -393,8 +394,8 @@ public class PortfolioFragment
 
         Activity activity = getActivity();
         if (!(activity instanceof BraveWalletActivity)) return;
-        mPortfolioModel.fetchNonNftAssets(
-                selectedNetwork, (BraveWalletBaseActivity) activity, (portfolioHelper) -> {
+        mPortfolioModel.fetchAssetsByType(TokenUtils.TokenType.NON_NFTS, selectedNetwork,
+                (BraveWalletBaseActivity) activity, (portfolioHelper) -> {
                     if (!AndroidUtils.canUpdateFragmentUi(this)) return;
                     mPortfolioHelper = portfolioHelper;
 

--- a/android/java/org/chromium/chrome/browser/crypto_wallet/fragments/PortfolioFragment.java
+++ b/android/java/org/chromium/chrome/browser/crypto_wallet/fragments/PortfolioFragment.java
@@ -473,8 +473,8 @@ public class PortfolioFragment
         bottomSheetDialogFragment.setDismissListener(
                 new EditVisibleAssetsBottomSheetDialogFragment.DismissListener() {
                     @Override
-                    public void onDismiss(Boolean isAssetsListChanged) {
-                        if (isAssetsListChanged != null && isAssetsListChanged) {
+                    public void onDismiss(boolean isAssetsListChanged) {
+                        if (isAssetsListChanged) {
                             updatePortfolioGetPendingTx();
                         }
                     }

--- a/android/java/org/chromium/chrome/browser/crypto_wallet/fragments/PortfolioFragment.java
+++ b/android/java/org/chromium/chrome/browser/crypto_wallet/fragments/PortfolioFragment.java
@@ -406,13 +406,11 @@ public class PortfolioFragment
                     mBalance.setText(mFiatSumString);
                     mBalance.invalidate();
 
-                    List<BlockchainToken> tokens = new ArrayList<>();
-                    tokens.addAll(mPortfolioHelper.getUserAssets());
-
                     LiveDataUtil.observeOnce(
                             mWalletModel.getCryptoModel().getNetworkModel().mCryptoNetworks,
                             networkInfos -> {
-                                setUpCoinList(tokens, mPortfolioHelper.getPerTokenCryptoSum(),
+                                setUpCoinList(mPortfolioHelper.getUserAssets(),
+                                        mPortfolioHelper.getPerTokenCryptoSum(),
                                         mPortfolioHelper.getPerTokenFiatSum(), networkInfos);
                             });
                     updatePortfolioGraph();

--- a/android/java/org/chromium/chrome/browser/crypto_wallet/fragments/PortfolioFragment.java
+++ b/android/java/org/chromium/chrome/browser/crypto_wallet/fragments/PortfolioFragment.java
@@ -452,18 +452,18 @@ public class PortfolioFragment
         // TODO(pav): Remove this workaround once all network option is supported by
         // EditVisibleAssetsBottomSheetDialogFragment. This workaround is to show default network
         // assets in EditVisibleAssetsBottomSheetDialogFragment when "All Networks" option is
-        // selected
+        // selected. Check also NftGridFragment#onEditVisibleAssetsClick().
         if (selectedNetwork.chainId.equals(
                     NetworkUtils.getAllNetworkOption(getContext()).chainId)) {
             LiveDataUtil.observeOnce(
                     mWalletModel.getCryptoModel().getNetworkModel().mDefaultNetwork,
-                    defaultNetwork -> { showEditVisibleDialog(defaultNetwork); });
+                    defaultNetwork -> { showEditVisibleAssetsDialog(defaultNetwork); });
             return;
         }
-        showEditVisibleDialog(selectedNetwork);
+        showEditVisibleAssetsDialog(selectedNetwork);
     }
 
-    private void showEditVisibleDialog(NetworkInfo selectedNetwork) {
+    private void showEditVisibleAssetsDialog(NetworkInfo selectedNetwork) {
         EditVisibleAssetsBottomSheetDialogFragment bottomSheetDialogFragment =
                 EditVisibleAssetsBottomSheetDialogFragment.newInstance(
                         WalletCoinAdapter.AdapterType.EDIT_VISIBLE_ASSETS_LIST, false);

--- a/android/java/org/chromium/chrome/browser/crypto_wallet/fragments/PortfolioFragment.java
+++ b/android/java/org/chromium/chrome/browser/crypto_wallet/fragments/PortfolioFragment.java
@@ -401,7 +401,7 @@ public class PortfolioFragment
 
         Activity activity = getActivity();
         if (!(activity instanceof BraveWalletActivity)) return;
-        mPortfolioModel.fetchAssets(
+        mPortfolioModel.fetchNonNftAssets(
                 selectedNetwork, (BraveWalletBaseActivity) activity, (portfolioHelper) -> {
                     if (!AndroidUtils.canUpdateFragmentUi(this)) return;
                     mPortfolioHelper = portfolioHelper;
@@ -414,13 +414,7 @@ public class PortfolioFragment
                     mBalance.invalidate();
 
                     List<BlockchainToken> tokens = new ArrayList<>();
-
-                    for (BlockchainToken token : mPortfolioHelper.getUserAssets()) {
-                        if (!token.isErc721 && !token.isNft) {
-                            // Add only coins and not NFTs.
-                            tokens.add(token);
-                        }
-                    }
+                    tokens.addAll(mPortfolioHelper.getUserAssets());
 
                     LiveDataUtil.observeOnce(
                             mWalletModel.getCryptoModel().getNetworkModel().mCryptoNetworks,

--- a/android/java/org/chromium/chrome/browser/crypto_wallet/fragments/dapps/AddTokenFragment.java
+++ b/android/java/org/chromium/chrome/browser/crypto_wallet/fragments/dapps/AddTokenFragment.java
@@ -125,7 +125,7 @@ public class AddTokenFragment extends BaseDAppsFragment {
                     mCurrentAddSuggestTokenRequest.token.contractAddress,
                     mCurrentAddSuggestTokenRequest.token.symbol,
                     getActivity().getResources().getDisplayMetrics().density, null, getActivity(),
-                    false, (float) 0.9);
+                    false, (float) 0.9, true);
         }
         String tokenName = mCurrentAddSuggestTokenRequest.token.name;
         if (tokenName.isEmpty()) {

--- a/android/java/org/chromium/chrome/browser/crypto_wallet/permission/BravePermissionAccountsListAdapter.java
+++ b/android/java/org/chromium/chrome/browser/crypto_wallet/permission/BravePermissionAccountsListAdapter.java
@@ -216,7 +216,7 @@ public class BravePermissionAccountsListAdapter
 
     private void setBlockiesBitmapResource(ImageView iconImg, String source) {
         mExecutor.execute(() -> {
-            final Bitmap bitmap = Blockies.createIcon(source, true);
+            final Bitmap bitmap = Blockies.createIcon(source, true, true);
             mHandler.post(() -> {
                 if (iconImg != null) {
                     iconImg.setImageBitmap(bitmap);

--- a/android/java/org/chromium/chrome/browser/crypto_wallet/util/Blockies.java
+++ b/android/java/org/chromium/chrome/browser/crypto_wallet/util/Blockies.java
@@ -1,7 +1,7 @@
 /* Copyright (c) 2021 The Brave Authors. All rights reserved.
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
- * You can obtain one at http://mozilla.org/MPL/2.0/. */
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 package org.chromium.chrome.browser.crypto_wallet.util;
 
@@ -27,12 +27,12 @@ public class Blockies {
             "#67D4B4", "#AFCE57", "#F0CB44", "#F28A29", "#FC798F", "#C1226E", "#FAB5EE", "#9677EE",
             "#5433B0"};
 
-    public static Bitmap createIcon(String address, boolean lowerCase) {
+    public static Bitmap createIcon(String address, boolean lowerCase, boolean circular) {
         if (lowerCase) {
-            return createIcon(address.toLowerCase(Locale.getDefault()));
+            return createIcon(address.toLowerCase(Locale.getDefault()), circular);
         }
 
-        return createIcon(address);
+        return createIcon(address, circular);
     }
 
     public static Drawable createBackground(String address, boolean lowerCase) {
@@ -50,7 +50,7 @@ public class Blockies {
         return gd;
     }
 
-    private static Bitmap createIcon(String address) {
+    private static Bitmap createIcon(String address, boolean circular) {
         seedrand(address);
 
         String color = createColor();
@@ -59,11 +59,11 @@ public class Blockies {
 
         double[] imgdata = createImageData();
 
-        return createCanvas(imgdata, color, bgColor, spotColor, SCALE);
+        return createCanvas(imgdata, color, bgColor, spotColor, SCALE, circular);
     }
 
     private static Bitmap createCanvas(
-            double[] imgData, String color, String bgcolor, String spotcolor, int scale) {
+            double[] imgData, String color, String bgcolor, String spotcolor, int scale, boolean circular) {
         int width = (int) Math.sqrt(imgData.length);
 
         int w = width * scale;
@@ -96,7 +96,7 @@ public class Blockies {
             }
         }
 
-        return blur(getCroppedBitmap(bmp), 1f, 40);
+        return blur(getCroppedBitmap(bmp, circular), 1f, 40);
     }
 
     private static double rand() {
@@ -183,7 +183,7 @@ public class Blockies {
         }
     }
 
-    public static Bitmap getCroppedBitmap(Bitmap bitmap) {
+    public static Bitmap getCroppedBitmap(Bitmap bitmap, boolean circular) {
         Bitmap output =
                 Bitmap.createBitmap(bitmap.getWidth(), bitmap.getHeight(), Bitmap.Config.ARGB_8888);
         Canvas canvas = new Canvas(output);
@@ -196,8 +196,11 @@ public class Blockies {
         paint.setFilterBitmap(true);
         canvas.drawARGB(0, 0, 0, 0);
         paint.setColor(color);
-        canvas.drawCircle(
-                bitmap.getWidth() / 2, bitmap.getHeight() / 2, bitmap.getWidth() / 2, paint);
+        if (circular) {
+            canvas.drawCircle(bitmap.getWidth() / 2, bitmap.getHeight() / 2, bitmap.getWidth() / 2, paint);
+        } else {
+            canvas.drawRoundRect(0, 0, bitmap.getWidth(), bitmap.getHeight(), WalletConstants.RECT_ROUNDED_CORNERS_DP, WalletConstants.RECT_ROUNDED_CORNERS_DP, paint);
+        }
         paint.setXfermode(new PorterDuffXfermode(PorterDuff.Mode.SRC_IN));
         canvas.drawBitmap(bitmap, rect, rect, paint);
 

--- a/android/java/org/chromium/chrome/browser/crypto_wallet/util/Blockies.java
+++ b/android/java/org/chromium/chrome/browser/crypto_wallet/util/Blockies.java
@@ -199,7 +199,7 @@ public class Blockies {
         if (circular) {
             canvas.drawCircle(bitmap.getWidth() / 2, bitmap.getHeight() / 2, bitmap.getWidth() / 2, paint);
         } else {
-            canvas.drawRoundRect(0, 0, bitmap.getWidth(), bitmap.getHeight(), WalletConstants.RECT_ROUNDED_CORNERS_DP, WalletConstants.RECT_ROUNDED_CORNERS_DP, paint);
+            canvas.drawRoundRect(0, 0, bitmap.getWidth(), bitmap.getHeight(), WalletConstants.SMALL_RECT_ROUNDED_CORNERS_DP, WalletConstants.SMALL_RECT_ROUNDED_CORNERS_DP, paint);
         }
         paint.setXfermode(new PorterDuffXfermode(PorterDuff.Mode.SRC_IN));
         canvas.drawBitmap(bitmap, rect, rect, paint);

--- a/android/java/org/chromium/chrome/browser/crypto_wallet/util/Blockies.java
+++ b/android/java/org/chromium/chrome/browser/crypto_wallet/util/Blockies.java
@@ -29,7 +29,7 @@ public class Blockies {
 
     public static Bitmap createIcon(String address, boolean lowerCase, boolean circular) {
         if (lowerCase) {
-            return createIcon(address.toLowerCase(Locale.getDefault()), circular);
+            return createIcon(address.toLowerCase(Locale.ENGLISH), circular);
         }
 
         return createIcon(address, circular);

--- a/android/java/org/chromium/chrome/browser/crypto_wallet/util/Blockies.java
+++ b/android/java/org/chromium/chrome/browser/crypto_wallet/util/Blockies.java
@@ -62,8 +62,8 @@ public class Blockies {
         return createCanvas(imgdata, color, bgColor, spotColor, SCALE, circular);
     }
 
-    private static Bitmap createCanvas(
-            double[] imgData, String color, String bgcolor, String spotcolor, int scale, boolean circular) {
+    private static Bitmap createCanvas(double[] imgData, String color, String bgcolor,
+            String spotcolor, int scale, boolean circular) {
         int width = (int) Math.sqrt(imgData.length);
 
         int w = width * scale;
@@ -197,9 +197,12 @@ public class Blockies {
         canvas.drawARGB(0, 0, 0, 0);
         paint.setColor(color);
         if (circular) {
-            canvas.drawCircle(bitmap.getWidth() / 2, bitmap.getHeight() / 2, bitmap.getWidth() / 2, paint);
+            canvas.drawCircle(
+                    bitmap.getWidth() / 2, bitmap.getHeight() / 2, bitmap.getWidth() / 2, paint);
         } else {
-            canvas.drawRoundRect(0, 0, bitmap.getWidth(), bitmap.getHeight(), WalletConstants.SMALL_RECT_ROUNDED_CORNERS_DP, WalletConstants.SMALL_RECT_ROUNDED_CORNERS_DP, paint);
+            canvas.drawRoundRect(0, 0, bitmap.getWidth(), bitmap.getHeight(),
+                    WalletConstants.SMALL_RECT_ROUNDED_CORNERS_DP,
+                    WalletConstants.SMALL_RECT_ROUNDED_CORNERS_DP, paint);
         }
         paint.setXfermode(new PorterDuffXfermode(PorterDuff.Mode.SRC_IN));
         canvas.drawBitmap(bitmap, rect, rect, paint);

--- a/android/java/org/chromium/chrome/browser/crypto_wallet/util/Blockies.java
+++ b/android/java/org/chromium/chrome/browser/crypto_wallet/util/Blockies.java
@@ -201,8 +201,8 @@ public class Blockies {
                     bitmap.getWidth() / 2, bitmap.getHeight() / 2, bitmap.getWidth() / 2, paint);
         } else {
             canvas.drawRoundRect(0, 0, bitmap.getWidth(), bitmap.getHeight(),
-                    WalletConstants.SMALL_RECT_ROUNDED_CORNERS_DP,
-                    WalletConstants.SMALL_RECT_ROUNDED_CORNERS_DP, paint);
+                    WalletConstants.RECT_SHARP_ROUNDED_CORNERS_DP,
+                    WalletConstants.RECT_SHARP_ROUNDED_CORNERS_DP, paint);
         }
         paint.setXfermode(new PorterDuffXfermode(PorterDuff.Mode.SRC_IN));
         canvas.drawBitmap(bitmap, rect, rect, paint);

--- a/android/java/org/chromium/chrome/browser/crypto_wallet/util/PortfolioHelper.java
+++ b/android/java/org/chromium/chrome/browser/crypto_wallet/util/PortfolioHelper.java
@@ -110,7 +110,7 @@ public class PortfolioHelper {
         return Double.valueOf(mFiatHistory[mFiatHistory.length - 1].price);
     }
 
-    public void fetchAllAssetsAndDetails(Callbacks.Callback1<PortfolioHelper> callback) {
+    public void fetchNonNftAssetsAndDetails(Callbacks.Callback1<PortfolioHelper> callback) {
         resetResultData();
         if (mActivity.get() == null || mSelectedNetworks.isEmpty()) return;
         int totalNetworks = mSelectedNetworks.size();
@@ -120,8 +120,8 @@ public class PortfolioHelper {
         for (NetworkInfo networkInfo : mSelectedNetworks) {
             List<AccountInfo> accountInfosPerCoin = JavaUtils.filter(
                     mAccountInfos, accountInfo -> accountInfo.coin == networkInfo.coin);
-            Utils.getTxExtraInfo(mActivity, mCryptoNetworks, networkInfo,
-                    accountInfosPerCoin.toArray(new AccountInfo[0]), null, true,
+            Utils.getTxExtraInfo(mActivity, TokenUtils.TokenType.NON_NFTS, mCryptoNetworks,
+                    networkInfo, accountInfosPerCoin.toArray(new AccountInfo[0]), null, true,
                     (assetPrices, userAssetsList, nativeAssetsBalances,
                             blockchainTokensBalances) -> {
                         mUserAssets.addAll(Arrays.asList(userAssetsList));
@@ -186,8 +186,8 @@ public class PortfolioHelper {
         resetResultData();
         if (mActivity.get() == null || mActivity.get().isFinishing()) return;
 
-        Utils.getTxExtraInfo(mActivity, mCryptoNetworks, mSelectedNetwork, mAccountInfos, null,
-                true,
+        Utils.getTxExtraInfo(mActivity, TokenUtils.TokenType.ALL, mCryptoNetworks, mSelectedNetwork,
+                mAccountInfos, null, true,
                 (assetPrices, userAssetsList, nativeAssetsBalances, blockchainTokensBalances) -> {
                     mUserAssets.addAll(Arrays.asList(userAssetsList));
                     // Sum across accounts

--- a/android/java/org/chromium/chrome/browser/crypto_wallet/util/PortfolioHelper.java
+++ b/android/java/org/chromium/chrome/browser/crypto_wallet/util/PortfolioHelper.java
@@ -110,7 +110,8 @@ public class PortfolioHelper {
         return Double.valueOf(mFiatHistory[mFiatHistory.length - 1].price);
     }
 
-    public void fetchNonNftAssetsAndDetails(Callbacks.Callback1<PortfolioHelper> callback) {
+    public void fetchAssetsAndDetails(
+            TokenUtils.TokenType type, Callbacks.Callback1<PortfolioHelper> callback) {
         resetResultData();
         if (mActivity.get() == null || mSelectedNetworks.isEmpty()) return;
         int totalNetworks = mSelectedNetworks.size();
@@ -120,8 +121,8 @@ public class PortfolioHelper {
         for (NetworkInfo networkInfo : mSelectedNetworks) {
             List<AccountInfo> accountInfosPerCoin = JavaUtils.filter(
                     mAccountInfos, accountInfo -> accountInfo.coin == networkInfo.coin);
-            Utils.getTxExtraInfo(mActivity, TokenUtils.TokenType.NON_NFTS, mCryptoNetworks,
-                    networkInfo, accountInfosPerCoin.toArray(new AccountInfo[0]), null, true,
+            Utils.getTxExtraInfo(mActivity, type, mCryptoNetworks, networkInfo,
+                    accountInfosPerCoin.toArray(new AccountInfo[0]), null, true,
                     (assetPrices, userAssetsList, nativeAssetsBalances,
                             blockchainTokensBalances) -> {
                         mUserAssets.addAll(Arrays.asList(userAssetsList));

--- a/android/java/org/chromium/chrome/browser/crypto_wallet/util/Utils.java
+++ b/android/java/org/chromium/chrome/browser/crypto_wallet/util/Utils.java
@@ -755,8 +755,8 @@ public class Utils {
             return;
         }
         executor.execute(() -> {
-            Bitmap bitmap1 = Blockies.createIcon(addresses[0], true);
-            Bitmap bitmap2 = scaleDown(Blockies.createIcon(addresses[1], true), (float) 0.6);
+            Bitmap bitmap1 = Blockies.createIcon(addresses[0], true, true);
+            Bitmap bitmap2 = scaleDown(Blockies.createIcon(addresses[1], true, true), (float) 0.6);
             final Bitmap bitmap = overlayBitmapToCenter(bitmap1, bitmap2);
             handler.post(() -> {
                 if (iconImg != null) {
@@ -791,10 +791,10 @@ public class Utils {
 
     public static void setBlockiesBitmapCustomAsset(ExecutorService executor, Handler handler,
             ImageView iconImg, String source, String symbol, float scale, TextView textView,
-            Context context, boolean drawCaratDown, float scaleDown) {
+            Context context, boolean drawCaratDown, float scaleDown, boolean circular) {
         executor.execute(() -> {
             final Bitmap bitmap =
-                    drawTextToBitmap(scaleDown(Blockies.createIcon(source, true), scaleDown),
+                    drawTextToBitmap(scaleDown(Blockies.createIcon(source, true, circular), scaleDown),
                             symbol.isEmpty() ? "" : symbol.substring(0, 1), scale, scaleDown);
             handler.post(() -> {
                 if (iconImg != null) {
@@ -830,7 +830,7 @@ public class Utils {
     public static void setBlockiesBitmapResource(ExecutorService executor, Handler handler,
             ImageView iconImg, String source, boolean makeLowerCase) {
         executor.execute(() -> {
-            final Bitmap bitmap = Blockies.createIcon(source, makeLowerCase);
+            final Bitmap bitmap = Blockies.createIcon(source, makeLowerCase, true);
             handler.post(() -> {
                 if (iconImg != null) {
                     iconImg.setImageBitmap(bitmap);

--- a/android/java/org/chromium/chrome/browser/crypto_wallet/util/Utils.java
+++ b/android/java/org/chromium/chrome/browser/crypto_wallet/util/Utils.java
@@ -1558,10 +1558,30 @@ public class Utils {
                 "#", symbolLowerCase, contractAddress, token.tokenId, token.chainId);
     }
 
-    // Please only use this function when you need all the info (tokens, prices and balances) at the
-    // same time!
+    /**
+     * Gets tokens, prices and balances, all at the same time for a given token type.
+     * See {@link TokenUtils.TokenType}.
+     *
+     * @param activityRef Weak reference to Brave Wallet base a ctivity.
+     * @param tokenType Token type used for filtering (e.g. {@code TokenType.NON_NFTS}).
+     * @param allNetworks List of all networks, used to log P3A records.
+     * @param selectedNetwork Currently selected network.
+     * @param accountInfos Array of account info.
+     * @param filterByTokens Tokens used for fetching prices and balances.
+     *                       It may be {@code null} for fetching all tokens of a given token type.
+     *                       When {@code userAssetsOnly} is {@code true}, it should be set as
+     *                       {@code null}.
+     * @param userAssetsOnly {@code true} for fetching only user assets. It should be used with
+     *         {@code filterByTokens} set as {@code null}.
+     * @param callback Callback containing four parameters: asset prices, token list, assets
+     *         balances, blockchain token balances.
+     *
+     * <b>Note:</b>: Use this method wisely, and only if tokens, prices and balances are needed
+     * at the same time.
+     */
     public static void getTxExtraInfo(WeakReference<BraveWalletBaseActivity> activityRef,
-            List<NetworkInfo> allNetworks, NetworkInfo selectedNetwork, AccountInfo[] accountInfos,
+            TokenUtils.TokenType tokenType, List<NetworkInfo> allNetworks,
+            NetworkInfo selectedNetwork, AccountInfo[] accountInfos,
             BlockchainToken[] filterByTokens, boolean userAssetsOnly,
             Callbacks.Callback4<HashMap<String, Double>, BlockchainToken[], HashMap<String, Double>,
                     HashMap<String, HashMap<String, Double>>> callback) {
@@ -1581,8 +1601,7 @@ public class Utils {
         AsyncUtils.MultiResponseHandler multiResponse = new AsyncUtils.MultiResponseHandler(3);
 
         TokenUtils.getUserOrAllTokensFiltered(braveWalletService, blockchainRegistry,
-                selectedNetwork, selectedNetwork.coin, TokenUtils.TokenType.ALL, userAssetsOnly,
-                tokens -> {
+                selectedNetwork, selectedNetwork.coin, tokenType, userAssetsOnly, tokens -> {
                     final BlockchainToken[] fullTokenList = tokens;
                     if (filterByTokens != null) {
                         if (userAssetsOnly)

--- a/android/java/org/chromium/chrome/browser/crypto_wallet/util/Utils.java
+++ b/android/java/org/chromium/chrome/browser/crypto_wallet/util/Utils.java
@@ -793,9 +793,9 @@ public class Utils {
             ImageView iconImg, String source, String symbol, float scale, TextView textView,
             Context context, boolean drawCaratDown, float scaleDown, boolean circular) {
         executor.execute(() -> {
-            final Bitmap bitmap =
-                    drawTextToBitmap(scaleDown(Blockies.createIcon(source, true, circular), scaleDown),
-                            symbol.isEmpty() ? "" : symbol.substring(0, 1), scale, scaleDown);
+            final Bitmap bitmap = drawTextToBitmap(
+                    scaleDown(Blockies.createIcon(source, true, circular), scaleDown),
+                    symbol.isEmpty() ? "" : symbol.substring(0, 1), scale, scaleDown);
             handler.post(() -> {
                 if (iconImg != null) {
                     iconImg.setImageBitmap(bitmap);

--- a/android/java/org/chromium/chrome/browser/crypto_wallet/util/Utils.java
+++ b/android/java/org/chromium/chrome/browser/crypto_wallet/util/Utils.java
@@ -820,9 +820,9 @@ public class Utils {
 
         Rect bounds = new Rect();
         paint.getTextBounds(text, 0, text.length(), bounds);
-        int x = (bitmap.getWidth() - bounds.width()) / 2;
-        int y = (bitmap.getHeight() + bounds.height()) / 2;
-        canvas.drawText(text, x, y, paint);
+        float x = (bitmap.getWidth() - bounds.width()) / 2f;
+        float y = (bitmap.getHeight() + bounds.height()) / 2f;
+        canvas.drawText(text, x - bounds.left, y - bounds.bottom, paint);
 
         return bitmap;
     }

--- a/android/java/org/chromium/chrome/browser/crypto_wallet/util/WalletConstants.java
+++ b/android/java/org/chromium/chrome/browser/crypto_wallet/util/WalletConstants.java
@@ -8,6 +8,10 @@ import java.util.Collections;
 import java.util.List;
 
 public final class WalletConstants {
+
+    // Radius of the oval used to round the corners in density-independent pixels.
+    public final static int RECT_ROUNDED_CORNERS_DP = 16;
+
     public static final long MILLI_SECOND = 1000;
 
     // The maximum bitmap size used by {@code WebContents#downloadImage}.

--- a/android/java/org/chromium/chrome/browser/crypto_wallet/util/WalletConstants.java
+++ b/android/java/org/chromium/chrome/browser/crypto_wallet/util/WalletConstants.java
@@ -10,7 +10,8 @@ import java.util.List;
 public final class WalletConstants {
 
     // Radius of the oval used to round the corners in density-independent pixels.
-    public final static int RECT_ROUNDED_CORNERS_DP = 16;
+    public final static int SMALL_RECT_ROUNDED_CORNERS_DP = 4;
+    public final static int RECT_ROUNDED_CORNERS_DP = 12;
 
     public static final long MILLI_SECOND = 1000;
 

--- a/android/java/org/chromium/chrome/browser/crypto_wallet/util/WalletConstants.java
+++ b/android/java/org/chromium/chrome/browser/crypto_wallet/util/WalletConstants.java
@@ -8,7 +8,6 @@ import java.util.Collections;
 import java.util.List;
 
 public final class WalletConstants {
-
     // Radius of the oval used to round the corners in density-independent pixels.
     public final static int SMALL_RECT_ROUNDED_CORNERS_DP = 4;
     public final static int RECT_ROUNDED_CORNERS_DP = 12;

--- a/android/java/org/chromium/chrome/browser/crypto_wallet/util/WalletConstants.java
+++ b/android/java/org/chromium/chrome/browser/crypto_wallet/util/WalletConstants.java
@@ -9,7 +9,7 @@ import java.util.List;
 
 public final class WalletConstants {
     // Radius of the oval used to round the corners in density-independent pixels.
-    public final static int SMALL_RECT_ROUNDED_CORNERS_DP = 4;
+    public final static int RECT_SHARP_ROUNDED_CORNERS_DP = 4;
     public final static int RECT_ROUNDED_CORNERS_DP = 12;
 
     public static final long MILLI_SECOND = 1000;

--- a/android/java/res/layout/brave_wallet_add_custom_asset.xml
+++ b/android/java/res/layout/brave_wallet_add_custom_asset.xml
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="300dp"
     android:layout_height="wrap_content"
     android:orientation="vertical" >
 
     <TextView
+        android:id="@+id/add_asset_dialog_title"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_marginTop="10dp"
@@ -14,7 +14,6 @@
         android:layout_marginStart="24dp"
         android:layout_marginEnd="24dp"
         android:textColor="@color/wallet_text_color"
-        android:text="@string/wallet_add_custom_asset"
         android:textSize="18sp" />
 
     <View
@@ -103,28 +102,6 @@
         android:textSize="14sp"
         tools:ignore="LabelFor, Autofill" />
 
-    <TextView
-        android:id="@+id/advanced_title"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_marginTop="10dp"
-        android:layout_marginBottom="10dp"
-        android:layout_marginStart="24dp"
-        android:layout_marginEnd="24dp"
-        app:drawableEndCompat="@drawable/arrow_down"
-        android:textColor="@color/wallet_text_color"
-        android:text="@string/wallet_add_custom_asset_advanced"
-        android:textSize="18sp" />
-
-    <View
-        android:id="@+id/advanced_section_separator"
-        android:layout_width="match_parent"
-        android:layout_height="1dp"
-        android:layout_marginStart="12dp"
-        android:layout_marginEnd="12dp"
-        android:background="@color/wallet_text_color"
-        android:layout_marginBottom="8dp"/>
-
     <LinearLayout
         android:id="@+id/advanced_section"
         android:layout_width="match_parent"
@@ -153,14 +130,6 @@
             android:textSize="14sp"
             tools:ignore="LabelFor, Autofill" />
     </LinearLayout>
-
-    <CheckBox
-       android:id="@+id/nft_check"
-       android:layout_width="wrap_content"
-       android:layout_height="wrap_content"
-       android:layout_marginStart="24dp"
-       android:text="@string/wallet_add_solana_nft_checkbox"
-       android:visibility="gone" />
 
     <LinearLayout
         android:layout_width="match_parent"

--- a/android/java/res/layout/edit_visible_assets_bottom_sheet.xml
+++ b/android/java/res/layout/edit_visible_assets_bottom_sheet.xml
@@ -28,7 +28,6 @@
             style="@style/BraveWalletTextView"
             android:layout_width="0dp"
             android:paddingVertical="8dp"
-            android:text="@string/wallet_add_custom_asset"
             android:textColor="@color/brave_action_color"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toStartOf="@id/edit_visible_tv_network"

--- a/android/java/res/layout/fragment_nft_grid.xml
+++ b/android/java/res/layout/fragment_nft_grid.xml
@@ -28,8 +28,7 @@
             <FrameLayout
                 android:layout_height="wrap_content"
                 android:layout_width="0dp"
-                android:layout_weight=".6"
-                >
+                android:layout_weight=".6">
                 <ProgressBar
                     android:layout_gravity="start|center_vertical"
                     android:id="@+id/frag_nft_grid_pb_asset_discovery"

--- a/android/java/res/layout/fragment_nft_grid.xml
+++ b/android/java/res/layout/fragment_nft_grid.xml
@@ -5,6 +5,7 @@
      You can obtain one at https://mozilla.org/MPL/2.0/. -->
 
 <androidx.core.widget.NestedScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:background="@color/wallet_dn_bg_primary"
@@ -15,12 +16,46 @@
         android:layout_height="wrap_content"
         android:orientation="vertical">
 
-        <ProgressBar
-            android:id="@+id/frag_port_pb_asset_discovery"
-            android:indeterminateDrawable="@drawable/progress_indeterminate_orange"
-            android:layout_width="24dp"
-            android:layout_height="24dp"
-            android:visibility="gone"/>
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginBottom="16dp"
+            android:gravity="center"
+            android:orientation="horizontal"
+            android:paddingStart="16dp"
+            android:paddingEnd="16dp">
+
+            <FrameLayout
+                android:layout_height="wrap_content"
+                android:layout_width="0dp"
+                android:layout_weight=".6"
+                >
+                <ProgressBar
+                    android:layout_gravity="start|center_vertical"
+                    android:id="@+id/frag_nft_grid_pb_asset_discovery"
+                    android:indeterminateDrawable="@drawable/progress_indeterminate_orange"
+                    android:layout_width="24dp"
+                    android:layout_height="24dp"
+                    android:visibility="gone" />
+            </FrameLayout>
+
+
+            <android.widget.Button
+                android:id="@+id/fragment_nft_grid_btn_change_networks"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_margin="16dp"
+                android:layout_weight=".4"
+                android:background="@drawable/rounded_holo_button"
+                android:drawableEnd="@drawable/ic_arrow_down_circular_day_night"
+                android:minHeight="0dp"
+                android:paddingHorizontal="8dp"
+                android:paddingVertical="2dp"
+                android:textAllCaps="false"
+                android:textColor="@color/brave_wallet_day_night_text_color"
+                app:autoSizeTextType="uniform" />
+
+        </LinearLayout>
 
         <LinearLayout
             android:layout_width="match_parent"

--- a/android/java/res/layout/wallet_nft_item.xml
+++ b/android/java/res/layout/wallet_nft_item.xml
@@ -13,12 +13,27 @@
     android:padding="16dp"
     android:orientation="vertical">
 
-    <ImageView
-        android:id="@+id/icon"
+    <FrameLayout
         android:layout_width="148dp"
         android:layout_height="148dp"
-        android:layout_gravity="top|center_horizontal"
-        android:contentDescription="@null"/>
+        android:layout_gravity="top|center_horizontal">
+
+        <ImageView
+            android:id="@+id/icon"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:contentDescription="@null"/>
+
+        <ImageView
+            android:id="@+id/network_icon"
+            android:layout_gravity="bottom|end"
+            android:layout_margin="4dp"
+            android:layout_width="20dp"
+            android:layout_height="20dp"
+            android:contentDescription="@null"/>
+
+
+    </FrameLayout>
 
     <LinearLayout
         android:layout_width="wrap_content"

--- a/browser/ui/android/strings/android_brave_strings.grd
+++ b/browser/ui/android/strings/android_brave_strings.grd
@@ -2723,8 +2723,8 @@ If you don't accept this request, VPN will not reconnect and your internet conne
     <message name="IDS_WALLET_ADD_CUSTOM_ASSET" desc="Add custom asset clickable name">
       Add custom asset
     </message>
-    <message name="IDS_WALLET_ADD_CUSTOM_ASSET_ADVANCED" desc="Advanced section name">
-      Advanced
+    <message name="IDS_WALLET_ADD_NFT" desc="Add NFT clickable name">
+      Add NFT
     </message>
     <message name="IDS_WALLET_ADD_CUSTOM_ASSET_ADD_BUTTON" desc="Add custom asset dialog Add button text">
       Add
@@ -3460,9 +3460,6 @@ If you don't accept this request, VPN will not reconnect and your internet conne
     </message>
     <message name="IDS_WALLET_SIGN_MESSAGE_DETAILS_MESSAGE_SECTION" desc="A message section template of sign message details" translateable="false">
       <ph name="BEGIN_BOLD">&lt;b&gt;</ph>Message:<ph name="END_BOLD">&lt;/b&gt;</ph><ph name="BREAK">&lt;br&gt;</ph><ph name="ESCAPED_MESSAGE_TEXT">%1$s</ph>
-    </message>
-    <message name="IDS_WALLET_ADD_SOLANA_NFT_CHECKBOX" desc="A title for a Solana NFT custom assets checkbox" translateable="false">
-      NFT
     </message>
     <message name="IDS_WALLET_ADD_CUSTOM_ASSET_TOKEN_ADDRESS" desc="Add custom asset dialog Token contract address field for Solana NFT">
       Token address


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
## Resolves https://github.com/brave/brave-browser/issues/29444

⚠️ **Note:** check the [main umbrella issue](https://github.com/brave/brave-browser/issues/29291) first, to have an overview of what's been addressed in this PR and what is out of scope.

## Details

### Integrates multichain support for NFT grid screen.

![Screenshot_1680879899](https://user-images.githubusercontent.com/3308503/230631581-e473ed97-24e1-418c-86bc-9ff68e9ed592.png)

Shows network selector in the same position as the network selector of portfolio fragment.

---

### Improves `ImageLoader` and fix illegal argument exception

Improves `ImageLoader` by switching in favor of `RequestManager`. Doing so, the downloading process will be tied to the lifecycle of the view/activity/fragment requesting it. Preventing illegal argument exceptions that may arise if a download was completed and the view/activity/fragment (requesting it) already destroyed. (A similar fix was already implemented to mitigate this issue: https://github.com/brave/brave-core/pull/17891)

---

### Tweaks and improves calculations to center blockies

#### Before

![Screenshot_1680277415](https://user-images.githubusercontent.com/3308503/230633253-4481682d-fd74-4600-b6d2-5266c71324d6.png)

#### After

![Screenshot_1680536555 (1)](https://user-images.githubusercontent.com/3308503/230633087-2ebd57c3-e22c-4447-8fe2-2cccced1e67c.png)

Now the letters are rendered in the center on a rounded rectangle background (aligned with iOS platform)

---

### Addresses previous comments

* Addresses [comment #1150817680](https://github.com/brave/brave-core/pull/17797#discussion_r1150817680).
* Addresses [comment #1151711434](https://github.com/brave/brave-core/pull/17796/files#r1151711434).

---

### Improves loading spinner behavior

![Screenshot_1680880805](https://user-images.githubusercontent.com/3308503/230633924-6c23caaa-fbce-4137-a4f4-75360d5606c7.png)

Improves loading spinner behavior by showing and hiding it at better times.

---

### Improves custom asset dialog

![Screenshot_1680880922](https://user-images.githubusercontent.com/3308503/230634442-23f850c2-fbad-456c-a5b7-56c327c79072.png)
![Screenshot_1680880940](https://user-images.githubusercontent.com/3308503/230634446-21629daf-fbd1-4bc6-a88b-a723f0a545a1.png)

Custom asset dialog now reflects the right fields whether shown from Nft grid or portfolio fragment.

---

### Adds network icons in the lower right corner

![Screenshot_1680881089](https://user-images.githubusercontent.com/3308503/230634702-3e94bf77-cf3e-4373-8c97-3bb5fe0d4984.png)

Shows network icons in the lower right corner (size and place aligned with iOS)

---

### Shows right info for each NFT

In order to be consistent with iOS and Desktop platforms, shows token name + id in the title, and NFT symbol in the subtitle for both screens: NFT grid, and NFT details.

(Note: some of the screenshots were taken before implementing this change).

---

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-arm64, CI/skip-linux-x64, CI/skip-android, CI/skip-macos, CI/skip-ios, CI/skip-windows-arm64, CI/skip-windows-x64, CI/skip-windows-x86 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

### Network Selector

- Open Brave Wallet
- Navigate to NFT grid section
- Add multiple Solana and Ethereum NFTs
- Tap on Network selector 
- Choose Ethereum Mainnet
- Observe that only Ethereum NFTs are displayed
- Tap on Network selector 
- Choose Solana Mainnet
- Observe that only Solana NFTs are displayed

### Custom asset dialog validation

- Open Brave Wallet
- Navigate to NFT grid section
- Tap on Edit visible NFTs
- Tap on Edit NFT
- Add contract address
- Observe the Add button is disabled
- Add token id
- Observe Add button is enabled



