### PR TITLE
Update the `NewBadgeLabel` class to use new design

### DIFF
--- a/browser/ui/color/brave_color_mixer.cc
+++ b/browser/ui/color/brave_color_mixer.cc
@@ -65,6 +65,8 @@ void AddChromeLightThemeColorMixer(ui::ColorProvider* provider,
 
   mixer[kColorTabThrobber] = {SkColorSetRGB(0xd7, 0x55, 0x26)};
   mixer[kColorBookmarkBarForeground] = {kColorTabForegroundActiveFrameActive};
+  mixer[ui::kColorBadgeBackground] = {SkColorSetRGB(95, 92, 241)};
+  mixer[ui::kColorBadgeForeground] = {SkColorSetRGB(245, 244, 254)};
   mixer[kColorDownloadShelfButtonText] = {gfx::kBraveGrey800};
   mixer[kColorForTest] = {kLightColorForTest};
   mixer[kColorNewTabButtonBackgroundFrameActive] = {ui::kColorFrameActive};
@@ -104,6 +106,8 @@ void AddChromeDarkThemeColorMixer(ui::ColorProvider* provider,
 
   mixer[kColorTabThrobber] = {SkColorSetRGB(0xd7, 0x55, 0x26)};
   mixer[kColorBookmarkBarForeground] = {kColorTabForegroundActiveFrameActive};
+  mixer[ui::kColorBadgeBackground] = {SkColorSetRGB(135, 132, 244)};
+  mixer[ui::kColorBadgeForeground] = {SkColorSetRGB(14, 14, 52)};
   mixer[kColorDownloadShelfButtonText] = {SK_ColorWHITE};
   mixer[kColorForTest] = {kDarkColorForTest};
   mixer[kColorNewTabButtonBackgroundFrameActive] = {ui::kColorFrameActive};

--- a/chromium_src/ui/views/badge_painter.cc
+++ b/chromium_src/ui/views/badge_painter.cc
@@ -1,0 +1,29 @@
+// Copyright (c) 2023 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#include "cc/paint/paint_flags.h"
+#include "ui/gfx/font_list.h"
+#include "ui/gfx/geometry/insets.h"
+
+namespace gfx {
+
+gfx::Insets BraveAdjustVisualBorderForFont(const gfx::FontList& badge_font,
+                                           const gfx::Insets& desired_insets) {
+  return gfx::Insets::VH(3, 8);
+}
+
+}  // namespace gfx
+
+// If we don't turn on antialiasing, the rounded corners on the label look
+// terrible.
+#define setColor      \
+  setAntiAlias(true); \
+  flags.setColor
+#define AdjustVisualBorderForFont BraveAdjustVisualBorderForFont
+
+#include "src/ui/views/badge_painter.cc"
+
+#undef AdjustVisualBorderForFont
+#undef setColor

--- a/chromium_src/ui/views/badge_painter.cc
+++ b/chromium_src/ui/views/badge_painter.cc
@@ -6,6 +6,7 @@
 #include "cc/paint/paint_flags.h"
 #include "ui/gfx/font_list.h"
 #include "ui/gfx/geometry/insets.h"
+#include "ui/gfx/text_utils.h"
 
 namespace gfx {
 


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/30173

Dark
![image](https://github.com/brave/brave-core/assets/7678024/70f7e82d-a8dc-4f83-ad4f-7b140c71c6a5)

Light
![image](https://github.com/brave/brave-core/assets/7678024/9c31a23f-03a2-4f18-a53f-01587c57bd92)


<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-arm64, CI/skip-linux-x64, CI/skip-android, CI/skip-macos, CI/skip-ios, CI/skip-windows-arm64, CI/skip-windows-x64, CI/skip-windows-x86 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

Once https://github.com/brave/brave-browser/issues/30269 is resolved, we should use the Leo tokens instead of creating new SkColors.

## Submitter Checklist:

- [ ] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

