### PR TITLE
[Uplift 1.56]: Fix bug with overflowing keys

### DIFF
--- a/browser/resources/settings/shortcuts_page/components/ConfigureShortcut.tsx
+++ b/browser/resources/settings/shortcuts_page/components/ConfigureShortcut.tsx
@@ -24,6 +24,7 @@ const KeysContainer = styled.div`
   flex: 1;
 
   display: flex;
+  flex-wrap: wrap;
   justify-content: center;
   align-items: center;
 


### PR DESCRIPTION
Uplift of https://github.com/brave/brave-core/pull/19189 which fixes https://github.com/brave/brave-browser/issues/31482 to 1.56.x