### PR TITLE
feat(wallet) Add empty state shown when NFT auto discovery is enabled

### DIFF
--- a/components/brave_wallet/browser/brave_wallet_constants.h
+++ b/components/brave_wallet/browser/brave_wallet_constants.h
@@ -1205,7 +1205,15 @@ constexpr webui::LocalizedString kLocalizedStrings[] = {
     {"braveWalletEnableNftAutoDiscoveryModalConfirm",
      IDS_BRAVE_WALLET_ENABLE_NFT_AUTODISCOVERY_MODAL_CONFIRM},
     {"braveWalletEnableNftAutoDiscoveryModalCancel",
-     IDS_BRAVE_WALLET_ENABLE_NFT_AUTODISCOVERY_MODAL_CANCEL}};
+     IDS_BRAVE_WALLET_ENABLE_NFT_AUTODISCOVERY_MODAL_CANCEL},
+    {"braveWalletAutoDiscoveryEmptyStateHeading",
+     IDS_BRAVE_WALLET_AUTO_DISCOVERY_EMPTY_STATE_HEADING},
+    {"braveWalletAutoDiscoveryEmptyStateSubHeading",
+     IDS_BRAVE_WALLET_AUTO_DISCOVERY_EMPTY_STATE_SUB_HEADING},
+    {"braveWalletAutoDiscoveryEmptyStateFooter",
+     IDS_BRAVE_WALLET_AUTO_DISCOVERY_EMPTY_STATE_FOOTER},
+    {"braveWalletAutoDiscoveryEmptyStateActions",
+     IDS_BRAVE_WALLET_AUTO_DISCOVERY_EMPTY_STATE_ACTIONS}};
 
 // 0x swap constants
 constexpr char kGoerliSwapBaseAPIURL[] = "https://goerli.api.0x.org/";

