### PR TITLE
fix(wallet): Sort Assets at Group Level

### DIFF
--- a/components/brave_wallet_ui/components/desktop/views/portfolio/components/token-lists/token-list.tsx
+++ b/components/brave_wallet_ui/components/desktop/views/portfolio/components/token-lists/token-list.tsx
@@ -181,54 +181,10 @@ export const TokenLists = ({
     return AssetFilterOptions.find(item => item.id === selectedAssetFilter) ?? HighToLowAssetsFilterOption
   }, [selectedAssetFilter])
 
-  const sortedFungibleTokensList: UserAssetInfoType[] = React.useMemo(() => {
-    if (
-      assetFilterItemInfo.id === 'highToLow' ||
-      assetFilterItemInfo.id === 'lowToHigh'
-    ) {
-      return [...fungibleTokens].sort(function (a, b) {
-        const aBalance = a.assetBalance
-        const bBalance = b.assetBalance
-
-        const bFiatBalance = computeFiatAmount({
-          spotPriceRegistry,
-          value: bBalance,
-          token: b.asset
-        })
-
-        const aFiatBalance = computeFiatAmount({
-          spotPriceRegistry,
-          value: aBalance,
-          token: a.asset
-        })
-
-        return assetFilterItemInfo.id === 'highToLow'
-          ? bFiatBalance.minus(aFiatBalance).toNumber()
-          : aFiatBalance.minus(bFiatBalance).toNumber()
-      })
-    }
-    if (
-      assetFilterItemInfo.id === 'aToZ' ||
-      assetFilterItemInfo.id === 'zToA'
-    ) {
-      return [...fungibleTokens].sort(function (a, b) {
-        const aName = a.asset.name.toUpperCase()
-        const bName = b.asset.name.toUpperCase()
-        return assetFilterItemInfo.id === 'aToZ'
-          ? aName.localeCompare(bName)
-          : bName.localeCompare(aName)
-      })
-    }
-    return fungibleTokens
-  }, [
-    assetFilterItemInfo.id,
-    fungibleTokens,
-    spotPriceRegistry
-  ])
 
   const filteredAssetList = React.useMemo(() => {
     const listToUse = isPortfolio
-      ? sortedFungibleTokensList
+      ? fungibleTokens
       : userAssetList
     if (searchValue === '') {
       return listToUse
@@ -244,15 +200,62 @@ export const TokenLists = ({
     })
   }, [
     searchValue,
-    sortedFungibleTokensList,
+    fungibleTokens,
     isPortfolio,
     userAssetList
+  ])
+
+  // Returns a sorted list of assets based on the users
+  // sort by pref.
+  const getSortedFungibleTokensList = React.useCallback(
+    (tokens: UserAssetInfoType[]) => {
+      if (
+        assetFilterItemInfo.id === 'highToLow' ||
+        assetFilterItemInfo.id === 'lowToHigh'
+      ) {
+        return [...tokens].sort(function (a, b) {
+          const aBalance = a.assetBalance
+          const bBalance = b.assetBalance
+
+          const bFiatBalance = computeFiatAmount({
+            spotPriceRegistry,
+            value: bBalance,
+            token: b.asset
+          })
+
+          const aFiatBalance = computeFiatAmount({
+            spotPriceRegistry,
+            value: aBalance,
+            token: a.asset
+          })
+
+          return assetFilterItemInfo.id === 'highToLow'
+            ? bFiatBalance.minus(aFiatBalance).toNumber()
+            : aFiatBalance.minus(bFiatBalance).toNumber()
+        })
+      }
+      if (
+        assetFilterItemInfo.id === 'aToZ' ||
+        assetFilterItemInfo.id === 'zToA'
+      ) {
+        return [...tokens].sort(function (a, b) {
+          const aName = a.asset.name.toUpperCase()
+          const bName = b.asset.name.toUpperCase()
+          return assetFilterItemInfo.id === 'aToZ'
+            ? aName.localeCompare(bName)
+            : bName.localeCompare(aName)
+        })
+      }
+      return tokens
+    }, [
+    assetFilterItemInfo.id,
+    spotPriceRegistry
   ])
 
   // Returns a list of assets based on provided network
   const getAssetsByNetwork = React.useCallback(
     (network: BraveWallet.NetworkInfo) => {
-      return filteredAssetList
+      return getSortedFungibleTokensList(filteredAssetList)
         .filter(
           (asset) =>
             networkEntityAdapter
@@ -264,23 +267,27 @@ export const TokenLists = ({
             networkEntityAdapter
               .selectId(network).toString()
         )
-    }, [filteredAssetList])
+    }, [
+    filteredAssetList,
+    getSortedFungibleTokensList
+  ])
 
   // Returns the full fiat value of provided network
   const getNetworkFiatValue = React.useCallback(
     (network: BraveWallet.NetworkInfo) => {
       // Return an empty string to display a loading
       // skeleton while assets are populated.
-      if (sortedFungibleTokensList.length === 0) {
+      if (filteredAssetList.length === 0) {
         return Amount.empty()
       }
+      const networksAssets = getAssetsByNetwork(network)
       // Return a 0 balance if the network has no
       // assets to display.
-      if (getAssetsByNetwork(network).length === 0) {
+      if (networksAssets.length === 0) {
         return new Amount(0)
       }
 
-      const amounts = getAssetsByNetwork(network)
+      const amounts = networksAssets
         .map((asset) => computeFiatAmount({
           spotPriceRegistry,
           value: asset.assetBalance,
@@ -298,13 +305,13 @@ export const TokenLists = ({
     }, [
     computeFiatAmount,
     getAssetsByNetwork,
-    sortedFungibleTokensList,
+    filteredAssetList,
     defaultCurrencies.fiat,
     spotPriceRegistry
   ])
 
-  // Returns a list of assets based on provided account
-  const getAssetsByAccount = React.useCallback(
+  // Returns a list of assets based on provided coin type
+  const getAssetsByCoin = React.useCallback(
     (account: WalletAccountType) => {
       return filteredAssetList
         .filter(
@@ -319,7 +326,7 @@ export const TokenLists = ({
   const getFilteredOutAssetsByAccount = React.useCallback(
     (account: WalletAccountType) => {
       if (hideSmallBalances) {
-        return getAssetsByAccount(account).filter(
+        return getAssetsByCoin(account).filter(
           (token) =>
             computeFiatAmount({
               spotPriceRegistry,
@@ -329,11 +336,32 @@ export const TokenLists = ({
         )
       }
 
-      return getAssetsByAccount(account)
+      return getAssetsByCoin(account)
     }, [
-    getAssetsByAccount,
+    getAssetsByCoin,
     hideSmallBalances,
     spotPriceRegistry
+  ])
+
+  // Returns a new list of assets with the accounts
+  // balance for each token.
+  const getAccountsAssetBalances = React.useCallback(
+    (account: WalletAccountType) => {
+      return getFilteredOutAssetsByAccount(account)
+        .map((asset) => ({
+          ...asset,
+          assetBalance: getBalance(account, asset.asset)
+        }))
+    }, [getFilteredOutAssetsByAccount])
+
+  // Returns a sorted assets list for an account.
+  const getSortedAssetsByAccount = React.useCallback(
+    (account: WalletAccountType) => {
+      const accountsAssets = getAccountsAssetBalances(account)
+      return getSortedFungibleTokensList(accountsAssets)
+    }, [
+    getAccountsAssetBalances,
+    getSortedFungibleTokensList
   ])
 
   // Returns the full fiat value of provided account
@@ -341,26 +369,25 @@ export const TokenLists = ({
     (account: WalletAccountType) => {
       // Return an empty string to display a loading
       // skeleton while assets are populated.
-      if (sortedFungibleTokensList.length === 0) {
+      if (filteredAssetList.length === 0) {
         return Amount.empty()
       }
+      const accountsAssets = getSortedAssetsByAccount(account)
       // Return a 0 balance if the account has no
       // assets to display.
       if (
-        getFilteredOutAssetsByAccount(account)
+        accountsAssets
           .length === 0
       ) {
         return new Amount(0)
       }
 
       const amounts =
-        getFilteredOutAssetsByAccount(account)
+        accountsAssets
           .map((asset) => {
-            const balance =
-              getBalance(account, asset.asset)
             return computeFiatAmount({
               spotPriceRegistry,
-              value: balance,
+              value: asset.assetBalance,
               token: asset.asset
             })
           })
@@ -374,8 +401,8 @@ export const TokenLists = ({
         ? reducedAmounts
         : Amount.empty()
     }, [
-    getFilteredOutAssetsByAccount,
-    sortedFungibleTokensList
+    getSortedAssetsByAccount,
+    filteredAssetList
   ])
 
   const onCloseSearchBar = React.useCallback(() => {
@@ -384,25 +411,30 @@ export const TokenLists = ({
   }, [])
 
   const listUiByNetworks = React.useMemo(() => {
-    return networks?.sort((a, b) => {
+    if (!networks) {
+      return undefined
+    }
+    return [...networks].sort((a, b) => {
       const aBalance = getNetworkFiatValue(a)
       const bBalance = getNetworkFiatValue(b)
       return bBalance.minus(aBalance).toNumber()
-    })?.map((network) =>
-      <AssetGroupContainer
+    })?.map((network) => {
+      const networksFiatValue = getNetworkFiatValue(network)
+      const networksAssets = getAssetsByNetwork(network)
+      return <AssetGroupContainer
         key={networkEntityAdapter
           .selectId(network).toString()}
         balance={
-          getNetworkFiatValue(network)
+          networksFiatValue
             .isUndefined()
             ? ''
-            : getNetworkFiatValue(network)
+            : networksFiatValue
               .formatAsFiat(defaultCurrencies.fiat)
         }
         network={network}
-        isDisabled={getAssetsByNetwork(network).length === 0}
+        isDisabled={networksAssets.length === 0}
       >
-        {getAssetsByNetwork(network)
+        {networksAssets
           .map(
             (token, index) =>
               renderToken(
@@ -414,7 +446,7 @@ export const TokenLists = ({
           <PortfolioAssetItemLoadingSkeleton />
         }
       </AssetGroupContainer>
-    )
+    })
   }, [
     getAssetsByNetwork,
     getNetworkFiatValue,
@@ -425,27 +457,29 @@ export const TokenLists = ({
   ])
 
   const listUiByAccounts = React.useMemo(() => {
-    return accounts?.sort((a, b) => {
+    if (!accounts) {
+      return undefined
+    }
+    return [...accounts].sort((a, b) => {
       const aBalance = getAccountFiatValue(a)
       const bBalance = getAccountFiatValue(b)
       return bBalance.minus(aBalance).toNumber()
-    })?.map((account) =>
-      <AssetGroupContainer
+    })?.map((account) => {
+      const accountsFiatValue = getAccountFiatValue(account)
+      const accountsAssets = getSortedAssetsByAccount(account)
+      return <AssetGroupContainer
         key={account.accountId.uniqueKey}
         balance={
-          getAccountFiatValue(account)
+          accountsFiatValue
             .isUndefined()
             ? ''
-            : getAccountFiatValue(account)
+            : accountsFiatValue
               .formatAsFiat(defaultCurrencies.fiat)
         }
         account={account}
-        isDisabled={
-          getFilteredOutAssetsByAccount(account).length
-          === 0
-        }
+        isDisabled={accountsAssets.length === 0}
       >
-        {getFilteredOutAssetsByAccount(account)
+        {accountsAssets
           .map(
             (token, index) =>
               renderToken(
@@ -457,9 +491,9 @@ export const TokenLists = ({
           <PortfolioAssetItemLoadingSkeleton />
         }
       </AssetGroupContainer>
-    )
+    })
   }, [
-    getFilteredOutAssetsByAccount,
+    getSortedAssetsByAccount,
     getAccountFiatValue,
     renderToken,
     accounts,
@@ -475,7 +509,7 @@ export const TokenLists = ({
           ? listUiByAccounts
           : <>
             {
-              filteredAssetList
+              getSortedFungibleTokensList(filteredAssetList)
                 .map((token, index) =>
                   renderToken(
                     { index, item: token, viewMode: 'list' }
@@ -505,7 +539,8 @@ export const TokenLists = ({
     listUiByAccounts,
     renderToken,
     assetAutoDiscoveryCompleted,
-    isPortfolio
+    isPortfolio,
+    getSortedFungibleTokensList
   ])
 
   // effects


### PR DESCRIPTION
## Description 
Fixes a bug where assets were being sorted at a `global` level on the `Portfolio` page

<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves <https://github.com/brave/brave-browser/issues/31602>

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-arm64, CI/skip-linux-x64, CI/skip-android, CI/skip-macos, CI/skip-ios, CI/skip-windows-arm64, CI/skip-windows-x64, CI/skip-windows-x86 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
   1. Go to the `Portfolio` page and add multiple accounts with token balances
   2. Group you `Portfolio` by `Accounts` and sort your assets from `High to Low`
   3. Assets should be sorted at a group level

Before:

https://github.com/brave/brave-browser/assets/40611140/3164c515-b5fd-46f8-a633-0a3632579266

After:

https://github.com/brave/brave-core/assets/40611140/8c7f1cf2-3c24-4a00-9068-03d81ad4107d
