### PR TITLE
Add multi-model support

### DIFF
--- a/components/ai_chat/browser/ai_chat_api.cc
+++ b/components/ai_chat/browser/ai_chat_api.cc
@@ -130,8 +130,8 @@ void AIChatAPI::QueryPrompt(
     // custom positions.
     DCHECK(base::MatchPattern(prompt,
                               base::StrCat({"*", ai_chat::kHumanPrompt, "*"})));
-    DCHECK(
-        base::MatchPattern(prompt, base::StrCat({"*", ai_chat::kAIPrompt, "*"})));
+    DCHECK(base::MatchPattern(prompt,
+                              base::StrCat({"*", ai_chat::kAIPrompt, "*"})));
   }
 
   const GURL api_base_url = GetEndpointBaseUrl();

--- a/components/ai_chat/browser/ai_chat_api.cc
+++ b/components/ai_chat/browser/ai_chat_api.cc
@@ -124,13 +124,15 @@ void AIChatAPI::QueryPrompt(
         data_completed_callback,
     api_request_helper::APIRequestHelper::DataReceivedCallback
         data_received_callback) {
-  // All queries must have the "Human" and "AI" prompt markers. We do not
-  // prepend / append them here since callers may want to put them in
-  // custom positions.
-  DCHECK(base::MatchPattern(prompt,
-                            base::StrCat({"*", ai_chat::kHumanPrompt, "*"})));
-  DCHECK(
-      base::MatchPattern(prompt, base::StrCat({"*", ai_chat::kAIPrompt, "*"})));
+  if (ai_chat::features::kAIModelName.Get() != ai_chat::kOpenLlamaModelName) {
+    // All queries must have the "Human" and "AI" prompt markers. We do not
+    // prepend / append them here since callers may want to put them in
+    // custom positions.
+    DCHECK(base::MatchPattern(prompt,
+                              base::StrCat({"*", ai_chat::kHumanPrompt, "*"})));
+    DCHECK(
+        base::MatchPattern(prompt, base::StrCat({"*", ai_chat::kAIPrompt, "*"})));
+  }
 
   const GURL api_base_url = GetEndpointBaseUrl();
 

--- a/components/ai_chat/browser/ai_chat_tab_helper.cc
+++ b/components/ai_chat/browser/ai_chat_tab_helper.cc
@@ -281,14 +281,14 @@ void AIChatTabHelper::GenerateQuestions() {
          "\n\n", l10n_util::GetStringUTF8(IDS_AI_CHAT_PROMPT_END)});
   } else {
     prompt = base::StrCat(
-      {GetHumanPromptSegment(),
-       base::ReplaceStringPlaceholders(
-           l10n_util::GetStringUTF8(is_video_
-                                        ? IDS_AI_CHAT_VIDEO_PROMPT_SEGMENT
-                                        : IDS_AI_CHAT_ARTICLE_PROMPT_SEGMENT),
-           {article_text_}, nullptr),
-       "\n\n", l10n_util::GetStringUTF8(IDS_AI_CHAT_QUESTION_PROMPT_SEGMENT),
-       GetAssistantPromptSegment(), " <response>"});
+        {GetHumanPromptSegment(),
+         base::ReplaceStringPlaceholders(
+             l10n_util::GetStringUTF8(is_video_
+                                          ? IDS_AI_CHAT_VIDEO_PROMPT_SEGMENT
+                                          : IDS_AI_CHAT_ARTICLE_PROMPT_SEGMENT),
+             {article_text_}, nullptr),
+         "\n\n", l10n_util::GetStringUTF8(IDS_AI_CHAT_QUESTION_PROMPT_SEGMENT),
+         GetAssistantPromptSegment(), " <response>"});
   }
   // Make API request for questions.
   // Do not call SetRequestInProgress, this progress

