### PR TITLE
Disconnect Solana dapps when its permission is revoked

### DIFF
--- a/browser/brave_content_browser_client.cc
+++ b/browser/brave_content_browser_client.cc
@@ -384,11 +384,19 @@ void MaybeBindSolanaProvider(
     return;
   }
 
+  auto* host_content_settings_map =
+      HostContentSettingsMapFactory::GetForProfile(
+          frame_host->GetBrowserContext());
+  if (!host_content_settings_map) {
+    return;
+  }
+
   content::WebContents* web_contents =
       content::WebContents::FromRenderFrameHost(frame_host);
   mojo::MakeSelfOwnedReceiver(
       std::make_unique<brave_wallet::SolanaProviderImpl>(
-          keyring_service, brave_wallet_service, tx_service, json_rpc_service,
+          *host_content_settings_map, keyring_service, brave_wallet_service,
+          tx_service, json_rpc_service,
           std::make_unique<brave_wallet::BraveWalletProviderDelegateImpl>(
               web_contents, frame_host)),
       std::move(receiver));

--- a/browser/brave_wallet/solana_provider_renderer_browsertest.cc
+++ b/browser/brave_wallet/solana_provider_renderer_browsertest.cc
@@ -817,22 +817,6 @@ IN_PROC_BROWSER_TEST_F(SolanaProviderRendererTest, Disconnect) {
                 }
                 disconnect();)");
   EXPECT_EQ(base::Value(true), result.value);
-
-  // OnDisconnect
-  auto result2 = EvalJs(
-      web_contents(browser()),
-      R"(async function disconnect() {await window.braveSolana.disconnect()}
-         new Promise(resolve => {
-            window.braveSolana.on('disconnect', (arg) => {
-              if (!arg)
-                resolve(true)
-              else
-                resolve(false)
-            })
-          disconnect();
-         });
-        )");
-  EXPECT_EQ(base::Value(true), result2.value);
 }
 
 IN_PROC_BROWSER_TEST_F(SolanaProviderRendererTest, SignTransaction) {

--- a/components/brave_wallet/common/brave_wallet.mojom
+++ b/components/brave_wallet/common/brave_wallet.mojom
@@ -28,6 +28,8 @@ interface SolanaEventsListener {
   // base58 encoded account, account would be null when switching to an about to
   // be created account
   AccountChangedEvent(string? account);
+  // Wallet initiated disconnect event. Ex. permission revoked
+  DisconnectEvent();
 };
 
 // Pre-defined error codes specified in

--- a/components/brave_wallet/renderer/js_solana_provider.cc
+++ b/components/brave_wallet/renderer/js_solana_provider.cc
@@ -255,6 +255,12 @@ void JSSolanaProvider::AccountChangedEvent(
   FireEvent(solana::kAccountChangedEvent, std::move(args));
 }
 
+void JSSolanaProvider::DisconnectEvent() {
+  v8::Isolate* isolate = blink::MainThreadIsolate();
+  v8::HandleScope handle_scope(isolate);
+  FireEvent(kDisconnectEvent, std::vector<v8::Local<v8::Value>>());
+}
+
 void JSSolanaProvider::WillReleaseScriptContext(v8::Local<v8::Context>,
                                                 int32_t world_id) {
   if (world_id != content::ISOLATED_WORLD_ID_GLOBAL) {
@@ -365,7 +371,6 @@ v8::Local<v8::Promise> JSSolanaProvider::Disconnect(gin::Arguments* arguments) {
   std::ignore = resolver.ToLocalChecked()->Resolve(isolate->GetCurrentContext(),
                                                    v8::Undefined(isolate));
 
-  FireEvent(kDisconnectEvent, std::vector<v8::Local<v8::Value>>());
   return resolver.ToLocalChecked()->GetPromise();
 }
 

--- a/components/brave_wallet/renderer/js_solana_provider.h
+++ b/components/brave_wallet/renderer/js_solana_provider.h
@@ -51,6 +51,7 @@ class JSSolanaProvider final : public gin::Wrappable<JSSolanaProvider>,
 
   // mojom::SolanaEventsListener
   void AccountChangedEvent(const absl::optional<std::string>& account) override;
+  void DisconnectEvent() override;
 
  private:
   explicit JSSolanaProvider(content::RenderFrame* render_frame);

--- a/ios/browser/api/brave_wallet/brave_wallet_api.mm
+++ b/ios/browser/api/brave_wallet/brave_wallet_api.mm
@@ -130,9 +130,15 @@ BraveWalletProviderScriptKey const BraveWalletProviderScriptKeyWalletStandard =
   if (!json_rpc_service) {
     return nil;
   }
+  auto* host_content_settings_map =
+      ios::HostContentSettingsMapFactory::GetForBrowserState(browserState);
+  if (!host_content_settings_map) {
+    return nil;
+  }
 
   auto provider = std::make_unique<brave_wallet::SolanaProviderImpl>(
-      keyring_service, brave_wallet_service, tx_service, json_rpc_service,
+      *host_content_settings_map, keyring_service, brave_wallet_service,
+      tx_service, json_rpc_service,
       std::make_unique<brave_wallet::BraveWalletProviderDelegateBridge>(
           delegate));
   return [[BraveWalletSolanaProviderOwnedImpl alloc]

--- a/test/data/brave-wallet/solana_provider.html
+++ b/test/data/brave-wallet/solana_provider.html
@@ -8,6 +8,7 @@
   var signAllTransactionsResult = ''
   var requestResult = ''
   var accountChangedResult = ''
+  var disconnectEmitted = false
 
   function registerAccountChanged() {
     window.braveSolana.on('accountChanged', result => {
@@ -16,6 +17,13 @@
         } else {
           accountChangedResult = ''
         }
+        window.domAutomationController.send('result ready')
+    })
+  }
+
+  function registerDisconnect() {
+    window.braveSolana.on('disconnect', result => {
+        disconnectEmitted = true
         window.domAutomationController.send('result ready')
     })
   }
@@ -179,6 +187,12 @@
     let result = accountChangedResult;
     accountChangedResult = ''
     return result;
+  }
+
+  function getDisconnectEmitted() {
+    let result = disconnectEmitted
+    disconnectEmitted = false
+    return result
   }
 
   function getIsBraveWalletViaProxy() {


### PR DESCRIPTION
`disconnect` event now will be initiated from browser and it won't be emitted when there is no accounts connected

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/24974

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-arm64, CI/skip-linux-x64, CI/skip-android, CI/skip-macos, CI/skip-ios, CI/skip-windows-arm64, CI/skip-windows-x64, CI/skip-windows-x86 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
1. Setup wallet with fresh profile.
2. Open two tabs and each navigates to different pages and set network to Solana.
3. Open console on both tabs and type `await window.braveSolana.connect()`
4. Give permissions to both tabs, check both panels showing "Connected".
5. Open brave://settings/content/solana, there should be two entries.
6. Revoke the entry associated with tab A.
7. Switch to tab A and open panel, there is no "Connected" status shown.
8. Switch to tab B and open panel, it should still show "Connected".

