### PR TITLE
Fix read of encryption password for OSCrypt at KDE (uplift to 1.51.x)

### DIFF
--- a/chromium_src/components/os_crypt/sync/key_storage_kwallet.cc
+++ b/chromium_src/components/os_crypt/sync/key_storage_kwallet.cc
@@ -16,11 +16,12 @@ void Dummy(const int handle,
            bool* has_folder_ptr) {}
 }  // namespace
 
-#define BRAVE_KEY_STORAGE_KWALLET_GET_KEY_IMPL                             \
-  if (!kwallet_dbus_->ReadPassword(handle_, GetFolderName(), GetKeyName(), \
-                                   app_name_, &password)) {                \
-    return absl::nullopt;                                                  \
-    /* NOLINTNEXTLINE */                                                   \
+#define BRAVE_KEY_STORAGE_KWALLET_GET_KEY_IMPL                            \
+  if (kwallet_dbus_->ReadPassword(handle_, GetFolderName(), GetKeyName(), \
+                                  app_name_,                              \
+                                  &password) != KWalletDBus::SUCCESS) {   \
+    return absl::nullopt;                                                 \
+    /* NOLINTNEXTLINE */                                                  \
   } else if (false)
 
 #define BRAVE_KEY_STORAGE_KWALLET_INIT_FOLDER        \


### PR DESCRIPTION
Uplift of #18404
Resolves https://github.com/brave/brave-browser/issues/30147

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.