### PR TITLE
[Commands]: Fix crash opening a new guest window with the #quick-commands flag enabled (uplift to 1.57.x)

### DIFF
--- a/app/command_utils.cc.template
+++ b/app/command_utils.cc.template
@@ -11,7 +11,7 @@
 #include "base/containers/span.h"
 #include "base/feature_list.h"
 #include "brave/app/brave_command_ids.h"
-#include "brave/components/commander/common/features.h"
+#include "brave/components/commander/common/buildflags/buildflags.h"
 #include "brave/components/commands/common/features.h"
 #include "chrome/app/chrome_command_ids.h"
 #include "chrome/grit/chromium_strings.h"
@@ -20,6 +20,10 @@
 #include "components/strings/grit/components_strings.h"
 #include "ui/base/l10n/l10n_util.h"
 #include "ui/strings/grit/ui_strings.h"
+
+#if BUILDFLAG(ENABLE_COMMANDER)
+#include "brave/components/commander/common/features.h"
+#endif
 
 namespace commands {
 namespace {
@@ -36,15 +40,23 @@ COMMAND_IDS
 }  // namespace
 
 base::span<const int> GetCommands() {
+  #if BUILDFLAG(ENABLE_COMMANDER)
   DCHECK(base::FeatureList::IsEnabled(features::kBraveCommands) ||
-         commander::CommanderEnabled())
+         base::FeatureList::IsEnabled(::features::kBraveCommander))
+  #else
+  DCHECK(base::FeatureList::IsEnabled(features::kBraveCommands))
+  #endif
       << "This should only be used when |kBraveCommands| is enabled.";
   return kCommandIds;
 }
 
 std::string GetCommandName(int command_id) {
+  #if BUILDFLAG(ENABLE_COMMANDER)
   DCHECK(base::FeatureList::IsEnabled(features::kBraveCommands) ||
-         commander::CommanderEnabled())
+         base::FeatureList::IsEnabled(::features::kBraveCommander))
+  #else
+  DCHECK(base::FeatureList::IsEnabled(features::kBraveCommands))
+  #endif
       << "This should only be used when |kBraveCommands| is enabled.";
   auto it = kCommandTranslationIds.find(command_id);
   CHECK(it != kCommandTranslationIds.end())

--- a/browser/browser_context_keyed_service_factories.cc
+++ b/browser/browser_context_keyed_service_factories.cc
@@ -31,11 +31,10 @@
 #include "brave/browser/search_engines/search_engine_provider_service_factory.h"
 #include "brave/browser/search_engines/search_engine_tracker.h"
 #include "brave/browser/sync/brave_sync_alerts_service_factory.h"
-#include "brave/browser/ui/commander/commander_service_factory.h"
 #include "brave/browser/url_sanitizer/url_sanitizer_service_factory.h"
 #include "brave/components/brave_perf_predictor/browser/named_third_party_registry_factory.h"
 #include "brave/components/brave_vpn/common/buildflags/buildflags.h"
-#include "brave/components/commander/common/features.h"
+#include "brave/components/commander/common/buildflags/buildflags.h"
 #include "brave/components/greaselion/browser/buildflags/buildflags.h"
 #include "brave/components/ipfs/buildflags/buildflags.h"
 #include "brave/components/playlist/common/buildflags/buildflags.h"
@@ -82,6 +81,11 @@
 #if BUILDFLAG(ENABLE_PLAYLIST)
 #include "brave/browser/playlist/playlist_service_factory.h"
 #include "brave/components/playlist/common/features.h"
+#endif
+
+#if BUILDFLAG(ENABLE_COMMANDER)
+#include "brave/browser/ui/commander/commander_service_factory.h"
+#include "brave/components/commander/common/features.h"
 #endif
 
 #if defined(TOOLKIT_VIEWS)
