### PR TITLE
Fix permission reset on page reopen during ES keep-alive.

### DIFF
--- a/browser/ephemeral_storage/tld_ephemeral_lifetime.cc
+++ b/browser/ephemeral_storage/tld_ephemeral_lifetime.cc
@@ -44,8 +44,7 @@ TLDEphemeralLifetime::TLDEphemeralLifetime(
 TLDEphemeralLifetime::~TLDEphemeralLifetime() {
   if (ephemeral_storage_service_) {
     ephemeral_storage_service_->TLDEphemeralLifetimeDestroyed(
-        key_.second, storage_partition_config_,
-        std::move(on_destroy_callbacks_));
+        key_.second, storage_partition_config_);
   }
 
   ActiveTLDStorageAreas().erase(key_);
@@ -80,11 +79,6 @@ TLDEphemeralLifetime* TLDEphemeralLifetime::Get(
   auto it = ActiveTLDStorageAreas().find(key);
   DCHECK(it == ActiveTLDStorageAreas().end() || it->second.get());
   return it != ActiveTLDStorageAreas().end() ? it->second.get() : nullptr;
-}
-
-void TLDEphemeralLifetime::RegisterOnDestroyCallback(
-    OnDestroyCallback callback) {
-  on_destroy_callbacks_.push_back(std::move(callback));
 }
 
 }  // namespace ephemeral_storage

--- a/browser/ephemeral_storage/tld_ephemeral_lifetime.h
+++ b/browser/ephemeral_storage/tld_ephemeral_lifetime.h
@@ -10,7 +10,6 @@
 #include <utility>
 #include <vector>
 
-#include "base/functional/callback.h"
 #include "base/memory/raw_ptr.h"
 #include "base/memory/ref_counted.h"
 #include "base/memory/weak_ptr.h"
@@ -50,9 +49,6 @@ class TLDEphemeralLifetime : public base::RefCounted<TLDEphemeralLifetime> {
       const std::string& storage_domain,
       const content::StoragePartitionConfig& storage_partition_config);
 
