### PR TITLE
Fix crash in BraveWalletService::MigrateHiddenNetworks (uplift to 1.51.x)

### DIFF
--- a/browser/brave_wallet/brave_wallet_service_unittest.cc
+++ b/browser/brave_wallet/brave_wallet_service_unittest.cc
@@ -1879,6 +1879,23 @@ TEST_F(BraveWalletServiceUnitTest, MigradeDefaultHiddenNetworks) {
   }
 }
 
+TEST_F(BraveWalletServiceUnitTest, MigradeDefaultHiddenNetworks_NoList) {
+  ASSERT_EQ(GetPrefs()->GetInteger(kBraveWalletDefaultHiddenNetworksVersion),
+            0);
+  {
+    ScopedDictPrefUpdate update(GetPrefs(), kBraveWalletHiddenNetworks);
+    update.Get().Remove("ethereum");
+  }
+  BraveWalletService::MigrateHiddenNetworks(GetPrefs());
+  {
+    auto* list =
+        GetPrefs()->GetDict(kBraveWalletHiddenNetworks).FindList("ethereum");
+    EXPECT_NE(std::find_if(list->begin(), list->end(),
+                           [](const auto& v) { return v == "0x4cb2f"; }),
+              list->end());
+  }
+}
+
 TEST_F(BraveWalletServiceUnitTest, MigrateUserAssetsAddIsERC1155) {
   ASSERT_FALSE(
       GetPrefs()->GetBoolean(kBraveWalletUserAssetsAddIsERC1155Migrated));

--- a/components/brave_wallet/browser/brave_wallet_service.cc
+++ b/components/brave_wallet/browser/brave_wallet_service.cc
@@ -959,16 +959,19 @@ void BraveWalletService::MigrateHiddenNetworks(PrefService* prefs) {
   if (previous_version_code >= 1) {
     return;
   }
-  // Default hidden networks
-  ScopedDictPrefUpdate update(prefs, kBraveWalletHiddenNetworks);
-  auto& hidden_networks_pref = update.Get();
-  base::Value::List* hidden_eth_networks =
-      hidden_networks_pref.FindList(kEthereumPrefKey);
-  auto value = base::Value(mojom::kFilecoinEthereumTestnetChainId);
-  if (std::find_if(hidden_eth_networks->begin(), hidden_eth_networks->end(),
-                   [&value](auto& v) { return value == v; }) ==
-      hidden_eth_networks->end()) {
-    hidden_eth_networks->Append(std::move(value));
+  {
+    // Default hidden networks
+    ScopedDictPrefUpdate update(prefs, kBraveWalletHiddenNetworks);
+    auto& hidden_networks_pref = update.Get();
+    base::Value::List* hidden_eth_networks =
+        hidden_networks_pref.EnsureList(kEthereumPrefKey);
+
+    auto value = base::Value(mojom::kFilecoinEthereumTestnetChainId);
+    if (std::find_if(hidden_eth_networks->begin(), hidden_eth_networks->end(),
+                     [&value](auto& v) { return value == v; }) ==
+        hidden_eth_networks->end()) {
+      hidden_eth_networks->Append(std::move(value));
+    }
   }
 
   prefs->SetInteger(kBraveWalletDefaultHiddenNetworksVersion, 1);


### PR DESCRIPTION
Uplift of #18050
Resolves https://github.com/brave/brave-browser/issues/29707

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.