### PR TITLE
Disable omnibox::kOmniboxSteadyStateHeight feature (uplift to 1.54.x)

### DIFF
--- a/app/brave_main_delegate_browsertest.cc
+++ b/app/brave_main_delegate_browsertest.cc
@@ -208,6 +208,7 @@ IN_PROC_BROWSER_TEST_F(BraveMainDelegateBrowserTest, DisabledFeatures) {
     &ntp_features::kNtpChromeCartModule,
     &ntp_features::kNtpHistoryClustersModule,
     &ntp_features::kNtpHistoryClustersModuleLoad,
+    &omnibox::kOmniboxSteadyStateHeight,
     &omnibox::kRichAutocompletion,
     &optimization_guide::features::kOptimizationHints,
     &optimization_guide::features::kRemoteOptimizationGuideFetching,

--- a/chromium_src/components/omnibox/common/omnibox_features.cc
+++ b/chromium_src/components/omnibox/common/omnibox_features.cc
@@ -10,6 +10,7 @@
 namespace omnibox {
 
 OVERRIDE_FEATURE_DEFAULT_STATES({{
+    {kOmniboxSteadyStateHeight, base::FEATURE_DISABLED_BY_DEFAULT},
     {kRichAutocompletion, base::FEATURE_DISABLED_BY_DEFAULT},
 }});
 

--- a/test/filters/browser_tests-linux.filter
+++ b/test/filters/browser_tests-linux.filter
@@ -24,9 +24,6 @@
 -ExtensionDialogTest.*
 -ExtensionStartupTest.*
 -ExternalProtocolHandlerSandboxBrowserTest.*
--HeadlessModeDumpDomCommandBrowserTest.HeadlessDumpDom
--HeadlessModeLazyLoadingPrintToPdfCommandBrowserTest.HeadlessLazyLoadingPrintToPdf
--HeadlessModePrintToPdfCommandBrowserTest.HeadlessPrintToPdf
 -HeadlessModeProtocolBrowserTest.ScreencastBasics
 -HeadlessModeScreenshotCommandBrowserTest.HeadlessScreenshot
 -IndividualNetworkContextsPrefetchProxyBrowserTest.*

--- a/test/filters/browser_tests.filter
+++ b/test/filters/browser_tests.filter
@@ -737,8 +737,8 @@
 -PageInfoBubbleViewBrowserTestCookiesSubpage.ClickingFpsButton
 -PageInfoBubbleViewBrowserTestCookiesSubpage.ToggleForBlockingThirdPartyCookies
 
-# This test fails because we don't support the search companion
--CompanionPageBrowserTest.SigninLoadsInNewTab
+# These tests fails because we don't support the search companion
+-CompanionPageBrowserTest.*
 
 # Tests below this point have not been diagnosed or had issues created yet.
 -_/WebrtcLoggingPrivateApiStartEventLoggingTestFeatureAndPolicyEnabled.*

--- a/test/filters/browser_tests.filter
+++ b/test/filters/browser_tests.filter
@@ -803,6 +803,7 @@
 -All/QuietUIPromoBrowserTest.*
 -All/ReportingBrowserTest.*
 -All/SameOriginUaOriginTrialBrowserTest.*
+-All/SaveCardBubbleViewsFullFormBrowserTest.*/*
 -All/SaveCardBubbleViewsFullFormBrowserTestWithAutofillUpstream.*/*
 -All/SaveCardBubbleViewsSyncTransportFullFormBrowserTest.*/*
 -All/ScrollToTextFragmentPolicyTest.*
@@ -1016,10 +1017,15 @@
 -GlobalConfirmInfoBarTest.*
 -GlobalMediaControlsDialogTest.*
 -GooglePFTest.*
+-GooglePFTestDefaultFieldTrialValue.BaseGoogleSearchHasPFForPrefetch
+-GooglePFTestFieldTrialOverride.BaseGoogleSearchHasPFForPrefetch
 -GreaseEnterprisePolicyTest.*
 -GreaseFeatureParamOptOutTest.UpdatedGreaseFeatureParamOptOutTest
 -GuestStartupBrowserCreatorPickerTest.*
 -HangoutServicesBrowserTest.*
+-HeadlessModeDumpDomCommandBrowserTest.HeadlessDumpDom
+-HeadlessModeLazyLoadingPrintToPdfCommandBrowserTest.HeadlessLazyLoadingPrintToPdf
+-HeadlessModePrintToPdfCommandBrowserTest.HeadlessPrintToPdf
 -HintsFetcherBrowserTest.*
 -HintsFetcherSearchPageBrowserTest.*
 -HistoryBrowserTest.*

--- a/test/filters/browser_tests.filter
+++ b/test/filters/browser_tests.filter
@@ -737,8 +737,10 @@
 -PageInfoBubbleViewBrowserTestCookiesSubpage.ClickingFpsButton
 -PageInfoBubbleViewBrowserTestCookiesSubpage.ToggleForBlockingThirdPartyCookies
 
-# These tests fails because we don't support the search companion
+# These tests fail because we don't support the search companion.
 -CompanionPageBrowserTest.*
+-CompanionPagePolicyBrowserTest.*
+-CompanionPageSameTabBrowserTest.*
 
 # Tests below this point have not been diagnosed or had issues created yet.
 -_/WebrtcLoggingPrivateApiStartEventLoggingTestFeatureAndPolicyEnabled.*


### PR DESCRIPTION
Uplift of #19017
Resolves https://github.com/brave/brave-browser/issues/31218

In addition, this cherry-picks fixes for the following issues involving flaky upstream tests:

Resolves https://github.com/brave/internal/issues/1045
Resolves https://github.com/brave/internal/issues/1052
Resolves https://github.com/brave/brave-browser/issues/31279
Resolves https://github.com/brave/brave-browser/issues/31280
Resolves https://github.com/brave/brave-browser/issues/31281
Resolves https://github.com/brave/brave-browser/issues/31282
Resolves https://github.com/brave/brave-browser/issues/31283
Resolves https://github.com/brave/brave-browser/issues/31284
Resolves https://github.com/brave/brave-browser/issues/31285

Uplift of #19014
Uplift of #19037
Uplift of #19042