### PR TITLE
[Android] Removes unused divider in the main menu (uplift to 1.52.x)

### DIFF
--- a/android/java/org/chromium/chrome/browser/appmenu/BraveTabbedAppMenuPropertiesDelegate.java
+++ b/android/java/org/chromium/chrome/browser/appmenu/BraveTabbedAppMenuPropertiesDelegate.java
@@ -210,6 +210,26 @@ public class BraveTabbedAppMenuPropertiesDelegate extends TabbedAppMenuPropertie
         if (bookmarkItem != null && currentTab != null) {
             updateBookmarkMenuItemShortcut(bookmarkItem, currentTab, /*fromCCT=*/false);
         }
+
+        // Remove unused dividers. This needs to be done after the visibility of all the items is
+        // set.
+        boolean hasItemBetweenDividers = false;
+        for (int i = 0; i < menu.size(); ++i) {
+            MenuItem item = menu.getItem(i);
+            if (item.getItemId() == R.id.divider_line_id) {
+                if (!hasItemBetweenDividers) {
+                    // If there isn't any visible menu items between the two divider lines, mark
+                    // this line invisible.
+                    item.setVisible(false);
+                } else {
+                    hasItemBetweenDividers = false;
+                }
+            } else if (!hasItemBetweenDividers && item.isVisible()) {
+                // When the item isn't a divider line and is visible, we set hasItemBetweenDividers
+                // to be true.
+                hasItemBetweenDividers = true;
+            }
+        }
     }
 
     @Override


### PR DESCRIPTION
Uplift of #18322
Resolves https://github.com/brave/brave-browser/issues/30084

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.