### PR TITLE
Fix Brave Ads crash on an invalid wallet.

### DIFF
--- a/components/brave_ads/core/internal/deprecated/confirmations/confirmation_state_manager.cc
+++ b/components/brave_ads/core/internal/deprecated/confirmations/confirmation_state_manager.cc
@@ -221,6 +221,10 @@ void ConfirmationStateManager::Save() {
 
 absl::optional<OptedInInfo> ConfirmationStateManager::GetOptedIn(
     const base::Value::Dict& dict) const {
+  if (!wallet_.IsValid()) {
+    return absl::nullopt;
+  }
+
   OptedInInfo opted_in;
 
   // Token
@@ -266,7 +270,6 @@ absl::optional<OptedInInfo> ConfirmationStateManager::GetOptedIn(
         return absl::nullopt;
       }
 
-      CHECK(wallet_.IsValid());
       const absl::optional<std::string> signature =
           crypto::Sign(*unblinded_token_base64, wallet_.secret_key);
       if (!signature) {
@@ -497,8 +500,7 @@ bool ConfirmationStateManager::ParseUnblindedTokensFromDictionary(
   privacy::UnblindedTokenList filtered_unblinded_tokens =
       privacy::UnblindedTokensFromValue(*list);
 
-  if (!filtered_unblinded_tokens.empty()) {
-    CHECK(wallet_.IsValid());
+  if (wallet_.IsValid() && !filtered_unblinded_tokens.empty()) {
     const std::string public_key = wallet_.public_key;
 
     filtered_unblinded_tokens.erase(


### PR DESCRIPTION
Uplift of fixes from https://github.com/brave/brave-core/pull/18557
Resolves https://github.com/brave/brave-browser/issues/31213

Corresponding changes in master:
* https://github.com/brave/brave-core/blob/master/components/brave_ads/core/internal/deprecated/confirmations/confirmation_state_manager.cc#L199
* https://github.com/brave/brave-core/blob/master/components/brave_ads/core/internal/deprecated/confirmations/confirmation_state_manager.cc#L478

Pre-approval checklist: 
- [ ] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.