### PR TITLE
Persist NTP-SI index and for both Rewards and non-Rewards users

### DIFF
--- a/browser/ui/webui/new_tab_page/brave_new_tab_message_handler.h
+++ b/browser/ui/webui/new_tab_page/brave_new_tab_message_handler.h
@@ -32,7 +32,7 @@ class PrefService;
 class BraveNewTabMessageHandler : public content::WebUIMessageHandler,
                                   public brave_ads::AdsServiceObserver {
  public:
-  explicit BraveNewTabMessageHandler(Profile* profile);
+  BraveNewTabMessageHandler(Profile* profile, bool was_invisible_and_restored);
   BraveNewTabMessageHandler(const BraveNewTabMessageHandler&) = delete;
   BraveNewTabMessageHandler& operator=(const BraveNewTabMessageHandler&) =
       delete;
@@ -44,7 +44,8 @@ class BraveNewTabMessageHandler : public content::WebUIMessageHandler,
   static bool CanPromptBraveTalk(base::Time now);
   static BraveNewTabMessageHandler* Create(
       content::WebUIDataSource* html_source,
-      Profile* profile);
+      Profile* profile,
+      bool was_invisible_and_restored);
 
  private:
   // WebUIMessageHandler implementation.
@@ -77,6 +78,8 @@ class BraveNewTabMessageHandler : public content::WebUIMessageHandler,
   // Weak pointer.
   raw_ptr<Profile> profile_ = nullptr;
   raw_ptr<brave_ads::AdsService> ads_service_ = nullptr;
+
+  bool was_invisible_and_restored_ = false;
 
   base::ScopedObservation<brave_ads::AdsService, brave_ads::AdsServiceObserver>
       ads_service_observation_{this};

--- a/browser/ui/webui/new_tab_page/brave_new_tab_ui.cc
+++ b/browser/ui/webui/new_tab_page/brave_new_tab_ui.cc
@@ -7,6 +7,7 @@
 
 #include <utility>
 
+#include "base/check.h"
 #include "base/feature_list.h"
 #include "brave/browser/brave_news/brave_news_controller_factory.h"
 #include "brave/browser/new_tab/new_tab_shows_options.h"
@@ -25,7 +26,9 @@
 #include "chrome/common/pref_names.h"
 #include "components/grit/brave_components_resources.h"
 #include "components/strings/grit/components_strings.h"
+#include "content/public/browser/navigation_entry.h"
 #include "content/public/browser/url_data_source.h"
+#include "content/public/browser/web_contents.h"
 #include "content/public/browser/web_ui_data_source.h"
 
 using ntp_background_images::NTPCustomImagesSource;
@@ -35,6 +38,17 @@ BraveNewTabUI::BraveNewTabUI(content::WebUI* web_ui, const std::string& name)
           web_ui,
           true /* Needed for legacy non-mojom message handler */),
       page_factory_receiver_(this) {
+  content::WebContents* web_contents = web_ui->GetWebContents();
+  CHECK(web_contents);
+
+  content::NavigationEntry* navigation_entry =
+      web_contents->GetController().GetLastCommittedEntry();
+  const bool was_restored =
+      navigation_entry ? navigation_entry->IsRestored() : false;
+
+  const bool is_visible =
+      web_contents->GetVisibility() == content::Visibility::VISIBLE;
+
   Profile* profile = Profile::FromWebUI(web_ui);
   web_ui->OverrideTitle(
       brave_l10n::GetLocalizedResourceUTF16String(IDS_NEW_TAB_TITLE));
@@ -43,7 +57,7 @@ BraveNewTabUI::BraveNewTabUI(content::WebUI* web_ui, const std::string& name)
     content::WebUIDataSource* source =
         content::WebUIDataSource::CreateAndAdd(profile, name);
     source->SetDefaultResource(IDR_BRAVE_BLANK_NEW_TAB_HTML);
-    AddBackgroundColorToSource(source, web_ui->GetWebContents());
+    AddBackgroundColorToSource(source, web_contents);
     return;
   }
 
@@ -52,7 +66,7 @@ BraveNewTabUI::BraveNewTabUI(content::WebUI* web_ui, const std::string& name)
       web_ui, name, kBraveNewTabGenerated, kBraveNewTabGeneratedSize,
       IDR_BRAVE_NEW_TAB_HTML);
 
