### PR TITLE
Set tooltip texts for toggle button on vertical tabs

### DIFF
--- a/app/brave_generated_resources.grd
+++ b/app/brave_generated_resources.grd
@@ -1082,6 +1082,26 @@ Or change later at <ph name="SETTINGS_EXTENIONS_LINK">$2<ex>brave://settings/ext
       <message name="IDS_IMPORTED_FROM_BOOKMARK_FOLDER" desc="Name for bookmark panel folder imported from another browser">
         Imported from <ph name="BROWSER_NAME">$1<ex>Chrome</ex></ph>.
       </message>
+
+      <!-- Vertical tab strip -->
+      <if expr="toolkit_views">
+        <if expr="use_titlecase">
+          <message name="IDS_VERTICAL_TABS_EXPAND" desc="A tooltip text for button when vertical tab strip is minimized or floating">
+            Expand Tabs
+          </message>
+          <message name="IDS_VERTICAL_TABS_MINIMIZE" desc="A tooltip text for button when vertical tab strip is expanded">
+            Minimize Tabs
+          </message>
+        </if>
+        <if expr="not use_titlecase">
+          <message name="IDS_VERTICAL_TABS_EXPAND" desc="A tooltip text for button when vertical tab strip is minimized or floating">
+            Expand tabs
+          </message>
+          <message name="IDS_VERTICAL_TABS_MINIMIZE" desc="A tooltip text for button when vertical tab strip is expanded">
+            Minimize tabs
+          </message>
+        </if>
+      </if>
       <!--Add new items to the appropriate sections above -->
     </messages>
   </release>

--- a/browser/ui/views/frame/vertical_tab_strip_region_view.cc
+++ b/browser/ui/views/frame/vertical_tab_strip_region_view.cc
@@ -66,10 +66,6 @@ class ToggleButton : public BraveNewTabButton {
                           std::move(std::move(callback))),
         region_view_(region_view),
         tab_strip_(region_view_->tab_strip()) {
-    // TODO(sangwoo.ko) Temporary workaround before we have a proper tooltip
-    // text.
-    // https://github.com/brave/brave-browser/issues/24717
-    SetProperty(views::kSkipAccessibilityPaintChecks, true);
     SetPreferredSize(gfx::Size{GetIconWidth(), GetIconWidth()});
   }
   ~ToggleButton() override = default;
@@ -105,6 +101,15 @@ class ToggleButton : public BraveNewTabButton {
 
   void PaintFill(gfx::Canvas* canvas) const override {
     // dont' fill
+  }
+
+  std::u16string GetTooltipText(const gfx::Point& p) const override {
+    if (region_view_->state() == VerticalTabStripRegionView::State::kExpanded) {
+      return l10n_util::GetStringUTF16(IDS_VERTICAL_TABS_MINIMIZE);
+    }
+
+    // When it's minimized or floating.
+    return l10n_util::GetStringUTF16(IDS_VERTICAL_TABS_EXPAND);
   }
 
 #if DCHECK_IS_ON()
@@ -251,10 +256,10 @@ class VerticalTabNewTabButton : public BraveNewTabButton {
     // Set additional horizontal inset for '+' icon.
     if (region_view_->state() ==
         VerticalTabStripRegionView::State::kCollapsed) {
-      // // When |text_| is empty, the vertical tab strip could be minimized.
-      // // In this case we should align icon center.
-      // // TODO(sko) Should we keep this padding when it's transitioned to
-      // // floating mode?
+      // When |text_| is empty, the vertical tab strip could be minimized.
+      // In this case we should align icon center.
+      // TODO(sko) Should we keep this padding when it's transitioned to
+      // floating mode?
       SetImageHorizontalAlignment(
           views::ImageButton::HorizontalAlignment::ALIGN_CENTER);
     } else {


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/29593

* While expanded
<img width="140" alt="image" src="https://user-images.githubusercontent.com/5474642/230811978-77da5696-174e-4811-a1bc-2a3ccedfcda2.png">

* While floating
<img width="146" alt="image" src="https://user-images.githubusercontent.com/5474642/230812001-3080e119-1b1b-4e5f-83e2-3a82c9ae728f.png">

* While minimized
<img width="130" alt="image" src="https://user-images.githubusercontent.com/5474642/230812063-d2d511fa-30e0-464d-baee-e1732e893889.png">


<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-arm64, CI/skip-linux-x64, CI/skip-android, CI/skip-macos, CI/skip-ios, CI/skip-windows-arm64, CI/skip-windows-x64, CI/skip-windows-x86 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
* Enable vertical tabs
* Move mouse on the toggle button on the top of vertical tab strip.
* See if tooltip texts aren't empty
