### PR TITLE
[Shortcuts]: Fix display keys

### DIFF
--- a/browser/resources/settings/shortcuts_page/components/ConfigureShortcut.tsx
+++ b/browser/resources/settings/shortcuts_page/components/ConfigureShortcut.tsx
@@ -92,6 +92,8 @@ export default function ConfigureShortcut(props: {
       .reduce((prev, next) => ({ ...prev, [next[1]]: next[0] }), {})
   }, [commands])
 
+  const keys = useKeys(current.codes)
+
   React.useEffect(() => {
     const onDown = (e: KeyboardEvent) => {
       const hasModifier = e.ctrlKey || e.metaKey || e.altKey || e.shiftKey
@@ -101,7 +103,7 @@ export default function ConfigureShortcut(props: {
       if (e.code === "Enter" && !hasModifier && current.isValid) {
         props.onChange({
           codes: keysToString(current.codes),
-          keys: keysToString([])
+          keys: keysToString(keys)
         })
         return;
       }
@@ -145,8 +147,6 @@ export default function ConfigureShortcut(props: {
       document.removeEventListener('keydown', onDown)
     }
   }, [current])
-
-  const keys = useKeys(current.codes)
 
   const shortcut = current.codes.join('+');
   const conflict = acceleratorLookup[shortcut]
@@ -196,7 +196,7 @@ export default function ConfigureShortcut(props: {
           onClick={() => {
             props.onChange({
               codes: keysToString(current.codes),
-              keys: keysToString([])
+              keys: keysToString(keys)
             })
           }}
         >

--- a/browser/resources/settings/shortcuts_page/utils/commandsCache.ts
+++ b/browser/resources/settings/shortcuts_page/utils/commandsCache.ts
@@ -15,8 +15,7 @@ export const api = CommandsService.getRemote()
 
 export class CommandsCache
   extends CachingWrapper<Command>
-  implements CommandsListenerInterface
-{
+  implements CommandsListenerInterface {
   private receiver = new CommandsListenerReceiver(this)
   private controller: CommandsServiceRemote
 
@@ -65,5 +64,9 @@ export class CommandsCache
 
   resetAll() {
     this.controller.resetAccelerators();
+  }
+
+  getKeyFromCode(code: string): Promise<string> {
+    return this.controller.getKeyFromCode(code).then(c => c.key)
   }
 }

--- a/browser/ui/commands/accelerator_service.cc
+++ b/browser/ui/commands/accelerator_service.cc
@@ -227,6 +227,11 @@ void AcceleratorService::ResetAccelerators() {
   NotifyCommandsChanged(commands);
 }
 
+void AcceleratorService::GetKeyFromCode(const std::string& code,
+                                        GetKeyFromCodeCallback callback) {
+  std::move(callback).Run(CodeStringToKeyString(code));
+}
+
 void AcceleratorService::AddCommandsListener(
     mojo::PendingRemote<mojom::CommandsListener> listener) {
   auto id = mojo_listeners_.Add(std::move(listener));

--- a/browser/ui/commands/accelerator_service.h
+++ b/browser/ui/commands/accelerator_service.h
@@ -52,6 +52,9 @@ class AcceleratorService : public mojom::CommandsService, public KeyedService {
   void ResetAcceleratorsForCommand(int command_id) override;
   void ResetAccelerators() override;
 
+  void GetKeyFromCode(const std::string& code,
+                      GetKeyFromCodeCallback callback) override;
+
   void AddCommandsListener(
       mojo::PendingRemote<mojom::CommandsListener> listener) override;
   void AddObserver(Observer* observer);

--- a/components/commands/common/accelerator_parsing.cc
+++ b/components/commands/common/accelerator_parsing.cc
@@ -175,6 +175,11 @@ std::string KeyCodeToString(ui::KeyboardCode key_code) {
 
 }  // namespace
 
+std::string CodeStringToKeyString(const std::string& code_string) {
+  auto code = DomCodeStringToKeyboardCode(code_string);
+  return KeyCodeToString(code);
+}
+
 std::string ToKeysString(const ui::Accelerator& accelerator) {
   std::vector<std::string> parts = GetModifierNames(accelerator.modifiers());
   parts.push_back(KeyCodeToString(accelerator.key_code()));

--- a/components/commands/common/accelerator_parsing.h
+++ b/components/commands/common/accelerator_parsing.h
@@ -14,6 +14,10 @@
 
 namespace commands {
 
+// Converts a DomCode string to a human readable key string.
+COMPONENT_EXPORT(COMMANDS_COMMON)
+std::string CodeStringToKeyString(const std::string& code_string);
+
 // Converts an accelerator to a DomKeysString, which is all the DomKeys joined
 // around a '+' character.
 // Note: a KeysString is only really useful for displaying to  the user, as it

--- a/components/commands/common/commands.mojom
+++ b/components/commands/common/commands.mojom
@@ -37,6 +37,8 @@ interface CommandsService {
   ResetAccelerators();
 
   AddCommandsListener(pending_remote<CommandsListener> listener);
+
+  GetKeyFromCode(string code) => (string key);
 };
 
 struct CommandsEvent {


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/31625
Closes https://github.com/brave/brave-browser/issues/30879 (this is an alternative, much simpler solution)

The solution here is to not use the `key` property on the KeyboardEvent, and instead send the KeyCode to the backend, and convert it to a human friendly key there (we want the `DomKey` for the `DomCode`, not the key which would be typed).

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-arm64, CI/skip-linux-x64, CI/skip-android, CI/skip-macos, CI/skip-ios, CI/skip-windows-arm64, CI/skip-windows-x64, CI/skip-windows-x86 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [ ] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

1. Add a new shortcut for any command with `Control`+`=`. `Control`+`=` should be displayed while entering the shortcut and after saving it.
2. Add a new shortcut for any command with `Control`+`Shift`+`=`. `Control`+`Shift`+`=` (not `+`) should be displayed while entering the shortcut and after saving it. 
3. On macOS, create a shortcut using `Alt`+`P`. `Alt`+`P` should be displayed in the new shortcut dialog and after saving.