### PR TITLE
Fix fallback to custom push notifications.

### DIFF
--- a/browser/about_flags.cc
+++ b/browser/about_flags.cc
@@ -13,6 +13,7 @@
 #include "brave/browser/ethereum_remote_client/features.h"
 #include "brave/browser/ui/tabs/features.h"
 #include "brave/components/brave_ads/common/custom_notification_ad_feature.h"
+#include "brave/components/brave_ads/common/notification_ad_feature.h"
 #include "brave/components/brave_component_updater/browser/features.h"
 #include "brave/components/brave_federated/features.h"
 #include "brave/components/brave_news/common/features.h"

--- a/browser/ui/views/brave_ads/overview.md
+++ b/browser/ui/views/brave_ads/overview.md
@@ -1,52 +1,52 @@
-# Ad Notifications Overview
+# Notification Ads Overview
 
-This document is an overview of ad notification popup concepts, terminology, and architecture. The target audience is engineers using or working on ad notifications.
+This document is an overview of notification ad popup concepts, terminology, and architecture. The target audience is engineers using or working on notification ads.
 
 For more details about the Chromium UI Platform, see [overview.md].
 
-## Ad Notification Popup Views
+## Notification Ad Popup
 
-**AdNotificationPopupView** is responsible for the display of ad notifications and informing **AdNotificationDelegate** listeners of **AdNotificationPopupView** events.
+**NotificationAdPopup** is responsible for the display of notification ads and informing **NotificationAdDelegate** listeners of **NotificationAdPopup** events.
 
-**AdNotificationPopupView** needs an underlying canvas to paint onto. This is provided by adding **AdNotificationView** to a **views::widget**.
+**NotificationAdPopup** needs an underlying canvas to paint onto. This is provided by adding **NotificationAdView** to a **views::Widget**.
 
-## Ad Notification View Factory
+## Notification Ad View Factory
 
-**AdNotificationViewFactory** is responsible for creating different types of ad notifications. i.e., see [text_ad_notification_view.h](./text_ad_notification_view.h).
+**NotificationAdViewFactory** is responsible for creating different types of notification ads. i.e., see [text_notification_ad_view.h](./text_notification_ad_view.h).
 
-## Text Ad Notification View
+## Text Notification Ad View
 
-**TextAdNotificationView** is a subclass of **AdNotificationView** that lays out and renders a text ad notification with a solid background, control buttons, title and body text
+**TextNotificationAdView** is a subclass of **NotificationAdView** that lays out and renders a text notification ad with a solid background, control buttons, title and body text
 
-## Ad Notification View
+## Notification Ad View
 
-**AdNotificationView** is a base class for layout, rendering and mouse events of ad notifications.
+**NotificationAdView** is a base class for layout, rendering and mouse events of notification ads.
 
-Different **AdNotificationView** subclasses are responsible for implementing their own design. i.e, see [text_ad_notification_view.h](./text_ad_notification_view.h).
+Different **NotificationAdView** subclasses are responsible for implementing their own design. i.e, see [text_notification_ad_view.h](./text_ad_notification_view.h).
 
-## Ad Notification Background Painter
+## Notification Ad Background Painter
 
-**AdNotificationBackgroundPainter** is responsible for drawing a solid background below any other part of the **AdNotificationView** with rounded corners on macOS and Linux.
+**NotificationAdBackgroundPainter** is responsible for drawing a solid background below any other part of the **NotificationAdView** with rounded corners on macOS and Linux.
 
-## Ad Notification Header View
+## Notification Ad Header View
 
-**AdNotificationHeaderView** is responsible for the layout and rendering of the header which includes the title text.
+**NotificationAdHeaderView** is responsible for the layout and rendering of the header which includes the title text.
 
-## Ad Notification Control Buttons View
+## Notification Ad Control Buttons View
 
-**AdNotificationControlButtonsView** is responsible for the layout and rendering of the control buttons comprising of a BAT logo and close button.
+**NotificationAdControlButtonsView** is responsible for the layout and rendering of the control buttons comprising of a BAT logo and close button.
 
 ## Overall structure looks like this
 
 <pre>
 ┌──────────────────────────────────────────────────────────────────┐
-│AdNotificationPopup                                               │
+│NotificationAdPopup                                               │
 │ ┌──────────────────────────────────────────────────────────────┐ │
-│ │AdNotificationView                                            │ │
+│ │NotificationAdView                                            │ │
 │ │ ┌──────────────────────────────────────────────────────────┐ │ │
-│ │ │AdNotificationBackgroundPainter                           │ │ │
+│ │ │NotificationAdBackgroundPainter                           │ │ │
 │ │ │ ┌────────────────────────┐┌────────────────────────────┐ │ │ │
