### PR TITLE
Changes ChromeSwitchPreference to ChromeBaseCheckBoxPreference class

### DIFF
--- a/android/brave_java_sources.gni
+++ b/android/brave_java_sources.gni
@@ -421,7 +421,6 @@ brave_java_sources = [
   "../../brave/android/java/org/chromium/chrome/browser/toolbar/top/BraveTabSwitcherModeTopToolbar.java",
   "../../brave/android/java/org/chromium/chrome/browser/toolbar/top/BraveToolbarLayoutImpl.java",
   "../../brave/android/java/org/chromium/chrome/browser/toolbar/top/BraveTopToolbarCoordinator.java",
-  "../../brave/android/java/org/chromium/chrome/browser/ui/brave_tricks/checkbox_to_switch/CheckBoxPreference.java",
   "../../brave/android/java/org/chromium/chrome/browser/ui/messages/infobar/BraveSimpleConfirmInfoBarBuilder.java",
   "../../brave/android/java/org/chromium/chrome/browser/upgrade/BravePackageReplacedBroadcastReceiver.java",
   "../../brave/android/java/org/chromium/chrome/browser/upgrade/BraveUpgradeJobIntentServiceImpl.java",

--- a/android/java/org/chromium/chrome/browser/sync/settings/BraveManageSyncSettings.java
+++ b/android/java/org/chromium/chrome/browser/sync/settings/BraveManageSyncSettings.java
@@ -8,24 +8,24 @@ package org.chromium.chrome.browser.sync.settings;
 import android.os.Bundle;
 
 import androidx.annotation.Nullable;
+import androidx.annotation.VisibleForTesting;
 import androidx.preference.Preference;
 
 import org.chromium.chrome.R;
-import org.chromium.components.browser_ui.settings.ChromeBaseCheckBoxPreference;
+import org.chromium.components.browser_ui.settings.brave_tricks.checkbox_to_switch.ChromeBaseCheckBoxPreference;
 
-// See org.brave.bytecode.BraveManageSyncSettingsClassAdapter
+/**
+ * See org.brave.bytecode.BraveManageSyncSettingsClassAdapter
+ */
 public class BraveManageSyncSettings extends ManageSyncSettings {
     private static final String PREF_ADVANCED_CATEGORY = "advanced_category";
-    private static final String PREF_SYNC_REVIEW_DATA = "sync_review_data";
-    private static final String PREF_TURN_OFF_SYNC = "turn_off_sync";
-    private static final String PREF_SYNC_READING_LIST = "sync_reading_list";
-    private static final String PREF_SYNC_AUTOFILL = "sync_autofill";
 
     private Preference mGoogleActivityControls;
     private Preference mSyncEncryption;
 
     private ChromeBaseCheckBoxPreference mSyncPaymentsIntegration;
 
+    @VisibleForTesting
     @Override
     public void onCreatePreferences(@Nullable Bundle savedInstanceState, String rootKey) {
         super.onCreatePreferences(savedInstanceState, rootKey);

--- a/android/java/res/xml/manage_sync_preferences.xml
+++ b/android/java/res/xml/manage_sync_preferences.xml
@@ -22,42 +22,42 @@
         android:title="@string/sync_everything_pref"
         android:persistent="false"/>
 
-    <org.chromium.chrome.browser.ui.brave_tricks.checkbox_to_switch.CheckBoxPreference
+    <org.chromium.components.browser_ui.settings.brave_tricks.checkbox_to_switch.ChromeBaseCheckBoxPreference
         android:key="sync_autofill"
         android:title="@string/sync_autofill"
         android:persistent="false"/>
 
-    <org.chromium.chrome.browser.ui.brave_tricks.checkbox_to_switch.CheckBoxPreference
+    <org.chromium.components.browser_ui.settings.brave_tricks.checkbox_to_switch.ChromeBaseCheckBoxPreference
         android:key="sync_bookmarks"
         android:title="@string/sync_bookmarks"
         android:persistent="false"/>
 
-    <org.chromium.chrome.browser.ui.brave_tricks.checkbox_to_switch.CheckBoxPreference
+    <org.chromium.components.browser_ui.settings.brave_tricks.checkbox_to_switch.ChromeBaseCheckBoxPreference
         android:key="sync_payments_integration"
         android:title="@string/sync_payments_integration"
         android:persistent="false"/>
 
-    <org.chromium.chrome.browser.ui.brave_tricks.checkbox_to_switch.CheckBoxPreference
+    <org.chromium.components.browser_ui.settings.brave_tricks.checkbox_to_switch.ChromeBaseCheckBoxPreference
         android:key="sync_history"
         android:title="@string/sync_history"
         android:persistent="false"/>
 
-    <org.chromium.chrome.browser.ui.brave_tricks.checkbox_to_switch.CheckBoxPreference
+    <org.chromium.components.browser_ui.settings.brave_tricks.checkbox_to_switch.ChromeBaseCheckBoxPreference
         android:key="sync_passwords"
         android:title="@string/sync_passwords"
         android:persistent="false"/>
 
-    <org.chromium.chrome.browser.ui.brave_tricks.checkbox_to_switch.CheckBoxPreference
+    <org.chromium.components.browser_ui.settings.brave_tricks.checkbox_to_switch.ChromeBaseCheckBoxPreference
         android:key="sync_reading_list"
         android:title="@string/sync_reading_list"
         android:persistent="false"/>
 
-    <org.chromium.chrome.browser.ui.brave_tricks.checkbox_to_switch.CheckBoxPreference
+    <org.chromium.components.browser_ui.settings.brave_tricks.checkbox_to_switch.ChromeBaseCheckBoxPreference
         android:key="sync_recent_tabs"
         android:title="@string/sync_recent_tabs"
         android:persistent="false"/>
 
-    <org.chromium.chrome.browser.ui.brave_tricks.checkbox_to_switch.CheckBoxPreference
+    <org.chromium.components.browser_ui.settings.brave_tricks.checkbox_to_switch.ChromeBaseCheckBoxPreference
         android:key="sync_settings"
         android:title="@string/sync_settings"
         android:persistent="false"/>

--- a/components/browser_ui/settings/android/sources.gni
+++ b/components/browser_ui/settings/android/sources.gni
@@ -1,0 +1,6 @@
+# Copyright (c) 2023 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+brave_components_browser_ui_settings_android_java_sources = [ "//brave/components/browser_ui/settings/android/widget/java/src/org/chromium/components/browser_ui/settings/brave_tricks/checkbox_to_switch/ChromeBaseCheckBoxPreference.java" ]

--- a/components/browser_ui/settings/android/widget/java/src/org/chromium/components/browser_ui/settings/brave_tricks/checkbox_to_switch/ChromeBaseCheckBoxPreference.java
+++ b/components/browser_ui/settings/android/widget/java/src/org/chromium/components/browser_ui/settings/brave_tricks/checkbox_to_switch/ChromeBaseCheckBoxPreference.java
@@ -3,15 +3,18 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-package org.chromium.chrome.browser.ui.brave_tricks.checkbox_to_switch;
+package org.chromium.components.browser_ui.settings.brave_tricks.checkbox_to_switch;
 
 import android.content.Context;
 import android.util.AttributeSet;
 
 import org.chromium.components.browser_ui.settings.ChromeSwitchPreference;
 
-public class CheckBoxPreference extends ChromeSwitchPreference {
-    public CheckBoxPreference(Context context, AttributeSet attrs) {
+/**
+ * Redefinition of CheckBoxPreference to act as ChromeSwitchPreference in fact.
+ */
+public class ChromeBaseCheckBoxPreference extends ChromeSwitchPreference {
+    public ChromeBaseCheckBoxPreference(Context context, AttributeSet attrs) {
         super(context, attrs);
     }
 }

--- a/patches/chrome-android-java-src-org-chromium-chrome-browser-sync-settings-ManageSyncSettings.java.patch
+++ b/patches/chrome-android-java-src-org-chromium-chrome-browser-sync-settings-ManageSyncSettings.java.patch
@@ -1,7 +1,16 @@
 diff --git a/chrome/android/java/src/org/chromium/chrome/browser/sync/settings/ManageSyncSettings.java b/chrome/android/java/src/org/chromium/chrome/browser/sync/settings/ManageSyncSettings.java
-index 3b229431fc69c56bcbd4163ae46285a489882bf2..ee4d68cbdf2f0b83a02bb11e0429cf03462fb046 100644
+index 3b229431fc69c56bcbd4163ae46285a489882bf2..028279ee2599af11a538234a5a28df0bddad02f2 100644
 --- a/chrome/android/java/src/org/chromium/chrome/browser/sync/settings/ManageSyncSettings.java
 +++ b/chrome/android/java/src/org/chromium/chrome/browser/sync/settings/ManageSyncSettings.java
+@@ -53,7 +53,7 @@ import org.chromium.chrome.browser.sync.ui.PassphraseDialogFragment;
+ import org.chromium.chrome.browser.sync.ui.PassphraseTypeDialogFragment;
+ import org.chromium.chrome.browser.ui.signin.SignOutDialogCoordinator;
+ import org.chromium.chrome.browser.ui.signin.SignOutDialogCoordinator.Listener;
+-import org.chromium.components.browser_ui.settings.ChromeBaseCheckBoxPreference;
++import org.chromium.components.browser_ui.settings.brave_tricks.checkbox_to_switch.ChromeBaseCheckBoxPreference;
+ import org.chromium.components.browser_ui.settings.ChromeSwitchPreference;
+ import org.chromium.components.browser_ui.settings.SettingsUtils;
+ import org.chromium.components.signin.AccountManagerFacadeProvider;
 @@ -356,7 +356,7 @@ public class ManageSyncSettings extends PreferenceFragmentCompat
                          .getIdentityManager(Profile.getLastUsedRegularProfile())
                          .getPrimaryAccountInfo(ConsentLevel.SYNC));

--- a/patches/components-browser_ui-settings-android-BUILD.gn.patch
+++ b/patches/components-browser_ui-settings-android-BUILD.gn.patch
@@ -1,0 +1,12 @@
+diff --git a/components/browser_ui/settings/android/BUILD.gn b/components/browser_ui/settings/android/BUILD.gn
+index d97f250e7f2c1621d5f2805c8add77b0cb271321..bc2352cb5cb22e10a0f2a9b48b7f849f15086167 100644
+--- a/components/browser_ui/settings/android/BUILD.gn
++++ b/components/browser_ui/settings/android/BUILD.gn
+@@ -48,6 +48,7 @@ android_library("java") {
+   ]
+   resources_package = "org.chromium.components.browser_ui.settings"
+   annotation_processor_deps = [ "//base/android/jni_generator:jni_processor" ]
++  import("//brave/components/browser_ui/settings/android/sources.gni") sources += brave_components_browser_ui_settings_android_java_sources
+ }
+ 
+ android_resources("java_resources") {


### PR DESCRIPTION
Changes ChromeSwitchPreference to ChromeBaseCheckBoxPreference class for sync data types screen on Android.

Related Chromium changes:
https://source.chromium.org/chromium/chromium/src/+/29ac6dc2ea650d1768a9b222e6c49accf8100f19 [Signin]
```
[Android] Use a map for mSyncTypePreferences.

This is just a refactoring CL and will not change any logic.

Fixed: 1407184
Change-Id: I92a04692af00aefc6654ab9b681c9efae914ab10
Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/4422769
```
and

https://source.chromium.org/chromium/chromium/src/+/b3d30106aa25f614cfb46524e40972f9130573d5 
```
[ManagedSyncSettings] Sync Settings on Android Reflect Managed State

When sync is enabled and SyncTypesDisabledList policy is set with some data types, the checkboxes are not disabled. However, checking the boxes did not have any downstream effect.

This CL sets the managed preferences when sync types are disabled by the SyncTypesListDisabled policy.

Bug: b/277005858
Change-Id: Ibdb031885918e475972b94f488ac1e8f317372d4
Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/4507582
```

Fixes brave/brave-browser#30964

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/30964

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-arm64, CI/skip-linux-x64, CI/skip-android, CI/skip-macos, CI/skip-ios, CI/skip-windows-arm64, CI/skip-windows-x64, CI/skip-windows-x86 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

