### PR TITLE
Update shadow layer bounds when tab's layer bounds changes (uplift to 1.51.x)

### DIFF
--- a/browser/ui/views/tabs/brave_tab.cc
+++ b/browser/ui/views/tabs/brave_tab.cc
@@ -178,6 +178,20 @@ void BraveTab::UpdateIconVisibility() {
   }
 }
 
+void BraveTab::OnLayerBoundsChanged(const gfx::Rect& old_bounds,
+                                    ui::PropertyChangeReason reason) {
+  Tab::OnLayerBoundsChanged(old_bounds, reason);
+
+  if (!base::FeatureList::IsEnabled(tabs::features::kBraveVerticalTabs)) {
+    return;
+  }
+
+  if (shadow_layer_ && shadow_layer_->parent() &&
+      shadow_layer_->parent() == layer()->parent()) {
+    LayoutShadowLayer();
+  }
+}
+
 void BraveTab::Layout() {
   Tab::Layout();
   if (IsAtMinWidthForVerticalTabStrip()) {
@@ -209,14 +223,6 @@ void BraveTab::ReorderChildLayers(ui::Layer* parent_layer) {
 
   DCHECK_EQ(shadow_layer_->parent(), layer()->parent());
   layer()->parent()->StackBelow(shadow_layer_.get(), layer());
-}
-
-void BraveTab::OnBoundsChanged(const gfx::Rect& previous_bounds) {
-  Tab::OnBoundsChanged(previous_bounds);
-
-  if (shadow_layer_ && shadow_layer_->parent()) {
-    LayoutShadowLayer();
-  }
 }
 
 void BraveTab::MaybeAdjustLeftForPinnedTab(gfx::Rect* bounds,

--- a/browser/ui/views/tabs/brave_tab.h
+++ b/browser/ui/views/tabs/brave_tab.h
@@ -35,9 +35,11 @@ class BraveTab : public Tab {
   bool ShouldRenderAsNormalTab() const override;
   void Layout() override;
   void ReorderChildLayers(ui::Layer* parent_layer) override;
-  void OnBoundsChanged(const gfx::Rect& previous_bounds) override;
   void MaybeAdjustLeftForPinnedTab(gfx::Rect* bounds,
                                    int visual_width) const override;
+
+  void OnLayerBoundsChanged(const gfx::Rect& old_bounds,
+                            ui::PropertyChangeReason reason) override;
 
  private:
   bool IsAtMinWidthForVerticalTabStrip() const;


### PR DESCRIPTION
Uplift of #18111
Resolves https://github.com/brave/brave-browser/issues/29791

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.