### PR TITLE
Make whats-new browser test independent with current browser version

### DIFF
--- a/browser/ui/whats_new/BUILD.gn
+++ b/browser/ui/whats_new/BUILD.gn
@@ -14,7 +14,9 @@ source_set("browser_test") {
   deps = [
     "//brave/components/l10n/common",
     "//brave/components/l10n/common:test_support",
+    "//chrome/browser",
     "//chrome/browser:browser_process",
+    "//chrome/browser/profiles:profile",
     "//chrome/browser/ui",
     "//chrome/test:test_support_ui",
     "//components/prefs",

--- a/browser/ui/whats_new/whats_new_browsertest.cc
+++ b/browser/ui/whats_new/whats_new_browsertest.cc
@@ -10,6 +10,8 @@
 #include "brave/browser/ui/whats_new/whats_new_util.h"
 #include "brave/components/l10n/common/test/scoped_default_locale.h"
 #include "chrome/browser/browser_process.h"
+#include "chrome/browser/profiles/chrome_version_service.h"
+#include "chrome/browser/profiles/profile.h"
 #include "chrome/browser/ui/browser.h"
 #include "chrome/browser/ui/tabs/tab_strip_model.h"
 #include "chrome/test/base/in_process_browser_test.h"
@@ -19,13 +21,14 @@
 
 namespace whats_new {
 
+// Set current version 1.52 and whats-new target is 1.52.
 class BraveWhatsNewBrowserTest : public InProcessBrowserTest {
  public:
   BraveWhatsNewBrowserTest() {
     scoped_default_locale_ =
         std::make_unique<brave_l10n::test::ScopedDefaultLocale>("en_US");
     PrepareValidFieldTrialParams();
-    SetCurrentVersionForTesting(1.51);
+    SetCurrentVersionForTesting(1.52);
 
     // To disable tab presets for startup.
     // When preset tabs are used, whats-new page is not launched.
@@ -37,7 +40,7 @@ class BraveWhatsNewBrowserTest : public InProcessBrowserTest {
   void PrepareValidFieldTrialParams() {
     constexpr char kWhatsNewTrial[] = "WhatsNewStudy";
     std::map<std::string, std::string> params;
-    params["target_major_version"] = "1.51";
+    params["target_major_version"] = "1.52";
     ASSERT_TRUE(
         base::AssociateFieldTrialParams(kWhatsNewTrial, "Enabled", params));
     base::FieldTrialList::CreateFieldTrial(kWhatsNewTrial, "Enabled");
@@ -49,7 +52,8 @@ class BraveWhatsNewBrowserTest : public InProcessBrowserTest {
   std::unique_ptr<brave_l10n::test::ScopedDefaultLocale> scoped_default_locale_;
 };
 
-IN_PROC_BROWSER_TEST_F(BraveWhatsNewBrowserTest, PRE_WhatsNewPageLaunchTest) {
+IN_PROC_BROWSER_TEST_F(BraveWhatsNewBrowserTest,
+                       PRE_WhatsNewPageLaunchTestWithUpdatedUser) {
   // Whats-new page is not shown with onboarding page together.
   // It's upstream logic - see the comments of
   // StartupBrowserCreatorImpl::DetermineStartupTabs().
@@ -59,16 +63,45 @@ IN_PROC_BROWSER_TEST_F(BraveWhatsNewBrowserTest, PRE_WhatsNewPageLaunchTest) {
 
   // In production, fresh user doesn't see whats-new for that version.
   // For testing purpose, clear cache to test whether whats-new is launched in
-  // another launch.
+  // next launch.
   local_state()->SetDouble(prefs::kWhatsNewLastVersion, 0);
+
+  // Update profile created version to make this user already updated user.
+  // Set lower version(1.51) than current version(1.52).
+  ChromeVersionService::SetVersion(browser()->profile()->GetPrefs(),
+                                   "112.1.51.12");
 }
 
-IN_PROC_BROWSER_TEST_F(BraveWhatsNewBrowserTest, WhatsNewPageLaunchTest) {
+IN_PROC_BROWSER_TEST_F(BraveWhatsNewBrowserTest,
+                       WhatsNewPageLaunchTestWithUpdatedUser) {
   // Two tabs - first one is whats-new and another one is welcome
   EXPECT_EQ(2, tab_model()->count());
   EXPECT_EQ(GURL("https://brave.com/whats-new/"),
             tab_model()->GetActiveWebContents()->GetVisibleURL());
-  EXPECT_EQ(1.51, local_state()->GetDouble(prefs::kWhatsNewLastVersion));
+  EXPECT_EQ(1.52, local_state()->GetDouble(prefs::kWhatsNewLastVersion));
+}
+
+IN_PROC_BROWSER_TEST_F(BraveWhatsNewBrowserTest,
+                       PRE_WhatsNewPageLaunchTestWithFreshUser) {
+  // Whats-new page is not shown with onboarding page together.
+  // It's upstream logic - see the comments of
+  // StartupBrowserCreatorImpl::DetermineStartupTabs().
+  EXPECT_EQ(1, tab_model()->count());
+  EXPECT_EQ(GURL(" chrome://welcome/"),
+            tab_model()->GetActiveWebContents()->GetVisibleURL());
+
+  // Update profile created version to make this user as not updated user.
+  ChromeVersionService::SetVersion(browser()->profile()->GetPrefs(),
+                                   "112.1.52.12");
+}
+
+IN_PROC_BROWSER_TEST_F(BraveWhatsNewBrowserTest,
+                       WhatsNewPageLaunchTestWithFreshUser) {
+  // One tabs - it's is welcome page. whats-new tab is only added to updated
+  // user.
+  EXPECT_EQ(1, tab_model()->count());
+  EXPECT_NE(GURL("https://brave.com/whats-new/"),
+            tab_model()->GetActiveWebContents()->GetVisibleURL());
 }
 
 }  // namespace whats_new


### PR DESCRIPTION
issue: brave/brave-browser#29709
f/u PR for #18114

Existing test is failed in the uplift PR(https://github.com/brave/brave-core/pull/18142).
The reason is test code uses `1.51` as as target whats-new version and current verion for testing.
In the uplift PR, we also check profile created version. If profile created version and current version is same,
we don't launch whats-new tab. Because of this, whats-new tab is not launched in the beta(1.51) browser test.
Modified profile created version also for testing.

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves 

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-arm64, CI/skip-linux-x64, CI/skip-android, CI/skip-macos, CI/skip-ios, CI/skip-windows-arm64, CI/skip-windows-x64, CI/skip-windows-x86 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [ ] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

`BraveWhatsNewBrowserTest.*`