### PR TITLE
Move --crash-me flag to service run function

### DIFF
--- a/components/brave_vpn/browser/connection/win/brave_vpn_helper/service_main.cc
+++ b/components/brave_vpn/browser/connection/win/brave_vpn_helper/service_main.cc
@@ -36,12 +36,6 @@ bool ServiceMain::InitWithCommandLine(const base::CommandLine* command_line) {
     return false;
   }
 
-  // Crash itself if crash-me was used.
-  if (command_line->HasSwitch(kBraveVpnHelperCrashMe)) {
-    CHECK(!command_line->HasSwitch(kBraveVpnHelperCrashMe))
-        << "--crash-me was used.";
-  }
-
   // Run interactively if needed.
   if (command_line->HasSwitch(kConsoleSwitchName)) {
     run_routine_ = &ServiceMain::RunInteractive;
@@ -135,6 +129,13 @@ void ServiceMain::SetServiceStatus(DWORD state) {
 
 HRESULT ServiceMain::Run() {
   VLOG(1) << __func__;
+  auto* command_line = base::CommandLine::ForCurrentProcess();
+  // Crash itself if crash-me was used.
+  if (command_line && command_line->HasSwitch(kBraveVpnHelperCrashMe)) {
+    CHECK(!command_line->HasSwitch(kBraveVpnHelperCrashMe))
+        << "--crash-me was used.";
+  }
+
   base::SingleThreadTaskExecutor service_task_executor(
       base::MessagePumpType::UI);
   base::RunLoop loop;


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/29579

`--crash-me` flag added just to generate crash dumps and called too early before SERVICE_STARTED reported. The system expects service reported SERVICE_STARTED and restarts it if no SERVICE_STOPPED reported. No functional changes, just improve `--crash-me` flag to let the system restart the service after crash. This change allows to validate manually failure conditions.

https://user-images.githubusercontent.com/2965009/230656929-07b3ff3c-e768-4d11-b870-b760dae102fa.mp4

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-arm64, CI/skip-linux-x64, CI/skip-android, CI/skip-macos, CI/skip-ios, CI/skip-windows-arm64, CI/skip-windows-x64, CI/skip-windows-x86 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

- from issue
