### PR TITLE
Amend Rewards tips sent p3a metric

### DIFF
--- a/components/brave_rewards/browser/rewards_p3a.cc
+++ b/components/brave_rewards/browser/rewards_p3a.cc
@@ -32,11 +32,11 @@ const char kEnabledSourceHistogramName[] = "Brave.Rewards.EnabledSource";
 const char kInlineTipTriggerHistogramName[] = "Brave.Rewards.InlineTipTrigger";
 const char kToolbarButtonTriggerHistogramName[] =
     "Brave.Rewards.ToolbarButtonTrigger";
-const char kTipsSentHistogramName[] = "Brave.Rewards.TipsSent";
+const char kTipsSentHistogramName[] = "Brave.Rewards.TipsSent.2";
 const char kAutoContributionsStateHistogramName[] =
     "Brave.Rewards.AutoContributionsState.3";
 const char kAdTypesEnabledHistogramName[] = "Brave.Rewards.AdTypesEnabled";
-const int kTipsSentBuckets[] = {1, 3};
+const int kTipsSentBuckets[] = {0, 1, 3};
 
 void RecordAutoContributionsState(bool ac_enabled) {
   UMA_HISTOGRAM_EXACT_LINEAR(kAutoContributionsStateHistogramName, ac_enabled,
@@ -45,10 +45,6 @@ void RecordAutoContributionsState(bool ac_enabled) {
 
 void RecordTipsSent(size_t tip_count) {
   DCHECK_GE(tip_count, 0u);
-
-  if (tip_count == 0) {
-    return;
-  }
 
   p3a_utils::RecordToHistogramBucket(kTipsSentHistogramName, kTipsSentBuckets,
                                      tip_count);

--- a/components/p3a/metric_names.h
+++ b/components/p3a/metric_names.h
@@ -190,7 +190,7 @@ constexpr inline auto kCollectedSlowHistograms =
     "Brave.PrivacyHub.IsEnabled",
     "Brave.PrivacyHub.Views",
     "Brave.ReaderMode.NumberReaderModeActivated",
-    "Brave.Rewards.TipsSent",
+    "Brave.Rewards.TipsSent.2",
     "Brave.Sync.EnabledTypes",
     "Brave.Sync.SyncedObjectsCount",
     "Brave.Today.UsageMonthly",


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/31967

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-arm64, CI/skip-linux-x64, CI/skip-android, CI/skip-macos, CI/skip-ios, CI/skip-windows-arm64, CI/skip-windows-x64, CI/skip-windows-x86 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [ ] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

0. Start with fresh profile, enable rewards. Ensure `Brave.Rewards.TipsSent.2` does not exist on local state page.
1. Connect to an external wallet. Restart the browser.
2. Wait 30 seconds, ensure metric has value 0.
3. Set two monthly tips and send two one time tips to verified creators. Wait 30 seconds. Ensure tip sent metric is set to 2.
4. Advance system time forward by 31 days and restart browser, wait 30 seconds, ensure metric is set to 1, to note the 2 monthly tips only.