### PR TITLE
Remove code duplication between wireguard and IKEv2 connection implementation 

### DIFF
--- a/components/brave_vpn/browser/brave_vpn_service_unittest.cc
+++ b/components/brave_vpn/browser/brave_vpn_service_unittest.cc
@@ -689,7 +689,7 @@ TEST_F(BraveVPNServiceTest, ResetConnectionStateTest) {
   auto* test_api = static_cast<BraveVPNOSConnectionAPISim*>(GetConnectionAPI());
 
   // Set failed state before setting observer.
-  test_api->SetConnectionState(ConnectionState::CONNECT_FAILED);
+  test_api->SetConnectionStateForTesting(ConnectionState::CONNECT_FAILED);
 
   TestBraveVPNServiceObserver observer;
   AddObserver(observer.GetReceiver());
@@ -715,9 +715,9 @@ TEST_F(BraveVPNServiceTest, ConnectionStateUpdateWithPurchasedStateTest) {
   AddObserver(observer.GetReceiver());
   std::string env = skus::GetDefaultEnvironment();
   SetPurchasedState(env, PurchasedState::PURCHASED);
-  test_api->SetConnectionState(ConnectionState::CONNECTING);
+  test_api->SetConnectionStateForTesting(ConnectionState::CONNECTING);
   base::RunLoop().RunUntilIdle();
-  test_api->SetConnectionState(ConnectionState::CONNECTED);
+  test_api->SetConnectionStateForTesting(ConnectionState::CONNECTED);
   base::RunLoop().RunUntilIdle();
   EXPECT_EQ(ConnectionState::CONNECTED, observer.GetConnectionState());
 }
@@ -730,7 +730,7 @@ TEST_F(BraveVPNServiceTest, DisconnectedIfDisabledByPolicy) {
   AddObserver(observer.GetReceiver());
   std::string env = skus::GetDefaultEnvironment();
   SetPurchasedState(env, PurchasedState::PURCHASED);
-  test_api->SetConnectionState(ConnectionState::CONNECTED);
+  test_api->SetConnectionStateForTesting(ConnectionState::CONNECTED);
   base::RunLoop().RunUntilIdle();
   EXPECT_EQ(ConnectionState::CONNECTED, observer.GetConnectionState());
   BlockVPNByPolicy(true);

--- a/components/brave_vpn/browser/connection/BUILD.gn
+++ b/components/brave_vpn/browser/connection/BUILD.gn
@@ -15,6 +15,8 @@ source_set("api") {
 
   deps = [
     "//base",
+    "//brave/components/brave_vpn/browser/api",
+    "//brave/components/brave_vpn/browser/connection:common",
     "//brave/components/brave_vpn/common",
     "//brave/components/brave_vpn/common/mojom",
     "//services/network/public/cpp",

--- a/components/brave_vpn/browser/connection/brave_vpn_os_connection_api.cc
+++ b/components/brave_vpn/browser/connection/brave_vpn_os_connection_api.cc
@@ -5,6 +5,7 @@
 
 #include "brave/components/brave_vpn/browser/connection/brave_vpn_os_connection_api.h"
 
+#include "base/check_is_test.h"
 #include "base/feature_list.h"
 #include "base/memory/scoped_refptr.h"
 #include "brave/components/brave_vpn/common/features.h"
@@ -41,6 +42,126 @@ std::unique_ptr<BraveVPNOSConnectionAPI> CreateBraveVPNConnectionAPI(
   return CreateBraveVPNIKEv2ConnectionAPI(url_loader_factory, local_prefs,
                                           channel);
 #endif
+}
+
+BraveVPNOSConnectionAPI::BraveVPNOSConnectionAPI(
+    scoped_refptr<network::SharedURLLoaderFactory> url_loader_factory,
+    PrefService* local_prefs)
+    : url_loader_factory_(url_loader_factory),
+      region_data_manager_(url_loader_factory, local_prefs) {
+  DCHECK(url_loader_factory_);
+  // Safe to use Unretained here because |region_data_manager_| is owned
+  // instance.
+  region_data_manager_.set_selected_region_changed_callback(
+      base::BindRepeating(&BraveVPNOSConnectionAPI::NotifySelectedRegionChanged,
+                          base::Unretained(this)));
+  region_data_manager_.set_region_data_ready_callback(base::BindRepeating(
+      &BraveVPNOSConnectionAPI::NotifyRegionDataReady, base::Unretained(this)));
+  net::NetworkChangeNotifier::AddNetworkChangeObserver(this);
+}
+
+BraveVPNOSConnectionAPI::~BraveVPNOSConnectionAPI() {
+  net::NetworkChangeNotifier::RemoveNetworkChangeObserver(this);
+}
+
+mojom::ConnectionState BraveVPNOSConnectionAPI::GetConnectionState() const {
+  return connection_state_;
+}
+
+BraveVPNRegionDataManager& BraveVPNOSConnectionAPI::GetRegionDataManager() {
+  return region_data_manager_;
+}
+
+void BraveVPNOSConnectionAPI::AddObserver(Observer* observer) {
+  observers_.AddObserver(observer);
+}
+
+void BraveVPNOSConnectionAPI::RemoveObserver(Observer* observer) {
+  observers_.RemoveObserver(observer);
+}
+
+void BraveVPNOSConnectionAPI::SetConnectionStateForTesting(
+    mojom::ConnectionState state) {
+  UpdateAndNotifyConnectionStateChange(state);
+}
+
+void BraveVPNOSConnectionAPI::NotifyRegionDataReady(bool ready) const {
+  for (auto& obs : observers_) {
+    obs.OnRegionDataReady(ready);
+  }
+}
+
+void BraveVPNOSConnectionAPI::NotifySelectedRegionChanged(
+    const std::string& name) const {
+  for (auto& obs : observers_) {
+    obs.OnSelectedRegionChanged(name);
+  }
+}
+
+void BraveVPNOSConnectionAPI::OnNetworkChanged(
+    net::NetworkChangeNotifier::ConnectionType type) {
+  VLOG(1) << __func__ << " : " << type;
+  CheckConnection();
+}
+
+BraveVpnAPIRequest* BraveVPNOSConnectionAPI::GetAPIRequest() {
+  if (!url_loader_factory_) {
+    CHECK_IS_TEST();
+    return nullptr;
+  }
+
+  if (!api_request_) {
+    api_request_ = std::make_unique<BraveVpnAPIRequest>(url_loader_factory_);
+  }
+
+  return api_request_.get();
+}
+
+void BraveVPNOSConnectionAPI::ResetConnectionState() {
+  // Don't use UpdateAndNotifyConnectionStateChange() to update connection state
+  // and set state directly because we have a logic to ignore disconnected state
+  // when connect failed.
+  connection_state_ = mojom::ConnectionState::DISCONNECTED;
+  for (auto& obs : observers_) {
+    obs.OnConnectionStateChanged(connection_state_);
+  }
+}
+
+void BraveVPNOSConnectionAPI::UpdateAndNotifyConnectionStateChange(
+    mojom::ConnectionState state) {
+  // this is a simple state machine for handling connection state
+  if (connection_state_ == state) {
+    return;
+  }
+
+  connection_state_ = state;
+  for (auto& obs : observers_) {
+    obs.OnConnectionStateChanged(connection_state_);
+  }
+}
+
+bool BraveVPNOSConnectionAPI::QuickCancelIfPossible() {
+  if (!api_request_) {
+    return false;
+  }
+
+  // We're waiting responce from vpn server.
+  // Can do quick cancel in this situation by cancel that request.
+  ResetAPIRequestInstance();
+  return true;
+}
+
+void BraveVPNOSConnectionAPI::ResetAPIRequestInstance() {
+  api_request_.reset();
+}
+
+std::string BraveVPNOSConnectionAPI::GetLastConnectionError() const {
+  return last_connection_error_;
+}
+
+void BraveVPNOSConnectionAPI::SetLastConnectionError(const std::string& error) {
+  VLOG(2) << __func__ << " : " << error;
+  last_connection_error_ = error;
 }
 
 }  // namespace brave_vpn

--- a/components/brave_vpn/browser/connection/ikev2/brave_vpn_ras_connection_api_sim.cc
+++ b/components/brave_vpn/browser/connection/ikev2/brave_vpn_ras_connection_api_sim.cc
@@ -108,11 +108,6 @@ void BraveVPNOSConnectionAPISim::OnCreated(const std::string& name,
   BraveVPNOSConnectionAPIBase::OnCreated();
 }
 
-void BraveVPNOSConnectionAPISim::SetConnectionState(
-    mojom::ConnectionState state) {
-  BraveVPNOSConnectionAPIBase::SetConnectionState(state);
-}
-
 void BraveVPNOSConnectionAPISim::Disconnect() {
   BraveVPNOSConnectionAPIBase::Disconnect();
 }

--- a/components/brave_vpn/browser/connection/ikev2/brave_vpn_ras_connection_api_sim.h
+++ b/components/brave_vpn/browser/connection/ikev2/brave_vpn_ras_connection_api_sim.h
@@ -33,7 +33,6 @@ class BraveVPNOSConnectionAPISim : public BraveVPNOSConnectionAPIBase {
   friend class base::NoDestructor<BraveVPNOSConnectionAPISim>;
 
   // BraveVPNOSConnectionAPI overrides:
-  void SetConnectionState(mojom::ConnectionState state) override;
   void Connect() override;
   void Disconnect() override;
   void ToggleConnection() override;

--- a/components/brave_vpn/browser/connection/ikev2/brave_vpn_ras_connection_api_unittest.cc
+++ b/components/brave_vpn/browser/connection/ikev2/brave_vpn_ras_connection_api_unittest.cc
@@ -520,7 +520,7 @@ TEST_F(BraveVPNOSConnectionAPIUnitTest,
   auto* test_api =
       static_cast<BraveVPNOSConnectionAPIBase*>(GetConnectionAPI());
 
-  test_api->SetConnectionState(mojom::ConnectionState::CONNECTING);
+  test_api->SetConnectionStateForTesting(mojom::ConnectionState::CONNECTING);
   test_api->UpdateAndNotifyConnectionStateChange(
       mojom::ConnectionState::DISCONNECTED);
   EXPECT_EQ(mojom::ConnectionState::CONNECTING, test_api->GetConnectionState());

--- a/components/brave_vpn/browser/connection/wireguard/win/brave_vpn_wireguard_connection_api.cc
+++ b/components/brave_vpn/browser/connection/wireguard/win/brave_vpn_wireguard_connection_api.cc
@@ -5,12 +5,10 @@
 
 #include "brave/components/brave_vpn/browser/connection/wireguard/win/brave_vpn_wireguard_connection_api.h"
 
-#include "base/check_is_test.h"
 #include "brave/components/brave_vpn/common/brave_vpn_utils.h"
 #include "brave/components/brave_vpn/common/mojom/brave_vpn.mojom.h"
 #include "brave/components/brave_vpn/common/pref_names.h"
 #include "components/prefs/pref_service.h"
-#include "net/base/network_change_notifier.h"
 
 namespace brave_vpn {
 
@@ -29,19 +27,10 @@ BraveVPNWireguardConnectionAPI::BraveVPNWireguardConnectionAPI(
     scoped_refptr<network::SharedURLLoaderFactory> url_loader_factory,
     PrefService* local_prefs,
     version_info::Channel channel)
-    : local_prefs_(local_prefs),
-      url_loader_factory_(url_loader_factory),
-      region_data_manager_(url_loader_factory_, local_prefs_) {
+    : BraveVPNOSConnectionAPI(url_loader_factory, local_prefs),
+      local_prefs_(local_prefs),
+      url_loader_factory_(url_loader_factory) {
   DCHECK(url_loader_factory_ && local_prefs_);
-  // Safe to use Unretained here because |region_data_manager_| is owned
-  // instance.
-  region_data_manager_.set_selected_region_changed_callback(base::BindRepeating(
-      &BraveVPNWireguardConnectionAPI::NotifySelectedRegionChanged,
-      base::Unretained(this)));
-  region_data_manager_.set_region_data_ready_callback(base::BindRepeating(
-      &BraveVPNWireguardConnectionAPI::NotifyRegionDataReady,
-      base::Unretained(this)));
-  net::NetworkChangeNotifier::AddNetworkChangeObserver(this);
 }
 
 BraveVPNWireguardConnectionAPI::~BraveVPNWireguardConnectionAPI() {}
@@ -49,45 +38,6 @@ BraveVPNWireguardConnectionAPI::~BraveVPNWireguardConnectionAPI() {}
 std::string BraveVPNWireguardConnectionAPI::GetCurrentEnvironment() const {
   return local_prefs_->GetString(prefs::kBraveVPNEnvironment);
 }
-
-void BraveVPNWireguardConnectionAPI::OnNetworkChanged(
-    net::NetworkChangeNotifier::ConnectionType type) {
-  VLOG(1) << __func__ << " : " << type;
-  CheckConnection();
-}
-
-BraveVpnAPIRequest* BraveVPNWireguardConnectionAPI::GetAPIRequest() {
-  if (!url_loader_factory_) {
-    CHECK_IS_TEST();
-    return nullptr;
-  }
-
-  if (!api_request_) {
-    api_request_ = std::make_unique<BraveVpnAPIRequest>(url_loader_factory_);
-  }
-
-  return api_request_.get();
-}
-
-void BraveVPNWireguardConnectionAPI::UpdateAndNotifyConnectionStateChange(
-    ConnectionState state) {
-  // this is a simple state machine for handling connection state
-  if (connection_state_ == state) {
-    return;
-  }
-
-  connection_state_ = state;
-  for (auto& obs : observers_) {
-    obs.OnConnectionStateChanged(connection_state_);
-  }
-}
-
-mojom::ConnectionState BraveVPNWireguardConnectionAPI::GetConnectionState()
-    const {
-  return connection_state_;
-}
-
-void BraveVPNWireguardConnectionAPI::ResetConnectionState() {}
 
 void BraveVPNWireguardConnectionAPI::RemoveVPNConnection() {}
 
@@ -105,40 +55,7 @@ std::string BraveVPNWireguardConnectionAPI::GetHostname() const {
   return std::string();
 }
 
-void BraveVPNWireguardConnectionAPI::AddObserver(Observer* observer) {
-  observers_.AddObserver(observer);
-}
-
-void BraveVPNWireguardConnectionAPI::RemoveObserver(Observer* observer) {
-  observers_.RemoveObserver(observer);
-}
-
-void BraveVPNWireguardConnectionAPI::SetConnectionState(
-    mojom::ConnectionState state) {}
-
-std::string BraveVPNWireguardConnectionAPI::GetLastConnectionError() const {
-  return std::string();
-}
-
-BraveVPNRegionDataManager&
-BraveVPNWireguardConnectionAPI::GetRegionDataManager() {
-  return region_data_manager_;
-}
-
 void BraveVPNWireguardConnectionAPI::SetSelectedRegion(
     const std::string& name) {}
-
-void BraveVPNWireguardConnectionAPI::NotifyRegionDataReady(bool ready) const {
-  for (auto& obs : observers_) {
-    obs.OnRegionDataReady(ready);
-  }
-}
-
-void BraveVPNWireguardConnectionAPI::NotifySelectedRegionChanged(
-    const std::string& name) const {
-  for (auto& obs : observers_) {
-    obs.OnSelectedRegionChanged(name);
-  }
-}
 
 }  // namespace brave_vpn

--- a/components/brave_vpn/browser/connection/wireguard/win/brave_vpn_wireguard_connection_api.h
+++ b/components/brave_vpn/browser/connection/wireguard/win/brave_vpn_wireguard_connection_api.h
@@ -14,17 +14,13 @@
 #include "base/memory/weak_ptr.h"
 #include "brave/components/brave_vpn/browser/api/brave_vpn_api_request.h"
 #include "brave/components/brave_vpn/browser/connection/brave_vpn_os_connection_api.h"
-#include "brave/components/brave_vpn/browser/connection/brave_vpn_region_data_manager.h"
-#include "net/base/network_change_notifier.h"
 #include "services/network/public/cpp/shared_url_loader_factory.h"
 
 class PrefService;
 
 namespace brave_vpn {
 
-class BraveVPNWireguardConnectionAPI
-    : public BraveVPNOSConnectionAPI,
-      public net::NetworkChangeNotifier::NetworkChangeObserver {
+class BraveVPNWireguardConnectionAPI : public BraveVPNOSConnectionAPI {
  public:
   BraveVPNWireguardConnectionAPI(
       scoped_refptr<network::SharedURLLoaderFactory> url_loader_factory,
@@ -40,8 +36,6 @@ class BraveVPNWireguardConnectionAPI
   void FetchProfileCredentials();
 
   // BraveVPNOSConnectionAPI
-  mojom::ConnectionState GetConnectionState() const override;
-  void ResetConnectionState() override;
   void RemoveVPNConnection() override;
   void Connect() override;
   void Disconnect() override;
@@ -49,24 +43,8 @@ class BraveVPNWireguardConnectionAPI
   void CheckConnection() override;
   void ResetConnectionInfo() override;
   std::string GetHostname() const override;
-  void AddObserver(Observer* observer) override;
-  void RemoveObserver(Observer* observer) override;
-  void SetConnectionState(mojom::ConnectionState state) override;
-  // Returns user friendly error string if existed.
-  // Otherwise returns empty.
-  std::string GetLastConnectionError() const override;
-  BraveVPNRegionDataManager& GetRegionDataManager() override;
   void SetSelectedRegion(const std::string& name) override;
 
-  // net::NetworkChangeNotifier::NetworkChangeObserver
-  void OnNetworkChanged(
-      net::NetworkChangeNotifier::ConnectionType type) override;
-  // BraveVPNRegionDataManager callbacks
-  // Notify it's ready when |regions_| is not empty.
-  void NotifyRegionDataReady(bool ready) const;
-  void NotifySelectedRegionChanged(const std::string& name) const;
-  void UpdateAndNotifyConnectionStateChange(mojom::ConnectionState state);
-  BraveVpnAPIRequest* GetAPIRequest();
   std::string GetCurrentEnvironment() const;
 
  private:
@@ -77,12 +55,9 @@ class BraveVPNWireguardConnectionAPI
   // We can cancel connecting request quickly when fetching hostnames or
   // profile credentials is not yet finished by reset this.
   std::unique_ptr<BraveVpnAPIRequest> api_request_;
-  mojom::ConnectionState connection_state_ =
-      mojom::ConnectionState::DISCONNECTED;
-  base::ObserverList<Observer> observers_;
 
   scoped_refptr<network::SharedURLLoaderFactory> url_loader_factory_;
-  BraveVPNRegionDataManager region_data_manager_;
+
   base::WeakPtrFactory<BraveVPNWireguardConnectionAPI> weak_factory_{this};
 };
 


### PR DESCRIPTION
Resolves https://github.com/brave/brave-browser/issues/30378

**No functional changes**, There is code that can be shared between connections implementations, like network notifications, region data requests, connection state observers, api requests and so on. In order to avoid duplication of same code in Wireguard and IKEv2 implementations I moved shared code to `BraveVPNOSConnectionAPI` 

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-arm64, CI/skip-linux-x64, CI/skip-android, CI/skip-macos, CI/skip-ios, CI/skip-windows-arm64, CI/skip-windows-x64, CI/skip-windows-x86 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
- No manual tests required.