### PR TITLE
Android Java code now uses webcompat_report_api_endpoint arg

### DIFF
--- a/android/BUILD.gn
+++ b/android/BUILD.gn
@@ -5,6 +5,7 @@
 
 import("//brave/components/ipfs/buildflags/buildflags.gni")
 import("//brave/components/p3a/buildflags.gni")
+import("//brave/components/webcompat_reporter/buildflags/buildflags.gni")
 import("//build/config/android/rules.gni")
 
 declare_args() {
@@ -25,5 +26,6 @@ java_cpp_template("brave_config_java") {
     "BRAVE_ANDROID_DEVELOPER_OPTIONS_CODE=\"$brave_android_developer_options_code\"",
     "BRAVE_ANDROID_P3A_ENABLED=$brave_p3a_enabled",
     "BRAVE_ANDROID_ENABLE_IPFS=$enable_ipfs",
+    "BRAVE_ANDROID_WEBCOMPAT_REPORT_ENDPOINT=\"$webcompat_report_api_endpoint\"",
   ]
 }

--- a/android/java/org/chromium/chrome/browser/shields/BraveShieldsHandler.java
+++ b/android/java/org/chromium/chrome/browser/shields/BraveShieldsHandler.java
@@ -78,6 +78,7 @@ import org.chromium.chrome.browser.app.BraveActivity;
 import org.chromium.chrome.browser.brave_stats.BraveStatsUtil;
 import org.chromium.chrome.browser.flags.ChromeFeatureList;
 import org.chromium.chrome.browser.night_mode.GlobalNightModeStateProviderHolder;
+import org.chromium.chrome.browser.ntp_background_images.NTPBackgroundImagesBridge;
 import org.chromium.chrome.browser.onboarding.OnboardingPrefManager;
 import org.chromium.chrome.browser.preferences.website.BraveShieldsContentSettings;
 import org.chromium.chrome.browser.profiles.Profile;
