### PR TITLE
fix: stream transaction parsed values

### DIFF
--- a/components/brave_wallet_ui/common/async/handlers.ts
+++ b/components/brave_wallet_ui/common/async/handlers.ts
@@ -700,7 +700,8 @@ handler.on(WalletActions.transactionStatusChanged.type, async (store: Store, pay
       coinType: getCoinFromTxDataUnion(payload.txInfo.txDataUnion),
       fromAddress: payload.txInfo.fromAddress,
       txStatus: payload.txInfo.txStatus,
-      id: payload.txInfo.id
+      id: payload.txInfo.id,
+      chainId: payload.txInfo.chainId,
     })
   )
   const status = payload.txInfo.txStatus

--- a/components/brave_wallet_ui/common/hooks/transaction-parser.ts
+++ b/components/brave_wallet_ui/common/hooks/transaction-parser.ts
@@ -9,7 +9,8 @@ import * as React from 'react'
 import {
   BraveWallet,
   SerializableTransactionInfo,
-  SolFeeEstimates
+  SolFeeEstimates,
+  TransactionInfo
 } from '../../constants/types'
 
 // Utils
@@ -19,8 +20,7 @@ import {
   ParsedTransaction,
   ParsedTransactionFees,
   parseTransactionFeesWithoutPrices,
-  parseTransactionWithPrices,
-  TransactionInfo
+  parseTransactionWithPrices
 } from '../../utils/tx-utils'
 import { WalletSelectors } from '../selectors'
 

--- a/components/brave_wallet_ui/common/slices/api.slice.test.tsx
+++ b/components/brave_wallet_ui/common/slices/api.slice.test.tsx
@@ -7,7 +7,7 @@ import * as React from 'react'
 import { Provider } from 'react-redux'
 import { renderHook } from '@testing-library/react-hooks'
 
-import { useGetAllTransactionInfosForAddressCoinTypeQuery } from './api.slice'
+import { useGetTransactionsQuery } from './api.slice'
 
 import { mockAccount } from '../constants/mocks'
 import { createMockStore } from '../../utils/test-utils'
