### PR TITLE
What's new target version should be handled differently for channels (uplift to 1.51.x)

### DIFF
--- a/browser/ui/whats_new/whats_new_browsertest.cc
+++ b/browser/ui/whats_new/whats_new_browsertest.cc
@@ -40,7 +40,7 @@ class BraveWhatsNewBrowserTest : public InProcessBrowserTest {
   void PrepareValidFieldTrialParams() {
     constexpr char kWhatsNewTrial[] = "WhatsNewStudy";
     std::map<std::string, std::string> params;
-    params["target_major_version"] = "1.52";
+    params[GetTargetMajorVersionParamName()] = "1.52";
     ASSERT_TRUE(
         base::AssociateFieldTrialParams(kWhatsNewTrial, "Enabled", params));
     base::FieldTrialList::CreateFieldTrial(kWhatsNewTrial, "Enabled");

--- a/browser/ui/whats_new/whats_new_unittest.cc
+++ b/browser/ui/whats_new/whats_new_unittest.cc
@@ -42,7 +42,7 @@ class BraveWhatsNewTest : public testing::Test {
 
   void PrepareValidFieldTrialParams() {
     std::map<std::string, std::string> params;
-    params["target_major_version"] = "1.51";
+    params[GetTargetMajorVersionParamName()] = "1.51";
     ASSERT_TRUE(
         base::AssociateFieldTrialParams(kWhatsNewTrial, "Enabled", params));
   }

--- a/browser/ui/whats_new/whats_new_util.cc
+++ b/browser/ui/whats_new/whats_new_util.cc
@@ -61,8 +61,20 @@ absl::optional<double> GetCurrentBrowserVersion() {
 }
 
 bool DoesUserGetMajorUpdateSinceInstall() {
-  Profile* profile = ProfileManager::GetLastUsedProfile();
-  DCHECK(profile);
+  Profile* profile = ProfileManager::GetLastUsedProfileIfLoaded();
+
+  // This could happen when selected profile from profile chooser dialog is not
+  // the last active profile from previous running. As we don't know
+  // profile_created_version for this selected profile now, just return false
+  // and whats-new tab will not be shown for this launching. but that value
+  // could be get next time when this profile is selected again. This early
+  // return could be happened forever when user select another profile from
+  // profile chooser whenver launching. but I think this could be very very rare
+  // case. So, user could show whats-new tab eventually. Also this doesn't
+  // happen when profile chooser is not used even user has multiple profiles.
+  if (!profile) {
+    return false;
+  }
 
   const auto current_version = GetCurrentBrowserVersion();
   const auto profile_created_version = GetBraveMajorVersionAsDouble(

--- a/browser/ui/whats_new/whats_new_util.cc
+++ b/browser/ui/whats_new/whats_new_util.cc
@@ -19,16 +19,17 @@
 #include "chrome/browser/ui/browser.h"
 #include "chrome/browser/ui/browser_tabstrip.h"
 #include "chrome/browser/ui/tabs/tab_strip_model.h"
+#include "chrome/common/channel_info.h"
 #include "components/prefs/pref_registry_simple.h"
 #include "components/prefs/pref_service.h"
 #include "components/version_info/version_info.h"
 #include "url/gurl.h"
 
+using version_info::Channel;
+
 namespace {
 
 double g_testing_major_version = 0;
-constexpr char kWhatsNewTrial[] = "WhatsNewStudy";
-constexpr char kWhatsNewTargetMajorVersion[] = "target_major_version";
 
 // |version| has four components like 111.1.51.34.
 // First one is upstream's major version.
@@ -78,8 +79,10 @@ bool DoesUserGetMajorUpdateSinceInstall() {
 }
 
 absl::optional<double> GetTargetMajorVersion() {
+  constexpr char kWhatsNewTrial[] = "WhatsNewStudy";
+
   const std::string target_major_version_string = base::GetFieldTrialParamValue(
-      kWhatsNewTrial, kWhatsNewTargetMajorVersion);
+      kWhatsNewTrial, whats_new::GetTargetMajorVersionParamName());
   // Field trial doesn't have this value.
   if (target_major_version_string.empty()) {
     return absl::nullopt;
@@ -97,6 +100,22 @@ absl::optional<double> GetTargetMajorVersion() {
 }  // namespace
 
 namespace whats_new {
+
+std::string GetTargetMajorVersionParamName() {
+  switch (chrome::GetChannel()) {
+    case Channel::STABLE:
+      return "target_major_version_stable";
+    case Channel::BETA:
+      return "target_major_version_beta";
+    case Channel::DEV:
+      return "target_major_version_dev";
+    case Channel::CANARY:
+      return "target_major_version_nightly";
+    case Channel::UNKNOWN:
+      return "target_major_version_unknown";
+  }
+  NOTREACHED_NORETURN();
+}
 
 void SetCurrentVersionForTesting(double major_version) {
   g_testing_major_version = major_version;

--- a/browser/ui/whats_new/whats_new_util.h
+++ b/browser/ui/whats_new/whats_new_util.h
@@ -6,6 +6,8 @@
 #ifndef BRAVE_BROWSER_UI_WHATS_NEW_WHATS_NEW_UTIL_H_
 #define BRAVE_BROWSER_UI_WHATS_NEW_WHATS_NEW_UTIL_H_
 
+#include <string>
+
 class PrefRegistrySimple;
 class PrefService;
 class Browser;
@@ -17,6 +19,9 @@ bool ShouldShowBraveWhatsNewForState(PrefService* local_state);
 void RegisterLocalStatePrefs(PrefRegistrySimple* registry);
 void StartBraveWhatsNew(Browser* browser);
 void SetCurrentVersionForTesting(double major_version);
+
+// Param name is different for each channels.
+std::string GetTargetMajorVersionParamName();
 
 }  // namespace whats_new
 


### PR DESCRIPTION
Uplift of #18180
Uplift of #18223
fix https://github.com/brave/brave-browser/issues/29920
fix https://github.com/brave/brave-browser/issues/29963

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.