### PR TITLE
Adds a LinearLayoutManager wrapper for a RecyclerView crash workaround on Android (uplift to 1.50.x)

### DIFF
--- a/android/java/org/chromium/chrome/browser/brave_news/LinearLayoutManagerWrapper.java
+++ b/android/java/org/chromium/chrome/browser/brave_news/LinearLayoutManagerWrapper.java
@@ -14,9 +14,13 @@ import androidx.recyclerview.widget.RecyclerView;
 import org.chromium.base.Log;
 
 /*
- * Provides a custom LayoutManager to use on recyclerView to prevent an Android bug from crashing
+ * Provides a custom LayoutManager to use on recyclerView to prevent an Android bug from crashing.
+ * Check that issue and related PR for more information
+ * https://github.com/brave/brave-browser/issues/29634
  */
 public class LinearLayoutManagerWrapper extends LinearLayoutManager {
+    private static final String TAG = "LLManagerWrapper";
+
     public LinearLayoutManagerWrapper(Context context) {
         super(context);
     }
@@ -35,9 +39,11 @@ public class LinearLayoutManagerWrapper extends LinearLayoutManager {
         try {
             super.onLayoutChildren(recycler, state);
         } catch (IndexOutOfBoundsException e) {
-            e.printStackTrace();
+            Log.e(TAG, "IndexOutOfBoundsException in RecyclerView: ", e);
+            assert false;
         } catch (ClassCastException e) {
-            e.printStackTrace();
+            Log.e(TAG, "ClassCastException in RecyclerView: ", e);
+            assert false;
         }
     }
 }

--- a/android/java/org/chromium/chrome/browser/ntp/BraveNewTabPageLayout.java
+++ b/android/java/org/chromium/chrome/browser/ntp/BraveNewTabPageLayout.java
@@ -71,6 +71,7 @@ import org.chromium.chrome.browser.app.BraveActivity;
 import org.chromium.chrome.browser.brave_news.BraveNewsControllerFactory;
 import org.chromium.chrome.browser.brave_news.BraveNewsUtils;
 import org.chromium.chrome.browser.brave_news.CardBuilderFeedCard;
+import org.chromium.chrome.browser.brave_news.LinearLayoutManagerWrapper;
 import org.chromium.chrome.browser.brave_news.models.FeedItemCard;
 import org.chromium.chrome.browser.brave_news.models.FeedItemsCard;
 import org.chromium.chrome.browser.brave_stats.BraveStatsUtil;
@@ -379,8 +380,8 @@ public class BraveNewTabPageLayout
         });
 
         mRecyclerView = findViewById(R.id.recyclerview);
-        LinearLayoutManager linearLayoutManager =
-                new LinearLayoutManager(mActivity, LinearLayoutManager.VERTICAL, false);
+        LinearLayoutManagerWrapper linearLayoutManager =
+                new LinearLayoutManagerWrapper(mActivity, LinearLayoutManager.VERTICAL, false);
         mRecyclerView.setLayoutManager(linearLayoutManager);
         mRecyclerView.post(new Runnable() {
             @Override


### PR DESCRIPTION
Uplift of https://github.com/brave/brave-core/pull/18002
Resolves https://github.com/brave/brave-browser/issues/29634