### PR TITLE
Fix chromium API crash for activity result

### DIFF
--- a/android/java/org/chromium/chrome/browser/crypto_wallet/fragments/EditVisibleAssetsBottomSheetDialogFragment.java
+++ b/android/java/org/chromium/chrome/browser/crypto_wallet/fragments/EditVisibleAssetsBottomSheetDialogFragment.java
@@ -309,8 +309,12 @@ public class EditVisibleAssetsBottomSheetDialogFragment extends BottomSheetDialo
     public void onAttach(@NonNull Context context) {
         super.onAttach(context);
 
+        // Pass @{code ActivityResultRegistry} reference explicitly to avoid crash
+        // https://github.com/brave/brave-browser/issues/31882
         mAddAssetActivityResultLauncher = registerForActivityResult(
-                new ActivityResultContracts.StartActivityForResult(), result -> {
+                new ActivityResultContracts.StartActivityForResult(),
+                ((BraveWalletBaseActivity) requireActivity()).getActivityResultRegistry(),
+                result -> {
                     if (result.getResultCode() == Activity.RESULT_OK) {
                         Intent intent = result.getData();
                         if (intent == null) {

--- a/android/java/org/chromium/chrome/browser/crypto_wallet/fragments/NftGridFragment.java
+++ b/android/java/org/chromium/chrome/browser/crypto_wallet/fragments/NftGridFragment.java
@@ -136,13 +136,17 @@ public class NftGridFragment extends Fragment implements OnWalletListItemClick {
         });
         setUpObservers();
 
-        mAddAssetActivityResultLauncher = registerForActivityResult(
-                new ActivityResultContracts.StartActivityForResult(), result -> {
-                    if (result.getResultCode() == Activity.RESULT_OK) {
-                        mPbAssetDiscovery.setVisibility(View.VISIBLE);
-                        updateNftGrid();
-                    }
-                });
+        // Pass @{code ActivityResultRegistry} reference explicitly to avoid crash
+        // https://github.com/brave/brave-browser/issues/31882
+        mAddAssetActivityResultLauncher =
+                registerForActivityResult(new ActivityResultContracts.StartActivityForResult(),
+                        ((BraveWalletBaseActivity) requireActivity()).getActivityResultRegistry(),
+                        result -> {
+                            if (result.getResultCode() == Activity.RESULT_OK) {
+                                mPbAssetDiscovery.setVisibility(View.VISIBLE);
+                                updateNftGrid();
+                            }
+                        });
 
         return view;
     }

--- a/android/java/org/chromium/chrome/browser/vpn/activities/BraveVpnParentActivity.java
+++ b/android/java/org/chromium/chrome/browser/vpn/activities/BraveVpnParentActivity.java
@@ -43,8 +43,11 @@ public abstract class BraveVpnParentActivity
     abstract void showRestoreMenu(boolean shouldShowRestore);
     abstract void updateProfileView();
 
+    // Pass @{code ActivityResultRegistry} reference explicitly to avoid crash
+    // https://github.com/brave/brave-browser/issues/31882
     ActivityResultLauncher<Intent> intentActivityResultLauncher = registerForActivityResult(
-            new ActivityResultContracts.StartActivityForResult(), result -> {
+            new ActivityResultContracts.StartActivityForResult(), getActivityResultRegistry(),
+            result -> {
                 BraveVpnUtils.dismissProgressDialog();
                 if (result.getResultCode() == RESULT_OK) {
                     BraveVpnProfileUtils.getInstance().startVpn(BraveVpnParentActivity.this);


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/31882

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-arm64, CI/skip-linux-x64, CI/skip-android, CI/skip-macos, CI/skip-ios, CI/skip-windows-arm64, CI/skip-windows-x64, CI/skip-windows-x86 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
- Wallet should not crash after login and should be able to add new NFTs
-  Should be able to edit assets (hide/show)

[fix-activity-result-crash.webm](https://github.com/brave/brave-core/assets/11755381/471c044c-075e-4662-ae1a-5ee922fb023a)