### PR TITLE
Do not trigger notification ads when ads are not initialized. (uplift to 1.53.x)

### DIFF
--- a/components/brave_ads/core/internal/ads_impl.cc
+++ b/components/brave_ads/core/internal/ads_impl.cc
@@ -136,7 +136,9 @@ void AdsImpl::TriggerNotificationAdEvent(
     const mojom::NotificationAdEventType event_type) {
   CHECK(mojom::IsKnownEnumValue(event_type));
 
-  notification_ad_handler_.TriggerEvent(placement_id, event_type);
+  if (IsInitialized()) {
+    notification_ad_handler_.TriggerEvent(placement_id, event_type);
+  }
 }
 
 void AdsImpl::MaybeServeNewTabPageAd(MaybeServeNewTabPageAdCallback callback) {


### PR DESCRIPTION
Uplift of #18600
Resolves https://github.com/brave/brave-browser/issues/30553

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.