### PR TITLE
Add URL rewrite from chrome://chat

### DIFF
--- a/browser/brave_content_browser_client.cc
+++ b/browser/brave_content_browser_client.cc
@@ -35,6 +35,7 @@
 #include "brave/browser/profiles/profile_util.h"
 #include "brave/browser/skus/skus_service_factory.h"
 #include "brave/browser/ui/webui/skus_internals_ui.h"
+#include "brave/components/ai_chat/ai_chat_url_handler.h"
 #include "brave/components/brave_federated/features.h"
 #include "brave/components/brave_rewards/browser/rewards_protocol_handler.h"
 #include "brave/components/brave_search/browser/brave_search_default_host.h"
@@ -469,6 +470,10 @@ void BraveContentBrowserClient::BrowserURLHandlerCreated(
   handler->AddHandlerPair(&webtorrent::HandleTorrentURLRewrite,
                           &webtorrent::HandleTorrentURLReverseRewrite);
 #endif
+  if (ai_chat::features::IsAIChatEnabled()) {
+    handler->AddHandlerPair(&ai_chat::HandleURLRewrite,
+                            &ai_chat::HandleURLReverseRewrite);
+  }
 #if BUILDFLAG(ENABLE_IPFS)
   handler->AddHandlerPair(&ipfs::HandleIPFSURLRewrite,
                           &ipfs::HandleIPFSURLReverseRewrite);

--- a/components/ai_chat/BUILD.gn
+++ b/components/ai_chat/BUILD.gn
@@ -25,6 +25,8 @@ source_set("ai_chat") {
     "ai_chat_api.h",
     "ai_chat_tab_helper.cc",
     "ai_chat_tab_helper.h",
+    "ai_chat_url_handler.cc",
+    "ai_chat_url_handler.h",
     "constants.cc",
     "constants.h",
     "features.cc",
@@ -42,6 +44,7 @@ source_set("ai_chat") {
     "//brave/components/resources:strings_grit",
     "//components/prefs",
     "//content/public/browser",
+    "//content/public/common",
     "//net/traffic_annotation",
     "//services/network/public/cpp",
     "//third_party/abseil-cpp:absl",
@@ -53,4 +56,19 @@ source_set("ai_chat") {
 mojom("mojom") {
   sources = [ "ai_chat.mojom" ]
   public_deps = [ "//mojo/public/mojom/base" ]
+}
+
+source_set("unit_tests") {
+  testonly = true
+
+  sources = [ "ai_chat_url_handler_unittest.cc" ]
+
+  deps = [
+    ":ai_chat",
+    "//base",
+    "//base/test:test_support",
+    "//content/public/browser",
+    "//testing/gtest",
+    "//url",
+  ]
 }

--- a/components/ai_chat/DEPS
+++ b/components/ai_chat/DEPS
@@ -1,5 +1,6 @@
 include_rules = [
   "+content/public/browser",
+  "+content/public/common",
   "+services/network/public",
   "+ui",
 ]

--- a/components/ai_chat/ai_chat_url_handler.cc
+++ b/components/ai_chat/ai_chat_url_handler.cc
@@ -1,0 +1,46 @@
+/* Copyright (c) 2023 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "brave/components/ai_chat/ai_chat_url_handler.h"
+#include "brave/components/constants/webui_url_constants.h"
+#include "content/public/browser/browser_context.h"
+#include "content/public/common/url_constants.h"
+#include "url/gurl.h"
+
+namespace ai_chat {
+
+bool HandleURLRewrite(GURL* url, content::BrowserContext* browser_context) {
+  // Used to get chrome://chat to resolve to chrome-untrusted://chat
+  if (url->SchemeIs(content::kChromeUIScheme) && url->DomainIs(kChatUIHost)) {
+    GURL::Replacements replacements;
+    replacements.SetSchemeStr(content::kChromeUIUntrustedScheme);
+    *url = url->ReplaceComponents(replacements);
+    return true;
+  }
+
+  // Needed so that HandleURLReverseRewrite will get hit
+  if (url->SchemeIs(content::kChromeUIUntrustedScheme) &&
+      url->DomainIs(kChatUIHost)) {
+    return true;
+  }
+
+  return false;
+}
+
+bool HandleURLReverseRewrite(GURL* url,
+                             content::BrowserContext* browser_context) {
+  // Make chrome-untrusted://chat show up as chrome://chat
+  if (url->SchemeIs(content::kChromeUIUntrustedScheme) &&
+      url->DomainIs(kChatUIHost)) {
+    GURL::Replacements replacements;
+    replacements.SetSchemeStr(content::kChromeUIScheme);
+    *url = url->ReplaceComponents(replacements);
+    return true;
+  }
+
+  return false;
+}
+
+}  // namespace ai_chat

--- a/components/ai_chat/ai_chat_url_handler.h
+++ b/components/ai_chat/ai_chat_url_handler.h
@@ -1,0 +1,23 @@
+/* Copyright (c) 2023 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_COMPONENTS_AI_CHAT_AI_CHAT_URL_HANDLER_H_
+#define BRAVE_COMPONENTS_AI_CHAT_AI_CHAT_URL_HANDLER_H_
+
+namespace content {
+class BrowserContext;
+}
+
+class GURL;
+
+namespace ai_chat {
+
+bool HandleURLReverseRewrite(GURL* url,
+                             content::BrowserContext* browser_context);
+bool HandleURLRewrite(GURL* url, content::BrowserContext* browser_context);
+
+}  // namespace ai_chat
+
+#endif  // BRAVE_COMPONENTS_AI_CHAT_AI_CHAT_URL_HANDLER_H_

--- a/components/ai_chat/ai_chat_url_handler_unittest.cc
+++ b/components/ai_chat/ai_chat_url_handler_unittest.cc
@@ -1,0 +1,43 @@
+/* Copyright (c) 2023 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "brave/components/ai_chat/ai_chat_url_handler.h"
+#include "content/public/browser/browser_context.h"
+#include "testing/gtest/include/gtest/gtest.h"
+#include "url/gurl.h"
+
+namespace ai_chat {
+
+TEST(AIChatContentBrowserClientHelper, HandleURLRewrite) {
+  // Maps chrome://chat to chrome-untrusted://chat
+  GURL url("chrome://chat");
+  EXPECT_TRUE(HandleURLRewrite(&url, nullptr));
+  EXPECT_EQ(url, GURL("chrome-untrusted://chat"));
+
+  // chrome-untrusted://chat returns true so that URL reverse rewrite will be
+  // hit but does not change the URL
+  url = GURL("chrome-untrusted://chat");
+  EXPECT_TRUE(HandleURLRewrite(&url, nullptr));
+  EXPECT_EQ(url, GURL("chrome-untrusted://chat"));
+
+  // Preserves the URL path, parameters, and fragments
+  url = GURL("chrome://chat/test/test2?a=b&b=c#d");
+  EXPECT_TRUE(HandleURLRewrite(&url, nullptr));
+  EXPECT_EQ(url, GURL("chrome-untrusted://chat/test/test2?a=b&b=c#d"));
+}
+
+TEST(IPFSPortsTest, HandleURLReverseRewrite) {
+  // Makes chrome-untrusted://chat loads show up as chrome://chat
+  GURL url("chrome-untrusted://chat");
+  EXPECT_TRUE(HandleURLReverseRewrite(&url, nullptr));
+  EXPECT_EQ(url, GURL("chrome://chat"));
+
+  // Preserves the URL path, parameters, and fragments
+  url = GURL("chrome-untrusted://chat/test/test2?a=b&b=c#d");
+  EXPECT_TRUE(HandleURLReverseRewrite(&url, nullptr));
+  EXPECT_EQ(url, GURL("chrome://chat/test/test2?a=b&b=c#d"));
+}
+
+}  // namespace ai_chat

--- a/test/BUILD.gn
+++ b/test/BUILD.gn
@@ -190,6 +190,7 @@ test("brave_unit_tests") {
     "//brave/chromium_src/components/privacy_sandbox:unit_tests",
     "//brave/chromium_src/net/base:unit_tests",
     "//brave/components/adblock_rust_ffi",
+    "//brave/components/ai_chat:unit_tests",
     "//brave/components/api_request_helper:api_request_helper_unit_tests",
     "//brave/components/brave_adaptive_captcha/test:brave_adaptive_captcha_unit_tests",
     "//brave/components/brave_ads/browser:test_support",


### PR DESCRIPTION
This PR makes it so a user can type brave://chat and it will actually resolve internally to chrome-untrusted://chat
It also makes sure that if a user types in chrome-untrusted://chat it will show up as brave://chat in the URL bar. 

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/30555

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-arm64, CI/skip-linux-x64, CI/skip-android, CI/skip-macos, CI/skip-ios, CI/skip-windows-arm64, CI/skip-windows-x64, CI/skip-windows-x86 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

