### PR TITLE
Etherscan proxy migration (uplift to 1.57.x)

### DIFF
--- a/components/brave_wallet/api/asset_ratio.idl
+++ b/components/brave_wallet/api/asset_ratio.idl
@@ -64,50 +64,9 @@ namespace asset_ratio {
   //     "message": "OK",
   //     "result": []
   //
-  dictionary TokenInfoPayload {
-    // A list with result records.
-    TokenInfoResult[] result;
-  };
-
-
-  // A token info dictionary. Looks like this:
-  // {
-  //   "payload": {
-  //     "status": "1",
-  //     "message": "OK",
-  //     "result": [
-  //       {
-  //         "contractAddress": "0xdac17f958d2ee523a2206206994597c13d831ec7",
-  //         "tokenName": "Tether USD",
-  //         "symbol": "USDT",
-  //         "divisor": "6",
-  //         "tokenType": "ERC20",
-  //         "totalSupply": "39828710009874796",
-  //         "blueCheckmark": "true",
-  //         "description": "Tether gives you the joint benefits of open...",
-  //         "website": "https://tether.to/",
-  //         "email": "support@tether.to",
-  //         "blog": "https://tether.to/category/announcements/",
-  //         "reddit": "",
-  //         "slack": "",
-  //         "facebook": "",
-  //         "twitter": "https://twitter.com/Tether_to",
-  //         "bitcointalk": "",
-  //         "github": "",
-  //         "telegram": "",
-  //         "wechat": "",
-  //         "linkedin": "",
-  //         "discord": "",
-  //         "whitepaper": "https://path/to/TetherWhitePaper.pdf",
-  //         "tokenPriceUSD": "1.000000000000000000"
-  //       }
-  //     ]
-  //   },
-  //   "lastUpdated": "2021-12-09T22:02:23.187Z"
-  // }
   dictionary TokenInfo {
     // A list with result records.
-    TokenInfoPayload payload;
+    TokenInfoResult[] result;
   };
 
   // A CoinMarket payload record. Sample looks like:

--- a/components/brave_wallet/browser/asset_ratio_response_parser.cc
+++ b/components/brave_wallet/browser/asset_ratio_response_parser.cc
@@ -181,11 +181,10 @@ mojom::BlockchainTokenPtr ParseTokenInfo(const base::Value& json_value,
     return nullptr;
   }
 
-  if (token_info->payload.result.size() != 1) {
+  if (token_info->result.size() != 1) {
     return nullptr;
   }
-  const api::asset_ratio::TokenInfoResult& result =
-      token_info->payload.result.front();
+  const api::asset_ratio::TokenInfoResult& result = token_info->result.front();
 
   int decimals = 0;
   const auto eth_addr = EthAddress::FromHex(result.contract_address);

--- a/components/brave_wallet/browser/asset_ratio_response_parser_unittest.cc
+++ b/components/brave_wallet/browser/asset_ratio_response_parser_unittest.cc
@@ -145,36 +145,33 @@ TEST(AssetRatioResponseParserUnitTest, ParseGetTokenInfo) {
   // ERC20
   std::string json(R"(
     {
-      "payload": {
-        "status": "1",
-        "message": "OK",
-        "result": [{
-          "contractAddress": "0xdac17f958d2ee523a2206206994597c13d831ec7",
-          "tokenName": "Tether USD",
-          "symbol": "USDT",
-          "divisor": "6",
-          "tokenType": "ERC20",
-          "totalSupply": "39828710009874796",
-          "blueCheckmark": "true",
-          "description": "Tether gives you the joint benefits of open...",
-          "website": "https://tether.to/",
-          "email": "support@tether.to",
-          "blog": "https://tether.to/category/announcements/",
-          "reddit": "",
-          "slack": "",
-          "facebook": "",
-          "twitter": "https://twitter.com/Tether_to",
-          "bitcointalk": "",
-          "github": "",
-          "telegram": "",
-          "wechat": "",
-          "linkedin": "",
-          "discord": "",
-          "whitepaper": "https://path/to/TetherWhitePaper.pdf",
-          "tokenPriceUSD": "1.000000000000000000"
-        }]
-      },
-      "lastUpdated": "2021-12-09T22:02:23.187Z"
+      "status": "1",
+      "message": "OK",
+      "result": [{
+        "contractAddress": "0xdac17f958d2ee523a2206206994597c13d831ec7",
+        "tokenName": "Tether USD",
+        "symbol": "USDT",
+        "divisor": "6",
+        "tokenType": "ERC20",
+        "totalSupply": "39828710009874796",
+        "blueCheckmark": "true",
+        "description": "Tether gives you the joint benefits of open...",
+        "website": "https://tether.to/",
+        "email": "support@tether.to",
+        "blog": "https://tether.to/category/announcements/",
+        "reddit": "",
+        "slack": "",
+        "facebook": "",
+        "twitter": "https://twitter.com/Tether_to",
+        "bitcointalk": "",
+        "github": "",
+        "telegram": "",
+        "wechat": "",
+        "linkedin": "",
+        "discord": "",
+        "whitepaper": "https://path/to/TetherWhitePaper.pdf",
+        "tokenPriceUSD": "1.000000000000000000"
+      }]
     }
   )");
 
@@ -190,18 +187,15 @@ TEST(AssetRatioResponseParserUnitTest, ParseGetTokenInfo) {
   // ERC721
   json = (R"(
     {
-      "payload": {
-        "status": "1",
-        "message": "OK",
-        "result": [{
-          "contractAddress": "0x0e3a2a1f2146d86a604adc220b4967a898d7fe07",
-          "tokenName": "Gods Unchained Cards",
-          "symbol": "CARD",
-          "divisor": "0",
-          "tokenType": "ERC721"
-        }]
-      },
-      "lastUpdated": "2021-12-09T22:02:23.187Z"
+      "status": "1",
+      "message": "OK",
+      "result": [{
+        "contractAddress": "0x0e3a2a1f2146d86a604adc220b4967a898d7fe07",
+        "tokenName": "Gods Unchained Cards",
+        "symbol": "CARD",
+        "divisor": "0",
+        "tokenType": "ERC721"
+      }]
     }
   )");
   expected_token = mojom::BlockchainToken::New(
@@ -214,18 +208,15 @@ TEST(AssetRatioResponseParserUnitTest, ParseGetTokenInfo) {
 
   const std::string valid_json = (R"(
     {
-      "payload": {
-        "status": "1",
-        "message": "OK",
-        "result": [{
-          "contractAddress": "0xdac17f958d2ee523a2206206994597c13d831ec7",
-          "tokenName": "Tether USD",
-          "symbol": "USDT",
-          "divisor": "6",
-          "tokenType": "ERC20"
-        }]
-      },
-      "lastUpdated": "2021-12-09T22:02:23.187Z"
+      "status": "1",
+      "message": "OK",
+      "result": [{
+        "contractAddress": "0xdac17f958d2ee523a2206206994597c13d831ec7",
+        "tokenName": "Tether USD",
+        "symbol": "USDT",
+        "divisor": "6",
+        "tokenType": "ERC20"
+      }]
     }
   )");
   ASSERT_TRUE(
@@ -244,18 +235,15 @@ TEST(AssetRatioResponseParserUnitTest, ParseGetTokenInfo) {
   // Invalid decimals.
   json = (R"(
     {
-      "payload": {
-        "status": "1",
-        "message": "OK",
-        "result": [{
-          "contractAddress": "0xdac17f958d2ee523a2206206994597c13d831ec7",
-          "tokenName": "Tether USD",
-          "symbol": "USDT",
-          "divisor": "NOT A NUMBER",
-          "tokenType": "ERC20"
-        }]
-      },
-      "lastUpdated": "2021-12-09T22:02:23.187Z"
+      "status": "1",
+      "message": "OK",
+      "result": [{
+        "contractAddress": "0xdac17f958d2ee523a2206206994597c13d831ec7",
+        "tokenName": "Tether USD",
+        "symbol": "USDT",
+        "divisor": "NOT A NUMBER",
+        "tokenType": "ERC20"
+      }]
     }
   )");
   EXPECT_FALSE(ParseTokenInfo(ParseJson(json), "0x1", mojom::CoinType::ETH))

--- a/components/brave_wallet/browser/asset_ratio_service.cc
+++ b/components/brave_wallet/browser/asset_ratio_service.cc
@@ -109,6 +109,18 @@ absl::optional<std::string> ChainIdToStripeChainId(
   return chain_id_lookup->at(chain_id);
 }
 
+base::flat_map<std::string, std::string> MakeBraveServicesKeyHeader() {
+  base::flat_map<std::string, std::string> request_headers;
+  std::unique_ptr<base::Environment> env(base::Environment::Create());
+  std::string brave_key(BUILDFLAG(BRAVE_SERVICES_KEY));
+  if (env->HasVar("BRAVE_SERVICES_KEY")) {
+    env->GetVar("BRAVE_SERVICES_KEY", &brave_key);
+  }
+  request_headers["x-brave-key"] = std::move(brave_key);
+
+  return request_headers;
+}
+
 }  // namespace
 
 namespace brave_wallet {
@@ -172,7 +184,7 @@ GURL AssetRatioService::GetPriceURL(
   std::string from = VectorToCommaSeparatedList(from_assets);
   std::string to = VectorToCommaSeparatedList(to_assets);
   std::string spec = base::StringPrintf(
-      "%sv2/relative/provider/coingecko/%s/%s/%s",
+      "%s/v2/relative/provider/coingecko/%s/%s/%s",
       base_url_for_test_.is_empty() ? kAssetRatioBaseURL
                                     : base_url_for_test_.spec().c_str(),
       from.c_str(), to.c_str(), TimeFrameKeyToString(timeframe).c_str());
@@ -185,7 +197,7 @@ GURL AssetRatioService::GetPriceHistoryURL(
     const std::string& vs_asset,
     brave_wallet::mojom::AssetPriceTimeframe timeframe) {
   std::string spec = base::StringPrintf(
-      "%sv2/history/coingecko/%s/%s/%s",
+      "%s/v2/history/coingecko/%s/%s/%s",
       base_url_for_test_.is_empty() ? kAssetRatioBaseURL
                                     : base_url_for_test_.spec().c_str(),
       asset.c_str(), vs_asset.c_str(), TimeFrameKeyToString(timeframe).c_str());
@@ -304,17 +316,9 @@ void AssetRatioService::GetPrice(
       &AssetRatioService::OnGetPrice, weak_ptr_factory_.GetWeakPtr(),
       from_assets_lower, to_assets_lower, std::move(callback));
 
-  base::flat_map<std::string, std::string> request_headers;
-  std::unique_ptr<base::Environment> env(base::Environment::Create());
-  std::string brave_key(BUILDFLAG(BRAVE_SERVICES_KEY));
-  if (env->HasVar("BRAVE_SERVICES_KEY")) {
-    env->GetVar("BRAVE_SERVICES_KEY", &brave_key);
-  }
-  request_headers[kBraveServicesKeyHeader] = std::move(brave_key);
-
   api_request_helper_->Request(
       "GET", GetPriceURL(from_assets_lower, to_assets_lower, timeframe), "", "",
-      std::move(internal_callback), request_headers,
+      std::move(internal_callback), MakeBraveServicesKeyHeader(),
       {.auto_retry_on_network_change = true, .enable_cache = true});
 }
 
@@ -366,7 +370,7 @@ void AssetRatioService::GetStripeBuyURL(
 
   const std::string json_payload = GetJSON(payload);
 
-  GURL url = GURL(base::StringPrintf("%sv2/stripe/onramp_sessions",
+  GURL url = GURL(base::StringPrintf("%s/v2/stripe/onramp_sessions",
                                      base_url_for_test_.is_empty()
                                          ? kAssetRatioBaseURL
                                          : base_url_for_test_.spec().c_str()));
@@ -377,7 +381,7 @@ void AssetRatioService::GetStripeBuyURL(
 
   api_request_helper_->Request(
       "POST", url, json_payload, "application/json",
-      std::move(internal_callback), {},
+      std::move(internal_callback), MakeBraveServicesKeyHeader(),
       {.auto_retry_on_network_change = true, .enable_cache = false});
 }
 
@@ -427,7 +431,7 @@ void AssetRatioService::GetPriceHistory(
                      weak_ptr_factory_.GetWeakPtr(), std::move(callback));
   api_request_helper_->Request(
       "GET", GetPriceHistoryURL(asset_lower, vs_asset_lower, timeframe), "", "",
-      std::move(internal_callback), {},
+      std::move(internal_callback), MakeBraveServicesKeyHeader(),
       {.auto_retry_on_network_change = true, .enable_cache = true});
 }
 
@@ -449,7 +453,7 @@ void AssetRatioService::OnGetPriceHistory(GetPriceHistoryCallback callback,
 // static
 GURL AssetRatioService::GetTokenInfoURL(const std::string& contract_address) {
   std::string spec = base::StringPrintf(
-      "%sv2/etherscan/"
+      "%s/v3/etherscan/"
       "passthrough?module=token&action=tokeninfo&contractaddress=%s",
       base_url_for_test_.is_empty() ? kAssetRatioBaseURL
                                     : base_url_for_test_.spec().c_str(),
@@ -464,7 +468,7 @@ void AssetRatioService::GetTokenInfo(const std::string& contract_address,
                      weak_ptr_factory_.GetWeakPtr(), std::move(callback));
   api_request_helper_->Request(
       "GET", GetTokenInfoURL(contract_address), "", "",
-      std::move(internal_callback), {},
+      std::move(internal_callback), MakeBraveServicesKeyHeader(),
       {.auto_retry_on_network_change = true, .enable_cache = true});
 }
 
@@ -483,7 +487,7 @@ void AssetRatioService::OnGetTokenInfo(GetTokenInfoCallback callback,
 // static
 GURL AssetRatioService::GetCoinMarketsURL(const std::string& vs_asset,
                                           const uint8_t limit) {
-  GURL url = GURL(base::StringPrintf("%sv2/market/provider/coingecko",
+  GURL url = GURL(base::StringPrintf("%s/v2/market/provider/coingecko",
                                      base_url_for_test_.is_empty()
                                          ? kAssetRatioBaseURL
                                          : base_url_for_test_.spec().c_str()));
@@ -501,7 +505,7 @@ void AssetRatioService::GetCoinMarkets(const std::string& vs_asset,
                      weak_ptr_factory_.GetWeakPtr(), std::move(callback));
   api_request_helper_->Request(
       "GET", GetCoinMarketsURL(vs_asset_lower, limit), "", "",
-      std::move(internal_callback), {},
+      std::move(internal_callback), MakeBraveServicesKeyHeader(),
       {.auto_retry_on_network_change = true, .enable_cache = true});
 }
 

--- a/components/brave_wallet/browser/asset_ratio_service_unittest.cc
+++ b/components/brave_wallet/browser/asset_ratio_service_unittest.cc
@@ -418,7 +418,7 @@ TEST_F(AssetRatioServiceUnitTest, GetPriceHistoryURL) {
 TEST_F(AssetRatioServiceUnitTest, GetTokenInfoURL) {
   std::string url(kAssetRatioBaseURL);
   EXPECT_EQ(url +
-                "v2/etherscan/"
+                "/v3/etherscan/"
                 "passthrough?module=token&action=tokeninfo&contractaddress="
                 "0xdac17f958d2ee523a2206206994597c13d831ec7",
             AssetRatioService::GetTokenInfoURL(
@@ -429,36 +429,31 @@ TEST_F(AssetRatioServiceUnitTest, GetTokenInfoURL) {
 TEST_F(AssetRatioServiceUnitTest, GetTokenInfo) {
   SetInterceptor(R"(
     {
-      "payload": {
-        "status": "1",
-        "message": "OK",
-        "result": [{
-          "contractAddress": "0xdac17f958d2ee523a2206206994597c13d831ec7",
-          "tokenName": "Tether USD",
-          "symbol": "USDT",
-          "divisor": "6",
-          "tokenType": "ERC20",
-          "totalSupply": "39828710009874796",
-          "blueCheckmark": "true",
-          "description": "Tether gives you the joint benefits of open...",
-          "website": "https://tether.to/",
-          "email": "support@tether.to",
-          "blog": "https://tether.to/category/announcements/",
-          "reddit": "",
-          "slack": "",
-          "facebook": "",
-          "twitter": "https://twitter.com/Tether_to",
-          "bitcointalk": "",
-          "github": "",
-          "telegram": "",
-          "wechat": "",
-          "linkedin": "",
-          "discord": "",
-          "whitepaper": "https://path/to/TetherWhitePaper.pdf",
-          "tokenPriceUSD": "1.000000000000000000"
-        }]
-      },
-      "lastUpdated": "2021-12-09T22:02:23.187Z"
+      "result": [{
+        "contractAddress": "0xdac17f958d2ee523a2206206994597c13d831ec7",
+        "tokenName": "Tether USD",
+        "symbol": "USDT",
+        "divisor": "6",
+        "tokenType": "ERC20",
+        "totalSupply": "39828710009874796",
+        "blueCheckmark": "true",
+        "description": "Tether gives you the joint benefits of open...",
+        "website": "https://tether.to/",
+        "email": "support@tether.to",
+        "blog": "https://tether.to/category/announcements/",
+        "reddit": "",
+        "slack": "",
+        "facebook": "",
+        "twitter": "https://twitter.com/Tether_to",
+        "bitcointalk": "",
+        "github": "",
+        "telegram": "",
+        "wechat": "",
+        "linkedin": "",
+        "discord": "",
+        "whitepaper": "https://path/to/TetherWhitePaper.pdf",
+        "tokenPriceUSD": "1.000000000000000000"
+      }]
     }
   )");
   GetTokenInfo("0xdac17f958d2ee523a2206206994597c13d831ec7",

--- a/components/brave_wallet/browser/brave_wallet_constants.h
+++ b/components/brave_wallet/browser/brave_wallet_constants.h
@@ -19,7 +19,7 @@ namespace brave_wallet {
 
 constexpr char kBraveServicesKeyHeader[] = "x-brave-key";
 
-constexpr char kAssetRatioBaseURL[] = "https://ratios.rewards.brave.com/";
+constexpr char kAssetRatioBaseURL[] = "https://ratios.wallet.brave.com";
 
 constexpr uint256_t kDefaultSendEthGasLimit = 21000;
 constexpr uint256_t kDefaultERC20TransferGasLimit = 300000;


### PR DESCRIPTION
Uplift of #18972
Resolves https://github.com/brave/brave-browser/issues/31079
Related to https://github.com/brave/brave-core/pull/19520

This uplift is also needed for the Stripe onramp feature.  The original pull request was marked QA/No, but it would be great to test that Stripe specifically is working with this test plan:
1. Create a wallet
2. In the buy panel, select 'Ethereum' as the asset then 'Select purchase method'
3. Click Stripe and verify you are taken to a valid crypto.link purchase page 
4. If reasonably possible, make a small Ethereum purchase

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [ ] The associated issue milestone is set to the smallest version that the changes is landed on.