### PR TITLE
Add core Stripe onramp support

### DIFF
--- a/components/brave_wallet/api/asset_ratio.idl
+++ b/components/brave_wallet/api/asset_ratio.idl
@@ -196,5 +196,11 @@ namespace asset_ratio {
     // A payload list.
     CoinMarketPayload[] payload;
   };
+  
+  // A payload with a URL field
+  dictionary StripeBuyURLResponse {
+    // e.g "https://crypto.link.com?session_hash=abcdefgh"
+    DOMString url;
+  };
 
 };

--- a/components/brave_wallet/browser/asset_ratio_response_parser.cc
+++ b/components/brave_wallet/browser/asset_ratio_response_parser.cc
@@ -234,4 +234,21 @@ absl::optional<std::vector<mojom::CoinMarketPtr>> ParseCoinMarkets(
   return values;
 }
 
+absl::optional<std::string> ParseGetStripeBuyURL(
+    const base::Value& json_value) {
+  // Parses results like this:
+  // POST /v2/stripe/onramp_sessions
+  // {
+  //   "url": "https://crypto.link.com?session_hash=abcdefgh"
+  // }
+  auto stripe_buy_url_response =
+      api::asset_ratio::StripeBuyURLResponse::FromValueDeprecated(json_value);
+
+  if (!stripe_buy_url_response) {
+    return absl::nullopt;
+  }
+
+  return stripe_buy_url_response->url;
+}
+
 }  // namespace brave_wallet

--- a/components/brave_wallet/browser/asset_ratio_response_parser.cc
+++ b/components/brave_wallet/browser/asset_ratio_response_parser.cc
@@ -234,10 +234,8 @@ absl::optional<std::vector<mojom::CoinMarketPtr>> ParseCoinMarkets(
   return values;
 }
 
