### PR TITLE
Request auth when changing sync password pref

### DIFF
--- a/android/brave_java_sources.gni
+++ b/android/brave_java_sources.gni
@@ -412,6 +412,7 @@ brave_java_sources = [
   "../../brave/android/java/org/chromium/chrome/browser/suggestions/tile/BraveTileView.java",
   "../../brave/android/java/org/chromium/chrome/browser/sync/BraveSyncDevices.java",
   "../../brave/android/java/org/chromium/chrome/browser/sync/settings/BraveManageSyncSettings.java",
+  "../../brave/android/java/org/chromium/chrome/browser/sync/settings/BravePasswordAccessReauthenticationHelper.java",
   "../../brave/android/java/org/chromium/chrome/browser/tab/BraveTabHelpers.java",
   "../../brave/android/java/org/chromium/chrome/browser/tabbed_mode/BraveTabbedRootUiCoordinator.java",
   "../../brave/android/java/org/chromium/chrome/browser/tabmodel/BraveTabCreator.java",

--- a/android/java/apk_for_test.flags
+++ b/android/java/apk_for_test.flags
@@ -73,6 +73,12 @@
 -keep class org.chromium.chrome.browser.sync.settings.ManageSyncSettings {
     *** mGoogleActivityControls;
     *** mSyncEncryption;
+    *** mSyncEverything;
+}
+
+-keep class org.chromium.chrome.browser.password_manager.settings.PasswordAccessReauthenticationHelper {
+    *** mCallback;
+    *** mFragmentManager;
 }
 
 -keep class org.chromium.chrome.browser.search_engines.settings.SearchEngineAdapter {

--- a/android/java/org/chromium/chrome/browser/sync/settings/BravePasswordAccessReauthenticationHelper.java
+++ b/android/java/org/chromium/chrome/browser/sync/settings/BravePasswordAccessReauthenticationHelper.java
@@ -1,0 +1,49 @@
+/* Copyright (c) 2023 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+package org.chromium.chrome.browser.sync.settings;
+
+import android.content.Context;
+import android.view.View;
+
+import androidx.fragment.app.FragmentManager;
+
+import org.chromium.base.Callback;
+import org.chromium.chrome.browser.password_manager.settings.PasswordAccessReauthenticationHelper;
+import org.chromium.chrome.browser.password_manager.settings.ReauthenticationManager;
+import org.chromium.chrome.browser.password_manager.settings.ReauthenticationManager.ReauthScope;
+
+/**
+ * Class to replace description at Chromium's PasswordAccessReauthenticationHelper.reauthenticate
+ */
+public class BravePasswordAccessReauthenticationHelper
+        extends PasswordAccessReauthenticationHelper {
+    // Both fields below belong to PasswordAccessReauthenticationHelper and required to make
+    // protected with BravePasswordAccessReauthenticationHelperClassAdapter
+    private Callback<Boolean> mCallback;
+    private FragmentManager mFragmentManager;
+
+    public BravePasswordAccessReauthenticationHelper(
+            Context context, FragmentManager fragmentManager) {
+        super(context, fragmentManager);
+    }
+
+    public void reauthenticateWithDescription(int descriptionId, Callback<Boolean> callback) {
+        assert canReauthenticate();
+        assert mCallback == null;
+
+        assert mFragmentManager != null;
+
+        // Invoke the handler immediately if an authentication is still valid.
+        if (ReauthenticationManager.authenticationStillValid(ReauthScope.ONE_AT_A_TIME)) {
+            callback.onResult(true);
+            return;
+        }
+
+        mCallback = callback;
+        ReauthenticationManager.displayReauthenticationFragment(
+                descriptionId, View.NO_ID, mFragmentManager, ReauthScope.ONE_AT_A_TIME);
+    }
+}

--- a/android/javatests/org/chromium/chrome/browser/BytecodeTest.java
+++ b/android/javatests/org/chromium/chrome/browser/BytecodeTest.java
@@ -174,6 +174,8 @@ public class BytecodeTest {
         Assert.assertTrue(
                 classExists("org/chromium/chrome/browser/sync/settings/ManageSyncSettings"));
         Assert.assertTrue(classExists(
+                "org/chromium/chrome/browser/password_manager/settings/PasswordAccessReauthenticationHelper")); // presubmit: ignore-long-line
+        Assert.assertTrue(classExists(
                 "org/chromium/chrome/browser/search_engines/settings/SearchEngineAdapter"));
         Assert.assertTrue(classExists(
                 "org/chromium/chrome/browser/search_engines/settings/SearchEngineSettings"));
@@ -892,6 +894,14 @@ public class BytecodeTest {
                         "mGoogleActivityControls"));
         Assert.assertTrue(fieldExists(
                 "org/chromium/chrome/browser/sync/settings/ManageSyncSettings", "mSyncEncryption"));
+        Assert.assertTrue(fieldExists(
+                "org/chromium/chrome/browser/sync/settings/ManageSyncSettings", "mSyncEverything"));
+        Assert.assertTrue(fieldExists(
+                "org/chromium/chrome/browser/password_manager/settings/PasswordAccessReauthenticationHelper", // presubmit: ignore-long-line
+                "mCallback"));
+        Assert.assertTrue(fieldExists(
+                "org/chromium/chrome/browser/password_manager/settings/PasswordAccessReauthenticationHelper", // presubmit: ignore-long-line
+                "mFragmentManager"));
         Assert.assertTrue(
                 fieldExists("org/chromium/chrome/browser/toolbar/bottom/BottomControlsCoordinator",
                         "mMediator"));

--- a/browser/ui/android/strings/android_brave_strings.grd
+++ b/browser/ui/android/strings/android_brave_strings.grd
@@ -1365,6 +1365,12 @@ Are you sure you want to do this?
       <message name="IDS_ENABLING_PASSWORD_SYNC_AUTH_MESSAGE" desc="Description shown when we ask for auth while enabling passwords sync">
         Unlock to enable passwords sync
       </message>
+      <message name="IDS_SYNC_PASSWORD_REQUIRE_AUTH_SUMMARY" desc="Summary displayed on Sync passwords data preference turned off switch to inform user that authentication will be required">
+        Before you can sync passwords, you'll need to authenticate with your device biometrics/passcode. This extra security measure helps keep your passwords safe.
+      </message>
+      <message name="IDS_DEVICE_REQUIRE_AUTH_TO_SYNC_PASSWORDS_SUMMARY" desc="Summary displayed on Sync passwords data preference turned off switch to inform user that in order to turn on Passwords sync, device should have enabled lockscreen biometrics/passcode authentication">
+        To sync passwords, please enable biometrics/passcode authentication on your Android device. This extra security measure helps keep your passwords safe.
+      </message>
       <message name="IDS_BRAVE_PRIVACY_NOTICE_URL" desc="URL for the Brave privacy notice" translateable="false">
         https://brave.com/privacy_android
       </message>

--- a/browser/ui/android/strings/android_brave_strings.grd
+++ b/browser/ui/android/strings/android_brave_strings.grd
@@ -1359,6 +1359,12 @@ Are you sure you want to do this?
       <message name="IDS_SYNC_CAMERA_PERMISSION_WAS_NOT_GRANTED_TOAST" desc="Popup message displayed when user did not granted camera permission when joining the sync chain by scanning QR code">
         Camera permission was not granted
       </message>
+      <message name="IDS_PASSWORD_SYNC_TYPE_SET_SCREEN_LOCK" desc="Text prompting user to set up screen lock on their device in order to change Sync passwords type">
+        To enable passwords sync, first set a screen lock on your device
+      </message>
+      <message name="IDS_ENABLING_PASSWORD_SYNC_AUTH_MESSAGE" desc="Description shown when we ask for auth while enabling passwords sync">
+        Unlock to enable passwords sync
+      </message>
       <message name="IDS_BRAVE_PRIVACY_NOTICE_URL" desc="URL for the Brave privacy notice" translateable="false">
         https://brave.com/privacy_android
       </message>

--- a/build/android/bytecode/BUILD.gn
+++ b/build/android/bytecode/BUILD.gn
@@ -67,6 +67,7 @@ java_binary("java_bytecode_rewriter") {
     "//brave/build/android/bytecode/java/org/brave/bytecode/BraveNotificationBuilderClassAdapter.java",
     "//brave/build/android/bytecode/java/org/brave/bytecode/BraveNotificationManagerProxyImplClassAdapter.java",
     "//brave/build/android/bytecode/java/org/brave/bytecode/BraveNotificationPermissionRationaleDialogControllerClassAdapter.java",
+    "//brave/build/android/bytecode/java/org/brave/bytecode/BravePasswordAccessReauthenticationHelperClassAdapter.java",
     "//brave/build/android/bytecode/java/org/brave/bytecode/BravePasswordSettingsBaseClassAdapter.java",
     "//brave/build/android/bytecode/java/org/brave/bytecode/BravePermissionDialogDelegateClassAdapter.java",
     "//brave/build/android/bytecode/java/org/brave/bytecode/BravePermissionDialogModelClassAdapter.java",

--- a/build/android/bytecode/bytecode_rewriter.gni
+++ b/build/android/bytecode/bytecode_rewriter.gni
@@ -24,6 +24,7 @@ brave_bytecode_jars = [
   "obj/chrome/browser/locale/delegate_java.javac.jar",
   "obj/chrome/browser/notifications/java.javac.jar",
   "obj/chrome/browser/partnercustomizations/java.javac.jar",
+  "obj/chrome/browser/password_manager/android/java.javac.jar",
   "obj/chrome/browser/preferences/java.javac.jar",
   "obj/chrome/browser/safe_browsing/android/java.javac.jar",
   "obj/chrome/browser/search_engines/android/java.javac.jar",

--- a/build/android/bytecode/java/org/brave/bytecode/BraveClassAdapter.java
+++ b/build/android/bytecode/java/org/brave/bytecode/BraveClassAdapter.java
@@ -7,6 +7,9 @@ package org.brave.bytecode;
 
 import org.objectweb.asm.ClassVisitor;
 
+/**
+ * Adapter to perform Java asm patches on upstreams' classes.
+ */
 public class BraveClassAdapter {
     public static ClassVisitor createAdapter(ClassVisitor chain) {
         chain = new BraveActivityClassAdapter(chain);
@@ -66,6 +69,7 @@ public class BraveClassAdapter {
         chain = new BraveNotificationBuilderClassAdapter(chain);
         chain = new BraveNotificationManagerProxyImplClassAdapter(chain);
         chain = new BraveNotificationPermissionRationaleDialogControllerClassAdapter(chain);
+        chain = new BravePasswordAccessReauthenticationHelperClassAdapter(chain);
         chain = new BravePasswordSettingsBaseClassAdapter(chain);
         chain = new BravePermissionDialogDelegateClassAdapter(chain);
         chain = new BravePermissionDialogModelClassAdapter(chain);

--- a/build/android/bytecode/java/org/brave/bytecode/BraveManageSyncSettingsClassAdapter.java
+++ b/build/android/bytecode/java/org/brave/bytecode/BraveManageSyncSettingsClassAdapter.java
@@ -7,6 +7,9 @@ package org.brave.bytecode;
 
 import org.objectweb.asm.ClassVisitor;
 
+/**
+ * Adapter, used to make some fields from upstream's ManageSyncSettings be public
+ */
 public class BraveManageSyncSettingsClassAdapter extends BraveClassVisitor {
     static String sManageSyncSettingsClassName =
             "org/chromium/chrome/browser/sync/settings/ManageSyncSettings";
@@ -21,5 +24,8 @@ public class BraveManageSyncSettingsClassAdapter extends BraveClassVisitor {
 
         deleteField(sBraveManageSyncSettingsClassName, "mSyncEncryption");
         makeProtectedField(sManageSyncSettingsClassName, "mSyncEncryption");
+
+        deleteField(sBraveManageSyncSettingsClassName, "mSyncEverything");
+        makeProtectedField(sManageSyncSettingsClassName, "mSyncEverything");
     }
 }

--- a/build/android/bytecode/java/org/brave/bytecode/BravePasswordAccessReauthenticationHelperClassAdapter.java
+++ b/build/android/bytecode/java/org/brave/bytecode/BravePasswordAccessReauthenticationHelperClassAdapter.java
@@ -1,0 +1,28 @@
+/* Copyright (c) 2023 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+package org.brave.bytecode;
+
+import org.objectweb.asm.ClassVisitor;
+
+/**
+ * Adapter, used to make some fields from upstream's PasswordAccessReauthenticationHelper be public
+ */
+public class BravePasswordAccessReauthenticationHelperClassAdapter extends BraveClassVisitor {
+    static String sHelperClassName =
+            "org/chromium/chrome/browser/password_manager/settings/PasswordAccessReauthenticationHelper"; // presubmit: ignore-long-line
+    static String sBraveHelperClassName =
+            "org/chromium/chrome/browser/sync/settings/BravePasswordAccessReauthenticationHelper";
+
+    BravePasswordAccessReauthenticationHelperClassAdapter(ClassVisitor visitor) {
+        super(visitor);
+
+        deleteField(sBraveHelperClassName, "mCallback");
+        makeProtectedField(sHelperClassName, "mCallback");
+
+        deleteField(sBraveHelperClassName, "mFragmentManager");
+        makeProtectedField(sHelperClassName, "mFragmentManager");
+    }
+}


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/30268

This PR adds screen lock protection of Sync Password type in the same way like Chromium does protection for view/copy passwords. 
It is triggered when either `Sync Everything` or `Passwords` sync type gets enabled.
The result of successful authentication is stored for 60 sec and during this time any further `Passwords`/`Everything` type enabling doesn't ask new confirmation.

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-arm64, CI/skip-linux-x64, CI/skip-android, CI/skip-macos, CI/skip-ios, CI/skip-windows-arm64, CI/skip-windows-x64, CI/skip-windows-x86 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Screenshots:
Message about device lock screen|Message about auth will be required
---|---
![Screenshot_20231016-191738](https://github.com/brave/brave-core/assets/24739341/c581a885-fcdc-4dad-88f1-37e2cfc66083)|![Screenshot_20231016-191836](https://github.com/brave/brave-core/assets/24739341/cec3bd2c-8ca7-4b7e-8c1a-48287918b619)

## Test Plan:
Sync must be configured

**I. Lock screen is enabled on the device**
1. Open `Sync` => `Data Preferences`
2. Enable `Passwords` type - expected to see device lock screen
3. Unlock device
4. Ensure `Passwords` type is switched on now
5. Disable `Passwords` type - expected not to have device lock screen
6. Enable `Passwords` type - expected not to have device lock screen, as 60 sec didn't yet passed
7. Disable `Passwords` type, wait 60 sec, enable `Passwords` type - expected to see device lock screen

**II. Repeat (I) with `Sync everything` switch**

**III. Lock is not enabled on the device**
1. Open `Sync` => `Data Preferences`
2. Try to enable `Passwords` type - expected to see the toast message `To enable Passwords sync type, first set a screen lock on your device`, `Passwords` type must still be disabled

**IV. Repeat (III) with `Sync everything` switch**

**V. Optional - repeat steps I-IV on Android 8 device.**
