### PR TITLE
Add license information for VPN WireGuard Service

### DIFF
--- a/components/brave_vpn/browser/connection/wireguard/win/brave_vpn_wireguard_service/README.chromium
+++ b/components/brave_vpn/browser/connection/wireguard/win/brave_vpn_wireguard_service/README.chromium
@@ -1,0 +1,4 @@
+Name: Brave VPN WireGuard Service
+URL: https://github.com/brave/brave-core/tree/master/components/brave_vpn/browser/connection/wireguard/win/brave_vpn_wireguard_service
+License: GPL-2.0-or-later
+License File: /brave/common/licenses/GPL-2.0

--- a/components/brave_vpn/browser/connection/wireguard/win/brave_vpn_wireguard_service/README.md
+++ b/components/brave_vpn/browser/connection/wireguard/win/brave_vpn_wireguard_service/README.md
@@ -1,0 +1,26 @@
+# Brave VPN WireGuard Service
+
+Windows service which exposes COM and CLI interfaces that can be used to
+start/stop a WireGuard VPN connection given a configuration file.
+
+## License
+
+The following license statement applies to all files contained within this
+directory and any sub-directories:
+
+Brave VPN WireGuard Service
+Copyright (C) 2023 The Brave Authors
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.

--- a/script/brave_license_helper.py
+++ b/script/brave_license_helper.py
@@ -149,6 +149,9 @@ def AddBraveCredits(root, prune_paths, special_cases, prune_dirs,
     additional_list = list(additional_paths)
     additional_list += [
         os.path.join('brave', 'components', 'brave_new_tab_ui', 'data'),
+        os.path.join('brave', 'components', 'brave_vpn', 'browser',
+                     'connection', 'wireguard', 'win',
+                     'brave_vpn_wireguard_service'),
         os.path.join('brave', 'components', 'filecoin'),
     ]
 


### PR DESCRIPTION
Fixes brave/brave-browser#30902

Security review: https://github.com/brave/security/issues/1280

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-arm64, CI/skip-linux-x64, CI/skip-android, CI/skip-macos, CI/skip-ios, CI/skip-windows-arm64, CI/skip-windows-x64, CI/skip-windows-x86 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

1. Open `brave://credits`.
2. Look for _Brave VPN WireGuard Service_.
3. Verify that:
   -  the homepage is https://github.com/brave/brave-core/tree/master/components/brave_vpn/browser/connection/wireguard/win/brave_vpn_wireguard_service, and
   - the license is a copy of the _GNU General Public License_ (version 2).