### PR TITLE
Minor adjustments to tipping panel

### DIFF
--- a/browser/extensions/api/brave_rewards_api.cc
+++ b/browser/extensions/api/brave_rewards_api.cc
@@ -564,7 +564,7 @@ void BraveRewardsTipUserFunction::ShowTipDialog() {
     return;
   }
 
-  coordinator->ShowPanelForPublisher(params->publisher_key);
+  coordinator->ShowPanelForInlineTip(params->publisher_key);
 }
 
 BraveRewardsIncludeInAutoContributionFunction::

--- a/browser/ui/brave_rewards/rewards_panel_coordinator.cc
+++ b/browser/ui/brave_rewards/rewards_panel_coordinator.cc
@@ -43,6 +43,11 @@ bool RewardsPanelCoordinator::ShowAdaptiveCaptcha() {
       mojom::RewardsPanelArgs(mojom::RewardsPanelView::kAdaptiveCaptcha, ""));
 }
 
+bool RewardsPanelCoordinator::ShowInlineTipView() {
+  return OpenWithArgs(
+      mojom::RewardsPanelArgs(mojom::RewardsPanelView::kInlineTip, ""));
+}
+
 void RewardsPanelCoordinator::AddObserver(Observer* observer) {
   observers_.AddObserver(observer);
 }

--- a/browser/ui/brave_rewards/rewards_panel_coordinator.h
+++ b/browser/ui/brave_rewards/rewards_panel_coordinator.h
@@ -44,6 +44,9 @@ class RewardsPanelCoordinator
   // adaptive captcha for the user.
   bool ShowAdaptiveCaptcha();
 
