### PR TITLE
Fixes Brave Ads crashes if a user enables ShouldAlwaysTriggerBraveNewTabPageAdEvents feature and views a new tab page ad

### DIFF
--- a/components/brave_ads/core/internal/ads/inline_content_ad_handler.cc
+++ b/components/brave_ads/core/internal/ads/inline_content_ad_handler.cc
@@ -64,7 +64,7 @@ void InlineContentAdHandler::MaybeServe(
     const std::string& dimensions,
     MaybeServeInlineContentAdCallback callback) {
   CHECK(UserHasOptedInToBraveNewsAds())
-      << " should only be called if the user has opted-in to Brave News Ads";
+      << "Should only be called if the user has opted-in to Brave News Ads";
 
   serving_.MaybeServeAd(
       dimensions,
@@ -79,10 +79,10 @@ void InlineContentAdHandler::TriggerEvent(
     TriggerAdEventCallback callback) {
   CHECK(mojom::IsKnownEnumValue(event_type));
   CHECK_NE(mojom::InlineContentAdEventType::kServed, event_type)
-      << " should not be called with kServed as this event is handled when "
+      << "Should not be called with kServed as this event is handled when "
          "calling MaybeServe";
   CHECK(UserHasOptedInToBraveNewsAds())
-      << " should only be called if the user has opted-in to Brave News Ads";
+      << "Should only be called if the user has opted-in to Brave News Ads";
 
   event_handler_.FireEvent(
       placement_id, creative_instance_id, event_type,

--- a/components/brave_ads/core/internal/ads/new_tab_page_ad_handler.cc
+++ b/components/brave_ads/core/internal/ads/new_tab_page_ad_handler.cc
@@ -64,8 +64,9 @@ NewTabPageAdHandler::NewTabPageAdHandler(
 NewTabPageAdHandler::~NewTabPageAdHandler() = default;
 
 void NewTabPageAdHandler::MaybeServe(MaybeServeNewTabPageAdCallback callback) {
-  CHECK(UserHasJoinedBraveRewards())
-      << " should only be called if the user has joined Brave Rewards";
+  CHECK(ShouldAlwaysTriggerNewTabPageAdEvents() || UserHasJoinedBraveRewards())
+      << "Should only be called if the user has joined Brave Rewards or if "
+         "should always trigger new tab page ad events";
 
   serving_.MaybeServeAd(base::BindOnce(&NewTabPageAdHandler::MaybeServeCallback,
                                        weak_factory_.GetWeakPtr(),

--- a/components/brave_ads/core/internal/ads/notification_ad_handler.cc
+++ b/components/brave_ads/core/internal/ads/notification_ad_handler.cc
@@ -91,10 +91,10 @@ void NotificationAdHandler::TriggerEvent(
     TriggerAdEventCallback callback) {
   CHECK(mojom::IsKnownEnumValue(event_type));
   CHECK_NE(mojom::NotificationAdEventType::kServed, event_type)
-      << " should not be called with kServed as this event is handled when "
+      << "Should not be called with kServed as this event is handled when "
          "calling TriggerEvent with kViewed";
   CHECK(UserHasJoinedBraveRewards())
-      << " should only be called if user has joined Brave Rewards";
+      << "Should only be called if user has joined Brave Rewards";
 
   if (event_type == mojom::NotificationAdEventType::kViewed) {
     return event_handler_.FireEvent(

--- a/components/brave_ads/core/internal/ads/promoted_content_ad_handler.cc
+++ b/components/brave_ads/core/internal/ads/promoted_content_ad_handler.cc
@@ -43,7 +43,7 @@ void PromotedContentAdHandler::TriggerEvent(
     TriggerAdEventCallback callback) {
   CHECK(mojom::IsKnownEnumValue(event_type));
   CHECK_NE(mojom::PromotedContentAdEventType::kServed, event_type)
-      << " should not be called with kServed as this event is handled when "
+      << "Should not be called with kServed as this event is handled when "
          "calling TriggerEvent with kViewed";
 
   if (event_type == mojom::PromotedContentAdEventType::kViewed) {

--- a/components/brave_ads/core/internal/ads/search_result_ad_handler.cc
+++ b/components/brave_ads/core/internal/ads/search_result_ad_handler.cc
@@ -52,7 +52,7 @@ void SearchResultAd::TriggerEvent(
     TriggerAdEventCallback callback) {
   CHECK(mojom::IsKnownEnumValue(event_type));
   CHECK_NE(mojom::SearchResultAdEventType::kServed, event_type)
-      << " should not be called with kServed as this event is handled when "
+      << "Should not be called with kServed as this event is handled when "
          "calling TriggerEvent with kViewed";
 
   if (!UserHasJoinedBraveRewards() &&


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/31780

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-arm64, CI/skip-linux-x64, CI/skip-android, CI/skip-macos, CI/skip-ios, CI/skip-windows-arm64, CI/skip-windows-x64, CI/skip-windows-x86 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

