### PR TITLE
chore(wallet): Built out reusable Create Account Icon Component

### DIFF
--- a/components/brave_wallet_ui/components/desktop/asset-group-container/asset-group-container.style.ts
+++ b/components/brave_wallet_ui/components/desktop/asset-group-container/asset-group-container.style.ts
@@ -48,14 +48,3 @@ export const CollapseIcon = styled(Icon) <
   };
   margin-left: 16px;
 `
-
-export const AccountSquare = styled.div<{
-  orb: string
-}>`
-  width: 24px;
-  height: 24px;
-  border-radius: 4px;
-  background-image: url(${(p) => p.orb});
-  background-size: cover;
-  margin-right: 16px;
-`

--- a/components/brave_wallet_ui/components/desktop/asset-group-container/asset-group-container.tsx
+++ b/components/brave_wallet_ui/components/desktop/asset-group-container/asset-group-container.tsx
@@ -4,7 +4,6 @@
 // You can obtain one at https://mozilla.org/MPL/2.0/.
 
 import * as React from 'react'
-import { create } from 'ethereum-blockies'
 
 // Selectors
 import {
@@ -23,13 +22,15 @@ import {
   CreateNetworkIcon,
   LoadingSkeleton
 } from '../../shared'
+import {
+  CreateAccountIcon
+} from '../../shared/create-account-icon/create-account-icon'
 
 // Styled Components
 import {
   StyledWrapper,
   CollapseButton,
-  CollapseIcon,
-  AccountSquare
+  CollapseIcon
 } from './asset-group-container.style'
 import {
   Row,
@@ -63,17 +64,6 @@ export const AssetGroupContainer = (props: Props) => {
   // State
   const [isCollapsed, setIsCollapsed] = React.useState<boolean>(false)
 
-  // Memos
-  const orb = React.useMemo(() => {
-    return create(
-      {
-        seed: account?.address.toLowerCase(),
-        size: 8,
-        scale: 16
-      }
-    ).toDataURL()
-  }, [account?.address])
-
   return (
     <StyledWrapper
       fullWidth={true}
@@ -105,7 +95,12 @@ export const AssetGroupContainer = (props: Props) => {
           <Row
             width='unset'
           >
-            <AccountSquare orb={orb} />
+            <CreateAccountIcon
+              size='small'
+              address={account.address}
+              accountKind={account.accountId.kind}
+              marginRight={16}
+            />
             <Text
               textSize='14px'
               isBold={true}

--- a/components/brave_wallet_ui/components/desktop/popup-modals/filter-modals/filter-components/filter-accounts-section.tsx
+++ b/components/brave_wallet_ui/components/desktop/popup-modals/filter-modals/filter-components/filter-accounts-section.tsx
@@ -4,7 +4,6 @@
 // You can obtain one at https://mozilla.org/MPL/2.0/.
 
 import * as React from 'react'
-import { create } from 'ethereum-blockies'
 import Checkbox from '@brave/leo/react/checkbox'
 
 // Utils
@@ -20,9 +19,13 @@ import {
   selectAllAccountInfosFromQuery
 } from '../../../../../common/slices/entities/account-info.entity'
 
+// Components
+import {
+  CreateAccountIcon
+} from '../../../../shared/create-account-icon/create-account-icon'
+
 // Styled Components
 import {
-  AccountCircle,
   SelectAllButton,
   Title,
   CheckboxText,
@@ -51,16 +54,6 @@ export const FilterAccountsSection = (props: Props) => {
       })
 
   // Methods
-  const orb = React.useCallback((address: string) => {
-    return create(
-      {
-        seed: address.toLowerCase(),
-        size: 8,
-        scale: 16
-      }
-    ).toDataURL()
-  }, [])
-
   const isAccountFilteredOut = React.useCallback(
     (address: string) => {
       return filteredOutAccountAddresses.includes(address)
@@ -139,7 +132,11 @@ export const FilterAccountsSection = (props: Props) => {
                 () => onCheckAccount(account.address)
               }
             >
-              <AccountCircle orb={orb(account.address)} />
+              <CreateAccountIcon
+                size='medium'
+                address={account.address}
+                accountKind={account.accountId.kind}
+              />
               <Column
                 alignItems='flex-start'
               >

--- a/components/brave_wallet_ui/components/desktop/popup-modals/filter-modals/filter-components/filter-components.style.ts
+++ b/components/brave_wallet_ui/components/desktop/popup-modals/filter-modals/filter-components/filter-components.style.ts
@@ -37,17 +37,6 @@ export const SelectAllButton = styled(WalletButton)`
   color: ${leo.color.text.interactive};
 `
 
-export const AccountCircle = styled.div<{
-  orb: string
-}>`
-  width: 32px;
-  min-width: 32px;
-  height: 32px;
-  border-radius: 4px;
-  background-image: url(${(p) => p.orb});
-  background-size: cover;
-`
-
 export const Title = styled(Text)`
   color: ${leo.color.text.primary};
   line-height: 28px;

