### PR TITLE
Fixed error modal from rewards page is shown after startup

### DIFF
--- a/browser/sessions/brave_session_restore_browsertest.cc
+++ b/browser/sessions/brave_session_restore_browsertest.cc
@@ -23,15 +23,16 @@
 
 using BraveSessionRestoreBrowserTest = InProcessBrowserTest;
 
-IN_PROC_BROWSER_TEST_F(BraveSessionRestoreBrowserTest, Serialization) {
+IN_PROC_BROWSER_TEST_F(BraveSessionRestoreBrowserTest,
+                       SerializationClearNonEmptyPageState) {
   auto* tab_model = browser()->tab_strip_model();
   auto* web_contents = tab_model->GetActiveWebContents();
   SessionService* const session_service =
       SessionServiceFactory::GetForProfile(browser()->profile());
   ui_test_utils::NavigateToURLBlockUntilNavigationsComplete(
       browser(), GURL("brave://newtab/"), 1);
-  ASSERT_TRUE(EvalJs(web_contents,
-                     R"(
+  ASSERT_EQ(true, EvalJs(web_contents,
+                         R"(
         var textarea = document.createElement('textarea')
         textarea.textContent = '__some_text__'
         document.body.append(textarea);
@@ -42,8 +43,7 @@ IN_PROC_BROWSER_TEST_F(BraveSessionRestoreBrowserTest, Serialization) {
         var controls_ready = document.getElementsByTagName('textarea')[0].textContent === '__some_text__' &&
                              document.getElementsByTagName('input')[0].value === '__some_text__';
         controls_ready;
-      )")
-                  .ExtractBool());
+      )"));
   session_service->MoveCurrentSessionToLastSession();
   base::RunLoop loop;
   session_service->GetLastSession(base::BindLambdaForTesting(
@@ -61,6 +61,46 @@ IN_PROC_BROWSER_TEST_F(BraveSessionRestoreBrowserTest, Serialization) {
                       .ToEncodedData(),
                   serialized_navigation.encoded_page_state());
         EXPECT_FALSE(serialized_navigation.encoded_page_state().empty());
+        loop.Quit();
+      }));
+  loop.Run();
+}
+
+IN_PROC_BROWSER_TEST_F(BraveSessionRestoreBrowserTest,
+                       SerializationClearEmptyPageState) {
+  auto* tab_model = browser()->tab_strip_model();
+  auto* web_contents = tab_model->GetActiveWebContents();
+  SessionService* const session_service =
+      SessionServiceFactory::GetForProfile(browser()->profile());
+  ui_test_utils::NavigateToURLBlockUntilNavigationsComplete(
+      browser(), GURL("brave://rewards/"), 1);
+  ASSERT_EQ(true, EvalJs(web_contents,
+                         R"(
+        var textarea = document.createElement('textarea')
+        textarea.textContent = '__some_text__'
+        document.body.append(textarea);
+        var input = document.createElement('input')
+        input.autocomplete = 'on'
+        input.value = '__some_text__'
+        document.body.append(input);
+        var controls_ready = document.getElementsByTagName('textarea')[0].textContent === '__some_text__' &&
+                             document.getElementsByTagName('input')[0].value === '__some_text__';
+        controls_ready;
+      )"));
+  session_service->MoveCurrentSessionToLastSession();
+  base::RunLoop loop;
+  session_service->GetLastSession(base::BindLambdaForTesting(
+      [&](std::vector<std::unique_ptr<sessions::SessionWindow>> windows,
+          SessionID ignored_active_window, bool error_reading) {
+        EXPECT_EQ(windows.size(), 1u);
+        EXPECT_EQ(windows[0]->tabs.size(), 1u);
+        EXPECT_EQ(windows[0]->tabs[0]->navigations.size(), 2u);
+        const auto& serialized_navigation = windows[0]->tabs[0]->navigations[1];
+        EXPECT_EQ(serialized_navigation.virtual_url(),
+                  GURL("chrome://rewards/"));
+
+        // Check encoded data is empty.
+        EXPECT_TRUE(serialized_navigation.encoded_page_state().empty());
         loop.Quit();
       }));
   loop.Run();

--- a/chromium_src/components/sessions/content/content_serialized_navigation_driver.cc
+++ b/chromium_src/components/sessions/content/content_serialized_navigation_driver.cc
@@ -5,6 +5,7 @@
 
 #include <string>
 
+#include "base/containers/contains.h"
 #include "components/sessions/content/content_serialized_navigation_driver.h"
 #include "components/sessions/core/serialized_navigation_entry.h"
 #include "content/public/common/url_constants.h"
@@ -15,18 +16,30 @@
 #undef GetSanitizedPageStateForPickle
 
 namespace sessions {
+
 std::string ContentSerializedNavigationDriver::GetSanitizedPageStateForPickle(
     const sessions::SerializedNavigationEntry* navigation) const {
-  if (navigation->virtual_url().SchemeIs(content::kChromeUIScheme)) {
-    // chrome url can be re-written when it's restored during the tab but
-    // re-written url is ignored when encoded page state is empty.
-    // In ContentSerializedNavigationBuilder::ToNavigationEntry(), re-written
-    // url created by NavigationEntry's ctor is ignored by creating new page
-    // state with navigation's virtual_url. Sanitize all but make url info
-    // persisted. Use original_request_url as it's used when NavigationEntry is
-    // created.
-    return blink::PageState::CreateFromURL(navigation->original_request_url())
-        .ToEncodedData();
+  // Extension can override below three chrome urls.
+  // https://source.chromium.org/chromium/chromium/src/+/main:chrome/common/extensions/api/chrome_url_overrides.idl
+  constexpr std::array<const char*, 3> kAllowedChromeUrlsOverridingHostList = {
+      "newtab", "history", "bookmarks"};
+
+  const auto& virtual_url = navigation->virtual_url();
+  if (virtual_url.SchemeIs(content::kChromeUIScheme)) {
+    // If empty string is returned, chrome url overriding is ignored.
+    if (base::Contains(kAllowedChromeUrlsOverridingHostList,
+                       virtual_url.host())) {
+      // chrome url can be re-written when it's restored during the tab but
+      // re-written url is ignored when encoded page state is empty.
+      // In ContentSerializedNavigationBuilder::ToNavigationEntry(), re-written
+      // url created by NavigationEntry's ctor is ignored by creating new page
+      // state with navigation's virtual_url. Sanitize all but make url info
+      // persisted. Use original_request_url as it's used when NavigationEntry
+      // is created.
+      return blink::PageState::CreateFromURL(navigation->original_request_url())
+          .ToEncodedData();
+    }
+    return std::string();
   }
 
   return GetSanitizedPageStateForPickle_ChromiumImpl(navigation);

--- a/components/sessions/content/brave_content_serialized_navigation_driver_unittest.cc
+++ b/components/sessions/content/brave_content_serialized_navigation_driver_unittest.cc
@@ -25,11 +25,16 @@ TEST(BraveContentSerializedNavigationDriverTest,
   // When post data is present, the page state should be sanitized.
   EXPECT_EQ(std::string(), driver->GetSanitizedPageStateForPickle(&navigation));
 
-  navigation.set_virtual_url(GURL("chrome://wallet"));
-  // Check encoded data is not empty but clean state only with url info.
+  // Check encoded data is not empty but clean state only with url info for
+  // chrome overridable url by extension.
+  navigation.set_virtual_url(GURL("chrome://newtab"));
   EXPECT_EQ(blink::PageState::CreateFromURL(navigation.original_request_url())
                 .ToEncodedData(),
             driver->GetSanitizedPageStateForPickle(&navigation));
+
+  // Check encoded data is empty.
+  navigation.set_virtual_url(GURL("chrome://wallet"));
+  EXPECT_EQ(std::string(), driver->GetSanitizedPageStateForPickle(&navigation));
 }
 
 // Tests that PageState data is left unsanitized when post data is absent.
@@ -43,11 +48,17 @@ TEST(BraveContentSerializedNavigationDriverTest,
   ASSERT_FALSE(navigation.has_post_data());
   EXPECT_EQ(test_data::kEncodedPageState,
             driver->GetSanitizedPageStateForPickle(&navigation));
-  navigation.set_virtual_url(GURL("chrome://wallet"));
-  // Check encoded data is not empty but clean state only with url info.
+
+  // Check encoded data is not empty but clean state only with url info for
+  // chrome overridable url by extension.
+  navigation.set_virtual_url(GURL("chrome://newtab"));
   EXPECT_EQ(blink::PageState::CreateFromURL(navigation.original_request_url())
                 .ToEncodedData(),
             driver->GetSanitizedPageStateForPickle(&navigation));
+
+  // Check encoded data is empty.
+  navigation.set_virtual_url(GURL("chrome://wallet"));
+  EXPECT_EQ(std::string(), driver->GetSanitizedPageStateForPickle(&navigation));
 }
 
 }  // namespace sessions


### PR DESCRIPTION
fix https://github.com/brave/brave-browser/issues/31237
Fixed by returning empty string as page state sanitizing for chrome urls that is not overridden by extension.

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves 

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-arm64, CI/skip-linux-x64, CI/skip-android, CI/skip-macos, CI/skip-ios, CI/skip-windows-arm64, CI/skip-windows-x64, CI/skip-windows-x86 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

`BraveContentSerializedNavigationDriverTest.*`
`BraveSessionRestoreBrowserTest.*`

Please see the linked issue for manual test