### PR TITLE
Reconnect when network restored

### DIFF
--- a/components/brave_vpn/browser/connection/ikev2/brave_vpn_ras_connection_api_base.cc
+++ b/components/brave_vpn/browser/connection/ikev2/brave_vpn_ras_connection_api_base.cc
@@ -13,7 +13,6 @@
 #include "base/json/json_reader.h"
 #include "brave/components/brave_vpn/common/brave_vpn_data_types.h"
 #include "brave/components/brave_vpn/common/brave_vpn_utils.h"
-#include "third_party/abseil-cpp/absl/types/optional.h"
 
 namespace brave_vpn {
 
@@ -210,12 +209,40 @@ void BraveVPNOSConnectionAPIBase::OnConnectFailed() {
   UpdateAndNotifyConnectionStateChange(ConnectionState::CONNECT_FAILED);
 }
 
-void BraveVPNOSConnectionAPIBase::OnDisconnected() {
-  UpdateAndNotifyConnectionStateChange(ConnectionState::DISCONNECTED);
+bool BraveVPNOSConnectionAPIBase::MaybeReconnect() {
+  VLOG(2) << __func__;
 
-  if (needs_connect_) {
+  if (!needs_connect_) {
+    VLOG(2) << "Should be called only when reconnect expected";
+    return false;
+  }
+  if (GetConnectionState() != ConnectionState::DISCONNECTED) {
+    VLOG(2) << "For reconnection we expect DISCONNECTED status";
+    return false;
+  }
+  if (IsPlatformNetworkAvailable()) {
     needs_connect_ = false;
     Connect();
+    return true;
+  }
+  return false;
+}
+
+void BraveVPNOSConnectionAPIBase::OnNetworkChanged(
+    net::NetworkChangeNotifier::ConnectionType type) {
+  if (needs_connect_ && MaybeReconnect()) {
+    VLOG(2) << "Network is live, reconnecting";
+    return;
+  }
+  BraveVPNOSConnectionAPI::OnNetworkChanged(type);
+}
+
+void BraveVPNOSConnectionAPIBase::OnDisconnected() {
+  UpdateAndNotifyConnectionStateChange(ConnectionState::DISCONNECTED);
+  // Sometimes disconnected event happens before network state restored,
+  // we postpone reconnection in this cases.
+  if (needs_connect_ && !MaybeReconnect()) {
+    VLOG(2) << "Network is down, will be reconnected when connection restored";
   }
 }
 

--- a/components/brave_vpn/browser/connection/ikev2/brave_vpn_ras_connection_api_base.h
+++ b/components/brave_vpn/browser/connection/ikev2/brave_vpn_ras_connection_api_base.h
@@ -21,6 +21,7 @@
 #include "brave/components/brave_vpn/common/mojom/brave_vpn.mojom.h"
 #include "net/base/network_change_notifier.h"
 #include "services/network/public/cpp/shared_url_loader_factory.h"
+#include "third_party/abseil-cpp/absl/types/optional.h"
 
 class PrefService;
 
@@ -45,6 +46,8 @@ class BraveVPNOSConnectionAPIBase : public BraveVPNOSConnectionAPI {
       mojom::ConnectionState state) override;
   void SetSelectedRegion(const std::string& name) override;
   void FetchProfileCredentials() override;
+  void OnNetworkChanged(
+      net::NetworkChangeNotifier::ConnectionType type) override;
 
  protected:
   BraveVPNOSConnectionAPIBase(
@@ -58,6 +61,7 @@ class BraveVPNOSConnectionAPIBase : public BraveVPNOSConnectionAPI {
   virtual void ConnectImpl(const std::string& name) = 0;
   virtual void DisconnectImpl(const std::string& name) = 0;
   virtual void CheckConnectionImpl(const std::string& name) = 0;
+  virtual bool IsPlatformNetworkAvailable() = 0;
 
   // Subclass should call below callbacks whenever corresponding event happens.
   void OnCreated();
@@ -67,6 +71,7 @@ class BraveVPNOSConnectionAPIBase : public BraveVPNOSConnectionAPI {
   void OnConnectFailed();
   void OnDisconnected();
   void OnIsDisconnecting();
+  bool MaybeReconnect();
 
   std::string target_vpn_entry_name() const { return target_vpn_entry_name_; }
 
@@ -94,7 +99,6 @@ class BraveVPNOSConnectionAPIBase : public BraveVPNOSConnectionAPI {
   FRIEND_TEST_ALL_PREFIXES(BraveVPNOSConnectionAPIUnitTest, ConnectionInfoTest);
 
   void ResetConnectionInfo();
-
   void CreateVPNConnection();
   void OnGetProfileCredentials(const std::string& profile_credential,
                                bool success);
@@ -105,7 +109,6 @@ class BraveVPNOSConnectionAPIBase : public BraveVPNOSConnectionAPI {
   bool needs_connect_ = false;
   bool prevent_creation_ = false;
   std::string target_vpn_entry_name_;
-
   BraveVPNConnectionInfo connection_info_;
 };
 

--- a/components/brave_vpn/browser/connection/ikev2/brave_vpn_ras_connection_api_sim.cc
+++ b/components/brave_vpn/browser/connection/ikev2/brave_vpn_ras_connection_api_sim.cc
@@ -138,4 +138,15 @@ void BraveVPNOSConnectionAPISim::OnIsDisconnecting(const std::string& name) {
   BraveVPNOSConnectionAPIBase::OnIsDisconnecting();
 }
 
+void BraveVPNOSConnectionAPISim::SetNetworkAvailableForTesting(bool value) {
+  network_available_ = value;
+}
+
+bool BraveVPNOSConnectionAPISim::IsPlatformNetworkAvailable() {
+  if (network_available_.has_value()) {
+    return network_available_.value();
+  }
+  return true;
+}
+
 }  // namespace brave_vpn

--- a/components/brave_vpn/browser/connection/ikev2/brave_vpn_ras_connection_api_sim.h
+++ b/components/brave_vpn/browser/connection/ikev2/brave_vpn_ras_connection_api_sim.h
@@ -28,6 +28,7 @@ class BraveVPNOSConnectionAPISim : public BraveVPNOSConnectionAPIBase {
 
   bool IsConnectionCreated() const;
   bool IsConnectionChecked() const;
+  void SetNetworkAvailableForTesting(bool value);
 
  protected:
   friend class base::NoDestructor<BraveVPNOSConnectionAPISim>;
@@ -42,6 +43,7 @@ class BraveVPNOSConnectionAPISim : public BraveVPNOSConnectionAPIBase {
   void ConnectImpl(const std::string& name) override;
   void DisconnectImpl(const std::string& name) override;
   void CheckConnectionImpl(const std::string& name) override;
+  bool IsPlatformNetworkAvailable() override;
 
  private:
   friend class BraveVPNServiceTest;
@@ -66,6 +68,7 @@ class BraveVPNOSConnectionAPISim : public BraveVPNOSConnectionAPIBase {
   bool connection_created_ = false;
   bool check_connection_called_ = false;
 
+  absl::optional<bool> network_available_;
   base::WeakPtrFactory<BraveVPNOSConnectionAPISim> weak_factory_{this};
 };
 

--- a/components/brave_vpn/browser/connection/ikev2/mac/brave_vpn_ras_connection_api_mac.h
+++ b/components/brave_vpn/browser/connection/ikev2/mac/brave_vpn_ras_connection_api_mac.h
@@ -29,6 +29,7 @@ class BraveVPNOSConnectionAPIMac : public BraveVPNOSConnectionAPIBase {
   void ConnectImpl(const std::string& name) override;
   void DisconnectImpl(const std::string& name) override;
   void CheckConnectionImpl(const std::string& name) override;
+  bool IsPlatformNetworkAvailable() override;
   void ObserveVPNConnectionChange();
 
   id vpn_observer_ = nil;

--- a/components/brave_vpn/browser/connection/ikev2/mac/brave_vpn_ras_connection_api_mac.mm
+++ b/components/brave_vpn/browser/connection/ikev2/mac/brave_vpn_ras_connection_api_mac.mm
@@ -8,11 +8,14 @@
 #include <memory>
 
 #import <NetworkExtension/NetworkExtension.h>
+#include <SystemConfiguration/SystemConfiguration.h>
+#include <netinet/in.h>
 
 #include "base/files/file_path.h"
 #include "base/files/file_util.h"
 #include "base/mac/bundle_locations.h"
 #include "base/mac/foundation_util.h"
+#include "base/mac/scoped_cftyperef.h"
 #include "base/notreached.h"
 #include "base/strings/sys_string_conversions.h"
 
@@ -328,6 +331,25 @@ void BraveVPNOSConnectionAPIMac::ObserveVPNConnectionChange() {
                 VLOG(2) << "Received VPN connection status change notification";
                 CheckConnectionImpl(std::string());
               }];
+}
+
+bool BraveVPNOSConnectionAPIMac::IsPlatformNetworkAvailable() {
+  // 0.0.0.0 is a special token that causes reachability to monitor the general
+  // routing status of the device, both IPv4 and IPv6.
+  struct sockaddr_in addr = {0};
+  addr.sin_len = sizeof(addr);
+  addr.sin_family = AF_INET;
+  base::ScopedCFTypeRef<SCNetworkReachabilityRef> reachability(
+      SCNetworkReachabilityCreateWithAddress(
+          kCFAllocatorDefault, reinterpret_cast<struct sockaddr*>(&addr)));
+  SCNetworkReachabilityFlags flags;
+  BOOL success = SCNetworkReachabilityGetFlags(reachability, &flags);
+  if (!success) {
+    return false;
+  }
+  BOOL isReachable = flags & kSCNetworkReachabilityFlagsReachable;
+  BOOL needsConnection = flags & kSCNetworkReachabilityFlagsConnectionRequired;
+  return isReachable && !needsConnection;
 }
 
 }  // namespace brave_vpn

--- a/components/brave_vpn/browser/connection/ikev2/win/brave_vpn_ras_connection_api_win.h
+++ b/components/brave_vpn/browser/connection/ikev2/win/brave_vpn_ras_connection_api_win.h
@@ -38,6 +38,7 @@ class BraveVPNOSConnectionAPIWin : public BraveVPNOSConnectionAPIBase,
   void ConnectImpl(const std::string& name) override;
   void DisconnectImpl(const std::string& name) override;
   void CheckConnectionImpl(const std::string& name) override;
+  bool IsPlatformNetworkAvailable() override;
 
   // base::win::ObjectWatcher::Delegate overrides:
   void OnObjectSignaled(HANDLE object) override;


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/30792

Sometimes disconnected event happened before network restored and we are unable to fetch regions. Postponed check for reconnection for such cases and added logs to determine such states.

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-arm64, CI/skip-linux-x64, CI/skip-android, CI/skip-macos, CI/skip-ios, CI/skip-windows-arm64, CI/skip-windows-x64, CI/skip-windows-x86 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [x] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [x] New files have MPL-2.0 license header
- [x] Adequate test coverage exists to prevent regressions
- [x] Major classes, functions and non-trivial code blocks are well-commented
- [x] Changes in component dependencies are properly reflected in `gn`
- [x] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
- steps from issue