@@ -141,6 +145,9 @@ void EnsureBrowserContextKeyedServiceFactoriesBuilt() {
   if (base::FeatureList::IsEnabled(commands::features::kBraveCommands)) {
     commands::AcceleratorServiceFactory::GetInstance();
   }
+#endif
+
+#if BUILDFLAG(ENABLE_COMMANDER)
   if (base::FeatureList::IsEnabled(features::kBraveCommander)) {
     commander::CommanderServiceFactory::GetInstance();
   }

--- a/browser/sources.gni
+++ b/browser/sources.gni
@@ -47,6 +47,7 @@ import("//brave/components/ai_chat/common/buildflags/buildflags.gni")
 import("//brave/components/brave_vpn/common/buildflags/buildflags.gni")
 import("//brave/components/brave_wayback_machine/buildflags/buildflags.gni")
 import("//brave/components/brave_webtorrent/browser/buildflags/buildflags.gni")
+import("//brave/components/commander/common/buildflags/buildflags.gni")
 import("//brave/components/tor/buildflags/buildflags.gni")
 import("//extensions/buildflags/buildflags.gni")
 
@@ -165,6 +166,7 @@ brave_chrome_browser_deps = [
   "//brave/components/brave_wallet/common:pref_names",
   "//brave/components/brave_wayback_machine/buildflags",
   "//brave/components/brave_webtorrent/browser/buildflags",
+  "//brave/components/commander/common/buildflags",
   "//brave/components/constants",
   "//brave/components/cosmetic_filters/browser",
   "//brave/components/cosmetic_filters/common:mojom",
@@ -240,7 +242,7 @@ brave_chrome_browser_deps = [
   "//url",
 ]
 
-if (!is_android && !is_ios) {
+if (enable_commander) {
   brave_chrome_browser_deps += [
     "//brave/components/commander/browser",
     "//brave/components/commands/browser",

--- a/browser/ui/BUILD.gn
+++ b/browser/ui/BUILD.gn
@@ -9,6 +9,7 @@ import("//brave/build/config.gni")
 import("//brave/components/ai_chat/common/buildflags/buildflags.gni")
 import("//brave/components/brave_vpn/common/buildflags/buildflags.gni")
 import("//brave/components/brave_wayback_machine/buildflags/buildflags.gni")
+import("//brave/components/commander/common/buildflags/buildflags.gni")
 import("//brave/components/ipfs/buildflags/buildflags.gni")
 import("//brave/components/ntp_background_images/buildflags/buildflags.gni")
 import("//brave/components/playlist/common/buildflags/buildflags.gni")
@@ -90,15 +91,6 @@ source_set("ui") {
       "browser_commands.cc",
       "browser_commands.h",
       "browser_dialogs.h",
-      "commander/brave_simple_command_source.cc",
-      "commander/brave_simple_command_source.h",
-      "commander/commander_service.cc",
-      "commander/commander_service.h",
-      "commander/commander_service_factory.cc",
-      "commander/commander_service_factory.h",
-      "commander/commander_service_factory.h",
-      "commander/ranker.cc",
-      "commander/ranker.h",
       "content_settings/brave_autoplay_blocked_image_model.cc",
       "content_settings/brave_autoplay_blocked_image_model.h",
       "content_settings/brave_autoplay_content_setting_bubble_model.cc",
@@ -199,8 +191,6 @@ source_set("ui") {
       "whats_new/whats_new_util.h",
     ]
 
-    deps += [ "//chrome/browser/ui/commander:fuzzy_finder" ]
-
     if (enable_request_otr) {
       deps += [
         "//brave/components/request_otr/common",
@@ -252,6 +242,25 @@ source_set("ui") {
         "webui/settings/brave_tor_snowflake_extension_handler.h",
       ]
     }
+  }
+
+  if (enable_commander) {
+    sources += [
+      "commander/brave_simple_command_source.cc",
+      "commander/brave_simple_command_source.h",
+      "commander/commander_service.cc",
+      "commander/commander_service.h",
+      "commander/commander_service_factory.cc",
+      "commander/commander_service_factory.h",
+      "commander/commander_service_factory.h",
+      "commander/ranker.cc",
+      "commander/ranker.h",
+    ]
+
+    deps += [
+      "//brave/components/commander/browser",
+      "//chrome/browser/ui/commander:fuzzy_finder",
+    ]
   }
 
   if (toolkit_views) {
@@ -607,7 +616,6 @@ source_set("ui") {
       "//brave/app/theme:brave_theme_resources",
       "//brave/app/theme:brave_unscaled_resources",
       "//brave/components/brave_webtorrent:static_resources",
-      "//brave/components/commander/browser",
       "//brave/components/webcompat_reporter/browser",
       "//brave/components/webcompat_reporter/ui:generated_resources",
     ]

--- a/browser/ui/commander/commander_service_factory.cc
+++ b/browser/ui/commander/commander_service_factory.cc
@@ -10,6 +10,7 @@
 #include "brave/components/commander/common/pref_names.h"
 #include "chrome/browser/profiles/profile.h"
 #include "chrome/browser/profiles/profile_keyed_service_factory.h"
+#include "chrome/browser/profiles/profile_selections.h"
 #include "components/keyed_service/core/keyed_service.h"
 #include "components/pref_registry/pref_registry_syncable.h"
 #include "content/public/browser/browser_context.h"
@@ -34,6 +35,8 @@ CommanderServiceFactory::CommanderServiceFactory()
           "CommanderService",
           ProfileSelections::Builder()
               .WithRegular(ProfileSelection::kOwnInstance)
+              .WithGuest(ProfileSelection::kOwnInstance)
+              .WithSystem(ProfileSelection::kNone)
               .Build()) {}
 CommanderServiceFactory::~CommanderServiceFactory() = default;
 

--- a/browser/ui/views/location_bar/brave_location_bar_view.cc
+++ b/browser/ui/views/location_bar/brave_location_bar_view.cc
@@ -14,13 +14,11 @@
 #include "brave/browser/profiles/profile_util.h"
 #include "brave/browser/themes/brave_theme_service.h"
 #include "brave/browser/ui/color/brave_color_id.h"
-#include "brave/browser/ui/commander/commander_service_factory.h"
 #include "brave/browser/ui/views/brave_actions/brave_actions_container.h"
 #include "brave/browser/ui/views/location_bar/brave_news_location_view.h"
 #include "brave/browser/ui/views/playlist/playlist_action_icon_view.h"
 #include "brave/browser/ui/views/toolbar/brave_toolbar_view.h"
-#include "brave/components/commander/browser/commander_frontend_delegate.h"
-#include "brave/components/commander/common/features.h"
+#include "brave/components/commander/common/buildflags/buildflags.h"
 #include "brave/components/l10n/common/localization_util.h"
 #include "brave/grit/brave_theme_resources.h"
 #include "chrome/browser/profiles/profile.h"
@@ -54,6 +52,12 @@
 #include "brave/browser/ui/views/location_bar/ipfs_location_view.h"
 #include "brave/components/ipfs/ipfs_constants.h"
 #include "brave/components/ipfs/ipfs_utils.h"
+#endif
+
+#if BUILDFLAG(ENABLE_COMMANDER)
+#include "brave/browser/ui/commander/commander_service_factory.h"
+#include "brave/components/commander/browser/commander_frontend_delegate.h"
+#include "brave/components/commander/common/features.h"
 #endif
 
 namespace {
@@ -206,9 +210,15 @@ ui::ImageModel BraveLocationBarView::GetLocationIcon(
 }
 
 void BraveLocationBarView::OnOmniboxBlurred() {
-  if (commander::CommanderEnabled()) {
-    commander::CommanderServiceFactory::GetForBrowserContext(profile_)->Hide();
+#if BUILDFLAG(ENABLE_COMMANDER)
+  if (base::FeatureList::IsEnabled(features::kBraveCommander)) {
+    if (auto* commander_service =
+            commander::CommanderServiceFactory::GetForBrowserContext(
+                profile_)) {
+      commander_service->Hide();
+    }
   }
+#endif
   LocationBarView::OnOmniboxBlurred();
 }
 

--- a/chromium_src/chrome/browser/about_flags.cc
+++ b/chromium_src/chrome/browser/about_flags.cc
@@ -4,10 +4,15 @@
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 #include "brave/browser/about_flags.cc"
+#include "brave/components/commander/common/buildflags/buildflags.h"
+
+#if BUILDFLAG(ENABLE_COMMANDER)
 #include "brave/components/commander/common/features.h"
 
 // Note: We replace the kQuickCommands feature with the kBraveCommander feature
 // so we can use it from //components without DEPS violations.
 #define kQuickCommands kBraveCommander
+#endif
+
 #include "src/chrome/browser/about_flags.cc"
 #undef kQuickCommands

--- a/chromium_src/chrome/browser/autocomplete/chrome_autocomplete_provider_client.cc
+++ b/chromium_src/chrome/browser/autocomplete/chrome_autocomplete_provider_client.cc
@@ -4,8 +4,9 @@
 // You can obtain one at https://mozilla.org/MPL/2.0/.
 
 #include "src/chrome/browser/autocomplete/chrome_autocomplete_provider_client.cc"
+#include "brave/components/commander/common/buildflags/buildflags.h"
 
-#if !BUILDFLAG(IS_ANDROID) && !BUILDFLAG(IS_IOS)
+#if BUILDFLAG(ENABLE_COMMANDER)
 #include "brave/browser/ui/commander/commander_service_factory.h"
 #include "brave/components/commander/browser/commander_frontend_delegate.h"
 

--- a/chromium_src/chrome/browser/autocomplete/chrome_autocomplete_provider_client.h
+++ b/chromium_src/chrome/browser/autocomplete/chrome_autocomplete_provider_client.h
@@ -6,9 +6,10 @@
 #ifndef BRAVE_CHROMIUM_SRC_CHROME_BROWSER_AUTOCOMPLETE_CHROME_AUTOCOMPLETE_PROVIDER_CLIENT_H_
 #define BRAVE_CHROMIUM_SRC_CHROME_BROWSER_AUTOCOMPLETE_CHROME_AUTOCOMPLETE_PROVIDER_CLIENT_H_
 
+#include "brave/components/commander/common/buildflags/buildflags.h"
 #include "components/omnibox/browser/autocomplete_provider_client.h"
 
-#if !BUILDFLAG(IS_ANDROID) && !BUILDFLAG(IS_IOS)
+#if BUILDFLAG(ENABLE_COMMANDER)
 #include "brave/components/commander/browser/commander_frontend_delegate.h"
 #define GetLocalOrSyncableBookmarkModel       \
   GetLocalOrSyncableBookmarkModel() override; \

--- a/chromium_src/chrome/browser/sources.gni
+++ b/chromium_src/chrome/browser/sources.gni
@@ -10,6 +10,7 @@ import("//build/config/ui.gni")
 brave_chromium_src_chrome_browser_deps = [
   "//base",
   "//brave/components/brave_vpn/common/buildflags",
+  "//brave/components/commander/common/buildflags",
   "//brave/components/playlist/common/buildflags",
   "//brave/components/text_recognition/common/buildflags",
   "//chrome/common:channel_info",

--- a/chromium_src/chrome/browser/ui/browser_commands.cc
+++ b/chromium_src/chrome/browser/ui/browser_commands.cc
@@ -5,10 +5,13 @@
 
 #include "brave/browser/ui/browser_commands.h"
 
-#include "brave/browser/ui/commander/commander_service_factory.h"
-#include "brave/components/commander/browser/commander_frontend_delegate.h"
+#include "brave/components/commander/common/buildflags/buildflags.h"
 #include "chrome/browser/profiles/profile.h"
 #include "chrome/browser/ui/browser_commands.h"
+
+#if BUILDFLAG(ENABLE_COMMANDER)
+#include "brave/browser/ui/commander/commander_service_factory.h"
+#endif
 
 #define ToggleCommander ToggleCommander_ChromiumImpl
 #define ReloadBypassingCache ReloadBypassingCache_ChromiumImpl
@@ -36,8 +39,13 @@ ReadingListModel* GetReadingListModel(Browser* browser) {
 }
 
 void ToggleCommander(Browser* browser) {
-  commander::CommanderServiceFactory::GetForBrowserContext(browser->profile())
-      ->Toggle();
+#if BUILDFLAG(ENABLE_COMMANDER)
+  if (auto* commander_service =
+          commander::CommanderServiceFactory::GetForBrowserContext(
+              browser->profile())) {
+    commander_service->Toggle();
+  }
+#endif
 }
 
 }  // namespace chrome

--- a/chromium_src/chrome/browser/ui/commander/commander.cc
+++ b/chromium_src/chrome/browser/ui/commander/commander.cc
@@ -3,11 +3,15 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this file,
 // You can obtain one at https://mozilla.org/MPL/2.0/.
 
-#include "brave/components/commander/common/features.h"
+#include "brave/components/commander/common/buildflags/buildflags.h"
 #include "chrome/browser/ui/ui_features.h"
+
+#if BUILDFLAG(ENABLE_COMMANDER)
+#include "brave/components/commander/common/features.h"
 
 // We replace Chromium's flag with one of our own, because we want it to be
 // accessible from //components (which //chrome/ui/browser is not).
 #define kQuickCommands kBraveCommander
+#endif
 #include "src/chrome/browser/ui/commander/commander.cc"
 #undef kQuickCommands

--- a/chromium_src/components/omnibox/browser/actions/omnibox_action.h
+++ b/chromium_src/components/omnibox/browser/actions/omnibox_action.h
@@ -6,9 +6,11 @@
 #ifndef BRAVE_CHROMIUM_SRC_COMPONENTS_OMNIBOX_BROWSER_ACTIONS_OMNIBOX_ACTION_H_
 #define BRAVE_CHROMIUM_SRC_COMPONENTS_OMNIBOX_BROWSER_ACTIONS_OMNIBOX_ACTION_H_
 
+#include "brave/components/commander/common/buildflags/buildflags.h"
+
+#if BUILDFLAG(ENABLE_COMMANDER)
 #include "brave/components/commander/browser/commander_frontend_delegate.h"
 
-#if !BUILDFLAG(IS_ANDROID) && !BUILDFLAG(IS_IOS)
 #define OpenSharingHub  \
   OpenSharingHub() = 0; \
   virtual commander::CommanderFrontendDelegate* GetCommanderDelegate

--- a/chromium_src/components/omnibox/browser/autocomplete_controller.cc
+++ b/chromium_src/components/omnibox/browser/autocomplete_controller.cc
@@ -10,8 +10,7 @@
 #include "base/ranges/algorithm.h"
 #include "base/strings/string_util.h"
 #include "brave/components/brave_search_conversion/utils.h"
-#include "brave/components/commander/common/constants.h"
-#include "brave/components/commander/common/features.h"
+#include "brave/components/commander/common/buildflags/buildflags.h"
 #include "brave/components/omnibox/browser/brave_bookmark_provider.h"
 #include "brave/components/omnibox/browser/brave_history_quick_provider.h"
 #include "brave/components/omnibox/browser/brave_history_url_provider.h"
@@ -28,7 +27,10 @@
 #include "components/omnibox/browser/history_cluster_provider.h"
 #include "components/omnibox/browser/history_fuzzy_provider.h"
 
-#if !BUILDFLAG(IS_ANDROID) && !BUILDFLAG(IS_IOS)
+#if BUILDFLAG(ENABLE_COMMANDER)
+#include "brave/components/commander/common/buildflags/buildflags.h"
+#include "brave/components/commander/common/constants.h"
+#include "brave/components/commander/common/features.h"
 #include "brave/components/omnibox/browser/commander_provider.h"
 #endif
 
@@ -38,9 +40,9 @@ namespace {
 // If this input has triggered the commander then only show commander results.
 void MaybeShowCommands(AutocompleteResult* result,
                        const AutocompleteInput& input) {
-#if !BUILDFLAG(IS_ANDROID) && !BUILDFLAG(IS_IOS)
+#if BUILDFLAG(ENABLE_COMMANDER)
   // If this input isn't a command, return and don't do any work.
-  if (!commander::CommanderEnabled() ||
+  if (!base::FeatureList::IsEnabled(features::kBraveCommander) ||
       !base::StartsWith(input.text(), commander::kCommandPrefix)) {
     return;
   }
@@ -67,8 +69,8 @@ void MaybeShowCommands(AutocompleteResult* result,
 
 void MaybeAddCommanderProvider(AutocompleteController::Providers& providers,
                                AutocompleteController* controller) {
-#if !BUILDFLAG(IS_ANDROID) && !BUILDFLAG(IS_IOS)
-  if (commander::CommanderEnabled()) {
+#if BUILDFLAG(ENABLE_COMMANDER)
+  if (base::FeatureList::IsEnabled(features::kBraveCommander)) {
     providers.push_back(base::MakeRefCounted<commander::CommanderProvider>(
         controller->autocomplete_provider_client(), controller));
   }

--- a/chromium_src/components/omnibox/browser/mock_autocomplete_provider_client.h
+++ b/chromium_src/components/omnibox/browser/mock_autocomplete_provider_client.h
@@ -8,7 +8,9 @@
 
 #include "components/omnibox/browser/autocomplete_provider_client.h"
 
-#if !BUILDFLAG(IS_ANDROID) && !BUILDFLAG(IS_IOS)
+#include "brave/components/commander/common/buildflags/buildflags.h"
+
+#if BUILDFLAG(ENABLE_COMMANDER)
 #include "brave/components/commander/browser/commander_frontend_delegate.h"
 #define GetTopSites                                                          \
   GetTopSites_Unused() {                                                     \

--- a/chromium_src/components/omnibox/browser/omnibox_edit_model.cc
+++ b/chromium_src/components/omnibox/browser/omnibox_edit_model.cc
@@ -6,10 +6,11 @@
 #include "components/omnibox/browser/omnibox_edit_model.h"
 
 #include "base/memory/raw_ptr.h"
+#include "brave/components/commander/common/buildflags/buildflags.h"
 #include "components/omnibox/browser/omnibox_controller.h"
 #include "url/gurl.h"
 
-#if !BUILDFLAG(IS_ANDROID) && !BUILDFLAG(IS_IOS)
+#if BUILDFLAG(ENABLE_COMMANDER)
 #include "brave/components/commander/common/constants.h"
 #include "brave/components/commander/common/features.h"
 #endif
@@ -41,8 +42,8 @@ void BraveAdjustTextForCopy(GURL* url) {
 #undef BRAVE_ADJUST_TEXT_FOR_COPY
 
 bool OmniboxEditModel::CanPasteAndGo(const std::u16string& text) const {
-#if !BUILDFLAG(IS_ANDROID) && !BUILDFLAG(IS_IOS)
-  if (commander::CommanderEnabled() &&
+#if BUILDFLAG(ENABLE_COMMANDER)
+  if (base::FeatureList::IsEnabled(features::kBraveCommander) &&
       base::StartsWith(text, commander::kCommandPrefix)) {
     return false;
   }

--- a/components/commander/browser/BUILD.gn
+++ b/components/commander/browser/BUILD.gn
@@ -3,7 +3,9 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this file,
 # You can obtain one at https://mozilla.org/MPL/2.0/.
 
-assert(!is_android && !is_ios)
+import("//brave/components/commander/common/buildflags/buildflags.gni")
+
+assert(enable_commander)
 
 component("browser") {
   output_name = "commander_browser"

--- a/components/commander/common/BUILD.gn
+++ b/components/commander/common/BUILD.gn
@@ -3,7 +3,9 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this file,
 # You can obtain one at https://mozilla.org/MPL/2.0/.
 
-assert(!is_android && !is_ios)
+import("//brave/components/commander/common/buildflags/buildflags.gni")
+
+assert(enable_commander)
 
 component("common") {
   output_name = "commander_common"
@@ -19,4 +21,6 @@ component("common") {
   ]
 
   deps = [ "//base" ]
+
+  public_deps = [ "//brave/components/commander/common/buildflags" ]
 }

--- a/components/commander/common/buildflags/BUILD.gn
+++ b/components/commander/common/buildflags/BUILD.gn
@@ -1,0 +1,12 @@
+# Copyright (c) 2023 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import("//brave/components/commander/common/buildflags/buildflags.gni")
+import("//build/buildflag_header.gni")
+
+buildflag_header("buildflags") {
+  header = "buildflags.h"
+  flags = [ "ENABLE_COMMANDER=$enable_commander" ]
+}

--- a/components/commander/common/buildflags/buildflags.gni
+++ b/components/commander/common/buildflags/buildflags.gni
@@ -1,0 +1,8 @@
+# Copyright (c) 2023 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+
+declare_args() {
+  enable_commander = !is_android && !is_ios
+}

--- a/components/commander/common/constants.cc
+++ b/components/commander/common/constants.cc
@@ -5,8 +5,6 @@
 
 #include "brave/components/commander/common/constants.h"
 
-#include "base/strings/string_piece.h"
-
 namespace commander {
 
 const base::StringPiece16 kCommandPrefix(u":>");

--- a/components/commander/common/features.cc
+++ b/components/commander/common/features.cc
@@ -5,19 +5,10 @@
 
 #include "brave/components/commander/common/features.h"
 
-#include "base/feature_list.h"
-
 namespace features {
 
 BASE_FEATURE(kBraveCommander,
              "BraveCommander",
              base::FEATURE_DISABLED_BY_DEFAULT);
-}
 
-namespace commander {
-
-bool CommanderEnabled() {
-  return base::FeatureList::IsEnabled(features::kBraveCommander);
-}
-
-}  // namespace commander
+}  // namespace features

--- a/components/commander/common/features.h
+++ b/components/commander/common/features.h
@@ -17,10 +17,4 @@ COMPONENT_EXPORT(COMMANDER_COMMON) BASE_DECLARE_FEATURE(kBraveCommander);
 
 }  // namespace features
 
-namespace commander {
-
-COMPONENT_EXPORT(COMMANDER_COMMON) bool CommanderEnabled();
-
-}  // namespace commander
-
 #endif  // BRAVE_COMPONENTS_COMMANDER_COMMON_FEATURES_H_

--- a/components/omnibox/browser/BUILD.gn
+++ b/components/omnibox/browser/BUILD.gn
@@ -3,6 +3,8 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this file,
 # You can obtain one at http://mozilla.org/MPL/2.0/.
 
+import("//brave/components/commander/common/buildflags/buildflags.gni")
+
 source_set("unit_tests") {
   testonly = true
 
@@ -42,7 +44,7 @@ source_set("unit_tests") {
     "//testing/gtest",
   ]
 
-  if (!is_android && !is_ios) {
+  if (enable_commander) {
     sources +=
         [ "//brave/components/omnibox/browser/commander_provider_unittest.cc" ]
 

--- a/components/omnibox/browser/commander_action.cc
+++ b/components/omnibox/browser/commander_action.cc
@@ -14,8 +14,10 @@ CommanderAction::CommanderAction(uint32_t command_index, uint32_t result_set_id)
 CommanderAction::~CommanderAction() = default;
 
 void CommanderAction::Execute(ExecutionContext& context) const {
-  context.client_->GetCommanderDelegate()->SelectCommand(command_index_,
-                                                         result_set_id_);
+  // If we've generated and executed a command, our delegate must exist.
+  auto* delegate = context.client_->GetCommanderDelegate();
+  CHECK(delegate);
+  delegate->SelectCommand(command_index_, result_set_id_);
 }
 
 }  // namespace commander

--- a/components/omnibox/browser/commander_provider.cc
+++ b/components/omnibox/browser/commander_provider.cc
@@ -8,14 +8,9 @@
 #include <string>
 #include <utility>
 
-#include "base/functional/bind.h"
-#include "base/functional/callback_helpers.h"
 #include "base/memory/scoped_refptr.h"
 #include "base/strings/strcat.h"
-#include "base/strings/string_util.h"
-#include "base/strings/utf_string_conversions.h"
 #include "brave/components/commander/browser/commander_frontend_delegate.h"
-#include "brave/components/commander/browser/commander_item_model.h"
 #include "brave/components/commander/common/constants.h"
 #include "brave/components/omnibox/browser/commander_action.h"
 #include "components/omnibox/browser/autocomplete_match.h"
@@ -32,7 +27,9 @@ CommanderProvider::CommanderProvider(AutocompleteProviderClient* client,
     AddListener(listener);
   }
 
-  observation_.Observe(client_->GetCommanderDelegate());
+  if (auto* delegate = client_->GetCommanderDelegate()) {
+    observation_.Observe(client_->GetCommanderDelegate());
+  }
 }
 
 CommanderProvider::~CommanderProvider() = default;
@@ -45,7 +42,10 @@ void CommanderProvider::Start(const AutocompleteInput& input,
 
   matches_.clear();
   last_input_ = input.text();
-  client_->GetCommanderDelegate()->UpdateText();
+
+  if (auto* delegate = client_->GetCommanderDelegate()) {
+    delegate->UpdateText();
+  }
 }
 
 void CommanderProvider::Stop(bool clear_cached_results,
@@ -55,7 +55,11 @@ void CommanderProvider::Stop(bool clear_cached_results,
 }
 
 void CommanderProvider::OnCommanderUpdated() {
+  // This is called the CommanderFrontEndDelegate::Observer, so a delegate must
+  // always exist at this point.
   auto* delegate = client_->GetCommanderDelegate();
+  CHECK(delegate);
+
   matches_.clear();
 
   if (!last_input_.starts_with(commander::kCommandPrefix.data())) {

--- a/components/omnibox/browser/commander_provider.h
+++ b/components/omnibox/browser/commander_provider.h
@@ -11,10 +11,10 @@
 #include "base/memory/weak_ptr.h"
 #include "base/scoped_observation.h"
 #include "brave/components/commander/browser/commander_frontend_delegate.h"
-#include "brave/components/commander/browser/commander_item_model.h"
 #include "components/omnibox/browser/autocomplete_provider.h"
-#include "components/omnibox/browser/autocomplete_provider_client.h"
-#include "components/omnibox/browser/autocomplete_provider_listener.h"
+
+class AutocompleteProviderClient;
+class AutocompleteProviderListener;
 
 namespace commander {
 class CommanderProvider

--- a/components/omnibox/browser/sources.gni
+++ b/components/omnibox/browser/sources.gni
@@ -3,6 +3,8 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this file,
 # You can obtain one at http://mozilla.org/MPL/2.0/.
 
+import("//brave/components/commander/common/buildflags/buildflags.gni")
+
 brave_components_omnibox_browser_sources = [
   "//brave/components/omnibox/browser/brave_bookmark_provider.cc",
   "//brave/components/omnibox/browser/brave_bookmark_provider.h",
@@ -32,12 +34,13 @@ brave_components_omnibox_browser_sources = [
 brave_components_omnibox_browser_deps = [
   "//base",
   "//brave/components/brave_search_conversion",
+  "//brave/components/commander/common/buildflags",
   "//brave/components/constants",
   "//components/prefs",
   "//url",
 ]
 
-if (!is_android && !is_ios) {
+if (enable_commander) {
   brave_components_omnibox_browser_sources += [
     "//brave/components/omnibox/browser/commander_action.cc",
     "//brave/components/omnibox/browser/commander_action.h",

--- a/test/BUILD.gn
+++ b/test/BUILD.gn
@@ -416,7 +416,6 @@ test("brave_unit_tests") {
       "//brave/browser/ui/bookmark",
       "//brave/browser/ui/bookmark:unittest",
       "//brave/browser/ui/color:unit_tests",
-      "//brave/browser/ui/commander:unit_tests",
       "//brave/browser/ui/commands:unit_tests",
       "//brave/browser/ui/toolbar:brave_app_menu_unit_test",
       "//brave/browser/ui/views/download/bubble:unit_tests",
@@ -432,6 +431,11 @@ test("brave_unit_tests") {
       "//components/favicon/content",
     ]
   }
+
+  if (enable_commander) {
+    deps += [ "//brave/browser/ui/commander:unit_tests" ]
+  }
+
   if (enable_captive_portal_detection) {
     deps += [ "//brave/components/captive_portal/content:unit_tests" ]
   }
@@ -1101,11 +1105,14 @@ test("brave_browser_tests") {
       "//brave/app/theme:brave_theme_resources_grit",
       "//brave/app/theme:brave_unscaled_resources_grit",
       "//brave/browser/sharing_hub:browser_tests",
-      "//brave/browser/ui/commander:browser_tests",
       "//brave/browser/ui/whats_new:browser_test",
       "//chrome/browser/apps/app_service:app_service",
       "//chrome/browser/apps/app_service:constants",
     ]
+  }
+
+  if (enable_commander) {
+    deps += [ "//brave/browser/ui/commander:browser_tests" ]
   }
 
   if (enable_request_otr) {


### PR DESCRIPTION
Uplift of #19511
Resolves https://github.com/brave/brave-browser/issues/31997

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.