### PR TITLE
Patch download progress bar color

### DIFF
--- a/browser/resources/bookmarks/BUILD.gn
+++ b/browser/resources/bookmarks/BUILD.gn
@@ -4,14 +4,14 @@
 # you can obtain one at http://mozilla.org/MPL/2.0/.
 
 import("//tools/grit/preprocess_if_expr.gni")
-import("./sources.gni")
+import("sources.gni")
 
-# Move brave files to the place where chromium bookmarks page is compiled from. It should be the same directory
-# that build_webui.gni uses after it performs its own preprocess_if_expr. Once chromium and brave frontend files
-# are all in the same place, build_webui.gni will continue its typescript and rollup compile (etc.) from that
-# directory.
+# Move brave files to the place where chromium bookmarks page is compiled from.
+# It should be the same directory that build_webui.gni uses after it performs
+# its own preprocess_if_expr. Once chromium and brave frontend files are all in
+# the same place, build_webui.gni will continue its typescript and rollup
+# compile (etc.) from that directory.
 preprocess_if_expr("preprocess") {
-  in_folder = "./"
   out_folder = "$root_gen_dir/chrome/browser/resources/bookmarks/preprocessed"
   in_files = brave_bookmarks_ts_local_files
 }

--- a/browser/resources/downloads/BUILD.gn
+++ b/browser/resources/downloads/BUILD.gn
@@ -1,0 +1,17 @@
+# Copyright (c) 2023 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import("//tools/grit/preprocess_if_expr.gni")
+import("./sources.gni")
+
+# Move brave files to the place where chromium downloads page is compiled from. It should be the same directory
+# that build_webui.gni uses after it performs its own preprocess_if_expr. Once chromium and brave frontend files
+# are all in the same place, build_webui.gni will continue its typescript and rollup compile (etc.) from that
+# directory.
+preprocess_if_expr("preprocess") {
+  in_folder = "./"
+  out_folder = "$root_gen_dir/chrome/browser/resources/downloads/preprocessed"
+  in_files = brave_downloads_ts_local_files
+}

--- a/browser/resources/downloads/BUILD.gn
+++ b/browser/resources/downloads/BUILD.gn
@@ -4,14 +4,14 @@
 # You can obtain one at https://mozilla.org/MPL/2.0/.
 
 import("//tools/grit/preprocess_if_expr.gni")
-import("./sources.gni")
+import("sources.gni")
 
-# Move brave files to the place where chromium downloads page is compiled from. It should be the same directory
-# that build_webui.gni uses after it performs its own preprocess_if_expr. Once chromium and brave frontend files
-# are all in the same place, build_webui.gni will continue its typescript and rollup compile (etc.) from that
-# directory.
+# Move brave files to the place where chromium downloads page is compiled from.
+# It should be the same directory that build_webui.gni uses after it performs
+# its own preprocess_if_expr. Once chromium and brave frontend files are all in
+# the same place, build_webui.gni will continue its typescript and rollup
+# compile (etc.) from that directory.
 preprocess_if_expr("preprocess") {
-  in_folder = "./"
   out_folder = "$root_gen_dir/chrome/browser/resources/downloads/preprocessed"
   in_files = brave_downloads_ts_local_files
 }

--- a/browser/resources/downloads/brave_overrides/index.ts
+++ b/browser/resources/downloads/brave_overrides/index.ts
@@ -1,0 +1,6 @@
+// Copyright (c) 2023 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import './item.js'

--- a/browser/resources/downloads/brave_overrides/item.ts
+++ b/browser/resources/downloads/brave_overrides/item.ts
@@ -1,0 +1,18 @@
+// Copyright (c) 2023 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import {RegisterStyleOverride} from 'chrome://resources/brave/polymer_overriding.js'
+import {html} from 'chrome://resources/polymer/v3_0/polymer/polymer_bundled.min.js'
+
+RegisterStyleOverride(
+  'downloads-item',
+  html`
+    <style>
+      #progress {
+        --paper-progress-active-color: var(--leo-color-icon-interactive) !important;
+      }
+    </style>
+  `
+)

