### PR TITLE
[Android] Fix crash on not earning dialog (uplift to 1.52.x)

### DIFF
--- a/android/java/org/chromium/chrome/browser/toolbar/top/BraveToolbarLayoutImpl.java
+++ b/android/java/org/chromium/chrome/browser/toolbar/top/BraveToolbarLayoutImpl.java
@@ -551,7 +551,7 @@ public abstract class BraveToolbarLayoutImpl extends ToolbarLayout
                             BraveActivity.getBraveActivity().getSupportFragmentManager(),
                             RewardsYouAreNotEarningDialog.RewardsYouAreNotEarningDialogTAG);
 
-                } catch (BraveActivity.BraveActivityNotFoundException e) {
+                } catch (BraveActivity.BraveActivityNotFoundException | IllegalStateException e) {
                     Log.e(TAG, "showNotificationNotEarningDialog " + e);
                 }
             }


### PR DESCRIPTION
Uplift of #18766
Resolves https://github.com/brave/brave-browser/issues/30821

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.