### PR TITLE
Disable omnibox::kOmniboxSteadyStateHeight feature (uplift to 1.53.x)

### DIFF
--- a/app/brave_main_delegate_browsertest.cc
+++ b/app/brave_main_delegate_browsertest.cc
@@ -208,6 +208,7 @@ IN_PROC_BROWSER_TEST_F(BraveMainDelegateBrowserTest, DisabledFeatures) {
     &ntp_features::kNtpChromeCartModule,
     &ntp_features::kNtpHistoryClustersModule,
     &ntp_features::kNtpHistoryClustersModuleLoad,
+    &omnibox::kOmniboxSteadyStateHeight,
     &optimization_guide::features::kOptimizationHints,
     &optimization_guide::features::kRemoteOptimizationGuideFetching,
     &optimization_guide::features::

--- a/chromium_src/components/omnibox/common/omnibox_features.cc
+++ b/chromium_src/components/omnibox/common/omnibox_features.cc
@@ -1,0 +1,16 @@
+/* Copyright (c) 2023 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "base/feature_override.h"
+
+#include "src/components/omnibox/common/omnibox_features.cc"
+
+namespace omnibox {
+
+OVERRIDE_FEATURE_DEFAULT_STATES({{
+    {kOmniboxSteadyStateHeight, base::FEATURE_DISABLED_BY_DEFAULT},
+}});
+
+}  // namespace omnibox


### PR DESCRIPTION
Uplift of https://github.com/brave/brave-core/pull/19017
Resolves https://github.com/brave/brave-browser/issues/31218