### PR TITLE
AI Chat: questions should auto-generate when changing pref or opening UI, even after content has been fetched

### DIFF
--- a/components/ai_chat/browser/ai_chat_tab_helper.cc
+++ b/components/ai_chat/browser/ai_chat_tab_helper.cc
@@ -44,6 +44,11 @@ AIChatTabHelper::AIChatTabHelper(content::WebContents* web_contents)
       prefs::kBraveChatHasSeenDisclaimer,
       base::BindRepeating(&AIChatTabHelper::OnUserOptedIn,
                           weak_ptr_factory_.GetWeakPtr()));
+  pref_change_registrar_.Add(
+      prefs::kBraveChatAutoGenerateQuestions,
+      base::BindRepeating(
+          &AIChatTabHelper::OnPermissionChangedAutoGenerateQuestions,
+          weak_ptr_factory_.GetWeakPtr()));
   ai_chat_api_ =
       std::make_unique<AIChatAPI>(web_contents->GetBrowserContext()
                                       ->GetDefaultStoragePartition()
@@ -60,6 +65,7 @@ void AIChatTabHelper::OnConversationActiveChanged(bool is_conversation_active) {
   is_conversation_active_ = is_conversation_active;
   DVLOG(3) << "Conversation active changed: " << is_conversation_active;
   MaybeGeneratePageText();
+  MaybeGenerateQuestions();
 }
 
 bool AIChatTabHelper::HasUserOptedIn() {
@@ -68,6 +74,10 @@ bool AIChatTabHelper::HasUserOptedIn() {
 
 void AIChatTabHelper::OnUserOptedIn() {
   MaybeGeneratePageText();
+}
+
+void AIChatTabHelper::OnPermissionChangedAutoGenerateQuestions() {
+  MaybeGenerateQuestions();
 }
 
 std::string AIChatTabHelper::GetConversationHistoryString() {
@@ -140,6 +150,18 @@ void AIChatTabHelper::MaybeGeneratePageText() {
                      weak_ptr_factory_.GetWeakPtr(), current_navigation_id_));
 }
 
+void AIChatTabHelper::MaybeGenerateQuestions() {
+  // Automatically fetch questions related to page content, if allowed
+  bool can_auto_fetch_questions =
+      HasUserOptedIn() && is_conversation_active_ &&
+      pref_service_->GetBoolean(
+          ai_chat::prefs::kBraveChatAutoGenerateQuestions) &&
+      !article_text_.empty() && (suggested_questions_.size() <= 1);
+  if (can_auto_fetch_questions) {
+    GenerateQuestions();
+  }
+}
+
 void AIChatTabHelper::OnTabContentRetrieved(int64_t for_navigation_id,
                                             std::string contents_text,
                                             bool is_video) {
@@ -180,15 +202,7 @@ void AIChatTabHelper::OnTabContentRetrieved(int64_t for_navigation_id,
   suggested_questions_.emplace_back(is_video_ ? "Summarize this video"
                                               : "Summarize this page");
   OnSuggestedQuestionsChanged();
-  // Automatically fetch questions related to page content, if allowed
-  bool can_auto_fetch_questions =
-      HasUserOptedIn() && is_conversation_active_ &&
-      pref_service_->GetBoolean(
-          ai_chat::prefs::kBraveChatAutoGenerateQuestions) &&
-      !article_text_.empty() && (suggested_questions_.size() <= 1);
-  if (can_auto_fetch_questions) {
-    GenerateQuestions();
-  }
+  MaybeGenerateQuestions();
 }
 
 void AIChatTabHelper::CleanUp() {

--- a/components/ai_chat/browser/ai_chat_tab_helper.h
+++ b/components/ai_chat/browser/ai_chat_tab_helper.h
@@ -78,8 +78,10 @@ class AIChatTabHelper : public content::WebContentsObserver,
 
   bool HasUserOptedIn();
   void OnUserOptedIn();
+  void OnPermissionChangedAutoGenerateQuestions();
   std::string GetConversationHistoryString();
   void MaybeGeneratePageText();
+  void MaybeGenerateQuestions();
   void CleanUp();
   void OnTabContentRetrieved(int64_t for_navigation_id,
                              std::string contents_text,


### PR DESCRIPTION


<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/31430

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-arm64, CI/skip-linux-x64, CI/skip-android, CI/skip-macos, CI/skip-ios, CI/skip-windows-arm64, CI/skip-windows-x64, CI/skip-windows-x86 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [ ] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

