### PR TITLE
Create PlaylistTabHelper to detect media files from tabs

### DIFF
--- a/browser/brave_tab_helpers.cc
+++ b/browser/brave_tab_helpers.cc
@@ -23,6 +23,7 @@
 #include "brave/components/brave_wayback_machine/buildflags/buildflags.h"
 #include "brave/components/greaselion/browser/buildflags/buildflags.h"
 #include "brave/components/ipfs/buildflags/buildflags.h"
+#include "brave/components/playlist/common/buildflags/buildflags.h"
 #include "brave/components/request_otr/common/buildflags/buildflags.h"
 #include "brave/components/speedreader/common/buildflags/buildflags.h"
 #include "brave/components/tor/buildflags/buildflags.h"
@@ -77,6 +78,10 @@
 #if BUILDFLAG(ENABLE_REQUEST_OTR)
 #include "brave/browser/request_otr/request_otr_tab_helper.h"
 #include "brave/components/request_otr/common/features.h"
+#endif
+
+#if BUILDFLAG(ENABLE_PLAYLIST)
+#include "brave/browser/playlist/playlist_tab_helper.h"
 #endif
 
 namespace brave {
@@ -157,6 +162,10 @@ void AttachTabHelpers(content::WebContents* web_contents) {
     }
 #endif
   }
+
+#if BUILDFLAG(ENABLE_PLAYLIST)
+  playlist::PlaylistTabHelper::MaybeCreateForWebContents(web_contents);
+#endif
 }
 
 }  // namespace brave

