### PR TITLE
Update adblock-rust to v0.7.15

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -39,7 +39,7 @@ deps = {
   "third_party/rust/challenge_bypass_ristretto/v1/crate": "https://github.com/brave-intl/challenge-bypass-ristretto.git@a1da4641734adc8312215b38a8221962d2c8e045",
   "third_party/rust/futures_retry/v0_5/crate": "https://github.com/brave-intl/futures-retry.git@2aaaafbc3d394661534d4dbd14159d164243c20e",
   "third_party/rust/kuchiki/v0_8/crate": "https://github.com/brave/kuchiki.git@589eadca2c1d06ddda2919354590bfe1ace88a43",
-  "third_party/rust/adblock/v0_7/crate": "https://github.com/brave/adblock-rust.git@ed216e5302bce5baf9731d1efc919408f614499a",
+  "third_party/rust/adblock/v0_7/crate": "https://github.com/brave/adblock-rust.git@0730a439122677ef9900156e08fa577f09396100",
 
 }
 

--- a/components/adblock_rust_ffi/Cargo.toml
+++ b/components/adblock_rust_ffi/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Brian R. Bondy <netzen@gmail.com>"]
 edition = "2018"
 
 [dependencies]
-adblock = { version = "0.7.9", default-features = false, features = ["full-regex-handling", "debug-info", "css-validation"] }
+adblock = { version = "0.7.15", default-features = false, features = ["full-regex-handling", "debug-info", "css-validation"] }
 serde_json = "1.0"
 libc = "0.2"
 

--- a/third_party/rust/Cargo.lock
+++ b/third_party/rust/Cargo.lock
@@ -4,7 +4,7 @@ version = 3
 
 [[package]]
 name = "adblock"
-version = "0.7.9"
+version = "0.7.15"
 dependencies = [
  "base64",
  "bitflags",

--- a/third_party/rust/adblock/v0_7/BUILD.gn
+++ b/third_party/rust/adblock/v0_7/BUILD.gn
@@ -14,7 +14,7 @@ cargo_crate("lib") {
   build_native_rust_unit_tests = false
   sources = [ "crate/src/lib.rs" ]
   edition = "2018"
-  cargo_pkg_version = "0.7.9"
+  cargo_pkg_version = "0.7.15"
   cargo_pkg_authors =
       "Andrius Aucinas <aaucinas@brave.com>, Anton Lazarev <alazarev@brave.com>"
   cargo_pkg_name = "adblock"

--- a/third_party/rust/adblock/v0_7/README.chromium
+++ b/third_party/rust/adblock/v0_7/README.chromium
@@ -1,7 +1,7 @@
 Name: adblock
 URL: https://crates.io/crates/adblock
 Description: Native Rust module for Adblock Plus syntax (e.g. EasyList, EasyPrivacy) filter parsing and matching.
-Version: 0.7.9
+Version: 0.7.15
 Security Critical: yes
 License: MPL 2.0
 Revision: 8c1145002777adf00b04f1021153f8e098103341


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/31238

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-arm64, CI/skip-linux-x64, CI/skip-android, CI/skip-macos, CI/skip-ios, CI/skip-windows-arm64, CI/skip-windows-x64, CI/skip-windows-x86 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

### More permissive `Expires` parsing

See https://github.com/brave/brave-browser/issues/31238. When adding `https://malware-filter.gitlab.io/malware-filter/urlhaus-filter-agh-online.txt
` as a custom subscription list in `brave://settings/shields/filters`, the `Local State` file in the profile directory should include `"expires": 24` rather than `"expires": 168` as shown in the attached screenshot.

### Scriptlet argument `$` parsing

_Adapted from the `How to reproduce it` section of https://github.com/brave/adblock-rust/issues/299:_

> 1. Visit `https://brave.com` and enter `localStorage.setItem("Test", "0");` in the devtools console
> 2. Open Devtools's `Application -> Local Storage` panel and confirm that the storage entry `Test` exists and has the value `0`
> 3. Visit `brave://settings/shields/filters`, add `brave.com##+js(set-local-storage-item, Test, $remove$)` to the custom filters section, and save changes
> 4. Refresh `https://brave.com`
> 5. Reopen Devtools' `Application -> Local Storage` panel and confirm that the `Test` storage entry no longer exists.