### PR TITLE
Fixed bookmark items are not shown from menu bar on macOS

### DIFF
--- a/browser/brave_app_controller_mac_browsertest.mm
+++ b/browser/brave_app_controller_mac_browsertest.mm
@@ -19,14 +19,23 @@
 #include "brave/browser/brave_browser_features.h"
 #include "brave/browser/ui/views/frame/brave_browser_view.h"
 #include "chrome/app/chrome_command_ids.h"
+#include "chrome/browser/bookmarks/bookmark_model_factory.h"
 #include "chrome/browser/ui/browser.h"
+#include "chrome/browser/ui/browser_commands.h"
 #include "chrome/browser/ui/browser_finder.h"
 #include "chrome/browser/ui/browser_window.h"
+#include "chrome/browser/ui/cocoa/bookmarks/bookmark_menu_bridge.h"
 #include "chrome/browser/ui/location_bar/location_bar.h"
 #include "chrome/test/base/in_process_browser_test.h"
 #include "chrome/test/base/ui_test_utils.h"
+#include "components/bookmarks/browser/bookmark_model.h"
+#include "components/bookmarks/browser/bookmark_utils.h"
+#include "components/bookmarks/test/bookmark_test_helpers.h"
 #include "components/omnibox/browser/omnibox_view.h"
 #include "content/public/test/browser_test.h"
