### PR TITLE
Fixed vpn app menu is shown when disabled by policy (uplift to 1.52.x)

### DIFF
--- a/components/brave_vpn/common/brave_vpn_utils.cc
+++ b/components/brave_vpn/common/brave_vpn_utils.cc
@@ -85,7 +85,14 @@ void MigrateVPNSettings(PrefService* profile_prefs, PrefService* local_prefs) {
 bool IsBraveVPNDisabledByPolicy(PrefService* prefs) {
   DCHECK(prefs);
   return prefs->FindPreference(prefs::kManagedBraveVPNDisabled) &&
+  // Need to investigate more about this.
+  // IsManagedPreference() gives false on macOS when it's configured by
+  // "defaults write com.brave.Browser.beta BraveVPNDisabled -bool true".
+  // As kManagedBraveVPNDisabled is false by default and only can be set
+  // by policy, I think skipping this condition checking will be fine.
+#if !BUILDFLAG(IS_MAC)
          prefs->IsManagedPreference(prefs::kManagedBraveVPNDisabled) &&
+#endif
          prefs->GetBoolean(prefs::kManagedBraveVPNDisabled);
 }
 


### PR DESCRIPTION
Uplift of #18436
fix https://github.com/brave/brave-browser/issues/30239

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.