### PR TITLE
Add margin to right of tab group title

### DIFF
--- a/chromium_src/chrome/browser/ui/views/tabs/tab_group_style.cc
+++ b/chromium_src/chrome/browser/ui/views/tabs/tab_group_style.cc
@@ -17,6 +17,7 @@
 #undef TabGroupStyle
 
 const int TabGroupStyle::kStrokeThicknessForVerticalTabs = 4;
+const int TabGroupStyle::kTitleAdjustment = 2;
 
 SkPath TabGroupStyle::GetUnderlinePath(gfx::Rect local_bounds) const {
   if (!ShouldShowVerticalTabs()) {
@@ -55,4 +56,9 @@ bool TabGroupStyle::ShouldShowVerticalTabs() const {
   }
 
   return tabs::utils::ShouldShowVerticalTabs(tab_group_views_->GetBrowser());
+}
+
+int TabGroupStyle::GetTitleAdjustmentToTabGroupHeaderDesiredWidth(
+    const std::u16string title) const {
+  return kTitleAdjustment;
 }

--- a/chromium_src/chrome/browser/ui/views/tabs/tab_group_style.h
+++ b/chromium_src/chrome/browser/ui/views/tabs/tab_group_style.h
@@ -19,8 +19,13 @@ class TabGroupStyle : public TabGroupStyle_ChromiumImpl {
   using TabGroupStyle_ChromiumImpl::TabGroupStyle_ChromiumImpl;
 
   static const int kStrokeThicknessForVerticalTabs;
+  
+  static const int kTitleAdjustment;
 
   SkPath GetUnderlinePath(gfx::Rect local_bounds) const override;
+  
+  int TabGroupStyle::GetTitleAdjustmentToTabGroupHeaderDesiredWidth(
+    const std::u16string title) const override;
 
  private:
   bool ShouldShowVerticalTabs() const;


### PR DESCRIPTION
I confirm that no security/privacy review is needed

Ticket for this issue is https://github.com/brave/brave-browser/issues/29259

Description:
Before this PR, we only added a margin to empty title group headers, but non-empty headers also need some space between the header and its tabs.

Before:
<img width="305" alt="image" src="https://user-images.githubusercontent.com/55115030/233823544-60847890-a446-47dc-99fb-9646b2ab30f4.png">

After:
<img width="300" alt="IMG_2830" src="https://user-images.githubusercontent.com/55115030/233823563-b7ee647e-29e0-4f57-bcc5-cac8eebc9e9e.png">