--- a/browser/resources/downloads/sources.gni
+++ b/browser/resources/downloads/sources.gni
@@ -1,0 +1,14 @@
+# Copyright (c) 2023 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+
+brave_downloads_non_web_component_files = [
+  "brave_overrides/item.ts",
+  "brave_overrides/index.ts",
+]
+
+brave_downloads_preprocess_extra_deps =
+    [ "//brave/browser/resources/downloads:preprocess" ]
+
+brave_downloads_ts_local_files = brave_downloads_non_web_component_files

--- a/browser/resources/extensions/BUILD.gn
+++ b/browser/resources/extensions/BUILD.gn
@@ -4,14 +4,14 @@
 # You can obtain one at https://mozilla.org/MPL/2.0/.
 
 import("//tools/grit/preprocess_if_expr.gni")
-import("./sources.gni")
+import("sources.gni")
 
-# Move brave files to the place where chromium extensions page is compiled from. It should be the same directory
-# that build_webui.gni uses after it performs its own preprocess_if_expr. Once chromium and brave frontend files
-# are all in the same place, build_webui.gni will continue its typescript and rollup compile (etc.) from that
-# directory.
+# Move brave files to the place where chromium extensions page is compiled from.
+# It should be the same directory that build_webui.gni uses after it performs
+# its own preprocess_if_expr. Once chromium and brave frontend files are all in
+# the same place, build_webui.gni will continue its typescript and rollup
+# compile (etc.) from that directory.
 preprocess_if_expr("preprocess") {
-  in_folder = "./"
   out_folder = "$root_gen_dir/chrome/browser/resources/extensions/preprocessed"
   in_files = brave_extensions_local_ts_files + brave_extensions_local_html_files
 }

--- a/browser/resources/history/BUILD.gn
+++ b/browser/resources/history/BUILD.gn
@@ -4,14 +4,14 @@
 # you can obtain one at http://mozilla.org/MPL/2.0/.
 
 import("//tools/grit/preprocess_if_expr.gni")
-import("./sources.gni")
+import("sources.gni")
 
-# Move brave files to the place where chromium history page is compiled from. It should be the same directory
-# that build_webui.gni uses after it performs its own preprocess_if_expr. Once chromium and brave frontend files
-# are all in the same place, build_webui.gni will continue its typescript and rollup compile (etc.) from that
-# directory.
+# Move brave files to the place where chromium history page is compiled from.
+# It should be the same directory that build_webui.gni uses after it performs
+# its own preprocess_if_expr. Once chromium and brave frontend files are all in
+# the same place, build_webui.gni will continue its typescript and rollup
+# compile (etc.) from that directory.
 preprocess_if_expr("preprocess") {
-  in_folder = "./"
   out_folder = "$root_gen_dir/chrome/browser/resources/history/preprocessed"
   in_files = brave_history_local_html_files + brave_history_local_ts_files
 }

--- a/browser/resources/settings/BUILD.gn
+++ b/browser/resources/settings/BUILD.gn
@@ -3,7 +3,6 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this file,
 # you can obtain one at http://mozilla.org/MPL/2.0/.
 
-import("//brave/browser/resources/settings/sources.gni")
 import("//brave/browser/shell_integrations/buildflags/buildflags.gni")
 import("//brave/build/config.gni")
 import("//brave/components/brave_vpn/common/buildflags/buildflags.gni")
@@ -14,6 +13,7 @@ import("//chrome/common/features.gni")
 import("//extensions/buildflags/buildflags.gni")
 import("//tools/grit/preprocess_if_expr.gni")
 import("//ui/webui/resources/tools/generate_grd.gni")
+import("sources.gni")
 
 preprocess_folder = "preprocessed"
 
@@ -62,10 +62,11 @@ generate_grd("build_grd") {
   deps = [ ":preprocess" ]
 }
 
