### PR TITLE
Fix perf mac x64 url, adjust perf configurations

### DIFF
--- a/tools/perf/components/browser_type.py
+++ b/tools/perf/components/browser_type.py
@@ -206,7 +206,8 @@ class BraveBrowserTypeImpl(BrowserType):
 
   def _DownloadDmgAndExtract(self, tag: BraveVersion, out_dir: str) -> str:
     assert sys.platform == 'darwin'
-    dmg_name = f'Brave-Browser-{self._channel}-{platform.machine()}.dmg'
+    mac_platform = 'arm64' if platform.processor() == 'arm' else 'x64'
+    dmg_name = f'Brave-Browser-{self._channel}-{mac_platform}.dmg'
     url = _GetBraveDownloadUrl(tag, dmg_name)
     logging.info('Downloading %s', url)
     f = urlopen(url)

--- a/tools/perf/configs/dashboard/brave-pixel4.json
+++ b/tools/perf/configs/dashboard/brave-pixel4.json
@@ -1,0 +1,16 @@
+{
+  "configurations": [{
+    "dashboard-bot-name": "pixel4",
+    "browser-type": "brave",
+    "profile": "clean",
+    "extra-browser-args": [],
+    "extra-benchmark-args": [],
+    "save-artifacts": true,
+  }],
+  "benchmarks": [
+    {
+      "name": "speedometer2",
+      "pageset-repeat": 5
+    }
+  ]
+}

--- a/tools/perf/configs/dashboard/brave-win11-hp-laptop.json5
+++ b/tools/perf/configs/dashboard/brave-win11-hp-laptop.json5
@@ -5,7 +5,7 @@
     "profile": "brave-typical-win-v1.55.98",
     "extra-browser-args": [],
     "extra-benchmark-args": [],
-    "save-artifacts": false,
+    "save-artifacts": true,
   }],
   "benchmarks": [
     {
@@ -23,14 +23,6 @@
       "stories": [
         "load:chrome:blank",
         "load:media:youtube:2018",
-      ]
-    },
-    {
-      "name": "system_health.common_desktop",
-      "pageset-repeat": 10,
-      "stories": [
-        "load:chrome:blank",
-        "browse:news:hackernews:2020",
       ]
     },
     {


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/31751

The PR:
1. switches to the build-in mechanism to browser install (to support Chrome & compare builds);
2. adds pixel4 perf configuration;
3. disables `system_health.common_desktop` for Win CI. It has unclear failures, that blocks enabling the CI now.

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-arm64, CI/skip-linux-x64, CI/skip-android, CI/skip-macos, CI/skip-ios, CI/skip-windows-arm64, CI/skip-windows-x64, CI/skip-windows-x86 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

