### PR TITLE
Force aggressive cosmetic filtering on youtube

### DIFF
--- a/browser/brave_shields/ad_block_service_browsertest.cc
+++ b/browser/brave_shields/ad_block_service_browsertest.cc
@@ -92,14 +92,26 @@ using brave_shields::features::kCosmeticFilteringJsPerformance;
 
 AdBlockServiceTest::AdBlockServiceTest()
     : ws_server_(net::SpawnedTestServer::TYPE_WS,
-                 net::GetWebSocketTestDataDirectory()) {
+                 net::GetWebSocketTestDataDirectory()),
+      https_server_(net::EmbeddedTestServer::Type::TYPE_HTTPS) {
   brave_shields::SetDefaultAdBlockComponentIdAndBase64PublicKeyForTest(
       kDefaultAdBlockComponentTestId, kDefaultAdBlockComponentTest64PublicKey);
 }
 AdBlockServiceTest::~AdBlockServiceTest() = default;
 
+void AdBlockServiceTest::SetUpCommandLine(base::CommandLine* command_line) {
+  InProcessBrowserTest::SetUpCommandLine(command_line);
+  mock_cert_verifier_.SetUpCommandLine(command_line);
+}
+
+void AdBlockServiceTest::SetUpInProcessBrowserTestFixture() {
+  InProcessBrowserTest::SetUpInProcessBrowserTestFixture();
+  mock_cert_verifier_.SetUpInProcessBrowserTestFixture();
+}
+
 void AdBlockServiceTest::SetUpOnMainThread() {
   ExtensionBrowserTest::SetUpOnMainThread();
+  mock_cert_verifier_.mock_cert_verifier()->set_default_result(net::OK);
   host_resolver()->AddRule("*", "127.0.0.1");
   // Most tests are written for aggressive mode. Individual tests should reset
   // this using `DisableAggressiveMode` if they are testing standard mode
@@ -122,6 +134,11 @@ void AdBlockServiceTest::TearDownOnMainThread() {
   // Unset the host resolver so as not to interfere with later tests.
   brave::SetAdblockCnameHostResolverForTesting(nullptr);
   ExtensionBrowserTest::TearDownOnMainThread();
+}
+
+void AdBlockServiceTest::TearDownInProcessBrowserTestFixture() {
+  mock_cert_verifier_.TearDownInProcessBrowserTestFixture();
+  InProcessBrowserTest::TearDownInProcessBrowserTestFixture();
 }
 
 content::WebContents* AdBlockServiceTest::web_contents() {
@@ -195,6 +212,11 @@ void AdBlockServiceTest::InitEmbeddedTestServer() {
   brave::RegisterPathProvider();
   base::FilePath test_data_dir;
   base::PathService::Get(brave::DIR_TEST_DATA, &test_data_dir);
+
+  https_server_.ServeFilesFromDirectory(test_data_dir);
+  content::SetupCrossSiteRedirector(&https_server_);
+  ASSERT_TRUE(https_server_.Start());
+
   embedded_test_server()->ServeFilesFromDirectory(test_data_dir);
   content::SetupCrossSiteRedirector(embedded_test_server());
   ASSERT_TRUE(embedded_test_server()->Start());

--- a/browser/brave_shields/ad_block_service_browsertest.h
+++ b/browser/brave_shields/ad_block_service_browsertest.h
@@ -27,10 +27,13 @@ class AdBlockServiceTest : public extensions::ExtensionBrowserTest {
   ~AdBlockServiceTest() override;
 
   // ExtensionBrowserTest overrides
+  void SetUpCommandLine(base::CommandLine* command_line) override;
+  void SetUpInProcessBrowserTestFixture() override;
   void SetUpOnMainThread() override;
   void SetUp() override;
   void PreRunTestOnMainThread() override;
   void TearDownOnMainThread() override;
+  void TearDownInProcessBrowserTestFixture() override;
 
  protected:
   content::ContentMockCertVerifier mock_cert_verifier_;
@@ -66,6 +69,7 @@ class AdBlockServiceTest : public extensions::ExtensionBrowserTest {
 
   net::SpawnedTestServer ws_server_;
   net::EmbeddedTestServer dynamic_server_;
+  net::EmbeddedTestServer https_server_;
 };
 
 #endif  // BRAVE_BROWSER_BRAVE_SHIELDS_AD_BLOCK_SERVICE_BROWSERTEST_H_

--- a/browser/net/brave_ad_block_tp_network_delegate_helper.cc
+++ b/browser/net/brave_ad_block_tp_network_delegate_helper.cc
@@ -186,7 +186,7 @@ EngineFlags ShouldBlockRequestOnTaskRunner(
 
   bool force_aggressive = SameDomainOrHost(
       ctx->initiator_url,
-      url::Origin::CreateFromNormalizedTuple("https", "youtube.com", 80),
+      url::Origin::CreateFromNormalizedTuple("https", "youtube.com", 443),
       net::registry_controlled_domains::INCLUDE_PRIVATE_REGISTRIES);
 
   std::string rewritten_url;

--- a/components/cosmetic_filters/renderer/cosmetic_filters_js_handler.cc
+++ b/components/cosmetic_filters/renderer/cosmetic_filters_js_handler.cc
@@ -361,7 +361,11 @@ bool CosmeticFiltersJSHandler::ProcessURL(
   enabled_1st_party_cf_ =
       force_cosmetic_filtering ||
       render_frame_->GetWebFrame()->IsCrossOriginToOutermostMainFrame() ||
-      content_settings->IsFirstPartyCosmeticFilteringEnabled(url_);
+      content_settings->IsFirstPartyCosmeticFilteringEnabled(url_) ||
+      net::registry_controlled_domains::SameDomainOrHost(
+          url_,
+          url::Origin::CreateFromNormalizedTuple("https", "youtube.com", 443),
+          net::registry_controlled_domains::INCLUDE_PRIVATE_REGISTRIES);
 
   if (callback.has_value()) {
     SCOPED_UMA_HISTOGRAM_TIMER_MICROS(


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/30896

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-arm64, CI/skip-linux-x64, CI/skip-android, CI/skip-macos, CI/skip-ios, CI/skip-windows-arm64, CI/skip-windows-x64, CI/skip-windows-x86 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

Visit `youtube.com` and verify that there's no difference in parts of the page visible when toggling between `Block trackers & ads` and `Aggressively block trackers & ads` in the `Advanced controls` section of the Shields panel.

Toggling to `Allow all trackers & ads` or turning Shields off completely should still show preroll and page ads.