### PR TITLE
fix(wallet): Sort Portfolio Groups by Fiat Value

### DIFF
--- a/components/brave_wallet_ui/components/desktop/views/portfolio/components/token-lists/token-list.tsx
+++ b/components/brave_wallet_ui/components/desktop/views/portfolio/components/token-lists/token-list.tsx
@@ -231,13 +231,12 @@ export const TokenLists = ({
       // Return an empty string to display a loading
       // skeleton while assets are populated.
       if (sortedFungibleTokensList.length === 0) {
-        return ''
+        return Amount.empty()
       }
       // Return a 0 balance if the network has no
       // assets to display.
       if (getAssetsByNetwork(network).length === 0) {
         return new Amount(0)
-          .formatAsFiat(defaultCurrencies.fiat)
       }
 
       const amounts = getAssetsByNetwork(network)
@@ -256,13 +255,11 @@ export const TokenLists = ({
 
       return !reducedAmounts.isUndefined()
         ? reducedAmounts
-          .formatAsFiat(defaultCurrencies.fiat)
-        : ''
+        : Amount.empty()
     }, [
     computeFiatAmount,
     getAssetsByNetwork,
-    sortedFungibleTokensList,
-    defaultCurrencies.fiat
+    sortedFungibleTokensList
   ])
 
   // Returns a list of assets based on provided account
@@ -306,7 +303,7 @@ export const TokenLists = ({
       // Return an empty string to display a loading
       // skeleton while assets are populated.
       if (sortedFungibleTokensList.length === 0) {
-        return ''
+        return Amount.empty()
       }
       // Return a 0 balance if the account has no
       // assets to display.
@@ -315,7 +312,6 @@ export const TokenLists = ({
           .length === 0
       ) {
         return new Amount(0)
-          .formatAsFiat(defaultCurrencies.fiat)
       }
 
       const amounts =
@@ -339,21 +335,27 @@ export const TokenLists = ({
 
       return !reducedAmounts.isUndefined()
         ? reducedAmounts
-          .formatAsFiat(defaultCurrencies.fiat)
-        : ''
+        : Amount.empty()
     }, [
     getFilteredOutAssetsByAccount,
-    defaultCurrencies.fiat,
     sortedFungibleTokensList
   ])
 
   const listUiByNetworks = React.useMemo(() => {
-    return networks?.map((network) =>
+    return networks?.sort((a, b) => {
+      const aBalance = getNetworkFiatValue(a)
+      const bBalance = getNetworkFiatValue(b)
+      return bBalance.minus(aBalance).toNumber()
+    })?.map((network) =>
       <AssetGroupContainer
         key={networkEntityAdapter
           .selectId(network).toString()}
         balance={
           getNetworkFiatValue(network)
+            .isUndefined()
+            ? ''
+            : getNetworkFiatValue(network)
+              .formatAsFiat(defaultCurrencies.fiat)
         }
         network={network}
         isDisabled={getAssetsByNetwork(network).length === 0}
@@ -376,14 +378,25 @@ export const TokenLists = ({
     getNetworkFiatValue,
     renderToken,
     networks,
+    defaultCurrencies.fiat,
     assetAutoDiscoveryCompleted
   ])
 
   const listUiByAccounts = React.useMemo(() => {
-    return accounts?.map((account) =>
+    return accounts?.sort((a, b) => {
+      const aBalance = getAccountFiatValue(a)
+      const bBalance = getAccountFiatValue(b)
+      return bBalance.minus(aBalance).toNumber()
+    })?.map((account) =>
       <AssetGroupContainer
         key={account.address}
-        balance={getAccountFiatValue(account)}
+        balance={
+          getAccountFiatValue(account)
+            .isUndefined()
+            ? ''
+            : getAccountFiatValue(account)
+              .formatAsFiat(defaultCurrencies.fiat)
+        }
         account={account}
         isDisabled={
           getFilteredOutAssetsByAccount(account).length
@@ -408,6 +421,7 @@ export const TokenLists = ({
     getAccountFiatValue,
     renderToken,
     accounts,
+    defaultCurrencies.fiat,
     assetAutoDiscoveryCompleted
   ])
 


### PR DESCRIPTION
## Description 
Will now sort Portfolio groups `Accounts` or `Networks` by `Fiat Value`

<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves <https://github.com/brave/brave-browser/issues/31024>

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-arm64, CI/skip-linux-x64, CI/skip-android, CI/skip-macos, CI/skip-ios, CI/skip-windows-arm64, CI/skip-windows-x64, CI/skip-windows-x86 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
1. Go to the `Portfolio` page and group your portfolio by `Accounts`
2. Account groups should be sorted by `Fiat Value` high to low
3. Group your portfolio by `Networks`
4. Network groups should be sorted by `Fiat Value` high to low

Before:

https://github.com/brave/brave-core/assets/40611140/d58ff0c1-8112-4d3a-a45f-805ffef29ef4

After:

https://github.com/brave/brave-core/assets/40611140/03fb1c83-0a54-460f-ade3-ce351b4a4000
