### PR TITLE
Disable l10n for keyEquivalent entirely

### DIFF
--- a/browser/brave_app_controller_mac.mm
+++ b/browser/brave_app_controller_mac.mm
@@ -15,6 +15,23 @@
 
 @implementation BraveAppController
 
++ (void)disableKeyEquivalentLoclizationRecursively:(NSMenu*) menu
+    NS_AVAILABLE_MAC(12.0) {
+  // On some keyboard layout with dead keys, shortcuts that contains a dead key
+  // doesn't working at all. we should disable the localization and mirroring.
+  // https://github.com/brave/brave-browser/issues/31871
+
+  for (NSMenuItem* item in [menu itemArray]) {
+    // Setting this to NO will change allowsAutomaticKeyEquivalentMirroring to
+    // NO too.
+    // https://developer.apple.com/documentation/appkit/nsmenuitem/3787554-allowsautomatickeyequivalentloca?language=objc
+    item.allowsAutomaticKeyEquivalentLocalization = NO;
+    if (NSMenu* submenu = [item submenu]) {
+      [BraveAppController disableKeyEquivalentLoclizationRecursively:submenu];
+    }
+  }
+}
+
 - (void)mainMenuCreated {
   [super mainMenuCreated];
 
@@ -25,6 +42,10 @@
   _copyCleanLinkMenuItem = [editMenu itemWithTag:IDC_COPY_CLEAN_LINK];
   DCHECK(_copyCleanLinkMenuItem);
   [[_copyCleanLinkMenuItem menu] setDelegate:self];
+
+  if (@available(macos 12.0, *)) {
+    [BraveAppController disableKeyEquivalentLoclizationRecursively:[NSApp mainMenu]];
+  }
 }
 
 - (void)dealloc {

--- a/browser/ui/views/commands/default_accelerators_mac.mm
+++ b/browser/ui/views/commands/default_accelerators_mac.mm
@@ -50,25 +50,6 @@ bool CanConvertToAcceleratorMapping(NSMenuItem* item) {
 }
 
 AcceleratorMapping ToAcceleratorMapping(NSMenuItem* item) {
-  bool keyEquivalentLocalizationEnabled = NO;
-  bool keyEquivalentMirroringEnabled = NO;
-
-  if (@available(macos 12.0, *)) {
-    keyEquivalentLocalizationEnabled =
-        item.allowsAutomaticKeyEquivalentLocalization;
-    keyEquivalentMirroringEnabled = item.allowsAutomaticKeyEquivalentMirroring;
-
-    // We can't parse keyEquivalent into keycode properly when it's unicode
-    // character. So before starting parsing, disable l10n for a while.
-    // https://github.com/brave/brave-browser/issues/31770
-    if (keyEquivalentLocalizationEnabled) {
-      // Setting this to NO will change allowsAutomaticKeyEquivalentMirroring to
-      // NO too.
-      // https://developer.apple.com/documentation/appkit/nsmenuitem/3787554-allowsautomatickeyequivalentloca?language=objc
-      item.allowsAutomaticKeyEquivalentLocalization = NO;
-    }
-  }
-
   NSString* keyEquivalent = item.keyEquivalent;
   DVLOG(2) << __FUNCTION__ << item.tag << " > "
            << base::SysNSStringToUTF16(keyEquivalent);
@@ -120,12 +101,6 @@ AcceleratorMapping ToAcceleratorMapping(NSMenuItem* item) {
       (modifiers == ui::EF_COMMAND_DOWN &&
        [keyEquivalent isEqualToString:@"w"])) {
     modifiers |= ui::EF_SHIFT_DOWN;
-  }
-
-  if (@available(macos 12.0, *)) {
-    item.allowsAutomaticKeyEquivalentLocalization =
-        keyEquivalentLocalizationEnabled;
-    item.allowsAutomaticKeyEquivalentMirroring = keyEquivalentMirroringEnabled;
   }
 
   return {.keycode = ui::KeyboardCodeFromNSEvent(keyEvent),


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/31871

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-arm64, CI/skip-linux-x64, CI/skip-android, CI/skip-macos, CI/skip-ios, CI/skip-windows-arm64, CI/skip-windows-x64, CI/skip-windows-x86 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [ ] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

