### PR TITLE
Remove Block third-party cookies toggle from Cookies and site data popup in lock icon (uplift to 1.52.x)

### DIFF
--- a/app/BUILD.gn
+++ b/app/BUILD.gn
@@ -107,6 +107,7 @@ source_set("browser_tests") {
       "//components/omnibox/browser",
       "//components/optimization_guide/core",
       "//components/page_image_service",
+      "//components/page_info/core",
       "//components/performance_manager",
       "//components/permissions",
       "//components/privacy_sandbox",

--- a/app/brave_main_delegate_browsertest.cc
+++ b/app/brave_main_delegate_browsertest.cc
@@ -29,6 +29,7 @@
 #include "components/omnibox/common/omnibox_features.h"
 #include "components/optimization_guide/core/optimization_guide_features.h"
 #include "components/page_image_service/features.h"
+#include "components/page_info/core/features.h"
 #include "components/password_manager/core/common/password_manager_features.h"
 #include "components/performance_manager/public/features.h"
 #include "components/permissions/features.h"
@@ -210,6 +211,7 @@ IN_PROC_BROWSER_TEST_F(BraveMainDelegateBrowserTest, DisabledFeatures) {
         kRemoteOptimizationGuideFetchingAnonymousDataConsent,
     &page_image_service::kImageServiceSuggestPoweredImages,
 #if !BUILDFLAG(IS_ANDROID)
+    &page_info::kPageInfoCookiesSubpage,
     &permissions::features::kPermissionsPromptSurvey,
     &permissions::features::kPermissionStorageAccessAPI,
     &permissions::features::kRecordPermissionExpirationTimestamps,

--- a/chromium_src/components/page_info/core/features.cc
+++ b/chromium_src/components/page_info/core/features.cc
@@ -1,0 +1,19 @@
+/* Copyright (c) 2023 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "src/components/page_info/core/features.cc"
+
+#include "base/feature_override.h"
+#include "build/build_config.h"
+
+namespace page_info {
+
+OVERRIDE_FEATURE_DEFAULT_STATES({{
+#if !BUILDFLAG(IS_ANDROID)
+    {kPageInfoCookiesSubpage, base::FEATURE_DISABLED_BY_DEFAULT},
+#endif
+}});
+
+}  // namespace page_info

--- a/test/filters/browser_tests.filter
+++ b/test/filters/browser_tests.filter
@@ -693,6 +693,10 @@
 -CommerceHintFeatureDefaultWithGeoTest.EnableWithGeo
 -NewTabPageUtilBrowserTest.EnableCartByToT
 
+# These tests fail because we disable page_info::kPageInfoCookiesSubpage
+-PageInfoBubbleViewBrowserTestCookiesSubpage.ClickingFpsButton
+-PageInfoBubbleViewBrowserTestCookiesSubpage.ToggleForBlockingThirdPartyCookies
+
 # Tests below this point have not been diagnosed or had issues created yet.
 -_/WebrtcLoggingPrivateApiStartEventLoggingTestFeatureAndPolicyEnabled.*
 -AccessCodeCastHandlerBrowserTest.*

--- a/test/filters/unit_tests.filter
+++ b/test/filters/unit_tests.filter
@@ -307,6 +307,9 @@
 # the empty string.
 -CommanderFuzzyFinder.EmptyStringDoesNotMatch
 
+# This test fails because we disable page_info::kPageInfoCookiesSubpage
+-PageInfoBubbleViewCookiesSubpageTest.TextsOnButtonsAreCorrect
+
 # Tests below this point have not been diagnosed or had issues created yet.
 -AboutFlagsHistogramTest.*
 -AboutFlagsTest.*


### PR DESCRIPTION
Uplift of https://github.com/brave/brave-core/pull/18550
Resolves https://github.com/brave/brave-browser/issues/30396