### PR TITLE
Hide Vertical Tab strip widget when disabled

### DIFF
--- a/browser/ui/views/frame/vertical_tab_strip_widget_delegate_view.cc
+++ b/browser/ui/views/frame/vertical_tab_strip_widget_delegate_view.cc
@@ -10,6 +10,7 @@
 #include "base/check.h"
 #include "brave/browser/ui/views/frame/brave_browser_view.h"
 #include "brave/browser/ui/views/frame/vertical_tab_strip_region_view.h"
+#include "brave/browser/ui/views/tabs/vertical_tab_utils.h"
 #include "chrome/browser/ui/browser_list.h"
 #include "chrome/browser/ui/views/frame/browser_view.h"
 #include "chrome/browser/ui/views/theme_copying_widget.h"
@@ -138,9 +139,13 @@ VerticalTabStripWidgetDelegateView::VerticalTabStripWidgetDelegateView(
   SetLayoutManager(std::make_unique<views::FillLayout>());
 
   host_view_observation_.Observe(host_);
-  widget_observation_.Observe(host_->GetWidget());
+  widget_observation_.AddObservation(host_->GetWidget());
 
   ChildPreferredSizeChanged(region_view_);
+}
+
+void VerticalTabStripWidgetDelegateView::AddedToWidget() {
+  widget_observation_.AddObservation(GetWidget());
 }
 
 void VerticalTabStripWidgetDelegateView::ChildPreferredSizeChanged(
@@ -184,9 +189,27 @@ void VerticalTabStripWidgetDelegateView::OnViewIsDeleting(
   host_ = nullptr;
 }
 
+void VerticalTabStripWidgetDelegateView::OnWidgetVisibilityChanged(
+    views::Widget* widget,
+    bool visible) {
+  if (widget == GetWidget()) {
+    if (!tabs::utils::ShouldShowVerticalTabs(browser_view_->browser()) &&
+        visible) {
+      // This happens when restoring browser window. The upstream implementation
+      // make child widgets visible regardless of their previous visibility.
+      // https://github.com/brave/brave-browser/issues/29917
+      widget->Hide();
+    }
+  }
+}
+
 void VerticalTabStripWidgetDelegateView::OnWidgetBoundsChanged(
     views::Widget* widget,
     const gfx::Rect& new_bounds) {
+  if (widget == GetWidget()) {
+    return;
+  }
+
   // The parent widget could be resized because fullscreen status changed.
   // Try resetting preferred size.
   ChildPreferredSizeChanged(region_view_);
@@ -207,6 +230,8 @@ void VerticalTabStripWidgetDelegateView::UpdateWidgetBounds() {
     widget->Hide();
     return;
   }
+
+  DCHECK(tabs::utils::ShouldShowVerticalTabs(browser_view_->browser()));
 
   auto insets = host_->GetInsets();
   widget_bounds.set_width(widget_bounds.width() + insets.width());
@@ -232,7 +257,7 @@ void VerticalTabStripWidgetDelegateView::UpdateWidgetBounds() {
 
 void VerticalTabStripWidgetDelegateView::OnWidgetDestroying(
     views::Widget* widget) {
-  widget_observation_.Reset();
+  widget_observation_.RemoveObservation(widget);
 }
 
 #if BUILDFLAG(IS_MAC)

--- a/browser/ui/views/frame/vertical_tab_strip_widget_delegate_view.h
+++ b/browser/ui/views/frame/vertical_tab_strip_widget_delegate_view.h
@@ -8,6 +8,7 @@
 
 #include <memory>
 
+#include "base/scoped_multi_source_observation.h"
 #include "ui/views/view_observer.h"
 #include "ui/views/widget/widget_delegate.h"
 #include "ui/views/widget/widget_observer.h"
@@ -47,6 +48,7 @@ class VerticalTabStripWidgetDelegateView : public views::WidgetDelegateView,
   }
 
   // views::WidgetDelegateView:
+  void AddedToWidget() override;
   void ChildPreferredSizeChanged(views::View* child) override;
 
   // views::ViewObserver:
@@ -56,6 +58,7 @@ class VerticalTabStripWidgetDelegateView : public views::WidgetDelegateView,
   void OnViewIsDeleting(views::View* observed_view) override;
 
   // views::WidgetObserver:
+  void OnWidgetVisibilityChanged(views::Widget* widget, bool visible) override;
   void OnWidgetBoundsChanged(views::Widget* widget,
                              const gfx::Rect& new_bounds) override;
   void OnWidgetDestroying(views::Widget* widget) override;
@@ -76,7 +79,7 @@ class VerticalTabStripWidgetDelegateView : public views::WidgetDelegateView,
   base::ScopedObservation<views::View, views::ViewObserver>
       host_view_observation_{this};
 
-  base::ScopedObservation<views::Widget, views::WidgetObserver>
+  base::ScopedMultiSourceObservation<views::Widget, views::WidgetObserver>
       widget_observation_{this};
 };
 


### PR DESCRIPTION
On Mac, the vertical tab strip widget shows up when restoring the browser window. This is because upstream implementation makes all child widgets regardless of their previous visibility.

In order to fix that, observes the widget's visibility and double-check it should be visible.

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/29917

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-arm64, CI/skip-linux-x64, CI/skip-android, CI/skip-macos, CI/skip-ios, CI/skip-windows-arm64, CI/skip-windows-x64, CI/skip-windows-x86 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [ ] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

### Manually testable on Mac(without stage manager)
* context-click on a tab and choose Use Vertical Tabs
* now, context-click again and deselect Use Vertical Tabs to return to the default mode
* minimize Brave (but don't shut it down)
* restore the window
* examine the left panel