-# Move brave files to the place where chromium settings page is compiled from. It should be the same directory
-# that build_webui.gni uses after it performs its own preprocess_if_expr. Once chromium and brave frontend files
-# are all in the same place, build_webui.gni will continue its typescript and rollup compile (etc.) from that
-# directory.
+# Move brave files to the place where chromium settings page is compiled from.
+# It should be the same directory that build_webui.gni uses after it performs
+# its own preprocess_if_expr. Once chromium and brave frontend files are all in
+# the same place, build_webui.gni will continue its typescript and rollup
+# compile (etc.) from that directory.
 preprocess_if_expr("preprocess") {
   defines = [
     "enable_tor=$enable_tor",
@@ -74,7 +75,6 @@ preprocess_if_expr("preprocess") {
     "enable_extensions=$enable_extensions",
     "enable_pin_shortcut=$enable_pin_shortcut",
   ]
-  in_folder = "./"
   out_folder =
       "$root_gen_dir/chrome/browser/resources/settings/$preprocess_folder"
 

--- a/patches/chrome-browser-resources-downloads-BUILD.gn.patch
+++ b/patches/chrome-browser-resources-downloads-BUILD.gn.patch
@@ -1,0 +1,10 @@
+diff --git a/chrome/browser/resources/downloads/BUILD.gn b/chrome/browser/resources/downloads/BUILD.gn
+index 493fe1599942e..fdd3006a7ff9b 100644
+--- a/chrome/browser/resources/downloads/BUILD.gn
++++ b/chrome/browser/resources/downloads/BUILD.gn
+@@ -54,4 +54,5 @@ build_webui("build") {
+     optimize_webui_host = "downloads"
+     optimize_webui_in_files = [ "downloads.js" ]
+   }
++  import("//brave/browser/resources/downloads/sources.gni") non_web_component_files += brave_downloads_non_web_component_files exclude_ts_preprocess_files = brave_downloads_ts_local_files preprocess_deps = brave_downloads_preprocess_extra_deps
+ }

--- a/patches/chrome-browser-resources-downloads-downloads.html.patch
+++ b/patches/chrome-browser-resources-downloads-downloads.html.patch
@@ -6,7 +6,7 @@ index 61d82b65d9315f9ba29c1ad5358b1555669a2d4f..2370273c52b29c054965ce4193d5aa06
    <base href="chrome://downloads">
    <title>$i18n{title}</title>
    <link rel="stylesheet" href="chrome://resources/css/md_colors.css">
-+  <link rel="stylesheet" href="chrome://resources/brave/page_specific/downloads/downloads_loading_shim.css">
++  <link rel="stylesheet" href="chrome://resources/brave/page_specific/downloads/downloads_loading_shim.css"><link rel="stylesheet" href="chrome://resources/brave/leo/css/variables.css">
    <style>
      html {
        /* Remove 300ms delay for 'click' event, when using touch interface. */

--- a/patches/chrome-browser-resources-downloads-downloads.ts.patch
+++ b/patches/chrome-browser-resources-downloads-downloads.ts.patch
@@ -1,12 +1,13 @@
 diff --git a/chrome/browser/resources/downloads/downloads.ts b/chrome/browser/resources/downloads/downloads.ts
-index 0b05e22165c61dcb57aeeb46f251f697a6514978..3a29991b00072a5bef88025db1d14eb3571d8078 100644
+index 0b05e22165c61..195dd8bd5e2ea 100644
 --- a/chrome/browser/resources/downloads/downloads.ts
 +++ b/chrome/browser/resources/downloads/downloads.ts
-@@ -2,6 +2,7 @@
+@@ -2,6 +2,8 @@
  // Use of this source code is governed by a BSD-style license that can be
  // found in the LICENSE file.
  
 +import 'chrome://resources/brave/polymer_overriding.js'
++import './brave_overrides/index.js';
  import './manager.js';
  
  export {CrToastManagerElement} from 'chrome://resources/cr_elements/cr_toast/cr_toast_manager.js';


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/29714

~~**Note:** I'm waiting on https://github.com/brave/brave-browser/issues/29714 to land so I can use the Leo CSS variable.~~

This first patch just changes the download bar color. Hopefully in a followup patch we can start using Leo Components in the download page.

@aguscruiz suggested:
- Links (replace with `leo-link`)
- Buttons (replace with equivalent `leo-button`)

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-arm64, CI/skip-linux-x64, CI/skip-android, CI/skip-macos, CI/skip-ios, CI/skip-windows-arm64, CI/skip-windows-x64, CI/skip-windows-x86 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [ ] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

