### PR TITLE
Show window title with vertical tabs on Windows

### DIFF
--- a/browser/ui/tabs/brave_tab_prefs.cc
+++ b/browser/ui/tabs/brave_tab_prefs.cc
@@ -23,7 +23,13 @@ void RegisterBraveProfilePrefs(PrefRegistrySimple* registry) {
   registry->RegisterIntegerPref(kTabHoverMode, TabHoverMode::CARD);
   registry->RegisterBooleanPref(kVerticalTabsEnabled, false);
   registry->RegisterBooleanPref(kVerticalTabsCollapsed, false);
+#if BUILDFLAG(IS_WIN)
+  // On Windows, we show window title by default
+  // https://github.com/brave/brave-browser/issues/30027
+  registry->RegisterBooleanPref(kVerticalTabsShowTitleOnWindow, true);
+#else
   registry->RegisterBooleanPref(kVerticalTabsShowTitleOnWindow, false);
+#endif
   registry->RegisterBooleanPref(kVerticalTabsFloatingEnabled, true);
 }
 

--- a/browser/ui/views/tabs/vertical_tab_strip_browsertest.cc
+++ b/browser/ui/views/tabs/vertical_tab_strip_browsertest.cc
@@ -234,7 +234,7 @@ IN_PROC_BROWSER_TEST_F(VerticalTabStripBrowserTest, WindowTitle) {
                                                true);
 #endif
 
-  // Pre-condition: Window title is "hidden" by default on vertical tabs
+  // Pre-condition: Window title visibility differs per platform
 #if BUILDFLAG(IS_WIN)
   constexpr bool kWindowTitleVisibleByDefault = true;
 #else

--- a/browser/ui/views/tabs/vertical_tab_strip_browsertest.cc
+++ b/browser/ui/views/tabs/vertical_tab_strip_browsertest.cc
@@ -233,20 +233,35 @@ IN_PROC_BROWSER_TEST_F(VerticalTabStripBrowserTest, WindowTitle) {
   browser()->profile()->GetPrefs()->SetBoolean(prefs::kUseCustomChromeFrame,
                                                true);
 #endif
-  // Pre-condition: Window title is "hidden" by default on vertical tabs
-  ASSERT_TRUE(tabs::utils::ShouldShowVerticalTabs(browser()));
-  ASSERT_FALSE(tabs::utils::ShouldShowWindowTitleForVerticalTabs(browser()));
-  ASSERT_FALSE(browser_view()->ShouldShowWindowTitle());
-  ASSERT_FALSE(IsWindowTitleViewVisible());
 
-  // Show window title bar
-  brave::ToggleWindowTitleVisibilityForVerticalTabs(browser());
-  browser_non_client_frame_view()->Layout();
-  EXPECT_TRUE(tabs::utils::ShouldShowWindowTitleForVerticalTabs(browser()));
-  EXPECT_TRUE(browser_view()->ShouldShowWindowTitle());
-  EXPECT_GE(browser_non_client_frame_view()->GetTopInset(/*restored=*/false),
-            0);
-  EXPECT_TRUE(IsWindowTitleViewVisible());
+  // Pre-condition: Window title is "hidden" by default on vertical tabs
+#if BUILDFLAG(IS_WIN)
+  constexpr bool kWindowTitleVisibleByDefault = true;
+#else
+  constexpr bool kWindowTitleVisibleByDefault = false;
+#endif
+
+  ASSERT_TRUE(tabs::utils::ShouldShowVerticalTabs(browser()));
+  ASSERT_EQ(kWindowTitleVisibleByDefault,
+            tabs::utils::ShouldShowWindowTitleForVerticalTabs(browser()));
+  ASSERT_EQ(kWindowTitleVisibleByDefault,
+            browser_view()->ShouldShowWindowTitle());
+  ASSERT_EQ(kWindowTitleVisibleByDefault, IsWindowTitleViewVisible());
+
+  auto check_if_window_title_gets_visible = [&]() {
+    // Show window title bar
+    brave::ToggleWindowTitleVisibilityForVerticalTabs(browser());
+    browser_non_client_frame_view()->Layout();
+    EXPECT_TRUE(tabs::utils::ShouldShowWindowTitleForVerticalTabs(browser()));
+    EXPECT_TRUE(browser_view()->ShouldShowWindowTitle());
+    EXPECT_GE(browser_non_client_frame_view()->GetTopInset(/*restored=*/false),
+              0);
+    EXPECT_TRUE(IsWindowTitleViewVisible());
+  };
+
+  if constexpr (!kWindowTitleVisibleByDefault) {
+    check_if_window_title_gets_visible();
+  }
 
   // Hide window title bar
   brave::ToggleWindowTitleVisibilityForVerticalTabs(browser());
@@ -260,6 +275,10 @@ IN_PROC_BROWSER_TEST_F(VerticalTabStripBrowserTest, WindowTitle) {
             browser_non_client_frame_view()->GetTopInset(/*restored=*/false));
 #endif
   EXPECT_FALSE(IsWindowTitleViewVisible());
+
+  if constexpr (kWindowTitleVisibleByDefault) {
+    check_if_window_title_gets_visible();
+  }
 }
 
 IN_PROC_BROWSER_TEST_F(VerticalTabStripBrowserTest, NewTabVisibility) {


### PR DESCRIPTION
We decided to show window title by default on Win.

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/30027

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-arm64, CI/skip-linux-x64, CI/skip-android, CI/skip-macos, CI/skip-ios, CI/skip-windows-arm64, CI/skip-windows-x64, CI/skip-windows-x86 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [ ] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
* Enable vertical tab on Windows
* Window title should be visible by default without changing option.
