### PR TITLE
Fixed CHECK & DCHECK failure from download bubble (uplift to 1.53.x)

### DIFF
--- a/patches/chrome-browser-ui-views-download-bubble-download_bubble_security_view.cc.patch
+++ b/patches/chrome-browser-ui-views-download-bubble-download_bubble_security_view.cc.patch
@@ -1,0 +1,12 @@
+diff --git a/chrome/browser/ui/views/download/bubble/download_bubble_security_view.cc b/chrome/browser/ui/views/download/bubble/download_bubble_security_view.cc
+index 97b2152c4862ef6f8fbb4593446b9998f44757c6..35b36e4e0838e12b2acd074f31f1bcc932b71b4d 100644
+--- a/chrome/browser/ui/views/download/bubble/download_bubble_security_view.cc
++++ b/chrome/browser/ui/views/download/bubble/download_bubble_security_view.cc
+@@ -327,6 +327,7 @@ void DownloadBubbleSecurityView::UpdateAccessibilityTextAndFocus() {
+   // Announce that the subpage was opened to inform the user about the changes
+   // in the UI.
+ #if BUILDFLAG(IS_MAC)
++  GetViewAccessibility().OverrideRole(ax::mojom::Role::kAlert);
+   GetViewAccessibility().OverrideName(ui_info.warning_summary);
+   NotifyAccessibilityEvent(ax::mojom::Event::kAlert, true);
+ #else

--- a/patches/chrome-browser-ui-views-download-bubble-download_toolbar_button_view.cc.patch
+++ b/patches/chrome-browser-ui-views-download-bubble-download_toolbar_button_view.cc.patch
@@ -1,0 +1,20 @@
+diff --git a/chrome/browser/ui/views/download/bubble/download_toolbar_button_view.cc b/chrome/browser/ui/views/download/bubble/download_toolbar_button_view.cc
+index 394cded1d5e83248d5f26b371c2f2f521d760163..126eab298d57bdbd129873f5754aaf68ce6f06f3 100644
+--- a/chrome/browser/ui/views/download/bubble/download_toolbar_button_view.cc
++++ b/chrome/browser/ui/views/download/bubble/download_toolbar_button_view.cc
+@@ -419,6 +419,7 @@ void DownloadToolbarButtonView::OpenPrimaryDialog() {
+   primary_view_->SetVisible(true);
+   security_view_->SetVisible(false);
+   bubble_delegate_->SetButtons(ui::DIALOG_BUTTON_NONE);
++  bubble_delegate_->SetDefaultButton(ui::DIALOG_BUTTON_NONE);
+   bubble_delegate_->set_margins(GetPrimaryViewMargin());
+   ResizeDialog();
+ }
+@@ -468,6 +469,7 @@ void DownloadToolbarButtonView::CreateBubbleDialogDelegate(
+   bubble_delegate->SetShowTitle(false);
+   bubble_delegate->SetShowCloseButton(false);
+   bubble_delegate->SetButtons(ui::DIALOG_BUTTON_NONE);
++  bubble_delegate->SetDefaultButton(ui::DIALOG_BUTTON_NONE);
+   bubble_delegate->RegisterDeleteDelegateCallback(
+       base::BindOnce(&DownloadToolbarButtonView::OnBubbleDelegateDeleted,
+                      weak_factory_.GetWeakPtr()));


### PR DESCRIPTION
Uplift of #18703
fix https://github.com/brave/brave-browser/issues/30626

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.