--- a/browser/playlist/playlist_tab_helper.cc
+++ b/browser/playlist/playlist_tab_helper.cc
@@ -1,0 +1,90 @@
+/* Copyright (c) 2023 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "brave/browser/playlist/playlist_tab_helper.h"
+
+#include <utility>
+
+#include "brave/browser/playlist/playlist_service_factory.h"
+#include "brave/components/playlist/browser/playlist_service.h"
+#include "brave/components/playlist/common/features.h"
+
+namespace playlist {
+
+// static
+void PlaylistTabHelper::MaybeCreateForWebContents(
+    content::WebContents* contents) {
+  if (!base::FeatureList::IsEnabled(playlist::features::kPlaylist)) {
+    return;
+  }
+
+  // |service| could be null when the service is not supported for the
+  // browser context.
+  if (auto* service = PlaylistServiceFactory::GetForBrowserContext(
+          contents->GetBrowserContext())) {
+    content::WebContentsUserData<PlaylistTabHelper>::CreateForWebContents(
+        contents, service);
+  }
+}
+
+PlaylistTabHelper::PlaylistTabHelper(content::WebContents* contents,
+                                     PlaylistService* service)
+    : WebContentsUserData(*contents), service_(service) {
+  Observe(contents);
+  CHECK(service_);
+  service_->AddObserver(
+      playlist_observer_receiver_.InitWithNewPipeAndPassRemote());
+}
+
+PlaylistTabHelper::~PlaylistTabHelper() = default;
+
+void PlaylistTabHelper::DidFinishNavigation(
+    content::NavigationHandle* navigation_handle) {
+  // We're resetting data on finish, not on start, because navigation could fail
+  // or aborted.
+  ResetData();
+}
+
+void PlaylistTabHelper::DOMContentLoaded(
+    content::RenderFrameHost* render_frame_host) {
+  FindMediaFromCurrentContents();
+}
+
+void PlaylistTabHelper::OnMediaFilesUpdated(
+    const GURL& url,
+    std::vector<mojom::PlaylistItemPtr> items) {
+  OnFoundMediaFromContents(url, std::move(items));
+}
+
+void PlaylistTabHelper::ResetData() {
+  found_items_.clear();
+}
+
+void PlaylistTabHelper::FindMediaFromCurrentContents() {
+  CHECK(service_);
+
+  service_->FindMediaFilesFromContents(
+      web_contents(),
+      base::BindOnce(&PlaylistTabHelper::OnFoundMediaFromContents,
+                     weak_ptr_factory_.GetWeakPtr()));
+}
+
+void PlaylistTabHelper::OnFoundMediaFromContents(
+    const GURL& url,
+    std::vector<mojom::PlaylistItemPtr> items) {
+  if (url != web_contents()->GetVisibleURL()) {
+    return;
+  }
+
+  DVLOG(2) << __FUNCTION__ << " item count : " << items.size();
+
+  found_items_.insert(found_items_.end(),
+                      std::make_move_iterator(items.begin()),
+                      std::make_move_iterator(items.end()));
+}
+
+WEB_CONTENTS_USER_DATA_KEY_IMPL(PlaylistTabHelper);
+
+}  // namespace playlist

--- a/browser/playlist/playlist_tab_helper.h
+++ b/browser/playlist/playlist_tab_helper.h
@@ -1,0 +1,78 @@
+/* Copyright (c) 2023 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_BROWSER_PLAYLIST_PLAYLIST_TAB_HELPER_H_
+#define BRAVE_BROWSER_PLAYLIST_PLAYLIST_TAB_HELPER_H_
+
+#include <string>
+#include <vector>
+
+#include "base/memory/weak_ptr.h"
+#include "brave/components/playlist/common/mojom/playlist.mojom.h"
+#include "content/public/browser/web_contents_observer.h"
+#include "content/public/browser/web_contents_user_data.h"
+
+namespace playlist {
+
+class PlaylistService;
+
+class PlaylistTabHelper
+    : public content::WebContentsUserData<PlaylistTabHelper>,
+      public content::WebContentsObserver,
+      public mojom::PlaylistServiceObserver {
+ public:
+  static void MaybeCreateForWebContents(content::WebContents* contents);
+
+  ~PlaylistTabHelper() override;
+
+  const std::vector<mojom::PlaylistItemPtr>& found_items() const {
+    return found_items_;
+  }
+
+  // content::WebContentsObserver:
+  void DidFinishNavigation(
+      content::NavigationHandle* navigation_handle) override;
+  void DOMContentLoaded(content::RenderFrameHost* render_frame_host) override;
+
+  // mojom::PlaylistServiceObserver:
+  void OnEvent(mojom::PlaylistEvent event,
+               const std::string& playlist_id) override {}
+  void OnMediaFileDownloadProgressed(
+      const std::string& id,
+      int64_t total_bytes,
+      int64_t received_bytes,
+      int8_t percent_complete,
+      const std::string& time_remaining) override {}
+  void OnMediaFilesUpdated(const GURL& url,
+                           std::vector<mojom::PlaylistItemPtr> items) override;
+
+ private:
+  friend WebContentsUserData;
+  WEB_CONTENTS_USER_DATA_KEY_DECL();
+
+  // Hide factory function to enforce use MaybeCreateForWebContents()
+  template <typename... Args>
+  static void CreateForWebContents(content::WebContents*, Args&&...);
+
+  PlaylistTabHelper(content::WebContents* contents, PlaylistService* service);
+
+  void ResetData();
+  void FindMediaFromCurrentContents();
+  void OnFoundMediaFromContents(const GURL& url,
+                                std::vector<mojom::PlaylistItemPtr> items);
+
+  raw_ptr<PlaylistService> service_;
+
+  std::vector<mojom::PlaylistItemPtr> found_items_;
+
+  mojo::PendingReceiver<mojom::PlaylistServiceObserver>
+      playlist_observer_receiver_;
+
+  base::WeakPtrFactory<PlaylistTabHelper> weak_ptr_factory_{this};
+};
+
+}  // namespace playlist
+
+#endif  // BRAVE_BROWSER_PLAYLIST_PLAYLIST_TAB_HELPER_H_

--- a/browser/playlist/sources.gni
+++ b/browser/playlist/sources.gni
@@ -12,6 +12,8 @@ if (enable_playlist) {
   brave_browser_playlist_sources += [
     "//brave/browser/playlist/playlist_service_factory.cc",
     "//brave/browser/playlist/playlist_service_factory.h",
+    "//brave/browser/playlist/playlist_tab_helper.cc",
+    "//brave/browser/playlist/playlist_tab_helper.h",
   ]
 
   brave_browser_playlist_deps += [

--- a/browser/playlist/test/BUILD.gn
+++ b/browser/playlist/test/BUILD.gn
@@ -38,6 +38,10 @@ source_set("browser_tests") {
   } else {
     deps += [ "//chrome/test:test_support_ui" ]
   }
+
+  if (enable_playlist_webui) {
+    deps += [ "//brave/browser/ui/sidebar" ]
+  }
 }
 
 source_set("unit_tests") {

--- a/browser/playlist/test/playlist_browsertest.cc
+++ b/browser/playlist/test/playlist_browsertest.cc
@@ -13,6 +13,7 @@
 #include "base/test/bind.h"
 #include "base/test/scoped_feature_list.h"
 #include "brave/browser/playlist/playlist_service_factory.h"
+#include "brave/browser/playlist/playlist_tab_helper.h"
 #include "brave/components/constants/brave_paths.h"
 #include "brave/components/constants/webui_url_constants.h"
 #include "brave/components/playlist/browser/media_detector_component_manager.h"
@@ -230,4 +231,22 @@ IN_PROC_BROWSER_TEST_F(PlaylistBrowserTest, PlayWithoutLocalCache) {
         )-js")
         .ExtractBool();
   }));
+}
+
+IN_PROC_BROWSER_TEST_F(PlaylistBrowserTest, PlaylistTabHelper) {
+  auto* playlist_tab_helper =
+      playlist::PlaylistTabHelper::FromWebContents(GetActiveWebContents());
+  EXPECT_TRUE(playlist_tab_helper);
+  EXPECT_TRUE(playlist_tab_helper->found_items().empty());
+
+  ASSERT_TRUE(content::NavigateToURL(GetActiveWebContents(),
+                                     GetURL("/playlist/site_with_video.html")));
+
+  WaitUntil(base::BindLambdaForTesting(
+      [&]() { return playlist_tab_helper->found_items().size() > 0; }));
+
+  ASSERT_TRUE(content::NavigateToURL(
+      GetActiveWebContents(), GetURL("/playlist/site_without_video.html")));
+  // items should be cleared right away.
+  EXPECT_TRUE(playlist_tab_helper->found_items().empty());
 }

--- a/browser/ui/brave_browser.cc
+++ b/browser/ui/brave_browser.cc
@@ -3,10 +3,11 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+#include "brave/browser/ui/brave_browser.h"
+
 #include <memory>
 #include <utility>
 
-#include "brave/browser/ui/brave_browser.h"
 #include "brave/browser/ui/brave_browser_window.h"
 #include "brave/components/constants/pref_names.h"
 #include "chrome/browser/lifetime/browser_close_manager.h"

--- a/browser/ui/views/side_panel/playlist/playlist_side_panel_coordinator.h
+++ b/browser/ui/views/side_panel/playlist/playlist_side_panel_coordinator.h
@@ -33,6 +33,10 @@ class PlaylistSidePanelCoordinator
 
   void CreateAndRegisterEntry(SidePanelRegistry* global_registry);
 
+  BubbleContentsWrapperT<playlist::PlaylistUI>* contents_wrapper() {
+    return contents_wrapper_.get();
+  }
+
   // views::ViewObserver:
   void OnViewIsDeleting(views::View* view) override;
 

--- a/components/playlist/browser/playlist_service.h
+++ b/components/playlist/browser/playlist_service.h
@@ -121,6 +121,12 @@ class PlaylistService : public KeyedService,
 
   base::WeakPtr<PlaylistService> GetWeakPtr();
 
+  using FindMediaFilesFromContentsCallback =
+      base::OnceCallback<void(const GURL& target_url,
+                              std::vector<mojom::PlaylistItemPtr> items)>;
+  void FindMediaFilesFromContents(content::WebContents* contents,
+                                  FindMediaFilesFromContentsCallback callback);
+
   // mojom::PlaylistService:
   // TODO(sko) Make getters without callbacks and simplify codes in
   // PlaylistService and tests.

--- a/test/data/playlist/site_without_video.html
+++ b/test/data/playlist/site_without_video.html
@@ -1,0 +1,12 @@
+<!-- Copyright (c) 2022 The Brave Authors. All rights reserved.
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this file,
+You can obtain one at http://mozilla.org/MPL/2.0/. -->
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <title>This site doesn't have video</title>
+</head>
+<body>
+</body>
+</html>


### PR DESCRIPTION
* This tab helper will be attached all web contentes, that are in the tab strip model
* When an observed web contents navigates, tab helper will try finding media files with PlaylistService.

This tab helper will be used for a bubble to notify our users that we've found media files from pages they're browsing.

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/30506

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-arm64, CI/skip-linux-x64, CI/skip-android, CI/skip-macos, CI/skip-ios, CI/skip-windows-arm64, CI/skip-windows-x64, CI/skip-windows-x86 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [ ] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
### Automated
PlaylistBrowserTest.PlaylistTabHelper
