### PR TITLE
Disable IPFS WebUI on Android

### DIFF
--- a/browser/ipfs/content_browser_client_helper.cc
+++ b/browser/ipfs/content_browser_client_helper.cc
@@ -55,12 +55,14 @@ bool HandleIPFSURLRewrite(GURL* url, content::BrowserContext* browser_context) {
        base::EndsWith(url->host_piece(), kIpnsLocalhost))) {
     return true;
   }
+#if BUILDFLAG(ENABLE_IPFS_INTERNALS_WEBUI)
   if (url->SchemeIs(content::kChromeUIScheme) && url->DomainIs(kIPFSScheme)) {
     GURL::Replacements host_replacements;
     host_replacements.SetHostStr(kIPFSWebUIHost);
     *url = url->ReplaceComponents(host_replacements);
     return true;
   }
+#endif
   PrefService* prefs = user_prefs::UserPrefs::Get(browser_context);
   if (!IsIpfsResolveMethodDisabled(prefs) &&
       // When it's not the local gateway we don't want to show a ipfs:// URL.
@@ -105,10 +107,12 @@ bool HandleIPFSURLRewrite(GURL* url, content::BrowserContext* browser_context) {
 
 bool HandleIPFSURLReverseRewrite(GURL* url,
                                  content::BrowserContext* browser_context) {
+#if BUILDFLAG(ENABLE_IPFS_INTERNALS_WEBUI)
   if (url->SchemeIs(content::kChromeUIScheme) &&
       url->DomainIs(kIPFSWebUIHost)) {
     return true;
   }
+#endif
 
   std::size_t ipfs_pos = url->host_piece().find(kIpfsLocalhost);
   std::size_t ipns_pos = url->host_piece().find(kIpnsLocalhost);

--- a/browser/ipfs/content_browser_client_helper_unittest.cc
+++ b/browser/ipfs/content_browser_client_helper_unittest.cc
@@ -116,6 +116,7 @@ class ContentBrowserClientHelperUnitTest : public testing::Test {
     return web_contents()->GetBrowserContext();
   }
 
+#if BUILDFLAG(ENABLE_IPFS_INTERNALS_WEBUI)
   bool RedirectedToInternalPage(IPFSResolveMethodTypes method) {
     profile()->GetPrefs()->SetInteger(kIPFSResolveMethod,
                                       static_cast<int>(method));
@@ -125,6 +126,7 @@ class ContentBrowserClientHelperUnitTest : public testing::Test {
            HandleIPFSURLReverseRewrite(&ipfs_diagnostic, browser_context()) &&
            ipfs_diagnostic.spec() == kIPFSWebUIURL;
   }
+#endif
 
  private:
   content::BrowserTaskEnvironment task_environment_;
@@ -333,12 +335,14 @@ TEST_F(ContentBrowserClientHelperUnitTest, HandleIPFSURLReverseRewriteGateway) {
       "ipfs://bafybeiemxf5abjwjbikoz4mc3a3dla6ual3jsgpdr4cjr3oz3evfyavhwq/");
 }
 
+#if BUILDFLAG(ENABLE_IPFS_INTERNALS_WEBUI)
 TEST_F(ContentBrowserClientHelperUnitTest, HandleIPFSURLRewriteInternal) {
   ASSERT_TRUE(RedirectedToInternalPage(IPFSResolveMethodTypes::IPFS_LOCAL));
   ASSERT_TRUE(RedirectedToInternalPage(IPFSResolveMethodTypes::IPFS_GATEWAY));
   ASSERT_TRUE(RedirectedToInternalPage(IPFSResolveMethodTypes::IPFS_ASK));
   ASSERT_TRUE(RedirectedToInternalPage(IPFSResolveMethodTypes::IPFS_DISABLED));
 }
+#endif
 
 TEST_F(ContentBrowserClientHelperUnitTest, HandleIPFSURLRewriteCrypto) {
   profile()->GetPrefs()->SetInteger(

--- a/browser/ipfs/import/ipfs_import_controller.cc
+++ b/browser/ipfs/import/ipfs_import_controller.cc
@@ -286,10 +286,12 @@ void IpfsImportController::OnWebPageImportCompleted(
 
 void IpfsImportController::OnImportCompleted(const ipfs::ImportedData& data) {
   auto link = CreateAndCopyShareableLink(data);
+#if BUILDFLAG(ENABLE_IPFS_INTERNALS_WEBUI)
   if (!link.is_valid()) {
     // Open node diagnostic page if import failed
     link = GURL(kIPFSWebUIURL);
   }
+#endif
   PushNotification(GetImportNotificationTitle(data.state),
                    GetImportNotificationBody(data.state, link), link);
   if (data.state == ipfs::IPFS_IMPORT_SUCCESS) {

--- a/browser/ui/BUILD.gn
+++ b/browser/ui/BUILD.gn
@@ -57,7 +57,7 @@ source_set("ui") {
     ]
   }
 
-  if (enable_ipfs) {
+  if (enable_ipfs_internals_webui) {
     sources += [
       "webui/ipfs_ui.cc",
       "webui/ipfs_ui.h",
@@ -596,9 +596,12 @@ source_set("ui") {
   if (enable_ipfs) {
     deps += [
       "//brave/components/ipfs",
-      "//brave/components/ipfs_ui:generated_resources",
       "//components/component_updater",
     ]
+
+    if (enable_ipfs_internals_webui) {
+      deps += [ "//brave/components/ipfs_ui:generated_resources" ]
+    }
   }
 
   if (enable_speedreader && !is_android) {

--- a/browser/ui/webui/brave_web_ui_controller_factory.cc
+++ b/browser/ui/webui/brave_web_ui_controller_factory.cc
@@ -62,10 +62,12 @@
 
 #if BUILDFLAG(ENABLE_IPFS)
 #include "brave/browser/ipfs/ipfs_service_factory.h"
-#include "brave/browser/ui/webui/ipfs_ui.h"
 #include "brave/components/ipfs/features.h"
 #include "brave/components/ipfs/ipfs_utils.h"
-#endif
+#if BUILDFLAG(ENABLE_IPFS_INTERNALS_WEBUI)
+#include "brave/browser/ui/webui/ipfs_ui.h"
+#endif  // BUILDFLAG(ENABLE_IPFS_INTERNALS_WEBUI)
+#endif  // BUILDFLAG(ENABLE_IPFS)
 
 #if BUILDFLAG(ENABLE_PLAYLIST_WEBUI)
 #include "brave/browser/ui/webui/playlist_ui.h"
@@ -97,7 +99,7 @@ WebUIController* NewWebUI(WebUI* web_ui, const GURL& url) {
   } else if (host == kWebcompatReporterHost) {
     return new WebcompatReporterUI(web_ui, url.host());
 #endif
-#if BUILDFLAG(ENABLE_IPFS)
+#if BUILDFLAG(ENABLE_IPFS_INTERNALS_WEBUI)
   } else if (host == kIPFSWebUIHost &&
              ipfs::IpfsServiceFactory::IsIpfsEnabled(profile)) {
     return new IPFSUI(web_ui, url.host());
@@ -193,10 +195,10 @@ WebUIFactoryFunction GetWebUIFactoryFunction(WebUI* web_ui, const GURL& url) {
   if (url.host_piece() == kAdblockHost ||
       url.host_piece() == kAdblockInternalsHost ||
       url.host_piece() == kWebcompatReporterHost ||
-#if BUILDFLAG(ENABLE_IPFS)
+#if BUILDFLAG(ENABLE_IPFS_INTERNALS_WEBUI)
       (url.host_piece() == kIPFSWebUIHost &&
        base::FeatureList::IsEnabled(ipfs::features::kIpfsFeature)) ||
-#endif  // BUILDFLAG(ENABLE_IPFS)
+#endif  // BUILDFLAG(ENABLE_IPFS_INTERNALS_WEBUI)
 #if !BUILDFLAG(IS_ANDROID)
       url.host_piece() == kWalletPanelHost ||
       url.host_piece() == kWalletPageHost ||

--- a/browser/ui/webui/brave_webui_source.cc
+++ b/browser/ui/webui/brave_webui_source.cc
@@ -710,7 +710,7 @@ void CustomizeWebUIHTMLSource(content::WebUI* web_ui,
         { "customListSubscriptionsUnsubscribe", IDS_ADBLOCK_CUSTOM_LIST_SUBSCRIPTIONS_UNSUBSCRIBE },                          // NOLINT
       }
     }, {
-#if BUILDFLAG(ENABLE_IPFS)
+#if BUILDFLAG(ENABLE_IPFS_INTERNALS_WEBUI)
       std::string("ipfs-internals"), {
         { "connectedPeersTitle", IDS_IPFS_CONNECTED_PEERS_TITLE },
         { "addressesConfigTitle", IDS_IPFS_ADDRESSES_CONFIG_TITLE },

--- a/chromium_src/chrome/common/DEPS
+++ b/chromium_src/chrome/common/DEPS
@@ -1,6 +1,7 @@
 include_rules = [
   "+brave/common",
   "+brave/components/constants",
+  "+brave/components/ipfs/buildflags",
   "+brave/grit",
   "+components/version_info",
   "+components/component_updater",

--- a/chromium_src/chrome/common/webui_url_constants.cc
+++ b/chromium_src/chrome/common/webui_url_constants.cc
@@ -4,17 +4,23 @@
  * You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 #include "brave/components/constants/webui_url_constants.h"
+#include "brave/components/ipfs/buildflags/buildflags.h"
 #include "chrome/common/webui_url_constants.h"
 
-#define kChromeUIAttributionInternalsHost                                    \
-  kChromeUIAttributionInternalsHost, kAdblockHost, kAdblockInternalsHost,    \
-      kIPFSWebUIHost, kRewardsPageHost, kRewardsInternalsHost, kWelcomeHost, \
-      kWalletPageHost, kTorInternalsHost
+#define kChromeUIAttributionInternalsHost                                     \
+  kChromeUIAttributionInternalsHost, kAdblockHost, kAdblockInternalsHost,     \
+      kRewardsPageHost, kRewardsInternalsHost, kWelcomeHost, kWalletPageHost, \
+      kTorInternalsHost
 #define kChromeUIPerformanceSettingsURL kChromeUIPerformanceSettingsURL_UnUsed
 #define kPerformanceSubPage kPerformanceSubPage_UnUsed
 
+#if BUILDFLAG(ENABLE_IPFS_INTERNALS_WEBUI)
+#define kChromeUIBlobInternalsHost kChromeUIBlobInternalsHost, kIPFSWebUIHost
+#endif
+
 #include "src/chrome/common/webui_url_constants.cc"
 
+#undef kChromeUIBlobInternalsHost
 #undef kPerformanceSubPage
 #undef kChromeUIPerformanceSettingsURL
 #undef kChromeUIAttributionInternalsHost

--- a/components/constants/BUILD.gn
+++ b/components/constants/BUILD.gn
@@ -43,7 +43,10 @@ source_set("constants") {
   ]
 
   public_deps = [ ":brave_services_key" ]
-  deps = [ "//base" ]
+  deps = [
+    "//base",
+    "//brave/components/ipfs/buildflags",
+  ]
 }
 
 source_set("brave_service_key_helper") {

--- a/components/constants/webui_url_constants.cc
+++ b/components/constants/webui_url_constants.cc
@@ -4,12 +4,16 @@
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 #include "brave/components/constants/webui_url_constants.h"
+#include "brave/components/ipfs/buildflags/buildflags.h"
+#include "build/build_config.h"
 
 const char kAdblockHost[] = "adblock";
 const char kAdblockInternalsHost[] = "adblock-internals";
 const char kAdblockJS[] = "brave_adblock.js";
+#if BUILDFLAG(ENABLE_IPFS_INTERNALS_WEBUI)
 const char kIPFSWebUIHost[] = "ipfs-internals";
 const char kIPFSWebUIURL[] = "chrome://ipfs-internals/";
+#endif
 const char kWebcompatReporterHost[] = "webcompat";
 const char kRewardsPageHost[] = "rewards";
 const char kRewardsInternalsHost[] = "rewards-internals";

--- a/components/constants/webui_url_constants.h
+++ b/components/constants/webui_url_constants.h
@@ -6,13 +6,16 @@
 #ifndef BRAVE_COMPONENTS_CONSTANTS_WEBUI_URL_CONSTANTS_H_
 #define BRAVE_COMPONENTS_CONSTANTS_WEBUI_URL_CONSTANTS_H_
 
+#include "brave/components/ipfs/buildflags/buildflags.h"
 #include "build/build_config.h"
 
 extern const char kAdblockHost[];
 extern const char kAdblockInternalsHost[];
 extern const char kAdblockJS[];
+#if BUILDFLAG(ENABLE_IPFS_INTERNALS_WEBUI)
 extern const char kIPFSWebUIHost[];
 extern const char kIPFSWebUIURL[];
+#endif
 extern const char kWebcompatReporterHost[];
 extern const char kRewardsPageHost[];
 extern const char kRewardsInternalsHost[];

--- a/components/ipfs/buildflags/BUILD.gn
+++ b/components/ipfs/buildflags/BUILD.gn
@@ -1,3 +1,8 @@
+# Copyright (c) 2020 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+
 import("//brave/components/ipfs/buildflags/buildflags.gni")
 import("//build/buildflag_header.gni")
 
@@ -6,5 +11,6 @@ buildflag_header("buildflags") {
   flags = [
     "ENABLE_IPFS=$enable_ipfs",
     "ENABLE_IPFS_LOCAL_NODE=$enable_ipfs_local_node",
+    "ENABLE_IPFS_INTERNALS_WEBUI=$enable_ipfs_internals_webui",
   ]
 }

--- a/components/ipfs/buildflags/buildflags.gni
+++ b/components/ipfs/buildflags/buildflags.gni
@@ -1,7 +1,16 @@
+# Copyright (c) 2020 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+
 declare_args() {
   enable_ipfs = true
 }
 
 declare_args() {
   enable_ipfs_local_node = enable_ipfs && !is_ios
+}
+
+declare_args() {
+  enable_ipfs_internals_webui = enable_ipfs && !is_android && !is_ios
 }

--- a/components/ipfs_ui/BUILD.gn
+++ b/components/ipfs_ui/BUILD.gn
@@ -1,9 +1,17 @@
+# Copyright (c) 2020 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+
 import("//brave/components/common/typescript.gni")
 
+assert(!is_android && !is_ios)
+
 transpile_web_ui("ipfs_ui") {
-  entry_points = [
-    ["ipfs", rebase_path("ipfs.tsx")]
-  ]
+  entry_points = [ [
+        "ipfs",
+        rebase_path("ipfs.tsx"),
+      ] ]
 
   resource_name = "ipfs"
 }
@@ -11,7 +19,5 @@ transpile_web_ui("ipfs_ui") {
 pack_web_resources("generated_resources") {
   resource_name = "ipfs"
   output_dir = "$root_gen_dir/brave/components/ipfs_ui/resources"
-  deps = [
-    ":ipfs_ui"
-  ]
+  deps = [ ":ipfs_ui" ]
 }

--- a/components/resources/BUILD.gn
+++ b/components/resources/BUILD.gn
@@ -39,6 +39,7 @@ brave_grit("static_resources") {
   defines = [
     "enable_brave_vpn=$enable_brave_vpn",
     "enable_ipfs=$enable_ipfs",
+    "enable_ipfs_internals_webui=$enable_ipfs_internals_webui",
     "enable_playlist=$enable_playlist",
     "enable_playlist_webui=$enable_playlist_webui",
     "enable_speedreader=$enable_speedreader",
@@ -87,7 +88,7 @@ repack("resources") {
     ]
   }
 
-  if (enable_ipfs) {
+  if (enable_ipfs_internals_webui) {
     deps += [ "//brave/components/ipfs_ui:generated_resources" ]
     sources += [
       "$root_gen_dir/brave/components/ipfs_ui/resources/ipfs_generated.pak",
@@ -141,6 +142,7 @@ brave_grit("strings") {
   defines = [
     "enable_speedreader=$enable_speedreader",
     "enable_ipfs=$enable_ipfs",
+    "enable_ipfs_internals_webui=$enable_ipfs_internals_webui",
     "ethereum_remote_client_enabled=$ethereum_remote_client_enabled",
     "enable_tor=$enable_tor",
     "enable_brave_vpn=$enable_brave_vpn",

--- a/components/resources/ipfs_strings.grdp
+++ b/components/resources/ipfs_strings.grdp
@@ -1,44 +1,49 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <grit-part>
   <if expr="enable_ipfs">
-    <message name="IDS_IPFS_CONNECTED_PEERS_TITLE" desc="Number of peers connected">Connected peers:</message>
-    <message name="IDS_IPFS_ADDRESSES_CONFIG_TITLE" desc="Title of addresses config section">Addresses</message>
-    <message name="IDS_IPFS_REPO_STATS_TITLE" desc="Title of repo stats section">Repo Stats</message>
-    <message name="IDS_IPFS_NODE_INFO_TITLE" desc="Title of node info section">Node info</message>
+    <if expr="enable_ipfs_internals_webui">
+      <message name="IDS_IPFS_CONNECTED_PEERS_TITLE" desc="Number of peers connected">Connected peers:</message>
+      <message name="IDS_IPFS_ADDRESSES_CONFIG_TITLE" desc="Title of addresses config section">Addresses</message>
+      <message name="IDS_IPFS_REPO_STATS_TITLE" desc="Title of repo stats section">Repo Stats</message>
+      <message name="IDS_IPFS_NODE_INFO_TITLE" desc="Title of node info section">Node info</message>
+      <message name="IDS_IPFS_DAEMON_STATUS_TITLE" desc="Title of daemon status section">IPFS node status</message>
+      <message name="IDS_IPFS_API" desc="Title of the API config">API</message>
+      <message name="IDS_IPFS_GATEWAY" desc="Title of the gateway config">Gateway</message>
+      <message name="IDS_IPFS_SWARM" desc="Title of the swarm config">Swarm</message>
+      <message name="IDS_IPFS_REPO_OBJECTS" desc="Title of the objects repo stats section">Objects</message>
+      <message name="IDS_IPFS_REPO_SIZE" desc="Title of the size repo stats section">Size</message>
+      <message name="IDS_IPFS_REPO_STORAGE" desc="Title of the storage repo stats section">StorageMax</message>
+      <message name="IDS_IPFS_REPO_PATH" desc="Title of the path repo stats section">Path</message>
+      <message name="IDS_IPFS_REPO_VERSION" desc="Title of the version repo stats section">Version</message>
+      <message name="IDS_IPFS_NODE_INFO_ID" desc="Title of the id node info section">Peer ID</message>
+      <message name="IDS_IPFS_NODE_INFO_VERSION" desc="Title of the version node info section">Agent version</message>
+      <message name="IDS_IPFS_LAUNCHED" desc="Title of the launched status">Node is running</message>
+      <message name="IDS_IPFS_NOT_LAUNCHED" desc="Title of not launched status">Node is not running</message>
+      <message name="IDS_IPFS_LAUNCH" desc="Text of launch action">Start</message>
+      <message name="IDS_IPFS_SHUTDOWN" desc="Text of shutdown action">Stop</message>
+      <message name="IDS_IPFS_RESTART" desc="Text of shutdown action">Restart</message>
+      <message name="IDS_IPFS_NOT_INSTALLED" desc="Text of not installed state">Not Installed</message>
+      <message name="IDS_IPFS_INSTALLING" desc="Text of installing state">Installing IPFS...</message>
+      <message name="IDS_IPFS_RUN_GC_BUTTON" desc="Text of garbage collection button on state">Perform a garbage collection sweep</message>
+      <message name="IDS_IPFS_GC_ERROR" desc="Text of garbage collection error">Garbage collection error</message>
+      <message name="IDS_IPFS_PEERS_DETAILS_LINK" desc="Link to open details about peers on brave://ipfs.">
+        (details)
+      </message>
+      <message name="IDS_IPFS_INSTALL_AND_LAUNCH" desc="Title of brave://ipfs install and launch button.">
+        Install and start
+      </message>
+      <message name="IDS_IPFS_LEARN_MORE" desc="Link to open infromation about IPFS on brave://ipfs.">
+        Learn more about IPFS and privacy
+      </message>
+      <message name="IDS_IPFS_ROTATE_IDENTITY_TITLE" desc="The title for the link to rotate identity on ipfs diagnostic page.">
+        Manage Peer ID and IPNS keys
+      </message>
+      <message name="IDS_IPFS_OPEN_WEBUI" desc="Title of brave://ipfs webui button">My Node</message>
+    </if>
     <message name="IDS_IPFS_NODE_LAUNCH_ERROR" desc="Text of node launch error">An error occurred, please try to launch again</message>
     <message name="IDS_IPFS_NODE_INSTALLATION_ERROR" desc="Text of node installation error">An error occurred, please try to install the node again</message>
-    <message name="IDS_IPFS_DAEMON_STATUS_TITLE" desc="Title of daemon status section">IPFS node status</message>
-    <message name="IDS_IPFS_API" desc="Title of the API config">API</message>
-    <message name="IDS_IPFS_GATEWAY" desc="Title of the gateway config">Gateway</message>
-    <message name="IDS_IPFS_SWARM" desc="Title of the swarm config">Swarm</message>
-    <message name="IDS_IPFS_REPO_OBJECTS" desc="Title of the objects repo stats section">Objects</message>
-    <message name="IDS_IPFS_REPO_SIZE" desc="Title of the size repo stats section">Size</message>
-    <message name="IDS_IPFS_REPO_STORAGE" desc="Title of the storage repo stats section">StorageMax</message>
-    <message name="IDS_IPFS_REPO_PATH" desc="Title of the path repo stats section">Path</message>
-    <message name="IDS_IPFS_REPO_VERSION" desc="Title of the version repo stats section">Version</message>
-    <message name="IDS_IPFS_NODE_INFO_ID" desc="Title of the id node info section">Peer ID</message>
-    <message name="IDS_IPFS_NODE_INFO_VERSION" desc="Title of the version node info section">Agent version</message>
-    <message name="IDS_IPFS_LAUNCHED" desc="Title of the launched status">Node is running</message>
-    <message name="IDS_IPFS_NOT_LAUNCHED" desc="Title of not launched status">Node is not running</message>
-    <message name="IDS_IPFS_LAUNCH" desc="Text of launch action">Start</message>
-    <message name="IDS_IPFS_SHUTDOWN" desc="Text of shutdown action">Stop</message>
-    <message name="IDS_IPFS_RESTART" desc="Text of shutdown action">Restart</message>
-    <message name="IDS_IPFS_NOT_INSTALLED" desc="Text of not installed state">Not Installed</message>
-    <message name="IDS_IPFS_INSTALLING" desc="Text of installing state">Installing IPFS...</message>
-    <message name="IDS_IPFS_RUN_GC_BUTTON" desc="Text of garbage collection button on state">Perform a garbage collection sweep</message>
-    <message name="IDS_IPFS_GC_ERROR" desc="Text of garbage collection error">Garbage collection error</message>
     <message name="IDS_UTILITY_PROCESS_IPFS_NAME" desc="The utility process which manages IPFS daemon">IPFS Service</message>
-    <message name="IDS_IPFS_OPEN_WEBUI" desc="Title of brave://ipfs webui button">My Node</message>
     <message name="IDS_IPFS_BADGE_TITLE" desc="Title of page info badge in location bar">IPFS</message>
-    <message name="IDS_IPFS_PEERS_DETAILS_LINK" desc="Link to open details about peers on brave://ipfs.">
-      (details)
-    </message>
-    <message name="IDS_IPFS_INSTALL_AND_LAUNCH" desc="Title of brave://ipfs install and launch button.">
-      Install and start
-    </message>
-    <message name="IDS_IPFS_LEARN_MORE" desc="Link to open infromation about IPFS on brave://ipfs.">
-      Learn more about IPFS and privacy
-    </message>
     <message name="IDS_IPFS_SERVICE_LAUNCH_RETRY" desc="Retry button text for IPFS interstitial page.">
       Try again
     </message>
@@ -158,9 +163,6 @@
     </message>
     <message name="IDS_IPFS_IMPORT_PARTLY_COMPLETED_NOTIFICATION_BODY" desc="The title for ips import error notification.">
       The data was successfully uploaded but not moved to the brave-import directory. You can do this manually on the import settings page.
-    </message>
-    <message name="IDS_IPFS_ROTATE_IDENTITY_TITLE" desc="The title for the link to rotate identity on ipfs diagnostic page.">
-      Manage Peer ID and IPNS keys
     </message>
   </if>
 </grit-part>


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/29697, https://github.com/brave/brave-browser/issues/25103

This PR removes resources and some native code for ipfs-internals web ui page on Android. It allows to save only 162KB for now. This result may be improved with fixing of https://github.com/brave/brave-browser/issues/28060 .


<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-arm64, CI/skip-linux-x64, CI/skip-android, CI/skip-macos, CI/skip-ios, CI/skip-windows-arm64, CI/skip-windows-x64, CI/skip-windows-x86 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
1. Make fresh installation
2. Open ipfs://bafybeies3odi24wyk3e22rnautr57tiuk3b56nxrd53fxgtvr37abmz5j4/66.png link
3. Ensure you can still see this page
![image](https://user-images.githubusercontent.com/24739341/231821134-5b30c04e-99a9-4ab2-a58b-c7fbc159b860.png)
4. Press `Use a public gateway`
5. Ensure you can see the image
6. Navigate to about:chrome-urls
7. Ensure there is no brave://ipfs-internals
