### PR TITLE
feat(wallet): Nav Updated and Responsiveness

### DIFF
--- a/components/brave_wallet_ui/components/desktop/wallet-nav/nav-theme.css
+++ b/components/brave_wallet_ui/components/desktop/wallet-nav/nav-theme.css
@@ -5,46 +5,70 @@
 
 :root {
   /* Light Variables */
-  --nav-background: var(--leo-color-white);
-  --nav-border: var(--leo-color-divider-subtle);
+  --nav-background: var(--leo-color-container-background);
+  --nav-border: var(--leo-color-container-highlight);
   --nav-button-color: var(--leo-color-icon-default);
   --nav-button-background-hover:
   var(--leo-color-light-container-highlight);
   /* #1E2029 is not in the old design system */
   --nav-tool-tip-background: #1e2029;
+  --nav-page-text-color: var(--leo-color-text-secondary);
+  --nav-page-text-color-hover: var(--leo-color-text-interactive);
+  --nav-page-icon-color: var(--leo-color-gray-30);
+  --nav-page-icon-color-hover: var(--leo-color-icon-interactive);
+  --nav-page-indicator-color:
+  var(--leo-color-interaction-button-primary-background);
 }
 
 @media (prefers-color-scheme: dark) {
   :root {
     /* Dark Variables */
-    --nav-background: var(--leo-color-black);
-    --nav-border: var(--leo-color-divider-subtle);
+    --nav-background: var(--leo-color-container-background);
+    --nav-border: var(--leo-color-container-highlight);
     --nav-button-color: var(--leo-color-icon-default);
     --nav-button-background-hover:
     var(--leo-color-dark-gray-20);
     /* #17171F is not in the old design system */
     --nav-tool-tip-background: #17171f;
+    --nav-page-text-color: var(--leo-color-text-secondary);
+    --nav-page-text-color-hover: var(--leo-color-text-interactive);
+    --nav-page-icon-color: var(--leo-color-gray-30);
+    --nav-page-icon-color-hover: var(--leo-color-icon-interactive);
+    --nav-page-indicator-color:
+    var(--leo-color-interaction-button-primary-background);
   }
 }
 
 html[data-theme='light'] {
   /* Light Variables */
-  --nav-background: var(--leo-color-white);
-  --nav-border: var(--leo-color-divider-subtle);
+  --nav-background: var(--leo-color-container-background);
+  --nav-border: var(--leo-color-container-highlight);
   --nav-button-color: var(--leo-color-icon-default);
   --nav-button-background-hover:
   var(--leo-color-light-container-highlight);
   /* #1E2029 is not in the old design system */
   --nav-tool-tip-background: #1e2029;
+  --nav-page-text-color: var(--leo-color-text-secondary);
+  --nav-page-text-color-hover: var(--leo-color-text-interactive);
+  --nav-page-icon-color: var(--leo-color-gray-30);
+  --nav-page-icon-color-hover: var(--leo-color-icon-interactive);
+  --nav-page-indicator-color:
+  var(--leo-color-interaction-button-primary-background);
 }
 
 html[data-theme='dark'] {
   /* Dark Variables */
-  --nav-background: var(--leo-color-black);
-  --nav-border: var(--leo-color-divider-subtle);
+  --nav-background: var(--leo-color-container-background);
+  --nav-border: var(--leo-color-container-highlight);
   --nav-button-color: var(--leo-color-icon-default);
   --nav-button-background-hover:
   var(--leo-color-dark-gray-20);
   /* #17171F is not in the old design system */
   --nav-tool-tip-background: #17171f;
+  --nav-page-text-color: var(--leo-color-text-secondary);
+  --nav-page-text-color-hover: var(--leo-color-text-interactive);
+  --nav-page-icon-color: var(--leo-color-gray-30);
+  --nav-page-icon-color-hover: var(--leo-color-icon-interactive);
+  --nav-page-indicator-color:
+  var(--leo-color-interaction-button-primary-background);
 }

