### PR TITLE
modify keyring dependency

### DIFF
--- a/patches/chrome-installer-linux-debian-build.sh.patch
+++ b/patches/chrome-installer-linux-debian-build.sh.patch
@@ -1,5 +1,5 @@
 diff --git a/chrome/installer/linux/debian/build.sh b/chrome/installer/linux/debian/build.sh
-index 7cd40b9c37cce8370238c3a1b3850d209ad8d4e2..078f7790cec1fd3d222ef07b451c5a5bb19ad01b 100755
+index 7cd40b9c37cce8370238c3a1b3850d209ad8d4e2..19b35fdcb96d1a235b7ef2ab42cde14d19b92455 100755
 --- a/chrome/installer/linux/debian/build.sh
 +++ b/chrome/installer/linux/debian/build.sh
 @@ -21,7 +21,7 @@ gen_changelog() {
@@ -93,14 +93,12 @@ index 7cd40b9c37cce8370238c3a1b3850d209ad8d4e2..078f7790cec1fd3d222ef07b451c5a5b
  verify_channel
  
  # Some Debian packaging tools want these set.
-@@ -262,6 +278,10 @@ export ARCHITECTURE="${ARCHITECTURE}"
+@@ -262,6 +278,8 @@ export ARCHITECTURE="${ARCHITECTURE}"
  DEB_COMMON_DEPS="${OUTPUTDIR}/deb_common.deps"
  COMMON_DEPS=$(sed ':a;N;$!ba;s/\n/, /g' "${DEB_COMMON_DEPS}")
  COMMON_PREDEPS="dpkg (>= 1.14.0)"
 +# Ensure that our signing key is up-to-date (brave/brave-browser#4205).
-+if [ "$CHANNEL" = "stable" ]; then
-+  COMMON_DEPS="${COMMON_DEPS}, brave-keyring"
-+fi
++COMMON_DEPS="${COMMON_DEPS}, brave-keyring"
  
  # Make everything happen in the OUTPUTDIR.
  cd "${OUTPUTDIR}"

--- a/patches/chrome-installer-linux-rpm-build.sh.patch
+++ b/patches/chrome-installer-linux-rpm-build.sh.patch
@@ -1,5 +1,5 @@
 diff --git a/chrome/installer/linux/rpm/build.sh b/chrome/installer/linux/rpm/build.sh
-index 3053be4fbf88872a7ae743eed0b13291cb1862e7..77d6fb168ce8a3c6e5f74f68034a48943884635a 100755
+index 3053be4fbf88872a7ae743eed0b13291cb1862e7..7bfcb15f6c4e736db0321a6ff955f00fd8db95aa 100755
 --- a/chrome/installer/linux/rpm/build.sh
 +++ b/chrome/installer/linux/rpm/build.sh
 @@ -15,8 +15,9 @@ gen_spec() {
@@ -13,20 +13,18 @@ index 3053be4fbf88872a7ae743eed0b13291cb1862e7..77d6fb168ce8a3c6e5f74f68034a4894
      local INSTALLDIR="${INSTALLDIR}-${CHANNEL}"
      local PACKAGE="${PACKAGE}-${CHANNEL}"
      local MENUNAME="${MENUNAME} (${CHANNEL})"
-@@ -87,6 +88,12 @@ do_package() {
+@@ -87,6 +88,10 @@ do_package() {
    PROVIDES="${PACKAGE}"
    RPM_COMMON_DEPS="${OUTPUTDIR}/rpm_common.deps"
    DEPENDS=$(cat "${RPM_COMMON_DEPS}" | tr '\n' ',')
 +
 +  # Ensure that our signing key is up-to-date (brave/brave-browser#4205).
-+  if [ "$CHANNEL" = "stable" ]; then
-+    DEPENDS="brave-keyring, ${DEPENDS}"
-+  fi
++  DEPENDS="brave-keyring, ${DEPENDS}"
 +
    gen_spec
  
    # Create temporary rpmbuild dirs.
-@@ -109,7 +116,10 @@ do_package() {
+@@ -109,7 +114,10 @@ do_package() {
      --define "__os_install_post  %{nil}" \
      --define "_build_id_links none" \
      "${SPEC}"
@@ -38,7 +36,7 @@ index 3053be4fbf88872a7ae743eed0b13291cb1862e7..77d6fb168ce8a3c6e5f74f68034a4894
    mv "$RPMBUILD_DIR/RPMS/$ARCHITECTURE/${PKGNAME}.${ARCHITECTURE}.rpm" \
       "${OUTPUTDIR}"
    # Make sure the package is world-readable, otherwise it causes problems when
-@@ -145,7 +155,10 @@ verify_channel() {
+@@ -145,7 +153,10 @@ verify_channel() {
        CHANNEL=stable
        ;;
      unstable|dev|alpha )

--- a/patches/chrome-installer-linux-rpm-build.sh.patch
+++ b/patches/chrome-installer-linux-rpm-build.sh.patch
@@ -1,5 +1,5 @@
 diff --git a/chrome/installer/linux/rpm/build.sh b/chrome/installer/linux/rpm/build.sh
-index 3053be4fbf88872a7ae743eed0b13291cb1862e7..7bfcb15f6c4e736db0321a6ff955f00fd8db95aa 100755
+index 3053be4fbf88872a7ae743eed0b13291cb1862e7..15b0bb542d2f0fef5b688dde939a255b8eb3c149 100755
 --- a/chrome/installer/linux/rpm/build.sh
 +++ b/chrome/installer/linux/rpm/build.sh
 @@ -15,8 +15,9 @@ gen_spec() {
@@ -13,18 +13,16 @@ index 3053be4fbf88872a7ae743eed0b13291cb1862e7..7bfcb15f6c4e736db0321a6ff955f00f
      local INSTALLDIR="${INSTALLDIR}-${CHANNEL}"
      local PACKAGE="${PACKAGE}-${CHANNEL}"
      local MENUNAME="${MENUNAME} (${CHANNEL})"
-@@ -87,6 +88,10 @@ do_package() {
+@@ -87,6 +88,8 @@ do_package() {
    PROVIDES="${PACKAGE}"
    RPM_COMMON_DEPS="${OUTPUTDIR}/rpm_common.deps"
    DEPENDS=$(cat "${RPM_COMMON_DEPS}" | tr '\n' ',')
-+
 +  # Ensure that our signing key is up-to-date (brave/brave-browser#4205).
 +  DEPENDS="brave-keyring, ${DEPENDS}"
-+
    gen_spec
  
    # Create temporary rpmbuild dirs.
-@@ -109,7 +114,10 @@ do_package() {
+@@ -109,7 +112,10 @@ do_package() {
      --define "__os_install_post  %{nil}" \
      --define "_build_id_links none" \
      "${SPEC}"
@@ -36,7 +34,7 @@ index 3053be4fbf88872a7ae743eed0b13291cb1862e7..7bfcb15f6c4e736db0321a6ff955f00f
    mv "$RPMBUILD_DIR/RPMS/$ARCHITECTURE/${PKGNAME}.${ARCHITECTURE}.rpm" \
       "${OUTPUTDIR}"
    # Make sure the package is world-readable, otherwise it causes problems when
-@@ -145,7 +153,10 @@ verify_channel() {
+@@ -145,7 +151,10 @@ verify_channel() {
        CHANNEL=stable
        ;;
      unstable|dev|alpha )


### PR DESCRIPTION
Modifies the package dependency so the `brave-browser` package depends on the `keyring` package on all channels (not only stable).

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/30467

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-arm64, CI/skip-linux-x64, CI/skip-android, CI/skip-macos, CI/skip-ios, CI/skip-windows-arm64, CI/skip-windows-x64, CI/skip-windows-x86 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [ ] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

