### PR TITLE
Migrate 'Meta' in prefs into 'Command' on Mac

### DIFF
--- a/components/commands/browser/accelerator_pref_manager.h
+++ b/components/commands/browser/accelerator_pref_manager.h
@@ -37,6 +37,11 @@ class COMPONENT_EXPORT(COMMANDS_BROWSER) AcceleratorPrefManager {
   void SetDefaultAccelerators(const Accelerators& default_accelerators);
 
  private:
+#if BUILDFLAG(IS_MAC)
+  // https://github.com/brave/brave-core/pull/17872/files#r1166176986
+  void MigrateMetaKeyToCommandKey();
+#endif
+
   raw_ptr<PrefService> prefs_;
 };
 

--- a/components/commands/browser/accelerator_pref_manager_unittest.cc
+++ b/components/commands/browser/accelerator_pref_manager_unittest.cc
@@ -37,7 +37,12 @@ TEST_F(AcceleratorPrefManagerTest, CanAddAccelerators) {
   ASSERT_EQ(1u, accelerators[1].size());
   EXPECT_EQ(accelerator1, accelerators[1][0]);
 
-  ui::Accelerator accelerator2 = commands::FromCodesString("Ctrl+Cmd+KeyH");
+#if BUILDFLAG(IS_MAC)
+  ui::Accelerator accelerator2 =
+      commands::FromCodesString("Control+Command+KeyH");
+#else
+  ui::Accelerator accelerator2 = commands::FromCodesString("Control+Meta+KeyH");
+#endif
   manager().AddAccelerator(1, accelerator2);
 
   accelerators = manager().GetAccelerators();
@@ -47,7 +52,7 @@ TEST_F(AcceleratorPrefManagerTest, CanAddAccelerators) {
   EXPECT_EQ(accelerator1, accelerators[1][0]);
   EXPECT_EQ(accelerator2, accelerators[1][1]);
 
-  ui::Accelerator accelerator3 = commands::FromCodesString("Ctrl+KeyM");
+  ui::Accelerator accelerator3 = commands::FromCodesString("Control+KeyM");
   manager().AddAccelerator(100, accelerator3);
 
   accelerators = manager().GetAccelerators();
@@ -63,8 +68,13 @@ TEST_F(AcceleratorPrefManagerTest, CanAddAccelerators) {
 
 TEST_F(AcceleratorPrefManagerTest, CanRemoveAccelerators) {
   ui::Accelerator accelerator1 = commands::FromCodesString("Shift+Alt+KeyC");
-  ui::Accelerator accelerator2 = commands::FromCodesString("Ctrl+Cmd+KeyH");
-  ui::Accelerator accelerator3 = commands::FromCodesString("Ctrl+KeyM");
+#if BUILDFLAG(IS_MAC)
+  ui::Accelerator accelerator2 =
+      commands::FromCodesString("Control+Command+KeyH");
+#else
+  ui::Accelerator accelerator2 = commands::FromCodesString("Control+Meta+KeyH");
+#endif
+  ui::Accelerator accelerator3 = commands::FromCodesString("Control+KeyM");
   manager().AddAccelerator(1, accelerator1);
   manager().AddAccelerator(1, accelerator2);
   manager().AddAccelerator(100, accelerator3);

--- a/components/commands/common/accelerator_parsing.cc
+++ b/components/commands/common/accelerator_parsing.cc
@@ -12,6 +12,7 @@
 #include "base/check.h"
 #include "base/containers/contains.h"
 #include "base/no_destructor.h"
+#include "base/notreached.h"
 #include "base/strings/string_number_conversions.h"
 #include "base/strings/string_split.h"
 #include "base/strings/string_util.h"
@@ -117,11 +118,22 @@ std::vector<std::string> GetModifierNames(ui::KeyEventFlags flags) {
 ui::KeyEventFlags GetModifierFromKeys(
     const std::vector<std::string>& modifiers) {
   ui::KeyEventFlags result = ui::EF_NONE;
-  for (const auto& [modifier, name] : GetAllModifierNames()) {
-    if (base::Contains(modifiers, name)) {
-      result |= modifier;
+  const auto& modifier_names = GetAllModifierNames();
+  for (const auto& modifier : modifiers) {
+    auto iter = base::ranges::find_if(modifier_names,
+                                      [&modifier](const auto& modifier_name) {
+                                        return modifier_name.name == modifier;
+                                      });
+
+#if DCHECK_IS_ON()
+    if (iter == modifier_names.end()) {
+      NOTREACHED() << "Unknown modifier name was given: " << modifier;
     }
+#endif
+
+    result |= iter->modifier;
   }
+
   return result;
 }
 }  // namespace


### PR DESCRIPTION
Users who have been using 'Brave Commands' since before we changed 'Meta' to 'Command', they already have shortcut data using 'Meta' Key. After the change, AcceleratorParsing couldn't parse 'Meta' key so this ends up in broken shortcuts.

In order to solve this, add migration routine.

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/29755

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-arm64, CI/skip-linux-x64, CI/skip-android, CI/skip-macos, CI/skip-ios, CI/skip-windows-arm64, CI/skip-windows-x64, CI/skip-windows-x86 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [ ] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