--- a/components/brave_wallet_ui/components/shared/create-account-icon/create-account-icon.style.ts
+++ b/components/brave_wallet_ui/components/shared/create-account-icon/create-account-icon.style.ts
@@ -1,0 +1,56 @@
+// Copyright (c) 2023 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import styled from 'styled-components'
+import * as leo from '@brave/leo/tokens/css'
+import Icon from '@brave/leo/react/icon'
+
+export const AccountBox = styled.div<{
+  orb: string
+  size?: 'big' | 'medium' | 'small' | 'tiny'
+  marginRight?: number
+}>`
+  --box-big: 48px;
+  --box-medium: 32px;
+  --box-small: 24px;
+  --box-tiny: 20px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: ${(p) =>
+    p.size
+      ? `var(--box-${p.size})`
+      : 'var(--box-medium)'
+  };
+  height: ${(p) =>
+    p.size
+      ? `var(--box-${p.size})`
+      : 'var(--box-medium)'
+  };
+  border-radius: ${(p) =>
+    p.size === 'big' ? 8 : 4}px;
+  background-image: url(${(p) => p.orb});
+  background-size: cover;
+  margin-right: ${(p) =>
+    p.marginRight !== undefined
+      ? p.marginRight
+      : 0
+  }px;
+`
+
+export const AccountIcon = styled(Icon) <{
+  size?: 'big' | 'medium' | 'small' | 'tiny'
+}>`
+  --icon-big: 24px;
+  --icon-medium: 20px;
+  --icon-small: 16px;
+  --icon-tiny: 14px;
+  --leo-icon-size: ${(p) =>
+    p.size
+      ? `var(--icon-${p.size})`
+      : 'var(--icon-medium)'
+  };
+  color: ${leo.color.white};
+`

--- a/components/brave_wallet_ui/components/shared/create-account-icon/create-account-icon.tsx
+++ b/components/brave_wallet_ui/components/shared/create-account-icon/create-account-icon.tsx
@@ -1,0 +1,57 @@
+// Copyright (c) 2023 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+import * as React from 'react'
+import { create } from 'ethereum-blockies'
+
+// Types
+import { BraveWallet } from '../../../constants/types'
+
+// styles
+import {
+  AccountBox,
+  AccountIcon
+} from './create-account-icon.style'
+
+interface Props {
+  address: string
+  size?: 'big' | 'medium' | 'small' | 'tiny'
+  marginRight?: number
+  accountKind?: BraveWallet.AccountKind
+}
+
+export const CreateAccountIcon = (props: Props) => {
+  const {
+    address,
+    size,
+    marginRight,
+    accountKind
+  } = props
+
+  // Memos
+  const orb = React.useMemo(() => {
+    return create(
+      {
+        seed: address.toLowerCase(),
+        size: 8,
+        scale: 16
+      }
+    ).toDataURL()
+  }, [address])
+
+  return (
+    <AccountBox
+      orb={orb}
+      size={size}
+      marginRight={marginRight}
+    >
+      {accountKind === BraveWallet.AccountKind.kHardware &&
+        <AccountIcon
+          name='flashdrive'
+          size={size}
+        />
+      }
+    </AccountBox>
+  )
+}

--- a/ui/webui/resources/BUILD.gn
+++ b/ui/webui/resources/BUILD.gn
@@ -175,6 +175,7 @@ leo_icons = [
   "eye-on.svg",
   "filter-settings.svg",
   "flash.svg",
+  "flashdrive.svg",
   "graph.svg",
   "grid04.svg",
   "help-outline.svg",


### PR DESCRIPTION
## Description 
Introduces a `CreateAccountIcon` component to be used for Wallet V2 changes

- Account avatars will now be `square`
- Hardware wallet accounts will have a `thumb-drive` icon in the avatar.

note: (This is only being used in places where Wallet V2 work has been implemented, more of the wallet will be updated as we progress).

<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves <https://github.com/brave/brave-browser/issues/30575>

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-arm64, CI/skip-linux-x64, CI/skip-android, CI/skip-macos, CI/skip-ios, CI/skip-windows-arm64, CI/skip-windows-x64, CI/skip-windows-x86 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
1. Import a `Hardware Wallet` account
2. Go to the `Portfolio` page and group assets by `Accounts`
3. The account `avatars` should be `square` and avatars for `Hardware Wallets` should have a `thumb-drive` icon.

![Screenshot 24](https://github.com/brave/brave-core/assets/40611140/080cb02e-c6b9-4af2-ae65-2f44779c1770)

![Screenshot 25](https://github.com/brave/brave-core/assets/40611140/d882262b-bb67-498f-ba54-9319e8fa270e)
