### PR TITLE
Fix crash where target view is not in browser root view's hierarchy (uplift to 1.51.x)

### DIFF
--- a/chromium_src/chrome/browser/ui/views/frame/browser_root_view.cc
+++ b/chromium_src/chrome/browser/ui/views/frame/browser_root_view.cc
@@ -11,7 +11,7 @@
   if (views::View* target_v = TARGET_GETTER;                              \
       base::FeatureList::IsEnabled(tabs::features::kBraveVerticalTabs) && \
       tabs::utils::ShouldShowVerticalTabs(browser_view_->browser()) &&    \
-      target_v == tabstrip()) {                                           \
+      (target_v == tabstrip() || !THIS->Contains(target_v))) {            \
     ConvertPointToScreen(target_v, POINT);                                \
     ConvertPointFromScreen(THIS, POINT);                                  \
   } else {                                                                \


### PR DESCRIPTION
Uplift of #18201
Resolves https://github.com/brave/brave-browser/issues/29929

Pre-approval checklist: 
- [ ] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [ ] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [ ] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [ ] The associated issue milestone is set to the smallest version that the changes is landed on.