### PR TITLE
Observe FullscreenController for vertical tab bounds

### DIFF
--- a/browser/ui/views/frame/vertical_tab_strip_widget_delegate_view.cc
+++ b/browser/ui/views/frame/vertical_tab_strip_widget_delegate_view.cc
@@ -124,6 +124,10 @@ VerticalTabStripWidgetDelegateView::~VerticalTabStripWidgetDelegateView() {
   // Child views will be deleted after this. Marks `region_view_` nullptr
   // so that they dont' access the `region_view_` via this view.
   region_view_ = nullptr;
+
+  DCHECK(fullscreen_observation_.IsObserving())
+      << "We didn't start to observe FullscreenController from BrowserList's "
+         "callback";
 }
 
 VerticalTabStripWidgetDelegateView::VerticalTabStripWidgetDelegateView(
@@ -141,6 +145,10 @@ VerticalTabStripWidgetDelegateView::VerticalTabStripWidgetDelegateView(
 
   // At this point, Browser hasn't finished its initialization. In order to
   // access some of its member, we should observe BrowserList.
+  DCHECK(base::ranges::find(*BrowserList::GetInstance(),
+                            browser_view_->browser()) ==
+         BrowserList::GetInstance()->end())
+      << "Browser shouldn't be added at this point.";
   BrowserList::AddObserver(this);
 
   ChildPreferredSizeChanged(region_view_);

--- a/browser/ui/views/frame/vertical_tab_strip_widget_delegate_view.h
+++ b/browser/ui/views/frame/vertical_tab_strip_widget_delegate_view.h
@@ -9,12 +9,15 @@
 #include <memory>
 
 #include "base/scoped_multi_source_observation.h"
+#include "chrome/browser/ui/browser_list_observer.h"
+#include "chrome/browser/ui/exclusive_access/fullscreen_observer.h"
 #include "ui/views/view_observer.h"
 #include "ui/views/widget/widget_delegate.h"
 #include "ui/views/widget/widget_observer.h"
 
 class BrowserView;
 class VerticalTabStripRegionView;
+class FullscreenController;
 
 // This class wraps VerticalTabStripRegionView and show them atop a Widget.
 // Vertical tab strip could be overlaps with contents web view and
@@ -35,7 +38,9 @@ class VerticalTabStripRegionView;
 //
 class VerticalTabStripWidgetDelegateView : public views::WidgetDelegateView,
                                            public views::ViewObserver,
-                                           public views::WidgetObserver {
+                                           public views::WidgetObserver,
+                                           public BrowserListObserver,
+                                           public FullscreenObserver {
  public:
   METADATA_HEADER(VerticalTabStripWidgetDelegateView);
 
@@ -63,6 +68,12 @@ class VerticalTabStripWidgetDelegateView : public views::WidgetDelegateView,
                              const gfx::Rect& new_bounds) override;
   void OnWidgetDestroying(views::Widget* widget) override;
 
+  // BrowserListObserver:
+  void OnBrowserAdded(Browser* browser) override;
+
+  // FullscreenObserver:
+  void OnFullscreenStateChanged() override;
+
  private:
   VerticalTabStripWidgetDelegateView(BrowserView* browser_view,
                                      views::View* host);
@@ -81,6 +92,9 @@ class VerticalTabStripWidgetDelegateView : public views::WidgetDelegateView,
 
   base::ScopedMultiSourceObservation<views::Widget, views::WidgetObserver>
       widget_observation_{this};
+
+  base::ScopedObservation<FullscreenController, FullscreenObserver>
+      fullscreen_observation_{this};
 };
 
 #endif  // BRAVE_BROWSER_UI_VIEWS_FRAME_VERTICAL_TAB_STRIP_WIDGET_DELEGATE_VIEW_H_


### PR DESCRIPTION
When fullscreen state changes, we were depending on WidgetObserver::OnWidgetBoundsChanged(). But this seems to be insufficient.

* Widget bounds stay same in some cases
  * Transition from Browser fullscreen to Tab fullscreen

* Could have timing issue
  * If widget's bounds changes first, and then update fullscreen controller's state changes later, the preferred size returned from VerticalTabStripRegionView could be wrong - it will think it's still normal window, not fullscreen.

In order to solve this, we should observe FullscreenController directly.

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/30629

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-arm64, CI/skip-linux-x64, CI/skip-android, CI/skip-macos, CI/skip-ios, CI/skip-windows-arm64, CI/skip-windows-x64, CI/skip-windows-x86 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [ ] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

