### PR TITLE
fix(wallet): improve eth_feeHistory response parsing

### DIFF
--- a/components/brave_wallet/browser/eth_response_parser.cc
+++ b/components/brave_wallet/browser/eth_response_parser.cc
@@ -88,19 +88,26 @@ bool ParseEthGetFeeHistory(const base::Value& json_value,
   oldest_block->clear();
   reward->clear();
 
-  auto value = ParseResultValue(json_value);
+  auto value = ParseResultDict(json_value);
   if (!value) {
     return false;
   }
 
   auto fee_item_value =
-      json_rpc_responses::EthGetFeeHistoryResult::FromValueDeprecated(*value);
+      json_rpc_responses::EthGetFeeHistoryResult::FromValue(*value);
   if (!fee_item_value) {
     return false;
   }
 
   *base_fee_per_gas = fee_item_value->base_fee_per_gas;
-  *gas_used_ratio = fee_item_value->gas_used_ratio;
+
+  for (const auto& gas_used_value : fee_item_value->gas_used_ratio) {
+    if (!base::StringToDouble(gas_used_value,
+                              &gas_used_ratio->emplace_back())) {
+      return false;
+    }
+  }
+
   *oldest_block = fee_item_value->oldest_block;
 
   if (fee_item_value->reward) {

--- a/components/brave_wallet/browser/eth_response_parser_unittest.cc
+++ b/components/brave_wallet/browser/eth_response_parser_unittest.cc
@@ -382,11 +382,11 @@ TEST(EthResponseParserUnitTest, ParseEthGetFeeHistory) {
             "0x24beaded75"
           ],
           "gasUsedRatio": [
-            0.020687709938714324,
-            0.4678514936136911,
-            0.12914042746424212,
-            0.999758,
-            0.9054214892490816
+            "0.020687709938714324",
+            "0.4678514936136911",
+            "0.12914042746424212",
+            "0.999758",
+            "0.9054214892490816"
           ],
           "oldestBlock": "0xd6b1b0",
           "reward": [
@@ -443,14 +443,37 @@ TEST(EthResponseParserUnitTest, ParseEthGetFeeHistory) {
 
   // Empty result for the correct schema parses OK
   json = R"(
+    {
+      "jsonrpc":"2.0",
+      "id":1,
+      "result": {
+        "baseFeePerGas": [],
+        "gasUsedRatio": [],
+        "oldestBlock": "0xd6b1b0",
+        "reward": []
+      }
+    }
+  )";
+  base_fee_per_gas.clear();
+  gas_used_ratio.clear();
+  oldest_block.clear();
+  reward.clear();
+  EXPECT_TRUE(ParseEthGetFeeHistory(ParseJson(json), &base_fee_per_gas,
+                                    &gas_used_ratio, &oldest_block, &reward));
+  EXPECT_EQ(base_fee_per_gas, std::vector<std::string>());
+  EXPECT_EQ(gas_used_ratio, std::vector<double>());
+  EXPECT_EQ(oldest_block, "0xd6b1b0");
+  EXPECT_EQ(reward, std::vector<std::vector<std::string>>());
+
+  // Integer values in gasUsedRatio should be handled correctly
+  json = R"(
       {
         "jsonrpc":"2.0",
         "id":1,
         "result": {
           "baseFeePerGas": [],
-          "gasUsedRatio": [],
-          "oldestBlock": "0xd6b1b0",
-          "reward": []
+          "gasUsedRatio": ["1", "0"],
+          "oldestBlock": "0xd6b1b0"
         }
       })";
   base_fee_per_gas.clear();
@@ -460,7 +483,7 @@ TEST(EthResponseParserUnitTest, ParseEthGetFeeHistory) {
   EXPECT_TRUE(ParseEthGetFeeHistory(ParseJson(json), &base_fee_per_gas,
                                     &gas_used_ratio, &oldest_block, &reward));
   EXPECT_EQ(base_fee_per_gas, std::vector<std::string>());
-  EXPECT_EQ(gas_used_ratio, std::vector<double>());
+  EXPECT_EQ(gas_used_ratio, (std::vector<double>{1.0, 0.0}));
   EXPECT_EQ(oldest_block, "0xd6b1b0");
   EXPECT_EQ(reward, std::vector<std::vector<std::string>>());
 
@@ -504,7 +527,7 @@ TEST(EthResponseParserUnitTest, ParseEthGetFeeHistory) {
           "baseFeePerGas": [],
           "gasUsedRatio": [],
           "oldestBlock": "0xd6b1b0",
-          "reward": [[3]]
+          "reward": [[true]]
         }
       })";
   EXPECT_FALSE(ParseEthGetFeeHistory(ParseJson(json), &base_fee_per_gas,
@@ -518,7 +541,7 @@ TEST(EthResponseParserUnitTest, ParseEthGetFeeHistory) {
         "result": {
           "baseFeePerGas": [],
           "gasUsedRatio": [],
-          "oldestBlock": 3,
+          "oldestBlock": true,
           "reward": [[]]
         }
       })";
@@ -532,7 +555,7 @@ TEST(EthResponseParserUnitTest, ParseEthGetFeeHistory) {
         "id":1,
         "result": {
           "baseFeePerGas": [],
-          "gasUsedRatio": ["3"],
+          "gasUsedRatio": ["abc"],
           "oldestBlock": "0xd6b1b0",
           "reward": [[]]
         }
@@ -546,7 +569,7 @@ TEST(EthResponseParserUnitTest, ParseEthGetFeeHistory) {
         "jsonrpc":"2.0",
         "id":1,
         "result": {
-          "baseFeePerGas": [3],
+          "baseFeePerGas": [true],
           "gasUsedRatio": [],
           "oldestBlock": "0xd6b1b0",
           "reward": [[]]

--- a/components/brave_wallet/browser/json_rpc_responses.idl
+++ b/components/brave_wallet/browser/json_rpc_responses.idl
@@ -18,7 +18,7 @@ namespace json_rpc_responses {
 
   dictionary EthGetFeeHistoryResult {
     DOMString[] baseFeePerGas;
-    double[] gasUsedRatio;
+    DOMString[] gasUsedRatio;
     DOMString oldestBlock;
     any[]? reward;
   };

--- a/components/brave_wallet/browser/simulation_service.cc
+++ b/components/brave_wallet/browser/simulation_service.cc
@@ -46,7 +46,8 @@ net::NetworkTrafficAnnotationTag GetNetworkTrafficAnnotationTag() {
 //
 // For sample JSON response, refer to ParseJupiterQuote.
 absl::optional<std::string> ConvertAllNumbersToString(const std::string& json) {
-  auto converted_json = std::string(json::convert_all_numbers_to_string(json));
+  auto converted_json =
+      std::string(json::convert_all_numbers_to_string(json, ""));
   if (converted_json.empty()) {
     return absl::nullopt;
   }

--- a/components/brave_wallet/browser/swap_response_parser.cc
+++ b/components/brave_wallet/browser/swap_response_parser.cc
@@ -362,7 +362,8 @@ mojom::JupiterErrorResponsePtr ParseJupiterErrorResponse(
 //
 // For sample JSON response, refer to ParseJupiterQuote.
 absl::optional<std::string> ConvertAllNumbersToString(const std::string& json) {
-  auto converted_json = std::string(json::convert_all_numbers_to_string(json));
+  auto converted_json =
+      std::string(json::convert_all_numbers_to_string(json, ""));
   if (converted_json.empty()) {
     return absl::nullopt;
   }

--- a/components/brave_wallet/browser/wallet_data_files_installer.cc
+++ b/components/brave_wallet/browser/wallet_data_files_installer.cc
@@ -93,7 +93,7 @@ void OnSanitizedDappLists(data_decoder::JsonSanitizer::Result result) {
   }
 
   auto converted_json =
-      std::string(json::convert_all_numbers_to_string(*result));
+      std::string(json::convert_all_numbers_to_string(*result, ""));
   if (converted_json.empty()) {
     return;
   }

--- a/components/json/rs/src/lib.rs
+++ b/components/json/rs/src/lib.rs
@@ -23,15 +23,25 @@ mod ffi {
 // Parses and re-serializes json with the value at path converted from a uint64
 // to a string representation of the same number.
 // Returns an empty String if such conversion is not possible.
-// When optional is true, return the original string if path not found or value is null.
-// A path is a Unicode string with the reference tokens separated by /.
+// When optional is true, return the original string if path not found or value
+// is null. A path is a Unicode string with the reference tokens separated by /.
 // Inside tokens / is replaced by ~1 and ~ is replaced by ~0.
 // For more information read [RFC6901](https://tools.ietf.org/html/rfc6901).
-// Examples: convert_uint64_value_to_string("/a/b", json, false) for { a : { b : 1 }}
-//           convert_uint64_value_to_string("/a/0", json, false) for { a : [ 1 ]}
-//           convert_uint64_value_to_string("/a~0b/0", json, false) for { "a~b" : [ 1 ]}
-//           convert_uint64_value_to_string("/a~1b/0", json, false) for { "a/b" : [ 1 ]}
-//           convert_uint64_value_to_string("/a", json, true) for { a : null }
+// Examples:
+//   input: { a : { b : 1 }}
+//   convert_uint64_value_to_string("/a/b", json, false)
+//
+//   input: { a : [ 1 ]}
+//   convert_uint64_value_to_string("/a/0", json, false)
+//
+//   input: { "a~b" : [ 1 ]}
+//   convert_uint64_value_to_string("/a~0b/0", json, false)
+//
+//   input: { "a/b" : [ 1 ]}
+//   convert_uint64_value_to_string("/a~1b/0", json, false)
+//
+//   input: { a : null }
+//   convert_uint64_value_to_string("/a", json, true)
 pub fn convert_uint64_value_to_string(path: &str, json: &str, optional: bool) -> String {
     let result_value = serde_json::from_str(&json);
     if result_value.is_err() {
@@ -59,15 +69,25 @@ pub fn convert_uint64_value_to_string(path: &str, json: &str, optional: bool) ->
 // Parses and re-serializes json with the value at path converted from a int64
 // to a string representation of the same number.
 // Returns an empty String if such conversion is not possible.
-// When optional is true, return the original string if path not found or value is null.
-// A path is a Unicode string with the reference tokens separated by /.
+// When optional is true, return the original string if path not found or value
+// is null. A path is a Unicode string with the reference tokens separated by /.
 // Inside tokens / is replaced by ~1 and ~ is replaced by ~0.
 // For more information read [RFC6901](https://tools.ietf.org/html/rfc6901).
-// Examples: convert_int64_value_to_string("/a/b", json, false) for { a : { b : 1 }}
-//           convert_int64_value_to_string("/a/0", json, false) for { a : [ 1 ]}
-//           convert_int64_value_to_string("/a~0b/0", json, false) for { "a~b" : [ 1 ]}
-//           convert_int64_value_to_string("/a~1b/0", json, false) for { "a/b" : [ 1 ]}
-//           convert_int64_value_to_string("/a", json, true) for { a : null }
+// Examples:
+//   json: { a : { b : 1 }}
+//   convert_int64_value_to_string("/a/b", json, false)
+//
+//   json: { a : [ 1 ]}
+//   convert_int64_value_to_string("/a/0", json, false)
+//
+//   json: { "a~b" : [ 1 ]}
+//   convert_int64_value_to_string("/a~0b/0", json, false)
+//
+//   json: { "a/b" : [ 1 ]}
+//   convert_int64_value_to_string("/a~1b/0", json, false)
+//
+//   json: { a : null }
+//   convert_int64_value_to_string("/a", json, true)
 pub fn convert_int64_value_to_string(path: &str, json: &str, optional: bool) -> String {
     let result_value = serde_json::from_str(&json);
     if result_value.is_err() {
@@ -96,15 +116,25 @@ pub fn convert_int64_value_to_string(path: &str, json: &str, optional: bool) -> 
 // Parses and re-serializes json with the value at path converted from a string
 // to a uint64 representation of the same number.
 // Returns an empty String if such conversion is not possible.
-// When optional is true, return the original string if path not found or value is null.
-// A path is a Unicode string with the reference tokens separated by /.
+// When optional is true, return the original string if path not found or value
+// is null. A path is a Unicode string with the reference tokens separated by /.
 // Inside tokens / is replaced by ~1 and ~ is replaced by ~0.
 // For more information read [RFC6901](https://tools.ietf.org/html/rfc6901).
-// Examples: convert_string_value_to_uint64("/a/b", json, false) for { a : { b : '1' }} -> { a : { b : 1 }}
-//           convert_string_value_to_uint64("/a/0", json, false) for { a : [ '1' ]} -> { a : [ 1 ]}
-//           convert_string_value_to_uint64("/a~0c/b", json, false) for { "a~c" : { b : '1' }} -> { "a~c" : { b : 1 }}
-//           convert_string_value_to_uint64("/a~1b/0", json, false) for { "a/b" : [ '1' ]} -> { "a/b" : [ 1 ]}
-//           convert_string_value_to_uint64("/a", json, true) for { a : null }
+// Examples:
+//   json: { a : { b : '1' }} -> { a : { b : 1 }}
+//   convert_string_value_to_uint64("/a/b", json, false)
+//
+//   json: { a : [ '1' ]} -> { a : [ 1 ]}
+//   convert_string_value_to_uint64("/a/0", json, false)
+//
+//   json: { "a~c" : { b : '1' }} -> { "a~c" : { b : 1 }}
+//   convert_string_value_to_uint64("/a~0c/b", json, false)
+//
+//   json: { "a/b" : [ '1' ]} -> { "a/b" : [ 1 ]}
+//   convert_string_value_to_uint64("/a~1b/0", json, false)
+//
+//   json: { a : null }
+//   convert_string_value_to_uint64("/a", json, true)
 pub fn convert_string_value_to_uint64(path: &str, json: &str, optional: bool) -> String {
     let result_value = serde_json::from_str(&json);
     if result_value.is_err() {
@@ -137,15 +167,25 @@ pub fn convert_string_value_to_uint64(path: &str, json: &str, optional: bool) ->
 // Parses and re-serializes json with the value at path converted from a string
 // to a int64 representation of the same number.
 // Returns an empty String if such conversion is not possible.
-// When optional is true, return the original string if path not found or value is null.
-// A path is a Unicode string with the reference tokens separated by /.
+// When optional is true, return the original string if path not found or value
+// is null. A path is a Unicode string with the reference tokens separated by /.
 // Inside tokens / is replaced by ~1 and ~ is replaced by ~0.
 // For more information read [RFC6901](https://tools.ietf.org/html/rfc6901).
-// Examples: convert_string_value_to_int64("/a/b", json, false) for { a : { b : '1' }} -> { a : { b : 1 }}
-//           convert_string_value_to_int64("/a/0", json, false) for { a : [ '1' ]} -> { a : [ 1 ]}
-//           convert_string_value_to_uint64("/a~0c/b", json, false) for { "a~c" : { b : '1' }} -> { "a~c" : { b : 1 }}
-//           convert_string_value_to_uint64("/a~1b/0", json, false) for { "a/b" : [ '1' ]} -> { "a/b" : [ 1 ]}
-//           convert_string_value_to_uint64("/a", json, true) for { a : null }
+// Examples:
+//   json: { a : { b : '1' }} -> { a : { b : 1 }}
+//   convert_string_value_to_int64("/a/b", json, false)
+//
+//   json: { a : [ '1' ]} -> { a : [ 1 ]}
+//   convert_string_value_to_int64("/a/0", json, false)
+//
+//   json: { "a~c" : { b : '1' }} -> { "a~c" : { b : 1 }}
+//   convert_string_value_to_uint64("/a~0c/b", json, false)
+//
+//   json: { "a/b" : [ '1' ]} -> { "a/b" : [ 1 ]}
+//   convert_string_value_to_uint64("/a~1b/0", json, false)
+//
+//   json: { a : null }
+//   convert_string_value_to_uint64("/a", json, true)
 pub fn convert_string_value_to_int64(path: &str, json: &str, optional: bool) -> String {
     let result_value = serde_json::from_str(&json);
     if result_value.is_err() {
@@ -177,15 +217,18 @@ pub fn convert_string_value_to_int64(path: &str, json: &str, optional: bool) -> 
 }
 
 // Parses and re-serializes json with uint64 values for the given key of the
-// object located at path_to_object for all objects in the array located at path_to_array.
-// Original json string will be returned if object array at path is not found.
-// When the target uint64 value at key is not found in an object or is null,
-// the value will be unchanged.
+// object located at path_to_object for all objects in the array located at
+// path_to_array. Original json string will be returned if object array at path
+// is not found. When the target uint64 value at key is not found in an object
+// or is null, the value will be unchanged.
 // Examples:
-// convert_uint64_in_object_array_to_string("/a", "", "key", json) for
-// {a: [{"key": 1}, {"key": 2}, {"key": null]} -> {a: [{"key": "1"}, {"key": "2"}, {"key": null}]}
-// convert_uint64_in_object_array_to_string("/a", "/b", "key", json) for
-// {a: [{ "b": {"key": 1}}, {"b": {"key": 2}}, {"b": {"key": null]}} -> {a: [{"b": {"key": "1"}}, {"b": {"key": "2"}}, {"b": {"key": null}}]}
+//   in: {a: [{"key": 1}, {"key": 2}, {"key": null]}
+//   convert_uint64_in_object_array_to_string("/a", "", "key", json)
+//   out: {a: [{"key": "1"}, {"key": "2"}, {"key": null}]}
+//
+//   in: {a: [{ "b": {"key": 1}}, {"b": {"key": 2}}, {"b": {"key": null]}}
+//   convert_uint64_in_object_array_to_string("/a", "/b", "key", json)
+//   out: {a: [{"b": {"key": "1"}}, {"b": {"key": "2"}}, {"b": {"key": null}}]}
 pub fn convert_uint64_in_object_array_to_string(
     path_to_array: &str,
     path_to_object: &str,
@@ -253,7 +296,7 @@ pub fn convert_uint64_in_object_array_to_string(
 /// # Arguments
 /// * `json` - A arbitrary JSON string
 /// * `path` - A JSON pointer path to the field where the conversion is applied
-///            recursively. An empty string indicates the root of the JSON.
+///   recursively. An empty string indicates the root of the JSON.
 ///
 /// # Examples
 ///


### PR DESCRIPTION
The `gasUsedRatio` array in [`eth_feeHistory`](https://docs.infura.io/infura/networks/ethereum/json-rpc-methods/eth_feehistory) response may contain integers instead of floating-point numbers, which breaks the response parser.

Resolves https://github.com/brave/brave-browser/issues/30641

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-arm64, CI/skip-linux-x64, CI/skip-android, CI/skip-macos, CI/skip-ios, CI/skip-windows-arm64, CI/skip-windows-x64, CI/skip-windows-x86 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

Send/swap should work on Arbitrum.