### PR TITLE
Make vertical tab strip resizable.

### DIFF
--- a/browser/ui/tabs/brave_tab_prefs.cc
+++ b/browser/ui/tabs/brave_tab_prefs.cc
@@ -18,6 +18,8 @@ const char kVerticalTabsShowTitleOnWindow[] =
     "brave.tabs.vertical_tabs_show_title_on_window";
 const char kVerticalTabsFloatingEnabled[] =
     "brave.tabs.vertical_tabs_floating_enabled";
+const char kVerticalTabsExpandedWidth[] =
+    "brave.tabs.vertical_tabs_expanded_width";
 
 void RegisterBraveProfilePrefs(PrefRegistrySimple* registry) {
   registry->RegisterIntegerPref(kTabHoverMode, TabHoverMode::CARD);
@@ -31,6 +33,7 @@ void RegisterBraveProfilePrefs(PrefRegistrySimple* registry) {
   registry->RegisterBooleanPref(kVerticalTabsShowTitleOnWindow, false);
 #endif
   registry->RegisterBooleanPref(kVerticalTabsFloatingEnabled, true);
+  registry->RegisterIntegerPref(kVerticalTabsExpandedWidth, 250);
 }
 
 bool AreTooltipsEnabled(PrefService* prefs) {

--- a/browser/ui/tabs/brave_tab_prefs.h
+++ b/browser/ui/tabs/brave_tab_prefs.h
@@ -19,6 +19,7 @@ extern const char kVerticalTabsEnabled[];
 extern const char kVerticalTabsCollapsed[];
 extern const char kVerticalTabsShowTitleOnWindow[];
 extern const char kVerticalTabsFloatingEnabled[];
+extern const char kVerticalTabsExpandedWidth[];
 
 void RegisterBraveProfilePrefs(PrefRegistrySimple* registry);
 

--- a/browser/ui/views/frame/vertical_tab_strip_region_view.cc
+++ b/browser/ui/views/frame/vertical_tab_strip_region_view.cc
@@ -902,13 +902,6 @@ void VerticalTabStripRegionView::OnTabStripModelChanged(
 
 void VerticalTabStripRegionView::OnResize(int resize_amount,
                                           bool done_resizing) {
-  // Guard reentrancy.
-  if (resizing_) {
-    return;
-  }
-
-  base::AutoReset resizing(&resizing_, true);
-
   CHECK_NE(state_, State::kCollapsed);
 
   gfx::Rect bounds_in_screen = GetLocalBounds();
@@ -918,7 +911,6 @@ void VerticalTabStripRegionView::OnResize(int resize_amount,
       display::Screen::GetScreen()->GetCursorScreenPoint().x();
   if (!resize_offset_.has_value()) {
     resize_offset_ = cursor_position - bounds_in_screen.right();
-    LOG(ERROR) << *resize_offset_;
   }
   // Note that we're not using |resize_amount|. The variable is offset from
   // the initial point, it grows bigger and bigger.

--- a/browser/ui/views/frame/vertical_tab_strip_region_view.h
+++ b/browser/ui/views/frame/vertical_tab_strip_region_view.h
@@ -149,7 +149,6 @@ class VerticalTabStripRegionView : public views::View,
   raw_ptr<BraveNewTabButton> new_tab_button_ = nullptr;
 
   raw_ptr<views::View> resize_area_ = nullptr;
-  bool resizing_ = false;
   absl::optional<int> resize_offset_;
 
   // A pointer storing the global tab style to be used.

--- a/browser/ui/views/frame/vertical_tab_strip_region_view.h
+++ b/browser/ui/views/frame/vertical_tab_strip_region_view.h
@@ -15,8 +15,11 @@
 #include "chrome/browser/ui/tabs/tab_strip_model_observer.h"
 #include "chrome/browser/ui/views/frame/tab_strip_region_view.h"
 #include "components/prefs/pref_member.h"
+#include "ui/views/controls/resize_area_delegate.h"
+
 namespace views {
 class ScrollView;
+class ResizeArea;
 }
 
 class BraveNewTabButton;
@@ -26,7 +29,8 @@ class VerticalTabStripScrollContentsView;
 
 // Wraps TabStripRegion and show it vertically.
 class VerticalTabStripRegionView : public views::View,
-                                   public TabStripModelObserver {
+                                   public TabStripModelObserver,
+                                   public views::ResizeAreaDelegate {
  public:
   METADATA_HEADER(VerticalTabStripRegionView);
 
@@ -78,6 +82,8 @@ class VerticalTabStripRegionView : public views::View,
     layout_dirty_ = true;
   }
 
+  void ResetExpandedWidth();
+
   // views::View:
   gfx::Size CalculatePreferredSize() const override;
   gfx::Size GetMinimumSize() const override;
@@ -93,6 +99,9 @@ class VerticalTabStripRegionView : public views::View,
       TabStripModel* tab_strip_model,
       const TabStripModelChange& change,
       const TabStripSelectionChange& selection) override;
+
+  // views::ResizeAreaDelegate
+  void OnResize(int resize_amount, bool done_resizing) override;
 
  private:
   class ScrollHeaderView;
@@ -139,6 +148,10 @@ class VerticalTabStripRegionView : public views::View,
   // New tab button created for vertical tabs
   raw_ptr<BraveNewTabButton> new_tab_button_ = nullptr;
 
+  raw_ptr<views::View> resize_area_ = nullptr;
+  bool resizing_ = false;
+  absl::optional<int> resize_offset_;
+
   // A pointer storing the global tab style to be used.
   const raw_ptr<const TabStyle> tab_style_;
 
@@ -147,6 +160,8 @@ class VerticalTabStripRegionView : public views::View,
   BooleanPrefMember show_vertical_tabs_;
   BooleanPrefMember collapsed_pref_;
   BooleanPrefMember floating_mode_pref_;
+
+  IntegerPrefMember expanded_width_;
 
   base::OneShotTimer mouse_enter_timer_;
 

--- a/browser/ui/views/tabs/brave_new_tab_button.h
+++ b/browser/ui/views/tabs/brave_new_tab_button.h
@@ -36,6 +36,10 @@ class BraveNewTabButton : public NewTabButton {
   TabStrip* tab_strip() { return tab_strip_; }
   const TabStrip* tab_strip() const { return tab_strip_; }
 
+  views::InkDropContainerView* ink_drop_container() {
+    return base::to_address(ink_drop_container_);
+  }
+
   // Allow child classes to override PaintFill().
   virtual void OnPaintFill(gfx::Canvas* canvas) const;
 


### PR DESCRIPTION
Make the vertical tab strip resizable, with a minimum and maximum width approximately half/twice the standard tab width.


https://github.com/brave/brave-core/assets/5474642/317f2ec2-a655-4343-81ec-c7108c76630f



<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/30322

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-arm64, CI/skip-linux-x64, CI/skip-android, CI/skip-macos, CI/skip-ios, CI/skip-windows-arm64, CI/skip-windows-x64, CI/skip-windows-x86 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [ ] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
* Dragging the right side of vertical tab strip should change the width of it.
* Double-clicking the right side of it should reset the width to the default width.
* The changed width should be persistent even after restarting the browser.
