### PR TITLE
Fixed download bubble is not displayed when download completed (uplift to 1.53.x)

### DIFF
--- a/chromium_src/chrome/browser/ui/views/download/bubble/download_toolbar_button_view.cc
+++ b/chromium_src/chrome/browser/ui/views/download/bubble/download_toolbar_button_view.cc
@@ -55,7 +55,7 @@ SkColor DownloadToolbarButtonView::GetIconColor() const {
 
 void DownloadToolbarButtonView::PaintButtonContents(gfx::Canvas* canvas) {
   // Don't draw anything but alert icon when insecure download is in-progress.
-  if (HasInsecureDownloads(bubble_controller()->GetMainView())) {
+  if (HasInsecureDownloads()) {
     return;
   }
 
@@ -70,7 +70,7 @@ void DownloadToolbarButtonView::UpdateIcon() {
   DownloadToolbarButtonViewChromium::UpdateIcon();
 
   // Replace Icon when insecure download is in-progress.
-  if (HasInsecureDownloads(bubble_controller()->GetMainView())) {
+  if (HasInsecureDownloads()) {
     const gfx::VectorIcon* new_icon = &vector_icons::kNotSecureWarningIcon;
     SkColor icon_color =
         GetColorProvider()->GetColor(ui::kColorAlertMediumSeverityIcon);
@@ -88,9 +88,17 @@ void DownloadToolbarButtonView::UpdateIcon() {
   }
 }
 
-bool DownloadToolbarButtonView::HasInsecureDownloads(
-    const std::vector<DownloadUIModel::DownloadUIModelPtr>& models) const {
-  return base::ranges::any_of(models, [](const auto& model) {
+bool DownloadToolbarButtonView::HasInsecureDownloads() {
+  auto* update_service = bubble_controller()->update_service();
+  if (!update_service || !update_service->IsInitialized()) {
+    return false;
+  }
+
+  std::vector<DownloadUIModel::DownloadUIModelPtr> all_models;
+  update_service->GetAllModelsToDisplay(all_models,
+                                        /*force_backfill_download_items=*/true);
+
+  return base::ranges::any_of(all_models, [](const auto& model) {
     return (model->GetInsecureDownloadStatus() ==
                 download::DownloadItem::InsecureDownloadStatus::BLOCK ||
             model->GetInsecureDownloadStatus() ==

--- a/chromium_src/chrome/browser/ui/views/download/bubble/download_toolbar_button_view.h
+++ b/chromium_src/chrome/browser/ui/views/download/bubble/download_toolbar_button_view.h
@@ -39,8 +39,7 @@ class DownloadToolbarButtonView : public DownloadToolbarButtonViewChromium {
   void UpdateIcon() override;
 
  private:
-  bool HasInsecureDownloads(
-      const std::vector<DownloadUIModel::DownloadUIModelPtr>& models) const;
+  bool HasInsecureDownloads();
 };
 
 #endif  // BRAVE_CHROMIUM_SRC_CHROME_BROWSER_UI_VIEWS_DOWNLOAD_BUBBLE_DOWNLOAD_TOOLBAR_BUTTON_VIEW_H_


### PR DESCRIPTION
Uplift of #18788
fix https://github.com/brave/brave-browser/issues/30882

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.