### PR TITLE
[Shortcuts]: Only allow one key in the Shortcuts UI

### DIFF
--- a/browser/resources/settings/shortcuts_page/components/ConfigureShortcut.tsx
+++ b/browser/resources/settings/shortcuts_page/components/ConfigureShortcut.tsx
@@ -56,41 +56,46 @@ const keyTransforms = {
 const getKey = (key: string) => keyTransforms[key] || key
 
 class AcceleratorInfo {
-  codes: string[] = []
-  keys: string[] = []
+  get codes() {
+    return [...this.#modifiers, this.#key?.code!].filter(k => k)
+  }
+
+  get keys() {
+    return [...this.#modifiers, this.#key?.key!].filter(k => k)
+  }
+
+  #key?: { code: string, key: string }
+  #modifiers: string[] = []
 
   add(e: KeyboardEvent) {
     if (e.ctrlKey) {
-      this.codes.push(getKey('Control'))
-      this.keys.push(getKey('Control'))
+      this.#modifiers.push(getKey('Control'))
     }
     if (e.altKey) {
-      this.codes.push(getKey('Alt'))
-      this.keys.push(getKey('Alt'))
+      this.#modifiers.push(getKey('Alt'))
     }
 
     if (e.shiftKey) {
-      this.codes.push(getKey('Shift'))
-      this.keys.push(getKey('Shift'))
+      this.#modifiers.push(getKey('Shift'))
     }
 
     if (e.metaKey) {
-      this.codes.push(getKey('Meta'))
-      this.keys.push(getKey('Meta'))
+      this.#modifiers.push(getKey('Meta'))
     }
 
     if (!modifiers.includes(e.key)) {
-      this.codes.push(getKey(e.code))
-      this.keys.push(getKey(e.key))
+      this.#key = {
+        key: e.key,
+        code: e.code
+      }
     }
 
-    this.keys = Array.from(new Set(this.keys))
-    this.codes = Array.from(new Set(this.codes))
+    this.#modifiers = Array.from(new Set(this.#modifiers))
   }
 
   isValid() {
     // There needs to be at least one non-modifier key
-    return this.keys.some((k) => !modifiers.includes(k))
+    return !!this.#key
   }
 }
 

--- a/browser/resources/settings/shortcuts_page/components/ConfigureShortcut.tsx
+++ b/browser/resources/settings/shortcuts_page/components/ConfigureShortcut.tsx
@@ -94,7 +94,7 @@ class AcceleratorInfo {
   }
 
   isValid() {
-    // There needs to be at least one non-modifier key
+    // There needs to be one non-modifier key
     return !!this.#key
   }
 }


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/31577

Currently the UI let's you add multiple keys, which look like chords. Unfortunately, Chromium doesn't support chorded shortcuts and drops all but the last key. This updates the UI to share that limitation.

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-arm64, CI/skip-linux-x64, CI/skip-android, CI/skip-macos, CI/skip-ios, CI/skip-windows-arm64, CI/skip-windows-x64, CI/skip-windows-x86 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [ ] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

