### PR TITLE
Unobserve PlaylistTabHelper when it's destroyed

### DIFF
--- a/browser/playlist/playlist_tab_helper.cc
+++ b/browser/playlist/playlist_tab_helper.cc
@@ -39,7 +39,11 @@ PlaylistTabHelper::PlaylistTabHelper(content::WebContents* contents,
   service_->AddObserver(playlist_observer_receiver_.BindNewPipeAndPassRemote());
 }
 
-PlaylistTabHelper::~PlaylistTabHelper() = default;
+PlaylistTabHelper::~PlaylistTabHelper() {
+  for (auto& observer : observers_) {
+    observer.PlaylistTabHelperWillBeDestroyed();
+  }
+}
 
 void PlaylistTabHelper::AddObserver(PlaylistTabHelperObserver* observer) {
   observers_.AddObserver(observer);

--- a/browser/playlist/playlist_tab_helper_observer.h
+++ b/browser/playlist/playlist_tab_helper_observer.h
@@ -14,6 +14,7 @@ namespace playlist {
 
 class PlaylistTabHelperObserver : public base::CheckedObserver {
  public:
+  virtual void PlaylistTabHelperWillBeDestroyed() = 0;
   virtual void OnSavedItemsChanged(
       const std::vector<mojom::PlaylistItemPtr>& items) = 0;
   virtual void OnFoundItemsChanged(

--- a/browser/ui/views/playlist/playlist_action_icon_view.cc
+++ b/browser/ui/views/playlist/playlist_action_icon_view.cc
@@ -68,6 +68,10 @@ void PlaylistActionIconView::UpdateImpl() {
               playlist_tab_helper->found_items().size());
 }
 
+void PlaylistActionIconView::PlaylistTabHelperWillBeDestroyed() {
+  playlist_tab_helper_observation_.Reset();
+}
+
 void PlaylistActionIconView::OnSavedItemsChanged(
     const std::vector<playlist::mojom::PlaylistItemPtr>& saved_items) {
   auto* playlist_tab_helper = this->playlist_tab_helper();

--- a/browser/ui/views/playlist/playlist_action_icon_view.h
+++ b/browser/ui/views/playlist/playlist_action_icon_view.h
@@ -46,6 +46,7 @@ class PlaylistActionIconView : public PageActionIconView,
   }
 
   // PlaylistTabHelperObserver:
+  void PlaylistTabHelperWillBeDestroyed() override;
   void OnSavedItemsChanged(const std::vector<playlist::mojom::PlaylistItemPtr>&
                                saved_items) override;
   void OnFoundItemsChanged(const std::vector<playlist::mojom::PlaylistItemPtr>&


### PR DESCRIPTION
As PlaylistActionIconView outlives PlaylistTabHelper, we should unobserve it on destruction

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/internal/issues/1029
Resolves https://github.com/brave/brave-browser/issues/30675
Resolves https://github.com/brave/brave-browser/issues/30676
Resolves https://github.com/brave/internal/issues/1030

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-arm64, CI/skip-linux-x64, CI/skip-android, CI/skip-macos, CI/skip-ios, CI/skip-windows-arm64, CI/skip-windows-x64, CI/skip-windows-x86 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [ ] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

