### PR TITLE
Uplift of Enable BraveVPN and BraveVPNLinkSubscriptionAndroidUI by default (#17989)

### DIFF
--- a/browser/brave_vpn/brave_vpn_service_factory.cc
+++ b/browser/brave_vpn/brave_vpn_service_factory.cc
@@ -67,8 +67,10 @@ BraveVpnServiceFactory::~BraveVpnServiceFactory() = default;
 
 KeyedService* BraveVpnServiceFactory::BuildServiceInstanceFor(
     content::BrowserContext* context) const {
-  if (!IsBraveVPNEnabled())
+  if (!IsBraveVPNEnabled() ||
+      !g_brave_browser_process->brave_vpn_os_connection_api()) {
     return nullptr;
+  }
 
   auto* default_storage_partition = context->GetDefaultStoragePartition();
   auto shared_url_loader_factory =

--- a/components/brave_vpn/browser/brave_vpn_service_unittest.cc
+++ b/components/brave_vpn/browser/brave_vpn_service_unittest.cc
@@ -483,7 +483,7 @@ class BraveVPNServiceTest : public testing::Test {
 };
 
 TEST(BraveVPNFeatureTest, FeatureTest) {
-#if BUILDFLAG(IS_ANDROID) || BUILDFLAG(IS_IOS)
+#if !BUILDFLAG(IS_LINUX)
   EXPECT_TRUE(IsBraveVPNEnabled());
 #else
   EXPECT_FALSE(IsBraveVPNEnabled());

--- a/components/brave_vpn/common/features.cc
+++ b/components/brave_vpn/common/features.cc
@@ -14,7 +14,7 @@ namespace features {
 
 BASE_FEATURE(kBraveVPN,
              "BraveVPN",
-#if BUILDFLAG(IS_ANDROID) || BUILDFLAG(IS_IOS)
+#if !BUILDFLAG(IS_LINUX)
              base::FEATURE_ENABLED_BY_DEFAULT
 #else
              base::FEATURE_DISABLED_BY_DEFAULT
@@ -23,7 +23,7 @@ BASE_FEATURE(kBraveVPN,
 
 BASE_FEATURE(kBraveVPNLinkSubscriptionAndroidUI,
              "BraveVPNLinkSubscriptionAndroidUI",
-             base::FEATURE_DISABLED_BY_DEFAULT);
+             base::FEATURE_ENABLED_BY_DEFAULT);
 
 #if BUILDFLAG(IS_WIN)
 BASE_FEATURE(kBraveVPNDnsProtection,

--- a/test/base/testing_brave_browser_process.cc
+++ b/test/base/testing_brave_browser_process.cc
@@ -155,7 +155,6 @@ TestingBraveBrowserProcess::brave_farbling_service() {
 #if BUILDFLAG(ENABLE_BRAVE_VPN)
 brave_vpn::BraveVPNOSConnectionAPI*
 TestingBraveBrowserProcess::brave_vpn_os_connection_api() {
-  NOTREACHED();
   return nullptr;
 }
 #endif


### PR DESCRIPTION
Uplift of #17989
Resolves https://github.com/brave/brave-browser/issues/29612

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.