### PR TITLE
chore(wallet): pass API key as header to 0x API requests

### DIFF
--- a/build/commands/lib/config.js
+++ b/build/commands/lib/config.js
@@ -94,7 +94,6 @@ const parseExtraInputs = (inputs, accumulator, callback) => {
 const Config = function () {
   this.sardineClientId = getNPMConfig(['sardine_client_id']) || ''
   this.sardineClientSecret = getNPMConfig(['sardine_client_secret']) || ''
-  this.zeroExApiKey = getNPMConfig(['zero_ex_api_key']) || ''
   this.defaultBuildConfig = 'Component'
   this.buildConfig = this.defaultBuildConfig
   this.signTarget = 'sign_app'
@@ -123,6 +122,7 @@ const Config = function () {
   this.googleDefaultClientSecret = getNPMConfig(['google_default_client_secret']) || ''
   this.braveServicesKey = getNPMConfig(['brave_services_key']) || ''
   this.infuraProjectId = getNPMConfig(['brave_infura_project_id']) || ''
+  this.braveZeroExApiKey = getNPMConfig(['brave_zero_ex_api_key']) || ''
   this.bitflyerClientId = getNPMConfig(['bitflyer_client_id']) || ''
   this.bitflyerClientSecret = getNPMConfig(['bitflyer_client_secret']) || ''
   this.bitflyerStagingClientId = getNPMConfig(['bitflyer_staging_client_id']) || ''
@@ -264,7 +264,6 @@ Config.prototype.buildArgs = function () {
   let args = {
     sardine_client_id: this.sardineClientId,
     sardine_client_secret: this.sardineClientSecret,
-    zero_ex_api_key: this.zeroExApiKey,
     is_asan: this.isAsan(),
     enable_full_stack_frames_for_profiling: this.isAsan(),
     v8_enable_verify_heap: this.isAsan(),
@@ -293,6 +292,7 @@ Config.prototype.buildArgs = function () {
     google_default_client_id: this.googleDefaultClientId,
     google_default_client_secret: this.googleDefaultClientSecret,
     brave_infura_project_id: this.infuraProjectId,
+    brave_zero_ex_api_key: this.braveZeroExApiKey,
     bitflyer_client_id: this.bitflyerClientId,
     bitflyer_client_secret: this.bitflyerClientSecret,
     bitflyer_staging_client_id: this.bitflyerStagingClientId,
@@ -674,10 +674,6 @@ Config.prototype.update = function (options) {
     this.sardineClientId = options.sardine_client_id
   }
 
-  if (options.zero_ex_api_key) {
-    this.zeroExApiKey = options.zero_ex_api_key
-  }
-
   if (options.universal) {
     this.targetArch = 'arm64'
     this.isUniversalBinary = true
@@ -760,6 +756,10 @@ Config.prototype.update = function (options) {
 
   if (options.brave_infura_project_id) {
     this.infuraProjectId = options.brave_infura_project_id
+  }
+
+  if (options.brave_zero_ex_api_key) {
+    this.braveZeroExApiKey = options.brave_zero_ex_api_key
   }
 
   if (options.bitflyer_client_id) {

--- a/build/commands/lib/config.js
+++ b/build/commands/lib/config.js
@@ -94,6 +94,7 @@ const parseExtraInputs = (inputs, accumulator, callback) => {
 const Config = function () {
   this.sardineClientId = getNPMConfig(['sardine_client_id']) || ''
   this.sardineClientSecret = getNPMConfig(['sardine_client_secret']) || ''
+  this.zeroExApiKey = getNPMConfig(['zero_ex_api_key']) || ''
   this.defaultBuildConfig = 'Component'
   this.buildConfig = this.defaultBuildConfig
   this.signTarget = 'sign_app'
@@ -263,6 +264,7 @@ Config.prototype.buildArgs = function () {
   let args = {
     sardine_client_id: this.sardineClientId,
     sardine_client_secret: this.sardineClientSecret,
+    zero_ex_api_key: this.zeroExApiKey,
     is_asan: this.isAsan(),
     enable_full_stack_frames_for_profiling: this.isAsan(),
     v8_enable_verify_heap: this.isAsan(),
@@ -672,6 +674,10 @@ Config.prototype.update = function (options) {
     this.sardineClientId = options.sardine_client_id
   }
 
+  if (options.zero_ex_api_key) {
+    this.zeroExApiKey = options.zero_ex_api_key
+  }
+
   if (options.universal) {
     this.targetArch = 'arm64'
     this.isUniversalBinary = true
@@ -753,7 +759,7 @@ Config.prototype.update = function (options) {
   }
 
   if (options.brave_infura_project_id) {
-    this.infuraProjectId = options.infura_project_id
+    this.infuraProjectId = options.brave_infura_project_id
   }
 
   if (options.bitflyer_client_id) {

--- a/components/brave_wallet/browser/BUILD.gn
+++ b/components/brave_wallet/browser/BUILD.gn
@@ -11,13 +11,11 @@ import("//tools/json_schema_compiler/json_schema_api.gni")
 declare_args() {
   sardine_client_id = ""
   sardine_client_secret = ""
-  zero_ex_api_key = ""
 }
 
 if (is_official_build) {
   assert(sardine_client_id != "")
   assert(sardine_client_secret != "")
-  assert(zero_ex_api_key != "")
 }
 
 static_library("browser") {
@@ -221,10 +219,7 @@ static_library("browser") {
     deps += [ "//brave/components/ipfs" ]
   }
 
-  configs += [
-    ":sardine_config",
-    ":0x_config",
-  ]
+  configs += [ ":sardine_config" ]
 }
 
 if (!is_ios) {
@@ -374,8 +369,4 @@ config("sardine_config") {
     "SARDINE_CLIENT_ID=\"$sardine_client_id\"",
     "SARDINE_CLIENT_SECRET=\"$sardine_client_secret\"",
   ]
-}
-
-config("0x_config") {
-  defines = [ "ZERO_EX_API_KEY=\"$zero_ex_api_key\"" ]
 }

--- a/components/brave_wallet/browser/BUILD.gn
+++ b/components/brave_wallet/browser/BUILD.gn
@@ -11,11 +11,13 @@ import("//tools/json_schema_compiler/json_schema_api.gni")
 declare_args() {
   sardine_client_id = ""
   sardine_client_secret = ""
+  zero_ex_api_key = ""
 }
 
 if (is_official_build) {
   assert(sardine_client_id != "")
   assert(sardine_client_secret != "")
+  assert(zero_ex_api_key != "")
 }
 
 static_library("browser") {
@@ -219,7 +221,10 @@ static_library("browser") {
     deps += [ "//brave/components/ipfs" ]
   }
 
-  configs += [ ":sardine_config" ]
+  configs += [
+    ":sardine_config",
+    ":0x_config",
+  ]
 }
 
 if (!is_ios) {
@@ -369,4 +374,8 @@ config("sardine_config") {
     "SARDINE_CLIENT_ID=\"$sardine_client_id\"",
     "SARDINE_CLIENT_SECRET=\"$sardine_client_secret\"",
   ]
+}
+
+config("0x_config") {
+  defines = [ "ZERO_EX_API_KEY=\"$zero_ex_api_key\"" ]
 }

--- a/components/brave_wallet/browser/swap_service.cc
+++ b/components/brave_wallet/browser/swap_service.cc
@@ -121,6 +121,13 @@ GURL AppendJupiterQuoteParams(
   return url;
 }
 
+auto Get0xAPIHeaders() {
+  const std::string& zero_ex_api_key(ZERO_EX_API_KEY);
+  using headers_map = base::flat_map<std::string, std::string>;
+  return zero_ex_api_key.empty() ? headers_map{}
+                                 : headers_map{{"0x-api-key", zero_ex_api_key}};
+}
+
 }  // namespace
 
 namespace brave_wallet {
@@ -297,7 +304,7 @@ void SwapService::GetPriceQuote(mojom::SwapParamsPtr swap_params,
       "GET",
       GetPriceQuoteURL(std::move(swap_params),
                        json_rpc_service_->GetChainId(mojom::CoinType::ETH)),
-      "", "", true, std::move(internal_callback));
+      "", "", true, std::move(internal_callback), std::move(Get0xAPIHeaders()));
 }
 
 void SwapService::OnGetPriceQuote(GetPriceQuoteCallback callback,
@@ -340,7 +347,7 @@ void SwapService::GetTransactionPayload(
       GetTransactionPayloadURL(
           std::move(swap_params),
           json_rpc_service_->GetChainId(mojom::CoinType::ETH)),
-      "", "", true, std::move(internal_callback));
+      "", "", true, std::move(internal_callback), std::move(Get0xAPIHeaders()));
 }
 
 void SwapService::OnGetTransactionPayload(

--- a/components/brave_wallet/browser/swap_service.cc
+++ b/components/brave_wallet/browser/swap_service.cc
@@ -12,6 +12,7 @@
 #include "brave/components/brave_wallet/browser/json_rpc_service.h"
 #include "brave/components/brave_wallet/browser/swap_request_helper.h"
 #include "brave/components/brave_wallet/browser/swap_response_parser.h"
+#include "brave/components/brave_wallet/common/buildflags.h"
 #include "net/base/load_flags.h"
 #include "net/base/url_util.h"
 #include "services/network/public/cpp/shared_url_loader_factory.h"
@@ -121,11 +122,12 @@ GURL AppendJupiterQuoteParams(
   return url;
 }
 
-auto Get0xAPIHeaders() {
-  const std::string& zero_ex_api_key(ZERO_EX_API_KEY);
-  using headers_map = base::flat_map<std::string, std::string>;
-  return zero_ex_api_key.empty() ? headers_map{}
-                                 : headers_map{{"0x-api-key", zero_ex_api_key}};
+base::flat_map<std::string, std::string> Get0xAPIHeaders() {
+  std::string brave_zero_ex_api_key(BUILDFLAG(BRAVE_ZERO_EX_API_KEY));
+  if (brave_zero_ex_api_key.empty()) {
+    return {};
+  }
+  return {{"0x-api-key", std::move(brave_zero_ex_api_key)}};
 }
 
 }  // namespace
@@ -304,7 +306,7 @@ void SwapService::GetPriceQuote(mojom::SwapParamsPtr swap_params,
       "GET",
       GetPriceQuoteURL(std::move(swap_params),
                        json_rpc_service_->GetChainId(mojom::CoinType::ETH)),
-      "", "", true, std::move(internal_callback), std::move(Get0xAPIHeaders()));
+      "", "", true, std::move(internal_callback), Get0xAPIHeaders());
 }
 
 void SwapService::OnGetPriceQuote(GetPriceQuoteCallback callback,
@@ -347,7 +349,7 @@ void SwapService::GetTransactionPayload(
       GetTransactionPayloadURL(
           std::move(swap_params),
           json_rpc_service_->GetChainId(mojom::CoinType::ETH)),
-      "", "", true, std::move(internal_callback), std::move(Get0xAPIHeaders()));
+      "", "", true, std::move(internal_callback), Get0xAPIHeaders());
 }
 
 void SwapService::OnGetTransactionPayload(

--- a/components/brave_wallet/common/BUILD.gn
+++ b/components/brave_wallet/common/BUILD.gn
@@ -14,7 +14,7 @@ import("//tools/json_schema_compiler/json_schema_api.gni")
 preprocess_folder = "preprocessed"
 preprocess_mojo_manifest = "preprocessed_mojo_manifest.json"
 
-if (!is_official_build) {
+if (is_official_build) {
   assert(brave_zero_ex_api_key != "")
 }
 

--- a/components/brave_wallet/common/BUILD.gn
+++ b/components/brave_wallet/common/BUILD.gn
@@ -14,9 +14,16 @@ import("//tools/json_schema_compiler/json_schema_api.gni")
 preprocess_folder = "preprocessed"
 preprocess_mojo_manifest = "preprocessed_mojo_manifest.json"
 
+if (!is_official_build) {
+  assert(brave_zero_ex_api_key != "")
+}
+
 buildflag_header("buildflags") {
   header = "buildflags.h"
-  flags = [ "BRAVE_INFURA_PROJECT_ID=\"$brave_infura_project_id\"" ]
+  flags = [
+    "BRAVE_INFURA_PROJECT_ID=\"$brave_infura_project_id\"",
+    "BRAVE_ZERO_EX_API_KEY=\"$brave_zero_ex_api_key\"",
+  ]
 }
 
 static_library("common") {

--- a/components/brave_wallet/common/config.gni
+++ b/components/brave_wallet/common/config.gni
@@ -1,3 +1,4 @@
 declare_args() {
   brave_infura_project_id = ""
+  brave_zero_ex_api_key = ""
 }


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
No functional changes to Swap, but this change would soon be necessary in order to use 0x API when it becomes private.

**Note:** This PR is adapted from #17763. The changes need to be uplifted to Release, hence a new PR.


Resolves https://github.com/brave/brave-browser/issues/29652

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-arm64, CI/skip-linux-x64, CI/skip-android, CI/skip-macos, CI/skip-ios, CI/skip-windows-arm64, CI/skip-windows-x64, CI/skip-windows-x86 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
    - [x] Started a discussion in `#security-discussion` Slack channel.
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

I added a `brave_0x_api_key` entry to my local `~/.npmrc` file, and the arg got picked up as expected which I verified using log statements.