### PR TITLE
Adds android_aab_to_apk into Android builds to produce a correct arm64 apk via aab conversion

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -214,7 +214,11 @@ copy("theme_files") {
 group("create_dist") {
   deps = []
   if (is_android) {
-    deps += [ "build/android:sign_app" ]
+    if (android_aab_to_apk && target_cpu == "arm64") {
+      deps += [ "build/android:sign_app_convert_aab_to_apk" ]
+    } else {
+      deps += [ "build/android:sign_app" ]
+    }
   } else {
     deps += [ ":create_symbols_dist" ]
   }

--- a/build/android/BUILD.gn
+++ b/build/android/BUILD.gn
@@ -8,11 +8,39 @@ import("//brave/build/config.gni")
 import("//build/config/android/rules.gni")
 import("//tools/grit/grit_rule.gni")
 
+_apksigner = "$android_sdk_build_tools/apksigner"
+_jarsigner = "//third_party/jdk/current/bin/jarsigner"
+_zipalign = "$android_sdk_build_tools/zipalign"
+
+action("sign_app_convert_aab_to_apk") {
+  script = "//brave/build/android/aab_to_apk.py"
+
+  deps = [ ":sign_app" ]
+
+  target_aab_path = "$root_out_dir/apks/MonochromePublic6432.aab"
+  output_apk_path = "$root_out_dir/apks/Bravearm64Universal.apk"
+  output_path = "$root_out_dir/apks/"
+  bundletool = "//third_party/android_build_tools/bundletool/bundletool.jar"
+
+  outputs = [ output_apk_path ]
+
+  args = [
+    rebase_path(bundletool, root_out_dir),
+    rebase_path(target_aab_path, root_out_dir),
+    rebase_path(output_apk_path, root_out_dir),
+    rebase_path(output_path, root_out_dir),
+    rebase_path("$brave_android_keystore_path", root_out_dir),
+    "$brave_android_keystore_password",
+    "$brave_android_key_password",
+    "$brave_android_keystore_name",
+    rebase_path(_zipalign, root_out_dir),
+    rebase_path(_apksigner, root_out_dir),
+    rebase_path(_jarsigner, root_out_dir),
+  ]
+}
+
 action("sign_app") {
   script = "//brave/build/android/sign_apk.py"
-  _apksigner = "$android_sdk_build_tools/apksigner"
-  _jarsigner = "//third_party/jdk/current/bin/jarsigner"
-  _zipalign = "$android_sdk_build_tools/zipalign"
 
   deps = [ "//brave:create_symbols_dist" ]
 

--- a/build/android/aab_to_apk.py
+++ b/build/android/aab_to_apk.py
@@ -1,0 +1,65 @@
+# Copyright (c) 2023 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import argparse
+import os
+import shlex
+import subprocess
+import sys
+import zipfile
+import sign_apk
+
+
+def main():
+    argument_parser = argparse.ArgumentParser()
+    argument_parser.add_argument('bundletool')
+    argument_parser.add_argument('target_aab_path')
+    argument_parser.add_argument('output_apk_path')
+    argument_parser.add_argument('output_path')
+    argument_parser.add_argument('key_path')
+    argument_parser.add_argument('key_passwd')
+    argument_parser.add_argument('prvt_key_passwd')
+    argument_parser.add_argument('key_name')
+    argument_parser.add_argument('zipalign_path')
+    argument_parser.add_argument('apksigner_path')
+    argument_parser.add_argument('jarsigner_path')
+    args = argument_parser.parse_args()
+
+    apks_name = os.path.splitext(args.output_apk_path)[0] + ".apks"
+
+    if os.path.isfile(apks_name):
+        os.remove(apks_name)
+    command_line = "java -jar " + args.bundletool + " build-apks " + \
+                   "--bundle=" + args.target_aab_path + \
+                   " --output=" + apks_name + \
+                   " --mode=universal " + \
+                   "--ks=" + args.key_path + \
+                   " --ks-key-alias=" + args.key_name + \
+                   " --ks-pass=pass:" + args.key_passwd + \
+                   " --key-pass=pass:" + args.prvt_key_passwd
+    cmd_args = shlex.split(command_line)
+    subprocess.check_output(cmd_args)
+
+    universal_apk = args.output_path + 'universal.apk'
+    if os.path.isfile(universal_apk):
+        os.remove(universal_apk)
+    with zipfile.ZipFile(apks_name, 'r') as z:
+        z.extract('universal.apk', args.output_path)
+        z.close()
+
+    if os.path.isfile(args.output_apk_path):
+        os.remove(args.output_apk_path)
+    os.rename(universal_apk, args.output_apk_path)
+
+    if os.path.isfile(apks_name):
+        os.remove(apks_name)
+
+    sign_apk.sign(args.zipalign_path, args.apksigner_path, \
+        args.jarsigner_path, [ args.output_apk_path ], args.key_path, \
+        args.key_passwd, args.prvt_key_passwd, args.key_name)
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/build/commands/lib/config.js
+++ b/build/commands/lib/config.js
@@ -194,6 +194,7 @@ const Config = function () {
   this.goma_offline = false
   this.use_libfuzzer = false
   this.brave_ai_chat_endpoint = getNPMConfig(['brave_ai_chat_endpoint']) || ''
+  this.androidAabToApk = false
 
   if (process.env.GOMA_DIR !== undefined) {
     this.realGomaDir = process.env.GOMA_DIR
@@ -521,6 +522,7 @@ Config.prototype.buildArgs = function () {
       // it to 'pac'.
       args.arm_control_flow_integrity = 'pac'
     }
+    args.android_aab_to_apk = this.androidAabToApk
 
     // These do not exist on android
     // TODO - recheck
@@ -720,6 +722,9 @@ Config.prototype.update = function (options) {
     }
     if (options.android_override_version_name) {
       this.androidOverrideVersionName = options.android_override_version_name
+    }
+    if (options.android_aab_to_apk) {
+      this.androidAabToApk = options.android_aab_to_apk
     }
   }
 

--- a/build/commands/scripts/commands.js
+++ b/build/commands/scripts/commands.js
@@ -172,6 +172,8 @@ program
   .option('--use_goma [arg]', 'whether to use Goma for building', JSON.parse)
   .option('--goma_offline', 'use offline mode for goma')
   .option('--force_gn_gen', 'always run gn gen')
+  .option('--android_aab_to_apk',
+    'applies an aab to apk conversion to the output aab')
   .arguments('[build_config]')
   .action(createDist)
 

--- a/build/config.gni
+++ b/build/config.gni
@@ -1,3 +1,8 @@
+# Copyright (c) 2018 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+
 import("//build/config/apple/symbols.gni")
 import("//build/util/branding.gni")
 import("//chrome/version.gni")
@@ -43,6 +48,7 @@ declare_args() {
   # Enables brave/tools/redirect_cc target, replaces brave/chromium_src
   # overrides with empty ones to make //base buildable for redirect_cc.
   is_redirect_cc_build = false
+  android_aab_to_apk = false
 }
 
 declare_args() {


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/29388

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-arm64, CI/skip-linux-x64, CI/skip-android, CI/skip-macos, CI/skip-ios, CI/skip-windows-arm64, CI/skip-windows-x64, CI/skip-windows-x86 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

A command to execute the build is:
`npm run create_dist -- Release --target_os=android --target_arch=arm64 --target_android_output_format=aab --target_android_base=mono --channel=nightly --android_aab_to_apk`
The above builds aab, does aab->apk conversion and produces `Bravearm64Universal.apk`. It could be built on top of an aab build without `--android_aab_to_apk` flag to speed up the process.
Or alternatively we can build only once with the flag and collect aab and the new apk.