### PR TITLE
Add ability to start Brave Ads in a separate thread

### DIFF
--- a/browser/brave_ads/ads_service_factory.cc
+++ b/browser/brave_ads/ads_service_factory.cc
@@ -7,6 +7,7 @@
 
 #include "brave/browser/brave_adaptive_captcha/brave_adaptive_captcha_service_factory.h"
 #include "brave/browser/brave_ads/device_id/device_id_impl.h"
+#include "brave/browser/brave_ads/services/bat_ads_service_factory_impl.h"
 #include "brave/browser/brave_federated/brave_federated_service_factory.h"
 #include "brave/browser/brave_rewards/rewards_service_factory.h"
 #include "brave/browser/brave_rewards/rewards_util.h"
@@ -88,7 +89,8 @@ KeyedService* AdsServiceFactory::BuildServiceInstanceFor(
       std::make_unique<AdsServiceImpl>(
           profile, brave_adaptive_captcha_service,
           CreateAdsTooltipsDelegate(profile), std::make_unique<DeviceIdImpl>(),
-          history_service, rewards_service, notification_ad_async_data_store);
+          std::make_unique<BatAdsServiceFactoryImpl>(), history_service,
+          rewards_service, notification_ad_async_data_store);
   return ads_service.release();
 }
 

--- a/browser/brave_ads/services/BUILD.gn
+++ b/browser/brave_ads/services/BUILD.gn
@@ -1,0 +1,23 @@
+# Copyright (c) 2023 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+
+source_set("services") {
+  sources = [
+    "bat_ads_service_factory_impl.cc",
+    "bat_ads_service_factory_impl.h",
+    "service_sandbox_type.h",
+  ]
+
+  deps = [
+    "//base",
+    "//brave/app:brave_generated_resources_grit",
+    "//brave/components/brave_ads/browser",
+    "//brave/components/brave_ads/common",
+    "//brave/components/services/bat_ads:lib",
+    "//content/public/browser",
+    "//mojo/public/cpp/bindings",
+    "//mojo/public/cpp/system",
+  ]
+}

