### PR TITLE
P3A: add support for multihash attestation fingerprints

### DIFF
--- a/components/p3a/BUILD.gn
+++ b/components/p3a/BUILD.gn
@@ -101,6 +101,7 @@ source_set("unit_tests") {
     "message_manager_unittest.cc",
     "metric_log_store_unittest.cc",
     "metric_names_unittest.cc",
+    "nitro_utils/attestation_unittest.cc",
     "nitro_utils/cose_unittest.cc",
     "p2a_protocols_unittest.cc",
     "p3a_service_unittest.cc",

--- a/components/p3a/nitro_utils/attestation.h
+++ b/components/p3a/nitro_utils/attestation.h
@@ -6,6 +6,8 @@
 #ifndef BRAVE_COMPONENTS_P3A_NITRO_UTILS_ATTESTATION_H_
 #define BRAVE_COMPONENTS_P3A_NITRO_UTILS_ATTESTATION_H_
 
+#include <vector>
+
 #include "base/functional/callback.h"
 #include "services/network/public/cpp/shared_url_loader_factory.h"
 #include "url/gurl.h"
@@ -25,6 +27,20 @@ void RequestAndVerifyAttestationDocument(
     network::mojom::URLLoaderFactory* url_loader_factory,
     base::OnceCallback<void(scoped_refptr<net::X509Certificate>)>
         result_callback);
+
+// Functions used for unit tests
+//
+// These take the cbor serialization of just the attestation document
+// portion of the COSE Sign1 object returned by the AWS Nitro enclave
+// in reponse to remote attestation requests.
+//
+// Verify the nonce value passed with the attestation request.
+bool VerifyNonceForTesting(const std::vector<uint8_t>& attestation_bytes,
+                           const std::vector<uint8_t>& orig_nonce);
+// Verify the TLS certificate fingerprint returned with the attestation request.
+bool VerifyUserDataKeyForTesting(
+    const std::vector<uint8_t>& attestation_bytes,
+    scoped_refptr<net::X509Certificate> server_cert);
 
 }  // namespace nitro_utils
 