-absl::optional<std::string> ParseGetStripeBuyURL(
-    const base::Value& json_value) {
+absl::optional<std::string> ParseStripeBuyURL(const base::Value& json_value) {
   // Parses results like this:
-  // POST /v2/stripe/onramp_sessions
   // {
   //   "url": "https://crypto.link.com?session_hash=abcdefgh"
   // }

--- a/components/brave_wallet/browser/asset_ratio_response_parser.cc
+++ b/components/brave_wallet/browser/asset_ratio_response_parser.cc
@@ -240,7 +240,7 @@ absl::optional<std::string> ParseStripeBuyURL(const base::Value& json_value) {
   //   "url": "https://crypto.link.com?session_hash=abcdefgh"
   // }
   auto stripe_buy_url_response =
-      api::asset_ratio::StripeBuyURLResponse::FromValueDeprecated(json_value);
+      api::asset_ratio::StripeBuyURLResponse::FromValue(json_value);
 
   if (!stripe_buy_url_response) {
     return absl::nullopt;

--- a/components/brave_wallet/browser/asset_ratio_response_parser.h
+++ b/components/brave_wallet/browser/asset_ratio_response_parser.h
@@ -28,7 +28,7 @@ bool ParseAssetPriceHistory(const base::Value& json_value,
 absl::optional<std::vector<mojom::CoinMarketPtr>> ParseCoinMarkets(
     const base::Value& json_value);
 
-absl::optional<std::string> ParseGetStripeBuyURL(const base::Value& json_value);
+absl::optional<std::string> ParseStripeBuyURL(const base::Value& json_value);
 
 mojom::BlockchainTokenPtr ParseTokenInfo(const base::Value& json_value,
                                          const std::string& chain_id,

--- a/components/brave_wallet/browser/asset_ratio_response_parser.h
+++ b/components/brave_wallet/browser/asset_ratio_response_parser.h
@@ -28,6 +28,8 @@ bool ParseAssetPriceHistory(const base::Value& json_value,
 absl::optional<std::vector<mojom::CoinMarketPtr>> ParseCoinMarkets(
     const base::Value& json_value);
 
+absl::optional<std::string> ParseGetStripeBuyURL(const base::Value& json_value);
+
 mojom::BlockchainTokenPtr ParseTokenInfo(const base::Value& json_value,
                                          const std::string& chain_id,
                                          mojom::CoinType coin);

--- a/components/brave_wallet/browser/asset_ratio_response_parser_unittest.cc
+++ b/components/brave_wallet/browser/asset_ratio_response_parser_unittest.cc
@@ -344,22 +344,22 @@ TEST(AssetRatioResponseParserUnitTest, ParseCoinMarkets) {
   EXPECT_FALSE(ParseCoinMarkets(ParseJson(json)));
 }
 
-TEST(AssetRatioResponseParserUnitTest, ParseGetStripeBuyURL) {
+TEST(AssetRatioResponseParserUnitTest, ParseStripeBuyURL) {
   std::string json(R"({
       "url": "https://crypto.link.com?session_hash=abcdefgh"
   })");
 
-  auto parsed_value = ParseGetStripeBuyURL(ParseJson(json));
+  auto parsed_value = ParseStripeBuyURL(ParseJson(json));
   ASSERT_TRUE(parsed_value);
   EXPECT_EQ(*parsed_value, "https://crypto.link.com?session_hash=abcdefgh");
 
   // Invalid input
   json = R"({"url": []})";
-  EXPECT_FALSE(ParseGetStripeBuyURL(ParseJson(json)));
+  EXPECT_FALSE(ParseStripeBuyURL(ParseJson(json)));
   json = "3";
-  EXPECT_FALSE(ParseGetStripeBuyURL(ParseJson(json)));
+  EXPECT_FALSE(ParseStripeBuyURL(ParseJson(json)));
   json = "[3]";
-  EXPECT_FALSE(ParseGetStripeBuyURL(ParseJson(json)));
+  EXPECT_FALSE(ParseStripeBuyURL(ParseJson(json)));
 }
 
 }  // namespace brave_wallet

--- a/components/brave_wallet/browser/asset_ratio_response_parser_unittest.cc
+++ b/components/brave_wallet/browser/asset_ratio_response_parser_unittest.cc
@@ -344,4 +344,22 @@ TEST(AssetRatioResponseParserUnitTest, ParseCoinMarkets) {
   EXPECT_FALSE(ParseCoinMarkets(ParseJson(json)));
 }
 
+TEST(AssetRatioResponseParserUnitTest, ParseGetStripeBuyURL) {
+  std::string json(R"({
+      "url": "https://crypto.link.com?session_hash=abcdefgh"
+  })");
+
+  auto parsed_value = ParseGetStripeBuyURL(ParseJson(json));
+  ASSERT_TRUE(parsed_value);
+  EXPECT_EQ(*parsed_value, "https://crypto.link.com?session_hash=abcdefgh");
+
+  // Invalid input
+  json = R"({"url": []})";
+  EXPECT_FALSE(ParseGetStripeBuyURL(ParseJson(json)));
+  json = "3";
+  EXPECT_FALSE(ParseGetStripeBuyURL(ParseJson(json)));
+  json = "[3]";
+  EXPECT_FALSE(ParseGetStripeBuyURL(ParseJson(json)));
+}
+
 }  // namespace brave_wallet

--- a/components/brave_wallet/browser/asset_ratio_service.cc
+++ b/components/brave_wallet/browser/asset_ratio_service.cc
@@ -95,18 +95,13 @@ std::vector<std::string> VectorToLowerCase(const std::vector<std::string>& v) {
   return v_lower;
 }
 
-constexpr char kEthereum[] = "ethereum";
-constexpr char kSolana[] = "solana";
-constexpr char kPolygon[] = "polygon";
-constexpr char kBitcoin[] = "bitcoin";
-
 absl::optional<std::string> ChainIdToStripeChainId(
     const std::string& chain_id) {
   static base::NoDestructor<base::flat_map<std::string, std::string>>
-      chain_id_lookup({{brave_wallet::mojom::kMainnetChainId, kEthereum},
-                       {brave_wallet::mojom::kSolanaMainnet, kSolana},
-                       {brave_wallet::mojom::kPolygonMainnetChainId, kPolygon},
-                       {brave_wallet::mojom::kBitcoinMainnet, kBitcoin}});
+      chain_id_lookup(
+          {{brave_wallet::mojom::kMainnetChainId, "ethereum"},
+           {brave_wallet::mojom::kSolanaMainnet, "solana"},
+           {brave_wallet::mojom::kPolygonMainnetChainId, "polygon"}});
   if (!chain_id_lookup->contains(chain_id)) {
     return absl::nullopt;
   }
@@ -359,6 +354,7 @@ void AssetRatioService::GetStripeBuyURL(
       ChainIdToStripeChainId(chain_id);
   if (!destination_network) {
     std::move(callback).Run("", "UNSUPPORTED_CHAIN_ID");
+    return;
   }
 
   base::Value::Dict payload;

--- a/components/brave_wallet/browser/asset_ratio_service.cc
+++ b/components/brave_wallet/browser/asset_ratio_service.cc
@@ -260,13 +260,8 @@ void AssetRatioService::GetBuyUrlV1(mojom::OnRampProvider provider,
 
     std::move(callback).Run(std::move(transak_url.spec()), absl::nullopt);
   } else if (provider == mojom::OnRampProvider::kStripe) {
-    GetStripeBuyURL(std::move(callback), address,
-                    currency_code,  // source currecy
-                    amount,         // source exchange amount
-                    chain_id,       // destination_network
-                    symbol,         // destination_currency
-                    {}              // supported_destination_networks
-    );
+    GetStripeBuyURL(std::move(callback), address, currency_code, amount,
+                    chain_id, symbol);
   } else {
     std::move(callback).Run(url, "UNSUPPORTED_ONRAMP_PROVIDER");
   }
@@ -358,8 +353,7 @@ void AssetRatioService::GetStripeBuyURL(
     const std::string& source_currency,
     const std::string& source_exchange_amount,
     const std::string& chain_id,
-    const std::string& destination_currency,
-    const std::vector<std::string>& supported_destination_networks) {
+    const std::string& destination_currency) {
   // Convert the frontend supplied chain ID to the chain ID used by Stripe
   absl::optional<std::string> destination_network =
       ChainIdToStripeChainId(chain_id);
@@ -373,18 +367,6 @@ void AssetRatioService::GetStripeBuyURL(
   AddKeyIfNotEmpty(&payload, "source_exchange_amount", source_exchange_amount);
   AddKeyIfNotEmpty(&payload, "destination_network", *destination_network);
   AddKeyIfNotEmpty(&payload, "destination_currency", destination_currency);
-
-  // Convert supported_destination_networks to base::Value::List
-  base::Value::List supported_destination_networks_value;
-  for (const auto& network : supported_destination_networks) {
-    supported_destination_networks_value.Append(base::Value(network));
-  }
-
-  // Add supported_destination_networks to payload
-  if (!supported_destination_networks_value.empty()) {
-    payload.Set("supported_destination_networks",
-                std::move(supported_destination_networks_value));
-  }
 
   const std::string json_payload = GetJSON(payload);
 

--- a/components/brave_wallet/browser/asset_ratio_service.cc
+++ b/components/brave_wallet/browser/asset_ratio_service.cc
@@ -392,7 +392,7 @@ void AssetRatioService::OnGetStripeBuyURL(GetBuyUrlV1Callback callback,
     return;
   }
 
-  auto url = ParseGetStripeBuyURL(api_request_result.value_body());
+  auto url = ParseStripeBuyURL(api_request_result.value_body());
   if (!url) {
     std::move(callback).Run("", "PARSING_ERROR");
     return;

--- a/components/brave_wallet/browser/asset_ratio_service.h
+++ b/components/brave_wallet/browser/asset_ratio_service.h
@@ -118,7 +118,7 @@ class AssetRatioService : public KeyedService, public mojom::AssetRatioService {
       const std::string& address,
       const std::string& source_currency,
       const std::string& source_exchange_amount,
-      const std::string& destination_network,
+      const std::string& chain_id,
       const std::string& destination_currency,
       const std::vector<std::string>& supported_destination_networks);
 

--- a/components/brave_wallet/browser/asset_ratio_service.h
+++ b/components/brave_wallet/browser/asset_ratio_service.h
@@ -113,14 +113,12 @@ class AssetRatioService : public KeyedService, public mojom::AssetRatioService {
                              GetBuyUrlV1Callback callback,
                              APIRequestResult api_request_result);
 
-  void GetStripeBuyURL(
-      GetBuyUrlV1Callback callback,
-      const std::string& address,
-      const std::string& source_currency,
-      const std::string& source_exchange_amount,
-      const std::string& chain_id,
-      const std::string& destination_currency,
-      const std::vector<std::string>& supported_destination_networks);
+  void GetStripeBuyURL(GetBuyUrlV1Callback callback,
+                       const std::string& address,
+                       const std::string& source_currency,
+                       const std::string& source_exchange_amount,
+                       const std::string& chain_id,
+                       const std::string& destination_currency);
 
   void OnGetStripeBuyURL(GetBuyUrlV1Callback callback,
                          APIRequestResult api_request_result);

--- a/components/brave_wallet/browser/asset_ratio_service.h
+++ b/components/brave_wallet/browser/asset_ratio_service.h
@@ -103,6 +103,8 @@ class AssetRatioService : public KeyedService, public mojom::AssetRatioService {
       scoped_refptr<network::SharedURLLoaderFactory> url_loader_factory);
 
  private:
+  friend class AssetRatioServiceUnitTest;
+  FRIEND_TEST_ALL_PREFIXES(AssetRatioServiceUnitTest, GetStripeBuyURL);
   void OnGetSardineAuthToken(const std::string& network,
                              const std::string& address,
                              const std::string& symbol,
@@ -110,6 +112,18 @@ class AssetRatioService : public KeyedService, public mojom::AssetRatioService {
                              const std::string& currency_code,
                              GetBuyUrlV1Callback callback,
                              APIRequestResult api_request_result);
+
+  void GetStripeBuyURL(
+      GetBuyUrlV1Callback callback,
+      const std::string& address,
+      const std::string& source_currency,
+      const std::string& source_exchange_amount,
+      const std::string& destination_network,
+      const std::string& destination_currency,
+      const std::vector<std::string>& supported_destination_networks);
+
+  void OnGetStripeBuyURL(GetBuyUrlV1Callback callback,
+                         APIRequestResult api_request_result);
 
   void OnGetPrice(std::vector<std::string> from_assets,
                   std::vector<std::string> to_assets,

--- a/components/brave_wallet/browser/asset_ratio_service_unittest.cc
+++ b/components/brave_wallet/browser/asset_ratio_service_unittest.cc
@@ -534,4 +534,27 @@ TEST_F(AssetRatioServiceUnitTest, GetCoinMarketsUnexpectedResponse) {
   EXPECT_TRUE(callback_run);
 }
 
+TEST_F(AssetRatioServiceUnitTest, GetStripeBuyURL) {
+  // bool callback_run = false;
+  SetInterceptor(R"({
+      "url": "https://crypto.link.com?session_hash=abcdefgh"
+    })");
+
+  TestGetBuyUrlV1(mojom::OnRampProvider::kStripe, mojom::kMainnetChainId,
+                  "0xdeadbeef", "USDC", "55000000", "USD",
+                  "https://crypto.link.com?session_hash=abcdefgh",
+                  absl::nullopt);
+
+  // Test with unexpected response
+  SetInterceptor("mischief managed");
+  TestGetBuyUrlV1(mojom::OnRampProvider::kStripe, mojom::kMainnetChainId,
+                  "0xdeadbeef", "USDC", "55000000", "USD", "", "PARSING_ERROR");
+
+  // Test with non 2XX response
+  SetErrorInterceptor("");
+  TestGetBuyUrlV1(mojom::OnRampProvider::kStripe, mojom::kMainnetChainId,
+                  "0xdeadbeef", "USDC", "55000000", "USD", "",
+                  "INTERNAL_SERVICE_ERROR");
+}
+
 }  // namespace brave_wallet

--- a/components/brave_wallet/browser/asset_ratio_service_unittest.cc
+++ b/components/brave_wallet/browser/asset_ratio_service_unittest.cc
@@ -535,7 +535,6 @@ TEST_F(AssetRatioServiceUnitTest, GetCoinMarketsUnexpectedResponse) {
 }
 
 TEST_F(AssetRatioServiceUnitTest, GetStripeBuyURL) {
-  // bool callback_run = false;
   SetInterceptor(R"({
       "url": "https://crypto.link.com?session_hash=abcdefgh"
     })");

--- a/components/brave_wallet/common/brave_wallet.mojom
+++ b/components/brave_wallet/common/brave_wallet.mojom
@@ -717,7 +717,8 @@ interface KeyringServiceObserver {
 enum OnRampProvider {
   kRamp = 0,
   kSardine = 1,
-  kTransak = 2
+  kTransak = 2,
+  kStripe = 3
 };
 
 enum OffRampProvider {


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/30724

Adds support for a the Stripe onramp provider, in the `AssetRatioService::GetBuyUrlV1` API.   `GetBuyUrlV1` calls `GetStripeBuyUrl` if the onramp provider is `kStripe`.  `GetStripeBuyUrl` makes an API call to the API developed in https://github.com/brave-intl/bat-go/pull/1843 to fetch a buy URL, which is returned to the frontend.

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-arm64, CI/skip-linux-x64, CI/skip-android, CI/skip-macos, CI/skip-ios, CI/skip-windows-arm64, CI/skip-windows-x64, CI/skip-windows-x86 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

