### PR TITLE
Fixed StatusTrayRunnerTest unit test failure

### DIFF
--- a/browser/brave_vpn/win/brave_vpn_wireguard_service/status_tray/BUILD.gn
+++ b/browser/brave_vpn/win/brave_vpn_wireguard_service/status_tray/BUILD.gn
@@ -6,6 +6,7 @@
 source_set("status_tray") {
   sources = [
     "brave_vpn_tray_command_ids.h",
+    "brave_vpn_tray_strings_en.h",
     "status_tray_runner.cc",
     "status_tray_runner.h",
   ]

--- a/browser/brave_vpn/win/brave_vpn_wireguard_service/status_tray/brave_vpn_tray_strings_en.h
+++ b/browser/brave_vpn/win/brave_vpn_wireguard_service/status_tray/brave_vpn_tray_strings_en.h
@@ -1,0 +1,25 @@
+/* Copyright (c) 2023 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_BROWSER_BRAVE_VPN_WIN_BRAVE_VPN_WIREGUARD_SERVICE_STATUS_TRAY_BRAVE_VPN_TRAY_STRINGS_EN_H_
+#define BRAVE_BROWSER_BRAVE_VPN_WIN_BRAVE_VPN_WIREGUARD_SERVICE_STATUS_TRAY_BRAVE_VPN_TRAY_STRINGS_EN_H_
+
+namespace brave {
+// TODO(spylogsster): Replace by localized solution
+// https://github.com/brave/brave-browser/issues/30959
+constexpr char16_t kBraveVpnIconTooltip[] = u"Brave VPN: Disconnected";
+constexpr char16_t kBraveVpnIconTooltipConnected[] = u"Brave VPN: Connected";
+constexpr char16_t kBraveVpnIconTooltipError[] = u"Brave VPN: Error";
+constexpr char16_t kBraveVpnStatusItemName[] = u"Status: ";
+constexpr char16_t kBraveVpnConnectItemName[] = u"Connect";
+constexpr char16_t kBraveVpnDisconnectItemName[] = u"Disconnect";
+constexpr char16_t kBraveVpnManageAccountItemName[] = u"Manage Account";
+constexpr char16_t kBraveVpnAboutItemName[] = u"About Brave VPN";
+constexpr char16_t kBraveVpnRemoveItemName[] = u"Remove icon";
+constexpr char16_t kBraveVpnActiveText[] = u"Active";
+constexpr char16_t kBraveVpnInactiveText[] = u"Inactive";
+}  // namespace brave
+
+#endif  // BRAVE_BROWSER_BRAVE_VPN_WIN_BRAVE_VPN_WIREGUARD_SERVICE_STATUS_TRAY_BRAVE_VPN_TRAY_STRINGS_EN_H_

--- a/browser/brave_vpn/win/brave_vpn_wireguard_service/status_tray/status_tray_runner.cc
+++ b/browser/brave_vpn/win/brave_vpn_wireguard_service/status_tray/status_tray_runner.cc
@@ -22,6 +22,7 @@
 #include "base/task/single_thread_task_executor.h"
 #include "base/task/thread_pool/thread_pool_instance.h"
 #include "brave/browser/brave_vpn/win/brave_vpn_wireguard_service/status_tray/brave_vpn_tray_command_ids.h"
+#include "brave/browser/brave_vpn/win/brave_vpn_wireguard_service/status_tray/brave_vpn_tray_strings_en.h"
 #include "brave/browser/brave_vpn/win/brave_vpn_wireguard_service/status_tray/resources/resource.h"
 #include "brave/browser/brave_vpn/win/brave_vpn_wireguard_service/status_tray/status_icon/icon_utils.h"
 #include "brave/browser/brave_vpn/win/brave_vpn_wireguard_service/status_tray/status_icon/status_icon.h"
@@ -58,19 +59,17 @@ void OpenURLInBrowser(const char* url) {
 }
 
 std::u16string GetVpnStatusLabel(bool active) {
-  return l10n_util::GetStringUTF16(
-      active ? IDS_BRAVE_VPN_WIREGUARD_TRAY_STATUS_ITEM_ACTIVE
-             : IDS_BRAVE_VPN_WIREGUARD_TRAY_STATUS_ITEM_INACTIVE);
+  std::u16string label = brave::kBraveVpnStatusItemName;
+  label += (active ? brave::kBraveVpnActiveText : brave::kBraveVpnInactiveText);
+  return label;
 }
 
 std::u16string GetStatusIconTooltip(bool connected, bool error) {
   if (error) {
-    return l10n_util::GetStringUTF16(
-        IDS_BRAVE_VPN_WIREGUARD_TRAY_ICON_TOOLTIP_ERROR);
+    return brave::kBraveVpnIconTooltipError;
   }
-  return l10n_util::GetStringUTF16(
-      connected ? IDS_BRAVE_VPN_WIREGUARD_TRAY_ICON_TOOLTIP_CONNECTED
-                : IDS_BRAVE_VPN_WIREGUARD_TRAY_ICON_TOOLTIP_DISCONNECTED);
+  return connected ? brave::kBraveVpnIconTooltipConnected
+                   : brave::kBraveVpnIconTooltip;
 }
 
 gfx::ImageSkia GetStatusTrayIcon(bool connected, bool error) {
@@ -152,24 +151,17 @@ void StatusTrayRunner::OnMenuWillShow(ui::SimpleMenuModel* source) {
   source->SetEnabledAt(0, false);
   if (connected) {
     source->AddItem(IDC_BRAVE_VPN_TRAY_DISCONNECT_VPN_ITEM,
-                    l10n_util::GetStringUTF16(
-                        IDS_BRAVE_VPN_WIREGUARD_TRAY_DISCONNECT_ITEM));
+                    brave::kBraveVpnDisconnectItemName);
   } else {
-    source->AddItem(
-        IDC_BRAVE_VPN_TRAY_CONNECT_VPN_ITEM,
-        l10n_util::GetStringUTF16(IDS_BRAVE_VPN_WIREGUARD_TRAY_CONNECT_ITEM));
+    source->AddItem(IDC_BRAVE_VPN_TRAY_CONNECT_VPN_ITEM,
+                    brave::kBraveVpnConnectItemName);
   }
   source->AddSeparator(ui::NORMAL_SEPARATOR);
   source->AddItem(IDC_BRAVE_VPN_TRAY_MANAGE_ACCOUNT_ITEM,
-                  l10n_util::GetStringUTF16(
-                      IDS_BRAVE_VPN_WIREGUARD_TRAY_MANAGE_ACCOUNT_ITEM));
-  source->AddItem(
-      IDC_BRAVE_VPN_TRAY_ABOUT_ITEM,
-      l10n_util::GetStringUTF16(IDS_BRAVE_VPN_WIREGUARD_TRAY_ABOUT_ITEM));
+                  brave::kBraveVpnManageAccountItemName);
+  source->AddItem(IDC_BRAVE_VPN_TRAY_ABOUT_ITEM, brave::kBraveVpnAboutItemName);
   source->AddSeparator(ui::NORMAL_SEPARATOR);
-  source->AddItem(
-      IDC_BRAVE_VPN_TRAY_EXIT_ICON,
-      l10n_util::GetStringUTF16(IDS_BRAVE_VPN_WIREGUARD_TRAY_REMOVE_ICON_ITEM));
+  source->AddItem(IDC_BRAVE_VPN_TRAY_EXIT_ICON, brave::kBraveVpnRemoveItemName);
 }
 
 void StatusTrayRunner::OnConnected(bool success) {


### PR DESCRIPTION
issue - https://github.com/brave/brave-browser/issues/31597

Reverted part of https://github.com/brave/brave-core/pull/19204 that caused test crash.
Crash happens when accesing string resources in release build.

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves 

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-arm64, CI/skip-linux-x64, CI/skip-android, CI/skip-macos, CI/skip-ios, CI/skip-windows-arm64, CI/skip-windows-x64, CI/skip-windows-x86 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [ ] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

`StatusTrayRunner.*`