### PR TITLE
Allow tab container to have 0 height (uplift to 1.51.x)

### DIFF
--- a/browser/ui/views/tabs/brave_tab_strip.cc
+++ b/browser/ui/views/tabs/brave_tab_strip.cc
@@ -303,7 +303,11 @@ void BraveTabStrip::UpdateTabContainer() {
     }
 
     tab_container_->SetLayoutManager(std::make_unique<views::FlexLayout>())
-        ->SetOrientation(views::LayoutOrientation::kVertical);
+        ->SetOrientation(views::LayoutOrientation::kVertical)
+        .SetDefault(views::kFlexBehaviorKey,
+                    views::FlexSpecification(
+                        views::MinimumFlexSizeRule::kScaleToMinimumSnapToZero,
+                        views::MaximumFlexSizeRule::kPreferred));
   } else {
     if (base::FeatureList::IsEnabled(features::kScrollableTabStrip)) {
       auto* browser_view = static_cast<BraveBrowserView*>(


### PR DESCRIPTION
Uplift of #18143
Resolves https://github.com/brave/brave-browser/issues/29800

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [x] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [ ] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.