### PR TITLE
Fix command palette display

### DIFF
--- a/browser/ui/commander/commander_service.cc
+++ b/browser/ui/commander/commander_service.cc
@@ -56,7 +56,7 @@ CommanderService::CommanderService(Profile* profile)
   command_sources_.push_back(std::make_unique<BraveSimpleCommandSource>());
   command_sources_.push_back(std::make_unique<BookmarkCommandSource>());
   command_sources_.push_back(std::make_unique<WindowCommandSource>());
-  command_sources_.push_back(std::make_unique<TabCommandSource>());
+  command_sources_.push_back(std::make_unique<BraveTabCommandSource>());
 }
 
 CommanderService::~CommanderService() = default;

--- a/chromium_src/chrome/browser/ui/commander/tab_command_source.cc
+++ b/chromium_src/chrome/browser/ui/commander/tab_command_source.cc
@@ -1,0 +1,129 @@
+// Copyright (c) 2023 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#include "src/chrome/browser/ui/commander/tab_command_source.cc"  // IWYU pragma: export
+
+#include <string>
+#include <vector>
+
+#include "base/functional/bind.h"
+#include "chrome/browser/ui/commander/command_source.h"
+#include "chrome/browser/ui/commander/fuzzy_finder.h"
+#include "ui/gfx/range/range.h"
+
+namespace commander {
+
+BraveTabCommandSource::BraveTabCommandSource() = default;
+BraveTabCommandSource::~BraveTabCommandSource() = default;
+
+CommandSource::CommandResults BraveTabCommandSource::GetCommands(
+    const std::u16string& input,
+    Browser* browser) const {
+  CommandSource::CommandResults results;
+  FuzzyFinder finder(input);
+  std::vector<gfx::Range> ranges;
+
+  TabStripModel* tab_strip_model = browser->tab_strip_model();
+
+  if (CanCloseTabsToLeft(tab_strip_model)) {
+    if (auto item = ItemForTitle(u"Close tabs to the left", finder, &ranges)) {
+      item->command =
+          base::BindOnce(&CloseTabsToLeft, base::Unretained(browser));
+      results.push_back(std::move(item));
+    }
+  }
+
+  if (HasUnpinnedTabs(tab_strip_model)) {
+    if (auto item = ItemForTitle(u"Close unpinned tabs", finder, &ranges)) {
+      item->command =
+          base::BindOnce(&CloseUnpinnedTabs, base::Unretained(browser));
+      results.push_back(std::move(item));
+    }
+  }
+
+  if (CanMoveTabsToExistingWindow(browser)) {
+    if (auto item = ItemForTitle(u"Move tabs to window...", finder, &ranges)) {
+      item->command = std::make_pair(
+          u"Move tabs to window...",
+          base::BindRepeating(&MoveTabsToWindowCommandsForWindowsMatching,
+                              base::Unretained(browser)));
+      results.push_back(std::move(item));
+    }
+  }
+
+  if (CanAddAllToNewGroup(tab_strip_model)) {
+    if (auto item =
+            ItemForTitle(u"Move all tabs to new group", finder, &ranges)) {
+      item->command =
+          base::BindOnce(&AddAllToNewGroup, base::Unretained(browser));
+      results.push_back(std::move(item));
+    }
+  }
+
+  if (auto item =
+          ItemForTitle(u"Add tab to existing group...", finder, &ranges)) {
+    item->command = std::make_pair(
+        u"Add to existing group...",
+        base::BindRepeating(&AddTabsToGroupCommandsForGroupsMatching,
+                            base::Unretained(browser)));
+    results.push_back(std::move(item));
+  }
+
+  if (auto item = ItemForTitle(u"Mute all tabs", finder, &ranges)) {
+    item->command =
+        base::BindOnce(&MuteAllTabs, base::Unretained(browser), false);
+    results.push_back(std::move(item));
+  }
+
+  if (auto item = ItemForTitle(u"Mute other tabs", finder, &ranges)) {
+    item->command =
+        base::BindOnce(&MuteAllTabs, base::Unretained(browser), false);
+    results.push_back(std::move(item));
+  }
+
+  if (HasUnpinnedTabs(tab_strip_model)) {
+    if (auto item = ItemForTitle(u"Pin tab...", finder, &ranges)) {
+      item->command = std::make_pair(
+          u"Pin tab...",
+          base::BindRepeating(&TogglePinTabCommandsForTabsMatching,
+                              base::Unretained(browser), true));
+      results.push_back((std::move(item)));
+    }
+  }
+
+  if (HasPinnedTabs(tab_strip_model)) {
+    if (auto item = ItemForTitle(u"Unpin tab...", finder, &ranges)) {
+      item->command = std::make_pair(
+          u"Unpin tab...",
+          base::BindRepeating(&TogglePinTabCommandsForTabsMatching,
+                              base::Unretained(browser), false));
+      results.push_back((std::move(item)));
+    }
+
+    if (auto item = ItemForTitle(u"Scroll to top", finder, &ranges)) {
+      item->command = base::BindOnce(&ScrollToTop, base::Unretained(browser));
+      results.push_back(std::move(item));
+    }
+
+    if (auto item = ItemForTitle(u"Scroll to bottom", finder, &ranges)) {
+      item->command =
+          base::BindOnce(&ScrollToBottom, base::Unretained(browser));
+      results.push_back(std::move(item));
+    }
+
+    if (send_tab_to_self::ShouldDisplayEntryPoint(
+            tab_strip_model->GetActiveWebContents())) {
+      if (auto item = ItemForTitle(u"Send tab to self...", finder, &ranges)) {
+        item->command = base::BindOnce(&chrome::SendTabToSelfFromPageAction,
+                                       base::Unretained(browser));
+        results.push_back(std::move(item));
+      }
+    }
+  }
+
+  return results;
+}
+
+}  // namespace commander