@@ -28,9 +28,10 @@ describe('api slice: getAllTransactionInfosForAddressCoinType', () => {
 
     const { result, waitForValueToChange } = renderHook(
       () =>
-        useGetAllTransactionInfosForAddressCoinTypeQuery({
+        useGetTransactionsQuery({
           address: mockAccount.address,
-          coinType: mockAccount.coin
+          coinType: mockAccount.coin,
+          chainId: null
         }),
       renderHookOptionsWithCustomStore(store)
     )

--- a/components/brave_wallet_ui/components/desktop/portfolio-transaction-item/index.tsx
+++ b/components/brave_wallet_ui/components/desktop/portfolio-transaction-item/index.tsx
@@ -11,6 +11,7 @@ import * as EthereumBlockies from 'ethereum-blockies'
 // Types
 import {
   BraveWallet,
+  SerializableTransactionInfo,
   WalletRoutes
 } from '../../../constants/types'
 
@@ -22,8 +23,20 @@ import { getLocale } from '../../../../common/locale'
 import { WalletActions } from '../../../common/actions'
 import {
   getGasFeeFiatValue,
+  getTransactionFormattedSendCurrencyTotal,
+  getTransactionGasFee,
   getTransactionStatusString,
-  ParsedTransactionWithoutFiatValues
+  isFilecoinTransaction,
+  isSolanaTransaction,
+  getTransactionToAddress,
+  getIsTxApprovalUnlimited,
+  findTransactionToken,
+  getTransactionApprovalTargetAddress,
+  getTransactionErc721TokenId,
+  isSwapTransaction,
+  getETHSwapTransactionBuyAndSellTokens,
+  getTransactionTokenSymbol,
+  getTransactionTransferredValue
 } from '../../../utils/tx-utils'
 import { findTokenBySymbol } from '../../../utils/asset-utils'
 import {
@@ -32,6 +45,9 @@ import {
 } from '../../../common/slices/entities/account-info.entity'
 import { selectAllUserAssetsFromQueryResult } from '../../../common/slices/entities/blockchain-token.entity'
 import { makeNetworkAsset } from '../../../options/asset-options'
+import { getCoinFromTxDataUnion } from '../../../utils/network-utils'
+import { WalletSelectors } from '../../../common/selectors'
+import { getAddressLabelFromRegistry } from '../../../utils/account-utils'
 
 // Hooks
 import { useExplorer } from '../../../common/hooks'
@@ -42,6 +58,9 @@ import {
   useGetTokenSpotPriceQuery,
   useGetUserTokensRegistryQuery
 } from '../../../common/slices/api.slice'
+import {
+  useUnsafeWalletSelector
+} from '../../../common/hooks/use-safe-selector'
 
 // Styled Components
 import {
@@ -77,7 +96,7 @@ import TransactionTimestampTooltip from '../transaction-timestamp-tooltip'
 import { Skeleton, LoadingSkeletonStyleProps } from '../../shared/loading-skeleton/styles'
 
 export interface Props {
-  transaction: ParsedTransactionWithoutFiatValues
+  transaction: BraveWallet.TransactionInfo | SerializableTransactionInfo
   displayAccountName: boolean
   isFocused?: boolean
 }
@@ -93,18 +112,25 @@ export const PortfolioTransactionItem = React.forwardRef<HTMLDivElement, Props>(
   displayAccountName,
   isFocused
 }: Props, forwardedRef) => {
-  const {
-    formattedSendCurrencyTotal,
-    gasFee,
-    isFilecoinTransaction,
-    isSolanaTransaction
-  } = transaction
-
   // routing
   const history = useHistory()
 
   // redux
   const dispatch = useDispatch()
+  const fullTokenList = useUnsafeWalletSelector(WalletSelectors.fullTokenList)
+  const solFeeEstimates = useUnsafeWalletSelector(
+    WalletSelectors.solFeeEstimates
+  )
+
+  // partial tx parsing
+  const gasFee = getTransactionGasFee(transaction, solFeeEstimates)
+  const isFilecoinTx = isFilecoinTransaction(transaction)
+  const isSolanaTx = isSolanaTransaction(transaction)
+  const recipient = getTransactionToAddress(transaction)
+  const approvalTarget = getTransactionApprovalTargetAddress(transaction)
+  const erc721TokenId = getTransactionErc721TokenId(transaction)
+  const isSwap = isSwapTransaction(transaction)
+  const txCoinType = getCoinFromTxDataUnion(transaction.txDataUnion)
 
   // queries
   const {
@@ -117,8 +143,9 @@ export const PortfolioTransactionItem = React.forwardRef<HTMLDivElement, Props>(
     isLoading: isLoadingTxNetwork //
   } = useGetNetworkQuery({
     chainId: transaction.chainId,
-    coin: transaction.coinType
+    coin: txCoinType
   })
+
   const networkAsset = React.useMemo(() => {
     return makeNetworkAsset(txNetwork)
   }, [txNetwork])
@@ -140,24 +167,89 @@ export const PortfolioTransactionItem = React.forwardRef<HTMLDivElement, Props>(
 
   const account =
     accountInfosRegistry.entities[
-      accountInfoEntityAdaptor.selectId({ address: transaction.accountAddress })
+      accountInfoEntityAdaptor.selectId({ address: transaction.fromAddress })
     ]
 
+  // memos & computed from queries
+  const combinedTokensList = React.useMemo(
+    () => fullTokenList.concat(userVisibleTokensInfo),
+    [fullTokenList, userVisibleTokensInfo]
+  )
+
+  const txToken = findTransactionToken(
+    transaction,
+    combinedTokensList
+  )
+
+  const recipientLabel = getAddressLabelFromRegistry(
+    recipient,
+    accountInfosRegistry
+  )
+
+  const senderLabel = getAddressLabelFromRegistry(
+    transaction.fromAddress,
+    accountInfosRegistry
+  )
+
+  const approvalTargetLabel = getAddressLabelFromRegistry(
+    approvalTarget,
+    accountInfosRegistry
+  )
+
+  const { buyToken, sellToken, buyAmount, sellAmount } = React.useMemo(() => {
+    return getETHSwapTransactionBuyAndSellTokens({
+      nativeAsset: makeNetworkAsset(txNetwork),
+      tokensList: combinedTokensList,
+      tx: transaction
+    })
+  }, [txNetwork, combinedTokensList, transaction])
+
+  const txSymbol = getTransactionTokenSymbol({
+    tx: transaction,
+    txNetwork,
+    token: txToken,
+    sellToken
+  })
+
+  const normalizedTransferredValue = React.useMemo(() => {
+    const { normalized } = getTransactionTransferredValue({
+      tx: transaction,
+      sellToken,
+      token: txToken,
+      txNetwork
+    })
+    return normalized.format(6)
+  }, [
+    transaction,
+    sellToken,
+    txToken,
+    txNetwork
+  ])
+
+  const formattedSendCurrencyTotal = getTransactionFormattedSendCurrencyTotal({
+    normalizedTransferredValue,
+    tx: transaction,
+    sellToken,
+    token: txToken,
+    txNetwork
+  })
+
+  // price queries
   const {
     fiatValue,
     isLoading: isLoadingTokenSpotPrice
   } = useGetTokenSpotPriceQuery({
-    chainId: transaction.token?.chainId || '',
-    contractAddress: transaction.token?.contractAddress || '',
-    isErc721: transaction.token?.isErc721 || false,
-    symbol: transaction.token?.symbol || '',
-    tokenId: transaction.token?.tokenId || ''
+    chainId: txToken?.chainId || '',
+    contractAddress: txToken?.contractAddress || '',
+    isErc721: txToken?.isErc721 || false,
+    symbol: txToken?.symbol || '',
+    tokenId: txToken?.tokenId || ''
   }, {
-    skip: !transaction.token || !transaction.value,
+    skip: !txToken || !normalizedTransferredValue,
     // TODO: selector
     selectFromResult: (result) => {
       const price = result.data?.price || '0'
-      const fiatValue = new Amount(transaction.value)
+      const fiatValue = new Amount(normalizedTransferredValue)
         .times(price)
         .value?.toString() || '0'
 
@@ -213,22 +305,23 @@ export const PortfolioTransactionItem = React.forwardRef<HTMLDivElement, Props>(
   }, [showTransactionPopup])
 
   const onClickCopyTransactionHash = React.useCallback(
-    () => copyToClipboard(transaction.hash),
-    [transaction.hash]
+    () => copyToClipboard(transaction.txHash),
+    [transaction.txHash]
   )
 
   const onClickRetryTransaction = React.useCallback(
     () => {
       dispatch(WalletActions.retryTransaction({
-        coinType: transaction.coinType,
-        fromAddress: transaction.accountAddress,
+        coinType: txCoinType,
+        fromAddress: transaction.fromAddress,
         chainId: transaction.chainId,
         transactionId: transaction.id
       }))
     },
     [
-      transaction.coinType,
-      transaction.accountAddress,
+      txCoinType,
+      transaction.fromAddress,
+      transaction.chainId,
       transaction.id
     ]
   )
@@ -236,15 +329,16 @@ export const PortfolioTransactionItem = React.forwardRef<HTMLDivElement, Props>(
   const onClickSpeedupTransaction = React.useCallback(
     () => {
       dispatch(WalletActions.speedupTransaction({
-        coinType: transaction.coinType,
-        fromAddress: transaction.accountAddress,
+        coinType: txCoinType,
+        fromAddress: transaction.fromAddress,
         chainId: transaction.chainId,
         transactionId: transaction.id
       }))
     },
     [
-      transaction.coinType,
-      transaction.accountAddress,
+      txCoinType,
+      transaction.fromAddress,
+      transaction.chainId,
       transaction.id
     ]
   )
@@ -252,15 +346,16 @@ export const PortfolioTransactionItem = React.forwardRef<HTMLDivElement, Props>(
   const onClickCancelTransaction = React.useCallback(
     () => {
       dispatch(WalletActions.cancelTransaction({
-        coinType: transaction.coinType,
-        fromAddress: transaction.accountAddress,
+        coinType: txCoinType,
+        fromAddress: transaction.fromAddress,
         chainId: transaction.chainId,
         transactionId: transaction.id
       }))
     },
     [
-      transaction.coinType,
-      transaction.accountAddress,
+      txCoinType,
+      transaction.fromAddress,
+      transaction.chainId,
       transaction.id
     ]
   )
@@ -314,12 +409,20 @@ export const PortfolioTransactionItem = React.forwardRef<HTMLDivElement, Props>(
 
   // memos
   const fromOrb = React.useMemo(() => {
-    return EthereumBlockies.create({ seed: transaction.sender.toLowerCase(), size: 8, scale: 16 }).toDataURL()
-  }, [transaction.sender])
+    return EthereumBlockies.create({
+      seed: transaction.fromAddress.toLowerCase(),
+      size: 8,
+      scale: 16
+    }).toDataURL()
+  }, [transaction.fromAddress])
 
   const toOrb = React.useMemo(() => {
-    return EthereumBlockies.create({ seed: transaction.recipient.toLowerCase(), size: 8, scale: 16 }).toDataURL()
-  }, [transaction.recipient])
+    return EthereumBlockies.create({
+      seed: recipient.toLowerCase(),
+      size: 8,
+      scale: 16
+    }).toDataURL()
+  }, [recipient])
 
   const transactionIntentDescription = React.useMemo(() => {
     switch (true) {
@@ -330,16 +433,16 @@ export const PortfolioTransactionItem = React.forwardRef<HTMLDivElement, Props>(
         return (
           <DetailRow>
             <DetailTextDark>
-              <strong>{text}</strong> {
-                transaction.isApprovalUnlimited
-                  ? getLocale('braveWalletTransactionApproveUnlimited')
-                  : transaction.value
-              }{' '}
-              <AddressOrAsset onClick={onAssetClick(transaction.symbol)}>
-                {transaction.symbol}
-              </AddressOrAsset> -{' '}
-              <AddressOrAsset onClick={onAddressClick(transaction.approvalTarget)}>
-                {transaction.approvalTargetLabel}
+              <strong>{text}{' '}</strong>
+              {getIsTxApprovalUnlimited(transaction)
+                ? getLocale('braveWalletTransactionApproveUnlimited')
+                : normalizedTransferredValue}{' '}
+              <AddressOrAsset onClick={onAssetClick(txSymbol)}>
+                {txSymbol}
+              </AddressOrAsset>
+              {' '}-{' '}
+              <AddressOrAsset onClick={onAddressClick(approvalTarget)}>
+                {approvalTargetLabel}
               </AddressOrAsset>
             </DetailTextDark>
           </DetailRow>
@@ -350,37 +453,36 @@ export const PortfolioTransactionItem = React.forwardRef<HTMLDivElement, Props>(
         return (
           <DetailRow>
             <DetailTextDark>
-              {transaction.sellAmount?.format(6)}{' '}
-              <AddressOrAsset
-                onClick={onAssetClick(transaction.sellToken?.symbol)}
-              >
-                {transaction.sellToken?.symbol}
+              {sellAmount?.format(6)}{' '}
+              <AddressOrAsset onClick={onAssetClick(sellToken?.symbol)}>
+                {sellToken?.symbol}
               </AddressOrAsset>
             </DetailTextDark>
             <ArrowIcon />
             <DetailTextDark>
-              {transaction.minBuyAmount?.format(6)}{' '}
-              <AddressOrAsset onClick={onAddressClick(transaction.buyToken?.symbol)}>
-                {transaction.buyToken?.symbol}
+              {buyAmount?.format(6)}{' '}
+              <AddressOrAsset onClick={onAddressClick(buyToken?.symbol)}>
+                {buyToken?.symbol}
               </AddressOrAsset>
             </DetailTextDark>
           </DetailRow>
         )
       }
 
-      case transaction.txType !== BraveWallet.TransactionType.ETHSwap && transaction.isSwap: {
+      case transaction.txType !== BraveWallet.TransactionType.ETHSwap &&
+        isSwap: {
         return (
           <DetailRow>
             <DetailTextDark>
-              {transaction.value}{' '}
-              <AddressOrAsset onClick={onAssetClick(transaction.symbol)}>
-                {transaction.symbol}
+              {normalizedTransferredValue}{' '}
+              <AddressOrAsset onClick={onAssetClick(txSymbol)}>
+                {txSymbol}
               </AddressOrAsset>
             </DetailTextDark>
             <ArrowIcon />
             <DetailTextDark>
-              <AddressOrAsset onClick={onAddressClick(transaction.recipient)}>
-                {transaction.recipientLabel}
+              <AddressOrAsset onClick={onAddressClick(recipient)}>
+                {recipientLabel}
               </AddressOrAsset>
             </DetailTextDark>
           </DetailRow>
@@ -389,30 +491,48 @@ export const PortfolioTransactionItem = React.forwardRef<HTMLDivElement, Props>(
 
       case transaction.txType === BraveWallet.TransactionType.ETHSend:
       case transaction.txType === BraveWallet.TransactionType.ERC20Transfer:
-      case transaction.txType === BraveWallet.TransactionType.ERC721TransferFrom:
-      case transaction.txType === BraveWallet.TransactionType.ERC721SafeTransferFrom:
+      case transaction.txType ===
+        BraveWallet.TransactionType.ERC721TransferFrom:
+      case transaction.txType ===
+        BraveWallet.TransactionType.ERC721SafeTransferFrom:
       default: {
         return (
           <DetailRow>
             <DetailTextDark>
-              <AddressOrAsset onClick={onAddressClick(transaction.sender)}>
-                {transaction.senderLabel}
+              <AddressOrAsset onClick={onAddressClick(transaction.fromAddress)}>
+                {senderLabel}
               </AddressOrAsset>
             </DetailTextDark>
             <ArrowIcon />
             <DetailTextDark>
-              <AddressOrAsset onClick={onAddressClick(transaction.recipient)}>
-                {transaction.recipientLabel}
+              <AddressOrAsset onClick={onAddressClick(recipient)}>
+                {recipientLabel}
               </AddressOrAsset>
             </DetailTextDark>
           </DetailRow>
         )
       }
     }
-  }, [transaction, onAssetClick, onAddressClick])
+  }, [
+    transaction,
+    isSwap,
+    buyToken?.symbol,
+    buyAmount,
+    txSymbol,
+    senderLabel,
+    recipient,
+    recipientLabel,
+    normalizedTransferredValue,
+    sellAmount,
+    sellToken?.symbol,
+    approvalTargetLabel,
+    approvalTarget,
+    onAssetClick,
+    onAddressClick
+  ])
 
   const transactionActionLocale = React.useMemo(() => {
-    if (transaction.isSwap) {
+    if (isSwap) {
       return <strong>
         {getLocale('braveWalletSwap').toLocaleUpperCase()}
       </strong>
@@ -426,8 +546,8 @@ export const PortfolioTransactionItem = React.forwardRef<HTMLDivElement, Props>(
               'braveWalletApprovalTransactionIntent'
             ).toLocaleUpperCase()}{' '}
           </strong>
-          <AddressOrAsset onClick={onAssetClick(transaction.symbol)}>
-            {transaction.symbol}
+          <AddressOrAsset onClick={onAssetClick(txSymbol)}>
+            {txSymbol}
           </AddressOrAsset>
         </>
       )
@@ -444,13 +564,13 @@ export const PortfolioTransactionItem = React.forwardRef<HTMLDivElement, Props>(
             transaction.txType === BraveWallet.TransactionType.ERC721TransferFrom ||
             transaction.txType === BraveWallet.TransactionType.ERC721SafeTransferFrom
           }
-          onClick={onAssetClick(transaction.symbol)}
+          onClick={onAssetClick(txSymbol)}
         >
-          {transaction.symbol}
+          {txSymbol}
           {
             transaction.txType === BraveWallet.TransactionType.ERC721TransferFrom ||
               transaction.txType === BraveWallet.TransactionType.ERC721SafeTransferFrom
-              ? ' ' + transaction.erc721TokenId
+              ? ' ' + erc721TokenId
               : ''
           }
         </AddressOrAsset>
@@ -459,8 +579,8 @@ export const PortfolioTransactionItem = React.forwardRef<HTMLDivElement, Props>(
   }, [transaction, displayAccountName, onAssetClick])
 
   const wasTxRejected =
-    transaction.status !== BraveWallet.TransactionStatus.Rejected &&
-    transaction.status !== BraveWallet.TransactionStatus.Unapproved
+    transaction.txStatus !== BraveWallet.TransactionStatus.Rejected &&
+    transaction.txStatus !== BraveWallet.TransactionStatus.Unapproved
 
   const formattedGasFeeFiatValue = React.useMemo(() => {
     return new Amount(gasFeeFiat).formatAsFiat(defaultFiatCurrency)
@@ -522,9 +642,9 @@ export const PortfolioTransactionItem = React.forwardRef<HTMLDivElement, Props>(
 
       <StatusBalanceAndMoreContainer>
         <StatusRow>
-          <StatusBubble status={transaction.status} />
+          <StatusBubble status={transaction.txStatus} />
           <DetailTextDarkBold>
-            {getTransactionStatusString(transaction.status)}
+            {getTransactionStatusString(transaction.txStatus)}
           </DetailTextDarkBold>
         </StatusRow>
 
@@ -551,7 +671,7 @@ export const PortfolioTransactionItem = React.forwardRef<HTMLDivElement, Props>(
           </BalanceColumn>
 
           {/* Will remove this conditional for solana once https://github.com/brave/brave-browser/issues/22040 is implemented. */}
-          {(!isSolanaTransaction && !!txNetwork) ? (
+          {!isSolanaTx && !!txNetwork ? (
             <TransactionFeesTooltip
               text={
                 <>
@@ -563,7 +683,7 @@ export const PortfolioTransactionItem = React.forwardRef<HTMLDivElement, Props>(
                       <Skeleton {...skeletonProps} />
                     ) : (
                       txNetwork &&
-                      new Amount(transaction.gasFee)
+                      new Amount(gasFee)
                         .divideByDecimals(txNetwork.decimals)
                         .formatAsAsset(6, txNetwork.symbol)
                     )}
@@ -582,9 +702,9 @@ export const PortfolioTransactionItem = React.forwardRef<HTMLDivElement, Props>(
                 <CoinsIcon />
               </CoinsButton>
             </TransactionFeesTooltip>
-          ):
+          ) : (
             <CoinsButtonSpacer />
-          }
+          )}
 
           {wasTxRejected ? (
             <MoreButton onClick={onShowTransactionPopup}>
@@ -601,10 +721,13 @@ export const PortfolioTransactionItem = React.forwardRef<HTMLDivElement, Props>(
                 BraveWallet.TransactionStatus.Submitted,
                 BraveWallet.TransactionStatus.Confirmed,
                 BraveWallet.TransactionStatus.Dropped
-              ].includes(transaction.status) && (
+              ].includes(transaction.txStatus) && (
                 <>
                   <TransactionPopupItem
-                    onClick={onClickViewOnBlockExplorer('tx', transaction.hash)}
+                    onClick={onClickViewOnBlockExplorer(
+                      'tx',
+                      transaction.txHash
+                    )}
                     text={getLocale('braveWalletTransactionExplorer')}
                   />
                   <TransactionPopupItem
@@ -617,9 +740,9 @@ export const PortfolioTransactionItem = React.forwardRef<HTMLDivElement, Props>(
               {[
                 BraveWallet.TransactionStatus.Submitted,
                 BraveWallet.TransactionStatus.Approved
-              ].includes(transaction.status) &&
-                !isSolanaTransaction &&
-                !isFilecoinTransaction && (
+              ].includes(transaction.txStatus) &&
+                !isSolanaTx &&
+                !isFilecoinTx && (
                   <>
                     <TransactionPopupItem
                       onClick={onClickSpeedupTransaction}
@@ -632,9 +755,9 @@ export const PortfolioTransactionItem = React.forwardRef<HTMLDivElement, Props>(
                   </>
                 )}
 
-              {BraveWallet.TransactionStatus.Error === transaction.status &&
-                !isSolanaTransaction &&
-                !isFilecoinTransaction && (
+              {BraveWallet.TransactionStatus.Error === transaction.txStatus &&
+                !isSolanaTx &&
+                !isFilecoinTx && (
                   <TransactionPopupItem
                     onClick={onClickRetryTransaction}
                     text={getLocale('braveWalletTransactionRetry')}

--- a/components/brave_wallet_ui/components/desktop/portfolio-transaction-item/style.ts
+++ b/components/brave_wallet_ui/components/desktop/portfolio-transaction-item/style.ts
@@ -171,7 +171,6 @@ export const OrbAndTxDescriptionContainer = styled.div`
   align-items: center;
   justify-content: flex-start;
   flex-direction: row;
-  flex-wrap: wrap;
   width: 50%;
 `
 
@@ -235,7 +234,7 @@ export const StatusBalanceAndMoreContainer = styled.div`
   display: flex;
   align-self: flex-end;
   flex-direction: row;
-  justify-content: flex-end;
+  justify-content: center;
   align-items: center;
   width: 50%;
 `

--- a/components/brave_wallet_ui/components/desktop/views/accounts/account.tsx
+++ b/components/brave_wallet_ui/components/desktop/views/accounts/account.tsx
@@ -23,16 +23,14 @@ import {
 // utils
 import { reduceAddress } from '../../../../utils/reduce-address'
 import { getLocale } from '../../../../../common/locale'
-import {
-  parseTransactionWithPrices,
-  sortTransactionByDate
-} from '../../../../utils/tx-utils'
+import { sortTransactionByDate } from '../../../../utils/tx-utils'
 import { getBalance } from '../../../../utils/balance-utils'
 import {
-  getCoinFromTxDataUnion,
   getFilecoinKeyringIdFromNetwork
 } from '../../../../utils/network-utils'
-import { selectAllBlockchainTokensFromQueryResult, selectAllUserAssetsFromQueryResult } from '../../../../common/slices/entities/blockchain-token.entity'
+import {
+  selectAllUserAssetsFromQueryResult
+} from '../../../../common/slices/entities/blockchain-token.entity'
 
 // Styled Components
 import {
@@ -67,7 +65,6 @@ import { AccountButtonOptions } from '../../../../options/account-list-button-op
 import { useScrollIntoView } from '../../../../common/hooks/use-scroll-into-view'
 import {
   useGetNetworksQuery,
-  useGetTokensRegistryQuery,
   useGetUserTokensRegistryQuery
 } from '../../../../common/slices/api.slice'
 import { useMultiChainSellAssets } from '../../../../common/hooks/use-multi-chain-sell-assets'
@@ -90,22 +87,14 @@ export const Account = ({
   const dispatch = useDispatch()
 
   // unsafe selectors
-  const userVisibleTokensInfo = useUnsafeWalletSelector(WalletSelectors.userVisibleTokensInfo)
   const accounts = useUnsafeWalletSelector(WalletSelectors.accounts)
   const transactions = useUnsafeWalletSelector(WalletSelectors.transactions)
-  const solFeeEstimates = useUnsafeWalletSelector(WalletSelectors.solFeeEstimates)
-  const spotPrices = useUnsafeWalletSelector(WalletSelectors.transactionSpotPrices)
 
   // queries
   const { data: networkList = [] } = useGetNetworksQuery()
-  const { fullTokenList } = useGetTokensRegistryQuery(undefined, {
-    selectFromResult: (result) => ({
-      fullTokenList: selectAllBlockchainTokensFromQueryResult(result)
-    })
-  })
-  const { userVisibleTokensList } = useGetUserTokensRegistryQuery(undefined, {
+  const { userVisibleTokensInfo } = useGetUserTokensRegistryQuery(undefined, {
     selectFromResult: result => ({
-      userVisibleTokensList: selectAllUserAssetsFromQueryResult(result)
+      userVisibleTokensInfo: selectAllUserAssetsFromQueryResult(result)
     })
   })
 
@@ -148,34 +137,13 @@ export const Account = ({
       return sortTransactionByDate(
         transactions[selectedAccount.address],
         'descending'
-      ).map((tx) =>
-        parseTransactionWithPrices({
-          tx,
-          accounts,
-          fullTokenList,
-          userVisibleTokensList,
-          solFeeEstimates,
-          transactionNetwork: networkList.find(
-            (n) =>
-              n.chainId === tx.chainId &&
-              n.coin === getCoinFromTxDataUnion(tx.txDataUnion)
-          ),
-          spotPrices
-        })
       )
     } else {
       return []
     }
   }, [
-    accounts,
     selectedAccount?.address,
-    transactions,
-    accounts,
-    fullTokenList,
-    userVisibleTokensList,
-    solFeeEstimates,
-    networkList,
-    spotPrices
+    selectedAccount && transactions[selectedAccount.address],
   ])
 
   const accountsTokensList = React.useMemo(() => {

--- a/components/brave_wallet_ui/components/desktop/views/portfolio/components/accounts-and-transctions-list/index.tsx
+++ b/components/brave_wallet_ui/components/desktop/views/portfolio/components/accounts-and-transctions-list/index.tsx
@@ -9,7 +9,8 @@ import * as React from 'react'
 import {
   BraveWallet,
   AddAccountNavTypes,
-  WalletAccountType
+  WalletAccountType,
+  SerializableTransactionInfo
 } from '../../../../../../constants/types'
 
 // Utils
@@ -17,7 +18,6 @@ import { getLocale } from '../../../../../../../common/locale'
 import Amount from '../../../../../../utils/amount'
 import { WalletSelectors } from '../../../../../../common/selectors'
 import { getBalance } from '../../../../../../utils/balance-utils'
-import { ParsedTransaction } from '../../../../../../utils/tx-utils'
 
 // Components
 import {
@@ -58,7 +58,7 @@ export interface Props {
   selectedAsset: BraveWallet.BlockchainToken | undefined
   fullAssetFiatBalance: Amount
   formattedFullAssetBalance: string
-  selectedAssetTransactions: ParsedTransaction[]
+  selectedAssetTransactions: SerializableTransactionInfo[]
   onClickAddAccount: (tabId: AddAccountNavTypes) => () => void
 }
 
@@ -114,7 +114,7 @@ export const AccountsAndTransactionsList = ({
 
   const nonRejectedTransactions = React.useMemo(() => {
     return selectedAssetTransactions
-      .filter(t => t.status !== BraveWallet.TransactionStatus.Rejected)
+      .filter(t => t.txStatus !== BraveWallet.TransactionStatus.Rejected)
   }, [selectedAssetTransactions])
 
   // Methods

--- a/components/brave_wallet_ui/components/desktop/views/portfolio/portfolio-asset.tsx
+++ b/components/brave_wallet_ui/components/desktop/views/portfolio/portfolio-asset.tsx
@@ -20,7 +20,8 @@ import {
 import Amount from '../../../../utils/amount'
 import { mojoTimeDeltaToJSDate } from '../../../../../common/mojomUtils'
 import {
-  ParsedTransaction,
+  findTransactionToken,
+  getETHSwapTransactionBuyAndSellTokens,
   sortTransactionByDate
 } from '../../../../utils/tx-utils'
 import { getBalance } from '../../../../utils/balance-utils'
@@ -38,9 +39,13 @@ import {
   braveNftDisplayOrigin,
   UpdateNftPinningStatus
 } from '../../../../nft/nft-ui-messages'
-import { auroraSupportedContractAddresses } from '../../../../utils/asset-utils'
+import {
+  auroraSupportedContractAddresses,
+  getAssetIdKey
+} from '../../../../utils/asset-utils'
 import { getLocale } from '../../../../../common/locale'
 import { stripERC20TokenImageURL } from '../../../../utils/string-utils'
+import { makeNetworkAsset } from '../../../../options/asset-options'
 
 // actions
 import { WalletPageActions } from '../../../../page/actions'
@@ -61,7 +66,7 @@ import AccountsAndTransactionsList from './components/accounts-and-transctions-l
 import { BridgeToAuroraModal } from '../../popup-modals/bridge-to-aurora-modal/bridge-to-aurora-modal'
 
 // Hooks
-import { usePricing, useTransactionParser, useMultiChainBuyAssets } from '../../../../common/hooks'
+import { usePricing, useMultiChainBuyAssets } from '../../../../common/hooks'
 import {
   useSafePageSelector,
   useSafeWalletSelector,
@@ -234,7 +239,6 @@ export const PortfolioAsset = (props: Props) => {
   const [filteredAssetList, setfilteredAssetList] = React.useState<UserAssetInfoType[]>(userAssetList)
 
   // more custom hooks
-  const parseTransaction = useTransactionParser(selectedAssetsNetwork)
   const { computeFiatAmount } = usePricing(transactionSpotPrices)
   const openExplorer = useExplorer(selectedAssetsNetwork)
 
@@ -332,21 +336,38 @@ export const PortfolioAsset = (props: Props) => {
   const transactionsByNetwork = React.useMemo(() => {
     return accountsByNetwork.map((account) => {
       return transactions[account.address]
-    }).flat(1).map(parseTransaction)
+    }).flat(1)
   }, [
     accountsByNetwork,
     transactions
   ])
 
-  const selectedAssetTransactions: ParsedTransaction[] = React.useMemo(() => {
+  const selectedAssetTransactions = React.useMemo(() => {
     if (selectedAsset) {
       const filteredTransactions = transactionsByNetwork.filter((tx) => {
-        return tx && tx?.symbol === selectedAsset?.symbol
+        const token = findTransactionToken(tx, [selectedAsset])
+
+        const { sellToken, buyToken } = getETHSwapTransactionBuyAndSellTokens({
+          nativeAsset: makeNetworkAsset(selectedAssetsNetwork),
+          tokensList: [selectedAsset],
+          tx
+        })
+
+        return (
+          (token && getAssetIdKey(selectedAsset) === getAssetIdKey(token)) ||
+          (sellToken &&
+            getAssetIdKey(selectedAsset) === getAssetIdKey(sellToken)) ||
+          (buyToken && getAssetIdKey(selectedAsset) === getAssetIdKey(buyToken))
+        )
       })
       return sortTransactionByDate(filteredTransactions, 'descending')
     }
     return []
-  }, [selectedAsset, transactionsByNetwork, parseTransaction])
+  }, [
+    selectedAsset,
+    transactionsByNetwork,
+    selectedAssetsNetwork
+  ])
 
   const fullAssetBalances = React.useMemo(() => {
     if (selectedAsset?.contractAddress === '') {

--- a/components/brave_wallet_ui/constants/types.ts
+++ b/components/brave_wallet_ui/constants/types.ts
@@ -563,6 +563,10 @@ export type SerializableTransactionInfo = Omit<
   originInfo: SerializableOriginInfo | undefined
 }
 
+export type TransactionInfo =
+  | BraveWallet.TransactionInfo
+  | SerializableTransactionInfo
+
 export type SerializableAddSuggestTokenRequest = Omit<BraveWallet.AddSuggestTokenRequest, 'origin'> & {
   origin: SerializableOriginInfo
 }

--- a/components/brave_wallet_ui/utils/account-utils.ts
+++ b/components/brave_wallet_ui/utils/account-utils.ts
@@ -80,9 +80,14 @@ export const getAccountType = (
   return info.isImported ? 'Secondary' : 'Primary'
 }
 
-export const getAddressLabel = (
+export const getAddressLabel = <
+  T extends Array<{
+    address: string
+    name: string
+  }>
+>(
   address: string,
-  accounts: WalletAccountType[]
+  accounts: T
 ): string => {
   return (
     registry[address.toLowerCase()] ??
@@ -97,7 +102,7 @@ export const getAddressLabelFromRegistry = (
 ): string => {
   return (
     registry[address.toLowerCase()] ??
-    accounts.entities[address.toLowerCase()]?.name ??
+    accounts.entities[address]?.name ??
     reduceAddress(address)
   )
 }

--- a/components/brave_wallet_ui/utils/datetime-utils.ts
+++ b/components/brave_wallet_ui/utils/datetime-utils.ts
@@ -3,7 +3,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this file,
 // you can obtain one at https://mozilla.org/MPL/2.0/.
 
-import { SerializableTimeDelta } from '../constants/types'
+import { SerializableTimeDelta, TimeDelta } from '../constants/types'
 
 const monthMap = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec']
 
@@ -49,7 +49,7 @@ export function formatDateAsRelative (date: Date, now: Date = new Date()) {
  * @return {!Date}
  */
 export function serializedTimeDeltaToJSDate (
-  timeDelta: SerializableTimeDelta
+  timeDelta: SerializableTimeDelta | TimeDelta
 ): Date {
   return new Date(Number(timeDelta.microseconds) / 1000)
 }

--- a/components/brave_wallet_ui/utils/search-utils.ts
+++ b/components/brave_wallet_ui/utils/search-utils.ts
@@ -1,0 +1,172 @@
+// Copyright (c) 2023 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import { EntityState } from '@reduxjs/toolkit'
+
+// types
+import {
+  SerializableTransactionInfo,
+  BraveWallet,
+  TransactionInfo
+} from '../constants/types'
+import { AccountInfoEntity } from '../common/slices/entities/account-info.entity'
+
+// utils
+import {
+  NetworksRegistry,
+  networkEntityAdapter
+} from '../common/slices/entities/network.entity'
+import { makeNetworkAsset } from '../options/asset-options'
+import { getAddressLabelFromRegistry } from './account-utils'
+import Amount from './amount'
+import { getCoinFromTxDataUnion } from './network-utils'
+import {
+  findTransactionToken,
+  getETHSwapTransactionBuyAndSellTokens,
+  getTransactionApprovalTargetAddress,
+  getTransactionToAddress,
+  getTransactionIntent
+} from './tx-utils'
+
+export type SearchableTransaction = TransactionInfo & {
+  approvalTarget: string
+  approvalTargetLabel: string
+  buyToken?: BraveWallet.BlockchainToken
+  erc721BlockchainToken?: BraveWallet.BlockchainToken
+  intent: string
+  nativeAsset?: BraveWallet.BlockchainToken
+  recipient: string
+  recipientLabel: string
+  sellToken?: BraveWallet.BlockchainToken
+  sender: string
+  senderLabel: string
+  token?: BraveWallet.BlockchainToken
+}
+
+export const makeSearchableTransaction = (
+  tx: SerializableTransactionInfo,
+  combinedTokensListForSelectedChain: BraveWallet.BlockchainToken[],
+  networksRegistry: NetworksRegistry | undefined,
+  accountInfosRegistry: EntityState<AccountInfoEntity>
+): SearchableTransaction => {
+  const token = findTransactionToken(tx, combinedTokensListForSelectedChain)
+
+  const erc721BlockchainToken = [
+    BraveWallet.TransactionType.ERC721TransferFrom,
+    BraveWallet.TransactionType.ERC721SafeTransferFrom
+  ].includes(tx.txType)
+    ? token
+    : undefined
+
+  const txNetwork =
+    networksRegistry?.entities[
+      networkEntityAdapter.selectId({
+        chainId: tx.chainId,
+        coin: getCoinFromTxDataUnion(tx.txDataUnion)
+      })
+    ]
+  const nativeAsset = makeNetworkAsset(txNetwork)
+
+  const { buyToken, sellToken } = getETHSwapTransactionBuyAndSellTokens({
+    nativeAsset,
+    tokensList: combinedTokensListForSelectedChain,
+    tx
+  })
+
+  const approvalTarget = getTransactionApprovalTargetAddress(tx)
+  const approvalTargetLabel = getAddressLabelFromRegistry(
+    approvalTarget,
+    accountInfosRegistry
+  )
+
+  const sender = tx.fromAddress
+  const senderLabel = getAddressLabelFromRegistry(sender, accountInfosRegistry)
+  const recipient = getTransactionToAddress(tx)
+  const recipientLabel = getAddressLabelFromRegistry(
+    recipient,
+    accountInfosRegistry
+  )
+
+  const emptyAmount = new Amount('')
+
+  const intent = getTransactionIntent({
+    normalizedTransferredValue: '',
+    tx,
+    buyAmount: emptyAmount,
+    buyToken,
+    erc721TokenId: erc721BlockchainToken?.tokenId,
+    sellAmount: emptyAmount,
+    sellToken,
+    token,
+    transactionNetwork: txNetwork
+  })
+
+  return {
+    ...tx,
+    approvalTarget,
+    approvalTargetLabel,
+    buyToken,
+    erc721BlockchainToken,
+    intent,
+    nativeAsset,
+    recipient,
+    recipientLabel,
+    sellToken,
+    sender,
+    senderLabel,
+    token
+  }
+}
+
+const findTokenBySearchValue = (
+  searchValue: string,
+  token?: BraveWallet.BlockchainToken
+) => {
+  if (!token) {
+    return false
+  }
+
+  return (
+    token.name.toLowerCase().includes(searchValue) ||
+    token.symbol.toLowerCase().includes(searchValue) ||
+    token.contractAddress.toLowerCase().includes(searchValue)
+  )
+}
+
+export const filterTransactionsBySearchValue = (
+  txs: SearchableTransaction[],
+  lowerCaseSearchValue: string
+) => {
+  return txs.filter(tx => {
+    return (
+      // Tokens
+      findTokenBySearchValue(lowerCaseSearchValue, tx.token) ||
+      // Buy Token
+      findTokenBySearchValue(lowerCaseSearchValue, tx.buyToken) ||
+      // Sell Token
+      findTokenBySearchValue(lowerCaseSearchValue, tx.sellToken) ||
+      // ERC721 NFTs
+      findTokenBySearchValue(lowerCaseSearchValue, tx.erc721BlockchainToken) ||
+      // Sender
+      tx.sender.toLowerCase().includes(lowerCaseSearchValue) ||
+      tx.senderLabel.toLowerCase().includes(lowerCaseSearchValue) ||
+      // Receiver
+      tx.recipient.toLowerCase().includes(lowerCaseSearchValue) ||
+      tx.recipientLabel.toLowerCase().includes(lowerCaseSearchValue) ||
+      // Intent
+      tx.intent.toLowerCase().includes(lowerCaseSearchValue) ||
+      // Hash
+      tx.txHash.toLowerCase().includes(lowerCaseSearchValue) ||
+      // Approval Target
+      (tx.approvalTarget &&
+        tx.approvalTarget.toLowerCase().includes(lowerCaseSearchValue)) ||
+      (tx.approvalTargetLabel &&
+        tx.approvalTargetLabel.toLowerCase().includes(lowerCaseSearchValue)) ||
+      // Origin
+      tx.originInfo?.eTldPlusOne.toLowerCase().includes(lowerCaseSearchValue) ||
+      tx.originInfo?.originSpec.toLowerCase().includes(lowerCaseSearchValue)
+    )
+  })
+}

--- a/components/brave_wallet_ui/utils/tx-utils.ts
+++ b/components/brave_wallet_ui/utils/tx-utils.ts
@@ -17,7 +17,8 @@ import {
   SerializableTimeDelta,
   SerializableOriginInfo,
   SortingOrder,
-  AssetPriceWithContractAndChainId
+  AssetPriceWithContractAndChainId,
+  TransactionInfo
 } from '../constants/types'
 import { SolanaTransactionTypes } from '../common/constants/solana'
 import { MAX_UINT256, NATIVE_ASSET_CONTRACT_ADDRESS_0X } from '../common/constants/magics'
@@ -45,8 +46,6 @@ import {
   makeSerializableOriginInfo
 } from './model-serialization-utils'
 import { weiToEther } from './web3-utils'
-
-export type TransactionInfo = BraveWallet.TransactionInfo | SerializableTransactionInfo
 
 export type EIP1559TransactionInfo = TransactionInfo & {
   txDataUnion: {


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/29272

- Fixes a bug where the activity screen only loads transactions for the last-selected network for each coin-type
- Speeds up Transaction rendering by allowing the UI to partially render before parsing dependencies are available

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-arm64, CI/skip-linux-x64, CI/skip-android, CI/skip-macos, CI/skip-ios, CI/skip-windows-arm64, CI/skip-windows-x64, CI/skip-windows-x86 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

1. Create a wallet
2. submit a transaction on an EVM chain
3. switch to a different EVM chain
4. open/refresh the Activity (transactions) page
5. the transactions for both EVM networks should load

Repeat twice, replacing EVM networks with Filecoin and Solana networks
