### PR TITLE
Fallback from Wireguard to IKEv2

### DIFF
--- a/browser/brave_vpn/brave_vpn_service_factory.cc
+++ b/browser/brave_vpn/brave_vpn_service_factory.cc
@@ -15,6 +15,7 @@
 #include "brave/browser/skus/skus_service_factory.h"
 #include "brave/components/brave_vpn/browser/brave_vpn_service.h"
 #include "brave/components/brave_vpn/common/brave_vpn_utils.h"
+#include "brave/components/brave_vpn/common/features.h"
 #include "brave/components/skus/common/features.h"
 #include "build/build_config.h"
 #include "chrome/browser/browser_process.h"
@@ -28,6 +29,8 @@
 #if BUILDFLAG(IS_WIN)
 #include "brave/browser/brave_vpn/dns/brave_vpn_dns_observer_factory_win.h"
 #include "brave/browser/brave_vpn/dns/brave_vpn_dns_observer_service_win.h"
+#include "brave/browser/brave_vpn/win/brave_vpn_wireguard_observer_factory_win.h"
+#include "brave/browser/brave_vpn/win/brave_vpn_wireguard_observer_service_win.h"
 #endif
 
 namespace brave_vpn {
@@ -97,11 +100,22 @@ KeyedService* BraveVpnServiceFactory::BuildServiceInstanceFor(
       shared_url_loader_factory, local_state,
       user_prefs::UserPrefs::Get(context), callback);
 #if BUILDFLAG(IS_WIN)
-  auto* dns_observer_service =
-      brave_vpn::BraveVpnDnsObserverFactory::GetInstance()
-          ->GetServiceForContext(context);
-  if (dns_observer_service)
-    dns_observer_service->Observe(vpn_service);
+  if (base::FeatureList::IsEnabled(
+          brave_vpn::features::kBraveVPNUseWireguardService)) {
+    auto* observer_service =
+        brave_vpn::BraveVpnWireguardObserverFactory::GetInstance()
+            ->GetServiceForContext(context);
+    if (observer_service) {
+      observer_service->Observe(vpn_service);
+    }
+  } else {
+    auto* observer_service =
+        brave_vpn::BraveVpnDnsObserverFactory::GetInstance()
+            ->GetServiceForContext(context);
+    if (observer_service) {
+      observer_service->Observe(vpn_service);
+    }
+  }
 #endif
   return vpn_service;
 }

--- a/browser/brave_vpn/brave_vpn_service_factory.cc
+++ b/browser/brave_vpn/brave_vpn_service_factory.cc
@@ -63,9 +63,13 @@ BraveVpnServiceFactory::BraveVpnServiceFactory()
           "BraveVpnService",
           BrowserContextDependencyManager::GetInstance()) {
   DependsOn(skus::SkusServiceFactory::GetInstance());
-
 #if BUILDFLAG(IS_WIN)
-  DependsOn(brave_vpn::BraveVpnDnsObserverFactory::GetInstance());
+  if (base::FeatureList::IsEnabled(
+          brave_vpn::features::kBraveVPNUseWireguardService)) {
+    DependsOn(brave_vpn::BraveVpnWireguardObserverFactory::GetInstance());
+  } else {
+    DependsOn(brave_vpn::BraveVpnDnsObserverFactory::GetInstance());
+  }
 #endif
 }
 

