### PR TITLE
Not download language resources if notification ads are opted-out (uplift to 1.57.x)

### DIFF
--- a/components/brave_ads/browser/ads_service_impl.h
+++ b/components/brave_ads/browser/ads_service_impl.h
@@ -96,6 +96,10 @@ class AdsServiceImpl : public AdsService,
   using SimpleURLLoaderList =
       std::list<std::unique_ptr<network::SimpleURLLoader>>;
 
+  bool IsBatAdsServiceBound() const;
+
+  void RegisterResourceComponentsForDefaultLocale() const;
+
   bool UserHasOptedInToBravePrivateAds() const;
   bool UserHasOptedInToBraveNews() const;
 

--- a/components/brave_ads/browser/component_updater/resource_component.h
+++ b/components/brave_ads/browser/component_updater/resource_component.h
@@ -34,16 +34,14 @@ class ResourceComponent : public brave_component_updater::BraveComponent {
   void AddObserver(ResourceComponentObserver* observer);
   void RemoveObserver(ResourceComponentObserver* observer);
 
-  void RegisterComponentsForLocale(const std::string& locale);
+  void RegisterComponentForCountryCode(const std::string& country_code);
+  void RegisterComponentForLanguageCode(const std::string& language_code);
 
   void NotifyDidUpdateResourceComponent(const std::string& manifest_version,
                                         const std::string& id);
   absl::optional<base::FilePath> GetPath(const std::string& id, int version);
 
  private:
-  void RegisterComponentForCountryCode(const std::string& country_code);
-  void RegisterComponentForLanguageCode(const std::string& language_code);
-
   void LoadManifestCallback(const std::string& component_id,
                             const base::FilePath& install_dir,
                             const std::string& json);


### PR DESCRIPTION
Uplift of https://github.com/brave/brave-core/pull/19478
Resolves https://github.com/brave/brave-browser/issues/31963

- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR.
- [x] You have tested your change on Nightly. 
- [x] The PR milestones match the branch they are landing to. 

After you merge: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.
