### PR TITLE
fix(wallet): handle nullable reward in eth_feeHistory (uplift to 1.57.x)

### DIFF
--- a/components/brave_wallet/browser/eth_response_parser.cc
+++ b/components/brave_wallet/browser/eth_response_parser.cc
@@ -110,8 +110,15 @@ bool ParseEthGetFeeHistory(const base::Value& json_value,
 
   *oldest_block = fee_item_value->oldest_block;
 
-  if (fee_item_value->reward) {
-    for (const auto& reward_list_value : *fee_item_value->reward) {
+  // Reward can be missing or null, if reward percentiles param is not
+  // specified.
+  if (fee_item_value->reward && !fee_item_value->reward->is_none()) {
+    const auto* reward_list_values = fee_item_value->reward->GetIfList();
+    if (!reward_list_values) {
+      return false;
+    }
+
+    for (const auto& reward_list_value : *reward_list_values) {
       const auto* reward_list = reward_list_value.GetIfList();
       if (!reward_list) {
         return false;

--- a/components/brave_wallet/browser/eth_response_parser_unittest.cc
+++ b/components/brave_wallet/browser/eth_response_parser_unittest.cc
@@ -510,6 +510,29 @@ TEST(EthResponseParserUnitTest, ParseEthGetFeeHistory) {
   EXPECT_EQ(oldest_block, "0xd6b1b0");
   EXPECT_EQ(reward, std::vector<std::vector<std::string>>());
 
+  // null reward is OK which is treated the same as missing reward
+  json = R"(
+      {
+        "jsonrpc":"2.0",
+        "id":1,
+        "result": {
+          "baseFeePerGas": [],
+          "gasUsedRatio": [],
+          "oldestBlock": "0xd6b1b0",
+          "reward": null
+        }
+      })";
+  base_fee_per_gas.clear();
+  gas_used_ratio.clear();
+  oldest_block.clear();
+  reward.clear();
+  EXPECT_TRUE(ParseEthGetFeeHistory(ParseJson(json), &base_fee_per_gas,
+                                    &gas_used_ratio, &oldest_block, &reward));
+  EXPECT_EQ(base_fee_per_gas, std::vector<std::string>());
+  EXPECT_EQ(gas_used_ratio, std::vector<double>());
+  EXPECT_EQ(oldest_block, "0xd6b1b0");
+  EXPECT_EQ(reward, std::vector<std::vector<std::string>>());
+
   // Unexpected input
   EXPECT_FALSE(ParseEthGetFeeHistory(base::Value(), &base_fee_per_gas,
                                      &gas_used_ratio, &oldest_block, &reward));

--- a/components/brave_wallet/browser/json_rpc_responses.idl
+++ b/components/brave_wallet/browser/json_rpc_responses.idl
@@ -20,7 +20,7 @@ namespace json_rpc_responses {
     DOMString[] baseFeePerGas;
     DOMString[] gasUsedRatio;
     DOMString oldestBlock;
-    any[]? reward;
+    any? reward;
   };
 
   dictionary TransactionReceipt {


### PR DESCRIPTION
Uplift of #19481
Resolves https://github.com/brave/brave-browser/issues/31959

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.