### PR TITLE
(Wallet) Show full network name in the status bar

### DIFF
--- a/android/brave_java_resources.gni
+++ b/android/brave_java_resources.gni
@@ -937,6 +937,7 @@ brave_java_resources = [
   "java/res/layout/rewards_tipping_success_contribution_fragment.xml",
   "java/res/layout/rewards_you_are_not_earning_dialog.xml",
   "java/res/layout/search_preference.xml",
+  "java/res/layout/selected_network_item.xml",
   "java/res/layout/shimmer_skeleton_item.xml",
   "java/res/layout/swap_bottom_sheet.xml",
   "java/res/layout/tipping_banner_tipping_panel_inside_layout.xml",

--- a/android/java/org/chromium/chrome/browser/crypto_wallet/adapters/NetworkSpinnerAdapter.java
+++ b/android/java/org/chromium/chrome/browser/crypto_wallet/adapters/NetworkSpinnerAdapter.java
@@ -66,12 +66,9 @@ public class NetworkSpinnerAdapter extends BaseAdapter implements SpinnerAdapter
     // [ViewHolder]
     @SuppressLint("ViewHolder")
     public View getView(int position, View view, ViewGroup viewGroup) {
-        view = inflater.inflate(R.layout.network_spinner_items, null);
+        view = inflater.inflate(R.layout.selected_network_item, viewGroup, false);
         TextView name = view.findViewById(R.id.network_name_text);
-        name.setText(Utils.getShortNameOfNetwork(mNetworkInfos.get(position).chainName));
-        ImageView networkPicture = view.findViewById(R.id.network_picture);
-        networkPicture.setVisibility(View.GONE);
-        name.setCompoundDrawablesRelativeWithIntrinsicBounds(null, null, null, null);
+        name.setText(mNetworkInfos.get(position).chainName);
         return view;
     }
 

--- a/android/java/res/layout/activity_buy_send_swap.xml
+++ b/android/java/res/layout/activity_buy_send_swap.xml
@@ -39,14 +39,10 @@
                     android:layout_width="0dp"
                     android:layout_height="wrap_content"
                     android:layout_weight="2"
-                    android:textSize="12sp"
                     android:textColor="@color/wallet_text_color"
                     android:layout_gravity="center_vertical"
-                    android:prompt="@string/mainnet"
-                    android:paddingStart="8dp"
-                    android:paddingEnd="8dp"
-                    android:paddingTop="2dp"
-                    android:paddingBottom="2dp" />
+                    android:paddingEnd="32dp"
+                    />
 
             </LinearLayout>
 

--- a/android/java/res/layout/selected_network_item.xml
+++ b/android/java/res/layout/selected_network_item.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content">
+
+    <TextView
+        android:id="@+id/network_name_text"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center_vertical"
+        android:maxLines="2"
+        android:textColor="@color/wallet_text_color"
+        android:textSize="16sp" />
+
+</FrameLayout>


### PR DESCRIPTION
## Resolves https://github.com/brave/brave-browser/issues/30341

Shows full network name in the status bar.

![Screenshot_1686585901](https://github.com/brave/brave-core/assets/3308503/9c87d9b5-6b04-4c13-af8e-2c3a383c6f7a)


<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-arm64, CI/skip-linux-x64, CI/skip-android, CI/skip-macos, CI/skip-ios, CI/skip-windows-arm64, CI/skip-windows-x64, CI/skip-windows-x86 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
* Open Brave Wallet
* Tap on Eth asset
* Tap on Send button
* Observe the selected network name is displayed in full (E.g. Ethereum Mainnet)
* Pick another network (E.g. Aurora Mainnet)
* Observe the selected network is fully displayed

