### PR TITLE
Fix build timestamp generation on MacOS with git 2.39.x.

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -117,7 +117,7 @@ hooks = [
     'action': ['python3', '../build/util/lastchange.py',
                '--output', '../build/util/LASTCHANGE',
                '--source-dir', '.',
-               '--filter', '^[0-9]\+\.[0-9]\+\.[0-9]\+$'],
+               '--filter', '^[0-9]\{{1,\}}\.[0-9]\{{1,\}}\.[0-9]\{{1,\}}$'],
   },
 ]
 

--- a/base/BUILD.gn
+++ b/base/BUILD.gn
@@ -18,6 +18,7 @@ source_set("base") {
 source_set("base_unittests") {
   testonly = true
   sources = [
+    "build_time_unittest.cc",
     "feature_override_unittest.cc",
     "tools_sanity_unittest.cc",
   ]

--- a/base/build_time_unittest.cc
+++ b/base/build_time_unittest.cc
@@ -1,0 +1,36 @@
+/* Copyright (c) 2023 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "base/build_time.h"
+
+#include "base/time/time.h"
+#include "build/build_config.h"
+#include "testing/gtest/include/gtest/gtest.h"
+
+// Copied from base/build_time_unittest.cc:
+
+TEST(BuildTime, DateLooksValid) {
+  base::Time build_time = base::GetBuildTime();
+  base::Time::Exploded exploded_build_time;
+  build_time.UTCExplode(&exploded_build_time);
+  ASSERT_TRUE(exploded_build_time.HasValidValues());
+
+#if !defined(OFFICIAL_BUILD)
+  EXPECT_EQ(exploded_build_time.hour, 5);
+  EXPECT_EQ(exploded_build_time.minute, 0);
+  EXPECT_EQ(exploded_build_time.second, 0);
+#endif
+}
+
+TEST(BuildTime, InThePast) {
+  EXPECT_LT(base::GetBuildTime(), base::Time::Now());
+  EXPECT_LT(base::GetBuildTime(), base::Time::NowFromSystemTime());
+}
+
+// Brave-specific tests:
+
+TEST(BuildTime, TimestampIsNotZero) {
+  EXPECT_NE(base::GetBuildTime(), base::Time::FromTimeT(0));
+}


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Fix regex introduced by https://github.com/brave/brave-core/pull/19060 to work on git 2.39.x on MacOS. 

On `mac-imac7-sf` `git version 2.39.1` is unable to grep the correct commit. This lead to `LASTCHANGE.committime` being set to 0 which sets buildtime to 0 and makes HSTS preload list unusable.

`git 2.40.0+` works fine. There were some changes around regex library in MacOS git builds between `2.39.0` and `2.40.0`:
https://github.com/git/git/blob/a646b86cd10282de2ceb64ef33b5412e4fb2a54c/Documentation/RelNotes/2.39.0.txt#L64-L65
https://github.com/git/git/blob/a646b86cd10282de2ceb64ef33b5412e4fb2a54c/Documentation/RelNotes/2.40.0.txt#L201-L204

`\{1,\}` is equivalent to `\+` in POSIX Basic Regular Expressions.
https://www.regular-expressions.info/posix.html

Resolves https://github.com/brave/brave-browser/issues/31447

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-arm64, CI/skip-linux-x64, CI/skip-android, CI/skip-macos, CI/skip-ios, CI/skip-windows-arm64, CI/skip-windows-x64, CI/skip-windows-x86 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