--- a/components/p3a/nitro_utils/attestation.h
+++ b/components/p3a/nitro_utils/attestation.h
@@ -32,7 +32,7 @@ void RequestAndVerifyAttestationDocument(
 //
 // These take the cbor serialization of just the attestation document
 // portion of the COSE Sign1 object returned by the AWS Nitro enclave
-// in reponse to remote attestation requests.
+// in response to remote attestation requests.
 //
 // Verify the nonce value passed with the attestation request.
 bool VerifyNonceForTesting(const std::vector<uint8_t>& attestation_bytes,

--- a/components/p3a/nitro_utils/attestation_unittest.cc
+++ b/components/p3a/nitro_utils/attestation_unittest.cc
@@ -1,0 +1,114 @@
+// Copyright (c) 2023 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#include "brave/components/p3a/nitro_utils/attestation.h"
+
+#include <vector>
+
+#include "base/base64.h"
+#include "base/strings/string_number_conversions.h"
+#include "net/cert/x509_certificate.h"
+#include "testing/gtest/include/gtest/gtest.h"
+
+namespace nitro_utils {
+
+namespace {
+
+// Trimmed-down cbor+base64 attestation document for testing
+// python-cbor2 base64.b64encode(cbor2.dumps(map_dict, canonical=True))
+constexpr char kShortDocument[] =
+    "pmVub25jZVShkGajO9w8jptiAlBSISId8fsW9WZkaWdlc3RmU0hBMzg0aW1vZHVs"
+    "ZV9pZHgnaS0wYjQ2MzcxODcxOWFkYjI0YS1lbmMwMTg4OTc4NjRhYmFlNWQyaXRp"
+    "bWVzdGFtcBsAAAGIyxyk5Gl1c2VyX2RhdGFYT3NoYTI1NjpDAdOabr43snNXvkv/"
+    "2MrFUkqawkwDXxM30KIg0PKpejtzaGEyNTY6AAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+    "AAAAAAAAAAAAAABqcHVibGljX2tlefY=";
+constexpr char kExpectedNonce[] = "a19066a33bdc3c8e9b6202505221221df1fb16f5";
+
+// Version of the attestation document with randomized user_data and nonce
+constexpr char kBadDocument[] =
+    "pmVub25jZVSYQjMTB+E+8zgs690i18gcDtPF5WZkaWdlc3RmU0hBMzg0aW1vZHVs"
+    "ZV9pZHgnaS0wYjQ2MzcxODcxOWFkYjI0YS1lbmMwMTg4OTc4NjRhYmFlNWQyaXRp"
+    "bWVzdGFtcBsAAAGIyxyk5Gl1c2VyX2RhdGFYT3NoYTI1NjpZ1l7mBoYUN/QYaRUP"
+    "4qHov+2saZzBKCCBT16rA6fp6DtzaGEyNTY6psMTTAVeLx8shS1642BWxoW1q/dV"
+    "RMvN0XG/pFkT4cVqcHVibGljX2tlefY=";
+
+// TLS certificate from the same deployment as kShortDocument
+// Certificates can be downloaded with the browser or on the command line:
+// openssl s_client -showcerts -servername $HOST -connect $HOST:443 < /dev/null
+constexpr char kTLSCert[] =
+    "MIIEbjCCA1agAwIBAgISA0mFFumurFjCqNLirk4Wm7d1MA0GCSqGSIb3DQEBCwUA"
+    "MDIxCzAJBgNVBAYTAlVTMRYwFAYDVQQKEw1MZXQncyBFbmNyeXB0MQswCQYDVQQD"
+    "EwJSMzAeFw0yMzA2MDcxOTIyMzVaFw0yMzA5MDUxOTIyMzRaMCUxIzAhBgNVBAMT"
+    "GnN0YXItcmFuZHNydi5ic2cuYnJhdmUuY29tMFkwEwYHKoZIzj0CAQYIKoZIzj0D"
+    "AQcDQgAE1pQSA2iDztH1KCIsNV2lcgLaO4X0yyKWUK7pUHsblKbc9YDOmJTdY71C"
+    "LpnUkCCdcVzt3DpQPAlSWKaDWcprF6OCAlQwggJQMA4GA1UdDwEB/wQEAwIHgDAd"
+    "BgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDAYDVR0TAQH/BAIwADAdBgNV"
+    "HQ4EFgQUX4xa6dlCn+f0oyP3SX4mxviUiW0wHwYDVR0jBBgwFoAUFC6zF7dYVsuu"
+    "UAlA5h+vnYsUwsYwVQYIKwYBBQUHAQEESTBHMCEGCCsGAQUFBzABhhVodHRwOi8v"
+    "cjMuby5sZW5jci5vcmcwIgYIKwYBBQUHMAKGFmh0dHA6Ly9yMy5pLmxlbmNyLm9y"
+    "Zy8wJQYDVR0RBB4wHIIac3Rhci1yYW5kc3J2LmJzZy5icmF2ZS5jb20wTAYDVR0g"
+    "BEUwQzAIBgZngQwBAgEwNwYLKwYBBAGC3xMBAQEwKDAmBggrBgEFBQcCARYaaHR0"
+    "cDovL2Nwcy5sZXRzZW5jcnlwdC5vcmcwggEDBgorBgEEAdZ5AgQCBIH0BIHxAO8A"
+    "dgC3Pvsk35xNunXyOcW6WPRsXfxCz3qfNcSeHQmBJe20mQAAAYiXhoXoAAAEAwBH"
+    "MEUCIQCbUhIcQeR5JV9WOz6QW16E8jEfgTXgL83zKHkZ6F2onQIgaYbBQoVjr/5O"
+    "ykoma+PKcdBhuBEaUstwyGcFUP+J5coAdQCt9776fP8QyIudPZwePhhqtGcpXc+x"
+    "DCTKhYY069yCigAAAYiXhoYaAAAEAwBGMEQCIBhLLoiK6sZqFauJt7Ox3TkAwk60"
+    "nUyVJeZ5jlQFzyxAAiANHCJYdN4JOBBivDq8z2Al+/8wkDwqazDgtkKm23CQyjAN"
+    "BgkqhkiG9w0BAQsFAAOCAQEAJ4JJReEW05kimalJVibvTxdU8yNuBmPM+1KVD++H"
+    "3ho1dQVpMTMOROpyiBNLyiiiG1lSmWMzJ0gVWAJu1pi87L3Ki8qld+58XYWKVWBt"
+    "c2n5BNU3hCH3emoXzRRRA2VwXgX3oJ5qYnRrhPR3TvIvvh4uvYvUoNpE2l5ibqxC"
+    "L+QgFdJkBQLHGrsLnoxZxNXwhI3VUjmoY1SOSVj2CeDVNEzPOpYsVL+2dSWXgKYw"
+    "Q3L/xtSul9+NNKyzQecTqL8oUxIufYiPIpFZV/KicbzdOc/4S7uXoG8K5nbCnTba"
+    "Dua1VozCsqvNQppqo76rhWGtdecduwm7VCtm4XC66MFJIA==";
+
+class NitroAttestationTest : public testing::Test {
+ public:
+  NitroAttestationTest() = default;
+
+ protected:
+  std::vector<uint8_t> FromBase64(const char* b64_string) {
+    return *base::Base64Decode(b64_string);
+  }
+  std::vector<uint8_t> FromHex(const char* hex_string) {
+    std::vector<uint8_t> bytes;
+    base::HexStringToBytes(hex_string, &bytes);
+    return bytes;
+  }
+};
+
+}  // namespace
+
+TEST_F(NitroAttestationTest, Nonce) {
+  // Parse a test document to pass for comparison.
+  auto document = FromBase64(kShortDocument);
+  auto expected_nonce = FromHex(kExpectedNonce);
+  auto bad_document = FromBase64(kBadDocument);
+
+  // Does the document verify against the expected nonce?
+  EXPECT_TRUE(VerifyNonceForTesting(document, expected_nonce));
+
+  // Does the invalid document fail to very against the nonce?
+  EXPECT_FALSE(VerifyNonceForTesting(bad_document, expected_nonce));
+}
+
+TEST_F(NitroAttestationTest, UserData) {
+  // Parse a TLS cert whose fingerprint matches our test
+  // attestation document.
+  auto cert_bytes = FromBase64(kTLSCert);
+  auto cert = net::X509Certificate::CreateFromBytes(cert_bytes);
+  ASSERT_TRUE(cert);
+
+  // Test documents to pass for comparison
+  auto document = FromBase64(kShortDocument);
+  auto bad = FromBase64(kBadDocument);
+
+  // Does the document verify against the expected cert fingerprint?
+  EXPECT_TRUE(VerifyUserDataKeyForTesting(document, cert));
+
+  // Does the invalid document fail to verify against the same cert?
+  EXPECT_FALSE(VerifyUserDataKeyForTesting(bad, cert));
+}
+
+}  // namespace nitro_utils

--- a/components/p3a/nitro_utils/cose_unittest.cc
+++ b/components/p3a/nitro_utils/cose_unittest.cc
@@ -116,7 +116,7 @@ constexpr char kExampleDocument[] =
 
 class CoseSign1Test : public testing::Test {
  public:
-  CoseSign1Test() {}
+  CoseSign1Test() = default;
 
  protected:
   std::vector<uint8_t> LoadExampleDocument() {
@@ -189,7 +189,7 @@ TEST_F(CoseSign1Test, BadSignature) {
                  parsed_document.GetArray().end() - 1,
                  std::back_inserter(doc_arr),
                  [](const cbor::Value& val) { return val.Clone(); });
-  doc_arr.push_back(cbor::Value("bad signature"));
+  doc_arr.emplace_back("bad signature");
 
   EXPECT_FALSE(
       cose_sign1.DecodeFromBytes(SerializeDocument(cbor::Value(doc_arr))));


### PR DESCRIPTION
The current scheme for encoding the TLS certificate fingerprint in the AWS Nitro secure enclave attestation document is [hard to parse](https://github.com/brave/nitriding-daemon/issues/23) and we want to switch it to a sequence of multihash values, which are self-delimiting and more compact.

As the first step of this transition, support both the old and new schema, determined by the field length, which is different in the two encodings.

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/31131

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-arm64, CI/skip-linux-x64, CI/skip-android, CI/skip-macos, CI/skip-ios, CI/skip-windows-arm64, CI/skip-windows-x64, CI/skip-windows-x86 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

Unit test coverage should be sufficient for this until we transition the production service. I'm marked the corresponding issue QA/No.