### PR TITLE
Always enable brave today prefs for Ads library on iOS. (uplift to 1.57)

### DIFF
--- a/ios/browser/api/ads/BUILD.gn
+++ b/ios/browser/api/ads/BUILD.gn
@@ -36,6 +36,7 @@ source_set("ads") {
     "//brave/components/brave_ads/common",
     "//brave/components/brave_ads/core",
     "//brave/components/brave_federated/public/interfaces",
+    "//brave/components/brave_news/common",
     "//brave/components/brave_rewards/common",
     "//brave/ios/browser/api/common",
   ]

--- a/ios/browser/api/ads/brave_ads.h
+++ b/ios/browser/api/ads/brave_ads.h
@@ -59,7 +59,7 @@ OBJC_EXPORT
 /// Initializes the ads service
 - (void)initializeWithSysInfo:(BraveAdsSysInfo*)sysInfo
              buildChannelInfo:(BraveAdsBuildChannelInfo*)buildChannelInfo
-                   walletInfo:(BraveAdsWalletInfo*)walletInfo
+                   walletInfo:(nullable BraveAdsWalletInfo*)walletInfo
                    completion:(void (^)(bool))completion;
 
 /// Shuts down the ads service if its running


### PR DESCRIPTION
Uplift of https://github.com/brave/brave-core/pull/19596
Resolves https://github.com/brave/brave-browser/issues/32091

- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR.
- [ ] You have tested your change on Nightly. 
- [x] The PR milestones match the branch they are landing to. 

After you merge: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.
