### PR TITLE
Fixed extension's newtab is not loaded when it's restored during the startup

### DIFF
--- a/browser/sessions/brave_session_restore_browsertest.cc
+++ b/browser/sessions/brave_session_restore_browsertest.cc
@@ -18,10 +18,12 @@
 #include "net/dns/mock_host_resolver.h"
 #include "services/network/public/cpp/network_switches.h"
 #include "testing/gtest/include/gtest/gtest.h"
+#include "third_party/blink/public/common/page_state/page_state.h"
+#include "third_party/blink/public/common/page_state/page_state_serialization.h"
 
-using BraveSesstionRestoreBrowserTest = InProcessBrowserTest;
+using BraveSessionRestoreBrowserTest = InProcessBrowserTest;
 
-IN_PROC_BROWSER_TEST_F(BraveSesstionRestoreBrowserTest, Serialization) {
+IN_PROC_BROWSER_TEST_F(BraveSessionRestoreBrowserTest, Serialization) {
   auto* tab_model = browser()->tab_strip_model();
   auto* web_contents = tab_model->GetActiveWebContents();
   SessionService* const session_service =
@@ -53,7 +55,12 @@ IN_PROC_BROWSER_TEST_F(BraveSesstionRestoreBrowserTest, Serialization) {
         const auto& serialized_navigation = windows[0]->tabs[0]->navigations[1];
         EXPECT_EQ(serialized_navigation.virtual_url(),
                   GURL("chrome://newtab/"));
-        EXPECT_TRUE(serialized_navigation.encoded_page_state().empty());
+
+        // Check encoded data is not empty but clean state only with url info.
+        EXPECT_EQ(blink::PageState::CreateFromURL(GURL("chrome://newtab/"))
+                      .ToEncodedData(),
+                  serialized_navigation.encoded_page_state());
+        EXPECT_FALSE(serialized_navigation.encoded_page_state().empty());
         loop.Quit();
       }));
   loop.Run();

--- a/chromium_src/components/sessions/content/content_serialized_navigation_driver.cc
+++ b/chromium_src/components/sessions/content/content_serialized_navigation_driver.cc
@@ -17,8 +17,18 @@
 namespace sessions {
 std::string ContentSerializedNavigationDriver::GetSanitizedPageStateForPickle(
     const sessions::SerializedNavigationEntry* navigation) const {
-  if (navigation->virtual_url().SchemeIs(content::kChromeUIScheme))
-    return std::string();
+  if (navigation->virtual_url().SchemeIs(content::kChromeUIScheme)) {
+    // chrome url can be re-written when it's restored during the tab but
+    // re-written url is ignored when encoded page state is empty.
+    // In ContentSerializedNavigationBuilder::ToNavigationEntry(), re-written
+    // url created by NavigationEntry's ctor is ignored by creating new page
+    // state with navigation's virtual_url. Sanitize all but make url info
+    // persisted. Use original_request_url as it's used when NavigationEntry is
+    // created.
+    return blink::PageState::CreateFromURL(navigation->original_request_url())
+        .ToEncodedData();
+  }
+
   return GetSanitizedPageStateForPickle_ChromiumImpl(navigation);
 }
 

--- a/components/sessions/content/brave_content_serialized_navigation_driver_unittest.cc
+++ b/components/sessions/content/brave_content_serialized_navigation_driver_unittest.cc
@@ -8,6 +8,8 @@
 #include "components/sessions/core/serialized_navigation_entry.h"
 #include "components/sessions/core/serialized_navigation_entry_test_helper.h"
 #include "testing/gtest/include/gtest/gtest.h"
+#include "third_party/blink/public/common/page_state/page_state.h"
+#include "third_party/blink/public/common/page_state/page_state_serialization.h"
 
 namespace sessions {
 
@@ -24,7 +26,10 @@ TEST(BraveContentSerializedNavigationDriverTest,
   EXPECT_EQ(std::string(), driver->GetSanitizedPageStateForPickle(&navigation));
 
   navigation.set_virtual_url(GURL("chrome://wallet"));
-  EXPECT_EQ(std::string(), driver->GetSanitizedPageStateForPickle(&navigation));
+  // Check encoded data is not empty but clean state only with url info.
+  EXPECT_EQ(blink::PageState::CreateFromURL(navigation.original_request_url())
+                .ToEncodedData(),
+            driver->GetSanitizedPageStateForPickle(&navigation));
 }
 
 // Tests that PageState data is left unsanitized when post data is absent.
@@ -39,7 +44,10 @@ TEST(BraveContentSerializedNavigationDriverTest,
   EXPECT_EQ(test_data::kEncodedPageState,
             driver->GetSanitizedPageStateForPickle(&navigation));
   navigation.set_virtual_url(GURL("chrome://wallet"));
-  EXPECT_EQ(std::string(), driver->GetSanitizedPageStateForPickle(&navigation));
+  // Check encoded data is not empty but clean state only with url info.
+  EXPECT_EQ(blink::PageState::CreateFromURL(navigation.original_request_url())
+                .ToEncodedData(),
+            driver->GetSanitizedPageStateForPickle(&navigation));
 }
 
 }  // namespace sessions


### PR DESCRIPTION
fix https://github.com/brave/brave-browser/issues/30890

As we sanitize serialzed navigation(https://github.com/brave/brave-core/pull/14603), encoded page state is empty for all chrome url.
So, new page state is created with virtual url when it's restored during the startup. ContentSerializedNavigationBuilder::ToNavigationEntry() set new page state if it's empty.
When new page state is created, navigation's virtual url is created.
If url is re-written when NavigationEntryImpl is created, that re-written url is ignored.
To fix this, including url info only for chrome url's encoded page state.

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves 

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-arm64, CI/skip-linux-x64, CI/skip-android, CI/skip-macos, CI/skip-ios, CI/skip-windows-arm64, CI/skip-windows-x64, CI/skip-windows-x86 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [ ] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

`BraveSessionRestoreBrowserTest.Serialization`
`BraveContentSerializedNavigationDriverTest.*`

1. Install any NewTab extension such as https://chrome.google.com/webstore/detail/momentum/laookkfknpbbblfpciffpaejjkokdgca
2. Create another NTP and check extension's NTP is loaded
3. Relaunch and check that lastly opened NTP loaded extension's NTP