### PR TITLE
Animate vertical tab width

### DIFF
--- a/browser/ui/views/frame/vertical_tab_strip_region_view.h
+++ b/browser/ui/views/frame/vertical_tab_strip_region_view.h
@@ -30,7 +30,8 @@ class VerticalTabStripScrollContentsView;
 // Wraps TabStripRegion and show it vertically.
 class VerticalTabStripRegionView : public views::View,
                                    public TabStripModelObserver,
-                                   public views::ResizeAreaDelegate {
+                                   public views::ResizeAreaDelegate,
+                                   public views::AnimationDelegateViews {
  public:
   METADATA_HEADER(VerticalTabStripRegionView);
 
@@ -105,6 +106,10 @@ class VerticalTabStripRegionView : public views::View,
   // views::ResizeAreaDelegate
   void OnResize(int resize_amount, bool done_resizing) override;
 
+  // views::AnimationDelegateViews:
+  void AnimationProgressed(const gfx::Animation* animation) override;
+  void AnimationEnded(const gfx::Animation* animation) override;
+
  private:
   class HeaderView;
 
@@ -127,8 +132,12 @@ class VerticalTabStripRegionView : public views::View,
 
   void ScheduleFloatingModeTimer();
 
-  gfx::Size GetPreferredSizeForState(State state, bool include_border) const;
-  int GetPreferredWidthForState(State state, bool include_border) const;
+  gfx::Size GetPreferredSizeForState(State state,
+                                     bool include_border,
+                                     bool ignore_animation) const;
+  int GetPreferredWidthForState(State state,
+                                bool include_border,
+                                bool ignore_animation) const;
 
   // Returns valid object only when the related flag is enabled.
   TabStripScrollContainer* GetTabStripScrollContainer();
@@ -175,6 +184,8 @@ class VerticalTabStripRegionView : public views::View,
 
   bool layout_dirty_ = false;
   gfx::Size last_size_;
+
+  gfx::SlideAnimation width_animation_{this};
 
   base::WeakPtrFactory<VerticalTabStripRegionView> weak_factory_{this};
 };


### PR DESCRIPTION
Apply slide animation to the width.

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/30417

https://github.com/brave/brave-core/assets/5474642/cf8962b8-c393-4d23-877f-02c024a31f21



<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-arm64, CI/skip-linux-x64, CI/skip-android, CI/skip-macos, CI/skip-ios, CI/skip-windows-arm64, CI/skip-windows-x64, CI/skip-windows-x86 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [ ] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

