### PR TITLE
Updated Improved Search Suggestions default value

### DIFF
--- a/browser/brave_prefs_browsertest.cc
+++ b/browser/brave_prefs_browsertest.cc
@@ -160,8 +160,13 @@ IN_PROC_BROWSER_TEST_F(BraveProfilePrefsBrowserTest,
       spellcheck::prefs::kSpellCheckUseSpellingService));
   EXPECT_FALSE(chrome_test_utils::GetProfile(this)->GetPrefs()->GetBoolean(
       prefs::kSafeBrowsingExtendedReportingOptInAllowed));
+#if BUILDFLAG(IS_ANDROID)
+  // On desktop, value could be change based on current country and search
+  // provider. SearchEngineProviderServiceTest.DefaultSearchSuggestEnabledTest
+  // test about this.
   EXPECT_FALSE(chrome_test_utils::GetProfile(this)->GetPrefs()->GetBoolean(
       prefs::kSearchSuggestEnabled));
+#endif
   EXPECT_EQ(chrome_test_utils::GetProfile(this)->GetPrefs()->GetInteger(
                 prefetch::prefs::kNetworkPredictionOptions),
             static_cast<int>(prefetch::NetworkPredictionOptions::kDisabled));

--- a/browser/brave_profile_prefs.cc
+++ b/browser/brave_profile_prefs.cc
@@ -290,9 +290,13 @@ void RegisterProfilePrefs(user_prefs::PrefRegistrySyncable* registry) {
   registry->SetDefaultPrefValue(kSideSearchEnabled, base::Value(false));
 #endif
 
+#if BUILDFLAG(IS_ANDROID)
+  // On desktop NormalWindowSearchEngineProviderService controls
+  // its default value based on current country and search provider.
   // Disable search suggestion
   registry->SetDefaultPrefValue(prefs::kSearchSuggestEnabled,
                                 base::Value(false));
+#endif
 
   // Disable "Use a prediction service to load pages more quickly"
   registry->SetDefaultPrefValue(

--- a/browser/resources/settings/brave_overrides/personalization_options.ts
+++ b/browser/resources/settings/brave_overrides/personalization_options.ts
@@ -21,5 +21,18 @@ RegisterPolymerTemplateModifications({
           </settings-brave-personalization-options>
         `)
     }
+
+    // searchSugestToggle is moved to search engines section.
+    const searchSuggestToggleTemplate = templateContent.querySelector('template[is="dom-if"][if="[[showSearchSuggestToggle_()]]"]')
+    if (!searchSuggestToggleTemplate) {
+      console.error('[Brave Settings Overrides] Could not find searchSuggestToggle template')
+    } else {
+      const searchSuggestToggle =searchSuggestToggleTemplate.content.getElementById('searchSuggestToggle')
+      if (!searchSuggestToggle) {
+        console.error('[Brave Settings Overrides] Could not find searchSuggestToggle id')
+      } else {
+        searchSuggestToggle.setAttribute('hidden', 'true')
+      }
+    }
   },
 })

--- a/browser/resources/settings/brave_search_engines_page/brave_search_engines_page.html
+++ b/browser/resources/settings/brave_search_engines_page/brave_search_engines_page.html
@@ -9,6 +9,14 @@
     </settings-dropdown-menu>
   </div>
 </template>
+<template is="dom-if" if="[[shouldShowSearchSuggestToggle_()]]" restamp>
+  <settings-toggle-button id="searchSuggestToggle"
+      class="hr"
+      pref="{{prefs.search.suggest_enabled}}"
+      label="$i18n{searchSuggestPref}"
+      sub-label="$i18n{searchSuggestPrefDesc}">
+  </settings-toggle-button>
+</template>
 <if expr="enable_extensions">
 <settings-toggle-button id="webDiscoveryEnabled"
     class="cr-row"

--- a/browser/resources/settings/brave_search_engines_page/brave_search_engines_page.ts
+++ b/browser/resources/settings/brave_search_engines_page/brave_search_engines_page.ts
@@ -48,6 +48,10 @@ class BraveSearchEnginesPage extends BraveSearchEnginesPageBase {
       'private-search-engines-changed', updatePrivateSearchEngines)
   }
 
+  shouldShowSearchSuggestToggle_() {
+    return !loadTimeData.getBoolean('isGuest')
+  }
+
   shouldShowPrivateSearchProvider_(prefs) {
     // When default search engine is enforced, configured provider is not used.
     // If we install search provider extension, that extension will be used on normal and


### PR DESCRIPTION
fix https://github.com/brave/brave-browser/issues/29517

We'll turn it on when Brave Search is default provider in specific countries.
This PR doesn't change current value if user updated that option's value already.

In private(and tor) window, search suggestion doesn't work.
`SearchProvider` suggestions from a search engine and it blocks request for OTR profile.
```
bool SearchProvider::IsQuerySuitableForSuggest(bool* query_is_private) const {
  *query_is_private = IsQueryPotentiallyPrivate();

  // Don't run Suggest in incognito mode, if the engine doesn't support it, or
  // if the user has disabled it.  Also don't send potentially private data
  // to the default search provider.  (It's always okay to send explicit
  // keyword input to a keyword suggest server, if any.)
  const TemplateURL* default_url = providers_.GetDefaultProviderURL();
  const TemplateURL* keyword_url = providers_.GetKeywordProviderURL();
  return !client()->IsOffTheRecord() && client()->SearchSuggestEnabled() &&
         ((default_url && !default_url->suggestions_url().empty() &&
           !*query_is_private) ||
          (keyword_url && !keyword_url->suggestions_url().empty()));
}
```

Search suggestions option is moved to search engines section.
<img width="768" alt="Screenshot 2023-04-24 at 11 36 10 AM" src="https://user-images.githubusercontent.com/6786187/233888496-11114798-ede2-4b80-a58b-f1793d99a858.png">


<!-- Add brave-browser issue below that this PR will resolve -->
Resolves 

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-arm64, CI/skip-linux-x64, CI/skip-android, CI/skip-macos, CI/skip-ios, CI/skip-windows-arm64, CI/skip-windows-x64, CI/skip-windows-x86 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [ ] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

`SearchEngineProviderServiceTest.DefaultSearchSuggestEnabledTest`

1. Set os country one of `"IN", "CA", "DE", "FR", "GB", "US", "AT", "ES", "MX", "BR", "AR"`
2. Launch with clean profile
3. Set Brave Search as default provider
4. Check Improve Search Suggestions option is turned on
5. Set Non Brave Search and check Search Suggestions are turned off