### PR TITLE
fix(wallet): Use Toggles in Portfolio Settings

### DIFF
--- a/components/brave_wallet_ui/components/desktop/wallet-menus/portfolio-overview-menu.tsx
+++ b/components/brave_wallet_ui/components/desktop/wallet-menus/portfolio-overview-menu.tsx
@@ -6,7 +6,7 @@
 import * as React from 'react'
 import { useDispatch } from 'react-redux'
 import { useHistory, useLocation } from 'react-router-dom'
-import Checkbox from '@brave/leo/react/checkbox'
+import Toggle from '@brave/leo/react/toggle'
 
 // Types
 import { WalletRoutes } from '../../../constants/types'
@@ -35,7 +35,7 @@ import {
   StyledWrapper,
   PopupButtonText,
   ButtonIcon,
-  CheckBoxRow
+  ToggleRow
 } from './wellet-menus.style'
 import {
   Row
@@ -104,45 +104,47 @@ export const PortfolioOverviewMenu = () => {
 
   return (
     <StyledWrapper yPosition={42}>
-      <CheckBoxRow onClick={onToggleHideBalances}>
-        <ButtonIcon name='eye-off' />
-        <PopupButtonText>
-          {getLocale('braveWalletWalletPopupHideBalances')}
-        </PopupButtonText>
-        <Checkbox
-          checked={hidePortfolioBalances}
-          onChanged={onToggleHideBalances}
-          size='normal'
-        />
-      </CheckBoxRow>
+      <ToggleRow onClick={onToggleHideBalances}>
+        <Row>
+          <ButtonIcon name='eye-on' />
+          <PopupButtonText>
+            {getLocale('braveWalletWalletPopupHideBalances')}
+          </PopupButtonText>
+          <Toggle
+            checked={!hidePortfolioBalances}
+            onChanged={onToggleHideBalances}
+            size='small'
+          />
+        </Row>
+      </ToggleRow>
 
-      <CheckBoxRow onClick={onToggleHideGraph}>
+      <ToggleRow onClick={onToggleHideGraph}>
         <Row>
           <ButtonIcon name='graph' />
           <PopupButtonText>
             {getLocale('braveWalletWalletPopupShowGraph')}
           </PopupButtonText>
         </Row>
-        <Checkbox
+        <Toggle
           checked={!hidePortfolioGraph}
           onChanged={onToggleHideGraph}
-          size='normal'
+          size='small'
         />
-      </CheckBoxRow>
+      </ToggleRow>
 
-      <CheckBoxRow onClick={onToggleHideNFTsTab}>
+      <ToggleRow onClick={onToggleHideNFTsTab}>
         <Row>
           <ButtonIcon name='nft' />
           <PopupButtonText>
             {getLocale('braveWalletWalletNFTsTab')}
           </PopupButtonText>
         </Row>
-        <Checkbox
+        <Toggle
           checked={!hidePortfolioNFTsTab}
           onChanged={onToggleHideNFTsTab}
-          size='normal'
+          size='small'
         />
-      </CheckBoxRow>
+      </ToggleRow>
 
     </StyledWrapper>
   )

--- a/components/brave_wallet_ui/components/desktop/wallet-menus/wellet-menus.style.ts
+++ b/components/brave_wallet_ui/components/desktop/wallet-menus/wellet-menus.style.ts
@@ -73,13 +73,12 @@ export const ButtonIcon = styled(Icon)`
   margin-right: 16px;
 `
 
-export const CheckBoxRow = styled.label`
+export const ToggleRow = styled.label`
   display: flex;
   align-items: center;
   justify-content: space-between;
   cursor: pointer;
   width: 220px;
-  border-radius: 8px;
   padding: 12px 8px;
   margin: 0px 0px 8px 0px;
   background-color: transparent;

--- a/components/brave_wallet_ui/stories/locale.ts
+++ b/components/brave_wallet_ui/stories/locale.ts
@@ -257,8 +257,8 @@ provideStrings({
   braveWalletWalletPopupLock: 'Lock wallet',
   braveWalletWalletPopupBackup: 'Backup Wallet',
   braveWalletWalletPopupConnectedSites: 'Connected sites',
-  braveWalletWalletPopupHideBalances: 'Hide balances',
-  braveWalletWalletPopupShowGraph: 'Show graph',
+  braveWalletWalletPopupHideBalances: 'Balances',
+  braveWalletWalletPopupShowGraph: 'Graph',
   braveWalletWalletNFTsTab: 'NFTs tab',
 
   // Backup Warning

--- a/components/resources/wallet_strings.grdp
+++ b/components/resources/wallet_strings.grdp
@@ -174,8 +174,8 @@
   <message name="IDS_BRAVE_WALLET_WALLET_POPUP_LOCK" desc="Wallet popup lock crypto button">Lock wallet</message>
   <message name="IDS_BRAVE_WALLET_WALLET_POPUP_BACKUP" desc="Wallet popup backup wallet button">Backup Wallet</message>
   <message name="IDS_BRAVE_WALLET_WALLET_POPUP_CONNECTED_SITES" desc="Wallet popup connected sites button">Connected sites</message>
-  <message name="IDS_BRAVE_WALLET_WALLET_POPUP_HIDE_BALANCES" desc="Wallet popup hide balances checkbox">Hide balances</message>
-  <message name="IDS_BRAVE_WALLET_WALLET_POPUP_SHOW_GRAPH" desc="Wallet popup show graph checkbox">Show graph</message>
+  <message name="IDS_BRAVE_WALLET_WALLET_POPUP_HIDE_BALANCES" desc="Wallet popup hide balances checkbox">Balances</message>
+  <message name="IDS_BRAVE_WALLET_WALLET_POPUP_SHOW_GRAPH" desc="Wallet popup show graph checkbox">Graph</message>
   <message name="IDS_BRAVE_WALLET_WALLET_NFTS_TAB" desc="Wallet popup show NFTs tab checkbox">NFTs tab</message>
   <message name="IDS_BRAVE_WALLET_BACKUP_WARNING_TEXT" desc="Backup warning banner description">Back up your wallet now to protect your assets and ensure you never lose access.</message>
   <message name="IDS_BRAVE_WALLET_BACKUP_BUTTON" desc="Backup warning banner back up button">Back up now</message>


### PR DESCRIPTION
## Description 
Updates the `Portfolio` settings to use `Toggles` instead of `Checkboxes`

<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves <https://github.com/brave/brave-browser/issues/30422>

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-arm64, CI/skip-linux-x64, CI/skip-android, CI/skip-macos, CI/skip-ios, CI/skip-windows-arm64, CI/skip-windows-x64, CI/skip-windows-x86 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
1. Go to the `Portfolio` tab
2. Open the `Portfolio` settings
3. All settings should use `Toggles` instead of `Checkboxes`

Before:

https://github.com/brave/brave-core/assets/40611140/21e1607c-5406-41a6-8c6d-40a5fd363fb5

After:

https://github.com/brave/brave-core/assets/40611140/1d9d9e47-8a55-4d18-9409-111547ba472b
