### PR TITLE
Activate browser widget when clicking vertical tab (uplift to 1.51.x)

### DIFF
--- a/browser/ui/views/frame/vertical_tab_strip_widget_delegate_view.cc
+++ b/browser/ui/views/frame/vertical_tab_strip_widget_delegate_view.cc
@@ -59,17 +59,13 @@ class VerticalTabStripRootView : public views::internal::RootView {
 
     return result;
 #else
-    // On Mac, Last active browser of BrowserList is not updated in this case.
-    // So update it manually.
+    // On Mac, the parent widget doesn't get activated in this case. Then
+    // shortcut handling could malfunction. So activate it.
+    // https://github.com/brave/brave-browser/issues/29993
     auto* widget = GetWidget();
     DCHECK(widget);
     widget = widget->GetTopLevelWidget();
-
-    auto* browser_view =
-        BrowserView::GetBrowserViewForNativeWindow(widget->GetNativeWindow());
-    DCHECK(browser_view);
-
-    BrowserList::SetLastActive(browser_view->browser());
+    widget->Activate();
 
     return RootView::OnMousePressed(event);
 #endif


### PR DESCRIPTION
Uplift of #18242
Resolves https://github.com/brave/brave-browser/issues/29993

Pre-approval checklist: 
- [ ] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [ ] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [ ] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [ ] The associated issue milestone is set to the smallest version that the changes is landed on.