### PR TITLE
Added `remove from list` menu entry to download bubble item

### DIFF
--- a/app/brave_generated_resources.grd
+++ b/app/brave_generated_resources.grd
@@ -630,6 +630,9 @@ Or change later at <ph name="SETTINGS_EXTENIONS_LINK">$2<ex>brave://settings/ext
             By clicking OK, you acknowledge that your installation of Brave will NOT receive critical security fixes until you update to Windows 10 or later. This warning will NOT show again.
           </message>
         </if>
+        <message name="IDS_DOWNLOAD_BUBBLE_ITEM_CTX_MENU_REMOVE_ITEM" desc="Text for the download bubble context menu item for removing item from the list">
+          Remove from list
+        </message>
       </if>
 
       <!-- Brave Ads -->

--- a/browser/ui/views/download/bubble/BUILD.gn
+++ b/browser/ui/views/download/bubble/BUILD.gn
@@ -1,0 +1,23 @@
+# Copyright (c) 2023 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+
+source_set("unit_tests") {
+  testonly = true
+
+  sources = [ "download_bubble_unittest.cc" ]
+
+  deps = [
+    "//base",
+    "//chrome/browser",
+    "//chrome/test:test_support",
+    "//components/download/public/common:test_support",
+    "//components/safe_browsing/core/common",
+    "//content/test:test_support",
+    "//testing/gmock",
+    "//testing/gtest",
+    "//ui/base",
+    "//url",
+  ]
+}

