### PR TITLE
fix(wallet): Moved Portfolio Settings to Header

### DIFF
--- a/components/brave_wallet/browser/brave_wallet_constants.h
+++ b/components/brave_wallet/browser/brave_wallet_constants.h
@@ -279,8 +279,6 @@ constexpr webui::LocalizedString kLocalizedStrings[] = {
      IDS_BRAVE_WALLET_WALLET_POPUP_HIDE_BALANCES},
     {"braveWalletWalletPopupShowGraph",
      IDS_BRAVE_WALLET_WALLET_POPUP_SHOW_GRAPH},
-    {"braveWalletWalletPopupPortfolioCustomizations",
-     IDS_BRAVE_WALLET_WALLET_POPUP_PORTFOLIO_CUSTOMIZATIONS},
     {"braveWalletBackupWarningText", IDS_BRAVE_WALLET_BACKUP_WARNING_TEXT},
     {"braveWalletBackupButton", IDS_BRAVE_WALLET_BACKUP_BUTTON},
     {"braveWalletDismissButton", IDS_BRAVE_WALLET_DISMISS_BUTTON},

--- a/components/brave_wallet_ui/components/desktop/card-headers/card-headers.style.ts
+++ b/components/brave_wallet_ui/components/desktop/card-headers/card-headers.style.ts
@@ -5,6 +5,8 @@
 
 import styled from 'styled-components'
 import * as leo from '@brave/leo/tokens/css'
+import Icon from '@brave/leo/react/icon'
+import { WalletButton } from '../../shared/style'
 
 export const HeaderTitle = styled.span`
   font-family: Poppins;
@@ -13,4 +15,31 @@ export const HeaderTitle = styled.span`
   font-weight: 500;
   line-height: 40px;
   color: ${leo.color.text.primary};
