### PR TITLE
Fixes Brave Ads crashes if a user enables ShouldAlwaysTriggerBraveNewTabPageAdEvents feature and views a new tab page ad - 1.57.x

### DIFF
--- a/components/brave_ads/core/internal/ads/inline_content_ad_handler.cc
+++ b/components/brave_ads/core/internal/ads/inline_content_ad_handler.cc
@@ -65,7 +65,7 @@ void InlineContentAdHandler::MaybeServe(
     const std::string& dimensions,
     MaybeServeInlineContentAdCallback callback) {
   CHECK(UserHasOptedInToBraveNews())
-      << " should only be called if the user has opted-in to Brave News Ads";
+      << "Should only be called if the user has opted-in to Brave News Ads";
 
   serving_.MaybeServeAd(
       dimensions,
@@ -80,10 +80,10 @@ void InlineContentAdHandler::TriggerEvent(
     TriggerAdEventCallback callback) {
   CHECK(mojom::IsKnownEnumValue(event_type));
   CHECK_NE(mojom::InlineContentAdEventType::kServed, event_type)
-      << " should not be called with kServed as this event is handled when "
+      << "Should not be called with kServed as this event is handled when "
          "calling MaybeServe";
   CHECK(UserHasOptedInToBraveNews())
-      << " should only be called if the user has opted-in to Brave News Ads";
+      << "Should only be called if the user has opted-in to Brave News Ads";
 
   event_handler_.FireEvent(
       placement_id, creative_instance_id, event_type,

--- a/components/brave_ads/core/internal/ads/new_tab_page_ad_handler.cc
+++ b/components/brave_ads/core/internal/ads/new_tab_page_ad_handler.cc
@@ -64,8 +64,10 @@ NewTabPageAdHandler::NewTabPageAdHandler(
 NewTabPageAdHandler::~NewTabPageAdHandler() = default;
 
 void NewTabPageAdHandler::MaybeServe(MaybeServeNewTabPageAdCallback callback) {
-  CHECK(UserHasOptedInToBravePrivateAds())
-      << " should only be called if the user has opted-in to Brave Private Ads";
+  CHECK(ShouldAlwaysTriggerNewTabPageAdEvents() ||
+        UserHasOptedInToBravePrivateAds())
+      << "Should only be called if the user has joined Brave Rewards or if "
+         "should always trigger new tab page ad events";
 
   serving_.MaybeServeAd(base::BindOnce(&NewTabPageAdHandler::MaybeServeCallback,
                                        weak_factory_.GetWeakPtr(),

--- a/components/brave_ads/core/internal/ads/notification_ad_handler.cc
+++ b/components/brave_ads/core/internal/ads/notification_ad_handler.cc
@@ -92,10 +92,10 @@ void NotificationAdHandler::TriggerEvent(
     TriggerAdEventCallback callback) {
   CHECK(mojom::IsKnownEnumValue(event_type));
   CHECK_NE(mojom::NotificationAdEventType::kServed, event_type)
-      << " should not be called with kServed as this event is handled when "
+      << "Should not be called with kServed as this event is handled when "
          "calling TriggerEvent with kViewed";
   CHECK(UserHasOptedInToBravePrivateAds())
-      << " should only be called if user has opted-in to Brave Private Ads";
+      << "Should only be called if user has opted-in to Brave Private Ads";
 
   if (event_type == mojom::NotificationAdEventType::kViewed) {
     return event_handler_.FireEvent(

--- a/components/brave_ads/core/internal/ads/promoted_content_ad_handler.cc
+++ b/components/brave_ads/core/internal/ads/promoted_content_ad_handler.cc
@@ -43,7 +43,7 @@ void PromotedContentAdHandler::TriggerEvent(
     TriggerAdEventCallback callback) {
   CHECK(mojom::IsKnownEnumValue(event_type));
   CHECK_NE(mojom::PromotedContentAdEventType::kServed, event_type)
-      << " should not be called with kServed as this event is handled when "
+      << "Should not be called with kServed as this event is handled when "
          "calling TriggerEvent with kViewed";
 
   if (event_type == mojom::PromotedContentAdEventType::kViewed) {

--- a/components/brave_ads/core/internal/ads/search_result_ad_handler.cc
+++ b/components/brave_ads/core/internal/ads/search_result_ad_handler.cc
@@ -52,7 +52,7 @@ void SearchResultAd::TriggerEvent(
     TriggerAdEventCallback callback) {
   CHECK(mojom::IsKnownEnumValue(event_type));
   CHECK_NE(mojom::SearchResultAdEventType::kServed, event_type)
-      << " should not be called with kServed as this event is handled when "
+      << "Should not be called with kServed as this event is handled when "
          "calling TriggerEvent with kViewed";
 
   if (!UserHasOptedInToBravePrivateAds() &&


### PR DESCRIPTION
Uplift of https://github.com/brave/brave-core/pull/19384
Resolves https://github.com/brave/brave-browser/issues/31780

- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR.
- [x] You have tested your change on Nightly. 
- [x] The PR milestones match the branch they are landing to. 

After you merge: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.

