### PR TITLE
fix(wallet): Wallet Dark Mode Background Update

### DIFF
--- a/components/brave_wallet_ui/components/desktop/wallet-page-wrapper/wallet-page-wrapper.style.ts
+++ b/components/brave_wallet_ui/components/desktop/wallet-page-wrapper/wallet-page-wrapper.style.ts
@@ -82,7 +82,7 @@ export const BackgroundGradientWrapper = styled.div`
   left: 0px;
   right: 0px;
   opacity: 0.5;
-  background-color: ${(p) => p.theme.color.background01};
+  background-color: ${leo.color.container.highlight};
 `
 
 export const BackgroundGradientTopLayer = styled.div`
@@ -97,7 +97,14 @@ export const BackgroundGradientTopLayer = styled.div`
   transform: matrix(1, -0.06, -0.32, -0.95, 0, 0);
   z-index: 5;
   @media (prefers-color-scheme: dark) {
-    background: #101D3C;
+    /* #013F4B does not exist in design system */
+    background: #013F4B;
+    filter: blur(47px);
+    left: 35%;
+    right: -100%;
+    top: 2%;
+    bottom: 25%;
+    transform: matrix(-0.98, 0.19, -0.73, -0.68, 0, 0);
   }
 `
 
@@ -113,7 +120,14 @@ export const BackgroundGradientMiddleLayer = styled.div`
   transform: matrix(-1, 0.06, -0.32, -0.95, 0, 0);
   z-index: 4;
   @media (prefers-color-scheme: dark) {
-    background: #08484D;
+    /* #030A49 does not exist in design system */
+    background: #030A49;
+    filter: blur(70px);
+    left: -40%;
+    right: 17%;
+    top: 50%;
+    bottom: -80%;
+    transform: matrix(-0.98, 0.19, -0.73, -0.68, 0, 0);
   }
 `
 
@@ -129,7 +143,14 @@ export const BackgroundGradientBottomLayer = styled.div`
   transform: matrix(-1, 0.06, -0.32, -0.95, 0, 0);
   z-index: 3;
   @media (prefers-color-scheme: dark) {
-    background: #141C38;
+    /* #014B3A does not exist in design system */
+    background: #014B3A;
+    filter: blur(70px);
+    left: 25%;
+    right: -80%;
+    top: 15%;
+    bottom: -40%;
+    transform: matrix(-0.79, 0.61, -0.98, -0.22, 0, 0);
   }
 `
 


### PR DESCRIPTION
## Description 
Updates the `Wallet` dark-mode `Background` to match what's in Figma

<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves <https://github.com/brave/brave-browser/issues/29604>

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-arm64, CI/skip-linux-x64, CI/skip-android, CI/skip-macos, CI/skip-ios, CI/skip-windows-arm64, CI/skip-windows-x64, CI/skip-windows-x86 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

Before:

![Screenshot 56](https://user-images.githubusercontent.com/40611140/230950888-7709b443-60ae-4dd5-8475-a97d1a118c4e.png)

After:

![Screenshot 52](https://user-images.githubusercontent.com/40611140/230950907-942eeea8-1257-4386-950d-caa64e1e8fb5.png)
