### PR TITLE
Not download language resources if notification ads are opted-out.

### DIFF
--- a/components/brave_ads/browser/ads_service_impl.h
+++ b/components/brave_ads/browser/ads_service_impl.h
@@ -96,6 +96,10 @@ class AdsServiceImpl : public AdsService,
   using SimpleURLLoaderList =
       std::list<std::unique_ptr<network::SimpleURLLoader>>;
 
+  bool IsBatAdsServiceBound() const;
+
+  void RegisterResourceComponentsForDefaultLocale() const;
+
   bool UserHasOptedInToBraveRewards() const;
   bool UserHasOptedInToBraveNewsAds() const;
   bool UserHasOptedInToNewTabPageAds() const;

--- a/components/brave_ads/browser/component_updater/resource_component.h
+++ b/components/brave_ads/browser/component_updater/resource_component.h
@@ -34,16 +34,14 @@ class ResourceComponent : public brave_component_updater::BraveComponent {
   void AddObserver(ResourceComponentObserver* observer);
   void RemoveObserver(ResourceComponentObserver* observer);
 
-  void RegisterComponentsForLocale(const std::string& locale);
+  void RegisterComponentForCountryCode(const std::string& country_code);
+  void RegisterComponentForLanguageCode(const std::string& language_code);
 
   void NotifyDidUpdateResourceComponent(const std::string& manifest_version,
                                         const std::string& id);
   absl::optional<base::FilePath> GetPath(const std::string& id, int version);
 
  private:
-  void RegisterComponentForCountryCode(const std::string& country_code);
-  void RegisterComponentForLanguageCode(const std::string& language_code);
-
   void LoadManifestCallback(const std::string& component_id,
                             const base::FilePath& install_dir,
                             const std::string& json);


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/31963

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-arm64, CI/skip-linux-x64, CI/skip-android, CI/skip-macos, CI/skip-ios, CI/skip-windows-arm64, CI/skip-windows-x64, CI/skip-windows-x86 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

1) Run Brave Browser with a fresh profile
2) Make sure that flag is enabled on brave://flags (or enable it if not enabled):
    - brave-ads-should-always-run-brave-ads-service
3) Make sure that Brave Ads are started (there should be logs in Brave Rewards Log)

4) Make sure that language resources weren't downloaded. The folder `Brave-Browser-Nightly/ocilmpijebaopmdifcomolmpigakocmo` shouldn't exist.
5) Opt-in to Brave Rewards
6) Make sure that language resources were downloaded. The folder `Brave-Browser-Nightly/ocilmpijebaopmdifcomolmpigakocmo` should exist.
7) Make sure that `text processing` resource is loaded: `Successfully loaded feibnmjhecfbjpeciancnchbmlobenjn text classification resource` log message in Rewards Logs
8) Make sure that `text embedding` resource is loaded:  `Successfully loaded wtpwsrqtjxmfdwaymauprezkunxprysm text embedding resource` log message in Rewards Logs