### PR TITLE
Add Llama 2 prompt templates

### DIFF
--- a/components/ai_chat/browser/ai_chat_api.cc
+++ b/components/ai_chat/browser/ai_chat_api.cc
@@ -124,13 +124,16 @@ void AIChatAPI::QueryPrompt(
         data_completed_callback,
     api_request_helper::APIRequestHelper::DataReceivedCallback
         data_received_callback) {
-  // All queries must have the "Human" and "AI" prompt markers. We do not
-  // prepend / append them here since callers may want to put them in
-  // custom positions.
-  DCHECK(base::MatchPattern(prompt,
-                            base::StrCat({"*", ai_chat::kHumanPrompt, "*"})));
-  DCHECK(
-      base::MatchPattern(prompt, base::StrCat({"*", ai_chat::kAIPrompt, "*"})));
+  if (!ai_chat::UsesLlama2PromptTemplate(
+          ai_chat::features::kAIModelName.Get())) {
+    // All queries must have the "Human" and "AI" prompt markers. We do not
+    // prepend / append them here since callers may want to put them in
+    // custom positions.
+    DCHECK(base::MatchPattern(prompt,
+                              base::StrCat({"*", ai_chat::kHumanPrompt, "*"})));
+    DCHECK(base::MatchPattern(prompt,
+                              base::StrCat({"*", ai_chat::kAIPrompt, "*"})));
+  }
 
   const GURL api_base_url = GetEndpointBaseUrl();
 

--- a/components/ai_chat/browser/ai_chat_tab_helper.cc
+++ b/components/ai_chat/browser/ai_chat_tab_helper.cc
@@ -17,6 +17,7 @@
 #include "base/strings/string_util.h"
 #include "brave/components/ai_chat/browser/constants.h"
 #include "brave/components/ai_chat/browser/page_content_fetcher.h"
+#include "brave/components/ai_chat/common/features.h"
 #include "brave/components/ai_chat/common/mojom/ai_chat.mojom-shared.h"
 #include "brave/components/ai_chat/common/pref_names.h"
 #include "components/favicon/content/content_favicon_driver.h"
@@ -104,9 +105,10 @@ void AIChatTabHelper::AddToConversationHistory(const ConversationTurn& turn) {
 }
 
 void AIChatTabHelper::UpdateOrCreateLastAssistantEntry(
-    const std::string& updated_text) {
+    std::string updated_text) {
   if (chat_history_.empty() ||
       chat_history_.back().character_type != CharacterType::ASSISTANT) {
+    updated_text = base::TrimWhitespaceASCII(updated_text, base::TRIM_LEADING);
     AddToConversationHistory({CharacterType::ASSISTANT,
                               ConversationTurnVisibility::VISIBLE,
                               updated_text});
@@ -258,21 +260,29 @@ void AIChatTabHelper::GenerateQuestions() {
   has_generated_questions_ = true;
   OnSuggestedQuestionsChanged();
 
-  std::string prompt = base::StrCat(
-      {GetHumanPromptSegment(),
-       base::ReplaceStringPlaceholders(
-           l10n_util::GetStringUTF8(is_video_
-                                        ? IDS_AI_CHAT_VIDEO_PROMPT_SEGMENT
-                                        : IDS_AI_CHAT_ARTICLE_PROMPT_SEGMENT),
-           {article_text_}, nullptr),
-       "\n\n", l10n_util::GetStringUTF8(IDS_AI_CHAT_QUESTION_PROMPT_SEGMENT),
-       GetAssistantPromptSegment(), " <response>"});
+  std::string prompt;
+  std::vector<std::string> stop_sequences;
+  if (UsesLlama2PromptTemplate(ai_chat::features::kAIModelName.Get())) {
+    prompt = BuildLlama2GenerateQuestionsPrompt(is_video_, article_text_);
+    stop_sequences.push_back(ai_chat::kLlama2Eos);
+  } else {
+    prompt = base::StrCat(
+        {GetHumanPromptSegment(),
+         base::ReplaceStringPlaceholders(
+             l10n_util::GetStringUTF8(is_video_
+                                          ? IDS_AI_CHAT_VIDEO_PROMPT_SEGMENT
+                                          : IDS_AI_CHAT_ARTICLE_PROMPT_SEGMENT),
+             {article_text_}, nullptr),
+         "\n\n", l10n_util::GetStringUTF8(IDS_AI_CHAT_QUESTION_PROMPT_SEGMENT),
+         GetAssistantPromptSegment(), " <response>"});
+    stop_sequences.push_back("</response>");
+  }
   // Make API request for questions.
   // Do not call SetRequestInProgress, this progress
   // does not need to be shown to the UI.
   auto navigation_id_for_query = current_navigation_id_;
   ai_chat_api_->QueryPrompt(
-      prompt, {"</response>"},
+      prompt, stop_sequences,
       base::BindOnce(&AIChatTabHelper::OnAPISuggestedQuestionsResponse,
                      weak_ptr_factory_.GetWeakPtr(),
                      std::move(navigation_id_for_query)));
@@ -320,36 +330,8 @@ void AIChatTabHelper::OnAPISuggestedQuestionsResponse(
   DVLOG(2) << "Got questions:" << base::JoinString(suggested_questions_, "\n");
 }
 
-void AIChatTabHelper::MakeAPIRequestWithConversationHistoryUpdate(
-    const ConversationTurn& turn) {
-  // This function should not be presented in the UI if the user has not
-  // opted-in yet.
-  DCHECK(HasUserOptedIn());
-  DCHECK(is_conversation_active_);
-
-  DCHECK(turn.character_type == CharacterType::HUMAN);
-
-  bool is_suggested_question = false;
-
-  // If it's a suggested question, remove it
-  auto found_question_iter =
-      base::ranges::find(suggested_questions_, turn.text);
-  if (found_question_iter != suggested_questions_.end()) {
-    is_suggested_question = true;
-    suggested_questions_.erase(found_question_iter);
-    OnSuggestedQuestionsChanged();
-  }
-
-  std::string question_part;
-  // TODO(petemill): Tokenize the summary question so that we
-  // don't have to do this weird substitution.
-  if (turn.text == "Summarize this video") {
-    question_part =
-        l10n_util::GetStringUTF8(IDS_AI_CHAT_QUESTION_SUMMARIZE_VIDEO);
-  } else {
-    question_part = turn.text;
-  }
-
+std::string AIChatTabHelper::BuildClaudePrompt(const std::string& question_part,
+                                               bool is_suggested_question) {
   auto prompt_segment_article =
       article_text_.empty()
           ? ""
@@ -375,6 +357,198 @@ void AIChatTabHelper::MakeAPIRequestWithConversationHistoryUpdate(
            l10n_util::GetStringUTF8(IDS_AI_CHAT_ASSISTANT_PROMPT_SEGMENT),
            {prompt_segment_history, question_part}, nullptr),
        GetAssistantPromptSegment(), " <response>\n"});
+
+  return prompt;
+}
+
+std::string AIChatTabHelper::BuildLlama2Prompt(
+    const std::string& user_message) {
+  std::string system_message;
+  if (article_text_.empty()) {
+    system_message =
+        l10n_util::GetStringUTF8(IDS_AI_CHAT_LLAMA2_SYSTEM_MESSAGE_GENERIC);
+  } else if (is_video_) {
+    system_message = base::ReplaceStringPlaceholders(
+        l10n_util::GetStringUTF8(IDS_AI_CHAT_LLAMA2_SYSTEM_MESSAGE_VIDEO),
+        {article_text_}, nullptr);
+  } else {
+    system_message = base::ReplaceStringPlaceholders(
+        l10n_util::GetStringUTF8(IDS_AI_CHAT_LLAMA2_SYSTEM_MESSAGE_ARTICLE),
+        {article_text_}, nullptr);
+  }
+
+  auto conversation_history = GetConversationHistory();
+  // If there's no conversation history, then we just send a (partial)
+  // first sequence.
+  if (conversation_history.size() == 0) {
+    return BuildLlama2FirstSequence(system_message, user_message,
+                                    absl::nullopt);
+  }
+
+  // Use the first two messages to build the first sequence,
+  // which includes the system prompt.
+  std::string prompt =
+      BuildLlama2FirstSequence(system_message, conversation_history[0].text,
+                               conversation_history[1].text);
+
+  // Loop through the rest of the history two at a time building subsequent
+  // sequences.
+  for (size_t i = 2; i + 1 < conversation_history.size(); i += 2) {
+    const std::string& prev_user_message = conversation_history[i].text;
+    const std::string& assistant_message = conversation_history[i + 1].text;
+    prompt +=
+        BuildLlama2SubsequentSequence(prev_user_message, assistant_message);
+  }
+
+  // Build the final subsequent exchange using the current turn.
+  prompt += BuildLlama2SubsequentSequence(user_message, absl::nullopt);
+
+  // Trimming recommended by Meta
+  // https://huggingface.co/meta-llama/Llama-2-13b-chat#intended-use
+  prompt = base::TrimWhitespaceASCII(prompt, base::TRIM_ALL);
+  return prompt;
+}
+
+std::string AIChatTabHelper::BuildLlama2InstructionPrompt(
+    const std::string& instruction) {
+  return base::ReplaceStringPlaceholders(
+      R"( $1 $2 $3 )",
+      {ai_chat::kLlama2BIns, instruction, ai_chat::kLlama2EIns}, nullptr);
+}
+
+std::string AIChatTabHelper::BuildLlama2GenerateQuestionsPrompt(
+    bool is_video,
+    const std::string content) {
+  std::string content_template;
+  if (is_video) {
+    content_template =
+        l10n_util::GetStringUTF8(IDS_AI_CHAT_LLAMA2_GENERATE_QUESTIONS_VIDEO);
+  } else {
+    content_template =
+        l10n_util::GetStringUTF8(IDS_AI_CHAT_LLAMA2_GENERATE_QUESTIONS_ARTICLE);
+  }
+
+  const std::string& user_message =
+      base::ReplaceStringPlaceholders(content_template, {content}, nullptr);
+
+  return BuildLlama2FirstSequence(
+      l10n_util::GetStringUTF8(
+          IDS_AI_CHAT_LLAMA2_SYSTEM_MESSAGE_GENERATE_QUESTIONS),
+      user_message, absl::nullopt);
+}
+
+std::string AIChatTabHelper::BuildLlama2FirstSequence(
+    const std::string& system_message,
+    const std::string& user_message,
+    absl::optional<std::string> assistant_response) {
+  // Generates a partial sequence if there is no assistant_response:
+
+  // <s> [INST] <<SYS>>
+  // You will be acting as an assistant named Leo created by the company Brave.
+  // Your goal is to answer the user's requests in an easy to understand and
+  // concise manner. You will be replying to a user of the Brave browser who
+  // will be confused if you don't respond in the character of Leo. Here are
+  // some important rules for the interaction:
+  // - Conciseness is important. Your responses should not exceed 6 sentences.
+  // - Always respond in a neutral tone.
+  // - Always stay in character, as Leo, an AI from Brave.
+  // <</SYS>>
+  //
+  // How's it going? [/INST]
+
+  // Or, if there is an assistant_response:
+
+  // <s> [INST] <<SYS>>
+  // You will be acting as an assistant named Leo created by the company Brave.
+  // Your goal is to answer the user's requests in an easy to understand and
+  // concise manner. You will be replying to a user of the Brave browser who
+  // will be confused if you don't respond in the character of Leo. Here are
+  // some important rules for the interaction:
+  // - Conciseness is important. Your responses should not exceed 6 sentences.
+  // - Always respond in a neutral tone.
+  // - Always stay in character, as Leo, an AI from Brave.
+  // <</SYS>>
+  //
+  // How's it going? [/INST] Hey there! I'm Leo, your AI assistant here to help
+  // you out. I'm here to answer any questions you have, so feel free to ask me
+  // anything! What's up?</s>
+
+  // Create the system prompt through the first user message.
+  std::string system_prompt =
+      base::StrCat({ai_chat::kLlama2BSys, system_message, ai_chat::kLlama2ESys,
+                    user_message});
+
+  // Wrap in [INST] [/INST] tags.
+  std::string instruction_prompt = BuildLlama2InstructionPrompt(system_prompt);
+
+  if (!assistant_response) {
+    // Prepend just <s> if there's no assistant_response ( it will be completed
+    // by the model).
+    return base::StrCat({ai_chat::kLlama2Bos, instruction_prompt});
+  }
+
+  // Add assistant response and wrap in <s> </s> tags.
+  return base::StrCat({ai_chat::kLlama2Bos, instruction_prompt,
+                       *assistant_response, ai_chat::kLlama2Eos});
+}
+
+std::string AIChatTabHelper::BuildLlama2SubsequentSequence(
+    std::string user_message,
+    absl::optional<std::string> assistant_response) {
+  // Builds a prompt segment that looks like this:
+  // <s> [INST] Give me the first few numbers in the fibonacci sequence [/INST]
+
+  // or, if there's an assistant_response:
+
+  // <s> [INST] Give me the first few numbers in the fibonacci sequence [/INST]
+  // Hey there! Sure thing! The first few numbers in the Fibonacci sequence are:
+  // 1, 1, 2, 3, 5, 8, 13, and so on. </s>
+
+  user_message = BuildLlama2InstructionPrompt(user_message);
+  if (!assistant_response) {
+    return base::StrCat({ai_chat::kLlama2Bos, user_message});
+  }
+
+  return base::StrCat({ai_chat::kLlama2Bos, user_message, *assistant_response,
+                       ai_chat::kLlama2Eos});
+}
+
+void AIChatTabHelper::MakeAPIRequestWithConversationHistoryUpdate(
+    const ConversationTurn& turn) {
+  // This function should not be presented in the UI if the user has not
+  // opted-in yet.
+  DCHECK(HasUserOptedIn());
+  DCHECK(is_conversation_active_);
+
+  DCHECK(turn.character_type == CharacterType::HUMAN);
+
+  bool is_suggested_question = false;
+
+  // If it's a suggested question, remove it
+  auto found_question_iter =
+      base::ranges::find(suggested_questions_, turn.text);
+  if (found_question_iter != suggested_questions_.end()) {
+    is_suggested_question = true;
+    suggested_questions_.erase(found_question_iter);
+    OnSuggestedQuestionsChanged();
+  }
+
+  // TODO(petemill): Tokenize the summary question so that we
+  // don't have to do this weird substitution.
+  std::string question_part;
+  if (turn.text == "Summarize this video") {
+    question_part =
+        l10n_util::GetStringUTF8(IDS_AI_CHAT_QUESTION_SUMMARIZE_VIDEO_BULLETS);
+  } else {
+    question_part = turn.text;
+  }
+
+  std::string prompt;
+  if (UsesLlama2PromptTemplate(ai_chat::features::kAIModelName.Get())) {
+    prompt = BuildLlama2Prompt(question_part);
+  } else {
+    prompt = BuildClaudePrompt(question_part, is_suggested_question);
+  }
 
   if (turn.visibility != ConversationTurnVisibility::HIDDEN) {
     AddToConversationHistory(turn);
@@ -436,9 +610,12 @@ void AIChatTabHelper::OnAPIStreamDataComplete(
     if (result.value_body().is_dict()) {
       if (const std::string* completion =
               result.value_body().GetDict().FindString("completion")) {
+        // Trimming necessary for Llama 2 which prepends responses with a " ".
+        const std::string& trimmed =
+            std::string(base::TrimWhitespaceASCII(*completion, base::TRIM_ALL));
         AddToConversationHistory(
             ConversationTurn{CharacterType::ASSISTANT,
-                             ConversationTurnVisibility::VISIBLE, *completion});
+                             ConversationTurnVisibility::VISIBLE, trimmed});
       }
     }
   }

--- a/components/ai_chat/browser/ai_chat_tab_helper.cc
+++ b/components/ai_chat/browser/ai_chat_tab_helper.cc
@@ -403,13 +403,14 @@ std::string AIChatTabHelper::BuildLlama2Prompt(std::string user_message) {
   // first sequence.
   if (conversation_history.size() == 0) {
     return BuildLlama2FirstSequence(system_message, first_user_message,
-                                    absl::nullopt);
+                                    absl::nullopt, absl::nullopt);
   }
 
   // Use the first two messages to build the first sequence,
   // which includes the system prompt.
-  std::string prompt = BuildLlama2FirstSequence(
-      system_message, first_user_message, conversation_history[1].text);
+  std::string prompt =
+      BuildLlama2FirstSequence(system_message, first_user_message,
+                               conversation_history[1].text, absl::nullopt);
 
   // Loop through the rest of the history two at a time building subsequent
   // sequences.
@@ -454,13 +455,16 @@ std::string AIChatTabHelper::BuildLlama2GenerateQuestionsPrompt(
   return BuildLlama2FirstSequence(
       l10n_util::GetStringUTF8(
           IDS_AI_CHAT_LLAMA2_SYSTEM_MESSAGE_GENERATE_QUESTIONS),
-      user_message, absl::nullopt);
+      user_message, absl::nullopt,
+      l10n_util::GetStringUTF8(
+          IDS_AI_CHAT_LLAMA2_SYSTEM_MESSAGE_GENERATE_QUESTIONS_RESPONSE_SEED));
 }
 
 std::string AIChatTabHelper::BuildLlama2FirstSequence(
     const std::string& system_message,
     const std::string& user_message,
-    absl::optional<std::string> assistant_response) {
+    absl::optional<std::string> assistant_response,
+    absl::optional<std::string> assistant_response_seed) {
   // Generates a partial sequence if there is no assistant_response:
 
   // <s> [INST] <<SYS>>
@@ -504,6 +508,10 @@ std::string AIChatTabHelper::BuildLlama2FirstSequence(
   if (!assistant_response) {
     // Prepend just <s> if there's no assistant_response ( it will be completed
     // by the model).
+    if (assistant_response_seed) {
+      return base::StrCat(
+          {ai_chat::kLlama2Bos, instruction_prompt, *assistant_response_seed});
+    }
     return base::StrCat({ai_chat::kLlama2Bos, instruction_prompt});
   }
 

--- a/components/ai_chat/browser/ai_chat_tab_helper.cc
+++ b/components/ai_chat/browser/ai_chat_tab_helper.cc
@@ -432,8 +432,8 @@ std::string AIChatTabHelper::BuildLlama2Prompt(std::string user_message) {
 std::string AIChatTabHelper::BuildLlama2InstructionPrompt(
     const std::string& instruction) {
   return base::ReplaceStringPlaceholders(
-      R"( $1 $2 $3 )",
-      {ai_chat::kLlama2BIns, instruction, ai_chat::kLlama2EIns}, nullptr);
+      R"($1 $2 $3 )", {ai_chat::kLlama2BIns, instruction, ai_chat::kLlama2EIns},
+      nullptr);
 }
 
 std::string AIChatTabHelper::BuildLlama2GenerateQuestionsPrompt(

--- a/components/ai_chat/browser/ai_chat_tab_helper.cc
+++ b/components/ai_chat/browser/ai_chat_tab_helper.cc
@@ -106,9 +106,9 @@ void AIChatTabHelper::AddToConversationHistory(const ConversationTurn& turn) {
 
 void AIChatTabHelper::UpdateOrCreateLastAssistantEntry(
     std::string updated_text) {
+  updated_text = base::TrimWhitespaceASCII(updated_text, base::TRIM_LEADING);
   if (chat_history_.empty() ||
       chat_history_.back().character_type != CharacterType::ASSISTANT) {
-    updated_text = base::TrimWhitespaceASCII(updated_text, base::TRIM_LEADING);
     AddToConversationHistory({CharacterType::ASSISTANT,
                               ConversationTurnVisibility::VISIBLE,
                               updated_text});

--- a/components/ai_chat/browser/ai_chat_tab_helper.h
+++ b/components/ai_chat/browser/ai_chat_tab_helper.h
@@ -62,7 +62,7 @@ class AIChatTabHelper : public content::WebContentsObserver,
   // when the page changes.
   void OnConversationActiveChanged(bool is_conversation_active);
   void AddToConversationHistory(const mojom::ConversationTurn& turn);
-  void UpdateOrCreateLastAssistantEntry(const std::string& text);
+  void UpdateOrCreateLastAssistantEntry(std::string text);
   void MakeAPIRequestWithConversationHistoryUpdate(
       const mojom::ConversationTurn& turn);
   bool IsRequestInProgress();
@@ -115,7 +115,19 @@ class AIChatTabHelper : public content::WebContentsObserver,
                         const GURL& icon_url,
                         bool icon_url_changed,
                         const gfx::Image& image) override;
-
+  std::string BuildClaudePrompt(const std::string& question_part,
+                                bool is_suggested_question);
+  std::string BuildLlama2Prompt(const std::string& user_message);
+  std::string BuildLlama2FirstSequence(
+      const std::string& system_message,
+      const std::string& user_message,
+      absl::optional<std::string> assistant_response);
+  std::string BuildLlama2SubsequentSequence(
+      std::string user_message,
+      absl::optional<std::string> assistant_response);
+  std::string BuildLlama2InstructionPrompt(const std::string& instruction);
+  std::string BuildLlama2GenerateQuestionsPrompt(bool is_video,
+                                                 const std::string content);
   mojom::AutoGenerateQuestionsPref GetAutoGeneratePref();
 
   raw_ptr<PrefService> pref_service_;

--- a/components/ai_chat/browser/ai_chat_tab_helper.h
+++ b/components/ai_chat/browser/ai_chat_tab_helper.h
@@ -117,7 +117,7 @@ class AIChatTabHelper : public content::WebContentsObserver,
                         const gfx::Image& image) override;
   std::string BuildClaudePrompt(const std::string& question_part,
                                 bool is_suggested_question);
-  std::string BuildLlama2Prompt(const std::string& user_message);
+  std::string BuildLlama2Prompt(std::string user_message);
   std::string BuildLlama2FirstSequence(
       const std::string& system_message,
       const std::string& user_message,

--- a/components/ai_chat/browser/ai_chat_tab_helper.h
+++ b/components/ai_chat/browser/ai_chat_tab_helper.h
@@ -121,7 +121,8 @@ class AIChatTabHelper : public content::WebContentsObserver,
   std::string BuildLlama2FirstSequence(
       const std::string& system_message,
       const std::string& user_message,
-      absl::optional<std::string> assistant_response);
+      absl::optional<std::string> assistant_response,
+      absl::optional<std::string> assistant_response_seed);
   std::string BuildLlama2SubsequentSequence(
       std::string user_message,
       absl::optional<std::string> assistant_response);

--- a/components/ai_chat/browser/constants.cc
+++ b/components/ai_chat/browser/constants.cc
@@ -13,6 +13,17 @@ constexpr char kHumanPrompt[] = "Human:";
 constexpr char kHumanPromptPlaceholder[] = "\nH: ";
 constexpr char kAIPrompt[] = "Assistant:";
 constexpr char kAIPromptPlaceholder[] = "\n\nA: ";
+
+constexpr char kLlama2Chat13b[] = "llama-2-13b-chat";
+constexpr char kLlama2Chat13b8k[] = "llama-2-13b-chat-8k";
+constexpr char kLlama2Chat70b[] = "llama-2-70b-chat";
+constexpr char kLlama2Bos[] = "<s>";
+constexpr char kLlama2Eos[] = "</s>";
+constexpr char kLlama2BIns[] = "[INST]";
+constexpr char kLlama2EIns[] = "[/INST]";
+constexpr char kLlama2BSys[] = "<<SYS>>\n";
+constexpr char kLlama2ESys[] = "\n<</SYS>>\n\n";
+
 constexpr char kAIChatCompletionPath[] = "v1/complete";
 
 base::span<const webui::LocalizedString> GetLocalizedStrings() {
@@ -40,6 +51,17 @@ std::string GetHumanPromptSegment() {
 
 std::string GetAssistantPromptSegment() {
   return base::StrCat({"\n\n", kAIPrompt});
+}
+
+bool UsesLlama2PromptTemplate(const std::string& model) {
+  static std::map<std::string, bool> llama_2_models = {
+      {kLlama2Chat13b, true}, {kLlama2Chat13b8k, true}, {kLlama2Chat70b, true}};
+  auto model_pair = llama_2_models.find(model.c_str());
+  if (model_pair == llama_2_models.end()) {
+    return false;
+  }
+
+  return true;
 }
 
 }  // namespace ai_chat

--- a/components/ai_chat/browser/constants.cc
+++ b/components/ai_chat/browser/constants.cc
@@ -14,9 +14,6 @@ constexpr char kHumanPromptPlaceholder[] = "\nH: ";
 constexpr char kAIPrompt[] = "Assistant:";
 constexpr char kAIPromptPlaceholder[] = "\n\nA: ";
 
-constexpr char kLlama2Chat13b[] = "llama-2-13b-chat";
-constexpr char kLlama2Chat13b8k[] = "llama-2-13b-chat-8k";
-constexpr char kLlama2Chat70b[] = "llama-2-70b-chat";
 constexpr char kLlama2Bos[] = "<s>";
 constexpr char kLlama2Eos[] = "</s>";
 constexpr char kLlama2BIns[] = "[INST]";
@@ -54,14 +51,12 @@ std::string GetAssistantPromptSegment() {
 }
 
 bool UsesLlama2PromptTemplate(const std::string& model) {
-  static std::map<std::string, bool> llama_2_models = {
-      {kLlama2Chat13b, true}, {kLlama2Chat13b8k, true}, {kLlama2Chat70b, true}};
-  auto model_pair = llama_2_models.find(model.c_str());
-  if (model_pair == llama_2_models.end()) {
-    return false;
+  if (model.find("llama-2") != std::string::npos &&
+      model.find("chat") != std::string::npos) {
+    return true;
   }
 
-  return true;
+  return false;
 }
 
 }  // namespace ai_chat

--- a/components/ai_chat/browser/constants.h
+++ b/components/ai_chat/browser/constants.h
@@ -22,9 +22,6 @@ extern const char kAIPrompt[];
 extern const char kAIPromptPlaceholder[];
 
 // Llama 2
-extern const char kLlama2Chat13b[];
-extern const char kLlama2Chat13b8k[];
-extern const char kLlama2Chat70b[];
 extern const char kLlama2Bos[];
 extern const char kLlama2Eos[];
 extern const char kLlama2BIns[];

--- a/components/ai_chat/browser/constants.h
+++ b/components/ai_chat/browser/constants.h
@@ -13,13 +13,25 @@
 
 namespace ai_chat {
 
+// Claude
 // prefix for for user input
 extern const char kHumanPrompt[];
 extern const char kHumanPromptPlaceholder[];
-
 // prefix for AI assistant output
 extern const char kAIPrompt[];
 extern const char kAIPromptPlaceholder[];
+
+// Llama 2
+extern const char kLlama2Chat13b[];
+extern const char kLlama2Chat13b8k[];
+extern const char kLlama2Chat70b[];
+extern const char kLlama2Bos[];
+extern const char kLlama2Eos[];
+extern const char kLlama2BIns[];
+extern const char kLlama2EIns[];
+extern const char kLlama2BSys[];
+extern const char kLlama2ESys[];
+extern const char kLlama2DefaultSystemMessage[];
 
 extern const char kAIChatCompletionPath[];
 
@@ -27,6 +39,8 @@ base::span<const webui::LocalizedString> GetLocalizedStrings();
 
 std::string GetHumanPromptSegment();
 std::string GetAssistantPromptSegment();
+
+bool UsesLlama2PromptTemplate(const std::string& model);
 
 }  // namespace ai_chat
 

--- a/components/resources/ai_chat_prompts.grdp
+++ b/components/resources/ai_chat_prompts.grdp
@@ -49,32 +49,23 @@ Here are some important rules for the interaction:
 - Conciseness is important. Your responses should not exceed 6 sentences.
 - Always respond in a neutral tone.
 - Always stay in character, as Leo, an AI from Brave.
+- If you are unsure how to respond, say "Sorry, I didn't understand that. Could you rephrase your question?"
 </message>
 
-<message name="IDS_AI_CHAT_LLAMA2_SYSTEM_MESSAGE_VIDEO" translateable="false">
-You will be acting as an assistant named Leo created by the company Brave. Your goal is to answer the user's requests in an easy to understand and concise manner. You will be replying to a user of the Brave browser who will be confused if you don't respond in the character of Leo.
-Here are some important rules for the interaction:
-- Conciseness is important. Your responses should not exceed 6 sentences.
-- Always respond in a neutral tone.
-- Always stay in character, as Leo, an AI from Brave.
-- If you are unsure how to respond, say "Sorry, I didn't understand that. Could you rephrase your question?"
+<message name="IDS_AI_CHAT_ARTICLE_PROMPT_SEGMENT_LLAMA2" translateable="false">
+This is an article:
 
-This is the transcript of a video the user is watching:
+&lt;article&gt; <ph name="ARTICLE">$1</ph> &lt;/article&gt;
 
-<ph name="VIDEO">$1</ph>
+<ph name= "USER_PROMPT">$2</ph>
 </message>
 
-<message name="IDS_AI_CHAT_LLAMA2_SYSTEM_MESSAGE_ARTICLE" translateable="false">
-You will be acting as an assistant named Leo created by the company Brave. You are having a dialogue with a user of the Brave browser who is asking you questions. Your goal is to answer their questions in an easy to understand and concise manner. Here are some important rules for the interaction:
-- Conciseness is important. Your responses should not exceed 6 sentences.
-- Always respond in a neutral tone.
-- Always stay in character, as Leo, an AI from Brave.
-- If you are unsure how to respond, say "Sorry, I didn't understand that. Could you rephrase your question?"
+<message name="IDS_AI_CHAT_VIDEO_PROMPT_SEGMENT_LLAMA2" translateable="false">
+This is a video transcript:
 
-The user is reading this article:
-&lt;article&gt;
-<ph name="ARTICLE">$1</ph>
-&lt;/article&gt;
+<ph name="TRANSCRIPT">$1</ph>
+
+<ph name= "USER_PROMPT">$2</ph>
 </message>
 
 <message name="IDS_AI_CHAT_LLAMA2_GENERATE_QUESTIONS_VIDEO" translateable="false">

--- a/components/resources/ai_chat_prompts.grdp
+++ b/components/resources/ai_chat_prompts.grdp
@@ -39,6 +39,63 @@ Here is the conversational history (between the user and you) prior to the quest
 <message name="IDS_AI_CHAT_QUESTION_PROMPT_SEGMENT" translateable="false">
 Propose up to 3 very short questions that a reader may ask about the content. Consider intriguing or unusual elements of the content, or structurally important. Separate each suggested question with the character "|". End the question list with a &lt;/response&gt; tag.</message>
 
-<message name="IDS_AI_CHAT_QUESTION_SUMMARIZE_VIDEO" translateable="false">Provide a concise bullet list of the most important points of the video along with a short summary of each point. For each bullet point, prepend the time range when that point is discussed in seconds, e.g. [23s-68s].</message>
+<message name="IDS_AI_CHAT_QUESTION_SUMMARIZE_VIDEO_TIMESTAMPS" translateable="false"> For each bullet point, prepend the time range when that point is discussed in seconds, e.g. [23s-68s].</message>
 
+<message name="IDS_AI_CHAT_QUESTION_SUMMARIZE_VIDEO_BULLETS" translateable="false">Provide a concise bullet list of the most important points of the video along with a short summary of each point.</message>
+
+<message name="IDS_AI_CHAT_LLAMA2_SYSTEM_MESSAGE_GENERIC" translateable="false">
+You will be acting as an assistant named Leo created by the company Brave. Your goal is to answer the user's requests in an easy to understand and concise manner. You will be replying to a user of the Brave browser who will be confused if you don't respond in the character of Leo.
+Here are some important rules for the interaction:
+- Conciseness is important. Your responses should not exceed 6 sentences.
+- Always respond in a neutral tone.
+- Always stay in character, as Leo, an AI from Brave.
+</message>
+
+<message name="IDS_AI_CHAT_LLAMA2_SYSTEM_MESSAGE_VIDEO" translateable="false">
+You will be acting as an assistant named Leo created by the company Brave. Your goal is to answer the user's requests in an easy to understand and concise manner. You will be replying to a user of the Brave browser who will be confused if you don't respond in the character of Leo.
+Here are some important rules for the interaction:
+- Conciseness is important. Your responses should not exceed 6 sentences.
+- Always respond in a neutral tone.
+- Always stay in character, as Leo, an AI from Brave.
+- If you are unsure how to respond, say "Sorry, I didn't understand that. Could you rephrase your question?"
+
+This is the transcript of a video the user is watching:
+
+<ph name="VIDEO">$1</ph>
+</message>
+
+<message name="IDS_AI_CHAT_LLAMA2_SYSTEM_MESSAGE_ARTICLE" translateable="false">
+You will be acting as an assistant named Leo created by the company Brave. You are having a dialogue with a user of the Brave browser who is asking you questions. Your goal is to answer their questions in an easy to understand and concise manner. Here are some important rules for the interaction:
+- Conciseness is important. Your responses should not exceed 6 sentences.
+- Always respond in a neutral tone.
+- Always stay in character, as Leo, an AI from Brave.
+- If you are unsure how to respond, say "Sorry, I didn't understand that. Could you rephrase your question?"
+
+The user is reading this article:
+&lt;article&gt;
+<ph name="ARTICLE">$1</ph>
+&lt;/article&gt;
+</message>
+
+<message name="IDS_AI_CHAT_LLAMA2_GENERATE_QUESTIONS_VIDEO" translateable="false">
+This is a video transcript:
+
+<ph name="TRANSCRIPT">$1</ph>
+
+Propose up to 3 very short questions that a reader may ask about this video. Consider intriguing or unusual elements of the content, or structurally important. Separate each suggested question with the character "|". Do not number the questions.
+</message>
+
+<message name="IDS_AI_CHAT_LLAMA2_GENERATE_QUESTIONS_ARTICLE" translateable="false">
+This is an article:
+
+&lt;article&gt;
+<ph name="ARTICLE">$1</ph>
+&lt;/article&gt;
+
+Propose up to 3 very short questions that a reader may ask about the this article. Consider intriguing or unusual elements of the content, or structurally important. Separate each suggested question with the character "|". Do not number the questions.
+</message>
+
+<message name="IDS_AI_CHAT_LLAMA2_SYSTEM_MESSAGE_GENERATE_QUESTIONS" translateable="false">
+Your goal is to answer the user's requests exactly in concise manner.
+</message>
 </grit-part>

--- a/components/resources/ai_chat_prompts.grdp
+++ b/components/resources/ai_chat_prompts.grdp
@@ -72,7 +72,7 @@ This is a video transcript:
 
 <ph name="TRANSCRIPT">$1</ph>
 
-Propose up to 3 very short questions that a reader may ask about this video. Consider intriguing or unusual elements of the content, or structurally important. Separate each suggested question with the character "|". Do not number the questions.
+Propose up to 3 very short questions, around 10 words, that a reader may ask about this video. Consider intriguing or unusual elements of the content, or structurally important. Separate each suggested question with the character "|". Do not number the questions.
 </message>
 
 <message name="IDS_AI_CHAT_LLAMA2_GENERATE_QUESTIONS_ARTICLE" translateable="false">
@@ -82,7 +82,7 @@ This is an article:
 <ph name="ARTICLE">$1</ph>
 &lt;/article&gt;
 
-Propose up to 3 very short questions that a reader may ask about the this article. Consider intriguing or unusual elements of the content, or structurally important. Separate each suggested question with the character "|". Do not number the questions.
+Propose up to 3 very short questions, around 10 words, that a reader may ask about the this article. Consider intriguing or unusual elements of the content, or structurally important. Separate each suggested question with the character "|". Do not number the questions.
 </message>
 
 <message name="IDS_AI_CHAT_LLAMA2_SYSTEM_MESSAGE_GENERATE_QUESTIONS" translateable="false">

--- a/components/resources/ai_chat_prompts.grdp
+++ b/components/resources/ai_chat_prompts.grdp
@@ -39,7 +39,7 @@ Here is the conversational history (between the user and you) prior to the quest
 <message name="IDS_AI_CHAT_QUESTION_PROMPT_SEGMENT" translateable="false">
 Propose up to 3 very short questions that a reader may ask about the content. Consider intriguing or unusual elements of the content, or structurally important. Separate each suggested question with the character "|". End the question list with a &lt;/response&gt; tag.</message>
 
-<message name="IDS_AI_CHAT_QUESTION_SUMMARIZE_VIDEO_BULLETS" translateable="false">Provide a concise bullet list of the most important points of the video along with a short summary of each point.</message>
+<message name="IDS_AI_CHAT_QUESTION_SUMMARIZE_VIDEO_BULLETS" translateable="false">Provide a concise list of up to 6 bullets of the most important points of the video.</message>
 
 <message name="IDS_AI_CHAT_LLAMA2_SYSTEM_MESSAGE_GENERIC" translateable="false">
 You will be acting as an AI assistant named Leo created by the company Brave. Your goal is to answer the user's requests in an easy to understand and concise manner. You will be replying to a user of the Brave browser who will be confused if you don't respond in the character of Leo.

--- a/components/resources/ai_chat_prompts.grdp
+++ b/components/resources/ai_chat_prompts.grdp
@@ -82,7 +82,7 @@ This is an article:
 <ph name="ARTICLE">$1</ph>
 &lt;/article&gt;
 
-Propose up to 3 very short questions, around 10 words, that a reader may ask about the this article. Consider intriguing or unusual elements of the content, or structurally important. Separate each suggested question with the character "|". Do not number the questions.
+Propose up to 3 very short questions, around 10 words, that a reader may ask about the this article. Consider intriguing or unusual elements of the content, or structurally important.
 </message>
 
 <message name="IDS_AI_CHAT_LLAMA2_SYSTEM_MESSAGE_GENERATE_QUESTIONS" translateable="false">

--- a/components/resources/ai_chat_prompts.grdp
+++ b/components/resources/ai_chat_prompts.grdp
@@ -88,4 +88,9 @@ Propose up to 3 very short questions, around 10 words, that a reader may ask abo
 <message name="IDS_AI_CHAT_LLAMA2_SYSTEM_MESSAGE_GENERATE_QUESTIONS" translateable="false">
 Your goal is to answer the user's requests exactly in concise manner.
 </message>
+
+<message name="IDS_AI_CHAT_LLAMA2_SYSTEM_MESSAGE_GENERATE_QUESTIONS_RESPONSE_SEED" translateable="false">
+Sure, here are three intriguing or unusual questions that a reader may ask about the article:
+</message>
+
 </grit-part>

--- a/components/resources/ai_chat_prompts.grdp
+++ b/components/resources/ai_chat_prompts.grdp
@@ -39,8 +39,6 @@ Here is the conversational history (between the user and you) prior to the quest
 <message name="IDS_AI_CHAT_QUESTION_PROMPT_SEGMENT" translateable="false">
 Propose up to 3 very short questions that a reader may ask about the content. Consider intriguing or unusual elements of the content, or structurally important. Separate each suggested question with the character "|". End the question list with a &lt;/response&gt; tag.</message>
 
-<message name="IDS_AI_CHAT_QUESTION_SUMMARIZE_VIDEO_TIMESTAMPS" translateable="false"> For each bullet point, prepend the time range when that point is discussed in seconds, e.g. [23s-68s].</message>
-
 <message name="IDS_AI_CHAT_QUESTION_SUMMARIZE_VIDEO_BULLETS" translateable="false">Provide a concise bullet list of the most important points of the video along with a short summary of each point.</message>
 
 <message name="IDS_AI_CHAT_LLAMA2_SYSTEM_MESSAGE_GENERIC" translateable="false">

--- a/components/resources/ai_chat_prompts.grdp
+++ b/components/resources/ai_chat_prompts.grdp
@@ -72,7 +72,7 @@ This is a video transcript:
 
 <ph name="TRANSCRIPT">$1</ph>
 
-Propose up to 3 very short questions, around 10 words, that a reader may ask about this video. Consider intriguing or unusual elements of the content, or structurally important. Separate each suggested question with the character "|". Do not number the questions.
+Propose up to 3 very short questions, around 10 words, that a reader may ask about this video. Consider intriguing or unusual elements of the content, or structurally important.
 </message>
 
 <message name="IDS_AI_CHAT_LLAMA2_GENERATE_QUESTIONS_ARTICLE" translateable="false">
@@ -90,7 +90,7 @@ Your goal is to answer the user's requests exactly in concise manner.
 </message>
 
 <message name="IDS_AI_CHAT_LLAMA2_SYSTEM_MESSAGE_GENERATE_QUESTIONS_RESPONSE_SEED" translateable="false">
-Sure, here are three intriguing or unusual questions that a reader may ask about the article:
+Sure, here are three intriguing or unusual questions that a reader may ask about the article: &lt;ul&gt; &lt;li&gt;
 </message>
 
 </grit-part>

--- a/components/resources/ai_chat_prompts.grdp
+++ b/components/resources/ai_chat_prompts.grdp
@@ -42,11 +42,12 @@ Propose up to 3 very short questions that a reader may ask about the content. Co
 <message name="IDS_AI_CHAT_QUESTION_SUMMARIZE_VIDEO_BULLETS" translateable="false">Provide a concise bullet list of the most important points of the video along with a short summary of each point.</message>
 
 <message name="IDS_AI_CHAT_LLAMA2_SYSTEM_MESSAGE_GENERIC" translateable="false">
-You will be acting as an assistant named Leo created by the company Brave. Your goal is to answer the user's requests in an easy to understand and concise manner. You will be replying to a user of the Brave browser who will be confused if you don't respond in the character of Leo.
+You will be acting as an AI assistant named Leo created by the company Brave. Your goal is to answer the user's requests in an easy to understand and concise manner. You will be replying to a user of the Brave browser who will be confused if you don't respond in the character of Leo.
 Here are some important rules for the interaction:
 - Conciseness is important. Your responses should not exceed 6 sentences.
-- Always respond in a neutral tone.
-- Always stay in character, as Leo, an AI from Brave.
+- Do not say "Hey there!", go straight to the answer.
+- Always respond in a neutral and professional tone.
+- Always stay in character as an AI assistant from Brave.
 - If you are unsure how to respond, say "Sorry, I didn't understand that. Could you rephrase your question?"
 </message>
 


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/31548

## How to run AI chat using Open Llama
1. Be connected to the VPN
2. Set `brave_ai_chat_endpoint=llm.bsg.brave.software` in your npmrc prior to build
3. Specify the open llama model at runtime `npm run start -- --enable-features=AIChat:ai_model_name\/llama-2-13b-chat-8k`

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-arm64, CI/skip-linux-x64, CI/skip-android, CI/skip-macos, CI/skip-ios, CI/skip-windows-arm64, CI/skip-windows-x64, CI/skip-windows-x86 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [ ] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

