### PR TITLE
[Google Sign In] Use wc_getter instead of wc in OnPermissionRequestStatus (uplift to 1.57.x)

### DIFF
--- a/components/google_sign_in_permission/google_sign_in_permission_throttle.cc
+++ b/components/google_sign_in_permission/google_sign_in_permission_throttle.cc
@@ -29,11 +29,17 @@ namespace {
 
 void OnPermissionRequestStatus(
     content::NavigationEntry* pending_entry,
-    content::WebContents* contents,
+    content::WebContents::Getter wc_getter,
     const GURL& request_initiator_url,
     URLLoaderThrottle::Delegate* delegate,
     const std::vector<blink::mojom::PermissionStatus>& permission_statuses) {
   DCHECK_EQ(1u, permission_statuses.size());
+
+  auto* contents = wc_getter.Run();
+  if (!contents || !pending_entry) {
+    return;
+  }
+
   // Check if current pending navigation is the one we started out with.
   // This is done to prevent us from accessing a deleted Delegate, if
   // the user navigated away while the prompt was still up, or closed the
@@ -93,7 +99,7 @@ void GoogleSignInPermissionThrottle::WillStartRequest(
   GetPermissionAndMaybeCreatePrompt(
       contents, request_initiator_url, defer,
       base::BindOnce(&OnPermissionRequestStatus,
-                     contents->GetController().GetPendingEntry(), contents,
+                     contents->GetController().GetPendingEntry(), wc_getter_,
                      request_initiator_url, delegate_));
 }
 


### PR DESCRIPTION
Uplift of #19376
Resolves https://github.com/brave/brave-browser/issues/31615

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.