### PR TITLE
fix(wallet)Add leo variables to NFT chrome-untrusted html

### DIFF
--- a/browser/ui/webui/brave_wallet/nft/nft_ui.cc
+++ b/browser/ui/webui/brave_wallet/nft/nft_ui.cc
@@ -46,7 +46,8 @@ UntrustedNftUI::UntrustedNftUI(content::WebUI* web_ui)
       std::string("script-src 'self' chrome-untrusted://resources;"));
   untrusted_source->OverrideContentSecurityPolicy(
       network::mojom::CSPDirectiveName::StyleSrc,
-      std::string("style-src 'self' 'unsafe-inline';"));
+      std::string(
+          "style-src 'self' 'unsafe-inline' chrome-untrusted://resources;"));
   untrusted_source->OverrideContentSecurityPolicy(
       network::mojom::CSPDirectiveName::FontSrc,
       std::string("font-src 'self' data:;"));

--- a/components/brave_wallet_ui/components/desktop/nft-pinning-status/nft-pinning-status.style.ts
+++ b/components/brave_wallet_ui/components/desktop/nft-pinning-status/nft-pinning-status.style.ts
@@ -24,6 +24,7 @@ export const StyledWrapper = styled.div`
   justify-content: space-between;
   gap: 6px;
   position: relative;
+  margin-top: 8px;
 `
 
 export const ContentWrapper = styled.div<{

--- a/components/brave_wallet_ui/nft/nft.html
+++ b/components/brave_wallet_ui/nft/nft.html
@@ -7,6 +7,7 @@
 <head>
    <meta charset="UTF-8" />
    <title>NFT iframe</title>
+   <link rel="stylesheet" href="chrome-untrusted://resources/brave/leo/css/variables.css">
    <script src="chrome-untrusted://resources/js/load_time_data_deprecated.js"></script>
    <script src="/strings.js"></script>
    <style>


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
~Resolves https://github.com/brave/brave-browser/issues/29521~
Resolves https://github.com/brave/brave-browser/issues/30219

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-arm64, CI/skip-linux-x64, CI/skip-android, CI/skip-macos, CI/skip-ios, CI/skip-windows-arm64, CI/skip-windows-x64, CI/skip-windows-x86 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

<img width="1226" alt="Screenshot 2023-05-03 at 10 56 40" src="https://user-images.githubusercontent.com/48117473/235860855-b7024ceb-7c85-4c7e-89bb-a6251691adc0.png">