--- a/browser/brave_ads/services/bat_ads_service_factory_impl.cc
+++ b/browser/brave_ads/services/bat_ads_service_factory_impl.cc
@@ -1,0 +1,75 @@
+/* Copyright (c) 2023 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "brave/browser/brave_ads/services/bat_ads_service_factory_impl.h"
+
+#include <memory>
+#include <utility>
+
+#include "base/feature_list.h"
+#include "base/functional/bind.h"
+#include "base/task/single_thread_task_runner.h"
+#include "base/task/single_thread_task_runner_thread_mode.h"
+#include "base/task/thread_pool.h"
+#include "brave/browser/brave_ads/services/service_sandbox_type.h"  // IWYU pragma: keep
+#include "brave/components/services/bat_ads/bat_ads_service_impl.h"
+#include "brave/grit/brave_generated_resources.h"
+#include "content/public/browser/browser_thread.h"
+#include "content/public/browser/service_process_host.h"
+#include "mojo/public/cpp/bindings/pending_receiver.h"
+#include "mojo/public/cpp/bindings/self_owned_receiver.h"
+
+namespace brave_ads {
+
+namespace {
+
+BASE_FEATURE(kInProcessBraveAdsFeature,
+             "InProcessBraveAds",
+             base::FEATURE_DISABLED_BY_DEFAULT);
+
+// Binds the |receiver| to a new provider on a background task runner.
+void BindInProcessBatAdsService(
+    mojo::PendingReceiver<bat_ads::mojom::BatAdsService> receiver) {
+  mojo::MakeSelfOwnedReceiver(std::make_unique<bat_ads::BatAdsServiceImpl>(),
+                              std::move(receiver));
+}
+
+// Launches an in process Bat Ads Service.
+mojo::Remote<bat_ads::mojom::BatAdsService> LaunchInProcessBatAdsService() {
+  mojo::Remote<bat_ads::mojom::BatAdsService> remote;
+  base::ThreadPool::CreateSingleThreadTaskRunner(
+      {base::MayBlock(), base::WithBaseSyncPrimitives()},
+      base::SingleThreadTaskRunnerThreadMode::DEDICATED)
+      ->PostTask(FROM_HERE,
+                 base::BindOnce(&BindInProcessBatAdsService,
+                                remote.BindNewPipeAndPassReceiver()));
+  return remote;
+}
+
+// Launches a new Bat Ads Service utility process.
+mojo::Remote<bat_ads::mojom::BatAdsService> LaunchOutOfProcessBatAdsService() {
+  return content::ServiceProcessHost::Launch<bat_ads::mojom::BatAdsService>(
+      content::ServiceProcessHost::Options()
+          .WithDisplayName(IDS_SERVICE_BAT_ADS)
+          .Pass());
+}
+
+}  // namespace
+
+BatAdsServiceFactoryImpl::BatAdsServiceFactoryImpl() = default;
+
+BatAdsServiceFactoryImpl::~BatAdsServiceFactoryImpl() = default;
+
+mojo::Remote<bat_ads::mojom::BatAdsService> BatAdsServiceFactoryImpl::Launch()
+    const {
+  DCHECK_CURRENTLY_ON(content::BrowserThread::UI);
+
+  const bool in_process =
+      base::FeatureList::IsEnabled(kInProcessBraveAdsFeature);
+  return in_process ? LaunchInProcessBatAdsService()
+                    : LaunchOutOfProcessBatAdsService();
+}
+
+}  // namespace brave_ads

--- a/browser/brave_ads/services/bat_ads_service_factory_impl.h
+++ b/browser/brave_ads/services/bat_ads_service_factory_impl.h
@@ -1,0 +1,34 @@
+/* Copyright (c) 2023 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_BROWSER_BRAVE_ADS_SERVICES_BAT_ADS_SERVICE_FACTORY_IMPL_H_
+#define BRAVE_BROWSER_BRAVE_ADS_SERVICES_BAT_ADS_SERVICE_FACTORY_IMPL_H_
+
+#include "brave/components/brave_ads/browser/bat_ads_service_factory.h"
+#include "brave/components/services/bat_ads/public/interfaces/bat_ads.mojom.h"
+#include "mojo/public/cpp/bindings/remote.h"
+
+namespace brave_ads {
+
+class BatAdsServiceFactoryImpl : public BatAdsServiceFactory {
+ public:
+  BatAdsServiceFactoryImpl();
+
+  BatAdsServiceFactoryImpl(const BatAdsServiceFactoryImpl&) = delete;
+  BatAdsServiceFactoryImpl& operator=(const BatAdsServiceFactoryImpl&) = delete;
+
+  BatAdsServiceFactoryImpl(BatAdsServiceFactoryImpl&&) noexcept = delete;
+  BatAdsServiceFactoryImpl& operator=(BatAdsServiceFactoryImpl&&) noexcept =
+      delete;
+
+  ~BatAdsServiceFactoryImpl() override;
+
+  // BatAdsServiceFactory:
+  mojo::Remote<bat_ads::mojom::BatAdsService> Launch() const override;
+};
+
+}  // namespace brave_ads
+
+#endif  // BRAVE_BROWSER_BRAVE_ADS_SERVICES_BAT_ADS_SERVICE_FACTORY_IMPL_H_

--- a/browser/brave_ads/services/service_sandbox_type.h
+++ b/browser/brave_ads/services/service_sandbox_type.h
@@ -3,8 +3,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-#ifndef BRAVE_COMPONENTS_BRAVE_ADS_BROWSER_SERVICE_SANDBOX_TYPE_H_
-#define BRAVE_COMPONENTS_BRAVE_ADS_BROWSER_SERVICE_SANDBOX_TYPE_H_
+#ifndef BRAVE_BROWSER_BRAVE_ADS_SERVICES_SERVICE_SANDBOX_TYPE_H_
+#define BRAVE_BROWSER_BRAVE_ADS_SERVICES_SERVICE_SANDBOX_TYPE_H_
 
 #include "content/public/browser/service_process_host.h"  // IWYU pragma: keep
 
@@ -18,4 +18,4 @@ content::GetServiceSandboxType<bat_ads::mojom::BatAdsService>() {
   return sandbox::mojom::Sandbox::kUtility;
 }
 
-#endif  // BRAVE_COMPONENTS_BRAVE_ADS_BROWSER_SERVICE_SANDBOX_TYPE_H_
+#endif  // BRAVE_BROWSER_BRAVE_ADS_SERVICES_SERVICE_SANDBOX_TYPE_H_

--- a/browser/brave_ads/sources.gni
+++ b/browser/brave_ads/sources.gni
@@ -26,6 +26,7 @@ brave_browser_brave_ads_sources = [
 brave_browser_brave_ads_deps = [
   "//base",
   "//brave/browser/brave_ads/device_id",
+  "//brave/browser/brave_ads/services",
   "//brave/browser/brave_rewards:util",
   "//brave/browser/ui/brave_ads",
   "//brave/components/brave_ads/browser",

--- a/components/brave_ads/browser/BUILD.gn
+++ b/components/brave_ads/browser/BUILD.gn
@@ -57,9 +57,9 @@ source_set("browser") {
     "ads_service_impl.cc",
     "ads_service_impl.h",
     "ads_tooltips_delegate.h",
+    "bat_ads_service_factory.h",
     "device_id.cc",
     "device_id.h",
-    "service_sandbox_type.h",
   ]
 
   deps += [

--- a/components/brave_ads/browser/ads_service_impl.h
+++ b/components/brave_ads/browser/ads_service_impl.h
@@ -59,6 +59,7 @@ class SimpleURLLoader;
 namespace brave_ads {
 
 class AdsTooltipsDelegate;
+class BatAdsServiceFactory;
 class Database;
 class DeviceId;
 struct NewTabPageAdInfo;
@@ -76,6 +77,7 @@ class AdsServiceImpl : public AdsService,
           adaptive_captcha_service,
       std::unique_ptr<AdsTooltipsDelegate> ads_tooltips_delegate,
       std::unique_ptr<DeviceId> device_id,
+      std::unique_ptr<BatAdsServiceFactory> bat_ads_service_factory,
       history::HistoryService* history_service,
       brave_rewards::RewardsService* rewards_service,
       brave_federated::AsyncDataStore* notification_ad_timing_data_store);
@@ -463,6 +465,8 @@ class AdsServiceImpl : public AdsService,
   const std::unique_ptr<AdsTooltipsDelegate> ads_tooltips_delegate_;
 
   const std::unique_ptr<DeviceId> device_id_;
+
+  const std::unique_ptr<BatAdsServiceFactory> bat_ads_service_factory_;
 
   const scoped_refptr<base::SequencedTaskRunner> file_task_runner_;
 

--- a/components/brave_ads/browser/bat_ads_service_factory.h
+++ b/components/brave_ads/browser/bat_ads_service_factory.h
@@ -1,0 +1,24 @@
+/* Copyright (c) 2023 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_COMPONENTS_BRAVE_ADS_BROWSER_BAT_ADS_SERVICE_FACTORY_H_
+#define BRAVE_COMPONENTS_BRAVE_ADS_BROWSER_BAT_ADS_SERVICE_FACTORY_H_
+
+#include "brave/components/services/bat_ads/public/interfaces/bat_ads.mojom.h"
+#include "mojo/public/cpp/bindings/remote.h"
+
+namespace brave_ads {
+
+class BatAdsServiceFactory {
+ public:
+  virtual ~BatAdsServiceFactory() = default;
+
+  // Launches a new Bat Ads Service.
+  virtual mojo::Remote<bat_ads::mojom::BatAdsService> Launch() const = 0;
+};
+
+}  // namespace brave_ads
+
+#endif  // BRAVE_COMPONENTS_BRAVE_ADS_BROWSER_BAT_ADS_SERVICE_FACTORY_H_

--- a/components/services/bat_ads/BUILD.gn
+++ b/components/services/bat_ads/BUILD.gn
@@ -5,6 +5,7 @@
 
 static_library("lib") {
   visibility = [
+    "//brave/browser/brave_ads/services",
     "//brave/test:*",
     "//chrome/utility:*",
   ]
@@ -26,6 +27,7 @@ static_library("lib") {
   ]
 
   deps = [
+    "//brave/app:brave_generated_resources_grit",
     "//brave/components/brave_ads/core",
     "//mojo/public/cpp/bindings",
     "//mojo/public/cpp/system",

--- a/components/services/bat_ads/bat_ads_service_impl.cc
+++ b/components/services/bat_ads/bat_ads_service_impl.cc
@@ -10,8 +10,20 @@
 
 #include "brave/components/services/bat_ads/bat_ads_impl.h"
 #include "brave/components/services/bat_ads/public/interfaces/bat_ads.mojom.h"
+#include "mojo/public/cpp/bindings/sync_call_restrictions.h"
 
 namespace bat_ads {
+
+struct BatAdsServiceImpl::ScopedAllowSyncCall {
+  // TODO(https://github.com/brave/brave-browser/issues/29870): Get rid of
+  // scoped allow sync calls object when Brave Ads [Sync] mojom calls are
+  // refactored. mojo::ScopedAllowSyncCallForTesting is used to avoid patching
+  // of chromium sync_call_restrictions.h file.
+  mojo::ScopedAllowSyncCallForTesting scoped_allow;
+};
+
+BatAdsServiceImpl::BatAdsServiceImpl()
+    : scoped_allow_sync_(std::make_unique<ScopedAllowSyncCall>()) {}
 
 BatAdsServiceImpl::BatAdsServiceImpl(
     mojo::PendingReceiver<mojom::BatAdsService> receiver)

--- a/components/services/bat_ads/bat_ads_service_impl.h
+++ b/components/services/bat_ads/bat_ads_service_impl.h
@@ -6,6 +6,8 @@
 #ifndef BRAVE_COMPONENTS_SERVICES_BAT_ADS_BAT_ADS_SERVICE_IMPL_H_
 #define BRAVE_COMPONENTS_SERVICES_BAT_ADS_BAT_ADS_SERVICE_IMPL_H_
 
+#include <memory>
+
 #include "brave/components/brave_ads/common/interfaces/brave_ads.mojom-forward.h"
 #include "brave/components/services/bat_ads/public/interfaces/bat_ads.mojom.h"
 #include "mojo/public/cpp/bindings/pending_associated_receiver.h"
@@ -18,6 +20,10 @@ namespace bat_ads {
 
 class BatAdsServiceImpl : public mojom::BatAdsService {
  public:
+  // This constructor assumes the BatAdsServiceImpl will be bound to an
+  // externally owned receiver, such as through |mojo::MakeSelfOwnedReceiver()|.
+  BatAdsServiceImpl();
+
   explicit BatAdsServiceImpl(
       mojo::PendingReceiver<mojom::BatAdsService> receiver);
 
@@ -37,8 +43,11 @@ class BatAdsServiceImpl : public mojom::BatAdsService {
               CreateCallback callback) override;
 
  private:
-  mojo::Receiver<mojom::BatAdsService> receiver_;
+  mojo::Receiver<mojom::BatAdsService> receiver_{this};
   mojo::UniqueAssociatedReceiverSet<mojom::BatAds> associated_receivers_;
+
+  struct ScopedAllowSyncCall;
+  std::unique_ptr<ScopedAllowSyncCall> scoped_allow_sync_;
 };
 
 }  // namespace bat_ads


### PR DESCRIPTION
The functionality is controlled with `InProcessBraveAds` feature which is turned off by default.

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/29869

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-arm64, CI/skip-linux-x64, CI/skip-android, CI/skip-macos, CI/skip-ios, CI/skip-windows-arm64, CI/skip-windows-x64, CI/skip-windows-x86 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

### Test scenario 1
- Run Browser with fresh profile
- Enable Brave Ads
- Make sure that `Utility: Brave Ads Service` utility process is started

### Test scenario 2
- Run Browser with fresh profile with `--enable-features=InProcessBraveAds`
- Enable Brave Ads
- Make sure that there is no `Utility: Brave Ads Service` utility process
- Make sure that Brave Ads are initialized
- Do smoke testing for Brave Ads functionality