### PR TITLE
fix(wallet): Portfolio Search Balance Loading Skeleton

### DIFF
--- a/components/brave_wallet_ui/components/desktop/views/portfolio/components/token-lists/token-list.tsx
+++ b/components/brave_wallet_ui/components/desktop/views/portfolio/components/token-lists/token-list.tsx
@@ -142,23 +142,8 @@ export const TokenLists = ({
     return visibleTokens
   }, [visibleTokens, hideSmallBalances, computeFiatAmount])
 
-  const filteredAssetList = React.useMemo(() => {
-    if (searchValue === '') {
-      return filteredOutSmallBalanceTokens
-        .filter((asset) => asset.asset.visible)
-    }
-    return filteredOutSmallBalanceTokens.filter((item) => {
-      return (
-        item.asset.name.toLowerCase() === searchValue.toLowerCase() ||
-        item.asset.name.toLowerCase().startsWith(searchValue.toLowerCase()) ||
-        item.asset.symbol.toLocaleLowerCase() === searchValue.toLowerCase() ||
-        item.asset.symbol.toLowerCase().startsWith(searchValue.toLowerCase())
-      )
-    })
-  }, [searchValue, filteredOutSmallBalanceTokens])
-
   const fungibleTokens = React.useMemo(() => {
-    return filteredAssetList
+    return filteredOutSmallBalanceTokens
       .filter(
         (token) => !(
           token.asset.isErc721 ||
@@ -167,7 +152,7 @@ export const TokenLists = ({
         )
       )
   },
-    [filteredAssetList]
+    [filteredOutSmallBalanceTokens]
   )
 
   const assetFilterItemInfo = React.useMemo(() => {
@@ -208,10 +193,33 @@ export const TokenLists = ({
     computeFiatAmount
   ])
 
+  const filteredAssetList = React.useMemo(() => {
+    const listToUse = isPortfolio
+      ? sortedFungibleTokensList
+      : userAssetList
+    if (searchValue === '') {
+      return listToUse
+        .filter((asset) => asset.asset.visible)
+    }
+    return listToUse.filter((item) => {
+      return (
+        item.asset.name.toLowerCase() === searchValue.toLowerCase() ||
+        item.asset.name.toLowerCase().startsWith(searchValue.toLowerCase()) ||
+        item.asset.symbol.toLocaleLowerCase() === searchValue.toLowerCase() ||
+        item.asset.symbol.toLowerCase().startsWith(searchValue.toLowerCase())
+      )
+    })
+  }, [
+    searchValue,
+    sortedFungibleTokensList,
+    isPortfolio,
+    userAssetList
+  ])
+
   // Returns a list of assets based on provided network
   const getAssetsByNetwork = React.useCallback(
     (network: BraveWallet.NetworkInfo) => {
-      return sortedFungibleTokensList
+      return filteredAssetList
         .filter(
           (asset) =>
             networkEntityAdapter
@@ -223,7 +231,7 @@ export const TokenLists = ({
             networkEntityAdapter
               .selectId(network).toString()
         )
-    }, [sortedFungibleTokensList])
+    }, [filteredAssetList])
 
   // Returns the full fiat value of provided network
   const getNetworkFiatValue = React.useCallback(
@@ -265,12 +273,12 @@ export const TokenLists = ({
   // Returns a list of assets based on provided account
   const getAssetsByAccount = React.useCallback(
     (account: WalletAccountType) => {
-      return sortedFungibleTokensList
+      return filteredAssetList
         .filter(
           (asset) => asset.asset.coin ===
             account.accountId.coin
         )
-    }, [sortedFungibleTokensList])
+    }, [filteredAssetList])
 
   // Returns a list of assets based on provided account
   // and filters out small balances if hideSmallBalances
@@ -433,7 +441,7 @@ export const TokenLists = ({
           ? listUiByAccounts
           : <>
             {
-              sortedFungibleTokensList
+              filteredAssetList
                 .map((token, index) =>
                   renderToken(
                     { index, item: token, viewMode: 'list' }
@@ -447,7 +455,7 @@ export const TokenLists = ({
     }
     return <>
       {
-        sortedFungibleTokensList
+        filteredAssetList
           .map(
             (token, index) =>
               renderToken(
@@ -458,7 +466,7 @@ export const TokenLists = ({
     </>
   }, [
     selectedGroupAssetsByItem,
-    sortedFungibleTokensList,
+    filteredAssetList,
     listUiByNetworks,
     listUiByAccounts,
     renderToken,


### PR DESCRIPTION
## Description 
Fixes a bug where if you search for a token you don't have on the `Portfolio` screen, the group `balances` would show a `loading skeleton`.

<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves <https://github.com/brave/brave-browser/issues/31070>

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-arm64, CI/skip-linux-x64, CI/skip-android, CI/skip-macos, CI/skip-ios, CI/skip-windows-arm64, CI/skip-windows-x64, CI/skip-windows-x86 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
   1. Go to the `Portfolio` and group by networks.
   2. Search for a token that you don't have.
   3. The groups should show a `$0.00` balance instead of a `loading skeleton`.

Before:

https://github.com/brave/brave-core/assets/40611140/a1a2bee8-d91e-43b0-ba95-e7a68ada4ff2

After:

https://github.com/brave/brave-core/assets/40611140/237e7460-deac-4562-914f-c27fd21b8918
