### PR TITLE
Hide Vertical Tab strip widget when disabled (uplift to 1.52.x)

### DIFF
--- a/browser/ui/views/frame/vertical_tab_strip_widget_delegate_view.h
+++ b/browser/ui/views/frame/vertical_tab_strip_widget_delegate_view.h
@@ -8,6 +8,7 @@
 
 #include <memory>
 
+#include "base/scoped_multi_source_observation.h"
 #include "ui/views/view_observer.h"
 #include "ui/views/widget/widget_delegate.h"
 #include "ui/views/widget/widget_observer.h"
@@ -47,6 +48,7 @@ class VerticalTabStripWidgetDelegateView : public views::WidgetDelegateView,
   }
 
   // views::WidgetDelegateView:
+  void AddedToWidget() override;
   void ChildPreferredSizeChanged(views::View* child) override;
 
   // views::ViewObserver:
@@ -56,6 +58,7 @@ class VerticalTabStripWidgetDelegateView : public views::WidgetDelegateView,
   void OnViewIsDeleting(views::View* observed_view) override;
 
   // views::WidgetObserver:
+  void OnWidgetVisibilityChanged(views::Widget* widget, bool visible) override;
   void OnWidgetBoundsChanged(views::Widget* widget,
                              const gfx::Rect& new_bounds) override;
   void OnWidgetDestroying(views::Widget* widget) override;
@@ -76,7 +79,7 @@ class VerticalTabStripWidgetDelegateView : public views::WidgetDelegateView,
   base::ScopedObservation<views::View, views::ViewObserver>
       host_view_observation_{this};
 
-  base::ScopedObservation<views::Widget, views::WidgetObserver>
+  base::ScopedMultiSourceObservation<views::Widget, views::WidgetObserver>
       widget_observation_{this};
 };
 


### PR DESCRIPTION
Uplift of #18241
Resolves https://github.com/brave/brave-browser/issues/29917

Pre-approval checklist: 
- [ ] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [ ] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [ ] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [ ] The associated issue milestone is set to the smallest version that the changes is landed on.