### PR TITLE
Add flag to override download danger level

### DIFF
--- a/browser/about_flags.cc
+++ b/browser/about_flags.cc
@@ -857,6 +857,15 @@
           "back to HTTP.",                                                     \
           kOsAll,                                                              \
           FEATURE_VALUE_TYPE(net::features::kBraveHttpsByDefault),             \
+      },                                                                       \
+      {                                                                        \
+          "brave-override-download-danger-level",                              \
+          "Override download danger level",                                    \
+          "Disables download warnings for files which are considered "         \
+          "dangerous when Safe Browsing is disabled. Use at your own risks. "  \
+          "Not recommended.",                                                  \
+          kOsWin | kOsLinux | kOsMac,                                          \
+          FEATURE_VALUE_TYPE(features::kBraveOverrideDownloadDangerLevel),     \
       })                                                                       \
   BRAVE_IPFS_FEATURE_ENTRIES                                                   \
   BRAVE_NATIVE_WALLET_FEATURE_ENTRIES                                          \

--- a/browser/brave_browser_features.cc
+++ b/browser/brave_browser_features.cc
@@ -23,4 +23,10 @@ BASE_FEATURE(kBraveCopyCleanLinkByDefault,
 #endif
 );
 
+// Disable download warnings for dangerous files when Safe Browsing is
+// disabled.
+BASE_FEATURE(kBraveOverrideDownloadDangerLevel,
+             "brave-override-download-danger-level",
+             base::FEATURE_DISABLED_BY_DEFAULT);
+
 }  // namespace features

--- a/browser/brave_browser_features.h
+++ b/browser/brave_browser_features.h
@@ -12,6 +12,7 @@ namespace features {
 
 BASE_DECLARE_FEATURE(kBraveCleanupSessionCookiesOnSessionRestore);
 BASE_DECLARE_FEATURE(kBraveCopyCleanLinkByDefault);
+BASE_DECLARE_FEATURE(kBraveOverrideDownloadDangerLevel);
 
 }  // namespace features
 

--- a/chromium_src/chrome/browser/download/download_target_determiner.cc
+++ b/chromium_src/chrome/browser/download/download_target_determiner.cc
@@ -3,11 +3,22 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+#include "brave/browser/brave_browser_features.h"
+
 // Prompting the user for download location shouldn't be a factor in determining
 // the download's danger level.
 #define BRAVE_DOWNLOAD_TARGET_DETERMINER_GET_DANGER_LEVEL \
   true) {}                                                \
   if (
 
+#define BRAVE_DOWNLOAD_TARGET_DETERMINER_GET_DANGER_LEVEL2       \
+  if (danger_level == DownloadFileType::ALLOW_ON_USER_GESTURE) { \
+    if (base::FeatureList::IsEnabled(                            \
+            features::kBraveOverrideDownloadDangerLevel)) {      \
+      return DownloadFileType::NOT_DANGEROUS;                    \
+    }                                                            \
+  }
+
 #include "src/chrome/browser/download/download_target_determiner.cc"
 #undef BRAVE_DOWNLOAD_TARGET_DETERMINER_GET_DANGER_LEVEL
+#undef BRAVE_DOWNLOAD_TARGET_DETERMINER_GET_DANGER_LEVEL2

--- a/patches/chrome-browser-download-download_target_determiner.cc.patch
+++ b/patches/chrome-browser-download-download_target_determiner.cc.patch
@@ -1,5 +1,5 @@
 diff --git a/chrome/browser/download/download_target_determiner.cc b/chrome/browser/download/download_target_determiner.cc
-index 0927a4c06b273e58954cba1f6be70695370b83a8..fbc06b9fa3b99d1a7324012dc17fa5127bb160c7 100644
+index 0927a4c06b273e58954cba1f6be70695370b83a8..a388aba922dbef0b01fbcc59048c3af8244fe0c3 100644
 --- a/chrome/browser/download/download_target_determiner.cc
 +++ b/chrome/browser/download/download_target_determiner.cc
 @@ -1255,6 +1255,7 @@ DownloadFileType::DangerLevel DownloadTargetDeterminer::GetDangerLevel(
@@ -9,4 +9,12 @@ index 0927a4c06b273e58954cba1f6be70695370b83a8..fbc06b9fa3b99d1a7324012dc17fa512
 +      BRAVE_DOWNLOAD_TARGET_DETERMINER_GET_DANGER_LEVEL
        !download_->GetForcedFilePath().empty())
      return DownloadFileType::NOT_DANGEROUS;
+ 
+@@ -1293,6 +1294,7 @@ DownloadFileType::DangerLevel DownloadTargetDeterminer::GetDangerLevel(
+         ui::PAGE_TRANSITION_FROM_ADDRESS_BAR) != 0 ||
+        (download_->HasUserGesture() && visits == VISITED_REFERRER)))
+     return DownloadFileType::NOT_DANGEROUS;
++  BRAVE_DOWNLOAD_TARGET_DETERMINER_GET_DANGER_LEVEL2
+   return danger_level;
+ }
  


### PR DESCRIPTION
Fixes brave/brave-browser#28917

Security review: https://github.com/brave/security/issues/1306

This only applies when Safe Browsing is turned off.

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-arm64, CI/skip-linux-x64, CI/skip-android, CI/skip-macos, CI/skip-ios, CI/skip-windows-arm64, CI/skip-windows-x64, CI/skip-windows-x86 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

1. Start the browser and disable Safe Browsing from `brave://settings/security`.
2. Go to https://zoom.us/download and download Zoom for the platform you're testing on (e.g. the `.deb` on Linux, the `.exe` on Windows and the `.dmg` on Mac).
3. Confirm that the download is **blocked as dangerous**.
4. Go into `brave://flags/` and enable `brave-override-download-danger-level`.
5. Restart the browser.
6. Go back to https://zoom.us/download and download the same client as in step 2.
7. Confirm that the download is **not blocked**.