### PR TITLE
Return from PostEarlyInitialization if an exit code is already set. (uplift to 1.54.x)

### DIFF
--- a/app/brave_main_delegate.cc
+++ b/app/brave_main_delegate.cc
@@ -147,6 +147,11 @@ void BraveMainDelegate::PreSandboxStartup() {
 absl::optional<int> BraveMainDelegate::PostEarlyInitialization(
     ChromeMainDelegate::InvokedIn invoked_in) {
   auto result = ChromeMainDelegate::PostEarlyInitialization(invoked_in);
+  if (result.has_value()) {
+    // An exit code is set. Stop initialization.
+    return result;
+  }
+
   BraveCommandLineHelper command_line(base::CommandLine::ForCurrentProcess());
   std::string update_url = GetUpdateURLHost();
   if (!update_url.empty()) {


### PR DESCRIPTION
Uplift of #19097
Resolves https://github.com/brave/brave-browser/issues/31378

Pre-approval checklist: 
- [ ] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.