### PR TITLE
Prompt tuning for Summarizer AI

### DIFF
--- a/browser/ui/webui/ai_chat/ai_chat_ui_page_handler.cc
+++ b/browser/ui/webui/ai_chat/ai_chat_ui_page_handler.cc
@@ -60,7 +60,6 @@ void AIChatUIPageHandler::SubmitHumanConversationEntry(
   base::ReplaceSubstringsAfterOffset(&input_copy, 0, "<question>", "");
   base::ReplaceSubstringsAfterOffset(&input_copy, 0, "</question>", "");
 
-
   active_chat_tab_helper_->MakeAPIRequestWithConversationHistoryUpdate(
       {CharacterType::HUMAN, ConversationTurnVisibility::VISIBLE, input_copy});
 }

--- a/browser/ui/webui/ai_chat/ai_chat_ui_page_handler.cc
+++ b/browser/ui/webui/ai_chat/ai_chat_ui_page_handler.cc
@@ -55,6 +55,11 @@ void AIChatUIPageHandler::SubmitHumanConversationEntry(
   base::ReplaceSubstringsAfterOffset(&input_copy, 0, ai_chat::kAIPrompt, "");
   base::ReplaceSubstringsAfterOffset(&input_copy, 0, "<article>", "");
   base::ReplaceSubstringsAfterOffset(&input_copy, 0, "</article>", "");
+  base::ReplaceSubstringsAfterOffset(&input_copy, 0, "<history>", "");
+  base::ReplaceSubstringsAfterOffset(&input_copy, 0, "</history>", "");
+  base::ReplaceSubstringsAfterOffset(&input_copy, 0, "<question>", "");
+  base::ReplaceSubstringsAfterOffset(&input_copy, 0, "</question>", "");
+
 
   active_chat_tab_helper_->MakeAPIRequestWithConversationHistoryUpdate(
       {CharacterType::HUMAN, ConversationTurnVisibility::VISIBLE, input_copy});

--- a/browser/ui/webui/ai_chat/ai_chat_ui_page_handler.cc
+++ b/browser/ui/webui/ai_chat/ai_chat_ui_page_handler.cc
@@ -53,6 +53,8 @@ void AIChatUIPageHandler::SubmitHumanConversationEntry(
   // TODO(nullhook): Abstract prompt injection cleanups to a central place
   base::ReplaceSubstringsAfterOffset(&input_copy, 0, ai_chat::kHumanPrompt, "");
   base::ReplaceSubstringsAfterOffset(&input_copy, 0, ai_chat::kAIPrompt, "");
+  base::ReplaceSubstringsAfterOffset(&input_copy, 0, "<article>", "");
+  base::ReplaceSubstringsAfterOffset(&input_copy, 0, "</article>", "");
 
   active_chat_tab_helper_->MakeAPIRequestWithConversationHistoryUpdate(
       {CharacterType::HUMAN, ConversationTurnVisibility::VISIBLE, input_copy});

--- a/components/ai_chat/ai_chat.mojom
+++ b/components/ai_chat/ai_chat.mojom
@@ -11,7 +11,7 @@ enum CharacterType {
 };
 
 enum ConversationTurnVisibility {
-  DONT_ADD,
+  INTERNAL, // does not get added to chat history, used as a flag internally
   VISIBLE,
   HIDDEN
 };

--- a/components/ai_chat/ai_chat.mojom
+++ b/components/ai_chat/ai_chat.mojom
@@ -11,6 +11,7 @@ enum CharacterType {
 };
 
 enum ConversationTurnVisibility {
+  DONT_ADD,
   VISIBLE,
   HIDDEN
 };

--- a/components/ai_chat/ai_chat_api.cc
+++ b/components/ai_chat/ai_chat_api.cc
@@ -108,7 +108,7 @@ void AIChatAPI::QueryPrompt(ResponseCallback callback,
 
   dict.Set("prompt", prompt);
   dict.Set("max_tokens_to_sample", 400);
-  dict.Set("temperature", 0.7);
+  dict.Set("temperature", 1);
   dict.Set("top_k", -1);  // disabled
   dict.Set("top_p", 0.999);
   dict.Set("model", model_name);
@@ -118,7 +118,7 @@ void AIChatAPI::QueryPrompt(ResponseCallback callback,
   base::flat_map<std::string, std::string> headers;
   headers.emplace("x-brave-key", BUILDFLAG(BRAVE_SERVICES_KEY));
 
-  DVLOG(1) << __func__ << " Prompt: " << prompt << "\n";
+  DVLOG(1) << __func__ << " Prompt: |" << prompt << "|\n";
   DVLOG(1) << __func__ << " Using model: " << model_name;
 
   api_request_helper_.Request("POST", api_url, CreateJSONRequestBody(dict),

--- a/components/ai_chat/ai_chat_api.cc
+++ b/components/ai_chat/ai_chat_api.cc
@@ -102,6 +102,7 @@ void AIChatAPI::QueryPrompt(ResponseCallback callback,
   base::Value::Dict dict;
   base::Value::List stop_sequences;
   stop_sequences.Append("\n\nHuman:");
+  stop_sequences.Append("</response>");
 
   const auto model_name = ai_chat::features::kAIModelName.Get();
   DCHECK(!model_name.empty());

--- a/components/ai_chat/ai_chat_tab_helper.cc
+++ b/components/ai_chat/ai_chat_tab_helper.cc
@@ -136,7 +136,7 @@ const std::string& AIChatTabHelper::GetConversationHistoryString() {
                            turn.text);
   }
 
-  history_text_ = base::JoinString(turn_strings, "\n");
+  history_text_ = base::JoinString(turn_strings, "");
 
   return history_text_;
 }

--- a/components/ai_chat/ai_chat_tab_helper.cc
+++ b/components/ai_chat/ai_chat_tab_helper.cc
@@ -281,6 +281,7 @@ void AIChatTabHelper::DistillViaAlgorithm(const ui::AXTree& tree) {
 void AIChatTabHelper::CleanUp() {
   chat_history_.clear();
   article_summary_.clear();
+  article_text_.clear();
   SetRequestInProgress(false);
 
   for (auto& obs : observers_) {

--- a/components/ai_chat/ai_chat_tab_helper.cc
+++ b/components/ai_chat/ai_chat_tab_helper.cc
@@ -261,6 +261,8 @@ void AIChatTabHelper::DistillViaAlgorithm(const ui::AXTree& tree) {
   base::ReplaceSubstringsAfterOffset(&contents_text, 0, ai_chat::kHumanPrompt,
                                      "");
   base::ReplaceSubstringsAfterOffset(&contents_text, 0, ai_chat::kAIPrompt, "");
+  base::ReplaceSubstringsAfterOffset(&contents_text, 0, "<article>", "");
+  base::ReplaceSubstringsAfterOffset(&contents_text, 0, "</article>", "");
 
   VLOG(1) << __func__
           << " Number of chars in content text = " << contents_text.length()

--- a/components/ai_chat/ai_chat_tab_helper.cc
+++ b/components/ai_chat/ai_chat_tab_helper.cc
@@ -274,7 +274,7 @@ void AIChatTabHelper::DistillViaAlgorithm(const ui::AXTree& tree) {
 
   // We hide the prompt with article content from the user
   MakeAPIRequestWithConversationHistoryUpdate(
-      {CharacterType::HUMAN, ConversationTurnVisibility::DONT_ADD,
+      {CharacterType::HUMAN, ConversationTurnVisibility::INTERNAL,
        summarize_prompt});
 }
 
@@ -297,7 +297,7 @@ void AIChatTabHelper::MakeAPIRequestWithConversationHistoryUpdate(
   std::string prompt_with_history =
       base::StrCat({prompt, ai_chat::kAIPrompt, " <response>\n"});
 
-  if (turn.visibility != ConversationTurnVisibility::DONT_ADD) {
+  if (turn.visibility != ConversationTurnVisibility::INTERNAL) {
     AddToConversationHistory(turn);
   }
 
@@ -309,7 +309,7 @@ void AIChatTabHelper::MakeAPIRequestWithConversationHistoryUpdate(
   // the incoming response is expected to include the AI-generated summary.
   // TODO(nullhook): Improve this heuristic, as it may or may not be true.
   bool is_summarize_prompt =
-      turn.visibility == ConversationTurnVisibility::DONT_ADD ? true : false;
+      turn.visibility == ConversationTurnVisibility::INTERNAL ? true : false;
 
   ai_chat_api_->QueryPrompt(
       base::BindOnce(&AIChatTabHelper::OnAPIResponse, base::Unretained(this),

--- a/components/ai_chat/ai_chat_tab_helper.cc
+++ b/components/ai_chat/ai_chat_tab_helper.cc
@@ -287,7 +287,7 @@ void AIChatTabHelper::CleanUp() {
 }
 
 void AIChatTabHelper::MakeAPIRequestWithConversationHistoryUpdate(
-    const ConversationTurn &turn) {
+    const ConversationTurn& turn) {
   std::string prompt = base::ReplaceStringPlaceholders(
       l10n_util::GetStringUTF8(IDS_AI_CHAT_SUMMARIZE_PROMPT),
       {article_text_, GetConversationHistoryString(), turn.text}, nullptr);
@@ -309,10 +309,10 @@ void AIChatTabHelper::MakeAPIRequestWithConversationHistoryUpdate(
   bool is_summarize_prompt =
       turn.visibility == ConversationTurnVisibility::DONT_ADD ? true : false;
 
-  ai_chat_api_->QueryPrompt(base::BindOnce(&AIChatTabHelper::OnAPIResponse,
-                                           base::Unretained(this),
-                                           is_summarize_prompt),
-                            std::move(prompt_with_history));
+  ai_chat_api_->QueryPrompt(
+      base::BindOnce(&AIChatTabHelper::OnAPIResponse, base::Unretained(this),
+                     is_summarize_prompt),
+      std::move(prompt_with_history));
 }
 
 void AIChatTabHelper::OnAPIResponse(bool contains_summary,

--- a/components/ai_chat/ai_chat_tab_helper.cc
+++ b/components/ai_chat/ai_chat_tab_helper.cc
@@ -263,6 +263,10 @@ void AIChatTabHelper::DistillViaAlgorithm(const ui::AXTree& tree) {
   base::ReplaceSubstringsAfterOffset(&contents_text, 0, ai_chat::kAIPrompt, "");
   base::ReplaceSubstringsAfterOffset(&contents_text, 0, "<article>", "");
   base::ReplaceSubstringsAfterOffset(&contents_text, 0, "</article>", "");
+  base::ReplaceSubstringsAfterOffset(&contents_text, 0, "<history>", "");
+  base::ReplaceSubstringsAfterOffset(&contents_text, 0, "</history>", "");
+  base::ReplaceSubstringsAfterOffset(&contents_text, 0, "<question>", "");
+  base::ReplaceSubstringsAfterOffset(&contents_text, 0, "</question>", "");
 
   VLOG(1) << __func__
           << " Number of chars in content text = " << contents_text.length()

--- a/components/ai_chat/ai_chat_tab_helper.h
+++ b/components/ai_chat/ai_chat_tab_helper.h
@@ -77,6 +77,7 @@ class AIChatTabHelper : public content::WebContentsObserver,
 
   // TODO(nullhook): Abstract the data model
   std::vector<ai_chat::mojom::ConversationTurn> chat_history_;
+  std::string article_text_;
   std::string history_text_;
   std::string article_summary_;
   bool is_request_in_progress_;

--- a/components/ai_chat/constants.cc
+++ b/components/ai_chat/constants.cc
@@ -9,7 +9,9 @@ namespace ai_chat {
 
 // Note the blank space intentionally added
 constexpr char kHumanPrompt[] = "\n\nHuman: ";
+constexpr char kHumanPromptPlaceholder[] = "\n\nH: ";
 constexpr char kAIPrompt[] = "\n\nAssistant:";
+constexpr char kAIPromptPlaceholder[] = "\n\nA:";
 constexpr char kAIChatCompletionPath[] = "v1/complete";
 
 base::span<const webui::LocalizedString> GetLocalizedStrings() {

--- a/components/ai_chat/constants.h
+++ b/components/ai_chat/constants.h
@@ -13,9 +13,11 @@ namespace ai_chat {
 
 // prefix for for user input
 extern const char kHumanPrompt[];
+extern const char kHumanPromptPlaceholder[];
 
 // prefix for AI assistant output
 extern const char kAIPrompt[];
+extern const char kAIPromptPlaceholder[];
 
 extern const char kAIChatCompletionPath[];
 

--- a/components/resources/ai_chat_prompts.grdp
+++ b/components/resources/ai_chat_prompts.grdp
@@ -1,10 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <grit-part>
-  <message name="IDS_AI_CHAT_SUMMARIZE_PROMPT" translateable="false" desc="Default prompt for summarization">Summarize the following article in 3-4 sentences.
+  <message name="IDS_AI_CHAT_SUMMARIZE_PROMPT" translateable="false" desc="Default prompt for summarization">Here is an article in &lt;article&gt; tags:
+&lt;article&gt;
 <ph name="TEXT">$1</ph>
-For any subsequent questions, keep your answer concise and to the point.</message>
-<!-- For the following questions provide a simple, respond in at most 3-4 sentences. Use a neutral, objective tone.
-Here is an article in &lt;article&gt; tags:
-&lt;article&gt;<ph name="TEXT">$1</ph>&lt;/article&gt; -->
-<!-- Write a summary for the news article.</message> -->
+&lt;/article&gt;
+For the rest of the conversation, provide objective, neutral responses of maximum 3-4 sentences. Strictly avoid emotional language, lengthy bullet lists or convoluted phrasing. Start by writing a summary for the news article above.</message>
 </grit-part>

--- a/components/resources/ai_chat_prompts.grdp
+++ b/components/resources/ai_chat_prompts.grdp
@@ -1,7 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <grit-part>
-  <message name="IDS_AI_CHAT_SUMMARIZE_PROMPT" translateable="false" desc="Default prompt for summarization">
-    Write a concise summary and always respond in bullet points:
-    <ph name="TEXT">$1</ph>
-  </message>
+  <message name="IDS_AI_CHAT_SUMMARIZE_PROMPT" translateable="false" desc="Default prompt for summarization">Summarize the following article in 3-4 sentences.
+<ph name="TEXT">$1</ph>
+For any subsequent questions, keep your answer concise and to the point.</message>
+<!-- For the following questions provide a simple, respond in at most 3-4 sentences. Use a neutral, objective tone.
+Here is an article in &lt;article&gt; tags:
+&lt;article&gt;<ph name="TEXT">$1</ph>&lt;/article&gt; -->
+<!-- Write a summary for the news article.</message> -->
 </grit-part>

--- a/components/resources/ai_chat_prompts.grdp
+++ b/components/resources/ai_chat_prompts.grdp
@@ -2,7 +2,25 @@
 <grit-part>
   <message name="IDS_AI_CHAT_SUMMARIZE_PROMPT" translateable="false" desc="Default prompt for summarization">Here is an article in &lt;article&gt; tags:
 &lt;article&gt;
-<ph name="TEXT">$1</ph>
+<ph name="ARTICLE">$1</ph>
 &lt;/article&gt;
-For the rest of the conversation, provide objective, neutral responses of maximum 3-4 sentences. Strictly avoid emotional language, lengthy bullet lists or convoluted phrasing. Start by writing a summary for the news article above.</message>
+
+You will be acting as a news expert named David created by the company Brave News. Your goal is to summarize and answer questions about the news article above to users in a way that is simple and time efficient. You will be replying to users who are on the Brave browser and who will be confused if you don't respond in the character of David.
+Here are some important rules for the interaction:
+- Conciseness is important. Your responses should not exceed 3 sentences.
+- Always respond in a neutral tone.
+- Always stay in character, as David, an AI from Brave News.
+- If you are unsure how to respond, say "Sorry, I didn't understand that. Could you rephrase your question?"
+
+Here is the conversational history (between the user and you) prior to the question. It could be empty if there is no history:
+&lt;history&gt;
+<ph name="HISTORY">$2</ph>
+&lt;/history&gt;
+
+Here is the user's question:
+&lt;question&gt;
+<ph name="QUESTION">$3</ph>
+&lt;/question&gt;
+
+How do you respond to the user's question? Put your response in &lt;response&gt;&lt;/response&gt; tags.</message>
 </grit-part>

--- a/components/resources/ai_chat_prompts.grdp
+++ b/components/resources/ai_chat_prompts.grdp
@@ -7,7 +7,7 @@
 
 You will be acting as a news expert named David created by the company Brave News. Your goal is to summarize and answer questions about the news article above to users in a way that is simple and time efficient. You will be replying to users who are on the Brave browser and who will be confused if you don't respond in the character of David.
 Here are some important rules for the interaction:
-- Conciseness is important. Your responses should not exceed 3 sentences.
+- Conciseness is important. Your responses should not exceed 6 sentences.
 - Always respond in a neutral tone.
 - Always stay in character, as David, an AI from Brave News.
 - If you are unsure how to respond, say "Sorry, I didn't understand that. Could you rephrase your question?"


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/30171

Prompt should conform to the following format:
```
\n\nHuman: [HUMAN_TEXT]\n\nAssistant: [ASSISTANT_TEXT]\n\nHuman: [MORE HUMAN TEXT]\n\nAssistant:
```

This PR addresses the following issues:
- nits with prompt formatting
- summaries and responses are too long and filled with excessive detail
- instructions-following (if simply added at the beginning) wanes after just a few interactions, and agent goes free-form 

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-arm64, CI/skip-linux-x64, CI/skip-android, CI/skip-macos, CI/skip-ios, CI/skip-windows-arm64, CI/skip-windows-x64, CI/skip-windows-x86 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [ ] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

