### PR TITLE
Make upstream's remove_unused_imports.py to be usable at Brave repo

### DIFF
--- a/PRESUBMIT.py
+++ b/PRESUBMIT.py
@@ -391,15 +391,11 @@ def CheckJavaStyle(_original_check, input_api, output_api):
     if warnings:
         ret.append(output_api.PresubmitPromptWarning('\n'.join(warnings)))
     if errors:
-        remove_unused_imports_path = input_api.os_path.join(
-            input_api.PresubmitLocalPath(), 'tools', 'android', 'checkstyle',
-            'remove_unused_imports.py')
         msg = '\n'.join(errors)
         if 'Unused import:' in msg or 'Duplicate import' in msg:
             msg += """
 
-To remove unused imports: """ + input_api.os_path.relpath(
-                remove_unused_imports_path, local_path)
+To remove unused imports: ./tools/android/checkstyle/remove_unused_imports.sh"""
         ret.append(output_api.PresubmitError(msg))
     return ret
 

--- a/tools/android/checkstyle/remove_unused_imports.py
+++ b/tools/android/checkstyle/remove_unused_imports.py
@@ -1,0 +1,32 @@
+# Copyright (c) 2023 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import os
+
+
+def main():
+    src_dir = os.path.abspath(
+        os.path.join(__file__, os.pardir, os.pardir, os.pardir, os.pardir,
+                     os.pardir))
+    chromium_checkstyle_dir = os.path.join(src_dir, "tools", "android",
+                                           "checkstyle")
+    chromium_script = os.path.join(chromium_checkstyle_dir,
+                                   "remove_unused_imports.py")
+    chromium_style_path = os.path.join(chromium_checkstyle_dir,
+                                       "unused-imports.xml")
+
+    with open(chromium_script, "r") as f:
+        contents = f.read()
+        contents = contents.replace("main()", "chromium_main()")
+        contents = contents.replace("if __name__ == '__main__':",
+                                    "if __name__ != '__main__':")
+        exec(contents, globals(), globals())  # pylint: disable=exec-used
+
+    globals()['_STYLE_FILE'] = chromium_style_path
+    globals()['chromium_main']()
+
+
+if __name__ == '__main__':
+    main()

--- a/tools/android/checkstyle/remove_unused_imports.sh
+++ b/tools/android/checkstyle/remove_unused_imports.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+# Copyright (c) 2023 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+
+SCRIPT_DIR="$( dirname -- "${BASH_SOURCE[0]}"; )"
+SCRIPT_DIR="$( realpath -e -- "$SCRIPT_DIR"; )"
+
+CHROMIUM_CHECKSTYLE_DIR="$SCRIPT_DIR/../../../../tools/android/checkstyle"
+CHROMIUM_CHECKSTYLE_DIR="$( realpath -e -- "$CHROMIUM_CHECKSTYLE_DIR"; )"
+export PYTHONPATH="$CHROMIUM_CHECKSTYLE_DIR"
+
+python3  "$SCRIPT_DIR/remove_unused_imports.py"


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves brave/brave-browser#31045

At this PR:
- `tools/android/checkstyle/remove_unused_imports.sh` sets the PYTHONPATH to allow load Chromium's checkstyle modules;
- upstream's `remove_unused_imports.py` is loaded, modified to use correct path to`unused-imports.xml`and invoked.

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-arm64, CI/skip-linux-x64, CI/skip-android, CI/skip-macos, CI/skip-ios, CI/skip-windows-arm64, CI/skip-windows-x64, CI/skip-windows-x86 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
See STR at issue https://github.com/brave/brave-browser/issues/31045
