### PR TITLE
Handles TokenNoLongerValid response for subscriber credential fetching (uplift to 1.57.x)

### DIFF
--- a/components/brave_vpn/browser/brave_vpn_service.h
+++ b/components/brave_vpn/browser/brave_vpn_service.h
@@ -189,6 +189,7 @@ class BraveVpnService :
   void SetCurrentEnvironment(const std::string& env);
   void EnsureMojoConnected();
   void OnMojoConnectionError();
+  void RequestCredentialSummary(const std::string& domain);
   void OnCredentialSummary(const std::string& domain,
                            const std::string& summary_string);
   void OnPrepareCredentialsPresentation(

--- a/components/brave_vpn/browser/brave_vpn_service_helper.cc
+++ b/components/brave_vpn/browser/brave_vpn_service_helper.cc
@@ -20,6 +20,7 @@
 #include "brave/components/brave_vpn/common/pref_names.h"
 #include "brave/components/skus/browser/skus_utils.h"
 #include "components/prefs/pref_service.h"
+#include "components/prefs/scoped_user_pref_update.h"
 
 namespace brave_vpn {
 
@@ -94,6 +95,18 @@ void SetSkusCredential(PrefService* local_prefs,
                 base::TimeToValue(expiration_time));
   local_prefs->SetDict(prefs::kBraveVPNSubscriberCredential,
                        std::move(cred_dict));
+}
+
+void SetSkusCredentialFetchingRetried(PrefService* local_prefs, bool retried) {
+  ScopedDictPrefUpdate update(local_prefs,
+                              prefs::kBraveVPNSubscriberCredential);
+  update->Set(kRetriedSkusCredentialKey, base::Value(retried));
+}
+
+bool IsRetriedSkusCredential(PrefService* local_prefs) {
+  const base::Value::Dict& sub_cred_dict =
+      local_prefs->GetDict(prefs::kBraveVPNSubscriberCredential);
+  return sub_cred_dict.FindBool(kRetriedSkusCredentialKey).value_or(false);
 }
 
 base::Time GetExpirationTimeForSkusCredential(PrefService* local_prefs) {

--- a/components/brave_vpn/browser/brave_vpn_service_helper.h
+++ b/components/brave_vpn/browser/brave_vpn_service_helper.h
@@ -39,6 +39,8 @@ void ClearSubscriberCredential(PrefService* local_prefs);
 void SetSkusCredential(PrefService* local_prefs,
                        const std::string& skus_credential,
                        const base::Time& expiration_time);
+void SetSkusCredentialFetchingRetried(PrefService* local_prefs, bool retried);
+bool IsRetriedSkusCredential(PrefService* local_prefs);
 base::Time GetExpirationTimeForSkusCredential(PrefService* local_prefs);
 
 }  // namespace brave_vpn

--- a/components/brave_vpn/browser/brave_vpn_service_unittest.cc
+++ b/components/brave_vpn/browser/brave_vpn_service_unittest.cc
@@ -849,12 +849,22 @@ TEST_F(BraveVPNServiceTest, CheckInitialPurchasedStateTest) {
   EXPECT_EQ(PurchasedState::LOADING, GetPurchasedInfoSync());
 }
 
-TEST_F(BraveVPNServiceTest, SubscribedCredentials) {
+TEST_F(BraveVPNServiceTest, SubscribedCredentialsWithTokenNoLongerValid) {
   std::string env = skus::GetDefaultEnvironment();
-  SetPurchasedState(env, PurchasedState::PURCHASED);
-  EXPECT_EQ(PurchasedState::PURCHASED, GetPurchasedInfoSync());
-  OnGetSubscriberCredentialV12("Token No Longer Valid", false);
+
+  SetPurchasedState(env, PurchasedState::LOADING);
+  OnGetSubscriberCredentialV12(kTokenNoLongerValid, false);
+  EXPECT_EQ(PurchasedState::LOADING, GetPurchasedInfoSync());
+  EXPECT_TRUE(IsRetriedSkusCredential(&local_pref_service_));
+
+  // Retrying only once.
+  OnGetSubscriberCredentialV12(kTokenNoLongerValid, false);
   EXPECT_EQ(PurchasedState::FAILED, GetPurchasedInfoSync());
+  EXPECT_TRUE(IsRetriedSkusCredential(&local_pref_service_));
+
+  // Check retrying flag is cleared when we got valid subs-credential.
+  OnGetSubscriberCredentialV12("valid-subs-credentials", true);
+  EXPECT_FALSE(IsRetriedSkusCredential(&local_pref_service_));
 }
 
 // Test connection check is asked only when purchased state.

--- a/components/brave_vpn/common/brave_vpn_constants.h
+++ b/components/brave_vpn/common/brave_vpn_constants.h
@@ -44,6 +44,7 @@ constexpr int kP3AIntervalHours = 24;
 
 constexpr char kSubscriberCredentialKey[] = "credential";
 constexpr char kSkusCredentialKey[] = "skus_credential";
+constexpr char kRetriedSkusCredentialKey[] = "retried_skus_credential";
 constexpr char kSubscriberCredentialExpirationKey[] = "expiration";
 
 #if !BUILDFLAG(IS_ANDROID)


### PR DESCRIPTION
Uplift of #19449
fix https://github.com/brave/brave-browser/issues/31836

Pre-approval checklist: 
- [ ] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.