### PR TITLE
Complete animation when vertical tab's state changed (uplift to 1.51.x)

### DIFF
--- a/browser/ui/views/frame/vertical_tab_strip_region_view.cc
+++ b/browser/ui/views/frame/vertical_tab_strip_region_view.cc
@@ -579,11 +579,12 @@ void VerticalTabStripRegionView::SetState(State state) {
   mouse_enter_timer_.Stop();
   state_ = state;
 
-  original_region_view_->tab_strip_->SetAvailableWidthCallback(
-      base::BindRepeating(
-          &VerticalTabStripRegionView::GetAvailableWidthForTabContainer,
-          base::Unretained(this)));
-  original_region_view_->tab_strip_->tab_container_->InvalidateIdealBounds();
+  auto tab_strip = original_region_view_->tab_strip_;
+  tab_strip->SetAvailableWidthCallback(base::BindRepeating(
+      &VerticalTabStripRegionView::GetAvailableWidthForTabContainer,
+      base::Unretained(this)));
+  tab_strip->tab_container_->InvalidateIdealBounds();
+  tab_strip->tab_container_->CompleteAnimationAndLayout();
 
   PreferredSizeChanged();
 }


### PR DESCRIPTION
Uplift of #18100
Resolves https://github.com/brave/brave-browser/issues/29668

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.