### PR TITLE
Fixes “sometimes unblinded tokens are not refilled on clean profile after enabling rewards” - 1.57.x

### DIFF
--- a/components/brave_ads/core/internal/account/account.cc
+++ b/components/brave_ads/core/internal/account/account.cc
@@ -379,6 +379,8 @@ void Account::OnNotifyPrefDidChange(const std::string& path) {
 void Account::OnNotifyRewardsWalletDidUpdate(const std::string& payment_id,
                                              const std::string& recovery_seed) {
   SetWallet(payment_id, recovery_seed);
+
+  MaybeTopUpUnblindedTokens();
 }
 
 void Account::OnNotifyDidSolveAdaptiveCaptcha() {


### PR DESCRIPTION
Uplift of https://github.com/brave/brave-core/pull/19497
Resolves https://github.com/brave/brave-browser/issues/31985

- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR.
- [x] You have tested your change on Nightly. 
- [x] The PR milestones match the branch they are landing to. 

After you merge: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.

