### PR TITLE
fix(wallet): Remove Transition Durations

### DIFF
--- a/components/brave_wallet_ui/components/desktop/wallet-nav/wallet-nav-button/wallet-nav-button.style.ts
+++ b/components/brave_wallet_ui/components/desktop/wallet-nav/wallet-nav-button/wallet-nav-button.style.ts
@@ -33,8 +33,6 @@ export const StyledButton = styled(WalletButton) <{ isSelected?: boolean }>`
   &:last-child {
     margin-bottom: 0px;
   }
-  transition-duration: 0.1s;
-  transition-timing-function: ease;
   @media screen and (max-width: ${layoutSmallWidth}px) {
     padding: 6px 0px 3px 0px;
     width: 100%;
@@ -51,15 +49,11 @@ export const ButtonIcon = styled(Icon)`
   --leo-icon-size: 24px;
   color: var(--nav-button-color);
   margin-right: var(--icon-margin-right);
-  transition-duration: inherit;
-  transition-timing-function: inherit;
 `
 
 export const ButtonText = styled(Text)`
   color: var(--nav-button-color);
   display: var(--display-text);
-  transition-duration: inherit;
-  transition-timing-function: inherit;
   @media screen and (max-width: ${layoutSmallWidth}px) {
     font-size: 12px;
     font-weight: 400;

--- a/components/brave_wallet_ui/components/desktop/wallet-nav/wallet-nav.style.ts
+++ b/components/brave_wallet_ui/components/desktop/wallet-nav/wallet-nav.style.ts
@@ -22,8 +22,6 @@ export const Wrapper = styled.div`
   overflow: visible;
   z-index: 10;
   padding: 0px 8px;
-  transition-duration: 0.1s;
-  transition-timing-function: ease;
   &:hover {
     --display-text: flex;
     --icon-margin-right: 16px;
@@ -38,7 +36,6 @@ export const Wrapper = styled.div`
     padding: 8px 0px;
     border-radius: 0px;
     box-shadow: 0px -8px 16px rgba(0, 0, 0, 0.04);
-    transition-duration: 0.5s;
     --display-text: flex;
     &:hover {
       --display-text: flex;
@@ -54,8 +51,6 @@ export const Section = styled.div<{ showBorder?: boolean }>`
   flex-direction: column;
   width: 100%;
   padding: 8px 0px;
-  transition-duration: inherit;
-  transition-timing-function: inherit;
   border-bottom: ${(p) => p.showBorder
     ? `1px solid var(--nav-border)`
     : 'none'};
@@ -72,8 +67,6 @@ export const Section = styled.div<{ showBorder?: boolean }>`
 export const PageOptionsWrapper = styled.div`
   display: flex;
   flex-direction: column;
-  transition-duration: inherit;
-  transition-timing-function: inherit;
   @media screen and (max-width: ${layoutSmallWidth}px) {
     display: none;
   }
@@ -82,7 +75,6 @@ export const PageOptionsWrapper = styled.div`
 export const PanelOptionsWrapper = styled.div`
   display: none;
   width: 100%;
-  transition-duration: inherit;
   @media screen and (max-width: ${layoutSmallWidth}px) {
     display: flex;
   }

--- a/components/brave_wallet_ui/components/desktop/wallet-page-wrapper/wallet-page-wrapper.style.ts
+++ b/components/brave_wallet_ui/components/desktop/wallet-page-wrapper/wallet-page-wrapper.style.ts
@@ -51,8 +51,6 @@ export const LayoutCardWrapper = styled.div<{
   bottom: 0px;
   position: absolute;
   width: 100%;
-  transition-duration: 0.5s;
-  transition-timing-function: ease;
   overflow-x: hidden;
   overflow-y: auto;
   padding-bottom: 32px;
@@ -91,8 +89,6 @@ export const ContainerCard = styled.div<
   min-height: ${minCardHeight}px;
   max-width: ${(p) => p.maxWidth ? p.maxWidth : maxCardWidth}px;
   position: relative;
-  transition-duration: inherit;
-  transition-timing-function: inherit;
   @media screen and (max-width: ${layoutSmallWidth}px) {
     width: 100%;
   }
@@ -113,8 +109,6 @@ export const CardHeaderWrapper = styled.div`
   top: ${layoutTopPosition}px;
   position: fixed;
   width: 100%;
-  transition-duration: 0.5s;
-  transition-timing-function: ease;
   @media screen and (max-width: ${layoutSmallWidth}px) {
     padding: 0px 32px;
   }
@@ -138,8 +132,6 @@ export const CardHeader = styled.div<{
   padding: 0px 32px;
   position: relative;
   max-width: ${maxCardWidth}px;
-  transition-duration: inherit;
-  transition-timing-function: inherit;
   box-shadow: 0px 4px 13px -2px rgba(0, 0, 0, var(--shadow-opacity));
 `
 


### PR DESCRIPTION
## Description 
Removes the `Transition Durations` from the `Wallet Layout` to make everything more snappy.

<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves <https://github.com/brave/brave-browser/issues/30242>

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-arm64, CI/skip-linux-x64, CI/skip-android, CI/skip-macos, CI/skip-ios, CI/skip-windows-arm64, CI/skip-windows-x64, CI/skip-windows-x86 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
1. Go to the `Portfolio` page
2. Collapse the `Browser` width
3. The layout should snap into place rather than having a transition duration.

Before:

https://github.com/brave/brave-core/assets/40611140/1949eea1-2654-4d06-b994-94857dd9c3a3

After:

https://github.com/brave/brave-core/assets/40611140/4f1e61f4-7b93-49c6-8ea8-b6d0f654ca59
