### PR TITLE
Ensure monthly tips have a valid next contribution date

### DIFF
--- a/components/brave_rewards/core/contribution/contribution_monthly.cc
+++ b/components/brave_rewards/core/contribution/contribution_monthly.cc
@@ -78,6 +78,8 @@ void ContributionMonthly::OnNextContributionDateAdvanced(
            publisher->status == mojom::PublisherStatus::NOT_VERIFIED;
   });
 
+  BLOG(1, "Sending " << publishers.size() << " monthly contributions");
+
   for (const auto& item : publishers) {
     auto publisher = mojom::ContributionQueuePublisher::New();
     publisher->publisher_key = item->id;


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/29859

### Underlying Issue:

Prior to 1.52, monthly contributions are set to go out at the next "reconcile time" (the same as AC) and they may have a NULL value in the `next_contribution_at` field. When `next_contribution_at` is NULL, we use the current "reconcile stamp" value instead (the timestamp for the next AC) to determine when to trigger the next monthly contribution timer, and also to determine (once the timer is triggered) whether the next contribution is in the future.

The issue arises because the "reconcile stamp" may be updated in between the time when the monthly contribution timer is set and when the monthly contribution records are read. If this happens, then the monthly contribution date will appear to be a month out and will not be sent.

### Solution:

Arguably, we should have used a database migration to set all monthly contribution `next_contribution_at` fields. However, since we cannot use a migration now, this change will ensure that `next_contribution_at` values are set before setting the monthly contribution timer. This will ensure that when monthly contributions are processed the correct timestamp is used.

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-arm64, CI/skip-linux-x64, CI/skip-android, CI/skip-macos, CI/skip-ios, CI/skip-windows-arm64, CI/skip-windows-x64, CI/skip-windows-x86 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [ ] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

In `1.53` and `1.52`, monthly contributions are always given a valid date when created and the underlying issue will not reproduce. To test on those versions, we can perform [steps 1-6](https://github.com/brave/brave-browser/issues/29859#issuecomment-1525713378) in `1.51`, and then perform the remaining steps with a version that contains this fix. 