### PR TITLE
feat(wallet): Panel V2 Headers

### DIFF
--- a/components/brave_wallet_ui/common/selectors/ui-selectors.ts
+++ b/components/brave_wallet_ui/common/selectors/ui-selectors.ts
@@ -10,3 +10,5 @@ export const selectedPendingTransactionId = ({ ui }: State) =>
   ui.selectedPendingTransactionId
 export const transactionProviderErrorRegistry = ({ ui }: State) =>
   ui.transactionProviderErrorRegistry
+export const isPanel = ({ ui }: State) =>
+  ui.isPanel

--- a/components/brave_wallet_ui/common/slices/ui.slice.ts
+++ b/components/brave_wallet_ui/common/slices/ui.slice.ts
@@ -9,13 +9,16 @@ import { BraveWallet, UIState } from '../../constants/types'
 import { walletApi } from './api.slice'
 import { SetTransactionProviderErrorType } from '../constants/action_types'
 
-const defaultState: UIState = {
+export const defaultUIState: UIState = {
   selectedPendingTransactionId: undefined,
-  transactionProviderErrorRegistry: {}
+  transactionProviderErrorRegistry: {},
+  isPanel: false
 }
 
 // slice
-export const createUISlice = (initialState: UIState = defaultState) => {
+export const createUISlice = (
+  initialState: UIState = defaultUIState
+) => {
   return createSlice({
     name: 'ui',
     initialState,

--- a/components/brave_wallet_ui/components/desktop/card-headers/asset-details-header.tsx
+++ b/components/brave_wallet_ui/components/desktop/card-headers/asset-details-header.tsx
@@ -9,9 +9,13 @@ import { skipToken } from '@reduxjs/toolkit/query/react'
 // Selectors
 import {
   useUnsafePageSelector,
-  useSafePageSelector
+  useSafePageSelector,
+  useSafeUISelector
 } from '../../../common/hooks/use-safe-selector'
 import { PageSelectors } from '../../../page/selectors'
+import {
+  UISelectors
+} from '../../../common/selectors'
 
 // Utils
 import { getLocale } from '../../../../common/locale'
@@ -86,6 +90,9 @@ export const AssetDetailsHeader = (props: Props) => {
   const selectedAsset =
     useUnsafePageSelector(PageSelectors.selectedAsset)
   const selectedTimeline = useSafePageSelector(PageSelectors.selectedTimeline)
+
+  // UI Selectors (safe)
+  const isPanel = useSafeUISelector(UISelectors.isPanel)
 
   // queries
   const { data: assetsNetwork } = useGetNetworkQuery(
@@ -169,7 +176,7 @@ export const AssetDetailsHeader = (props: Props) => {
 
   return (
     <Row
-      padding='24px 0px'
+      padding={isPanel ? '12px 20px' : '24px 0px'}
       justifyContent='space-between'
     >
       <Row

--- a/components/brave_wallet_ui/components/desktop/card-headers/default-panel-header.tsx
+++ b/components/brave_wallet_ui/components/desktop/card-headers/default-panel-header.tsx
@@ -1,0 +1,100 @@
+// Copyright (c) 2023 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import * as React from 'react'
+
+// Hooks
+import {
+  useOnClickOutside
+} from '../../../common/hooks/useOnClickOutside'
+
+import {
+  DefaultPanelMenu
+} from '../wallet-menus/default-panel-menu'
+
+// Styled Components
+import {
+  Button,
+  ButtonIcon
+} from './shared-panel-headers.style'
+import {
+  HeaderTitle,
+  MenuWrapper
+} from './shared-card-headers.style'
+import { Row } from '../../shared/style'
+
+interface Props {
+  title: string
+  isPortfolio?: boolean
+}
+
+export const DefaultPanelHeader = (props: Props) => {
+  const {
+    title,
+    isPortfolio
+  } = props
+
+  // State
+  const [showSettingsMenu, setShowSettingsMenu] =
+    React.useState<boolean>(false)
+
+  // Refs
+  const settingsMenuRef =
+    React.useRef<HTMLDivElement>(null)
+
+  // Hooks
+  useOnClickOutside(
+    settingsMenuRef,
+    () => setShowSettingsMenu(false),
+    showSettingsMenu
+  )
+
+  // Methods
+  const onClickExpand = React.useCallback(() => {
+    chrome.tabs.create({ url: 'chrome://wallet/crypto' }, () => {
+      if (chrome.runtime.lastError) {
+        console.error('tabs.create failed: ' + chrome.runtime.lastError.message)
+      }
+    })
+  }, [])
+
+  return (
+    <Row
+      padding='18px 16px'
+      justifyContent='space-between'
+    >
+      <Button
+        onClick={onClickExpand}
+      >
+        <ButtonIcon name='expand' />
+      </Button>
+      <HeaderTitle
+        isPanel={true}
+      >
+        {title}
+      </HeaderTitle>
+      <MenuWrapper
+        ref={settingsMenuRef}
+      >
+        <Button
+          onClick={
+            () => setShowSettingsMenu(prev => !prev)
+          }
+        >
+          <ButtonIcon
+            name='more-horizontal'
+          />
+        </Button>
+        {showSettingsMenu &&
+          <DefaultPanelMenu
+            isPortfolio={isPortfolio}
+          />
+        }
+      </MenuWrapper>
+    </Row>
+  )
+}
+
+export default DefaultPanelHeader

--- a/components/brave_wallet_ui/components/desktop/card-headers/nft-asset-header.tsx
+++ b/components/brave_wallet_ui/components/desktop/card-headers/nft-asset-header.tsx
@@ -9,6 +9,14 @@
 
 import * as React from 'react'
 
+// Selectors
+import {
+  useSafeUISelector
+} from '../../../common/hooks/use-safe-selector'
+import {
+  UISelectors
+} from '../../../common/selectors'
+
 // utils
 import Amount from '../../../utils/amount'
 import { getLocale } from '../../../../common/locale'
@@ -31,9 +39,12 @@ interface Props {
 }
 
 export const NftAssetHeader = ({ assetName, tokenId, showSendButton, onBack, onSend }: Props) => {
+  // UI Selectors (safe)
+  const isPanel = useSafeUISelector(UISelectors.isPanel)
+
   return (
     <Row
-      padding='26px 0px'
+      padding={isPanel ? '12px 20px' : '26px 0px'}
       justifyContent='space-between'
       alignItems='center'
     >
@@ -50,7 +61,9 @@ export const NftAssetHeader = ({ assetName, tokenId, showSendButton, onBack, onS
             name='arrow-left'
           />
         </CircleButton>
-        <HeaderTitle>
+        <HeaderTitle
+          isPanel={isPanel}
+        >
           {assetName}&nbsp;{tokenId ? `#${new Amount(tokenId).toNumber()}` : ''}
         </HeaderTitle>
       </Row>

--- a/components/brave_wallet_ui/components/desktop/card-headers/page-title-header.tsx
+++ b/components/brave_wallet_ui/components/desktop/card-headers/page-title-header.tsx
@@ -4,6 +4,21 @@
 // You can obtain one at https://mozilla.org/MPL/2.0/.
 import * as React from 'react'
 
+// Selectors
+import {
+  UISelectors
+} from '../../../common/selectors'
+
+// Hooks
+import {
+  useSafeUISelector
+} from '../../../common/hooks/use-safe-selector'
+
+// Components
+import {
+  DefaultPanelHeader
+} from './default-panel-header'
+
 // styles
 import { Row } from '../../shared/style'
 import { ButtonIcon, CircleButton, HeaderTitle } from './shared-card-headers.style'
@@ -15,24 +30,36 @@ interface Props {
 }
 
 export const PageTitleHeader = ({ title, showBackButton, onBack }: Props) => {
+
+  // UI Selectors (safe)
+  const isPanel = useSafeUISelector(UISelectors.isPanel)
+
   return (
-    <Row
-      padding='24px 0px'
-      justifyContent='flex-start'
-    >
-      {showBackButton &&
-        <CircleButton
-          size={28}
-          marginRight={16}
-          onClick={onBack}
+    isPanel && !showBackButton
+      ? <DefaultPanelHeader
+        title={title}
+      />
+      : <Row
+        padding={isPanel ? '17px 20px' : '24px 0px'}
+        justifyContent='flex-start'
+      >
+        {showBackButton &&
+          <CircleButton
+            size={28}
+            marginRight={16}
+            onClick={onBack}
+          >
+            <ButtonIcon
+              size={16}
+              name='arrow-left'
+            />
+          </CircleButton>
+        }
+        <HeaderTitle
+          isPanel={isPanel}
         >
-          <ButtonIcon
-            size={16}
-            name='arrow-left'
-          />
-        </CircleButton>
-      }
-      <HeaderTitle>{title}</HeaderTitle>
-    </Row>
+          {title}
+        </HeaderTitle>
+      </Row>
   )
 }

--- a/components/brave_wallet_ui/components/desktop/card-headers/portfolio-overview-header.tsx
+++ b/components/brave_wallet_ui/components/desktop/card-headers/portfolio-overview-header.tsx
@@ -5,6 +5,16 @@
 
 import * as React from 'react'
 
+// Selectors
+import {
+  UISelectors
+} from '../../../common/selectors'
+
+// Components
+import {
+  DefaultPanelHeader
+} from './default-panel-header'
+
 // Utils
 import { getLocale } from '../../../../common/locale'
 
@@ -12,6 +22,9 @@ import { getLocale } from '../../../../common/locale'
 import {
   useOnClickOutside
 } from '../../../common/hooks/useOnClickOutside'
+import {
+  useSafeUISelector
+} from '../../../common/hooks/use-safe-selector'
 
 import {
   PortfolioOverviewMenu
@@ -27,6 +40,9 @@ import {
 import { Row } from '../../shared/style'
 
 export const PortfolioOverviewHeader = () => {
+  // UI Selectors (safe)
+  const isPanel = useSafeUISelector(UISelectors.isPanel)
+
   // State
   const [showPortfolioOverviewMenu, setShowPortfolioOverviewMenu] =
     React.useState<boolean>(false)
@@ -43,30 +59,35 @@ export const PortfolioOverviewHeader = () => {
   )
 
   return (
-    <Row
-      padding='24px 0px'
-      justifyContent='space-between'
-    >
-      <HeaderTitle>
-        {getLocale('braveWalletTopNavPortfolio')}
-      </HeaderTitle>
-      <MenuWrapper
-        ref={portfolioOverviewMenuRef}
+    isPanel
+      ? <DefaultPanelHeader
+        title={getLocale('braveWalletTopNavPortfolio')}
+        isPortfolio={true}
+      />
+      : <Row
+        padding='24px 0px'
+        justifyContent='space-between'
       >
-        <CircleButton
-          onClick={
-            () => setShowPortfolioOverviewMenu(prev => !prev)
-          }
+        <HeaderTitle>
+          {getLocale('braveWalletTopNavPortfolio')}
+        </HeaderTitle>
+        <MenuWrapper
+          ref={portfolioOverviewMenuRef}
         >
-          <ButtonIcon
-            name='tune'
-          />
-        </CircleButton>
-        {showPortfolioOverviewMenu &&
-          <PortfolioOverviewMenu />
-        }
-      </MenuWrapper>
-    </Row>
+          <CircleButton
+            onClick={
+              () => setShowPortfolioOverviewMenu(prev => !prev)
+            }
+          >
+            <ButtonIcon
+              name='tune'
+            />
+          </CircleButton>
+          {showPortfolioOverviewMenu &&
+            <PortfolioOverviewMenu />
+          }
+        </MenuWrapper>
+      </Row>
   )
 }
 

--- a/components/brave_wallet_ui/components/desktop/card-headers/shared-card-headers.style.ts
+++ b/components/brave_wallet_ui/components/desktop/card-headers/shared-card-headers.style.ts
@@ -8,12 +8,14 @@ import * as leo from '@brave/leo/tokens/css'
 import Icon from '@brave/leo/react/icon'
 import { WalletButton } from '../../shared/style'
 
-export const HeaderTitle = styled.span`
+export const HeaderTitle = styled.span<{
+  isPanel?: boolean
+}>`
   font-family: Poppins;
   font-style: normal;
-  font-size: 28px;
-  font-weight: 500;
-  line-height: 40px;
+  font-size: ${(p) => p.isPanel ? 16 : 28}px;
+  font-weight: ${(p) => p.isPanel ? 600 : 500};
+  line-height: ${(p) => p.isPanel ? 24 : 40}px;
   color: ${leo.color.text.primary};
 `
 

--- a/components/brave_wallet_ui/components/desktop/card-headers/shared-panel-headers.style.ts
+++ b/components/brave_wallet_ui/components/desktop/card-headers/shared-panel-headers.style.ts
@@ -1,0 +1,24 @@
+// Copyright (c) 2023 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import styled from 'styled-components'
+import * as leo from '@brave/leo/tokens/css'
+import Icon from '@brave/leo/react/icon'
+import { WalletButton } from '../../shared/style'
+
+export const Button = styled(WalletButton)`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  outline: none;
+  background: none;
+  border: none;
+`
+
+export const ButtonIcon = styled(Icon)`
+  --leo-icon-size: 24px;
+  color: ${leo.color.icon.default};
+`

--- a/components/brave_wallet_ui/components/desktop/wallet-menus/default-panel-menu.tsx
+++ b/components/brave_wallet_ui/components/desktop/wallet-menus/default-panel-menu.tsx
@@ -1,0 +1,279 @@
+// Copyright (c) 2023 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import * as React from 'react'
+import { useLocation, useHistory } from 'react-router-dom'
+import { useDispatch } from 'react-redux'
+import Toggle from '@brave/leo/react/toggle'
+
+// Selectors
+import {
+  useSafeWalletSelector
+} from '../../../common/hooks/use-safe-selector'
+import {
+  WalletSelectors
+} from '../../../common/selectors'
+
+// Types
+import {
+  BraveWallet,
+  WalletRoutes
+} from '../../../constants/types'
+
+// Constants
+import {
+  LOCAL_STORAGE_KEYS
+} from '../../../common/constants/local-storage-keys'
+
+// actions
+import { WalletActions } from '../../../common/actions'
+
+// utils
+import { getLocale } from '../../../../common/locale'
+import { useGetSelectedChainQuery } from '../../../common/slices/api.slice'
+
+// Styled Components
+import {
+  StyledWrapper,
+  PopupButton,
+  PopupButtonText,
+  ButtonIcon,
+  ToggleRow
+} from './wellet-menus.style'
+import {
+  VerticalDivider,
+  VerticalSpace,
+  Row
+} from '../../shared/style'
+
+export interface Props {
+  onClosePopup?: () => void
+  yPosition?: number
+  isPortfolio?: boolean
+}
+
+export const DefaultPanelMenu = (props: Props) => {
+  const {
+    onClosePopup,
+    yPosition,
+    isPortfolio
+  } = props
+
+  // Routing
+  const history = useHistory()
+  const { pathname: walletLocation } = useLocation()
+
+  // redux
+  const dispatch = useDispatch()
+
+  // selectors
+  const hidePortfolioGraph =
+    useSafeWalletSelector(WalletSelectors.hidePortfolioGraph)
+  const hidePortfolioBalances =
+    useSafeWalletSelector(WalletSelectors.hidePortfolioBalances)
+  const hidePortfolioNFTsTab =
+    useSafeWalletSelector(WalletSelectors.hidePortfolioNFTsTab)
+
+  // queries
+  const { data: selectedNetwork } = useGetSelectedChainQuery()
+
+  // methods
+  const lockWallet = React.useCallback(() => {
+    dispatch(WalletActions.lockWallet())
+  }, [])
+
+  const onClickConnectedSites = React.useCallback(() => {
+    if (!selectedNetwork) {
+      return
+    }
+
+    const route = selectedNetwork.coin === BraveWallet.CoinType.ETH
+      ? 'ethereum'
+      : 'solana'
+
+    chrome.tabs.create({ url: `brave://settings/content/${route}` }, () => {
+      if (chrome.runtime.lastError) {
+        console.error(
+          'tabs.create failed: ' +
+          chrome.runtime.lastError.message
+        )
+      }
+    })
+    if (onClosePopup) {
+      onClosePopup()
+    }
+  }, [selectedNetwork, onClosePopup])
+
+  const onClickHelpCenter = React.useCallback(() => {
+    chrome.tabs.create(
+      {
+        url: 'https://support.brave.com/hc/en-us/categories/360001059151-Brave-Wallet'
+      }, () => {
+        if (chrome.runtime.lastError) {
+          console.error(
+            'tabs.create failed: '
+            + chrome.runtime.lastError.message
+          )
+        }
+      })
+    if (onClosePopup) {
+      onClosePopup()
+    }
+  }, [onClosePopup])
+
+  const onClickSettings = React.useCallback(() => {
+    chrome.tabs.create({ url: 'chrome://settings/wallet' }, () => {
+      if (chrome.runtime.lastError) {
+        console.error(
+          'tabs.create failed: ' +
+          chrome.runtime.lastError.message
+        )
+      }
+    })
+    if (onClosePopup) {
+      onClosePopup()
+    }
+  }, [onClosePopup])
+
+  // Methods
+  const onToggleHideGraph = React.useCallback(() => {
+    window.localStorage.setItem(
+      LOCAL_STORAGE_KEYS.IS_PORTFOLIO_OVERVIEW_GRAPH_HIDDEN,
+      hidePortfolioGraph
+        ? 'false'
+        : 'true'
+    )
+    dispatch(
+      WalletActions
+        .setHidePortfolioGraph(
+          !hidePortfolioGraph
+        ))
+  }, [hidePortfolioGraph])
+
+  const onToggleHideBalances = React.useCallback(() => {
+    window.localStorage.setItem(
+      LOCAL_STORAGE_KEYS.HIDE_PORTFOLIO_BALANCES,
+      hidePortfolioBalances
+        ? 'false'
+        : 'true'
+    )
+    dispatch(
+      WalletActions
+        .setHidePortfolioBalances(
+          !hidePortfolioBalances
+        ))
+  }, [hidePortfolioBalances])
+
+  const onToggleHideNFTsTab = React.useCallback(() => {
+    if (walletLocation.includes(WalletRoutes.PortfolioNFTs)) {
+      history.push(WalletRoutes.PortfolioAssets)
+    }
+    window.localStorage.setItem(
+      LOCAL_STORAGE_KEYS.HIDE_PORTFOLIO_NFTS_TAB,
+      hidePortfolioNFTsTab
+        ? 'false'
+        : 'true'
+    )
+    dispatch(
+      WalletActions
+        .setHidePortfolioNFTsTab(
+          !hidePortfolioNFTsTab
+        ))
+  }, [hidePortfolioNFTsTab, walletLocation])
+
+  return (
+    <StyledWrapper
+      yPosition={yPosition}
+    >
+
+      <PopupButton onClick={lockWallet}>
+        <ButtonIcon name='lock' />
+        <PopupButtonText>
+          {getLocale('braveWalletWalletPopupLock')}
+        </PopupButtonText>
+      </PopupButton>
+
+      {
+        selectedNetwork &&
+        selectedNetwork.coin !== BraveWallet.CoinType.FIL &&
+        <PopupButton onClick={onClickConnectedSites}>
+          <ButtonIcon name='link-normal' />
+          <PopupButtonText>
+            {getLocale('braveWalletWalletPopupConnectedSites')}
+          </PopupButtonText>
+        </PopupButton>
+      }
+
+      <PopupButton onClick={onClickSettings}>
+        <ButtonIcon name='settings' />
+        <PopupButtonText>
+          {getLocale('braveWalletWalletPopupSettings')}
+        </PopupButtonText>
+      </PopupButton>
+
+      <VerticalDivider />
+      <VerticalSpace space='8px' />
+
+      {isPortfolio &&
+        <>
+          <ToggleRow onClick={onToggleHideBalances}>
+            <Row>
+              <ButtonIcon name='eye-on' />
+              <PopupButtonText>
+                {getLocale('braveWalletWalletPopupHideBalances')}
+              </PopupButtonText>
+              <Toggle
+                checked={!hidePortfolioBalances}
+                onChanged={onToggleHideBalances}
+                size='small'
+              />
+            </Row>
+          </ToggleRow>
+
+          <ToggleRow onClick={onToggleHideGraph}>
+            <Row>
+              <ButtonIcon name='graph' />
+              <PopupButtonText>
+                {getLocale('braveWalletWalletPopupShowGraph')}
+              </PopupButtonText>
+            </Row>
+            <Toggle
+              checked={!hidePortfolioGraph}
+              onChanged={onToggleHideGraph}
+              size='small'
+            />
+          </ToggleRow>
+
+          <ToggleRow onClick={onToggleHideNFTsTab}>
+            <Row>
+              <ButtonIcon name='nft' />
+              <PopupButtonText>
+                {getLocale('braveWalletWalletNFTsTab')}
+              </PopupButtonText>
+            </Row>
+            <Toggle
+              checked={!hidePortfolioNFTsTab}
+              onChanged={onToggleHideNFTsTab}
+              size='small'
+            />
+          </ToggleRow>
+
+          <VerticalDivider />
+          <VerticalSpace space='8px' />
+        </>
+      }
+
+      <PopupButton onClick={onClickHelpCenter}>
+        <ButtonIcon name='help-outline' />
+        <PopupButtonText>
+          {getLocale('braveWalletHelpCenter')}
+        </PopupButtonText>
+      </PopupButton>
+
+    </StyledWrapper>
+  )
+}
+
+export default DefaultPanelMenu

--- a/components/brave_wallet_ui/components/desktop/wallet-page-wrapper/wallet-page-wrapper.style.ts
+++ b/components/brave_wallet_ui/components/desktop/wallet-page-wrapper/wallet-page-wrapper.style.ts
@@ -15,7 +15,11 @@ export const layoutSmallWidth = 980
 export const layoutPanelWidth = 660
 export const layoutTopPosition = 68
 
-export const Wrapper = styled.div<{ noPadding?: boolean }>`
+export const Wrapper = styled.div<{
+  noPadding?: boolean
+  isPanel?: boolean
+}>`
+  --layout-top-position: ${(p) => p.isPanel ? 0 : layoutTopPosition}px;
   position: fixed;
   top: 0px;
   bottom: 0px;
@@ -30,7 +34,7 @@ export const Wrapper = styled.div<{ noPadding?: boolean }>`
   padding: ${(p) =>
     p.noPadding
       ? '0px'
-      : `${layoutTopPosition}px 0px`
+      : `var(--layout-top-position) 0px`
   };
 `
 
@@ -39,8 +43,8 @@ export const LayoutCardWrapper = styled.div<{
   headerHeight: number
 }>`
   --header-top-position:
-    calc(${layoutTopPosition}px + ${(p) => p.headerHeight}px);
-  --no-header-top-position: ${layoutTopPosition}px;
+    calc(var(--layout-top-position) + ${(p) => p.headerHeight}px);
+  --no-header-top-position: var(--layout-top-position);
   --top-position: ${(p) =>
     p.hideCardHeader
       ? 'var(--no-header-top-position)'
@@ -76,8 +80,8 @@ export const LayoutCardWrapper = styled.div<{
 
 export const ContainerCard = styled.div<
   {
-    noPadding?: boolean,
-    maxWidth?: number,
+    noPadding?: boolean
+    maxWidth?: number
     hideCardHeader?: boolean
     noMinCardHeight?: boolean
   }>`
@@ -118,13 +122,14 @@ export const ContainerCard = styled.div<
 
 
 export const CardHeaderWrapper = styled.div<{
-    maxWidth?: number,
-  }>`
+  maxWidth?: number
+  isPanel?: boolean
+}>`
   display: flex;
   flex-direction: column;
   justify-content: flex-start;
   align-items: center;
-  top: ${layoutTopPosition}px;
+  top: var(--layout-top-position);
   position: fixed;
   width: 100%;
   max-width: ${(p) =>
@@ -133,9 +138,9 @@ export const CardHeaderWrapper = styled.div<{
       : 'unset'
   };
   @media screen and (max-width: ${layoutScaleWithNav}px) {
-    padding: ${(p) => p.maxWidth ? '0px': '0px 32px 0px 304px'}; 
-    left: ${(p) => p.maxWidth ? 'unset': '0px'};
-    right: ${(p) => p.maxWidth ? 'unset': '0px'};
+    padding: ${(p) => p.maxWidth ? '0px' : '0px 32px 0px 304px'};
+    left: ${(p) => p.maxWidth ? 'unset' : '0px'};
+    right: ${(p) => p.maxWidth ? 'unset' : '0px'};
     align-items: flex-start;
   }
   @media screen and (max-width: ${layoutSmallWidth}px) {
@@ -151,6 +156,7 @@ export const CardHeaderWrapper = styled.div<{
 
 export const CardHeader = styled.div<{
   shadowOpacity?: number
+  isPanel?: boolean
 }>`
   --shadow-opacity: ${(p) =>
     p.shadowOpacity !== undefined
@@ -159,9 +165,9 @@ export const CardHeader = styled.div<{
   };
   display: flex;
   background-color: ${(p) => p.theme.color.background02};
-  border-radius: 24px 24px 0px 0px;
+  border-radius: ${(p) => p.isPanel ? '0px' : '24px 24px 0px 0px'};
   width: 100%;
-  padding: 0px 32px;
+  padding: ${(p) => p.isPanel ? '0px' : '0px 32px'};
   position: relative;
   max-width: ${maxCardWidth}px;
   box-shadow: 0px 4px 13px -2px rgba(0, 0, 0, var(--shadow-opacity));
@@ -290,7 +296,7 @@ export const BackgroundGradientBottomLayer = styled.div`
 `
 
 export const BlockForHeight = styled.div`
-  top: ${layoutTopPosition}px;
+  top: var(--layout-top-position);
   width: 1px;
   height: calc(${minCardHeight}px + 30px);
   display: flex;

--- a/components/brave_wallet_ui/components/desktop/wallet-page-wrapper/wallet-page-wrapper.tsx
+++ b/components/brave_wallet_ui/components/desktop/wallet-page-wrapper/wallet-page-wrapper.tsx
@@ -6,10 +6,16 @@
 import * as React from 'react'
 
 // Selectors
-import { WalletSelectors } from '../../../common/selectors'
+import {
+  WalletSelectors,
+  UISelectors
+} from '../../../common/selectors'
 
 // Hooks
-import { useSafeWalletSelector } from '../../../common/hooks/use-safe-selector'
+import {
+  useSafeWalletSelector,
+  useSafeUISelector
+} from '../../../common/hooks/use-safe-selector'
 
 // Components
 import { WalletNav } from '../wallet-nav/wallet-nav'
@@ -70,6 +76,7 @@ export const WalletPageWrapper = (props: Props) => {
   // Wallet Selectors (safe)
   const isWalletCreated = useSafeWalletSelector(WalletSelectors.isWalletCreated)
   const isWalletLocked = useSafeWalletSelector(WalletSelectors.isWalletLocked)
+  const isPanel = useSafeUISelector(UISelectors.isPanel)
 
   // State
   const [headerShadowOpacity, setHeaderShadowOpacity]
@@ -141,11 +148,15 @@ export const WalletPageWrapper = (props: Props) => {
           <BackgroundGradientBottomLayer />
         </BackgroundGradientWrapper>
       }
-      <Wrapper noPadding={noPadding}>
+      <Wrapper
+        noPadding={noPadding}
+        isPanel={isPanel}
+      >
         {
           isWalletCreated &&
           !isWalletLocked &&
           !hideHeader &&
+          !isPanel &&
           <TabHeader />
         }
         {
@@ -171,6 +182,7 @@ export const WalletPageWrapper = (props: Props) => {
             {cardHeader &&
               <CardHeaderWrapper
                 maxWidth={cardWidth}
+                isPanel={isPanel}
               >
                 <CardHeaderShadow
                   headerHeight={headerHeight}
@@ -191,9 +203,11 @@ export const WalletPageWrapper = (props: Props) => {
               <CardHeaderWrapper
                 ref={headerRef}
                 maxWidth={cardWidth}
+                isPanel={isPanel}
               >
                 <CardHeader
                   shadowOpacity={headerShadowOpacity}
+                  isPanel={isPanel}
                 >
                   <CardHeaderContentWrapper
                     dividerOpacity={headerDividerOpacity}

--- a/components/brave_wallet_ui/constants/types.ts
+++ b/components/brave_wallet_ui/constants/types.ts
@@ -228,6 +228,7 @@ export interface TokenRegistry {
 export interface UIState {
   selectedPendingTransactionId?: string | undefined
   transactionProviderErrorRegistry: TransactionProviderErrorRegistry
+  isPanel: boolean
 }
 
 export interface WalletState {

--- a/components/brave_wallet_ui/panel/store.ts
+++ b/components/brave_wallet_ui/panel/store.ts
@@ -18,7 +18,10 @@ import walletReducer from '../common/slices/wallet.slice'
 import pageReducer from '../page/reducers/page_reducer'
 import accountsTabReducer from '../page/reducers/accounts-tab-reducer'
 import { panelReducer } from './reducers/panel_reducer'
-import uiReducer from '../common/slices/ui.slice'
+import {
+  uiReducer,
+  defaultUIState
+} from '../common/slices/ui.slice'
 
 // utils
 import { setApiProxyFetcher } from '../common/async/base-query-cache'
@@ -31,6 +34,12 @@ const store = configureStore({
     wallet: walletReducer,
     ui: uiReducer,
     [walletApi.reducerPath]: walletApi.reducer
+  },
+  preloadedState: {
+    ui: {
+      ...defaultUIState,
+      isPanel: true
+    }
   },
   middleware: (getDefaultMiddleware) => getDefaultMiddleware({
     serializableCheck: false

--- a/components/brave_wallet_ui/stories/mock-data/mock-ui-state.ts
+++ b/components/brave_wallet_ui/stories/mock-data/mock-ui-state.ts
@@ -8,5 +8,6 @@ import { mockedErc20ApprovalTransaction } from './mock-transaction-info'
 
 export const mockUiState: UIState = {
   transactionProviderErrorRegistry: {},
-  selectedPendingTransactionId: mockedErc20ApprovalTransaction.id
+  selectedPendingTransactionId: mockedErc20ApprovalTransaction.id,
+  isPanel: false
 }

--- a/components/brave_wallet_ui/stories/wallet-concept.tsx
+++ b/components/brave_wallet_ui/stories/wallet-concept.tsx
@@ -28,6 +28,9 @@ export const _DesktopWalletConcept = () => {
       pageStateOverride={{
         hasInitialized: true
       }}
+      uiStateOverride={{
+        isPanel: true
+      }}
     >
       <Container />
     </WalletPageStory>

--- a/components/brave_wallet_ui/stories/wrappers/wallet-page-story-wrapper.tsx
+++ b/components/brave_wallet_ui/stories/wrappers/wallet-page-story-wrapper.tsx
@@ -15,7 +15,12 @@ import { createMockStore } from '../../utils/test-utils'
 import { WalletActions } from '../../common/actions'
 
 // types
-import { PageState, WalletRoutes, WalletState } from '../../constants/types'
+import {
+  PageState,
+  WalletRoutes,
+  WalletState,
+  UIState
+} from '../../constants/types'
 
 // components
 import { LibContext } from '../../common/context/lib.context'
@@ -29,6 +34,7 @@ export interface WalletPageStoryProps {
   walletStateOverride?: Partial<WalletState>
   pageStateOverride?: Partial<PageState>
   accountTabStateOverride?: Partial<AccountsTabState>
+  uiStateOverride?: Partial<UIState>
 }
 
 const mockedProxy = getMockedAPIProxy()
@@ -37,19 +43,22 @@ export const WalletPageStory: React.FC<React.PropsWithChildren<WalletPageStoryPr
   children,
   pageStateOverride,
   walletStateOverride,
-  accountTabStateOverride
+  accountTabStateOverride,
+  uiStateOverride
 }) => {
   // redux
   const store = React.useMemo(() => {
     return createMockStore({
       accountTabStateOverride,
       pageStateOverride,
-      walletStateOverride
+      walletStateOverride,
+      uiStateOverride
     })
   }, [
     accountTabStateOverride,
     pageStateOverride,
-    walletStateOverride
+    walletStateOverride,
+    uiStateOverride
   ])
 
   React.useEffect(() => {

--- a/ui/webui/resources/BUILD.gn
+++ b/ui/webui/resources/BUILD.gn
@@ -170,6 +170,7 @@ leo_icons = [
   "edit-box.svg",
   "edit-pencil.svg",
   "ethereum-on.svg",
+  "expand.svg",
   "eye-off.svg",
   "eye-on.svg",
   "filter-settings.svg",


### PR DESCRIPTION
## Description 
Built out the default `Wallet Panel V2` header and adjusted the UI to work in the `Panel`

<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves <https://github.com/brave/brave-browser/issues/31300>

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-arm64, CI/skip-linux-x64, CI/skip-android, CI/skip-macos, CI/skip-ios, CI/skip-windows-arm64, CI/skip-windows-x64, CI/skip-windows-x86 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
1. Go to brave://flags and enable `Enable Panel v2`
2. Restart the `Browser` and open the Wallet `Panel`
3. Check the `Header` for each tab
4. Sub-pages should have a `back` button and no `more menu`
6. Only the `Portfolio` page should have `Portfolio` controls in the `more menu`

note: (No header has been added to the `Swap` page yet.)

https://github.com/brave/brave-core/assets/40611140/e7728090-a530-4c1f-93da-f2c8d3f0cc41
