### PR TITLE
Add `#brave-adblock-scriptlet-debug-logs` flag for filter authors

### DIFF
--- a/browser/about_flags.cc
+++ b/browser/about_flags.cc
@@ -523,6 +523,16 @@
                                  kBraveAdblockMobileNotificationsListDefault), \
       },                                                                       \
       {                                                                        \
+          "brave-adblock-scriptlet-debug-logs",                                \
+          "Enable debug logging for scriptlet injections",                     \
+          "Enable console debugging for scriptlets injected by cosmetic "      \
+          "filtering, exposing additional information that can be useful for " \
+          "filter authors.",                                                   \
+          kOsDesktop,                                                          \
+          FEATURE_VALUE_TYPE(                                                  \
+              brave_shields::features::kBraveAdblockScriptletDebugLogs),       \
+      },                                                                       \
+      {                                                                        \
           "brave-dark-mode-block",                                             \
           "Enable dark mode blocking fingerprinting protection",               \
           "Always report light mode when fingerprinting protections set to "   \

--- a/components/brave_shields/common/features.cc
+++ b/components/brave_shields/common/features.cc
@@ -41,6 +41,9 @@ BASE_FEATURE(kBraveAdblockCookieListOptIn,
 BASE_FEATURE(kBraveAdblockCosmeticFiltering,
              "BraveAdblockCosmeticFiltering",
              base::FEATURE_ENABLED_BY_DEFAULT);
+BASE_FEATURE(kBraveAdblockScriptletDebugLogs,
+             "BraveAdblockScriptletDebugLogs",
+             base::FEATURE_DISABLED_BY_DEFAULT);
 BASE_FEATURE(kBraveAdblockCspRules,
              "BraveAdblockCspRules",
              base::FEATURE_ENABLED_BY_DEFAULT);

--- a/components/brave_shields/common/features.h
+++ b/components/brave_shields/common/features.h
@@ -21,6 +21,7 @@ BASE_DECLARE_FEATURE(kBraveAdblockCookieListOptIn);
 BASE_DECLARE_FEATURE(kBraveAdblockCosmeticFiltering);
 BASE_DECLARE_FEATURE(kBraveAdblockCspRules);
 BASE_DECLARE_FEATURE(kBraveAdblockMobileNotificationsListDefault);
+BASE_DECLARE_FEATURE(kBraveAdblockScriptletDebugLogs);
 BASE_DECLARE_FEATURE(kBraveDomainBlock);
 BASE_DECLARE_FEATURE(kBraveDomainBlock1PES);
 BASE_DECLARE_FEATURE(kBraveExtensionNetworkBlocking);

--- a/components/cosmetic_filters/renderer/cosmetic_filters_js_handler.cc
+++ b/components/cosmetic_filters/renderer/cosmetic_filters_js_handler.cc
@@ -45,7 +45,7 @@ const char kObservingScriptletEntryPoint[] =
 
 const char kScriptletInitScript[] =
     R"((function() {
-          let text = '(function() {\nconst scriptletGlobals = new Map();\nlet deAmpEnabled = %s;\n' + %s + '})()';
+          let text = '(function() {\nconst scriptletGlobals = new Map(%s);\nlet deAmpEnabled = %s;\n' + %s + '})()';
           let script;
           try {
             script = document.createElement('script');
@@ -411,11 +411,15 @@ void CosmeticFiltersJSHandler::ApplyRules(bool de_amp_enabled) {
 
   std::string scriptlet_script;
   base::Value* injected_script = resources_dict_->Find("injected_script");
+
   if (injected_script &&
       base::JSONWriter::Write(*injected_script, &scriptlet_script)) {
-    scriptlet_script = base::StringPrintf(kScriptletInitScript,
-                                          de_amp_enabled ? "true" : "false",
-                                          scriptlet_script.c_str());
+    const bool scriptlet_debug_enabled = false;
+
+    scriptlet_script = base::StringPrintf(
+        kScriptletInitScript,
+        scriptlet_debug_enabled ? "[[\"canDebug\", true]]" : "",
+        de_amp_enabled ? "true" : "false", scriptlet_script.c_str());
   }
   if (!scriptlet_script.empty()) {
     web_frame->ExecuteScriptInIsolatedWorld(

--- a/components/cosmetic_filters/renderer/cosmetic_filters_js_handler.cc
+++ b/components/cosmetic_filters/renderer/cosmetic_filters_js_handler.cc
@@ -414,7 +414,8 @@ void CosmeticFiltersJSHandler::ApplyRules(bool de_amp_enabled) {
 
   if (injected_script &&
       base::JSONWriter::Write(*injected_script, &scriptlet_script)) {
-    const bool scriptlet_debug_enabled = false;
+    const bool scriptlet_debug_enabled = base::FeatureList::IsEnabled(
+        brave_shields::features::kBraveAdblockScriptletDebugLogs);
 
     scriptlet_script = base::StringPrintf(
         kScriptletInitScript,


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/31438

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-arm64, CI/skip-linux-x64, CI/skip-android, CI/skip-macos, CI/skip-ios, CI/skip-windows-arm64, CI/skip-windows-x64, CI/skip-windows-x86 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

1. Add `brave.com##+js(aeld, click, , log, 1)` to the custom filters box in `brave://settings/shields/filters`
2. Visit https://brave.com and open the devtools console
3. Confirm that there are no lines in the console starting with `[UBO]`
4. Enable `#brave-adblock-scriptlet-debug-logs` in `brave://flags` and relaunch the browser
5. Reload https://brave.com and confirm that there are now lines starting with `[uBO]` in the console