--- a/components/brave_wallet_ui/components/desktop/wallet-nav/wallet-nav-button/wallet-nav-button.style.ts
+++ b/components/brave_wallet_ui/components/desktop/wallet-nav/wallet-nav-button/wallet-nav-button.style.ts
@@ -9,36 +9,51 @@ import { WalletButton, Text } from '../../../shared/style'
 import { layoutSmallWidth } from '../../wallet-page-wrapper/wallet-page-wrapper.style'
 
 export const StyledButton = styled(WalletButton) <{ isSelected?: boolean }>`
+  --icon-color: ${(p) =>
+    p.isSelected
+      ? 'var(--nav-page-icon-color-hover)'
+      : 'var(--nav-page-icon-color)'
+  };
+  --text-color: ${(p) =>
+    p.isSelected
+      ? 'var(--nav-page-text-color-hover)'
+      : 'var(--nav-page-text-color)'
+  };
+  --indicator-color: ${(p) =>
+    p.isSelected
+      ? 'var(--nav-page-indicator-color)'
+      : 'none'
+  };
+  &:hover {
+    --icon-color: var(--nav-page-icon-color-hover);
+    --text-color: var(--nav-page-text-color-hover);
+    }
   display: flex;
   align-items: center;
   justify-content: flex-start;
   width: 100%;
   cursor: pointer;
-  padding: 16px;
+  padding: 6px 0px;
   outline: none;
   border: none;
   background: none;
-  background-color: ${(p) => p.isSelected
-    ? 'var(--nav-button-background-hover)'
-    : 'none'};
-  border-radius: 6px;
-  margin-bottom: 8px;
-  color: var(--nav-button-color);
-  font-weight: 600;
-  font-size: 16px;
-  font-family: 'Poppins';
-  &:hover {
-    background-color: var(--nav-button-background-hover);
-  }
+  margin-bottom: 12px;
   &:last-child {
     margin-bottom: 0px;
   }
   @media screen and (max-width: ${layoutSmallWidth}px) {
+    border-radius: 6px;
     padding: 6px 0px 3px 0px;
     width: 100%;
     flex-direction: column;
     margin-bottom: 0px;
     margin-right: 8px;
+    background-color: ${(p) => p.isSelected
+    ? 'var(--nav-button-background-hover)'
+    : 'none'};
+    &:hover {
+      background-color: var(--nav-button-background-hover);
+    }
     &:last-child {
       margin-right: 0px;
     }
@@ -46,17 +61,39 @@ export const StyledButton = styled(WalletButton) <{ isSelected?: boolean }>`
 `
 
 export const ButtonIcon = styled(Icon)`
-  --leo-icon-size: 24px;
-  color: var(--nav-button-color);
-  margin-right: var(--icon-margin-right);
+  --leo-icon-size: 18px;
+  color: var(--icon-color);
+  margin-right: 16px;
+  @media screen and (max-width: ${layoutSmallWidth}px) {
+    color: var(--nav-button-color);
+    --leo-icon-size: 24px;
+    margin-right: 0px;
+  }
 `
 
 export const ButtonText = styled(Text)`
-  color: var(--nav-button-color);
-  display: var(--display-text);
+  color: var(--text-color);
+  font-family: 'Poppins';
+  font-style: normal;
+  font-weight: 600;
+  font-size: 15px;
+  line-height: 20px;
   @media screen and (max-width: ${layoutSmallWidth}px) {
+    color: var(--nav-button-color);
     font-size: 12px;
     font-weight: 400;
     line-height: 18px;
+  }
+`
+
+export const SelectedIndicator = styled.div`
+  display: flex;
+  width: 4px;
+  height: 32px;
+  margin-right: 20px;
+  background-color: var(--indicator-color);
+  border-radius: 0px 2px 2px 0px;
+  @media screen and (max-width: ${layoutSmallWidth}px) {
+    display: none;
   }
 `

--- a/components/brave_wallet_ui/components/desktop/wallet-nav/wallet-nav-button/wallet-nav-button.tsx
+++ b/components/brave_wallet_ui/components/desktop/wallet-nav/wallet-nav-button/wallet-nav-button.tsx
@@ -13,7 +13,12 @@ import { getLocale } from '../../../../../common/locale'
 import { NavOption } from '../../../../constants/types'
 
 // Styled Components
-import { StyledButton, ButtonIcon, ButtonText } from './wallet-nav-button.style'
+import {
+  StyledButton,
+  ButtonIcon,
+  ButtonText,
+  SelectedIndicator
+} from './wallet-nav-button.style'
 
 export interface Props {
   option: NavOption
@@ -36,6 +41,7 @@ export const WalletNavButton = (props: Props) => {
       onClick={onClick}
       isSelected={walletLocation.includes(option.route)}
     >
+      <SelectedIndicator />
       <ButtonIcon name={option.icon} />
       <ButtonText
         textSize='14px'

--- a/components/brave_wallet_ui/components/desktop/wallet-nav/wallet-nav.style.ts
+++ b/components/brave_wallet_ui/components/desktop/wallet-nav/wallet-nav.style.ts
@@ -7,25 +7,20 @@ import styled from 'styled-components'
 import { layoutSmallWidth, layoutTopPosition } from '../wallet-page-wrapper/wallet-page-wrapper.style'
 
 export const Wrapper = styled.div`
-  --display-text: none;
-  --icon-margin-right: 0px;
   display: flex;
   align-items: center;
   justify-content: center;
   flex-direction: column;
   background-color: var(--nav-background);
-  border-radius: 12px;
-  border: 1px solid var(--nav-border);
+  border-radius: 16px;
   position: absolute;
   top: ${layoutTopPosition}px;
   left: 32px;
   overflow: visible;
   z-index: 10;
