### PR TITLE
Give extra left side padding always to tab view

### DIFF
--- a/browser/ui/views/tabs/BUILD.gn
+++ b/browser/ui/views/tabs/BUILD.gn
@@ -32,3 +32,23 @@ source_set("browser_tests") {
     ]
   }
 }
+
+source_set("unit_tests") {
+  testonly = true
+
+  sources = [
+    "//chrome/browser/ui/views/tabs/fake_tab_slot_controller.cc",
+    "//chrome/browser/ui/views/tabs/fake_tab_slot_controller.h",
+    "brave_tab_unittest.cc",
+  ]
+
+  deps = [
+    "//base",
+    "//brave/common",
+    "//chrome/browser/ui",
+    "//chrome/test:test_support",
+    "//content/test:test_support",
+    "//testing/gmock",
+    "//testing/gtest",
+  ]
+}

--- a/browser/ui/views/tabs/brave_tab.cc
+++ b/browser/ui/views/tabs/brave_tab.cc
@@ -189,6 +189,17 @@ void BraveTab::UpdateIconVisibility() {
       showing_icon_ = !showing_alert_indicator_ && !showing_close_button_;
     }
   }
+
+  // Supplement extra left side padding by updating border.
+  // Upstream gives extra padding to balance with right side padding space but
+  // it's gone when tab doesn't have sufficient available width. In our case,
+  // As we have more narrow left & right padding than upstream, icon seems stick
+  // to left side when extra padding is not used.
+  // We only need to do that when |extra_padding_before_content_| is false.
+  // We update border here because |extra_padding_before_content_| is updated
+  // by Tab::UpdateIconVisibility(). After that layout happens. So, it's good
+  // time to update border now.
+  // UpdateBorder();
 }
 
 void BraveTab::ViewHierarchyChanged(
@@ -235,6 +246,25 @@ void BraveTab::Layout() {
       ink_drop->HostSizeChanged(close_button_->size());
     }
   }
+}
+
+gfx::Insets BraveTab::GetInsets() const {
+  // Supplement extra left side padding.
+  // Upstream gives extra padding to balance with right side padding space but
+  // it's gone when tab doesn't have sufficient available width. In our case,
+  // As we have more narrow left & right padding than upstream, icon seems stick
+  // to left side when extra padding is not used.
+  // We only need to do that when |extra_padding_before_content_| is false.
+  int extra_left_padding = 0;
+
+  // Add extra padding if upstream tab doesn't have it.
+  if (!extra_padding_before_content_) {
+    extra_left_padding = kExtraLeftPadding;
+  }
+
+  auto insets = Tab::GetInsets();
+  insets.set_left(insets.left() + extra_left_padding);
+  return insets;
 }
 
 void BraveTab::ReorderChildLayers(ui::Layer* parent_layer) {

--- a/browser/ui/views/tabs/brave_tab.h
+++ b/browser/ui/views/tabs/brave_tab.h
@@ -43,8 +43,11 @@ class BraveTab : public Tab {
       const views::ViewHierarchyChangedDetails& details) override;
   void OnLayerBoundsChanged(const gfx::Rect& old_bounds,
                             ui::PropertyChangeReason reason) override;
+  gfx::Insets GetInsets() const override;
 
  private:
+  friend class BraveTabTest;
+
   bool IsAtMinWidthForVerticalTabStrip() const;
 
   void UpdateShadowForActiveTab();
@@ -59,6 +62,8 @@ class BraveTab : public Tab {
   std::unique_ptr<ui::Layer> shadow_layer_;
   gfx::FontList normal_font_;
   gfx::FontList active_tab_font_;
+
+  static constexpr int kExtraLeftPadding = 4;
 };
 
 #endif  // BRAVE_BROWSER_UI_VIEWS_TABS_BRAVE_TAB_H_

--- a/browser/ui/views/tabs/brave_tab_unittest.cc
+++ b/browser/ui/views/tabs/brave_tab_unittest.cc
@@ -1,0 +1,44 @@
+// Copyright (c) 2023 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#include "brave/browser/ui/views/tabs/brave_tab.h"
+#include "chrome/browser/ui/views/tabs/fake_tab_slot_controller.h"
+#include "chrome/test/views/chrome_views_test_base.h"
+#include "testing/gtest/include/gtest/gtest.h"
+#include "ui/gfx/geometry/insets.h"
+#include "ui/gfx/geometry/rect.h"
+#include "ui/views/test/views_test_utils.h"
+
+class BraveTabTest : public ChromeViewsTestBase {
+ public:
+  BraveTabTest() = default;
+  ~BraveTabTest() override = default;
+
+  void LayoutAndCheckBorder(BraveTab* tab,
+                            const gfx::Rect& bounds,
+                            bool gave_extra_padding) {
+    tab->SetBoundsRect(bounds);
+    views::test::RunScheduledLayout(tab);
+
+    auto insets = tab->tab_style_views()->GetContentsInsets();
+    int left_inset = insets.left();
+    if (gave_extra_padding) {
+      left_inset += BraveTab::kExtraLeftPadding;
+    }
+    EXPECT_EQ(left_inset, tab->GetInsets().left());
+  }
+};
+
+TEST_F(BraveTabTest, ExtraPaddingLayoutTest) {
+  FakeTabSlotController tab_slot_controller;
+  BraveTab tab(&tab_slot_controller);
+
+  // Smaller width tab will be given extra padding.
+  LayoutAndCheckBorder(&tab, {0, 0, 30, 50}, true);
+  LayoutAndCheckBorder(&tab, {0, 0, 50, 50}, true);
+  LayoutAndCheckBorder(&tab, {0, 0, 100, 50}, false);
+  LayoutAndCheckBorder(&tab, {0, 0, 150, 50}, false);
+  LayoutAndCheckBorder(&tab, {0, 0, 30, 50}, true);
+}

--- a/test/BUILD.gn
+++ b/test/BUILD.gn
@@ -419,6 +419,7 @@ test("brave_unit_tests") {
       "//brave/browser/ui/commands:unit_tests",
       "//brave/browser/ui/toolbar:brave_app_menu_unit_test",
       "//brave/browser/ui/views/download/bubble:unit_tests",
+      "//brave/browser/ui/views/tabs:unit_tests",
       "//brave/browser/ui/webui/settings:unittests",
       "//brave/browser/ui/whats_new:unit_test",
       "//brave/components/brave_shields/common:mojom",


### PR DESCRIPTION
fix https://github.com/brave/brave-browser/issues/30469

Upstream gives extra padding to balance with right side padding space but
it's gone when tab doesn't have sufficient available width.
As we have more narrower left & right padding than upstream, icon seems stick
to left side when extra padding is not used. So use extra padding always.

Default border left inset as icon has left padding.
<img width="147" alt="Screenshot 2023-06-05 at 10 49 21 AM" src="https://github.com/brave/brave-core/assets/6786187/6a9d8326-5c4f-49cb-ad76-ffae6f47371d">

Increased border left inset as icon doesn't have left padding.
<img width="92" alt="Screenshot 2023-06-05 at 10 49 51 AM" src="https://github.com/brave/brave-core/assets/6786187/c5d431e9-4924-4f83-b87d-81304e538370">


<!-- Add brave-browser issue below that this PR will resolve -->
Resolves 

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-arm64, CI/skip-linux-x64, CI/skip-android, CI/skip-macos, CI/skip-ios, CI/skip-windows-arm64, CI/skip-windows-x64, CI/skip-windows-x86 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

`BraveTabTest.ExtraPaddingLayoutTest`