### PR TITLE
[PG] Fix parent script tracking on setTimeout events.

### DIFF
--- a/chromium_src/third_party/blink/renderer/bindings/core/v8/referrer_script_info.cc
+++ b/chromium_src/third_party/blink/renderer/bindings/core/v8/referrer_script_info.cc
@@ -8,6 +8,10 @@
 #if BUILDFLAG(ENABLE_BRAVE_PAGE_GRAPH)
 #define FromV8HostDefinedOptions FromV8HostDefinedOptions_ChromiumImpl
 #define ToV8HostDefinedOptions ToV8HostDefinedOptions_ChromiumImpl
+#define BRAVE_REFERRER_SCRIPT_INFO_IS_DEFAULT_VALUE \
+  (dom_node_id_ == kInvalidDOMNodeId && parent_script_id_ == 0)
+#else
+#define BRAVE_REFERRER_SCRIPT_INFO_IS_DEFAULT_VALUE true
 #endif  // BUILDFLAG(ENABLE_BRAVE_PAGE_GRAPH)
 
 #include "src/third_party/blink/renderer/bindings/core/v8/referrer_script_info.cc"

--- a/patches/third_party-blink-renderer-bindings-core-v8-referrer_script_info.cc.patch
+++ b/patches/third_party-blink-renderer-bindings-core-v8-referrer_script_info.cc.patch
@@ -1,0 +1,12 @@
+diff --git a/third_party/blink/renderer/bindings/core/v8/referrer_script_info.cc b/third_party/blink/renderer/bindings/core/v8/referrer_script_info.cc
+index 161e96583870bf826e2e7a6966eb512e362d1df2..ea05b436a6843653b884aa126893142aedf91d71 100644
+--- a/third_party/blink/renderer/bindings/core/v8/referrer_script_info.cc
++++ b/third_party/blink/renderer/bindings/core/v8/referrer_script_info.cc
+@@ -56,6 +56,7 @@ bool ReferrerScriptInfo::IsDefaultValue(
+   return GetStoredBaseUrl(*this, script_origin_resource_name).IsNull() &&
+          credentials_mode_ == network::mojom::CredentialsMode::kSameOrigin &&
+          nonce_.empty() && parser_state_ == kNotParserInserted &&
++         BRAVE_REFERRER_SCRIPT_INFO_IS_DEFAULT_VALUE &&
+          referrer_policy_ == network::mojom::ReferrerPolicy::kDefault;
+ }
+ 


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
`ReferrerScriptInfo::IsDefaultValue` didn't check `dom_node_id_` and `parent_script_id_` values, so PG wasn't aware of the actual script source when other values in `ReferrerScriptInfo` were set to default.

Resolves https://github.com/brave/brave-browser/issues/30852

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-arm64, CI/skip-linux-x64, CI/skip-android, CI/skip-macos, CI/skip-ios, CI/skip-windows-arm64, CI/skip-windows-x64, CI/skip-windows-x86 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

