### PR TITLE
Added resize handle to side panel

### DIFF
--- a/browser/prefs/brave_pref_service_incognito_allowlist.cc
+++ b/browser/prefs/brave_pref_service_incognito_allowlist.cc
@@ -14,6 +14,10 @@
 #include "brave/browser/ui/tabs/brave_tab_prefs.h"
 #endif
 
+#if defined(TOOLKIT_VIEWS)
+#include "brave/components/sidebar/pref_names.h"
+#endif
+
 namespace brave {
 
 const std::vector<const char*>& GetBravePersistentPrefNames() {
@@ -23,6 +27,9 @@ const std::vector<const char*>& GetBravePersistentPrefNames() {
         brave_tabs::kVerticalTabsExpandedWidth,
         brave_tabs::kVerticalTabsEnabled, brave_tabs::kVerticalTabsCollapsed,
         brave_tabs::kVerticalTabsFloatingEnabled,
+#endif
+#if defined(TOOLKIT_VIEWS)
+        sidebar::kSidePanelWidth,
 #endif
   });
 

--- a/browser/ui/BUILD.gn
+++ b/browser/ui/BUILD.gn
@@ -310,6 +310,8 @@ source_set("ui") {
       "views/side_panel/ai_chat/ai_chat_side_panel_utils_views.cc",
       "views/side_panel/brave_side_panel.cc",
       "views/side_panel/brave_side_panel.h",
+      "views/side_panel/brave_side_panel_resize_widget.cc",
+      "views/side_panel/brave_side_panel_resize_widget.h",
       "views/side_panel/playlist/playlist_side_panel_coordinator.cc",
       "views/side_panel/playlist/playlist_side_panel_coordinator.h",
       "views/side_panel/playlist/playlist_side_panel_web_view.cc",

--- a/browser/ui/views/frame/brave_browser_view.cc
+++ b/browser/ui/views/frame/brave_browser_view.cc
@@ -218,7 +218,10 @@ BraveBrowserView::BraveBrowserView(std::unique_ptr<Browser> browser)
     contents_container_->SetLayoutManager(
         std::make_unique<BraveContentsLayoutManager>(
             devtools_web_view_, contents_web_view_, sidebar_container_view_));
+
+#if defined(USE_AURA)
     sidebar_host_view_ = AddChildView(std::make_unique<views::View>());
+#endif
 
     pref_change_registrar_.Add(
         prefs::kSidePanelHorizontalAlignment,

--- a/browser/ui/views/frame/brave_browser_view.h
+++ b/browser/ui/views/frame/brave_browser_view.h
@@ -84,7 +84,10 @@ class BraveBrowserView : public BrowserView,
   void OnThemeChanged() override;
   TabSearchBubbleHost* GetTabSearchBubbleHost() override;
 
+#if defined(USE_AURA)
   views::View* sidebar_host_view() { return sidebar_host_view_; }
+#endif
+
   bool IsSidebarVisible() const;
 
   VerticalTabStripWidgetDelegateView*
@@ -143,10 +146,13 @@ class BraveBrowserView : public BrowserView,
 
   bool closing_confirm_dialog_activated_ = false;
   raw_ptr<SidebarContainerView> sidebar_container_view_ = nullptr;
-  raw_ptr<views::View> sidebar_host_view_ = nullptr;
   raw_ptr<views::View> vertical_tab_strip_host_view_ = nullptr;
   raw_ptr<VerticalTabStripWidgetDelegateView>
       vertical_tab_strip_widget_delegate_view_ = nullptr;
+
+#if defined(USE_AURA)
+  raw_ptr<views::View> sidebar_host_view_ = nullptr;
+#endif
 
 #if BUILDFLAG(ENABLE_BRAVE_VPN)
   BraveVPNPanelController vpn_panel_controller_{this};

--- a/browser/ui/views/side_panel/brave_side_panel.cc
+++ b/browser/ui/views/side_panel/brave_side_panel.cc
@@ -5,24 +5,31 @@
 
 #include "brave/browser/ui/views/side_panel/brave_side_panel.h"
 
-#include <memory>
-
+#include "base/functional/bind.h"
 #include "base/ranges/algorithm.h"
+#include "brave/browser/ui/views/frame/brave_browser_view.h"
+#include "brave/browser/ui/views/side_panel/brave_side_panel_resize_widget.h"
+#include "brave/components/sidebar/constants.h"
+#include "brave/components/sidebar/pref_names.h"
+#include "chrome/browser/profiles/profile.h"
 #include "chrome/browser/ui/color/chrome_color_id.h"
+#include "chrome/browser/ui/views/frame/browser_view.h"
 #include "ui/base/metadata/metadata_impl_macros.h"
 #include "ui/color/color_provider.h"
 #include "ui/views/border.h"
 #include "ui/views/layout/fill_layout.h"
 
 BraveSidePanel::BraveSidePanel(BrowserView* browser_view,
-                               HorizontalAlignment horizontal_alignment) {
+                               HorizontalAlignment horizontal_alignment)
+    : browser_view_(browser_view) {
   SetVisible(false);
   SetLayoutManager(std::make_unique<views::FillLayout>());
+  sidebar_width_.Init(
+      sidebar::kSidePanelWidth, browser_view_->GetProfile()->GetPrefs(),
+      base::BindRepeating(&BraveSidePanel::OnSidebarWidthChanged,
+                          base::Unretained(this)));
 
-  // TODO(pbos): Reconsider if SetPanelWidth() should add borders, if so move
-  // accounting for the border into SetPanelWidth(), otherwise remove this TODO.
-  constexpr int kDefaultWidth = 320;
-  SetPreferredSize(gfx::Size(kDefaultWidth, 1));
+  OnSidebarWidthChanged();
   AddObserver(this);
 }
 
@@ -31,16 +38,16 @@ BraveSidePanel::~BraveSidePanel() {
 }
 
 void BraveSidePanel::SetHorizontalAlignment(HorizontalAlignment alignment) {
-  horizontal_alighment_ = alignment;
+  horizontal_alignment_ = alignment;
   UpdateBorder();
 }
 
 BraveSidePanel::HorizontalAlignment BraveSidePanel::GetHorizontalAlignment() {
-  return horizontal_alighment_;
+  return horizontal_alignment_;
 }
 
 bool BraveSidePanel::IsRightAligned() {
-  return horizontal_alighment_ == kHorizontalAlignRight;
+  return horizontal_alignment_ == kHorizontalAlignRight;
 }
 
 void BraveSidePanel::UpdateVisibility() {
@@ -60,6 +67,10 @@ void BraveSidePanel::UpdateBorder() {
   }
 }
 
+void BraveSidePanel::OnSidebarWidthChanged() {
+  SetPanelWidth(sidebar_width_.GetValue());
+}
+
 void BraveSidePanel::ChildVisibilityChanged(View* child) {
   UpdateVisibility();
 }
@@ -67,6 +78,16 @@ void BraveSidePanel::ChildVisibilityChanged(View* child) {
 void BraveSidePanel::OnThemeChanged() {
   View::OnThemeChanged();
   UpdateBorder();
+}
+
+gfx::Size BraveSidePanel::GetMinimumSize() const {
+  // Use default width as a minimum width.
+  return gfx::Size(sidebar::kDefaultSidePanelWidth, 0);
+}
+
+void BraveSidePanel::AddedToWidget() {
+  resize_widget_ = std::make_unique<SidePanelResizeWidget>(
+      this, static_cast<BraveBrowserView*>(browser_view_), this);
 }
 
 void BraveSidePanel::OnChildViewAdded(View* observed_view, View* child) {
@@ -79,11 +100,31 @@ void BraveSidePanel::OnChildViewRemoved(View* observed_view, View* child) {
 
 void BraveSidePanel::SetPanelWidth(int width) {
   // Only the width is used by BrowserViewLayout.
-  SetPreferredSize(gfx::Size(width, 1));
+  SetPreferredSize(gfx::Size(width, 0));
 }
 
 void BraveSidePanel::OnResize(int resize_amount, bool done_resizing) {
-  // Do Nothing.
+  DCHECK(GetVisible());
+
+  if (!starting_width_on_resize_) {
+    starting_width_on_resize_ = width();
+  }
+  int proposed_width = *starting_width_on_resize_ +
+                       (IsRightAligned() ? -resize_amount : resize_amount);
+  if (done_resizing) {
+    starting_width_on_resize_ = absl::nullopt;
+  }
+
+  const int minimum_width = GetMinimumSize().width();
+  if (proposed_width < minimum_width) {
+    proposed_width = minimum_width;
+  }
+
+  if (width() != proposed_width) {
+    SetPanelWidth(proposed_width);
+  }
+
+  sidebar_width_.SetValue(proposed_width);
 }
 
 BEGIN_METADATA(BraveSidePanel, views::View)

--- a/browser/ui/views/side_panel/brave_side_panel.h
+++ b/browser/ui/views/side_panel/brave_side_panel.h
@@ -6,6 +6,11 @@
 #ifndef BRAVE_BROWSER_UI_VIEWS_SIDE_PANEL_BRAVE_SIDE_PANEL_H_
 #define BRAVE_BROWSER_UI_VIEWS_SIDE_PANEL_BRAVE_SIDE_PANEL_H_
 
+#include <memory>
+
+#include "base/memory/raw_ptr.h"
+#include "components/prefs/pref_member.h"
+#include "third_party/abseil-cpp/absl/types/optional.h"
 #include "ui/base/metadata/metadata_header_macros.h"
 #include "ui/gfx/geometry/size.h"
 #include "ui/views/controls/resize_area_delegate.h"
@@ -13,6 +18,11 @@
 #include "ui/views/view_observer.h"
 
 class BrowserView;
+class SidePanelResizeWidget;
+
+namespace sidebar {
+class SidebarBrowserTest;
+}  // namespace sidebar
 
 // Replacement for chromium's SidePanel which defines a
 // unique inset and border style compared to Brave
@@ -44,21 +54,30 @@ class BraveSidePanel : public views::View,
   // views::ResizeAreaDelegate:
   void OnResize(int resize_amount, bool done_resizing) override;
 
-  void SetMinimumSidePanelContentsWidthForTesting(int width) {}
-
- private:
-  void UpdateVisibility();
-  void UpdateBorder();
-
   // views::View:
   void ChildVisibilityChanged(View* child) override;
   void OnThemeChanged() override;
+  gfx::Size GetMinimumSize() const override;
+  void AddedToWidget() override;
+
+  void SetMinimumSidePanelContentsWidthForTesting(int width) {}
+
+ private:
+  friend class sidebar::SidebarBrowserTest;
+
+  void UpdateVisibility();
+  void UpdateBorder();
+  void OnSidebarWidthChanged();
 
   // views::ViewObserver:
   void OnChildViewAdded(View* observed_view, View* child) override;
   void OnChildViewRemoved(View* observed_view, View* child) override;
 
-  HorizontalAlignment horizontal_alighment_ = kHorizontalAlignLeft;
+  HorizontalAlignment horizontal_alignment_ = kHorizontalAlignLeft;
+  absl::optional<int> starting_width_on_resize_;
+  raw_ptr<BrowserView> browser_view_ = nullptr;
+  IntegerPrefMember sidebar_width_;
+  std::unique_ptr<SidePanelResizeWidget> resize_widget_;
 };
 
 #endif  // BRAVE_BROWSER_UI_VIEWS_SIDE_PANEL_BRAVE_SIDE_PANEL_H_

--- a/browser/ui/views/side_panel/brave_side_panel_resize_widget.cc
+++ b/browser/ui/views/side_panel/brave_side_panel_resize_widget.cc
@@ -1,0 +1,76 @@
+/* Copyright (c) 2023 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "brave/browser/ui/views/side_panel/brave_side_panel_resize_widget.h"
+
+#include <utility>
+
+#include "brave/browser/ui/views/frame/brave_browser_view.h"
+#include "brave/browser/ui/views/side_panel/brave_side_panel.h"
+#include "ui/views/controls/resize_area.h"
+#include "ui/views/layout/fill_layout.h"
+#include "ui/views/widget/widget.h"
+
+#if defined(USE_AURA)
+#include "ui/aura/window.h"
+#include "ui/views/view_constants_aura.h"
+#endif
+
+SidePanelResizeWidget::SidePanelResizeWidget(
+    BraveSidePanel* panel,
+    BraveBrowserView* browser_view,
+    views::ResizeAreaDelegate* resize_area_delegate)
+    : panel_(panel) {
+  DCHECK(browser_view->GetWidget());
+
+  observations_.AddObservation(panel_);
+  observations_.AddObservation(browser_view->contents_container());
+
+  widget_ = std::make_unique<views::Widget>();
+  views::Widget::InitParams params(views::Widget::InitParams::TYPE_CONTROL);
+  params.delegate = this;
+  params.name = "SidePanelResizeWidget";
+  params.ownership = views::Widget::InitParams::WIDGET_OWNS_NATIVE_WIDGET;
+  params.parent = browser_view->GetWidget()->GetNativeView();
+  params.opacity = views::Widget::InitParams::WindowOpacity::kTranslucent;
+  params.activatable = views::Widget::InitParams::Activatable::kNo;
+  widget_->Init(std::move(params));
+
+  auto resize_area = std::make_unique<views::ResizeArea>(resize_area_delegate);
+  widget_->SetContentsView(std::move(resize_area));
+
+#if defined(USE_AURA)
+  widget_->GetNativeView()->SetProperty(views::kHostViewKey,
+                                        browser_view->sidebar_host_view());
+#endif
+
+  widget_->ShowInactive();
+}
+
+SidePanelResizeWidget::~SidePanelResizeWidget() = default;
+
+void SidePanelResizeWidget::OnViewBoundsChanged(views::View* observed_view) {
+  auto rect = panel_->GetLocalBounds();
+  auto point = rect.origin();
+  views::View::ConvertPointToTarget(panel_, panel_->GetWidget()->GetRootView(),
+                                    &point);
+  rect.set_origin(point);
+  constexpr int kWidgetNarrowWidth = 5;
+  if (!panel_->IsRightAligned()) {
+    rect.set_x(rect.right() - kWidgetNarrowWidth);
+  }
+  rect.set_width(kWidgetNarrowWidth);
+
+  widget_->GetContentsView()->SetPreferredSize(rect.size());
+
+#if BUILDFLAG(IS_MAC)
+  // On Mac, we can't set empty bounds for the widget.
+  if (rect.IsEmpty()) {
+    rect.set_size({kWidgetNarrowWidth, 1});
+  }
+#endif
+
+  widget_->SetBounds(rect);
+}

--- a/browser/ui/views/side_panel/brave_side_panel_resize_widget.h
+++ b/browser/ui/views/side_panel/brave_side_panel_resize_widget.h
@@ -1,0 +1,47 @@
+/* Copyright (c) 2023 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_BROWSER_UI_VIEWS_SIDE_PANEL_BRAVE_SIDE_PANEL_RESIZE_WIDGET_H_
+#define BRAVE_BROWSER_UI_VIEWS_SIDE_PANEL_BRAVE_SIDE_PANEL_RESIZE_WIDGET_H_
+
+#include <memory>
+
+#include "base/memory/raw_ptr.h"
+#include "base/scoped_multi_source_observation.h"
+#include "ui/views/view_observer.h"
+#include "ui/views/widget/widget_delegate.h"
+
+class BraveSidePanel;
+class BraveBrowserView;
+
+namespace views {
+class ResizeAreaDelegate;
+class Widget;
+}  // namespace views
+
+// Transparent widget that includes resize area only on side panel.
+// Need widget to get proper event on the webview of side panel.
+// BraveSidePanel owns this widget.
+class SidePanelResizeWidget : public views::ViewObserver,
+                              public views::WidgetDelegate {
+ public:
+  SidePanelResizeWidget(BraveSidePanel* panel,
+                        BraveBrowserView* browser_view,
+                        views::ResizeAreaDelegate* resize_area_delegate);
+  ~SidePanelResizeWidget() override;
+  SidePanelResizeWidget(const SidePanelResizeWidget&) = delete;
+  SidePanelResizeWidget& operator=(const SidePanelResizeWidget&) = delete;
+
+  // views::ViewObserver overrides:
+  void OnViewBoundsChanged(views::View* observed_view) override;
+
+ private:
+  raw_ptr<BraveSidePanel> panel_ = nullptr;
+  std::unique_ptr<views::Widget> widget_;
+  base::ScopedMultiSourceObservation<views::View, views::ViewObserver>
+      observations_{this};
+};
+
+#endif  // BRAVE_BROWSER_UI_VIEWS_SIDE_PANEL_BRAVE_SIDE_PANEL_RESIZE_WIDGET_H_

--- a/browser/ui/views/sidebar/sidebar_container_view.cc
+++ b/browser/ui/views/sidebar/sidebar_container_view.cc
@@ -217,7 +217,7 @@ void SidebarContainerView::Layout() {
                                    control_view_preferred_width, height());
   if (side_panel_->GetVisible()) {
     side_panel_->SetBounds(side_panel_x, 0,
-                           side_panel_->GetPreferredSize().width(), height());
+                           width() - control_view_preferred_width, height());
   }
 }
 

--- a/components/sidebar/constants.h
+++ b/components/sidebar/constants.h
@@ -13,6 +13,7 @@ constexpr char kSidebarItemTypeKey[] = "type";
 constexpr char kSidebarItemBuiltInItemTypeKey[] = "built_in_item_type";
 constexpr char kSidebarItemTitleKey[] = "title";
 constexpr char kSidebarItemOpenInPanelKey[] = "open_in_panel";
+constexpr int kDefaultSidePanelWidth = 320;
 
 // list is provided from chrome layer.
 constexpr char kBraveTalkURL[] = "https://talk.brave.com/widget";

--- a/components/sidebar/pref_names.h
+++ b/components/sidebar/pref_names.h
@@ -14,6 +14,7 @@ constexpr char kSidebarHiddenBuiltInItems[] =
 constexpr char kSidebarShowOption[] = "brave.sidebar.sidebar_show_option";
 constexpr char kSidebarItemAddedFeedbackBubbleShowCount[] =
     "brave.sidebar.item_added_feedback_bubble_shown_count";
+constexpr char kSidePanelWidth[] = "brave.sidebar.side_panel_width";
 
 // Indicates that sidebar alignment was changed by the browser itself, not by
 // users.

--- a/components/sidebar/sidebar_service.cc
+++ b/components/sidebar/sidebar_service.cc
@@ -86,6 +86,7 @@ void SidebarService::RegisterProfilePrefs(PrefRegistrySimple* registry,
           ? static_cast<int>(ShowSidebarOption::kShowNever)
           : static_cast<int>(ShowSidebarOption::kShowAlways));
   registry->RegisterIntegerPref(kSidebarItemAddedFeedbackBubbleShowCount, 0);
+  registry->RegisterIntegerPref(kSidePanelWidth, kDefaultSidePanelWidth);
 }
 
 SidebarService::SidebarService(PrefService* prefs) : prefs_(prefs) {


### PR DESCRIPTION
fix https://github.com/brave/brave-browser/issues/30808

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves 

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-arm64, CI/skip-linux-x64, CI/skip-android, CI/skip-macos, CI/skip-ios, CI/skip-windows-arm64, CI/skip-windows-x64, CI/skip-windows-x86 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

1. Resize side panel by grabbing side panel border on both sided sidebar position.
2. Re-launch and check previously resized width is persisted when side panel is opened.
3. Check resize works properly after resizing browser window, vertical tab width.
4. Check sidebar doesn't occupy whole content page

`SidebarBrowserTest, SidePanelResizeTest`