### PR TITLE
Do not trigger user activity events for restored tabs (uplift to 1.51.x)

### DIFF
--- a/browser/brave_ads/ads_tab_helper.cc
+++ b/browser/brave_ads/ads_tab_helper.cc
@@ -122,10 +122,13 @@ void AdsTabHelper::DidFinishNavigation(
     return;
   }
 
-  // Some browser initiated navigations have HasUserGesture set to false. This
-  // should eventually be fixed in crbug.com/617904.
-  if (navigation_handle->HasUserGesture() ||
-      !navigation_handle->IsRendererInitiated()) {
+  const bool tab_not_restored =
+      navigation_handle->GetRestoreType() == content::RestoreType::kNotRestored;
+
+  // Some browser initiated navigations have HasUserGesture set to false.
+  // This should eventually be fixed in crbug.com/617904.
+  if (tab_not_restored && (navigation_handle->HasUserGesture() ||
+                           !navigation_handle->IsRendererInitiated())) {
     const int32_t page_transition =
         static_cast<int32_t>(navigation_handle->GetPageTransition());
 
@@ -135,9 +138,7 @@ void AdsTabHelper::DidFinishNavigation(
   redirect_chain_ = navigation_handle->GetRedirectChain();
 
   if (!navigation_handle->IsSameDocument()) {
-    should_process_ = navigation_handle->GetRestoreType() ==
-                      content::RestoreType::kNotRestored;
-
+    should_process_ = tab_not_restored;
     return;
   }
 


### PR DESCRIPTION
Uplift of #18130
Resolves https://github.com/brave/brave-browser/issues/29830

Pre-approval checklist: 
- [ ] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [ ] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [ ] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [ ] The associated issue milestone is set to the smallest version that the changes is landed on.