### PR TITLE
Add all Leo skia colors to light and dark color mixers

### DIFF
--- a/browser/ui/color/brave_color_mixer.cc
+++ b/browser/ui/color/brave_color_mixer.cc
@@ -19,6 +19,7 @@
 #include "chrome/browser/ui/color/chrome_color_id.h"
 #include "ui/color/color_id.h"
 #include "ui/color/color_provider.h"
+#include "ui/color/color_provider_manager.h"
 #include "ui/color/color_recipe.h"
 #include "ui/gfx/color_palette.h"
 #include "ui/gfx/color_utils.h"
@@ -239,6 +240,20 @@ void AddChromeDarkThemeColorMixer(ui::ColorProvider* provider,
   mixer[kColorDownloadToolbarButtonActive] = {SkColorSetRGB(0x87, 0x84, 0xF4)};
   mixer[kColorDownloadToolbarButtonRingBackground] = {
       SkColorSetARGB(0x33, 0x16, 0x17, 0x1D)};
+}
+
+void AddLeoColorMixer(ui::ColorProvider* provider,
+                      const ui::ColorProviderManager::Key& key) {
+  auto leo_theme = key.color_mode == ui::ColorProviderManager::ColorMode::kLight
+                       ? leo::Theme::kLight
+                       : leo::Theme::kDark;
+  ui::ColorMixer& mixer = provider->AddMixer();
+  for (int i = static_cast<int>(leo::Color::kLeoColorsStart);
+       i != static_cast<int>(leo::Color::kLeoColorsEnd); i++) {
+    leo::Color color_name = static_cast<leo::Color>(i);
+    auto color_value = leo::GetColor(color_name, leo_theme);
+    mixer[static_cast<int>(color_name)] = {color_value};
+  }
 }
 
 }  // namespace
@@ -503,6 +518,7 @@ void AddBraveThemeColorMixer(ui::ColorProvider* provider,
   key.color_mode == ui::ColorProviderManager::ColorMode::kDark
       ? AddBraveDarkThemeColorMixer(provider, key)
       : AddBraveLightThemeColorMixer(provider, key);
+  AddLeoColorMixer(provider, key);
 #if BUILDFLAG(ENABLE_BRAVE_VPN)
   AddBraveVpnColorMixer(provider, key);
 #endif


### PR DESCRIPTION
This makes referring to the colors from UI classes easier by not having to redefine a new variable with a leo dark or light equivalent. It takes advantage of the fact that all Leo colors already have light and dark equivalents. UI that wishes to have different Leo colors for light and dark can and will still need to specify that explicitly.

Requires https://github.com/brave/leo/pull/343
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves 

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-arm64, CI/skip-linux-x64, CI/skip-android, CI/skip-macos, CI/skip-ios, CI/skip-windows-arm64, CI/skip-windows-x64, CI/skip-windows-x86 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [ ] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

