### PR TITLE
Use Leo Dialog on Configure Shortcuts page

### DIFF
--- a/browser/resources/settings/shortcuts_page/components/ConfigureShortcut.tsx
+++ b/browser/resources/settings/shortcuts_page/components/ConfigureShortcut.tsx
@@ -37,7 +37,8 @@ const HintText = styled.div`
 `
 
 const InUseAlert = styled(Alert)`
-  margin: ${spacing[24]};
+  margin-top: ${spacing[24]};
+  display: block;
 `
 
 const modifiers = ['Control', 'Alt', 'Shift', 'Meta']

--- a/browser/resources/settings/shortcuts_page/components/ConfigureShortcut.tsx
+++ b/browser/resources/settings/shortcuts_page/components/ConfigureShortcut.tsx
@@ -2,36 +2,19 @@
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this file,
 // You can obtain one at https://mozilla.org/MPL/2.0/.
+
 import * as React from 'react'
 import styled from 'styled-components'
 import Keys from './Keys'
 import { keysToString, stringToKeys } from '../utils/accelerator'
-import { color, effect, font, radius, spacing } from '@brave/leo/tokens/css'
+import { color, font, spacing } from '@brave/leo/tokens/css'
 import Button from '@brave/leo/react/button'
 import Alert from '@brave/leo/react/alert'
 import { useCommands } from '../commands'
+import Dialog from '@brave/leo/react/dialog'
 
-const Dialog = styled.dialog`
-  border: none;
-  border-radius: ${radius[16]};
-
-  ::backdrop {
-    backdrop-filter: blur(2px);
-  }
-`
-
-const Container = styled.div`
-  background: ${color.white};
-  width: 420px;
-  min-height: 252px;
-  margin: auto;
-
-  display: flex;
-  flex-direction: column;
-  align-items: stretch;
-  justify-content: center;
-
-  box-shadow: ${effect.elevation[5]};
+const StyledDialog = styled(Dialog)`
+  --leo-dialog-width: 402px;
 `
 
 const KeysContainer = styled.div`
@@ -44,18 +27,6 @@ const KeysContainer = styled.div`
 
   gap: ${spacing[8]};
   margin-top: ${spacing[32]};
-`
-
-const ActionsContainer = styled.div`
-  display: flex;
-  flex-direction: row;
-  justify-content: stretch;
-  gap: ${spacing[8]};
-  margin: 0 ${spacing[24]} ${spacing[32]} ${spacing[24]};
-
-  > * {
-    flex: 1;
-  }
 `
 
 const HintText = styled.div`
@@ -135,6 +106,24 @@ export default function ConfigureShortcut(props: {
 
   React.useEffect(() => {
     const onDown = (e: KeyboardEvent) => {
+      const hasModifier = e.ctrlKey || e.metaKey || e.altKey || e.shiftKey
+
+      // Enter on it's own is used to accept the current combination, if the
+      // current keys are a valid shortcut.
+      if (e.code === "Enter" && !hasModifier && maxKeys.current.isValid()) {
+        props.onChange({
+          codes: keysToString(maxKeys.current.codes),
+          keys: keysToString(maxKeys.current.keys)
+        })
+        return;
+      }
+
+      // Escape on it's own cancels the change
+      if (e.code === "Escape" && !hasModifier) {
+        props.onCancel?.()
+        return;
+      }
+
       e.preventDefault()
       setCurrentKeys((keys) => {
         if (keys.length === 0) {
@@ -166,15 +155,9 @@ export default function ConfigureShortcut(props: {
     ? maxKeys.current.keys
     : stringToKeys(props.value ?? '')
 
-  const dialogRef = React.useRef<HTMLDialogElement>()
-  React.useEffect(() => {
-    dialogRef.current?.showModal()
-  }, [])
-
   const conflict = acceleratorLookup[maxKeys.current.codes.join('+')]
   return (
-    <Dialog ref={dialogRef as any}>
-      <Container>
+    <StyledDialog isOpen onClose={props.onCancel}>
         <KeysContainer>
           {keys.length ? (
             <Keys keys={keys} large />
@@ -192,7 +175,7 @@ export default function ConfigureShortcut(props: {
             shortcut.
           </InUseAlert>
         )}
-        <ActionsContainer>
+        <div slot='actions'>
           <Button
             size="large"
             kind="plain-faint"
@@ -217,8 +200,7 @@ export default function ConfigureShortcut(props: {
           >
             Save
           </Button>
-        </ActionsContainer>
-      </Container>
-    </Dialog>
+        </div>
+    </StyledDialog>
   )
 }


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/30895

Old Dark Dialog
![image](https://github.com/brave/brave-core/assets/7678024/0d952d36-dcf1-494d-8edf-ce4e3063a64a)

New Dark Dialog
![image](https://github.com/brave/brave-core/assets/7678024/9186fcff-4891-42b0-a59b-4d099e2cdc3d)

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-arm64, CI/skip-linux-x64, CI/skip-android, CI/skip-macos, CI/skip-ios, CI/skip-windows-arm64, CI/skip-windows-x64, CI/skip-windows-x86 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [ ] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

1. Configure a shortcut on chrome://settings/system/shortcuts in dark mode
2. The shortcuts dialog should not be white