### PR TITLE
Decouple Brave Ads idle threshold

### DIFF
--- a/components/brave_ads/browser/ads_service.cc
+++ b/components/brave_ads/browser/ads_service.cc
@@ -43,8 +43,6 @@ void AdsService::RegisterProfilePrefs(
 
   registry->RegisterInt64Pref(prefs::kMaximumNotificationAdsPerHour, -1);
 
-  registry->RegisterIntegerPref(prefs::kIdleTimeThreshold, 15);
-
   registry->RegisterBooleanPref(prefs::kShouldAllowSubdivisionTargeting, false);
   registry->RegisterStringPref(prefs::kSubdivisionTargetingSubdivision, "AUTO");
   registry->RegisterStringPref(

--- a/components/brave_ads/browser/ads_service_impl.h
+++ b/components/brave_ads/browser/ads_service_impl.h
@@ -138,7 +138,6 @@ class AdsServiceImpl : public AdsService,
   void OnEnabledPrefChanged();
   void OnEnabledPrefChangedCallback(
       brave_rewards::mojom::RewardsWalletPtr wallet);
-  void OnIdleTimeThresholdPrefChanged();
   void OnBraveNewsOptedInPrefChanged();
   void OnNewTabPageShowTodayPrefChanged();
   void NotifyPrefChanged(const std::string& path) const;

--- a/components/brave_ads/common/BUILD.gn
+++ b/components/brave_ads/common/BUILD.gn
@@ -20,6 +20,8 @@ static_library("common") {
     "pref_names.h",
     "search_result_ad_feature.cc",
     "search_result_ad_feature.h",
+    "user_attention_feature.cc",
+    "user_attention_feature.h",
   ]
 
   deps = [ "//base" ]

--- a/components/brave_ads/common/pref_names.cc
+++ b/components/brave_ads/common/pref_names.cc
@@ -50,9 +50,6 @@ const char kServeAdAt[] = "brave.brave_ads.serve_ad_at";
 // Browser version
 const char kBrowserVersionNumber[] = "brave.brave_ads.browser_version_number";
 
-// Stores the idle time threshold before checking if an ad can be served
-const char kIdleTimeThreshold[] = "brave.brave_ads.idle_threshold";
-
 // Stores whether Brave ads should allow subdivision ad targeting
 const char kShouldAllowSubdivisionTargeting[] =
     "brave.brave_ads.should_allow_ads_subdivision_targeting";

--- a/components/brave_ads/common/pref_names.h
+++ b/components/brave_ads/common/pref_names.h
@@ -37,9 +37,6 @@ extern const char kNotificationAds[];
 extern const char kServeAdAt[];
 extern const char kBrowserVersionNumber[];
 
-// Idle state prefs
-extern const char kIdleTimeThreshold[];
-
 // Subdivision targeting prefs
 extern const char kShouldAllowSubdivisionTargeting[];
 extern const char kSubdivisionTargetingSubdivision[];

--- a/components/brave_ads/common/user_attention_feature.cc
+++ b/components/brave_ads/common/user_attention_feature.cc
@@ -1,0 +1,18 @@
+/* Copyright (c) 2023 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "brave/components/brave_ads/common/user_attention_feature.h"
+
+namespace brave_ads {
+
+BASE_FEATURE(kUserAttentionFeature,
+             "UserAttention",
+             base::FEATURE_ENABLED_BY_DEFAULT);
+
+bool IsUserAttentionFeatureEnabled() {
+  return base::FeatureList::IsEnabled(kUserAttentionFeature);
+}
+
+}  // namespace brave_ads

--- a/components/brave_ads/common/user_attention_feature.h
+++ b/components/brave_ads/common/user_attention_feature.h
@@ -1,0 +1,27 @@
+/* Copyright (c) 2023 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_COMPONENTS_BRAVE_ADS_COMMON_USER_ATTENTION_FEATURE_H_
+#define BRAVE_COMPONENTS_BRAVE_ADS_COMMON_USER_ATTENTION_FEATURE_H_
+
+#include "base/feature_list.h"
+#include "base/metrics/field_trial_params.h"
+
+namespace base {
+class TimeDelta;
+}  // namespace base
+
+namespace brave_ads {
+
+BASE_DECLARE_FEATURE(kUserAttentionFeature);
+
+bool IsUserAttentionFeatureEnabled();
+
+constexpr base::FeatureParam<base::TimeDelta> kIdleThreshold{
+    &kUserAttentionFeature, "idle_threshold", base::Seconds(5)};
+
+}  // namespace brave_ads
+
+#endif  // BRAVE_COMPONENTS_BRAVE_ADS_COMMON_USER_ATTENTION_FEATURE_H_

--- a/components/brave_ads/common/user_attention_feature_unittest.cc
+++ b/components/brave_ads/common/user_attention_feature_unittest.cc
@@ -1,0 +1,62 @@
+/* Copyright (c) 2023 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "brave/components/brave_ads/common/user_attention_feature.h"
+
+#include <vector>
+
+#include "base/test/scoped_feature_list.h"
+#include "testing/gtest/include/gtest/gtest.h"
+
+// npm run test -- brave_unit_tests --filter=BraveAds*
+
+namespace brave_ads {
+
+TEST(BraveAdsUserAttentionFeatureTest, GetIdleThreshold) {
+  // Arrange
+  base::FieldTrialParams params;
+  params["idle_threshold"] = "7s";
+  std::vector<base::test::FeatureRefAndParams> enabled_features;
+  enabled_features.emplace_back(kUserAttentionFeature, params);
+
+  const std::vector<base::test::FeatureRef> disabled_features;
+
+  base::test::ScopedFeatureList scoped_feature_list;
+  scoped_feature_list.InitWithFeaturesAndParameters(enabled_features,
+                                                    disabled_features);
+
+  // Act
+
+  // Assert
+  EXPECT_EQ(base::Seconds(7), kIdleThreshold.Get());
+}
+
+TEST(BraveAdsUserAttentionFeatureTest, DefaultIdleThreshold) {
+  // Arrange
+
+  // Act
+
+  // Assert
+  EXPECT_EQ(base::Seconds(5), kIdleThreshold.Get());
+}
+
+TEST(BraveAdsUserAttentionFeatureTest, DefaultIdleThresholdWhenDisabled) {
+  // Arrange
+  const std::vector<base::test::FeatureRefAndParams> enabled_features;
+
+  std::vector<base::test::FeatureRef> disabled_features;
+  disabled_features.emplace_back(kUserAttentionFeature);
+
+  base::test::ScopedFeatureList scoped_feature_list;
+  scoped_feature_list.InitWithFeaturesAndParameters(enabled_features,
+                                                    disabled_features);
+
+  // Act
+
+  // Assert
+  EXPECT_EQ(base::Seconds(5), kIdleThreshold.Get());
+}
+
+}  // namespace brave_ads

--- a/components/brave_ads/core/ads_client_notifier.h
+++ b/components/brave_ads/core/ads_client_notifier.h
@@ -105,15 +105,14 @@ class AdsClientNotifier {
   virtual void NotifyUserGestureEventTriggered(
       int32_t page_transition_type) const;
 
-  // Invoked when a user has been idle for the threshold set in
-  // |prefs::kIdleTimeThreshold|. NOTE: This should not be called on mobile
-  // devices.
+  // Invoked when a user has been idle for the given threshold. NOTE: This
+  // should not be called on mobile devices.
   void NotifyUserDidBecomeIdle() const;
 
-  // Called when a user is no longer idle. |idle_time| is the amount of time in
-  // seconds that the user was idle. |screen_was_locked| should be |true| if the
-  // screen was locked, otherwise |false|. NOTE: This should not be called on
-  // mobile devices.
+  // Called when a user is no longer idle. |idle_time| is the duration of time
+  // that the user was idle. |screen_was_locked| should be |true| if the screen
+  // was locked, otherwise |false|. NOTE: This should not be called on mobile
+  // devices.
   void NotifyUserDidBecomeActive(base::TimeDelta idle_time,
                                  bool screen_was_locked) const;
 

--- a/components/brave_ads/core/ads_client_notifier_observer.h
+++ b/components/brave_ads/core/ads_client_notifier_observer.h
@@ -100,9 +100,8 @@ class AdsClientNotifierObserver : public base::CheckedObserver {
   virtual void OnNotifyUserGestureEventTriggered(int32_t page_transition_type) {
   }
 
-  // Invoked when a user has been idle for the threshold set in
-  // |prefs::kIdleTimeThreshold|. NOTE: This should not be called on mobile
-  // devices.
+  // Invoked when a user has been idle for the given threshold. NOTE: This
+  // should not be called on mobile devices.
   virtual void OnNotifyUserDidBecomeIdle() {}
 
   // Called when a user is no longer idle. |idle_time| is the amount of time in

--- a/components/brave_ads/core/internal/common/unittest/unittest_base_util.cc
+++ b/components/brave_ads/core/internal/common/unittest/unittest_base_util.cc
@@ -220,8 +220,6 @@ void MockDefaultPrefs() {
 
   SetDefaultInt64Pref(prefs::kMaximumNotificationAdsPerHour, -1);
 
-  SetDefaultIntegerPref(prefs::kIdleTimeThreshold, 15);
-
   SetDefaultBooleanPref(prefs::kShouldAllowSubdivisionTargeting, false);
   SetDefaultStringPref(prefs::kSubdivisionTargetingSubdivision, "AUTO");
   SetDefaultStringPref(prefs::kSubdivisionTargetingAutoDetectedSubdivision, "");

--- a/components/brave_ads/core/internal/flags/did_override/did_override_features_from_command_line_util.cc
+++ b/components/brave_ads/core/internal/flags/did_override/did_override_features_from_command_line_util.cc
@@ -15,6 +15,7 @@
 #include "base/strings/string_split.h"
 #include "brave/components/brave_ads/common/notification_ad_feature.h"
 #include "brave/components/brave_ads/common/search_result_ad_feature.h"
+#include "brave/components/brave_ads/common/user_attention_feature.h"
 #include "brave/components/brave_ads/core/internal/account/account_feature.h"
 #include "brave/components/brave_ads/core/internal/ads/inline_content_ad_feature.h"
 #include "brave/components/brave_ads/core/internal/ads/new_tab_page_ad_feature.h"
@@ -47,7 +48,8 @@ const base::Feature* const kFeatures[] = {&kAccountFeature,
                                           &kPurchaseIntentFeature,
                                           &kSearchResultAdFeature,
                                           &kTextClassificationFeature,
-                                          &kUserActivityFeature};
+                                          &kUserActivityFeature,
+                                          &kUserAttentionFeature};
 
 constexpr char kFeaturesSeparators[] = ",:<";
 

--- a/components/brave_ads/core/internal/flags/did_override/did_override_features_from_command_line_util_unittest.cc
+++ b/components/brave_ads/core/internal/flags/did_override/did_override_features_from_command_line_util_unittest.cc
@@ -15,6 +15,7 @@
 #include "base/test/scoped_feature_list.h"
 #include "brave/components/brave_ads/common/notification_ad_feature.h"
 #include "brave/components/brave_ads/common/search_result_ad_feature.h"
+#include "brave/components/brave_ads/common/user_attention_feature.h"
 #include "brave/components/brave_ads/core/internal/account/account_feature.h"
 #include "brave/components/brave_ads/core/internal/ads/inline_content_ad_feature.h"
 #include "brave/components/brave_ads/core/internal/ads/new_tab_page_ad_feature.h"
@@ -76,6 +77,7 @@ struct ParamInfo final {
     {{::switches::kEnableFeatures, kSearchResultAdFeature.name}, true},
     {{::switches::kEnableFeatures, kTextClassificationFeature.name}, true},
     {{::switches::kEnableFeatures, kUserActivityFeature.name}, true},
+    {{::switches::kEnableFeatures, kUserAttentionFeature.name}, true},
     {{::switches::kEnableFeatures, {}}, false},
     {{variations::switches::kForceFieldTrialParams, "FooBar"}, false},
     {{variations::switches::kForceFieldTrialParams,
@@ -119,6 +121,8 @@ struct ParamInfo final {
       kTextClassificationFeature.name},
      true},
     {{variations::switches::kForceFieldTrialParams, kUserActivityFeature.name},
+     true},
+    {{variations::switches::kForceFieldTrialParams, kUserAttentionFeature.name},
      true},
     {{variations::switches::kForceFieldTrialParams, {}}, false}};
 

--- a/components/brave_ads/core/internal/user_attention/user_idle_detection/user_idle_detection.cc
+++ b/components/brave_ads/core/internal/user_attention/user_idle_detection/user_idle_detection.cc
@@ -10,13 +10,10 @@
 #include "brave/components/brave_ads/core/internal/ads_client_helper.h"
 #include "brave/components/brave_ads/core/internal/common/logging_util.h"
 #include "brave/components/brave_ads/core/internal/diagnostics/entries/last_unidle_time_diagnostic_util.h"
-#include "brave/components/brave_ads/core/internal/user_attention/user_idle_detection/user_idle_detection_util.h"
 
 namespace brave_ads {
 
 UserIdleDetection::UserIdleDetection() {
-  MaybeUpdateIdleTimeThreshold();
-
   AdsClientHelper::AddObserver(this);
 }
 
@@ -37,8 +34,6 @@ void UserIdleDetection::OnNotifyUserDidBecomeActive(
   if (screen_was_locked) {
     BLOG(1, "Screen was locked before the user become active");
   }
-
-  MaybeUpdateIdleTimeThreshold();
 
   SetLastUnIdleTimeDiagnosticEntry(base::Time::Now());
 }

--- a/components/brave_ads/core/internal/user_attention/user_idle_detection/user_idle_detection_feature.h
+++ b/components/brave_ads/core/internal/user_attention/user_idle_detection/user_idle_detection_feature.h
@@ -19,9 +19,6 @@ BASE_DECLARE_FEATURE(kUserIdleDetectionFeature);
 
 bool IsUserIdleDetectionFeatureEnabled();
 
-constexpr base::FeatureParam<base::TimeDelta> kIdleTimeThreshold{
-    &kUserIdleDetectionFeature, "idle_time_threshold", base::Seconds(5)};
-
 constexpr base::FeatureParam<base::TimeDelta> kMaximumIdleTime{
     &kUserIdleDetectionFeature, "maximum_idle_time", base::Seconds(0)};
 

--- a/components/brave_ads/core/internal/user_attention/user_idle_detection/user_idle_detection_feature_unittest.cc
+++ b/components/brave_ads/core/internal/user_attention/user_idle_detection/user_idle_detection_feature_unittest.cc
@@ -40,52 +40,6 @@ TEST(BraveAdsUserIdleDetectionFeatureTest, IsDisabled) {
   EXPECT_FALSE(IsUserIdleDetectionFeatureEnabled());
 }
 
-TEST(BraveAdsUserIdleDetectionFeatureTest, GetIdleTimeThreshold) {
-  // Arrange
-  base::FieldTrialParams params;
-  params["idle_time_threshold"] = "7s";
-  std::vector<base::test::FeatureRefAndParams> enabled_features;
-  enabled_features.emplace_back(kUserIdleDetectionFeature, params);
-
-  const std::vector<base::test::FeatureRef> disabled_features;
-
-  base::test::ScopedFeatureList scoped_feature_list;
-  scoped_feature_list.InitWithFeaturesAndParameters(enabled_features,
-                                                    disabled_features);
-
-  // Act
-
-  // Assert
-  EXPECT_EQ(base::Seconds(7), kIdleTimeThreshold.Get());
-}
-
-TEST(BraveAdsUserIdleDetectionFeatureTest, DefaultIdleTimeThreshold) {
-  // Arrange
-
-  // Act
-
-  // Assert
-  EXPECT_EQ(base::Seconds(5), kIdleTimeThreshold.Get());
-}
-
-TEST(BraveAdsUserIdleDetectionFeatureTest,
-     DefaultIdleTimeThresholdWhenDisabled) {
-  // Arrange
-  const std::vector<base::test::FeatureRefAndParams> enabled_features;
-
-  std::vector<base::test::FeatureRef> disabled_features;
-  disabled_features.emplace_back(kUserIdleDetectionFeature);
-
-  base::test::ScopedFeatureList scoped_feature_list;
-  scoped_feature_list.InitWithFeaturesAndParameters(enabled_features,
-                                                    disabled_features);
-
-  // Act
-
-  // Assert
-  EXPECT_EQ(base::Seconds(5), kIdleTimeThreshold.Get());
-}
-
 TEST(BraveAdsUserIdleDetectionFeatureTest, GetMaximumIdleTime) {
   // Arrange
   base::FieldTrialParams params;

--- a/components/brave_ads/core/internal/user_attention/user_idle_detection/user_idle_detection_util.cc
+++ b/components/brave_ads/core/internal/user_attention/user_idle_detection/user_idle_detection_util.cc
@@ -6,8 +6,6 @@
 #include "brave/components/brave_ads/core/internal/user_attention/user_idle_detection/user_idle_detection_util.h"
 
 #include "base/time/time.h"
-#include "brave/components/brave_ads/common/pref_names.h"
-#include "brave/components/brave_ads/core/internal/ads_client_helper.h"
 #include "brave/components/brave_ads/core/internal/user_attention/user_idle_detection/user_idle_detection_feature.h"
 
 namespace brave_ads {
@@ -23,23 +21,6 @@ bool HasExceededMaximumIdleTime(const base::TimeDelta idle_time) {
   }
 
   return idle_time > maximum_idle_time;
-}
-
-bool MaybeUpdateIdleTimeThreshold() {
-  const int last_idle_time_threshold =
-      AdsClientHelper::GetInstance()->GetIntegerPref(prefs::kIdleTimeThreshold);
-
-  const int idle_time_threshold =
-      static_cast<int>(kIdleTimeThreshold.Get().InSeconds());
-
-  if (idle_time_threshold == last_idle_time_threshold) {
-    return false;
-  }
-
-  AdsClientHelper::GetInstance()->SetIntegerPref(prefs::kIdleTimeThreshold,
-                                                 idle_time_threshold);
-
-  return true;
 }
 
 }  // namespace brave_ads

--- a/components/brave_ads/core/internal/user_attention/user_idle_detection/user_idle_detection_util.h
+++ b/components/brave_ads/core/internal/user_attention/user_idle_detection/user_idle_detection_util.h
@@ -16,8 +16,6 @@ bool MaybeScreenWasLocked(bool screen_was_locked);
 
 bool HasExceededMaximumIdleTime(base::TimeDelta idle_time);
 
-bool MaybeUpdateIdleTimeThreshold();
-
 }  // namespace brave_ads
 
 #endif  // BRAVE_COMPONENTS_BRAVE_ADS_CORE_INTERNAL_USER_ATTENTION_USER_IDLE_DETECTION_USER_IDLE_DETECTION_UTIL_H_

--- a/components/brave_ads/core/internal/user_attention/user_idle_detection/user_idle_detection_util_unittest.cc
+++ b/components/brave_ads/core/internal/user_attention/user_idle_detection/user_idle_detection_util_unittest.cc
@@ -8,9 +8,7 @@
 #include <vector>
 
 #include "base/test/scoped_feature_list.h"
-#include "brave/components/brave_ads/common/pref_names.h"
 #include "brave/components/brave_ads/core/internal/common/unittest/unittest_base.h"
-#include "brave/components/brave_ads/core/internal/common/unittest/unittest_pref_util.h"
 #include "brave/components/brave_ads/core/internal/user_attention/user_idle_detection/user_idle_detection_feature.h"
 
 // npm run test -- brave_unit_tests --filter=BraveAds*
@@ -153,52 +151,6 @@ TEST_F(BraveAdsUserIdleDetectionUtilTest, HasExceededMaximumIdleTime) {
 
   // Assert
   EXPECT_TRUE(HasExceededMaximumIdleTime(base::Seconds(11)));
-}
-
-TEST_F(BraveAdsUserIdleDetectionUtilTest, UpdateIdleTimeThreshold) {
-  // Arrange
-  base::FieldTrialParams params;
-  params["idle_time_threshold"] = "5s";
-  std::vector<base::test::FeatureRefAndParams> enabled_features;
-  enabled_features.emplace_back(kUserIdleDetectionFeature, params);
-
-  const std::vector<base::test::FeatureRef> disabled_features;
-
-  base::test::ScopedFeatureList scoped_feature_list;
-  scoped_feature_list.InitWithFeaturesAndParameters(enabled_features,
-                                                    disabled_features);
-
-  SetDefaultIntegerPref(prefs::kIdleTimeThreshold, 10);
-
-  ASSERT_TRUE(MaybeUpdateIdleTimeThreshold());
-
-  // Act
-
-  // Assert
-  EXPECT_EQ(5, ads_client_mock_.GetIntegerPref(prefs::kIdleTimeThreshold));
-}
-
-TEST_F(BraveAdsUserIdleDetectionUtilTest, DoNotUpdateIdleTimeThreshold) {
-  // Arrange
-  base::FieldTrialParams params;
-  params["idle_time_threshold"] = "10s";
-  std::vector<base::test::FeatureRefAndParams> enabled_features;
-  enabled_features.emplace_back(kUserIdleDetectionFeature, params);
-
-  const std::vector<base::test::FeatureRef> disabled_features;
-
-  base::test::ScopedFeatureList scoped_feature_list;
-  scoped_feature_list.InitWithFeaturesAndParameters(enabled_features,
-                                                    disabled_features);
-
-  SetDefaultIntegerPref(prefs::kIdleTimeThreshold, 10);
-
-  ASSERT_FALSE(MaybeUpdateIdleTimeThreshold());
-
-  // Act
-
-  // Assert
-  EXPECT_EQ(10, ads_client_mock_.GetIntegerPref(prefs::kIdleTimeThreshold));
 }
 
 }  // namespace brave_ads

--- a/test/BUILD.gn
+++ b/test/BUILD.gn
@@ -115,6 +115,7 @@ test("brave_unit_tests") {
     "//brave/components/brave_ads/common/brave_ads_feature_unittest.cc",
     "//brave/components/brave_ads/common/notification_ad_feature_unittest.cc",
     "//brave/components/brave_ads/common/search_result_ad_feature_unittest.cc",
+    "//brave/components/brave_ads/common/user_attention_feature_unittest.cc",
     "//brave/components/brave_ads/content/browser/search_result_ad/search_result_ad_handler_unittest.cc",
     "//brave/components/brave_ads/core/search_result_ad/search_result_ad_converting_util_unittest.cc",
     "//brave/components/brave_ads/core/search_result_ad/search_result_ad_util_unittest.cc",


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/31650

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-arm64, CI/skip-linux-x64, CI/skip-android, CI/skip-macos, CI/skip-ios, CI/skip-windows-arm64, CI/skip-windows-x64, CI/skip-windows-x86 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [ ] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

Confirm when a user becomes active, indicating the user interacted with the keyboard or another input device that notification ads are shown, including testing with Griffin feature `UserAttention`/`idle_threshold` which supersedes  `UserIdleDetection`/`idle_time_threshold`.