### PR TITLE
Automatically run asset discovery when kBraveWalletNftDiscoveryEnabled setting is turned on

### DIFF
--- a/browser/brave_wallet/asset_discovery_manager_unittest.cc
+++ b/browser/brave_wallet/asset_discovery_manager_unittest.cc
@@ -164,12 +164,12 @@ class AssetDiscoveryManagerUnitTest : public testing::Test {
   void TestDiscoverAssetsOnAllSupportedChains(
       const std::map<mojom::CoinType, std::vector<std::string>>&
           account_addresses,
-      bool triggered_by_accounts_added,
+      bool bypass_rate_limit,
       bool expect_events_fired,
       const std::vector<std::string>& expected_token_contract_addresses,
       size_t expected_ending_queue_size = 0u) {
     asset_discovery_manager_->DiscoverAssetsOnAllSupportedChains(
-        account_addresses, triggered_by_accounts_added);
+        account_addresses, bypass_rate_limit);
     if (expect_events_fired) {
       wallet_service_observer_->WaitForOnDiscoverAssetsCompleted(
           expected_token_contract_addresses);

--- a/browser/brave_wallet/asset_discovery_manager_unittest.cc
+++ b/browser/brave_wallet/asset_discovery_manager_unittest.cc
@@ -46,10 +46,10 @@ const char kPasswordBrave[] = "brave";
 
 }  // namespace
 
-class TestBraveWalletServiceObserverForAssetDiscovery
+class TestBraveWalletServiceObserverForAssetDiscoveryManager
     : public brave_wallet::BraveWalletServiceObserverBase {
  public:
-  TestBraveWalletServiceObserverForAssetDiscovery() = default;
+  TestBraveWalletServiceObserverForAssetDiscoveryManager() = default;
 
   void OnDiscoverAssetsStarted() override {
     on_discover_assets_started_fired_ = true;
@@ -136,8 +136,8 @@ class AssetDiscoveryManagerUnitTest : public testing::Test {
     asset_discovery_manager_ = std::make_unique<AssetDiscoveryManager>(
         shared_url_loader_factory_, wallet_service_.get(), json_rpc_service_,
         keyring_service_, GetPrefs());
-    wallet_service_observer_ =
-        std::make_unique<TestBraveWalletServiceObserverForAssetDiscovery>();
+    wallet_service_observer_ = std::make_unique<
+        TestBraveWalletServiceObserverForAssetDiscoveryManager>();
     wallet_service_->AddObserver(wallet_service_observer_->GetReceiver());
   }
 
@@ -148,7 +148,7 @@ class AssetDiscoveryManagerUnitTest : public testing::Test {
   }
   network::TestURLLoaderFactory url_loader_factory_;
   scoped_refptr<network::SharedURLLoaderFactory> shared_url_loader_factory_;
-  std::unique_ptr<TestBraveWalletServiceObserverForAssetDiscovery>
+  std::unique_ptr<TestBraveWalletServiceObserverForAssetDiscoveryManager>
       wallet_service_observer_;
   content::BrowserTaskEnvironment task_environment_;
   std::unique_ptr<ScopedTestingLocalState> local_state_;

--- a/browser/brave_wallet/asset_discovery_task_unittest.cc
+++ b/browser/brave_wallet/asset_discovery_task_unittest.cc
@@ -22,6 +22,7 @@
 #include "brave/components/brave_wallet/browser/brave_wallet_utils.h"
 #include "brave/components/brave_wallet/browser/json_rpc_service.h"
 #include "brave/components/brave_wallet/browser/keyring_service.h"
+#include "brave/components/brave_wallet/browser/pref_names.h"
 #include "brave/components/brave_wallet/browser/tx_service.h"
 #include "brave/components/brave_wallet/common/features.h"
 #include "brave/components/brave_wallet/common/test_utils.h"
@@ -1614,7 +1615,8 @@ TEST_F(AssetDiscoveryTaskUnitTest, DiscoverNFTs) {
   GURL url;
 
   // Empty addresses yields empty expected_contract_addresses
-  wallet_service_->SetNftDiscoveryEnabled(true);
+  GetPrefs()->SetBoolean(kBraveWalletNftDiscoveryEnabled, true);
+
   TestDiscoverNFTsOnAllSupportedChains(chain_ids, addresses,
                                        expected_contract_addresses);
 
@@ -1648,11 +1650,11 @@ TEST_F(AssetDiscoveryTaskUnitTest, DiscoverNFTs) {
   expected_contract_addresses.push_back(
       "0x1111111111111111111111111111111111111111");
   // First test nothing is discovered when NFT discovery is not enabled.
-  wallet_service_->SetNftDiscoveryEnabled(false);
+  GetPrefs()->SetBoolean(kBraveWalletNftDiscoveryEnabled, false);
   TestDiscoverNFTsOnAllSupportedChains(chain_ids, addresses, {});
 
   // Enable and verify 1 ETH address yields 1 discovered NFT
-  wallet_service_->SetNftDiscoveryEnabled(true);
+  GetPrefs()->SetBoolean(kBraveWalletNftDiscoveryEnabled, true);
   TestDiscoverNFTsOnAllSupportedChains(chain_ids, addresses,
                                        expected_contract_addresses);
 

--- a/browser/brave_wallet/brave_wallet_service_unittest.cc
+++ b/browser/brave_wallet/brave_wallet_service_unittest.cc
@@ -219,10 +219,8 @@ class TestBraveWalletServiceObserver
 
   void OnNetworkListChanged() override { network_list_changed_fired_ = true; }
 
-  void OnDiscoverAssetsCompleted(
-      std::vector<mojom::BlockchainTokenPtr> discovered_assets) override {
-    on_discover_assets_completed_fired_ = true;
-  }
+  MOCK_METHOD1(OnDiscoverAssetsCompleted,
+               void(std::vector<mojom::BlockchainTokenPtr>));
 
   mojom::DefaultWallet GetDefaultEthereumWallet() {
     return default_ethereum_wallet_;
@@ -245,9 +243,6 @@ class TestBraveWalletServiceObserver
     return default_base_cryptocurrency_changed_fired_;
   }
   bool OnNetworkListChangedFired() { return network_list_changed_fired_; }
-  bool OnDiscoverAssetsCompletedFired() {
-    return on_discover_assets_completed_fired_;
-  }
 
   mojo::PendingRemote<brave_wallet::mojom::BraveWalletServiceObserver>
   GetReceiver() {
@@ -260,7 +255,6 @@ class TestBraveWalletServiceObserver
     default_base_currency_changed_fired_ = false;
     default_base_cryptocurrency_changed_fired_ = false;
     network_list_changed_fired_ = false;
-    on_discover_assets_completed_fired_ = false;
   }
 
  private:
@@ -273,7 +267,6 @@ class TestBraveWalletServiceObserver
   bool default_base_currency_changed_fired_ = false;
   bool default_base_cryptocurrency_changed_fired_ = false;
   bool network_list_changed_fired_ = false;
-  bool on_discover_assets_completed_fired_ = false;
   std::string currency_;
   std::string cryptocurrency_;
   mojo::Receiver<brave_wallet::mojom::BraveWalletServiceObserver>
@@ -2587,17 +2580,17 @@ TEST_F(BraveWalletServiceUnitTest, SetNftDiscoveryEnabled) {
 
   // Setting NFT discovery enabled should update the pref and trigger asset
   // discovery
+  EXPECT_CALL(*observer_, OnDiscoverAssetsCompleted(testing::_)).Times(1);
   service_->SetNftDiscoveryEnabled(true);
   base::RunLoop().RunUntilIdle();
   EXPECT_TRUE(GetPrefs()->GetBoolean(kBraveWalletNftDiscoveryEnabled));
-  EXPECT_TRUE(observer_->OnDiscoverAssetsCompletedFired());
-  observer_->Reset();
 
   // Unsetting NFT discovery enabled should update the pref and not trigger
   // asset discovery
+  EXPECT_CALL(*observer_, OnDiscoverAssetsCompleted(testing::_)).Times(0);
   service_->SetNftDiscoveryEnabled(false);
+  base::RunLoop().RunUntilIdle();
   EXPECT_FALSE(GetPrefs()->GetBoolean(kBraveWalletNftDiscoveryEnabled));
-  EXPECT_FALSE(observer_->OnDiscoverAssetsCompletedFired());
 }
 
 TEST_F(BraveWalletServiceUnitTest, RecordGeneralUsageMetrics) {

--- a/browser/brave_wallet/brave_wallet_service_unittest.cc
+++ b/browser/brave_wallet/brave_wallet_service_unittest.cc
@@ -2583,6 +2583,7 @@ TEST_F(BraveWalletServiceUnitTest, SetNftDiscoveryEnabled) {
   EXPECT_CALL(*observer_, OnDiscoverAssetsCompleted(testing::_)).Times(1);
   service_->SetNftDiscoveryEnabled(true);
   base::RunLoop().RunUntilIdle();
+  EXPECT_TRUE(testing::Mock::VerifyAndClearExpectations(&observer_));
   EXPECT_TRUE(GetPrefs()->GetBoolean(kBraveWalletNftDiscoveryEnabled));
 
   // Unsetting NFT discovery enabled should update the pref and not trigger
@@ -2590,6 +2591,7 @@ TEST_F(BraveWalletServiceUnitTest, SetNftDiscoveryEnabled) {
   EXPECT_CALL(*observer_, OnDiscoverAssetsCompleted(testing::_)).Times(0);
   service_->SetNftDiscoveryEnabled(false);
   base::RunLoop().RunUntilIdle();
+  EXPECT_TRUE(testing::Mock::VerifyAndClearExpectations(&observer_));
   EXPECT_FALSE(GetPrefs()->GetBoolean(kBraveWalletNftDiscoveryEnabled));
 }
 

--- a/components/brave_wallet/browser/asset_discovery_manager.cc
+++ b/components/brave_wallet/browser/asset_discovery_manager.cc
@@ -79,7 +79,7 @@ void AssetDiscoveryManager::DiscoverAssetsOnAllSupportedChains(
     return;
   }
 
-  // Check if request should be rate limited throttled based on last
+  // Check if request should be throttled based on
   // kBraveWalletLastDiscoveredAssetsAt
   const base::Time assets_last_discovered_at =
       prefs_->GetTime(kBraveWalletLastDiscoveredAssetsAt);

--- a/components/brave_wallet/browser/asset_discovery_manager.cc
+++ b/components/brave_wallet/browser/asset_discovery_manager.cc
@@ -67,9 +67,8 @@ AssetDiscoveryManager::~AssetDiscoveryManager() = default;
 void AssetDiscoveryManager::DiscoverAssetsOnAllSupportedChains(
     const std::map<mojom::CoinType, std::vector<std::string>>&
         account_addresses,
-    bool triggered_by_accounts_added) {
-  if (triggered_by_accounts_added) {
-    // Always add asset discovery when an account is added
+    bool bypass_rate_limit) {
+  if (bypass_rate_limit) {
     AddTask(account_addresses);
     return;
   }

--- a/components/brave_wallet/browser/asset_discovery_manager.h
+++ b/components/brave_wallet/browser/asset_discovery_manager.h
@@ -61,7 +61,7 @@ class AssetDiscoveryManager : public mojom::KeyringServiceObserver {
   void DiscoverAssetsOnAllSupportedChains(
       const std::map<mojom::CoinType, std::vector<std::string>>&
           account_addresses,
-      bool triggered_by_accounts_added);
+      bool bypass_rate_limit);
 
   void SetQueueForTesting(
       std::queue<std::unique_ptr<AssetDiscoveryTask>> queue) {

--- a/components/brave_wallet/browser/brave_wallet_service.cc
+++ b/components/brave_wallet/browser/brave_wallet_service.cc
@@ -216,6 +216,10 @@ BraveWalletService::BraveWalletService(
       base::BindRepeating(&BraveWalletService::OnNetworkListChanged,
                           base::Unretained(this)));
   pref_change_registrar_.Add(
+      kBraveWalletNftDiscoveryEnabled,
+      base::BindRepeating(&BraveWalletService::OnBraveWalletNftDiscoveryEnabled,
+                          base::Unretained(this)));
+  pref_change_registrar_.Add(
       kBraveWalletSelectedNetworks,
       base::BindRepeating(&BraveWalletService::OnNetworkChanged,
                           weak_ptr_factory_.GetWeakPtr()));
@@ -754,6 +758,12 @@ void BraveWalletService::OnDefaultBaseCryptocurrencyChanged() {
 void BraveWalletService::OnNetworkListChanged() {
   for (const auto& observer : observers_) {
     observer->OnNetworkListChanged();
+  }
+}
+
+void BraveWalletService::OnBraveWalletNftDiscoveryEnabled() {
+  if (profile_prefs_->GetBoolean(kBraveWalletNftDiscoveryEnabled)) {
+    DiscoverAssetsOnAllSupportedChains(true);
   }
 }
 
@@ -1660,11 +1670,6 @@ void BraveWalletService::GetNftDiscoveryEnabled(
 
 void BraveWalletService::SetNftDiscoveryEnabled(bool enabled) {
   profile_prefs_->SetBoolean(kBraveWalletNftDiscoveryEnabled, enabled);
-
-  // Asset discovery is immediately run when NFT discovery is enabled
-  if (enabled) {
-    DiscoverAssetsOnAllSupportedChains(true);
-  }
 }
 
 void BraveWalletService::GetBalanceScannerSupportedChains(

--- a/components/brave_wallet/browser/brave_wallet_service.cc
+++ b/components/brave_wallet/browser/brave_wallet_service.cc
@@ -1623,6 +1623,11 @@ void BraveWalletService::Base58Encode(
 }
 
 void BraveWalletService::DiscoverAssetsOnAllSupportedChains() {
+  DiscoverAssetsOnAllSupportedChains(false);
+}
+
+void BraveWalletService::DiscoverAssetsOnAllSupportedChains(
+    bool bypass_rate_limit) {
   std::map<mojom::CoinType, std::vector<std::string>> addresses;
   // Fetch ETH addresses
   mojom::KeyringInfoPtr keyring_info = keyring_service_->GetKeyringInfoSync(
@@ -1643,8 +1648,8 @@ void BraveWalletService::DiscoverAssetsOnAllSupportedChains() {
   addresses[mojom::CoinType::SOL] = std::move(sol_account_addresses);
 
   // Discover assets owned by the SOL and ETH addresses on all supported chains
-  asset_discovery_manager_->DiscoverAssetsOnAllSupportedChains(addresses,
-                                                               false);
+  asset_discovery_manager_->DiscoverAssetsOnAllSupportedChains(
+      addresses, bypass_rate_limit);
 }
 
 void BraveWalletService::GetNftDiscoveryEnabled(
@@ -1655,6 +1660,11 @@ void BraveWalletService::GetNftDiscoveryEnabled(
 
 void BraveWalletService::SetNftDiscoveryEnabled(bool enabled) {
   profile_prefs_->SetBoolean(kBraveWalletNftDiscoveryEnabled, enabled);
+
+  // Asset discovery is immediately run when NFT discovery is enabled
+  if (enabled) {
+    DiscoverAssetsOnAllSupportedChains(true);
+  }
 }
 
 void BraveWalletService::GetBalanceScannerSupportedChains(

--- a/components/brave_wallet/browser/brave_wallet_service.h
+++ b/components/brave_wallet/browser/brave_wallet_service.h
@@ -295,6 +295,7 @@ class BraveWalletService : public KeyedService,
   void OnDefaultBaseCurrencyChanged();
   void OnDefaultBaseCryptocurrencyChanged();
   void OnNetworkListChanged();
+  void OnBraveWalletNftDiscoveryEnabled();
 
   static absl::optional<std::string> GetChecksumAddress(
       const std::string& contract_address,

--- a/components/brave_wallet/browser/brave_wallet_service.h
+++ b/components/brave_wallet/browser/brave_wallet_service.h
@@ -328,6 +328,7 @@ class BraveWalletService : public KeyedService,
   void CancelAllSignAllTransactionsCallbacks();
   void CancelAllGetEncryptionPublicKeyCallbacks();
   void CancelAllDecryptCallbacks();
+  void DiscoverAssetsOnAllSupportedChains(bool bypass_rate_limit);
 
   base::OnceClosure sign_tx_request_added_cb_for_testing_;
   base::OnceClosure sign_all_txs_request_added_cb_for_testing_;


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/30141

Clients had issues because after they called SetNftDiscoveryEnabled(true), subsequent calls to run asset discovery were rate limited (we enforce maximum 1 asset discovery run per minute). This pull request addresses this issue by automatically running asset discovery whenever the SetNftDiscoveryEnabled(true) is called from core, bypassing any rate limits the frontends are restricted by.

It also renames 'triggered_by_accounts_added' parameter to 'bypass_rate_limits'.  Previously the only reason rate limits were ignored was after an account was added, but since that's not the case anymore, I've updated the parameter name to be more general.

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-arm64, CI/skip-linux-x64, CI/skip-android, CI/skip-macos, CI/skip-ios, CI/skip-windows-arm64, CI/skip-windows-x64, CI/skip-windows-x86 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [ ] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

