### PR TITLE
[Android] bump second digit in versionCode generation script (uplift to 1.54.x)

### DIFF
--- a/patches/build-util-android_chrome_version.py.patch
+++ b/patches/build-util-android_chrome_version.py.patch
@@ -15,7 +15,7 @@ index f00cd99d2bfa5793d6ed5d96025885ad83af412f..eadeb2cd4b6fc947ab7677b9c8319e1c
  
    base_version_code = int(
 -      '%s%03d00' % (version_values['BUILD'], int(version_values['PATCH'])))
-+      '%02d%02d%03d00' % (int(version_values['MINOR']) + 40, int(version_values['BUILD']), int(version_values['PATCH'])))
++      '%02d%02d%03d00' % (int(version_values['MINOR']) + 41, int(version_values['BUILD']), int(version_values['PATCH'])))
  
    if is_next_build:
      base_version_code += _NEXT_BUILD_VERSION_CODE_DIFF


### PR DESCRIPTION
Uplift of #19020
Resolves https://github.com/brave/brave-browser/issues/31262

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.