### PR TITLE
Update verified badge on Rewards modals

### DIFF
--- a/components/brave_rewards/resources/ui/components/profile/index.tsx
+++ b/components/brave_rewards/resources/ui/components/profile/index.tsx
@@ -3,6 +3,9 @@
  * You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 import * as React from 'react'
+
+import Icon from '@brave/leo/react/icon'
+
 import {
   StyledWrapper,
   StyledContent,
@@ -29,7 +32,7 @@ import {
   StyledVerifiedDivider
 } from './style'
 import { getLocale } from 'brave-ui/helpers'
-import { VerifiedSIcon, UnVerifiedSIcon, LoaderIcon, CheckmarkCircleS } from 'brave-ui/components/icons'
+import { UnVerifiedSIcon, LoaderIcon, CheckmarkCircleS } from 'brave-ui/components/icons'
 
 export type Provider = 'twitter' | 'youtube' | 'twitch' | 'reddit' | 'vimeo' | 'github'
 
@@ -82,7 +85,7 @@ export default class Profile extends React.PureComponent<Props, {}> {
     return (
       <>
         <StyledInlineVerified>
-          <VerifiedSIcon />
+          <Icon name='verification-filled-color' />
         </StyledInlineVerified>{' '}
         <StyledVerifiedText>
           {getLocale('verifiedPublisher')}
@@ -291,7 +294,7 @@ export default class Profile extends React.PureComponent<Props, {}> {
           <StyledImage src={this.getSrc(src)} />
           {verified && type === 'small' ? (
             <StyledVerified>
-              <VerifiedSIcon />
+              <Icon name='verification-filled-color' />
             </StyledVerified>
           ) : null}
         </StyledImageWrapper>

--- a/components/brave_rewards/resources/ui/components/profile/style.ts
+++ b/components/brave_rewards/resources/ui/components/profile/style.ts
@@ -92,14 +92,12 @@ export const StyledImage = styled.img`
 `
 
 export const StyledVerified = styled('span')<{}>`
-  top: -6px;
+  top: -4px;
   right: -8px;
   width: 16px;
   height: 16px;
-  color: ${p => p.theme.palette.blurple500};
-  background-color: #FFFFFF;
-  border-radius: 20px;
   position: absolute;
+  --leo-icon-size: 16px;
 `
 
 export const StyledContent = styled('div')<Partial<Props>>`


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/30817
Resolves https://github.com/brave/brave-browser/issues/30844

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-arm64, CI/skip-linux-x64, CI/skip-android, CI/skip-macos, CI/skip-ios, CI/skip-windows-arm64, CI/skip-windows-x64, CI/skip-windows-x86 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [ ] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

<img width="570" alt="Screenshot 2023-06-07 at 3 16 09 PM" src="https://github.com/brave/brave-core/assets/5995084/71d407a8-e2ec-4eab-9723-ac900e66a077">
<img width="412" alt="Screenshot 2023-06-07 at 3 16 20 PM" src="https://github.com/brave/brave-core/assets/5995084/6fddc350-e450-401a-8784-cce07d4c39a5">
