### PR TITLE
Non-managed side panel entry should handled properly

### DIFF
--- a/browser/ui/sidebar/sidebar.h
+++ b/browser/ui/sidebar/sidebar.h
@@ -19,6 +19,10 @@ class Sidebar {
   // Update sidebar item's UI state.
   virtual void UpdateSidebarItemsState() = 0;
 
+  // Return true if active tab(web contents) has associated
+  // side panel.
+  virtual bool HasActiveContextualEntry() = 0;
+
  protected:
   virtual ~Sidebar() {}
 };

--- a/browser/ui/sidebar/sidebar_controller.cc
+++ b/browser/ui/sidebar/sidebar_controller.cc
@@ -33,8 +33,8 @@ namespace sidebar {
 
 namespace {
 
-constexpr SidebarItem::BuiltInItemType kTabSpecificPanelTypes[] = {
-    SidebarItem::BuiltInItemType::kChatUI};
+constexpr SidePanelEntryId kTabSpecificPanelEntryIds[] = {
+    SidePanelEntryId::kChatUI};
 
 SidebarService* GetSidebarService(Browser* browser) {
   return SidebarServiceFactory::GetForProfile(browser->profile());
@@ -102,7 +102,7 @@ void SidebarController::ActivateItemAt(absl::optional<size_t> index,
   // disengaged means there is no active item.
   if (!index) {
     sidebar_model_->SetActiveIndex(index);
-    browser_active_panel_type_ = absl::nullopt;
+
     if (helper) {
       // This tab doesn't have a tab-specific panel now
       helper->RegisterPanelInactive();
@@ -117,10 +117,8 @@ void SidebarController::ActivateItemAt(absl::optional<size_t> index,
   if (item.open_in_panel) {
     sidebar_model_->SetActiveIndex(index);
     // Handle when item type is not tab-specific
-    if (!base::Contains(kTabSpecificPanelTypes, item.built_in_item_type)) {
-      // Remember to restore this item if any Tab opens a tab-specific panel in
-      // the future.
-      browser_active_panel_type_ = item.built_in_item_type;
+    if (!base::Contains(kTabSpecificPanelEntryIds,
+                        SidePanelIdFromSideBarItem(item))) {
       // Register that this tab doesn't have a tab-specific panel anymore.
       if (helper) {
         helper->RegisterPanelInactive();
@@ -195,6 +193,22 @@ bool SidebarController::ActiveTabFromOtherBrowsersForHost(const GURL& url) {
   return false;
 }
 
+void SidebarController::SetBrowserActivePanelKey(
+    absl::optional<SidePanelEntryKey> entry_key) {
+  DCHECK(entry_key);
+  if (base::Contains(kTabSpecificPanelEntryIds, entry_key->id())) {
+    return;
+  }
+
+  // Remember to restore this item if any Tab opens a tab-specific panel in
+  // the future.
+  browser_active_panel_key_ = entry_key;
+}
+
+void SidebarController::ClearBrowserActivePanelKey() {
+  browser_active_panel_key_ = absl::nullopt;
+}
+
 void SidebarController::IterateOrLoadAtActiveTab(const GURL& url) {
   // Get target tab index
   const auto all_index = GetAllExistingTabIndexForHost(browser_, url.host());
@@ -243,56 +257,70 @@ void SidebarController::OnTabStripModelChanged(
     TabStripModel* tab_strip_model,
     const TabStripModelChange& change,
     const TabStripSelectionChange& selection) {
+  if (!selection.active_tab_changed()) {
+    return;
+  }
+
+  auto* panel_ui = SidePanelUI::GetSidePanelUIForBrowser(browser_);
+  if (!panel_ui) {
+    return;
+  }
+
   // When the active tab changes, make sure to restore either any tab-specific
   // panel, or the browser-wide panel if the tab doesn't have a tab-specific
   // panel.
-  if (selection.active_tab_changed()) {
-    auto* panel_ui = SidePanelUI::GetSidePanelUIForBrowser(browser_);
-    if (!panel_ui) {
-      return;
-    }
-    // Is there a tab-specific panel for the new active tab?
-    absl::optional<SidebarItem::BuiltInItemType> wanted_panel =
-        selection.new_contents
-            ? SidebarTabHelper::FromWebContents(selection.new_contents)
-                  ->active_panel()
-            : absl::nullopt;
-    if (wanted_panel.has_value()) {
-      auto wanted_index = sidebar_model_->GetIndexOf(wanted_panel.value());
-      // built-in items can be removed in-between tab activations, so we might
-      // not get a valid index for this type.
-      if (wanted_index.has_value() &&
-          sidebar_model_->active_index() != wanted_index.value()) {
-        // Don't pass through null values, as we don't want to close existing
-        // panels if we're not opening a tab-specific panel.
-        if (!panel_ui->GetCurrentEntryId()) {
-          // Open/Close by tab change doesn't need animation.
-          // UI could refer this for prevent animation.
-          operation_from_active_tab_change_ = true;
-        }
+  DVLOG(1) << __func__ << " : Active tab changed.";
 
-        ActivatePanelItem(wanted_panel.value());
+  // Is there a tab-specific panel for the new active tab?
+  absl::optional<SidebarItem::BuiltInItemType> wanted_panel =
+      selection.new_contents
+          ? SidebarTabHelper::FromWebContents(selection.new_contents)
+                ->active_panel()
+          : absl::nullopt;
+  if (wanted_panel.has_value()) {
+    auto wanted_index = sidebar_model_->GetIndexOf(wanted_panel.value());
+    // built-in items can be removed in-between tab activations, so we might
+    // not get a valid index for this type.
+    if (wanted_index.has_value() &&
+        sidebar_model_->active_index() != wanted_index.value()) {
+      // Don't pass through null values, as we don't want to close existing
+      // panels if we're not opening a tab-specific panel.
+      if (!panel_ui->GetCurrentEntryId()) {
+        // Open/Close by tab change doesn't need animation.
+        // UI could refer this for prevent animation.
+        operation_from_active_tab_change_ = true;
       }
-    } else {
-      // There is no tab-specific panel for the new active tab
-      if (browser_active_panel_type_.has_value()) {
-        // - restore previous active index
-        ActivatePanelItem(browser_active_panel_type_.value());
-      } else {
-        // - close any tab-specific panel from the previous tab
-        auto current_entry_id = panel_ui->GetCurrentEntryId();
-        // When extension side panel is opened, it's not set to
-        // |browser_active_panel_type_|. We don't call ActivateItemAt() for
-        // extension item as our SidebarModel can't manage it now. Only
-        // tab-specific panel should be closed here if it's used.
-        if (current_entry_id &&
-            (current_entry_id != SidePanelEntryId::kExtension)) {
-          // Open/Close by tab change doesn't need animation.
-          // UI could refer this for preven animation.
-          operation_from_active_tab_change_ = true;
-          panel_ui->Close();
-        }
-      }
+
+      DVLOG(1) << __func__ << " : Show per-tab panel";
+      ActivatePanelItem(wanted_panel.value());
+    }
+    return;
+  }
+
+  // If active tab has contextual side panel, we should not activate another
+  // panel here. Instead, SidePanelCoordinator::OnTabStripModelChanged()
+  // will set contextual panel for active tab. As SidePanelRegistry is only
+  // available from views, we need to ask it to view layer(sidebar_).
+  // TODO(simonhong): Check kChatUI could be contextual entry instead of
+  // handling via SidebarTabHelper.
+  if (sidebar_->HasActiveContextualEntry()) {
+    DVLOG(1) << __func__
+             << " : Just return cause there is active contextual entry.";
+    return;
+  }
+
+  // There is no tab-specific panel for the new active tab
+  if (browser_active_panel_key_) {
+    // Show browser active panel if existed.
+    DVLOG(1) << __func__ << " : Show browser active panel.";
+    panel_ui->Show(browser_active_panel_key_.value());
+  } else {
+    // Otherwise, close panel if it was previous tab specific panel.
+    auto current_id = panel_ui->GetCurrentEntryId();
+    if (current_id && base::Contains(kTabSpecificPanelEntryIds, *current_id)) {
+      DVLOG(1) << __func__ << " : Close previous per-tab panel.";
+      operation_from_active_tab_change_ = true;
+      panel_ui->Close();
     }
   }
 }

--- a/browser/ui/sidebar/sidebar_controller.h
+++ b/browser/ui/sidebar/sidebar_controller.h
@@ -13,6 +13,7 @@
 #include "base/scoped_observation.h"
 #include "brave/components/sidebar/sidebar_item.h"
 #include "brave/components/sidebar/sidebar_service.h"
+#include "chrome/browser/ui/side_panel/side_panel_entry_key.h"
 #include "chrome/browser/ui/tabs/tab_strip_model_observer.h"
 #include "third_party/abseil-cpp/absl/types/optional.h"
 #include "ui/base/window_open_disposition.h"
@@ -66,6 +67,8 @@ class SidebarController : public SidebarService::Observer,
   void LoadAtTab(const GURL& url);
 
   bool IsActiveIndex(absl::optional<size_t> index) const;
+  void SetBrowserActivePanelKey(absl::optional<SidePanelEntryKey> entry_key);
+  void ClearBrowserActivePanelKey();
   bool GetIsPanelOperationFromActiveTabChangeAndReset();
 
   bool DoesBrowserHaveOpenedTabForItem(const SidebarItem& item) const;
@@ -99,10 +102,9 @@ class SidebarController : public SidebarService::Observer,
   raw_ptr<BraveBrowser> browser_ = nullptr;
   // Interface to view.
   raw_ptr<Sidebar> sidebar_ = nullptr;
-  // If there is a tab-specific panel open, this is the type to restore
+  // If there is a tab-specific panel open, this is the entry key to restore
   // when changing active tab to a tab without a tab-specific panel open.
-  absl::optional<SidebarItem::BuiltInItemType> browser_active_panel_type_ =
-      absl::nullopt;
+  absl::optional<SidePanelEntryKey> browser_active_panel_key_;
 
   // True if panel opening/closing request from active tab change.
   bool operation_from_active_tab_change_ = false;

--- a/browser/ui/views/sidebar/sidebar_container_view.h
+++ b/browser/ui/views/sidebar/sidebar_container_view.h
@@ -44,6 +44,9 @@ class SidePanelEntry;
 // and panel view includes each panel's webview.
 // This class controls the visibility of control and panel view based on panel
 // item state and show options.
+// In the comments, we use the term "managed panel entry" and it means that
+// entry is managed by sidebar model. Only managed entry has its item in sidebar
+// UI.
 class SidebarContainerView
     : public sidebar::Sidebar,
       public SidebarControlView::Delegate,
@@ -74,6 +77,7 @@ class SidebarContainerView
   void SetSidebarShowOption(
       sidebar::SidebarService::ShowSidebarOption show_option) override;
   void UpdateSidebarItemsState() override;
+  bool HasActiveContextualEntry() override;
 
   // SidebarControlView::Delegate overrides:
   void MenuClosed() override;


### PR DESCRIPTION
fix https://github.com/brave/brave-browser/issues/31446

Managed entry is the panel entry that managed by sidebar controller.
Sidebar UI has their item.
Non-managed entries include extension side panel or removed entries from SidebarUI.
These non-managed entry also should be set as browser active panel type and shown/hidden properly.

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves 

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-arm64, CI/skip-linux-x64, CI/skip-android, CI/skip-macos, CI/skip-ios, CI/skip-windows-arm64, CI/skip-windows-x64, CI/skip-windows-x86 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [ ] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

`SidebarBrowserTest*`

Please refer to the issue for manual test.