### PR TITLE
Disables omnibox::kRichAutocompletion by default.

### DIFF
--- a/app/brave_main_delegate_browsertest.cc
+++ b/app/brave_main_delegate_browsertest.cc
@@ -205,6 +205,7 @@ IN_PROC_BROWSER_TEST_F(BraveMainDelegateBrowserTest, DisabledFeatures) {
     &ntp_features::kNtpChromeCartModule,
     &ntp_features::kNtpHistoryClustersModule,
     &ntp_features::kNtpHistoryClustersModuleLoad,
+    &omnibox::kRichAutocompletion,
     &optimization_guide::features::kOptimizationHints,
     &optimization_guide::features::kRemoteOptimizationGuideFetching,
     &optimization_guide::features::

--- a/chromium_src/components/omnibox/common/omnibox_features.cc
+++ b/chromium_src/components/omnibox/common/omnibox_features.cc
@@ -1,0 +1,16 @@
+/* Copyright (c) 2023 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "base/feature_override.h"
+
+#include "src/components/omnibox/common/omnibox_features.cc"
+
+namespace omnibox {
+
+OVERRIDE_FEATURE_DEFAULT_STATES({{
+    {kRichAutocompletion, base::FEATURE_DISABLED_BY_DEFAULT},
+}});
+
+}  // namespace omnibox

--- a/components/omnibox/browser/commander_provider.cc
+++ b/components/omnibox/browser/commander_provider.cc
@@ -74,7 +74,6 @@ void CommanderProvider::OnCommanderUpdated() {
     // This is neat but it would be nice if we could always show it instead of
     // only when we have a result selected.
     match.contents = option.annotation;
-    match.additional_text = delegate->GetPrompt();
     if (!option.annotation.empty()) {
       match.contents_class = {
           ACMatchClassification(0, ACMatchClassification::DIM)};

--- a/components/omnibox/browser/commander_provider_unittest.cc
+++ b/components/omnibox/browser/commander_provider_unittest.cc
@@ -194,19 +194,6 @@ TEST_F(CommanderProviderTest, RemovingPrefixClearsMatches) {
   EXPECT_EQ(0u, provider()->matches().size());
 }
 
-TEST_F(CommanderProviderTest, PromptingForMoreInputSetsAnnotation) {
-  provider()->Start(
-      CreateInput(base::StrCat({commander::kCommandPrefix, u" Hello World"})),
-      false);
-
-  delegate()->Notify({commander::CommandItemModel(u"Foo", {}, u"")},
-                     u"What thing?");
-
-  EXPECT_EQ(1u, provider()->matches().size());
-  EXPECT_EQ(u"What thing?", provider()->matches()[0].additional_text);
-  EXPECT_EQ(u":> Foo", provider()->matches()[0].description);
-}
-
 TEST_F(CommanderProviderTest, NoMatchRangeAllDimStyle) {
   provider()->Start(CreateInput(u":> Hello World"), false);
 


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/28198

Per @rebron, disables omnibox::kRichAutocompletion while upstream figures out how to improve this functionality (https://bugs.chromium.org/p/chromium/issues/detail?id=1394443).

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-arm64, CI/skip-linux-x64, CI/skip-android, CI/skip-macos, CI/skip-ios, CI/skip-windows-arm64, CI/skip-windows-x64, CI/skip-windows-x86 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [ ] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

