### PR TITLE
fix(wallet): Loading Overlap on Menu

### DIFF
--- a/components/brave_wallet_ui/components/desktop/line-chart/index.tsx
+++ b/components/brave_wallet_ui/components/desktop/line-chart/index.tsx
@@ -22,7 +22,8 @@ import CustomTooltip from './custom-tooltip'
 import {
   StyledWrapper,
   LoadingOverlay,
-  LoadIcon
+  LoadIcon,
+  AreaWrapper
 } from './style'
 import { CustomReferenceDot } from './custom-reference-dot'
 
@@ -78,9 +79,7 @@ function LineChart ({
   // render
   return (
     <StyledWrapper style={customStyle}>
-      <LoadingOverlay isLoading={isLoading}>
-        <LoadIcon />
-      </LoadingOverlay>
+      <AreaWrapper>
       <ResponsiveContainer width='100%' height='99%'>
         <AreaChart
           data={chartData}
@@ -145,6 +144,10 @@ function LineChart ({
           />
         </AreaChart>
       </ResponsiveContainer>
+      </AreaWrapper>
+      <LoadingOverlay isLoading={isLoading}>
+        <LoadIcon />
+      </LoadingOverlay>
     </StyledWrapper>
   )
 }

--- a/components/brave_wallet_ui/components/desktop/line-chart/style.ts
+++ b/components/brave_wallet_ui/components/desktop/line-chart/style.ts
@@ -62,6 +62,16 @@ export const ChartDate = styled.span`
   color: ${leo.color.text.secondary};
 `
 
+export const AreaWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  height: 100%;
+  position: absolute;
+`
+
 export const LoadingOverlay = styled.div<{
   isLoading: boolean
 }>`
@@ -72,7 +82,6 @@ export const LoadingOverlay = styled.div<{
   width: 100%;
   height: 100%;
   position: absolute;
-  z-index: 10;
   backdrop-filter: blur(5px);
 `
 

--- a/components/brave_wallet_ui/components/shared/loading-skeleton/styles.ts
+++ b/components/brave_wallet_ui/components/shared/loading-skeleton/styles.ts
@@ -37,7 +37,6 @@ export const Skeleton = styled.span<Partial<LoadingSkeletonStyleProps>>`
   line-height: 1;
   position: relative;
   overflow: hidden;
-  z-index: 1;
   opacity: ${p => p.useLightTheme ? 0.6 : 1};
 
   @media (prefers-color-scheme: dark) {


### PR DESCRIPTION
## Description 
Fixes a bug where the `Line Chart` loading state and other loading `Skeletons` were overlapping the `Portfolio Settings Menu`

<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves <https://github.com/brave/brave-browser/issues/31263>

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-arm64, CI/skip-linux-x64, CI/skip-android, CI/skip-macos, CI/skip-ios, CI/skip-windows-arm64, CI/skip-windows-x64, CI/skip-windows-x86 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
1. Go to the `Portfolio` page
2. Reload the page and quickly open the `Portfolio Settings Menu` and scroll down the page.
3. The `Line Chart` loading state and other loading `Skeletons` should not overlap the `Portfolio Settings Menu`

Before:

https://github.com/brave/brave-core/assets/40611140/00725547-12b2-4991-b5eb-3f64f965e03d

After:

https://github.com/brave/brave-core/assets/40611140/17d40df4-5c0c-4886-8857-e760fa59ebcd
