### PR TITLE
Remove BraveVPN connection when uninstalling the browser

### DIFF
--- a/browser/permissions/localhost_access_permission_browsertest.cc
+++ b/browser/permissions/localhost_access_permission_browsertest.cc
@@ -269,7 +269,7 @@ class LocalhostAccessBrowserTest : public InProcessBrowserTest {
   base::test::ScopedFeatureList feature_list_;
   raw_ptr<Browser> current_browser_;
   std::unique_ptr<brave_shields::TestFiltersProvider> source_provider_;
-  localhost_permission::LocalhostPermissionComponent*
+  raw_ptr<localhost_permission::LocalhostPermissionComponent>
       localhost_permission_component_;
 
  private:

--- a/chromium_src/chrome/installer/DEPS
+++ b/chromium_src/chrome/installer/DEPS
@@ -1,5 +1,5 @@
 include_rules = [
-  "+brave/components/brave_vpn/browser/connection/ikev2/win/brave_vpn_helper",
+  "+brave/components/brave_vpn/browser/connection/ikev2/win",
   "+brave/components/brave_vpn/common/buildflags",
   "+brave/installer",
   "+chrome/common",

--- a/chromium_src/chrome/installer/setup/sources.gni
+++ b/chromium_src/chrome/installer/setup/sources.gni
@@ -14,7 +14,10 @@ if (is_win) {
     "//brave/installer/util",
   ]
   if (enable_brave_vpn) {
-    brave_chromium_src_chrome_installer_setup_deps += [ "//brave/components/brave_vpn/browser/connection/ikev2/win/brave_vpn_helper:common" ]
+    brave_chromium_src_chrome_installer_setup_deps += [
+      "//brave/components/brave_vpn/browser/connection/ikev2/win:utils",
+      "//brave/components/brave_vpn/browser/connection/ikev2/win/brave_vpn_helper:common",
+    ]
   }
   if (is_official_build) {
     # These should be added to the lib target, but don't want to add another

--- a/chromium_src/chrome/installer/setup/sources.gni
+++ b/chromium_src/chrome/installer/setup/sources.gni
@@ -15,7 +15,7 @@ if (is_win) {
   ]
   if (enable_brave_vpn) {
     brave_chromium_src_chrome_installer_setup_deps += [
-      "//brave/components/brave_vpn/browser/connection/ikev2/win:utils",
+      "//brave/components/brave_vpn/browser/connection/ikev2/win:ras_utils",
       "//brave/components/brave_vpn/browser/connection/ikev2/win/brave_vpn_helper:common",
     ]
   }

--- a/chromium_src/chrome/installer/setup/uninstall.cc
+++ b/chromium_src/chrome/installer/setup/uninstall.cc
@@ -8,7 +8,7 @@
 #if BUILDFLAG(ENABLE_BRAVE_VPN)
 #include "brave/components/brave_vpn/browser/connection/ikev2/win/brave_vpn_helper/brave_vpn_helper_constants.h"
 #include "brave/components/brave_vpn/browser/connection/ikev2/win/brave_vpn_helper/brave_vpn_helper_state.h"
-#include "brave/components/brave_vpn/browser/connection/ikev2/win/utils.h"
+#include "brave/components/brave_vpn/browser/connection/ikev2/win/ras_utils.h"
 #endif
 #define UninstallProduct UninstallProduct_ChromiumImpl
 

--- a/chromium_src/chrome/installer/setup/uninstall.cc
+++ b/chromium_src/chrome/installer/setup/uninstall.cc
@@ -8,6 +8,7 @@
 #if BUILDFLAG(ENABLE_BRAVE_VPN)
 #include "brave/components/brave_vpn/browser/connection/ikev2/win/brave_vpn_helper/brave_vpn_helper_constants.h"
 #include "brave/components/brave_vpn/browser/connection/ikev2/win/brave_vpn_helper/brave_vpn_helper_state.h"
+#include "brave/components/brave_vpn/browser/connection/ikev2/win/utils.h"
 #endif
 #define UninstallProduct UninstallProduct_ChromiumImpl
 
@@ -63,6 +64,7 @@ InstallStatus UninstallProduct(const ModifyParams& modify_params,
        ShellUtil::QuickIsChromeRegisteredInHKLM(chrome_exe, suffix))) {
     DeleteBraveFileKeys(HKEY_LOCAL_MACHINE);
   }
+#if BUILDFLAG(ENABLE_BRAVE_VPN)
   if (installer_state->system_install()) {
     if (!InstallServiceWorkItem::DeleteService(
             brave_vpn::GetBraveVpnHelperServiceName(),
@@ -71,6 +73,8 @@ InstallStatus UninstallProduct(const ModifyParams& modify_params,
                    << brave_vpn::GetBraveVpnHelperServiceName();
     }
   }
+  brave_vpn::ras::RemoveEntry(brave_vpn::GetBraveVPNConnectionName());
+#endif
   return UninstallProduct_ChromiumImpl(modify_params, remove_all,
                                        force_uninstall, cmd_line);
 }

--- a/components/brave_vpn/browser/brave_vpn_service.cc
+++ b/components/brave_vpn/browser/brave_vpn_service.cc
@@ -187,12 +187,6 @@ bool BraveVpnService::IsConnected() const {
   return GetConnectionState() == ConnectionState::CONNECTED;
 }
 
-void BraveVpnService::RemoveVPNConnection() {
-  DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
-  VLOG(2) << __func__;
-  connection_api_->RemoveVPNConnection();
-}
-
 void BraveVpnService::Connect() {
   DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
 

--- a/components/brave_vpn/browser/brave_vpn_service.h
+++ b/components/brave_vpn/browser/brave_vpn_service.h
@@ -81,7 +81,6 @@ class BraveVpnService :
   bool IsBraveVPNEnabled() const;
 #if !BUILDFLAG(IS_ANDROID)
   void ToggleConnection();
-  void RemoveVPNConnection();
   mojom::ConnectionState GetConnectionState() const;
   bool IsConnected() const;
 

--- a/components/brave_vpn/browser/connection/brave_vpn_os_connection_api.h
+++ b/components/brave_vpn/browser/connection/brave_vpn_os_connection_api.h
@@ -59,7 +59,6 @@ class BraveVPNOSConnectionAPI
   std::string GetLastConnectionError() const;
 
   // Connection dependent APIs.
-  virtual void RemoveVPNConnection() = 0;
   virtual void Connect() = 0;
   virtual void Disconnect() = 0;
   virtual void ToggleConnection() = 0;

--- a/components/brave_vpn/browser/connection/ikev2/brave_vpn_ras_connection_api_base.cc
+++ b/components/brave_vpn/browser/connection/ikev2/brave_vpn_ras_connection_api_base.cc
@@ -161,11 +161,6 @@ void BraveVPNOSConnectionAPIBase::ToggleConnection() {
   can_disconnect ? Disconnect() : Connect();
 }
 
-void BraveVPNOSConnectionAPIBase::RemoveVPNConnection() {
-  VLOG(2) << __func__;
-  RemoveVPNConnectionImpl(target_vpn_entry_name_);
-}
-
 void BraveVPNOSConnectionAPIBase::CheckConnection() {
   CheckConnectionImpl(target_vpn_entry_name_);
 }

--- a/components/brave_vpn/browser/connection/ikev2/brave_vpn_ras_connection_api_base.h
+++ b/components/brave_vpn/browser/connection/ikev2/brave_vpn_ras_connection_api_base.h
@@ -42,7 +42,6 @@ class BraveVPNOSConnectionAPIBase : public BraveVPNOSConnectionAPI {
   void Connect() override;
   void Disconnect() override;
   void ToggleConnection() override;
-  void RemoveVPNConnection() override;
   void CheckConnection() override;
   void ResetConnectionInfo() override;
   std::string GetHostname() const override;
@@ -61,7 +60,6 @@ class BraveVPNOSConnectionAPIBase : public BraveVPNOSConnectionAPI {
   virtual void CreateVPNConnectionImpl(const BraveVPNConnectionInfo& info) = 0;
   virtual void ConnectImpl(const std::string& name) = 0;
   virtual void DisconnectImpl(const std::string& name) = 0;
-  virtual void RemoveVPNConnectionImpl(const std::string& name) = 0;
   virtual void CheckConnectionImpl(const std::string& name) = 0;
 
   // Subclass should call below callbacks whenever corresponding event happens.

--- a/components/brave_vpn/browser/connection/ikev2/brave_vpn_ras_connection_api_sim.cc
+++ b/components/brave_vpn/browser/connection/ikev2/brave_vpn_ras_connection_api_sim.cc
@@ -88,13 +88,6 @@ void BraveVPNOSConnectionAPISim::Connect() {
   BraveVPNOSConnectionAPIBase::Connect();
 }
 
-void BraveVPNOSConnectionAPISim::RemoveVPNConnectionImpl(
-    const std::string& name) {
-  base::SequencedTaskRunner::GetCurrentDefault()->PostTask(
-      FROM_HERE, base::BindOnce(&BraveVPNOSConnectionAPISim::OnRemoved,
-                                weak_factory_.GetWeakPtr(), name, true));
-}
-
 void BraveVPNOSConnectionAPISim::CheckConnectionImpl(const std::string& name) {
   check_connection_called_ = true;
 }
@@ -156,8 +149,5 @@ void BraveVPNOSConnectionAPISim::OnDisconnected(const std::string& name,
 void BraveVPNOSConnectionAPISim::OnIsDisconnecting(const std::string& name) {
   BraveVPNOSConnectionAPIBase::OnIsDisconnecting();
 }
-
-void BraveVPNOSConnectionAPISim::OnRemoved(const std::string& name,
-                                           bool success) {}
 
 }  // namespace brave_vpn

--- a/components/brave_vpn/browser/connection/ikev2/brave_vpn_ras_connection_api_sim.h
+++ b/components/brave_vpn/browser/connection/ikev2/brave_vpn_ras_connection_api_sim.h
@@ -42,7 +42,6 @@ class BraveVPNOSConnectionAPISim : public BraveVPNOSConnectionAPIBase {
 
   // BraveVPNOSConnectionAPIBase interfaces:
   void CreateVPNConnectionImpl(const BraveVPNConnectionInfo& info) override;
-  void RemoveVPNConnectionImpl(const std::string& name) override;
   void ConnectImpl(const std::string& name) override;
   void DisconnectImpl(const std::string& name) override;
   void CheckConnectionImpl(const std::string& name) override;

--- a/components/brave_vpn/browser/connection/ikev2/mac/brave_vpn_ras_connection_api_mac.h
+++ b/components/brave_vpn/browser/connection/ikev2/mac/brave_vpn_ras_connection_api_mac.h
@@ -26,7 +26,6 @@ class BraveVPNOSConnectionAPIMac : public BraveVPNOSConnectionAPIBase {
  private:
   // BraveVPNOSConnectionAPIBase overrides:
   void CreateVPNConnectionImpl(const BraveVPNConnectionInfo& info) override;
-  void RemoveVPNConnectionImpl(const std::string& name) override;
   void ConnectImpl(const std::string& name) override;
   void DisconnectImpl(const std::string& name) override;
   void CheckConnectionImpl(const std::string& name) override;

--- a/components/brave_vpn/browser/connection/ikev2/mac/brave_vpn_ras_connection_api_mac.mm
+++ b/components/brave_vpn/browser/connection/ikev2/mac/brave_vpn_ras_connection_api_mac.mm
@@ -62,21 +62,6 @@ NSData* GetPasswordRefForAccount() {
   return (__bridge NSData*)copy_result;
 }
 
-OSStatus RemoveKeychainItemForAccount() {
-  NSString* bundle_id = [[NSBundle mainBundle] bundleIdentifier];
-  NSDictionary* query = @{
-    (__bridge id)kSecClass : (__bridge id)kSecClassGenericPassword,
-    (__bridge id)kSecAttrService : bundle_id,
-    (__bridge id)kSecAttrAccount : kBraveVPNKey,
-    (__bridge id)kSecReturnPersistentRef : (__bridge id)kCFBooleanTrue,
-  };
-  OSStatus result = SecItemDelete((__bridge CFDictionaryRef)query);
-  if (result != errSecSuccess && result != errSecItemNotFound) {
-    LOG(ERROR) << "Error: deleting password entry(status:" << result << ")";
-  }
-  return result;
-}
-
 OSStatus StorePassword(const NSString* password, std::string* error_str) {
   DCHECK(error_str);
   std::string error;
@@ -248,31 +233,6 @@ void BraveVPNOSConnectionAPIMac::CreateVPNConnectionImpl(
         }];
       }];
     }];
-  }];
-}
-
-void BraveVPNOSConnectionAPIMac::RemoveVPNConnectionImpl(
-    const std::string& name) {
-  NEVPNManager* vpn_manager = [NEVPNManager sharedManager];
-  [vpn_manager loadFromPreferencesWithCompletionHandler:^(NSError* error) {
-    if (error) {
-      SetLastConnectionError(
-          base::SysNSStringToUTF8([error localizedDescription]));
-      LOG(ERROR) << "RemoveVPNConnection - loadFromPrefs: "
-                 << GetLastConnectionError();
-    } else {
-      [vpn_manager
-          removeFromPreferencesWithCompletionHandler:^(NSError* remove_error) {
-            if (remove_error) {
-              SetLastConnectionError(
-                  base::SysNSStringToUTF8([remove_error localizedDescription]));
-              LOG(ERROR) << "RemoveVPNConnection - removeFromPrefs: "
-                         << GetLastConnectionError();
-            }
-            VLOG(2) << "RemoveVPNConnection - successfully removed";
-          }];
-    }
-    RemoveKeychainItemForAccount();
   }];
 }
 

--- a/components/brave_vpn/browser/connection/ikev2/win/BUILD.gn
+++ b/components/brave_vpn/browser/connection/ikev2/win/BUILD.gn
@@ -8,10 +8,10 @@ import("//brave/components/brave_vpn/common/buildflags/buildflags.gni")
 assert(enable_brave_vpn)
 assert(is_win)
 
-source_set("utils") {
+source_set("ras_utils") {
   sources = [
-    "utils.cc",
-    "utils.h",
+    "ras_utils.cc",
+    "ras_utils.h",
   ]
   libs = [ "rasapi32.lib" ]
   deps = [
@@ -30,7 +30,7 @@ source_set("win") {
   ]
 
   deps = [
-    ":utils",
+    ":ras_utils",
     "brave_vpn_helper",
     "//base",
     "//brave/components/brave_vpn/browser/api",
@@ -52,6 +52,6 @@ executable("vpntool") {
   deps = [
     ":win",
     "//base",
-    "//brave/components/brave_vpn/browser/connection/ikev2/win:utils",
+    "//brave/components/brave_vpn/browser/connection/ikev2/win:ras_utils",
   ]
 }

--- a/components/brave_vpn/browser/connection/ikev2/win/brave_vpn_helper/BUILD.gn
+++ b/components/brave_vpn/browser/connection/ikev2/win/brave_vpn_helper/BUILD.gn
@@ -50,7 +50,7 @@ source_set("lib") {
   deps = [
     ":common",
     "//base",
-    "//brave//components/brave_vpn/browser/connection/ikev2/win:utils",
+    "//brave//components/brave_vpn/browser/connection/ikev2/win:ras_utils",
     "//brave//components/brave_vpn/common",
     "//brave/components/brave_vpn/browser/connection/common/win",
     "//third_party/abseil-cpp:absl",
@@ -106,7 +106,7 @@ source_set("unit_tests") {
     ":lib",
     "//base",
     "//base/test:test_support",
-    "//brave/components/brave_vpn/browser/connection/ikev2/win:utils",
+    "//brave/components/brave_vpn/browser/connection/ikev2/win:ras_utils",
     "//brave/components/brave_vpn/common",
     "//testing/gtest",
     "//third_party/abseil-cpp:absl",

--- a/components/brave_vpn/browser/connection/ikev2/win/brave_vpn_helper/vpn_dns_handler.cc
+++ b/components/brave_vpn/browser/connection/ikev2/win/brave_vpn_helper/vpn_dns_handler.cc
@@ -14,7 +14,7 @@
 #include "brave/components/brave_vpn/browser/connection/ikev2/win/brave_vpn_helper/brave_vpn_helper_constants.h"
 #include "brave/components/brave_vpn/browser/connection/ikev2/win/brave_vpn_helper/brave_vpn_helper_state.h"
 #include "brave/components/brave_vpn/browser/connection/ikev2/win/brave_vpn_helper/vpn_utils.h"
-#include "brave/components/brave_vpn/browser/connection/ikev2/win/utils.h"
+#include "brave/components/brave_vpn/browser/connection/ikev2/win/ras_utils.h"
 #include "brave/components/brave_vpn/common/brave_vpn_constants.h"
 
 namespace brave_vpn {

--- a/components/brave_vpn/browser/connection/ikev2/win/brave_vpn_helper/vpn_dns_handler.cc
+++ b/components/brave_vpn/browser/connection/ikev2/win/brave_vpn_helper/vpn_dns_handler.cc
@@ -55,7 +55,7 @@ void VpnDnsHandler::SetCloseEngineResultForTesting(bool value) {
 }
 
 void VpnDnsHandler::SetConnectionResultForTesting(
-    internal::CheckConnectionResult result) {
+    ras::CheckConnectionResult result) {
   connection_result_for_testing_ = result;
 }
 
@@ -106,22 +106,21 @@ bool VpnDnsHandler::RemoveFilters(const std::wstring& connection_name) {
   return success;
 }
 
-internal::CheckConnectionResult VpnDnsHandler::GetVpnEntryStatus() {
+ras::CheckConnectionResult VpnDnsHandler::GetVpnEntryStatus() {
   VLOG(1) << __func__;
   if (connection_result_for_testing_.has_value()) {
     return connection_result_for_testing_.value();
   }
-  return internal::CheckConnection(GetBraveVPNConnectionName());
+  return ras::CheckConnection(GetBraveVPNConnectionName());
 }
 
 void VpnDnsHandler::DisconnectVPN() {
   if (connection_result_for_testing_.has_value()) {
-    connection_result_for_testing_ =
-        internal::CheckConnectionResult::DISCONNECTED;
+    connection_result_for_testing_ = ras::CheckConnectionResult::DISCONNECTED;
     return;
   }
 
-  auto result = internal::DisconnectEntry(GetBraveVPNConnectionName());
+  auto result = ras::DisconnectEntry(GetBraveVPNConnectionName());
   if (!result.success) {
     VLOG(1) << "Failed to disconnect entry:" << result.error_description;
   }
@@ -130,7 +129,7 @@ void VpnDnsHandler::DisconnectVPN() {
 void VpnDnsHandler::UpdateFiltersState() {
   VLOG(1) << __func__;
   switch (GetVpnEntryStatus()) {
-    case internal::CheckConnectionResult::CONNECTED:
+    case ras::CheckConnectionResult::CONNECTED:
       VLOG(1) << "BraveVPN connected, set filters";
       if (IsActive()) {
         VLOG(1) << "Filters are already installed";
@@ -144,7 +143,7 @@ void VpnDnsHandler::UpdateFiltersState() {
       }
       SetFiltersInstalledFlag();
       break;
-    case internal::CheckConnectionResult::DISCONNECTED:
+    case ras::CheckConnectionResult::DISCONNECTED:
       VLOG(1) << "BraveVPN Disconnected, remove filters";
       if (!RemoveFilters(GetBraveVPNConnectionName())) {
         VLOG(1) << "Failed to remove DNS filters";
@@ -191,7 +190,7 @@ void VpnDnsHandler::ScheduleExit() {
 }
 
 void VpnDnsHandler::Exit() {
-  if (GetVpnEntryStatus() == internal::CheckConnectionResult::CONNECTED) {
+  if (GetVpnEntryStatus() == ras::CheckConnectionResult::CONNECTED) {
     VLOG(1) << __func__ << " vpn is active, do not exit";
     return;
   }

--- a/components/brave_vpn/browser/connection/ikev2/win/brave_vpn_helper/vpn_dns_handler.h
+++ b/components/brave_vpn/browser/connection/ikev2/win/brave_vpn_helper/vpn_dns_handler.h
@@ -18,9 +18,9 @@
 
 namespace brave_vpn {
 
-namespace internal {
+namespace ras {
 enum class CheckConnectionResult;
-}  // namespace internal
+}  // namespace ras
 
 class BraveVpnDnsDelegate;
 class MockVpnDnsHandler;
@@ -36,14 +36,14 @@ class VpnDnsHandler : public base::win::ObjectWatcher::Delegate {
   // base::win::ObjectWatcher::Delegate overrides:
   void OnObjectSignaled(HANDLE object) override;
 
-  internal::CheckConnectionResult GetVpnEntryStatus();
+  ras::CheckConnectionResult GetVpnEntryStatus();
   bool CloseEngineSession();
 
   bool SetFilters(const std::wstring& connection_name);
   bool RemoveFilters(const std::wstring& connection_name);
   bool IsActive() const;
   bool IsExitTimerRunningForTesting();
-  void SetConnectionResultForTesting(internal::CheckConnectionResult result);
+  void SetConnectionResultForTesting(ras::CheckConnectionResult result);
   void SetCloseEngineResultForTesting(bool value);
   void SetPlatformFiltersResultForTesting(bool value);
   void SetWaitingIntervalBeforeExitForTesting(int value);
@@ -62,8 +62,7 @@ class VpnDnsHandler : public base::win::ObjectWatcher::Delegate {
   void Exit();
   virtual void SubscribeForRasNotifications(HANDLE event_handle);
 
-  absl::optional<internal::CheckConnectionResult>
-      connection_result_for_testing_;
+  absl::optional<ras::CheckConnectionResult> connection_result_for_testing_;
   absl::optional<bool> platform_filters_result_for_testing_;
   absl::optional<bool> close_engine_result_for_testing_;
   absl::optional<int> waiting_interval_before_exit_for_testing_;

--- a/components/brave_vpn/browser/connection/ikev2/win/brave_vpn_helper/vpn_dns_handler_unittest.cc
+++ b/components/brave_vpn/browser/connection/ikev2/win/brave_vpn_helper/vpn_dns_handler_unittest.cc
@@ -36,7 +36,7 @@ class MockVpnDnsHandler : public VpnDnsHandler, public BraveVpnDnsDelegate {
   void SubscribeForRasNotifications(HANDLE event_handle) override {
     event_handle_ = event_handle;
   }
-  void SetConnectionResultForTesting(internal::CheckConnectionResult result) {
+  void SetConnectionResultForTesting(ras::CheckConnectionResult result) {
     VpnDnsHandler::SetConnectionResultForTesting(result);
   }
   void SetPlatformFiltersResultForTesting(bool value) {
@@ -84,7 +84,7 @@ TEST_F(VpnDnsHandlerTest, Disconnected) {
       base::BindLambdaForTesting([&]() { callback_called = true; }));
   EXPECT_FALSE(handler.IsActive());
   handler.SetConnectionResultForTesting(
-      internal::CheckConnectionResult::DISCONNECTED);
+      ras::CheckConnectionResult::DISCONNECTED);
   handler.StartMonitoring();
   base::RunLoop().RunUntilIdle();
   FastForwardBy(base::Seconds(1));
@@ -96,13 +96,12 @@ TEST_F(VpnDnsHandlerTest, ConnectingFailed) {
   MockVpnDnsHandler handler(
       base::BindLambdaForTesting([&]() { callback_called = true; }));
   EXPECT_FALSE(handler.IsActive());
-  handler.SetConnectionResultForTesting(
-      internal::CheckConnectionResult::CONNECTING);
+  handler.SetConnectionResultForTesting(ras::CheckConnectionResult::CONNECTING);
   handler.StartMonitoring();
   base::RunLoop().RunUntilIdle();
   EXPECT_FALSE(handler.IsActive());
   handler.SetConnectionResultForTesting(
-      internal::CheckConnectionResult::DISCONNECTED);
+      ras::CheckConnectionResult::DISCONNECTED);
   EXPECT_FALSE(handler.IsExitTimerRunningForTesting());
   // Repeating interval to check the connection is live.
   // kCheckConnectionIntervalInSeconds
@@ -119,13 +118,11 @@ TEST_F(VpnDnsHandlerTest, ConnectingSuccessFailedToSetFilters) {
   MockVpnDnsHandler handler(
       base::BindLambdaForTesting([&]() { callback_called = true; }));
   EXPECT_FALSE(handler.IsActive());
-  handler.SetConnectionResultForTesting(
-      internal::CheckConnectionResult::CONNECTING);
+  handler.SetConnectionResultForTesting(ras::CheckConnectionResult::CONNECTING);
   handler.StartMonitoring();
   base::RunLoop().RunUntilIdle();
 
-  handler.SetConnectionResultForTesting(
-      internal::CheckConnectionResult::CONNECTED);
+  handler.SetConnectionResultForTesting(ras::CheckConnectionResult::CONNECTED);
   handler.SetPlatformFiltersResultForTesting(false);
   EXPECT_FALSE(handler.IsExitTimerRunningForTesting());
   // Repeating interval to check the connection is live.
@@ -145,13 +142,11 @@ TEST_F(VpnDnsHandlerTest, ConnectingSuccessFiltersInstalled) {
       base::BindLambdaForTesting([&]() { callback_called = true; }));
   EXPECT_FALSE(handler.IsActive());
   EXPECT_EQ(handler.GetEventHandle(), nullptr);
-  handler.SetConnectionResultForTesting(
-      internal::CheckConnectionResult::CONNECTING);
+  handler.SetConnectionResultForTesting(ras::CheckConnectionResult::CONNECTING);
   handler.StartMonitoring();
   base::RunLoop().RunUntilIdle();
   EXPECT_NE(handler.GetEventHandle(), nullptr);
-  handler.SetConnectionResultForTesting(
-      internal::CheckConnectionResult::CONNECTED);
+  handler.SetConnectionResultForTesting(ras::CheckConnectionResult::CONNECTED);
   handler.SetPlatformFiltersResultForTesting(true);
   // Repeating interval to check the connection is live.
   // kCheckConnectionIntervalInSeconds
@@ -165,7 +160,7 @@ TEST_F(VpnDnsHandlerTest, ConnectingSuccessFiltersInstalled) {
 
   // Disconnected.
   handler.SetConnectionResultForTesting(
-      internal::CheckConnectionResult::DISCONNECTED);
+      ras::CheckConnectionResult::DISCONNECTED);
 
   // BraveVpn changed state.
   handler.OnObjectSignaled(handler.GetEventHandle());
@@ -183,8 +178,7 @@ TEST_F(VpnDnsHandlerTest, Connected) {
       base::BindLambdaForTesting([&]() { callback_called = true; }));
   EXPECT_FALSE(handler.IsActive());
   // Connected.
-  handler.SetConnectionResultForTesting(
-      internal::CheckConnectionResult::CONNECTED);
+  handler.SetConnectionResultForTesting(ras::CheckConnectionResult::CONNECTED);
   handler.StartMonitoring();
   base::RunLoop().RunUntilIdle();
   // Set filters immediately as vpn is connected.
@@ -194,7 +188,7 @@ TEST_F(VpnDnsHandlerTest, Connected) {
 
   // Disconnected.
   handler.SetConnectionResultForTesting(
-      internal::CheckConnectionResult::DISCONNECTED);
+      ras::CheckConnectionResult::DISCONNECTED);
   // BraveVpn changed state.
   handler.OnObjectSignaled(handler.GetEventHandle());
   EXPECT_TRUE(handler.IsExitTimerRunningForTesting());
@@ -210,8 +204,7 @@ TEST_F(VpnDnsHandlerTest, CheckConnectedState) {
       base::BindLambdaForTesting([&]() { callback_called = true; }));
   EXPECT_FALSE(handler.IsActive());
   // Connected.
-  handler.SetConnectionResultForTesting(
-      internal::CheckConnectionResult::CONNECTED);
+  handler.SetConnectionResultForTesting(ras::CheckConnectionResult::CONNECTED);
   handler.UpdateFiltersState();
   // Set filters immediately as vpn is connected.
   EXPECT_TRUE(handler.IsActive());
@@ -224,8 +217,7 @@ TEST_F(VpnDnsHandlerTest, CheckConnectingState) {
       base::BindLambdaForTesting([&]() { callback_called = true; }));
   EXPECT_FALSE(handler.IsActive());
   // Connecting.
-  handler.SetConnectionResultForTesting(
-      internal::CheckConnectionResult::CONNECTING);
+  handler.SetConnectionResultForTesting(ras::CheckConnectionResult::CONNECTING);
   handler.UpdateFiltersState();
   // Do nothing and wait until connected event.
   EXPECT_FALSE(handler.IsActive());
@@ -241,7 +233,7 @@ TEST_F(VpnDnsHandlerTest, CheckDisconnectedState) {
   EXPECT_TRUE(handler.IsActive());
   // Disconnected.
   handler.SetConnectionResultForTesting(
-      internal::CheckConnectionResult::DISCONNECTED);
+      ras::CheckConnectionResult::DISCONNECTED);
   handler.UpdateFiltersState();
   base::RunLoop().RunUntilIdle();
   // Remove filters
@@ -260,7 +252,7 @@ TEST_F(VpnDnsHandlerTest, DisconnectAndReconnectRightAfterBySignal) {
   EXPECT_TRUE(handler.IsActive());
   // Disconnected.
   handler.SetConnectionResultForTesting(
-      internal::CheckConnectionResult::DISCONNECTED);
+      ras::CheckConnectionResult::DISCONNECTED);
   handler.UpdateFiltersState();
   base::RunLoop().RunUntilIdle();
   // Filters removed
@@ -268,8 +260,7 @@ TEST_F(VpnDnsHandlerTest, DisconnectAndReconnectRightAfterBySignal) {
   EXPECT_TRUE(handler.IsExitTimerRunningForTesting());
   // Emulate vpn connect after some time.
   FastForwardBy(base::Seconds(2));
-  handler.SetConnectionResultForTesting(
-      internal::CheckConnectionResult::CONNECTED);
+  handler.SetConnectionResultForTesting(ras::CheckConnectionResult::CONNECTED);
   handler.OnObjectSignaled(handler.GetEventHandle());
   EXPECT_FALSE(handler.IsExitTimerRunningForTesting());
   // Exit should not happen because connection is on.
@@ -292,7 +283,7 @@ TEST_F(VpnDnsHandlerTest, DisconnectAndReconnectRightAfterByPolling) {
 
   // Disconnected.
   handler.SetConnectionResultForTesting(
-      internal::CheckConnectionResult::DISCONNECTED);
+      ras::CheckConnectionResult::DISCONNECTED);
   handler.UpdateFiltersState();
   base::RunLoop().RunUntilIdle();
   // Filters removed
@@ -300,8 +291,7 @@ TEST_F(VpnDnsHandlerTest, DisconnectAndReconnectRightAfterByPolling) {
   EXPECT_TRUE(handler.IsExitTimerRunningForTesting());
   // Emulate vpn connect after some time.
   FastForwardBy(base::Seconds(2));
-  handler.SetConnectionResultForTesting(
-      internal::CheckConnectionResult::CONNECTED);
+  handler.SetConnectionResultForTesting(ras::CheckConnectionResult::CONNECTED);
   // Exit should not happen because connection is on.
   // Polling should reset exit timer.
   FastForwardBy(base::Seconds(4));

--- a/components/brave_vpn/browser/connection/ikev2/win/brave_vpn_helper/vpn_dns_handler_unittest.cc
+++ b/components/brave_vpn/browser/connection/ikev2/win/brave_vpn_helper/vpn_dns_handler_unittest.cc
@@ -14,7 +14,7 @@
 #include "base/test/task_environment.h"
 #include "brave/components/brave_vpn/browser/connection/ikev2/win/brave_vpn_helper/brave_vpn_dns_delegate.h"
 #include "brave/components/brave_vpn/browser/connection/ikev2/win/brave_vpn_helper/brave_vpn_helper_constants.h"
-#include "brave/components/brave_vpn/browser/connection/ikev2/win/utils.h"
+#include "brave/components/brave_vpn/browser/connection/ikev2/win/ras_utils.h"
 #include "brave/components/brave_vpn/common/brave_vpn_constants.h"
 #include "testing/gtest/include/gtest/gtest.h"
 

--- a/components/brave_vpn/browser/connection/ikev2/win/brave_vpn_ras_connection_api_win.cc
+++ b/components/brave_vpn/browser/connection/ikev2/win/brave_vpn_ras_connection_api_win.cc
@@ -21,22 +21,22 @@
 // Most of Windows implementations are based on Brian Clifton
 // (brian@clifton.me)'s work (https://github.com/bsclifton/winvpntool).
 
-using brave_vpn::internal::CheckConnectionResult;
-using brave_vpn::internal::CreateEntry;
-using brave_vpn::internal::GetPhonebookPath;
-using brave_vpn::internal::RasOperationResult;
-using brave_vpn::internal::RemoveEntry;
+using brave_vpn::ras::CheckConnectionResult;
+using brave_vpn::ras::CreateEntry;
+using brave_vpn::ras::GetPhonebookPath;
+using brave_vpn::ras::RasOperationResult;
+using brave_vpn::ras::RemoveEntry;
 
 namespace brave_vpn {
 
 namespace {
 
 RasOperationResult ConnectEntry(const std::wstring& name) {
-  return brave_vpn::internal::ConnectEntry(name);
+  return brave_vpn::ras::ConnectEntry(name);
 }
 
 RasOperationResult DisconnectEntry(const std::wstring& name) {
-  return brave_vpn::internal::DisconnectEntry(name);
+  return brave_vpn::ras::DisconnectEntry(name);
 }
 
 }  // namespace
@@ -87,19 +87,10 @@ void BraveVPNOSConnectionAPIWin::DisconnectImpl(const std::string& name) {
                      weak_factory_.GetWeakPtr()));
 }
 
-void BraveVPNOSConnectionAPIWin::RemoveVPNConnectionImpl(
-    const std::string& name) {
-  base::ThreadPool::PostTaskAndReplyWithResult(
-      FROM_HERE, {base::MayBlock()},
-      base::BindOnce(&RemoveEntry, base::UTF8ToWide(name)),
-      base::BindOnce(&BraveVPNOSConnectionAPIWin::OnRemoved,
-                     weak_factory_.GetWeakPtr(), name));
-}
-
 void BraveVPNOSConnectionAPIWin::CheckConnectionImpl(const std::string& name) {
   base::ThreadPool::PostTaskAndReplyWithResult(
       FROM_HERE, {base::MayBlock()},
-      base::BindOnce(&internal::CheckConnection, base::UTF8ToWide(name)),
+      base::BindOnce(&ras::CheckConnection, base::UTF8ToWide(name)),
       base::BindOnce(&BraveVPNOSConnectionAPIWin::OnCheckConnection,
                      weak_factory_.GetWeakPtr(), name));
 }
@@ -166,13 +157,6 @@ void BraveVPNOSConnectionAPIWin::OnDisconnected(
     return;
   }
   SetLastConnectionError(result.error_description);
-}
-
-void BraveVPNOSConnectionAPIWin::OnRemoved(const std::string& name,
-                                           const RasOperationResult& result) {
-  if (!result.success) {
-    SetLastConnectionError(result.error_description);
-  }
 }
 
 void BraveVPNOSConnectionAPIWin::StartVPNConnectionChangeMonitoring() {

--- a/components/brave_vpn/browser/connection/ikev2/win/brave_vpn_ras_connection_api_win.cc
+++ b/components/brave_vpn/browser/connection/ikev2/win/brave_vpn_ras_connection_api_win.cc
@@ -15,7 +15,7 @@
 #include "base/notreached.h"
 #include "base/strings/utf_string_conversions.h"
 #include "base/task/thread_pool.h"
-#include "brave/components/brave_vpn/browser/connection/ikev2/win/utils.h"
+#include "brave/components/brave_vpn/browser/connection/ikev2/win/ras_utils.h"
 #include "brave/components/brave_vpn/common/brave_vpn_constants.h"
 
 // Most of Windows implementations are based on Brian Clifton

--- a/components/brave_vpn/browser/connection/ikev2/win/brave_vpn_ras_connection_api_win.h
+++ b/components/brave_vpn/browser/connection/ikev2/win/brave_vpn_ras_connection_api_win.h
@@ -16,9 +16,9 @@
 #include "brave/components/brave_vpn/browser/connection/ikev2/win/utils.h"
 
 namespace brave_vpn {
-namespace internal {
+namespace ras {
 enum class CheckConnectionResult;
-}  // namespace internal
+}  // namespace ras
 
 class BraveVPNOSConnectionAPIWin : public BraveVPNOSConnectionAPIBase,
                                    public base::win::ObjectWatcher::Delegate {
@@ -35,7 +35,6 @@ class BraveVPNOSConnectionAPIWin : public BraveVPNOSConnectionAPIBase,
  private:
   // BraveVPNOSConnectionAPIBase interfaces:
   void CreateVPNConnectionImpl(const BraveVPNConnectionInfo& info) override;
-  void RemoveVPNConnectionImpl(const std::string& name) override;
   void ConnectImpl(const std::string& name) override;
   void DisconnectImpl(const std::string& name) override;
   void CheckConnectionImpl(const std::string& name) override;
@@ -44,13 +43,11 @@ class BraveVPNOSConnectionAPIWin : public BraveVPNOSConnectionAPIBase,
   void OnObjectSignaled(HANDLE object) override;
 
   void OnCreated(const std::string& name,
-                 const internal::RasOperationResult& result);
-  void OnConnected(const internal::RasOperationResult& result);
-  void OnDisconnected(const internal::RasOperationResult& result);
-  void OnRemoved(const std::string& name,
-                 const internal::RasOperationResult& result);
+                 const ras::RasOperationResult& result);
+  void OnConnected(const ras::RasOperationResult& result);
+  void OnDisconnected(const ras::RasOperationResult& result);
   void OnCheckConnection(const std::string& name,
-                         internal::CheckConnectionResult result);
+                         ras::CheckConnectionResult result);
 
   void StartVPNConnectionChangeMonitoring();
 

--- a/components/brave_vpn/browser/connection/ikev2/win/brave_vpn_ras_connection_api_win.h
+++ b/components/brave_vpn/browser/connection/ikev2/win/brave_vpn_ras_connection_api_win.h
@@ -13,7 +13,7 @@
 #include "base/win/windows_types.h"
 #include "brave/components/brave_vpn/browser/connection/brave_vpn_connection_info.h"
 #include "brave/components/brave_vpn/browser/connection/ikev2/brave_vpn_ras_connection_api_base.h"
-#include "brave/components/brave_vpn/browser/connection/ikev2/win/utils.h"
+#include "brave/components/brave_vpn/browser/connection/ikev2/win/ras_utils.h"
 
 namespace brave_vpn {
 namespace ras {

--- a/components/brave_vpn/browser/connection/ikev2/win/ras_utils.cc
+++ b/components/brave_vpn/browser/connection/ikev2/win/ras_utils.cc
@@ -3,7 +3,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-#include "brave/components/brave_vpn/browser/connection/ikev2/win/utils.h"
+#include "brave/components/brave_vpn/browser/connection/ikev2/win/ras_utils.h"
 
 #include <windows.h>
 

--- a/components/brave_vpn/browser/connection/ikev2/win/ras_utils.h
+++ b/components/brave_vpn/browser/connection/ikev2/win/ras_utils.h
@@ -3,8 +3,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-#ifndef BRAVE_COMPONENTS_BRAVE_VPN_BROWSER_CONNECTION_IKEV2_WIN_UTILS_H_
-#define BRAVE_COMPONENTS_BRAVE_VPN_BROWSER_CONNECTION_IKEV2_WIN_UTILS_H_
+#ifndef BRAVE_COMPONENTS_BRAVE_VPN_BROWSER_CONNECTION_IKEV2_WIN_RAS_UTILS_H_
+#define BRAVE_COMPONENTS_BRAVE_VPN_BROWSER_CONNECTION_IKEV2_WIN_RAS_UTILS_H_
 
 #include <string>
 
@@ -44,4 +44,4 @@ CheckConnectionResult CheckConnection(const std::wstring& entry_name);
 
 }  // namespace brave_vpn
 
-#endif  // BRAVE_COMPONENTS_BRAVE_VPN_BROWSER_CONNECTION_IKEV2_WIN_UTILS_H_
+#endif  // BRAVE_COMPONENTS_BRAVE_VPN_BROWSER_CONNECTION_IKEV2_WIN_RAS_UTILS_H_

--- a/components/brave_vpn/browser/connection/ikev2/win/utils.cc
+++ b/components/brave_vpn/browser/connection/ikev2/win/utils.cc
@@ -369,7 +369,7 @@ RasOperationResult RemoveEntry(const std::wstring& entry_name) {
     return GetRasErrorResult(error_get_phone_book_path,
                              "GetPhonebookPath() from RemoveEntry()");
   }
-
+  DisconnectEntry(entry_name);
   DWORD dw_ret = RasDeleteEntry(phone_book_path.c_str(), entry_name.c_str());
   if (dw_ret != ERROR_SUCCESS) {
     return GetRasErrorResult(GetRasErrorMessage(dw_ret), "RasDeleteEntry()");

--- a/components/brave_vpn/browser/connection/ikev2/win/utils.cc
+++ b/components/brave_vpn/browser/connection/ikev2/win/utils.cc
@@ -80,7 +80,7 @@ absl::optional<std::string> SetCredentials(LPCTSTR phone_book_path,
       RasSetCredentials(phone_book_path, entry_name, &credentials, FALSE);
   if (dw_ret != ERROR_SUCCESS) {
     return base::StrCat(
-        {"RasSetCredential() - ", internal::GetRasErrorMessage(dw_ret)});
+        {"RasSetCredential() - ", ras::GetRasErrorMessage(dw_ret)});
   }
 
   return absl::nullopt;
@@ -153,15 +153,15 @@ std::wstring TryGetPhonebookPath(int key, const std::wstring& entry_name) {
   return L"";
 }
 
-internal::RasOperationResult GetRasSuccessResult() {
-  internal::RasOperationResult result;
+ras::RasOperationResult GetRasSuccessResult() {
+  ras::RasOperationResult result;
   result.success = true;
   return result;
 }
 
-internal::RasOperationResult GetRasErrorResult(const std::string& error,
-                                               const std::string& caller = {}) {
-  internal::RasOperationResult result;
+ras::RasOperationResult GetRasErrorResult(const std::string& error,
+                                          const std::string& caller = {}) {
+  ras::RasOperationResult result;
   result.success = false;
   result.error_description =
       caller.empty() ? error : base::StrCat({caller, " - ", error});
@@ -170,7 +170,7 @@ internal::RasOperationResult GetRasErrorResult(const std::string& error,
 
 }  // namespace
 
-namespace internal {
+namespace ras {
 
 // https://docs.microsoft.com/en-us/windows/win32/api/ras/nf-ras-rasgeterrorstringa
 std::string GetRasErrorMessage(DWORD error) {
@@ -593,6 +593,6 @@ CheckConnectionResult CheckConnection(const std::wstring& entry_name) {
   return result;
 }
 
-}  // namespace internal
+}  // namespace ras
 
 }  // namespace brave_vpn

--- a/components/brave_vpn/browser/connection/ikev2/win/utils.cc
+++ b/components/brave_vpn/browser/connection/ikev2/win/utils.cc
@@ -369,7 +369,11 @@ RasOperationResult RemoveEntry(const std::wstring& entry_name) {
     return GetRasErrorResult(error_get_phone_book_path,
                              "GetPhonebookPath() from RemoveEntry()");
   }
-  DisconnectEntry(entry_name);
+  auto disconnected = DisconnectEntry(entry_name);
+  if (!disconnected.success) {
+    VLOG(2) << __func__ << ": Unable to disconnect " << entry_name
+            << ", error:" << disconnected.error_description;
+  }
   DWORD dw_ret = RasDeleteEntry(phone_book_path.c_str(), entry_name.c_str());
   if (dw_ret != ERROR_SUCCESS) {
     return GetRasErrorResult(GetRasErrorMessage(dw_ret), "RasDeleteEntry()");

--- a/components/brave_vpn/browser/connection/ikev2/win/utils.h
+++ b/components/brave_vpn/browser/connection/ikev2/win/utils.h
@@ -14,7 +14,7 @@ namespace brave_vpn {
 
 class BraveVPNConnectionInfo;
 
-namespace internal {
+namespace ras {
 
 enum class CheckConnectionResult {
   CONNECTED,
@@ -40,7 +40,7 @@ RasOperationResult DisconnectEntry(const std::wstring& entry_name);
 RasOperationResult ConnectEntry(const std::wstring& entry_name);
 CheckConnectionResult CheckConnection(const std::wstring& entry_name);
 
-}  // namespace internal
+}  // namespace ras
 
 }  // namespace brave_vpn
 

--- a/components/brave_vpn/browser/connection/ikev2/win/winvpntool.cc
+++ b/components/brave_vpn/browser/connection/ikev2/win/winvpntool.cc
@@ -15,7 +15,7 @@
 
 #include "base/command_line.h"
 #include "base/logging.h"
-#include "brave/components/brave_vpn/browser/connection/ikev2/win/utils.h"
+#include "brave/components/brave_vpn/browser/connection/ikev2/win/ras_utils.h"
 
 // Simple Windows VPN configuration tool (using RAS API)
 // By Brian Clifton (brian@clifton.me)

--- a/components/brave_vpn/browser/connection/wireguard/win/brave_vpn_wireguard_connection_api.cc
+++ b/components/brave_vpn/browser/connection/wireguard/win/brave_vpn_wireguard_connection_api.cc
@@ -39,8 +39,6 @@ std::string BraveVPNWireguardConnectionAPI::GetCurrentEnvironment() const {
   return local_prefs_->GetString(prefs::kBraveVPNEnvironment);
 }
 
-void BraveVPNWireguardConnectionAPI::RemoveVPNConnection() {}
-
 void BraveVPNWireguardConnectionAPI::Connect() {}
 
 void BraveVPNWireguardConnectionAPI::Disconnect() {}

--- a/components/brave_vpn/browser/connection/wireguard/win/brave_vpn_wireguard_connection_api.h
+++ b/components/brave_vpn/browser/connection/wireguard/win/brave_vpn_wireguard_connection_api.h
@@ -36,7 +36,6 @@ class BraveVPNWireguardConnectionAPI : public BraveVPNOSConnectionAPI {
   void FetchProfileCredentials();
 
   // BraveVPNOSConnectionAPI
-  void RemoveVPNConnection() override;
   void Connect() override;
   void Disconnect() override;
   void ToggleConnection() override;


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/30416

- Removed unused RemoveVPNConnection interface for BraveVpn classes.
- Remove RAS BraveVpn system connection entry on uninstalling.
- Renamed `internal` namespace to `ras` for the ras utility functions as they are used outside from installer now.

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-arm64, CI/skip-linux-x64, CI/skip-android, CI/skip-macos, CI/skip-ios, CI/skip-windows-arm64, CI/skip-windows-x64, CI/skip-windows-x86 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

- steps from issue
- additionally worth to check that vpn entry could be successfully created on next installs