### PR TITLE
Respect `Expires` field for custom adblock subscriptions

### DIFF
--- a/browser/brave_shields/ad_block_service_browsertest.cc
+++ b/browser/brave_shields/ad_block_service_browsertest.cc
@@ -792,6 +792,7 @@ IN_PROC_BROWSER_TEST_F(AdBlockServiceTest, SubscribeToCustomSubscription) {
     ASSERT_EQ(subscriptions[0].last_successful_update_attempt, base::Time());
     ASSERT_EQ(subscriptions[0].enabled, true);
     ASSERT_EQ(subscriptions[0].homepage, absl::nullopt);
+    ASSERT_EQ(subscriptions[0].expires, 7 * 24);
     ASSERT_EQ(subscriptions[0].title, absl::nullopt);
   }
 
@@ -840,6 +841,7 @@ IN_PROC_BROWSER_TEST_F(AdBlockServiceTest, SubscribeToCustomSubscription) {
               subscriptions[0].last_update_attempt);
     ASSERT_EQ(subscriptions[0].enabled, false);
     ASSERT_EQ(subscriptions[0].homepage, "https://example.com/list.txt");
+    ASSERT_EQ(subscriptions[0].expires, 3 * 24);
     ASSERT_EQ(subscriptions[0].title, "Test list");
   }
 

--- a/components/adblock_rust_ffi/src/lib.h
+++ b/components/adblock_rust_ffi/src/lib.h
@@ -11,6 +11,8 @@
 #include <stdint.h>
 #include <stdlib.h>
 
+#define C_SUBSCRIPTION_DEFAULT_EXPIRES_HOURS (7 * 24)
+
 /**
  * Main adblocking engine that allows efficient querying of resources to block.
  */

--- a/components/adblock_rust_ffi/src/lib.h
+++ b/components/adblock_rust_ffi/src/lib.h
@@ -16,6 +16,8 @@
  */
 typedef struct C_Engine C_Engine;
 
