### PR TITLE
Fix IPFS gateway Android setting

### DIFF
--- a/android/BUILD.gn
+++ b/android/BUILD.gn
@@ -3,6 +3,7 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this file,
 # You can obtain one at https://mozilla.org/MPL/2.0/.
 
+import("//brave/components/ipfs/buildflags/buildflags.gni")
 import("//brave/components/p3a/buildflags.gni")
 import("//build/config/android/rules.gni")
 
@@ -23,5 +24,6 @@ java_cpp_template("brave_config_java") {
   defines = [
     "BRAVE_ANDROID_DEVELOPER_OPTIONS_CODE=\"$brave_android_developer_options_code\"",
     "BRAVE_ANDROID_P3A_ENABLED=$brave_p3a_enabled",
+    "BRAVE_ANDROID_ENABLE_IPFS=$enable_ipfs",
   ]
 }

--- a/android/java/org/chromium/chrome/browser/privacy/settings/BravePrivacySettingsIPFSUtils.java
+++ b/android/java/org/chromium/chrome/browser/privacy/settings/BravePrivacySettingsIPFSUtils.java
@@ -24,7 +24,7 @@ public class BravePrivacySettingsIPFSUtils {
         if (BraveConfig.IPFS_ENABLED) {
             return UserPrefs.get(Profile.getLastUsedRegularProfile())
                            .getInteger(BravePref.IPFS_RESOLVE_METHOD)
-                    == IPFSResolveMethodTypes.IPFS_ASK;
+                    != IPFSResolveMethodTypes.IPFS_DISABLED;
         } else {
             return false;
         }

--- a/build/android/java/templates/BraveConfig.template
+++ b/build/android/java/templates/BraveConfig.template
@@ -9,21 +9,7 @@ package org.chromium.chrome.browser;
  *  Brave configuration.
  */
 public class BraveConfig {
-#if defined(BRAVE_ANDROID_DEVELOPER_OPTIONS_CODE)
   public static final String DEVELOPER_OPTIONS_CODE = BRAVE_ANDROID_DEVELOPER_OPTIONS_CODE;
-#else
-  public static final String DEVELOPER_OPTIONS_CODE = "";
-#endif
-
-#if defined(BRAVE_ANDROID_P3A_ENABLED)
   public static final boolean P3A_ENABLED = BRAVE_ANDROID_P3A_ENABLED;
-#else
-  public static final boolean P3A_ENABLED = false;
-#endif
-
-#if defined(ENABLE_IPFS)
-  public static final boolean IPFS_ENABLED = ENABLE_IPFS;
-#else
-  public static final boolean IPFS_ENABLED = false;
-#endif
+  public static final boolean IPFS_ENABLED = BRAVE_ANDROID_ENABLE_IPFS;
 }


### PR DESCRIPTION
Resolves https://github.com/brave/brave-browser/issues/29647

ENABLE_IPFS flag was not taken into respect

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-arm64, CI/skip-linux-x64, CI/skip-android, CI/skip-macos, CI/skip-ios, CI/skip-windows-arm64, CI/skip-windows-x64, CI/skip-windows-x86 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
0) Check whether IPFS Gateway setting is enabled by default on Android
1) Switch IPFS Gateway setting on Android
2) Re-enter settings page
3) Make sure setting has proper state
4) Make sure ipfs:// urls are loading when setting is enabled and are not loading when it is disabled