+  // Opens the Rewards panel after an "inline tip" button has been activated.
+  bool ShowInlineTipView();
+
   class Observer : public base::CheckedObserver {
    public:
     // Called when an application component requests that the Rewards panel be

--- a/browser/ui/brave_rewards/tip_panel_coordinator.h
+++ b/browser/ui/brave_rewards/tip_panel_coordinator.h
@@ -33,6 +33,9 @@ class TipPanelCoordinator : public BrowserUserData<TipPanelCoordinator> {
   // Displays the tip panel for the specified publisher.
   void ShowPanelForPublisher(const std::string& publisher_id);
 
+  // Displays the tip panel after an inline tip button has been displayed.
+  void ShowPanelForInlineTip(const std::string& publisher_id);
+
   class Observer : public base::CheckedObserver {
    public:
     // Called when an application component requests the tip panel.
@@ -57,9 +60,11 @@ class TipPanelCoordinator : public BrowserUserData<TipPanelCoordinator> {
   friend class BrowserUserData<TipPanelCoordinator>;
 
   void GetUserTypeCallback(const std::string& publisher_id,
+                           bool inline_tip,
                            ledger::mojom::UserType user_type);
 
   void IsPublisherRegisteredCallback(const std::string& publisher_id,
+                                     bool inline_tip,
                                      bool is_publisher_registered);
 
   void OpenPanel(const std::string& publisher_id);

--- a/browser/ui/webui/brave_rewards/tip_panel_ui.cc
+++ b/browser/ui/webui/brave_rewards/tip_panel_ui.cc
@@ -58,7 +58,8 @@ static constexpr webui::LocalizedString kStrings[] = {
     {"shareText", IDS_REWARDS_TIP_SHARE_TEXT},
     {"unexpectedErrorTitle", IDS_REWARDS_TIP_UNEXPECTED_ERROR_TITLE},
     {"unexpectedErrorText", IDS_REWARDS_TIP_UNEXPECTED_ERROR_TEXT},
-    {"defaultCreatorDescription", IDS_REWARDS_TIP_DEFAULT_CREATOR_DESCRIPTION}};
+    {"defaultCreatorDescription", IDS_REWARDS_TIP_DEFAULT_CREATOR_DESCRIPTION},
+    {"platformPublisherTitle", IDS_REWARDS_PANEL_PLATFORM_PUBLISHER_TITLE}};
 
 }  // namespace
 

--- a/components/brave_rewards/common/mojom/rewards_panel.mojom
+++ b/components/brave_rewards/common/mojom/rewards_panel.mojom
@@ -9,7 +9,8 @@ enum RewardsPanelView {
   kDefault,
   kRewardsTour,
   kGrantCaptcha,
-  kAdaptiveCaptcha
+  kAdaptiveCaptcha,
+  kInlineTip
 };
 
 struct RewardsPanelArgs {

--- a/components/brave_rewards/resources/rewards_panel/components/limited_view.tsx
+++ b/components/brave_rewards/resources/rewards_panel/components/limited_view.tsx
@@ -21,6 +21,8 @@ export function LimitedView () {
   const host = React.useContext(HostContext)
   const { getString, getPluralString } = React.useContext(LocaleContext)
 
+  const [requestedView, setRequestedView] =
+    React.useState(host.state.requestedView)
   const [adsEnabled, setAdsEnabled] =
     React.useState(host.state.settings.adsEnabled)
   const [publisherInfo, setPublisherInfo] =
@@ -32,6 +34,7 @@ export function LimitedView () {
     React.useState(derivedState.canConnectAccount(host.state))
 
   useHostListener(host, (state) => {
+    setRequestedView(state.requestedView)
     setAdsEnabled(state.settings.adsEnabled)
     setPublisherInfo(state.publisherInfo)
     setPublishersVisitedCount(state.publishersVisitedCount)
@@ -77,7 +80,7 @@ export function LimitedView () {
       )
     }
 
-    if (publisherInfo) {
+    if (publisherInfo && requestedView === 'inline-tip') {
       return (
         <style.connect>
           <style.connectAction>

--- a/components/brave_rewards/resources/rewards_panel/lib/extension_host.ts
+++ b/components/brave_rewards/resources/rewards_panel/lib/extension_host.ts
@@ -187,15 +187,16 @@ export function createHost (): Host {
     switch (args.view) {
       case mojom.RewardsPanelView.kRewardsTour:
         stateManager.update({ requestedView: 'rewards-tour' })
-        return true
+        break
       case mojom.RewardsPanelView.kGrantCaptcha:
         loadGrantCaptcha(args.data, 'pending')
-        return true
+        break
       case mojom.RewardsPanelView.kAdaptiveCaptcha:
         loadAdaptiveCaptcha()
-        return true
-      default:
-        return false
+        break
+      case mojom.RewardsPanelView.kInlineTip:
+        stateManager.update({ requestedView: 'inline-tip' })
+        break
     }
   }
 

--- a/components/brave_rewards/resources/rewards_panel/lib/interfaces.ts
+++ b/components/brave_rewards/resources/rewards_panel/lib/interfaces.ts
@@ -78,7 +78,7 @@ export interface Options {
   vbatExpired: boolean
 }
 
-type RequestedView = 'rewards-tour'
+type RequestedView = 'rewards-tour' | 'inline-tip'
 
 export interface HostState {
   openTime: number

--- a/components/brave_rewards/resources/tip_panel/components/amount_input.tsx
+++ b/components/brave_rewards/resources/tip_panel/components/amount_input.tsx
@@ -12,7 +12,7 @@ import { SwapIcon } from './icons/swap_icon'
 
 import * as style from './amount_input.style'
 
-const minimumAmount = 0.25
+const minimumAmount = 0
 const maximumAmount = 100
 const amountStep = 0.25
 
@@ -39,19 +39,6 @@ function currencySymbol (currency: string) {
   return ''
 }
 
-function getDefaultOption (balance: number, options: number[]) {
-  // Select the highest amount that is greater than or equal to the user's
-  // balance, starting from the middle option.
-  if (options.length > 0) {
-    for (let i = Math.floor(options.length / 2); i >= 0; --i) {
-      if (i === 0 || options[i] <= balance) {
-        return optional(options[i])
-      }
-    }
-  }
-  return optional<number>()
-}
-
 interface Props {
   amountOptions: number[]
   userBalance: number
@@ -63,8 +50,7 @@ interface Props {
 export function AmountInput (props: Props) {
   const { getString } = useLocaleContext()
 
-  const [selectedOption, setSelectedOption] =
-    React.useState(getDefaultOption(props.userBalance, props.amountOptions))
+  const [selectedOption, setSelectedOption] = React.useState(optional(0))
   const [customAmount, setCustomAmount] = React.useState(0)
   const [customAmountText, setCustomAmountText] = React.useState('')
   const [exchangePrimary, setExchangePrimary] = React.useState(false)
@@ -101,7 +87,7 @@ export function AmountInput (props: Props) {
     }
     setCustomAmountText(textValue)
     let updatedAmount = parseFloat(textValue || '0')
-    if (isNaN(customAmount)) {
+    if (isNaN(updatedAmount)) {
       return customAmount
     }
     if (exchangePrimary) {

--- a/components/brave_rewards/resources/tip_panel/components/app.style.ts
+++ b/components/brave_rewards/resources/tip_panel/components/app.style.ts
@@ -76,8 +76,12 @@ export const errorCode = styled.div`
 `
 
 export const creator = styled.div`
-  flex: 1 1 400px;
-  margin: 120px 56px 32px;
+  flex: 1 1 auto;
+  margin: 120px 56px 48px;
+
+  .narrow-view & {
+    margin-bottom: 16px;
+  }
 `
 
 export const form = styled.div`

--- a/components/brave_rewards/resources/tip_panel/components/creator_view.tsx
+++ b/components/brave_rewards/resources/tip_panel/components/creator_view.tsx
@@ -7,6 +7,8 @@ import * as React from 'react'
 
 import { useModelState } from '../lib/model_context'
 import { useLocaleContext } from '../lib/locale_strings'
+import { formatMessage } from '../../shared/lib/locale_context'
+import { lookupPublisherPlatformName } from '../../shared/lib/publisher_platform'
 import { NewTabLink } from '../../shared/components/new_tab_link'
 import { VerifiedIcon } from './icons/verified_icon'
 import { LaunchIcon } from './icons/launch_icon'
@@ -31,6 +33,19 @@ export function CreatorView () {
     styleProps['--creator-avatar-image-url'] = `url("${creatorBanner.logo}")`
   }
 
+  function getName () {
+    if (creatorBanner.title) {
+      return creatorBanner.title
+    }
+    if (creatorBanner.provider) {
+      return formatMessage(getString('platformPublisherTitle'), [
+        creatorBanner.name,
+        lookupPublisherPlatformName(creatorBanner.provider)
+      ])
+    }
+    return creatorBanner.name
+  }
+
   function renderLink (platform: string, url: string) {
     const Icon = getSocialIcon(platform)
     if (!Icon) {
@@ -46,14 +61,23 @@ export function CreatorView () {
   const renderedLinks = Object.entries(creatorBanner.links).map(
     ([key, value]) => renderLink(key, value))
 
+  if (creatorBanner.web3Url) {
+    if (renderedLinks.length > 0) {
+      renderedLinks.push(<style.linkDivider />)
+    }
+    renderedLinks.push(
+      <NewTabLink href={creatorBanner.web3Url}>
+        <LaunchIcon />
+      </NewTabLink>
+    )
+  }
+
   return (
     <style.root style={styleProps as React.CSSProperties}>
       <style.background />
       <style.avatar />
       <style.title>
-        <style.name>
-          {creatorBanner.title || creatorBanner.name}
-        </style.name>
+        <style.name>{getName()}</style.name>
         {
           creatorVerified &&
             <style.verifiedCheck>
@@ -67,18 +91,7 @@ export function CreatorView () {
       <style.text>
         {creatorBanner.description || getString('defaultCreatorDescription')}
       </style.text>
-      <style.links>
-        {renderedLinks}
-        {
-          creatorBanner.web3Url &&
-            <>
-              {renderedLinks.length > 0 && <style.linkDivider />}
-              <NewTabLink href={creatorBanner.web3Url}>
-                <LaunchIcon />
-              </NewTabLink>
-            </>
-        }
-      </style.links>
+      {renderedLinks.length > 0 && <style.links>{renderedLinks}</style.links>}
     </style.root>
   )
 }

--- a/components/brave_rewards/resources/tip_panel/lib/locale_strings.ts
+++ b/components/brave_rewards/resources/tip_panel/lib/locale_strings.ts
@@ -41,7 +41,8 @@ export const localeStrings = {
   shareText: 'I earned crypto rewards with the Brave Browser, and just contributed $1 BAT of it to $2. Learn how you can support your favorite creators and sites too: https://brave.com/rewards',
   unexpectedErrorTitle: 'An unexpected error has occurred',
   unexpectedErrorText: 'Please reopen the contribution panel to try again.',
-  defaultCreatorDescription: 'Welcome! Users can support this content creator by sending them contributions. It’s a way of thanking them for making great content.'
+  defaultCreatorDescription: 'Welcome! Users can support this content creator by sending them contributions. It’s a way of thanking them for making great content.',
+  platformPublisherTitle: '$1 on $2'
 }
 
 export type StringKey = keyof typeof localeStrings

--- a/components/brave_rewards/resources/tip_panel/lib/model.ts
+++ b/components/brave_rewards/resources/tip_panel/lib/model.ts
@@ -8,6 +8,7 @@ import { ExternalWalletProvider } from '../../shared/lib/external_wallet'
 
 export interface CreatorBanner {
   name: string
+  provider: string
   title: string
   description: string
   logo: string
@@ -58,6 +59,7 @@ export function defaultState (): ModelState {
     error: null,
     creatorBanner: {
       name: '',
+      provider: '',
       title: '',
       description: '',
       logo: '',

--- a/components/brave_rewards/resources/tip_panel/lib/webui_model.ts
+++ b/components/brave_rewards/resources/tip_panel/lib/webui_model.ts
@@ -68,6 +68,7 @@ export function createModel (): Model {
     function mapBanner () {
       return banner || {
         name: '',
+        provider: '',
         title: '',
         description: '',
         logo: '',

--- a/components/brave_rewards/resources/tip_panel/stories/storybook_model.ts
+++ b/components/brave_rewards/resources/tip_panel/stories/storybook_model.ts
@@ -15,6 +15,7 @@ export function createModel (): Model {
     monthlyContributionSet: false,
     creatorBanner: {
       name: 'brave.com',
+      provider: '',
       title: 'Brave Software',
       description:
         'Thanks for stopping by. Brave is on a mission to fix the web by ' +
@@ -29,7 +30,7 @@ export function createModel (): Model {
         youtube: 'https://www.youtube.com/bravesoftware',
         twitch: 'https://twitch.tv/bravesoftware'
       },
-      web3Url: 'https://creators.brave.com'
+      web3Url: 'https://www.brave.com'
     },
     creatorVerified: true,
     creatorWallets: ['gemini'],


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/29891
Resolves https://github.com/brave/brave-browser/issues/29886
Resolves https://github.com/brave/brave-browser/issues/29858
Resolves https://github.com/brave/brave-browser/issues/29815

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-arm64, CI/skip-linux-x64, CI/skip-android, CI/skip-macos, CI/skip-ios, CI/skip-windows-arm64, CI/skip-windows-x64, CI/skip-windows-x86 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [ ] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

Fixed spacing in "narrow view":

<img width="564" alt="Screenshot 2023-04-20 at 1 58 58 PM" src="https://user-images.githubusercontent.com/5995084/233450887-078b6b0b-427b-417e-850f-bc38735c3bed.png">

Default amount is zero:

<img width="513" alt="Screenshot 2023-04-20 at 2 00 31 PM" src="https://user-images.githubusercontent.com/5995084/233450899-d3b04f88-a946-4912-8603-ed48fdab13dd.png">

Generic messaging displayed on "publisher" pages:

<img width="465" alt="Screenshot 2023-04-20 at 2 02 06 PM" src="https://user-images.githubusercontent.com/5995084/233450900-a4c7ca97-c251-4098-9729-aabb1e73da1a.png">

"Contribution" messaging displayed when inline tip is clicked:

<img width="653" alt="Screenshot 2023-04-20 at 2 02 26 PM" src="https://user-images.githubusercontent.com/5995084/233450904-382ea138-bc4a-47e7-a6d5-7970dd2a46dc.png">

Default banner title includes platform if applicable:

<img width="679" alt="Screenshot 2023-04-20 at 2 04 00 PM" src="https://user-images.githubusercontent.com/5995084/233450909-e2138fff-e4d9-4bcb-834c-24dff3a57fa3.png">
