### PR TITLE
Replace "ads enabled duration" P3A question with "ad types enabled", report NTP-SI P3A data when rewards is disabled

### DIFF
--- a/browser/brave_rewards/rewards_prefs_util.cc
+++ b/browser/brave_rewards/rewards_prefs_util.cc
@@ -30,6 +30,10 @@ void MigrateObsoleteProfilePrefs(PrefService* prefs) {
   // Added 05/2023
   prefs->ClearPref(prefs::kAdsWereDisabled);
   prefs->ClearPref(prefs::kHasAdsP3AState);
+
+  // Added 07/2023
+  prefs->ClearPref(prefs::kAdsEnabledTimestamp);
+  prefs->ClearPref(prefs::kAdsEnabledTimeDelta);
 }
 
 }  // namespace brave_rewards

--- a/browser/ntp_background/ntp_p3a_helper_impl_unittest.cc
+++ b/browser/ntp_background/ntp_p3a_helper_impl_unittest.cc
@@ -12,8 +12,9 @@
 #include "base/test/metrics/histogram_tester.h"
 #include "brave/browser/ntp_background/ntp_p3a_helper_impl.h"
 #include "brave/components/brave_ads/browser/ads_service.h"
-#include "brave/components/brave_ads/common/pref_names.h"
 #include "brave/components/brave_referrals/browser/brave_referrals_service.h"
+#include "brave/components/brave_rewards/browser/rewards_service.h"
+#include "brave/components/brave_rewards/common/pref_names.h"
 #include "brave/components/p3a/metric_log_type.h"
 #include "brave/components/p3a/p3a_config.h"
 #include "brave/components/p3a/p3a_service.h"
@@ -54,6 +55,7 @@ class NTPP3AHelperImplTest : public testing::Test {
     NTPP3AHelperImpl::RegisterLocalStatePrefs(local_state_.registry());
 
     brave_ads::AdsService::RegisterProfilePrefs(prefs_.registry());
+    brave_rewards::RewardsService::RegisterProfilePrefs(prefs_.registry());
 
     p3a::P3AConfig config;
     config.p3a_json_upload_url = GURL(kTestP3AJsonHost);
@@ -238,7 +240,7 @@ TEST_F(NTPP3AHelperImplTest, LandCountReported) {
           .has_value());
 }
 