--- a/components/brave_wallet_ui/components/desktop/views/nfts/components/auto-discovery-empty-state/auto-discovery-empty-state.styles.tsx
+++ b/components/brave_wallet_ui/components/desktop/views/nfts/components/auto-discovery-empty-state/auto-discovery-empty-state.styles.tsx
@@ -1,0 +1,50 @@
+// Copyright (c) 2023 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+import styled from 'styled-components'
+import * as leo from '@brave/leo/tokens/css'
+
+import { WalletButton } from '../../../../../shared/style'
+
+export const StyledWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  margin-top: 10px;
+`
+
+export const Heading = styled.h3`
+  font-family: 'Poppins';
+  font-style: normal;
+  font-weight: 600;
+  font-size: 14px;
+  line-height: 24px;
+  text-align: center;
+  color: ${leo.color.text.secondary};
+  margin: 0 0 8px 0;
+  padding: 0;
+`
+
+export const Description = styled.span`
+  font-family: 'Poppins';
+  font-style: normal;
+  font-weight: 400;
+  font-size: 12px;
+  line-height: 18px;
+  color: ${leo.color.text.tertiary};
+`
+
+export const ActionButton = styled(WalletButton)`
+  font-family: 'Poppins';
+  font-style: normal;
+  font-weight: 600;
+  font-size: 12px;
+  line-height: 18px;
+  background: transparent;
+  color: ${leo.color.interaction.buttonPrimaryBackground};
+  border: none;
+  cursor: pointer;
+`

--- a/components/brave_wallet_ui/components/desktop/views/nfts/components/auto-discovery-empty-state/auto-discovery-empty-state.tsx
+++ b/components/brave_wallet_ui/components/desktop/views/nfts/components/auto-discovery-empty-state/auto-discovery-empty-state.tsx
@@ -1,0 +1,49 @@
+// Copyright (c) 2023 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+import * as React from 'react'
+
+// utils
+import { getLocale, splitStringForTag } from '../../../../../../../common/locale'
+
+// styles
+import {
+  ActionButton,
+  Description,
+  Heading,
+  StyledWrapper
+} from './auto-discovery-empty-state.styles'
+import { Row } from '../../../../../shared/style'
+
+
+interface Props {
+  onImportNft: () => void
+  onRefresh: () => void
+}
+
+export const AutoDiscoveryEmptyState = ({ onImportNft, onRefresh }: Props) => {
+  const { duringTag: refreshBtnText, afterTag } = splitStringForTag(getLocale('braveWalletAutoDiscoveryEmptyStateActions'))
+  const { beforeTag: or, duringTag: importText } = splitStringForTag(afterTag || '', 3)
+
+  return (
+    <StyledWrapper>
+      <Heading>
+        {getLocale('braveWalletAutoDiscoveryEmptyStateHeading')}
+      </Heading>
+      <Description>
+        {getLocale('braveWalletAutoDiscoveryEmptyStateSubHeading')}
+      </Description>
+      <Row margin="48px 0 8px 0" marginBottom={8}>
+        <Description>
+          {getLocale('braveWalletAutoDiscoveryEmptyStateFooter')}
+        </Description>
+      </Row>
+      <Description>
+        <ActionButton onClick={onRefresh}>{refreshBtnText}</ActionButton>
+        {or}
+        <ActionButton onClick={onImportNft}>{importText}</ActionButton>
+      </Description>
+    </StyledWrapper>
+  )
+}

--- a/components/brave_wallet_ui/stories/locale.ts
+++ b/components/brave_wallet_ui/stories/locale.ts
@@ -898,7 +898,7 @@ provideStrings({
   braveWalletEnableNftAutoDiscoveryModalDescription: 'Brave Wallet can use a third-party service to automatically display your NFTs. Brave will share your wallet addresses with $1SimpleHash$2 to provide this service. $3Learn more.$4',
   braveWalletEnableNftAutoDiscoveryModalConfirm: 'Yes, proceed',
   braveWalletEnableNftAutoDiscoveryModalCancel: 'No thanks, I\'ll do it manually',
-  braveWalletAutoDiscoveryEmptyStateHeading: 'NFT auto discovery turned on',
+  braveWalletAutoDiscoveryEmptyStateHeading: 'No NFTs to display',
   braveWalletAutoDiscoveryEmptyStateSubHeading: 'Once an NFT is detected, it\’ll be displayed here.',
   braveWalletAutoDiscoveryEmptyStateFooter: 'Can\’t see your NFTs?',
   braveWalletAutoDiscoveryEmptyStateActions: '$1Refresh$2 or $3Import Manually$4'

--- a/components/brave_wallet_ui/stories/locale.ts
+++ b/components/brave_wallet_ui/stories/locale.ts
@@ -897,5 +897,9 @@ provideStrings({
   braveWalletEnableNftAutoDiscoveryModalHeader: 'Want your NFTs displayed automatically?',
   braveWalletEnableNftAutoDiscoveryModalDescription: 'Brave Wallet can use a third-party service to automatically display your NFTs. Brave will share your wallet addresses with $1SimpleHash$2 to provide this service. $3Learn more.$4',
   braveWalletEnableNftAutoDiscoveryModalConfirm: 'Yes, proceed',
-  braveWalletEnableNftAutoDiscoveryModalCancel: 'No thanks, I\'ll do it manually'
+  braveWalletEnableNftAutoDiscoveryModalCancel: 'No thanks, I\'ll do it manually',
+  braveWalletAutoDiscoveryEmptyStateHeading: 'NFT auto discovery turned on',
+  braveWalletAutoDiscoveryEmptyStateSubHeading: 'Once an NFT is detected, it\’ll be displayed here.',
+  braveWalletAutoDiscoveryEmptyStateFooter: 'Can\’t see your NFTs?',
+  braveWalletAutoDiscoveryEmptyStateActions: '$1Refresh$2 or $3Import Manually$4'
 })

--- a/components/brave_wallet_ui/stories/wallet-components.tsx
+++ b/components/brave_wallet_ui/stories/wallet-components.tsx
@@ -26,6 +26,7 @@ import { mockNetwork } from '../common/constants/mocks'
 import { NftPinningStatus } from '../components/desktop/nft-pinning-status/nft-pinning-status'
 import { NftsEmptyState } from '../components/desktop/views/nfts/components/nfts-empty-state/nfts-empty-state'
 import { EnableNftDiscoveryModal } from '../components/desktop/popup-modals/enable-nft-discovery-modal/enable-nft-discovery-modal'
+import { AutoDiscoveryEmptyState } from '../components/desktop/views/nfts/components/auto-discovery-empty-state/auto-discovery-empty-state'
 
 export default {
   title: 'Wallet/Desktop/Components',
@@ -255,4 +256,17 @@ export const _EnableNftDiscoveryModal = () => {
 
 _EnableNftDiscoveryModal.story = {
   title: 'Enable NFT Discovery Modal'
+}
+
+export const _AutoDiscoveryEmptyState = () => {
+  return (
+    <AutoDiscoveryEmptyState
+      onImportNft={() => console.log('Import NFT')}
+      onRefresh={() => console.log('Import NFT')}
+    />
+  )
+}
+
+_AutoDiscoveryEmptyState.story = {
+  title: 'NFT Auto Discovery Empty State'
 }

--- a/components/resources/wallet_strings.grdp
+++ b/components/resources/wallet_strings.grdp
@@ -894,4 +894,8 @@
   <message name="IDS_BRAVE_WALLET_ENABLE_NFT_AUTODISCOVERY_MODAL_DESCRIPTION" desc="Enable NFT auto-discovery modal description">Brave Wallet can use a third-party service to automatically display your NFTs. Brave will share your wallet addresses with <ph name="BEFORE_UNDERLINE">$1</ph>SimpleHash<ph name="AFTER_UNDERLINE">$2</ph> to provide this service. <ph name="BEFORE_URL">$3</ph>Learn more.<ph name="AFTER_URL">$4</ph></message>
   <message name="IDS_BRAVE_WALLET_ENABLE_NFT_AUTODISCOVERY_MODAL_CONFIRM" desc="Enable NFT auto-discovery modal confirm button text">Yes, proceed</message>
   <message name="IDS_BRAVE_WALLET_ENABLE_NFT_AUTODISCOVERY_MODAL_CANCEL" desc="Enable NFT auto-discovery modal cancel button text">No thanks, I’ll do it manually</message>
+  <message name="IDS_BRAVE_WALLET_AUTO_DISCOVERY_EMPTY_STATE_HEADING" desc="NFTs tab empty state heading when auto discovery is enabled">NFT auto discovery turned on</message>
+  <message name="IDS_BRAVE_WALLET_AUTO_DISCOVERY_EMPTY_STATE_SUB_HEADING" desc="NFTs tab empty state sub heading when auto discovery is enabled">Once an NFT is detected, it’ll be displayed here.</message>
+  <message name="IDS_BRAVE_WALLET_AUTO_DISCOVERY_EMPTY_STATE_FOOTER" desc="NFTs tab empty state footer when auto discovery is enabled">Can’t see your NFTs?</message>
+  <message name="IDS_BRAVE_WALLET_AUTO_DISCOVERY_EMPTY_STATE_ACTIONS" desc="NFTs tab empty state action button text when auto discovery is enabled"><ph name="REFRESH">$1</ph>Refresh<ph name="REFRESH_END">$2</ph> or <ph name="IMPORT">$3</ph>Import Manually<ph name="IMPORT_END">$4</ph></message>
 </grit-part>

--- a/components/resources/wallet_strings.grdp
+++ b/components/resources/wallet_strings.grdp
@@ -894,7 +894,7 @@
   <message name="IDS_BRAVE_WALLET_ENABLE_NFT_AUTODISCOVERY_MODAL_DESCRIPTION" desc="Enable NFT auto-discovery modal description">Brave Wallet can use a third-party service to automatically display your NFTs. Brave will share your wallet addresses with <ph name="BEFORE_UNDERLINE">$1</ph>SimpleHash<ph name="AFTER_UNDERLINE">$2</ph> to provide this service. <ph name="BEFORE_URL">$3</ph>Learn more.<ph name="AFTER_URL">$4</ph></message>
   <message name="IDS_BRAVE_WALLET_ENABLE_NFT_AUTODISCOVERY_MODAL_CONFIRM" desc="Enable NFT auto-discovery modal confirm button text">Yes, proceed</message>
   <message name="IDS_BRAVE_WALLET_ENABLE_NFT_AUTODISCOVERY_MODAL_CANCEL" desc="Enable NFT auto-discovery modal cancel button text">No thanks, I’ll do it manually</message>
-  <message name="IDS_BRAVE_WALLET_AUTO_DISCOVERY_EMPTY_STATE_HEADING" desc="NFTs tab empty state heading when auto discovery is enabled">NFT auto discovery turned on</message>
+  <message name="IDS_BRAVE_WALLET_AUTO_DISCOVERY_EMPTY_STATE_HEADING" desc="NFTs tab empty state heading when auto discovery is enabled">No NFTs to display</message>
   <message name="IDS_BRAVE_WALLET_AUTO_DISCOVERY_EMPTY_STATE_SUB_HEADING" desc="NFTs tab empty state sub heading when auto discovery is enabled">Once an NFT is detected, it’ll be displayed here.</message>
   <message name="IDS_BRAVE_WALLET_AUTO_DISCOVERY_EMPTY_STATE_FOOTER" desc="NFTs tab empty state footer when auto discovery is enabled">Can’t see your NFTs?</message>
   <message name="IDS_BRAVE_WALLET_AUTO_DISCOVERY_EMPTY_STATE_ACTIONS" desc="NFTs tab empty state action button text when auto discovery is enabled"><ph name="REFRESH">$1</ph>Refresh<ph name="REFRESH_END">$2</ph> or <ph name="IMPORT">$3</ph>Import Manually<ph name="IMPORT_END">$4</ph></message>


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/30105

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-arm64, CI/skip-linux-x64, CI/skip-android, CI/skip-macos, CI/skip-ios, CI/skip-windows-arm64, CI/skip-windows-x64, CI/skip-windows-x86 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
<img width="752" alt="Screenshot 2023-05-03 at 16 26 41" src="https://user-images.githubusercontent.com/48117473/235929749-30631dee-5ad5-49cb-83d9-8e946f7904ea.png">
<img width="748" alt="Screenshot 2023-05-03 at 16 26 14" src="https://user-images.githubusercontent.com/48117473/235929767-ffb50b7f-81ad-493e-90dc-b92e444c12a8.png">


