### PR TITLE
fix(wallet): Missing Group By Option for Portfolio

### DIFF
--- a/components/brave_wallet_ui/components/desktop/popup-modals/filter-modals/portfolio-filters-modal.tsx
+++ b/components/brave_wallet_ui/components/desktop/popup-modals/filter-modals/portfolio-filters-modal.tsx
@@ -257,7 +257,7 @@ export const PortfolioFiltersModal = (props: Props) => {
           fullWidth={true}
           alignItems='flex-start'
         >
-          {showNftFilters && 
+          {showNftFilters &&
             <>
               <FilterToggleSection
                 title={getLocale('braveWalletShowNetworkLogoOnNftsTitle')}
@@ -267,15 +267,6 @@ export const PortfolioFiltersModal = (props: Props) => {
                 setIsSelected={
                   () => setShowNetworkLogo(prev => !prev)
                 }
-              />
-
-              <FilterDropdownSection
-                title={getLocale('braveWalletPortfolioGroupByTitle')}
-                description={getLocale('braveWalletPortfolioGroupByDescription')}
-                icon='stack'
-                dropdownOptions={GroupAssetsByOptions}
-                selectedOptionId={selectedGroupAssetsByOption}
-                onSelectOption={setSelectedGroupAssetsByOption}
               />
 
               {/* This is commented out until Spam NFTs feature is implemented in core */}
@@ -290,6 +281,15 @@ export const PortfolioFiltersModal = (props: Props) => {
               /> */}
             </>
           }
+
+          <FilterDropdownSection
+            title={getLocale('braveWalletPortfolioGroupByTitle')}
+            description={getLocale('braveWalletPortfolioGroupByDescription')}
+            icon='stack'
+            dropdownOptions={GroupAssetsByOptions}
+            selectedOptionId={selectedGroupAssetsByOption}
+            onSelectOption={setSelectedGroupAssetsByOption}
+          />
 
           {!showNftFilters &&
             <>


### PR DESCRIPTION
## Description 
Fixes a bug where the `Group By` options was missing for Portfolio `Assets`

<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves <https://github.com/brave/brave-browser/issues/31350>

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-arm64, CI/skip-linux-x64, CI/skip-android, CI/skip-macos, CI/skip-ios, CI/skip-windows-arm64, CI/skip-windows-x64, CI/skip-windows-x86 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

   1. Go to the `Portfolio` tab
   2. Open the `Filters and display settings`
   3. The `Group By` option should be available 

Before:

https://github.com/brave/brave-browser/assets/40611140/06ddee98-93a6-4b4e-9242-33dfa6b10825

After:

https://github.com/brave/brave-core/assets/40611140/1fd930e5-9548-4f29-a796-8b8ac23b5177
