### PR TITLE
Keep web contents alive and wait for media files to be added

### DIFF
--- a/android/java/org/chromium/chrome/browser/playlist/PlaylistServiceObserverImpl.java
+++ b/android/java/org/chromium/chrome/browser/playlist/PlaylistServiceObserverImpl.java
@@ -6,7 +6,9 @@
 package org.chromium.chrome.browser.playlist;
 
 import org.chromium.mojo.system.MojoException;
+import org.chromium.playlist.mojom.PlaylistItem;
 import org.chromium.playlist.mojom.PlaylistServiceObserver;
+import org.chromium.url.mojom.Url;
 
 public class PlaylistServiceObserverImpl implements PlaylistServiceObserver {
     public interface PlaylistServiceObserverImplDelegate {
@@ -36,6 +38,9 @@ public class PlaylistServiceObserverImpl implements PlaylistServiceObserver {
         mDelegate.onMediaFileDownloadProgressed(
                 id, totalBytes, receivedBytes, percentComplete, timeRemaining);
     }
+
+    @Override
+    public void onMediaFilesUpdated(Url pageUrl, PlaylistItem[] items) {}
 
     @Override
     public void close() {

--- a/browser/brave_content_browser_client.cc
+++ b/browser/brave_content_browser_client.cc
@@ -209,7 +209,9 @@ using extensions::ChromeContentBrowserClientExtensionsPart;
 
 #if BUILDFLAG(ENABLE_PLAYLIST)
 #include "brave/browser/playlist/playlist_service_factory.h"
+#include "brave/components/playlist/browser/playlist_render_frame_browser_client.h"
 #include "brave/components/playlist/browser/playlist_service.h"
+#include "brave/components/playlist/common/mojom/playlist.mojom.h"
 #endif
 
 #if BUILDFLAG(ENABLE_PLAYLIST_WEBUI)
@@ -254,6 +256,22 @@ void BindCosmeticFiltersResources(
       FROM_HERE, base::BindOnce(&BindCosmeticFiltersResourcesOnTaskRunner,
                                 std::move(receiver)));
 }
+
+#if BUILDFLAG(ENABLE_PLAYLIST)
+void BindPlaylistRenderFrameBrowserClient(
+    content::RenderFrameHost* const frame_host,
+    mojo::PendingReceiver<playlist::mojom::PlaylistRenderFrameBrowserClient>
+        receiver) {
+  auto* playlist_service =
+      playlist::PlaylistServiceFactory::GetForBrowserContext(
+          frame_host->GetBrowserContext());
+  DCHECK(playlist_service);
+  mojo::MakeSelfOwnedReceiver(
+      std::make_unique<playlist::PlaylistRenderFrameBrowserClient>(
+          frame_host->GetGlobalId(), playlist_service->GetWeakPtr()),
+      std::move(receiver));
+}
+#endif  // BUILDFLAG(ENABLE_PLAYLIST)
 
 void MaybeBindWalletP3A(
     content::RenderFrameHost* const frame_host,
@@ -658,6 +676,11 @@ void BraveContentBrowserClient::RegisterBrowserInterfaceBindersForFrame(
   content::RegisterWebUIControllerInterfaceBinder<
       brave_new_tab_page::mojom::PageHandlerFactory, BraveNewTabUI>(map);
 #endif
+
+#if BUILDFLAG(ENABLE_PLAYLIST)
+  map->Add<playlist::mojom::PlaylistRenderFrameBrowserClient>(
+      base::BindRepeating(&BindPlaylistRenderFrameBrowserClient));
+#endif  // BUILDFLAG(ENABLE_PLAYLIST)
 }
 
 bool BraveContentBrowserClient::HandleExternalProtocol(

--- a/chromium_src/third_party/blink/common/web_preferences/web_preferences_mojom_traits.cc
+++ b/chromium_src/third_party/blink/common/web_preferences/web_preferences_mojom_traits.cc
@@ -24,6 +24,7 @@ bool StructTraits<blink::mojom::WebPreferencesDataView,
   }
   out->force_cosmetic_filtering = data.force_cosmetic_filtering();
   out->hide_media_src_api = data.hide_media_src_api();
+  out->should_detect_media_files = data.should_detect_media_files();
   return true;
 }
 

--- a/chromium_src/third_party/blink/public/common/web_preferences/web_preferences.h
+++ b/chromium_src/third_party/blink/public/common/web_preferences/web_preferences.h
@@ -27,6 +27,7 @@ struct BLINK_COMMON_EXPORT WebPreferences : public WebPreferences_ChromiumImpl {
 
   bool force_cosmetic_filtering = false;
   bool hide_media_src_api = false;
+  bool should_detect_media_files = false;
 };
 
 }  // namespace web_pref

--- a/chromium_src/third_party/blink/public/common/web_preferences/web_preferences_mojom_traits.h
+++ b/chromium_src/third_party/blink/public/common/web_preferences/web_preferences_mojom_traits.h
@@ -31,6 +31,11 @@ struct BLINK_COMMON_EXPORT StructTraits<blink::mojom::WebPreferencesDataView,
     return r.hide_media_src_api;
   }
 
