### PR TITLE
Turn on vertical tab strip feature by default (uplift to 1.52.x)

### DIFF
--- a/browser/ui/tabs/BUILD.gn
+++ b/browser/ui/tabs/BUILD.gn
@@ -29,7 +29,6 @@ source_set("tabs") {
     ]
 
     deps = [
-      ":buildflags",
       "//brave/common/",
       "//chrome/app:generated_resources",
       "//components/prefs",
@@ -37,15 +36,5 @@ source_set("tabs") {
       "//content/public/browser",
       "//ui/color",
     ]
-  }
-}
-
-buildflag_header("buildflags") {
-  header = "buildflags.h"
-  if (brave_channel == "development" || brave_channel == "nightly" ||
-      brave_channel == "beta") {
-    flags = [ "VERTICAL_TAB_FLAG_DEFAULT_ON=1" ]
-  } else {
-    flags = [ "VERTICAL_TAB_FLAG_DEFAULT_ON=0" ]
   }
 }

--- a/browser/ui/tabs/features.cc
+++ b/browser/ui/tabs/features.cc
@@ -5,17 +5,11 @@
 
 #include "brave/browser/ui/tabs/features.h"
 
-#include "brave/browser/ui/tabs/buildflags.h"
-
 namespace tabs::features {
 
 BASE_FEATURE(kBraveVerticalTabs,
              "BraveVerticalTabs",
-#if BUILDFLAG(VERTICAL_TAB_FLAG_DEFAULT_ON)
              base::FEATURE_ENABLED_BY_DEFAULT);
-#else
-             base::FEATURE_DISABLED_BY_DEFAULT);
-#endif
 
 #if BUILDFLAG(IS_LINUX)
 BASE_FEATURE(kBraveChangeActiveTabOnScrollEvent,


### PR DESCRIPTION
Uplift of #18465
Resolves https://github.com/brave/brave-browser/issues/29659

Pre-approval checklist: 
- [ ] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.