### PR TITLE
Fix for BraveSyncServiceImplTest.ForcedSetDecryptionPassphrase test at cr115

### DIFF
--- a/components/sync/driver/brave_sync_service_impl_unittest.cc
+++ b/components/sync/driver/brave_sync_service_impl_unittest.cc
@@ -263,6 +263,19 @@ TEST_F(BraveSyncServiceImplTest, ForcedSetDecryptionPassphrase) {
   brave_sync_service_impl()->Initialize();
   EXPECT_FALSE(engine());
   brave_sync_service_impl()->SetSyncCode(kValidSyncCode);
+
+  // By default Brave enables Bookmarks datatype when sync is enabled.
+  // This caused DCHECK at DataTypeManagerImpl::DataTypeManagerImpl
+  // after OnEngineInitialized(true, false) call.
+  // Current unit test is intended to verify fix for brave/brave-browser#22898
+  // and is about set encryption passphrase later setup after right after
+  // enabling sync, for example when internet connection is unstable. Related
+  // Chromium commit 3241d114b8036bb6d53931ba34b3bf819258c29d Prior to this
+  // commit DataTypeManagerImpl wasn't created for bookmarks at
+  // ForcedSetDecryptionPassphrase test.
+  brave_sync_service_impl()->GetUserSettings()->SetSelectedTypes(
+      false, syncer::UserSelectableTypeSet());
+
   task_environment_.RunUntilIdle();
 
   brave_sync_service_impl()->GetUserSettings()->SetFirstSetupComplete(


### PR DESCRIPTION

By default Brave enables Bookmarks datatype when sync is enabled. This caused DCHECK at DataTypeManagerImpl::DataTypeManagerImpl after OnEngineInitialized(true, false) call.
ForcedSetDecryptionPassphrase test is intended to verify fix for brave/brave-browser#22898 and is about set encryption passphrase later setup after right after enabling sync, for example when internet connection is unstable. Related Prior to the mentioned below Chromium commit DataTypeManagerImpl wasn't created for bookmarks at ForcedSetDecryptionPassphrase test.

Related Chromium change:

https://source.chromium.org/chromium/chromium/src/+/3241d114b8036bb6d53931ba34b3bf819258c29d

SyncServiceImpl::GetModelTypesForTransportOnlyMode(): Include NIGORI

SyncServiceImpl::GetModelTypesForTransportOnlyMode() returns the set of types that are supported in transport-only mode.
Before this CL, the returned set didn't include NIGORI (even though NIGORI *is* supported in transport-only mode). This had little practical impact, since NIGORI isn't configured along with other data types anyway - however, it *did* affect the "interested data types" for the purpose of invalidations.
This CL special-cases NIGORI (or more precisely, ControlTypes()) in GetModelTypesForTransportOnlyMode(), similar to existing logic in SyncUserSettingsImpl::GetPreferredDataTypes(). This makes NIGORI part of the "interested data types" also in transport-only mode.

Bug: 1358482
Change-Id: Ie7f4ff360ba98850869dfe8602e4bc8b86e8c9b0

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/30435

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-arm64, CI/skip-linux-x64, CI/skip-android, CI/skip-macos, CI/skip-ios, CI/skip-windows-arm64, CI/skip-windows-x64, CI/skip-windows-x86 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

