### PR TITLE
Improve vertical tab animation

### DIFF
--- a/browser/ui/views/frame/vertical_tab_strip_region_view.cc
+++ b/browser/ui/views/frame/vertical_tab_strip_region_view.cc
@@ -710,7 +710,8 @@ void VerticalTabStripRegionView::SetState(State state) {
     return;
 
   mouse_enter_timer_.Stop();
-  state_ = state;
+
+  last_state_ = std::exchange(state_, state);
 
   auto tab_strip = original_region_view_->tab_strip_;
   tab_strip->SetAvailableWidthCallback(base::BindRepeating(

--- a/browser/ui/views/frame/vertical_tab_strip_region_view.h
+++ b/browser/ui/views/frame/vertical_tab_strip_region_view.h
@@ -57,6 +57,8 @@ class VerticalTabStripRegionView : public views::View,
   ~VerticalTabStripRegionView() override;
 
   State state() const { return state_; }
+  State last_state() const { return last_state_; }
+  bool is_animating() const { return width_animation_.is_animating(); }
 
   const TabStrip* tab_strip() const {
     return original_region_view_->tab_strip_;
@@ -184,6 +186,7 @@ class VerticalTabStripRegionView : public views::View,
   const raw_ptr<const TabStyle> tab_style_;
 
   State state_ = State::kExpanded;
+  State last_state_ = State::kExpanded;
 
   BooleanPrefMember show_vertical_tabs_;
   BooleanPrefMember collapsed_pref_;

--- a/browser/ui/views/tabs/brave_tab.cc
+++ b/browser/ui/views/tabs/brave_tab.cc
@@ -189,17 +189,6 @@ void BraveTab::UpdateIconVisibility() {
       showing_icon_ = !showing_alert_indicator_ && !showing_close_button_;
     }
   }
-
-  // Supplement extra left side padding by updating border.
-  // Upstream gives extra padding to balance with right side padding space but
-  // it's gone when tab doesn't have sufficient available width. In our case,
-  // As we have more narrow left & right padding than upstream, icon seems stick
-  // to left side when extra padding is not used.
-  // We only need to do that when |extra_padding_before_content_| is false.
-  // We update border here because |extra_padding_before_content_| is updated
-  // by Tab::UpdateIconVisibility(). After that layout happens. So, it's good
-  // time to update border now.
-  // UpdateBorder();
 }
 
 void BraveTab::ViewHierarchyChanged(
@@ -299,33 +288,9 @@ void BraveTab::MaybeAdjustLeftForPinnedTab(gfx::Rect* bounds,
     return;
   }
 
-  if (!ShouldRenderAsNormalTab()) {
-    // In case it's pinned tab, use the same calculation with the upstream.
-    Tab::MaybeAdjustLeftForPinnedTab(bounds, visual_width);
-    return;
-  }
-
-  auto* browser_view =
-      BrowserView::GetBrowserViewForBrowser(controller_->GetBrowser());
-  if (!browser_view) {
-    Tab::MaybeAdjustLeftForPinnedTab(bounds, visual_width);
-    return;
-  }
-
-  auto* widget_delegate_view = static_cast<BraveBrowserView*>(browser_view)
-                                   ->vertical_tab_strip_widget_delegate_view();
-  CHECK(widget_delegate_view);
-  auto* region_view = widget_delegate_view->vertical_tab_strip_region_view();
-  CHECK(region_view);
-
-  if (region_view->state() == VerticalTabStripRegionView::State::kFloating) {
-    // In case we're in floating mode, set the same left padding with the one
-    // we use for the collapsed state, so that the favicon doesn't moves left
-    // and right.
-    bounds->set_x((tabs::kVerticalTabMinWidth - gfx::kFaviconSize) / 2);
-  }
-
-  // For else cases(non-pinned tabs), we don't do anything just like upstream.
+  // We keep favicon on fixed position so that it won't move left and right
+  // during animation.
+  bounds->set_x((tabs::kVerticalTabMinWidth - gfx::kFaviconSize) / 2);
 }
 
 bool BraveTab::ShouldRenderAsNormalTab() const {

--- a/browser/ui/views/tabs/brave_tab_container.cc
+++ b/browser/ui/views/tabs/brave_tab_container.cc
@@ -12,6 +12,7 @@
 #include "brave/browser/ui/tabs/brave_tab_prefs.h"
 #include "brave/browser/ui/tabs/features.h"
 #include "brave/browser/ui/views/tabs/brave_tab_group_header.h"
+#include "brave/browser/ui/views/tabs/brave_tab_strip.h"
 #include "brave/browser/ui/views/tabs/vertical_tab_utils.h"
 #include "chrome/browser/profiles/profile.h"
 #include "chrome/browser/ui/color/chrome_color_id.h"
@@ -284,9 +285,8 @@ void BraveTabContainer::UpdateLayoutOrientation() {
 
   layout_helper_->set_use_vertical_tabs(
       tabs::utils::ShouldShowVerticalTabs(tab_slot_controller_->GetBrowser()));
-  // When these two prefs are true, vertical tabs could be in floating mode.
-  layout_helper_->set_floating_mode(*vertical_tabs_floating_mode_enabled_ &&
-                                    *vertical_tabs_collapsed_);
+  layout_helper_->set_tab_strip(
+      static_cast<BraveTabStrip*>(base::to_address(tab_slot_controller_)));
   InvalidateLayout();
 }
 

--- a/chromium_src/chrome/browser/ui/views/tabs/tab_strip_layout_helper.cc
+++ b/chromium_src/chrome/browser/ui/views/tabs/tab_strip_layout_helper.cc
@@ -4,11 +4,13 @@
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 #include "chrome/browser/ui/views/tabs/tab_strip_layout_helper.h"
+#include "brave/browser/ui/views/tabs/brave_tab_strip.h"
 
-#define CalculateTabBounds                                               \
-  use_vertical_tabs_&& FillGroupInfo(tab_widths)                         \
-      ? tabs::CalculateVerticalTabBounds(layout_constants, tab_widths,   \
-                                         tabstrip_width, floating_mode_) \
+#define CalculateTabBounds                                                     \
+  use_vertical_tabs_&& FillGroupInfo(tab_widths)                               \
+      ? tabs::CalculateVerticalTabBounds(layout_constants, tab_widths,         \
+                                         tabstrip_width,                       \
+                                         tab_strip_->IsVerticalTabsFloating()) \
       : CalculateTabBounds
 
 #include "src/chrome/browser/ui/views/tabs/tab_strip_layout_helper.cc"

--- a/chromium_src/chrome/browser/ui/views/tabs/tab_strip_layout_helper.h
+++ b/chromium_src/chrome/browser/ui/views/tabs/tab_strip_layout_helper.h
@@ -8,6 +8,8 @@
 
 #include "brave/browser/ui/views/tabs/brave_tab_strip_layout_helper.h"
 
+class BraveTabStrip;
+
 // As TabStripLayoutHelper's destructor is not virtual, it'd be safer not to
 // make virtual methods and child class of it
 #define UpdateIdealBounds                                           \
@@ -17,15 +19,15 @@
   void set_use_vertical_tabs(bool vertical) {                       \
     use_vertical_tabs_ = vertical;                                  \
   }                                                                 \
-  void set_floating_mode(bool floating) {                           \
-    floating_mode_ = floating;                                      \
+  void set_tab_strip(BraveTabStrip* tab_strip) {                    \
+    tab_strip_ = tab_strip;                                         \
   }                                                                 \
                                                                     \
  private:                                                           \
   friend class BraveTabContainer;                                   \
   bool FillGroupInfo(std::vector<TabWidthConstraints>& tab_widths); \
   bool use_vertical_tabs_ = false;                                  \
-  bool floating_mode_ = false;                                      \
+  raw_ptr<BraveTabStrip> tab_strip_ = nullptr;                      \
                                                                     \
  public:                                                            \
   int UpdateIdealBounds


### PR DESCRIPTION
* Fix favicon position so that it doesn't move left and right during the animation

* Fix pinned tabs layout during animation - We were depending only on the pref values and it returns wrong value during the anmation. As a result, pinned tabs are laid out bad during animation.

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/30897

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-arm64, CI/skip-linux-x64, CI/skip-android, CI/skip-macos, CI/skip-ios, CI/skip-windows-arm64, CI/skip-windows-x64, CI/skip-windows-x86 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [ ] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
* When expanding and collapsing vertical tab strip, the favicon shouldn't move around.
