### PR TITLE
Implement Fullscreen from Playlist

### DIFF
--- a/browser/ui/BUILD.gn
+++ b/browser/ui/BUILD.gn
@@ -317,6 +317,8 @@ source_set("ui") {
       "views/side_panel/brave_side_panel.h",
       "views/side_panel/brave_side_panel_resize_widget.cc",
       "views/side_panel/brave_side_panel_resize_widget.h",
+      "views/side_panel/playlist/playlist_contents_wrapper.cc",
+      "views/side_panel/playlist/playlist_contents_wrapper.h",
       "views/side_panel/playlist/playlist_side_panel_coordinator.cc",
       "views/side_panel/playlist/playlist_side_panel_coordinator.h",
       "views/side_panel/playlist/playlist_side_panel_web_view.cc",

--- a/browser/ui/views/frame/brave_contents_layout_manager.cc
+++ b/browser/ui/views/frame/brave_contents_layout_manager.cc
@@ -48,7 +48,15 @@ void BraveContentsLayoutManager::Layout(views::View* contents_container) {
   const gfx::Rect bounds(sidebar_x, 0, proposed_sidebar_width, contents_height);
   sidebar_container_view_->SetBoundsRect(host_->GetMirroredRect(bounds));
 
+#if BUILDFLAG(IS_MAC)
+  // On Mac, we shouldn't set empty rect for web view. That could cause crash
+  // from StatusBubbleViews. As StatusBubbleViews width is one third of the
+  // base view, sets 3 here so that StatusBubbleViews can have at least 1 width.
+  gfx::Size container_size(contents_width > 0 ? contents_width : 3,
+                           contents_height);
+#else
   gfx::Size container_size(contents_width, contents_height);
+#endif
   gfx::Rect new_devtools_bounds;
   gfx::Rect new_contents_bounds;
 

--- a/browser/ui/views/frame/brave_contents_layout_manager.cc
+++ b/browser/ui/views/frame/brave_contents_layout_manager.cc
@@ -6,6 +6,7 @@
 #include "brave/browser/ui/views/frame/brave_contents_layout_manager.h"
 
 #include <algorithm>
+#include <limits>
 
 #include "ui/views/view.h"
 
@@ -79,6 +80,11 @@ int BraveContentsLayoutManager::CalculateTargetSideBarWidth() const {
   int proposed_sidebar_width =
       sidebar_container_view_->GetPreferredSize().width();
   const int contents_width = host_->width();
+
+  if (proposed_sidebar_width == std::numeric_limits<int>::max()) {
+    // Takes up the entire space for fullscreen.
+    return contents_width;
+  }
 
   // Guarantee 20% width for contents at least.
   if ((contents_width - proposed_sidebar_width) <= contents_width * 0.2) {

--- a/browser/ui/views/side_panel/playlist/playlist_contents_wrapper.cc
+++ b/browser/ui/views/side_panel/playlist/playlist_contents_wrapper.cc
@@ -1,0 +1,138 @@
+/* Copyright (c) 2023 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "brave/browser/ui/views/side_panel/playlist/playlist_contents_wrapper.h"
+
+#include "brave/browser/ui/views/side_panel/playlist/playlist_side_panel_coordinator.h"
+#include "chrome/browser/ui/exclusive_access/exclusive_access_manager.h"
+#include "chrome/browser/ui/exclusive_access/fullscreen_controller.h"
+#include "chrome/browser/ui/exclusive_access/fullscreen_within_tab_helper.h"
+#include "chrome/browser/ui/side_panel/side_panel_ui.h"
+#include "chrome/browser/ui/views/frame/browser_view.h"
+#include "third_party/blink/public/mojom/frame/fullscreen.mojom.h"
+#include "ui/views/widget/widget.h"
+
+PlaylistContentsWrapper::PlaylistContentsWrapper(
+    const GURL& webui_url,
+    content::BrowserContext* browser_context,
+    int task_manager_string_id,
+    bool webui_resizes_host,
+    bool esc_closes_ui,
+    BrowserView* browser_view,
+    PlaylistSidePanelCoordinator* coordinator)
+    : BubbleContentsWrapperT(webui_url,
+                             browser_context,
+                             task_manager_string_id,
+                             webui_resizes_host,
+                             esc_closes_ui),
+      browser_view_(browser_view),
+      coordinator_(coordinator) {}
+
+PlaylistContentsWrapper::~PlaylistContentsWrapper() = default;
+
+bool PlaylistContentsWrapper::CanEnterFullscreenModeForTab(
+    content::RenderFrameHost* requesting_frame,
+    const blink::mojom::FullscreenOptions& options) {
+  return true;
+}
+
+void PlaylistContentsWrapper::EnterFullscreenModeForTab(
+    content::RenderFrameHost* requesting_frame,
+    const blink::mojom::FullscreenOptions& options) {
+  FullscreenWithinTabHelper::CreateForWebContents(web_contents());
+  FullscreenWithinTabHelper::FromWebContents(web_contents())
+      ->SetIsFullscreenWithinTab(true);
+
+  auto* fullscreen_controller = browser_view_->browser()
+                                    ->exclusive_access_manager()
+                                    ->fullscreen_controller();
+  was_browser_fullscreen_ = fullscreen_controller->IsFullscreenForBrowser();
+  DCHECK(!fullscreen_controller->IsTabFullscreen())
+      << "We don't expect this case. In tab fullscreen, sidebar is not "
+         "visible.";
+
+  auto* widget = browser_view_->GetWidget();
+  DCHECK(widget);
+  fullscreen_display_id_ = options.display_id;
+  if (was_browser_fullscreen_) {
+    // In case it was in fullscreen for browser, we should trigger layout here.
+    auto side_panel_web_view = coordinator_->side_panel_web_view();
+    DCHECK(side_panel_web_view);
+    side_panel_web_view->InvalidateLayout();
+  } else {
+    widget->SetFullscreen(true, fullscreen_display_id_);
+  }
+
+  fullscreen_observation_.Observe(fullscreen_controller);
+}
+
+void PlaylistContentsWrapper::ExitFullscreenModeForTab(
+    content::WebContents* contents) {
+  // The exit request from renderer.
+  DCHECK(IsFullscreenForPlaylist());
+
+  auto* widget = browser_view_->GetWidget();
+  DCHECK(widget);
+  if (was_browser_fullscreen_) {
+    OnExitFullscreen();
+  } else {
+    widget->SetFullscreen(false);
+    // Other clean-ups will be done OnExtiFullscreen() when it's triggered by
+    // fullscreen controller.
+  }
+}
+
+void PlaylistContentsWrapper::OnFullscreenStateChanged() {
+  // There're two known ways where this is triggered
+  //  * press fullscreen button on the web page -> ExitFullscreenModeForTab()
+  //    will be invoked by the renderer.
+  //  * press shortcut key, such as Fn + f or F11 -> The browser will handle
+  //    shortcut  and this will be invoked.
+  // TODO(sko) When shortcut was pressed, we can't determine if we should go
+  // back to fullscreen for browser, as the browser already has exited
+  // fullscreen by itself. We might need more customization in BrowserView or
+  // FullscreenController.
+  auto* widget = browser_view_->GetWidget();
+  DCHECK(widget);
+
+  if (!widget->IsFullscreen() && IsFullscreenForPlaylist()) {
+    DVLOG(2) << __FUNCTION__ << " Will exit fullscreen";
+    OnExitFullscreen();
+  }
+}
+
+bool PlaylistContentsWrapper::IsFullscreenForTabOrPending(
+    const content::WebContents* web_contents) {
+  return IsFullscreenForPlaylist();
+}
+
+content::FullscreenState PlaylistContentsWrapper::GetFullscreenState(
+    const content::WebContents* web_contents) const {
+  if (IsFullscreenForPlaylist()) {
+    return {.target_mode = content::FullscreenMode::kContent,
+            .target_display_id = fullscreen_display_id_};
+  }
+
+  return {};
+}
+
+bool PlaylistContentsWrapper::IsFullscreenForPlaylist() const {
+  if (auto* fullscreen_tab_helper = FullscreenWithinTabHelper::FromWebContents(
+          const_cast<PlaylistContentsWrapper*>(this)->web_contents())) {
+    return fullscreen_tab_helper->is_fullscreen_within_tab();
+  }
+
+  return false;
+}
+
+void PlaylistContentsWrapper::OnExitFullscreen() {
+  FullscreenWithinTabHelper::RemoveForWebContents(web_contents());
+  fullscreen_observation_.Reset();
+  fullscreen_display_id_ = display::kInvalidDisplayId;
+
+  auto side_panel_web_view = coordinator_->side_panel_web_view();
+  DCHECK(side_panel_web_view);
+  side_panel_web_view->InvalidateLayout();
+}

--- a/browser/ui/views/side_panel/playlist/playlist_contents_wrapper.cc
+++ b/browser/ui/views/side_panel/playlist/playlist_contents_wrapper.cc
@@ -79,7 +79,7 @@ void PlaylistContentsWrapper::ExitFullscreenModeForTab(
     OnExitFullscreen();
   } else {
     widget->SetFullscreen(false);
-    // Other clean-ups will be done OnExtiFullscreen() when it's triggered by
+    // Other clean-ups will be done OnExitFullscreen() when it's triggered by
     // fullscreen controller.
   }
 }

--- a/browser/ui/views/side_panel/playlist/playlist_contents_wrapper.h
+++ b/browser/ui/views/side_panel/playlist/playlist_contents_wrapper.h
@@ -1,0 +1,64 @@
+/* Copyright (c) 2023 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_BROWSER_UI_VIEWS_SIDE_PANEL_PLAYLIST_PLAYLIST_CONTENTS_WRAPPER_H_
+#define BRAVE_BROWSER_UI_VIEWS_SIDE_PANEL_PLAYLIST_PLAYLIST_CONTENTS_WRAPPER_H_
+
+#include "base/scoped_observation.h"
+#include "brave/browser/ui/webui/playlist_ui.h"
+#include "chrome/browser/ui/exclusive_access/fullscreen_observer.h"
+#include "chrome/browser/ui/views/bubble/bubble_contents_wrapper.h"
+
+class BrowserView;
+class PlaylistSidePanelCoordinator;
+class FullscreenController;
+
+// Implements WebContentsDelegate parts for Playlist features.
+class PlaylistContentsWrapper
+    : public BubbleContentsWrapperT<playlist::PlaylistUI>,
+      public FullscreenObserver {
+ public:
+  PlaylistContentsWrapper(const GURL& webui_url,
+                          content::BrowserContext* browser_context,
+                          int task_manager_string_id,
+                          bool webui_resizes_host,
+                          bool esc_closes_ui,
+                          BrowserView* browser_view,
+                          PlaylistSidePanelCoordinator* coordinator);
+  ~PlaylistContentsWrapper() override;
+
+  // BubbleContentsWrapperT<playlist::PlaylistUI>:
+  bool CanEnterFullscreenModeForTab(
+      content::RenderFrameHost* requesting_frame,
+      const blink::mojom::FullscreenOptions& options) override;
+  void EnterFullscreenModeForTab(
+      content::RenderFrameHost* requesting_frame,
+      const blink::mojom::FullscreenOptions& options) override;
+  void ExitFullscreenModeForTab(content::WebContents* contents) override;
+
+  bool IsFullscreenForTabOrPending(
+      const content::WebContents* web_contents) override;
+  content::FullscreenState GetFullscreenState(
+      const content::WebContents* web_contents) const override;
+
+  // FullscreenObserver:
+  void OnFullscreenStateChanged() override;
+
+ private:
+  bool IsFullscreenForPlaylist() const;
+
+  void OnExitFullscreen();
+
+  raw_ptr<BrowserView> browser_view_ = nullptr;
+  raw_ptr<PlaylistSidePanelCoordinator> coordinator_ = nullptr;
+
+  bool was_browser_fullscreen_ = false;
+  int64_t fullscreen_display_id_ = display::kInvalidDisplayId;
+
+  base::ScopedObservation<FullscreenController, FullscreenObserver>
+      fullscreen_observation_{this};
+};
+
+#endif  // BRAVE_BROWSER_UI_VIEWS_SIDE_PANEL_PLAYLIST_PLAYLIST_CONTENTS_WRAPPER_H_

--- a/browser/ui/views/side_panel/playlist/playlist_side_panel_coordinator.h
+++ b/browser/ui/views/side_panel/playlist/playlist_side_panel_coordinator.h
@@ -10,8 +10,9 @@
 #include <string>
 
 #include "base/scoped_observation.h"
+#include "brave/browser/ui/views/side_panel/playlist/playlist_contents_wrapper.h"
+#include "brave/browser/ui/views/side_panel/playlist/playlist_side_panel_web_view.h"
 #include "chrome/browser/ui/browser_user_data.h"
-#include "chrome/browser/ui/views/bubble/bubble_contents_wrapper.h"
 #include "ui/views/view.h"
 #include "ui/views/view_observer.h"
 
@@ -41,6 +42,10 @@ class PlaylistSidePanelCoordinator
   void ActivatePanel();
   void LoadPlaylist(const std::string& playlist_id, const std::string& item_id);
 
+  base::WeakPtr<PlaylistSidePanelWebView> side_panel_web_view() {
+    return side_panel_web_view_;
+  }
+
   // views::ViewObserver:
   void OnViewIsDeleting(views::View* view) override;
 
@@ -53,8 +58,9 @@ class PlaylistSidePanelCoordinator
 
   raw_ptr<Browser> browser_ = nullptr;
 
-  std::unique_ptr<BubbleContentsWrapperT<playlist::PlaylistUI>>
-      contents_wrapper_;
+  std::unique_ptr<PlaylistContentsWrapper> contents_wrapper_;
+
+  base::WeakPtr<PlaylistSidePanelWebView> side_panel_web_view_;
 
   base::ScopedObservation<views::View, views::ViewObserver> view_observation_{
       this};

--- a/browser/ui/views/side_panel/playlist/playlist_side_panel_web_view.cc
+++ b/browser/ui/views/side_panel/playlist/playlist_side_panel_web_view.cc
@@ -15,3 +15,7 @@ PlaylistSidePanelWebView::PlaylistSidePanelWebView(
           contents_wrapper) {}
 
 PlaylistSidePanelWebView::~PlaylistSidePanelWebView() = default;
+
+base::WeakPtr<PlaylistSidePanelWebView> PlaylistSidePanelWebView::GetWeakPtr() {
+  return weak_ptr_factory_.GetWeakPtr();
+}

--- a/browser/ui/views/side_panel/playlist/playlist_side_panel_web_view.h
+++ b/browser/ui/views/side_panel/playlist/playlist_side_panel_web_view.h
@@ -21,6 +21,11 @@ class PlaylistSidePanelWebView : public SidePanelWebUIView {
   PlaylistSidePanelWebView(const PlaylistSidePanelWebView&) = delete;
   PlaylistSidePanelWebView& operator=(const PlaylistSidePanelWebView&) = delete;
   ~PlaylistSidePanelWebView() override;
+
+  base::WeakPtr<PlaylistSidePanelWebView> GetWeakPtr();
+
+ private:
+  base::WeakPtrFactory<PlaylistSidePanelWebView> weak_ptr_factory_{this};
 };
 
 #endif  // BRAVE_BROWSER_UI_VIEWS_SIDE_PANEL_PLAYLIST_PLAYLIST_SIDE_PANEL_WEB_VIEW_H_

--- a/browser/ui/views/sidebar/sidebar_container_view.cc
+++ b/browser/ui/views/sidebar/sidebar_container_view.cc
@@ -163,25 +163,14 @@ bool SidebarContainerView::IsSidebarVisible() const {
 }
 
 bool SidebarContainerView::IsFullscreenForCurrentEntry() const {
-  auto* side_panel_registry =
-      SidePanelCoordinator::GetGlobalSidePanelRegistry(browser_);
-  if (!side_panel_registry) {
-    return false;
-  }
-
-  auto active_entry = side_panel_registry->active_entry();
-  if (!active_entry) {
-    return false;
-  }
-
   // For now, we only supports fullscreen from playlist.
+  if (side_panel_coordinator_->GetCurrentEntryId() !=
+      SidePanelEntryId::kPlaylist) {
+    return false;
+  }
+
   // TODO(sko) Do we have a more general way to get WebContents of the active
   // entry?
-  if ((*active_entry)->key() !=
-      SidePanelEntryKey(SidePanelEntryId::kPlaylist)) {
-    return false;
-  }
-
   auto web_view = PlaylistSidePanelCoordinator::FromBrowser(browser_)
                       ->side_panel_web_view();
   if (!web_view) {

--- a/browser/ui/views/sidebar/sidebar_container_view.cc
+++ b/browser/ui/views/sidebar/sidebar_container_view.cc
@@ -6,6 +6,7 @@
 #include "brave/browser/ui/views/sidebar/sidebar_container_view.h"
 
 #include <algorithm>
+#include <limits>
 #include <utility>
 
 #include "base/auto_reset.h"
@@ -20,6 +21,7 @@
 #include "brave/browser/ui/views/frame/brave_browser_view.h"
 #include "brave/browser/ui/views/frame/brave_contents_layout_manager.h"
 #include "brave/browser/ui/views/side_panel/brave_side_panel.h"
+#include "brave/browser/ui/views/side_panel/playlist/playlist_side_panel_coordinator.h"
 #include "brave/browser/ui/views/sidebar/sidebar_control_view.h"
 #include "brave/components/constants/pref_names.h"
 #include "brave/components/sidebar/sidebar_item.h"
@@ -28,6 +30,7 @@
 #include "chrome/browser/ui/color/chrome_color_id.h"
 #include "chrome/browser/ui/exclusive_access/exclusive_access_manager.h"
 #include "chrome/browser/ui/exclusive_access/fullscreen_controller.h"
+#include "chrome/browser/ui/exclusive_access/fullscreen_within_tab_helper.h"
 #include "chrome/browser/ui/tabs/tab_strip_model.h"
 #include "chrome/browser/ui/views/frame/browser_view.h"
 #include "chrome/browser/ui/views/side_panel/side_panel_entry.h"
@@ -40,7 +43,9 @@
 #include "ui/events/types/event_type.h"
 #include "ui/gfx/geometry/point.h"
 #include "ui/views/border.h"
+#include "ui/views/controls/webview/webview.h"
 #include "ui/views/event_monitor.h"
+#include "ui/views/view_utils.h"
 #include "ui/views/widget/widget.h"
 #include "url/gurl.h"
 
@@ -157,6 +162,47 @@ bool SidebarContainerView::IsSidebarVisible() const {
   return sidebar_control_view_ && sidebar_control_view_->GetVisible();
 }
 
+bool SidebarContainerView::IsFullscreenForCurrentEntry() const {
+  auto* side_panel_registry =
+      SidePanelCoordinator::GetGlobalSidePanelRegistry(browser_);
+  if (!side_panel_registry) {
+    return false;
+  }
+
+  auto active_entry = side_panel_registry->active_entry();
+  if (!active_entry) {
+    return false;
+  }
+
+  // For now, we only supports fullscreen from playlist.
+  // TODO(sko) Do we have a more general way to get WebContents of the active
+  // entry?
+  if ((*active_entry)->key() !=
+      SidePanelEntryKey(SidePanelEntryId::kPlaylist)) {
+    return false;
+  }
+
+  auto web_view = PlaylistSidePanelCoordinator::FromBrowser(browser_)
+                      ->side_panel_web_view();
+  if (!web_view) {
+    return false;
+  }
+
+  auto* contents = web_view->web_contents();
+  if (!contents) {
+    return false;
+  }
+
+  if (auto* fullscreen_tab_helper =
+          FullscreenWithinTabHelper::FromWebContents(contents);
+      fullscreen_tab_helper &&
+      fullscreen_tab_helper->is_fullscreen_within_tab()) {
+    return true;
+  }
+
+  return false;
+}
+
 void SidebarContainerView::SetSidebarShowOption(ShowSidebarOption show_option) {
   DVLOG(2) << __func__;
 
@@ -243,8 +289,9 @@ void SidebarContainerView::AddChildViews() {
 }
 
 void SidebarContainerView::Layout() {
-  if (!initialized_)
+  if (!initialized_) {
     return View::Layout();
+  }
 
   const int control_view_preferred_width =
       sidebar_control_view_->GetPreferredSize().width();
@@ -266,8 +313,13 @@ void SidebarContainerView::Layout() {
 
 gfx::Size SidebarContainerView::CalculatePreferredSize() const {
   if (!initialized_ || !sidebar_control_view_->GetVisible() ||
-      IsFullscreenByTab())
+      IsFullscreenByTab()) {
     return View::CalculatePreferredSize();
+  }
+
+  if (IsFullscreenForCurrentEntry()) {
+    return {std::numeric_limits<int>::max(), 0};
+  }
 
   auto start_width = animation_start_width_;
   auto end_width = animation_end_width_;
@@ -332,8 +384,9 @@ void SidebarContainerView::OnMouseExited(const ui::MouseEvent& event) {
 
   // When context menu is shown, this view can get this exited callback.
   // In that case, ignore this callback because mouse is still in this view.
-  if (IsMouseHovered())
+  if (IsMouseHovered()) {
     return;
+  }
 
   if (ShouldForceShowSidebar()) {
     StartBrowserWindowEventMonitoring();
@@ -649,8 +702,9 @@ void SidebarContainerView::UpdateToolbarButtonVisibility() {
 }
 
 void SidebarContainerView::StartBrowserWindowEventMonitoring() {
-  if (browser_window_event_monitor_)
+  if (browser_window_event_monitor_) {
     return;
+  }
 
   DVLOG(1) << __func__;
   browser_window_event_monitor_ = views::EventMonitor::CreateWindowMonitor(

--- a/browser/ui/views/sidebar/sidebar_container_view.h
+++ b/browser/ui/views/sidebar/sidebar_container_view.h
@@ -73,6 +73,8 @@ class SidebarContainerView
 
   BraveSidePanel* side_panel() { return side_panel_; }
 
+  bool IsFullscreenForCurrentEntry() const;
+
   // Sidebar overrides:
   void SetSidebarShowOption(
       sidebar::SidebarService::ShowSidebarOption show_option) override;

--- a/components/playlist/browser/resources/components/videoFrame.tsx
+++ b/components/playlist/browser/resources/components/videoFrame.tsx
@@ -31,7 +31,7 @@ export default function VideoFrame ({ playing }: Props) {
           ? 'chrome-untrusted://playlist-player'
           : 'iframe.html?id=playlist-components--video-player'
       }
-      allow='autoplay'
+      allow='autoplay; fullscreen;'
       scrolling='no'
       sandbox='allow-scripts allow-same-origin'
       playing={playing}


### PR DESCRIPTION
* Implement WebContentsDelegate part for fullscreen request handling
* Modify BraveContentsLayoutManager so that we can enter fullscreen in the context of fullscreen for browser.
  * This might have sideeffects but the easiest way to achieve fullscreen.

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/32027

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-arm64, CI/skip-linux-x64, CI/skip-android, CI/skip-macos, CI/skip-ios, CI/skip-windows-arm64, CI/skip-windows-x64, CI/skip-windows-x86 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [ ] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