+  static bool should_detect_media_files(
+      const blink::web_pref::WebPreferences& r) {
+    return r.should_detect_media_files;
+  }
+
   static bool Read(blink::mojom::WebPreferencesDataView r,
                    blink::web_pref::WebPreferences* out);
 };

--- a/chromium_src/third_party/blink/public/mojom/webpreferences/web_preferences.mojom
+++ b/chromium_src/third_party/blink/public/mojom/webpreferences/web_preferences.mojom
@@ -16,4 +16,9 @@ struct WebPreferences {
   // the media source API from the page. This is used by Playlist so that
   // it can get downloadable media urls instead of blob url.
   bool hide_media_src_api;
+
+  // If |should_detect_media_files| is true, PlaylistRenderFrameObserver will
+  // try to inject JavaScript to detect <video> and <audio> tag, that are
+  // dynamically attached.
+  bool should_detect_media_files;
 };

--- a/components/playlist/browser/BUILD.gn
+++ b/components/playlist/browser/BUILD.gn
@@ -25,6 +25,8 @@ static_library("browser") {
     "playlist_media_file_download_manager.h",
     "playlist_media_file_downloader.cc",
     "playlist_media_file_downloader.h",
+    "playlist_render_frame_browser_client.cc",
+    "playlist_render_frame_browser_client.h",
     "playlist_service.cc",
     "playlist_service.h",
     "playlist_service_observer.h",

--- a/components/playlist/browser/playlist_download_request_manager.cc
+++ b/components/playlist/browser/playlist_download_request_manager.cc
@@ -54,7 +54,9 @@ void PlaylistDownloadRequestManager::SetPlaylistJavaScriptWorldId(
   // Never allow running in main world (0).
   CHECK(id > content::ISOLATED_WORLD_ID_CONTENT_END);
   // Only allow ID to be set once.
-  CHECK(!PlaylistJavaScriptWorldIdIsSet());
+  if (PlaylistJavaScriptWorldIdIsSet()) {
+    CHECK_IS_TEST();
+  }
   g_playlist_javascript_world_id = id;
 }
 
@@ -66,8 +68,6 @@ PlaylistDownloadRequestManager::PlaylistDownloadRequestManager(
 PlaylistDownloadRequestManager::~PlaylistDownloadRequestManager() = default;
 
 void PlaylistDownloadRequestManager::CreateWebContents() {
-  DCHECK(!web_contents_);
-
   content::WebContents::CreateParams create_params(context_, nullptr);
   web_contents_ = content::WebContents::Create(create_params);
   if (base::FeatureList::IsEnabled(features::kPlaylistFakeUA)) {
@@ -243,8 +243,6 @@ void PlaylistDownloadRequestManager::ProcessFoundMedia(
     return;
   }
 
-  web_contents_.reset();
-
   /* Expected output:
     [
       {
@@ -345,6 +343,7 @@ void PlaylistDownloadRequestManager::ConfigureWebPrefsForBackgroundWebContents(
   if (web_contents_ && web_contents_.get() == web_contents) {
     web_prefs->force_cosmetic_filtering = true;
     web_prefs->hide_media_src_api = true;
+    web_prefs->should_detect_media_files = true;
   }
 }
 

--- a/components/playlist/browser/playlist_download_request_manager.h
+++ b/components/playlist/browser/playlist_download_request_manager.h
@@ -73,6 +73,9 @@ class PlaylistDownloadRequestManager : public content::WebContentsObserver {
       content::WebContents* web_contents,
       blink::web_pref::WebPreferences* web_prefs);
 
+  content::WebContents* background_contents() { return web_contents_.get(); }
+
+  // This will create or get web contents
   content::WebContents* GetBackgroundWebContentsForTesting();
 
   const MediaDetectorComponentManager* media_detector_component_manager()

--- a/components/playlist/browser/playlist_download_request_manager.h
+++ b/components/playlist/browser/playlist_download_request_manager.h
@@ -73,7 +73,9 @@ class PlaylistDownloadRequestManager : public content::WebContentsObserver {
       content::WebContents* web_contents,
       blink::web_pref::WebPreferences* web_prefs);
 
-  content::WebContents* background_contents() { return web_contents_.get(); }
+  const content::WebContents* background_contents() const {
+    return web_contents_.get();
+  }
 
   // This will create or get web contents
   content::WebContents* GetBackgroundWebContentsForTesting();

--- a/components/playlist/browser/playlist_render_frame_browser_client.cc
+++ b/components/playlist/browser/playlist_render_frame_browser_client.cc
@@ -1,0 +1,41 @@
+/* Copyright (c) 2023 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "brave/components/playlist/browser/playlist_render_frame_browser_client.h"
+
+#include "brave/components/playlist/browser/playlist_service.h"
+
+namespace playlist {
+
+PlaylistRenderFrameBrowserClient::PlaylistRenderFrameBrowserClient(
+    content::GlobalRenderFrameHostId frame_id,
+    const base::WeakPtr<PlaylistService>& service)
+    : frame_id_(frame_id), service_(service) {
+  DVLOG(2) << __FUNCTION__ << " " << frame_id_;
+}
+
+PlaylistRenderFrameBrowserClient::~PlaylistRenderFrameBrowserClient() {
+  DVLOG(2) << __FUNCTION__ << " " << frame_id_;
+}
+
+void PlaylistRenderFrameBrowserClient::OnMediaUpdatedFromRenderFrame() {
+  DVLOG(2) << __FUNCTION__ << " " << frame_id_;
+  auto* render_frame_host = content::RenderFrameHost::FromID(frame_id_);
+  if (!render_frame_host) {
+    return;
+  }
+
+  auto* web_contents =
+      content::WebContents::FromRenderFrameHost(render_frame_host);
+  if (!web_contents) {
+    return;
+  }
+
+  if (service_) {
+    service_->OnMediaUpdatedFromContents(web_contents);
+  }
+}
+
+}  // namespace playlist

--- a/components/playlist/browser/playlist_render_frame_browser_client.h
+++ b/components/playlist/browser/playlist_render_frame_browser_client.h
@@ -1,0 +1,34 @@
+/* Copyright (c) 2023 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_COMPONENTS_PLAYLIST_BROWSER_PLAYLIST_RENDER_FRAME_BROWSER_CLIENT_H_
+#define BRAVE_COMPONENTS_PLAYLIST_BROWSER_PLAYLIST_RENDER_FRAME_BROWSER_CLIENT_H_
+
+#include "base/memory/weak_ptr.h"
+#include "brave/components/playlist/common/mojom/playlist.mojom.h"
+#include "content/public/browser/global_routing_id.h"
+
+namespace playlist {
+
+class PlaylistService;
+class PlaylistRenderFrameBrowserClient
+    : public mojom::PlaylistRenderFrameBrowserClient {
+ public:
+  PlaylistRenderFrameBrowserClient(
+      content::GlobalRenderFrameHostId frame_id,
+      const base::WeakPtr<PlaylistService>& service);
+  ~PlaylistRenderFrameBrowserClient() override;
+
+  // mojom::PlaylistRenderFrameBrowserClient:
+  void OnMediaUpdatedFromRenderFrame() override;
+
+ private:
+  content::GlobalRenderFrameHostId frame_id_;
+  base::WeakPtr<PlaylistService> service_;
+};
+
+}  // namespace playlist
+
+#endif  // BRAVE_COMPONENTS_PLAYLIST_BROWSER_PLAYLIST_RENDER_FRAME_BROWSER_CLIENT_H_

--- a/components/playlist/browser/playlist_service.h
+++ b/components/playlist/browser/playlist_service.h
@@ -22,6 +22,7 @@
 #include "brave/components/playlist/common/mojom/playlist.mojom.h"
 #include "components/keyed_service/core/keyed_service.h"
 #include "mojo/public/cpp/bindings/remote_set.h"
+
 #if BUILDFLAG(IS_ANDROID)
 #include "mojo/public/cpp/bindings/receiver_set.h"
 #endif  // BUILDFLAG(IS_ANDROID)
@@ -42,6 +43,7 @@ class WebContents;
 class CosmeticFilteringPlaylistFlagEnabledTest;
 class PlaylistBrowserTest;
 class PlaylistRenderFrameObserverBrowserTest;
+class PlaylistDownloadRequestManagerBrowserTest;
 class PrefService;
 
 namespace playlist {
@@ -113,7 +115,9 @@ class PlaylistService : public KeyedService,
       content::WebContents* web_contents,
       blink::web_pref::WebPreferences* web_prefs);
 
-  // mojom::Service:
+  base::WeakPtr<PlaylistService> GetWeakPtr();
+
+  // mojom::PlaylistService:
   // TODO(sko) Make getters without callbacks and simplify codes in
   // PlaylistService and tests.
   void GetAllPlaylists(GetAllPlaylistsCallback callback) override;
@@ -164,10 +168,13 @@ class PlaylistService : public KeyedService,
   void AddObserver(
       mojo::PendingRemote<mojom::PlaylistServiceObserver> observer) override;
 
+  void OnMediaUpdatedFromContents(content::WebContents* contents);
+
  private:
   friend class ::CosmeticFilteringPlaylistFlagEnabledTest;
   friend class ::PlaylistBrowserTest;
   friend class ::PlaylistRenderFrameObserverBrowserTest;
+  friend class ::PlaylistDownloadRequestManagerBrowserTest;
 
   FRIEND_TEST_ALL_PREFIXES(PlaylistServiceUnitTest, CreatePlaylist);
   FRIEND_TEST_ALL_PREFIXES(PlaylistServiceUnitTest, CreatePlaylistItem);
@@ -242,6 +249,8 @@ class PlaylistService : public KeyedService,
   void NotifyPlaylistChanged(const PlaylistChangeParams& params);
   void NotifyPlaylistChanged(mojom::PlaylistEvent playlist_event,
                              const std::string& playlist_id);
+  void NotifyMediaFilesUpdated(const GURL& url,
+                               std::vector<mojom::PlaylistItemPtr> items);
 
   void UpdatePlaylistItemValue(const std::string& id, base::Value value);
   void RemovePlaylistItemValue(const std::string& id);

--- a/components/playlist/common/mojom/playlist.mojom
+++ b/components/playlist/common/mojom/playlist.mojom
@@ -132,4 +132,12 @@ interface PlaylistServiceObserver {
       int64 received_bytes,
       int8 percent_complete,
       string time_remaining);
+
+  OnMediaFilesUpdated(
+      url.mojom.Url page_url,
+      array<PlaylistItem> items);
+};
+
+interface PlaylistRenderFrameBrowserClient {
+  OnMediaUpdatedFromRenderFrame();
 };

--- a/components/playlist/renderer/BUILD.gn
+++ b/components/playlist/renderer/BUILD.gn
@@ -11,6 +11,8 @@ assert(enable_playlist)
 # https://github.com/brave/brave-browser/issues/27764
 static_library("renderer") {
   sources = [
+    "playlist_js_handler.cc",
+    "playlist_js_handler.h",
     "playlist_render_frame_observer.cc",
     "playlist_render_frame_observer.h",
   ]
@@ -19,9 +21,12 @@ static_library("renderer") {
 
   deps = [
     "//content/public/renderer",
+    "//gin",
+    "//mojo/public/cpp/bindings",
     "//third_party/blink/public:blink_headers",
     "//third_party/blink/public/common",
     "//url",
+    "//v8",
     "//v8",
   ]
 }

--- a/components/playlist/renderer/BUILD.gn
+++ b/components/playlist/renderer/BUILD.gn
@@ -27,6 +27,5 @@ static_library("renderer") {
     "//third_party/blink/public/common",
     "//url",
     "//v8",
-    "//v8",
   ]
 }

--- a/components/playlist/renderer/DEPS
+++ b/components/playlist/renderer/DEPS
@@ -5,7 +5,9 @@
 
 include_rules = [
   "+content/public/renderer",
-  "+third_party/blink/public/common",
-  "+third_party/blink/public/platform",
-  "+third_party/blink/public/web",
+  "+content/public/renderer",
+  "+gin",
+  "+third_party/blink/public",
+  "+third_party/blink/public",
+  "+v8/include",
 ]

--- a/components/playlist/renderer/DEPS
+++ b/components/playlist/renderer/DEPS
@@ -5,9 +5,7 @@
 
 include_rules = [
   "+content/public/renderer",
-  "+content/public/renderer",
   "+gin",
-  "+third_party/blink/public",
   "+third_party/blink/public",
   "+v8/include",
 ]

--- a/components/playlist/renderer/playlist_js_handler.cc
+++ b/components/playlist/renderer/playlist_js_handler.cc
@@ -1,0 +1,107 @@
+/* Copyright (c) 2023 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "brave/components/playlist/renderer/playlist_js_handler.h"
+
+#include "base/functional/callback.h"
+#include "base/logging.h"
+#include "content/public/renderer/render_frame.h"
+#include "gin/converter.h"
+#include "gin/function_template.h"
+#include "third_party/blink/public/common/browser_interface_broker_proxy.h"
+#include "third_party/blink/public/web/blink.h"
+
+namespace {
+
+template <typename Signature>
+void BindFunctionToObject(v8::Isolate* isolate,
+                          v8::Local<v8::Object> javascript_object,
+                          const std::string& function_name,
+                          const base::RepeatingCallback<Signature>& callback) {
+  v8::Local<v8::Context> context = isolate->GetCurrentContext();
+  // Get the isolate associated with this object.
+  javascript_object
+      ->Set(context, gin::StringToSymbol(isolate, function_name),
+            gin::CreateFunctionTemplate(isolate, callback)
+                ->GetFunction(context)
+                .ToLocalChecked())
+      .Check();
+}
+
+}  // namespace
+
+namespace playlist {
+
+PlaylistJSHandler::PlaylistJSHandler(content::RenderFrame* render_frame)
+    : render_frame_(render_frame) {
+  EnsureConnectedToClient();
+}
+
+PlaylistJSHandler::~PlaylistJSHandler() {}
+
+void PlaylistJSHandler::AddWorkerObjectToFrame(v8::Local<v8::Context> context) {
+  v8::Isolate* isolate = blink::MainThreadIsolate();
+  v8::HandleScope handle_scope(isolate);
+  if (context.IsEmpty()) {
+    return;
+  }
+
+  CreateWorkerObject(isolate, context);
+}
+
+bool PlaylistJSHandler::EnsureConnectedToClient() {
+  if (!client_.is_bound()) {
+    render_frame_->GetBrowserInterfaceBroker()->GetInterface(
+        client_.BindNewPipeAndPassReceiver());
+    client_.set_disconnect_handler(
+        base::BindOnce(&PlaylistJSHandler::OnClientDisconnect,
+                       weak_ptr_factory_.GetWeakPtr()));
+  }
+
+  return client_.is_bound();
+}
+
+void PlaylistJSHandler::OnClientDisconnect() {
+  client_.reset();
+  EnsureConnectedToClient();
+}
+
+void PlaylistJSHandler::CreateWorkerObject(v8::Isolate* isolate,
+                                           v8::Local<v8::Context> context) {
+  DVLOG(2) << __FUNCTION__;
+  v8::Local<v8::Object> global = context->Global();
+  v8::Local<v8::Value> pl_worker;
+  if (!global->Get(context, gin::StringToV8(isolate, "pl_worker"))
+           .ToLocal(&pl_worker) ||
+      !pl_worker->IsObject()) {
+    v8::Local<v8::Object> pl_worker_object;
+    pl_worker_object = v8::Object::New(isolate);
+    global
+        ->Set(context, gin::StringToSymbol(isolate, "pl_worker"),
+              pl_worker_object)
+        .Check();
+    BindFunctionsToWorkerObject(isolate, pl_worker_object);
+  }
+}
+
+void PlaylistJSHandler::BindFunctionsToWorkerObject(
+    v8::Isolate* isolate,
+    v8::Local<v8::Object> worker_object) {
+  DVLOG(2) << __FUNCTION__;
+  BindFunctionToObject(isolate, worker_object, "onMediaUpdated",
+                       base::BindRepeating(&PlaylistJSHandler::OnMediaUpdated,
+                                           base::Unretained(this)));
+}
+
+void PlaylistJSHandler::OnMediaUpdated(const std::string& src) {
+  DVLOG(2) << __FUNCTION__ << " " << src;
+  if (!EnsureConnectedToClient()) {
+    return;
+  }
+
+  client_->OnMediaUpdatedFromRenderFrame();
+}
+
+}  // namespace playlist

--- a/components/playlist/renderer/playlist_js_handler.cc
+++ b/components/playlist/renderer/playlist_js_handler.cc
@@ -92,7 +92,7 @@ void PlaylistJSHandler::BindFunctionsToWorkerObject(
   DVLOG(2) << __FUNCTION__;
   BindFunctionToObject(isolate, worker_object, "onMediaUpdated",
                        base::BindRepeating(&PlaylistJSHandler::OnMediaUpdated,
-                                           base::Unretained(this)));
+                                           weak_ptr_factory_.GetWeakPtr()));
 }
 
 void PlaylistJSHandler::OnMediaUpdated(const std::string& src) {

--- a/components/playlist/renderer/playlist_js_handler.h
+++ b/components/playlist/renderer/playlist_js_handler.h
@@ -1,0 +1,49 @@
+/* Copyright (c) 2023 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_COMPONENTS_PLAYLIST_RENDERER_PLAYLIST_JS_HANDLER_H_
+#define BRAVE_COMPONENTS_PLAYLIST_RENDERER_PLAYLIST_JS_HANDLER_H_
+
+#include <memory>
+#include <string>
+
+#include "base/memory/weak_ptr.h"
+#include "brave/components/playlist/common/mojom/playlist.mojom.h"
+#include "mojo/public/cpp/bindings/remote.h"
+#include "v8/include/v8.h"
+
+namespace content {
+class RenderFrame;
+}  // namespace content
+
+namespace playlist {
+
+class PlaylistJSHandler {
+ public:
+  explicit PlaylistJSHandler(content::RenderFrame* render_frame);
+  ~PlaylistJSHandler();
+
+  void AddWorkerObjectToFrame(v8::Local<v8::Context> context);
+
+ private:
+  bool EnsureConnectedToClient();
+  void OnClientDisconnect();
+
+  void CreateWorkerObject(v8::Isolate* isolate, v8::Local<v8::Context> context);
+  void BindFunctionsToWorkerObject(v8::Isolate* isolate,
+                                   v8::Local<v8::Object> worker_object);
+
+  void OnMediaUpdated(const std::string& src);
+
+  content::RenderFrame* render_frame_ = nullptr;
+
+  mojo::Remote<playlist::mojom::PlaylistRenderFrameBrowserClient> client_;
+
+  base::WeakPtrFactory<PlaylistJSHandler> weak_ptr_factory_{this};
+};
+
+}  // namespace playlist
+
+#endif  // BRAVE_COMPONENTS_PLAYLIST_RENDERER_PLAYLIST_JS_HANDLER_H_

--- a/components/playlist/renderer/playlist_render_frame_observer.cc
+++ b/components/playlist/renderer/playlist_render_frame_observer.cc
@@ -8,8 +8,10 @@
 #include <vector>
 
 #include "brave/components/playlist/common/features.h"
+#include "brave/components/playlist/renderer/playlist_js_handler.h"
 #include "content/public/renderer/render_frame.h"
 #include "third_party/blink/public/common/web_preferences/web_preferences.h"
+#include "third_party/blink/public/platform/web_isolated_world_info.h"
 #include "third_party/blink/public/platform/web_string.h"
 #include "third_party/blink/public/web/web_local_frame.h"
 #include "third_party/blink/public/web/web_script_source.h"
@@ -17,21 +19,24 @@
 namespace playlist {
 
 PlaylistRenderFrameObserver::PlaylistRenderFrameObserver(
-    content::RenderFrame* render_frame)
+    content::RenderFrame* render_frame,
+    const int32_t isolated_world_id)
     : RenderFrameObserver(render_frame),
-      RenderFrameObserverTracker<PlaylistRenderFrameObserver>(render_frame) {}
+      RenderFrameObserverTracker<PlaylistRenderFrameObserver>(render_frame),
+      isolated_world_id_(isolated_world_id),
+      javascript_handler_(std::make_unique<PlaylistJSHandler>(render_frame)) {}
 
 PlaylistRenderFrameObserver::~PlaylistRenderFrameObserver() = default;
 
 void PlaylistRenderFrameObserver::RunScriptsAtDocumentStart() {
-  if (!render_frame()->GetBlinkPreferences().hide_media_src_api)
-    return;
+  const auto& blink_preferences = render_frame()->GetBlinkPreferences();
+  if (blink_preferences.hide_media_src_api) {
+    HideMediaSourceAPI();
+  }
 
-  HideMediaSourceAPI();
-}
-
-void PlaylistRenderFrameObserver::OnDestruct() {
-  delete this;
+  if (blink_preferences.should_detect_media_files) {
+    InstallMediaDetector();
+  }
 }
 
 void PlaylistRenderFrameObserver::HideMediaSourceAPI() {
@@ -58,6 +63,71 @@ void PlaylistRenderFrameObserver::HideMediaSourceAPI() {
 
   web_frame->ExecuteScript(blink::WebScriptSource(
       blink::WebString::FromUTF16(kScriptToHideMediaSourceAPI)));
+}
+
+void PlaylistRenderFrameObserver::InstallMediaDetector() {
+  DVLOG(2) << __FUNCTION__;
+
+  static const char16_t kScriptToDetectVideoAndAudio[] =
+      uR"-(
+    (function() {
+      // Firstly, we try to get find all <video> or <audio> tags periodically,
+      // for a a while from the start up. If we find them, then we attach 
+      // MutationObservers to them to detect source URL.
+      // After a given amount of time, we do this in requestIdleCallback().
+      // Note that there's a global object named |pl_worker|. This worker is
+      // created and bound by PlaylistJSHandler.
+
+      let mutationSources = new Set();
+      const findNewMediaAndObserveMutation = () => {
+          return document.querySelectorAll('video, audio').forEach((mediaNode) => {
+              if (mutationSources.has(mediaNode)) return
+
+              mutationSources.add(mediaNode)
+              pl_worker.onMediaUpdated(mediaNode.src)
+
+              new MutationObserver(mutations => {
+                mutations.forEach(mutation => { pl_worker.onMediaUpdated(mutation.target.src); })
+              }).observe(mediaNode, { attributeFilter: ['src'] })
+          });
+      }
+
+      const pollingIntervalId = window.setInterval(findNewMediaAndObserveMutation);
+      window.setTimeout(() => {
+          window.clearInterval(pollingIntervalId)
+          window.requestIdleCallback(findNewMediaAndObserveMutation)
+          // TODO(sko) We might want to check if idle callback is waiting too long.
+          // In that case, we should get back to the polling style. And also, this
+          // time could be too long for production.
+      }, 20000, pollingIntervalId)
+    })();
+    )-";
+
+  blink::WebLocalFrame* web_frame = render_frame()->GetWebFrame();
+  if (web_frame->IsProvisional()) {
+    return;
+  }
+
+  web_frame->ExecuteScriptInIsolatedWorld(
+      isolated_world_id_,
+      blink::WebScriptSource(
+          blink::WebString::FromUTF16(kScriptToDetectVideoAndAudio)),
+      blink::BackForwardCacheAware::kAllow);
+}
+
+void PlaylistRenderFrameObserver::OnDestruct() {
+  delete this;
+}
+
+void PlaylistRenderFrameObserver::DidCreateScriptContext(
+    v8::Local<v8::Context> context,
+    int32_t world_id) {
+  if (world_id != isolated_world_id_) {
+    return;
+  }
+
+  DVLOG(2) << __FUNCTION__ << "Will add Playlist worker object to the frame";
+  javascript_handler_->AddWorkerObjectToFrame(context);
 }
 
 }  // namespace playlist

--- a/components/playlist/renderer/playlist_render_frame_observer.cc
+++ b/components/playlist/renderer/playlist_render_frame_observer.cc
@@ -78,28 +78,28 @@ void PlaylistRenderFrameObserver::InstallMediaDetector() {
       // Note that there's a global object named |pl_worker|. This worker is
       // created and bound by PlaylistJSHandler.
 
-      let mutationSources = new Set();
+      const mutationSources = new Set();
+      const mutationObserver = new MutationObserver(mutations => {
+          mutations.forEach(mutation => { pl_worker.onMediaUpdated(mutation.target.src); })
+      });
       const findNewMediaAndObserveMutation = () => {
           return document.querySelectorAll('video, audio').forEach((mediaNode) => {
               if (mutationSources.has(mediaNode)) return
 
               mutationSources.add(mediaNode)
               pl_worker.onMediaUpdated(mediaNode.src)
-
-              new MutationObserver(mutations => {
-                mutations.forEach(mutation => { pl_worker.onMediaUpdated(mutation.target.src); })
-              }).observe(mediaNode, { attributeFilter: ['src'] })
+              mutationObserver.observe(mediaNode, { attributeFilter: ['src'] })
           });
       }
 
-      const pollingIntervalId = window.setInterval(findNewMediaAndObserveMutation);
+      const pollingIntervalId = window.setInterval(findNewMediaAndObserveMutation, 1000);
       window.setTimeout(() => {
           window.clearInterval(pollingIntervalId)
           window.requestIdleCallback(findNewMediaAndObserveMutation)
           // TODO(sko) We might want to check if idle callback is waiting too long.
           // In that case, we should get back to the polling style. And also, this
           // time could be too long for production.
-      }, 20000, pollingIntervalId)
+      }, 20000)
     })();
     )-";
 

--- a/components/playlist/renderer/playlist_render_frame_observer.h
+++ b/components/playlist/renderer/playlist_render_frame_observer.h
@@ -6,17 +6,23 @@
 #ifndef BRAVE_COMPONENTS_PLAYLIST_RENDERER_PLAYLIST_RENDER_FRAME_OBSERVER_H_
 #define BRAVE_COMPONENTS_PLAYLIST_RENDERER_PLAYLIST_RENDER_FRAME_OBSERVER_H_
 
+#include <memory>
+
 #include "content/public/renderer/render_frame_observer.h"
 #include "content/public/renderer/render_frame_observer_tracker.h"
 #include "url/gurl.h"
+#include "v8/include/v8.h"
 
 namespace playlist {
+
+class PlaylistJSHandler;
 
 class PlaylistRenderFrameObserver
     : public content::RenderFrameObserver,
       public content::RenderFrameObserverTracker<PlaylistRenderFrameObserver> {
  public:
-  explicit PlaylistRenderFrameObserver(content::RenderFrame* render_frame);
+  PlaylistRenderFrameObserver(content::RenderFrame* render_frame,
+                              const int32_t isolated_world_id);
 
   void RunScriptsAtDocumentStart();
 
@@ -24,9 +30,17 @@ class PlaylistRenderFrameObserver
   ~PlaylistRenderFrameObserver() override;
 
   void HideMediaSourceAPI();
+  void InstallMediaDetector();
 
   // RenderFrameObserver:
   void OnDestruct() override;
+  void DidCreateScriptContext(v8::Local<v8::Context> context,
+                              int32_t world_id) override;
+
+ private:
+  const int32_t isolated_world_id_ = 0;
+
+  std::unique_ptr<PlaylistJSHandler> javascript_handler_;
 };
 
 }  // namespace playlist

--- a/renderer/brave_content_renderer_client.cc
+++ b/renderer/brave_content_renderer_client.cc
@@ -130,7 +130,8 @@ void BraveContentRendererClient::RenderFrameCreated(
 
 #if BUILDFLAG(ENABLE_PLAYLIST)
   if (base::FeatureList::IsEnabled(playlist::features::kPlaylist)) {
-    new playlist::PlaylistRenderFrameObserver(render_frame);
+    new playlist::PlaylistRenderFrameObserver(render_frame,
+                                              ISOLATED_WORLD_ID_BRAVE_INTERNAL);
   }
 #endif
 }


### PR DESCRIPTION
There could be additional media files added to a page after we already executed detection script. In order to detect them, attach MutationObserver via PlaylistRenderFrameObserver

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/29768
Resolves https://github.com/brave/brave-browser/issues/29488

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-arm64, CI/skip-linux-x64, CI/skip-android, CI/skip-macos, CI/skip-ios, CI/skip-windows-arm64, CI/skip-windows-x64, CI/skip-windows-x86 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [ ] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
### Automated
PlaylistDownloadRequestManagerBrowserTest.DynamicallyAddedMedia

### note
locally tested and verified that it's working - @deeppandya is going to follow up with this.

