### PR TITLE
brave://skus-internals stub code

### DIFF
--- a/browser/brave_content_browser_client.cc
+++ b/browser/brave_content_browser_client.cc
@@ -33,6 +33,7 @@
 #include "brave/browser/profiles/brave_renderer_updater_factory.h"
 #include "brave/browser/profiles/profile_util.h"
 #include "brave/browser/skus/skus_service_factory.h"
+#include "brave/browser/ui/webui/skus_internals_ui.h"
 #include "brave/components/brave_federated/features.h"
 #include "brave/components/brave_rewards/browser/rewards_protocol_handler.h"
 #include "brave/components/brave_search/browser/brave_search_default_host.h"
@@ -68,6 +69,8 @@
 #include "brave/components/playlist/common/buildflags/buildflags.h"
 #include "brave/components/playlist/common/features.h"
 #include "brave/components/request_otr/common/buildflags/buildflags.h"
+#include "brave/components/skus/common/features.h"
+#include "brave/components/skus/common/skus_internals.mojom.h"
 #include "brave/components/skus/common/skus_sdk.mojom.h"
 #include "brave/components/speedreader/common/buildflags/buildflags.h"
 #include "brave/components/tor/buildflags/buildflags.h"
@@ -547,6 +550,10 @@ void BraveContentBrowserClient::RegisterWebUIInterfaceBrokers(
     registry.ForWebUI<AIChatUI>().Add<ai_chat::mojom::PageHandler>();
   }
 #endif
