### PR TITLE
Make resizable area for toolbar

### DIFF
--- a/browser/ui/views/frame/brave_non_client_hit_test_helper.h
+++ b/browser/ui/views/frame/brave_non_client_hit_test_helper.h
@@ -17,7 +17,8 @@ namespace brave {
 // Helper function to set additional draggable area in client view.
 // Returns HTNOWHERE if the point is not what we're interested in. In that
 // case, caller should depend on the default behavior.
-int NonClientHitTest(BrowserView* browser_view, const gfx::Point& point);
+int NonClientHitTest(BrowserView* browser_view,
+                     const gfx::Point& point_in_widget);
 
 }  // namespace brave
 

--- a/browser/ui/views/frame/brave_non_client_hit_test_helper_browsertest.cc
+++ b/browser/ui/views/frame/brave_non_client_hit_test_helper_browsertest.cc
@@ -3,6 +3,9 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+#include "base/test/scoped_feature_list.h"
+#include "brave/browser/ui/browser_commands.h"
+#include "brave/browser/ui/tabs/features.h"
 #include "chrome/browser/ui/views/frame/browser_non_client_frame_view.h"
 #include "chrome/browser/ui/views/frame/browser_view.h"
 #include "chrome/browser/ui/views/toolbar/reload_button.h"
@@ -13,12 +16,20 @@
 
 using BraveNonClientHitTestHelperBrowserTest = InProcessBrowserTest;
 
+// TODO(sko) It might be good to have resizable area tests. But testing it
+// is pretty flaky depending on platforms.
 IN_PROC_BROWSER_TEST_F(BraveNonClientHitTestHelperBrowserTest, Toolbar) {
   auto* browser_view = static_cast<BrowserView*>(browser()->window());
   auto* toolbar = browser_view->toolbar();
   auto* frame_view = browser_view->frame()->GetFrameView();
 
-  gfx::Point point;
+  for (auto* view : toolbar->GetChildrenInZOrder()) {
+    // When a point is on children view, hit test result will be HTCLIENT.
+    // In order to make this test without flakiness, hide theme.
+    view->SetVisible(false);
+  }
+
+  gfx::Point point = toolbar->GetLocalBounds().CenterPoint();
   views::View::ConvertPointToWidget(toolbar, &point);
 
   // Dragging a window with the toolbar on it should work.
@@ -33,6 +44,11 @@ IN_PROC_BROWSER_TEST_F(BraveNonClientHitTestHelperBrowserTest, Toolbar) {
   // check.
   toolbar->SetVisible(true);
   point = gfx::Point();
+
+  for (auto* view : toolbar->GetChildrenInZOrder()) {
+    view->SetVisible(true);
+  }
+
   views::View::ConvertPointToWidget(toolbar->reload_button(), &point);
   EXPECT_NE(HTCAPTION, frame_view->NonClientHitTest(point));
 }

--- a/browser/ui/views/toolbar/brave_toolbar_view.cc
+++ b/browser/ui/views/toolbar/brave_toolbar_view.cc
@@ -125,7 +125,8 @@ BraveToolbarView::~BraveToolbarView() = default;
 void BraveToolbarView::Init() {
   ToolbarView::Init();
 
-  // This will allow us to move this window by dragging toolbar
+  // This will allow us to move this window by dragging toolbar.
+  // See brave_non_client_hit_test_helper.h
   views::SetHitTestComponent(this, HTCAPTION);
 
   // For non-normal mode, we don't have to more.
@@ -346,6 +347,7 @@ void BraveToolbarView::ViewHierarchyChanged(
   if (details.is_add && details.parent == this) {
     // Mark children of this view as client area so that they are not perceived
     // as client area.
+    // See brave_non_client_hit_test_helper.h
     views::SetHitTestComponent(details.child, HTCLIENT);
   }
 }

--- a/chromium_src/chrome/browser/ui/views/frame/glass_browser_frame_view.h
+++ b/chromium_src/chrome/browser/ui/views/frame/glass_browser_frame_view.h
@@ -1,0 +1,19 @@
+// Copyright (c) 2023 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#ifndef BRAVE_CHROMIUM_SRC_CHROME_BROWSER_UI_VIEWS_FRAME_GLASS_BROWSER_FRAME_VIEW_H_
+#define BRAVE_CHROMIUM_SRC_CHROME_BROWSER_UI_VIEWS_FRAME_GLASS_BROWSER_FRAME_VIEW_H_
+
+#define caption_button_container_for_testing \
+  caption_button_container() const {         \
+    return caption_button_container_;        \
+  }                                          \
+  const GlassBrowserCaptionButtonContainer* caption_button_container_for_testing
+
+#include "src/chrome/browser/ui/views/frame/glass_browser_frame_view.h"  // IWYU pragma: export
+
+#undef caption_button_container_for_testing
+
+#endif  // BRAVE_CHROMIUM_SRC_CHROME_BROWSER_UI_VIEWS_FRAME_GLASS_BROWSER_FRAME_VIEW_H_


### PR DESCRIPTION
When using vertical tabs and not showing title bar, toolbar area should provide resizable area for users.

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/29842

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-arm64, CI/skip-linux-x64, CI/skip-android, CI/skip-macos, CI/skip-ios, CI/skip-windows-arm64, CI/skip-windows-x64, CI/skip-windows-x86 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [ ] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
* Enable vertical tab strip
* hide window title from context menu of tabs
* When moving mouse over the edge of toolbar, the resize cursor should be shown and window should be resizable there.
