### PR TITLE
fix(wallet) Fix market view display in the panel

### DIFF
--- a/browser/ui/webui/brave_wallet/wallet_panel_ui.cc
+++ b/browser/ui/webui/brave_wallet/wallet_panel_ui.cc
@@ -71,7 +71,12 @@ WalletPanelUI::WalletPanelUI(content::WebUI* web_ui)
   source->OverrideContentSecurityPolicy(
       network::mojom::CSPDirectiveName::FrameSrc,
       std::string("frame-src ") + kUntrustedTrezorURL + " " +
-          kUntrustedLedgerURL + " " + kUntrustedNftURL + ";");
+          kUntrustedLedgerURL + " " + kUntrustedNftURL + " " +
+          kUntrustedMarketURL + ";");
+  source->OverrideContentSecurityPolicy(
+      network::mojom::CSPDirectiveName::ImgSrc,
+      std::string("img-src 'self' chrome://resources chrome://erc-token-images "
+                  "https://assets.cgproxy.brave.com data:;"));
   source->AddString("braveWalletTrezorBridgeUrl", kUntrustedTrezorURL);
   source->AddString("braveWalletNftBridgeUrl", kUntrustedNftURL);
   source->AddString("braveWalletMarketUiBridgeUrl", kUntrustedMarketURL);

--- a/components/brave_wallet_ui/market/market-ui-messages.ts
+++ b/components/brave_wallet_ui/market/market-ui-messages.ts
@@ -15,6 +15,7 @@ import {
 import { isComponentInStorybook } from '../utils/string-utils'
 
 const marketUiOrigin = loadTimeData.getString('braveWalletMarketUiBridgeUrl')
+export const braveWalletPanelOrigin = 'chrome://wallet-panel.top-chrome'
 
 // remove trailing /
 export const braveMarketUiOrigin = marketUiOrigin.endsWith('/') ? marketUiOrigin.slice(0, -1) : marketUiOrigin

--- a/components/brave_wallet_ui/market/market.tsx
+++ b/components/brave_wallet_ui/market/market.tsx
@@ -41,7 +41,8 @@ import {
   UpdateDepositableAssetsMessage,
   UpdateCoinMarketMessage,
   UpdateTradableAssetsMessage,
-  UpdateIframeHeightMessage
+  UpdateIframeHeightMessage,
+  braveWalletPanelOrigin
 } from './market-ui-messages'
 import { filterCoinMarkets, searchCoinMarkets, sortCoinMarkets } from '../utils/coin-market-utils'
 
@@ -115,32 +116,32 @@ const App = () => {
 
   const onMessageEventListener = React.useCallback((event: MessageEvent<MarketCommandMessage>) => {
     // validate message origin
-    if (event.origin !== braveWalletOrigin) return
-
-    const message = event.data
-    switch (message.command) {
-      case MarketUiCommand.UpdateCoinMarkets: {
-        const { payload } = message as UpdateCoinMarketMessage
-        setCoinMarkets(payload.coins)
-        setDefaultCurrencies(payload.defaultCurrencies)
-        break
-      }
-
-      case MarketUiCommand.UpdateTradableAssets: {
-        const { payload } = message as UpdateTradableAssetsMessage
-        setTradableAssets(payload)
-        break
-      }
-
-      case MarketUiCommand.UpdateBuyableAssets: {
-        const { payload } = message as UpdateBuyableAssetsMessage
-        setBuyableAssets(payload)
-        break
-      }
-
-      case MarketUiCommand.UpdateDepositableAssets: {
-        const { payload } = message as UpdateDepositableAssetsMessage
-        setDepositableAssets(payload)
+    if (event.origin === braveWalletOrigin || event.origin === braveWalletPanelOrigin) {
+      const message = event.data
+      switch (message.command) {
+        case MarketUiCommand.UpdateCoinMarkets: {
+          const { payload } = message as UpdateCoinMarketMessage
+          setCoinMarkets(payload.coins)
+          setDefaultCurrencies(payload.defaultCurrencies)
+          break
+        }
+  
+        case MarketUiCommand.UpdateTradableAssets: {
+          const { payload } = message as UpdateTradableAssetsMessage
+          setTradableAssets(payload)
+          break
+        }
+  
+        case MarketUiCommand.UpdateBuyableAssets: {
+          const { payload } = message as UpdateBuyableAssetsMessage
+          setBuyableAssets(payload)
+          break
+        }
+  
+        case MarketUiCommand.UpdateDepositableAssets: {
+          const { payload } = message as UpdateDepositableAssetsMessage
+          setDepositableAssets(payload)
+        }
       }
     }
   }, [])


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/31313

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-arm64, CI/skip-linux-x64, CI/skip-android, CI/skip-macos, CI/skip-ios, CI/skip-windows-arm64, CI/skip-windows-x64, CI/skip-windows-x86 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
- Open wallet panel(make sure Panel v2 flag is enabled)
- Navigate to market tab
- Market data should be displayed successfully

<img width="404" alt="Screenshot 2023-07-03 at 14 17 11" src="https://github.com/brave/brave-core/assets/48117473/23a71ec1-0086-422c-b36b-25442722568e">