+typedef struct C_EngineDebugInfo C_EngineDebugInfo;
+
 /**
  * Includes information about any "special comments" as described by
  * https://help.eyeo.com/adblockplus/how-to-write-filters#special-comments
@@ -56,15 +58,15 @@ struct C_Engine* engine_create_from_buffer_with_metadata(
     struct C_FilterListMetadata** metadata);
 
 /**
- * Create a new `Engine`, interpreting `rules` as a null-terminated C string and
- * then parsing as a filter list in ABP syntax.
+ * Create a new `Engine`, interpreting `rules` as a null-terminated C string
+ * and then parsing as a filter list in ABP syntax.
  */
 struct C_Engine* engine_create(const char* rules);
 
 /**
- * Create a new `Engine`, interpreting `rules` as a null-terminated C string and
- * then parsing as a filter list in ABP syntax. Also populates metadata from the
- * filter list into `metadata`.
+ * Create a new `Engine`, interpreting `rules` as a null-terminated C string
+ * and then parsing as a filter list in ABP syntax. Also populates metadata
+ * from the filter list into `metadata`.
  */
 struct C_Engine* engine_create_with_metadata(
     const char* rules,
@@ -156,11 +158,12 @@ bool filter_list_metadata_homepage(const struct C_FilterListMetadata* metadata,
                                    char** homepage);
 
 /**
- * Puts a pointer to the title of the `FilterListMetadata` into `title`. Returns
- * `true` if a title was returned.
+ * Puts a pointer to the title of the `FilterListMetadata` into `title`.
+ * Returns `true` if a title was returned.
  */
 bool filter_list_metadata_title(const struct C_FilterListMetadata* metadata,
                                 char** title);
+
 
 /**
  * Destroy a `FilterListMetadata` once you are done with it.
@@ -168,53 +171,55 @@ bool filter_list_metadata_title(const struct C_FilterListMetadata* metadata,
 void filter_list_metadata_destroy(struct C_FilterListMetadata* metadata);
 
 /**
- * Destroy a `*c_char` once you are done with it.
- */
-void c_char_buffer_destroy(char* s);
-
-/**
- * A structure to hold debug information of engine. Matches to rust
- * EngineDebugInfo.
- */
-typedef struct C_Engine_Debug_Info C_Engine_Debug_Info;
-
-/**
  * Get EngineDebugInfo from the engine. Should be destoyed later by calling
  * engine_debug_info_destroy(..).
  */
-C_Engine_Debug_Info* get_engine_debug_info(struct C_Engine* engine);
+struct C_EngineDebugInfo* get_engine_debug_info(struct C_Engine* engine);
 
-// Returns the field of EngineDebugInfo structure.
-void engine_debug_info_get_attr(struct C_Engine_Debug_Info* debug_info,
+/**
+ * Returns the field of EngineDebugInfo structure.
+ */
+void engine_debug_info_get_attr(struct C_EngineDebugInfo* debug_info,
                                 size_t* compiled_regex_count,
                                 size_t* regex_data_size);
 
-// Returns the fields of EngineDebugInfo->regex_data[index].
-// |regex| stay untouched if it ==None in the original structure.
-// |index| must be in range [0, regex_data.len() - 1].
-void engine_debug_info_get_regex_entry(struct C_Engine_Debug_Info* debug_info,
+/**
+ * Returns the fields of EngineDebugInfo->regex_data[index].
+ *
+ * |regex| stay untouched if it ==None in the original structure.
+ *
+ * |index| must be in range [0, regex_data.len() - 1].
+ */
+void engine_debug_info_get_regex_entry(struct C_EngineDebugInfo* debug_info,
                                        size_t index,
                                        uint64_t* id,
                                        char** regex,
                                        uint64_t* unused_sec,
-                                       size_t* usage_count);
+                                       uintptr_t* usage_count);
 
 /**
  * Destroy a `EngineDebugInfo` once you are done with it.
  */
-void engine_debug_info_destroy(struct C_Engine_Debug_Info* debug_info);
+void engine_debug_info_destroy(struct C_EngineDebugInfo* debug_info);
 
 void discard_regex(struct C_Engine* engine, uint64_t regex_id);
 
 /**
  * Setup discard policy for adblock regexps.
+ *
  * |cleanup_interval_sec| how ofter the engine should check the policy.
+ *
  * |discard_unused_sec| time in sec after unused regex will be discarded. Zero
  * means disable discarding completely.
  */
 void setup_discard_policy(struct C_Engine* engine,
                           uint64_t cleanup_interval_sec,
                           uint64_t discard_unused_sec);
+
+/**
+ * Destroy a `*c_char` once you are done with it.
+ */
+void c_char_buffer_destroy(char* s);
 
 /**
  * Returns a set of cosmetic filtering resources specific to the given url, in
@@ -237,6 +242,11 @@ char* engine_hidden_class_id_selectors(struct C_Engine* engine,
                                        size_t exceptions_size);
 
 #if BUILDFLAG(IS_IOS)
+/**
+ * Converts a list in adblock syntax to its corresponding iOS content-blocking
+ * syntax. `truncated` will be set to indicate whether or not some rules had to
+ * be removed to avoid iOS's maximum rule count limit.
+ */
 char* convert_rules_to_content_blocking(const char* rules, bool* truncated);
 #endif
 

--- a/components/adblock_rust_ffi/src/lib.h
+++ b/components/adblock_rust_ffi/src/lib.h
@@ -164,6 +164,13 @@ bool filter_list_metadata_homepage(const struct C_FilterListMetadata* metadata,
 bool filter_list_metadata_title(const struct C_FilterListMetadata* metadata,
                                 char** title);
 
+/**
+ * Returns the amount of time this filter list should be considered valid for,
+ * in hours. Defaults to 168 (i.e. 7 days) if unspecified by the
+ * `FilterListMetadata`.
+ */
+uint16_t filter_list_metadata_expires(
+    const struct C_FilterListMetadata* metadata);
 
 /**
  * Destroy a `FilterListMetadata` once you are done with it.

--- a/components/adblock_rust_ffi/src/lib.rs
+++ b/components/adblock_rust_ffi/src/lib.rs
@@ -343,6 +343,9 @@ pub unsafe extern "C" fn filter_list_metadata_title(
     }
 }
 
+#[no_mangle]
+pub const SUBSCRIPTION_DEFAULT_EXPIRES_HOURS: u16 = 7 * 24;
+
 /// Returns the amount of time this filter list should be considered valid for,
 /// in hours. Defaults to 168 (i.e. 7 days) if unspecified by the
 /// `FilterListMetadata`.
@@ -350,12 +353,10 @@ pub unsafe extern "C" fn filter_list_metadata_title(
 pub unsafe extern "C" fn filter_list_metadata_expires(metadata: *const FilterListMetadata) -> u16 {
     use adblock::lists::ExpiresInterval;
 
-    const DEFAULT_EXPIRES_HOURS: u16 = 7 * 24;
-
     match (*metadata).expires.as_ref() {
         Some(ExpiresInterval::Days(d)) => 24 * *d as u16,
         Some(ExpiresInterval::Hours(h)) => *h,
-        None => DEFAULT_EXPIRES_HOURS,
+        None => SUBSCRIPTION_DEFAULT_EXPIRES_HOURS,
     }
 }
 

--- a/components/adblock_rust_ffi/src/lib.rs
+++ b/components/adblock_rust_ffi/src/lib.rs
@@ -343,6 +343,22 @@ pub unsafe extern "C" fn filter_list_metadata_title(
     }
 }
 
+/// Returns the amount of time this filter list should be considered valid for,
+/// in hours. Defaults to 168 (i.e. 7 days) if unspecified by the
+/// `FilterListMetadata`.
+#[no_mangle]
+pub unsafe extern "C" fn filter_list_metadata_expires(metadata: *const FilterListMetadata) -> u16 {
+    use adblock::lists::ExpiresInterval;
+
+    const DEFAULT_EXPIRES_HOURS: u16 = 7 * 24;
+
+    match (*metadata).expires.as_ref() {
+        Some(ExpiresInterval::Days(d)) => 24 * *d as u16,
+        Some(ExpiresInterval::Hours(h)) => *h,
+        None => DEFAULT_EXPIRES_HOURS,
+    }
+}
+
 /// Destroy a `FilterListMetadata` once you are done with it.
 #[no_mangle]
 pub unsafe extern "C" fn filter_list_metadata_destroy(metadata: *mut FilterListMetadata) {

--- a/components/adblock_rust_ffi/src/lib.rs
+++ b/components/adblock_rust_ffi/src/lib.rs
@@ -351,6 +351,8 @@ pub unsafe extern "C" fn filter_list_metadata_destroy(metadata: *mut FilterListM
     }
 }
 
+/// Get EngineDebugInfo from the engine. Should be destoyed later by calling
+/// engine_debug_info_destroy(..).
 #[no_mangle]
 pub unsafe extern "C" fn get_engine_debug_info(engine: *mut Engine) -> *mut EngineDebugInfo {
     assert!(!engine.is_null());
@@ -358,6 +360,7 @@ pub unsafe extern "C" fn get_engine_debug_info(engine: *mut Engine) -> *mut Engi
     Box::into_raw(Box::new(engine.get_debug_info()))
 }
 
+/// Returns the field of EngineDebugInfo structure.
 #[no_mangle]
 pub unsafe extern "C" fn engine_debug_info_get_attr(
     debug_info: *mut EngineDebugInfo,
@@ -371,6 +374,11 @@ pub unsafe extern "C" fn engine_debug_info_get_attr(
     *regex_data_size = info.blocker_debug_info.regex_data.len();
 }
 
+/// Returns the fields of EngineDebugInfo->regex_data[index].
+///
+/// |regex| stay untouched if it ==None in the original structure.
+///
+/// |index| must be in range [0, regex_data.len() - 1].
 #[no_mangle]
 pub unsafe extern "C" fn engine_debug_info_get_regex_entry(
     debug_info: *mut EngineDebugInfo,
@@ -394,6 +402,7 @@ pub unsafe extern "C" fn engine_debug_info_get_regex_entry(
     *usage_count = entry.usage_count;
 }
 
+/// Destroy a `EngineDebugInfo` once you are done with it.
 #[no_mangle]
 pub unsafe extern "C" fn engine_debug_info_destroy(debug_info: *mut EngineDebugInfo) {
     if !debug_info.is_null() {
@@ -408,6 +417,12 @@ pub unsafe extern "C" fn discard_regex(engine: *mut Engine, regex_id: u64) {
     engine.discard_regex(regex_id);
 }
 
+/// Setup discard policy for adblock regexps.
+///
+/// |cleanup_interval_sec| how ofter the engine should check the policy.
+///
+/// |discard_unused_sec| time in sec after unused regex will be discarded. Zero
+/// means disable discarding completely.
 #[no_mangle]
 pub unsafe extern "C" fn setup_discard_policy(
     engine: *mut Engine,

--- a/components/adblock_rust_ffi/src/wrapper.cc
+++ b/components/adblock_rust_ffi/src/wrapper.cc
@@ -41,6 +41,8 @@ FilterListMetadata::FilterListMetadata(C_FilterListMetadata* metadata) {
     title = absl::make_optional(std::string(str_buffer));
     c_char_buffer_destroy(str_buffer);
   }
+
+  expires = filter_list_metadata_expires(metadata);
 }
 
 FilterListMetadata::FilterListMetadata(const std::string& list)

--- a/components/adblock_rust_ffi/src/wrapper.h
+++ b/components/adblock_rust_ffi/src/wrapper.h
@@ -56,6 +56,7 @@ typedef ADBLOCK_EXPORT struct FilterListMetadata {
 
   absl::optional<std::string> homepage;
   absl::optional<std::string> title;
+  uint16_t expires;
 
   FilterListMetadata(FilterListMetadata&&);
 

--- a/components/adblock_rust_ffi/src/wrapper.h
+++ b/components/adblock_rust_ffi/src/wrapper.h
@@ -47,6 +47,9 @@ const std::string ADBLOCK_EXPORT
 ConvertRulesToContentBlockingRules(const std::string& rules, bool* truncated);
 #endif
 
+const ADBLOCK_EXPORT uint16_t kSubscriptionDefaultExpiresHours =
+    C_SUBSCRIPTION_DEFAULT_EXPIRES_HOURS;
+
 typedef ADBLOCK_EXPORT struct FilterListMetadata {
   FilterListMetadata();
   explicit FilterListMetadata(C_FilterListMetadata* metadata);
@@ -56,7 +59,8 @@ typedef ADBLOCK_EXPORT struct FilterListMetadata {
 
   absl::optional<std::string> homepage;
   absl::optional<std::string> title;
-  uint16_t expires;
+  // Normalized to a value in hours
+  uint16_t expires = kSubscriptionDefaultExpiresHours;
 
   FilterListMetadata(FilterListMetadata&&);
 

--- a/components/brave_shields/browser/ad_block_subscription_service_manager.cc
+++ b/components/brave_shields/browser/ad_block_subscription_service_manager.cc
@@ -18,6 +18,7 @@
 #include "base/task/thread_pool.h"
 #include "base/time/time.h"
 #include "base/values.h"
+#include "brave/components/adblock_rust_ffi/src/wrapper.h"
 #include "brave/components/brave_shields/browser/ad_block_filters_provider_manager.h"
 #include "brave/components/brave_shields/browser/ad_block_subscription_filters_provider.h"
 #include "brave/components/brave_shields/browser/ad_block_subscription_service_manager_observer.h"
@@ -33,6 +34,8 @@ namespace brave_shields {
 base::TimeDelta* g_testing_subscription_retry_interval;
 
 namespace {
+
+const uint16_t kSubscriptionMaxExpiresHours = 14 * 24;
 
 bool SkipGURLField(base::StringPiece value, GURL* field) {
   return true;
@@ -62,13 +65,13 @@ bool ParseOptionalStringField(const base::Value* value,
 
 bool ParseExpiresWithFallback(const base::Value* value, uint16_t* field) {
   if (value == nullptr) {
-    *field = kSubscriptionDefaultExpiresHours;
+    *field = adblock::kSubscriptionDefaultExpiresHours;
     return true;
   } else if (!value->is_int()) {
     return false;
   } else {
     int64_t i = value->GetInt();
-    if (i < 0 || i > 14 * 24) {
+    if (i < 0 || i > kSubscriptionMaxExpiresHours) {
       return false;
     }
     *field = (uint16_t)i;

--- a/components/brave_shields/browser/ad_block_subscription_service_manager.h
+++ b/components/brave_shields/browser/ad_block_subscription_service_manager.h
@@ -42,6 +42,8 @@ class AdBlockServiceTest;
 
 namespace brave_shields {
 
+const uint16_t kSubscriptionDefaultExpiresHours = 7 * 24;
+
 struct SubscriptionInfo {
   SubscriptionInfo();
   ~SubscriptionInfo();
@@ -64,6 +66,7 @@ struct SubscriptionInfo {
 
   absl::optional<std::string> homepage;
   absl::optional<std::string> title;
+  uint16_t expires = kSubscriptionDefaultExpiresHours;
 
   static void RegisterJSONConverter(
       base::JSONValueConverter<SubscriptionInfo>*);

--- a/components/brave_shields/browser/ad_block_subscription_service_manager.h
+++ b/components/brave_shields/browser/ad_block_subscription_service_manager.h
@@ -27,6 +27,10 @@
 
 class PrefService;
 
+namespace adblock {
+extern const uint16_t kSubscriptionDefaultExpiresHours;
+}  // namespace adblock
+
 namespace base {
 template <typename StructType>
 class JSONValueConverter;
@@ -41,8 +45,6 @@ class AdBlockSubscriptionFiltersProvider;
 class AdBlockServiceTest;
 
 namespace brave_shields {
-
-const uint16_t kSubscriptionDefaultExpiresHours = 7 * 24;
 
 struct SubscriptionInfo {
   SubscriptionInfo();
@@ -66,7 +68,7 @@ struct SubscriptionInfo {
 
   absl::optional<std::string> homepage;
   absl::optional<std::string> title;
-  uint16_t expires = kSubscriptionDefaultExpiresHours;
+  uint16_t expires = adblock::kSubscriptionDefaultExpiresHours;
 
   static void RegisterJSONConverter(
       base::JSONValueConverter<SubscriptionInfo>*);

--- a/test/data/list.txt
+++ b/test/data/list.txt
@@ -1,3 +1,4 @@
 ! Title: Test list
 ! Homepage: https://example.com/list.txt
+! Expires: 3 days
 ||b.com^*logo.png^


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/17909

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-arm64, CI/skip-linux-x64, CI/skip-android, CI/skip-macos, CI/skip-ios, CI/skip-windows-arm64, CI/skip-windows-x64, CI/skip-windows-x86 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

Take a deep breath, this is a complicated one! :sweat_smile: 

1. Visit `brave://settings/shields/filters`
2. Create a new subscription to any filter list with an `! Expires:` metadata comment with a value other than `7 days`, e.g. `https://raw.githubusercontent.com/miyurusankalpa/adblock-list-sri-lanka/master/lkfilter.txt`
3. Once the subscription has loaded successfully, exit the browser completely
4. Using a text editor, open the file named `Local State` file in the browser's profile directory
5. Search for the key `"list_subscriptions"`, then locate the URL you subscribed to in step 2. For the next steps, consider the contents within the following `{...}`.
6. There should be an `"expires"` key with a value corresponding to the number of hours in the list's `! Expires:` value. The example list above has a value of `5 days`, so the corresponding value here should be `120`.
7. The `"last_successful_update_attempt"` and `"last_update_attempt"` fields are timestamps in microseconds that should have the same value, assuming the last list download did not fail. Modify both values by subtracting a value _less than_ the `! Expires:` value. For example, if the list takes 5 days to expire, you might subtract 4 days and 20 hours, or `(4days * 24 + 20hours) * 60 * 60 * 1000000 = 417600000000` microseconds.
8. Save and close the file.
9. Launch the browser again. If you've done everything correctly, the list entry's `Last updated` column should reflect the amount of time you selected in step 7.
10. Leave the browser open for about 5 minutes. The list should _not_ be automatically updated within this time.
11. Exit the browser completely, then reopen the `Local State` file and modify the same `"last_successful_update_attempt"` and `"last_update_attempt"` fields by subtracting a value that, combined with the previous value selected in step 7, would total _more than_ the `! Expires:` value. For example, if the list takes 5 days to expire and you initially subtracted 4 days and 20 hours, you may subtract 4 or more additional hours (i.e. >= `4hours * 60 * 60 * 1000000` microseconds) here.
12. Save and close the file.
13. Launch the browser again. The list entry's `Last updated` column should once again reflect the new total of both amounts of time you selected. But be quick, because...
14. Within about 5 minutes, the list should be automatically updated.

It'd also be good to make sure that the list updates automatically when it passes over the update time threshold naturally while open. To test this...
- At step 7, select a value that is just a few minutes short of the `! Expires:` value. For example, if the list takes 5 days to expire, subtract [4 days, 23 hours, and 52 minutes](https://bravesoftware.slack.com/archives/C01P8A0QHKP/p1686349126563779)<sup>①</sup>.
- Then, at step 10, leave the browser open until the remainder of the time (in this case, 8 minutes) plus about 5 minutes passes. The list should be automatically updated.
- Disregard steps 11-14.

① - I tried. If it doesn't get implemented in Brave Search by the time you're testing, you might still be able to use Google for it.