### PR TITLE
fix(wallet): min-height for card panel width

### DIFF
--- a/components/brave_wallet_ui/components/desktop/wallet-page-wrapper/wallet-page-wrapper.style.ts
+++ b/components/brave_wallet_ui/components/desktop/wallet-page-wrapper/wallet-page-wrapper.style.ts
@@ -7,9 +7,10 @@ import styled from 'styled-components'
 import * as leo from '@brave/leo/tokens/css'
 import { Row } from '../../shared/style'
 
-const minCardHeight = 531
+const minCardHeight = 497
 const maxCardWidth = 768
 const layoutScaleWithNav = 1374
+const layoutSmallCardBottom = 67
 export const layoutSmallWidth = 980
 export const layoutPanelWidth = 660
 export const layoutTopPosition = 68
@@ -40,15 +41,16 @@ export const LayoutCardWrapper = styled.div<{
   --header-top-position:
     calc(${layoutTopPosition}px + ${(p) => p.headerHeight}px);
   --no-header-top-position: ${layoutTopPosition}px;
-  display: flex;
-  flex-direction: column;
-  justify-content: flex-start;
-  align-items: center;
-  top: ${(p) =>
+  --top-position: ${(p) =>
     p.hideCardHeader
       ? 'var(--no-header-top-position)'
       : 'var(--header-top-position)'
   };
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-start;
+  align-items: center;
+  top: var(--top-position);
   bottom: 0px;
   position: absolute;
   width: 100%;
@@ -63,7 +65,7 @@ export const LayoutCardWrapper = styled.div<{
     align-items: flex-start;
   }
   @media screen and (max-width: ${layoutSmallWidth}px) {
-    bottom: 67px;
+    bottom: ${layoutSmallCardBottom}px;
     padding: 0px 32px 32px 32px;
     align-items: center;
   }
@@ -104,6 +106,7 @@ export const ContainerCard = styled.div<
     width: 100%;
   }
   @media screen and (max-width: ${layoutPanelWidth}px) {
+    min-height: calc(100vh - ${layoutSmallCardBottom}px - var(--top-position));
     border-radius: ${(p) =>
     p.hideCardHeader
       ? '24px 24px 0px 0px'


### PR DESCRIPTION
## Description 
Adds a `min-height` to the Wallet `Card` for `panel` widths so the card stretches to the bottom of the screen.

<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves <https://github.com/brave/brave-browser/issues/30433>

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-arm64, CI/skip-linux-x64, CI/skip-android, CI/skip-macos, CI/skip-ios, CI/skip-windows-arm64, CI/skip-windows-x64, CI/skip-windows-x86 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
1. Create a new `Wallet` and go to the `Activity` tab
2. Shrink the `width` of the `Browser` until it snaps to the `panel` layout.
3. The height of the Wallet `Card` should stretch all the way to the bottom of the screen.

Before:

https://github.com/brave/brave-core/assets/40611140/990a0c91-330d-4cb4-b0cf-29b06875faf3

After:

https://github.com/brave/brave-core/assets/40611140/df0fd071-0180-4e19-9e76-ef44247a6645
