### PR TITLE
feat: reusable pending transaction fee component

### DIFF
--- a/components/brave_wallet/browser/brave_wallet_constants.h
+++ b/components/brave_wallet/browser/brave_wallet_constants.h
@@ -47,6 +47,7 @@ constexpr char kSimpleHashBraveProxyUrl[] =
     "https://simplehash.wallet.brave.com";
 
 constexpr webui::LocalizedString kLocalizedStrings[] = {
+    {"braveWalletNetworkFees", IDS_BRAVE_WALLET_NETWORK_FEES},
     {"braveWalletSolanaSysvarRentProgram",
      IDS_BRAVE_WALLET_SOLANA_SYSVAR_RENT_PROGRAM},
     {"braveWalletSolanaMetaDataProgram",

--- a/components/brave_wallet_ui/components/extension/confirm-transaction-panel/swap.style.tsx
+++ b/components/brave_wallet_ui/components/extension/confirm-transaction-panel/swap.style.tsx
@@ -5,7 +5,6 @@
 
 import styled from 'styled-components'
 
-import { SettingsAdvancedIcon } from 'brave-ui/components/icons'
 import ArrowDown2Icon from '../../../assets/svg-icons/arrow-down-2.svg'
 import { AssetIconFactory, AssetIconProps, WalletButton } from '../../shared/style'
 
@@ -171,50 +170,6 @@ export const NetworkDescriptionText = styled.span`
   font-size: 12px;
   display: flex;
   align-items: center;
-  color: ${p => p.theme.color.text03};
-`
-
-export const NetworkFeeAndSettingsContainer = styled.div`
-  display: flex;
-  justify-content: space-between;
-  width: calc(100% - 8px);
-`
-
-export const NetworkFeeContainer = styled.div``
-
-export const NetworkFeeTitle = styled.div`
-  font-family: 'Poppins';
-  font-style: normal;
-  font-weight: 500;
-  font-size: 12px;
-  line-height: 20px;
-  color: ${p => p.theme.color.text03};
-`
-
-export const NetworkFeeValue = styled.div`
-  font-family: 'Poppins';
-  font-style: normal;
-  font-weight: 500;
-  font-size: 14px;
-  line-height: 18px;
-  display: flex;
-  align-items: center;
-  letter-spacing: 0.01em;
-  color: ${p => p.theme.color.text02};
-  gap: 6px;
-`
-
-export const Settings = styled(WalletButton)`
-  display: flex;
-  align-self: flex-start;
-  cursor: pointer;
-  outline: none;
-  border: none;
-  background: none;
-`
-
-export const SettingsIcon = styled(SettingsAdvancedIcon)`
-  width: 14px;
   color: ${p => p.theme.color.text03};
 `
 

--- a/components/brave_wallet_ui/components/extension/confirm-transaction-panel/swap.tsx
+++ b/components/brave_wallet_ui/components/extension/confirm-transaction-panel/swap.tsx
@@ -31,12 +31,6 @@ import {
   NetworkDescriptionText,
   Spacer,
   SwapAssetAmountSymbol,
-  NetworkFeeAndSettingsContainer,
-  NetworkFeeTitle,
-  NetworkFeeContainer,
-  NetworkFeeValue,
-  Settings,
-  SettingsIcon
 } from './swap.style'
 import { EditButton, NetworkText, StyledWrapper, TopRow } from './style'
 import { CreateNetworkIcon, LoadingSkeleton, withPlaceholderIcon } from '../../shared'
@@ -49,6 +43,9 @@ import { EditPendingTransactionGas } from './common/gas'
 import { TransactionQueueStep } from './common/queue'
 import { Footer } from './common/footer'
 import AdvancedTransactionSettings from '../advanced-transaction-settings'
+import {
+  PendingTransactionNetworkFeeAndSettings //
+} from '../pending-transaction-network-fee/pending-transaction-network-fee'
 
 // Types
 import { BraveWallet } from '../../../constants/types'
@@ -58,8 +55,7 @@ import { UNKNOWN_TOKEN_COINGECKO_ID } from '../../../common/constants/magics'
 import { usePendingTransactions } from '../../../common/hooks/use-pending-transaction'
 import { useGetNetworkQuery } from '../../../common/slices/api.slice'
 import {
-  useSafeWalletSelector,
-  useUnsafeWalletSelector
+  useUnsafeWalletSelector //
 } from '../../../common/hooks/use-safe-selector'
 
 interface Props {
@@ -71,9 +67,6 @@ export function ConfirmSwapTransaction (props: Props) {
   const { onConfirm, onReject } = props
 
   // redux
-  const defaultFiatCurrency = useSafeWalletSelector(
-    WalletSelectors.defaultFiatCurrency
-  )
   const activeOrigin = useUnsafeWalletSelector(WalletSelectors.activeOrigin)
   const transactionInfo = useUnsafeWalletSelector(
     WalletSelectors.selectedPendingTransaction
@@ -87,7 +80,6 @@ export function ConfirmSwapTransaction (props: Props) {
   // hooks
   const {
     transactionDetails,
-    transactionsNetwork,
     fromOrb,
     toOrb,
     updateUnapprovedTransactionNonce
@@ -188,28 +180,12 @@ export function ConfirmSwapTransaction (props: Props) {
         />
       </SwapDetails>
 
-      <NetworkFeeAndSettingsContainer>
-        <NetworkFeeContainer>
-          <NetworkFeeTitle>Network fee</NetworkFeeTitle>
-          <NetworkFeeValue>
-            <CreateNetworkIcon network={transactionsNetwork} marginRight={0} />
-            {transactionDetails?.gasFeeFiat ? (
-              new Amount(transactionDetails.gasFeeFiat).formatAsFiat(
-                defaultFiatCurrency
-              )
-            ) : (
-              <LoadingSkeleton width={38} />
-            )}
-            <EditButton onClick={onToggleEditGas}>
-              {getLocale('braveWalletAllowSpendEditButton')}
-            </EditButton>
-          </NetworkFeeValue>
-        </NetworkFeeContainer>
-
-        <Settings onClick={onToggleAdvancedTransactionSettings}>
-          <SettingsIcon />
-        </Settings>
-      </NetworkFeeAndSettingsContainer>
+      <PendingTransactionNetworkFeeAndSettings
+        onToggleAdvancedTransactionSettings={
+          onToggleAdvancedTransactionSettings
+        }
+        onToggleEditGas={onToggleEditGas}
+      />
 
       <Footer
         onConfirm={onConfirm}

--- a/components/brave_wallet_ui/components/extension/pending-transaction-network-fee/pending-transaction-network-fee.style.tsx
+++ b/components/brave_wallet_ui/components/extension/pending-transaction-network-fee/pending-transaction-network-fee.style.tsx
@@ -1,0 +1,53 @@
+// Copyright (c) 2023 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import styled from 'styled-components'
+import { SettingsAdvancedIcon } from 'brave-ui/components/icons'
+
+import { WalletButton } from '../../shared/style'
+
+export const NetworkFeeAndSettingsContainer = styled.div`
+  display: flex;
+  justify-content: space-between;
+  width: calc(100% - 8px);
+`
+
+export const NetworkFeeContainer = styled.div``
+
+export const NetworkFeeTitle = styled.div`
+  font-family: 'Poppins';
+  font-style: normal;
+  font-weight: 500;
+  font-size: 12px;
+  line-height: 20px;
+  color: ${p => p.theme.color.text03};
+`
+
+export const NetworkFeeValue = styled.div`
+  font-family: 'Poppins';
+  font-style: normal;
+  font-weight: 500;
+  font-size: 14px;
+  line-height: 18px;
+  display: flex;
+  align-items: center;
+  letter-spacing: 0.01em;
+  color: ${p => p.theme.color.text02};
+  gap: 6px;
+`
+
+export const Settings = styled(WalletButton)`
+  display: flex;
+  align-self: flex-start;
+  cursor: pointer;
+  outline: none;
+  border: none;
+  background: none;
+`
+
+export const SettingsIcon = styled(SettingsAdvancedIcon)`
+  width: 14px;
+  color: ${p => p.theme.color.text03};
+`

--- a/components/brave_wallet_ui/components/extension/pending-transaction-network-fee/pending-transaction-network-fee.tsx
+++ b/components/brave_wallet_ui/components/extension/pending-transaction-network-fee/pending-transaction-network-fee.tsx
@@ -1,0 +1,76 @@
+// Copyright (c) 2023 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import * as React from 'react'
+
+// utils
+import Amount from '../../../utils/amount'
+import { getLocale } from '../../../../common/locale'
+
+// components
+import { CreateNetworkIcon } from '../../shared/create-network-icon/index'
+import LoadingSkeleton from '../../shared/loading-skeleton'
+import { EditButton } from '../confirm-transaction-panel/style'
+
+// hooks
+import {
+  usePendingTransactions //
+} from '../../../common/hooks/use-pending-transaction'
+import {
+  useGetDefaultFiatCurrencyQuery //
+} from '../../../common/slices/api.slice'
+
+// style
+import {
+  NetworkFeeAndSettingsContainer,
+  NetworkFeeContainer,
+  NetworkFeeTitle,
+  NetworkFeeValue,
+  Settings,
+  SettingsIcon
+} from './pending-transaction-network-fee.style'
+
+interface Props {
+  onToggleEditGas?: () => void
+  onToggleAdvancedTransactionSettings?: () => void
+}
+
+export const PendingTransactionNetworkFeeAndSettings: React.FC<Props> = ({
+  onToggleAdvancedTransactionSettings,
+  onToggleEditGas
+}) => {
+  // custom hooks
+  const { transactionDetails, transactionsNetwork } = usePendingTransactions()
+
+  // queries
+  const { data: defaultFiatCurrency } = useGetDefaultFiatCurrencyQuery()
+
+  return (
+    <NetworkFeeAndSettingsContainer>
+      <NetworkFeeContainer>
+        <NetworkFeeTitle>{getLocale('braveWalletNetworkFees')}</NetworkFeeTitle>
+        <NetworkFeeValue>
+          <CreateNetworkIcon network={transactionsNetwork} marginRight={0} />
+          {transactionDetails?.gasFeeFiat ? (
+            new Amount(transactionDetails.gasFeeFiat).formatAsFiat(
+              defaultFiatCurrency
+            )
+          ) : (
+            <LoadingSkeleton width={38} />
+          )}
+          <EditButton onClick={onToggleEditGas}>
+            {getLocale('braveWalletAllowSpendEditButton')}
+          </EditButton>
+        </NetworkFeeValue>
+      </NetworkFeeContainer>
+
+      {onToggleAdvancedTransactionSettings && (
+        <Settings onClick={onToggleAdvancedTransactionSettings}>
+          <SettingsIcon />
+        </Settings>
+      )}
+    </NetworkFeeAndSettingsContainer>
+  )
+}

--- a/components/brave_wallet_ui/stories/locale.ts
+++ b/components/brave_wallet_ui/stories/locale.ts
@@ -527,6 +527,7 @@ provideStrings({
   braveWalletTransactionGasLimit: 'Gas Limit',
   braveWalletTransactionGasPremium: 'Gas Premium',
   braveWalletTransactionGasFeeCap: 'Gas Fee Cap',
+  braveWalletNetworkFees: 'Network fees',
 
   // Wallet Main Panel
   braveWalletPanelTitle: 'Brave Wallet',

--- a/components/resources/wallet_strings.grdp
+++ b/components/resources/wallet_strings.grdp
@@ -914,4 +914,5 @@
   <message name="IDS_BRAVE_WALLET_AUTO_DISCOVERY_EMPTY_STATE_SUB_HEADING" desc="NFTs tab empty state sub heading when auto discovery is enabled">Once an NFT is detected, it’ll be displayed here.</message>
   <message name="IDS_BRAVE_WALLET_AUTO_DISCOVERY_EMPTY_STATE_FOOTER" desc="NFTs tab empty state footer when auto discovery is enabled">Can’t see your NFTs?</message>
   <message name="IDS_BRAVE_WALLET_AUTO_DISCOVERY_EMPTY_STATE_ACTIONS" desc="NFTs tab empty state action button text when auto discovery is enabled"><ph name="REFRESH">$1</ph>Refresh<ph name="REFRESH_END">$2</ph> or <ph name="IMPORT">$3</ph>Import Manually<ph name="IMPORT_END">$4</ph></message>
+  <message name="IDS_BRAVE_WALLET_NETWORK_FEES" desc="Label for blockchain network fees">Network fees</message>
 </grit-part>


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/30235

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-arm64, CI/skip-linux-x64, CI/skip-android, CI/skip-macos, CI/skip-ios, CI/skip-windows-arm64, CI/skip-windows-x64, CI/skip-windows-x86 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
Network fee edit button, setting button, and value shown during swaps should remain functional without regressions.
![Screenshot 2023-05-09 at 2 29 11 PM](https://github.com/brave/brave-core/assets/30185185/61524b28-665c-45bc-855b-978d1737b432)
![Screenshot 2023-05-09 at 2 29 19 PM](https://github.com/brave/brave-core/assets/30185185/7fd15d77-43e7-4251-911f-e3de4f84cc1e)
