### PR TITLE
Add P3A metrics for News opt-in, daily & monthly usage

### DIFF
--- a/components/brave_news/browser/brave_news_controller.cc
+++ b/components/brave_news/browser/brave_news_controller.cc
@@ -622,7 +622,7 @@ void BraveNewsController::Prefetch() {
 }
 
 void BraveNewsController::OnOptInChange() {
-  p3a::RecordOptInChange(prefs_);
+  p3a::RecordFeatureEnabledChange(prefs_);
   ConditionallyStartOrStopTimer();
 }
 

--- a/components/brave_news/browser/brave_news_controller.cc
+++ b/components/brave_news/browser/brave_news_controller.cc
@@ -116,12 +116,12 @@ BraveNewsController::BraveNewsController(
   // Set up preference listeners
   pref_change_registrar_.Init(prefs_);
   pref_change_registrar_.Add(
-      prefs::kNewTabPageShowToday,
-      base::BindRepeating(&BraveNewsController::ConditionallyStartOrStopTimer,
+      prefs::kBraveNewsOptedIn,
+      base::BindRepeating(&BraveNewsController::OnOptInChange,
                           base::Unretained(this)));
   pref_change_registrar_.Add(
-      prefs::kBraveNewsOptedIn,
-      base::BindRepeating(&BraveNewsController::ConditionallyStartOrStopTimer,
+      prefs::kNewTabPageShowToday,
+      base::BindRepeating(&BraveNewsController::OnOptInChange,
                           base::Unretained(this)));
   pref_change_registrar_.Add(
       prefs::kBraveNewsChannels,
@@ -619,6 +619,11 @@ void BraveNewsController::CheckForFeedsUpdate() {
 void BraveNewsController::Prefetch() {
   VLOG(1) << "PREFETCHING: ensuring feed has been retrieved";
   feed_controller_.EnsureFeedIsCached();
+}
+
+void BraveNewsController::OnOptInChange() {
+  p3a::RecordOptInChange(prefs_);
+  ConditionallyStartOrStopTimer();
 }
 
 void BraveNewsController::ConditionallyStartOrStopTimer() {

--- a/components/brave_news/browser/brave_news_controller.h
+++ b/components/brave_news/browser/brave_news_controller.h
@@ -136,6 +136,7 @@ class BraveNewsController : public KeyedService,
   void OnPublishersUpdated(brave_news::PublishersController*) override;
 
  private:
+  void OnOptInChange();
   void ConditionallyStartOrStopTimer();
   void CheckForFeedsUpdate();
   void CheckForPublishersUpdate();

--- a/components/brave_news/browser/brave_news_p3a.cc
+++ b/components/brave_news/browser/brave_news_p3a.cc
@@ -21,6 +21,27 @@
 namespace brave_news {
 namespace p3a {
 
+constexpr char kDaysInMonthUsedCountHistogramName[] =
+    "Brave.Today.DaysInMonthUsedCount";
+constexpr char kWeeklySessionCountHistogramName[] =
+    "Brave.Today.WeeklySessionCount";
+constexpr char kWeeklyMaxCardVisitsHistogramName[] =
+    "Brave.Today.WeeklyMaxCardVisitsCount";
+constexpr char kWeeklyMaxCardViewsHistogramName[] =
+    "Brave.Today.WeeklyMaxCardViewsCount";
+constexpr char kTotalCardViewsHistogramName[] =
+    "Brave.Today.WeeklyTotalCardViews";
+constexpr char kWeeklyDisplayAdsViewedHistogramName[] =
+    "Brave.Today.WeeklyDisplayAdsViewedCount";
+constexpr char kDirectFeedsTotalHistogramName[] =
+    "Brave.Today.DirectFeedsTotal";
+constexpr char kWeeklyAddedDirectFeedsHistogramName[] =
+    "Brave.Today.WeeklyAddedDirectFeedsCount";
+constexpr char kLastUsageTimeHistogramName[] = "Brave.Today.LastUsageTime";
+constexpr char kNewUserReturningHistogramName[] =
+    "Brave.Today.NewUserReturning";
+constexpr char kIsEnabledHistogramName[] = "Brave.Today.IsEnabled";
+
 namespace {
 
 uint16_t UpdateWeeklyStorageWithValueAndGetMax(PrefService* prefs,
@@ -165,6 +186,12 @@ void RecordTotalCardViews(PrefService* prefs,
           << " curr session = " << cards_viewed_session_total_count;
   p3a_utils::RecordToHistogramBucket(kTotalCardViewsHistogramName, buckets,
                                      total);
+}
+
+void RecordOptInChange(PrefService* prefs) {
+  bool enabled = prefs->GetBoolean(prefs::kBraveNewsOptedIn) &&
+                 prefs->GetBoolean(prefs::kNewTabPageShowToday);
+  UMA_HISTOGRAM_BOOLEAN(kIsEnabledHistogramName, enabled);
 }
 
 void RecordAtInit(PrefService* prefs) {

--- a/components/brave_news/browser/brave_news_p3a.h
+++ b/components/brave_news/browser/brave_news_p3a.h
@@ -14,25 +14,17 @@ class PrefService;
 namespace brave_news {
 namespace p3a {
 
-constexpr char kDaysInMonthUsedCountHistogramName[] =
-    "Brave.Today.DaysInMonthUsedCount";
-constexpr char kWeeklySessionCountHistogramName[] =
-    "Brave.Today.WeeklySessionCount";
-constexpr char kWeeklyMaxCardVisitsHistogramName[] =
-    "Brave.Today.WeeklyMaxCardVisitsCount";
-constexpr char kWeeklyMaxCardViewsHistogramName[] =
-    "Brave.Today.WeeklyMaxCardViewsCount";
-constexpr char kTotalCardViewsHistogramName[] =
-    "Brave.Today.WeeklyTotalCardViews";
-constexpr char kWeeklyDisplayAdsViewedHistogramName[] =
-    "Brave.Today.WeeklyDisplayAdsViewedCount";
-constexpr char kDirectFeedsTotalHistogramName[] =
-    "Brave.Today.DirectFeedsTotal";
-constexpr char kWeeklyAddedDirectFeedsHistogramName[] =
-    "Brave.Today.WeeklyAddedDirectFeedsCount";
-constexpr char kLastUsageTimeHistogramName[] = "Brave.Today.LastUsageTime";
-constexpr char kNewUserReturningHistogramName[] =
-    "Brave.Today.NewUserReturning";
+extern const char kDaysInMonthUsedCountHistogramName[];
+extern const char kWeeklySessionCountHistogramName[];
+extern const char kWeeklyMaxCardVisitsHistogramName[];
+extern const char kWeeklyMaxCardViewsHistogramName[];
+extern const char kTotalCardViewsHistogramName[];
+extern const char kWeeklyDisplayAdsViewedHistogramName[];
+extern const char kDirectFeedsTotalHistogramName[];
+extern const char kWeeklyAddedDirectFeedsHistogramName[];
+extern const char kLastUsageTimeHistogramName[];
+extern const char kNewUserReturningHistogramName[];
+extern const char kIsEnabledHistogramName[];
 
 void RecordAtInit(PrefService* prefs);
 void RecordAtSessionStart(PrefService* prefs);
@@ -46,6 +38,7 @@ void RecordWeeklyAddedDirectFeedsCount(PrefService* prefs, int change);
 void RecordDirectFeedsTotal(PrefService* prefs);
 void RecordTotalCardViews(PrefService* prefs,
                           uint64_t cards_viewed_session_total_count);
+void RecordOptInChange(PrefService* prefs);
 void RegisterProfilePrefs(PrefRegistrySimple* registry);
 
 }  // namespace p3a

--- a/components/brave_news/browser/brave_news_p3a.h
+++ b/components/brave_news/browser/brave_news_p3a.h
@@ -14,7 +14,6 @@ class PrefService;
 namespace brave_news {
 namespace p3a {
 
-extern const char kDaysInMonthUsedCountHistogramName[];
 extern const char kWeeklySessionCountHistogramName[];
 extern const char kWeeklyMaxCardVisitsHistogramName[];
 extern const char kWeeklyMaxCardViewsHistogramName[];
@@ -25,6 +24,8 @@ extern const char kWeeklyAddedDirectFeedsHistogramName[];
 extern const char kLastUsageTimeHistogramName[];
 extern const char kNewUserReturningHistogramName[];
 extern const char kIsEnabledHistogramName[];
+extern const char kUsageMonthlyHistogramName[];
+extern const char kUsageDailyHistogramName[];
 
 void RecordAtInit(PrefService* prefs);
 void RecordAtSessionStart(PrefService* prefs);
@@ -38,7 +39,7 @@ void RecordWeeklyAddedDirectFeedsCount(PrefService* prefs, int change);
 void RecordDirectFeedsTotal(PrefService* prefs);
 void RecordTotalCardViews(PrefService* prefs,
                           uint64_t cards_viewed_session_total_count);
-void RecordOptInChange(PrefService* prefs);
+void RecordFeatureEnabledChange(PrefService* prefs);
 void RegisterProfilePrefs(PrefRegistrySimple* registry);
 
 }  // namespace p3a

--- a/components/brave_news/browser/brave_news_p3a_unittest.cc
+++ b/components/brave_news/browser/brave_news_p3a_unittest.cc
@@ -395,5 +395,18 @@ TEST_F(BraveNewsP3ATest, TestNewUserReturningNotFollowingDay) {
   histogram_tester_.ExpectBucketCount(kNewUserReturningHistogramName, 1, 1);
 }
 
+TEST_F(BraveNewsP3ATest, TestIsEnabled) {
+  PrefService* prefs = GetPrefs();
+
+  prefs->SetBoolean(prefs::kBraveNewsOptedIn, true);
+  prefs->SetBoolean(prefs::kNewTabPageShowToday, true);
+  RecordOptInChange(prefs);
+  histogram_tester_.ExpectUniqueSample(kIsEnabledHistogramName, 1, 1);
+
+  prefs->SetBoolean(prefs::kNewTabPageShowToday, false);
+  RecordOptInChange(prefs);
+  histogram_tester_.ExpectBucketCount(kIsEnabledHistogramName, 0, 1);
+}
+
 }  // namespace p3a
 }  // namespace brave_news

--- a/components/brave_news/browser/brave_news_p3a_unittest.cc
+++ b/components/brave_news/browser/brave_news_p3a_unittest.cc
@@ -309,36 +309,6 @@ TEST_F(BraveNewsP3ATest, TestLastUsageTime) {
   histogram_tester_.ExpectBucketCount(kLastUsageTimeHistogramName, 6, 2);
 }
 
-TEST_F(BraveNewsP3ATest, TestDaysInMonthUsedCount) {
-  PrefService* prefs = GetPrefs();
-  RecordAtInit(prefs);
-  // Should not report if News was never used
-  histogram_tester_.ExpectTotalCount(kDaysInMonthUsedCountHistogramName, 0);
-
-  RecordAtSessionStart(prefs);
-  histogram_tester_.ExpectBucketCount(kDaysInMonthUsedCountHistogramName, 1, 1);
-  task_environment_.AdvanceClock(base::Days(1));
-  RecordAtSessionStart(prefs);
-  histogram_tester_.ExpectBucketCount(kDaysInMonthUsedCountHistogramName, 2, 1);
-  task_environment_.AdvanceClock(base::Days(14));
-  RecordAtSessionStart(prefs);
-  RecordAtSessionStart(prefs);
-  RecordAtSessionStart(prefs);
-  task_environment_.AdvanceClock(base::Days(1));
-  RecordAtSessionStart(prefs);
-  RecordAtSessionStart(prefs);
-  RecordAtSessionStart(prefs);
-
-  histogram_tester_.ExpectTotalCount(kDaysInMonthUsedCountHistogramName, 8);
-  histogram_tester_.ExpectBucketCount(kDaysInMonthUsedCountHistogramName, 3, 6);
-
-  task_environment_.AdvanceClock(base::Days(20));
-  RecordAtInit(prefs);
-
-  histogram_tester_.ExpectTotalCount(kDaysInMonthUsedCountHistogramName, 9);
-  histogram_tester_.ExpectBucketCount(kDaysInMonthUsedCountHistogramName, 2, 2);
-}
-
 TEST_F(BraveNewsP3ATest, TestNewUserReturningFollowingDay) {
   PrefService* prefs = GetPrefs();
   RecordAtInit(prefs);
@@ -400,12 +370,24 @@ TEST_F(BraveNewsP3ATest, TestIsEnabled) {
 
   prefs->SetBoolean(prefs::kBraveNewsOptedIn, true);
   prefs->SetBoolean(prefs::kNewTabPageShowToday, true);
-  RecordOptInChange(prefs);
+  RecordFeatureEnabledChange(prefs);
   histogram_tester_.ExpectUniqueSample(kIsEnabledHistogramName, 1, 1);
 
   prefs->SetBoolean(prefs::kNewTabPageShowToday, false);
-  RecordOptInChange(prefs);
+  RecordFeatureEnabledChange(prefs);
   histogram_tester_.ExpectBucketCount(kIsEnabledHistogramName, 0, 1);
+}
+
+TEST_F(BraveNewsP3ATest, TestGeneralUsage) {
+  PrefService* prefs = GetPrefs();
+
+  RecordAtInit(prefs);
+  histogram_tester_.ExpectTotalCount(kUsageDailyHistogramName, 0);
+  histogram_tester_.ExpectTotalCount(kUsageMonthlyHistogramName, 0);
+
+  RecordAtSessionStart(prefs);
+  histogram_tester_.ExpectUniqueSample(kUsageDailyHistogramName, 1, 1);
+  histogram_tester_.ExpectUniqueSample(kUsageMonthlyHistogramName, 1, 1);
 }
 
 }  // namespace p3a

--- a/components/p3a/metric_names.h
+++ b/components/p3a/metric_names.h
@@ -193,6 +193,7 @@ constexpr inline auto kCollectedExpressHistograms =
   base::MakeFixedFlatSet<base::StringPiece>({
     "Brave.Core.UsageDaily",
     "Brave.Rewards.EnabledInstallationTime",
+    "Brave.Today.IsEnabled",
     "Brave.Wallet.UsageDaily"
 });
 
@@ -207,6 +208,7 @@ constexpr inline auto kEphemeralHistograms =
     "Brave.Rewards.InlineTipTrigger",
     "Brave.Rewards.TipsSent",
     "Brave.Rewards.ToolbarButtonTrigger",
+    "Brave.Today.IsEnabled",
     "Brave.Wallet.UsageDaily",
     "Brave.Wallet.UsageMonthly",
     "Brave.Wallet.UsageWeekly"

--- a/components/p3a/metric_names.h
+++ b/components/p3a/metric_names.h
@@ -71,7 +71,6 @@ constexpr inline auto kCollectedTypicalHistograms =
     "Brave.Shields.UsageStatus",
     "Brave.SpeedReader.Enabled",
     "Brave.SpeedReader.ToggleCount",
-    "Brave.Today.DaysInMonthUsedCount",
     "Brave.Today.DirectFeedsTotal",
     "Brave.Today.LastUsageTime",
     "Brave.Today.NewUserReturning",
@@ -186,6 +185,7 @@ constexpr inline auto kCollectedSlowHistograms =
     "Brave.Rewards.TipsSent",
     "Brave.Sync.EnabledTypes",
     "Brave.Sync.SyncedObjectsCount",
+    "Brave.Today.UsageMonthly",
     "Brave.Wallet.UsageMonthly"
 });
 
@@ -194,6 +194,7 @@ constexpr inline auto kCollectedExpressHistograms =
     "Brave.Core.UsageDaily",
     "Brave.Rewards.EnabledInstallationTime",
     "Brave.Today.IsEnabled",
+    "Brave.Today.UsageDaily",
     "Brave.Wallet.UsageDaily"
 });
 
@@ -209,6 +210,8 @@ constexpr inline auto kEphemeralHistograms =
     "Brave.Rewards.TipsSent",
     "Brave.Rewards.ToolbarButtonTrigger",
     "Brave.Today.IsEnabled",
+    "Brave.Today.UsageDaily",
+    "Brave.Today.UsageMonthly",
     "Brave.Wallet.UsageDaily",
     "Brave.Wallet.UsageMonthly",
     "Brave.Wallet.UsageWeekly"


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/30154

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-arm64, CI/skip-linux-x64, CI/skip-android, CI/skip-macos, CI/skip-ios, CI/skip-windows-arm64, CI/skip-windows-x64, CI/skip-windows-x86 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [ ] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

For news opt-in:

0. Start with fresh profile, ensure metric does not exist in local state.
1. Enable Brave News, ensure metric has value 1.
2. Wait for the metric to be sent. Advance system time by 1 day, restart browser, ensure metric no longer exists.
3. Disable Brave News, ensure metric has value 0.

For monthly and daily usage metrics (perform twice for monthly & daily):

0. Start with fresh profile, ensure metric does not exist in local state.
1. Use Brave News, ensure metric has value 1 for given cadence.
2. Wait for the metric to be sent. Advance system time by 1 unit of time (depending on cadence), restart browser, ensure metric no longer exists.
3. Use Brave News, ensure metric has value 1.