### PR TITLE
Don't show favicon when alert indicator is visible (uplift to 1.52.x)

### DIFF
--- a/browser/ui/views/tabs/brave_tab.cc
+++ b/browser/ui/views/tabs/brave_tab.cc
@@ -184,8 +184,9 @@ void BraveTab::UpdateIconVisibility() {
               controller()->GetBrowser());
       // When floating mode enabled, we don't show close button as the tab strip
       // will be expanded as soon as mouse hovers onto the tab.
-      showing_close_button_ = !can_enter_floating_mode && is_active;
-      showing_icon_ = !showing_close_button_;
+      showing_close_button_ =
+          !showing_alert_indicator_ && !can_enter_floating_mode && is_active;
+      showing_icon_ = !showing_alert_indicator_ && !showing_close_button_;
     }
   }
 }


### PR DESCRIPTION
Uplift of #18275
Resolves https://github.com/brave/brave-browser/issues/30021

Pre-approval checklist: 
- [ ] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [ ] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [ ] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [ ] The associated issue milestone is set to the smallest version that the changes is landed on.