--- a/chromium_src/chrome/browser/ui/commander/tab_command_source.h
+++ b/chromium_src/chrome/browser/ui/commander/tab_command_source.h
@@ -1,0 +1,30 @@
+// Copyright (c) 2023 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#ifndef BRAVE_CHROMIUM_SRC_CHROME_BROWSER_UI_COMMANDER_TAB_COMMAND_SOURCE_H_
+#define BRAVE_CHROMIUM_SRC_CHROME_BROWSER_UI_COMMANDER_TAB_COMMAND_SOURCE_H_
+
+#include "src/chrome/browser/ui/commander/tab_command_source.h"  // IWYU pragma: export
+
+#include "chrome/browser/ui/commander/command_source.h"
+
+namespace commander {
+
+class BraveTabCommandSource : public CommandSource {
+ public:
+  BraveTabCommandSource();
+  ~BraveTabCommandSource() override;
+
+  BraveTabCommandSource(const BraveTabCommandSource& other) = delete;
+  BraveTabCommandSource& operator=(const BraveTabCommandSource& other) = delete;
+
+  // Command source overrides
+  CommandSource::CommandResults GetCommands(const std::u16string& input,
+                                            Browser* browser) const override;
+};
+
+}  // namespace commander
+
+#endif  // BRAVE_CHROMIUM_SRC_CHROME_BROWSER_UI_COMMANDER_TAB_COMMAND_SOURCE_H_

--- a/components/omnibox/browser/commander_provider.cc
+++ b/components/omnibox/browser/commander_provider.cc
@@ -68,8 +68,8 @@ void CommanderProvider::OnCommanderUpdated() {
     const auto& option = items[i];
     AutocompleteMatch match(this, rank--, false,
                             AutocompleteMatchType::BOOKMARK_TITLE);
-    match.actions.push_back(
-        base::MakeRefCounted<CommanderAction>(i, delegate->GetResultSetId()));
+    match.takeover_action =
+        base::MakeRefCounted<CommanderAction>(i, delegate->GetResultSetId());
 
     // This is neat but it would be nice if we could always show it instead of
     // only when we have a result selected.

--- a/components/omnibox/browser/commander_provider_unittest.cc
+++ b/components/omnibox/browser/commander_provider_unittest.cc
@@ -177,7 +177,7 @@ TEST_F(CommanderProviderTest, ItemsAreConvertedToMatches) {
     // scrolling through the commands doesn't affect what the user typed.
     EXPECT_EQ(u":> Hello World", match.fill_into_edit);
     // Check the matches have actions.
-    EXPECT_NE(0u, match.actions.size());
+    EXPECT_TRUE(match.takeover_action);
   }
 }
 


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/31170

In CR115 Chromium changed how takeover actions work, which resulted in us displaying some OmniBox pedals.

Additionally, some builtin Chromium commands are duplicates of our SimpleCommands, so they need to be removed. Unfortunately, this involves replacing the built in `TabCommandSource`.

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-arm64, CI/skip-linux-x64, CI/skip-android, CI/skip-macos, CI/skip-ios, CI/skip-windows-arm64, CI/skip-windows-x64, CI/skip-windows-x86 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [ ] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

Part 1:
1. Enable the #quick-commands flag
2. Press Ctrl+Space

The commands displayed should **NOT** have little icons under them.


Part 2:
1. Search for `Close tabs`
There should be no duplicates.