+
+  if (base::FeatureList::IsEnabled(skus::features::kSkusFeature)) {
+    registry.ForWebUI<SkusInternalsUI>().Add<skus::mojom::SkusInternals>();
+  }
 }
 
 bool BraveContentBrowserClient::AllowWorkerFingerprinting(

--- a/browser/ui/BUILD.gn
+++ b/browser/ui/BUILD.gn
@@ -46,6 +46,8 @@ source_set("ui") {
     "webui/brave_web_ui_controller_factory.h",
     "webui/brave_webui_source.cc",
     "webui/brave_webui_source.h",
+    "webui/skus_internals_ui.cc",
+    "webui/skus_internals_ui.h",
   ]
 
   # It doesn't make sense to view accelerators on iOS & Android.
@@ -485,6 +487,9 @@ source_set("ui") {
     "//brave/components/p3a_utils",
     "//brave/components/playlist/common/buildflags",
     "//brave/components/resources:static_resources",
+    "//brave/components/skus/browser/resources:generated_resources",
+    "//brave/components/skus/common",
+    "//brave/components/skus/common:mojom",
     "//brave/components/text_recognition/common/buildflags",
     "//brave/components/time_period_storage",
     "//brave/components/tor/buildflags",

--- a/browser/ui/webui/brave_web_ui_controller_factory.cc
+++ b/browser/ui/webui/brave_web_ui_controller_factory.cc
@@ -15,6 +15,7 @@
 #include "brave/browser/ui/webui/brave_adblock_ui.h"
 #include "brave/browser/ui/webui/brave_rewards_internals_ui.h"
 #include "brave/browser/ui/webui/brave_rewards_page_ui.h"
+#include "brave/browser/ui/webui/skus_internals_ui.h"
 #include "brave/components/brave_federated/features.h"
 #include "brave/components/brave_rewards/common/rewards_util.h"
 #include "brave/components/brave_shields/common/features.h"
@@ -22,6 +23,7 @@
 #include "brave/components/constants/webui_url_constants.h"
 #include "brave/components/ipfs/buildflags/buildflags.h"
 #include "brave/components/playlist/common/buildflags/buildflags.h"
+#include "brave/components/skus/common/features.h"
 #include "brave/components/tor/buildflags/buildflags.h"
 #include "build/build_config.h"
 #include "chrome/browser/profiles/profile.h"
@@ -94,6 +96,8 @@ WebUIController* NewWebUI(WebUI* web_ui, const GURL& url) {
     return new BraveAdblockUI(web_ui, url.host());
   } else if (host == kAdblockInternalsHost) {
     return new BraveAdblockInternalsUI(web_ui, url.host());
+  } else if (host == kSkusInternalsHost) {
+    return new SkusInternalsUI(web_ui, url.host());
 #if !BUILDFLAG(IS_ANDROID)
   } else if (host == kWebcompatReporterHost) {
     return new WebcompatReporterUI(web_ui, url.host());
@@ -191,6 +195,8 @@ WebUIFactoryFunction GetWebUIFactoryFunction(WebUI* web_ui, const GURL& url) {
   if (url.host_piece() == kAdblockHost ||
       url.host_piece() == kAdblockInternalsHost ||
       url.host_piece() == kWebcompatReporterHost ||
+      (url.host_piece() == kSkusInternalsHost &&
+       base::FeatureList::IsEnabled(skus::features::kSkusFeature)) ||
 #if BUILDFLAG(ENABLE_IPFS_INTERNALS_WEBUI)
       (url.host_piece() == kIPFSWebUIHost &&
        base::FeatureList::IsEnabled(ipfs::features::kIpfsFeature)) ||

--- a/browser/ui/webui/skus_internals_ui.cc
+++ b/browser/ui/webui/skus_internals_ui.cc
@@ -1,0 +1,39 @@
+// Copyright (c) 2023 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#include "brave/browser/ui/webui/skus_internals_ui.h"
+
+#include <utility>
+
+#include "base/notreached.h"
+#include "brave/browser/ui/webui/brave_webui_source.h"
+#include "brave/components/skus/browser/resources/grit/skus_internals_generated_map.h"
+#include "components/grit/brave_components_resources.h"
+
+SkusInternalsUI::SkusInternalsUI(content::WebUI* web_ui,
+                                 const std::string& name)
+    : content::WebUIController(web_ui) {
+  CreateAndAddWebUIDataSource(web_ui, name, kSkusInternalsGenerated,
+                              kSkusInternalsGeneratedSize,
+                              IDR_SKUS_INTERNALS_HTML);
+}
+
+SkusInternalsUI::~SkusInternalsUI() = default;
+
+void SkusInternalsUI::BindInterface(
+    mojo::PendingReceiver<skus::mojom::SkusInternals> pending_receiver) {
+  if (skus_internals_receiver_.is_bound()) {
+    skus_internals_receiver_.reset();
+  }
+
+  skus_internals_receiver_.Bind(std::move(pending_receiver));
+}
+
+void SkusInternalsUI::GetEventLog(GetEventLogCallback callback) {
+  // TODO(simonhong): Ask log to SkusService
+  NOTIMPLEMENTED_LOG_ONCE();
+}
+
+WEB_UI_CONTROLLER_TYPE_IMPL(SkusInternalsUI)

--- a/browser/ui/webui/skus_internals_ui.h
+++ b/browser/ui/webui/skus_internals_ui.h
@@ -1,0 +1,34 @@
+// Copyright (c) 2023 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#ifndef BRAVE_BROWSER_UI_WEBUI_SKUS_INTERNALS_UI_H_
+#define BRAVE_BROWSER_UI_WEBUI_SKUS_INTERNALS_UI_H_
+
+#include <string>
+
+#include "brave/components/skus/common/skus_internals.mojom.h"
+#include "content/public/browser/web_ui_controller.h"
+
+class SkusInternalsUI : public content::WebUIController,
+                        public skus::mojom::SkusInternals {
+ public:
+  SkusInternalsUI(content::WebUI* web_ui, const std::string& host);
+  ~SkusInternalsUI() override;
+  SkusInternalsUI(const SkusInternalsUI&) = delete;
+  SkusInternalsUI& operator=(const SkusInternalsUI&) = delete;
+
+  void BindInterface(
+      mojo::PendingReceiver<skus::mojom::SkusInternals> pending_receiver);
+
+ private:
+  // skus::mojom::SkusInternals overrides:
+  void GetEventLog(GetEventLogCallback callback) override;
+
+  mojo::Receiver<skus::mojom::SkusInternals> skus_internals_receiver_{this};
+
+  WEB_UI_CONTROLLER_TYPE_DECL();
+};
+
+#endif  // BRAVE_BROWSER_UI_WEBUI_SKUS_INTERNALS_UI_H_

--- a/chromium_src/chrome/common/webui_url_constants.cc
+++ b/chromium_src/chrome/common/webui_url_constants.cc
@@ -10,7 +10,7 @@
 #define kChromeUIAttributionInternalsHost                                     \
   kChromeUIAttributionInternalsHost, kAdblockHost, kAdblockInternalsHost,     \
       kRewardsPageHost, kRewardsInternalsHost, kWelcomeHost, kWalletPageHost, \
-      kTorInternalsHost
+      kTorInternalsHost, kSkusInternalsHost
 #define kChromeUIPerformanceSettingsURL kChromeUIPerformanceSettingsURL_UnUsed
 #define kPerformanceSubPage kPerformanceSubPage_UnUsed
 

--- a/components/constants/webui_url_constants.cc
+++ b/components/constants/webui_url_constants.cc
@@ -10,6 +10,7 @@
 const char kAdblockHost[] = "adblock";
 const char kAdblockInternalsHost[] = "adblock-internals";
 const char kAdblockJS[] = "brave_adblock.js";
+const char kSkusInternalsHost[] = "skus-internals";
 #if BUILDFLAG(ENABLE_IPFS_INTERNALS_WEBUI)
 const char kIPFSWebUIHost[] = "ipfs-internals";
 const char kIPFSWebUIURL[] = "chrome://ipfs-internals/";

--- a/components/constants/webui_url_constants.h
+++ b/components/constants/webui_url_constants.h
@@ -12,6 +12,7 @@
 extern const char kAdblockHost[];
 extern const char kAdblockInternalsHost[];
 extern const char kAdblockJS[];
+extern const char kSkusInternalsHost[];
 #if BUILDFLAG(ENABLE_IPFS_INTERNALS_WEBUI)
 extern const char kIPFSWebUIHost[];
 extern const char kIPFSWebUIURL[];

--- a/components/resources/BUILD.gn
+++ b/components/resources/BUILD.gn
@@ -57,12 +57,14 @@ repack("resources") {
       "//brave/components/brave_adblock_ui:generated_resources",
       "//brave/components/brave_adblock_ui/adblock_internals:generated_resources",
       "//brave/components/cosmetic_filters/resources/data:generated_resources",
+      "//brave/components/skus/browser/resources:generated_resources",
     ]
 
     sources += [
       "$root_gen_dir/brave/components/brave_adblock/adblock_internals/resources/brave_adblock_internals_generated.pak",
       "$root_gen_dir/brave/components/brave_adblock/resources/brave_adblock_generated.pak",
       "$root_gen_dir/brave/components/cosmetic_filters/resources/cosmetic_filters_generated.pak",
+      "$root_gen_dir/brave/components/skus/browser/resources/skus_internals_generated.pak",
     ]
   }
 

--- a/components/resources/brave_components_resources.grd
+++ b/components/resources/brave_components_resources.grd
@@ -69,6 +69,7 @@
       <part file="../brave_perf_predictor/resources/brave_perf_predictor_resources.grdp" />
       <part file="../commands/browser/resources/commands_resources.grdp" />
       <part file="../playlist/browser/resources/playlist_resources.grdp" />
+      <part file="../skus/browser/resources/skus_internals_resources.grdp" />
       <part file="brave_blank_page_resources.grdp" />
       <part file="brave_translate_resources.grdp" />
       <part file="speedreader_resources.grdp" />

--- a/components/skus/browser/resources/BUILD.gn
+++ b/components/skus/browser/resources/BUILD.gn
@@ -1,0 +1,26 @@
+# Copyright (c) 2023 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import("//brave/components/common/typescript.gni")
+
+transpile_web_ui("skus_internals_ui") {
+  entry_points = [ [
+        "skus_internals",
+        rebase_path("skus_internals.tsx"),
+      ] ]
+
+  public_deps = [
+    "//brave/components/skus/common:mojom_js",
+    "//mojo/public/mojom/base",
+  ]
+
+  resource_name = "skus_internals"
+}
+
+pack_web_resources("generated_resources") {
+  resource_name = "skus_internals"
+  output_dir = "$root_gen_dir/brave/components/skus/browser/resources"
+  deps = [ ":skus_internals_ui" ]
+}

--- a/components/skus/browser/resources/skus_internals.html
+++ b/components/skus/browser/resources/skus_internals.html
@@ -1,0 +1,28 @@
+<!--
+ Copyright (c) 2023 The Brave Authors. All rights reserved.
+ This Source Code Form is subject to the terms of the Mozilla Public
+ License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ You can obtain one at https://mozilla.org/MPL/2.0/.
+-->
+
+<!doctype html>
+<html lang="en">
+
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width">
+  <title>Skus internals</title>
+  <link rel="stylesheet" href="chrome://resources/css/text_defaults.css">
+  <script src="/skus_internals.bundle.js"></script>
+  <style>
+    body {
+      margin: 0;
+    }
+  </style>
+</head>
+
+<body>
+  <div id="root"></div>
+</body>
+
+</html>

--- a/components/skus/browser/resources/skus_internals.tsx
+++ b/components/skus/browser/resources/skus_internals.tsx
@@ -1,0 +1,17 @@
+// Copyright (c) 2023 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import * as React from 'react'
+import { render } from 'react-dom'
+
+function App() {
+  return (
+    <div>Log here</div>
+  )
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+  render(<App />, document.getElementById('root'))
+})

--- a/components/skus/browser/resources/skus_internals_resources.grdp
+++ b/components/skus/browser/resources/skus_internals_resources.grdp
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<grit-part>
+   <include name="IDR_SKUS_INTERNALS_HTML" file="../skus/browser/resources/skus_internals.html" type="BINDATA" />
+</grit-part>

--- a/components/skus/browser/resources/tsconfig.json
+++ b/components/skus/browser/resources/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../../tsconfig",
+  "include": [
+    "**/*.ts",
+    "**/*.tsx",
+    "**/*.d.ts",
+    "../../definitions/*.d.ts"
+  ]
+}

--- a/components/skus/common/BUILD.gn
+++ b/components/skus/common/BUILD.gn
@@ -14,7 +14,10 @@ static_library("common") {
 }
 
 mojom("mojom") {
-  sources = [ "skus_sdk.mojom" ]
+  sources = [
+    "skus_internals.mojom",
+    "skus_sdk.mojom",
+  ]
 
   deps = [ "//mojo/public/mojom/base" ]
 }

--- a/components/skus/common/skus_internals.mojom
+++ b/components/skus/common/skus_internals.mojom
@@ -1,0 +1,10 @@
+// Copyright (c) 2023 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+module skus.mojom;
+
+interface SkusInternals {
+  GetEventLog() => (string response);
+};

--- a/resources/resource_ids.spec
+++ b/resources/resource_ids.spec
@@ -221,5 +221,9 @@
   "<(SHARED_INTERMEDIATE_DIR)/brave/web-ui-ai_chat_ui/ai_chat_ui.grd": {
     "META": {"sizes": {"includes": [50]}},
     "includes": [61500],
+  },
+  "<(SHARED_INTERMEDIATE_DIR)/brave/web-ui-skus_internals/skus_internals.grd": {
+    "META": {"sizes": {"includes": [100]}},
+    "includes": [61550],
   }
 }


### PR DESCRIPTION
fix https://github.com/brave/brave-browser/issues/30153

brave://skus-internals page will show skus service's event logs.
This PR just makes brave://skus-internal loadable.
Gathering & showing logs will be done as a next step.

<img width="792" alt="image" src="https://user-images.githubusercontent.com/6786187/236114745-d9070e78-2ca7-4374-8259-15a37bd06e5d.png">

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves 

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-arm64, CI/skip-linux-x64, CI/skip-android, CI/skip-macos, CI/skip-ios, CI/skip-windows-arm64, CI/skip-windows-x64, CI/skip-windows-x86 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [ ] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

1. Launch Brave and load brave://skus-internals
2. Check page is loaded. (contents is not ready)