### PR TITLE
Handles TokenNoLongerValid response for subscriber credential fetching

### DIFF
--- a/components/brave_vpn/browser/brave_vpn_service.h
+++ b/components/brave_vpn/browser/brave_vpn_service.h
@@ -189,6 +189,7 @@ class BraveVpnService :
   void SetCurrentEnvironment(const std::string& env);
   void EnsureMojoConnected();
   void OnMojoConnectionError();
+  void RequestCredentialSummary(const std::string& domain);
   void OnCredentialSummary(const std::string& domain,
                            const std::string& summary_string);
   void OnPrepareCredentialsPresentation(

--- a/components/brave_vpn/browser/brave_vpn_service_helper.cc
+++ b/components/brave_vpn/browser/brave_vpn_service_helper.cc
@@ -20,6 +20,7 @@
 #include "brave/components/brave_vpn/common/pref_names.h"
 #include "brave/components/skus/browser/skus_utils.h"
 #include "components/prefs/pref_service.h"
+#include "components/prefs/scoped_user_pref_update.h"
 
 namespace brave_vpn {
 
@@ -94,6 +95,18 @@ void SetSkusCredential(PrefService* local_prefs,
                 base::TimeToValue(expiration_time));
   local_prefs->SetDict(prefs::kBraveVPNSubscriberCredential,
                        std::move(cred_dict));
+}
+
+void SetSkusCredentialFetchingRetried(PrefService* local_prefs, bool retried) {
+  ScopedDictPrefUpdate update(local_prefs,
+                              prefs::kBraveVPNSubscriberCredential);
+  update->Set(kRetriedSkusCredentialKey, base::Value(retried));
+}
+
+bool IsRetriedSkusCredential(PrefService* local_prefs) {
+  const base::Value::Dict& sub_cred_dict =
+      local_prefs->GetDict(prefs::kBraveVPNSubscriberCredential);
+  return sub_cred_dict.FindBool(kRetriedSkusCredentialKey).value_or(false);
 }
 
 base::Time GetExpirationTimeForSkusCredential(PrefService* local_prefs) {

--- a/components/brave_vpn/browser/brave_vpn_service_helper.h
+++ b/components/brave_vpn/browser/brave_vpn_service_helper.h
@@ -39,6 +39,8 @@ void ClearSubscriberCredential(PrefService* local_prefs);
 void SetSkusCredential(PrefService* local_prefs,
                        const std::string& skus_credential,
                        const base::Time& expiration_time);
+void SetSkusCredentialFetchingRetried(PrefService* local_prefs, bool retried);
+bool IsRetriedSkusCredential(PrefService* local_prefs);
 base::Time GetExpirationTimeForSkusCredential(PrefService* local_prefs);
 
 }  // namespace brave_vpn

--- a/components/brave_vpn/browser/brave_vpn_service_unittest.cc
+++ b/components/brave_vpn/browser/brave_vpn_service_unittest.cc
@@ -849,12 +849,22 @@ TEST_F(BraveVPNServiceTest, CheckInitialPurchasedStateTest) {
   EXPECT_EQ(PurchasedState::LOADING, GetPurchasedInfoSync());
 }
 
-TEST_F(BraveVPNServiceTest, SubscribedCredentials) {
+TEST_F(BraveVPNServiceTest, SubscribedCredentialsWithTokenNoLongerValid) {
   std::string env = skus::GetDefaultEnvironment();
-  SetPurchasedState(env, PurchasedState::PURCHASED);
-  EXPECT_EQ(PurchasedState::PURCHASED, GetPurchasedInfoSync());
-  OnGetSubscriberCredentialV12("Token No Longer Valid", false);
+
+  SetPurchasedState(env, PurchasedState::LOADING);
+  OnGetSubscriberCredentialV12(kTokenNoLongerValid, false);
+  EXPECT_EQ(PurchasedState::LOADING, GetPurchasedInfoSync());
+  EXPECT_TRUE(IsRetriedSkusCredential(&local_pref_service_));
+
+  // Retrying only once.
+  OnGetSubscriberCredentialV12(kTokenNoLongerValid, false);
   EXPECT_EQ(PurchasedState::FAILED, GetPurchasedInfoSync());
+  EXPECT_TRUE(IsRetriedSkusCredential(&local_pref_service_));
+
+  // Check retrying flag is cleared when we got valid subs-credential.
+  OnGetSubscriberCredentialV12("valid-subs-credentials", true);
+  EXPECT_FALSE(IsRetriedSkusCredential(&local_pref_service_));
 }
 
 // Test connection check is asked only when purchased state.

--- a/components/brave_vpn/common/brave_vpn_constants.h
+++ b/components/brave_vpn/common/brave_vpn_constants.h
@@ -44,6 +44,7 @@ constexpr int kP3AIntervalHours = 24;
 
 constexpr char kSubscriberCredentialKey[] = "credential";
 constexpr char kSkusCredentialKey[] = "skus_credential";
+constexpr char kRetriedSkusCredentialKey[] = "retried_skus_credential";
 constexpr char kSubscriberCredentialExpirationKey[] = "expiration";
 
 #if !BUILDFLAG(IS_ANDROID)


### PR DESCRIPTION
fix https://github.com/brave/brave-browser/issues/31836

We'll try to issue new skus-credential for fetching subscriber-credential
one more time when we got TokenNoLongerValid.

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves 

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-arm64, CI/skip-linux-x64, CI/skip-android, CI/skip-macos, CI/skip-ios, CI/skip-windows-arm64, CI/skip-windows-x64, CI/skip-windows-x86 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

`BraveVPNServiceTest.SubscribedCredentialsWithTokenNoLongerValid`