### PR TITLE
Fixed crash when private window is launched directly

### DIFF
--- a/browser/search_engines/normal_window_search_engine_provider_service.cc
+++ b/browser/search_engines/normal_window_search_engine_provider_service.cc
@@ -1,7 +1,7 @@
 /* Copyright (c) 2022 The Brave Authors. All rights reserved.
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
- * You can obtain one at http://mozilla.org/MPL/2.0/. */
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 #include "brave/browser/search_engines/normal_window_search_engine_provider_service.h"
 
@@ -31,7 +31,7 @@ NormalWindowSearchEngineProviderService::
   template_url_service_subscription_ =
       service->RegisterOnLoadedCallback(base::BindOnce(
           &NormalWindowSearchEngineProviderService::OnTemplateURLServiceLoaded,
-          base::Unretained(this), profile));
+          base::Unretained(this)));
 }
 
 NormalWindowSearchEngineProviderService::
@@ -42,8 +42,7 @@ void NormalWindowSearchEngineProviderService::Shutdown() {
   private_search_provider_guid_.Destroy();
 }
 
-void NormalWindowSearchEngineProviderService::OnTemplateURLServiceLoaded(
-    Profile* profile) {
+void NormalWindowSearchEngineProviderService::OnTemplateURLServiceLoaded() {
   template_url_service_subscription_ = {};
   PrepareInitialPrivateSearchProvider();
 }

--- a/browser/search_engines/normal_window_search_engine_provider_service.h
+++ b/browser/search_engines/normal_window_search_engine_provider_service.h
@@ -1,7 +1,7 @@
 /* Copyright (c) 2022 The Brave Authors. All rights reserved.
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
- * You can obtain one at http://mozilla.org/MPL/2.0/. */
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 #ifndef BRAVE_BROWSER_SEARCH_ENGINES_NORMAL_WINDOW_SEARCH_ENGINE_PROVIDER_SERVICE_H_
 #define BRAVE_BROWSER_SEARCH_ENGINES_NORMAL_WINDOW_SEARCH_ENGINE_PROVIDER_SERVICE_H_
@@ -35,7 +35,7 @@ class NormalWindowSearchEngineProviderService : public KeyedService {
   // KeyedService overrides:
   void Shutdown() override;
 
-  void OnTemplateURLServiceLoaded(Profile* profile);
+  void OnTemplateURLServiceLoaded();
   void PrepareInitialPrivateSearchProvider();
   void OnPreferenceChanged();
 

--- a/browser/search_engines/private_window_search_engine_provider_service.cc
+++ b/browser/search_engines/private_window_search_engine_provider_service.cc
@@ -1,7 +1,7 @@
 /* Copyright (c) 2019 The Brave Authors. All rights reserved.
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
- * You can obtain one at http://mozilla.org/MPL/2.0/. */
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 #include "brave/browser/search_engines/private_window_search_engine_provider_service.h"
 
@@ -22,12 +22,6 @@ PrivateWindowSearchEngineProviderService::
       base::BindRepeating(
           &PrivateWindowSearchEngineProviderService::OnPreferenceChanged,
           base::Unretained(this)));
-  UpdateExtensionPrefsAndProvider();
-
-  // Monitor normal profile's search engine changing because private window
-  // should use that search engine provider when extension search provider is
-  // used.
-  observation_.Observe(original_template_url_service_);
 }
 
 PrivateWindowSearchEngineProviderService::
@@ -58,6 +52,15 @@ void PrivateWindowSearchEngineProviderService::
     otr_template_url_service_->SetUserSelectedDefaultSearchProvider(
         template_url);
   }
