### PR TITLE
APIRequestHelper doesn't create DataDecoder until request needs parsing

### DIFF
--- a/browser/brave_wallet/brave_wallet_p3a_unittest.cc
+++ b/browser/brave_wallet/brave_wallet_p3a_unittest.cc
@@ -17,7 +17,6 @@
 #include "chrome/test/base/testing_browser_process.h"
 #include "chrome/test/base/testing_profile_manager.h"
 #include "content/public/test/browser_task_environment.h"
-#include "services/data_decoder/public/cpp/test_support/in_process_data_decoder.h"
 #include "testing/gtest/include/gtest/gtest.h"
 
 namespace brave_wallet {
@@ -50,7 +49,6 @@ class BraveWalletP3AUnitTest : public testing::Test {
   raw_ptr<KeyringService> keyring_service_;
   raw_ptr<BraveWalletService> wallet_service_;
   raw_ptr<BraveWalletP3A> wallet_p3a_;
-  data_decoder::test::InProcessDataDecoder in_process_data_decoder_;
 };
 
 TEST_F(BraveWalletP3AUnitTest, KeyringCreated) {

--- a/browser/brave_wallet/notifications/wallet_notification_service_unittest.cc
+++ b/browser/brave_wallet/notifications/wallet_notification_service_unittest.cc
@@ -19,7 +19,6 @@
 #include "chrome/test/base/testing_profile.h"
 #include "components/prefs/testing_pref_service.h"
 #include "content/public/test/browser_task_environment.h"
-#include "services/data_decoder/public/cpp/test_support/in_process_data_decoder.h"
 #include "services/network/public/cpp/weak_wrapper_shared_url_loader_factory.h"
 #include "services/network/test/test_url_loader_factory.h"
 #include "testing/gtest/include/gtest/gtest.h"
@@ -81,7 +80,6 @@ class WalletNotificationServiceUnitTest : public testing::Test {
   std::unique_ptr<JsonRpcService> json_rpc_service_;
   std::unique_ptr<KeyringService> keyring_service_;
   std::unique_ptr<TxService> tx_service_;
-  data_decoder::test::InProcessDataDecoder in_process_data_decoder_;
 };
 
 TEST_F(WalletNotificationServiceUnitTest, ShouldShowNotifications) {

--- a/browser/playlist/test/playlist_service_unittest.cc
+++ b/browser/playlist/test/playlist_service_unittest.cc
@@ -38,7 +38,6 @@
 #include "net/test/embedded_test_server/embedded_test_server.h"
 #include "net/test/embedded_test_server/http_request.h"
 #include "net/test/embedded_test_server/http_response.h"
-#include "services/data_decoder/public/cpp/test_support/in_process_data_decoder.h"
 #include "testing/gmock/include/gmock/gmock-matchers.h"
 #include "testing/gmock/include/gmock/gmock.h"
 #include "testing/gtest/include/gtest/gtest.h"
@@ -249,8 +248,6 @@ class PlaylistServiceUnitTest : public testing::Test {
 
   std::unique_ptr<net::EmbeddedTestServer> https_server_;
   std::unique_ptr<content::TestHostResolver> host_resolver_;
-
-  data_decoder::test::InProcessDataDecoder in_process_data_decoder_;
 };
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/components/ai_chat/ai_chat_api.h
+++ b/components/ai_chat/ai_chat_api.h
@@ -23,14 +23,10 @@ class AIChatAPI {
   AIChatAPI& operator=(const AIChatAPI&) = delete;
   ~AIChatAPI();
 
-  using ResponseCallback = base::RepeatingCallback<void(const std::string&)>;
-  using CompletionCallback =
-      base::OnceCallback<void(bool success, int response_code)>;
-
   // This function queries both types of APIs: SSE and non-SSE.
   // In non-SSE cases, only the data_completed_callback will be triggered.
   void QueryPrompt(const std::string& prompt,
-                   api_request_helper::APIRequestHelper::DataCompletedCallback
+                   api_request_helper::APIRequestHelper::ResultCallback
                        data_completed_callback,
                    api_request_helper::APIRequestHelper::DataReceivedCallback
                        data_received_callback = base::NullCallback());

--- a/components/ai_chat/ai_chat_tab_helper.cc
+++ b/components/ai_chat/ai_chat_tab_helper.cc
@@ -369,8 +369,8 @@ void AIChatTabHelper::OnAPIStreamDataReceived(
 
 void AIChatTabHelper::OnAPIStreamDataComplete(
     bool is_summarize_prompt,
-    api_request_helper::APIRequestResult result,
-    bool success) {
+    api_request_helper::APIRequestResult result) {
+  const bool success = result.Is2XXResponseCode();
   if (success) {
     // TODO(nullhook): Remove this as we don't cache summaries anymore
     if (is_summarize_prompt && !chat_history_.empty()) {
@@ -391,7 +391,7 @@ void AIChatTabHelper::OnAPIStreamDataComplete(
     }
   }
 
-  if (!success || !result.Is2XXResponseCode()) {
+  if (!success) {
     // TODO(petemill): show error state separate from assistant message
     AddToConversationHistory(ConversationTurn{
         CharacterType::ASSISTANT, ConversationTurnVisibility::VISIBLE,

--- a/components/ai_chat/ai_chat_tab_helper.h
+++ b/components/ai_chat/ai_chat_tab_helper.h
@@ -65,8 +65,7 @@ class AIChatTabHelper : public content::WebContentsObserver,
   void CleanUp();
   void OnAPIStreamDataReceived(data_decoder::DataDecoder::ValueOrError result);
   void OnAPIStreamDataComplete(bool is_summarize_prompt,
-                               api_request_helper::APIRequestResult result,
-                               bool success);
+                               api_request_helper::APIRequestResult result);
 
   // content::WebContentsObserver:
   void PrimaryPageChanged(content::Page& page) override;

--- a/components/api_request_helper/api_request_helper.cc
+++ b/components/api_request_helper/api_request_helper.cc
@@ -366,7 +366,15 @@ void APIRequestHelper::URLLoaderHandler::OnComplete(bool success) {
 }
 
 void APIRequestHelper::URLLoaderHandler::OnRetry(
-    base::OnceClosure start_retry) {}
+    base::OnceClosure start_retry) {
+  std::move(start_retry).Run();
+  // We assume that a consumer of APIRequestHelper doesn't
+  // care about discarding partial responses received so far
+  // before a retry, especially if it's SSE. If this assumption
+  // becomes incorrect, perhaps that caller should make the request
+  // directly, or APIRequestHelper could accept a callback, or move
+  // to an observer model.
+}
 
 void APIRequestHelper::URLLoaderHandler::OnResponse(
     ResultCallback callback,

--- a/components/brave_news/browser/suggestions_controller_unittest.cc
+++ b/components/brave_news/browser/suggestions_controller_unittest.cc
@@ -103,7 +103,6 @@ class SuggestionsControllerTest : public testing::Test {
   content::BrowserTaskEnvironment browser_task_environment_;
   TestingProfile profile_;
   network::TestURLLoaderFactory test_url_loader_factory_;
-  data_decoder::test::InProcessDataDecoder in_process_data_decoder_;
   api_request_helper::APIRequestHelper api_request_helper_;
 
   DirectFeedController direct_feed_controller_;

--- a/components/brave_vpn/browser/connection/ikev2/BUILD.gn
+++ b/components/brave_vpn/browser/connection/ikev2/BUILD.gn
@@ -58,7 +58,6 @@ source_set("unit_tests") {
     "//brave/components/brave_vpn/common/mojom",
     "//components/sync_preferences:test_support",
     "//content/test:test_support",
-    "//services/data_decoder/public/cpp:test_support",
     "//services/network:test_support",
     "//testing/gtest",
     "//third_party/abseil-cpp:absl",

--- a/components/brave_vpn/browser/connection/ikev2/brave_vpn_ras_connection_api_unittest.cc
+++ b/components/brave_vpn/browser/connection/ikev2/brave_vpn_ras_connection_api_unittest.cc
@@ -20,7 +20,6 @@
 #include "brave/components/brave_vpn/common/pref_names.h"
 #include "components/sync_preferences/testing_pref_service_syncable.h"
 #include "content/public/test/browser_task_environment.h"
-#include "services/data_decoder/public/cpp/test_support/in_process_data_decoder.h"
 #include "services/network/public/cpp/weak_wrapper_shared_url_loader_factory.h"
 #include "services/network/test/test_url_loader_factory.h"
 #include "testing/gtest/include/gtest/gtest.h"
@@ -260,7 +259,6 @@ class BraveVPNOSConnectionAPIUnitTest : public testing::Test {
   network::TestURLLoaderFactory url_loader_factory_;
   content::BrowserTaskEnvironment task_environment_;
   std::unique_ptr<BraveVPNOSConnectionAPI> connection_api_;
-  data_decoder::test::InProcessDataDecoder in_process_data_decoder_;
 };
 
 TEST_F(BraveVPNOSConnectionAPIUnitTest, LoadRegionDataFromPrefsTest) {

--- a/components/brave_wallet/browser/solana_transaction_unittest.cc
+++ b/components/brave_wallet/browser/solana_transaction_unittest.cc
@@ -25,7 +25,6 @@
 #include "brave/components/brave_wallet/common/features.h"
 #include "brave/components/brave_wallet/common/solana_utils.h"
 #include "components/sync_preferences/testing_pref_service_syncable.h"
-#include "services/data_decoder/public/cpp/test_support/in_process_data_decoder.h"
 #include "services/network/public/cpp/weak_wrapper_shared_url_loader_factory.h"
 #include "services/network/test/test_url_loader_factory.h"
 #include "testing/gtest/include/gtest/gtest.h"
@@ -110,7 +109,6 @@ class SolanaTransactionUnitTest : public testing::Test {
   scoped_refptr<network::SharedURLLoaderFactory> shared_url_loader_factory_;
   std::unique_ptr<JsonRpcService> json_rpc_service_;
   std::unique_ptr<KeyringService> keyring_service_;
-  data_decoder::test::InProcessDataDecoder in_process_data_decoder_;
 };
 
 TEST_F(SolanaTransactionUnitTest, GetSignedTransaction) {


### PR DESCRIPTION
Moves `DataDecoder` construction to the point where it's required. Reuses a `DataDecoder` instance only for each request, which is the way it was when we called `ParseJsonIsolated` prior to https://github.com/brave/brave-core/pull/18376. The complication now though is that we support streaming responses, so we want to keep the same `DataDecoder` instance for the lifetime of the response.
We don't want that instance of `DataDecoder` to be deleted before all the decoding operations is completed, so when the request is finished we wait to delete the request's wrapper class (which owns this `DataDecoder` instance) until all the parsing is completed (which usually takes much longer than the response being completed). We accomplish this by counting the number of parse operations and waiting until a callback has been called that many times (like a `base::BarrierCallback` but we don't need it's function of providing an array of all the callback arguments).

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/30937

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-arm64, CI/skip-linux-x64, CI/skip-android, CI/skip-macos, CI/skip-ios, CI/skip-windows-arm64, CI/skip-windows-x64, CI/skip-windows-x86 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
- Brave News still receives content (this tests the one-off requests)
- Brave AI still receives streaming summary (this tests the streaming requests)
