### PR TITLE
fix(wallet): Allow Market Data Tab to Scroll with Page

### DIFF
--- a/components/brave_wallet_ui/components/desktop/views/market/index.tsx
+++ b/components/brave_wallet_ui/components/desktop/views/market/index.tsx
@@ -33,7 +33,8 @@ import {
   UpdateCoinMarketMessage,
   UpdateTradableAssetsMessage,
   UpdateBuyableAssetsMessage,
-  UpdateDepositableAssetsMessage
+  UpdateDepositableAssetsMessage,
+  UpdateIframeHeightMessage
 } from '../../../../market/market-ui-messages'
 
 const defaultCurrency = 'usd'
@@ -43,6 +44,7 @@ export const MarketView = () => {
   // State
   const [buyAssets, setBuyAssets] = React.useState<BraveWallet.BlockchainToken[]>([])
   const [iframeLoaded, setIframeLoaded] = React.useState<boolean>(false)
+  const [iframeHeight, setIframeHeight] = React.useState<number>(0)
   const marketDataIframeRef = React.useRef<HTMLIFrameElement>(null)
 
   // Redux
@@ -93,6 +95,11 @@ export const MarketView = () => {
       case MarketUiCommand.SelectDeposit: {
         const { payload } = message as SelectDepositMessage
         onSelectDeposit(payload)
+      }
+
+      case MarketUiCommand.UpdateIframeHeight: {
+        const { payload } = message as UpdateIframeHeightMessage
+        setIframeHeight(payload)
       }
     }
   }, [onSelectCoinMarket, onSelectBuy, onSelectDeposit])
@@ -161,6 +168,7 @@ export const MarketView = () => {
           <LoadIcon />
         </LoadIconWrapper>
         : <MarketDataIframe
+          iframeHeight={iframeHeight}
           ref={marketDataIframeRef}
           onLoad={onMarketDataFrameLoad}
           src="chrome-untrusted://market-display"

--- a/components/brave_wallet_ui/components/desktop/views/market/style.ts
+++ b/components/brave_wallet_ui/components/desktop/views/market/style.ts
@@ -66,9 +66,15 @@ export const LoadIconWrapper = styled.div`
   align-items: center;
   justify-content: center;
 `
-export const MarketDataIframe = styled.iframe`
+export const MarketDataIframe = styled.iframe<{
+  iframeHeight: number
+}>`
   width: 100%;
   height: 100%;
-  min-height: calc(100vh - 172px);
+  min-height: ${(p) =>
+    p.iframeHeight
+      ? `calc(${p.iframeHeight}px + 72px)`
+      : 'unset'
+  };
   border: none;
 `

--- a/components/brave_wallet_ui/components/market-datatable/index.tsx
+++ b/components/brave_wallet_ui/components/market-datatable/index.tsx
@@ -48,6 +48,7 @@ export interface Props {
   isDepositSupported: (coinMarket: BraveWallet.CoinMarket) => boolean
   onClickBuy: (coinMarket: BraveWallet.CoinMarket) => void
   onClickDeposit: (coinMarket: BraveWallet.CoinMarket) => void
+  onUpdateIframeHeight: (height: number) => void
   fiatCurrency: string
 }
 
@@ -160,9 +161,10 @@ export const MarketDataTable = (props: Props) => {
     isBuySupported,
     isDepositSupported,
     onClickBuy,
-    onClickDeposit
+    onClickDeposit,
+    onUpdateIframeHeight
   } = props
-
+  const wrapperRef = React.useRef<HTMLDivElement>(null)
   // Memos
   const rows: Row[] = React.useMemo(() => {
     return coinMarketData.map((coinMarketItem: BraveWallet.CoinMarket) => {
@@ -178,8 +180,17 @@ export const MarketDataTable = (props: Props) => {
     })
   }, [coinMarketData, isBuySupported, isDepositSupported, onClickBuy, onClickDeposit])
 
+  const onContentLoad = React.useCallback(() => {
+    if (wrapperRef.current) {
+      onUpdateIframeHeight(wrapperRef.current.scrollHeight)
+    }
+  }, [onUpdateIframeHeight, wrapperRef.current])
+
   return (
-    <StyledWrapper>
+    <StyledWrapper
+      onLoad={onContentLoad}
+      ref={wrapperRef}
+    >
       <TableWrapper>
         <Table
           headers={headers}

--- a/components/brave_wallet_ui/market/market-ui-messages.ts
+++ b/components/brave_wallet_ui/market/market-ui-messages.ts
@@ -27,7 +27,8 @@ export const enum MarketUiCommand {
   SelectDeposit = 'select-deposit',
   UpdateTradableAssets = 'update-tradable-assets',
   UpdateBuyableAssets = 'update-buyable-assets',
-  UpdateDepositableAssets = 'update-depositable-assets'
+  UpdateDepositableAssets = 'update-depositable-assets',
+  UpdateIframeHeight = 'update-iframe-height'
 }
 
 export type MarketCommandMessage = {
@@ -64,6 +65,11 @@ export type UpdateBuyableAssetsMessage = MarketCommandMessage & {
 export type UpdateDepositableAssetsMessage = MarketCommandMessage & {
   payload: BraveWallet.BlockchainToken[]
 }
+
+export type UpdateIframeHeightMessage =
+  MarketCommandMessage & {
+    payload: number
+  }
 
 export const sendMessageToMarketUiFrame = (targetWindow: Window | null, message: MarketCommandMessage) => {
   if (targetWindow && !isComponentInStorybook()) {

--- a/components/brave_wallet_ui/market/market.tsx
+++ b/components/brave_wallet_ui/market/market.tsx
@@ -40,8 +40,8 @@ import {
   UpdateBuyableAssetsMessage,
   UpdateDepositableAssetsMessage,
   UpdateCoinMarketMessage,
-  UpdateTradableAssetsMessage
-
+  UpdateTradableAssetsMessage,
+  UpdateIframeHeightMessage
 } from './market-ui-messages'
 import { filterCoinMarkets, searchCoinMarkets, sortCoinMarkets } from '../utils/coin-market-utils'
 
@@ -99,6 +99,15 @@ const App = () => {
     }
     sendMessageToWalletUi(parent, message)
   }, [])
+
+  const onUpdateIframeHeight = React.useCallback(
+    (height: number) => {
+      const message: UpdateIframeHeightMessage = {
+        command: MarketUiCommand.UpdateIframeHeight,
+        payload: height
+      }
+      sendMessageToWalletUi(parent, message)
+    }, [])
 
   const onSelectFilter = (value: MarketAssetFilterOption) => {
     setCurrentFilter(value)
@@ -202,6 +211,7 @@ const App = () => {
             isDepositSupported={isDepositSupported}
             onClickBuy={onClickBuy}
             onClickDeposit={onClickDeposit}
+            onUpdateIframeHeight={onUpdateIframeHeight}
           />
         </>
       </BraveCoreThemeProvider>


### PR DESCRIPTION
## Description 
Allows the `Market` data tab to scroll with the page rather than inside the container.

<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves <https://github.com/brave/brave-browser/issues/30446>

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-arm64, CI/skip-linux-x64, CI/skip-android, CI/skip-macos, CI/skip-ios, CI/skip-windows-arm64, CI/skip-windows-x64, CI/skip-windows-x86 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
1. Go to the `Market` tab
2. Everything should scroll with the page rather than inside the container.

Before:

https://github.com/brave/brave-core/assets/40611140/2e2451c1-c7d0-4886-be90-9a3d2d3101d7

After:

https://github.com/brave/brave-core/assets/40611140/0777e2f4-7ed7-4d3a-8a4f-c618560d6a16
