### PR TITLE
[iOS] Add override for `ios_partition_alloc_enabled` to fix launch crash (uplift to 1.50.x)

### DIFF
--- a/build/commands/lib/config.js
+++ b/build/commands/lib/config.js
@@ -537,6 +537,12 @@ Config.prototype.buildArgs = function () {
     args.ios_enable_credential_provider_extension = false
     args.ios_enable_widget_kit_extension = false
 
+    // This is currently being flipped on and off by the Chromium team to test
+    // however it causes crashes for us at launch. Check `ios/features.gni`
+    // in the future to see if this is no longer needed
+    // https://github.com/brave/brave-browser/issues/29934
+    args.ios_partition_alloc_enabled = false
+
     args.ios_provider_target = "//brave/ios/browser/providers:brave_providers"
 
     args.ios_locales_pack_extra_source_patterns = [


### PR DESCRIPTION
Uplift of #18194
Resolves https://github.com/brave/brave-browser/issues/29933

Pre-approval checklist: 
- [ ] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.