@@ -831,7 +832,12 @@ public class BraveShieldsHandler implements BraveRewardsHelper.LargeIconReadyCal
         mSubmitButton.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View view) {
-                BraveShieldsUtils.BraveShieldsWorkerTask mWorkerTask = new BraveShieldsUtils.BraveShieldsWorkerTask(mTitle);
+                // Profile.getLastUsedRegularProfile requires to run in UI thread,
+                // so get api key here and pass it to IO worker task
+                String referralApiKey =
+                        NTPBackgroundImagesBridge.getInstance(mProfile).getReferralApiKey();
+                BraveShieldsUtils.BraveShieldsWorkerTask mWorkerTask =
+                        new BraveShieldsUtils.BraveShieldsWorkerTask(mTitle, referralApiKey);
                 mWorkerTask.executeOnExecutor(AsyncTask.THREAD_POOL_EXECUTOR);
                 mReportBrokenSiteLayout.setVisibility(View.GONE);
                 mThankYouLayout.setVisibility(View.VISIBLE);

--- a/build/android/java/templates/BraveConfig.template
+++ b/build/android/java/templates/BraveConfig.template
@@ -12,4 +12,5 @@ public class BraveConfig {
   public static final String DEVELOPER_OPTIONS_CODE = BRAVE_ANDROID_DEVELOPER_OPTIONS_CODE;
   public static final boolean P3A_ENABLED = BRAVE_ANDROID_P3A_ENABLED;
   public static final boolean IPFS_ENABLED = BRAVE_ANDROID_ENABLE_IPFS;
+  public static final String WEBCOMPAT_REPORT_ENDPOINT = BRAVE_ANDROID_WEBCOMPAT_REPORT_ENDPOINT;
 }

--- a/components/webcompat_reporter/browser/BUILD.gn
+++ b/components/webcompat_reporter/browser/BUILD.gn
@@ -3,19 +3,9 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this file,
 # You can obtain one at https://mozilla.org/MPL/2.0/.
 
-import("//build/buildflag_header.gni")
 import("//build/config/features.gni")
 
 assert(!is_android)
-
-declare_args() {
-  webcompat_report_api_endpoint = "https://webcompat.brave.com/1/webcompat"
-}
-
-buildflag_header("buildflags") {
-  header = "buildflags.h"
-  flags = [ "WEBCOMPAT_REPORT_ENDPOINT=\"$webcompat_report_api_endpoint\"" ]
-}
 
 static_library("browser") {
   sources = [
@@ -24,11 +14,11 @@ static_library("browser") {
   ]
 
   deps = [
-    ":buildflags",
     "//base",
     "//brave/components/brave_referrals/browser",
     "//brave/components/brave_stats/browser",
     "//brave/components/constants",
+    "//brave/components/webcompat_reporter/buildflags",
     "//content/public/browser",
     "//net",
     "//services/network/public/cpp",

--- a/components/webcompat_reporter/browser/webcompat_report_uploader.cc
+++ b/components/webcompat_reporter/browser/webcompat_report_uploader.cc
@@ -13,7 +13,7 @@
 #include "base/json/json_writer.h"
 #include "brave/components/brave_referrals/browser/brave_referrals_service.h"
 #include "brave/components/brave_stats/browser/brave_stats_updater_util.h"
-#include "brave/components/webcompat_reporter/browser/buildflags.h"
+#include "brave/components/webcompat_reporter/buildflags/buildflags.h"
 #include "content/public/browser/browser_task_traits.h"
 #include "net/base/load_flags.h"
 #include "net/base/privacy_mode.h"

--- a/components/webcompat_reporter/buildflags/BUILD.gn
+++ b/components/webcompat_reporter/buildflags/BUILD.gn
@@ -1,0 +1,12 @@
+# Copyright (c) 2023 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import("//brave/components/webcompat_reporter/buildflags/buildflags.gni")
+import("//build/buildflag_header.gni")
+
+buildflag_header("buildflags") {
+  header = "buildflags.h"
+  flags = [ "WEBCOMPAT_REPORT_ENDPOINT=\"$webcompat_report_api_endpoint\"" ]
+}

--- a/components/webcompat_reporter/buildflags/buildflags.gni
+++ b/components/webcompat_reporter/buildflags/buildflags.gni
@@ -1,0 +1,8 @@
+# Copyright (c) 2023 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+
+declare_args() {
+  webcompat_report_api_endpoint = "https://webcompat.brave.com/1/webcompat"
+}


### PR DESCRIPTION
This PR brings `WEBCOMPAT_REPORT_ENDPOINT` from `.npmrc` into `BraveConfig.java` so Android uses now the same url as desktop.

Also was fixed failed assertion at `Profile.getLastUsedRegularProfile()` from non-UI thread, so it was impossible to send feedback from debug build.

During my tests I saw SUCCESS status just once and many times I saw status 500 (internal server error)  - with both new (`https://webcompat.brave.com/1/webcompat`) and old (`https://laptop-updates.brave.com/1/webcompat`) urls. Maybe it happened because `brave_stats_api_key` is required, but I don't have it.

Besides all this PR fixes build-time warning introduced at https://github.com/brave/brave-core/pull/18129
```
WARNING at the command-line "--args":1:2314: Build argument has no effect.
webcompat_report_api_endpoint="https://webcompat.brave.com/1/webcompat"
                              ^----------------------------------------
The variable "webcompat_report_api_endpoint" was set as a build argument
but never appeared in a declare_args() block in any buildfile.
```

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/30034

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-arm64, CI/skip-linux-x64, CI/skip-android, CI/skip-macos, CI/skip-ios, CI/skip-windows-arm64, CI/skip-windows-x64, CI/skip-windows-x86 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
1. Open some website
2. Turn the shields off
3. Press `Report a broken site`, expected not to crash and see `Thank you` message.

