### PR TITLE
fix(wallet): Portfolio Panel UI Cleanup

### DIFF
--- a/components/brave_wallet_ui/components/desktop/asset-group-container/asset-group-container.style.ts
+++ b/components/brave_wallet_ui/components/desktop/asset-group-container/asset-group-container.style.ts
@@ -6,9 +6,16 @@
 import styled from 'styled-components'
 import * as leo from '@brave/leo/tokens/css'
 import Icon from '@brave/leo/react/icon'
-import { Column, WalletButton } from '../../shared/style'
+import {
+  Column,
+  Row,
+  WalletButton
+} from '../../shared/style'
+import {
+  layoutPanelWidth
+} from '../wallet-page-wrapper/wallet-page-wrapper.style'
 
-export const StyledWrapper = styled(Column)<{ hasBorder: boolean}>`
+export const StyledWrapper = styled(Column) <{ hasBorder: boolean }>`
   border: ${p => p.hasBorder ? `1px solid ${leo.color.divider.subtle}` : 'none'};
   border-radius: 12px;
   margin-bottom: 16px;
@@ -47,4 +54,14 @@ export const CollapseIcon = styled(Icon) <
       : 'rotate(180deg)'
   };
   margin-left: 16px;
+`
+
+export const AccountDescriptionWrapper = styled(Row)`
+  align-items: center;
+  justify-content: flex-start;
+  @media screen and (max-width: ${layoutPanelWidth}px) {
+    flex-direction: column;
+    align-items: flex-start;
+    justify-content: center
+  }
 `

--- a/components/brave_wallet_ui/components/desktop/asset-group-container/asset-group-container.tsx
+++ b/components/brave_wallet_ui/components/desktop/asset-group-container/asset-group-container.tsx
@@ -30,7 +30,8 @@ import {
 import {
   StyledWrapper,
   CollapseButton,
-  CollapseIcon
+  CollapseIcon,
+  AccountDescriptionWrapper
 } from './asset-group-container.style'
 import {
   Row,
@@ -106,21 +107,25 @@ export const AssetGroupContainer = (props: Props) => {
               accountKind={account.accountId.kind}
               marginRight={16}
             />
-            <Text
-              textSize='14px'
-              isBold={true}
-              textColor='text01'
+            <AccountDescriptionWrapper
+              width='unset'
             >
-              {account.name}
-            </Text>
-            <HorizontalSpace space='8px' />
-            <Text
-              textSize='12px'
-              isBold={false}
-              textColor='text02'
-            >
-              {reduceAddress(account.address)}
-            </Text>
+              <Text
+                textSize='14px'
+                isBold={true}
+                textColor='text01'
+              >
+                {account.name}
+              </Text>
+              <HorizontalSpace space='8px' />
+              <Text
+                textSize='12px'
+                isBold={false}
+                textColor='text02'
+              >
+                {reduceAddress(account.address)}
+              </Text>
+            </AccountDescriptionWrapper>
           </Row>
         }
 

--- a/components/brave_wallet_ui/components/desktop/views/nfts/components/nfts.tsx
+++ b/components/brave_wallet_ui/components/desktop/views/nfts/components/nfts.tsx
@@ -51,7 +51,13 @@ import {
 import { Row, ScrollableColumn } from '../../../../shared/style'
 import { AddOrEditNftModal } from '../../../popup-modals/add-edit-nft-modal/add-edit-nft-modal'
 import { NftsEmptyState } from './nfts-empty-state/nfts-empty-state'
-import { ButtonIcon, CircleButton } from '../../portfolio/style'
+import {
+  ButtonIcon,
+  CircleButton,
+  SearchBarWrapper,
+  ControlBarWrapper,
+  SearchButtonWrapper
+} from '../../portfolio/style'
 import { AssetGroupContainer } from '../../../asset-group-container/asset-group-container'
 import { networkEntityAdapter } from '../../../../../common/slices/entities/network.entity'
 
@@ -84,6 +90,7 @@ export const Nfts = (props: Props) => {
     localStorage.getItem(LOCAL_STORAGE_KEYS.IS_ENABLE_NFT_AUTO_DISCOVERY_MODAL_HIDDEN) === null
   )
   const [selectedTab, setSelectedTab] = React.useState<string>('nfts')
+  const [showSearchBar, setShowSearchBar] = React.useState<boolean>(false)
 
   // hooks
   const history = useHistory()
@@ -153,6 +160,10 @@ export const Nfts = (props: Props) => {
     )
   }, [searchValue])
 
+  const onCloseSearchBar = React.useCallback(() => {
+    setShowSearchBar(false)
+    setSearchValue('')
+  }, [])
 
   // memos
   const [sortedNfts, sortedHiddenNfts] = React.useMemo(() => {
@@ -304,41 +315,78 @@ export const Nfts = (props: Props) => {
 
   return (
     <>
-      <Row
+      <ControlBarWrapper
         justifyContent='space-between'
         alignItems='center'
-        padding='0px 32px'
-        marginBottom={12}
+        showSearchBar={showSearchBar}
+        isNFTView={true}
       >
-        <Tabs options={tabOptions} onSelect={onSelectTab} />
-        <Row  width='unset'>
-          <Row style={{ width: 230 }} margin='0px 12px 0px 0px'>
+        {!showSearchBar &&
+          <Tabs options={tabOptions} onSelect={onSelectTab} />
+        }
+        <Row
+          width={showSearchBar ? '100%' : 'unset'}
+        >
+          <SearchBarWrapper
+            margin='0px 12px 0px 0px'
+            showSearchBar={showSearchBar}
+          >
             <SearchBar
               placeholder={getLocale('braveWalletSearchText')}
               action={onSearchValueChange}
               value={searchValue}
               isV2={true}
             />
-          </Row>
-          {isNftPinningFeatureEnabled && nonFungibleTokens.length > 0 && (
-            <CircleButton
-              onClick={onClickIpfsButton}
-              marginRight={12}
+          </SearchBarWrapper>
+          {showSearchBar &&
+            <Row
+              width='unset'
             >
-              <ButtonIcon name='product-ipfs-outline' />
-            </CircleButton>
-          )}
-          <CircleButton
-            onClick={toggleShowAddNftModal}
-            marginRight={12}
-          >
-            <ButtonIcon name='plus-add' />
-          </CircleButton>
-          <CircleButton onClick={onShowPortfolioSettings}>
-            <ButtonIcon name='filter-settings' />
-          </CircleButton>
+              <CircleButton
+                onClick={onCloseSearchBar}
+              >
+                <ButtonIcon name='close' />
+              </CircleButton>
+            </Row>
+          }
+          {!showSearchBar &&
+            <Row
+              width='unset'
+            >
+              <SearchButtonWrapper
+                width='unset'
+              >
+                <CircleButton
+                  marginRight={12}
+                  onClick={() => setShowSearchBar(true)}
+                >
+                  <ButtonIcon name='search' />
+                </CircleButton>
+              </SearchButtonWrapper>
+              {
+                isNftPinningFeatureEnabled &&
+                nonFungibleTokens.length > 0 &&
+                (
+                  <CircleButton
+                    onClick={onClickIpfsButton}
+                    marginRight={12}
+                  >
+                    <ButtonIcon name='product-ipfs-outline' />
+                  </CircleButton>
+                )}
+              <CircleButton
+                onClick={toggleShowAddNftModal}
+                marginRight={12}
+              >
+                <ButtonIcon name='plus-add' />
+              </CircleButton>
+              <CircleButton onClick={onShowPortfolioSettings}>
+                <ButtonIcon name='filter-settings' />
+              </CircleButton>
+            </Row>
+          }
         </Row>
-      </Row>
+      </ControlBarWrapper>
 
       <ScrollableColumn padding='10px 20px 20px 20px'>
         {nftList.length === 0 && hiddenNfts.length === 0 ? (

--- a/components/brave_wallet_ui/components/desktop/views/portfolio/components/token-lists/token-list.tsx
+++ b/components/brave_wallet_ui/components/desktop/views/portfolio/components/token-lists/token-list.tsx
@@ -68,7 +68,10 @@ import {
 import {
   FilterTokenRow,
   CircleButton,
-  ButtonIcon
+  ButtonIcon,
+  SearchBarWrapper,
+  ControlBarWrapper,
+  SearchButtonWrapper
 } from '../../style'
 
 interface Props {
@@ -113,6 +116,7 @@ export const TokenLists = ({
 
   // state
   const [searchValue, setSearchValue] = React.useState<string>(tokenId ?? '')
+  const [showSearchBar, setShowSearchBar] = React.useState<boolean>(false)
 
   // methods
 
@@ -372,6 +376,11 @@ export const TokenLists = ({
     sortedFungibleTokensList
   ])
 
+  const onCloseSearchBar = React.useCallback(() => {
+    setShowSearchBar(false)
+    setSearchValue('')
+  }, [])
+
   const listUiByNetworks = React.useMemo(() => {
     return networks?.sort((a, b) => {
       const aBalance = getNetworkFiatValue(a)
@@ -522,24 +531,25 @@ export const TokenLists = ({
       }
 
       {isPortfolio &&
-        <Row
+        <ControlBarWrapper
           justifyContent='space-between'
           alignItems='center'
-          padding='0px 32px'
-          marginBottom={16}
+          showSearchBar={showSearchBar}
         >
-          <Text
-            textSize='16px'
-            isBold={true}
-          >
-            {getLocale('braveWalletAccountsAssets')}
-          </Text>
+          {!showSearchBar &&
+            <Text
+              textSize='16px'
+              isBold={true}
+            >
+              {getLocale('braveWalletAccountsAssets')}
+            </Text>
+          }
           <Row
-            width='unset'
+            width={showSearchBar ? '100%' : 'unset'}
           >
-            <Row
-              style={{ width: 230 }}
+            <SearchBarWrapper
               margin='0px 12px 0px 0px'
+              showSearchBar={showSearchBar}
             >
               <SearchBar
                 placeholder={getLocale('braveWalletSearchText')}
@@ -547,25 +557,48 @@ export const TokenLists = ({
                 value={searchValue}
                 isV2={true}
               />
-            </Row>
-            <Row
-              width='unset'
-            >
-              <CircleButton
-                marginRight={12}
-                onClick={showAddAssetsModal}
+            </SearchBarWrapper>
+            {showSearchBar &&
+              <Row
+                width='unset'
               >
-                <ButtonIcon name='list-settings' />
-              </CircleButton>
+                <CircleButton
+                  onClick={onCloseSearchBar}
+                >
+                  <ButtonIcon name='close' />
+                </CircleButton>
+              </Row>
+            }
+            {!showSearchBar &&
+              <Row
+                width='unset'
+              >
+                <SearchButtonWrapper
+                  width='unset'
+                >
+                  <CircleButton
+                    marginRight={12}
+                    onClick={() => setShowSearchBar(true)}
+                  >
+                    <ButtonIcon name='search' />
+                  </CircleButton>
+                </SearchButtonWrapper>
+                <CircleButton
+                  marginRight={12}
+                  onClick={showAddAssetsModal}
+                >
+                  <ButtonIcon name='list-settings' />
+                </CircleButton>
 
-              <CircleButton
-                onClick={onShowPortfolioSettings}
-              >
-                <ButtonIcon name='filter-settings' />
-              </CircleButton>
-            </Row>
+                <CircleButton
+                  onClick={onShowPortfolioSettings}
+                >
+                  <ButtonIcon name='filter-settings' />
+                </CircleButton>
+              </Row>
+            }
           </Row>
-        </Row>
+        </ControlBarWrapper>
       }
 
       {enableScroll

--- a/components/brave_wallet_ui/components/desktop/views/portfolio/portfolio-overview.tsx
+++ b/components/brave_wallet_ui/components/desktop/views/portfolio/portfolio-overview.tsx
@@ -521,7 +521,7 @@ export const PortfolioOverview = ({ onToggleShowIpfsBanner }: Props) => {
       </Column>
 
       {!hidePortfolioNFTsTab &&
-        <ControlsRow padding='24px 0px'>
+        <ControlsRow>
           <SegmentedControl
             navOptions={PortfolioNavOptions}
             width={384}

--- a/components/brave_wallet_ui/components/desktop/views/portfolio/style.ts
+++ b/components/brave_wallet_ui/components/desktop/views/portfolio/style.ts
@@ -237,6 +237,10 @@ export const SelectTimelineWrapper = styled(Row)`
 export const ControlsRow = styled(Row)`
   box-shadow: 0px -1px 1px rgba(0, 0, 0, 0.02);
   border-radius: 16px;
+  padding: 24px 16px;
+  @media screen and (max-width: ${layoutPanelWidth}px) {
+    padding: 16px;
+  }
 `
 
 export const BalanceAndButtonsWrapper = styled(Column)`
@@ -293,4 +297,37 @@ export const CircleButton = styled(WalletButton) <{
 export const ButtonIcon = styled(Icon)`
   --leo-icon-size: 18px;
   color: ${leo.color.icon.interactive};
