### PR TITLE
Fix Brave Ads crash when redeeming conversion ad events - 1.52.x

### DIFF
--- a/components/brave_ads/core/internal/BUILD.gn
+++ b/components/brave_ads/core/internal/BUILD.gn
@@ -107,6 +107,7 @@ source_set("internal") {
     "account/transactions/transactions_util.h",
     "account/user_data/build_channel_user_data.cc",
     "account/user_data/build_channel_user_data.h",
+    "account/user_data/build_user_data_callback.h",
     "account/user_data/catalog_user_data.cc",
     "account/user_data/catalog_user_data.h",
     "account/user_data/conversion_user_data.cc",

--- a/components/brave_ads/core/internal/account/confirmations/confirmation_user_data_builder.cc
+++ b/components/brave_ads/core/internal/account/confirmations/confirmation_user_data_builder.cc
@@ -12,6 +12,7 @@
 #include "base/functional/callback.h"
 #include "base/values.h"
 #include "brave/components/brave_ads/core/internal/account/user_data/build_channel_user_data.h"
+#include "brave/components/brave_ads/core/internal/account/user_data/build_user_data_callback.h"
 #include "brave/components/brave_ads/core/internal/account/user_data/catalog_user_data.h"
 #include "brave/components/brave_ads/core/internal/account/user_data/conversion_user_data.h"
 #include "brave/components/brave_ads/core/internal/account/user_data/created_at_timestamp_user_data.h"
@@ -25,39 +26,34 @@
 
 namespace brave_ads {
 
-ConfirmationUserDataBuilder::ConfirmationUserDataBuilder(
-    TransactionInfo transaction)
-    : transaction_(std::move(transaction)) {
-  DCHECK(transaction_.IsValid());
-}
+namespace {
 
-ConfirmationUserDataBuilder::~ConfirmationUserDataBuilder() = default;
-
-void ConfirmationUserDataBuilder::Build(
-    UserDataBuilderCallback callback) const {
-  BuildConversionUserData(
-      transaction_.creative_instance_id, transaction_.confirmation_type,
-      base::BindOnce(&ConfirmationUserDataBuilder::OnGetConversion,
-                     weak_factory_.GetWeakPtr(), std::move(callback)));
-}
-
-///////////////////////////////////////////////////////////////////////////////
-
-void ConfirmationUserDataBuilder::OnGetConversion(
-    UserDataBuilderCallback callback,
-    base::Value::Dict user_data) const {
+void BuildCallback(const TransactionInfo& transaction,
+                   BuildUserDataCallback callback,
+                   base::Value::Dict user_data) {
   user_data.Merge(BuildBuildChannelUserData());
   user_data.Merge(BuildCatalogUserData());
-  user_data.Merge(BuildCreatedAtTimestampUserData(transaction_));
+  user_data.Merge(BuildCreatedAtTimestampUserData(transaction));
   user_data.Merge(BuildLocaleUserData());
   user_data.Merge(BuildMutatedUserData());
   user_data.Merge(BuildPlatformUserData());
-  user_data.Merge(BuildRotatingHashUserData(transaction_));
-  user_data.Merge(BuildSegmentUserData(transaction_));
+  user_data.Merge(BuildRotatingHashUserData(transaction));
+  user_data.Merge(BuildSegmentUserData(transaction));
   user_data.Merge(BuildStudiesUserData());
   user_data.Merge(BuildVersionNumberUserData());
 
   std::move(callback).Run(std::move(user_data));
+}
+
+}  // namespace
+
+void BuildConfirmationUserData(const TransactionInfo& transaction,
+                               BuildUserDataCallback callback) {
+  CHECK(transaction.IsValid());
+
+  BuildConversionUserData(
+      transaction.creative_instance_id, transaction.confirmation_type,
+      base::BindOnce(&BuildCallback, transaction, std::move(callback)));
 }
 
 }  // namespace brave_ads

--- a/components/brave_ads/core/internal/account/confirmations/confirmation_user_data_builder.h
+++ b/components/brave_ads/core/internal/account/confirmations/confirmation_user_data_builder.h
@@ -6,27 +6,13 @@
 #ifndef BRAVE_COMPONENTS_BRAVE_ADS_CORE_INTERNAL_ACCOUNT_CONFIRMATIONS_CONFIRMATION_USER_DATA_BUILDER_H_
 #define BRAVE_COMPONENTS_BRAVE_ADS_CORE_INTERNAL_ACCOUNT_CONFIRMATIONS_CONFIRMATION_USER_DATA_BUILDER_H_
 
-#include "base/memory/weak_ptr.h"
 #include "brave/components/brave_ads/core/internal/account/transactions/transaction_info.h"
-#include "brave/components/brave_ads/core/internal/account/user_data/user_data_builder_interface.h"
+#include "brave/components/brave_ads/core/internal/account/user_data/build_user_data_callback.h"
 
 namespace brave_ads {
 
-class ConfirmationUserDataBuilder final : public UserDataBuilderInterface {
- public:
-  explicit ConfirmationUserDataBuilder(TransactionInfo transaction);
-  ~ConfirmationUserDataBuilder() override;
-
-  void Build(UserDataBuilderCallback callback) const override;
-
- private:
-  void OnGetConversion(UserDataBuilderCallback callback,
-                       base::Value::Dict user_data) const;
-
-  TransactionInfo transaction_;
-
-  base::WeakPtrFactory<ConfirmationUserDataBuilder> weak_factory_{this};
-};
+void BuildConfirmationUserData(const TransactionInfo& transaction,
+                               BuildUserDataCallback callback);
 
 }  // namespace brave_ads
 

--- a/components/brave_ads/core/internal/account/confirmations/confirmation_user_data_builder_unittest.cc
+++ b/components/brave_ads/core/internal/account/confirmations/confirmation_user_data_builder_unittest.cc
@@ -56,15 +56,15 @@ TEST_F(BraveAdsConfirmationUserDataBuilderTest,
   // Act
 
   // Assert
-  const ConfirmationUserDataBuilder user_data_builder(transaction);
-  user_data_builder.Build(base::BindOnce([](base::Value::Dict user_data) {
-    std::string json;
-    ASSERT_TRUE(base::JSONWriter::Write(user_data, &json));
+  BuildConfirmationUserData(
+      transaction, base::BindOnce([](base::Value::Dict user_data) {
+        std::string json;
+        ASSERT_TRUE(base::JSONWriter::Write(user_data, &json));
 
-    const std::string pattern =
-        R"~({"buildChannel":"release","catalog":\[{"id":"29e5c8bc0ba319069980bb390d8e8f9b58c05a20"}],"countryCode":"US","createdAtTimestamp":"2020-11-18T12:00:00.000Z","mutated":true,"platform":"windows","rotating_hash":"(.{44})","segment":"untargeted","studies":\[],"versionNumber":"\d{1,}\.\d{1,}\.\d{1,}\.\d{1,}"})~";
-    EXPECT_TRUE(RE2::FullMatch(json, pattern));
-  }));
+        const std::string pattern =
+            R"~({"buildChannel":"release","catalog":\[{"id":"29e5c8bc0ba319069980bb390d8e8f9b58c05a20"}],"countryCode":"US","createdAtTimestamp":"2020-11-18T12:00:00.000Z","mutated":true,"platform":"windows","rotating_hash":"(.{44})","segment":"untargeted","studies":\[],"versionNumber":"\d{1,}\.\d{1,}\.\d{1,}\.\d{1,}"})~";
+        EXPECT_TRUE(RE2::FullMatch(json, pattern));
+      }));
 }
 
 TEST_F(BraveAdsConfirmationUserDataBuilderTest,
@@ -94,15 +94,15 @@ TEST_F(BraveAdsConfirmationUserDataBuilderTest,
   // Act
 
   // Assert
-  const ConfirmationUserDataBuilder user_data_builder(transaction);
-  user_data_builder.Build(base::BindOnce([](base::Value::Dict user_data) {
-    std::string json;
-    ASSERT_TRUE(base::JSONWriter::Write(user_data, &json));
+  BuildConfirmationUserData(
+      transaction, base::BindOnce([](base::Value::Dict user_data) {
+        std::string json;
+        ASSERT_TRUE(base::JSONWriter::Write(user_data, &json));
 
-    const std::string pattern =
-        R"~({"buildChannel":"release","catalog":\[{"id":"29e5c8bc0ba319069980bb390d8e8f9b58c05a20"}],"conversionEnvelope":{"alg":"crypto_box_curve25519xsalsa20poly1305","ciphertext":"(.{64})","epk":"(.{44})","nonce":"(.{32})"},"countryCode":"US","createdAtTimestamp":"2020-11-18T12:00:00.000Z","mutated":true,"platform":"windows","rotating_hash":"(.{44})","segment":"untargeted","studies":\[],"versionNumber":"\d{1,}\.\d{1,}\.\d{1,}\.\d{1,}"})~";
-    EXPECT_TRUE(RE2::FullMatch(json, pattern));
-  }));
+        const std::string pattern =
+            R"~({"buildChannel":"release","catalog":\[{"id":"29e5c8bc0ba319069980bb390d8e8f9b58c05a20"}],"conversionEnvelope":{"alg":"crypto_box_curve25519xsalsa20poly1305","ciphertext":"(.{64})","epk":"(.{44})","nonce":"(.{32})"},"countryCode":"US","createdAtTimestamp":"2020-11-18T12:00:00.000Z","mutated":true,"platform":"windows","rotating_hash":"(.{44})","segment":"untargeted","studies":\[],"versionNumber":"\d{1,}\.\d{1,}\.\d{1,}\.\d{1,}"})~";
+        EXPECT_TRUE(RE2::FullMatch(json, pattern));
+      }));
 }
 
 }  // namespace brave_ads

--- a/components/brave_ads/core/internal/account/confirmations/confirmations.cc
+++ b/components/brave_ads/core/internal/account/confirmations/confirmations.cc
@@ -116,7 +116,10 @@ void Confirmations::Retry() {
 void Confirmations::OnRetry() {
   const ConfirmationList& failed_confirmations =
       ConfirmationStateManager::GetInstance().GetFailedConfirmations();
-  DCHECK(!failed_confirmations.empty());
+  if (failed_confirmations.empty()) {
+    BLOG(1, "No failed confirmations to retry");
+    return;
+  }
 
   BLOG(1, "Retry sending failed confirmations");
 

--- a/components/brave_ads/core/internal/account/confirmations/confirmations.cc
+++ b/components/brave_ads/core/internal/account/confirmations/confirmations.cc
@@ -153,10 +153,10 @@ void Confirmations::BuildDynamicUserData(const TransactionInfo& transaction) {
 void Confirmations::BuildFixedUserData(
     const TransactionInfo& transaction,
     base::Value::Dict dynamic_opted_in_user_data) {
-  const ConfirmationUserDataBuilder user_data_builder(transaction);
-  user_data_builder.Build(base::BindOnce(
-      &Confirmations::CreateAndRedeem, weak_factory_.GetWeakPtr(), transaction,
-      std::move(dynamic_opted_in_user_data)));
+  BuildConfirmationUserData(
+      transaction, base::BindOnce(&Confirmations::CreateAndRedeem,
+                                  weak_factory_.GetWeakPtr(), transaction,
+                                  std::move(dynamic_opted_in_user_data)));
 }
 
 void Confirmations::CreateAndRedeem(

--- a/components/brave_ads/core/internal/account/user_data/build_user_data_callback.h
+++ b/components/brave_ads/core/internal/account/user_data/build_user_data_callback.h
@@ -1,0 +1,19 @@
+/* Copyright (c) 2023 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_COMPONENTS_BRAVE_ADS_CORE_INTERNAL_ACCOUNT_USER_DATA_BUILD_USER_DATA_CALLBACK_H_
+#define BRAVE_COMPONENTS_BRAVE_ADS_CORE_INTERNAL_ACCOUNT_USER_DATA_BUILD_USER_DATA_CALLBACK_H_
+
+#include "base/functional/callback_forward.h"
+#include "base/values.h"
+
+namespace brave_ads {
+
+using BuildUserDataCallback =
+    base::OnceCallback<void(/*user_data*/ base::Value::Dict)>;
+
+}  // namespace brave_ads
+
+#endif  // BRAVE_COMPONENTS_BRAVE_ADS_CORE_INTERNAL_ACCOUNT_USER_DATA_BUILD_USER_DATA_CALLBACK_H_

--- a/components/brave_ads/core/internal/account/utility/redeem_confirmation/redeem_confirmation_factory.cc
+++ b/components/brave_ads/core/internal/account/utility/redeem_confirmation/redeem_confirmation_factory.cc
@@ -7,7 +7,7 @@
 
 #include <utility>
 
-#include "brave/components/brave_ads/core/internal/account/account_util.h"
+#include "brave/components/brave_ads/core/internal/account/confirmations/confirmation_info.h"
 #include "brave/components/brave_ads/core/internal/account/utility/redeem_confirmation/redeem_opted_in_confirmation.h"
 #include "brave/components/brave_ads/core/internal/account/utility/redeem_confirmation/redeem_opted_out_confirmation.h"
 
@@ -17,7 +17,7 @@ namespace brave_ads {
 void RedeemConfirmationFactory::BuildAndRedeemConfirmation(
     base::WeakPtr<RedeemConfirmationDelegate> delegate,
     const ConfirmationInfo& confirmation) {
-  if (!ShouldRewardUser()) {
+  if (!confirmation.opted_in) {
     return RedeemOptedOutConfirmation::CreateAndRedeem(std::move(delegate),
                                                        confirmation);
   }

--- a/components/brave_ads/core/internal/account/utility/redeem_confirmation/redeem_opted_out_confirmation.cc
+++ b/components/brave_ads/core/internal/account/utility/redeem_confirmation/redeem_opted_out_confirmation.cc
@@ -53,7 +53,6 @@ void RedeemOptedOutConfirmation::Redeem(
     RedeemOptedOutConfirmation redeem_confirmation,
     const ConfirmationInfo& confirmation) {
   DCHECK(IsValid(confirmation));
-  DCHECK(!ShouldRewardUser());
   DCHECK(!confirmation.opted_in);
 
   BLOG(1, "Redeem opted-out confirmation");

--- a/components/brave_ads/core/internal/deprecated/confirmations/confirmation_state_manager.cc
+++ b/components/brave_ads/core/internal/deprecated/confirmations/confirmation_state_manager.cc
@@ -17,6 +17,7 @@
 #include "base/ranges/algorithm.h"
 #include "base/strings/string_number_conversions.h"
 #include "brave/components/brave_ads/common/pref_names.h"
+#include "brave/components/brave_ads/core/internal/account/account_util.h"
 #include "brave/components/brave_ads/core/internal/account/confirmations/confirmation_util.h"
 #include "brave/components/brave_ads/core/internal/account/confirmations/opted_in_info.h"
 #include "brave/components/brave_ads/core/internal/ads_client_helper.h"
@@ -135,7 +136,7 @@ base::Value::Dict GetFailedConfirmationsAsDictionary(
         continue;
       }
 
-      dict.Set("credential", *opted_in_credential);
+      confirmation_dict.Set("credential", *opted_in_credential);
     }
 
     list.Append(std::move(confirmation_dict));
@@ -396,10 +397,25 @@ bool ConfirmationStateManager::GetFailedConfirmationsFromDictionary(
   return true;
 }
 
-const ConfirmationList& ConfirmationStateManager::GetFailedConfirmations()
-    const {
+ConfirmationList ConfirmationStateManager::GetFailedConfirmations() const {
   DCHECK(is_initialized_);
-  return failed_confirmations_;
+
+  if (ShouldRewardUser()) {
+    return failed_confirmations_;
+  }
+
+  // User is not opted-in to Brave Private Ads so only return opted-out
+  // confirmations, opted-in confirmations will be redeemed if and when the user
+  // rejoins Brave Private Ads.
+  ConfirmationList opted_out_confirmations;
+
+  base::ranges::copy_if(failed_confirmations_,
+                        std::back_inserter(opted_out_confirmations),
+                        [](const ConfirmationInfo& confirmation) {
+                          return !confirmation.opted_in;
+                        });
+
+  return opted_out_confirmations;
 }
 
 void ConfirmationStateManager::AppendFailedConfirmation(

--- a/components/brave_ads/core/internal/deprecated/confirmations/confirmation_state_manager.h
+++ b/components/brave_ads/core/internal/deprecated/confirmations/confirmation_state_manager.h
@@ -46,7 +46,7 @@ class ConfirmationStateManager final {
   bool GetFailedConfirmationsFromDictionary(
       const base::Value::Dict& dict,
       ConfirmationList* confirmations) const;
-  const ConfirmationList& GetFailedConfirmations() const;
+  ConfirmationList GetFailedConfirmations() const;
   void AppendFailedConfirmation(const ConfirmationInfo& confirmation);
   bool RemoveFailedConfirmation(const ConfirmationInfo& confirmation);
   void reset_failed_confirmations() { failed_confirmations_.clear(); }


### PR DESCRIPTION
Uplift of https://github.com/brave/brave-core/pull/18557
Resolves https://github.com/brave/brave-browser/issues/29888 (this uplift only resolves this crash)

- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR.
- [x] You have tested your change on Nightly. 
- [x] The PR milestones match the branch they are landing to. 

After you merge: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.