-  AddBackgroundColorToSource(source, web_ui->GetWebContents());
+  AddBackgroundColorToSource(source, web_contents);
 
   source->AddBoolean("featureCustomBackgroundEnabled",
                      !profile->GetPrefs()->IsManagedPreference(
@@ -69,8 +83,8 @@ BraveNewTabUI::BraveNewTabUI(content::WebUI* web_ui, const std::string& name)
       "featureFlagBraveNewsV2Enabled",
       base::FeatureList::IsEnabled(brave_news::features::kBraveNewsV2Feature));
 
-  web_ui->AddMessageHandler(
-      base::WrapUnique(BraveNewTabMessageHandler::Create(source, profile)));
+  web_ui->AddMessageHandler(base::WrapUnique(BraveNewTabMessageHandler::Create(
+      source, profile, was_restored && !is_visible)));
   web_ui->AddMessageHandler(
       base::WrapUnique(new TopSitesMessageHandler(profile)));
 

--- a/components/ntp_background_images/browser/view_counter_model.cc
+++ b/components/ntp_background_images/browser/view_counter_model.cc
@@ -5,14 +5,19 @@
 
 #include "brave/components/ntp_background_images/browser/view_counter_model.h"
 
-#include "base/check_op.h"
+#include "base/check.h"
 #include "base/logging.h"
 #include "base/rand_util.h"
+#include "brave/components/ntp_background_images/common/pref_names.h"
+#include "components/prefs/pref_service.h"
 
 namespace ntp_background_images {
 
-ViewCounterModel::ViewCounterModel() {
-  count_to_branded_wallpaper_ = kInitialCountToBrandedWallpaper;
+ViewCounterModel::ViewCounterModel(PrefService* prefs) : prefs_(prefs) {
+  CHECK(prefs);
+
+  count_to_branded_wallpaper_ =
+      prefs->GetInteger(prefs::kCountToBrandedWallpaper);
 }
 
 ViewCounterModel::~ViewCounterModel() = default;
@@ -87,7 +92,6 @@ void ViewCounterModel::RegisterPageViewForBrandedImages() {
 
     if (always_show_branded_wallpaper_) {
       // Reset count and increse image index for next time.
-      count_to_branded_wallpaper_ = kRegularCountToBrandedWallpaper;
       campaigns_current_branded_image_index_[current_campaign_index_]++;
       campaigns_current_branded_image_index_[current_campaign_index_] %=
           campaigns_total_branded_image_count_[current_campaign_index_];
@@ -106,6 +110,9 @@ void ViewCounterModel::RegisterPageViewForBrandedImages() {
       current_campaign_index_ = base::RandInt(0, total_campaign_count_ - 1);
     }
   }
+
+  prefs_->SetInteger(prefs::kCountToBrandedWallpaper,
+                     count_to_branded_wallpaper_);
 }
 
 void ViewCounterModel::RegisterPageViewForBackgroundImages() {

--- a/components/ntp_background_images/browser/view_counter_model.h
+++ b/components/ntp_background_images/browser/view_counter_model.h
@@ -10,12 +10,17 @@
 #include <vector>
 
 #include "base/gtest_prod_util.h"
+#include "base/memory/raw_ptr.h"
+
+class PrefService;
 
 namespace ntp_background_images {
 
+constexpr int kInitialCountToBrandedWallpaper = 1;
+
 class ViewCounterModel {
  public:
-  ViewCounterModel();
+  explicit ViewCounterModel(PrefService* prefs);
   ~ViewCounterModel();
 
   ViewCounterModel(const ViewCounterModel&) = delete;
@@ -47,11 +52,12 @@ class ViewCounterModel {
   void IncreaseBackgroundWallpaperImageIndex();
 
  private:
-  static const int kInitialCountToBrandedWallpaper = 1;
-  static const int kRegularCountToBrandedWallpaper = 3;
+  static constexpr int kRegularCountToBrandedWallpaper = 3;
 
   friend class NTPBackgroundImagesViewCounterTest;
   FRIEND_TEST_ALL_PREFIXES(ViewCounterModelTest, NTPSponsoredImagesTest);
+  FRIEND_TEST_ALL_PREFIXES(ViewCounterModelTest,
+                           NTPSponsoredImagesCountToBrandedWallpaperTest);
   FRIEND_TEST_ALL_PREFIXES(ViewCounterModelTest, NTPBackgroundImagesTest);
   FRIEND_TEST_ALL_PREFIXES(ViewCounterModelTest, NTPBackgroundImagesOnlyTest);
   FRIEND_TEST_ALL_PREFIXES(ViewCounterModelTest,
@@ -65,7 +71,8 @@ class ViewCounterModel {
   void RegisterPageViewForBackgroundImages();
 
   // For NTP SI.
-  int count_to_branded_wallpaper_ = 0;
+  raw_ptr<PrefService> prefs_ = nullptr;
+  int count_to_branded_wallpaper_ = kInitialCountToBrandedWallpaper;
   bool always_show_branded_wallpaper_ = false;
   bool show_branded_wallpaper_ = true;
   size_t current_campaign_index_ = 0;

--- a/components/ntp_background_images/browser/view_counter_model_unittest.cc
+++ b/components/ntp_background_images/browser/view_counter_model_unittest.cc
@@ -4,6 +4,9 @@
 // you can obtain one at http://mozilla.org/MPL/2.0/.
 
 #include "brave/components/ntp_background_images/browser/view_counter_model.h"
+#include "brave/components/ntp_background_images/browser/view_counter_service.h"
+#include "brave/components/ntp_background_images/common/pref_names.h"
+#include "components/sync_preferences/testing_pref_service_syncable.h"
 #include "testing/gtest/include/gtest/gtest.h"
 
 namespace {
@@ -13,8 +16,29 @@ const std::vector<size_t> kTestCampaignsTotalImageCount = {3, 2, 3};
 
 namespace ntp_background_images {
 
-TEST(ViewCounterModelTest, NTPSponsoredImagesTest) {
-  ViewCounterModel model;
+class ViewCounterModelTest : public testing::Test {
+ public:
+  ViewCounterModelTest() = default;
+  ~ViewCounterModelTest() override = default;
+
+  void SetUp() override {
+    auto* registry = prefs()->registry();
+    ViewCounterService::RegisterProfilePrefs(registry);
+  }
+
+  sync_preferences::TestingPrefServiceSyncable* prefs() { return &prefs_; }
+
+  void SetCountToBrandedWallPaper(int count) {
+    prefs()->SetInteger(prefs::kCountToBrandedWallpaper, count);
+  }
+
+ protected:
+  sync_preferences::TestingPrefServiceSyncable prefs_;
+};
+
+TEST_F(ViewCounterModelTest, NTPSponsoredImagesTest) {
+  ViewCounterModel model(prefs());
+
   model.SetCampaignsTotalBrandedImageCount(kTestCampaignsTotalImageCount);
 
   // Check randomly picked campaign index.
@@ -28,7 +52,7 @@ TEST(ViewCounterModelTest, NTPSponsoredImagesTest) {
   EXPECT_FALSE(model.always_show_branded_wallpaper_);
 
   // Loading initial count times.
-  for (int i = 0; i < ViewCounterModel::kInitialCountToBrandedWallpaper; ++i) {
+  for (int i = 0; i < kInitialCountToBrandedWallpaper; ++i) {
     EXPECT_FALSE(model.ShouldShowBrandedWallpaper());
     model.RegisterPageView();
   }
@@ -57,13 +81,50 @@ TEST(ViewCounterModelTest, NTPSponsoredImagesTest) {
   }
 }
 
-TEST(ViewCounterModelTest, NTPBackgroundImagesTest) {
-  ViewCounterModel model;
+TEST_F(ViewCounterModelTest, NTPSponsoredImagesCountToBrandedWallpaperTest) {
+  SetCountToBrandedWallPaper(1);
+
+  ViewCounterModel model(prefs());
+
+  model.SetCampaignsTotalBrandedImageCount(kTestCampaignsTotalImageCount);
+
+  // Check randomly picked campaign index.
+  EXPECT_TRUE(model.current_campaign_index_ >= 0 &&
+              model.current_campaign_index_ <
+                  kTestCampaignsTotalImageCount.size());
+
+  // Set current campaign index explicitely to test easily.
+  model.current_campaign_index_ = 1;
+
+  EXPECT_FALSE(model.always_show_branded_wallpaper_);
+
+  // Count is 1 so we should not show branded wallpaper.
+  EXPECT_FALSE(model.ShouldShowBrandedWallpaper());
+  model.RegisterPageView();
+
+  // Count is 0 so we should show branded wallpaper.
+  EXPECT_TRUE(model.ShouldShowBrandedWallpaper());
+  model.RegisterPageView();
+
+  // Loading regular-count times from 3 to 0 and do not show branded wallpaper.
+  for (int i = 0; i < ViewCounterModel::kRegularCountToBrandedWallpaper; ++i) {
+    EXPECT_FALSE(model.ShouldShowBrandedWallpaper());
+    model.RegisterPageView();
+  }
+
+  // Count is 0 so we should show branded wallpaper.
+  EXPECT_TRUE(model.ShouldShowBrandedWallpaper());
+  model.RegisterPageView();
+}
+
+TEST_F(ViewCounterModelTest, NTPBackgroundImagesTest) {
+  ViewCounterModel model(prefs());
+
   model.SetCampaignsTotalBrandedImageCount(kTestCampaignsTotalImageCount);
   model.set_total_image_count(kTestImageCount);
 
   // Loading initial count times.
-  for (int i = 0; i < ViewCounterModel::kInitialCountToBrandedWallpaper; ++i) {
+  for (int i = 0; i < kInitialCountToBrandedWallpaper; ++i) {
     EXPECT_EQ(i, model.current_wallpaper_image_index());
     model.RegisterPageView();
   }
@@ -75,16 +136,16 @@ TEST(ViewCounterModelTest, NTPBackgroundImagesTest) {
   int expected_wallpaper_index;
   for (int i = 0; i < ViewCounterModel::kRegularCountToBrandedWallpaper; ++i) {
     expected_wallpaper_index =
-        (i + ViewCounterModel::kInitialCountToBrandedWallpaper) %
-        model.total_image_count_;
+        (i + kInitialCountToBrandedWallpaper) % model.total_image_count_;
     EXPECT_EQ(expected_wallpaper_index, model.current_wallpaper_image_index());
     model.RegisterPageView();
   }
 }
 
 // Test for background images only case (SI not active)
-TEST(ViewCounterModelTest, NTPBackgroundImagesOnlyTest) {
-  ViewCounterModel model;
+TEST_F(ViewCounterModelTest, NTPBackgroundImagesOnlyTest) {
+  ViewCounterModel model(prefs());
+
   model.set_total_image_count(kTestImageCount);
   model.SetCampaignsTotalBrandedImageCount(kTestCampaignsTotalImageCount);
 
@@ -94,7 +155,7 @@ TEST(ViewCounterModelTest, NTPBackgroundImagesOnlyTest) {
       model.GetCurrentBrandedImageIndex();
 
   int expected_wallpaper_index;
-  const int kTestPageViewCount = 30;
+  constexpr int kTestPageViewCount = 30;
   for (int i = 0; i < kTestPageViewCount; ++i) {
     expected_wallpaper_index = i % model.total_image_count_;
     EXPECT_EQ(expected_wallpaper_index, model.current_wallpaper_image_index());
@@ -114,8 +175,9 @@ TEST(ViewCounterModelTest, NTPBackgroundImagesOnlyTest) {
   }
 }
 
-TEST(ViewCounterModelTest, NTPSuperReferralTest) {
-  ViewCounterModel model;
+TEST_F(ViewCounterModelTest, NTPSuperReferralTest) {
+  ViewCounterModel model(prefs());
+
   model.set_always_show_branded_wallpaper(true);
   model.SetCampaignsTotalBrandedImageCount({kTestImageCount});
   model.set_total_image_count(kTestImageCount);
@@ -136,13 +198,14 @@ TEST(ViewCounterModelTest, NTPSuperReferralTest) {
   }
 }
 
-TEST(ViewCounterModelTest, NTPFailedToLoadSponsoredImagesTest) {
-  ViewCounterModel model;
+TEST_F(ViewCounterModelTest, NTPFailedToLoadSponsoredImagesTest) {
+  ViewCounterModel model(prefs());
+
   model.SetCampaignsTotalBrandedImageCount(kTestCampaignsTotalImageCount);
   model.set_total_image_count(kTestImageCount);
 
-  // Loading initial count times.
-  for (int i = 0; i < ViewCounterModel::kInitialCountToBrandedWallpaper; ++i) {
+  // Loading initial count model.
+  for (int i = 0; i < kInitialCountToBrandedWallpaper; ++i) {
     EXPECT_EQ(i, model.current_wallpaper_image_index());
     model.RegisterPageView();
   }

--- a/components/ntp_background_images/browser/view_counter_service.cc
+++ b/components/ntp_background_images/browser/view_counter_service.cc
@@ -57,6 +57,8 @@ void ViewCounterService::RegisterProfilePrefs(
     user_prefs::PrefRegistrySyncable* registry) {
   registry->RegisterBooleanPref(
       prefs::kBrandedWallpaperNotificationDismissed, false);
+  registry->RegisterIntegerPref(prefs::kCountToBrandedWallpaper,
+                                kInitialCountToBrandedWallpaper);
   registry->RegisterBooleanPref(
       prefs::kNewTabPageShowSponsoredImagesBackgroundImage, true);
   // Integer type is used because this pref is used by radio button group in
@@ -79,6 +81,7 @@ ViewCounterService::ViewCounterService(
       ads_service_(ads_service),
       prefs_(prefs),
       is_supported_locale_(is_supported_locale),
+      model_(prefs),
       custom_bi_service_(custom_service),
       ntp_p3a_helper_(std::move(ntp_p3a_helper)) {
   DCHECK(service_);

--- a/components/ntp_background_images/browser/view_counter_service_unittest.cc
+++ b/components/ntp_background_images/browser/view_counter_service_unittest.cc
@@ -226,7 +226,7 @@ class NTPBackgroundImagesViewCounterTest : public testing::Test {
   }
 
   int GetInitialCountToBrandedWallpaper() const {
-    return ViewCounterModel::kInitialCountToBrandedWallpaper;
+    return kInitialCountToBrandedWallpaper;
   }
 
   absl::optional<base::Value::Dict> TryGetFirstSponsoredImageWallpaper() {
@@ -353,6 +353,8 @@ TEST_F(NTPBackgroundImagesViewCounterTest, IsActiveOptedIn) {
 
 TEST_F(NTPBackgroundImagesViewCounterTest, PrefsWithModelTest) {
   auto& model = view_counter_->model_;
+
+  EXPECT_EQ(kInitialCountToBrandedWallpaper, model.show_branded_wallpaper_);
   EXPECT_TRUE(model.show_wallpaper_);
   EXPECT_TRUE(model.show_branded_wallpaper_);
   EXPECT_FALSE(model.always_show_branded_wallpaper_);

--- a/components/ntp_background_images/common/pref_names.cc
+++ b/components/ntp_background_images/common/pref_names.cc
@@ -10,6 +10,7 @@ namespace prefs {
 
 const char kBrandedWallpaperNotificationDismissed[] =
     "brave.branded_wallpaper_notification_dismissed";
+const char kCountToBrandedWallpaper[] = "brave.count_to_branded_wallpaper";
 const char kNewTabPageShowSponsoredImagesBackgroundImage[] =
     "brave.new_tab_page.show_branded_background_image";
 const char kNewTabPageSuperReferralThemesOption[] =

--- a/components/ntp_background_images/common/pref_names.h
+++ b/components/ntp_background_images/common/pref_names.h
@@ -13,6 +13,7 @@ namespace prefs {
 // The one is sponsored images wallpaper and the other is super referral
 // wallpaper.
 extern const char kNewTabPageShowSponsoredImagesBackgroundImage[];
+extern const char kCountToBrandedWallpaper[];
 extern const char kNewTabPageSuperReferralThemesOption[];
 extern const char kBrandedWallpaperNotificationDismissed[];
 extern const char kNewTabPageShowBackgroundImage[];


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/30010

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-arm64, CI/skip-linux-x64, CI/skip-android, CI/skip-macos, CI/skip-ios, CI/skip-windows-arm64, CI/skip-windows-x64, CI/skip-windows-x86 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

- Confirm on fresh install the first NTT ad is shown on the 2nd new tab
- Confirm subsequent NTT ads are shown every 4th new tab
- Confirm browser relaunches persist the the count between new tabs
- Confirm restored tabs (non visible) do not increment the count after relaunching the browser
- Confirm opening a new tab and relaunching the browser many times shows an NTT ad every nth tab