### PR TITLE
Add feature flag to enable P3A Constellation enclave attestation, which is disabled by default (uplift to 1.57.x)

### DIFF
--- a/components/p3a/features.cc
+++ b/components/p3a/features.cc
@@ -11,9 +11,17 @@ namespace features {
 BASE_FEATURE(kConstellation,
              "BraveP3AConstellation",
              base::FEATURE_DISABLED_BY_DEFAULT);
+BASE_FEATURE(kConstellationEnclaveAttestation,
+             "BraveP3AConstellationEnclaveAttestation",
+             base::FEATURE_DISABLED_BY_DEFAULT);
 
 bool IsConstellationEnabled() {
   return base::FeatureList::IsEnabled(features::kConstellation);
+}
+
+bool IsConstellationEnclaveAttestationEnabled() {
+  return base::FeatureList::IsEnabled(
+      features::kConstellationEnclaveAttestation);
 }
 
 }  // namespace features

--- a/components/p3a/features.h
+++ b/components/p3a/features.h
@@ -13,8 +13,11 @@ namespace features {
 
 // See https://github.com/brave/brave-browser/issues/24338 for more info.
 BASE_DECLARE_FEATURE(kConstellation);
+// See https://github.com/brave/brave-browser/issues/31718 for more info.
+BASE_DECLARE_FEATURE(kConstellationEnclaveAttestation);
 
 bool IsConstellationEnabled();
+bool IsConstellationEnclaveAttestationEnabled();
 
 }  // namespace features
 }  // namespace p3a

--- a/components/p3a/message_manager_unittest.cc
+++ b/components/p3a/message_manager_unittest.cc
@@ -63,7 +63,10 @@ class P3AMessageManagerTest : public testing::Test,
  protected:
   void SetUpManager(bool is_constellation_enabled) {
     if (is_constellation_enabled) {
-      scoped_feature_list_.InitWithFeatures({features::kConstellation}, {});
+      scoped_feature_list_.InitWithFeatures(
+          {features::kConstellation,
+           features::kConstellationEnclaveAttestation},
+          {});
     }
 
     base::Time future_mock_time;

--- a/components/p3a/star_randomness_meta.h
+++ b/components/p3a/star_randomness_meta.h
@@ -75,6 +75,8 @@ class StarRandomnessMeta {
   RandomnessServerInfo* GetCachedRandomnessServerInfo();
 
  private:
+  bool ShouldAttestEnclave();
+
   void AttestServer(bool make_info_request_after);
 
   void HandleServerInfoResponse(std::unique_ptr<std::string> response_body);


### PR DESCRIPTION
Uplift of #19345
Resolves https://github.com/brave/brave-browser/issues/31718

Pre-approval checklist: 
- [ ] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.