+`
+
+export const MenuWrapper = styled.div`
+  position: relative;
+`
+
+export const CircleButton = styled(WalletButton)`
+  --button-border-color: ${leo.color.primary[20]};
+  @media (prefers-color-scheme: dark) {
+    --button-border-color: ${leo.color.primary[50]};
+  }
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  outline: none;
+  background: none;
+  background-color: ${leo.color.container.background};
+  border-radius: 100%;
+  border: 1px solid var(--button-border-color);
+  height: 36px;
+  width: 36px;
+`
+
+export const ButtonIcon = styled(Icon)`
+  --leo-icon-size: 18px;
+  color: ${leo.color.icon.interactive};
 `

--- a/components/brave_wallet_ui/components/desktop/card-headers/portfolio-overview-header.tsx
+++ b/components/brave_wallet_ui/components/desktop/card-headers/portfolio-overview-header.tsx
@@ -8,13 +8,40 @@ import * as React from 'react'
 // Utils
 import { getLocale } from '../../../../common/locale'
 
+// Hooks
+import {
+  useOnClickOutside
+} from '../../../common/hooks/useOnClickOutside'
+
+import {
+  PortfolioOverviewMenu
+} from '../wallet-menus/portfolio-overview-menu'
+
 // Styled Components
 import {
-  HeaderTitle
+  HeaderTitle,
+  CircleButton,
+  ButtonIcon,
+  MenuWrapper
 } from './card-headers.style'
 import { Row } from '../../shared/style'
 
 export const PortfolioOverviewHeader = () => {
+  // State
+  const [showPortfolioOverviewMenu, setShowPortfolioOverviewMenu] =
+    React.useState<boolean>(false)
+
+  // Refs
+  const portfolioOverviewMenuRef =
+    React.useRef<HTMLDivElement>(null)
+
+  // Hooks
+  useOnClickOutside(
+    portfolioOverviewMenuRef,
+    () => setShowPortfolioOverviewMenu(false),
+    showPortfolioOverviewMenu
+  )
+
   return (
     <Row
       padding='24px 0px'
@@ -23,6 +50,22 @@ export const PortfolioOverviewHeader = () => {
       <HeaderTitle>
         {getLocale('braveWalletTopNavPortfolio')}
       </HeaderTitle>
+      <MenuWrapper
+        ref={portfolioOverviewMenuRef}
+      >
+        <CircleButton
+          onClick={
+            () => setShowPortfolioOverviewMenu(prev => !prev)
+          }
+        >
+          <ButtonIcon
+            name='more-vertical'
+          />
+        </CircleButton>
+        {showPortfolioOverviewMenu &&
+          <PortfolioOverviewMenu />
+        }
+      </MenuWrapper>
     </Row>
   )
 }

--- a/components/brave_wallet_ui/components/desktop/wallet-menus/portfolio-overview-menu.tsx
+++ b/components/brave_wallet_ui/components/desktop/wallet-menus/portfolio-overview-menu.tsx
@@ -1,0 +1,112 @@
+// Copyright (c) 2023 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import * as React from 'react'
+import { useDispatch } from 'react-redux'
+import Checkbox from '@brave/leo/react/checkbox'
+
+// Actions
+import { WalletActions } from '../../../common/actions'
+
+// Selectors
+import {
+  useSafeWalletSelector
+} from '../../../common/hooks/use-safe-selector'
+import {
+  WalletSelectors
+} from '../../../common/selectors'
+
+// Utils
+import { getLocale } from '../../../../common/locale'
+
+// Constants
+import {
+  LOCAL_STORAGE_KEYS
+} from '../../../common/constants/local-storage-keys'
+
+// Styled Components
+import {
+  StyledWrapper,
+  PopupButtonText,
+  ButtonIcon,
+  CheckBoxRow
+} from './wellet-menus.style'
+import {
+  Row
+} from '../../shared/style'
+
+export const PortfolioOverviewMenu = () => {
+
+  // Redux
+  const dispatch = useDispatch()
+
+  const hidePortfolioGraph =
+    useSafeWalletSelector(WalletSelectors.hidePortfolioGraph)
+  const hidePortfolioBalances =
+    useSafeWalletSelector(WalletSelectors.hidePortfolioBalances)
+
+  // Methods
+  const onToggleHideGraph = React.useCallback(() => {
+    window.localStorage.setItem(
+      LOCAL_STORAGE_KEYS.IS_PORTFOLIO_OVERVIEW_GRAPH_HIDDEN,
+      hidePortfolioGraph
+        ? 'false'
+        : 'true'
+    )
+    dispatch(
+      WalletActions
+        .setHidePortfolioGraph(
+          !hidePortfolioGraph
+        ))
+  }, [hidePortfolioGraph])
+
+  const onToggleHideBalances = React.useCallback(() => {
+    window.localStorage.setItem(
+      LOCAL_STORAGE_KEYS.HIDE_PORTFOLIO_BALANCES,
+      hidePortfolioBalances
+        ? 'false'
+        : 'true'
+    )
+    dispatch(
+      WalletActions
+        .setHidePortfolioBalances(
+          !hidePortfolioBalances
+        ))
+  }, [hidePortfolioBalances])
+
+  return (
+    <StyledWrapper yPosition={42}>
+      <CheckBoxRow onClick={onToggleHideBalances}>
+        <ButtonIcon name='eye-off' />
+        <PopupButtonText>
+          {getLocale('braveWalletWalletPopupHideBalances')}
+        </PopupButtonText>
+        <Checkbox
+          checked={hidePortfolioBalances}
+          onChanged={onToggleHideBalances}
+          size='normal'
+        />
+      </CheckBoxRow>
+
+      <CheckBoxRow onClick={onToggleHideGraph}>
+        <Row>
+          {/* This graph icon needs to be updated to the
+              one in figma once it is added to leo. */}
+          <ButtonIcon name='graph' />
+          <PopupButtonText>
+            {getLocale('braveWalletWalletPopupShowGraph')}
+          </PopupButtonText>
+        </Row>
+        <Checkbox
+          checked={!hidePortfolioGraph}
+          onChanged={onToggleHideGraph}
+          size='normal'
+        />
+      </CheckBoxRow>
+    </StyledWrapper>
+  )
+}
+
+export default PortfolioOverviewMenu

--- a/components/brave_wallet_ui/components/desktop/wallet-menus/wallet-settings-menu.tsx
+++ b/components/brave_wallet_ui/components/desktop/wallet-menus/wallet-settings-menu.tsx
@@ -5,21 +5,9 @@
 
 import * as React from 'react'
 import { useDispatch } from 'react-redux'
-import Checkbox from '@brave/leo/react/checkbox'
-
-// Selectors
-import {
-  useSafeWalletSelector
-} from '../../../common/hooks/use-safe-selector'
-import {
-  WalletSelectors
-} from '../../../common/selectors'
 
 // Types
 import { BraveWallet } from '../../../constants/types'
-import {
-  LOCAL_STORAGE_KEYS
-} from '../../../common/constants/local-storage-keys'
 
 // actions
 import { WalletActions } from '../../../common/actions'
@@ -34,13 +22,10 @@ import {
   PopupButton,
   PopupButtonText,
   ButtonIcon,
-  CheckBoxRow,
-  SectionTitle
 } from './wellet-menus.style'
 import {
   VerticalDivider,
   VerticalSpace,
-  Row
 } from '../../shared/style'
 
 export interface Props {
@@ -48,7 +33,6 @@ export interface Props {
   onClickBackup?: () => void
   onClosePopup?: () => void
   yPosition?: number
-  isPanel?: boolean
 }
 
 export const WalletSettingsMenu = (props: Props) => {
@@ -56,8 +40,7 @@ export const WalletSettingsMenu = (props: Props) => {
     onClickViewOnBlockExplorer,
     onClickBackup,
     onClosePopup,
-    yPosition,
-    isPanel
+    yPosition
   } = props
 
   // redux
@@ -66,41 +49,7 @@ export const WalletSettingsMenu = (props: Props) => {
   // queries
   const { data: selectedNetwork } = useGetSelectedChainQuery()
 
-  // redux
-  const hidePortfolioGraph =
-    useSafeWalletSelector(WalletSelectors.hidePortfolioGraph)
-  const hidePortfolioBalances =
-    useSafeWalletSelector(WalletSelectors.hidePortfolioBalances)
-
   // methods
-  const onToggleHideGraph = React.useCallback(() => {
-    window.localStorage.setItem(
-      LOCAL_STORAGE_KEYS.IS_PORTFOLIO_OVERVIEW_GRAPH_HIDDEN,
-      hidePortfolioGraph
-        ? 'false'
-        : 'true'
-    )
-    dispatch(
-      WalletActions
-        .setHidePortfolioGraph(
-          !hidePortfolioGraph
-        ))
-  }, [hidePortfolioGraph])
-
-  const onToggleHideBalances = React.useCallback(() => {
-    window.localStorage.setItem(
-      LOCAL_STORAGE_KEYS.HIDE_PORTFOLIO_BALANCES,
-      hidePortfolioBalances
-        ? 'false'
-        : 'true'
-    )
-    dispatch(
-      WalletActions
-        .setHidePortfolioBalances(
-          !hidePortfolioBalances
-        ))
-  }, [hidePortfolioBalances])
-
   const lockWallet = React.useCallback(() => {
     dispatch(WalletActions.lockWallet())
   }, [])
@@ -206,65 +155,15 @@ export const WalletSettingsMenu = (props: Props) => {
         </PopupButton>
       }
 
+      <VerticalDivider />
+      <VerticalSpace space='8px' />
+
       <PopupButton onClick={onClickHelpCenter}>
         <ButtonIcon name='help-outline' />
         <PopupButtonText>
           {getLocale('braveWalletHelpCenter')}
         </PopupButtonText>
       </PopupButton>
-
-      {/* We can remove this prop once PanelV2 is ready. */}
-      {!isPanel &&
-        <>
-          <VerticalDivider />
-          <VerticalSpace space='14px' />
-
-          <Row
-            justifyContent='flex-start'
-            padding='0px 0px 0px 8px'
-            marginBottom={8}
-          >
-            <SectionTitle
-              textSize='12px'
-              textColor='text02'
-              textAlign='left'
-              isBold={true}
-            >
-              {getLocale(
-                'braveWalletWalletPopupPortfolioCustomizations'
-              )}
-            </SectionTitle>
-          </Row>
-
-          <CheckBoxRow onClick={onToggleHideBalances}>
-            <ButtonIcon name='eye-off' />
-            <PopupButtonText>
-              {getLocale('braveWalletWalletPopupHideBalances')}
-            </PopupButtonText>
-            <Checkbox
-              checked={hidePortfolioBalances}
-              onChanged={onToggleHideBalances}
-              size='normal'
-            />
-          </CheckBoxRow>
-
-          <CheckBoxRow onClick={onToggleHideGraph}>
-            <Row>
-              {/* This graph icon needs to be updated to the
-              one in figma once it is added to leo. */}
-              <ButtonIcon name='graph' />
-              <PopupButtonText>
-                {getLocale('braveWalletWalletPopupShowGraph')}
-              </PopupButtonText>
-            </Row>
-            <Checkbox
-              checked={!hidePortfolioGraph}
-              onChanged={onToggleHideGraph}
-              size='normal'
-            />
-          </CheckBoxRow>
-        </>
-      }
 
     </StyledWrapper>
   )

--- a/components/brave_wallet_ui/components/desktop/wallet-menus/wellet-menus.style.ts
+++ b/components/brave_wallet_ui/components/desktop/wallet-menus/wellet-menus.style.ts
@@ -6,7 +6,7 @@
 import styled from 'styled-components'
 import * as leo from '@brave/leo/tokens/css'
 import Icon from '@brave/leo/react/icon'
-import { WalletButton, Text } from '../../shared/style'
+import { WalletButton } from '../../shared/style'
 
 export const StyledWrapper = styled.div<
   {
@@ -79,8 +79,4 @@ export const CheckBoxRow = styled.label`
   padding: 12px 8px;
   margin: 0px 0px 8px 0px;
   background-color: transparent;
