### PR TITLE
fix: add block explorer link for unknown tokens

### DIFF
--- a/components/brave_wallet_ui/common/constants/magics.ts
+++ b/components/brave_wallet_ui/common/constants/magics.ts
@@ -8,3 +8,9 @@ export const MAX_UINT256 = '0xffffffffffffffffffffffffffffffffffffffffffffffffff
 export const NATIVE_ASSET_CONTRACT_ADDRESS_0X = '0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee'
 
 export const WRAPPED_SOL_CONTRACT_ADDRESS = 'So11111111111111111111111111111111111111112'
+
+/**
+ * Set this as a token's coingecko id to flag the token as "unknown"
+ * This will allow for fallback UI when we do have all the required token info
+ */
+export const UNKNOWN_TOKEN_COINGECKO_ID = 'UNKNOWN_TOKEN'

--- a/components/brave_wallet_ui/components/extension/confirm-transaction-panel/swap.tsx
+++ b/components/brave_wallet_ui/components/extension/confirm-transaction-panel/swap.tsx
@@ -9,6 +9,7 @@ import * as React from 'react'
 import { WalletSelectors } from '../../../common/selectors'
 import { getLocale } from '../../../../common/locale'
 import Amount from '../../../utils/amount'
+import { openBlockExplorerURL } from '../../../utils/block-explorer-utils'
 
 // Styled components
 import {
@@ -51,6 +52,7 @@ import AdvancedTransactionSettings from '../advanced-transaction-settings'
 
 // Types
 import { BraveWallet } from '../../../constants/types'
+import { UNKNOWN_TOKEN_COINGECKO_ID } from '../../../common/constants/magics'
 
 // Hooks
 import { usePendingTransactions } from '../../../common/hooks/use-pending-transaction'
@@ -146,7 +148,11 @@ export function ConfirmSwapTransaction (props: Props) {
       {transactionDetails?.sellToken &&
         transactionDetails?.buyToken &&
         transactionDetails?.minBuyAmount &&
-        transactionDetails?.sellAmount && (
+        transactionDetails?.sellAmount &&
+        transactionDetails?.buyToken?.coingeckoId !==
+          UNKNOWN_TOKEN_COINGECKO_ID &&
+        transactionDetails?.sellToken?.coingeckoId !==
+          UNKNOWN_TOKEN_COINGECKO_ID && (
           <ExchangeRate>
             1 {transactionDetails.sellToken.symbol} ={' '}
             {transactionDetails.minBuyAmount
@@ -250,6 +256,9 @@ function SwapAsset (props: SwapAssetProps) {
     return ''
   }, [network])
 
+  // computed
+  const isUnknownAsset = asset?.coingeckoId === UNKNOWN_TOKEN_COINGECKO_ID
+
   return (
     <SwapAssetContainer top={type === 'maker'}>
       <SwapAssetHeader>
@@ -296,6 +305,19 @@ function SwapAsset (props: SwapAssetProps) {
               <LoadingSkeleton width={200} height={18} />
               <Spacer />
               <LoadingSkeleton width={200} height={18} />
+            </>
+          ) : isUnknownAsset ? (
+            <>
+              <SwapAssetAmountSymbol>{asset.symbol}</SwapAssetAmountSymbol>
+              <EditButton
+                onClick={openBlockExplorerURL({
+                  type: 'token',
+                  network,
+                  value: asset.contractAddress
+                })}
+              >
+                {getLocale('braveWalletTransactionExplorer')}
+              </EditButton>
             </>
           ) : (
             <>

--- a/components/brave_wallet_ui/stories/mock-data/mock-asset-options.ts
+++ b/components/brave_wallet_ui/stories/mock-data/mock-asset-options.ts
@@ -64,7 +64,7 @@ export const mockBinanceCoinErc20Token = {
 }
 
 export const mockBitcoinErc20Token = {
-  contractAddress: '4',
+  contractAddress: '0x2260fac5e5542a773aa44fbcfedf7c193bc2c599',
   name: 'Bitcoin',
   symbol: 'BTC',
   logo: BTCIconUrl,
@@ -133,6 +133,14 @@ export const mockMoonCatNFT = {
 
 export const mockAccountAssetOptions: BraveWallet.BlockchainToken[] = [
   mockEthToken,
+  mockBasicAttentionToken,
+  mockBinanceCoinErc20Token,
+  mockBitcoinErc20Token,
+  mockAlgorandErc20Token,
+  mockZrxErc20Token
+]
+
+export const mockErc20TokensList = [
   mockBasicAttentionToken,
   mockBinanceCoinErc20Token,
   mockBitcoinErc20Token,

--- a/components/brave_wallet_ui/utils/tx-utils.ts
+++ b/components/brave_wallet_ui/utils/tx-utils.ts
@@ -21,7 +21,11 @@ import {
   TransactionInfo
 } from '../constants/types'
 import { SolanaTransactionTypes } from '../common/constants/solana'
-import { MAX_UINT256, NATIVE_ASSET_CONTRACT_ADDRESS_0X } from '../common/constants/magics'
+import {
+  MAX_UINT256,
+  NATIVE_ASSET_CONTRACT_ADDRESS_0X,
+  UNKNOWN_TOKEN_COINGECKO_ID
+} from '../common/constants/magics'
 import { SwapExchangeProxy } from '../common/constants/registry'
 
 // utils
@@ -430,7 +434,24 @@ export const getETHSwapTransactionBuyAndSellTokens = ({
     .map(address =>
       address === NATIVE_ASSET_CONTRACT_ADDRESS_0X
         ? nativeAsset
-        : findTokenByContractAddress(address, tokensList) || nativeAsset
+        : findTokenByContractAddress(address, tokensList) ||
+        // token not found
+        // return a "faked" coin (will need to "discover" it later)
+        {
+          chainId: tx.chainId,
+          coin: getCoinFromTxDataUnion(tx.txDataUnion),
+          contractAddress: address,
+          symbol: '???',
+          isErc20: true,
+          coingeckoId: UNKNOWN_TOKEN_COINGECKO_ID,
+          name: address,
+          logo: 'chrome://erc-token-images/',
+          tokenId: '',
+          isErc1155: false,
+          isErc721: false,
+          isNft: false,
+          visible: true
+        } as BraveWallet.BlockchainToken
     ).filter((t): t is BraveWallet.BlockchainToken => Boolean(t))
 
   const sellToken = fillTokens.length === 1


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/23565

- Fixes showing the native asset in place of unknown tokens during swap transactions

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-arm64, CI/skip-linux-x64, CI/skip-android, CI/skip-macos, CI/skip-ios, CI/skip-windows-arm64, CI/skip-windows-x64, CI/skip-windows-x86 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
1. Create and fund a wallet
2. use matcha.xyz to create a swap transaction to a token that is not in the known tokens list or the user's assets list.
3. view the swap confirmation screen
4. the unknown token should be displayed as "???", with a link to view the token via a block-explorer
5. open the transaction activity page
6. view the pending transaction
7.  the unknown token should be displayed as "???"


![Screenshot 2023-04-25 at 4 16 57 PM](https://user-images.githubusercontent.com/30185185/235190243-dd9aaf38-b9c5-4786-985f-b6a272d18338.png)


![Screenshot 2023-04-25 at 12 41 17 PM](https://user-images.githubusercontent.com/30185185/235190305-b87a078e-346f-4ec9-adf7-e2f12c699213.png)

