### PR TITLE
fix(wallet): Remove isFetching Condition for Loading Skeletons

### DIFF
--- a/components/brave_wallet_ui/components/desktop/views/accounts/account.tsx
+++ b/components/brave_wallet_ui/components/desktop/views/accounts/account.tsx
@@ -202,8 +202,7 @@ export const Account = () => {
 
   const {
     data: spotPriceRegistry,
-    isLoading: isLoadingSpotPrices,
-    isFetching: isFetchingSpotPrices
+    isLoading: isLoadingSpotPrices
   } = useGetTokenSpotPricesQuery(
     tokenPriceIds.length ? { ids: tokenPriceIds } : skipToken,
     querySubscriptionOptions60s
@@ -324,9 +323,9 @@ export const Account = () => {
             showSellModal={() => onClickShowSellModal(item)}
             isSellSupported={checkIsAssetSellSupported(item)}
             spotPrice={
-              spotPriceRegistry && !isLoadingSpotPrices && !isFetchingSpotPrices
+              spotPriceRegistry && !isLoadingSpotPrices
                 ? getTokenPriceAmountFromRegistry(spotPriceRegistry, item)
-                    .format()
+                  .format()
                 : ''
             }
           />

--- a/components/brave_wallet_ui/components/desktop/views/portfolio/portfolio-overview.tsx
+++ b/components/brave_wallet_ui/components/desktop/views/portfolio/portfolio-overview.tsx
@@ -242,8 +242,7 @@ export const PortfolioOverview = ({ onToggleShowIpfsBanner }: Props) => {
 
   const {
     data: spotPriceRegistry,
-    isLoading: isLoadingSpotPrices,
-    isFetching: isFetchingSpotPrices
+    isLoading: isLoadingSpotPrices
   } = useGetTokenSpotPricesQuery(
     tokenPriceIds.length ? { ids: tokenPriceIds } : skipToken,
     querySubscriptionOptions60s
@@ -259,7 +258,7 @@ export const PortfolioOverview = ({ onToggleShowIpfsBanner }: Props) => {
       return Amount.empty()
     }
 
-    if (isLoadingSpotPrices || isFetchingSpotPrices) {
+    if (isLoadingSpotPrices) {
       return Amount.empty()
     }
 
@@ -281,7 +280,6 @@ export const PortfolioOverview = ({ onToggleShowIpfsBanner }: Props) => {
       visibleAssetOptions,
       spotPriceRegistry,
       isLoadingSpotPrices,
-      isFetchingSpotPrices,
       allNetworksAreHidden
     ])
 
@@ -504,13 +502,12 @@ export const PortfolioOverview = ({ onToggleShowIpfsBanner }: Props) => {
                 hideBalances={hidePortfolioBalances}
                 spotPrice={
                   spotPriceRegistry &&
-                    !isLoadingSpotPrices &&
-                    !isFetchingSpotPrices
-                      ? getTokenPriceAmountFromRegistry(
-                          spotPriceRegistry,
-                          item.asset
-                        ).format()
-                      : ''
+                    !isLoadingSpotPrices
+                    ? getTokenPriceAmountFromRegistry(
+                      spotPriceRegistry,
+                      item.asset
+                    ).format()
+                    : ''
                 }
               />
             }

--- a/components/brave_wallet_ui/components/extension/assets-panel/index.tsx
+++ b/components/brave_wallet_ui/components/extension/assets-panel/index.tsx
@@ -150,8 +150,7 @@ const AssetsPanel = (props: Props) => {
 
   const {
     data: spotPriceRegistry,
-    isLoading: isLoadingSpotPrices,
-    isFetching: isFetchingSpotPrices
+    isLoading: isLoadingSpotPrices
   } = useGetTokenSpotPricesQuery(
     tokenPriceIds.length && !isLoadingBalances && !isFetchingBalances
       ? { ids: tokenPriceIds }
@@ -180,9 +179,9 @@ const AssetsPanel = (props: Props) => {
           }
           token={token}
           spotPrice={
-            spotPriceRegistry && !isLoadingSpotPrices && !isFetchingSpotPrices
+            spotPriceRegistry && !isLoadingSpotPrices
               ? getTokenPriceAmountFromRegistry(spotPriceRegistry, token)
-                  .format()
+                .format()
               : ''
           }
           isPanel={true}

--- a/components/brave_wallet_ui/components/extension/connected-panel/index.tsx
+++ b/components/brave_wallet_ui/components/extension/connected-panel/index.tsx
@@ -124,8 +124,7 @@ export const ConnectedPanel = (props: Props) => {
 
   const {
     data: spotPriceRegistry,
-    isLoading: isLoadingSpotPrices,
-    isFetching: isFetchingSpotPrices
+    isLoading: isLoadingSpotPrices
   } = useGetTokenSpotPricesQuery(
     networkTokenPriceIds.length ? { ids: networkTokenPriceIds } : skipToken,
     querySubscriptionOptions60s
@@ -232,8 +231,7 @@ export const ConnectedPanel = (props: Props) => {
       isLoadingBalances ||
       isFetchingBalances ||
       !spotPriceRegistry ||
-      isLoadingSpotPrices ||
-      isFetchingSpotPrices
+      isLoadingSpotPrices
     ) {
       return Amount.empty()
     }
@@ -247,8 +245,7 @@ export const ConnectedPanel = (props: Props) => {
     isLoadingBalances,
     isFetchingBalances,
     spotPriceRegistry,
-    isLoadingSpotPrices,
-    isFetchingSpotPrices
+    isLoadingSpotPrices
   ])
 
   const isConnected = React.useMemo((): boolean => {


### PR DESCRIPTION
## Description 
Fixes a bug where `Loading Skeletons` were displayed every time balances were refreshed in the background.

<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves <https://github.com/brave/brave-browser/issues/31177>

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-arm64, CI/skip-linux-x64, CI/skip-android, CI/skip-macos, CI/skip-ios, CI/skip-windows-arm64, CI/skip-windows-x64, CI/skip-windows-x86 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

   1. Go to the `Portfolio` page
   2. Wait `60` seconds
   3. `Loading Skeletons` should not be displayed when prices are refreshed in the background.
