### PR TITLE
Link to our Safe Browsing support page from settings and error pages

### DIFF
--- a/android/java/org/chromium/chrome/browser/help/BraveHelpAndFeedbackLauncher.java
+++ b/android/java/org/chromium/chrome/browser/help/BraveHelpAndFeedbackLauncher.java
@@ -21,7 +21,7 @@ import javax.annotation.Nonnull;
 public class BraveHelpAndFeedbackLauncher extends HelpAndFeedbackLauncherImpl {
     protected static final String FALLBACK_SUPPORT_URL = "https://community.brave.com/";
     private static final String SAFE_BROWSING_URL =
-            "https://brave.com/privacy/browser/#safe-browsing";
+            "https://support.brave.com/hc/articles/15222663599629-Safe-Browsing-in-Brave";
     private static final String TAG = "BraveHelpAndFeedbackLauncher";
 
     @Override

--- a/chromium_src/chrome/common/url_constants.cc
+++ b/chromium_src/chrome/common/url_constants.cc
@@ -182,7 +182,8 @@ const char kResetProfileSettingsLearnMoreURL[] =
     "360017903152-How-do-I-reset-Brave-settings-to-default-";
 
 const char kSafeBrowsingHelpCenterURL[] =
-    "https://support.brave.com/";
+    "https://support.brave.com/hc/en-us/articles/"
+    "15222663599629-Safe-Browsing-in-Brave";
 
 const char kSafetyTipHelpCenterURL[] =
     "https://support.brave.com/";

--- a/chromium_src/components/safe_browsing/content/browser/base_blocking_page.cc
+++ b/chromium_src/components/safe_browsing/content/browser/base_blocking_page.cc
@@ -1,0 +1,36 @@
+/* Copyright (c) 2023 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "components/security_interstitials/core/safe_browsing_loud_error_ui.h"
+
+namespace {
+
+const char kSafeBrowsingHelpCenterURL[] =
+    "https://support.brave.com/hc/en-us/articles/"
+    "15222663599629-Safe-Browsing-in-Brave";
+
+}  // namespace
+
+namespace security_interstitials {
+
+class BraveSafeBrowsingLoudErrorUI : public SafeBrowsingLoudErrorUI {
+ public:
+  using SafeBrowsingLoudErrorUI::SafeBrowsingLoudErrorUI;
+
+  void HandleCommand(SecurityInterstitialCommand command) override {
+    if (command == CMD_OPEN_HELP_CENTER) {
+      controller()->OpenURL(should_open_links_in_new_tab(),
+                            GURL(kSafeBrowsingHelpCenterURL));
+    } else {
+      SafeBrowsingLoudErrorUI::HandleCommand(command);
+    }
+  }
+};
+
+}  // namespace security_interstitials
+
+#define SafeBrowsingLoudErrorUI BraveSafeBrowsingLoudErrorUI
+#include "src/components/safe_browsing/content/browser/base_blocking_page.cc"
+#undef SafeBrowsingLoudErrorUI


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves brave/brave-browser#20514

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-arm64, CI/skip-linux-x64, CI/skip-android, CI/skip-macos, CI/skip-ios, CI/skip-windows-arm64, CI/skip-windows-x64, CI/skip-windows-x86 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

On Desktop:

1. Start Brave and wait for 5 minutes (before that, Safe Browsing is not guaranteed to be enabled).
2. Open https://testsafebrowsing.appspot.com/s/malware.html and in the security interstitial, click the *Learn more* link.
3. Confirm that it opens https://support.brave.com/hc/en-us/articles/15222663599629-Safe-Browsing-in-Brave in a new tab.
4. Open `brave://settings/security` and click the question mark in the top right corner.
5. Confirm that it opens https://support.brave.com/hc/en-us/articles/15222663599629-Safe-Browsing-in-Brave in a new tab.

On Android:

1. Start Brave and wait for 5 minutes (before that, Safe Browsing is not guaranteed to be enabled).
2. Open https://testsafebrowsing.appspot.com/s/malware.html and in the security interstitial, click the *Learn more* link.
3. Confirm that it opens https://support.brave.com/hc/en-us/articles/15222663599629-Safe-Browsing-in-Brave in a new tab.
4. Open *Settings*, then *Brave Shields & Privacy* and finally *Safe Browsing*.
5. Click the question mark in the top right corner.
6. Confirm that it opens https://support.brave.com/hc/en-us/articles/15222663599629-Safe-Browsing-in-Brave in a new tab.