### PR TITLE
feat(wallet): Allow Full Width Portfolio Graph

### DIFF
--- a/components/brave_wallet_ui/components/desktop/line-chart/index.tsx
+++ b/components/brave_wallet_ui/components/desktop/line-chart/index.tsx
@@ -81,7 +81,7 @@ function LineChart ({
       <LoadingOverlay isLoading={isLoading}>
         <LoadIcon />
       </LoadingOverlay>
-      <ResponsiveContainer width='99%' height='99%'>
+      <ResponsiveContainer width='100%' height='99%'>
         <AreaChart
           data={chartData}
           margin={{ top: 5, left: 0, right: 0, bottom: 0 }}

--- a/components/brave_wallet_ui/components/desktop/views/portfolio/components/token-lists/token-list.tsx
+++ b/components/brave_wallet_ui/components/desktop/views/portfolio/components/token-lists/token-list.tsx
@@ -56,6 +56,7 @@ interface Props {
   enableScroll?: boolean
   maxListHeight?: string
   estimatedItemSize: number
+  horizontalPadding?: number
 }
 
 export const TokenLists = ({
@@ -67,7 +68,8 @@ export const TokenLists = ({
   maxListHeight,
   hideAssetFilter,
   hideAccountFilter,
-  hideAutoDiscovery
+  hideAutoDiscovery,
+  horizontalPadding
 }: Props) => {
   // routing
   const history = useHistory()
@@ -210,7 +212,7 @@ export const TokenLists = ({
   // render
   return (
     <>
-      <FilterTokenRow>
+      <FilterTokenRow horizontalPadding={horizontalPadding}>
 
         <Column flex={1} style={{ minWidth: '25%' }} alignItems='flex-start'>
           <SearchBar
@@ -234,7 +236,14 @@ export const TokenLists = ({
 
       {enableScroll
         ? (
-          <ScrollableColumn maxHeight={maxListHeight}>
+          <ScrollableColumn
+            maxHeight={maxListHeight}
+            padding={
+              `0px ${horizontalPadding !== undefined
+                ? horizontalPadding
+                : 0}px`
+            }
+          >
             {listUi}
           </ScrollableColumn>
         )
@@ -242,7 +251,9 @@ export const TokenLists = ({
       }
 
       {!hideAddButton &&
-        <ButtonRow>
+        <ButtonRow
+          horizontalPadding={horizontalPadding}
+        >
           <AddButton
             buttonType='secondary'
             onSubmit={showAddAssetsModal}

--- a/components/brave_wallet_ui/components/desktop/views/portfolio/portfolio-overview.tsx
+++ b/components/brave_wallet_ui/components/desktop/views/portfolio/portfolio-overview.tsx
@@ -281,6 +281,7 @@ export const PortfolioOverview = () => {
         networks={networks || []}
         estimatedItemSize={58}
         enableScroll={true}
+        horizontalPadding={20}
         renderToken={({ item, viewMode }) =>
           viewMode === 'list'
             ? <PortfolioAssetItem

--- a/components/brave_wallet_ui/components/desktop/views/portfolio/style.ts
+++ b/components/brave_wallet_ui/components/desktop/views/portfolio/style.ts
@@ -50,13 +50,22 @@ export const PriceText = styled.span`
   color: ${(p) => p.theme.color.text01};
 `
 
-export const ButtonRow = styled.div<{ noMargin?: boolean }>`
+export const ButtonRow = styled.div<
+  {
+    noMargin?: boolean,
+    horizontalPadding?: number
+  }>`
   display: flex;
   flex-direction: row;
   align-items: center;
   justify-content: flex-start;
   width: 100%;
   margin: ${(p) => p.noMargin ? '0px' : '20px 0px'};
+  padding: 0px ${(p) =>
+    p.horizontalPadding !== undefined
+      ? p.horizontalPadding
+      : 0
+  }px;
 `
 
 export const BalanceRow = styled.div<{ gap?: string }>`
@@ -228,12 +237,20 @@ export const CoinGeckoText = styled.span`
   margin: 15px 0px;
 `
 
-export const FilterTokenRow = styled.div`
+export const FilterTokenRow = styled.div<
+  {
+    horizontalPadding?: number
+  }>`
   display: flex;
   flex-direction: row;
   flex-wrap: wrap;
   width: 100%;
   gap: 14px;
+  padding: 0px ${(p) =>
+    p.horizontalPadding !== undefined
+      ? p.horizontalPadding
+      : 0
+  }px;
 `
 
 export const NftMultimedia = styled.iframe<{ visible?: boolean }>`

--- a/components/brave_wallet_ui/components/desktop/wallet-page-wrapper/wallet-page-wrapper.style.ts
+++ b/components/brave_wallet_ui/components/desktop/wallet-page-wrapper/wallet-page-wrapper.style.ts
@@ -41,7 +41,8 @@ export const LayoutCardWrapper = styled.div<{
 
 export const ContainerCard = styled.div<
   {
-    cardOverflow?: 'auto' | 'hidden' | 'visible'
+    cardOverflow?: 'auto' | 'hidden' | 'visible',
+    noPadding?: boolean
   }>`
   display: flex;
   flex-direction: column;
@@ -51,7 +52,7 @@ export const ContainerCard = styled.div<
   box-sizing: border-box;
   justify-content: flex-start;
   align-items: center;
-  padding: 20px;
+  padding: ${(p) => p.noPadding ? 0 : 20}px;
   width: 100%;
   min-height: ${minCardHeight}px;
   max-height: calc(100vh - 132px);

--- a/components/brave_wallet_ui/components/desktop/wallet-page-wrapper/wallet-page-wrapper.tsx
+++ b/components/brave_wallet_ui/components/desktop/wallet-page-wrapper/wallet-page-wrapper.tsx
@@ -111,6 +111,7 @@ export const WalletPageWrapper = (props: Props) => {
           >
             <ContainerCard
               cardOverflow={cardOverflow}
+              noPadding={walletLocation === WalletRoutes.Portfolio}
             >
               {children}
             </ContainerCard>


### PR DESCRIPTION
## Description 
Now allows the `Portfolio Graph` to be full width of the card container

<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves <https://github.com/brave/brave-browser/issues/30022>

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-arm64, CI/skip-linux-x64, CI/skip-android, CI/skip-macos, CI/skip-ios, CI/skip-windows-arm64, CI/skip-windows-x64, CI/skip-windows-x86 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
1. Go to the `Portfolio` tab.
2. The graph should be the full width of the card container.

Before:

![Screenshot 22](https://user-images.githubusercontent.com/40611140/234693617-e7580c87-a5fb-4962-9400-dc7a3c03393f.png)

After:

![Screenshot 21](https://user-images.githubusercontent.com/40611140/234693641-f8fc23a0-6ca3-41e2-9eab-17fd8dd07091.png)