+}
+
+void PrivateWindowSearchEngineProviderService::Initialize() {
+  UpdateExtensionPrefsAndProvider();
+
+  // Monitor normal profile's search engine changing because private window
+  // should use that search engine provider when extension search provider is
+  // used.
+  observation_.Observe(original_template_url_service_);
 }
 
 void PrivateWindowSearchEngineProviderService::Shutdown() {

--- a/browser/search_engines/private_window_search_engine_provider_service.h
+++ b/browser/search_engines/private_window_search_engine_provider_service.h
@@ -1,7 +1,7 @@
 /* Copyright (c) 2019 The Brave Authors. All rights reserved.
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
- * You can obtain one at http://mozilla.org/MPL/2.0/. */
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 #ifndef BRAVE_BROWSER_SEARCH_ENGINES_PRIVATE_WINDOW_SEARCH_ENGINE_PROVIDER_SERVICE_H_
 #define BRAVE_BROWSER_SEARCH_ENGINES_PRIVATE_WINDOW_SEARCH_ENGINE_PROVIDER_SERVICE_H_
@@ -32,7 +32,8 @@ class PrivateWindowSearchEngineProviderService
   // TemplateURLServiceObserver overrides:
   void OnTemplateURLServiceChanged() override;
 
-  // SearchEngineProviderService overrides:
+  // PrivateWindowSearchEngineProviderServiceBase overrides:
+  void Initialize() override;
   void Shutdown() override;
 
   void OnPreferenceChanged(const std::string& pref_name);

--- a/browser/search_engines/private_window_search_engine_provider_service_base.h
+++ b/browser/search_engines/private_window_search_engine_provider_service_base.h
@@ -1,14 +1,14 @@
 /* Copyright (c) 2019 The Brave Authors. All rights reserved.
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
- * You can obtain one at http://mozilla.org/MPL/2.0/. */
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 #ifndef BRAVE_BROWSER_SEARCH_ENGINES_PRIVATE_WINDOW_SEARCH_ENGINE_PROVIDER_SERVICE_BASE_H_
 #define BRAVE_BROWSER_SEARCH_ENGINES_PRIVATE_WINDOW_SEARCH_ENGINE_PROVIDER_SERVICE_BASE_H_
 
-#include <string>
-
+#include "base/callback_list.h"
 #include "base/memory/raw_ptr.h"
+#include "base/memory/weak_ptr.h"
 #include "components/keyed_service/core/keyed_service.h"
 
 class Profile;
@@ -26,6 +26,10 @@ class PrivateWindowSearchEngineProviderServiceBase : public KeyedService {
       const PrivateWindowSearchEngineProviderServiceBase&) = delete;
 
  protected:
+  // KeyedService overrides:
+  void Shutdown() override;
+
+  virtual void Initialize() {}
   bool ShouldUseExtensionSearchProvider() const;
   void UseExtensionSearchProvider();
 
@@ -38,6 +42,11 @@ class PrivateWindowSearchEngineProviderServiceBase : public KeyedService {
 
  private:
   bool CouldAddExtensionTemplateURL(const TemplateURL* url);
+  void OnTemplateURLServiceLoaded();
+
+  base::CallbackListSubscription template_url_service_subscription_;
+  base::WeakPtrFactory<PrivateWindowSearchEngineProviderServiceBase>
+      weak_factory_{this};
 };
 
 #endif  // BRAVE_BROWSER_SEARCH_ENGINES_PRIVATE_WINDOW_SEARCH_ENGINE_PROVIDER_SERVICE_BASE_H_

--- a/browser/search_engines/search_engine_provider_service_browsertest.cc
+++ b/browser/search_engines/search_engine_provider_service_browsertest.cc
@@ -164,6 +164,11 @@ IN_PROC_BROWSER_TEST_F(SearchEngineProviderServiceTest,
   Profile* incognito_profile =
       profile->GetPrimaryOTRProfile(/*create_if_needed=*/true);
 
+  // Need to wait as
+  // PrivateWindowSearchEngineProviderServiceBase::Initialize() is
+  // run as posted task.
+  base::RunLoop().RunUntilIdle();
+
   auto* service = TemplateURLServiceFactory::GetForProfile(profile);
   EXPECT_TRUE(VerifyTemplateURLServiceLoad(service));
 
@@ -309,6 +314,11 @@ IN_PROC_BROWSER_TEST_F(ExtensionBrowserTest,
 
   Profile* incognito_profile =
       profile()->GetPrimaryOTRProfile(/*create_if_needed=*/true);
+
+  // Need to wait as
+  // PrivateWindowSearchEngineProviderServiceBase::Initialize() is
+  // run as posted task.
+  base::RunLoop().RunUntilIdle();
 
   auto* incognito_url_service =
       TemplateURLServiceFactory::GetForProfile(incognito_profile);

--- a/browser/search_engines/tor_window_search_engine_provider_service.cc
+++ b/browser/search_engines/tor_window_search_engine_provider_service.cc
@@ -1,7 +1,7 @@
 /* Copyright (c) 2019 The Brave Authors. All rights reserved.
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
- * You can obtain one at http://mozilla.org/MPL/2.0/. */
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 #include "brave/browser/search_engines/tor_window_search_engine_provider_service.h"
 
@@ -21,14 +21,16 @@ TorWindowSearchEngineProviderService::TorWindowSearchEngineProviderService(
   auto provider_data = TemplateURLDataFromPrepopulatedEngine(
       TemplateURLPrepopulateData::brave_search_tor);
   default_template_url_for_tor_ = std::make_unique<TemplateURL>(*provider_data);
-
-  ConfigureSearchEngineProvider();
-
-  observation_.Observe(original_template_url_service_);
 }
 
 TorWindowSearchEngineProviderService::~TorWindowSearchEngineProviderService() =
     default;
+
+void TorWindowSearchEngineProviderService::Initialize() {
+  ConfigureSearchEngineProvider();
+
+  observation_.Observe(original_template_url_service_);
+}
 
 void TorWindowSearchEngineProviderService::Shutdown() {
   PrivateWindowSearchEngineProviderServiceBase::Shutdown();

--- a/browser/search_engines/tor_window_search_engine_provider_service.h
+++ b/browser/search_engines/tor_window_search_engine_provider_service.h
@@ -1,7 +1,7 @@
 /* Copyright (c) 2019 The Brave Authors. All rights reserved.
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
- * You can obtain one at http://mozilla.org/MPL/2.0/. */
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 #ifndef BRAVE_BROWSER_SEARCH_ENGINES_TOR_WINDOW_SEARCH_ENGINE_PROVIDER_SERVICE_H_
 #define BRAVE_BROWSER_SEARCH_ENGINES_TOR_WINDOW_SEARCH_ENGINE_PROVIDER_SERVICE_H_
@@ -31,7 +31,8 @@ class TorWindowSearchEngineProviderService
   TorWindowSearchEngineProviderService& operator=(
       const TorWindowSearchEngineProviderService&) = delete;
 
-  // SearchEngineProviderService overrides:
+  // PrivateWindowSearchEngineProviderServiceBase overrides:
+  void Initialize() override;
   void Shutdown() override;
 
   // TemplateURLServiceObserver overrides:


### PR DESCRIPTION
fix https://github.com/brave/brave-browser/issues/30305

When search provider extension is installed, launching private window directly causes crash at startup.
PrivateWindowSearchEngineProviderService uses not loaded TemplateURLService. TemplateURLService couldn't give proper data till it's loaded.

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves 

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-arm64, CI/skip-linux-x64, CI/skip-android, CI/skip-macos, CI/skip-ios, CI/skip-windows-arm64, CI/skip-windows-x64, CI/skip-windows-x86 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [ ] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

1. Launch brave and install any search engine extension(ex, [Ecosia](https://chrome.google.com/webstore/detail/ecosia-the-search-engine/eedlgdlajadkbbjoobobefphmfkcchfk)) 
2. Check extension's provider is set as a default provider in normal & private window
3.  Re-launch brave `--incognito` cmdline switch to launch private window only
4. Check launched w/o any crash and extension's provider is set properly