### PR TITLE
Fix custom notification ad default positioning.

### DIFF
--- a/browser/ui/views/brave_ads/bounds_util.cc
+++ b/browser/ui/views/brave_ads/bounds_util.cc
@@ -53,6 +53,12 @@ void AdjustBoundsToFitWorkArea(const gfx::Rect& work_area, gfx::Rect* bounds) {
 
 }  // namespace
 
+gfx::Rect GetDefaultDisplayScreenWorkArea(gfx::NativeView browser_native_view) {
+  return kUseSameZOrderAsBrowserWindow.Get()
+             ? GetNearestDisplayScreenWorkArea(browser_native_view)
+             : GetPrimaryDisplayScreenWorkArea();
+}
+
 void AdjustBoundsAndSnapToFitWorkAreaForNativeView(views::Widget* widget,
                                                    gfx::Rect* bounds) {
   CHECK(widget);

--- a/browser/ui/views/brave_ads/bounds_util.h
+++ b/browser/ui/views/brave_ads/bounds_util.h
@@ -6,6 +6,8 @@
 #ifndef BRAVE_BROWSER_UI_VIEWS_BRAVE_ADS_BOUNDS_UTIL_H_
 #define BRAVE_BROWSER_UI_VIEWS_BRAVE_ADS_BOUNDS_UTIL_H_
 
+#include "ui/gfx/native_widget_types.h"
+
 namespace gfx {
 class Rect;
 }  // namespace gfx
@@ -19,6 +21,8 @@ class Widget;
 }  // namespace views
 
 namespace brave_ads {
+
+gfx::Rect GetDefaultDisplayScreenWorkArea(gfx::NativeView browser_native_view);
 
 void AdjustBoundsAndSnapToFitWorkAreaForNativeView(views::Widget* widget,
                                                    gfx::Rect* bounds);

--- a/browser/ui/views/brave_ads/notification_ad_popup.cc
+++ b/browser/ui/views/brave_ads/notification_ad_popup.cc
@@ -36,6 +36,7 @@
 #include "ui/gfx/geometry/rect.h"
 #include "ui/gfx/geometry/size.h"
 #include "ui/gfx/geometry/vector2d.h"
+#include "ui/gfx/native_widget_types.h"
 #include "ui/gfx/shadow_util.h"
 #include "ui/gfx/shadow_value.h"
 #include "ui/gfx/skia_paint_util.h"
@@ -257,8 +258,8 @@ void NotificationAdPopup::OnWidgetBoundsChanged(views::Widget* widget,
     return AdjustBoundsAndSnapToFitWorkAreaForWidget(widget, CalculateBounds());
   }
 
-  const gfx::Point origin = new_bounds.origin();
-  SaveOrigin(origin);
+  widget_origin_ = new_bounds.origin();
+  SaveWidgetOrigin(widget_origin_, widget->GetNativeView());
 }
 
 void NotificationAdPopup::AnimationEnded(const gfx::Animation* animation) {
@@ -326,63 +327,88 @@ void NotificationAdPopup::CreatePopup(gfx::NativeWindow browser_native_window,
   CreateWidgetView(browser_native_window, browser_native_view);
 }
 
-gfx::Point NotificationAdPopup::GetDefaultOriginForSize(const gfx::Size& size) {
-  const gfx::Rect display_bounds =
-      display::Screen::GetScreen()->GetPrimaryDisplay().bounds();
+bool NotificationAdPopup::WasNotificationAdPopupShownBefore() const {
+  return profile_->GetPrefs()->HasPrefPath(
+             prefs::kNotificationAdLastNormalizedDisplayCoordinateX) &&
+         profile_->GetPrefs()->HasPrefPath(
+             prefs::kNotificationAdLastNormalizedDisplayCoordinateY);
+}
 
+void NotificationAdPopup::SetInitialWidgetOrigin(
+    gfx::NativeView browser_native_view) {
+  const gfx::Size size = CalculateViewSize();
+  widget_origin_ = GetWidgetOriginForSize(size, browser_native_view);
+}
+
+gfx::Point NotificationAdPopup::GetWidgetOriginForSize(
+    const gfx::Size& size,
+    gfx::NativeView browser_native_view) {
   const gfx::Rect display_work_area =
-      display::Screen::GetScreen()->GetPrimaryDisplay().work_area();
+      GetDefaultDisplayScreenWorkArea(browser_native_view);
+
+  double normalized_display_coordinate_x =
+      kCustomNotificationAdNormalizedDisplayCoordinateX.Get();
+  double normalized_display_coordinate_y =
+      kCustomNotificationAdNormalizedDisplayCoordinateY.Get();
+
+  if (WasNotificationAdPopupShownBefore()) {
+    normalized_display_coordinate_x = profile_->GetPrefs()->GetDouble(
+        prefs::kNotificationAdLastNormalizedDisplayCoordinateX);
+    normalized_display_coordinate_y = profile_->GetPrefs()->GetDouble(
+        prefs::kNotificationAdLastNormalizedDisplayCoordinateY);
+  }
 
   // Calculate position
-  const double width = static_cast<double>(display_bounds.width());
-  const double normalized_display_coordinate_x =
-      kCustomNotificationAdNormalizedDisplayCoordinateX.Get();
-  int x = static_cast<int>(width * normalized_display_coordinate_x);
-  x -= size.width() / 2.0;
+  const double width =
+      static_cast<double>(display_work_area.width() - size.width());
+  const int x = static_cast<int>(width * normalized_display_coordinate_x);
 
-  const double height = static_cast<double>(display_bounds.height());
-  const double normalized_display_coordinate_y =
-      kCustomNotificationAdNormalizedDisplayCoordinateY.Get();
-  int y = static_cast<int>(height * normalized_display_coordinate_y);
-  y -= size.height() / 2.0;
+  const double height =
+      static_cast<double>(display_work_area.height() - size.height());
+  const int y = static_cast<int>(height * normalized_display_coordinate_y);
 
-  const gfx::Point origin(x, y);
+  gfx::Point origin = display_work_area.origin();
+  origin.Offset(x, y);
 
   // Adjust to fit display work area
   gfx::Rect bounds(origin, size);
   bounds.AdjustToFit(display_work_area);
 
-  // Apply insets
-  const gfx::Vector2d insets(kCustomNotificationAdInsetX.Get(),
-                             kCustomNotificationAdInsetY.Get());
-  bounds += insets;
+  if (!WasNotificationAdPopupShownBefore()) {
+    // Apply default insets
+    const gfx::Vector2d insets(kCustomNotificationAdInsetX.Get(),
+                               kCustomNotificationAdInsetY.Get());
+    bounds += insets;
 
-  // Adjust to fit display work area
-  bounds.AdjustToFit(display_work_area);
+    // Adjust to fit display work area
+    bounds.AdjustToFit(display_work_area);
+  }
 
   return bounds.origin();
 }
 
-gfx::Point NotificationAdPopup::GetOriginForSize(const gfx::Size& size) {
-  if (!profile_->GetPrefs()->HasPrefPath(
-          prefs::kNotificationAdLastScreenPositionX) ||
-      !profile_->GetPrefs()->HasPrefPath(
-          prefs::kNotificationAdLastScreenPositionY)) {
-    return GetDefaultOriginForSize(size);
-  }
+void NotificationAdPopup::SaveWidgetOrigin(const gfx::Point& origin,
+                                           gfx::NativeView native_view) const {
+  const gfx::Rect display_work_area =
+      GetDefaultDisplayScreenWorkArea(native_view);
 
-  const int x = profile_->GetPrefs()->GetInteger(
-      prefs::kNotificationAdLastScreenPositionX);
-  const int y = profile_->GetPrefs()->GetInteger(
-      prefs::kNotificationAdLastScreenPositionY);
-  return gfx::Point(x, y);
-}
+  gfx::Vector2d offset = origin - display_work_area.origin();
 
-void NotificationAdPopup::SaveOrigin(const gfx::Point& origin) const {
-  profile_->GetPrefs()->SetInteger(prefs::kNotificationAdLastScreenPositionX,
-                                   origin.x());
-  profile_->GetPrefs()->SetInteger(prefs::kNotificationAdLastScreenPositionY,
-                                   origin.y());
+  const gfx::Size size = CalculateViewSize();
+  const double width =
+      static_cast<double>(display_work_area.width() - size.width());
+  const double normalized_display_coordinate_x = offset.x() / width;
+
+  const double height =
+      static_cast<double>(display_work_area.height() - size.height());
+  const double normalized_display_coordinate_y = offset.y() / height;
+
+  profile_->GetPrefs()->SetDouble(
+      prefs::kNotificationAdLastNormalizedDisplayCoordinateX,
+      normalized_display_coordinate_x);
+  profile_->GetPrefs()->SetDouble(
+      prefs::kNotificationAdLastNormalizedDisplayCoordinateY,
+      normalized_display_coordinate_y);
 }
 
 gfx::Size NotificationAdPopup::CalculateViewSize() const {
@@ -396,8 +422,7 @@ gfx::Size NotificationAdPopup::CalculateViewSize() const {
 
 gfx::Rect NotificationAdPopup::CalculateBounds() {
   const gfx::Size size = CalculateViewSize();
-  const gfx::Point origin = GetOriginForSize(size);
-  return gfx::Rect(origin, size);
+  return gfx::Rect(widget_origin_, size);
 }
 
 void NotificationAdPopup::RecomputeAlignment() {
@@ -430,6 +455,7 @@ void NotificationAdPopup::CreateWidgetView(
   widget->set_focus_on_creation(false);
   widget_observation_.Observe(widget);
 
+  SetInitialWidgetOrigin(browser_native_view);
   widget->InitWidget(this, CalculateBounds(), browser_native_window,
                      browser_native_view);
 

--- a/browser/ui/views/brave_ads/notification_ad_popup.h
+++ b/browser/ui/views/brave_ads/notification_ad_popup.h
@@ -109,16 +109,15 @@ class NotificationAdPopup : public views::WidgetDelegateView,
     kFadeOut
   };
 
-  raw_ptr<Profile> profile_ = nullptr;  // NOT OWNED
-
   void CreatePopup(gfx::NativeWindow browser_native_window,
                    gfx::NativeView browser_native_view);
 
-  NotificationAd notification_ad_;
-
-  gfx::Point GetDefaultOriginForSize(const gfx::Size& size);
-  gfx::Point GetOriginForSize(const gfx::Size& size);
-  void SaveOrigin(const gfx::Point& origin) const;
+  bool WasNotificationAdPopupShownBefore() const;
+  void SetInitialWidgetOrigin(gfx::NativeView browser_native_view);
+  gfx::Point GetWidgetOriginForSize(const gfx::Size& size,
+                                    gfx::NativeView browser_native_view);
+  void SaveWidgetOrigin(const gfx::Point& origin,
+                        gfx::NativeView native_view) const;
 
   gfx::Size CalculateViewSize() const;
   gfx::Rect CalculateBounds();
@@ -132,22 +131,29 @@ class NotificationAdPopup : public views::WidgetDelegateView,
                         gfx::NativeView browser_native_view);
   void CloseWidgetView();
 
-  raw_ptr<NotificationAdView> notification_ad_view_ = nullptr;
-
   void FadeIn();
   void FadeOut();
 
-  const std::unique_ptr<gfx::LinearAnimation> animation_;
-  AnimationState animation_state_ = AnimationState::kIdle;
   void StartAnimation();
   void UpdateAnimation();
 
   bool IsWidgetValid() const;
 
+  raw_ptr<Profile> profile_ = nullptr;  // NOT OWNED
+
+  NotificationAd notification_ad_;
+
+  raw_ptr<NotificationAdView> notification_ad_view_ = nullptr;
+
+  const std::unique_ptr<gfx::LinearAnimation> animation_;
+  AnimationState animation_state_ = AnimationState::kIdle;
+
   gfx::Point initial_mouse_pressed_location_;
   bool is_dragging_ = false;
 
   bool inside_adjust_bounds_ = false;
+
+  gfx::Point widget_origin_;
 
   base::ScopedObservation<views::Widget, views::WidgetObserver>
       widget_observation_{this};

--- a/components/brave_ads/browser/ads_service.cc
+++ b/components/brave_ads/browser/ads_service.cc
@@ -34,8 +34,10 @@ void AdsService::RegisterProfilePrefs(
 
   registry->RegisterBooleanPref(prefs::kEnabled, false);
 
-  registry->RegisterIntegerPref(prefs::kNotificationAdLastScreenPositionX, 0);
-  registry->RegisterIntegerPref(prefs::kNotificationAdLastScreenPositionY, 0);
+  registry->RegisterDoublePref(
+      prefs::kNotificationAdLastNormalizedDisplayCoordinateX, 0.0);
+  registry->RegisterDoublePref(
+      prefs::kNotificationAdLastNormalizedDisplayCoordinateY, 0.0);
   registry->RegisterBooleanPref(prefs::kNotificationAdDidFallbackToCustom,
                                 false);
 

--- a/components/brave_ads/common/pref_names.cc
+++ b/components/brave_ads/common/pref_names.cc
@@ -17,13 +17,13 @@ const char kP2AStoragePrefNamePrefix[] = "brave.weekly_storage.";
 const char kShouldShowOnboardingNotification[] =
     "brave.brave_ads.should_show_my_first_ad_notification";
 
-// Stores the last screen position of custom notification ads and whether to
-// fallback from native to custom notification ads if native notifications are
-// disabled
-const char kNotificationAdLastScreenPositionX[] =
-    "brave.brave_ads.ad_notification.last_screen_position_x";
-const char kNotificationAdLastScreenPositionY[] =
-    "brave.brave_ads.ad_notification.last_screen_position_y";
+// Stores the last normalized screen position of custom notification ads and
+// whether to fallback from native to custom notification ads if native
+// notifications are disabled
+const char kNotificationAdLastNormalizedDisplayCoordinateX[] =
+    "brave.brave_ads.ad_notification.last_normalized_display_coordinate_x";
+const char kNotificationAdLastNormalizedDisplayCoordinateY[] =
+    "brave.brave_ads.ad_notification.last_normalized_display_coordinate_y";
 const char kNotificationAdDidFallbackToCustom[] =
     "brave.brave_ads.ad_notification.did_fallback_to_custom";
 

--- a/components/brave_ads/common/pref_names.h
+++ b/components/brave_ads/common/pref_names.h
@@ -16,8 +16,8 @@ extern const char kP2AStoragePrefNamePrefix[];
 
 // Notification prefs
 extern const char kShouldShowOnboardingNotification[];
-extern const char kNotificationAdLastScreenPositionX[];
-extern const char kNotificationAdLastScreenPositionY[];
+extern const char kNotificationAdLastNormalizedDisplayCoordinateX[];
+extern const char kNotificationAdLastNormalizedDisplayCoordinateY[];
 extern const char kNotificationAdDidFallbackToCustom[];
 
 // Migration prefs


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/31649

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-arm64, CI/skip-linux-x64, CI/skip-android, CI/skip-macos, CI/skip-ios, CI/skip-windows-arm64, CI/skip-windows-x64, CI/skip-windows-x86 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

- Start with a fresh profile, with the initial position and inset defined. Command line for the top left position with zero insets:
  `--enable-features=CustomNotificationAds:normalized_display_coordinate_x/0.0/normalized_display_coordinate_y/0.0/inset_x/0/inset_y/0`
- Enable custom ad notifications
- Join Brave Rewards
- Make sure that a custom notification ad is shown in the right position
- Drug the custom notification ad to a new position, click the ad
- Make sure that the next custom notification ad is shown at the new position
- 