### PR TITLE
[Shortcuts] Display NumPad keys differently

### DIFF
--- a/components/commands/common/accelerator_parsing.cc
+++ b/components/commands/common/accelerator_parsing.cc
@@ -124,25 +124,60 @@ ui::KeyEventFlags GetModifierFromKeys(
   }
   return result;
 }
+
+std::string KeyCodeToString(ui::KeyboardCode key_code) {
+  switch (key_code) {
+    case ui::VKEY_LMENU:
+    case ui::VKEY_MENU:
+      return kMenu;
+    case ui::VKEY_RMENU:
+      return kRMenu;
+    case ui::VKEY_NUMPAD0:
+      return "Num0";
+    case ui::VKEY_NUMPAD1:
+      return "Num1";
+    case ui::VKEY_NUMPAD2:
+      return "Num2";
+    case ui::VKEY_NUMPAD3:
+      return "Num3";
+    case ui::VKEY_NUMPAD4:
+      return "Num4";
+    case ui::VKEY_NUMPAD5:
+      return "Num5";
+    case ui::VKEY_NUMPAD6:
+      return "Num6";
+    case ui::VKEY_NUMPAD7:
+      return "Num7";
+    case ui::VKEY_NUMPAD8:
+      return "Num8";
+    case ui::VKEY_NUMPAD9:
+      return "Num9";
+    case ui::VKEY_ADD:
+      return "NumAdd";
+    case ui::VKEY_SUBTRACT:
+      return "NumSubtract";
+    case ui::VKEY_MULTIPLY:
+      return "NumMultiply";
+    case ui::VKEY_DIVIDE:
+      return "NumDivide";
+    case ui::VKEY_DECIMAL:
+      return "NumDecimal";
+    default:
+      auto domcode = ui::UsLayoutKeyboardCodeToDomCode(key_code);
+      ui::DomKey domkey;
+      ui::KeyboardCode out_code;
+      if (!ui::DomCodeToUsLayoutDomKey(domcode, 0, &domkey, &out_code)) {
+        return "Unknown Key: " + base::NumberToString(key_code);
+      }
+      return ui::KeycodeConverter::DomKeyToKeyString(domkey);
+  }
+}
+
 }  // namespace
 
 std::string ToKeysString(const ui::Accelerator& accelerator) {
   std::vector<std::string> parts = GetModifierNames(accelerator.modifiers());
-  auto domcode = ui::UsLayoutKeyboardCodeToDomCode(accelerator.key_code());
-  ui::DomKey domkey;
-  ui::KeyboardCode out_code;
-
-  if (accelerator.key_code() == ui::VKEY_LMENU ||
-      accelerator.key_code() == ui::VKEY_MENU) {
-    parts.push_back(kMenu);
-  } else if (accelerator.key_code() == ui::VKEY_RMENU) {
-    parts.push_back(kRMenu);
-  } else if (!ui::DomCodeToUsLayoutDomKey(domcode, 0, &domkey, &out_code)) {
-    parts.push_back("Unknown Key: " +
-                    base::NumberToString(accelerator.key_code()));
-  } else {
-    parts.push_back(ui::KeycodeConverter::DomKeyToKeyString(domkey));
-  }
+  parts.push_back(KeyCodeToString(accelerator.key_code()));
   return base::JoinString(parts, "+");
 }
 


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/31035

Before:
![image](https://github.com/brave/brave-core/assets/7678024/6bc4b726-b161-4bd7-8412-bf197b5c08ac)

After:
![image](https://github.com/brave/brave-core/assets/7678024/f4aa2b6a-27f0-483e-b86f-50b9e2a96b3d)

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-arm64, CI/skip-linux-x64, CI/skip-android, CI/skip-macos, CI/skip-ios, CI/skip-windows-arm64, CI/skip-windows-x64, CI/skip-windows-x86 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [ ] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

Open chrome://settings/system/shortcuts and search for `Select`. The select tab commands should have one shortcut for `NumN` and one for `N`