-  padding: 0px 8px;
-  &:hover {
-    --display-text: flex;
-    --icon-margin-right: 16px;
-  }
+  width: 240px;
+  padding: 12px 0px;
+  box-shadow: 0px 1px 4px rgba(0, 0, 0, 0.07);
   @media screen and (max-width: ${layoutSmallWidth}px) {
     flex-direction: row;
     top: unset;
@@ -36,11 +31,7 @@ export const Wrapper = styled.div`
     padding: 8px 0px;
     border-radius: 0px;
     box-shadow: 0px -8px 16px rgba(0, 0, 0, 0.04);
-    --display-text: flex;
-    &:hover {
-      --display-text: flex;
-      --icon-margin-right: 0px;
-    }
+    width: unset;
   }
 `
 
@@ -50,7 +41,7 @@ export const Section = styled.div<{ showBorder?: boolean }>`
   justify-content: center;
   flex-direction: column;
   width: 100%;
-  padding: 8px 0px;
+  padding: 12px 0px;
   border-bottom: ${(p) => p.showBorder
     ? `1px solid var(--nav-border)`
     : 'none'};
@@ -67,6 +58,7 @@ export const Section = styled.div<{ showBorder?: boolean }>`
 export const PageOptionsWrapper = styled.div`
   display: flex;
   flex-direction: column;
+  width: 100%;
   @media screen and (max-width: ${layoutSmallWidth}px) {
     display: none;
   }

--- a/components/brave_wallet_ui/components/desktop/wallet-page-wrapper/wallet-page-wrapper.style.ts
+++ b/components/brave_wallet_ui/components/desktop/wallet-page-wrapper/wallet-page-wrapper.style.ts
@@ -9,7 +9,8 @@ import { Row } from '../../shared/style'
 
 const minCardHeight = 531
 const maxCardWidth = 768
-export const layoutSmallWidth = 983
+const layoutScaleWithNav = 1374
+export const layoutSmallWidth = 980
 export const layoutPanelWidth = 660
 export const layoutTopPosition = 68
 
@@ -57,9 +58,14 @@ export const LayoutCardWrapper = styled.div<{
   &::-webkit-scrollbar {
     display: none;
   }
+  @media screen and (max-width: ${layoutScaleWithNav}px) {
+    padding: 0px 32px 32px 304px;
+    align-items: flex-start;
+  }
   @media screen and (max-width: ${layoutSmallWidth}px) {
     bottom: 67px;
     padding: 0px 32px 32px 32px;
+    align-items: center;
   }
   @media screen and (max-width: ${layoutPanelWidth}px) {
     padding: 0px;
@@ -90,6 +96,11 @@ export const ContainerCard = styled.div<
   max-width: ${(p) => p.maxWidth ? p.maxWidth : maxCardWidth}px;
   position: relative;
   @media screen and (max-width: ${layoutSmallWidth}px) {
+    max-width: ${(p) =>
+    p.maxWidth
+      ? `${p.maxWidth}px`
+      : 'unset'
+  };
     width: 100%;
   }
   @media screen and (max-width: ${layoutPanelWidth}px) {
@@ -109,7 +120,16 @@ export const CardHeaderWrapper = styled.div`
   top: ${layoutTopPosition}px;
   position: fixed;
   width: 100%;
+  @media screen and (max-width: ${layoutScaleWithNav}px) {
+    padding: 0px 32px 0px 304px;
+    left: 0px;
+    right: 0px;
+    align-items: flex-start;
+  }
   @media screen and (max-width: ${layoutSmallWidth}px) {
+    left: unset;
+    right: unset;
+    align-items: center;
     padding: 0px 32px;
   }
   @media screen and (max-width: ${layoutPanelWidth}px) {
@@ -133,6 +153,9 @@ export const CardHeader = styled.div<{
   position: relative;
   max-width: ${maxCardWidth}px;
   box-shadow: 0px 4px 13px -2px rgba(0, 0, 0, var(--shadow-opacity));
+  @media screen and (max-width: ${layoutSmallWidth}px) {
+    max-width: unset;
+  }
 `
 
 export const CardHeaderShadow = styled(CardHeader) <{


### PR DESCRIPTION
## Description 
- Updates the `Wallet Nav` to the new `2.0` designs
- Updates the layout responsiveness to accommodate the new `nav`

<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves <https://github.com/brave/brave-browser/issues/30122>

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-arm64, CI/skip-linux-x64, CI/skip-android, CI/skip-macos, CI/skip-ios, CI/skip-windows-arm64, CI/skip-windows-x64, CI/skip-windows-x86 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

### Testing the Nav
1. Open the `Wallet` test the new `Side Nav` and make sure all routes work

https://github.com/brave/brave-core/assets/40611140/f5878866-d20c-47d7-b9a8-def517b8dfc8

### Testing the Responsiveness
1. Go to the `Portfolio` page and shrink the `Width` of the `Browser`
2. The `Card` container should eventually but up against the `Nav` and then eventually change to the `Bottom` nav.

https://github.com/brave/brave-core/assets/40611140/9a31b301-17ba-463d-a5bc-a28a76908749
