### PR TITLE
Exclude unwind tables on stable builds

### DIFF
--- a/build/commands/lib/config.js
+++ b/build/commands/lib/config.js
@@ -504,6 +504,8 @@ Config.prototype.buildArgs = function () {
     } else if (this.channel === '') {
       args.android_channel = 'stable'
       args.chrome_public_manifest_package = 'com.brave.browser'
+      // Don't include unwind tables on stable builds, we can save 2.8..19.6 MBs
+      args.exclude_unwind_tables = true
     } else if (this.channel === 'beta') {
       args.chrome_public_manifest_package = 'com.brave.browser_beta'
       args.exclude_unwind_tables = false


### PR DESCRIPTION
Investigated `exclude_unwind_tables` and `enable_frame_pointers`  build parameters.
Default values before this PR were:
  | exclude_unwind_tables | enable_frame_pointers
-- | -- | --
Nightly arm32 | "false" | false
Nightly arm64 | "false" | true
Stable arm32 | "false" | false
Stable arm64 | "false" | true

Effect on modifying these is below:

  | apk arm32 | aab arm32 | apk arm64 | aab arm64
-- | -- | -- | -- | --
Nightly Initial | 157,588,154 | 86,393,506 | 264,101,133 | 131,926,529
Nightly exclude_unwind_tables=true | 157,588,154 | 86,393,506 | 264,101,133 | 131,926,529
Delta on Nightly | 0 | 0 | 0 | 0
Stable initial | 153,079,227 | 83,646,675 | 259,592,224 | 131,826,241
Stable exclude_unwind_tables=true | 150,246,435 | 82,304,973 | 239,920,824 | 124,516,365
Delta on Stable | -2,832,792 | -1,341,702 | -19,671,400 | -7,309,876
  |   |   |   |  
Stable exclude_unwind_tables=true enable_frame_pointers=false | 150,656,234 | 82,304,973 | 237,885,807 | 124,326,635
Delta on no_ut and no_fp | 409,799 | 0 | -2,035,017 | -189,730

This PR modifies only `exclude_unwind_tables` parameter. 
`enable_frame_pointers` is untouched because:
1. Effect from applying `enable_frame_pointers=false` varies, and somehow on apk arm32 the size has been increased.
2. `enable_frame_pointers` is not at `declare_args() {}` section, so cannot be set via args.gn and it needs patch.


There is a [warning](https://source.chromium.org/chromium/chromium/src/+/main:build/config/compiler/compiler.gni;l=121;drc=f18541c566eca7373acee0c7d0a25ca091602982?q=build%2Fconfig%2Fcompiler%2Fcompiler.gni&ss=chromium%2Fchromium%2Fsrc)
```
  # Include the unwind tables on Android even for official builds, as otherwise
  # the crash dumps generated by Android's debuggerd are largely useless, and
  # having this additional mechanism to understand issues is particularly helpful
  # to WebView.
```
So I tested Stable arm32 apk, arm32 aab, arm64 aab with `exclude_unwind_tables=true` to ensure:
- stack can be symbolized by tombstone message at logcat with `/src/third_party/android_platform/development/scripts/stack` tool;
- minidumps sent to backtrace.io have symbolized stacks. 
In all cases the stack was symbolized successfully.

Also I tested that builds with `exclude_unwind_tables=true && enable_frame_pointers=false` as well have symbolized crash dump stacks, though this PR doesn't touch `enable_frame_pointers` and documentation says that problems could be in such case.

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/30711

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-arm64, CI/skip-linux-x64, CI/skip-android, CI/skip-macos, CI/skip-ios, CI/skip-windows-arm64, CI/skip-windows-x64, CI/skip-windows-x86 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
1. Ensure it builds well
2. Ensure you can see symbolized crash call stacks at backtrace.io and that it is possible to symbolize crash call stacks from logcat tombstone message.
