### PR TITLE
Update ink drop on tab close button properly (uplift to 1.51.x)

### DIFF
--- a/browser/ui/views/tabs/brave_tab.cc
+++ b/browser/ui/views/tabs/brave_tab.cc
@@ -22,6 +22,8 @@
 #include "ui/compositor/paint_recorder.h"
 #include "ui/gfx/favicon_size.h"
 #include "ui/gfx/skia_paint_util.h"
+#include "ui/views/animation/ink_drop.h"
+#include "ui/views/view_class_properties.h"
 
 namespace {
 
@@ -184,7 +186,17 @@ void BraveTab::Layout() {
     if (showing_close_button_) {
       close_button_->SetX(GetLocalBounds().CenterPoint().x() -
                           (close_button_->width() / 2));
-      close_button_->SetButtonPadding({});
+      gfx::Insets* current_padding =
+          close_button_->GetProperty(views::kInternalPaddingKey);
+      DCHECK(current_padding);
+
+      // Use the same padding for all sides.
+      close_button_->SetButtonPadding(gfx::Insets(current_padding->left()));
+
+      // In order to reset ink drop bounds based on new padding.
+      auto* ink_drop = views::InkDrop::Get(close_button_)->GetInkDrop();
+      DCHECK(ink_drop);
+      ink_drop->HostSizeChanged(close_button_->size());
     }
   }
 }


### PR DESCRIPTION
Uplift of #18092
Resolves https://github.com/brave/brave-browser/issues/29614

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.