### PR TITLE
Force layout when vertical tab strip bounds changed

### DIFF
--- a/browser/ui/views/frame/vertical_tab_strip_region_view.cc
+++ b/browser/ui/views/frame/vertical_tab_strip_region_view.cc
@@ -605,11 +605,6 @@ void VerticalTabStripRegionView::UpdateStateAfterDragAndDropFinished(
 
 VerticalTabStripRegionView::ScopedStateResetter
 VerticalTabStripRegionView::ExpandTabStripForDragging() {
-  if (state_ == State::kExpanded) {
-    LOG(ERROR) << __FUNCTION__ << " " << base::debug::StackTrace(20);
-    return {};
-  }
-
   auto resetter = std::make_unique<base::ScopedClosureRunner>(base::BindOnce(
       &VerticalTabStripRegionView::UpdateStateAfterDragAndDropFinished,
       weak_factory_.GetWeakPtr(), state_));

--- a/browser/ui/views/frame/vertical_tab_strip_region_view.cc
+++ b/browser/ui/views/frame/vertical_tab_strip_region_view.cc
@@ -605,6 +605,9 @@ void VerticalTabStripRegionView::UpdateStateAfterDragAndDropFinished(
 
 VerticalTabStripRegionView::ScopedStateResetter
 VerticalTabStripRegionView::ExpandTabStripForDragging() {
+  if (state_ == State::kExpanded)
+    return {};
+
   auto resetter = std::make_unique<base::ScopedClosureRunner>(base::BindOnce(
       &VerticalTabStripRegionView::UpdateStateAfterDragAndDropFinished,
       weak_factory_.GetWeakPtr(), state_));

--- a/browser/ui/views/frame/vertical_tab_strip_region_view.cc
+++ b/browser/ui/views/frame/vertical_tab_strip_region_view.cc
@@ -589,14 +589,30 @@ void VerticalTabStripRegionView::SetState(State state) {
   PreferredSizeChanged();
 }
 
+void VerticalTabStripRegionView::UpdateStateAfterDragAndDropFinished(
+    State original_state) {
+  DCHECK_NE(original_state, State::kExpanded)
+      << "As per ExpandTabStripForDragging(), this shouldn't happen";
+
+  if (tabs::utils::IsFloatingVerticalTabsEnabled(browser_) &&
+      IsMouseHovered()) {
+    SetState(State::kFloating);
+    return;
+  }
+
+  SetState(State::kCollapsed);
+}
+
 VerticalTabStripRegionView::ScopedStateResetter
 VerticalTabStripRegionView::ExpandTabStripForDragging() {
-  if (state_ == State::kExpanded)
+  if (state_ == State::kExpanded) {
+    LOG(ERROR) << __FUNCTION__ << " " << base::debug::StackTrace(20);
     return {};
+  }
 
-  auto resetter = std::make_unique<base::ScopedClosureRunner>(
-      base::BindOnce(&VerticalTabStripRegionView::SetState,
-                     weak_factory_.GetWeakPtr(), State::kCollapsed));
+  auto resetter = std::make_unique<base::ScopedClosureRunner>(base::BindOnce(
+      &VerticalTabStripRegionView::UpdateStateAfterDragAndDropFinished,
+      weak_factory_.GetWeakPtr(), state_));
 
   SetState(State::kExpanded);
   // In this case, we dont' wait for the widget bounds to be changed so that
@@ -777,8 +793,18 @@ void VerticalTabStripRegionView::OnBoundsChanged(
     return;
   }
 
-  if (previous_bounds.size() != size())
+  if (previous_bounds.size() != size()) {
+    if (GetAvailableWidthForTabContainer() != tab_strip()->width()) {
+      // During/After the drag and drop session, tab strip container might have
+      // ignored Layout() request. As the container bounds changed, we should
+      // force it to layout.
+      // https://github.com/brave/brave-browser/issues/29941
+      tab_strip()->tab_container_->InvalidateIdealBounds();
+      tab_strip()->tab_container_->CompleteAnimationAndLayout();
+    }
+
     ScrollActiveTabToBeVisible();
+  }
 
 #if DCHECK_IS_ON()
   if (auto width = GetContentsBounds().width(); width) {

--- a/browser/ui/views/frame/vertical_tab_strip_region_view.h
+++ b/browser/ui/views/frame/vertical_tab_strip_region_view.h
@@ -103,6 +103,8 @@ class VerticalTabStripRegionView : public views::View,
 
   void SetState(State state);
 
+  void UpdateStateAfterDragAndDropFinished(State original_state);
+
   void UpdateLayout(bool in_destruction = false);
 
   void UpdateTabSearchButtonVisibility();

--- a/browser/ui/views/tabs/brave_tab_group_header.cc
+++ b/browser/ui/views/tabs/brave_tab_group_header.cc
@@ -14,7 +14,10 @@
 #include "chrome/browser/ui/views/tabs/tab_slot_controller.h"
 #include "ui/base/metadata/metadata_impl_macros.h"
 #include "ui/views/background.h"
+#include "ui/views/bubble/bubble_dialog_delegate_view.h"
 #include "ui/views/controls/label.h"
+#include "ui/views/widget/widget.h"
+#include "ui/views/widget/widget_delegate.h"
 
 namespace {
 
@@ -39,6 +42,25 @@ SkColor GetGroupBackgroundColorForVerticalTabs(
 }  // namespace
 
 BraveTabGroupHeader::~BraveTabGroupHeader() = default;
+
+void BraveTabGroupHeader::AddedToWidget() {
+  TabGroupHeader::AddedToWidget();
+  if (!ShouldShowVerticalTabs()) {
+    return;
+  }
+
+  if (editor_bubble_tracker_.is_open()) {
+    auto* bubble_delegate = editor_bubble_tracker_.widget()
+                                ->widget_delegate()
+                                ->AsBubbleDialogDelegate();
+    DCHECK(bubble_delegate);
+    // Technically, this can happen when tab strip's orientation changes
+    // with the editor bubble open. It re-parents the widget which can cause
+    // DCHECK failure. We should call SetAnchorView again to reset
+    // the anchor widget.
+    bubble_delegate->SetAnchorView(this);
+  }
+}
 
 void BraveTabGroupHeader::VisualsChanged() {
   TabGroupHeader::VisualsChanged();

--- a/browser/ui/views/tabs/brave_tab_group_header.h
+++ b/browser/ui/views/tabs/brave_tab_group_header.h
@@ -22,6 +22,7 @@ class BraveTabGroupHeader : public TabGroupHeader {
   ~BraveTabGroupHeader() override;
 
   // TabGroupHeader:
+  void AddedToWidget() override;
   void VisualsChanged() override;
   void Layout() override;
 

--- a/browser/ui/views/tabs/brave_tab_strip.cc
+++ b/browser/ui/views/tabs/brave_tab_strip.cc
@@ -203,6 +203,10 @@ void BraveTabStrip::UpdateTabContainer() {
       BraveCompoundTabContainer::kViewClassName;
   base::ScopedClosureRunner layout_lock;
   if (should_use_compound_tab_container != is_using_compound_tab_container) {
+    // Before removing any child, we should complete the 'tab closing animation'
+    // so that we don't delete views twice.
+    tab_container_->CompleteAnimationAndLayout();
+
     // Resets TabContainer to use.
     auto original_container = RemoveChildViewT(
         static_cast<TabContainer*>(base::to_address(tab_container_)));


### PR DESCRIPTION
* When drag-and-drop session is active or finished, tab strip sometimes doesn't lay out itself. But when the parent view's bounds changes, we should force it to layout.

* In addition to that, this PR makes the vertical tab's state after drag and drop session. We collapsed it regardless mouse-hover state. But as of now, we'll set it 'floating' mode when mouse is over the tab strip.

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/29941
Resolves https://github.com/brave/brave-browser/issues/29937

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-arm64, CI/skip-linux-x64, CI/skip-android, CI/skip-macos, CI/skip-ios, CI/skip-windows-arm64, CI/skip-windows-x64, CI/skip-windows-x86 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [ ] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
* Enable vertical tab strip and floating mode
* Test 1: Press down a tab before the vertical tab strip is expanded and don't release the mouse
  * Tabs should be as wide as tab strip.
* Test 2: When dragging a tab into another window and drop it there, tab strip should stay open if mouse is over tab strip.
  
