### PR TITLE
Fixes Brave Ads crash on Android

### DIFF
--- a/components/brave_ads/browser/ads_service_impl.cc
+++ b/components/brave_ads/browser/ads_service_impl.cc
@@ -237,7 +237,6 @@ mojom::DBCommandResponseInfoPtr RunDBTransactionOnFileTaskRunner(
     mojom::DBTransactionInfoPtr transaction,
     Database* database) {
   CHECK(transaction);
-  CHECK(database);
 
   mojom::DBCommandResponseInfoPtr command_response =
       mojom::DBCommandResponseInfo::New();

--- a/components/brave_ads/core/internal/ads_impl.cc
+++ b/components/brave_ads/core/internal/ads_impl.cc
@@ -153,8 +153,10 @@ void AdsImpl::TriggerNewTabPageAdEvent(
     const mojom::NewTabPageAdEventType event_type) {
   CHECK(mojom::IsKnownEnumValue(event_type));
 
-  new_tab_page_ad_handler_.TriggerEvent(placement_id, creative_instance_id,
-                                        event_type);
+  if (IsInitialized()) {
+    new_tab_page_ad_handler_.TriggerEvent(placement_id, creative_instance_id,
+                                          event_type);
+  }
 }
 
 void AdsImpl::TriggerPromotedContentAdEvent(
@@ -163,8 +165,10 @@ void AdsImpl::TriggerPromotedContentAdEvent(
     const mojom::PromotedContentAdEventType event_type) {
   CHECK(mojom::IsKnownEnumValue(event_type));
 
-  promoted_content_ad_handler_.TriggerEvent(placement_id, creative_instance_id,
-                                            event_type);
+  if (IsInitialized()) {
+    promoted_content_ad_handler_.TriggerEvent(placement_id,
+                                              creative_instance_id, event_type);
+  }
 }
 
 void AdsImpl::MaybeServeInlineContentAd(
@@ -183,8 +187,10 @@ void AdsImpl::TriggerInlineContentAdEvent(
     const mojom::InlineContentAdEventType event_type) {
   CHECK(mojom::IsKnownEnumValue(event_type));
 
-  inline_content_ad_handler_.TriggerEvent(placement_id, creative_instance_id,
-                                          event_type);
+  if (IsInitialized()) {
+    inline_content_ad_handler_.TriggerEvent(placement_id, creative_instance_id,
+                                            event_type);
+  }
 }
 
 void AdsImpl::TriggerSearchResultAdEvent(
@@ -201,6 +207,10 @@ void AdsImpl::PurgeOrphanedAdEventsForType(
     const mojom::AdType ad_type,
     PurgeOrphanedAdEventsForTypeCallback callback) {
   CHECK(mojom::IsKnownEnumValue(ad_type));
+
+  if (!IsInitialized()) {
+    return std::move(callback).Run(/*success*/ false);
+  }
 
   PurgeOrphanedAdEvents(
       ad_type,
@@ -222,6 +232,10 @@ void AdsImpl::PurgeOrphanedAdEventsForType(
 }
 
 void AdsImpl::RemoveAllHistory(RemoveAllHistoryCallback callback) {
+  if (!IsInitialized()) {
+    return std::move(callback).Run(/*success*/ false);
+  }
+
   ClientStateManager::GetInstance().RemoveAllHistory();
 
   std::move(callback).Run(/*success*/ true);
@@ -247,21 +261,37 @@ void AdsImpl::GetStatementOfAccounts(GetStatementOfAccountsCallback callback) {
 }
 
 void AdsImpl::GetDiagnostics(GetDiagnosticsCallback callback) {
+  if (!IsInitialized()) {
+    return std::move(callback).Run(/*diagnostics*/ absl::nullopt);
+  }
+
   DiagnosticManager::GetInstance().GetDiagnostics(std::move(callback));
 }
 
 mojom::UserReactionType AdsImpl::ToggleLikeAd(const base::Value::Dict& value) {
+  if (!IsInitialized()) {
+    return mojom::UserReactionType::kNeutral;
+  }
+
   return HistoryManager::GetInstance().LikeAd(AdContentFromValue(value));
 }
 
 mojom::UserReactionType AdsImpl::ToggleDislikeAd(
     const base::Value::Dict& value) {
+  if (!IsInitialized()) {
+    return mojom::UserReactionType::kNeutral;
+  }
+
   return HistoryManager::GetInstance().DislikeAd(AdContentFromValue(value));
 }
 
 mojom::UserReactionType AdsImpl::ToggleLikeCategory(
     const std::string& category,
     const mojom::UserReactionType user_reaction_type) {
+  if (!IsInitialized()) {
+    return mojom::UserReactionType::kNeutral;
+  }
+
   return HistoryManager::GetInstance().LikeCategory(category,
                                                     user_reaction_type);
 }
@@ -269,15 +299,27 @@ mojom::UserReactionType AdsImpl::ToggleLikeCategory(
 mojom::UserReactionType AdsImpl::ToggleDislikeCategory(
     const std::string& category,
     const mojom::UserReactionType user_reaction_type) {
+  if (!IsInitialized()) {
+    return mojom::UserReactionType::kNeutral;
+  }
+
   return HistoryManager::GetInstance().DislikeCategory(category,
                                                        user_reaction_type);
 }
 
 bool AdsImpl::ToggleSaveAd(const base::Value::Dict& value) {
+  if (!IsInitialized()) {
+    return false;
+  }
+
   return HistoryManager::GetInstance().ToggleSaveAd(AdContentFromValue(value));
 }
 
 bool AdsImpl::ToggleMarkAdAsInappropriate(const base::Value::Dict& value) {
+  if (!IsInitialized()) {
+    return false;
+  }
+
   return HistoryManager::GetInstance().ToggleMarkAdAsInappropriate(
       AdContentFromValue(value));
 }


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/30343

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-arm64, CI/skip-linux-x64, CI/skip-android, CI/skip-macos, CI/skip-ios, CI/skip-windows-arm64, CI/skip-windows-x64, CI/skip-windows-x86 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

No steps to reproduce, however, the crash was due to triggering a new tab page ad viewed event before ads was initialized. This is a long standing issue, however, we now get a crash on Android because we made a recent change from DCHECK (debug only) to CHECK to capture edge cases like this in production builds.