### PR TITLE
Fix ad serve race condition on ads startup. (uplift to 1.52.x)

### DIFF
--- a/components/brave_ads/core/internal/ads/serving/notification_ad_serving_util.cc
+++ b/components/brave_ads/core/internal/ads/serving/notification_ad_serving_util.cc
@@ -14,11 +14,19 @@ namespace brave_ads {
 
 namespace {
 
-constexpr base::TimeDelta kServeFirstAdAfterDelay = base::Minutes(2);
+constexpr base::TimeDelta kServeFirstAdAfter = base::Minutes(2);
 constexpr base::TimeDelta kMinimumDelayBeforeServingAnAd = base::Minutes(1);
 
 bool HasPreviouslyServedAnAd() {
   return AdsClientHelper::GetInstance()->HasPrefPath(prefs::kServeAdAt);
+}
+
+base::TimeDelta DelayBeforeServingAnAd() {
+  return ServeAdAt() - base::Time::Now();
+}
+
+bool ShouldHaveServedAdInThePast() {
+  return DelayBeforeServingAnAd().is_negative();
 }
 
 bool ShouldServeAd() {
@@ -31,26 +39,26 @@ bool ShouldServeAdsAtRegularIntervals() {
   return PlatformHelper::GetInstance().IsMobile();
 }
 
-base::Time ServeAdAt() {
-  return AdsClientHelper::GetInstance()->GetTimePref(prefs::kServeAdAt);
-}
-
 void SetServeAdAt(const base::Time serve_ad_at) {
   AdsClientHelper::GetInstance()->SetTimePref(prefs::kServeAdAt, serve_ad_at);
 }
 
+base::Time ServeAdAt() {
+  return AdsClientHelper::GetInstance()->GetTimePref(prefs::kServeAdAt);
+}
+
 base::TimeDelta CalculateDelayBeforeServingAnAd() {
   if (!HasPreviouslyServedAnAd()) {
-    return kServeFirstAdAfterDelay;
+    return kServeFirstAdAfter;
   }
 
-  if (ShouldServeAd()) {
+  if (ShouldHaveServedAdInThePast() || ShouldServeAd()) {
     return kMinimumDelayBeforeServingAnAd;
   }
 
-  base::TimeDelta delay = ServeAdAt() - base::Time::Now();
-  if (delay.is_negative()) {
-    delay = base::TimeDelta();
+  const base::TimeDelta delay = DelayBeforeServingAnAd();
+  if (delay < kMinimumDelayBeforeServingAnAd) {
+    return kMinimumDelayBeforeServingAnAd;
   }
 
   return delay;

--- a/components/brave_ads/core/internal/ads/serving/notification_ad_serving_util.h
+++ b/components/brave_ads/core/internal/ads/serving/notification_ad_serving_util.h
@@ -15,9 +15,10 @@ namespace brave_ads {
 
 bool ShouldServeAdsAtRegularIntervals();
 
-base::TimeDelta CalculateDelayBeforeServingAnAd();
-base::Time ServeAdAt();
 void SetServeAdAt(base::Time serve_ad_at);
+base::Time ServeAdAt();
+
+base::TimeDelta CalculateDelayBeforeServingAnAd();
 
 }  // namespace brave_ads
 

--- a/components/brave_ads/core/internal/ads/serving/notification_ad_serving_util_unittest.cc
+++ b/components/brave_ads/core/internal/ads/serving/notification_ad_serving_util_unittest.cc
@@ -18,7 +18,18 @@ namespace brave_ads {
 class BraveAdsNotificationAdServingUtilTest : public UnitTestBase {};
 
 TEST_F(BraveAdsNotificationAdServingUtilTest,
-       ShouldServeAdsAtRegularIntervals) {
+       ShouldServeAdsAtRegularIntervalsOnIOS) {
+  // Arrange
+  MockPlatformHelper(platform_helper_mock_, PlatformType::kIOS);
+
+  // Act
+
+  // Assert
+  EXPECT_TRUE(ShouldServeAdsAtRegularIntervals());
+}
+
+TEST_F(BraveAdsNotificationAdServingUtilTest,
+       ShouldServeAdsAtRegularIntervalsOnAndroid) {
   // Arrange
   MockPlatformHelper(platform_helper_mock_, PlatformType::kAndroid);
 
@@ -29,9 +40,31 @@ TEST_F(BraveAdsNotificationAdServingUtilTest,
 }
 
 TEST_F(BraveAdsNotificationAdServingUtilTest,
-       ShouldNotServeAdsAtRegularIntervals) {
+       ShouldNotServeAdsAtRegularIntervalsOnMacOS) {
+  // Arrange
+  MockPlatformHelper(platform_helper_mock_, PlatformType::kMacOS);
+
+  // Act
+
+  // Assert
+  EXPECT_FALSE(ShouldServeAdsAtRegularIntervals());
+}
+
+TEST_F(BraveAdsNotificationAdServingUtilTest,
+       ShouldNotServeAdsAtRegularIntervalsOnWindows) {
   // Arrange
   MockPlatformHelper(platform_helper_mock_, PlatformType::kWindows);
+
+  // Act
+
+  // Assert
+  EXPECT_FALSE(ShouldServeAdsAtRegularIntervals());
+}
+
+TEST_F(BraveAdsNotificationAdServingUtilTest,
+       ShouldNotServeAdsAtRegularIntervalsOnLinux) {
+  // Arrange
+  MockPlatformHelper(platform_helper_mock_, PlatformType::kLinux);
 
   // Act
 
@@ -79,6 +112,19 @@ TEST_F(BraveAdsNotificationAdServingUtilTest, CalculateDelayBeforeServingAnAd) {
 
   // Assert
   EXPECT_EQ(DistantFuture() - Now(), CalculateDelayBeforeServingAnAd());
+}
+
+TEST_F(BraveAdsNotificationAdServingUtilTest,
+       CalculateMinimumDelayBeforeServingAnAd) {
+  // Arrange
+  SetServeAdAt(Now());
+
+  AdvanceClockBy(base::Seconds(1));
+
+  // Act
+
+  // Assert
+  EXPECT_EQ(base::Minutes(1), CalculateDelayBeforeServingAnAd());
 }
 
 }  // namespace brave_ads


### PR DESCRIPTION
Uplift of #18887
Resolves https://github.com/brave/brave-browser/issues/30988

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.