### PR TITLE
fix(wallet): remove extra fields from eth_signTypedData_v4 message

### DIFF
--- a/components/brave_wallet/browser/ethereum_provider_impl.cc
+++ b/components/brave_wallet/browser/ethereum_provider_impl.cc
@@ -926,7 +926,6 @@ void EthereumProviderImpl::CommonRequestOrSendAsync(
     std::string address;
     std::string message;
     base::Value::Dict domain;
-    std::vector<uint8_t> message_to_sign;
     std::vector<uint8_t> domain_hash_out;
     std::vector<uint8_t> primary_hash_out;
     if (method == kEthSignTypedDataV4) {

--- a/components/brave_wallet/common/eth_request_helper.cc
+++ b/components/brave_wallet/common/eth_request_helper.cc
@@ -496,13 +496,13 @@ bool ParseEthSignTypedDataParams(const std::string& json,
     return false;
   }
 
-  *domain_hash_out = domain_hash->first;
-  *domain_out = std::move(domain_hash->second);
-
   auto primary_hash = helper->GetTypedDataPrimaryHash(*primary_type, *message);
   if (!primary_hash) {
     return false;
   }
+
+  *domain_hash_out = domain_hash->first;
+  *domain_out = std::move(domain_hash->second);
 
   *primary_hash_out = primary_hash->first;
   if (!base::JSONWriter::Write(std::move(primary_hash->second), message_out)) {

--- a/components/brave_wallet/common/eth_request_helper.cc
+++ b/components/brave_wallet/common/eth_request_helper.cc
@@ -481,9 +481,6 @@ bool ParseEthSignTypedDataParams(const std::string& json,
   }
 
   *address = *address_str;
-  if (!base::JSONWriter::Write(*message, message_out)) {
-    return false;
-  }
 
   auto* types = dict->FindDict("types");
   if (!types) {
@@ -498,14 +495,19 @@ bool ParseEthSignTypedDataParams(const std::string& json,
   if (!domain_hash) {
     return false;
   }
+
+  *domain_hash_out = domain_hash->first;
+  *domain_out = std::move(domain_hash->second);
+
   auto primary_hash = helper->GetTypedDataPrimaryHash(*primary_type, *message);
   if (!primary_hash) {
     return false;
   }
-  *domain_hash_out = *domain_hash;
-  *primary_hash_out = *primary_hash;
 
-  *domain_out = std::move(*domain);
+  *primary_hash_out = primary_hash->first;
+  if (!base::JSONWriter::Write(std::move(primary_hash->second), message_out)) {
+    return false;
+  }
 
   return true;
 }

--- a/components/brave_wallet/common/eth_sign_typed_data_helper.cc
+++ b/components/brave_wallet/common/eth_sign_typed_data_helper.cc
@@ -130,21 +130,22 @@ std::vector<uint8_t> EthSignTypedDataHelper::GetTypeHash(
   return std::vector<uint8_t>(type_hash.begin(), type_hash.end());
 }
 
-absl::optional<std::vector<uint8_t>> EthSignTypedDataHelper::HashStruct(
-    const std::string primary_type_name,
-    const base::Value::Dict& data) const {
+absl::optional<std::pair<std::vector<uint8_t>, base::Value::Dict>>
+EthSignTypedDataHelper::HashStruct(const std::string primary_type_name,
+                                   const base::Value::Dict& data) const {
   auto encoded_data = EncodeData(primary_type_name, data);
   if (!encoded_data) {
     return absl::nullopt;
   }
-  return KeccakHash(*encoded_data);
+  return std::make_pair(KeccakHash(encoded_data->first),
+                        std::move(encoded_data->second));
 }
 
 // Encode the json data by the its type defined in json custom types starting
 // from primary type. See unittests for some examples.
-absl::optional<std::vector<uint8_t>> EthSignTypedDataHelper::EncodeData(
-    const std::string& primary_type_name,
-    const base::Value::Dict& data) const {
+absl::optional<std::pair<std::vector<uint8_t>, base::Value::Dict>>
+EthSignTypedDataHelper::EncodeData(const std::string& primary_type_name,
+                                   const base::Value::Dict& data) const {
   const auto* primary_type = types_.FindList(primary_type_name);
   if (!primary_type) {
     return absl::nullopt;
@@ -153,6 +154,8 @@ absl::optional<std::vector<uint8_t>> EthSignTypedDataHelper::EncodeData(
 
   const std::vector<uint8_t> type_hash = GetTypeHash(primary_type_name);
   result.insert(result.end(), type_hash.begin(), type_hash.end());
+
+  base::Value::Dict sanitized_data;
 
   for (const auto& item : *primary_type) {
     const auto& field = item.GetDict();
@@ -168,6 +171,7 @@ absl::optional<std::vector<uint8_t>> EthSignTypedDataHelper::EncodeData(
         return absl::nullopt;
       }
       result.insert(result.end(), encoded_field->begin(), encoded_field->end());
+      sanitized_data.Set(*name_str, value->Clone());
     } else {
       if (version_ == Version::kV4) {
         for (size_t i = 0; i < 32; ++i) {
@@ -176,7 +180,7 @@ absl::optional<std::vector<uint8_t>> EthSignTypedDataHelper::EncodeData(
       }
     }
   }
-  return result;
+  return std::make_pair(result, std::move(sanitized_data));
 }
 
 // Encode each field of a custom type, if a field is also a custom type it
@@ -355,20 +359,20 @@ absl::optional<std::vector<uint8_t>> EthSignTypedDataHelper::EncodeField(
     if (!encoded_data) {
       return absl::nullopt;
     }
-    std::vector<uint8_t> encoded_value = KeccakHash(*encoded_data);
+    std::vector<uint8_t> encoded_value = KeccakHash(encoded_data->first);
 
     result.insert(result.end(), encoded_value.begin(), encoded_value.end());
   }
   return result;
 }
 
-absl::optional<std::vector<uint8_t>>
+absl::optional<std::pair<std::vector<uint8_t>, base::Value::Dict>>
 EthSignTypedDataHelper::GetTypedDataDomainHash(
     const base::Value::Dict& domain_separator) const {
   return HashStruct("EIP712Domain", domain_separator);
 }
 
-absl::optional<std::vector<uint8_t>>
+absl::optional<std::pair<std::vector<uint8_t>, base::Value::Dict>>
 EthSignTypedDataHelper::GetTypedDataPrimaryHash(
     const std::string& primary_type_name,
     const base::Value::Dict& message) const {

--- a/components/brave_wallet/common/eth_sign_typed_data_helper.h
+++ b/components/brave_wallet/common/eth_sign_typed_data_helper.h
@@ -8,6 +8,7 @@
 
 #include <memory>
 #include <string>
+#include <utility>
 #include <vector>
 
 #include "base/containers/flat_map.h"
@@ -33,20 +34,20 @@ class EthSignTypedDataHelper {
   void SetVersion(Version version);
 
   std::vector<uint8_t> GetTypeHash(const std::string primary_type_name) const;
-  absl::optional<std::vector<uint8_t>> HashStruct(
+  absl::optional<std::pair<std::vector<uint8_t>, base::Value::Dict>> HashStruct(
       const std::string primary_type_name,
       const base::Value::Dict& data) const;
-  absl::optional<std::vector<uint8_t>> EncodeData(
+  absl::optional<std::pair<std::vector<uint8_t>, base::Value::Dict>> EncodeData(
       const std::string& primary_type_name,
       const base::Value::Dict& data) const;
   static absl::optional<std::vector<uint8_t>> GetTypedDataMessageToSign(
       const std::vector<uint8_t>& domain_hash,
       const std::vector<uint8_t>& primary_hash);
-  absl::optional<std::vector<uint8_t>> GetTypedDataPrimaryHash(
-      const std::string& primary_type_name,
-      const base::Value::Dict& message) const;
-  absl::optional<std::vector<uint8_t>> GetTypedDataDomainHash(
-      const base::Value::Dict& domain_separator) const;
+  absl::optional<std::pair<std::vector<uint8_t>, base::Value::Dict>>
+  GetTypedDataPrimaryHash(const std::string& primary_type_name,
+                          const base::Value::Dict& message) const;
+  absl::optional<std::pair<std::vector<uint8_t>, base::Value::Dict>>
+  GetTypedDataDomainHash(const base::Value::Dict& domain_separator) const;
 
  private:
   FRIEND_TEST_ALL_PREFIXES(EthSignedTypedDataHelperUnitTest, EncodeTypes);


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/30354

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-arm64, CI/skip-linux-x64, CI/skip-android, CI/skip-macos, CI/skip-ios, CI/skip-windows-arm64, CI/skip-windows-x64, CI/skip-windows-x86 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan

Ping me for QA steps - I'll expose my localhost which is running a dapp that reproduces the issue.

|Before|After|
|--|--|
|<img src="https://github.com/brave/brave-core/assets/3684187/2a0bba98-fed5-4c34-b723-b0eb99455d98">|<img src="https://github.com/brave/brave-core/assets/3684187/7e7d633e-0761-40e8-8ad2-f351879ae761">|