### PR TITLE
Changes `GetCountryCode()` to use `countryid_at_install`. (uplift to 1.51.x)

### DIFF
--- a/components/brave_rewards/browser/rewards_service_impl.cc
+++ b/components/brave_rewards/browser/rewards_service_impl.cc
@@ -625,10 +625,12 @@ void RewardsServiceImpl::GetUserType(
 }
 
 std::string RewardsServiceImpl::GetCountryCode() const {
-  std::string declared_geo =
-      profile_->GetPrefs()->GetString(prefs::kDeclaredGeo);
-  return !declared_geo.empty() ? declared_geo
-                               : country_codes::GetCurrentCountryCode();
+  auto* prefs = profile_->GetPrefs();
+  std::string declared_geo = prefs->GetString(prefs::kDeclaredGeo);
+  return !declared_geo.empty()
+             ? declared_geo
+             : country_codes::CountryIDToCountryString(
+                   country_codes::GetCountryIDFromPrefs(prefs));
 }
 
 void RewardsServiceImpl::GetAvailableCountries(


### PR DESCRIPTION
Uplift of #18025
Resolves https://github.com/brave/brave-browser/issues/29609

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.