### PR TITLE
Move sidebar whenever the preference is changed

### DIFF
--- a/browser/ui/browser_commands.cc
+++ b/browser/ui/browser_commands.cc
@@ -241,17 +241,10 @@ void ToggleWindowTitleVisibilityForVerticalTabs(Browser* browser) {
 void ToggleVerticalTabStrip(Browser* browser) {
   auto* profile = browser->profile()->GetOriginalProfile();
   auto* prefs = profile->GetPrefs();
-  auto* sidebar_service =
-      sidebar::SidebarServiceFactory::GetForProfile(profile);
   const bool was_using_vertical_tab_strip =
       prefs->GetBoolean(brave_tabs::kVerticalTabsEnabled);
   prefs->SetBoolean(brave_tabs::kVerticalTabsEnabled,
                     !was_using_vertical_tab_strip);
-  if (was_using_vertical_tab_strip) {
-    sidebar_service->RestoreSidebarAlignmentIfNeeded();
-  } else {
-    sidebar_service->MoveSidebarToRightTemporarily();
-  }
 }
 
 void ToggleVerticalTabStripFloatingMode(Browser* browser) {

--- a/browser/ui/sidebar/sidebar_service_delegate_impl.cc
+++ b/browser/ui/sidebar/sidebar_service_delegate_impl.cc
@@ -27,6 +27,11 @@ void SidebarServiceDelegateImpl::MoveSidebarToRightTemporarily() {
            ->IsDefaultValue())
     return;
 
+  if (changing_sidebar_alignment_temporarily_) {
+    // We already changed the alignment.
+    return;
+  }
+
   base::AutoReset<bool> resetter(&changing_sidebar_alignment_temporarily_,
                                  true);
   prefs_->SetBoolean(prefs::kSidePanelHorizontalAlignment,

--- a/browser/ui/views/frame/vertical_tab_strip_region_view.cc
+++ b/browser/ui/views/frame/vertical_tab_strip_region_view.cc
@@ -13,12 +13,14 @@
 #include "brave/app/vector_icons/vector_icons.h"
 #include "brave/browser/ui/brave_browser.h"
 #include "brave/browser/ui/color/brave_color_id.h"
+#include "brave/browser/ui/sidebar/sidebar_service_factory.h"
 #include "brave/browser/ui/tabs/brave_tab_prefs.h"
 #include "brave/browser/ui/tabs/features.h"
 #include "brave/browser/ui/views/tabs/brave_new_tab_button.h"
 #include "brave/browser/ui/views/tabs/brave_tab_search_button.h"
 #include "brave/browser/ui/views/tabs/brave_tab_strip_layout_helper.h"
 #include "brave/browser/ui/views/tabs/vertical_tab_utils.h"
+#include "brave/components/sidebar/sidebar_service.h"
 #include "chrome/browser/profiles/profile.h"
 #include "chrome/browser/themes/theme_properties.h"
 #include "chrome/browser/ui/exclusive_access/exclusive_access_manager.h"
@@ -535,8 +537,9 @@ VerticalTabStripRegionView::VerticalTabStripRegionView(
   auto* prefs = browser_->profile()->GetOriginalProfile()->GetPrefs();
   show_vertical_tabs_.Init(
       brave_tabs::kVerticalTabsEnabled, prefs,
-      base::BindRepeating(&VerticalTabStripRegionView::UpdateLayout,
-                          base::Unretained(this), false));
+      base::BindRepeating(
+          &VerticalTabStripRegionView::OnShowVerticalTabsPrefChanged,
+          base::Unretained(this)));
   UpdateLayout();
 
   collapsed_pref_.Init(
@@ -690,6 +693,21 @@ void VerticalTabStripRegionView::Layout() {
                   scroll_contents_view_->GetPreferredSize().height())});
   }
   UpdateTabSearchButtonVisibility();
+}
+
+void VerticalTabStripRegionView::OnShowVerticalTabsPrefChanged() {
+  auto* profile = browser_->profile()->GetOriginalProfile();
+  auto* sidebar_service =
+      sidebar::SidebarServiceFactory::GetForProfile(profile);
+  DCHECK(sidebar_service);
+
+  if (*show_vertical_tabs_) {
+    sidebar_service->MoveSidebarToRightTemporarily();
+  } else {
+    sidebar_service->RestoreSidebarAlignmentIfNeeded();
+  }
+
+  UpdateLayout(/* in_destruction= */ false);
 }
 
 void VerticalTabStripRegionView::UpdateLayout(bool in_destruction) {

--- a/browser/ui/views/frame/vertical_tab_strip_region_view.h
+++ b/browser/ui/views/frame/vertical_tab_strip_region_view.h
@@ -105,6 +105,8 @@ class VerticalTabStripRegionView : public views::View,
 
   void UpdateStateAfterDragAndDropFinished(State original_state);
 
+  void OnShowVerticalTabsPrefChanged();
+
   void UpdateLayout(bool in_destruction = false);
 
   void UpdateTabSearchButtonVisibility();


### PR DESCRIPTION
When the preference is changed via brave://settings/appearance page, we are not moving sidebar to the right. We should apply the same mechanism as we did with the context menu

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/29992

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-arm64, CI/skip-linux-x64, CI/skip-android, CI/skip-macos, CI/skip-ios, CI/skip-windows-arm64, CI/skip-windows-x64, CI/skip-windows-x86 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [ ] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
* User data dir should be clean
* Use vertical tabs via context menu or settings page
  * Either way, the sidebar should move to the right side of browser.
