### PR TITLE
Update Rewards title colors in settings page and panel

### DIFF
--- a/components/brave_rewards/resources/page/components/ads_panel.style.ts
+++ b/components/brave_rewards/resources/page/components/ads_panel.style.ts
@@ -7,9 +7,7 @@ import styled from 'styled-components'
 
 import * as mixins from '../../shared/lib/css_mixins'
 
-export const root = styled.div`
-  --settings-panel-title-color: #C12D7C;
-`
+export const root = styled.div``
 
 export const description = styled.div`
   color: var(--brave-palette-neutral600);

--- a/components/brave_rewards/resources/page/components/auto_contribute_panel.style.ts
+++ b/components/brave_rewards/resources/page/components/auto_contribute_panel.style.ts
@@ -7,9 +7,7 @@ import styled from 'styled-components'
 
 import * as mixins from '../../shared/lib/css_mixins'
 
-export const root = styled.div`
-  --settings-panel-title-color: #A43CE4;
-`
+export const root = styled.div``
 
 export const description = styled.div`
   color: var(--brave-palette-neutral600);

--- a/components/brave_rewards/resources/page/components/monthly_tips_panel.style.ts
+++ b/components/brave_rewards/resources/page/components/monthly_tips_panel.style.ts
@@ -7,9 +7,7 @@ import styled from 'styled-components'
 
 import * as mixins from '../../shared/lib/css_mixins'
 
-export const root = styled.div`
-  --settings-panel-title-color: #696fdc;
-`
+export const root = styled.div``
 
 export const description = styled.div`
   color: var(--brave-palette-neutral600);

--- a/components/brave_rewards/resources/page/components/settings_panel.style.ts
+++ b/components/brave_rewards/resources/page/components/settings_panel.style.ts
@@ -38,7 +38,7 @@ export const title = styled.div`
   font-weight: 600;
   font-size: 22px;
   line-height: 28px;
-  color: var(--settings-panel-title-color, #495057);
+  color: var(--brave-palette-black);
 `
 
 export const config = styled.div`

--- a/components/brave_rewards/resources/page/components/tips_panel.style.ts
+++ b/components/brave_rewards/resources/page/components/tips_panel.style.ts
@@ -7,9 +7,7 @@ import styled from 'styled-components'
 
 import * as mixins from '../../shared/lib/css_mixins'
 
-export const root = styled.div`
-  --settings-panel-title-color: #696fdc;
-`
+export const root = styled.div``
 
 export const description = styled.div`
   color: var(--brave-palette-neutral600);

--- a/components/brave_rewards/resources/shared/components/wallet_card/rewards_summary.style.ts
+++ b/components/brave_rewards/resources/shared/components/wallet_card/rewards_summary.style.ts
@@ -75,15 +75,15 @@ export const dataTable = styled.div`
   }
 
   tr:nth-child(1) td.amount {
-    color: #b13c7a;
+    color: var(--brave-palette-black);
   }
 
   tr:nth-child(2) td.amount {
-    color: #b13c7a;
+    color: var(--brave-palette-black);
   }
 
   tr:nth-child(3) td.amount {
-    color: #8d58c4;
+    color: var(--brave-palette-black);
   }
 
   td.exchange {


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/30971

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-arm64, CI/skip-linux-x64, CI/skip-android, CI/skip-macos, CI/skip-ios, CI/skip-windows-arm64, CI/skip-windows-x64, CI/skip-windows-x86 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [ ] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## UI:

![rewards-title-colors](https://github.com/brave/brave-core/assets/5033691/6f6e30a0-2f90-4092-b21e-c73d8e39c130)

## Test Plan:
- Verify title colors in brave://settings and BAT colors in wallet card (both in brave://settings and the Rewards panel)