-TEST_F(NTPP3AHelperImplTest, StopSendingAfterEnablingAds) {
+TEST_F(NTPP3AHelperImplTest, StopSendingAfterEnablingRewards) {
   const std::string histogram_name = GetExpectedHistogramName(kViewsEventType);
 
   ntp_p3a_helper_->RecordView(kTestCreativeMetricId);
@@ -260,7 +262,7 @@ TEST_F(NTPP3AHelperImplTest, StopSendingAfterEnablingAds) {
 
   ntp_p3a_helper_->RecordView(kTestCreativeMetricId);
 
-  prefs_.SetBoolean(brave_ads::prefs::kOptedInToNotificationAds, true);
+  prefs_.SetBoolean(brave_rewards::prefs::kEnabled, true);
 
   ntp_p3a_helper_->OnP3ARotation(p3a::MetricLogType::kExpress,
                                  /*is_star*/ false);

--- a/components/brave_rewards/browser/rewards_p3a.cc
+++ b/components/brave_rewards/browser/rewards_p3a.cc
@@ -9,6 +9,7 @@
 #include "base/metrics/histogram_macros.h"
 #include "brave/components/brave_ads/common/pref_names.h"
 #include "brave/components/brave_rewards/common/pref_names.h"
+#include "brave/components/ntp_background_images/common/pref_names.h"
 #include "brave/components/p3a_utils/bucket.h"
 #include "components/prefs/pref_service.h"
 
@@ -34,8 +35,7 @@ const char kToolbarButtonTriggerHistogramName[] =
 const char kTipsSentHistogramName[] = "Brave.Rewards.TipsSent";
 const char kAutoContributionsStateHistogramName[] =
     "Brave.Rewards.AutoContributionsState.3";
-const char kAdsEnabledDurationHistogramName[] =
-    "Brave.Rewards.AdsEnabledDuration";
+const char kAdTypesEnabledHistogramName[] = "Brave.Rewards.AdTypesEnabled";
 const int kTipsSentBuckets[] = {1, 3};
 
 void RecordAutoContributionsState(bool ac_enabled) {
@@ -60,54 +60,25 @@ void RecordNoWalletCreatedForAllMetrics() {
                              2);
 }
 
-void RecordAdsEnabledDuration(PrefService* prefs, bool ads_enabled) {
-  base::Time enabled_timestamp = prefs->GetTime(prefs::kAdsEnabledTimestamp);
-  base::TimeDelta enabled_time_delta =
-      prefs->GetTimeDelta(prefs::kAdsEnabledTimeDelta);
-  AdsEnabledDuration enabled_duration;
-
-  if (enabled_timestamp.is_null()) {
-    // No previous timestamp, so record one of the non-duration states.
-    if (ads_enabled) {
-      // Ads have been enabled.
-      // Remember when so we can measure the duration on later changes.
-      prefs->SetTime(prefs::kAdsEnabledTimestamp, base::Time::Now());
-    }
-  } else {
-    // Previous timestamp available.
-    if (!ads_enabled) {
-      // Ads have been disabled. Record the duration they were on.
-      enabled_time_delta = base::Time::Now() - enabled_timestamp;
-      VLOG(1) << "Rewards disabled after " << enabled_time_delta;
-      // Null the timestamp so we're ready for a fresh measurement.
-      // Store the enabled time delta so we can keep reporting the duration.
-      prefs->SetTime(prefs::kAdsEnabledTimestamp, base::Time());
-      prefs->SetTimeDelta(prefs::kAdsEnabledTimeDelta, enabled_time_delta);
-    }
+void RecordAdTypesEnabled(PrefService* prefs) {
+  if (!prefs->GetBoolean(prefs::kEnabled)) {
+    UMA_HISTOGRAM_EXACT_LINEAR(kAdTypesEnabledHistogramName, INT_MAX - 1, 4);
+    return;
   }
-  // Set the threshold at three units so each bin represents the
-  // nominal value as an order-of-magnitude: more than three days
-  // is a week, more than three weeks is a month, and so on.
-  constexpr int threshold = 3;
-  constexpr int days_per_week = 7;
-  constexpr double days_per_month = 30.44;  // average length
-  if (ads_enabled) {
-    enabled_duration = AdsEnabledDuration::kStillEnabled;
-  } else if (enabled_time_delta.is_zero()) {
-    enabled_duration = AdsEnabledDuration::kNever;
-  } else if (enabled_time_delta < base::Hours(threshold)) {
-    enabled_duration = AdsEnabledDuration::kHours;
-  } else if (enabled_time_delta < base::Days(threshold)) {
-    enabled_duration = AdsEnabledDuration::kDays;
-  } else if (enabled_time_delta < base::Days(threshold * days_per_week)) {
-    enabled_duration = AdsEnabledDuration::kWeeks;
-  } else if (enabled_time_delta < base::Days(threshold * days_per_month)) {
-    enabled_duration = AdsEnabledDuration::kMonths;
-  } else {
-    enabled_duration = AdsEnabledDuration::kQuarters;
+  bool ntp_enabled =
+      prefs->GetBoolean(ntp_background_images::prefs::
+                            kNewTabPageShowSponsoredImagesBackgroundImage);
+  bool notification_enabled =
+      prefs->GetBoolean(brave_ads::prefs::kOptedInToNotificationAds);
+  AdTypesEnabled answer = AdTypesEnabled::kNone;
+  if (ntp_enabled && notification_enabled) {
+    answer = AdTypesEnabled::kAll;
+  } else if (ntp_enabled) {
+    answer = AdTypesEnabled::kNTP;
+  } else if (notification_enabled) {
+    answer = AdTypesEnabled::kNotification;
   }
-
-  UMA_HISTOGRAM_ENUMERATION(kAdsEnabledDurationHistogramName, enabled_duration);
+  UMA_HISTOGRAM_ENUMERATION(kAdTypesEnabledHistogramName, answer);
 }
 
 ConversionMonitor::ConversionMonitor() = default;

--- a/components/brave_rewards/browser/rewards_p3a.h
+++ b/components/brave_rewards/browser/rewards_p3a.h
@@ -19,7 +19,7 @@ extern const char kInlineTipTriggerHistogramName[];
 extern const char kToolbarButtonTriggerHistogramName[];
 extern const char kTipsSentHistogramName[];
 extern const char kAutoContributionsStateHistogramName[];
-extern const char kAdsEnabledDurationHistogramName[];
+extern const char kAdTypesEnabledHistogramName[];
 
 enum class AutoContributionsState {
   kNoWallet,
@@ -35,34 +35,21 @@ enum class PanelTrigger {
   kMaxValue = kNTP
 };
 
-enum class AdsState {
-  kNoWallet,
-  kRewardsDisabled,
-  kAdsDisabled,
-  kAdsEnabled,
-  kAdsEnabledThenDisabledRewardsOn,
-  kAdsEnabledThenDisabledRewardsOff,
-  kMaxValue = kAdsEnabledThenDisabledRewardsOff,
-};
-
 void RecordTipsSent(size_t tip_count);
 
 void RecordAutoContributionsState(bool ac_enabled);
 
 void RecordNoWalletCreatedForAllMetrics();
 
-enum class AdsEnabledDuration {
-  kNever,
-  kStillEnabled,
-  kHours,
-  kDays,
-  kWeeks,
-  kMonths,
-  kQuarters,
-  kMaxValue = kQuarters,
+enum class AdTypesEnabled {
+  kNone,
+  kNTP,
+  kNotification,
+  kAll,
+  kMaxValue = kAll,
 };
 
-void RecordAdsEnabledDuration(PrefService* prefs, bool ads_enabled);
+void RecordAdTypesEnabled(PrefService* prefs);
 
 class ConversionMonitor {
  public:

--- a/components/brave_rewards/browser/rewards_service.cc
+++ b/components/brave_rewards/browser/rewards_service.cc
@@ -43,9 +43,6 @@ void RewardsService::RegisterProfilePrefs(PrefRegistrySimple* registry) {
   registry->RegisterBooleanPref(prefs::kEnabled, false);
   registry->RegisterStringPref(prefs::kDeclaredGeo, "");
   registry->RegisterStringPref(prefs::kUserVersion, "");
-  registry->RegisterTimePref(prefs::kAdsEnabledTimestamp, base::Time());
-  registry->RegisterTimeDeltaPref(prefs::kAdsEnabledTimeDelta,
-                                  base::TimeDelta());
   registry->RegisterDictionaryPref(prefs::kExternalWallets);
   registry->RegisterUint64Pref(prefs::kServerPublisherListStamp, 0ull);
   registry->RegisterStringPref(prefs::kUpholdAnonAddress, "");
@@ -101,6 +98,10 @@ void RewardsService::RegisterProfilePrefsForMigration(
   // Added 05/2023
   registry->RegisterBooleanPref(prefs::kAdsWereDisabled, false);
   registry->RegisterBooleanPref(prefs::kHasAdsP3AState, false);
+  // Added 07/2023
+  registry->RegisterTimePref(prefs::kAdsEnabledTimestamp, base::Time());
+  registry->RegisterTimeDeltaPref(prefs::kAdsEnabledTimeDelta,
+                                  base::TimeDelta());
 }
 
 }  // namespace brave_rewards

--- a/components/brave_rewards/browser/rewards_service_impl.cc
+++ b/components/brave_rewards/browser/rewards_service_impl.cc
@@ -52,6 +52,7 @@
 #include "brave/components/brave_rewards/core/global_constants.h"
 #include "brave/components/brave_rewards/core/rewards_database.h"
 #include "brave/components/brave_rewards/resources/grit/brave_rewards_resources.h"
+#include "brave/components/ntp_background_images/common/pref_names.h"
 #include "brave/grit/brave_generated_resources.h"
 #include "chrome/browser/bitmap_fetcher/bitmap_fetcher_service_factory.h"
 #include "chrome/browser/favicon/favicon_service_factory.h"
@@ -323,6 +324,8 @@ RewardsServiceImpl::RewardsServiceImpl(Profile* profile)
     greaselion_service_->AddObserver(this);
   }
 #endif
+
+  p3a::RecordAdTypesEnabled(profile_->GetPrefs());
 }
 
 RewardsServiceImpl::~RewardsServiceImpl() {
@@ -366,9 +369,6 @@ void RewardsServiceImpl::Init(
 
   CheckPreferences();
   InitPrefChangeRegistrar();
-  p3a::RecordAdsEnabledDuration(
-      profile_->GetPrefs(), profile_->GetPrefs()->GetBoolean(
-                                brave_ads::prefs::kOptedInToNotificationAds));
 }
 
 void RewardsServiceImpl::InitPrefChangeRegistrar() {
@@ -379,6 +379,11 @@ void RewardsServiceImpl::InitPrefChangeRegistrar() {
                           base::Unretained(this)));
   profile_pref_change_registrar_.Add(
       brave_ads::prefs::kOptedInToNotificationAds,
+      base::BindRepeating(&RewardsServiceImpl::OnPreferenceChanged,
+                          base::Unretained(this)));
+  profile_pref_change_registrar_.Add(
+      ntp_background_images::prefs::
+          kNewTabPageShowSponsoredImagesBackgroundImage,
       base::BindRepeating(&RewardsServiceImpl::OnPreferenceChanged,
                           base::Unretained(this)));
 }
@@ -393,11 +398,10 @@ void RewardsServiceImpl::OnPreferenceChanged(const std::string& key) {
     RecordBackendP3AStats();
   }
 
-  if (key == prefs::kAutoContributeEnabled ||
+  if (key == ntp_background_images::prefs::
+                 kNewTabPageShowSponsoredImagesBackgroundImage ||
       key == brave_ads::prefs::kOptedInToNotificationAds) {
-    p3a::RecordAdsEnabledDuration(
-        profile_->GetPrefs(), profile_->GetPrefs()->GetBoolean(
-                                  brave_ads::prefs::kOptedInToNotificationAds));
+    p3a::RecordAdTypesEnabled(profile_->GetPrefs());
   }
 
 #if BUILDFLAG(ENABLE_GREASELION)
@@ -540,6 +544,7 @@ void RewardsServiceImpl::CreateRewardsWallet(
       }
 
       self->conversion_monitor_.RecordRewardsEnable();
+      p3a::RecordAdTypesEnabled(prefs);
 
       std::move(callback).Run(CreateRewardsWalletResult::kSuccess);
     };
@@ -1382,6 +1387,8 @@ void RewardsServiceImpl::OnStopEngineForCompleteReset(
   diagnostic_log_->Delete(base::BindOnce(
       &RewardsServiceImpl::OnDiagnosticLogDeletedForCompleteReset, AsWeakPtr(),
       std::move(callback)));
+
+  p3a::RecordAdTypesEnabled(profile_->GetPrefs());
 }
 
 void RewardsServiceImpl::OnDiagnosticLogDeletedForCompleteReset(

--- a/components/brave_rewards/browser/test/rewards_p3a_browsertest.cc
+++ b/components/brave_rewards/browser/test/rewards_p3a_browsertest.cc
@@ -23,6 +23,7 @@
 #include "brave/components/brave_rewards/browser/test/common/rewards_browsertest_util.h"
 #include "brave/components/brave_rewards/common/pref_names.h"
 #include "brave/components/constants/brave_paths.h"
+#include "brave/components/ntp_background_images/common/pref_names.h"
 #include "chrome/browser/profiles/profile.h"
 #include "chrome/test/base/in_process_browser_test.h"
 #include "components/network_session_configurator/common/network_switches.h"
@@ -141,13 +142,16 @@ IN_PROC_BROWSER_TEST_F(RewardsP3ABrowserTest, RewardsDisabled) {
   histogram_tester_->ExpectTotalCount(p3a::kAutoContributionsStateHistogramName,
                                       0);
   histogram_tester_->ExpectTotalCount(p3a::kTipsSentHistogramName, 0);
-  histogram_tester_->ExpectUniqueSample(p3a::kAdsEnabledDurationHistogramName,
-                                        p3a::AdsEnabledDuration::kNever, 1);
+  histogram_tester_->ExpectUniqueSample(p3a::kAdTypesEnabledHistogramName,
+                                        INT_MAX - 1, 1);
 }
 
 IN_PROC_BROWSER_TEST_F(RewardsP3ABrowserTest, RewardsReset) {
   test_util::StartProcess(rewards_service_);
   WaitForRewardsInitialization();
+
+  histogram_tester_->ExpectUniqueSample(p3a::kAdTypesEnabledHistogramName,
+                                        INT_MAX - 1, 1);
   TurnOnRewards();
 
   histogram_tester_->ExpectUniqueSample(
@@ -156,81 +160,27 @@ IN_PROC_BROWSER_TEST_F(RewardsP3ABrowserTest, RewardsReset) {
                                         INT_MAX - 1, 1);
 }
 
-IN_PROC_BROWSER_TEST_F(RewardsP3ABrowserTest, Duration) {
+IN_PROC_BROWSER_TEST_F(RewardsP3ABrowserTest, ToggleAdTypes) {
   test_util::StartProcess(rewards_service_);
   WaitForRewardsInitialization();
 
   PrefService* prefs = browser()->profile()->GetPrefs();
 
-  // Turn rewards on.
   TurnOnRewards();
-  histogram_tester_->ExpectBucketCount(p3a::kAdsEnabledDurationHistogramName,
-                                       p3a::AdsEnabledDuration::kStillEnabled,
-                                       1);
 
-  // We can't turn rewards back off without shutting down the rewards
-  // process, which interferes with other tests running in parallel.
-  // Instead rely on the fact that the EnabledDuration P3A measurement
-  // is made by the rewards service preference observer.
   prefs->SetBoolean(brave_ads::prefs::kOptedInToNotificationAds, false);
-  histogram_tester_->ExpectBucketCount(p3a::kAdsEnabledDurationHistogramName,
-                                       p3a::AdsEnabledDuration::kHours, 1);
+  histogram_tester_->ExpectBucketCount(p3a::kAdTypesEnabledHistogramName,
+                                       p3a::AdTypesEnabled::kNTP, 1);
 
-  // Mock turning rewards back on.
+  prefs->SetBoolean(ntp_background_images::prefs::
+                        kNewTabPageShowSponsoredImagesBackgroundImage,
+                    false);
+  histogram_tester_->ExpectBucketCount(p3a::kAdTypesEnabledHistogramName,
+                                       p3a::AdTypesEnabled::kNone, 1);
+
   prefs->SetBoolean(brave_ads::prefs::kOptedInToNotificationAds, true);
-  // Adjust the stored timestamp to measure a longer duration.
-  auto earlier = base::Time::Now() - base::Minutes(90);
-  VLOG(1) << "Backdating timestamp to " << earlier;
-  prefs->SetTime(prefs::kAdsEnabledTimestamp, earlier);
-
-  // Mock turning rewards off.
-  prefs->SetBoolean(brave_ads::prefs::kOptedInToNotificationAds, false);
-  histogram_tester_->ExpectBucketCount(p3a::kAdsEnabledDurationHistogramName,
-                                       p3a::AdsEnabledDuration::kHours, 2);
-
-  // Mock turning rewards back on.
-  prefs->SetBoolean(brave_ads::prefs::kOptedInToNotificationAds, true);
-  auto yesterday = base::Time::Now() - base::Days(1);
-  VLOG(1) << "Backdating timestamp to " << yesterday;
-  prefs->SetTime(prefs::kAdsEnabledTimestamp, yesterday);
-
-  // Mock turning rewards off.
-  prefs->SetBoolean(brave_ads::prefs::kOptedInToNotificationAds, false);
-  histogram_tester_->ExpectBucketCount(p3a::kAdsEnabledDurationHistogramName,
-                                       p3a::AdsEnabledDuration::kDays, 1);
-
-  // Mock turning rewards on for more than a week.
-  prefs->SetBoolean(brave_ads::prefs::kOptedInToNotificationAds, true);
-  auto last_week = base::Time::Now() - base::Days(12);
-  VLOG(1) << "Backdating timestamp to " << last_week;
-  prefs->SetTime(prefs::kAdsEnabledTimestamp, last_week);
-
-  // Mock turning rewards off.
-  prefs->SetBoolean(brave_ads::prefs::kOptedInToNotificationAds, false);
-  histogram_tester_->ExpectBucketCount(p3a::kAdsEnabledDurationHistogramName,
-                                       p3a::AdsEnabledDuration::kWeeks, 1);
-
-  // Mock turning rewards on for more than a month.
-  prefs->SetBoolean(brave_ads::prefs::kOptedInToNotificationAds, true);
-  auto last_month = base::Time::Now() - base::Days(40);
-  VLOG(1) << "Backdating timestamp to " << last_month;
-  prefs->SetTime(prefs::kAdsEnabledTimestamp, last_month);
-
-  // Mock turning rewards off.
-  prefs->SetBoolean(brave_ads::prefs::kOptedInToNotificationAds, false);
-  histogram_tester_->ExpectBucketCount(p3a::kAdsEnabledDurationHistogramName,
-                                       p3a::AdsEnabledDuration::kMonths, 1);
-
-  // Mock turning rewards on for our longest measured value.
-  prefs->SetBoolean(brave_ads::prefs::kOptedInToNotificationAds, true);
-  auto long_ago = base::Time::Now() - base::Days(128);
-  VLOG(1) << "Backdating timestamp to " << long_ago;
-  prefs->SetTime(prefs::kAdsEnabledTimestamp, long_ago);
-
-  // Mock turning rewards off.
-  prefs->SetBoolean(brave_ads::prefs::kOptedInToNotificationAds, false);
-  histogram_tester_->ExpectBucketCount(p3a::kAdsEnabledDurationHistogramName,
-                                       p3a::AdsEnabledDuration::kQuarters, 1);
+  histogram_tester_->ExpectBucketCount(p3a::kAdTypesEnabledHistogramName,
+                                       p3a::AdTypesEnabled::kNotification, 1);
 }
 
 #if !BUILDFLAG(IS_ANDROID)

--- a/components/brave_rewards/common/pref_names.h
+++ b/components/brave_rewards/common/pref_names.h
@@ -23,8 +23,6 @@ extern const char kShowButton[];  // DEPRECATED
 extern const char kShowLocationBarButton[];
 extern const char kEnabled[];  // DEPRECATED
 extern const char kDeclaredGeo[];
-extern const char kAdsEnabledTimeDelta[];
-extern const char kAdsEnabledTimestamp[];
 extern const char kNotifications[];
 extern const char kNotificationTimerInterval[];
 extern const char kBackupNotificationInterval[];  // DEPRECATED
@@ -81,6 +79,8 @@ extern const char kWalletCreationEnvironment[];
 // deprecated p3a prefs
 extern const char kAdsWereDisabled[];
 extern const char kHasAdsP3AState[];
+extern const char kAdsEnabledTimeDelta[];
+extern const char kAdsEnabledTimestamp[];
 
 }  // namespace brave_rewards::prefs
 

--- a/components/ntp_background_images/browser/view_counter_service.cc
+++ b/components/ntp_background_images/browser/view_counter_service.cc
@@ -126,9 +126,8 @@ void ViewCounterService::BrandedWallpaperWillBeDisplayed(
         brave_ads::mojom::NewTabPageAdEventType::kViewed,
         /*intentional*/ base::DoNothing());
 
-    if (ntp_p3a_helper_ &&
-        !prefs_->GetBoolean(brave_rewards::prefs::kEnabled)) {
-      // Should only report to P3A if ads are disabled, as required by spec.
+    if (ntp_p3a_helper_) {
+      // Should only report to P3A if rewards is disabled, as required by spec.
       ntp_p3a_helper_->RecordView(creative_instance_id);
     }
   }
@@ -334,7 +333,7 @@ void ViewCounterService::BrandedWallpaperLogoClicked(
       brave_ads::mojom::NewTabPageAdEventType::kClicked,
       /*intentional*/ base::DoNothing());
 
-  if (ntp_p3a_helper_ && !prefs_->GetBoolean(brave_rewards::prefs::kEnabled)) {
+  if (ntp_p3a_helper_) {
     // Should only report to P3A if ads are disabled, as required by spec.
     ntp_p3a_helper_->RecordClickAndMaybeLand(creative_instance_id);
   }

--- a/components/p3a/metric_names.h
+++ b/components/p3a/metric_names.h
@@ -45,7 +45,7 @@ constexpr inline auto kCollectedTypicalHistograms =
     "Brave.Playlist.FirstTimeOffset",
     "Brave.Playlist.NewUserReturning",
     "Brave.Playlist.UsageDaysInWeek",
-    "Brave.Rewards.AdsEnabledDuration",
+    "Brave.Rewards.AdTypesEnabled",
     "Brave.Rewards.AutoContributionsState.3",
     "Brave.Rewards.EnabledSource",
     "Brave.Rewards.InlineTipTrigger",

--- a/test/BUILD.gn
+++ b/test/BUILD.gn
@@ -889,6 +889,7 @@ test("brave_browser_tests") {
     "//brave/components/l10n/common",
     "//brave/components/l10n/common:test_support",
     "//brave/components/ntp_background_images/buildflags",
+    "//brave/components/ntp_background_images/common",
     "//brave/components/resources:strings_grit",
     "//brave/components/skus/common",
     "//brave/components/speedreader/common/buildflags",


### PR DESCRIPTION


<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/31841

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-arm64, CI/skip-linux-x64, CI/skip-android, CI/skip-macos, CI/skip-ios, CI/skip-windows-arm64, CI/skip-windows-x64, CI/skip-windows-x86 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [ ] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

0. Start with fresh profile, ensure metric does not exist.
1. Enable rewards, ensure metric value is 3.
2. Disable notification ads, ensure metric value is 1.
3. Disable NTP ads, ensure metric value is 0.
4. Enable notification ads, ensure metric value is 2.
5. Reset rewards, ensure metric disappears.

Regression testing of https://github.com/brave/brave-core/pull/14595 recommended.