### PR TITLE
Fix build warning on macOS

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -73,7 +73,7 @@ hooks = [
     'pattern': '.',
     # Required for download_cryptography below. Specifically, newer versions of
     # pip are required for obtaining binary wheels on Arm64 macOS.
-    'action': ['python3', '-m', 'pip', '-q', '--disable-pip-version-check', 'install', '-U', 'pip'],
+    'action': ['python3', '-m', 'pip', '-q', '--disable-pip-version-check', 'install', '-U', '--no-warn-script-location', 'pip'],
   },
   {
     'name': 'download_cryptography',


### PR DESCRIPTION
Resolves https://github.com/brave/brave-browser/issues/32082.