### PR TITLE
fix(wallet): Remove Outside Click Event for Filters Modal

### DIFF
--- a/components/brave_wallet_ui/components/desktop/popup-modals/filter-modals/portfolio-filters-modal.tsx
+++ b/components/brave_wallet_ui/components/desktop/popup-modals/filter-modals/portfolio-filters-modal.tsx
@@ -38,9 +38,6 @@ import {
 } from '../../../../common/constants/magics'
 
 // Hooks
-import {
-  useOnClickOutside
-} from '../../../../common/hooks/useOnClickOutside'
 import { useLib } from '../../../../common/hooks/useLib'
 
 // Utils
@@ -113,17 +110,7 @@ export const PortfolioFiltersModal = (props: Props) => {
   const [selectedGroupAssetsByOption, setSelectedGroupAssetsByOption] =
     React.useState<string>(selectedGroupAssetsByItem)
 
-  // refs
-  const portfolioFiltersRef =
-    React.useRef<HTMLDivElement>(null)
-
   // Hooks
-  useOnClickOutside(
-    portfolioFiltersRef,
-    () => onClose(),
-    true
-  )
-
   const { refreshTokenPriceHistory } = useLib()
 
   const onUpdateSelectedGroupAssetsByOption = React.useCallback(() => {
@@ -235,7 +222,6 @@ export const PortfolioFiltersModal = (props: Props) => {
       title={getLocale('braveWalletPortfolioFiltersTitle')}
       width='500px'
       borderRadius={16}
-      ref={portfolioFiltersRef}
     >
       <ScrollableColumn>
         <Column


### PR DESCRIPTION
## Description 
Removes the `Out Side Click` closing event for the `Portfolio Filters` modal to prevent accidental closing of unsaved changes.

<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves <https://github.com/brave/brave-browser/issues/31021>

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-arm64, CI/skip-linux-x64, CI/skip-android, CI/skip-macos, CI/skip-ios, CI/skip-windows-arm64, CI/skip-windows-x64, CI/skip-windows-x86 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
1. Go to the `Portfolio` view and open the `Filters and display settings` modal
2. Click outside of the modal, it should not close.

Before:

https://github.com/brave/brave-core/assets/40611140/6c684875-2d2b-403e-98dd-d3737992a448

After:

https://github.com/brave/brave-core/assets/40611140/294fb991-6c8a-42e8-83c7-891e4888eca6
