### PR TITLE
fix(wallet): fix EIP-1559 gas estimation issue with zksync

### DIFF
--- a/components/brave_wallet/browser/eth_gas_utils.cc
+++ b/components/brave_wallet/browser/eth_gas_utils.cc
@@ -16,6 +16,33 @@ namespace brave_wallet {
 
 namespace eth {
 
+absl::optional<uint256_t> ScaleBaseFeePerGas(const std::string value) {
+  uint256_t value_uint256;
+  if (!HexValueToUint256(value, &value_uint256)) {
+    return absl::nullopt;
+  }
+
+  // We use "double" math and this is unlikely to get hit, so return
+  // absl::nullopt if the value is too big.
+  if (value_uint256 > kMaxSafeIntegerUint64) {
+    return absl::nullopt;
+  }
+
+  // Compiler crashes without these 2 casts :(
+  double value_double =
+      static_cast<double>(static_cast<uint64_t>(value_uint256));
+
+  // The base fee is not part of the RLP. We only specify priority fee and max
+  // fee. So the excess will be refunded and it will be at most 33% It's best
+  // to assume a larger value here so there's a better chance it will get in
+  // the next block and if it's too high it will go back to the user.
+  value_double *= 1.33;
+  value_double = std::floor(value_double);
+
+  // Compiler crashes without these 2 casts :(
+  return (uint256_t)(uint64_t)value_double;
+}
+
 // Assumes there are 3 reward percentiles per element
 // The first for low, the second for avg, and the third for high.
 // The following calculations will be made:
@@ -48,30 +75,12 @@ bool GetSuggested1559Fees(const std::vector<std::string>& base_fee_per_gas,
   // "pending" is the last element in base_fee_per_gas
   // "latest" is the 2nd last element in base_fee_per_gas
   std::string pending_base_fee_per_gas = base_fee_per_gas.back();
-  uint256_t pending_base_fee_per_gas_uint;
-  if (!HexValueToUint256(pending_base_fee_per_gas,
-                         &pending_base_fee_per_gas_uint)) {
+
+  auto scaled_base_fee_per_gas = ScaleBaseFeePerGas(pending_base_fee_per_gas);
+  if (!scaled_base_fee_per_gas) {
     return false;
   }
-
-  // We use "double" math and this is unlikely to get hit, so return false
-  // if the value is too big.
-  if (pending_base_fee_per_gas_uint > kMaxSafeIntegerUint64) {
-    return false;
-  }
-
-  // Compiler crashes without these 2 casts :(
-  double pending_base_fee_per_gas_dbl =
-      static_cast<double>(static_cast<uint64_t>(pending_base_fee_per_gas_uint));
-  // The base fee is not part of the RLP. We only specify priority fee and max
-  // fee. So the excess will be refunded and it will be at most 33% It's best
-  // to assume a larger value here so there's a better chance it will get in the
-  // next block and if it's too high it will go back to the user
-  pending_base_fee_per_gas_dbl *= 1.33;
-  pending_base_fee_per_gas_dbl = std::floor(pending_base_fee_per_gas_dbl);
-  // Compiler crashes without these 2 casts :(
-  *suggested_base_fee_per_gas =
-      (uint256_t)(uint64_t)pending_base_fee_per_gas_dbl;
+  *suggested_base_fee_per_gas = *scaled_base_fee_per_gas;
 
   const uint256_t fallback_priority_fee = uint256_t(2e9);
   *low_priority_fee = fallback_priority_fee;

--- a/components/brave_wallet/browser/eth_gas_utils.h
+++ b/components/brave_wallet/browser/eth_gas_utils.h
@@ -15,7 +15,7 @@ namespace brave_wallet {
 
 namespace eth {
 
-absl::optional<uint256_t> ScaleBaseFeePerGas(const std::string value);
+absl::optional<uint256_t> ScaleBaseFeePerGas(const std::string& value);
 
 bool GetSuggested1559Fees(const std::vector<std::string>& base_fee_per_gas,
                           const std::vector<double>& gas_used_ratio,

--- a/components/brave_wallet/browser/eth_gas_utils.h
+++ b/components/brave_wallet/browser/eth_gas_utils.h
@@ -15,6 +15,8 @@ namespace brave_wallet {
 
 namespace eth {
 
+absl::optional<uint256_t> ScaleBaseFeePerGas(const std::string value);
+
 bool GetSuggested1559Fees(const std::vector<std::string>& base_fee_per_gas,
                           const std::vector<double>& gas_used_ratio,
                           const std::string& oldest_block,

--- a/components/brave_wallet/browser/eth_gas_utils_unittest.cc
+++ b/components/brave_wallet/browser/eth_gas_utils_unittest.cc
@@ -8,11 +8,27 @@
 #include <vector>
 
 #include "brave/components/brave_wallet/browser/eth_gas_utils.h"
+#include "brave/components/brave_wallet/common/hex_utils.h"
 #include "testing/gtest/include/gtest/gtest.h"
 
 namespace brave_wallet {
 
 namespace eth {
+
+TEST(EthGasUtilsTest, ScaleBaseFeePerGas) {
+  // OK: scale 0x64 (100)
+  EXPECT_EQ(ScaleBaseFeePerGas("0x64"), 133ULL);
+
+  // OK: scale 0x0 (0)
+  EXPECT_EQ(ScaleBaseFeePerGas("0x0"), 0ULL);
+
+  // KO: invalid hex
+  EXPECT_FALSE(ScaleBaseFeePerGas("invalid"));
+
+  // KO: value is too big
+  EXPECT_FALSE(
+      ScaleBaseFeePerGas(Uint256ValueToHex(kMaxSafeIntegerUint64 + 1)));
+}
 
 TEST(EthGasUtilsTest, GetSuggested1559Fees) {
   const std::vector<std::string> base_fee_per_gas{

--- a/components/brave_wallet/browser/eth_tx_manager.cc
+++ b/components/brave_wallet/browser/eth_tx_manager.cc
@@ -1136,19 +1136,30 @@ void EthTxManager::RetryTransaction(const std::string& chain_id,
 void EthTxManager::GetGasEstimation1559(const std::string& chain_id,
                                         GetGasEstimation1559Callback callback) {
   json_rpc_service_->GetFeeHistory(
-      chain_id,
-      base::BindOnce(&EthTxManager::OnGetGasEstimation1559,
-                     weak_factory_.GetWeakPtr(), std::move(callback)));
+      chain_id, base::BindOnce(&EthTxManager::OnGetGasEstimation1559,
+                               weak_factory_.GetWeakPtr(), std::move(callback),
+                               chain_id));
 }
 
 void EthTxManager::OnGetGasEstimation1559(
     GetGasEstimation1559Callback callback,
+    const std::string& chain_id,
     const std::vector<std::string>& base_fee_per_gas,
     const std::vector<double>& gas_used_ratio,
     const std::string& oldest_block,
     const std::vector<std::vector<std::string>>& reward,
     mojom::ProviderError error,
     const std::string& error_message) {
+  // If eth_feeHistory method was not found, try to get the base fee
+  // from eth_getBlockByNumber.
+  if (error == mojom::ProviderError::kMethodNotFound) {
+    json_rpc_service_->GetBaseFeePerGas(
+        chain_id, base::BindOnce(&EthTxManager::OnGetBaseFeePerGas,
+                                 weak_factory_.GetWeakPtr(),
+                                 std::move(callback), chain_id));
+    return;
+  }
+
   if (error != mojom::ProviderError::kSuccess) {
     std::move(callback).Run(nullptr);
     return;
@@ -1180,6 +1191,37 @@ void EthTxManager::OnGetGasEstimation1559(
       Uint256ValueToHex(suggested_base_fee_per_gas + avg_priority_fee);
   estimation->fast_max_fee_per_gas =
       Uint256ValueToHex(suggested_base_fee_per_gas + high_priority_fee);
+  std::move(callback).Run(std::move(estimation));
+}
+
+void EthTxManager::OnGetBaseFeePerGas(GetGasEstimation1559Callback callback,
+                                      const std::string& chain_id,
+                                      const std::string& base_fee_per_gas,
+                                      mojom::ProviderError error,
+                                      const std::string& error_message) {
+  if (base_fee_per_gas.empty()) {
+    std::move(callback).Run(nullptr);
+    return;
+  }
+
+  mojom::GasEstimation1559Ptr estimation = mojom::GasEstimation1559::New();
+  auto scaled_base_fee_per_gas_uint256 =
+      eth::ScaleBaseFeePerGas(base_fee_per_gas);
+  if (!scaled_base_fee_per_gas_uint256) {
+    std::move(callback).Run(nullptr);
+    return;
+  }
+
+  const auto& scaled_base_fee_per_gas =
+      Uint256ValueToHex(*scaled_base_fee_per_gas_uint256);
+
+  estimation->base_fee_per_gas = scaled_base_fee_per_gas;
+  estimation->slow_max_priority_fee_per_gas = "0x0";
+  estimation->avg_max_priority_fee_per_gas = "0x0";
+  estimation->fast_max_priority_fee_per_gas = "0x0";
+  estimation->slow_max_fee_per_gas = scaled_base_fee_per_gas;
+  estimation->avg_max_fee_per_gas = scaled_base_fee_per_gas;
+  estimation->fast_max_fee_per_gas = scaled_base_fee_per_gas;
   std::move(callback).Run(std::move(estimation));
 }
 

--- a/components/brave_wallet/browser/eth_tx_manager.cc
+++ b/components/brave_wallet/browser/eth_tx_manager.cc
@@ -1154,9 +1154,9 @@ void EthTxManager::OnGetGasEstimation1559(
   // from eth_getBlockByNumber.
   if (error == mojom::ProviderError::kMethodNotFound) {
     json_rpc_service_->GetBaseFeePerGas(
-        chain_id, base::BindOnce(&EthTxManager::OnGetBaseFeePerGas,
-                                 weak_factory_.GetWeakPtr(),
-                                 std::move(callback), chain_id));
+        chain_id,
+        base::BindOnce(&EthTxManager::OnGetBaseFeePerGas,
+                       weak_factory_.GetWeakPtr(), std::move(callback)));
     return;
   }
 
@@ -1195,7 +1195,6 @@ void EthTxManager::OnGetGasEstimation1559(
 }
 
 void EthTxManager::OnGetBaseFeePerGas(GetGasEstimation1559Callback callback,
-                                      const std::string& chain_id,
                                       const std::string& base_fee_per_gas,
                                       mojom::ProviderError error,
                                       const std::string& error_message) {

--- a/components/brave_wallet/browser/eth_tx_manager.h
+++ b/components/brave_wallet/browser/eth_tx_manager.h
@@ -228,6 +228,7 @@ class EthTxManager : public TxManager, public EthBlockTracker::Observer {
       const std::string& error_message);
   void OnGetGasEstimation1559(
       GetGasEstimation1559Callback callback,
+      const std::string& chain_id,
       const std::vector<std::string>& base_fee_per_gas,
       const std::vector<double>& gas_used_ratio,
       const std::string& oldest_block,
@@ -285,6 +286,12 @@ class EthTxManager : public TxManager, public EthBlockTracker::Observer {
       bool status,
       mojom::ProviderErrorUnionPtr error_union,
       const std::string& error_message);
+
+  void OnGetBaseFeePerGas(GetGasEstimation1559Callback callback,
+                          const std::string& chain_id,
+                          const std::string& base_fee_per_gas,
+                          mojom::ProviderError error,
+                          const std::string& error_message);
 
   // EthBlockTracker::Observer:
   void OnLatestBlock(const std::string& chain_id,

--- a/components/brave_wallet/browser/eth_tx_manager.h
+++ b/components/brave_wallet/browser/eth_tx_manager.h
@@ -288,7 +288,6 @@ class EthTxManager : public TxManager, public EthBlockTracker::Observer {
       const std::string& error_message);
 
   void OnGetBaseFeePerGas(GetGasEstimation1559Callback callback,
-                          const std::string& chain_id,
                           const std::string& base_fee_per_gas,
                           mojom::ProviderError error,
                           const std::string& error_message);

--- a/components/brave_wallet/browser/json_rpc_service.cc
+++ b/components/brave_wallet/browser/json_rpc_service.cc
@@ -613,19 +613,20 @@ void JsonRpcService::MaybeUpdateIsEip1559(const std::string& chain_id) {
     return;
   }
 
-  GetIsEip1559(chain_id,
-               base::BindOnce(&JsonRpcService::UpdateIsEip1559,
-                              weak_ptr_factory_.GetWeakPtr(), chain_id));
+  GetBaseFeePerGas(chain_id,
+                   base::BindOnce(&JsonRpcService::UpdateIsEip1559,
+                                  weak_ptr_factory_.GetWeakPtr(), chain_id));
 }
 
 void JsonRpcService::UpdateIsEip1559(const std::string& chain_id,
-                                     bool is_eip1559,
+                                     const std::string& base_fee_per_gas,
                                      mojom::ProviderError error,
                                      const std::string& error_message) {
   if (error != mojom::ProviderError::kSuccess) {
     return;
   }
 
+  bool is_eip1559 = !base_fee_per_gas.empty();
   bool changed = false;
   if (chain_id == brave_wallet::mojom::kLocalhostChainId) {
     changed = prefs_->GetBoolean(kSupportEip1559OnLocalhostChain) != is_eip1559;
@@ -2108,21 +2109,26 @@ void JsonRpcService::OnGetGasPrice(GetGasPriceCallback callback,
   std::move(callback).Run(*result, mojom::ProviderError::kSuccess, "");
 }
 
-void JsonRpcService::GetIsEip1559(const std::string& chain_id,
-                                  GetIsEip1559Callback callback) {
+// Retrieves the BASEFEE per gas for a given chain ID.
+//
+// If the chain does not support EIP-1559, and assuming no other provider
+// errors, an empty string as base fee with kSuccess error will be delivered
+// to the provided callback.
+void JsonRpcService::GetBaseFeePerGas(const std::string& chain_id,
+                                      GetBaseFeePerGasCallback callback) {
   auto internal_callback =
-      base::BindOnce(&JsonRpcService::OnGetIsEip1559,
+      base::BindOnce(&JsonRpcService::OnGetBaseFeePerGas,
                      weak_ptr_factory_.GetWeakPtr(), std::move(callback));
   RequestInternal(eth::eth_getBlockByNumber(kEthereumBlockTagLatest, false),
                   true, GetNetworkURL(prefs_, chain_id, mojom::CoinType::ETH),
                   std::move(internal_callback));
 }
 
-void JsonRpcService::OnGetIsEip1559(GetIsEip1559Callback callback,
-                                    APIRequestResult api_request_result) {
+void JsonRpcService::OnGetBaseFeePerGas(GetBaseFeePerGasCallback callback,
+                                        APIRequestResult api_request_result) {
   if (!api_request_result.Is2XXResponseCode()) {
     std::move(callback).Run(
-        false, mojom::ProviderError::kInternalError,
+        "", mojom::ProviderError::kInternalError,
         l10n_util::GetStringUTF8(IDS_WALLET_INTERNAL_ERROR));
     return;
   }
@@ -2133,13 +2139,17 @@ void JsonRpcService::OnGetIsEip1559(GetIsEip1559Callback callback,
     std::string error_message;
     ParseErrorResult<mojom::ProviderError>(api_request_result.value_body(),
                                            &error, &error_message);
-    std::move(callback).Run(false, error, error_message);
+    std::move(callback).Run("", error, error_message);
     return;
   }
 
   const std::string* base_fee = result->FindString("baseFeePerGas");
-  std::move(callback).Run(base_fee && !base_fee->empty(),
-                          mojom::ProviderError::kSuccess, "");
+  if (base_fee && !base_fee->empty()) {
+    std::move(callback).Run(*base_fee, mojom::ProviderError::kSuccess, "");
+  } else {
+    // Successful response, but the chain does not support EIP-1559.
+    std::move(callback).Run("", mojom::ProviderError::kSuccess, "");
+  }
 }
 
 void JsonRpcService::GetBlockByNumber(const std::string& chain_id,

--- a/components/brave_wallet/browser/json_rpc_service.h
+++ b/components/brave_wallet/browser/json_rpc_service.h
@@ -314,11 +314,12 @@ class JsonRpcService : public KeyedService, public mojom::JsonRpcService {
                               const std::string& error_message)>;
   void GetGasPrice(const std::string& chain_id, GetGasPriceCallback callback);
 
-  using GetIsEip1559Callback =
-      base::OnceCallback<void(bool is_eip1559,
+  using GetBaseFeePerGasCallback =
+      base::OnceCallback<void(const std::string& base_fee_per_gas,
                               mojom::ProviderError error,
                               const std::string& error_message)>;
-  void GetIsEip1559(const std::string& chain_id, GetIsEip1559Callback callback);
+  void GetBaseFeePerGas(const std::string& chain_id,
+                        GetBaseFeePerGasCallback callback);
 
   using GetBlockByNumberCallback =
       base::OnceCallback<void(base::Value result,
@@ -594,14 +595,14 @@ class JsonRpcService : public KeyedService, public mojom::JsonRpcService {
                         APIRequestResult api_request_result);
   void OnGetGasPrice(GetGasPriceCallback callback,
                      APIRequestResult api_request_result);
-  void OnGetIsEip1559(GetIsEip1559Callback callback,
-                      APIRequestResult api_request_result);
+  void OnGetBaseFeePerGas(GetBaseFeePerGasCallback callback,
+                          APIRequestResult api_request_result);
   void OnGetBlockByNumber(GetBlockByNumberCallback callback,
                           APIRequestResult api_request_result);
 
   void MaybeUpdateIsEip1559(const std::string& chain_id);
   void UpdateIsEip1559(const std::string& chain_id,
-                       bool is_eip1559,
+                       const std::string& base_fee_per_gas,
                        mojom::ProviderError error,
                        const std::string& error_message);
 

--- a/components/brave_wallet/browser/json_rpc_service_unittest.cc
+++ b/components/brave_wallet/browser/json_rpc_service_unittest.cc
@@ -3500,58 +3500,56 @@ TEST_F(UnstoppableDomainsUnitTest, ResolveDns_ManyCalls) {
   testing::Mock::VerifyAndClearExpectations(&callback3);
 }
 
-TEST_F(JsonRpcServiceUnitTest, GetIsEip1559) {
+TEST_F(JsonRpcServiceUnitTest, GetBaseFeePerGas) {
   bool callback_called = false;
   GURL expected_network =
       GetNetwork(mojom::kLocalhostChainId, mojom::CoinType::ETH);
   // Successful path when the network is EIP1559
   SetIsEip1559Interceptor(expected_network, true);
-  json_rpc_service_->GetIsEip1559(
+  json_rpc_service_->GetBaseFeePerGas(
       mojom::kLocalhostChainId,
-      base::BindOnce(&OnBoolResponse, &callback_called,
-                     mojom::ProviderError::kSuccess, "", true));
+      base::BindOnce(&OnStringResponse, &callback_called,
+                     mojom::ProviderError::kSuccess, "", "0x181f22e7a9"));
   base::RunLoop().RunUntilIdle();
   EXPECT_TRUE(callback_called);
 
   // Successful path when the network is not EIP1559
   callback_called = false;
   SetIsEip1559Interceptor(expected_network, false);
-  json_rpc_service_->GetIsEip1559(
+  json_rpc_service_->GetBaseFeePerGas(
       mojom::kLocalhostChainId,
-      base::BindOnce(&OnBoolResponse, &callback_called,
-                     mojom::ProviderError::kSuccess, "", false));
+      base::BindOnce(&OnStringResponse, &callback_called,
+                     mojom::ProviderError::kSuccess, "", ""));
   base::RunLoop().RunUntilIdle();
   EXPECT_TRUE(callback_called);
 
   callback_called = false;
   SetHTTPRequestTimeoutInterceptor();
-  json_rpc_service_->GetIsEip1559(
+  json_rpc_service_->GetBaseFeePerGas(
       mojom::kLocalhostChainId,
-      base::BindOnce(&OnBoolResponse, &callback_called,
+      base::BindOnce(&OnStringResponse, &callback_called,
                      mojom::ProviderError::kInternalError,
-                     l10n_util::GetStringUTF8(IDS_WALLET_INTERNAL_ERROR),
-                     false));
+                     l10n_util::GetStringUTF8(IDS_WALLET_INTERNAL_ERROR), ""));
   base::RunLoop().RunUntilIdle();
   EXPECT_TRUE(callback_called);
 
   callback_called = false;
   SetInvalidJsonInterceptor();
-  json_rpc_service_->GetIsEip1559(
+  json_rpc_service_->GetBaseFeePerGas(
       mojom::kLocalhostChainId,
-      base::BindOnce(&OnBoolResponse, &callback_called,
+      base::BindOnce(&OnStringResponse, &callback_called,
                      mojom::ProviderError::kParsingError,
-                     l10n_util::GetStringUTF8(IDS_WALLET_PARSING_ERROR),
-                     false));
+                     l10n_util::GetStringUTF8(IDS_WALLET_PARSING_ERROR), ""));
   base::RunLoop().RunUntilIdle();
   EXPECT_TRUE(callback_called);
 
   callback_called = false;
   SetLimitExceededJsonErrorResponse();
-  json_rpc_service_->GetIsEip1559(
+  json_rpc_service_->GetBaseFeePerGas(
       mojom::kLocalhostChainId,
-      base::BindOnce(&OnBoolResponse, &callback_called,
+      base::BindOnce(&OnStringResponse, &callback_called,
                      mojom::ProviderError::kLimitExceeded,
-                     "Request exceeds defined limit", false));
+                     "Request exceeds defined limit", ""));
   base::RunLoop().RunUntilIdle();
   EXPECT_TRUE(callback_called);
 }


### PR DESCRIPTION
It's possible that an EVM chain supports EIP-1559 (i.e., there's a `baseFeePerGas` field in the response of `eth_getBlockByNumber` RPC), but it doesn't implement `eth_feeHistory`. This is the case with zksync, but looks like other rollups and app-chains can have this behaviour too. This PR adds a fallback to retrieve the baseFee from the block headers, in case the `eth_feeHistory` method does not exist.

⚠️ It is now twice as slow to query EIP-1559 gas estimations on zksync, which is refreshed every 15s for liveness. Users will most certainly notice a lag, particularly if the RPC endpoint is a slow one. I'm currently working on a separate task to optimise refetching of these estimates, in addition to general performance improvements to the panel, but that is outside the scope of this PR.

Resolves https://github.com/brave/brave-browser/issues/30473

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-arm64, CI/skip-linux-x64, CI/skip-android, CI/skip-macos, CI/skip-ios, CI/skip-windows-arm64, CI/skip-windows-x64, CI/skip-windows-x86 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

(add zksync Era mainnet first)

1. Swaps on https://syncswap.xyz should work.
2. Sends on zksync should work. You can easily bridge some ETH to zksync using https://bungee.exchange.