### PR TITLE
Hide original tab search button when pref is off (uplift to 1.53.x)

### DIFF
--- a/browser/ui/views/frame/vertical_tab_strip_region_view.cc
+++ b/browser/ui/views/frame/vertical_tab_strip_region_view.cc
@@ -19,6 +19,7 @@
 #include "brave/browser/ui/views/tabs/brave_tab_search_button.h"
 #include "brave/browser/ui/views/tabs/brave_tab_strip_layout_helper.h"
 #include "brave/browser/ui/views/tabs/vertical_tab_utils.h"
+#include "brave/components/constants/pref_names.h"
 #include "chrome/browser/profiles/profile.h"
 #include "chrome/browser/themes/theme_properties.h"
 #include "chrome/browser/ui/exclusive_access/exclusive_access_manager.h"
@@ -745,7 +746,7 @@ void VerticalTabStripRegionView::Layout() {
                                       header_view_->height()});
     contents_view_->SetPosition({contents_bounds.origin().x(),
                                  header_view_->y() + header_view_->height()});
-    UpdateTabSearchButtonVisibility();
+    UpdateOriginalTabSearchButtonVisibility();
 
     return;
   }
@@ -779,7 +780,7 @@ void VerticalTabStripRegionView::Layout() {
                   contents_view_->GetPreferredSize().height())});
   }
 
-  UpdateTabSearchButtonVisibility();
+  UpdateOriginalTabSearchButtonVisibility();
 
   // Put resize area on the right side, overlapped with contents.
   constexpr int kResizeAreaWidth = 4;
@@ -998,10 +999,12 @@ void VerticalTabStripRegionView::ResetExpandedWidth() {
   PreferredSizeChanged();
 }
 
-void VerticalTabStripRegionView::UpdateTabSearchButtonVisibility() {
+void VerticalTabStripRegionView::UpdateOriginalTabSearchButtonVisibility() {
   const bool is_vertical_tabs = tabs::utils::ShouldShowVerticalTabs(browser_);
+  const bool use_search_button =
+      browser_->profile()->GetPrefs()->GetBoolean(kTabsSearchShow);
   if (auto* tab_search_button = original_region_view_->tab_search_button()) {
-    tab_search_button->SetVisible(!is_vertical_tabs);
+    tab_search_button->SetVisible(!is_vertical_tabs && use_search_button);
   }
 }
 

--- a/browser/ui/views/frame/vertical_tab_strip_region_view.h
+++ b/browser/ui/views/frame/vertical_tab_strip_region_view.h
@@ -109,6 +109,8 @@ class VerticalTabStripRegionView : public views::View,
   class HeaderView;
 
   FRIEND_TEST_ALL_PREFIXES(VerticalTabStripBrowserTest, VisualState);
+  FRIEND_TEST_ALL_PREFIXES(VerticalTabStripBrowserTest,
+                           OriginalTabSearchButton);
 
   bool IsTabFullscreen() const;
 
@@ -120,7 +122,7 @@ class VerticalTabStripRegionView : public views::View,
 
   void UpdateLayout(bool in_destruction = false);
 
-  void UpdateTabSearchButtonVisibility();
+  void UpdateOriginalTabSearchButtonVisibility();
 
   void OnCollapsedPrefChanged();
   void OnFloatingModePrefChanged();

--- a/browser/ui/views/tabs/vertical_tab_strip_browsertest.cc
+++ b/browser/ui/views/tabs/vertical_tab_strip_browsertest.cc
@@ -15,6 +15,7 @@
 #include "brave/browser/ui/views/tabs/brave_browser_tab_strip_controller.h"
 #include "brave/browser/ui/views/tabs/brave_tab_context_menu_contents.h"
 #include "brave/browser/ui/views/tabs/vertical_tab_utils.h"
+#include "brave/components/constants/pref_names.h"
 #include "build/build_config.h"
 #include "chrome/browser/profiles/profile.h"
 #include "chrome/browser/ui/browser.h"
@@ -28,6 +29,7 @@
 #include "chrome/browser/ui/views/frame/tab_strip_region_view.h"
 #include "chrome/browser/ui/views/location_bar/location_bar_view.h"
 #include "chrome/browser/ui/views/tabs/new_tab_button.h"
+#include "chrome/browser/ui/views/tabs/tab_search_button.h"
 #include "chrome/browser/ui/views/tabs/tab_strip.h"
 #include "chrome/common/pref_names.h"
 #include "chrome/test/base/in_process_browser_test.h"
@@ -527,6 +529,44 @@ IN_PROC_BROWSER_TEST_F(VerticalTabStripStringBrowserTest, ContextMenuString) {
 #endif
     }));
   }
+}
+
+IN_PROC_BROWSER_TEST_F(VerticalTabStripBrowserTest, OriginalTabSearchButton) {
+  auto* widget_delegate_view =
+      browser_view()->vertical_tab_strip_widget_delegate_view();
+  ASSERT_TRUE(widget_delegate_view);
+
+  auto* region_view = widget_delegate_view->vertical_tab_strip_region_view();
+  ASSERT_TRUE(region_view);
+
+  auto* original_tab_search_button =
+      region_view->original_region_view_->tab_search_button();
+  if (!original_tab_search_button) {
+    // On Windows 10, the button is on the window frame and vertical tab strip
+    // does nothing to it.
+    return;
+  }
+
+  ASSERT_TRUE(original_tab_search_button->GetVisible());
+
+  // The button should be hidden when using vertical tab strip
+  ToggleVerticalTabStrip();
+  EXPECT_FALSE(original_tab_search_button->GetVisible());
+
+  // The button should reappear when getting back to horizontal tab strip.
+  ToggleVerticalTabStrip();
+  EXPECT_TRUE(original_tab_search_button->GetVisible());
+
+  // Turn off the button with a preference.
+  browser()->profile()->GetPrefs()->SetBoolean(kTabsSearchShow, false);
+  EXPECT_FALSE(original_tab_search_button->GetVisible());
+
+  // Turn on and off vertical tab strip
+  ToggleVerticalTabStrip();
+  ToggleVerticalTabStrip();
+
+  // the original tab search button should stay hidden
+  EXPECT_FALSE(original_tab_search_button->GetVisible());
 }
 
 class VerticalTabStripDragAndDropBrowserTest


### PR DESCRIPTION
Uplift of #18814
Resolves https://github.com/brave/brave-browser/issues/30829

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.