### PR TITLE
Fix the regression of search conversion promotion in omnibox

### DIFF
--- a/browser/ui/views/omnibox/brave_search_conversion_promotion_view.cc
+++ b/browser/ui/views/omnibox/brave_search_conversion_promotion_view.cc
@@ -149,11 +149,11 @@ class ButtonTypeDismissButton : public views::ImageButton {
   ButtonTypeDismissButton& operator=(const ButtonTypeDismissButton&) = delete;
 
   void GetAccessibleNodeData(ui::AXNodeData* node_data) override {
-    node_data->SetName(brave_l10n::GetLocalizedResourceUTF16String(
-        IDS_ACC_BRAVE_SEARCH_CONVERSION_DISMISS_BUTTON));
     // Although this appears visually as a button, expose as a list box option
     // so that it matches the other options within its list box container.
     node_data->role = ax::mojom::Role::kListBoxOption;
+    node_data->SetName(brave_l10n::GetLocalizedResourceUTF16String(
+        IDS_ACC_BRAVE_SEARCH_CONVERSION_DISMISS_BUTTON));
   }
 };
 

--- a/browser/ui/views/omnibox/brave_search_conversion_promotion_view.cc
+++ b/browser/ui/views/omnibox/brave_search_conversion_promotion_view.cc
@@ -597,10 +597,15 @@ gfx::Size BraveSearchConversionPromotionView::CalculatePreferredSize() const {
   views::View* active_child = (type_ == ConversionType::kButton)
                                   ? button_type_container_
                                   : banner_type_container_;
-  auto size = active_child->GetPreferredSize();
-  if (type_ == ConversionType::kBanner) {
-    size.Enlarge(0, kBannerTypeMargin + kBannerTypeMarginBottom);
+  DCHECK(active_child);
+  if (type_ == ConversionType::kButton) {
+    return active_child->GetPreferredSize();
   }
+
+  // Ask preferred size + margin for banner.
+  auto size = active_child->GetPreferredSize();
+  auto* margin = active_child->GetProperty(views::kMarginsKey);
+  size.Enlarge(0, margin->height());
   return size;
 }
 

--- a/browser/ui/views/omnibox/brave_search_conversion_promotion_view.cc
+++ b/browser/ui/views/omnibox/brave_search_conversion_promotion_view.cc
@@ -271,6 +271,15 @@ void BraveSearchConversionPromotionView::ResetChildrenVisibility() {
 void BraveSearchConversionPromotionView::SetTypeAndInput(
     brave_search_conversion::ConversionType type,
     const std::u16string& input) {
+  // Don't need to update promotion ui if input is same.
+  // Not sure why but upstream calls OmniboxResultView::SetMatch() multiple
+  // times for same match. As this called again after selected,
+  // |selected_| state is cleared if not early returned for same input
+  // condition.
+  if (input_ == input) {
+    return;
+  }
+
   DCHECK_NE(ConversionType::kNone, type);
 
   type_ = type;

--- a/browser/ui/views/omnibox/brave_search_conversion_promotion_view.cc
+++ b/browser/ui/views/omnibox/brave_search_conversion_promotion_view.cc
@@ -103,8 +103,14 @@ class HorizontalGradientBackground : public views::Background {
         ui::NativeTheme::GetInstanceForNativeUi()->ShouldUseDarkColors()
             ? IDR_BRAVE_SEARCH_CONVERSION_BANNER_GRAPHIC_DARK
             : IDR_BRAVE_SEARCH_CONVERSION_BANNER_GRAPHIC);
-    canvas->DrawImageInt(*graphic, bounds.right() - graphic->width(),
-                         bounds.y());
+
+    // Scale image to fit with host view's height.
+    const float image_scale = bounds.height() / graphic->height();
+    const int target_graphic_width = graphic->width() * image_scale;
+    const int target_graphic_height = graphic->height() * image_scale;
+    canvas->DrawImageInt(*graphic, 0, 0, graphic->width(), graphic->height(),
+                         bounds.right() - target_graphic_width, bounds.y(),
+                         target_graphic_width, target_graphic_height, true);
   }
 };
 

--- a/chromium_src/components/omnibox/browser/autocomplete_controller.cc
+++ b/chromium_src/components/omnibox/browser/autocomplete_controller.cc
@@ -89,9 +89,9 @@ void MaybeAddCommanderProvider(AutocompleteController::Providers& providers,
       !provider_client_->IsOffTheRecord())                            \
     providers_.push_back(new PromotionProvider(provider_client_.get()));
 
-// This sort should be done in the middle of
-// AutocompleteController::UpdateResult() because result should be updated
-// before notifying at the last of UpdateResult().
+// This sort should be done right after AutocompleteResult::SortAndCull() in
+// the AutocompleteController::SortCullAndAnnotateResult() to make our sorting
+// run last but before notifying.
 #define BRAVE_AUTOCOMPLETE_CONTROLLER_UPDATE_RESULT \
   SortBraveSearchPromotionMatch(&result_);          \
   MaybeShowCommands(&result_, input_);

--- a/chromium_src/components/omnibox/browser/autocomplete_controller.h
+++ b/chromium_src/components/omnibox/browser/autocomplete_controller.h
@@ -1,0 +1,17 @@
+/* Copyright (c) 2023 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_CHROMIUM_SRC_COMPONENTS_OMNIBOX_BROWSER_AUTOCOMPLETE_CONTROLLER_H_
+#define BRAVE_CHROMIUM_SRC_COMPONENTS_OMNIBOX_BROWSER_AUTOCOMPLETE_CONTROLLER_H_
+
+#define AutocompleteProviderTest \
+  OmniboxPromotionTest;          \
+  friend class AutocompleteProviderTest
+
+#include "src/components/omnibox/browser/autocomplete_controller.h"  // IWYU pragma: export
+
+#undef AutocompleteProviderTest
+
+#endif  // BRAVE_CHROMIUM_SRC_COMPONENTS_OMNIBOX_BROWSER_AUTOCOMPLETE_CONTROLLER_H_

--- a/components/omnibox/browser/promotion_unittest.cc
+++ b/components/omnibox/browser/promotion_unittest.cc
@@ -3,9 +3,11 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+#include <iterator>
 #include <memory>
 
 #include "base/memory/scoped_refptr.h"
+#include "base/ranges/algorithm.h"
 #include "base/test/scoped_feature_list.h"
 #include "brave/components/brave_search_conversion/features.h"
 #include "brave/components/brave_search_conversion/types.h"
@@ -18,6 +20,7 @@
 #include "brave/components/search_engines/brave_prepopulated_engines.h"
 #include "components/omnibox/browser/autocomplete_controller.h"
 #include "components/omnibox/browser/autocomplete_input.h"
+#include "components/omnibox/browser/autocomplete_match.h"
 #include "components/omnibox/browser/autocomplete_result.h"
 #include "components/omnibox/browser/mock_autocomplete_provider_client.h"
 #include "components/omnibox/browser/test_scheme_classifier.h"
@@ -32,8 +35,44 @@
 using brave_search_conversion::ConversionType;
 using brave_search_conversion::GetPromoURL;
 using brave_search_conversion::RegisterPrefs;
+using ::testing::Eq;
 using ::testing::NiceMock;
 using ::testing::Return;
+
+namespace {
+
+// Provides 2 dummy matches to make multiple matches for testing promotion
+// entry position sorting.
+class DummyProvider : public AutocompleteProvider {
+ public:
+  explicit DummyProvider(AutocompleteProvider::Type type)
+      : AutocompleteProvider(type) {}
+  DummyProvider(const DummyProvider&) = delete;
+  DummyProvider& operator=(const DummyProvider&) = delete;
+
+  // AutocompleteProvider overrides:
+  void Start(const AutocompleteInput& input, bool minimal_changes) override {
+    if (type_ == AutocompleteProvider::TYPE_SEARCH) {
+      AutocompleteMatch match(nullptr, 800, true,
+                              AutocompleteMatchType::SEARCH_WHAT_YOU_TYPED);
+      match.keyword = u"brave";
+      matches_.push_back(match);
+
+      match.keyword = u"browser";
+      matches_.push_back(match);
+    } else {
+      AutocompleteMatch match(nullptr, 600, true,
+                              AutocompleteMatchType::BOOKMARK_TITLE);
+      matches_.push_back(match);
+      matches_.push_back(match);
+    }
+  }
+
+ private:
+  ~DummyProvider() override = default;
+};
+
+}  // namespace
 
 class OmniboxPromotionTest : public testing::Test {
  public:
@@ -66,9 +105,12 @@ class OmniboxPromotionTest : public testing::Test {
     ON_CALL(*client_mock, IsOffTheRecord()).WillByDefault(Return(incognito));
     controller_ = std::make_unique<AutocompleteController>(
         std::move(client_mock), AutocompleteProvider::TYPE_SEARCH);
+    controller_->providers_.push_back(
+        new DummyProvider(AutocompleteProvider::TYPE_SEARCH));
+    controller_->providers_.push_back(
+        new DummyProvider(AutocompleteProvider::TYPE_BOOKMARK));
   }
 
-  // Give 4 matches.
   ACMatches CreateTestMatches() {
     ACMatches matches;
     // Make first item is search query with default provider.
@@ -114,9 +156,12 @@ TEST_F(OmniboxPromotionTest, ProfileTest) {
   EXPECT_FALSE(HasPromotionMatch());
 }
 
-TEST_F(OmniboxPromotionTest, PromotionProviderTest) {
-  base::test::ScopedFeatureList feature_list;
-  feature_list.InitAndEnableFeature(
+TEST_F(OmniboxPromotionTest, PromotionEntrySortTest) {
+  constexpr int kTotalMatchCount = 6;
+  base::test::ScopedFeatureList feature_list_button;
+
+  // Test button type search conversion.
+  feature_list_button.InitAndEnableFeature(
       brave_search_conversion::features::kOmniboxButton);
 
   CreateController(false);
@@ -124,16 +169,56 @@ TEST_F(OmniboxPromotionTest, PromotionProviderTest) {
   AutocompleteInput input(u"brave", metrics::OmniboxEventProto::OTHER,
                           classifier_);
   controller_->Start(input);
+  EXPECT_EQ(static_cast<size_t>(kTotalMatchCount),
+            controller_->result().size());
   int promotion_match_count = 0;
   for (const auto& match : controller_->result()) {
     if (IsBraveSearchPromotionMatch(match)) {
       promotion_match_count++;
     }
   }
+
+  // There is one button promotion entry.
   EXPECT_EQ(1, promotion_match_count);
 
-  // Check promotion match is not added.
-  feature_list.Reset();
+  auto brave_search_conversion_match =
+      base::ranges::find_if(controller_->result(), IsBraveSearchPromotionMatch);
+  EXPECT_NE(brave_search_conversion_match, controller_->result().end());
+
+  // Located as second entry for button type.
+  EXPECT_EQ(1, std::distance(controller_->result().begin(),
+                             brave_search_conversion_match));
+
+  // Turn off button type and on banner type search conversion.
+  feature_list_button.Reset();
+  base::test::ScopedFeatureList feature_list_banner;
+  feature_list_banner.InitAndEnableFeature(
+      brave_search_conversion::features::kOmniboxBanner);
+
+  CreateController(false);
+  EXPECT_TRUE(controller_->result().empty());
+  controller_->Start(input);
+  promotion_match_count = 0;
+  for (const auto& match : controller_->result()) {
+    if (IsBraveSearchPromotionMatch(match)) {
+      promotion_match_count++;
+    }
+  }
+
+  // There is one banner promotion entry.
+  EXPECT_EQ(1, promotion_match_count);
+
+  brave_search_conversion_match =
+      base::ranges::find_if(controller_->result(), IsBraveSearchPromotionMatch);
+  EXPECT_NE(brave_search_conversion_match, controller_->result().end());
+
+  // Located as last entry for banner type.
+  EXPECT_EQ(kTotalMatchCount - 1, std::distance(controller_->result().begin(),
+                                                brave_search_conversion_match));
+
+  feature_list_banner.Reset();
+
+  // Check promotion match is not added when feature is off.
   controller_->Start(input);
   EXPECT_FALSE(HasPromotionMatch());
 }

--- a/patches/components-omnibox-browser-autocomplete_controller.cc.patch
+++ b/patches/components-omnibox-browser-autocomplete_controller.cc.patch
@@ -1,5 +1,5 @@
 diff --git a/components/omnibox/browser/autocomplete_controller.cc b/components/omnibox/browser/autocomplete_controller.cc
-index 9b0e176e76377591440323c478d194ab281b6af6..7e2b1e3819840c3eac1bf252e1de25bfa1de29c3 100644
+index 9b0e176e76377591440323c478d194ab281b6af6..b20fb1dada1033baa8cd0fa4cf456b81c1474e33 100644
 --- a/components/omnibox/browser/autocomplete_controller.cc
 +++ b/components/omnibox/browser/autocomplete_controller.cc
 @@ -846,6 +846,7 @@ void AutocompleteController::InitializeAsyncProviders(int provider_types) {
@@ -10,11 +10,11 @@ index 9b0e176e76377591440323c478d194ab281b6af6..7e2b1e3819840c3eac1bf252e1de25bf
    }
    // Providers run in the order they're added.  Add `HistoryURLProvider` after
    // `SearchProvider` because:
-@@ -1124,6 +1125,7 @@ void AutocompleteController::UpdateResult(
-   // `SortCullAndAnnotateResult()`. Here, the result is sorted, trimmed to a
-   // small number of "best" matches, and annotated with relevant information
-   // before notifying listeners that the result is ready.
+@@ -1136,6 +1137,7 @@ void AutocompleteController::SortCullAndAnnotateResult(
+     absl::optional<AutocompleteMatch> default_match_to_preserve) {
+   result_.SortAndCull(input_, template_url_service_, triggered_feature_service_,
+                       default_match_to_preserve);
 +  BRAVE_AUTOCOMPLETE_CONTROLLER_UPDATE_RESULT
-   SortCullAndAnnotateResult(last_default_match, last_default_associated_keyword,
-                             force_notify_default_match_changed,
-                             default_match_to_preserve);
+ 
+ #if DCHECK_IS_ON()
+   result_.Validate();


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/31735

This PR fixes current search conversion UI regressions.
And we'll apply new promotion desigin as a next issue.

W/o this PR, graphic is not fit with it's host.
![스크린샷 2023-07-20 131343](https://github.com/brave/brave-core/assets/6786187/1e2af3e9-a09d-4d8c-9123-62e8d1c56fc5)


After:
![스크린샷 2023-07-20 131047](https://github.com/brave/brave-core/assets/6786187/68703cf1-74a6-4f78-b0e7-98690204a6fd)


<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-arm64, CI/skip-linux-x64, CI/skip-android, CI/skip-macos, CI/skip-ios, CI/skip-windows-arm64, CI/skip-windows-x64, CI/skip-windows-x86 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

1. Launch with `--enable-features=BraveSearchOmniboxBanner`
2. Set non brave search as default search engine
3. Type anything in omnibox and check banner type promotion is shown at last
4. When selected or hovered, UI should be changed
5. Launch with `--enable-features=BraveSearchOmniboxButton`
6. Type anything in omnibox and check button type promotion is shown at second
7. When selected, it should have indicator on left
8. Check banner graphic is fit to banner's height

`OmniboxPromotionTest.*`

~~NOTE: This PR doesn't fix the third item(UI regression) in the issue as we have another UI for search promotion.
Layout regression will be handled together when applying new design.~~ => _**Fixed**_