### PR TITLE
Process wallet permission requests in FIFO order instead of fixed order of Accepted->Denied->Cancelled

### DIFF
--- a/browser/permissions/permission_manager_browsertest.cc
+++ b/browser/permissions/permission_manager_browsertest.cc
@@ -8,6 +8,7 @@
 #include "base/functional/bind.h"
 #include "base/memory/raw_ptr.h"
 #include "base/ranges/algorithm.h"
+#include "base/test/mock_callback.h"
 #include "base/test/scoped_feature_list.h"
 #include "brave/components/brave_wallet/browser/permission_utils.h"
 #include "brave/components/brave_wallet/common/features.h"
@@ -37,6 +38,8 @@
 #include "net/test/embedded_test_server/embedded_test_server.h"
 #include "url/gurl.h"
 #include "url/origin.h"
+
+using testing::ElementsAreArray;
 
 namespace permissions {
 
@@ -169,9 +172,16 @@ IN_PROC_BROWSER_TEST_F(PermissionManagerBrowserTest, RequestPermissions) {
     auto observer = std::make_unique<PermissionRequestManagerObserver>(
         permission_request_manager);
 
+    base::MockCallback<base::OnceCallback<void(
+        const std::vector<blink::mojom::PermissionStatus>&)>>
+        callback;
+    EXPECT_CALL(callback,
+                Run(ElementsAreArray({blink::mojom::PermissionStatus::ASK,
+                                      blink::mojom::PermissionStatus::ASK})))
+        .Times(1);
     permission_manager()->RequestPermissionsForOrigin(
         permissions, web_contents()->GetPrimaryMainFrame(), origin.GetURL(),
-        true, base::DoNothing());
+        true, callback.Get());
 
     content::RunAllTasksUntilIdle();
 
@@ -193,6 +203,7 @@ IN_PROC_BROWSER_TEST_F(PermissionManagerBrowserTest, RequestPermissions) {
 
     // Test dismissing request.
     permissions::BraveWalletPermissionContext::Cancel(web_contents());
+    testing::Mock::VerifyAndClearExpectations(&callback);
     EXPECT_TRUE(observer->IsRequestsFinalized()) << "case: " << i;
     EXPECT_TRUE(!observer->IsShowingBubble()) << "case: " << i;
     EXPECT_TRUE(IsPendingGroupedRequestsEmpty(cases[i].type)) << "case: " << i;
@@ -206,9 +217,14 @@ IN_PROC_BROWSER_TEST_F(PermissionManagerBrowserTest, RequestPermissions) {
     }
 
     observer->Reset();
+    EXPECT_CALL(
+        callback,
+        Run(ElementsAreArray({blink::mojom::PermissionStatus::ASK,
+                              blink::mojom::PermissionStatus::GRANTED})))
+        .Times(1);
     permission_manager()->RequestPermissionsForOrigin(
         permissions, web_contents()->GetPrimaryMainFrame(), origin.GetURL(),
-        true, base::DoNothing());
+        true, callback.Get());
 
     content::RunAllTasksUntilIdle();
     EXPECT_TRUE(permission_request_manager->IsRequestInProgress())
@@ -232,6 +248,7 @@ IN_PROC_BROWSER_TEST_F(PermissionManagerBrowserTest, RequestPermissions) {
         std::vector<std::string>{addresses[1]},
         brave_wallet::mojom::PermissionLifetimeOption::kForever,
         web_contents());
+    testing::Mock::VerifyAndClearExpectations(&callback);
     std::vector<ContentSetting> expected_settings(
         {ContentSetting::CONTENT_SETTING_ASK,
          ContentSetting::CONTENT_SETTING_ALLOW});


### PR DESCRIPTION
Otherwise the PermissionRequest callback is not called as expected order so `BravePermissionManager::RequestPermissionsForOrigin` will have callback called with array order different than original requests order.

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/30802

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-arm64, CI/skip-linux-x64, CI/skip-android, CI/skip-macos, CI/skip-ios, CI/skip-windows-arm64, CI/skip-windows-x64, CI/skip-windows-x86 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [ ] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
1. Make sure wallet has two Ethereum accounts and no Ethereum permission for example.com
2. Navigate to example.com
3. Type `await window.ethereum.request({method:'eth_requestAccounts'})` in console
4. Select the second account and confirm
5. console should output the address of second account
