### PR TITLE
Add P3A metrics for Android Privacy Hub report

### DIFF
--- a/android/brave_java_sources.gni
+++ b/android/brave_java_sources.gni
@@ -237,6 +237,7 @@ brave_java_sources = [
   "../../brave/android/java/org/chromium/chrome/browser/local_database/DisplayAdsTable.java",
   "../../brave/android/java/org/chromium/chrome/browser/local_database/SavedBandwidthTable.java",
   "../../brave/android/java/org/chromium/chrome/browser/local_database/TopSiteTable.java",
+  "../../brave/android/java/org/chromium/chrome/browser/misc_metrics/PrivacyHubMetricsFactory.java",
   "../../brave/android/java/org/chromium/chrome/browser/night_mode/settings/BraveRadioButtonGroupThemePreference.java",
   "../../brave/android/java/org/chromium/chrome/browser/night_mode/settings/BraveThemePreferences.java",
   "../../brave/android/java/org/chromium/chrome/browser/notifications/BraveNotificationPlatformBridge.java",

--- a/android/java/org/chromium/chrome/browser/brave_stats/BraveStatsUtil.java
+++ b/android/java/org/chromium/chrome/browser/brave_stats/BraveStatsUtil.java
@@ -103,11 +103,12 @@ public class BraveStatsUtil {
 
     public static void showBraveStats() {
         try {
+            BraveActivity activity = BraveActivity.getBraveActivity();
             BraveStatsBottomSheetDialogFragment braveStatsBottomSheetDialogFragment =
                     BraveStatsBottomSheetDialogFragment.newInstance();
             braveStatsBottomSheetDialogFragment.show(
-                    BraveActivity.getBraveActivity().getSupportFragmentManager(),
-                    STATS_FRAGMENT_TAG);
+                    activity.getSupportFragmentManager(), STATS_FRAGMENT_TAG);
+            activity.getPrivacyHubMetrics().recordView();
         } catch (BraveActivity.BraveActivityNotFoundException e) {
             Log.e(TAG, "showBraveStats " + e);
         }

--- a/android/java/org/chromium/chrome/browser/misc_metrics/PrivacyHubMetricsFactory.java
+++ b/android/java/org/chromium/chrome/browser/misc_metrics/PrivacyHubMetricsFactory.java
@@ -1,0 +1,51 @@
+/* Copyright (c) 2023 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+package org.chromium.chrome.browser.misc_metrics;
+
+import org.chromium.base.annotations.JNINamespace;
+import org.chromium.base.annotations.NativeMethods;
+import org.chromium.misc_metrics.mojom.PrivacyHubMetrics;
+import org.chromium.mojo.bindings.ConnectionErrorHandler;
+import org.chromium.mojo.bindings.Interface;
+import org.chromium.mojo.bindings.Interface.Proxy.Handler;
+import org.chromium.mojo.system.MessagePipeHandle;
+import org.chromium.mojo.system.impl.CoreImpl;
+
+@JNINamespace("chrome::android")
+public class PrivacyHubMetricsFactory {
+    private static final Object lock = new Object();
+    private static PrivacyHubMetricsFactory instance;
+
+    public static PrivacyHubMetricsFactory getInstance() {
+        synchronized (lock) {
+            if (instance == null) {
+                instance = new PrivacyHubMetricsFactory();
+            }
+        }
+        return instance;
+    }
+
+    private PrivacyHubMetricsFactory() {}
+
+    public PrivacyHubMetrics getMetricsService(ConnectionErrorHandler connectionErrorHandler) {
+        long nativeHandle = PrivacyHubMetricsFactoryJni.get().getInterfaceToPrivacyHubMetrics();
+        MessagePipeHandle handle = wrapNativeHandle(nativeHandle);
+        PrivacyHubMetrics metricsService = PrivacyHubMetrics.MANAGER.attachProxy(handle, 0);
+        Handler handler = ((Interface.Proxy) metricsService).getProxyHandler();
+        handler.setErrorHandler(connectionErrorHandler);
+
+        return metricsService;
+    }
+
+    private MessagePipeHandle wrapNativeHandle(long nativeHandle) {
+        return CoreImpl.getInstance().acquireNativeHandle(nativeHandle).toMessagePipeHandle();
+    }
+
+    @NativeMethods
+    interface Natives {
+        long getInterfaceToPrivacyHubMetrics();
+    }
+}

--- a/android/java/org/chromium/chrome/browser/onboarding/OnboardingPrefManager.java
+++ b/android/java/org/chromium/chrome/browser/onboarding/OnboardingPrefManager.java
@@ -12,7 +12,10 @@ import android.content.Intent;
 import android.content.SharedPreferences;
 
 import org.chromium.base.ContextUtils;
+import org.chromium.base.Log;
 import org.chromium.chrome.browser.BraveAdsNativeHelper;
+import org.chromium.chrome.browser.app.BraveActivity;
+import org.chromium.chrome.browser.app.BraveActivity.BraveActivityNotFoundException;
 import org.chromium.chrome.browser.notifications.BraveOnboardingNotification;
 import org.chromium.chrome.browser.notifications.retention.RetentionNotificationUtil;
 import org.chromium.chrome.browser.profiles.Profile;
@@ -27,6 +30,8 @@ import java.util.Map;
  * Provides information regarding onboarding.
  */
 public class OnboardingPrefManager {
+    private static final String TAG = "OnboardingPrefMgr";
+
     private static final String PREF_ONBOARDING = "onboarding";
     private static final String PREF_P3A_ONBOARDING = "p3a_onboarding";
     private static final String PREF_CROSS_PROMO_MODAL = "cross_promo_modal";
@@ -173,6 +178,12 @@ public class OnboardingPrefManager {
         SharedPreferences.Editor sharedPreferencesEditor = mSharedPreferences.edit();
         sharedPreferencesEditor.putBoolean(PREF_BRAVE_STATS, enabled);
         sharedPreferencesEditor.apply();
+        try {
+            BraveActivity activity = BraveActivity.getBraveActivity();
+            activity.getPrivacyHubMetrics().recordEnabledStatus(enabled);
+        } catch (BraveActivityNotFoundException e) {
+            Log.e(TAG, "Could not report privacy hub enabled change to P3A: " + e);
+        }
     }
 
     public boolean isBraveStatsNotificationEnabled() {

--- a/browser/brave_browser_process.h
+++ b/browser/brave_browser_process.h
@@ -65,6 +65,7 @@ class LocalhostPermissionComponent;
 
 namespace misc_metrics {
 class MenuMetrics;
+class PrivacyHubMetrics;
 }  // namespace misc_metrics
 
 namespace request_otr {
@@ -148,6 +149,7 @@ class BraveBrowserProcess {
   virtual brave_ads::ResourceComponent* resource_component() = 0;
   virtual brave::BraveFarblingService* brave_farbling_service() = 0;
   virtual misc_metrics::MenuMetrics* menu_metrics() = 0;
+  virtual misc_metrics::PrivacyHubMetrics* privacy_hub_metrics() = 0;
 };
 
 extern BraveBrowserProcess* g_brave_browser_process;

--- a/browser/brave_browser_process_impl.cc
+++ b/browser/brave_browser_process_impl.cc
@@ -39,6 +39,7 @@
 #include "brave/components/https_upgrade_exceptions/browser/https_upgrade_exceptions_service.h"
 #include "brave/components/localhost_permission/localhost_permission_component.h"
 #include "brave/components/misc_metrics/menu_metrics.h"
+#include "brave/components/misc_metrics/privacy_hub_metrics.h"
 #include "brave/components/ntp_background_images/browser/ntp_background_images_service.h"
 #include "brave/components/p3a/buildflags.h"
 #include "brave/components/p3a/histograms_braveizer.h"
@@ -532,4 +533,13 @@ misc_metrics::MenuMetrics* BraveBrowserProcessImpl::menu_metrics() {
   }
 #endif
   return menu_metrics_.get();
+}
+
+misc_metrics::PrivacyHubMetrics*
+BraveBrowserProcessImpl::privacy_hub_metrics() {
+  if (!privacy_hub_metrics_) {
+    privacy_hub_metrics_ =
+        std::make_unique<misc_metrics::PrivacyHubMetrics>(local_state());
+  }
+  return privacy_hub_metrics_.get();
 }

--- a/browser/brave_browser_process_impl.h
+++ b/browser/brave_browser_process_impl.h
@@ -60,6 +60,7 @@ class DebounceComponentInstaller;
 
 namespace misc_metrics {
 class MenuMetrics;
+class PrivacyHubMetrics;
 }  // namespace misc_metrics
 
 namespace request_otr {
@@ -153,6 +154,7 @@ class BraveBrowserProcessImpl : public BraveBrowserProcess,
 #endif
   brave::BraveFarblingService* brave_farbling_service() override;
   misc_metrics::MenuMetrics* menu_metrics() override;
+  misc_metrics::PrivacyHubMetrics* privacy_hub_metrics() override;
 
  private:
   // BrowserProcessImpl overrides:
@@ -230,6 +232,7 @@ class BraveBrowserProcessImpl : public BraveBrowserProcess,
 
   std::unique_ptr<brave::BraveFarblingService> brave_farbling_service_;
   std::unique_ptr<misc_metrics::MenuMetrics> menu_metrics_;
+  std::unique_ptr<misc_metrics::PrivacyHubMetrics> privacy_hub_metrics_;
   std::unique_ptr<brave_ads::BraveStatsHelper> brave_stats_helper_;
 
   SEQUENCE_CHECKER(sequence_checker_);

--- a/browser/brave_local_state_prefs.cc
+++ b/browser/brave_local_state_prefs.cc
@@ -27,6 +27,7 @@
 #include "brave/components/misc_metrics/general_browser_usage.h"
 #include "brave/components/misc_metrics/menu_metrics.h"
 #include "brave/components/misc_metrics/page_metrics_service.h"
+#include "brave/components/misc_metrics/privacy_hub_metrics.h"
 #include "brave/components/ntp_background_images/browser/ntp_background_images_service.h"
 #include "brave/components/ntp_background_images/browser/view_counter_service.h"
 #include "brave/components/p3a/p3a_service.h"
@@ -139,6 +140,7 @@ void RegisterLocalStatePrefs(PrefRegistrySimple* registry) {
   misc_metrics::PageMetricsService::RegisterPrefs(registry);
   brave_ads::BraveStatsHelper::RegisterLocalStatePrefs(registry);
   misc_metrics::GeneralBrowserUsage::RegisterPrefs(registry);
+  misc_metrics::PrivacyHubMetrics::RegisterPrefs(registry);
 
   playlist::PlaylistServiceFactory::RegisterLocalStatePrefs(registry);
 }

--- a/browser/misc_metrics/privacy_hub_metrics_factory_android.cc
+++ b/browser/misc_metrics/privacy_hub_metrics_factory_android.cc
@@ -1,0 +1,21 @@
+/* Copyright (c) 2023 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "base/android/jni_android.h"
+#include "brave/browser/brave_browser_process.h"
+#include "brave/build/android/jni_headers/PrivacyHubMetricsFactory_jni.h"
+#include "brave/components/misc_metrics/privacy_hub_metrics.h"
+
+namespace chrome {
+namespace android {
+static jlong JNI_PrivacyHubMetricsFactory_GetInterfaceToPrivacyHubMetrics(
+    JNIEnv* env) {
+  auto pending = g_brave_browser_process->privacy_hub_metrics()->MakeRemote();
+
+  return static_cast<jlong>(pending.PassPipe().release().value());
+}
+
+}  // namespace android
+}  // namespace chrome

--- a/browser/misc_metrics/sources.gni
+++ b/browser/misc_metrics/sources.gni
@@ -20,3 +20,6 @@ brave_browser_misc_metrics_deps = [
   "//components/keyed_service/core",
   "//content/public/browser",
 ]
+
+brave_browser_misc_metrics_android_sources =
+    [ "//brave/browser/misc_metrics/privacy_hub_metrics_factory_android.cc" ]

--- a/browser/sources.gni
+++ b/browser/sources.gni
@@ -305,6 +305,7 @@ if (is_android) {
   ]
 
   brave_chrome_browser_sources += brave_browser_brave_wallet_android_sources
+  brave_chrome_browser_sources += brave_browser_misc_metrics_android_sources
   brave_chrome_browser_deps += brave_browser_brave_wallet_android_deps
 
   brave_chrome_browser_deps += [

--- a/build/android/BUILD.gn
+++ b/build/android/BUILD.gn
@@ -228,6 +228,7 @@ generate_jni("jni_headers") {
     "//brave/android/java/org/chromium/chrome/browser/crypto_wallet/permission/BraveDappPermissionPromptDialog.java",
     "//brave/android/java/org/chromium/chrome/browser/crypto_wallet/util/WalletNativeUtils.java",
     "//brave/android/java/org/chromium/chrome/browser/informers/BraveSyncAccountDeletedInformer.java",
+    "//brave/android/java/org/chromium/chrome/browser/misc_metrics/PrivacyHubMetricsFactory.java",
     "//brave/android/java/org/chromium/chrome/browser/notifications/BraveNotificationPlatformBridge.java",
     "//brave/android/java/org/chromium/chrome/browser/notifications/BraveNotificationSettingsBridge.java",
     "//brave/android/java/org/chromium/chrome/browser/ntp_background_images/NTPBackgroundImagesBridge.java",

--- a/build/android/config.gni
+++ b/build/android/config.gni
@@ -34,6 +34,7 @@ brave_chrome_java_deps = [
   "//brave/components/brave_wallet/common:mojom_java",
   "//brave/components/browser_ui/accessibility/android:java",
   "//brave/components/browser_ui/site_settings/android:java",
+  "//brave/components/misc_metrics/common:mojom_java",
   "//brave/components/playlist/common/mojom:mojom_java",
   "//brave/components/safe_browsing/android:brave_safe_browsing_java",
   "//brave/components/variations/android:java",

--- a/components/misc_metrics/BUILD.gn
+++ b/components/misc_metrics/BUILD.gn
@@ -13,6 +13,8 @@ static_library("misc_metrics") {
     "page_metrics_service.h",
     "pref_names.cc",
     "pref_names.h",
+    "privacy_hub_metrics.cc",
+    "privacy_hub_metrics.h",
   ]
 
   deps = [
@@ -24,4 +26,6 @@ static_library("misc_metrics") {
     "//components/prefs",
     "//url",
   ]
+
+  public_deps = [ "//brave/components/misc_metrics/common:mojom" ]
 }

--- a/components/misc_metrics/common/BUILD.gn
+++ b/components/misc_metrics/common/BUILD.gn
@@ -1,0 +1,12 @@
+# Copyright (c) 2023 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import("//mojo/public/tools/bindings/mojom.gni")
+
+mojom("mojom") {
+  generate_java = true
+  sources = [ "misc_metrics.mojom" ]
+  public_deps = [ "//mojo/public/mojom/base" ]
+}

--- a/components/misc_metrics/common/misc_metrics.mojom
+++ b/components/misc_metrics/common/misc_metrics.mojom
@@ -1,0 +1,15 @@
+// Copyright (c) 2023 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+module misc_metrics.mojom;
+
+// Handler for Privacy Hub events from UI.
+interface PrivacyHubMetrics {
+  // Records view of Privacy Hub report.
+  RecordView();
+
+  // Records enabled status of Privacy Hub report.
+  RecordEnabledStatus(bool isEnabled);
+};

--- a/components/misc_metrics/pref_names.cc
+++ b/components/misc_metrics/pref_names.cc
@@ -14,4 +14,6 @@ const char kMiscMetricsMenuGroupActionCounts[] =
 const char kMiscMetricsMenuShownStorage[] =
     "brave.misc_metrics.menu_shown_storage";
 const char kMiscMetricsPagesLoadedCount[] = "brave.core_metrics.pages_loaded";
+const char kMiscMetricsPrivacyHubViews[] =
+    "brave.misc_metrics.privacy_hub_views";
 }  // namespace misc_metrics

--- a/components/misc_metrics/pref_names.h
+++ b/components/misc_metrics/pref_names.h
@@ -12,6 +12,7 @@ extern const char kMiscMetricsMenuDismissStorage[];
 extern const char kMiscMetricsMenuGroupActionCounts[];
 extern const char kMiscMetricsMenuShownStorage[];
 extern const char kMiscMetricsPagesLoadedCount[];
+extern const char kMiscMetricsPrivacyHubViews[];
 }  // namespace misc_metrics
 
 #endif  // BRAVE_COMPONENTS_MISC_METRICS_PREF_NAMES_H_

--- a/components/misc_metrics/privacy_hub_metrics.cc
+++ b/components/misc_metrics/privacy_hub_metrics.cc
@@ -1,0 +1,70 @@
+/* Copyright (c) 2023 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "brave/components/misc_metrics/privacy_hub_metrics.h"
+
+#include "base/metrics/histogram_macros.h"
+#include "brave/components/misc_metrics/pref_names.h"
+#include "brave/components/p3a_utils/bucket.h"
+#include "components/prefs/pref_registry_simple.h"
+#include "components/prefs/pref_service.h"
+
+namespace misc_metrics {
+
+namespace {
+const int kViewsMonthlyBucketValues[] = {1, 10, 20};
+}  // namespace
+
+const char kViewsMonthlyHistogramName[] = "Brave.PrivacyHub.Views";
+const char kIsEnabledHistogramName[] = "Brave.PrivacyHub.IsEnabled";
+const base::TimeDelta kReportUpdateInterval = base::Days(1);
+
+PrivacyHubMetrics::PrivacyHubMetrics(PrefService* local_state)
+    : view_storage_(local_state, kMiscMetricsPrivacyHubViews) {
+  SetUpTimer();
+}
+
+PrivacyHubMetrics::~PrivacyHubMetrics() = default;
+
+void PrivacyHubMetrics::RegisterPrefs(PrefRegistrySimple* registry) {
+  registry->RegisterListPref(kMiscMetricsPrivacyHubViews);
+}
+
+#if BUILDFLAG(IS_ANDROID)
+mojo::PendingRemote<mojom::PrivacyHubMetrics> PrivacyHubMetrics::MakeRemote() {
+  mojo::PendingRemote<mojom::PrivacyHubMetrics> remote;
+  receivers_.Add(this, remote.InitWithNewPipeAndPassReceiver());
+  return remote;
+}
+#endif  // BUILDFLAG(IS_ANDROID)
+
+void PrivacyHubMetrics::RecordView() {
+  view_storage_.AddDelta(1u);
+  RecordViewCount();
+}
+
+void PrivacyHubMetrics::RecordEnabledStatus(bool is_enabled) {
+  // suspend metric if not enabled; we only want to report
+  // if the feature is enabled
+  int histogram_value = is_enabled ? 1 : INT_MAX - 1;
+  UMA_HISTOGRAM_EXACT_LINEAR(kIsEnabledHistogramName, histogram_value, 2);
+}
+
+void PrivacyHubMetrics::RecordViewCount() {
+  auto sum = view_storage_.GetMonthlySum();
+  if (sum > 0) {
+    p3a_utils::RecordToHistogramBucket(kViewsMonthlyHistogramName,
+                                       kViewsMonthlyBucketValues, sum);
+  }
+  SetUpTimer();
+}
+
+void PrivacyHubMetrics::SetUpTimer() {
+  report_timer_.Start(FROM_HERE, base::Time::Now() + kReportUpdateInterval,
+                      base::BindOnce(&PrivacyHubMetrics::RecordViewCount,
+                                     base::Unretained(this)));
+}
+
+}  // namespace misc_metrics

--- a/components/misc_metrics/privacy_hub_metrics.h
+++ b/components/misc_metrics/privacy_hub_metrics.h
@@ -1,0 +1,60 @@
+/* Copyright (c) 2023 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_COMPONENTS_MISC_METRICS_PRIVACY_HUB_METRICS_H_
+#define BRAVE_COMPONENTS_MISC_METRICS_PRIVACY_HUB_METRICS_H_
+
+#include "base/timer/wall_clock_timer.h"
+
+#include "brave/components/misc_metrics/common/misc_metrics.mojom.h"
+#include "brave/components/time_period_storage/monthly_storage.h"
+
+#if BUILDFLAG(IS_ANDROID)
+#include "mojo/public/cpp/bindings/receiver_set.h"
+#endif  // BUILDFLAG(IS_ANDROID)
+
+class PrefRegistrySimple;
+class PrefService;
+
+namespace misc_metrics {
+
+extern const char kViewsMonthlyHistogramName[];
+extern const char kIsEnabledHistogramName[];
+
+// TODO(djandries): consider refactoring this into a more generic
+// metrics service if we receive additional metric requests for features
+// that don't have a mojo service that we can piggyback onto.
+class PrivacyHubMetrics : public mojom::PrivacyHubMetrics {
+ public:
+  explicit PrivacyHubMetrics(PrefService* local_state);
+  ~PrivacyHubMetrics() override;
+
+  PrivacyHubMetrics(const PrivacyHubMetrics&) = delete;
+  PrivacyHubMetrics& operator=(const PrivacyHubMetrics&) = delete;
+
+  static void RegisterPrefs(PrefRegistrySimple* registry);
+
+#if BUILDFLAG(IS_ANDROID)
+  mojo::PendingRemote<mojom::PrivacyHubMetrics> MakeRemote();
+#endif  // BUILDFLAG(IS_ANDROID)
+
+  void RecordView() override;
+  void RecordEnabledStatus(bool is_enabled) override;
+
+ private:
+  void RecordViewCount();
+  void SetUpTimer();
+
+  MonthlyStorage view_storage_;
+  base::WallClockTimer report_timer_;
+
+#if BUILDFLAG(IS_ANDROID)
+  mojo::ReceiverSet<mojom::PrivacyHubMetrics> receivers_;
+#endif  // BUILDFLAG(IS_ANDROID)
+};
+
+}  // namespace misc_metrics
+
+#endif  // BRAVE_COMPONENTS_MISC_METRICS_PRIVACY_HUB_METRICS_H_

--- a/components/misc_metrics/privacy_hub_metrics_unittest.cc
+++ b/components/misc_metrics/privacy_hub_metrics_unittest.cc
@@ -1,0 +1,50 @@
+/* Copyright (c) 2023 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include <memory>
+
+#include "base/test/metrics/histogram_tester.h"
+#include "brave/components/misc_metrics/privacy_hub_metrics.h"
+#include "components/prefs/testing_pref_service.h"
+#include "content/public/test/browser_task_environment.h"
+#include "testing/gtest/include/gtest/gtest.h"
+
+namespace misc_metrics {
+
+class PrivacyHubMetricsUnitTest : public testing::Test {
+ public:
+  PrivacyHubMetricsUnitTest()
+      : task_environment_(base::test::TaskEnvironment::TimeSource::MOCK_TIME) {}
+
+  void SetUp() override {
+    misc_metrics::PrivacyHubMetrics::RegisterPrefs(local_state_.registry());
+    privacy_hub_metrics_ = std::make_unique<PrivacyHubMetrics>(&local_state_);
+  }
+
+ protected:
+  content::BrowserTaskEnvironment task_environment_;
+  TestingPrefServiceSimple local_state_;
+  base::HistogramTester histogram_tester_;
+  std::unique_ptr<PrivacyHubMetrics> privacy_hub_metrics_;
+};
+
+TEST_F(PrivacyHubMetricsUnitTest, Views) {
+  histogram_tester_.ExpectTotalCount(kViewsMonthlyHistogramName, 0);
+
+  for (size_t i = 0; i < 4; i++) {
+    privacy_hub_metrics_->RecordView();
+  }
+
+  histogram_tester_.ExpectBucketCount(kViewsMonthlyHistogramName, 0, 1);
+  histogram_tester_.ExpectBucketCount(kViewsMonthlyHistogramName, 1, 3);
+
+  task_environment_.FastForwardBy(base::Days(30));
+  histogram_tester_.ExpectBucketCount(kViewsMonthlyHistogramName, 1, 32);
+
+  task_environment_.FastForwardBy(base::Days(10));
+  histogram_tester_.ExpectBucketCount(kViewsMonthlyHistogramName, 1, 32);
+}
+
+}  // namespace misc_metrics

--- a/components/p3a/metric_names.h
+++ b/components/p3a/metric_names.h
@@ -184,6 +184,8 @@ constexpr inline auto kCollectedSlowHistograms =
     "Brave.General.BottomBarLocation",
     "Brave.P3A.TestSlowMetric",
     "Brave.Playlist.LastUsageTime",
+    "Brave.PrivacyHub.IsEnabled",
+    "Brave.PrivacyHub.Views",
     "Brave.ReaderMode.NumberReaderModeActivated",
     "Brave.Rewards.TipsSent",
     "Brave.Sync.EnabledTypes",
@@ -207,6 +209,7 @@ constexpr inline auto kEphemeralHistograms =
   base::MakeFixedFlatSet<base::StringPiece>({
     "Brave.Playlist.UsageDaysInWeek",
     "Brave.Playlist.FirstTimeOffset",
+    "Brave.PrivacyHub.Views",
     "Brave.Rewards.EnabledInstallationTime",
     "Brave.Rewards.EnabledSource",
     "Brave.Rewards.InlineTipTrigger",

--- a/test/BUILD.gn
+++ b/test/BUILD.gn
@@ -140,6 +140,7 @@ test("brave_unit_tests") {
     "//brave/components/content_settings/core/browser/brave_content_settings_utils_unittest.cc",
     "//brave/components/misc_metrics/general_browser_usage_unittest.cc",
     "//brave/components/misc_metrics/menu_metrics_unittest.cc",
+    "//brave/components/misc_metrics/privacy_hub_metrics_unittest.cc",
     "//brave/components/ntp_background_images/browser/ntp_background_images_service_unittest.cc",
     "//brave/components/ntp_background_images/browser/ntp_background_images_source_unittest.cc",
     "//brave/components/ntp_background_images/browser/view_counter_model_unittest.cc",

--- a/test/base/testing_brave_browser_process.cc
+++ b/test/base/testing_brave_browser_process.cc
@@ -186,6 +186,12 @@ misc_metrics::MenuMetrics* TestingBraveBrowserProcess::menu_metrics() {
   return nullptr;
 }
 
+misc_metrics::PrivacyHubMetrics*
+TestingBraveBrowserProcess::privacy_hub_metrics() {
+  NOTREACHED();
+  return nullptr;
+}
+
 void TestingBraveBrowserProcess::SetAdBlockService(
     std::unique_ptr<brave_shields::AdBlockService> service) {
   ad_block_service_ = std::move(service);

--- a/test/base/testing_brave_browser_process.h
+++ b/test/base/testing_brave_browser_process.h
@@ -87,6 +87,7 @@ class TestingBraveBrowserProcess : public BraveBrowserProcess {
   brave_vpn::BraveVPNOSConnectionAPI* brave_vpn_os_connection_api() override;
 #endif
   misc_metrics::MenuMetrics* menu_metrics() override;
+  misc_metrics::PrivacyHubMetrics* privacy_hub_metrics() override;
 
   // Populate the mock process with services. Consumer is responsible for
   // cleaning these up after completion of a test.


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/30623

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-arm64, CI/skip-linux-x64, CI/skip-android, CI/skip-macos, CI/skip-ios, CI/skip-windows-arm64, CI/skip-windows-x64, CI/skip-windows-x86 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [ ] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

For `Brave.PrivacyHub.IsEnabled`:

0. Start with fresh profile, ensure metric does not exist in local state.
1. Enable the privacy report
2. Ensure the metric exists with the value 1.
3. Disable the privacy report
4. Ensure the metric is removed from local state.

For `Brave.PrivacyHub.Views`:

0. Start with fresh profile, ensure metric does not exist in local state.
1. Enable and view the privacy report.
2. Ensure the metric exists with the value 0.
3. Test different metric values by opening the privacy report several times.
4. Advance system time by 31 days, do not access report. Ensure metric does not exist in local state.
5. Open privacy report, ensure metric reappears with correct value.