### PR TITLE
Add GetEthTokenSymbol and GetEthTokenDecimals to JsonRpcService

### DIFF
--- a/components/brave_wallet/browser/json_rpc_service.cc
+++ b/components/brave_wallet/browser/json_rpc_service.cc
@@ -2663,8 +2663,7 @@ void JsonRpcService::GetEthTokenSymbol(const std::string& contract_address,
         l10n_util::GetStringUTF8(IDS_WALLET_INVALID_PARAMETERS));
     return;
   }
-  std::string data;
-  const std::string function_hash = GetFunctionHash("symbol()");
+  const std::string data = GetFunctionHash("symbol()");
   auto internal_callback =
       base::BindOnce(&JsonRpcService::OnGetEthTokenSymbol,
                      weak_ptr_factory_.GetWeakPtr(), std::move(callback));

--- a/components/brave_wallet/browser/json_rpc_service.cc
+++ b/components/brave_wallet/browser/json_rpc_service.cc
@@ -2667,9 +2667,8 @@ void JsonRpcService::GetEthTokenSymbol(const std::string& contract_address,
   auto internal_callback =
       base::BindOnce(&JsonRpcService::OnGetEthTokenSymbol,
                      weak_ptr_factory_.GetWeakPtr(), std::move(callback));
-  RequestInternal(eth::eth_call("", contract_address, "", "", "", data,
-                                kEthereumBlockTagLatest),
-                  true, network_url, std::move(internal_callback));
+  RequestInternal(eth::eth_call(contract_address, data), true, network_url,
+                  std::move(internal_callback));
 }
 
 void JsonRpcService::OnGetEthTokenSymbol(GetEthTokenSymbolCallback callback,
@@ -2707,9 +2706,8 @@ void JsonRpcService::GetEthTokenDecimals(const std::string& contract_address,
   auto internal_callback =
       base::BindOnce(&JsonRpcService::OnGetEthTokenDecimals,
                      weak_ptr_factory_.GetWeakPtr(), std::move(callback));
-  RequestInternal(eth::eth_call("", contract_address, "", "", "", data,
-                                kEthereumBlockTagLatest),
-                  true, network_url, std::move(internal_callback));
+  RequestInternal(eth::eth_call(contract_address, data), true, network_url,
+                  std::move(internal_callback));
 }
 
 void JsonRpcService::OnGetEthTokenDecimals(

--- a/components/brave_wallet/browser/json_rpc_service.h
+++ b/components/brave_wallet/browser/json_rpc_service.h
@@ -409,6 +409,10 @@ class JsonRpcService : public KeyedService, public mojom::JsonRpcService {
                            mojom::ProviderError error,
                            const std::string& error_message);
 
+  void GetEthTokenSymbol(const std::string& contract_address,
+                         const std::string& chain_id,
+                         GetEthTokenSymbolCallback callback) override;
+
   using SwitchEthereumChainRequestCallback =
       base::OnceCallback<void(mojom::ProviderError error,
                               const std::string& error_message)>;
@@ -630,6 +634,9 @@ class JsonRpcService : public KeyedService, public mojom::JsonRpcService {
 
   void OnGetSupportsInterface(GetSupportsInterfaceCallback callback,
                               APIRequestResult api_request_result);
+
+  void OnGetEthTokenSymbol(GetEthTokenSymbolCallback callback,
+                           APIRequestResult api_request_result);
 
   // Solana
   void OnGetSolanaBalance(GetSolanaBalanceCallback callback,

--- a/components/brave_wallet/browser/json_rpc_service.h
+++ b/components/brave_wallet/browser/json_rpc_service.h
@@ -413,6 +413,10 @@ class JsonRpcService : public KeyedService, public mojom::JsonRpcService {
                          const std::string& chain_id,
                          GetEthTokenSymbolCallback callback) override;
 
+  void GetEthTokenDecimals(const std::string& contract_address,
+                           const std::string& chain_id,
+                           GetEthTokenDecimalsCallback callback) override;
+
   using SwitchEthereumChainRequestCallback =
       base::OnceCallback<void(mojom::ProviderError error,
                               const std::string& error_message)>;
@@ -638,6 +642,8 @@ class JsonRpcService : public KeyedService, public mojom::JsonRpcService {
   void OnGetEthTokenSymbol(GetEthTokenSymbolCallback callback,
                            APIRequestResult api_request_result);
 
+  void OnGetEthTokenDecimals(GetEthTokenDecimalsCallback callback,
+                             APIRequestResult api_request_result);
   // Solana
   void OnGetSolanaBalance(GetSolanaBalanceCallback callback,
                           APIRequestResult api_request_result);

--- a/components/brave_wallet/browser/json_rpc_service_unittest.cc
+++ b/components/brave_wallet/browser/json_rpc_service_unittest.cc
@@ -665,7 +665,7 @@ constexpr char kJsonRpcResponseTemplate[] = R"({
       "result":"$1"
   })";
 
-std::string formatJsonRpcResponse(const std::string& value) {
+std::string FormatJsonRpcResponse(const std::string& value) {
   return base::ReplaceStringPlaceholders(kJsonRpcResponseTemplate, {value},
                                          nullptr);
 }
@@ -6654,7 +6654,7 @@ TEST_F(JsonRpcServiceUnitTest, GetEthTokenSymbol) {
       "0000000000000000000000000000000000000000000000000000000000000003"
       "4241540000000000000000000000000000000000000000000000000000000000";
   SetInterceptor(GetNetwork(mojom::kMainnetChainId, mojom::CoinType::ETH),
-                 "eth_call", "", formatJsonRpcResponse(bat_symbol_result));
+                 "eth_call", "", FormatJsonRpcResponse(bat_symbol_result));
   TestGetEthTokenSymbol("0x0D8775F648430679A709E98d2b0Cb6250d2887EF",
                         mojom::kMainnetChainId, "BAT",
                         mojom::ProviderError::kSuccess, "");
@@ -6691,7 +6691,7 @@ TEST_F(JsonRpcServiceUnitTest, GetEthTokenDecimals) {
       "0x"
       "0000000000000000000000000000000000000000000000000000000000000012";
   SetInterceptor(GetNetwork(mojom::kMainnetChainId, mojom::CoinType::ETH),
-                 "eth_call", "", formatJsonRpcResponse(bat_decimals_result));
+                 "eth_call", "", FormatJsonRpcResponse(bat_decimals_result));
   TestGetEthTokenDecimals("0x0D8775F648430679A709E98d2b0Cb6250d2887EF",
                           mojom::kMainnetChainId, "0x12",
                           mojom::ProviderError::kSuccess, "");

--- a/components/brave_wallet/common/brave_wallet.mojom
+++ b/components/brave_wallet/common/brave_wallet.mojom
@@ -1184,7 +1184,7 @@ interface JsonRpcService {
 
   // Fetches decimals of an ERC20 or ERC721 token.
   GetEthTokenDecimals(string chain_id,
-                      string contract_address) => (string symbol,
+                      string contract_address) => (string decimals,
                                                    ProviderError error,
                                                    string error_message);
   // Solana JSON RPCs

--- a/components/brave_wallet/common/brave_wallet.mojom
+++ b/components/brave_wallet/common/brave_wallet.mojom
@@ -1176,6 +1176,12 @@ interface JsonRpcService {
   // Obtains the quantity of ERC1155 tokens a user has
   GetERC1155TokenBalance(string contract_address, string token_id, string account_address, string chain_id) => (string balance, ProviderError error, string error_message);
 
+  // Fetches symbol of an ERC20 or ERC721 token.
+  GetEthTokenSymbol(string chain_id,
+                    string contract_address) => (string symbol,
+                                                 ProviderError error,
+                                                 string error_message);
+
   // Solana JSON RPCs
   // https://docs.solana.com/developing/clients/jsonrpc-api
 

--- a/components/brave_wallet/common/brave_wallet.mojom
+++ b/components/brave_wallet/common/brave_wallet.mojom
@@ -1182,6 +1182,11 @@ interface JsonRpcService {
                                                  ProviderError error,
                                                  string error_message);
 
+  // Fetches decimals of an ERC20 or ERC721 token.
+  GetEthTokenDecimals(string chain_id,
+                      string contract_address) => (string symbol,
+                                                   ProviderError error,
+                                                   string error_message);
   // Solana JSON RPCs
   // https://docs.solana.com/developing/clients/jsonrpc-api
 


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/29983

Exposes two APIs to the frontend, GetEthTokenSymbol and GetEthTokenDecimals, so that this data can be fetched. The first use case is for swaps with unknown tokens, however we can also use this to pre-fetch symbols when users are adding NFTs manually so they do not need to input it themselves.

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-arm64, CI/skip-linux-x64, CI/skip-android, CI/skip-macos, CI/skip-ios, CI/skip-windows-arm64, CI/skip-windows-x64, CI/skip-windows-x86 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

