### PR TITLE
Add caching to APIRequestHelper and enable for AssetRatioService (uplift to 1.51.x)

### DIFF
--- a/components/api_request_helper/api_request_helper.cc
+++ b/components/api_request_helper/api_request_helper.cc
@@ -119,8 +119,8 @@ APIRequestHelper::Ticket APIRequestHelper::Request(
     ResponseConversionCallback conversion_callback) {
   return Request(method, url, payload, payload_content_type,
                  std::move(callback),
-                 APIRequestOptions(auto_retry_on_network_change, max_body_size,
-                                   absl::nullopt),
+                 APIRequestOptions(auto_retry_on_network_change, false,
+                                   max_body_size, absl::nullopt),
                  headers, std::move(conversion_callback));
 }
 
@@ -135,6 +135,7 @@ APIRequestHelper::Ticket APIRequestHelper::Request(
     ResponseConversionCallback conversion_callback) {
   auto loader = CreateLoader(method, url, payload, payload_content_type,
                              request_options.auto_retry_on_network_change,
+                             request_options.enable_cache,
                              true /* allow_http_error_result*/, headers);
 
   if (request_options.timeout) {
@@ -171,7 +172,7 @@ APIRequestHelper::Ticket APIRequestHelper::Download(
   auto iter = url_loaders_.insert(
       url_loaders_.begin(),
       CreateLoader({}, url, payload, payload_content_type,
-                   auto_retry_on_network_change,
+                   auto_retry_on_network_change, false /* enable_cache */,
                    false /*allow_http_error_result*/, headers));
   iter->get()->DownloadToFile(
       url_loader_factory_.get(),
@@ -192,12 +193,17 @@ std::unique_ptr<network::SimpleURLLoader> APIRequestHelper::CreateLoader(
     const std::string& payload,
     const std::string& payload_content_type,
     bool auto_retry_on_network_change,
+    bool enable_cache,
     bool allow_http_error_result,
     const base::flat_map<std::string, std::string>& headers) {
   auto request = std::make_unique<network::ResourceRequest>();
   request->url = url;
-  request->load_flags = net::LOAD_BYPASS_CACHE | net::LOAD_DISABLE_CACHE |
-                        net::LOAD_DO_NOT_SAVE_COOKIES;
+  request->load_flags = net::LOAD_DO_NOT_SAVE_COOKIES;
+  if (!enable_cache) {
+    request->load_flags =
+        request->load_flags | net::LOAD_BYPASS_CACHE | net::LOAD_DISABLE_CACHE;
+  }
+
   request->credentials_mode = network::mojom::CredentialsMode::kOmit;
   if (!method.empty())
     request->method = method;

--- a/components/api_request_helper/api_request_helper.h
+++ b/components/api_request_helper/api_request_helper.h
@@ -75,6 +75,7 @@ class APIRequestResult {
 
 struct APIRequestOptions {
   bool auto_retry_on_network_change = false;
+  bool enable_cache = false;
   size_t max_body_size = -1u;
   absl::optional<base::TimeDelta> timeout;
 };
@@ -100,6 +101,10 @@ class APIRequestHelper {
   // into string before validating the response. For these purposes
   // conversion_callback is added which receives raw response and can perform
   // necessary conversions.
+  //
+  // This method will be deprecated soon, please use the one underneath with
+  // APIRequestOption parameter.
+  // https://github.com/brave/brave-browser/issues/29611
   Ticket Request(
       const std::string& method,
       const GURL& url,
@@ -143,6 +148,7 @@ class APIRequestHelper {
       const std::string& payload,
       const std::string& payload_content_type,
       bool auto_retry_on_network_change,
+      bool enable_cache,
       bool allow_http_error_result,
       const base::flat_map<std::string, std::string>& headers);
 

--- a/components/api_request_helper/api_request_helper_unittest.cc
+++ b/components/api_request_helper/api_request_helper_unittest.cc
@@ -14,6 +14,7 @@
 #include "base/test/task_environment.h"
 #include "base/test/values_test_util.h"
 #include "base/values.h"
+#include "net/base/load_flags.h"
 #include "net/traffic_annotation/network_traffic_annotation.h"
 #include "net/traffic_annotation/network_traffic_annotation_test_helper.h"
 #include "services/data_decoder/public/cpp/test_support/in_process_data_decoder.h"
@@ -54,13 +55,21 @@ class ApiRequestHelperUnitTest : public testing::Test {
 
   void SetInterceptor(const std::string& expected_method,
                       const GURL& expected_url,
-                      const std::string& content_to_respond) {
+                      const std::string& content_to_respond,
+                      bool enable_cache) {
     url_loader_factory_.SetInterceptor(base::BindLambdaForTesting(
-        [&, expected_method, expected_url,
-         content_to_respond](const network::ResourceRequest& request) {
+        [&, expected_method, expected_url, content_to_respond,
+         enable_cache](const network::ResourceRequest& request) {
           url_loader_factory_.ClearResponses();
           EXPECT_EQ(request.url, expected_url);
           EXPECT_EQ(request.method, expected_method);
+          if (enable_cache) {
+            EXPECT_EQ(request.load_flags, net::LOAD_DO_NOT_SAVE_COOKIES);
+          } else {
+            EXPECT_EQ(request.load_flags, net::LOAD_DO_NOT_SAVE_COOKIES |
+                                              net::LOAD_BYPASS_CACHE |
+                                              net::LOAD_DISABLE_CACHE);
+          }
           url_loader_factory_.AddResponse(request.url.spec(),
                                           content_to_respond);
         }));
@@ -85,7 +94,8 @@ class ApiRequestHelperUnitTest : public testing::Test {
                    const int expected_http_code = 200,
                    const int expected_error_code = net::OK,
                    APIRequestHelper::ResponseConversionCallback
-                       conversion_callback = base::NullCallback()) {
+                       conversion_callback = base::NullCallback(),
+                   bool enable_cache = false) {
     GURL network_url("http://localhost/");
 
     APIRequestResult expected_result(
@@ -94,10 +104,11 @@ class ApiRequestHelperUnitTest : public testing::Test {
     base::MockCallback<APIRequestHelper::ResultCallback> callback;
     EXPECT_CALL(callback, Run(MatchesAPIRequestResult(&expected_result)));
 
-    SetInterceptor("POST", network_url, server_raw_response);
-    api_request_helper_->Request("POST", network_url, "", "application/json",
-                                 false, callback.Get(), {}, -1u,
-                                 std::move(conversion_callback));
+    SetInterceptor("POST", network_url, server_raw_response, enable_cache);
+    api_request_helper_->Request(
+        "POST", network_url, "", "application/json", callback.Get(),
+        APIRequestOptions(false, enable_cache, -1u, absl::nullopt), {},
+        std::move(conversion_callback));
     base::RunLoop().RunUntilIdle();
   }
 
@@ -178,6 +189,13 @@ TEST_F(ApiRequestHelperUnitTest, Is2XXResponseCode) {
       APIRequestResult(300, {}, {}, {}, net::OK, GURL()).Is2XXResponseCode());
   EXPECT_FALSE(
       APIRequestResult(500, {}, {}, {}, net::OK, GURL()).Is2XXResponseCode());
+}
+
+TEST_F(ApiRequestHelperUnitTest, EnableCache) {
+  SendRequest("{}", "{}", base::Value(base::Value::Type::DICT), 200, net::OK,
+              base::NullCallback(), false);
+  SendRequest("{}", "{}", base::Value(base::Value::Type::DICT), 200, net::OK,
+              base::NullCallback(), true);
 }
 
 }  // namespace api_request_helper

--- a/components/brave_wallet/browser/asset_ratio_service.cc
+++ b/components/brave_wallet/browser/asset_ratio_service.cc
@@ -292,10 +292,12 @@ void AssetRatioService::GetPrice(
     env->GetVar("BRAVE_SERVICES_KEY", &brave_key);
   }
   request_headers["x-brave-key"] = std::move(brave_key);
-
   api_request_helper_->Request(
       "GET", GetPriceURL(from_assets_lower, to_assets_lower, timeframe), "", "",
-      true, std::move(internal_callback), request_headers);
+      std::move(internal_callback),
+      api_request_helper::APIRequestOptions{
+          .auto_retry_on_network_change = true, .enable_cache = true},
+      request_headers);
 }
 
 void AssetRatioService::OnGetSardineAuthToken(
@@ -352,7 +354,9 @@ void AssetRatioService::GetPriceHistory(
                      weak_ptr_factory_.GetWeakPtr(), std::move(callback));
   api_request_helper_->Request(
       "GET", GetPriceHistoryURL(asset_lower, vs_asset_lower, timeframe), "", "",
-      true, std::move(internal_callback));
+      std::move(internal_callback),
+      api_request_helper::APIRequestOptions{
+          .auto_retry_on_network_change = true, .enable_cache = true});
 }
 
 void AssetRatioService::OnGetPriceHistory(GetPriceHistoryCallback callback,
@@ -386,8 +390,11 @@ void AssetRatioService::GetTokenInfo(const std::string& contract_address,
   auto internal_callback =
       base::BindOnce(&AssetRatioService::OnGetTokenInfo,
                      weak_ptr_factory_.GetWeakPtr(), std::move(callback));
-  api_request_helper_->Request("GET", GetTokenInfoURL(contract_address), "", "",
-                               true, std::move(internal_callback));
+  api_request_helper_->Request(
+      "GET", GetTokenInfoURL(contract_address), "", "",
+      std::move(internal_callback),
+      api_request_helper::APIRequestOptions{
+          .auto_retry_on_network_change = true, .enable_cache = true});
 }
 
 void AssetRatioService::OnGetTokenInfo(GetTokenInfoCallback callback,
@@ -421,8 +428,11 @@ void AssetRatioService::GetCoinMarkets(const std::string& vs_asset,
   auto internal_callback =
       base::BindOnce(&AssetRatioService::OnGetCoinMarkets,
                      weak_ptr_factory_.GetWeakPtr(), std::move(callback));
-  api_request_helper_->Request("GET", GetCoinMarketsURL(vs_asset_lower, limit),
-                               "", "", true, std::move(internal_callback));
+  api_request_helper_->Request(
+      "GET", GetCoinMarketsURL(vs_asset_lower, limit), "", "",
+      std::move(internal_callback),
+      api_request_helper::APIRequestOptions{
+          .auto_retry_on_network_change = true, .enable_cache = true});
 }
 
 void AssetRatioService::OnGetCoinMarkets(GetCoinMarketsCallback callback,


### PR DESCRIPTION
Uplift of two pull requests:
* PR https://github.com/brave/brave-core/pull/17958, issue https://github.com/brave/brave-browser/issues/29071 (issue)
* PR https://github.com/brave/brave-core/pull/18227, issue https://github.com/brave/brave-browser/issues/29972 (issue).
Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.