### PR TITLE
Remove query trackers from Hive newsletters

### DIFF
--- a/browser/net/brave_query_filter.cc
+++ b/browser/net/brave_query_filter.cc
@@ -61,9 +61,13 @@ static constexpr auto kSimpleQueryStringTrackers =
          "vgo_ee"});
 
 static constexpr auto kConditionalQueryStringTrackers =
-    base::MakeFixedFlatMap<base::StringPiece, base::StringPiece>(
-        {// https://github.com/brave/brave-browser/issues/9018
-         {"mkt_tok", "([uU]nsubscribe|emailWebview)"}});
+    base::MakeFixedFlatMap<base::StringPiece, base::StringPiece>({
+        // https://github.com/brave/brave-browser/issues/9018
+        {"mkt_tok", "([uU]nsubscribe|emailWebview)"},
+        // https://github.com/brave/brave-browser/issues/30731
+        {"h_sid", "/email/"},
+        {"h_slt", "/email/"},
+    });
 
 static constexpr auto kScopedQueryStringTrackers =
     base::MakeFixedFlatMap<base::StringPiece, base::StringPiece>({


### PR DESCRIPTION
Fixes brave/brave-browser#30731

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-arm64, CI/skip-linux-x64, CI/skip-android, CI/skip-macos, CI/skip-ios, CI/skip-windows-arm64, CI/skip-windows-x64, CI/skip-windows-x86 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

1. Open <https://brave.com/?h_sid=1234&h_slt=eyJoYXNoIjogImFiY2QxMjM0IiwgInVzZXItaWQiOiAxMjM0NTZ9>.
2. Confirm that the URL in the URL bar is just <https://brave.com/> (i.e. the query parameters have automatically been removed.
3. Open <https://app.hive.co/email/28077/view/public?h_sid=1271475706-5aba9932b99a399aeb76f234&hash=a5a07febf520004>.
4. Make sure that the email is displayed. Broken images are expected, but the text should be there and we shouldn't get an HTTP 403 error.