### PR TITLE
[PG] Map events without ScriptId and DOMNodeId to a parser node.

### DIFF
--- a/third_party/blink/renderer/core/brave_page_graph/graph_item/edge/execute/edge_execute.cc
+++ b/third_party/blink/renderer/core/brave_page_graph/graph_item/edge/execute/edge_execute.cc
@@ -5,6 +5,7 @@
 
 #include "brave/third_party/blink/renderer/core/brave_page_graph/graph_item/edge/execute/edge_execute.h"
 
+#include "brave/third_party/blink/renderer/core/brave_page_graph/graph_item/node/actor/node_actor.h"
 #include "brave/third_party/blink/renderer/core/brave_page_graph/graph_item/node/actor/node_script.h"
 #include "brave/third_party/blink/renderer/core/brave_page_graph/graph_item/node/html/node_html_element.h"
 #include "brave/third_party/blink/renderer/core/brave_page_graph/graph_item/node/node_extensions.h"
@@ -22,7 +23,7 @@ EdgeExecute::EdgeExecute(GraphItemContext* context,
     : GraphEdge(context, out_node, in_node) {}
 
 EdgeExecute::EdgeExecute(GraphItemContext* context,
-                         NodeScript* out_node,
+                         NodeActor* out_node,
                          NodeScript* in_node)
     : GraphEdge(context, out_node, in_node) {}
 

--- a/third_party/blink/renderer/core/brave_page_graph/graph_item/edge/execute/edge_execute.h
+++ b/third_party/blink/renderer/core/brave_page_graph/graph_item/edge/execute/edge_execute.h
@@ -13,6 +13,7 @@ namespace brave_page_graph {
 
 class NodeExtensions;
 class NodeHTMLElement;
+class NodeActor;
 class NodeScript;
 
 class EdgeExecute : public GraphEdge {
@@ -25,7 +26,7 @@ class EdgeExecute : public GraphEdge {
               NodeScript* in_node);
   // Used by imported module scripts and eval
   EdgeExecute(GraphItemContext* context,
-              NodeScript* out_node,
+              NodeActor* out_node,
               NodeScript* in_node);
   ~EdgeExecute() override;
 

--- a/third_party/blink/renderer/core/brave_page_graph/page_graph.cc
+++ b/third_party/blink/renderer/core/brave_page_graph/page_graph.cc
@@ -1599,10 +1599,8 @@ void PageGraph::RegisterScriptCompilation(
         GetHTMLElementNode(script_data.source.dom_node_id);
     AddEdge<EdgeExecute>(script_elm_node, code_node);
   } else {
-    DCHECK(execution_context_nodes_.Contains(execution_context));
-    AddEdge<EdgeExecute>(
-        execution_context_nodes_.at(execution_context).extensions_node,
-        code_node);
+    NodeActor* const acting_node = GetCurrentActingNode(execution_context);
+    AddEdge<EdgeExecute>(acting_node, code_node);
   }
 }
 


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Previously such event were mapped to "extensions" node, which is ambiguous, because these events may actually come from either extension or the webpage itself. We currently cannot safely distinguish the source, so it's better to treat all of them as "parser"-triggered instead of "extension"-triggered.

Related https://github.com/brave/brave-browser/issues/30853

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-arm64, CI/skip-linux-x64, CI/skip-android, CI/skip-macos, CI/skip-ios, CI/skip-windows-arm64, CI/skip-windows-x64, CI/skip-windows-x86 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