-`
-
-export const SectionTitle = styled(Text)`
-  text-transform: uppercase;
 `

--- a/components/brave_wallet_ui/components/extension/connected-header/index.tsx
+++ b/components/brave_wallet_ui/components/extension/connected-header/index.tsx
@@ -45,7 +45,6 @@ export const ConnectedHeader = (props: Props) => {
       {showMore &&
         <WalletSettingsMenu
           onClickViewOnBlockExplorer={onClickViewOnBlockExplorer}
-          isPanel={true}
         />
       }
     </HeaderWrapper>

--- a/components/brave_wallet_ui/stories/locale.ts
+++ b/components/brave_wallet_ui/stories/locale.ts
@@ -259,7 +259,6 @@ provideStrings({
   braveWalletWalletPopupConnectedSites: 'Connected sites',
   braveWalletWalletPopupHideBalances: 'Hide balances',
   braveWalletWalletPopupShowGraph: 'Show graph',
-  braveWalletWalletPopupPortfolioCustomizations: 'Portfolio customizations',
 
   // Backup Warning
   braveWalletBackupWarningText: 'Back up your wallet now to protect your assets and ensure you never lose access.',

--- a/components/resources/wallet_strings.grdp
+++ b/components/resources/wallet_strings.grdp
@@ -176,7 +176,6 @@
   <message name="IDS_BRAVE_WALLET_WALLET_POPUP_CONNECTED_SITES" desc="Wallet popup connected sites button">Connected sites</message>
   <message name="IDS_BRAVE_WALLET_WALLET_POPUP_HIDE_BALANCES" desc="Wallet popup hide balances checkbox">Hide balances</message>
   <message name="IDS_BRAVE_WALLET_WALLET_POPUP_SHOW_GRAPH" desc="Wallet popup show graph checkbox">Show graph</message>
-  <message name="IDS_BRAVE_WALLET_WALLET_POPUP_PORTFOLIO_CUSTOMIZATIONS" desc="Wallet popup portfolio customizations sections">Portfolio customizations</message>
   <message name="IDS_BRAVE_WALLET_BACKUP_WARNING_TEXT" desc="Backup warning banner description">Back up your wallet now to protect your assets and ensure you never lose access.</message>
   <message name="IDS_BRAVE_WALLET_BACKUP_BUTTON" desc="Backup warning banner back up button">Back up now</message>
   <message name="IDS_BRAVE_WALLET_DISMISS_BUTTON" desc="Backup warning banner dismiss button">Dismiss</message>


### PR DESCRIPTION
## Description 
Moved `Portfolio` settings into the `Portfolio` sticky header.

<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves <https://github.com/brave/brave-browser/issues/30216>

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-arm64, CI/skip-linux-x64, CI/skip-android, CI/skip-macos, CI/skip-ios, CI/skip-windows-arm64, CI/skip-windows-x64, CI/skip-windows-x86 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
1. Go to the `Portfolio` page
2. Open the `Wallet Settings` menu, you should not see any `Portfolio` settings
3. Open the `Portfolio Settings` on the `Portfolio` header
4. Test `Hide balances` and `Show graph`, both should work and persist as expected.

https://github.com/brave/brave-core/assets/40611140/83146ad6-08bf-46d7-871c-ef23b6b3d6ed
