### PR TITLE
feat(wallet) Move help centre link from account modal to main container

### DIFF
--- a/components/brave_wallet_ui/page/screens/swap/components/swap/account-modal/account-modal.tsx
+++ b/components/brave_wallet_ui/page/screens/swap/components/swap/account-modal/account-modal.tsx
@@ -32,7 +32,6 @@ import { RefreshBlockchainStateParams } from '../../../constants/types'
 
 // Components
 import { AccountListItemButton } from './account-list-item-button'
-import { AccountModalButton } from './account-modal-button'
 
 // Styled Components
 import { ModalBox, Title } from './account-modal.style'
@@ -80,14 +79,6 @@ export const AccountModal = (props: Props) => {
       refreshBlockchainState
     ]
   )
-
-  const onClickHelpCenter = React.useCallback(() => {
-    window.open(
-      'https://support.brave.com/hc/en-us/articles/8155407080845-Brave-Swaps-FAQ',
-      '_blank',
-      'noopener'
-    )
-  }, [])
 
   return (
     <ModalBox>
@@ -166,11 +157,6 @@ export const AccountModal = (props: Props) => {
           icon={PortfolioIcon}
           onClick={onClickViewPortfolio}
         /> */}
-        <AccountModalButton
-          text={getLocale('braveSwapHelpCenter')}
-          iconName='info-outline'
-          onClick={onClickHelpCenter}
-        />
       </Column>
     </ModalBox>
   )

--- a/components/brave_wallet_ui/page/screens/swap/components/swap/swap-container/swap-container.style.ts
+++ b/components/brave_wallet_ui/page/screens/swap/components/swap/swap-container/swap-container.style.ts
@@ -115,7 +115,13 @@ export const Container = styled(StyledDiv)`
   }
 `
 
-export const PrivacyButton = styled(StyledButton)`
+export const Row = styled.div`
+  display: flex;
+  flex-direction: row;
+  gap: 5px;
+`
+
+export const ActionButton = styled(StyledButton)`
   font-family: 'Poppins';
   font-style: normal;
   font-weight: 500;

--- a/components/brave_wallet_ui/page/screens/swap/components/swap/swap-container/swap-container.tsx
+++ b/components/brave_wallet_ui/page/screens/swap/components/swap/swap-container/swap-container.tsx
@@ -24,8 +24,9 @@ import { Header } from '../header/header'
 import {
   Background,
   Container,
-  PrivacyButton,
-  Wrapper
+  ActionButton,
+  Wrapper,
+  Row
 } from './swap-container.style'
 
 interface Props {
@@ -49,6 +50,15 @@ export const SwapContainer = (props: Props) => {
   // Refs
   const ref = React.createRef<HTMLInputElement>()
 
+  // Methods
+  const onClickHelpCenter = React.useCallback(() => {
+    window.open(
+      'https://support.brave.com/hc/en-us/categories/360001059151-Brave-Wallet',
+      '_blank',
+      'noopener'
+    )
+  }, [])
+
   // Effects
   React.useEffect(() => {
     // Keeps track of the Swap Containers Height to update
@@ -65,15 +75,16 @@ export const SwapContainer = (props: Props) => {
 
   return (
     <Wrapper>
-      <Header
-        refreshBlockchainState={refreshBlockchainState}
-      />
+      <Header refreshBlockchainState={refreshBlockchainState} />
       <Container ref={ref}>{children}</Container>
-      <PrivacyButton
-        onClick={showPrivacyModal}
-      >
-        {getLocale('braveSwapPrivacyPolicy')}
-      </PrivacyButton>
+      <Row>
+        <ActionButton onClick={showPrivacyModal}>
+          {getLocale('braveSwapPrivacyPolicy')}
+        </ActionButton>
+        <ActionButton onClick={onClickHelpCenter}>
+          {getLocale('braveSwapHelpCenter')}
+        </ActionButton>
+      </Row>
       <Background
         height={backgroundHeight}
         network={selectedNetwork?.chainId ?? ''}


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/30372

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-arm64, CI/skip-linux-x64, CI/skip-android, CI/skip-macos, CI/skip-ios, CI/skip-windows-arm64, CI/skip-windows-x64, CI/skip-windows-x86 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

<img width="642" alt="Screenshot 2023-06-02 at 18 18 39" src="https://github.com/brave/brave-core/assets/48117473/1c41829e-bd06-40da-9b09-2ca9865e6e54">