+
+using bookmarks::BookmarkModel;
+using bookmarks::BookmarkNode;
 
 namespace {
 
@@ -37,6 +46,13 @@ class BraveAppControllerBrowserTest : public InProcessBrowserTest {
   BraveAppControllerBrowserTest() {
     features_.InitWithFeatureState(features::kBraveCopyCleanLinkByDefault,
                                    true);
+  }
+
+  BookmarkModel* WaitForBookmarkModel(Profile* profile) {
+    BookmarkModel* bookmark_model =
+        BookmarkModelFactory::GetForBrowserContext(profile);
+    bookmarks::test::WaitForBookmarkModelToLoad(bookmark_model);
+    return bookmark_model;
   }
 
  private:
@@ -196,6 +212,54 @@ IN_PROC_BROWSER_TEST_F(BraveAppControllerBrowserTest,
   [ac menuNeedsUpdate:[clean_link_menu_item menu]];
   base::RunLoop().RunUntilIdle();
   EXPECT_TRUE([clean_link_menu_item isHidden]);
+}
+
+IN_PROC_BROWSER_TEST_F(BraveAppControllerBrowserTest,
+                       BookmarkItemsFromMenuBarTest) {
+  AppController* ac =
+      base::mac::ObjCCastStrict<AppController>([NSApp delegate]);
+  [ac mainMenuCreated];
+  [ac setLastProfile:browser()->profile()];
+
+  // Added one bookmark item.
+  constexpr char kPersistBookmarkURL[] = "http://www.cnn.com/";
+  constexpr char16_t kPersistBookmarkTitle[] = u"CNN";
+  BookmarkModel* bookmark_model = WaitForBookmarkModel(browser()->profile());
+  bookmarks::AddIfNotBookmarked(bookmark_model, GURL(kPersistBookmarkURL),
+                                kPersistBookmarkTitle);
+
+  // Update menubar's bookmark menu to make it includes above item.
+  NSMenu* normal_window_submenu = [ac bookmarkMenuBridge]->BookmarkMenu();
+  [[normal_window_submenu delegate] menuNeedsUpdate:normal_window_submenu];
+
+  // Total 5 items - basic 3 items(Bookmark Manager, Bookmark This Tab... and
+  // Bookmark All Tabs..), separator and bookmark item. and check last item is
+  // bookmark item.
+  EXPECT_EQ(5, [normal_window_submenu numberOfItems]);
+  EXPECT_EQ(
+      std::u16string(kPersistBookmarkTitle),
+      base::SysNSStringToUTF16([[normal_window_submenu itemAtIndex:4] title]));
+
+  // Create private browser and check bookmark menubar has same items.
+  auto* private_browser = CreateIncognitoBrowser(browser()->profile());
+  [ac setLastProfile:private_browser->profile()];
+  NSMenu* private_browser_submenu = [ac bookmarkMenuBridge]->BookmarkMenu();
+  [[private_browser_submenu delegate] menuNeedsUpdate:private_browser_submenu];
+  EXPECT_EQ(5, [private_browser_submenu numberOfItems]);
+  EXPECT_EQ(std::u16string(kPersistBookmarkTitle),
+            base::SysNSStringToUTF16(
+                [[private_browser_submenu itemAtIndex:4] title]));
+
+  // Close private browser and check bookmark menubar still has same items.
+  chrome::CloseWindow(private_browser);
+  ui_test_utils::WaitForBrowserToClose();
+
+  [ac setLastProfile:browser()->profile()];
+  [[normal_window_submenu delegate] menuNeedsUpdate:normal_window_submenu];
+  EXPECT_EQ(5, [normal_window_submenu numberOfItems]);
+  EXPECT_EQ(
+      std::u16string(kPersistBookmarkTitle),
+      base::SysNSStringToUTF16([[normal_window_submenu itemAtIndex:4] title]));
 }
 
 }  // namespace

--- a/patches/chrome-browser-app_controller_mac.mm.patch
+++ b/patches/chrome-browser-app_controller_mac.mm.patch
@@ -1,0 +1,13 @@
+diff --git a/chrome/browser/app_controller_mac.mm b/chrome/browser/app_controller_mac.mm
+index 8463c92b822ddd3d8aca9795b4145c536346597e..8d4b45e3d0db698720c01ccacc4672ddb77d476e 100644
+--- a/chrome/browser/app_controller_mac.mm
++++ b/chrome/browser/app_controller_mac.mm
+@@ -1103,7 +1103,7 @@ class AppControllerNativeThemeObserver : public ui::NativeThemeObserver {
+   }
+ 
+   auto it = _profileBookmarkMenuBridgeMap.find(profilePath);
+-  if (it != _profileBookmarkMenuBridgeMap.end() &&
++  if (it != _profileBookmarkMenuBridgeMap.end() && !isOffTheRecord &&
+       (!base::FeatureList::IsEnabled(features::kDestroyProfileOnBrowserClose) ||
+        (it->second->GetProfile() && !isOffTheRecord))) {
+     // Clean up the dangling Profile* in |_profileBookmarkMenuBridgeMap|.


### PR DESCRIPTION
fix https://github.com/brave/brave-browser/issues/25644

So far, cached bookmarkMenuBridge is cleared  when private window is removed.
As it's shared with normal profile, it should be cleared only when normal profile is removed.
Although there is related comment for this in the below upstream code,
this rule was not followed when `kDestroyProfileOnBrowserClose` is disabled.
As upstream enables it by default, I assume that upstream couldn't catch this issue.
```
// No need to clean up when |isOffTheRecord|, because BookmarkMenuBridge
// always points to a non-OTR profile.
```
```
  auto it = _profileBookmarkMenuBridgeMap.find(profilePath);
  if (it != _profileBookmarkMenuBridgeMap.end() &&
      (!base::FeatureList::IsEnabled(features::kDestroyProfileOnBrowserClose) ||
       (it->second->GetProfile() && !isOffTheRecord))) {
    // Clean up the dangling Profile* in |_profileBookmarkMenuBridgeMap|.
    //
    // No need to clean up when |isOffTheRecord|, because BookmarkMenuBridge
    // always points to a non-OTR profile.
    _profileBookmarkMenuBridgeMap.erase(it);
  }
```
When it's cleared with OTR profile destruction,
bookmarkMenuBridge is not created again for remained normal profile.
Then, bookmarks menubar doesn't  show any bookmark items.
Regardless of `kDestroyProfileOnBrowserClose` enabling state,
`bookmarkMenuBridge` should not be cleard when OTR profile is removed.

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves 

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-arm64, CI/skip-linux-x64, CI/skip-android, CI/skip-macos, CI/skip-ios, CI/skip-windows-arm64, CI/skip-windows-x64, CI/skip-windows-x86 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [ ] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

`BraveAppControllerBrowserTest.BookmarkItemsFromMenuBarTest`

1. Launch Brave and create some bookmark items
2. Launch private window
3. Close private window
4. Make normal window activated
5. Go to menubar's bookmark menu and check all bookmark items are shown properly