### PR TITLE
Auto Discovery for Filecoin and Solana Accounts

### DIFF
--- a/components/brave_wallet/browser/BUILD.gn
+++ b/components/brave_wallet/browser/BUILD.gn
@@ -20,6 +20,8 @@ if (is_official_build) {
 
 static_library("browser") {
   sources = [
+    "account_discovery_manager.cc",
+    "account_discovery_manager.h",
     "asset_discovery_manager.cc",
     "asset_discovery_manager.h",
     "asset_discovery_task.cc",

--- a/components/brave_wallet/browser/account_discovery_manager.cc
+++ b/components/brave_wallet/browser/account_discovery_manager.cc
@@ -1,0 +1,159 @@
+// Copyright (c) 2023 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#include "brave/components/brave_wallet/browser/account_discovery_manager.h"
+
+#include "brave/components/brave_wallet/browser/brave_wallet_utils.h"
+#include "brave/components/brave_wallet/browser/json_rpc_service.h"
+
+namespace brave_wallet {
+namespace {
+const int kDiscoveryAttempts = 20;
+}
+
+AccountDiscoveryManager::DiscoveryContext::DiscoveryContext(
+    const mojom::CoinType& coin_type,
+    const std::string& keyring_id,
+    const std::string& chain_id,
+    size_t discovery_account_index,
+    int attempts_left)
+    : coin_type(coin_type),
+      keyring_id(keyring_id),
+      chain_id(chain_id),
+      discovery_account_index(discovery_account_index),
+      attempts_left(attempts_left) {}
+
+AccountDiscoveryManager::DiscoveryContext::~DiscoveryContext() = default;
+
+AccountDiscoveryManager::AccountDiscoveryManager(
+    JsonRpcService* rpc_service,
+    KeyringService* keyring_service)
+    : json_rpc_service_(rpc_service), keyring_service_(keyring_service) {}
+
+void AccountDiscoveryManager::StartDiscovery() {
+  if (keyring_service_->IsKeyringCreated(mojom::kDefaultKeyringId)) {
+    AddDiscoveryAccount(std::make_unique<DiscoveryContext>(
+        mojom::CoinType::ETH, mojom::kDefaultKeyringId, mojom::kMainnetChainId,
+        keyring_service_->GetAccountsNumber(mojom::kDefaultKeyringId)
+            .value_or(0),
+        kDiscoveryAttempts));
+  }
+  if (IsFilecoinEnabled() &&
+      keyring_service_->IsKeyringCreated(mojom::kFilecoinKeyringId)) {
+    AddDiscoveryAccount(std::make_unique<DiscoveryContext>(
+        mojom::CoinType::FIL, mojom::kFilecoinKeyringId,
+        mojom::kFilecoinMainnet,
+        keyring_service_->GetAccountsNumber(mojom::kFilecoinKeyringId)
+            .value_or(0),
+        kDiscoveryAttempts));
+  }
+  if (IsSolanaEnabled() &&
+      keyring_service_->IsKeyringCreated(mojom::kSolanaKeyringId)) {
+    AddDiscoveryAccount(std::make_unique<DiscoveryContext>(
+        mojom::CoinType::SOL, mojom::kSolanaKeyringId, mojom::kSolanaMainnet,
+        keyring_service_->GetAccountsNumber(mojom::kSolanaKeyringId)
+            .value_or(0),
+        kDiscoveryAttempts));
+  }
+}
+
+AccountDiscoveryManager::~AccountDiscoveryManager() {}
+
+void AccountDiscoveryManager::AddDiscoveryAccount(
+    std::unique_ptr<DiscoveryContext> context) {
+  if (context->attempts_left <= 0) {
+    return;
+  }
+
+  auto addr = keyring_service_->GetDiscoveryAddress(
+      context->keyring_id, context->discovery_account_index);
+  if (!addr) {
+    NOTREACHED();
+    return;
+  }
+
+  auto chain_id = context->chain_id;
+  auto coin_type = context->coin_type;
+  if (context->coin_type == mojom::CoinType::ETH) {
+    json_rpc_service_->GetEthTransactionCount(
+        chain_id, addr.value(),
+        base::BindOnce(&AccountDiscoveryManager::OnEthGetTransactionCount,
+                       weak_ptr_factory_.GetWeakPtr(), std::move(context)));
+  } else if (context->coin_type == mojom::CoinType::SOL) {
+    json_rpc_service_->GetSolanaBalance(
+        addr.value(), chain_id,
+        base::BindOnce(&AccountDiscoveryManager::OnResolveSolanaAccountBalance,
+                       weak_ptr_factory_.GetWeakPtr(), std::move(context)));
+  } else if (context->coin_type == mojom::CoinType::FIL) {
+    json_rpc_service_->GetBalance(
+        addr.value(), coin_type, chain_id,
+        base::BindOnce(&AccountDiscoveryManager::OnResolveAccountBalance,
+                       weak_ptr_factory_.GetWeakPtr(), std::move(context)));
+
+  } else {
+    NOTREACHED();
+  }
+}
+
+void AccountDiscoveryManager::OnResolveAccountBalance(
+    std::unique_ptr<DiscoveryContext> context,
+    const std::string& value,
+    mojom::ProviderError error,
+    const std::string& error_message) {
+  if (error != mojom::ProviderError::kSuccess) {
+    return;
+  }
+  ProcessDiscoveryResult(std::move(context), value != "0");
+}
+
+void AccountDiscoveryManager::OnResolveSolanaAccountBalance(
+    std::unique_ptr<DiscoveryContext> context,
+    uint64_t value,
+    mojom::SolanaProviderError error,
+    const std::string& error_message) {
+  if (error != mojom::SolanaProviderError::kSuccess) {
+    return;
+  }
+  ProcessDiscoveryResult(std::move(context), value > 0);
+}
+
+void AccountDiscoveryManager::OnEthGetTransactionCount(
+    std::unique_ptr<DiscoveryContext> context,
+    uint256_t result,
+    mojom::ProviderError error,
+    const std::string& error_message) {
+  if (error != mojom::ProviderError::kSuccess) {
+    return;
+  }
+  ProcessDiscoveryResult(std::move(context), result > 0);
+}
+
+void AccountDiscoveryManager::ProcessDiscoveryResult(
+    std::unique_ptr<DiscoveryContext> context,
+    bool result) {
+  if (result) {
+    auto last_account_index =
+        keyring_service_->GetAccountsNumber(context->keyring_id);
+    if (!last_account_index) {
+      NOTREACHED();
+      return;
+    }
+    if (context->discovery_account_index + 1 > last_account_index.value()) {
+      keyring_service_->AddAccountsWithDefaultName(
+          context->coin_type, context->keyring_id,
+          context->discovery_account_index - last_account_index.value() + 1);
+    }
+
+    context->discovery_account_index++;
+    context->attempts_left = kDiscoveryAttempts;
+    AddDiscoveryAccount(std::move(context));
+  } else {
+    context->discovery_account_index++;
+    context->attempts_left--;
+    AddDiscoveryAccount(std::move(context));
+  }
+}
+
+}  // namespace brave_wallet

--- a/components/brave_wallet/browser/account_discovery_manager.cc
+++ b/components/brave_wallet/browser/account_discovery_manager.cc
@@ -82,11 +82,16 @@ void AccountDiscoveryManager::AddDiscoveryAccount(
         base::BindOnce(&AccountDiscoveryManager::OnEthGetTransactionCount,
                        weak_ptr_factory_.GetWeakPtr(), std::move(context)));
   } else if (context->coin_type == mojom::CoinType::SOL) {
+    // We use balance for Solana account discovery since pratically
+    // getSignaturesForAddress method could work not properly sometimes when
+    // node losts bigtable connection
     json_rpc_service_->GetSolanaBalance(
         addr.value(), chain_id,
         base::BindOnce(&AccountDiscoveryManager::OnResolveSolanaAccountBalance,
                        weak_ptr_factory_.GetWeakPtr(), std::move(context)));
   } else if (context->coin_type == mojom::CoinType::FIL) {
+    // We use balance for Filecoin account discovery since proper method is
+    // limited https://github.com/filecoin-project/lotus/issues/9728
     json_rpc_service_->GetBalance(
         addr.value(), coin_type, chain_id,
         base::BindOnce(&AccountDiscoveryManager::OnResolveAccountBalance,

--- a/components/brave_wallet/browser/account_discovery_manager.h
+++ b/components/brave_wallet/browser/account_discovery_manager.h
@@ -1,0 +1,71 @@
+// Copyright (c) 2023 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#ifndef BRAVE_COMPONENTS_BRAVE_WALLET_BROWSER_ACCOUNT_DISCOVERY_MANAGER_H_
+#define BRAVE_COMPONENTS_BRAVE_WALLET_BROWSER_ACCOUNT_DISCOVERY_MANAGER_H_
+
+#include <memory>
+#include <string>
+#include <utility>
+
+#include "base/memory/raw_ptr.h"
+#include "base/memory/weak_ptr.h"
+#include "brave/components/brave_wallet/browser/brave_wallet_utils.h"
+#include "brave/components/brave_wallet/browser/json_rpc_service.h"
+#include "brave/components/brave_wallet/browser/keyring_service.h"
+#include "components/prefs/pref_service.h"
+
+namespace brave_wallet {
+
+class AccountDiscoveryManager {
+ public:
+  AccountDiscoveryManager(JsonRpcService* rpc_service,
+                          KeyringService* keyring_service);
+  ~AccountDiscoveryManager();
+
+  void StartDiscovery();
+
+ private:
+  struct DiscoveryContext {
+    DiscoveryContext(const mojom::CoinType& coin_type,
+                     const std::string& keyring_id,
+                     const std::string& chain_id,
+                     size_t discovery_account_index,
+                     int attempts_left);
+    ~DiscoveryContext();
+    mojom::CoinType coin_type;
+    std::string keyring_id;
+    std::string chain_id;
+    size_t discovery_account_index;
+    int attempts_left;
+  };
+
+  void AddDiscoveryAccount(std::unique_ptr<DiscoveryContext> context);
+
+  void OnEthGetTransactionCount(std::unique_ptr<DiscoveryContext> context,
+                                uint256_t result,
+                                mojom::ProviderError error,
+                                const std::string& error_message);
+  void OnResolveAccountBalance(std::unique_ptr<DiscoveryContext> context,
+                               const std::string& value,
+                               mojom::ProviderError error,
+                               const std::string& error_message);
+  void OnResolveSolanaAccountBalance(std::unique_ptr<DiscoveryContext> context,
+                                     uint64_t value,
+                                     mojom::SolanaProviderError error,
+                                     const std::string& error_message);
+
+  void ProcessDiscoveryResult(std::unique_ptr<DiscoveryContext> context,
+                              bool result);
+
+  raw_ptr<brave_wallet::JsonRpcService> json_rpc_service_;
+  raw_ptr<brave_wallet::KeyringService> keyring_service_;
+
+  base::WeakPtrFactory<AccountDiscoveryManager> weak_ptr_factory_{this};
+};
+
+}  // namespace brave_wallet
+
+#endif  // BRAVE_COMPONENTS_BRAVE_WALLET_BROWSER_ACCOUNT_DISCOVERY_MANAGER_H_

--- a/components/brave_wallet/browser/account_discovery_manager.h
+++ b/components/brave_wallet/browser/account_discovery_manager.h
@@ -19,6 +19,10 @@
 
 namespace brave_wallet {
 
+// Start account discovery process. Consecutively look for accounts with at
+// least one transaction. Add such ones and all missing previous ones(so no
+// gaps). Stop discovering when there are 20 consecutive accounts with no
+// transactions.
 class AccountDiscoveryManager {
  public:
   AccountDiscoveryManager(JsonRpcService* rpc_service,

--- a/components/brave_wallet/browser/brave_wallet_service.cc
+++ b/components/brave_wallet/browser/brave_wallet_service.cc
@@ -1293,8 +1293,9 @@ void BraveWalletService::OnGetImportInfo(
               return;
             }
             if (number_of_accounts > 1) {
-              keyring_service->AddAccountsWithDefaultName(number_of_accounts -
-                                                          1);
+              keyring_service->AddAccountsWithDefaultName(
+                  mojom::CoinType::ETH, mojom::kDefaultKeyringId,
+                  number_of_accounts - 1);
             }
             std::move(callback).Run(is_valid_mnemonic, absl::nullopt);
           },

--- a/components/brave_wallet/browser/keyring_service.cc
+++ b/components/brave_wallet/browser/keyring_service.cc
@@ -13,6 +13,7 @@
 #include "base/command_line.h"
 #include "base/logging.h"
 #include "base/notreached.h"
+#include "base/strings/strcat.h"
 #include "base/strings/string_number_conversions.h"
 #include "base/strings/string_split.h"
 #include "base/strings/string_util.h"
@@ -1709,8 +1710,8 @@ void KeyringService::AddAccountsWithDefaultName(
     } else if (coin_type == mojom::CoinType::SOL) {
       prefix = "Solana ";
     }
-    auto add_result =
-        AddAccountForKeyring(keyring_id, prefix + GetAccountName(i));
+    auto add_result = AddAccountForKeyring(
+        keyring_id, base::StrCat({prefix, GetAccountName(i)}));
     if (add_result) {
       account_infos.push_back(add_result.value());
     }

--- a/components/brave_wallet/browser/keyring_service.cc
+++ b/components/brave_wallet/browser/keyring_service.cc
@@ -137,7 +137,6 @@ const char kLegacyBraveWallet[] = "legacy_brave_wallet";
 const char kHardwareAccounts[] = "hardware";
 const char kHardwareDerivationPath[] = "derivation_path";
 const char kSelectedAccount[] = "selected_account";
-const int kDiscoveryAttempts = 20;
 const char kKeyringNotFound[] = "";
 
 std::string GetRootPath(const std::string& keyring_id) {
@@ -688,11 +687,6 @@ HDKeyring* KeyringService::RestoreKeyring(const std::string& keyring_id,
     return nullptr;
   }
 
-  // Some keyrings just create encryptors for lazily keyring creation.
-  if (keyring_id != mojom::kDefaultKeyringId && !IsBitcoinKeyring(keyring_id)) {
-    return nullptr;
-  }
-
   auto* keyring =
       CreateKeyringInternal(keyring_id, mnemonic, is_legacy_brave_wallet);
   if (!keyring) {
@@ -837,32 +831,9 @@ void KeyringService::RestoreWallet(const std::string& mnemonic,
 
   if (IsFilecoinEnabled()) {
     // Restore mainnet filecoin acc
-    auto* filecoin_keyring =
-        RestoreKeyring(mojom::kFilecoinKeyringId, mnemonic, password, false);
-    if (filecoin_keyring && !GetDerivedAccountsNumberForKeyring(
-                                profile_prefs_, mojom::kFilecoinKeyringId)) {
-      auto address =
-          AddAccountForKeyring(mojom::kFilecoinKeyringId, GetAccountName(1));
-      if (address) {
-        SetPrefForKeyring(profile_prefs_, kSelectedAccount,
-                          base::Value(*address), mojom::kFilecoinKeyringId);
-      }
-    }
-
+    RestoreKeyring(mojom::kFilecoinKeyringId, mnemonic, password, false);
     // Restore testnet filecoin acc
-    auto* testnet_filecoin_keyring = RestoreKeyring(
-        mojom::kFilecoinTestnetKeyringId, mnemonic, password, false);
-    if (testnet_filecoin_keyring &&
-        !GetDerivedAccountsNumberForKeyring(profile_prefs_,
-                                            mojom::kFilecoinTestnetKeyringId)) {
-      auto address = AddAccountForKeyring(mojom::kFilecoinTestnetKeyringId,
-                                          GetAccountName(1));
-      if (address) {
-        SetPrefForKeyring(profile_prefs_, kSelectedAccount,
-                          base::Value(*address),
-                          mojom::kFilecoinTestnetKeyringId);
-      }
-    }
+    RestoreKeyring(mojom::kFilecoinTestnetKeyringId, mnemonic, password, false);
   }
 
   if (IsSolanaEnabled()) {
@@ -870,14 +841,6 @@ void KeyringService::RestoreWallet(const std::string& mnemonic,
         RestoreKeyring(mojom::kSolanaKeyringId, mnemonic, password, false);
     if (solana_keyring && !GetDerivedAccountsNumberForKeyring(
                               profile_prefs_, mojom::kSolanaKeyringId)) {
-      auto address =
-          AddAccountForKeyring(mojom::kSolanaKeyringId, GetAccountName(1));
-      if (address) {
-        SetPrefForKeyring(profile_prefs_, kSelectedAccount,
-                          base::Value(*address), mojom::kSolanaKeyringId);
-        NotifyAccountsAdded(mojom::CoinType::SOL, {address.value()});
-      }
-    } else {
       MaybeCreateDefaultSolanaAccount();
     }
   }
@@ -887,14 +850,9 @@ void KeyringService::RestoreWallet(const std::string& mnemonic,
     RestoreKeyring(mojom::kBitcoinKeyring84TestId, mnemonic, password, false);
   }
 
-  if (keyring) {
-    discovery_weak_factory_.InvalidateWeakPtrs();
-    // Start account discovery process. Consecutively look for accounts with at
-    // least one transaction. Add such ones and all missing previous ones(so no
-    // gaps). Stop discovering when there are 20 consecutive accounts with no
-    // transactions.
-    AddDiscoveryAccountsForKeyring(1, kDiscoveryAttempts);
-  }
+  account_discovery_manager_ =
+      std::make_unique<AccountDiscoveryManager>(json_rpc_service_, this);
+  account_discovery_manager_->StartDiscovery();
 
   std::move(callback).Run(keyring);
 }
@@ -1434,56 +1392,6 @@ absl::optional<std::string> KeyringService::AddAccountForKeyring(
   return added_accounts[0].address;
 }
 
-void KeyringService::AddDiscoveryAccountsForKeyring(
-    size_t discovery_account_index,
-    int attempts_left) {
-  if (attempts_left <= 0) {
-    return;
-  }
-  auto* keyring = GetHDKeyringById(mojom::kDefaultKeyringId);
-  if (!keyring) {
-    return;
-  }
-  json_rpc_service_->GetEthTransactionCount(
-      mojom::kMainnetChainId,
-      keyring->GetDiscoveryAddress(discovery_account_index),
-      base::BindOnce(&KeyringService::OnGetTransactionCount,
-                     discovery_weak_factory_.GetWeakPtr(),
-                     discovery_account_index, attempts_left));
-}
-
-void KeyringService::OnGetTransactionCount(size_t discovery_account_index,
-                                           int attempts_left,
-                                           uint256_t result,
-                                           mojom::ProviderError error,
-                                           const std::string& error_message) {
-  if (error != mojom::ProviderError::kSuccess) {
-    return;
-  }
-
-  if (result > 0) {
-    auto* keyring = GetHDKeyringById(mojom::kDefaultKeyringId);
-    if (!keyring) {
-      return;
-    }
-
-    size_t last_account_index = GetDerivedAccountsNumberForKeyring(
-        profile_prefs_, mojom::kDefaultKeyringId);
-    DCHECK_GT(last_account_index, 0u);
-    last_account_index--;
-    if (discovery_account_index > last_account_index) {
-      AddAccountsWithDefaultName(discovery_account_index - last_account_index);
-      NotifyAccountsChanged();
-    }
-
-    AddDiscoveryAccountsForKeyring(discovery_account_index + 1,
-                                   kDiscoveryAttempts);
-  } else {
-    AddDiscoveryAccountsForKeyring(discovery_account_index + 1,
-                                   attempts_left - 1);
-  }
-}
-
 absl::optional<std::string> KeyringService::ImportAccountForKeyring(
     const std::string& keyring_id,
     const std::string& account_name,
@@ -1673,6 +1581,16 @@ absl::optional<std::string> KeyringService::SignTransactionByFilecoinKeyring(
   return static_cast<FilecoinKeyring*>(keyring)->SignTransaction(tx);
 }
 
+absl::optional<std::string> KeyringService::GetDiscoveryAddress(
+    std::string keyring_id,
+    int index) {
+  auto* hd_keyring = GetHDKeyringById(keyring_id);
+  if (!hd_keyring) {
+    return absl::nullopt;
+  }
+  return hd_keyring->GetDiscoveryAddress(index);
+}
+
 void KeyringService::SignTransactionByDefaultKeyring(const std::string& address,
                                                      EthTransaction* tx,
                                                      uint256_t chain_id) {
@@ -1771,18 +1689,34 @@ std::vector<uint8_t> KeyringService::SignMessageBySolanaKeyring(
   return keyring->SignMessage(address, message);
 }
 
-void KeyringService::AddAccountsWithDefaultName(size_t number) {
-  auto* keyring = GetHDKeyringById(mojom::kDefaultKeyringId);
+void KeyringService::AddAccountsWithDefaultName(
+    const mojom::CoinType& coin_type,
+    const std::string& keyring_id,
+    size_t number) {
+  auto* keyring = GetHDKeyringById(keyring_id);
   if (!keyring) {
-    DCHECK(false) << "Should only be called when default keyring exists";
+    NOTREACHED();
     return;
   }
 
-  size_t current_num = GetDerivedAccountsNumberForKeyring(
-      profile_prefs_, mojom::kDefaultKeyringId);
+  std::vector<std::string> account_infos;
+  size_t current_num =
+      GetDerivedAccountsNumberForKeyring(profile_prefs_, keyring_id);
   for (size_t i = current_num + 1; i <= current_num + number; ++i) {
-    AddAccountForKeyring(mojom::kDefaultKeyringId, GetAccountName(i));
+    std::string prefix;
+    if (coin_type == mojom::CoinType::FIL) {
+      prefix = "Filecoin ";
+    } else if (coin_type == mojom::CoinType::SOL) {
+      prefix = "Solana ";
+    }
+    auto add_result =
+        AddAccountForKeyring(keyring_id, prefix + GetAccountName(i));
+    if (add_result) {
+      account_infos.push_back(add_result.value());
+    }
   }
+  NotifyAccountsChanged();
+  NotifyAccountsAdded(coin_type, account_infos);
 }
 
 bool KeyringService::IsLocked(const std::string& keyring_id) const {
@@ -1934,10 +1868,10 @@ void KeyringService::IsLocked(IsLockedCallback callback) {
 }
 
 void KeyringService::Reset(bool notify_observer) {
+  account_discovery_manager_.reset();
   StopAutoLockTimer();
   encryptors_.clear();
   keyrings_.clear();
-  discovery_weak_factory_.InvalidateWeakPtrs();
   ClearKeyringServiceProfilePrefs(profile_prefs_);
   if (notify_observer) {
     for (const auto& observer : observers_) {
@@ -2567,6 +2501,15 @@ KeyringService::SignMessageByBitcoinKeyring(
   }
 
   return bitcoin_keyring->SignMessage(key_id, message);
+}
+
+absl::optional<size_t> KeyringService::GetAccountsNumber(
+    const std::string& keyring_id) {
+  auto* keyring = GetHDKeyringById(keyring_id);
+  if (!keyring) {
+    return absl::nullopt;
+  }
+  return keyring->GetAccounts().size();
 }
 
 void KeyringService::MaybeUnlockWithCommandLine() {

--- a/components/brave_wallet/browser/keyring_service.h
+++ b/components/brave_wallet/browser/keyring_service.h
@@ -208,9 +208,9 @@ class KeyringService : public KeyedService, public mojom::KeyringService {
       const std::vector<uint8_t>& ciphertext,
       const std::string& address);
 
-  virtual void AddAccountsWithDefaultName(const mojom::CoinType& coin_type,
-                                          const std::string& keyring_id,
-                                          size_t number);
+  void AddAccountsWithDefaultName(const mojom::CoinType& coin_type,
+                                  const std::string& keyring_id,
+                                  size_t number);
 
   bool IsLocked(const std::string& keyring_id) const;
   bool IsLockedSync() const;


### PR DESCRIPTION
Resolves https://github.com/brave/brave-browser/issues/28002
Resolves https://github.com/brave/brave-browser/issues/22969

Filecoin and Solana accounts discovery:
Discovery process is moved to a new class AccountDiscoveryManager.
Since Filecoin transactions discovery is currently disabled https://github.com/filecoin-project/lotus/issues/9728 and Solana 
[getSignaturesForAddress](https://docs.solana.com/api/http#getsignaturesforaddress) method is working, unstable we use balance fetching instead.
Lazily keyring creation is partly removed since keyrings are needed when wallet is restored.


<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-arm64, CI/skip-linux-x64, CI/skip-android, CI/skip-macos, CI/skip-ios, CI/skip-windows-arm64, CI/skip-windows-x64, CI/skip-windows-x86 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
Verify that accounts with non-zero balance(for SOL and FIL) or non-zero transactions count(ETH) are restored when wallet is restored from seed phrase.
Test cases could be taken from https://github.com/brave/brave-browser/issues/18104 