### PR TITLE
fix(wallet): Portfolio Dropdown Filter Width

### DIFF
--- a/components/brave_wallet_ui/components/desktop/popup-modals/filter-modals/filter-components/filter-components.style.ts
+++ b/components/brave_wallet_ui/components/desktop/popup-modals/filter-modals/filter-components/filter-components.style.ts
@@ -5,6 +5,7 @@
 
 import styled from 'styled-components'
 import * as leo from '@brave/leo/tokens/css'
+import Dropdown from '@brave/leo/react/dropdown'
 import LeoIcon from '@brave/leo/react/icon'
 
 // Constants
@@ -74,6 +75,6 @@ export const Icon = styled(LeoIcon)`
   color: ${leo.color.icon.default};
 `
 
-export const DropdownWrapper = styled.div`
+export const DropdownFilter = styled(Dropdown)`
   min-width: 40%;
 `

--- a/components/brave_wallet_ui/components/desktop/popup-modals/filter-modals/filter-components/filter-dropdown-section.tsx
+++ b/components/brave_wallet_ui/components/desktop/popup-modals/filter-modals/filter-components/filter-dropdown-section.tsx
@@ -4,7 +4,6 @@
 // You can obtain one at https://mozilla.org/MPL/2.0/.
 
 import * as React from 'react'
-import Dropdown from '@brave/leo/react/dropdown'
 
 // Utils
 import {
@@ -22,7 +21,7 @@ import {
   Description,
   IconWrapper,
   Icon,
-  DropdownWrapper
+  DropdownFilter
 } from './filter-components.style'
 import {
   Row,
@@ -100,25 +99,23 @@ export const FilterDropdownSection = (props: Props) => {
           </Description>
         </Column>
       </Row>
-      <DropdownWrapper>
-        <Dropdown
-          onChange={(e) => onSelectOption(e.detail.value)}
-          value={selectedOptionId}
-        >
-          <div slot='value'>
-            {getLocale(selectedDropdownName)}
-          </div>
-          {dropdownOptions.map((option) =>
+      <DropdownFilter
+        onChange={(e) => onSelectOption(e.detail.value)}
+        value={selectedOptionId}
+      >
+        <div slot='value'>
+          {getLocale(selectedDropdownName)}
+        </div>
+        {dropdownOptions.map((option) =>
 
-            <dropdown-option
-              value={option.id}
-              key={option.id}
-            >
-              {getLocale(option.name)}
-            </dropdown-option>
-          )}
-        </Dropdown>
-      </DropdownWrapper>
+          <dropdown-option
+            value={option.id}
+            key={option.id}
+          >
+            {getLocale(option.name)}
+          </dropdown-option>
+        )}
+      </DropdownFilter>
     </Row>
   )
 }


### PR DESCRIPTION
## Description 
Fixes the Portfolios `Filters and display settings` dropdown filter width (as per design)

<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves <https://github.com/brave/brave-browser/issues/31559>

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-arm64, CI/skip-linux-x64, CI/skip-android, CI/skip-macos, CI/skip-ios, CI/skip-windows-arm64, CI/skip-windows-x64, CI/skip-windows-x86 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
   1. Open the Portfolio `Filters and display settings`
   2. Both `dropdown's` should have the same width as per design

Before:

![Screenshot 51](https://github.com/brave/brave-browser/assets/40611140/a71c5e6a-0aea-45c9-951f-27dc72f91571)

After:

![Screenshot 52](https://github.com/brave/brave-core/assets/40611140/87c1bec0-e4a4-4c8e-ab7d-69d598770ea6)