--- a/components/ai_chat/browser/ai_chat_tab_helper.cc
+++ b/components/ai_chat/browser/ai_chat_tab_helper.cc
@@ -350,8 +350,10 @@ std::string AIChatTabHelper::BuildClaudePrompt(
   // TODO(petemill): Tokenize the summary question so that we
   // don't have to do this weird substitution.
   if (turn.text == "Summarize this video") {
-    question_part =
-        l10n_util::GetStringUTF8(IDS_AI_CHAT_QUESTION_SUMMARIZE_VIDEO);
+    question_part = base::StrCat(
+        {l10n_util::GetStringUTF8(IDS_AI_CHAT_QUESTION_SUMMARIZE_VIDEO_BULLETS),
+         l10n_util::GetStringUTF8(
+             IDS_AI_CHAT_QUESTION_SUMMARIZE_VIDEO_TIMESTAMPS)});
   } else {
     question_part = turn.text;
   }
@@ -392,8 +394,9 @@ std::string AIChatTabHelper::BuildLlamaPrompt(
   // TODO(petemill): Tokenize the summary question so that we
   // don't have to do this weird substitution.
   if (turn.text == "Summarize this video") {
+    // Only ask llama to include bullet points in the summary, not timestamps.
     question_part =
-        l10n_util::GetStringUTF8(IDS_AI_CHAT_QUESTION_SUMMARIZE_VIDEO);
+        l10n_util::GetStringUTF8(IDS_AI_CHAT_QUESTION_SUMMARIZE_VIDEO_BULLETS);
   } else {
     question_part = turn.text;
   }

--- a/components/ai_chat/browser/ai_chat_tab_helper.cc
+++ b/components/ai_chat/browser/ai_chat_tab_helper.cc
@@ -17,6 +17,7 @@
 #include "base/strings/string_util.h"
 #include "brave/components/ai_chat/browser/constants.h"
 #include "brave/components/ai_chat/browser/page_content_fetcher.h"
+#include "brave/components/ai_chat/common/features.h"
 #include "brave/components/ai_chat/common/mojom/ai_chat.mojom-shared.h"
 #include "brave/components/ai_chat/common/pref_names.h"
 #include "components/favicon/content/content_favicon_driver.h"
@@ -86,10 +87,17 @@ void AIChatTabHelper::OnPermissionChangedAutoGenerateQuestions() {
 std::string AIChatTabHelper::GetConversationHistoryString() {
   std::vector<std::string> turn_strings;
   for (const ConversationTurn& turn : chat_history_) {
-    turn_strings.push_back((turn.character_type == CharacterType::HUMAN
-                                ? ai_chat::kHumanPromptPlaceholder
-                                : ai_chat::kAIPromptPlaceholder) +
-                           turn.text);
+    if (ai_chat::features::kAIModelName.Get() == kOpenLlamaModelName) {
+      turn_strings.push_back((turn.character_type == CharacterType::HUMAN
+                                  ? ai_chat::kHumanLabelLlama
+                                  : ai_chat::kAILabelLlama) +
+                             turn.text);
+    } else {
+      turn_strings.push_back((turn.character_type == CharacterType::HUMAN
+                                  ? ai_chat::kHumanPromptPlaceholder
+                                  : ai_chat::kAIPromptPlaceholder) +
+                             turn.text);
+    }
   }
 
   return base::JoinString(turn_strings, "");
@@ -258,7 +266,21 @@ void AIChatTabHelper::GenerateQuestions() {
   has_generated_questions_ = true;
   OnSuggestedQuestionsChanged();
 
-  std::string prompt = base::StrCat(
+  std::string prompt;
+  if (ai_chat::features::kAIModelName.Get() == kOpenLlamaModelName) {
+    if (is_video_) {
+      // Suggested questions on videos is not supported for llama right now.
+      return;
+    }
+    prompt = base::StrCat(
+        {l10n_util::GetStringUTF8(IDS_AI_CHAT_LLAMA_PROMPT_START), "\n",
+         base::ReplaceStringPlaceholders(
+             l10n_util::GetStringUTF8(
+                 IDS_AI_CHAT_ARTICLE_QUESTION_LLAMA_PROMPT_SEGMENT),
+             {article_text_}, nullptr),
+         "\n\n", l10n_util::GetStringUTF8(IDS_AI_CHAT_PROMPT_END)});
+  } else {
+    prompt = base::StrCat(
       {GetHumanPromptSegment(),
        base::ReplaceStringPlaceholders(
            l10n_util::GetStringUTF8(is_video_
@@ -267,6 +289,7 @@ void AIChatTabHelper::GenerateQuestions() {
            {article_text_}, nullptr),
        "\n\n", l10n_util::GetStringUTF8(IDS_AI_CHAT_QUESTION_PROMPT_SEGMENT),
        GetAssistantPromptSegment(), " <response>"});
+  }
   // Make API request for questions.
   // Do not call SetRequestInProgress, this progress
   // does not need to be shown to the UI.
@@ -320,26 +343,9 @@ void AIChatTabHelper::OnAPISuggestedQuestionsResponse(
   DVLOG(2) << "Got questions:" << base::JoinString(suggested_questions_, "\n");
 }
 
-void AIChatTabHelper::MakeAPIRequestWithConversationHistoryUpdate(
-    const ConversationTurn& turn) {
-  // This function should not be presented in the UI if the user has not
-  // opted-in yet.
-  DCHECK(HasUserOptedIn());
-  DCHECK(is_conversation_active_);
-
-  DCHECK(turn.character_type == CharacterType::HUMAN);
-
-  bool is_suggested_question = false;
-
-  // If it's a suggested question, remove it
-  auto found_question_iter =
-      base::ranges::find(suggested_questions_, turn.text);
-  if (found_question_iter != suggested_questions_.end()) {
-    is_suggested_question = true;
-    suggested_questions_.erase(found_question_iter);
-    OnSuggestedQuestionsChanged();
-  }
-
+std::string AIChatTabHelper::BuildClaudePrompt(
+    const mojom::ConversationTurn& turn,
+    bool is_suggested_question) {
   std::string question_part;
   // TODO(petemill): Tokenize the summary question so that we
   // don't have to do this weird substitution.
@@ -375,6 +381,65 @@ void AIChatTabHelper::MakeAPIRequestWithConversationHistoryUpdate(
            l10n_util::GetStringUTF8(IDS_AI_CHAT_ASSISTANT_PROMPT_SEGMENT),
            {prompt_segment_history, question_part}, nullptr),
        GetAssistantPromptSegment(), " <response>\n"});
+
+  return prompt;
+}
+
+std::string AIChatTabHelper::BuildLlamaPrompt(
+    const mojom::ConversationTurn& turn,
+    bool is_suggested_question) {
+  std::string question_part;
+  // TODO(petemill): Tokenize the summary question so that we
+  // don't have to do this weird substitution.
+  if (turn.text == "Summarize this video") {
+    question_part =
+        l10n_util::GetStringUTF8(IDS_AI_CHAT_QUESTION_SUMMARIZE_VIDEO);
+  } else {
+    question_part = turn.text;
+  }
+
+  std::string prompt = base::StrCat({
+      l10n_util::GetStringUTF8(IDS_AI_CHAT_LLAMA_PROMPT_START),
+      "\n",
+      base::ReplaceStringPlaceholders(
+          l10n_util::GetStringUTF8(
+              is_video_ ? IDS_AI_CHAT_VIDEO_LLAMA_PROMPT_SEGMENT
+                        : IDS_AI_CHAT_ARTICLE_LLAMA_PROMPT_SEGMENT),
+          {article_text_, GetConversationHistoryString(), question_part},
+          nullptr),
+      "\n\n",
+      l10n_util::GetStringUTF8(IDS_AI_CHAT_PROMPT_END),
+  });
+
+  return prompt;
+}
+
+void AIChatTabHelper::MakeAPIRequestWithConversationHistoryUpdate(
+    const ConversationTurn& turn) {
+  // This function should not be presented in the UI if the user has not
+  // opted-in yet.
+  DCHECK(HasUserOptedIn());
+  DCHECK(is_conversation_active_);
+
+  DCHECK(turn.character_type == CharacterType::HUMAN);
+
+  bool is_suggested_question = false;
+
+  // If it's a suggested question, remove it
+  auto found_question_iter =
+      base::ranges::find(suggested_questions_, turn.text);
+  if (found_question_iter != suggested_questions_.end()) {
+    is_suggested_question = true;
+    suggested_questions_.erase(found_question_iter);
+    OnSuggestedQuestionsChanged();
+  }
+
+  std::string prompt;
+  if (ai_chat::features::kAIModelName.Get() == kOpenLlamaModelName) {
+    prompt = BuildLlamaPrompt(turn, is_suggested_question);
+  } else {
+    prompt = BuildClaudePrompt(turn, is_suggested_question);
+  }
 
   if (turn.visibility != ConversationTurnVisibility::HIDDEN) {
     AddToConversationHistory(turn);

--- a/components/ai_chat/browser/ai_chat_tab_helper.cc
+++ b/components/ai_chat/browser/ai_chat_tab_helper.cc
@@ -401,14 +401,26 @@ std::string AIChatTabHelper::BuildLlamaPrompt(
     question_part = turn.text;
   }
 
+  auto prompt_segment_article =
+      article_text_.empty()
+          ? ""
+          : base::StrCat(
+                {base::ReplaceStringPlaceholders(
+                     l10n_util::GetStringUTF8(
+                         is_video_ ? IDS_AI_CHAT_VIDEO_PROMPT_SEGMENT
+                                   : IDS_AI_CHAT_ARTICLE_PROMPT_SEGMENT),
+                     {article_text_}, nullptr),
+                 "\n"});
+
   std::string prompt = base::StrCat({
       l10n_util::GetStringUTF8(IDS_AI_CHAT_LLAMA_PROMPT_START),
       "\n",
       base::ReplaceStringPlaceholders(
           l10n_util::GetStringUTF8(
               is_video_ ? IDS_AI_CHAT_VIDEO_LLAMA_PROMPT_SEGMENT
-                        : IDS_AI_CHAT_ARTICLE_LLAMA_PROMPT_SEGMENT),
-          {article_text_, GetConversationHistoryString(), question_part},
+                        : IDS_AI_CHAT_ASSISTANT_LLAMA_PROMPT_SEGMENT),
+          {prompt_segment_article, GetConversationHistoryString(),
+           question_part},
           nullptr),
       "\n\n",
       l10n_util::GetStringUTF8(IDS_AI_CHAT_PROMPT_END),

--- a/components/ai_chat/browser/ai_chat_tab_helper.h
+++ b/components/ai_chat/browser/ai_chat_tab_helper.h
@@ -115,6 +115,10 @@ class AIChatTabHelper : public content::WebContentsObserver,
                         const GURL& icon_url,
                         bool icon_url_changed,
                         const gfx::Image& image) override;
+  std::string BuildClaudePrompt(const mojom::ConversationTurn& turn,
+                                bool is_suggested_question);
+  std::string BuildLlamaPrompt(const mojom::ConversationTurn& turn,
+                               bool is_suggested_question);
 
   mojom::AutoGenerateQuestionsPref GetAutoGeneratePref();
 

--- a/components/ai_chat/browser/constants.cc
+++ b/components/ai_chat/browser/constants.cc
@@ -13,7 +13,10 @@ constexpr char kHumanPrompt[] = "Human:";
 constexpr char kHumanPromptPlaceholder[] = "\nH: ";
 constexpr char kAIPrompt[] = "Assistant:";
 constexpr char kAIPromptPlaceholder[] = "\n\nA: ";
+constexpr char kAILabelLlama[] = "\nLeo: ";
+constexpr char kHumanLabelLlama[] = "\nUser: ";
 constexpr char kAIChatCompletionPath[] = "v1/complete";
+constexpr char kOpenLlamaModelName[] = "open-llama-13b-open-instruct-8k";
 
 base::span<const webui::LocalizedString> GetLocalizedStrings() {
   constexpr webui::LocalizedString kLocalizedStrings[] = {

--- a/components/ai_chat/browser/constants.h
+++ b/components/ai_chat/browser/constants.h
@@ -16,12 +16,15 @@ namespace ai_chat {
 // prefix for for user input
 extern const char kHumanPrompt[];
 extern const char kHumanPromptPlaceholder[];
+extern const char kHumanLabelLlama[];
 
 // prefix for AI assistant output
 extern const char kAIPrompt[];
 extern const char kAIPromptPlaceholder[];
+extern const char kAILabelLlama[];
 
 extern const char kAIChatCompletionPath[];
+extern const char kOpenLlamaModelName[];
 
 base::span<const webui::LocalizedString> GetLocalizedStrings();
 

--- a/components/resources/ai_chat_prompts.grdp
+++ b/components/resources/ai_chat_prompts.grdp
@@ -39,7 +39,9 @@ Here is the conversational history (between the user and you) prior to the quest
 <message name="IDS_AI_CHAT_QUESTION_PROMPT_SEGMENT" translateable="false">
 Propose up to 3 very short questions that a reader may ask about the content. Consider intriguing or unusual elements of the content, or structurally important. Separate each suggested question with the character "|". End the question list with a &lt;/response&gt; tag.</message>
 
-<message name="IDS_AI_CHAT_QUESTION_SUMMARIZE_VIDEO" translateable="false">Provide a concise bullet list of the most important points of the video along with a short summary of each point. For each bullet point, prepend the time range when that point is discussed in seconds, e.g. [23s-68s].</message>
+<message name="IDS_AI_CHAT_QUESTION_SUMMARIZE_VIDEO_TIMESTAMPS" translateable="false"> For each bullet point, prepend the time range when that point is discussed in seconds, e.g. [23s-68s].</message>
+
+<message name="IDS_AI_CHAT_QUESTION_SUMMARIZE_VIDEO_BULLETS" translateable="false">Provide a concise bullet list of the most important points of the video along with a short summary of each point.</message>
 
 <message name="IDS_AI_CHAT_LLAMA_PROMPT_START" translateable="false">
 Below is an instruction that describes a task. Write a response that appropriately completes the request.

--- a/components/resources/ai_chat_prompts.grdp
+++ b/components/resources/ai_chat_prompts.grdp
@@ -41,4 +41,35 @@ Propose up to 3 very short questions that a reader may ask about the content. Co
 
 <message name="IDS_AI_CHAT_QUESTION_SUMMARIZE_VIDEO" translateable="false">Provide a concise bullet list of the most important points of the video along with a short summary of each point. For each bullet point, prepend the time range when that point is discussed in seconds, e.g. [23s-68s].</message>
 
+<message name="IDS_AI_CHAT_LLAMA_PROMPT_START" translateable="false">
+Below is an instruction that describes a task. Write a response that appropriately completes the request.
+
+### Instruction:</message>
+
+<message name="IDS_AI_CHAT_VIDEO_LLAMA_PROMPT_SEGMENT" translateable="false">
+The following is XML describing a video's transcript. The text elements are delimited within text tags with the following format &lt;text start="1.23" dur="1.23"&gt;&lt;/text&gt; where the "start" attribute indicates the start time in seconds of the contained line, and the "dur" attribute indicates its duration in seconds.
+&lt;transcript&gt;<ph name="TRANSCRIPT">$1</ph>&lt;/transcript&gt;
+
+Provide a concise bullet list of the most important points of the video along with a short summary of each point.
+</message>
+
+<message name="IDS_AI_CHAT_ARTICLE_QUESTION_LLAMA_PROMPT_SEGMENT" translateable="false">
+Propose a couple very short questions about this article that a reader may ask about the content. Consider intriguing or unusual elements of the content, or structurally important. Separate each question with the vertical bar character "|".
+&lt;article&gt;<ph name="ARTICLE">$1</ph>&lt;/article&gt;
+</message>
+
+<message name="IDS_AI_CHAT_ARTICLE_LLAMA_PROMPT_SEGMENT" translateable="false">
+You are Leo, an AI assistant created by the company Brave. You are having a dialogue with a user of the Brave browser who is asking questions about an article they are reading. Your goal is to answer questions in an easy to understand and concise manner. Here are some important rules for the interaction:
+- Conciseness is important. Your responses should not exceed 6 sentences.
+- Always respond in a neutral tone.
+- Always stay in character, as Leo, an AI from Brave.
+- If you are unsure how to respond, say "Sorry, I didn't understand that. Could you rephrase your question?"
+
+This is the article:
+&lt;article&gt;<ph name="ARTICLE">$1</ph>&lt;/article&gt;
+<ph name="HISTORY">$2</ph>
+User: <ph name="QUESTION">$3</ph>
+</message>
+
+<message name="IDS_AI_CHAT_PROMPT_END" translateable="false">### Response:</message>
 </grit-part>

--- a/components/resources/ai_chat_prompts.grdp
+++ b/components/resources/ai_chat_prompts.grdp
@@ -60,16 +60,13 @@ Propose a couple very short questions about this article that a reader may ask a
 &lt;article&gt;<ph name="ARTICLE">$1</ph>&lt;/article&gt;
 </message>
 
-<message name="IDS_AI_CHAT_ARTICLE_LLAMA_PROMPT_SEGMENT" translateable="false">
-You are Leo, an AI assistant created by the company Brave. You are having a dialogue with a user of the Brave browser who is asking questions about an article they are reading. Your goal is to answer questions in an easy to understand and concise manner. Here are some important rules for the interaction:
+<message name="IDS_AI_CHAT_ASSISTANT_LLAMA_PROMPT_SEGMENT" translateable="false">
+You are Leo, an AI assistant created by the company Brave. You are having a dialogue with a user of the Brave browser who is asking you questions. Your goal is to answer their questions in an easy to understand and concise manner. Here are some important rules for the interaction:
 - Conciseness is important. Your responses should not exceed 6 sentences.
 - Always respond in a neutral tone.
 - Always stay in character, as Leo, an AI from Brave.
 - If you are unsure how to respond, say "Sorry, I didn't understand that. Could you rephrase your question?"
-
-This is the article:
-&lt;article&gt;<ph name="ARTICLE">$1</ph>&lt;/article&gt;
-<ph name="HISTORY">$2</ph>
+<ph name="ARTICLE">$1</ph><ph name="HISTORY">$2</ph>
 User: <ph name="QUESTION">$3</ph>
 </message>
 


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/31548

Abstract the logic such that different prompt templates can be used based on the model used, and makes a first pass at the prompt templates for the open-llama-13b-open-instruct-8k model.

## How to run AI chat using Open Llama
1. Be connected to the VPN
2. Set `brave_ai_chat_endpoint=llm.bsg.brave.software` in your npmrc prior to build
3. Specify the open llama model at runtime `npm run start -- --enable-features=AIChat:ai_model_name\/open-llama-13b-open-instruct-8k`

## New prompt template and rationale
The [open-llama-13b-open-instruct](https://huggingface.co/VMware/open-llama-13b-open-instruct) model we're using was trained on this [dataset](https://huggingface.co/datasets/VMware/open-instruct-v1-oasst-dolly-hhrlhf) which uses the alpaca prompt template:
```
Below is an instruction that describes a task. Write a response that appropriately completes the request.

### Instruction:
<prompt>

### Response:
```
First I tried simply wrapping the existing Claude prompts in this template, however the results were not good. I made adjustments to the prompts to improve output, but tried to deviate as little as possible from the original prompts.  This is an example of a prompt sent to the open llama model after a few exchanges with Leo:
```
Below is an instruction that describes a task. Write a response that appropriately completes the request.

### Instruction:
You are Leo, an AI assistant created by the company Brave. You are having a dialogue with a user of the Brave browser who is asking you questions. Your goal is to answer their questions in an easy to understand and concise manner. Here are some important rules for the interaction:
- Conciseness is important. Your responses should not exceed 6 sentences.
- Always respond in a neutral tone.
- Always stay in character, as Leo, an AI from Brave.
- If you are unsure how to respond, say "Sorry, I didn't understand that. Could you rephrase your question?"
Here is an article in <article> tags:
<article>
A recent outbreak of wildfires in western Canada is again sending a plume of unhealthy smoke into the United States. Air quality alerts were in effect Saturday for at least eight states across the northern Plains and upper Midwest as smoke from the wildfires returns. Smoke will be heaviest across parts of Montana, the Dakotas, Minnesota and Iowa on Saturday before shifting southeastward later in the weekend. Minneapolis and Des Moines, Iowa, will see the worst of the smoke Saturday while cities such as Chicago, St. Louis, Detroit, and Cincinnati will begin to see the effects on Sunday. The Midwest will continue to see poor air quality and decreased visibility into early next week as the smoke lingers. Chicago   experienced some of the worst air quality in the world  amid heavy smoke in late-June. This time, the smoke plume is not coming from the Canadian province of Quebec. It is instead funneling across Canada from much further away in the West, so it shouldn’t reach the Northeast like it did in early June, when New York City’s skies  turned an apocalyptic shade of orange . On Friday, the encroaching smoke dropped air quality in parts of Montana and North Dakota to code red, or unhealthy levels on the Air Quality Index, and to code orange, or unhealthy for sensitive groups, in Minnesota, according to airnow.gov. Wildfire smoke contains tiny pollutants known as particle matter, or PM 2.5, that can get into the lungs and bloodstream once inhaled. These pollutants most commonly cause difficulty breathing and eye and throat irritation, but have also been linked to more serious long-term health issues like lung cancer, according to  the Centers for Disease Control and Prevention. The plume was birthed from nearly 400 fires sparked in Canada’s province of British Columbia in the past week, nearly half of which were started by 51,000 lightning strikes from thunderstorms,  the BC Wildfire Service said . Some of those thunderstorms were “dry” or produced inconsequential amounts of rain to help squelch any fires, a dangerous prospect in a province experiencing  the worst level of drought. Parts of the US will be at risk of smoke for the foreseeable future depending on weather patterns and fire flareups because Canada is experiencing  its worst fire season on record . More than 24 million acres have burned so far this year, an area roughly the size of Indiana. British Columbia has had more than 1,000 fires start since April. Those fires have already burned through nearly three times the amount of land compared to an average year in British Columbia over the last 10 years, the BC Wildfire Service said. One firefighter died Thursday responding to one of the blazes near Revelstoke, British Columbia,  a press release from the firefighter’s union  said. The BC Wildfire Service confirmed the death to CNN. The firefighter has not been identified. Prime Minister Justin Trudeau  eulogized the firefighter  on Twitter Friday. “The news from British Columbia – that one of the firefighters bravely battling wildfires has lost her life – is heartbreaking,” Trudeau said. “At this incredibly difficult time, I’m sending my deepest condolences to her family, her friends, and her fellow firefighters.”
</article>

A user is reading this article.

User: Is the recent wildfire outbreak in western Canada worse than usual?
Leo: Yes, the recent wildfire outbreak in western Canada is worse than usual. This year, more than 24 million acres of land have burned, which is three times the amount of land that has burned in an average year. There have also been almost 400 fires started this year, which is almost twice as much as the amount of fires that usually occur. The smoke from these fires is causing poor air quality and is being carried across the United States, affecting many states. The smoke is also causing health issues, such as difficulty breathing and eye and throat irritation. It is important to stay safe during these conditions and avoid unnecessary outdoor activity.
User: How did Trudeau react to the news of a firefighter's death?
Leo: Justin Trudeau, the Canadian prime minister, is mourning the loss of a firefighter who died battling wildfires near Revelstoke, British Columbia. In a tweet, he said: "The news from British Columbia - that one of the firefighters bravely battling wildfires has lost her life - is heartbreaking. At this incredibly difficult time, I'm sending my deepest condolences to her family, her friends, and her fellow firefighters."
User: How did the fires start?
Leo: The fires in Canada were started by 51,000 lightning strikes. The strikes were "dry", which means they did not produce much rain to help put the fires out. The area has also been experiencing a record-breaking drought.
User: Where will the smoke be heaviest?
Leo: The smoke will be heaviest across parts of Montana, the Dakotas, Minnesota and Iowa on Saturday, then shift southeastward later in the weekend. Chicago, St. Louis, Detroit, and Cincinnati will also see the effects of the smoke next week. It is important to stay safe and avoid unnecessary outdoor activity during this time.
User: Will the smoke reach the Northeast?

### Response:
```
With these changes I was able to get better results, however the model still struggles, especially with videos.  In particular question generation for videos performs poorly enough that I disabled it for llama in the PR.

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-arm64, CI/skip-linux-x64, CI/skip-android, CI/skip-macos, CI/skip-ios, CI/skip-windows-arm64, CI/skip-windows-x64, CI/skip-windows-x86 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [ ] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

