### PR TITLE
Update Rust to 1.67.1, add support for native arm64 MacOS toolchain.

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -6,7 +6,7 @@ gclient_gn_args = [
 ]
 
 vars = {
-  'brave_rust_version': '"1.67.0"',
+  'brave_rust_version': Str('1.67.1'),
   'download_prebuilt_sparkle': True,
 }
 
@@ -70,40 +70,21 @@ hooks = [
   {
     'name': 'download_rust_deps',
     'pattern': '.',
-    'condition': 'checkout_android',
     'action': [
-      'vpython3', 'script/download_rust_deps.py', Var('brave_rust_version'), 'android'
+      'vpython3', 'script/download_rust_deps.py',
+      '--rust_version={brave_rust_version}',
+      '--checkout_android={checkout_android}',
+      '--checkout_ios={checkout_ios}',
+      '--checkout_linux={checkout_linux}',
+      '--checkout_mac={checkout_mac}',
+      '--checkout_win={checkout_win}',
     ]
-  },
-  {
-    'name': 'download_rust_deps',
-    'pattern': '.',
-    'condition': 'checkout_mac or checkout_ios',
-    'action': [
-      'vpython3', 'script/download_rust_deps.py', Var('brave_rust_version'), 'ios'
-    ]
-  },
-  {
-    'name': 'download_rust_deps',
-    'pattern': '.',
-    'condition': 'checkout_win',
-    'action': [
-      'vpython3', 'script/download_rust_deps.py', Var('brave_rust_version'), 'win32'
-    ]
-  },
-  {
-    'name': 'download_rust_deps',
-    'pattern': '.',
-    'condition': 'checkout_linux',
-    'action': [
-      'vpython3', 'script/download_rust_deps.py', Var('brave_rust_version'), 'linux'
-    ],
   },
   {
     # Install Web Discovery Project dependencies for Windows, Linux, and macOS
     'name': 'web_discovery_project_npm_deps',
     'pattern': '.',
-    'condition': 'not checkout_android and not checkout_ios',
+    'condition': 'checkout_linux or checkout_mac or checkout_win',
     'action': ['vpython3', 'script/web_discovery_project.py', '--install'],
   },
   {

--- a/build/cargo.gni
+++ b/build/cargo.gni
@@ -115,8 +115,13 @@ template("cargo_build") {
     ]
 
     if (is_apple) {
+      if (host_cpu == "arm64") {
+        rust_host_toolchain = "aarch64-apple-darwin"
+      } else {
+        rust_host_toolchain = "x86_64-apple-darwin"
+      }
       toolchain_home =
-          "$rustup_home/toolchains/$brave_rust_version-x86_64-apple-darwin"
+          "$rustup_home/toolchains/$brave_rust_version-$rust_host_toolchain"
       std_src_home = "$toolchain_home/lib/rustlib/src/rust/library/std/src"
       force_rebuild_inputs += [ "$std_src_home/personality/gcc.rs" ]
     }

--- a/script/download_rust_deps.py
+++ b/script/download_rust_deps.py
@@ -1,13 +1,11 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # Copyright (c) 2019 The Brave Authors. All rights reserved.
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this file,
 # You can obtain one at https://mozilla.org/MPL/2.0/.
-
 """Script to download rust_deps."""
 
 import argparse
-import ast
 import os
 import shutil
 import subprocess
@@ -16,30 +14,27 @@ import sys
 import deps
 from deps_config import DEPS_PACKAGES_URL
 
-try:
-    from urllib2 import URLError
-except ImportError:  # For Py3 compatibility
-    from urllib.error import URLError  # pylint: disable=no-name-in-module,import-error
-
 from lib.config import BRAVE_CORE_ROOT, CHROMIUM_ROOT
+from lib.util import get_host_os, get_host_arch, str2bool
 
 RUSTUP_PATH = os.path.join(BRAVE_CORE_ROOT, 'build', 'rustup')
 
 
-def get_url(platform, rust_version):
-    if platform in ("win32", "cygwin"):
-        filename = "rust_deps_win_" + rust_version + ".zip"
-    elif platform == 'darwin':
-        filename = "rust_deps_mac_" + rust_version + ".gz"
-    elif platform == 'ios':
-        filename = "rust_deps_ios_" + rust_version + ".gz"
-    elif platform.startswith('linux'):
-        filename = "rust_deps_linux_" + rust_version + ".gz"
-    else:
-        print('Invalid platform for Rust deps: %s' % platform)
-        print('Exiting.')
-        sys.exit(1)
+def host_rust_toolchain(rust_version):
+    if get_host_os() == 'linux':
+        return f'{rust_version}-x86_64-unknown-linux-gnu'
+    if get_host_os() == 'mac':
+        if get_host_arch() == 'arm64':
+            return f'{rust_version}-aarch64-apple-darwin'
+        return f'{rust_version}-x86_64-apple-darwin'
+    if get_host_os() == 'win':
+        return f'{rust_version}-x86_64-pc-windows-msvc'
+    raise RuntimeError(f'Unsupported host_os: {get_host_os()}')
 
+
+def get_url(rust_version):
+    ext = 'zip' if get_host_os() == 'win' else 'gz'
+    filename = f'rust_deps_{host_rust_toolchain(rust_version)}.{ext}'
     return DEPS_PACKAGES_URL + "/rust-deps/" + filename
 
 
@@ -50,47 +45,30 @@ def should_download(rustup_home):
     return True
 
 
-def download_and_unpack_rust_deps(platform, rust_version, rustup_home):
+def download_and_unpack_rust_deps(rust_version, rustup_home):
     if not should_download(rustup_home):
         return
 
-    url = get_url('ios' if platform == 'ios' else sys.platform, rust_version)
+    url = get_url(rust_version)
 
-    try:
-        deps.DownloadAndUnpack(url, RUSTUP_PATH)
-    except URLError:
-        print('Failed to download Rust deps: %s' % url)
-        print('Exiting.')
-        sys.exit(1)
-
-
-def get_android_api_level(target_arch):
-    return {
-        'arm': '19',
-        'arm64': '24',
-        'x86': '19',
-        'x86_64': '24',
-    }[target_arch]
-
-
-def get_android_target(target_arch):
-    return {
-        'arm': 'arm-linux-androideabi',
-        'arm64': 'aarch64-linux-android',
-        'x86': 'i686-linux-android',
-        'x86_64': 'x86_64-linux-android',
-    }[target_arch]
-
-
-def get_android_linker(target_arch):
-    return get_android_target(target_arch) + "-clang"
+    deps.DownloadAndUnpack(url, RUSTUP_PATH)
 
 
 def parse_args():
     parser = argparse.ArgumentParser(description='Download rust deps')
 
-    parser.add_argument('rust_version')
-    parser.add_argument('platform')
+    parser.add_argument('--rust_version')
+    parser.add_argument('--checkout_android', default=False, type=str2bool)
+    parser.add_argument('--checkout_ios', default=False, type=str2bool)
+    parser.add_argument('--checkout_linux',
+                        default=get_host_os() == 'linux',
+                        type=str2bool)
+    parser.add_argument('--checkout_mac',
+                        default=get_host_os() == 'mac',
+                        type=str2bool)
+    parser.add_argument('--checkout_win',
+                        default=get_host_os() == 'win',
+                        type=str2bool)
 
     args = parser.parse_args()
     return args
@@ -124,9 +102,9 @@ def run_rust_tool(tool, tool_args, rustup_home):
     env['RUSTUP_HOME'] = rustup_home
     env['CARGO_HOME'] = rustup_home
 
-    rustup_bin = os.path.abspath(os.path.join(rustup_home, 'bin'))
-    tool_path = os.path.join(
-        rustup_bin, tool + (".exe" if sys.platform == "win32" else ""))
+    if get_host_os() == 'win':
+        tool += '.exe'
+    tool_path = os.path.abspath(os.path.join(rustup_home, 'bin', tool))
 
     try:
         subprocess.check_call([tool_path] + tool_args, env=env)
@@ -138,19 +116,54 @@ def run_rust_tool(tool, tool_args, rustup_home):
 def main():
     args = parse_args()
 
-    rust_version = ast.literal_eval(args.rust_version)
+    rust_version = args.rust_version
     rustup_home = os.path.join(RUSTUP_PATH, rust_version)
 
-    if args.platform == 'android':
-        download_and_unpack_rust_deps(sys.platform, rust_version, rustup_home)
-    else:
-        download_and_unpack_rust_deps(args.platform, rust_version, rustup_home)
+    download_and_unpack_rust_deps(rust_version, rustup_home)
 
-    if sys.platform == 'darwin':
-        rustup_add_target('x86_64-apple-darwin', rustup_home)
-        rustup_add_target('aarch64-apple-darwin', rustup_home)
-        # a separate directory is not created for aarch64-apple-darwin
-        toolchain = rust_version + '-x86_64-apple-darwin'
+    rustup_targets = set()
+
+    if args.checkout_android:
+        rustup_targets.update([
+            'aarch64-linux-android',
+            'arm-linux-androideabi',
+            'armv7-linux-androideabi',
+            'aarch64-linux-android',
+            'i686-linux-android',
+            'x86_64-linux-android',
+        ])
+
+    if args.checkout_ios:
+        rustup_targets.update([
+            'aarch64-apple-ios',
+            'aarch64-apple-ios-sim',
+            'x86_64-apple-ios',
+        ])
+
+    if args.checkout_linux:
+        rustup_targets.update([
+            'aarch64-unknown-linux-gnu',
+            'x86_64-unknown-linux-gnu',
+        ])
+
+    if args.checkout_mac:
+        rustup_targets.update([
+            'aarch64-apple-darwin',
+            'x86_64-apple-darwin',
+        ])
+
+    if args.checkout_win:
+        rustup_targets.update([
+            'aarch64-pc-windows-msvc',
+            'i686-pc-windows-msvc',
+            'x86_64-pc-windows-msvc',
+        ])
+
+    for rustup_target in rustup_targets:
+        rustup_add_target(rustup_target, rustup_home)
+
+    if args.checkout_mac:
+        toolchain = host_rust_toolchain(rust_version)
         run_rust_tool(
             'rustup',
             ['component', 'add', 'rust-src', '--toolchain', toolchain],
@@ -159,8 +172,7 @@ def main():
         # https://github.com/rust-lang/rust/issues/102754#issuecomment-1421438735
         patched_file = os.path.join(BRAVE_CORE_ROOT, 'build', 'rust',
                                     'gcc.rs.patched')
-        orig_file = os.path.join(rustup_home, 'toolchains',
-                                 rust_version + '-x86_64-apple-darwin', 'lib',
+        orig_file = os.path.join(rustup_home, 'toolchains', toolchain, 'lib',
                                  'rustlib', 'src', 'rust', 'library', 'std',
                                  'src', 'personality', 'gcc.rs')
         shutil.copyfile(patched_file, orig_file)
@@ -186,7 +198,7 @@ def main():
         "version": cxx_version,
     }, {
         "name": "cargo-audit",
-        "version": "0.17.4",
+        "version": "0.17.5",
         "locked": True,
         "features": "vendored-openssl",
     }]

--- a/script/lib/util.py
+++ b/script/lib/util.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # Copyright (c) 2021 The Brave Authors. All rights reserved.
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this file,
@@ -6,6 +5,7 @@
 
 from __future__ import print_function
 
+import argparse
 import atexit
 import contextlib
 import errno
@@ -27,8 +27,27 @@ import zipfile
 from .config import is_verbose_mode
 from .env_util import get_vs_env
 
+_PLATFORM_MAPPING = {
+    'cygwin': 'win',
+    'darwin': 'mac',
+    'linux2': 'linux',
+    'linux': 'linux',
+    'win32': 'win',
+}
+
 BOTO_DIR = os.path.abspath(os.path.join(__file__, '..', '..', '..', 'vendor',
                                         'boto'))
+
+
+def get_host_os():
+    """Returns the host OS with a predictable string."""
+    if sys.platform in _PLATFORM_MAPPING:
+        return _PLATFORM_MAPPING[sys.platform]
+
+    try:
+        return os.uname().sysname.lower()
+    except AttributeError:
+        return sys.platform
 
 
 def get_host_arch():
@@ -40,6 +59,8 @@ def get_host_arch():
         host_arch = 'ia32'
     elif host_arch in ['x86_64', 'amd64']:
         host_arch = 'x64'
+    elif host_arch.startswith('arm64') or host_arch.startswith('aarch64'):
+        host_arch = 'arm64'
     elif host_arch.startswith('arm'):
         host_arch = 'arm'
 
@@ -293,11 +314,12 @@ def import_vs_env(target_arch):
     os.environ.update(env)
 
 
-def get_platform():
-    PLATFORM = {
-        'cygwin': 'win32',
-        'darwin': 'darwin',
-        'linux2': 'linux',
-        'win32': 'win32',
-    }[sys.platform]
-    return PLATFORM
+def str2bool(v):
+    if isinstance(v, bool):
+        return v
+    v = v.lower()
+    if v in ('yes', 'true', 't', 'y', '1'):
+        return True
+    if v in ('no', 'false', 'f', 'n', '0'):
+        return False
+    raise argparse.ArgumentTypeError('Boolean value expected.')


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Rust toolchain build process was updated in [`devops` repository](https://github.com/brave/devops/pull/9482). Please [read PR description](https://github.com/brave/devops/pull/9482#issue-1653689584) to understand all changes.

This PR acks these changes and downloads/unpack Rust package using the host architecture.

Resolves https://github.com/brave/brave-browser/issues/30012

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-arm64, CI/skip-linux-x64, CI/skip-android, CI/skip-macos, CI/skip-ios, CI/skip-windows-arm64, CI/skip-windows-x64, CI/skip-windows-x86 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

