### PR TITLE
Observe FullscreenController for vertical tab bounds (#18653) (uplift to 1.56.x)

### DIFF
--- a/browser/ui/views/frame/vertical_tab_strip_widget_delegate_view.h
+++ b/browser/ui/views/frame/vertical_tab_strip_widget_delegate_view.h
@@ -9,12 +9,15 @@
 #include <memory>
 
 #include "base/scoped_multi_source_observation.h"
+#include "chrome/browser/ui/browser_list_observer.h"
+#include "chrome/browser/ui/exclusive_access/fullscreen_observer.h"
 #include "ui/views/view_observer.h"
 #include "ui/views/widget/widget_delegate.h"
 #include "ui/views/widget/widget_observer.h"
 
 class BrowserView;
 class VerticalTabStripRegionView;
+class FullscreenController;
 
 // This class wraps VerticalTabStripRegionView and show them atop a Widget.
 // Vertical tab strip could be overlaps with contents web view and
@@ -35,7 +38,9 @@ class VerticalTabStripRegionView;
 //
 class VerticalTabStripWidgetDelegateView : public views::WidgetDelegateView,
                                            public views::ViewObserver,
-                                           public views::WidgetObserver {
+                                           public views::WidgetObserver,
+                                           public BrowserListObserver,
+                                           public FullscreenObserver {
  public:
   METADATA_HEADER(VerticalTabStripWidgetDelegateView);
 
@@ -63,6 +68,12 @@ class VerticalTabStripWidgetDelegateView : public views::WidgetDelegateView,
                              const gfx::Rect& new_bounds) override;
   void OnWidgetDestroying(views::Widget* widget) override;
 
+  // BrowserListObserver:
+  void OnBrowserAdded(Browser* browser) override;
+
+  // FullscreenObserver:
+  void OnFullscreenStateChanged() override;
+
  private:
   VerticalTabStripWidgetDelegateView(BrowserView* browser_view,
                                      views::View* host);
@@ -81,6 +92,9 @@ class VerticalTabStripWidgetDelegateView : public views::WidgetDelegateView,
 
   base::ScopedMultiSourceObservation<views::Widget, views::WidgetObserver>
       widget_observation_{this};
+
+  base::ScopedObservation<FullscreenController, FullscreenObserver>
+      fullscreen_observation_{this};
 };
 
 #endif  // BRAVE_BROWSER_UI_VIEWS_FRAME_VERTICAL_TAB_STRIP_WIDGET_DELEGATE_VIEW_H_


### PR DESCRIPTION
* Observe FullscreenController for vertical tab bounds

When fullscreen state changes, we were depending on WidgetObserver::OnWidgetBoundsChanged(). But this seems to be insufficient.

* Widget bounds stay same in some cases
  * Transition from Browser fullscreen to Tab fullscreen

* Could have timing issue
  * If widget's bounds changes first, and then update fullscreen controller's state changes later, the preferred size returned from VerticalTabStripRegionView could be wrong - it will think it's still normal window, not fullscreen.

In order to solve this, we should observe FullscreenController directly.

* Add DCHECKs for pre/post invariants.

Resolves https://github.com/brave/brave-browser/issues/30629

Uplift from #18653