-│ │ │ │AdNotificationHeaderView││AdNotificationControlButtons│ │ │ │
+│ │ │ │NotificationAdHeaderView││NotificationAdControlButtons│ │ │ │
 │ │ │ └────────────────────────┘└────────────────────────────┘ │ │ │
 │ │ │ ┌──────────────────────────────────────────────────────┐ │ │ │
 │ │ │ │                                                      │ │ │ │

--- a/components/brave_ads/browser/ads_service_impl.cc
+++ b/components/brave_ads/browser/ads_service_impl.cc
@@ -781,16 +781,11 @@ bool AdsServiceImpl::ShouldShowCustomNotificationAds() {
   const bool can_show_native_notifications =
       NotificationHelper::GetInstance()->CanShowNotifications();
 
-  bool can_fallback_to_custom_notification_ads =
+  const bool can_fallback_to_custom_notification_ads =
+      IsAllowedToFallbackToCustomNotificationAdFeatureEnabled() &&
       kCanFallbackToCustomNotificationAds.Get();
   if (!can_fallback_to_custom_notification_ads) {
     ClearPref(prefs::kNotificationAdDidFallbackToCustom);
-  } else {
-    const bool allowed_to_fallback_to_custom_notification_ads =
-        IsAllowedToFallbackToCustomNotificationAdFeatureEnabled();
-    if (!allowed_to_fallback_to_custom_notification_ads) {
-      can_fallback_to_custom_notification_ads = false;
-    }
   }
 
   const bool should_show = IsCustomNotificationAdFeatureEnabled();

--- a/components/brave_ads/common/custom_notification_ad_constants.h
+++ b/components/brave_ads/common/custom_notification_ad_constants.h
@@ -10,9 +10,6 @@
 
 namespace brave_ads {
 
-// Do not fallback to custom notification ad by default
-constexpr bool kDefaultCanFallbackToCustomNotificationAds = false;
-
 #if !BUILDFLAG(IS_ANDROID) && !BUILDFLAG(IS_IOS)
 
 // Default ad notification fade animation duration in milliseconds

--- a/components/brave_ads/common/custom_notification_ad_feature.cc
+++ b/components/brave_ads/common/custom_notification_ad_feature.cc
@@ -13,17 +13,8 @@ BASE_FEATURE(kCustomNotificationAdFeature,
              "CustomNotificationAds",
              base::FEATURE_DISABLED_BY_DEFAULT);
 
-BASE_FEATURE(kAllowedToFallbackToCustomNotificationAdFeature,
-             "AllowedToFallbackToCustomAdNotifications",
-             base::FEATURE_ENABLED_BY_DEFAULT);
-
 bool IsCustomNotificationAdFeatureEnabled() {
   return base::FeatureList::IsEnabled(kCustomNotificationAdFeature);
-}
-
-bool IsAllowedToFallbackToCustomNotificationAdFeatureEnabled() {
-  return base::FeatureList::IsEnabled(
-      kAllowedToFallbackToCustomNotificationAdFeature);
 }
 
 }  // namespace brave_ads

--- a/components/brave_ads/common/custom_notification_ad_feature.h
+++ b/components/brave_ads/common/custom_notification_ad_feature.h
@@ -16,17 +16,8 @@
 namespace brave_ads {
 
 BASE_DECLARE_FEATURE(kCustomNotificationAdFeature);
-BASE_DECLARE_FEATURE(kAllowedToFallbackToCustomNotificationAdFeature);
 
 bool IsCustomNotificationAdFeatureEnabled();
-
-bool IsAllowedToFallbackToCustomNotificationAdFeatureEnabled();
-
-// Set to true to fallback to custom notification ads if native notifications
-// are disabled or false to never fallback
-constexpr base::FeatureParam<bool> kCanFallbackToCustomNotificationAds{
-    &kCustomNotificationAdFeature, "can_fallback_to_custom_notifications",
-    kDefaultCanFallbackToCustomNotificationAds};
 
 #if !BUILDFLAG(IS_ANDROID) && !BUILDFLAG(IS_IOS)
 

--- a/components/brave_ads/common/notification_ad_constants.h
+++ b/components/brave_ads/common/notification_ad_constants.h
@@ -22,6 +22,9 @@ constexpr int kDefaultNotificationAdTimeout = 120;
 constexpr int kDefaultNotificationAdTimeout = 30;
 #endif  // !BUILDFLAG(IS_ANDROID) && !BUILDFLAG(IS_IOS)
 
+// Do not fallback to custom notification ad by default
+constexpr bool kDefaultCanFallbackToCustomNotificationAds = false;
+
 }  // namespace brave_ads
 
 #endif  // BRAVE_COMPONENTS_BRAVE_ADS_COMMON_NOTIFICATION_AD_CONSTANTS_H_

--- a/components/brave_ads/common/notification_ad_feature.cc
+++ b/components/brave_ads/common/notification_ad_feature.cc
@@ -12,7 +12,7 @@ BASE_FEATURE(kNotificationAdFeature,
              base::FEATURE_ENABLED_BY_DEFAULT);
 
 BASE_FEATURE(kAllowedToFallbackToCustomNotificationAdFeature,
-             "AllowedToFallbackToCustomAdNotifications",
+             "AllowedToFallbackToCustomNotificationAd",
              base::FEATURE_ENABLED_BY_DEFAULT);
 
 bool IsNotificationAdFeatureEnabled() {

--- a/components/brave_ads/common/notification_ad_feature.cc
+++ b/components/brave_ads/common/notification_ad_feature.cc
@@ -11,8 +11,17 @@ BASE_FEATURE(kNotificationAdFeature,
              "NotificationAds",
              base::FEATURE_ENABLED_BY_DEFAULT);
 
+BASE_FEATURE(kAllowedToFallbackToCustomNotificationAdFeature,
+             "AllowedToFallbackToCustomAdNotifications",
+             base::FEATURE_ENABLED_BY_DEFAULT);
+
 bool IsNotificationAdFeatureEnabled() {
   return base::FeatureList::IsEnabled(kNotificationAdFeature);
+}
+
+bool IsAllowedToFallbackToCustomNotificationAdFeatureEnabled() {
+  return base::FeatureList::IsEnabled(
+      kAllowedToFallbackToCustomNotificationAdFeature);
 }
 
 }  // namespace brave_ads

--- a/components/brave_ads/common/notification_ad_feature.h
+++ b/components/brave_ads/common/notification_ad_feature.h
@@ -13,8 +13,11 @@
 namespace brave_ads {
 
 BASE_DECLARE_FEATURE(kNotificationAdFeature);
+BASE_DECLARE_FEATURE(kAllowedToFallbackToCustomNotificationAdFeature);
 
 bool IsNotificationAdFeatureEnabled();
+
+bool IsAllowedToFallbackToCustomNotificationAdFeatureEnabled();
 
 // Ad notification timeout in seconds. Set to 0 to never time out
 constexpr base::FeatureParam<int> kNotificationAdTimeout{
@@ -27,6 +30,12 @@ constexpr base::FeatureParam<int> kDefaultNotificationAdsPerHour{
 
 constexpr base::FeatureParam<int> kMaximumNotificationAdsPerDay{
     &kNotificationAdFeature, "maximum_ads_per_day", 100};
+
+// Set to true to fallback to custom notification ads if native notifications
+// are disabled or false to never fallback
+constexpr base::FeatureParam<bool> kCanFallbackToCustomNotificationAds{
+    &kNotificationAdFeature, "can_fallback_to_custom_notifications",
+    kDefaultCanFallbackToCustomNotificationAds};
 
 }  // namespace brave_ads
 

--- a/components/brave_ads/common/notification_ad_feature_unittest.cc
+++ b/components/brave_ads/common/notification_ad_feature_unittest.cc
@@ -130,4 +130,33 @@ TEST(BraveAdsNotificationAdFeatureTest, DefaultMaximumAdsPerDayWhenDisabled) {
   EXPECT_EQ(100, kMaximumNotificationAdsPerDay.Get());
 }
 
+TEST(BraveAdsNotificationAdFeatureTest,
+     CanFallbackToCustomNotificationAdsDefault) {
+  // Arrange
+
+  // Act
+
+  // Assert
+  EXPECT_EQ(false, kCanFallbackToCustomNotificationAds.Get());
+}
+
+TEST(BraveAdsNotificationAdFeatureTest, CanFallbackToCustomNotificationAds) {
+  // Arrange
+  std::vector<base::test::FeatureRefAndParams> enabled_features;
+  base::FieldTrialParams params;
+  params["can_fallback_to_custom_notifications"] = "true";
+  enabled_features.emplace_back(kNotificationAdFeature, params);
+
+  const std::vector<base::test::FeatureRef> disabled_features;
+
+  base::test::ScopedFeatureList scoped_feature_list;
+  scoped_feature_list.InitWithFeaturesAndParameters(enabled_features,
+                                                    disabled_features);
+
+  // Act
+
+  // Assert
+  EXPECT_EQ(true, kCanFallbackToCustomNotificationAds.Get());
+}
+
 }  // namespace brave_ads


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/20218

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-arm64, CI/skip-linux-x64, CI/skip-android, CI/skip-macos, CI/skip-ios, CI/skip-windows-arm64, CI/skip-windows-x64, CI/skip-windows-x86 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

- Run Brave with `--enable-features=NotificationAds:can_fallback_to_custom_notifications/true`
- Disable notifications for Brave in the System Preferences
- Trigger a notification ad
- Make sure that Custom Ad notification is shown
- Enable notifications for Brave in the System Preferences
- Trigger a notification ad
- Make sure that Custom Ad notification is shown (Browser now in notifications fallback mode)
- Set AllowedToFallbackToCustomAdNotifications to disabled in brave://flags
- Trigger a notification ad
- Make sure that a native notification ad is shown