-  // Add a callback to a callback list to be called on destruction.
-  void RegisterOnDestroyCallback(OnDestroyCallback callback);
-
   const TLDEphemeralLifetimeKey& key() const { return key_; }
   const content::StoragePartitionConfig& storage_partition_config() const {
     return storage_partition_config_;
@@ -67,7 +63,6 @@ class TLDEphemeralLifetime : public base::RefCounted<TLDEphemeralLifetime> {
   TLDEphemeralLifetimeKey key_;
   base::WeakPtr<EphemeralStorageService> ephemeral_storage_service_;
   const content::StoragePartitionConfig storage_partition_config_;
-  std::vector<OnDestroyCallback> on_destroy_callbacks_;
 
   base::WeakPtrFactory<TLDEphemeralLifetime> weak_factory_{this};
 };

--- a/browser/permissions/permission_lifetime_manager_factory.cc
+++ b/browser/permissions/permission_lifetime_manager_factory.cc
@@ -9,6 +9,7 @@
 #include <utility>
 
 #include "base/no_destructor.h"
+#include "brave/browser/ephemeral_storage/ephemeral_storage_service_factory.h"
 #include "brave/browser/permissions/permission_origin_lifetime_monitor_impl.h"
 #include "brave/components/permissions/permission_lifetime_manager.h"
 #include "chrome/browser/content_settings/host_content_settings_map_factory.h"
@@ -36,7 +37,9 @@ PermissionLifetimeManagerFactory::GetInstance() {
 PermissionLifetimeManagerFactory::PermissionLifetimeManagerFactory()
     : BrowserContextKeyedServiceFactory(
           "PermissionLifetimeManagerFactory",
-          BrowserContextDependencyManager::GetInstance()) {}
+          BrowserContextDependencyManager::GetInstance()) {
+  DependsOn(EphemeralStorageServiceFactory::GetInstance());
+}
 
 PermissionLifetimeManagerFactory::~PermissionLifetimeManagerFactory() = default;
 

--- a/components/ephemeral_storage/BUILD.gn
+++ b/components/ephemeral_storage/BUILD.gn
@@ -10,6 +10,8 @@ static_library("ephemeral_storage") {
     "ephemeral_storage_service.cc",
     "ephemeral_storage_service.h",
     "ephemeral_storage_service_delegate.h",
+    "ephemeral_storage_service_observer.h",
+    "ephemeral_storage_types.h",
     "url_storage_checker.cc",
     "url_storage_checker.h",
   ]

--- a/components/ephemeral_storage/ephemeral_storage_service_delegate.h
+++ b/components/ephemeral_storage/ephemeral_storage_service_delegate.h
@@ -9,15 +9,10 @@
 #include <string>
 #include <utility>
 
-#include "content/public/browser/storage_partition_config.h"
+#include "brave/components/ephemeral_storage/ephemeral_storage_types.h"
 #include "url/origin.h"
 
 namespace ephemeral_storage {
-
-// TLD ephemeral area is keyed by the TLD-specific security domain and
-// StoragePartitionConfig.
-using TLDEphemeralAreaKey =
-    std::pair<std::string, content::StoragePartitionConfig>;
 
 // Delegate performs cleanup for all required parts (chrome, content, etc.).
 class EphemeralStorageServiceDelegate {

--- a/components/ephemeral_storage/ephemeral_storage_service_observer.h
+++ b/components/ephemeral_storage/ephemeral_storage_service_observer.h
@@ -11,7 +11,7 @@
 
 namespace ephemeral_storage {
 
-// Handles Ephemeral Storage cleanup/queuing and other events.
+// Observer to monitor Ephemeral Storage events.
 class EphemeralStorageServiceObserver : public base::CheckedObserver {
  public:
   virtual void OnCleanupTLDEphemeralArea(const TLDEphemeralAreaKey& key) {}

--- a/components/ephemeral_storage/ephemeral_storage_service_observer.h
+++ b/components/ephemeral_storage/ephemeral_storage_service_observer.h
@@ -1,0 +1,22 @@
+/* Copyright (c) 2023 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_COMPONENTS_EPHEMERAL_STORAGE_EPHEMERAL_STORAGE_SERVICE_OBSERVER_H_
+#define BRAVE_COMPONENTS_EPHEMERAL_STORAGE_EPHEMERAL_STORAGE_SERVICE_OBSERVER_H_
+
+#include "base/observer_list_types.h"
+#include "brave/components/ephemeral_storage/ephemeral_storage_types.h"
+
+namespace ephemeral_storage {
+
+// Handles Ephemeral Storage cleanup/queuing and other events.
+class EphemeralStorageServiceObserver : public base::CheckedObserver {
+ public:
+  virtual void OnCleanupTLDEphemeralArea(const TLDEphemeralAreaKey& key) {}
+};
+
+}  // namespace ephemeral_storage
+
+#endif  // BRAVE_COMPONENTS_EPHEMERAL_STORAGE_EPHEMERAL_STORAGE_SERVICE_OBSERVER_H_

--- a/components/ephemeral_storage/ephemeral_storage_types.h
+++ b/components/ephemeral_storage/ephemeral_storage_types.h
@@ -1,0 +1,23 @@
+/* Copyright (c) 2023 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_COMPONENTS_EPHEMERAL_STORAGE_EPHEMERAL_STORAGE_TYPES_H_
+#define BRAVE_COMPONENTS_EPHEMERAL_STORAGE_EPHEMERAL_STORAGE_TYPES_H_
+
+#include <string>
+#include <utility>
+
+#include "content/public/browser/storage_partition_config.h"
+
+namespace ephemeral_storage {
+
+// TLD ephemeral area is keyed by the TLD-specific security domain and
+// StoragePartitionConfig.
+using TLDEphemeralAreaKey =
+    std::pair<std::string, content::StoragePartitionConfig>;
+
+}  // namespace ephemeral_storage
+
+#endif  // BRAVE_COMPONENTS_EPHEMERAL_STORAGE_EPHEMERAL_STORAGE_TYPES_H_


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Permission cleanup event on tab close was incorrectly lost if the tab was reopened shortly after. This PR changes the way `OnCleanupTLDEphemeralArea` event is passed to `PermissionOriginLifetimeMonitorImpl` by implementing an observer instead of passing callbacks here and there.

Resolves https://github.com/brave/brave-browser/issues/31072

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-arm64, CI/skip-linux-x64, CI/skip-android, CI/skip-macos, CI/skip-ios, CI/skip-windows-arm64, CI/skip-windows-x64, CI/skip-windows-x86 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