+`
+
+export const SearchBarWrapper = styled(Row) <{
+  showSearchBar: boolean
+}>`
+  width: 230px;
+  @media screen and (max-width: ${layoutPanelWidth}px) {
+    display: ${(p) => p.showSearchBar ? 'flex' : 'none'};
+    width: 100%;
+  }
+`
+
+export const ControlBarWrapper = styled(Row) <{
+  showSearchBar: boolean
+  isNFTView?: boolean
+}>`
+  padding: 0px 32px;
+  margin-bottom: 16px;
+  @media screen and (max-width: ${layoutPanelWidth}px) {
+    padding: ${(p) => p.showSearchBar
+    ? p.isNFTView
+      ? '2px'
+      : '0px'
+    : '4px'} 24px 0px 24px;
+    margin-bottom: ${(p) => p.showSearchBar ? 12 : 16}px;
+  }
+`
+
+export const SearchButtonWrapper = styled(Row)`
+  display: none;
+  @media screen and (max-width: ${layoutPanelWidth}px) {
+    display: flex;
+  }
 `

--- a/components/brave_wallet_ui/components/shared/create-account-icon/create-account-icon.style.ts
+++ b/components/brave_wallet_ui/components/shared/create-account-icon/create-account-icon.style.ts
@@ -24,6 +24,11 @@ export const AccountBox = styled.div<{
       ? `var(--box-${p.size})`
       : 'var(--box-medium)'
   };
+  min-width: ${(p) =>
+    p.size
+      ? `var(--box-${p.size})`
+      : 'var(--box-medium)'
+  };
   height: ${(p) =>
     p.size
       ? `var(--box-${p.size})`

--- a/components/brave_wallet_ui/components/shared/segmented-control/segmented-control.style.ts
+++ b/components/brave_wallet_ui/components/shared/segmented-control/segmented-control.style.ts
@@ -10,6 +10,9 @@ import * as leo from '@brave/leo/tokens/css'
 import {
   StyledButton
 } from '../../../page/screens/send/shared.styles'
+import {
+  layoutPanelWidth
+} from '../../desktop/wallet-page-wrapper/wallet-page-wrapper.style'
 
 export const ButtonsContainer = styled.div<{
   width?: number;
@@ -29,6 +32,9 @@ export const ButtonsContainer = styled.div<{
   height: 48px;
   background-color: ${leo.color.container.highlight};
   border-radius: 100px;
+  @media screen and (max-width: ${layoutPanelWidth}px) {
+    height: 40px;
+  }
 `
 
 export const Button = styled(StyledButton) <{
@@ -55,4 +61,9 @@ export const Button = styled(StyledButton) <{
       ? leo.color.text.primary
       : leo.color.text.secondary
   };
+  @media screen and (max-width: ${layoutPanelWidth}px) {
+    padding: 8px;
+    font-size: 12px;
+    line-height: 16px;
+  }
 `

--- a/components/brave_wallet_ui/stories/mock-data/mock-wallet-state.ts
+++ b/components/brave_wallet_ui/stories/mock-data/mock-wallet-state.ts
@@ -11,7 +11,7 @@ import { BraveWallet, WalletAccountType, WalletState } from '../../constants/typ
 import { AllNetworksOptionDefault } from '../../options/network-filter-options'
 import { HighToLowAssetsFilterOption } from '../../options/asset-filter-options'
 import { AllAccountsOptionUniqueKey } from '../../options/account-filter-options'
-import { NoneGroupByOption } from '../../options/group-assets-by-options'
+import { AccountsGroupByOption } from '../../options/group-assets-by-options'
 
 // mocks
 import { LAMPORTS_PER_SOL } from '../../common/constants/solana'
@@ -281,6 +281,6 @@ export const mockWalletState: WalletState = {
   filteredOutPortfolioNetworkKeys: [],
   filteredOutPortfolioAccountAddresses: [],
   hidePortfolioSmallBalances: false,
-  selectedGroupAssetsByItem: NoneGroupByOption.id,
+  selectedGroupAssetsByItem: AccountsGroupByOption.id,
   showNetworkLogoOnNfts: false
 }


### PR DESCRIPTION
## Description 
Added some needed `Media Queries` and styling to the `Portfolio Views` for the `Panel V2`.

<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves <https://github.com/brave/brave-browser/issues/31311>

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-arm64, CI/skip-linux-x64, CI/skip-android, CI/skip-macos, CI/skip-ios, CI/skip-windows-arm64, CI/skip-windows-x64, CI/skip-windows-x86 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
1. Go to brave://flags and enable `Enable Panel v2`
2. Restart the `Browser` and open the Wallet `Panel`
3. Make sure the `UI` looks okay on the `Portfolio` tab.

Before:

https://github.com/brave/brave-core/assets/40611140/5c735a38-3a28-4bcf-b128-e551b86bd394

After:

https://github.com/brave/brave-core/assets/40611140/76597188-4917-435f-af03-8ec2951772b1