--- a/browser/brave_vpn/sources.gni
+++ b/browser/brave_vpn/sources.gni
@@ -21,6 +21,10 @@ if (enable_brave_vpn) {
       "//brave/browser/brave_vpn/dns/brave_vpn_dns_observer_factory_win.h",
       "//brave/browser/brave_vpn/dns/brave_vpn_dns_observer_service_win.cc",
       "//brave/browser/brave_vpn/dns/brave_vpn_dns_observer_service_win.h",
+      "//brave/browser/brave_vpn/win/brave_vpn_wireguard_observer_factory_win.cc",
+      "//brave/browser/brave_vpn/win/brave_vpn_wireguard_observer_factory_win.h",
+      "//brave/browser/brave_vpn/win/brave_vpn_wireguard_observer_service_win.cc",
+      "//brave/browser/brave_vpn/win/brave_vpn_wireguard_observer_service_win.h",
     ]
 
     brave_browser_brave_vpn_deps += [
@@ -28,8 +32,10 @@ if (enable_brave_vpn) {
       "//brave/browser:browser_process",
       "//brave/components/brave_vpn/browser/connection/ikev2/win/brave_vpn_helper:common",
       "//brave/components/brave_vpn/common/win",
+      "//brave/components/brave_vpn/common/wireguard/win",
       "//chrome/common:constants",
       "//net",
+      "//third_party/abseil-cpp:absl",
     ]
   }
   brave_browser_brave_vpn_deps += [

--- a/browser/brave_vpn/win/BUILD.gn
+++ b/browser/brave_vpn/win/BUILD.gn
@@ -1,0 +1,19 @@
+# Copyright (c) 2023 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import("//brave/components/brave_vpn/common/buildflags/buildflags.gni")
+import("//testing/test.gni")
+
+assert(enable_brave_vpn && is_win)
+
+source_set("unit_tests") {
+  testonly = true
+  sources = [ "brave_vpn_wireguard_observer_service_win_unittest.cc" ]
+  deps = [
+    "//chrome/test:test_support",
+    "//testing/gtest",
+    "//third_party/abseil-cpp:absl",
+  ]
+}

--- a/browser/brave_vpn/win/brave_vpn_wireguard_observer_factory_win.cc
+++ b/browser/brave_vpn/win/brave_vpn_wireguard_observer_factory_win.cc
@@ -1,0 +1,50 @@
+/* Copyright (c) 2023 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "brave/browser/brave_vpn/win/brave_vpn_wireguard_observer_factory_win.h"
+
+#include "base/feature_list.h"
+#include "base/no_destructor.h"
+#include "brave/browser/brave_vpn/vpn_utils.h"
+#include "brave/browser/brave_vpn/win/brave_vpn_wireguard_observer_service_win.h"
+#include "brave/components/brave_vpn/common/features.h"
+#include "components/keyed_service/content/browser_context_dependency_manager.h"
+#include "content/public/browser/browser_context.h"
+
+namespace brave_vpn {
+
+// static
+BraveVpnWireguardObserverFactory*
+BraveVpnWireguardObserverFactory::GetInstance() {
+  static base::NoDestructor<BraveVpnWireguardObserverFactory> instance;
+  return instance.get();
+}
+
+BraveVpnWireguardObserverFactory::~BraveVpnWireguardObserverFactory() = default;
+
+BraveVpnWireguardObserverFactory::BraveVpnWireguardObserverFactory()
+    : BrowserContextKeyedServiceFactory(
+          "BraveVpnWireguardObserverService",
+          BrowserContextDependencyManager::GetInstance()) {}
+
+KeyedService* BraveVpnWireguardObserverFactory::BuildServiceInstanceFor(
+    content::BrowserContext* context) const {
+  return new BraveVpnWireguardObserverService();
+}
+
+// static
+BraveVpnWireguardObserverService*
+BraveVpnWireguardObserverFactory::GetServiceForContext(
+    content::BrowserContext* context) {
+  if (!base::FeatureList::IsEnabled(
+          brave_vpn::features::kBraveVPNUseWireguardService)) {
+    return nullptr;
+  }
+  DCHECK(brave_vpn::IsAllowedForContext(context));
+  return static_cast<BraveVpnWireguardObserverService*>(
+      GetInstance()->GetServiceForBrowserContext(context, true));
+}
+
+}  // namespace brave_vpn

--- a/browser/brave_vpn/win/brave_vpn_wireguard_observer_factory_win.cc
+++ b/browser/brave_vpn/win/brave_vpn_wireguard_observer_factory_win.cc
@@ -38,10 +38,8 @@ KeyedService* BraveVpnWireguardObserverFactory::BuildServiceInstanceFor(
 BraveVpnWireguardObserverService*
 BraveVpnWireguardObserverFactory::GetServiceForContext(
     content::BrowserContext* context) {
-  if (!base::FeatureList::IsEnabled(
-          brave_vpn::features::kBraveVPNUseWireguardService)) {
-    return nullptr;
-  }
+  DCHECK(base::FeatureList::IsEnabled(
+      brave_vpn::features::kBraveVPNUseWireguardService));
   DCHECK(brave_vpn::IsAllowedForContext(context));
   return static_cast<BraveVpnWireguardObserverService*>(
       GetInstance()->GetServiceForBrowserContext(context, true));

--- a/browser/brave_vpn/win/brave_vpn_wireguard_observer_factory_win.h
+++ b/browser/brave_vpn/win/brave_vpn_wireguard_observer_factory_win.h
@@ -1,0 +1,49 @@
+/* Copyright (c) 2023 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_BROWSER_BRAVE_VPN_WIN_BRAVE_VPN_WIREGUARD_OBSERVER_FACTORY_WIN_H_
+#define BRAVE_BROWSER_BRAVE_VPN_WIN_BRAVE_VPN_WIREGUARD_OBSERVER_FACTORY_WIN_H_
+
+#include "components/keyed_service/content/browser_context_keyed_service_factory.h"
+
+namespace base {
+template <typename T>
+class NoDestructor;
+}  // namespace base
+
+namespace content {
+class BrowserContext;
+}  // namespace content
+
+namespace brave_vpn {
+
+class BraveVpnWireguardObserverService;
+
+class BraveVpnWireguardObserverFactory
+    : public BrowserContextKeyedServiceFactory {
+ public:
+  BraveVpnWireguardObserverFactory(const BraveVpnWireguardObserverFactory&) =
+      delete;
+  BraveVpnWireguardObserverFactory& operator=(
+      const BraveVpnWireguardObserverFactory&) = delete;
+
+  static BraveVpnWireguardObserverFactory* GetInstance();
+  static BraveVpnWireguardObserverService* GetServiceForContext(
+      content::BrowserContext* context);
+
+ private:
+  friend base::NoDestructor<BraveVpnWireguardObserverFactory>;
+
+  BraveVpnWireguardObserverFactory();
+  ~BraveVpnWireguardObserverFactory() override;
+
+  // BrowserContextKeyedServiceFactory overrides:
+  KeyedService* BuildServiceInstanceFor(
+      content::BrowserContext* context) const override;
+};
+
+}  // namespace brave_vpn
+
+#endif  // BRAVE_BROWSER_BRAVE_VPN_WIN_BRAVE_VPN_WIREGUARD_OBSERVER_FACTORY_WIN_H_

--- a/browser/brave_vpn/win/brave_vpn_wireguard_observer_service_win.cc
+++ b/browser/brave_vpn/win/brave_vpn_wireguard_observer_service_win.cc
@@ -1,0 +1,44 @@
+/* Copyright (c) 2023 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "brave/browser/brave_vpn/win/brave_vpn_wireguard_observer_service_win.h"
+
+#include "brave/browser/ui/views/brave_vpn/brave_vpn_fallback_dialog_view.h"
+#include "brave/components/brave_vpn/common/wireguard/win/storage_utils.h"
+#include "chrome/browser/ui/browser_finder.h"
+
+namespace brave_vpn {
+
+BraveVpnWireguardObserverService::BraveVpnWireguardObserverService() = default;
+
+BraveVpnWireguardObserverService::~BraveVpnWireguardObserverService() = default;
+
+void BraveVpnWireguardObserverService::ShowFallbackDialog() {
+  if (dialog_callback_) {
+    dialog_callback_.Run();
+    return;
+  }
+  BraveVpnFallbackDialogView::Show(chrome::FindLastActive());
+}
+
+void BraveVpnWireguardObserverService::OnConnectionStateChanged(
+    brave_vpn::mojom::ConnectionState state) {
+  if (state == brave_vpn::mojom::ConnectionState::DISCONNECTED ||
+      state == brave_vpn::mojom::ConnectionState::CONNECT_FAILED) {
+    if (ShouldShowFallbackDialog()) {
+      ShowFallbackDialog();
+    }
+  }
+}
+
+bool BraveVpnWireguardObserverService::ShouldShowFallbackDialog() const {
+  if (should_fallback_for_testing_.has_value()) {
+    return should_fallback_for_testing_.value();
+  }
+
+  return wireguard::ShouldFallbackToIKEv2();
+}
+
+}  // namespace brave_vpn

--- a/browser/brave_vpn/win/brave_vpn_wireguard_observer_service_win.cc
+++ b/browser/brave_vpn/win/brave_vpn_wireguard_observer_service_win.cc
@@ -5,9 +5,8 @@
 
 #include "brave/browser/brave_vpn/win/brave_vpn_wireguard_observer_service_win.h"
 
-#include "brave/browser/ui/views/brave_vpn/brave_vpn_fallback_dialog_view.h"
+#include "brave/browser/ui/browser_dialogs.h"
 #include "brave/components/brave_vpn/common/wireguard/win/storage_utils.h"
-#include "chrome/browser/ui/browser_finder.h"
 
 namespace brave_vpn {
 
@@ -20,7 +19,7 @@ void BraveVpnWireguardObserverService::ShowFallbackDialog() {
     dialog_callback_.Run();
     return;
   }
-  BraveVpnFallbackDialogView::Show(chrome::FindLastActive());
+  brave::ShowBraveVpnIKEv2FallbackDialog();
 }
 
 void BraveVpnWireguardObserverService::OnConnectionStateChanged(

--- a/browser/brave_vpn/win/brave_vpn_wireguard_observer_service_win.h
+++ b/browser/brave_vpn/win/brave_vpn_wireguard_observer_service_win.h
@@ -1,0 +1,52 @@
+/* Copyright (c) 2023 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_BROWSER_BRAVE_VPN_WIN_BRAVE_VPN_WIREGUARD_OBSERVER_SERVICE_WIN_H_
+#define BRAVE_BROWSER_BRAVE_VPN_WIN_BRAVE_VPN_WIREGUARD_OBSERVER_SERVICE_WIN_H_
+
+#include <utility>
+
+#include "brave/components/brave_vpn/browser/brave_vpn_service_observer.h"
+#include "components/keyed_service/core/keyed_service.h"
+#include "third_party/abseil-cpp/absl/types/optional.h"
+
+namespace brave_vpn {
+
+class BraveVpnWireguardObserverService
+    : public brave_vpn::BraveVPNServiceObserver,
+      public KeyedService {
+ public:
+  BraveVpnWireguardObserverService();
+  ~BraveVpnWireguardObserverService() override;
+  BraveVpnWireguardObserverService(const BraveVpnWireguardObserverService&) =
+      delete;
+  BraveVpnWireguardObserverService operator=(
+      const BraveVpnWireguardObserverService&) = delete;
+
+  // brave_vpn::BraveVPNServiceObserver
+  void OnConnectionStateChanged(
+      brave_vpn::mojom::ConnectionState state) override;
+
+  void SetDialogCallbackForTesting(base::RepeatingClosure callback) {
+    dialog_callback_ = std::move(callback);
+  }
+
+  void SetFallbackForTesting(bool should_fallback_for_testing) {
+    should_fallback_for_testing_ = should_fallback_for_testing;
+  }
+
+ private:
+  friend class BraveVpnWireguardObserverServiceUnitTest;
+
+  void ShowFallbackDialog();
+  bool ShouldShowFallbackDialog() const;
+
+  absl::optional<bool> should_fallback_for_testing_;
+  base::RepeatingClosure dialog_callback_;
+};
+
+}  // namespace brave_vpn
+
+#endif  // BRAVE_BROWSER_BRAVE_VPN_WIN_BRAVE_VPN_WIREGUARD_OBSERVER_SERVICE_WIN_H_

--- a/browser/brave_vpn/win/brave_vpn_wireguard_observer_service_win.h
+++ b/browser/brave_vpn/win/brave_vpn_wireguard_observer_service_win.h
@@ -29,6 +29,9 @@ class BraveVpnWireguardObserverService
   void OnConnectionStateChanged(
       brave_vpn::mojom::ConnectionState state) override;
 
+ private:
+  friend class BraveVpnWireguardObserverServiceUnitTest;
+
   void SetDialogCallbackForTesting(base::RepeatingClosure callback) {
     dialog_callback_ = std::move(callback);
   }
@@ -36,9 +39,6 @@ class BraveVpnWireguardObserverService
   void SetFallbackForTesting(bool should_fallback_for_testing) {
     should_fallback_for_testing_ = should_fallback_for_testing;
   }
-
- private:
-  friend class BraveVpnWireguardObserverServiceUnitTest;
 
   void ShowFallbackDialog();
   bool ShouldShowFallbackDialog() const;

--- a/browser/brave_vpn/win/brave_vpn_wireguard_observer_service_win_unittest.cc
+++ b/browser/brave_vpn/win/brave_vpn_wireguard_observer_service_win_unittest.cc
@@ -1,0 +1,74 @@
+/* Copyright (c) 2023 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "brave/browser/brave_vpn/win/brave_vpn_wireguard_observer_service_win.h"
+
+#include <memory>
+
+#include "base/run_loop.h"
+#include "base/test/bind.h"
+#include "content/public/test/browser_task_environment.h"
+#include "testing/gtest/include/gtest/gtest.h"
+
+namespace brave_vpn {
+
+class BraveVpnWireguardObserverServiceUnitTest : public testing::Test {
+ public:
+  BraveVpnWireguardObserverServiceUnitTest() {}
+
+  void SetUp() override { CreateWireguardObserverService(); }
+
+  void CreateWireguardObserverService() {
+    wireguard_observer_service_.reset(new BraveVpnWireguardObserverService());
+    wireguard_observer_service_->SetDialogCallbackForTesting(base::DoNothing());
+  }
+
+  void ResetWireguardObserverService() { wireguard_observer_service_.reset(); }
+
+  void TearDown() override {
+    // BraveVpnWireguardObserverService destructor must be called before
+    // the task runner is destroyed.
+    ResetWireguardObserverService();
+  }
+
+  void FireBraveVPNStateChange(mojom::ConnectionState state) {
+    wireguard_observer_service_->OnConnectionStateChanged(state);
+  }
+
+  bool WasVpnFallbackShownForState(mojom::ConnectionState state,
+                                   bool fallback) {
+    bool callback_called = false;
+    wireguard_observer_service_->SetDialogCallbackForTesting(
+        base::BindLambdaForTesting([&]() { callback_called = true; }));
+    wireguard_observer_service_->SetFallbackForTesting(fallback);
+    FireBraveVPNStateChange(state);
+    return callback_called;
+  }
+
+ private:
+  content::BrowserTaskEnvironment task_environment_;
+  std::unique_ptr<BraveVpnWireguardObserverService> wireguard_observer_service_;
+};
+
+TEST_F(BraveVpnWireguardObserverServiceUnitTest, FallbackToIKEv2) {
+  EXPECT_FALSE(
+      WasVpnFallbackShownForState(mojom::ConnectionState::CONNECTING, true));
+  EXPECT_FALSE(
+      WasVpnFallbackShownForState(mojom::ConnectionState::CONNECTED, true));
+  EXPECT_FALSE(
+      WasVpnFallbackShownForState(mojom::ConnectionState::DISCONNECTING, true));
+
+  EXPECT_TRUE(
+      WasVpnFallbackShownForState(mojom::ConnectionState::DISCONNECTED, true));
+  EXPECT_TRUE(WasVpnFallbackShownForState(
+      mojom::ConnectionState::CONNECT_FAILED, true));
+
+  EXPECT_FALSE(
+      WasVpnFallbackShownForState(mojom::ConnectionState::DISCONNECTED, false));
+  EXPECT_FALSE(WasVpnFallbackShownForState(
+      mojom::ConnectionState::CONNECT_FAILED, false));
+}
+
+}  // namespace brave_vpn

--- a/browser/brave_vpn/win/brave_vpn_wireguard_service/service/BUILD.gn
+++ b/browser/brave_vpn/win/brave_vpn_wireguard_service/service/BUILD.gn
@@ -15,6 +15,8 @@ source_set("service") {
     "install_utils.h",
     "process_utils.cc",
     "process_utils.h",
+    "tunnel_utils.cc",
+    "tunnel_utils.h",
     "wireguard_service_runner.cc",
     "wireguard_service_runner.h",
     "wireguard_tunnel_service.cc",

--- a/browser/brave_vpn/win/brave_vpn_wireguard_service/service/tunnel_utils.cc
+++ b/browser/brave_vpn/win/brave_vpn_wireguard_service/service/tunnel_utils.cc
@@ -1,0 +1,65 @@
+/* Copyright (c) 2023 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "brave/components/brave_vpn/browser/connection/wireguard/win/brave_vpn_wireguard_service/service/tunnel_utils.h"
+
+#include "base/logging.h"
+#include "base/win/registry.h"
+#include "brave/components/brave_vpn/common/wireguard/win/service_constants.h"
+
+namespace brave_vpn {
+
+namespace wireguard {
+
+namespace {
+constexpr wchar_t kBraveWireguardConfigKeyName[] = L"ConfigPath";
+}  // namespace
+
+// Increments number of launches for the wireguard tunnel service.
+void IncrementWireguardTunnelLaunchedFlag() {
+  base::win::RegKey key(
+      HKEY_LOCAL_MACHINE,
+      brave_vpn::GetBraveVpnWireguardServiceRegistryStoragePath().c_str(),
+      KEY_ALL_ACCESS);
+  if (!key.Valid()) {
+    VLOG(1) << "Failed to open wireguard service storage";
+    return;
+  }
+  DWORD launch = 0;
+  key.ReadValueDW(kBraveVpnWireguardCounterOfTunnelLaunches, &launch);
+  launch++;
+  key.WriteValue(kBraveVpnWireguardCounterOfTunnelLaunches, launch);
+}
+
+// Resets number of launches for the wireguard tunnel service.
+void ResetWireguardTunnelLaunchedFlag() {
+  base::win::RegKey key(
+      HKEY_LOCAL_MACHINE,
+      brave_vpn::GetBraveVpnWireguardServiceRegistryStoragePath().c_str(),
+      KEY_ALL_ACCESS);
+  if (!key.Valid()) {
+    VLOG(1) << "Failed to open vpn service storage";
+    return;
+  }
+  key.DeleteValue(kBraveVpnWireguardCounterOfTunnelLaunches);
+}
+
+bool UpdateLastUsedConfigPath(const base::FilePath& config_path) {
+  base::win::RegKey storage;
+  if (storage.Create(
+          HKEY_LOCAL_MACHINE,
+          brave_vpn::GetBraveVpnWireguardServiceRegistryStoragePath().c_str(),
+          KEY_SET_VALUE) != ERROR_SUCCESS) {
+    return false;
+  }
+  if (storage.WriteValue(kBraveWireguardConfigKeyName,
+                         config_path.value().c_str()) != ERROR_SUCCESS) {
+    return false;
+  }
+  return true;
+}
+
+}  // namespace wireguard
+}  // namespace brave_vpn

--- a/browser/brave_vpn/win/brave_vpn_wireguard_service/service/tunnel_utils.cc
+++ b/browser/brave_vpn/win/brave_vpn_wireguard_service/service/tunnel_utils.cc
@@ -19,7 +19,7 @@ constexpr wchar_t kBraveWireguardConfigKeyName[] = L"ConfigPath";
 }  // namespace
 
 // Increments number of usages for the wireguard tunnel service.
-void IncrementWireguardUsageFlag() {
+void IncrementWireguardTunnelUsageFlag() {
   base::win::RegKey key(
       HKEY_LOCAL_MACHINE,
       GetBraveVpnWireguardServiceRegistryStoragePath().c_str(), KEY_ALL_ACCESS);

--- a/browser/brave_vpn/win/brave_vpn_wireguard_service/service/tunnel_utils.cc
+++ b/browser/brave_vpn/win/brave_vpn_wireguard_service/service/tunnel_utils.cc
@@ -3,11 +3,12 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-#include "brave/components/brave_vpn/browser/connection/wireguard/win/brave_vpn_wireguard_service/service/tunnel_utils.h"
+#include "brave/browser/brave_vpn/win/brave_vpn_wireguard_service/service/tunnel_utils.h"
 
 #include "base/logging.h"
 #include "base/win/registry.h"
 #include "brave/components/brave_vpn/common/wireguard/win/service_constants.h"
+#include "brave/components/brave_vpn/common/wireguard/win/storage_utils.h"
 
 namespace brave_vpn {
 
@@ -17,41 +18,38 @@ namespace {
 constexpr wchar_t kBraveWireguardConfigKeyName[] = L"ConfigPath";
 }  // namespace
 
-// Increments number of launches for the wireguard tunnel service.
-void IncrementWireguardTunnelLaunchedFlag() {
+// Increments number of usages for the wireguard tunnel service.
+void IncrementWireguardUsageFlag() {
   base::win::RegKey key(
       HKEY_LOCAL_MACHINE,
-      brave_vpn::GetBraveVpnWireguardServiceRegistryStoragePath().c_str(),
-      KEY_ALL_ACCESS);
+      GetBraveVpnWireguardServiceRegistryStoragePath().c_str(), KEY_ALL_ACCESS);
   if (!key.Valid()) {
     VLOG(1) << "Failed to open wireguard service storage";
     return;
   }
   DWORD launch = 0;
-  key.ReadValueDW(kBraveVpnWireguardCounterOfTunnelLaunches, &launch);
+  key.ReadValueDW(kBraveVpnWireguardCounterOfTunnelUsage, &launch);
   launch++;
-  key.WriteValue(kBraveVpnWireguardCounterOfTunnelLaunches, launch);
+  key.WriteValue(kBraveVpnWireguardCounterOfTunnelUsage, launch);
 }
 
 // Resets number of launches for the wireguard tunnel service.
-void ResetWireguardTunnelLaunchedFlag() {
+void ResetWireguardTunnelUsageFlag() {
   base::win::RegKey key(
       HKEY_LOCAL_MACHINE,
-      brave_vpn::GetBraveVpnWireguardServiceRegistryStoragePath().c_str(),
-      KEY_ALL_ACCESS);
+      GetBraveVpnWireguardServiceRegistryStoragePath().c_str(), KEY_ALL_ACCESS);
   if (!key.Valid()) {
     VLOG(1) << "Failed to open vpn service storage";
     return;
   }
-  key.DeleteValue(kBraveVpnWireguardCounterOfTunnelLaunches);
+  key.DeleteValue(kBraveVpnWireguardCounterOfTunnelUsage);
 }
 
 bool UpdateLastUsedConfigPath(const base::FilePath& config_path) {
   base::win::RegKey storage;
-  if (storage.Create(
-          HKEY_LOCAL_MACHINE,
-          brave_vpn::GetBraveVpnWireguardServiceRegistryStoragePath().c_str(),
-          KEY_SET_VALUE) != ERROR_SUCCESS) {
+  if (storage.Create(HKEY_LOCAL_MACHINE,
+                     GetBraveVpnWireguardServiceRegistryStoragePath().c_str(),
+                     KEY_SET_VALUE) != ERROR_SUCCESS) {
     return false;
   }
   if (storage.WriteValue(kBraveWireguardConfigKeyName,

--- a/browser/brave_vpn/win/brave_vpn_wireguard_service/service/tunnel_utils.h
+++ b/browser/brave_vpn/win/brave_vpn_wireguard_service/service/tunnel_utils.h
@@ -3,8 +3,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-#ifndef BRAVE_COMPONENTS_BRAVE_VPN_BROWSER_CONNECTION_WIREGUARD_WIN_BRAVE_VPN_WIREGUARD_SERVICE_SERVICE_TUNNEL_UTILS_H_
-#define BRAVE_COMPONENTS_BRAVE_VPN_BROWSER_CONNECTION_WIREGUARD_WIN_BRAVE_VPN_WIREGUARD_SERVICE_SERVICE_TUNNEL_UTILS_H_
+#ifndef BRAVE_BROWSER_BRAVE_VPN_WIN_BRAVE_VPN_WIREGUARD_SERVICE_SERVICE_TUNNEL_UTILS_H_
+#define BRAVE_BROWSER_BRAVE_VPN_WIN_BRAVE_VPN_WIREGUARD_SERVICE_SERVICE_TUNNEL_UTILS_H_
 
 #include "base/files/file_path.h"
 
@@ -12,12 +12,12 @@ namespace brave_vpn {
 
 namespace wireguard {
 
-void IncrementWireguardTunnelLaunchedFlag();
-void ResetWireguardTunnelLaunchedFlag();
+void IncrementWireguardUsageFlag();
+void ResetWireguardTunnelUsageFlag();
 bool UpdateLastUsedConfigPath(const base::FilePath& config_path);
 
 }  // namespace wireguard
+
 }  // namespace brave_vpn
 
-#endif  // #define
-        // BRAVE_COMPONENTS_BRAVE_VPN_BROWSER_CONNECTION_WIREGUARD_WIN_BRAVE_VPN_WIREGUARD_SERVICE_SERVICE_TUNNEL_UTILS_H_
+#endif  // BRAVE_BROWSER_BRAVE_VPN_WIN_BRAVE_VPN_WIREGUARD_SERVICE_SERVICE_TUNNEL_UTILS_H_

--- a/browser/brave_vpn/win/brave_vpn_wireguard_service/service/tunnel_utils.h
+++ b/browser/brave_vpn/win/brave_vpn_wireguard_service/service/tunnel_utils.h
@@ -12,7 +12,7 @@ namespace brave_vpn {
 
 namespace wireguard {
 
-void IncrementWireguardUsageFlag();
+void IncrementWireguardTunnelUsageFlag();
 void ResetWireguardTunnelUsageFlag();
 bool UpdateLastUsedConfigPath(const base::FilePath& config_path);
 

--- a/browser/brave_vpn/win/brave_vpn_wireguard_service/service/tunnel_utils.h
+++ b/browser/brave_vpn/win/brave_vpn_wireguard_service/service/tunnel_utils.h
@@ -1,0 +1,23 @@
+/* Copyright (c) 2023 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_COMPONENTS_BRAVE_VPN_BROWSER_CONNECTION_WIREGUARD_WIN_BRAVE_VPN_WIREGUARD_SERVICE_SERVICE_TUNNEL_UTILS_H_
+#define BRAVE_COMPONENTS_BRAVE_VPN_BROWSER_CONNECTION_WIREGUARD_WIN_BRAVE_VPN_WIREGUARD_SERVICE_SERVICE_TUNNEL_UTILS_H_
+
+#include "base/files/file_path.h"
+
+namespace brave_vpn {
+
+namespace wireguard {
+
+void IncrementWireguardTunnelLaunchedFlag();
+void ResetWireguardTunnelLaunchedFlag();
+bool UpdateLastUsedConfigPath(const base::FilePath& config_path);
+
+}  // namespace wireguard
+}  // namespace brave_vpn
+
+#endif  // #define
+        // BRAVE_COMPONENTS_BRAVE_VPN_BROWSER_CONNECTION_WIREGUARD_WIN_BRAVE_VPN_WIREGUARD_SERVICE_SERVICE_TUNNEL_UTILS_H_

--- a/browser/brave_vpn/win/brave_vpn_wireguard_service/service/wireguard_tunnel_service.cc
+++ b/browser/brave_vpn/win/brave_vpn_wireguard_service/service/wireguard_tunnel_service.cc
@@ -187,6 +187,7 @@ namespace wireguard {
 // Creates and launches a new Wireguard Windows service using passed config.
 // Before to start a new service it checks and removes existing if exists.
 bool LaunchWireguardService(const std::wstring& config) {
+  IncrementWireguardUsageFlag();
   if (!RemoveExistingWireguardService()) {
     VLOG(1) << "Failed to remove existing brave wireguard service";
     return false;
@@ -304,7 +305,6 @@ int RunWireguardTunnelService(const base::FilePath& config_file_path) {
   }
 
   {
-    IncrementWireguardTunnelLaunchedFlag();
     base::FilePath directory;
     if (!base::PathService::Get(base::DIR_EXE, &directory)) {
       return S_FALSE;
@@ -322,7 +322,7 @@ int RunWireguardTunnelService(const base::FilePath& config_file_path) {
     }
 
     if (tunnel_proc(config_file_path.value().c_str())) {
-      ResetWireguardTunnelLaunchedFlag();
+      ResetWireguardTunnelUsageFlag();
       return S_OK;
     }
     VLOG(1) << "Failed to activate tunnel service:"
@@ -349,11 +349,13 @@ bool WireguardGenerateKeypair(std::string* public_key,
   if (!generate_proc) {
     VLOG(1) << __func__ << ": WireGuardGenerateKeypair not found error: "
             << tunnel_lib.GetError()->ToString();
+    IncrementWireguardUsageFlag();
     return false;
   }
   if (generate_proc(public_key_bytes.data(), private_key_bytes.data())) {
     VLOG(1) << __func__ << "Unable to generate keys, error:"
             << tunnel_lib.GetError()->ToString();
+    IncrementWireguardUsageFlag();
     return false;
   }
 

--- a/browser/brave_vpn/win/brave_vpn_wireguard_service/service/wireguard_tunnel_service.cc
+++ b/browser/brave_vpn/win/brave_vpn_wireguard_service/service/wireguard_tunnel_service.cc
@@ -187,7 +187,7 @@ namespace wireguard {
 // Creates and launches a new Wireguard Windows service using passed config.
 // Before to start a new service it checks and removes existing if exists.
 bool LaunchWireguardService(const std::wstring& config) {
-  IncrementWireguardUsageFlag();
+  IncrementWireguardTunnelUsageFlag();
   if (!RemoveExistingWireguardService()) {
     VLOG(1) << "Failed to remove existing brave wireguard service";
     return false;
@@ -349,13 +349,13 @@ bool WireguardGenerateKeypair(std::string* public_key,
   if (!generate_proc) {
     VLOG(1) << __func__ << ": WireGuardGenerateKeypair not found error: "
             << tunnel_lib.GetError()->ToString();
-    IncrementWireguardUsageFlag();
+    IncrementWireguardTunnelUsageFlag();
     return false;
   }
   if (generate_proc(public_key_bytes.data(), private_key_bytes.data())) {
     VLOG(1) << __func__ << "Unable to generate keys, error:"
             << tunnel_lib.GetError()->ToString();
-    IncrementWireguardUsageFlag();
+    IncrementWireguardTunnelUsageFlag();
     return false;
   }
 

--- a/browser/brave_vpn/win/brave_vpn_wireguard_service/service/wireguard_tunnel_service.cc
+++ b/browser/brave_vpn/win/brave_vpn_wireguard_service/service/wireguard_tunnel_service.cc
@@ -22,6 +22,7 @@
 #include "base/win/sid.h"
 #include "base/win/windows_types.h"
 #include "brave/browser/brave_vpn/win/brave_vpn_wireguard_service/service/process_utils.h"
+#include "brave/browser/brave_vpn/win/brave_vpn_wireguard_service/service/tunnel_utils.h"
 #include "brave/components/brave_vpn/common/win/scoped_sc_handle.h"
 #include "brave/components/brave_vpn/common/win/utils.h"
 #include "brave/components/brave_vpn/common/wireguard/win/service_constants.h"
@@ -303,6 +304,7 @@ int RunWireguardTunnelService(const base::FilePath& config_file_path) {
   }
 
   {
+    IncrementWireguardTunnelLaunchedFlag();
     base::FilePath directory;
     if (!base::PathService::Get(base::DIR_EXE, &directory)) {
       return S_FALSE;
@@ -320,6 +322,7 @@ int RunWireguardTunnelService(const base::FilePath& config_file_path) {
     }
 
     if (tunnel_proc(config_file_path.value().c_str())) {
+      ResetWireguardTunnelLaunchedFlag();
       return S_OK;
     }
     VLOG(1) << "Failed to activate tunnel service:"

--- a/browser/ui/BUILD.gn
+++ b/browser/ui/BUILD.gn
@@ -359,6 +359,8 @@ source_set("ui") {
         sources += [
           "views/brave_vpn/brave_vpn_dns_settings_notificiation_dialog_view.cc",
           "views/brave_vpn/brave_vpn_dns_settings_notificiation_dialog_view.h",
+          "views/brave_vpn/brave_vpn_fallback_dialog_view.cc",
+          "views/brave_vpn/brave_vpn_fallback_dialog_view.h",
           "webui/settings/brave_settings_secure_dns_handler.cc",
           "webui/settings/brave_settings_secure_dns_handler.h",
         ]

--- a/browser/ui/browser_dialogs.h
+++ b/browser/ui/browser_dialogs.h
@@ -7,6 +7,7 @@
 #define BRAVE_BROWSER_UI_BROWSER_DIALOGS_H_
 
 #include "base/functional/callback_forward.h"
+#include "brave/components/brave_vpn/common/buildflags/buildflags.h"
 #include "brave/components/text_recognition/common/buildflags/buildflags.h"
 
 class Browser;
@@ -30,6 +31,9 @@ void ShowTextRecognitionDialog(content::WebContents* web_contents,
                                const SkBitmap& image);
 #endif
 
+#if BUILDFLAG(ENABLE_BRAVE_VPN)
+void ShowBraveVpnIKEv2FallbackDialog();
+#endif
 }  // namespace brave
 
 #endif  // BRAVE_BROWSER_UI_BROWSER_DIALOGS_H_

--- a/browser/ui/views/brave_vpn/brave_vpn_fallback_dialog_view.cc
+++ b/browser/ui/views/brave_vpn/brave_vpn_fallback_dialog_view.cc
@@ -1,0 +1,156 @@
+/* Copyright (c) 2023 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "brave/browser/ui/views/brave_vpn/brave_vpn_fallback_dialog_view.h"
+
+#include <memory>
+#include <utility>
+
+#include "brave/browser/brave_features_internal_names.h"
+#include "brave/components/brave_vpn/common/pref_names.h"
+#include "chrome/browser/about_flags.h"
+#include "chrome/browser/browser_process.h"
+#include "chrome/browser/lifetime/application_lifetime.h"
+#include "chrome/browser/profiles/profile.h"
+#include "chrome/browser/ui/browser_tabstrip.h"
+#include "chrome/browser/ui/views/frame/browser_view.h"
+#include "components/constrained_window/constrained_window_views.h"
+#include "components/flags_ui/pref_service_flags_storage.h"
+#include "components/grit/brave_components_strings.h"
+#include "ui/base/l10n/l10n_util.h"
+#include "ui/base/metadata/metadata_impl_macros.h"
+#include "ui/views/controls/button/checkbox.h"
+#include "ui/views/controls/link.h"
+#include "ui/views/controls/styled_label.h"
+#include "ui/views/layout/box_layout.h"
+
+namespace brave_vpn {
+
+namespace {
+
+constexpr char kBraveVPNLearnMoreURL[] =
+    "https://support.brave.com/hc/en-us/articles/";
+
+constexpr int kChildSpacing = 16;
+constexpr int kPadding = 24;
+constexpr int kTopPadding = 32;
+constexpr int kBottomPadding = 26;
+constexpr int kDialogWidth = 600;
+
+}  // namespace
+
+// static
+void BraveVpnFallbackDialogView::Show(Browser* browser) {
+  auto* prefs = browser->profile()->GetPrefs();
+  if (!prefs->GetBoolean(prefs::kBraveVPNWireguardFallbackDialog)) {
+    return;
+  }
+
+  // The dialog eats mouse events which results in the close button
+  // getting stuck in the hover state. Reset the window controls to
+  // prevent this.
+  BrowserView::GetBrowserViewForBrowser(browser)
+      ->GetWidget()
+      ->non_client_view()
+      ->ResetWindowControls();
+
+  constrained_window::CreateBrowserModalDialogViews(
+      new BraveVpnFallbackDialogView(browser),
+      browser->window()->GetNativeWindow())
+      ->Show();
+}
+
+BraveVpnFallbackDialogView::BraveVpnFallbackDialogView(Browser* browser)
+    : browser_(browser), prefs_(browser->profile()->GetPrefs()) {
+  SetLayoutManager(std::make_unique<views::BoxLayout>(
+      views::BoxLayout::Orientation::kVertical,
+      gfx::Insets::TLBR(kTopPadding, kPadding, kBottomPadding, kPadding),
+      kChildSpacing));
+  SetButtons(ui::DIALOG_BUTTON_OK | ui::DIALOG_BUTTON_CANCEL);
+  SetButtonLabel(
+      ui::DIALOG_BUTTON_OK,
+      l10n_util::GetStringUTF16(IDS_BRAVE_VPN_FALLBACK_DIALOG_OK_TEXT));
+  SetButtonLabel(
+      ui::DIALOG_BUTTON_CANCEL,
+      l10n_util::GetStringUTF16(IDS_BRAVE_VPN_FALLBACK_DIALOG_CANCEL_TEXT));
+  SetAcceptCallback(base::BindOnce(&BraveVpnFallbackDialogView::OnAccept,
+                                   base::Unretained(this)));
+  auto* header_label = AddChildView(std::make_unique<views::Label>(
+      l10n_util::GetStringUTF16(IDS_BRAVE_VPN_FALLBACK_DIALOG_TITLE)));
+  header_label->SetHorizontalAlignment(gfx::ALIGN_LEFT);
+
+  const std::u16string contents_text =
+      l10n_util::GetStringUTF16(IDS_BRAVE_VPN_FALLBACK_DIALOG_TEXT);
+
+  std::u16string learn_more_link_text =
+      l10n_util::GetStringUTF16(IDS_BRAVE_VPN_FALLBACK_DIALOG_LEARN_MORE_TEXT);
+  std::u16string full_text = l10n_util::GetStringFUTF16(
+      IDS_BRAVE_VPN_FALLBACK_DIALOG_TEXT, learn_more_link_text);
+  const int main_message_length =
+      full_text.size() - learn_more_link_text.size();
+
+  auto* contents_label = AddChildView(std::make_unique<views::StyledLabel>());
+  contents_label->SetTextContext(views::style::CONTEXT_DIALOG_BODY_TEXT);
+  views::StyledLabel::RangeStyleInfo message_style;
+  contents_label->SetText(full_text);
+  contents_label->AddStyleRange(gfx::Range(0, main_message_length),
+                                message_style);
+  contents_label->SizeToFit(kDialogWidth);
+
+  RegisterWindowClosingCallback(base::BindOnce(
+      &BraveVpnFallbackDialogView::OnClosing, base::Unretained(this)));
+
+  // Add "Learn more" link.
+  views::StyledLabel::RangeStyleInfo link_style =
+      views::StyledLabel::RangeStyleInfo::CreateForLink(base::BindRepeating(
+          &BraveVpnFallbackDialogView::OnLearnMoreLinkClicked,
+          base::Unretained(this)));
+  contents_label->AddStyleRange(
+      gfx::Range(main_message_length, full_text.size()), link_style);
+  contents_label->SetHorizontalAlignment(gfx::HorizontalAlignment::ALIGN_LEFT);
+
+  dont_ask_again_checkbox_ =
+      AddChildView(std::make_unique<views::Checkbox>(l10n_util::GetStringUTF16(
+          IDS_BRAVE_VPN_DNS_SETTINGS_NOTIFICATION_DIALOG_CHECKBOX_TEXT)));
+}
+
+BraveVpnFallbackDialogView::~BraveVpnFallbackDialogView() = default;
+
+void BraveVpnFallbackDialogView::OnLearnMoreLinkClicked() {
+  chrome::AddSelectedTabWithURL(browser_, GURL(kBraveVPNLearnMoreURL),
+                                ui::PAGE_TRANSITION_AUTO_TOPLEVEL);
+  CancelDialog();
+}
+
+ui::ModalType BraveVpnFallbackDialogView::GetModalType() const {
+  return ui::MODAL_TYPE_WINDOW;
+}
+
+bool BraveVpnFallbackDialogView::ShouldShowCloseButton() const {
+  return false;
+}
+
+bool BraveVpnFallbackDialogView::ShouldShowWindowTitle() const {
+  return false;
+}
+
+void BraveVpnFallbackDialogView::OnClosing() {
+  prefs_->SetBoolean(prefs::kBraveVPNWireguardFallbackDialog,
+                     !dont_ask_again_checkbox_->GetChecked());
+}
+
+void BraveVpnFallbackDialogView::OnAccept() {
+  flags_ui::PrefServiceFlagsStorage flags_storage(
+      g_browser_process->local_state());
+
+  about_flags::SetFeatureEntryEnabled(
+      &flags_storage, kBraveVPNWireguardFeatureInternalName, false);
+  chrome::AttemptRestart();
+}
+
+BEGIN_METADATA(BraveVpnFallbackDialogView, views::DialogDelegateView)
+END_METADATA
+
+}  // namespace brave_vpn

--- a/browser/ui/views/brave_vpn/brave_vpn_fallback_dialog_view.cc
+++ b/browser/ui/views/brave_vpn/brave_vpn_fallback_dialog_view.cc
@@ -14,6 +14,7 @@
 #include "chrome/browser/browser_process.h"
 #include "chrome/browser/lifetime/application_lifetime.h"
 #include "chrome/browser/profiles/profile.h"
+#include "chrome/browser/ui/browser_finder.h"
 #include "chrome/browser/ui/browser_tabstrip.h"
 #include "chrome/browser/ui/views/frame/browser_view.h"
 #include "components/constrained_window/constrained_window_views.h"
@@ -25,6 +26,12 @@
 #include "ui/views/controls/link.h"
 #include "ui/views/controls/styled_label.h"
 #include "ui/views/layout/box_layout.h"
+
+namespace brave {
+void ShowBraveVpnIKEv2FallbackDialog() {
+  brave_vpn::BraveVpnFallbackDialogView::Show(chrome::FindLastActive());
+}
+}  // namespace brave
 
 namespace brave_vpn {
 

--- a/browser/ui/views/brave_vpn/brave_vpn_fallback_dialog_view.cc
+++ b/browser/ui/views/brave_vpn/brave_vpn_fallback_dialog_view.cc
@@ -55,14 +55,6 @@ void BraveVpnFallbackDialogView::Show(Browser* browser) {
     return;
   }
 
-  // The dialog eats mouse events which results in the close button
-  // getting stuck in the hover state. Reset the window controls to
-  // prevent this.
-  BrowserView::GetBrowserViewForBrowser(browser)
-      ->GetWidget()
-      ->non_client_view()
-      ->ResetWindowControls();
-
   constrained_window::CreateBrowserModalDialogViews(
       new BraveVpnFallbackDialogView(browser),
       browser->window()->GetNativeWindow())

--- a/browser/ui/views/brave_vpn/brave_vpn_fallback_dialog_view.h
+++ b/browser/ui/views/brave_vpn/brave_vpn_fallback_dialog_view.h
@@ -1,0 +1,50 @@
+/* Copyright (c) 2023 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_BROWSER_UI_VIEWS_BRAVE_VPN_BRAVE_VPN_FALLBACK_DIALOG_VIEW_H_
+#define BRAVE_BROWSER_UI_VIEWS_BRAVE_VPN_BRAVE_VPN_FALLBACK_DIALOG_VIEW_H_
+
+#include "ui/views/window/dialog_delegate.h"
+
+class Browser;
+class PrefService;
+
+namespace views {
+class Checkbox;
+}
+
+namespace brave_vpn {
+
+class BraveVpnFallbackDialogView : public views::DialogDelegateView {
+ public:
+  METADATA_HEADER(BraveVpnFallbackDialogView);
+
+  static void Show(Browser* browser);
+
+  BraveVpnFallbackDialogView(const BraveVpnFallbackDialogView&) = delete;
+  BraveVpnFallbackDialogView& operator=(const BraveVpnFallbackDialogView&) =
+      delete;
+
+ private:
+  explicit BraveVpnFallbackDialogView(Browser* browser);
+  ~BraveVpnFallbackDialogView() override;
+
+  void OnAccept();
+  void OnClosing();
+  void OnLearnMoreLinkClicked();
+
+  // views::DialogDelegate overrides:
+  ui::ModalType GetModalType() const override;
+  bool ShouldShowCloseButton() const override;
+  bool ShouldShowWindowTitle() const override;
+
+  raw_ptr<Browser> browser_ = nullptr;
+  raw_ptr<PrefService> prefs_ = nullptr;
+  raw_ptr<views::Checkbox> dont_ask_again_checkbox_ = nullptr;
+};
+
+}  // namespace brave_vpn
+
+#endif  // BRAVE_BROWSER_UI_VIEWS_BRAVE_VPN_BRAVE_VPN_FALLBACK_DIALOG_VIEW_H_

--- a/components/brave_vpn/common/brave_vpn_utils.cc
+++ b/components/brave_vpn/common/brave_vpn_utils.cc
@@ -155,6 +155,7 @@ void RegisterProfilePrefs(user_prefs::PrefRegistrySyncable* registry) {
   registry->RegisterBooleanPref(prefs::kBraveVPNShowButton, true);
 #if BUILDFLAG(IS_WIN)
   registry->RegisterBooleanPref(prefs::kBraveVPNShowNotificationDialog, true);
+  registry->RegisterBooleanPref(prefs::kBraveVPNWireguardFallbackDialog, true);
 #endif
 #if BUILDFLAG(IS_ANDROID)
   registry->RegisterStringPref(prefs::kBraveVPNPurchaseTokenAndroid, "");

--- a/components/brave_vpn/common/pref_names.h
+++ b/components/brave_vpn/common/pref_names.h
@@ -27,6 +27,8 @@ constexpr char kBraveVpnShowDNSPolicyWarningDialog[] =
     "brave.brave_vpn.show_dns_policy_warning_dialog";
 constexpr char kBraveVPNShowNotificationDialog[] =
     "brave.brave_vpn.show_notification_dialog";
+constexpr char kBraveVPNWireguardFallbackDialog[] =
+    "brave.brave_vpn.show_wireguard_fallback_dialog";
 #endif  // BUILDFLAG(IS_WIN)
 constexpr char kBraveVPNWireguardProfileCredentials[] =
     "brave.brave_vpn.wireguard.profile_credentials";

--- a/components/brave_vpn/common/wireguard/win/service_constants.h
+++ b/components/brave_vpn/common/wireguard/win/service_constants.h
@@ -11,6 +11,10 @@ namespace brave_vpn {
 constexpr wchar_t kBraveVpnWireguardServiceExecutable[] =
     L"brave_vpn_wireguard_service.exe";
 
+// Registry flag to count service launches for the fallback.
+constexpr wchar_t kBraveVpnWireguardCounterOfTunnelLaunches[] =
+    L"tunnel_launches_counter";
+
 // Register and configure windows service.
 constexpr char kBraveVpnWireguardServiceInstallSwitchName[] = "install";
 

--- a/components/brave_vpn/common/wireguard/win/service_constants.h
+++ b/components/brave_vpn/common/wireguard/win/service_constants.h
@@ -12,7 +12,7 @@ constexpr wchar_t kBraveVpnWireguardServiceExecutable[] =
     L"brave_vpn_wireguard_service.exe";
 
 // Registry flag to count service launches for the fallback.
-constexpr wchar_t kBraveVpnWireguardCounterOfTunnelLaunches[] =
+constexpr wchar_t kBraveVpnWireguardCounterOfTunnelUsage[] =
     L"tunnel_launches_counter";
 
 // Register and configure windows service.

--- a/components/brave_vpn/common/wireguard/win/storage_utils.cc
+++ b/components/brave_vpn/common/wireguard/win/storage_utils.cc
@@ -65,7 +65,7 @@ bool ShouldFallbackToIKEv2() {
       GetBraveVpnWireguardServiceRegistryStoragePath().c_str(), KEY_READ);
   if (!key.Valid()) {
     VLOG(1) << "Failed to open wireguard service storage";
-    return false;
+    return true;
   }
   DWORD launch = 0;
   key.ReadValueDW(kBraveVpnWireguardCounterOfTunnelUsage, &launch);

--- a/components/brave_vpn/common/wireguard/win/storage_utils.h
+++ b/components/brave_vpn/common/wireguard/win/storage_utils.h
@@ -17,10 +17,8 @@ std::wstring GetBraveVpnWireguardServiceRegistryStoragePath();
 
 bool IsVPNTrayIconEnabled();
 void EnableVPNTrayIcon(bool value);
-
-bool UpdateLastUsedConfigPath(const base::FilePath& config_path);
 absl::optional<base::FilePath> GetLastUsedConfigPath();
-
+bool ShouldFallbackToIKEv2();
 }  // namespace wireguard
 }  // namespace brave_vpn
 

--- a/components/brave_vpn/common/wireguard/win/wireguard_utils.cc
+++ b/components/brave_vpn/common/wireguard/win/wireguard_utils.cc
@@ -168,7 +168,7 @@ wireguard::WireguardKeyPair WireguardGenerateKeypairImpl() {
           service.Get(), RPC_C_AUTHN_DEFAULT, RPC_C_AUTHZ_DEFAULT,
           COLE_DEFAULT_PRINCIPAL, RPC_C_AUTHN_LEVEL_PKT_PRIVACY,
           RPC_C_IMP_LEVEL_IMPERSONATE, nullptr, EOAC_DYNAMIC_CLOAKING))) {
-    VLOG(1) << "Unable to call EnableVpn interface";
+    VLOG(1) << "Unable to call CoSetProxyBlanket";
     return absl::nullopt;
   }
 

--- a/components/resources/brave_vpn_strings.grdp
+++ b/components/resources/brave_vpn_strings.grdp
@@ -239,8 +239,14 @@
     <message name="IDS_BRAVE_VPN_DNS_SETTINGS_NOTIFICATION_DIALOG_TITLE" desc="A title of text shown to user when he enabled Brave VPN without DoH and we override settings">
       Brave VPN on Windows
     </message>
+    <message name="IDS_BRAVE_VPN_FALLBACK_DIALOG_TITLE" desc="A title of text shown to user when Brave VPN Wireguard is asking for fallback to IKEv2">
+      Brave VPN on Windows
+    </message>
   </if>
   <message name="IDS_BRAVE_VPN_DNS_SETTINGS_NOTIFICATION_DIALOG_LEARN_MORE_TEXT" desc="A text shown to user when he enabled Brave VPN without DoH and we override settings to visit help center">
+    Learn more.
+  </message>
+  <message name="IDS_BRAVE_VPN_FALLBACK_DIALOG_LEARN_MORE_TEXT" desc="A text shown to user when Brave VPN Wireguard is asking for fallback to IKEv2">
     Learn more.
   </message>
 
@@ -257,6 +263,20 @@ However, we noticed this helper service is not running - and we don't want to le
 
 <ph name="LEARN_MORE">$1<ex>Learn more.</ex></ph>
   </message>
+  <message name="IDS_BRAVE_VPN_FALLBACK_DIALOG_TEXT" desc="A text shown to user when Brave VPN Wireguard is asking for fallback to IKEv2">
+Looks like there are some issues with the WireGuard connection. Want to enable IKEv2 fallback for a reliable VPN? Simply restart your browser.
+
+Need help with compatibility or configuration? Reach out to our friendly support team.
+You can always revert back to WireGuard on brave://flags/#brave-vpn-wireguard.
+
+Let's get you connected!
+
+<ph name="LEARN_MORE">$1<ex>Learn more.</ex></ph>
+  </message>
+
+  <message name="IDS_BRAVE_VPN_FALLBACK_DIALOG_CHECKBOX_TEXT" desc="A text shown to user on dialog's checkbpox when Brave VPN Wireguard is asking for fallback to IKEv2">
+    Do not warn me about this anymore.
+  </message>
 
   <message name="IDS_BRAVE_VPN_DNS_SETTINGS_NOTIFICATION_DIALOG_CHECKBOX_TEXT" desc="A text shown to user on dialog's checkbpox when he enabled Brave VPN and we override settings">
     Do not warn me about this anymore.
@@ -264,6 +284,15 @@ However, we noticed this helper service is not running - and we don't want to le
   <message name="IDS_BRAVE_VPN_DNS_SETTINGS_NOTIFICATION_DIALOG_OK_TEXT" desc="A text shown to user on dialog's ok button when he enabled Brave VPN and we override settings">
     Ok
   </message>
+
+  <message name="IDS_BRAVE_VPN_FALLBACK_DIALOG_OK_TEXT" desc="A text shown to user on dialog's ok button when Brave VPN Wireguard is asking for fallback to IKEv2">
+    Restart browser
+  </message>
+
+  <message name="IDS_BRAVE_VPN_FALLBACK_DIALOG_CANCEL_TEXT" desc="A text shown to user on dialog's cancel button when Brave VPN Wireguard is asking for fallback to IKEv2">
+    Cancel
+  </message>
+
   <message name="IDS_BRAVE_VPN_DNS_POLICY_CHECKBOX" desc="A text shown to user on dialog's checkbpox when he enabled Brave VPN with disabled DoH by policies">
     Do not warn me about this anymore.
   </message>

--- a/test/BUILD.gn
+++ b/test/BUILD.gn
@@ -338,6 +338,7 @@ test("brave_unit_tests") {
     if (is_win) {
       deps += [
         "//brave/browser/brave_vpn/dns:unit_tests",
+        "//brave/browser/brave_vpn/win:unit_tests",
         "//brave/browser/brave_vpn/win/brave_vpn_wireguard_service/status_tray:unit_tests",
       ]
     }


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/30666

- Moved tunnel related utility functions to the tunnel level (added tunnel_utils.cc/h)
- Added tunnel usage flag:
  - Incremented when:
     - We failed to generate keypair using tunnel.dll
     - We setup vpn connection using tunnel.dll
  - Dropped on successful vpn disconnect.
- Added fallback dialog:
  - Detects bad state of wireguard vpn, failed attemts exceeded the limit.
  - Asks user to fallback to IKEv2, if yes, resets experiment flag and restarts the browser.
  - User can check the flag to skip this dialog if required.
  
![image](https://github.com/brave/brave-core/assets/2965009/31359de1-6597-44ab-9ee6-0c1de4ec77fb)


<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-arm64, CI/skip-linux-x64, CI/skip-android, CI/skip-macos, CI/skip-ios, CI/skip-windows-arm64, CI/skip-windows-x64, CI/skip-windows-x86 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

- case 1:
   - Install browser to program files
   - Enable wireguard experiment
   - Remove tunnel.dll or wireguard.dll and try to connect, after 3-4 attempts the browser should show the fallback dialog
 - case 2:
   - Install browser to program files
   - Enable wireguard experiment
   - Connect to VPN
   - Kill brave_vpn_wireguard_service.exe from Task Manager 
   - Repeat last 2 steps few times and you should see the fallback dialog.

 