### PR TITLE
Fixed side panel extension crash

### DIFF
--- a/chromium_src/chrome/browser/ui/views/side_panel/side_panel_coordinator.cc
+++ b/chromium_src/chrome/browser/ui/views/side_panel/side_panel_coordinator.cc
@@ -38,14 +38,12 @@ absl::optional<SidePanelEntry::Id> GetDefaultEntryId(Profile* profile) {
 
 // Choose Brave's own default, and exclude items that user has removed
 // from sidebar. If none are enabled, do nothing.
-#define BRAVE_SIDE_PANEL_COORDINATOR_SHOW                            \
-  if (!entry_id.has_value()) {                                       \
-    auto last_active_entry = GetLastActiveEntryKey();                \
-    entry_id = last_active_entry.has_value()                         \
-                   ? last_active_entry.value().id()                  \
-                   : GetDefaultEntryId(browser_view_->GetProfile()); \
-    if (!entry_id.has_value())                                       \
-      return;                                                        \
+#define BRAVE_SIDE_PANEL_COORDINATOR_SHOW                      \
+  if (!entry_id.has_value() && !GetLastActiveEntryKey()) {     \
+    entry_id = GetDefaultEntryId(browser_view_->GetProfile()); \
+    if (!entry_id.has_value()) {                               \
+      return;                                                  \
+    }                                                          \
   }
 
 // Undef upstream's to avoid redefined error.


### PR DESCRIPTION
fix https://github.com/brave/brave-browser/issues/31328

When last entry is extension, crash could be happened because we fetches only id from last extension entry. and then upstream tries to create SidePanelEntryKey with only that entry id. However extension's SidePanelEntryKey should be created with another ctor with id and extension id.
If GetLastActiveEntryKey() can give value when entry_id is null, let upstream handle it instead of fetching id from it.

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves 

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-arm64, CI/skip-linux-x64, CI/skip-android, CI/skip-macos, CI/skip-ios, CI/skip-windows-arm64, CI/skip-windows-x64, CI/skip-windows-x86 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

Please refer to the issue