### PR TITLE
Fix vertical tab scroll clamping (#18656) (uplift to 1.56.x)

### DIFF
--- a/browser/ui/views/frame/vertical_tab_strip_region_view.cc
+++ b/browser/ui/views/frame/vertical_tab_strip_region_view.cc
@@ -1109,13 +1109,16 @@ void VerticalTabStripRegionView::ScrollActiveTabToBeVisible() {
   // Unfortunately, ScrollView's API doesn't work well for us. So we manually
   // adjust scroll offset. Note that we change contents view's position as
   // we disabled layered scroll view.
-  if (visible_rect.y() > tab_bounds_in_contents_view.bottom()) {
-    contents_view_->SetPosition(
+  if (visible_rect.CenterPoint().y() >=
+      tab_bounds_in_contents_view.CenterPoint().y()) {
+    scroll_view_->contents()->SetPosition(
         {0, -static_cast<int>(tab_bounds_in_contents_view.y())});
   } else {
-    contents_view_->SetPosition(
-        {0, -static_cast<int>(tab_bounds_in_contents_view.bottom()) +
-                scroll_view_->height() - header_view_->height()});
+    scroll_view_->contents()->SetPosition(
+        {0, std::min(0, scroll_view_->height() -
+                            static_cast<int>(
+                                tab_bounds_in_contents_view.bottom() +
+                                tabs::kMarginForVerticalTabContainers))});
   }
 }
 


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/31925

Uplift from https://github.com/brave/brave-core/pull/18656