--- a/browser/ui/views/download/bubble/download_bubble_unittest.cc
+++ b/browser/ui/views/download/bubble/download_bubble_unittest.cc
@@ -1,0 +1,152 @@
+/* Copyright (c) 2023 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "base/test/scoped_feature_list.h"
+#include "chrome/browser/download/download_commands.h"
+#include "chrome/browser/download/download_item_model.h"
+#include "chrome/browser/ui/views/download/download_shelf_context_menu_view.h"
+#include "chrome/test/base/testing_browser_process.h"
+#include "chrome/test/base/testing_profile.h"
+#include "chrome/test/base/testing_profile_manager.h"
+#include "components/download/public/common/mock_download_item.h"
+#include "components/safe_browsing/core/common/features.h"
+#include "content/public/test/browser_task_environment.h"
+#include "testing/gmock/include/gmock/gmock.h"
+#include "testing/gtest/include/gtest/gtest.h"
+#include "ui/base/models/simple_menu_model.h"
+#include "url/gurl.h"
+
+using download::DownloadItem;
+using ::testing::_;
+using ::testing::NiceMock;
+using ::testing::Return;
+using ::testing::ReturnRefOfCopy;
+
+namespace {
+
+// Default target path for a mock download item in DownloadItemModelTest.
+const base::FilePath::CharType kDefaultTargetFilePath[] =
+    FILE_PATH_LITERAL("/foo/bar/foo.bar");
+
+const base::FilePath::CharType kDefaultDisplayFileName[] =
+    FILE_PATH_LITERAL("foo.bar");
+
+// Default URL for a mock download item in DownloadItemModelTest.
+const char kDefaultURL[] = "http://example.com/foo.bar";
+}  // namespace
+
+class DownloadBubbleTest : public testing::Test {
+ public:
+  DownloadBubbleTest()
+      : model_(&item_),
+        testing_profile_manager_(TestingBrowserProcess::GetGlobal()) {}
+
+  ~DownloadBubbleTest() override = default;
+
+  void SetUp() override {
+    ASSERT_TRUE(testing_profile_manager_.SetUp());
+    testing_profile_manager_.CreateTestingProfile("testing_profile");
+  }
+
+  // Sets up defaults for the download item and sets |model_| to a new
+  // DownloadItemModel that uses the mock download item.
+  void SetupDownloadItemDefaults() {
+    ON_CALL(item_, GetReceivedBytes()).WillByDefault(Return(1));
+    ON_CALL(item_, GetTotalBytes()).WillByDefault(Return(2));
+    ON_CALL(item_, TimeRemaining(_)).WillByDefault(Return(false));
+    ON_CALL(item_, GetMimeType()).WillByDefault(Return("text/html"));
+    ON_CALL(item_, AllDataSaved()).WillByDefault(Return(false));
+    ON_CALL(item_, GetOpenWhenComplete()).WillByDefault(Return(false));
+    ON_CALL(item_, GetFileExternallyRemoved()).WillByDefault(Return(false));
+    ON_CALL(item_, GetURL()).WillByDefault(ReturnRefOfCopy(GURL(kDefaultURL)));
+    ON_CALL(item_, GetFileNameToReportUser())
+        .WillByDefault(Return(base::FilePath(kDefaultDisplayFileName)));
+    ON_CALL(item_, GetTargetFilePath())
+        .WillByDefault(ReturnRefOfCopy(base::FilePath(kDefaultTargetFilePath)));
+    ON_CALL(item_, GetTargetDisposition())
+        .WillByDefault(Return(DownloadItem::TARGET_DISPOSITION_OVERWRITE));
+    ON_CALL(item_, IsPaused()).WillByDefault(Return(false));
+    ON_CALL(item_, CanResume()).WillByDefault(Return(false));
+    ON_CALL(item_, GetInsecureDownloadStatus())
+        .WillByDefault(
+            Return(download::DownloadItem::InsecureDownloadStatus::SAFE));
+    ON_CALL(item_, GetDangerType())
+        .WillByDefault(Return(download::DOWNLOAD_DANGER_TYPE_NOT_DANGEROUS));
+  }
+
+  void SetupCompletedDownloadItem() {
+    EXPECT_CALL(item_, GetState())
+        .WillRepeatedly(Return(DownloadItem::COMPLETE));
+  }
+
+  void SetupInProgressDownloadItem() {
+    EXPECT_CALL(item_, GetState())
+        .WillRepeatedly(Return(DownloadItem::IN_PROGRESS));
+  }
+
+  void SetupCancelledDownloadItem() {
+    EXPECT_CALL(item_, GetState())
+        .WillRepeatedly(Return(DownloadItem::CANCELLED));
+  }
+
+  content::BrowserTaskEnvironment task_environment_;
+  NiceMock<download::MockDownloadItem> item_;
+  DownloadItemModel model_;
+  TestingProfileManager testing_profile_manager_;
+};
+
+TEST_F(DownloadBubbleTest, ContextMenuCompletedItemTest) {
+  SetupDownloadItemDefaults();
+  SetupCompletedDownloadItem();
+
+  // Check complete item has remove from list menu entry;
+  DownloadShelfContextMenuView ctx_menu(model_.GetWeakPtr());
+  auto* menu_model = ctx_menu.GetMenuModel();
+  EXPECT_TRUE(menu_model->GetIndexOfCommandId(
+      static_cast<int>(BraveDownloadCommands::REMOVE_FROM_LIST)));
+}
+
+TEST_F(DownloadBubbleTest, ContextMenuInProgressItemTest) {
+  SetupDownloadItemDefaults();
+  SetupInProgressDownloadItem();
+
+  // Check in-progress item doesn't have remove from list menu entry;
+  DownloadShelfContextMenuView ctx_menu(model_.GetWeakPtr());
+  auto* menu_model = ctx_menu.GetMenuModel();
+  EXPECT_FALSE(menu_model->GetIndexOfCommandId(
+      static_cast<int>(BraveDownloadCommands::REMOVE_FROM_LIST)));
+}
+
+TEST_F(DownloadBubbleTest, ContextMenuCancelledItemTest) {
+  SetupDownloadItemDefaults();
+  SetupCancelledDownloadItem();
+
+  // Check cancelled item has remove from list menu entry;
+  DownloadShelfContextMenuView ctx_menu(model_.GetWeakPtr());
+  auto* menu_model = ctx_menu.GetMenuModel();
+  EXPECT_TRUE(menu_model->GetIndexOfCommandId(
+      static_cast<int>(BraveDownloadCommands::REMOVE_FROM_LIST)));
+}
+
+class DownloadBubbleFeatureDisabledTest : public DownloadBubbleTest {
+ public:
+  DownloadBubbleFeatureDisabledTest() {
+    feature_list_.InitAndDisableFeature(safe_browsing::kDownloadBubble);
+  }
+
+  base::test::ScopedFeatureList feature_list_;
+};
+
+TEST_F(DownloadBubbleFeatureDisabledTest, ContextMenuCompletedTest) {
+  SetupDownloadItemDefaults();
+  SetupCompletedDownloadItem();
+
+  // Check completed item doesn't have remove from list menu entry when feature
+  // is disabled.
+  DownloadShelfContextMenuView ctx_menu(model_.GetWeakPtr());
+  auto* menu_model = ctx_menu.GetMenuModel();
+  EXPECT_FALSE(menu_model->GetIndexOfCommandId(
+      static_cast<int>(BraveDownloadCommands::REMOVE_FROM_LIST)));
+}

--- a/chromium_src/chrome/browser/download/download_commands.h
+++ b/chromium_src/chrome/browser/download/download_commands.h
@@ -1,0 +1,17 @@
+/* Copyright (c) 2023 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_CHROMIUM_SRC_CHROME_BROWSER_DOWNLOAD_DOWNLOAD_COMMANDS_H_
+#define BRAVE_CHROMIUM_SRC_CHROME_BROWSER_DOWNLOAD_DOWNLOAD_COMMANDS_H_
+
+#include "src/chrome/browser/download/download_commands.h"  // IWYU pragma: export
+
+// Create brave specific commands set instead of appending to
+// DownloadCommands::Command to avoid many upstream changes.
+enum class BraveDownloadCommands {
+  REMOVE_FROM_LIST = DownloadCommands::Command::MAX + 1
+};
+
+#endif  // BRAVE_CHROMIUM_SRC_CHROME_BROWSER_DOWNLOAD_DOWNLOAD_COMMANDS_H_

--- a/chromium_src/chrome/browser/download/download_shelf_context_menu.h
+++ b/chromium_src/chrome/browser/download/download_shelf_context_menu.h
@@ -1,0 +1,19 @@
+/* Copyright (c) 2023 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_CHROMIUM_SRC_CHROME_BROWSER_DOWNLOAD_DOWNLOAD_SHELF_CONTEXT_MENU_H_
+#define BRAVE_CHROMIUM_SRC_CHROME_BROWSER_DOWNLOAD_DOWNLOAD_SHELF_CONTEXT_MENU_H_
+
+#define GetMenuModel \
+  UnUsed() {         \
+    return nullptr;  \
+  }                  \
+  virtual ui::SimpleMenuModel* GetMenuModel
+
+#include "src/chrome/browser/download/download_shelf_context_menu.h"  // IWYU pragma: export
+
+#undef GetMenuModel
+
+#endif  // BRAVE_CHROMIUM_SRC_CHROME_BROWSER_DOWNLOAD_DOWNLOAD_SHELF_CONTEXT_MENU_H_

--- a/chromium_src/chrome/browser/ui/views/download/download_shelf_context_menu_view.cc
+++ b/chromium_src/chrome/browser/ui/views/download/download_shelf_context_menu_view.cc
@@ -1,0 +1,98 @@
+/* Copyright (c) 2023 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "chrome/browser/ui/views/download/download_shelf_context_menu_view.h"
+#include "brave/grit/brave_generated_resources.h"
+#include "chrome/browser/download/bubble/download_bubble_prefs.h"
+#include "chrome/browser/download/download_ui_model.h"
+#include "chrome/browser/profiles/profile_manager.h"
+#include "ui/base/l10n/l10n_util.h"
+#include "ui/base/models/simple_menu_model.h"
+
+#define DownloadShelfContextMenuView DownloadShelfContextMenuViewChromium
+
+#include "src/chrome/browser/ui/views/download/download_shelf_context_menu_view.cc"
+
+#undef DownloadShelfContextMenuView
+
+DownloadShelfContextMenuView::~DownloadShelfContextMenuView() = default;
+
+ui::SimpleMenuModel* DownloadShelfContextMenuView::GetMenuModel() {
+  auto* model = DownloadShelfContextMenuViewChromium::GetMenuModel();
+  if (!model) {
+    return nullptr;
+  }
+
+  // Only add "Remove item from list" entry to download bubble.
+  if (!download::IsDownloadBubbleEnabled(
+          ProfileManager::GetLastUsedProfile())) {
+    return model;
+  }
+
+  auto* download = GetDownload();
+  if (download->GetDownloadItem() == nullptr) {
+    return model;
+  }
+
+  // Early return if |model| has the item. |model| is cached by base class.
+  if (auto index = model->GetIndexOfCommandId(
+          static_cast<int>(BraveDownloadCommands::REMOVE_FROM_LIST))) {
+    return model;
+  }
+
+  // Don't add "Remove item fro list" entry to in-progress state.
+  if (download->GetState() != download::DownloadItem::COMPLETE &&
+      download->GetState() != download::DownloadItem::CANCELLED) {
+    return model;
+  }
+
+  if (auto index =
+          model->GetIndexOfCommandId(DownloadCommands::SHOW_IN_FOLDER)) {
+    model->InsertItemAt(
+        *index + 1, static_cast<int>(BraveDownloadCommands::REMOVE_FROM_LIST),
+        l10n_util::GetStringUTF16(
+            IDS_DOWNLOAD_BUBBLE_ITEM_CTX_MENU_REMOVE_ITEM));
+  }
+
+  return model;
+}
+
+bool DownloadShelfContextMenuView::IsCommandIdEnabled(int command_id) const {
+  if (static_cast<BraveDownloadCommands>(command_id) ==
+      BraveDownloadCommands::REMOVE_FROM_LIST) {
+    return true;
+  }
+
+  return DownloadShelfContextMenuViewChromium::IsCommandIdEnabled(command_id);
+}
+
+bool DownloadShelfContextMenuView::IsCommandIdChecked(int command_id) const {
+  if (static_cast<BraveDownloadCommands>(command_id) ==
+      BraveDownloadCommands::REMOVE_FROM_LIST) {
+    return false;
+  }
+
+  return DownloadShelfContextMenuViewChromium::IsCommandIdChecked(command_id);
+}
+
+bool DownloadShelfContextMenuView::IsCommandIdVisible(int command_id) const {
+  if (static_cast<BraveDownloadCommands>(command_id) ==
+      BraveDownloadCommands::REMOVE_FROM_LIST) {
+    return true;
+  }
+
+  return DownloadShelfContextMenuViewChromium::IsCommandIdVisible(command_id);
+}
+
+void DownloadShelfContextMenuView::ExecuteCommand(int command_id,
+                                                  int event_flags) {
+  if (static_cast<BraveDownloadCommands>(command_id) ==
+      BraveDownloadCommands::REMOVE_FROM_LIST) {
+    GetDownload()->GetDownloadItem()->Remove();
+    return;
+  }
+
+  DownloadShelfContextMenuViewChromium::ExecuteCommand(command_id, event_flags);
+}

--- a/chromium_src/chrome/browser/ui/views/download/download_shelf_context_menu_view.h
+++ b/chromium_src/chrome/browser/ui/views/download/download_shelf_context_menu_view.h
@@ -1,0 +1,37 @@
+/* Copyright (c) 2023 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_CHROMIUM_SRC_CHROME_BROWSER_UI_VIEWS_DOWNLOAD_DOWNLOAD_SHELF_CONTEXT_MENU_VIEW_H_
+#define BRAVE_CHROMIUM_SRC_CHROME_BROWSER_UI_VIEWS_DOWNLOAD_DOWNLOAD_SHELF_CONTEXT_MENU_VIEW_H_
+
+#define DownloadShelfContextMenuView DownloadShelfContextMenuViewChromium
+// To make private methods accessible from our subclass.
+#define OnMenuClosed \
+  UnUsed() {}        \
+                     \
+ protected:          \
+  void OnMenuClosed
+
+#include "src/chrome/browser/ui/views/download/download_shelf_context_menu_view.h"  // IWYU pragma: export
+
+#undef OnMenuClosed
+#undef DownloadShelfContextMenuView
+
+class DownloadShelfContextMenuView
+    : public DownloadShelfContextMenuViewChromium {
+ public:
+  using DownloadShelfContextMenuViewChromium::
+      DownloadShelfContextMenuViewChromium;
+  ~DownloadShelfContextMenuView() override;
+
+  // DownloadShelfContextMenuViewChromium overrides:
+  ui::SimpleMenuModel* GetMenuModel() override;
+  bool IsCommandIdEnabled(int command_id) const override;
+  bool IsCommandIdChecked(int command_id) const override;
+  bool IsCommandIdVisible(int command_id) const override;
+  void ExecuteCommand(int command_id, int event_flags) override;
+};
+
+#endif  // BRAVE_CHROMIUM_SRC_CHROME_BROWSER_UI_VIEWS_DOWNLOAD_DOWNLOAD_SHELF_CONTEXT_MENU_VIEW_H_

--- a/test/BUILD.gn
+++ b/test/BUILD.gn
@@ -412,6 +412,7 @@ test("brave_unit_tests") {
       "//brave/browser/ui/commander:unit_tests",
       "//brave/browser/ui/commands:unit_tests",
       "//brave/browser/ui/toolbar:brave_app_menu_unit_test",
+      "//brave/browser/ui/views/download/bubble:unit_tests",
       "//brave/browser/ui/webui/settings:unittests",
       "//brave/browser/ui/whats_new:unit_test",
       "//brave/components/brave_shields/common:mojom",


### PR DESCRIPTION
fix https://github.com/brave/brave-browser/issues/29475

Completed item
<img width="493" alt="Screenshot 2023-04-10 at 4 57 17 PM" src="https://user-images.githubusercontent.com/6786187/230855596-a32e6f66-7dde-4b96-8203-68f64810a938.png">
Cancelled item
<img width="482" alt="Screenshot 2023-04-10 at 4 56 07 PM" src="https://user-images.githubusercontent.com/6786187/230855656-674a48cb-a9f9-40d2-a36b-86898bb59def.png">
In-progress item (no remove from list entry)
<img width="472" alt="Screenshot 2023-04-10 at 4 58 22 PM" src="https://user-images.githubusercontent.com/6786187/230855773-25ee0c7d-e463-42b7-808e-65597572c709.png">
Paused item (no remove from list entry)
<img width="442" alt="Screenshot 2023-04-10 at 4 58 37 PM" src="https://user-images.githubusercontent.com/6786187/230855811-44ad6e31-019c-499d-acfb-1b2f933af844.png">


<!-- Add brave-browser issue below that this PR will resolve -->
Resolves 

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-arm64, CI/skip-linux-x64, CI/skip-android, CI/skip-macos, CI/skip-ios, CI/skip-windows-arm64, CI/skip-windows-x64, CI/skip-windows-x86 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [ ] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

`DownloadBubbleTest.*`
`DownloadBubbleFeatureDisabledTest.*`

1. Start any file download
2. Check `Remove from list` is only shown for `completed` or `cancelled` item