### PR TITLE
[Uplift 1.53] [Shortcuts]: Fix crash in the wild (#19137)

### DIFF
--- a/components/commands/common/accelerator_parsing.cc
+++ b/components/commands/common/accelerator_parsing.cc
@@ -192,6 +192,14 @@ ui::Accelerator FromCodesString(const std::string& value) {
   std::vector<std::string> parts = base::SplitString(
       value, "+", base::TRIM_WHITESPACE, base::SPLIT_WANT_ALL);
 
+  // Not sure why, but some clients are encountering empty accelerators. If we
+  // encounter one in the wild, just return an empty accelerator instead of
+  // crashing:
+  // https://github.com/brave/brave-browser/issues/31419
+  if (parts.empty()) {
+    return ui::Accelerator();
+  }
+
   auto keyname = parts[parts.size() - 1];
   auto keycode = DomCodeStringToKeyboardCode(keyname);
 


### PR DESCRIPTION
Uplift of https://github.com/brave/brave-core/pull/19137 which fixes https://github.com/brave/brave-browser/issues/31419 to 1.53.x