### PR TITLE
Introduce IPFS promo infobar

### DIFF
--- a/app/brave_generated_resources.grd
+++ b/app/brave_generated_resources.grd
@@ -886,7 +886,7 @@ Or change later at <ph name="SETTINGS_EXTENIONS_LINK">$2<ex>brave://settings/ext
         Learn more about IPFS and privacy
       </message>
       <message name="IDS_BRAVE_IPFS_INFOBAR_TEXT" desc="Text that promotes turning on autoredirect to the configured gateway setting">
-        Would you like to handle content-addressed resources with native IPFS support (ipfs:// and ipns://) built into Brave?
+        This page is available on the IPFS network. Would you like to load IPFS pages using Brave's built-in support (via ipfs:// or ipns://)?
       </message>
       <message name="IDS_BRAVE_IPFS_INFOBAR_APPROVE" desc="Turns on promoted setting">
         Always

--- a/app/brave_generated_resources.grd
+++ b/app/brave_generated_resources.grd
@@ -885,6 +885,21 @@ Or change later at <ph name="SETTINGS_EXTENIONS_LINK">$2<ex>brave://settings/ext
       <message name="IDS_BRAVE_IPFS_LEARN_MORE">
         Learn more about IPFS and privacy
       </message>
+      <message name="IDS_BRAVE_IPFS_INFOBAR_TEXT" desc="Text that promotes turning on autoredirect to the configured gateway setting">
+        Would you like to handle content-addressed resources with native IPFS support (ipfs:// and ipns://) built into Brave?
+      </message>
+      <message name="IDS_BRAVE_IPFS_INFOBAR_APPROVE" desc="Turns on promoted setting">
+        Always
+      </message>
+      <message name="IDS_BRAVE_IPFS_INFOBAR_APPROVE_ONCE" desc="Redirects to the ipfs:// or ipns:// resource for once">
+        Only This Time
+      </message>
+      <message name="IDS_BRAVE_IPFS_INFOBAR_NEVER" desc="Closed infobar and disables it showing">
+        No Thanks
+      </message>
+      <message name="IDS_BRAVE_IPFS_INFOBAR_LINK" desc="Link redirects to the privacy description article">
+        Learn how this affects my privacy
+      </message>
 
       <!-- Brave Wayback Machine -->
       <message name="IDS_BRAVE_WAYBACK_MACHINE_INFOBAR_PAGE_MISSING_TEXT" desc="The label for sorry message when page is not available on infobar">

--- a/browser/infobars/brave_ipfs_infobar_delegate.cc
+++ b/browser/infobars/brave_ipfs_infobar_delegate.cc
@@ -18,9 +18,9 @@
 #include "ui/views/vector_icons.h"
 
 // BraveIPFSInfoBarDelegateObserver
-BraveIPFSInfoBarDelegateObserver::BraveIPFSInfoBarDelegateObserver() {}
+BraveIPFSInfoBarDelegateObserver::BraveIPFSInfoBarDelegateObserver() = default;
 
-BraveIPFSInfoBarDelegateObserver::~BraveIPFSInfoBarDelegateObserver() {}
+BraveIPFSInfoBarDelegateObserver::~BraveIPFSInfoBarDelegateObserver() = default;
 
 // BraveIPFSInfoBarDelegate
 // static
@@ -50,8 +50,7 @@ bool BraveIPFSInfoBarDelegate::HasCheckbox() const {
 }
 
 std::u16string BraveIPFSInfoBarDelegate::GetCheckboxText() const {
-  NOTREACHED();
-  return std::u16string();
+  NOTREACHED_NORETURN();
 }
 
 void BraveIPFSInfoBarDelegate::SetCheckboxChecked(bool checked) {
@@ -105,9 +104,8 @@ std::u16string BraveIPFSInfoBarDelegate::GetButtonLabel(
       return brave_l10n::GetLocalizedResourceUTF16String(
           IDS_BRAVE_IPFS_INFOBAR_NEVER);
     default:
-      NOTREACHED();
+      NOTREACHED_NORETURN();
   }
-  return std::u16string();
 }
 
 std::vector<int> BraveIPFSInfoBarDelegate::GetButtonsOrder() const {

--- a/browser/infobars/brave_ipfs_infobar_delegate.cc
+++ b/browser/infobars/brave_ipfs_infobar_delegate.cc
@@ -1,0 +1,145 @@
+/* Copyright (c) 2023 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "brave/browser/infobars/brave_ipfs_infobar_delegate.h"
+
+#include <algorithm>
+#include <utility>
+
+#include "brave/browser/ui/views/infobars/brave_confirm_infobar.h"
+#include "brave/components/ipfs/ipfs_constants.h"
+#include "brave/components/ipfs/pref_names.h"
+#include "brave/components/l10n/common/localization_util.h"
+#include "brave/grit/brave_generated_resources.h"
+#include "components/infobars/core/infobar.h"
+#include "components/prefs/pref_service.h"
+#include "ui/views/vector_icons.h"
+
+// BraveIPFSInfoBarDelegateObserver
+BraveIPFSInfoBarDelegateObserver::BraveIPFSInfoBarDelegateObserver() {}
+
+BraveIPFSInfoBarDelegateObserver::~BraveIPFSInfoBarDelegateObserver() {}
+
+// BraveIPFSInfoBarDelegate
+// static
+void BraveIPFSInfoBarDelegate::Create(
+    infobars::ContentInfoBarManager* infobar_manager,
+    std::unique_ptr<BraveIPFSInfoBarDelegateObserver> observer,
+    PrefService* local_state) {
+  if (!local_state->GetBoolean(kShowIPFSPromoInfobar)) {
+    return;
+  }
+  infobar_manager->AddInfoBar(std::make_unique<BraveConfirmInfoBar>(
+                                  std::make_unique<BraveIPFSInfoBarDelegate>(
+                                      std::move(observer), local_state)),
+                              true);
+}
+
+BraveIPFSInfoBarDelegate::BraveIPFSInfoBarDelegate(
+    std::unique_ptr<BraveIPFSInfoBarDelegateObserver> observer,
+    PrefService* local_state)
+    : observer_(std::move(observer)), local_state_(local_state) {}
+
+BraveIPFSInfoBarDelegate::~BraveIPFSInfoBarDelegate() {}
+
+// BraveConfirmInfoBarDelegate
+bool BraveIPFSInfoBarDelegate::HasCheckbox() const {
+  return false;
+}
+
+std::u16string BraveIPFSInfoBarDelegate::GetCheckboxText() const {
+  NOTREACHED();
+  return std::u16string();
+}
+
+void BraveIPFSInfoBarDelegate::SetCheckboxChecked(bool checked) {
+  NOTREACHED();
+}
+
+bool BraveIPFSInfoBarDelegate::InterceptClosing() {
+  return false;
+}
+
+// ConfirmInfoBarDelegate
+infobars::InfoBarDelegate::InfoBarIdentifier
+BraveIPFSInfoBarDelegate::GetIdentifier() const {
+  return BRAVE_IPFS_INFOBAR_DELEGATE;
+}
+
+const gfx::VectorIcon& BraveIPFSInfoBarDelegate::GetVectorIcon() const {
+  return views::kInfoIcon;
+}
+
+bool BraveIPFSInfoBarDelegate::ShouldExpire(
+    const NavigationDetails& details) const {
+  return details.is_navigation_to_different_page;
+}
+
+void BraveIPFSInfoBarDelegate::InfoBarDismissed() {}
+
+std::u16string BraveIPFSInfoBarDelegate::GetMessageText() const {
+  return brave_l10n::GetLocalizedResourceUTF16String(
+      IDS_BRAVE_IPFS_INFOBAR_TEXT);
+}
+
+int BraveIPFSInfoBarDelegate::GetButtons() const {
+  return BUTTON_OK | BUTTON_CANCEL | BUTTON_EXTRA;
+}
+
+bool BraveIPFSInfoBarDelegate::IsProminent(int id) const {
+  return id == BUTTON_OK || id == BUTTON_EXTRA;
+}
+
+std::u16string BraveIPFSInfoBarDelegate::GetButtonLabel(
+    InfoBarButton button) const {
+  switch (button) {
+    case InfoBarButton::BUTTON_OK:
+      return brave_l10n::GetLocalizedResourceUTF16String(
+          IDS_BRAVE_IPFS_INFOBAR_APPROVE);
+    case InfoBarButton::BUTTON_EXTRA:
+      return brave_l10n::GetLocalizedResourceUTF16String(
+          IDS_BRAVE_IPFS_INFOBAR_APPROVE_ONCE);
+    case InfoBarButton::BUTTON_CANCEL:
+      return brave_l10n::GetLocalizedResourceUTF16String(
+          IDS_BRAVE_IPFS_INFOBAR_NEVER);
+    default:
+      NOTREACHED();
+  }
+  return std::u16string();
+}
+
+std::vector<int> BraveIPFSInfoBarDelegate::GetButtonsOrder() const {
+  return {InfoBarButton::BUTTON_OK, InfoBarButton::BUTTON_EXTRA,
+          InfoBarButton::BUTTON_CANCEL};
+}
+
+std::u16string BraveIPFSInfoBarDelegate::GetLinkText() const {
+  return brave_l10n::GetLocalizedResourceUTF16String(
+      IDS_BRAVE_IPFS_INFOBAR_LINK);
+}
+
+GURL BraveIPFSInfoBarDelegate::GetLinkURL() const {
+  return GURL(ipfs::kIPFSLearnMorePrivacyURL);
+}
+
+bool BraveIPFSInfoBarDelegate::Accept() {
+  if (observer_) {
+    local_state_->SetBoolean(kShowIPFSPromoInfobar, false);
+    observer_->OnRedirectToIPFS(true);
+  }
+  return true;
+}
+
+bool BraveIPFSInfoBarDelegate::ExtraButtonPressed() {
+  if (observer_) {
+    observer_->OnRedirectToIPFS(false);
+  }
+  return true;
+}
+
+bool BraveIPFSInfoBarDelegate::Cancel() {
+  local_state_->SetBoolean(kShowIPFSPromoInfobar, false);
+  return true;
+}

--- a/browser/infobars/brave_ipfs_infobar_delegate.h
+++ b/browser/infobars/brave_ipfs_infobar_delegate.h
@@ -24,8 +24,8 @@ class ContentInfoBarManager;
 class BraveIPFSInfoBarDelegateObserver {
  public:
   BraveIPFSInfoBarDelegateObserver();
-  virtual ~BraveIPFSInfoBarDelegateObserver();
   virtual void OnRedirectToIPFS(bool remember) = 0;
+  virtual ~BraveIPFSInfoBarDelegateObserver();
 };
 
 class BraveIPFSInfoBarDelegate : public BraveConfirmInfoBarDelegate {
@@ -34,7 +34,7 @@ class BraveIPFSInfoBarDelegate : public BraveConfirmInfoBarDelegate {
   BraveIPFSInfoBarDelegate& operator=(const BraveIPFSInfoBarDelegate&) = delete;
 
   BraveIPFSInfoBarDelegate(
-      std::unique_ptr<BraveIPFSInfoBarDelegateObserver> observer_,
+      std::unique_ptr<BraveIPFSInfoBarDelegateObserver> observer,
       PrefService* local_state);
   ~BraveIPFSInfoBarDelegate() override;
 

--- a/browser/infobars/brave_ipfs_infobar_delegate.h
+++ b/browser/infobars/brave_ipfs_infobar_delegate.h
@@ -1,0 +1,73 @@
+/* Copyright (c) 2023 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_BROWSER_INFOBARS_BRAVE_IPFS_INFOBAR_DELEGATE_H_
+#define BRAVE_BROWSER_INFOBARS_BRAVE_IPFS_INFOBAR_DELEGATE_H_
+
+#include <memory>
+#include <vector>
+
+#include "base/compiler_specific.h"
+#include "base/memory/raw_ptr.h"
+#include "brave/components/infobars/core/brave_confirm_infobar_delegate.h"
+#include "components/infobars/content/content_infobar_manager.h"
+#include "url/gurl.h"
+
+class PrefService;
+
+namespace infobars {
+class ContentInfoBarManager;
+}  // namespace infobars
+
+class BraveIPFSInfoBarDelegateObserver {
+ public:
+  BraveIPFSInfoBarDelegateObserver();
+  virtual ~BraveIPFSInfoBarDelegateObserver();
+  virtual void OnRedirectToIPFS(bool remember) = 0;
+};
+
+class BraveIPFSInfoBarDelegate : public BraveConfirmInfoBarDelegate {
+ public:
+  BraveIPFSInfoBarDelegate(const BraveIPFSInfoBarDelegate&) = delete;
+  BraveIPFSInfoBarDelegate& operator=(const BraveIPFSInfoBarDelegate&) = delete;
+
+  BraveIPFSInfoBarDelegate(
+      std::unique_ptr<BraveIPFSInfoBarDelegateObserver> observer_,
+      PrefService* local_state);
+  ~BraveIPFSInfoBarDelegate() override;
+
+  static void Create(infobars::ContentInfoBarManager* infobar_manager,
+                     std::unique_ptr<BraveIPFSInfoBarDelegateObserver> observer,
+                     PrefService* local_state);
+
+ private:
+  // BraveConfirmInfoBarDelegate
+  bool HasCheckbox() const override;
+  std::u16string GetCheckboxText() const override;
+  void SetCheckboxChecked(bool checked) override;
+  bool InterceptClosing() override;
+
+  // ConfirmInfoBarDelegate
+  infobars::InfoBarDelegate::InfoBarIdentifier GetIdentifier() const override;
+  const gfx::VectorIcon& GetVectorIcon() const override;
+  bool ShouldExpire(const NavigationDetails& details) const override;
+  void InfoBarDismissed() override;
+  std::u16string GetMessageText() const override;
+  int GetButtons() const override;
+  std::vector<int> GetButtonsOrder() const override;
+  bool IsProminent(int id) const override;
+  std::u16string GetButtonLabel(InfoBarButton button) const override;
+  std::u16string GetLinkText() const override;
+  GURL GetLinkURL() const override;
+
+  bool Accept() override;
+  bool Cancel() override;
+  bool ExtraButtonPressed() override;
+
+  std::unique_ptr<BraveIPFSInfoBarDelegateObserver> observer_;
+  raw_ptr<PrefService> local_state_ = nullptr;
+};
+
+#endif  // BRAVE_BROWSER_INFOBARS_BRAVE_IPFS_INFOBAR_DELEGATE_H_

--- a/browser/infobars/sources.gni
+++ b/browser/infobars/sources.gni
@@ -49,6 +49,16 @@ if (!is_android) {
       "//brave/components/ipfs",
       "//components/user_prefs",
     ]
+    if (!is_android) {
+      brave_browser_infobar_sources += [
+        "//brave/browser/infobars/brave_ipfs_infobar_delegate.cc",
+        "//brave/browser/infobars/brave_ipfs_infobar_delegate.h",
+      ]
+      brave_browser_infobar_deps += [
+        "//brave/browser/ui/views/infobars:infobars",
+        "//brave/components/infobars/core:core",
+      ]
+    }
   }
 
   if (enable_brave_wayback_machine) {

--- a/browser/ipfs/ipfs_tab_helper.cc
+++ b/browser/ipfs/ipfs_tab_helper.cc
@@ -71,7 +71,7 @@ namespace ipfs {
 class BraveIPFSInfoBarDelegateObserverImpl
     : public BraveIPFSInfoBarDelegateObserver {
  public:
-  BraveIPFSInfoBarDelegateObserverImpl(
+  explicit BraveIPFSInfoBarDelegateObserverImpl(
       base::WeakPtr<IPFSTabHelper> ipfs_tab_helper)
       : ipfs_tab_helper_(ipfs_tab_helper) {}
 
@@ -86,7 +86,7 @@ class BraveIPFSInfoBarDelegateObserverImpl
     }
   }
 
-  ~BraveIPFSInfoBarDelegateObserverImpl() override {}
+  ~BraveIPFSInfoBarDelegateObserverImpl() override = default;
 
  private:
   base::WeakPtr<IPFSTabHelper> ipfs_tab_helper_;

--- a/browser/ipfs/ipfs_tab_helper.cc
+++ b/browser/ipfs/ipfs_tab_helper.cc
@@ -16,6 +16,7 @@
 #include "brave/components/ipfs/ipfs_constants.h"
 #include "brave/components/ipfs/ipfs_utils.h"
 #include "brave/components/ipfs/pref_names.h"
+#include "build/buildflag.h"
 #include "chrome/browser/net/system_network_context_manager.h"
 #include "chrome/browser/shell_integration.h"
 #include "chrome/common/channel_info.h"
@@ -27,6 +28,10 @@
 #include "net/base/url_util.h"
 #include "net/http/http_status_code.h"
 #include "url/origin.h"
+
+#if !BUILDFLAG(IS_ANDROID)
+#include "brave/browser/infobars/brave_ipfs_infobar_delegate.h"
+#endif
 
 namespace {
 
@@ -61,6 +66,32 @@ void SetupIPFSProtocolHandler(const std::string& protocol) {
 }  // namespace
 
 namespace ipfs {
+
+#if !BUILDFLAG(IS_ANDROID)
+class BraveIPFSInfoBarDelegateObserverImpl
+    : public BraveIPFSInfoBarDelegateObserver {
+ public:
+  BraveIPFSInfoBarDelegateObserverImpl(
+      base::WeakPtr<IPFSTabHelper> ipfs_tab_helper)
+      : ipfs_tab_helper_(ipfs_tab_helper) {}
+
+  void OnRedirectToIPFS(bool enable_gateway_autoredirect) override {
+    if (ipfs_tab_helper_.get() &&
+        ipfs_tab_helper_->ipfs_resolved_url_.is_valid()) {
+      if (enable_gateway_autoredirect) {
+        ipfs_tab_helper_->pref_service_->SetBoolean(
+            kIPFSAutoRedirectToConfiguredGateway, true);
+      }
+      ipfs_tab_helper_->LoadUrl(ipfs_tab_helper_->ipfs_resolved_url_);
+    }
+  }
+
+  ~BraveIPFSInfoBarDelegateObserverImpl() override {}
+
+ private:
+  base::WeakPtr<IPFSTabHelper> ipfs_tab_helper_;
+};
+#endif  // !BUILDFLAG(IS_ANDROID)
 
 IPFSTabHelper::~IPFSTabHelper() = default;
 
@@ -143,6 +174,20 @@ void IPFSTabHelper::LoadUrl(const GURL& gurl) {
 }
 
 void IPFSTabHelper::UpdateLocationBar() {
+#if !BUILDFLAG(IS_ANDROID)
+  auto* content_infobar_manager =
+      infobars::ContentInfoBarManager::FromWebContents(web_contents());
+  // Check whether content_infobar_manager is present for unit tests
+  if (content_infobar_manager && ipfs_resolved_url_.is_valid() &&
+      !pref_service_->GetBoolean(kIPFSAutoRedirectToConfiguredGateway)) {
+    BraveIPFSInfoBarDelegate::Create(
+        content_infobar_manager,
+        std::make_unique<BraveIPFSInfoBarDelegateObserverImpl>(
+            weak_ptr_factory_.GetWeakPtr()),
+        pref_service_);
+  }
+#endif
+
   if (web_contents()->GetDelegate())
     web_contents()->GetDelegate()->NavigationStateChanged(
         web_contents(), content::INVALIDATE_TYPE_URL);

--- a/browser/ipfs/ipfs_tab_helper.h
+++ b/browser/ipfs/ipfs_tab_helper.h
@@ -106,6 +106,7 @@ class IPFSTabHelper : public content::WebContentsObserver,
   FRIEND_TEST_ALL_PREFIXES(IpfsTabHelperUnitTest,
                            GatewayIPNS_No_Redirect_WhenNoDnsLink);
   friend class content::WebContentsUserData<IPFSTabHelper>;
+  friend class BraveIPFSInfoBarDelegateObserverImpl;
   explicit IPFSTabHelper(content::WebContents* web_contents);
 
   GURL GetCurrentPageURL() const;

--- a/browser/ipfs/ipfs_tab_helper_browsertest.cc
+++ b/browser/ipfs/ipfs_tab_helper_browsertest.cc
@@ -6,6 +6,8 @@
 #include "brave/browser/ipfs/ipfs_tab_helper.h"
 
 #include "brave/browser/ipfs/ipfs_host_resolver.h"
+#include "brave/browser/ui/views/infobars/brave_confirm_infobar.h"
+#include "brave/components/infobars/core/brave_confirm_infobar_delegate.h"
 #include "brave/components/ipfs/ipfs_utils.h"
 #include "brave/components/ipfs/pref_names.h"
 #include "build/build_config.h"
@@ -13,6 +15,8 @@
 #include "chrome/common/channel_info.h"
 #include "chrome/test/base/in_process_browser_test.h"
 #include "chrome/test/base/ui_test_utils.h"
+#include "components/infobars/content/content_infobar_manager.h"
+#include "components/infobars/core/infobar.h"
 #include "components/prefs/pref_service.h"
 #include "components/user_prefs/user_prefs.h"
 #include "content/public/browser/browser_context.h"
@@ -646,3 +650,203 @@ IN_PROC_BROWSER_TEST_F(IpfsTabHelperBrowserTest,
   ASSERT_TRUE(WaitForLoadStop(active_contents()));
   EXPECT_EQ(active_contents()->GetVisibleURL(), expected_final_url);
 }
+
+#if !BUILDFLAG(IS_ANDROID)
+IN_PROC_BROWSER_TEST_F(IpfsTabHelperBrowserTest, IPFSPromoInfobar) {
+  ASSERT_TRUE(
+      ipfs::IPFSTabHelper::MaybeCreateForWebContents(active_contents()));
+  ipfs::IPFSTabHelper* helper =
+      ipfs::IPFSTabHelper::FromWebContents(active_contents());
+  ASSERT_TRUE(helper);
+  auto* prefs =
+      user_prefs::UserPrefs::Get(active_contents()->GetBrowserContext());
+
+  prefs->SetBoolean(kIPFSAutoRedirectToConfiguredGateway, false);
+  prefs->SetInteger(
+      kIPFSResolveMethod,
+      static_cast<int>(ipfs::IPFSResolveMethodTypes::IPFS_GATEWAY));
+  GURL gateway_url = embedded_test_server()->GetURL("a.com", "/");
+  prefs->SetString(kIPFSPublicGatewayAddress, gateway_url.spec());
+
+  const GURL test_url = embedded_test_server()->GetURL(
+      "navigate_to.com", base::StringPrintf("/ipfs/%s/wiki/"
+                                            "empty.html?query#ref",
+                                            kCid1));
+  // gateway url.
+  GURL expected_final_url;
+  ipfs::TranslateIPFSURI(GURL(base::StringPrintf("ipfs://%s/"
+                                                 "wiki/empty.html?query#ref",
+                                                 kCid1)),
+                         &expected_final_url, gateway_url, false);
+
+  auto find_infobar =
+      [](infobars::ContentInfoBarManager* content_infobar_manager)
+      -> infobars::InfoBar* {
+    for (size_t i = 0; i < content_infobar_manager->infobar_count(); i++) {
+      auto* infobar = content_infobar_manager->infobar_at(i);
+      if (infobar->delegate()->GetIdentifier() ==
+          BraveConfirmInfoBarDelegate::BRAVE_IPFS_INFOBAR_DELEGATE) {
+        return infobar;
+      }
+    }
+    return nullptr;
+  };
+
+  // Press cancel
+  {
+    ASSERT_TRUE(ui_test_utils::NavigateToURLWithDisposition(
+        browser(), test_url, WindowOpenDisposition::NEW_FOREGROUND_TAB,
+        ui_test_utils::BROWSER_TEST_WAIT_FOR_LOAD_STOP));
+    ASSERT_TRUE(WaitForLoadStop(active_contents()));
+
+    // Get last shown infobar
+    auto* infobar = find_infobar(
+        infobars::ContentInfoBarManager::FromWebContents(active_contents()));
+    ASSERT_TRUE(infobar);
+    static_cast<BraveConfirmInfoBar*>(infobar)->GetDelegate()->Cancel();
+    ASSERT_FALSE(prefs->GetBoolean(kIPFSAutoRedirectToConfiguredGateway));
+    ASSERT_TRUE(WaitForLoadStop(active_contents()));
+    EXPECT_EQ(active_contents()->GetVisibleURL(), test_url);
+    ASSERT_FALSE(prefs->GetBoolean(kShowIPFSPromoInfobar));
+  }
+
+  // Try to show infobar second time - it shouldn't be shown
+  {
+    ASSERT_TRUE(ui_test_utils::NavigateToURLWithDisposition(
+        browser(), test_url, WindowOpenDisposition::NEW_FOREGROUND_TAB,
+        ui_test_utils::BROWSER_TEST_WAIT_FOR_LOAD_STOP));
+    ASSERT_TRUE(WaitForLoadStop(active_contents()));
+
+    // Get last shown infobar
+    auto* infobar = find_infobar(
+        infobars::ContentInfoBarManager::FromWebContents(active_contents()));
+    ASSERT_FALSE(infobar);
+  }
+
+  // Reset infobar state
+  prefs->SetBoolean(kShowIPFSPromoInfobar, true);
+
+  // Test that infobar shows several times if extra button is pressed
+  for (int i = 0; i < 2; i++) {
+    {
+      ASSERT_TRUE(ui_test_utils::NavigateToURLWithDisposition(
+          browser(), test_url, WindowOpenDisposition::NEW_FOREGROUND_TAB,
+          ui_test_utils::BROWSER_TEST_WAIT_FOR_LOAD_STOP));
+      ASSERT_TRUE(WaitForLoadStop(active_contents()));
+
+      // Get last shown infobar
+      auto* infobar = find_infobar(
+          infobars::ContentInfoBarManager::FromWebContents(active_contents()));
+      ASSERT_TRUE(infobar);
+      static_cast<BraveConfirmInfoBar*>(infobar)
+          ->GetDelegate()
+          ->ExtraButtonPressed();
+
+      ASSERT_FALSE(prefs->GetBoolean(kIPFSAutoRedirectToConfiguredGateway));
+      ASSERT_TRUE(WaitForLoadStop(active_contents()));
+      EXPECT_EQ(active_contents()->GetVisibleURL(), expected_final_url);
+      ASSERT_TRUE(prefs->GetBoolean(kShowIPFSPromoInfobar));
+    }
+  }
+
+  // Test accept button, which enables the feature
+  {
+    ASSERT_TRUE(ui_test_utils::NavigateToURLWithDisposition(
+        browser(), test_url, WindowOpenDisposition::NEW_FOREGROUND_TAB,
+        ui_test_utils::BROWSER_TEST_WAIT_FOR_LOAD_STOP));
+    ASSERT_TRUE(WaitForLoadStop(active_contents()));
+
+    // Get last shown infobar
+    auto* infobar = find_infobar(
+        infobars::ContentInfoBarManager::FromWebContents(active_contents()));
+    ASSERT_TRUE(infobar);
+    static_cast<BraveConfirmInfoBar*>(infobar)->GetDelegate()->Accept();
+
+    ASSERT_TRUE(prefs->GetBoolean(kIPFSAutoRedirectToConfiguredGateway));
+    ASSERT_TRUE(WaitForLoadStop(active_contents()));
+    EXPECT_EQ(active_contents()->GetVisibleURL(), expected_final_url);
+    ASSERT_FALSE(prefs->GetBoolean(kShowIPFSPromoInfobar));
+  }
+
+  // Infobar shouldn't be shown after that
+  {
+    ASSERT_TRUE(ui_test_utils::NavigateToURLWithDisposition(
+        browser(), test_url, WindowOpenDisposition::NEW_FOREGROUND_TAB,
+        ui_test_utils::BROWSER_TEST_WAIT_FOR_LOAD_STOP));
+    ASSERT_TRUE(WaitForLoadStop(active_contents()));
+
+    // Get last shown infobar
+    auto* infobar = find_infobar(
+        infobars::ContentInfoBarManager::FromWebContents(active_contents()));
+    ASSERT_FALSE(infobar);
+  }
+}
+
+IN_PROC_BROWSER_TEST_F(IpfsTabHelperBrowserTest, IPFSPromoInfobar_NowShown) {
+  ASSERT_TRUE(
+      ipfs::IPFSTabHelper::MaybeCreateForWebContents(active_contents()));
+  ipfs::IPFSTabHelper* helper =
+      ipfs::IPFSTabHelper::FromWebContents(active_contents());
+  ASSERT_TRUE(helper);
+  auto* prefs =
+      user_prefs::UserPrefs::Get(active_contents()->GetBrowserContext());
+
+  prefs->SetBoolean(kIPFSAutoRedirectToConfiguredGateway, false);
+  prefs->SetInteger(
+      kIPFSResolveMethod,
+      static_cast<int>(ipfs::IPFSResolveMethodTypes::IPFS_GATEWAY));
+  GURL gateway_url = embedded_test_server()->GetURL("a.com", "/");
+  prefs->SetString(kIPFSPublicGatewayAddress, gateway_url.spec());
+
+  const GURL test_url_1 = embedded_test_server()->GetURL(
+      "navigate_to.com", base::StringPrintf("/ipfs/%s/wiki/"
+                                            "empty.html?query#ref",
+                                            kCid1));
+  const GURL test_url_2 =
+      embedded_test_server()->GetURL("navigate_to.com", "/abc");
+
+  auto find_infobar =
+      [](infobars::ContentInfoBarManager* content_infobar_manager)
+      -> infobars::InfoBar* {
+    for (size_t i = 0; i < content_infobar_manager->infobar_count(); i++) {
+      auto* infobar = content_infobar_manager->infobar_at(i);
+      if (infobar->delegate()->GetIdentifier() ==
+          BraveConfirmInfoBarDelegate::BRAVE_IPFS_INFOBAR_DELEGATE) {
+        return infobar;
+      }
+    }
+    return nullptr;
+  };
+
+  // Infobar shouldn't be shown after that
+  {
+    ASSERT_TRUE(ui_test_utils::NavigateToURL(browser(), test_url_2));
+    ASSERT_TRUE(WaitForLoadStop(active_contents()));
+
+    // Get last shown infobar
+    auto* infobar = find_infobar(
+        infobars::ContentInfoBarManager::FromWebContents(active_contents()));
+    ASSERT_FALSE(infobar);
+  }
+
+  {
+    ASSERT_TRUE(ui_test_utils::NavigateToURL(browser(), test_url_1));
+    ASSERT_TRUE(WaitForLoadStop(active_contents()));
+
+    // Get last shown infobar
+    auto* infobar = find_infobar(
+        infobars::ContentInfoBarManager::FromWebContents(active_contents()));
+    ASSERT_TRUE(infobar);
+  }
+
+  {
+    ASSERT_TRUE(ui_test_utils::NavigateToURL(browser(), test_url_2));
+    ASSERT_TRUE(WaitForLoadStop(active_contents()));
+
+    // Get last shown infobar
+    auto* infobar = find_infobar(
+        infobars::ContentInfoBarManager::FromWebContents(active_contents()));
+    ASSERT_FALSE(infobar);
+  }
+}
+#endif  // !BUILDFLAG(IS_ANDROID)

--- a/browser/ipfs/test/BUILD.gn
+++ b/browser/ipfs/test/BUILD.gn
@@ -67,7 +67,7 @@ source_set("browsertests") {
       "//brave/browser/ui/views/infobars:infobars",
       "//brave/common:common",
       "//brave/components/constants",
-      "//brave/components/infobars/core:core",
+      "//brave/components/infobars/core",
       "//brave/components/ipfs",
       "//chrome/test:test_support",
       "//chrome/test:test_support_ui",

--- a/browser/ipfs/test/BUILD.gn
+++ b/browser/ipfs/test/BUILD.gn
@@ -64,8 +64,10 @@ source_set("browsertests") {
     deps = [
       "//base/test:test_support",
       "//brave/browser",
+      "//brave/browser/ui/views/infobars:infobars",
       "//brave/common:common",
       "//brave/components/constants",
+      "//brave/components/infobars/core:core",
       "//brave/components/ipfs",
       "//chrome/test:test_support",
       "//chrome/test:test_support_ui",

--- a/browser/ui/startup/brave_obsolete_system_infobar_delegate.cc
+++ b/browser/ui/startup/brave_obsolete_system_infobar_delegate.cc
@@ -62,6 +62,10 @@ int BraveObsoleteSystemInfoBarDelegate::GetButtons() const {
   return BUTTON_NONE;
 }
 
+std::vector<int> BraveObsoleteSystemInfoBarDelegate::GetButtonsOrder() const {
+  return {};
+}
+
 void BraveObsoleteSystemInfoBarDelegate::OnConfirmDialogClosing(bool suppress) {
   if (suppress) {
     if (PrefService* local_state = g_browser_process->local_state()) {

--- a/browser/ui/startup/brave_obsolete_system_infobar_delegate.h
+++ b/browser/ui/startup/brave_obsolete_system_infobar_delegate.h
@@ -7,6 +7,7 @@
 #define BRAVE_BROWSER_UI_STARTUP_BRAVE_OBSOLETE_SYSTEM_INFOBAR_DELEGATE_H_
 
 #include <string>
+#include <vector>
 
 #include "base/memory/weak_ptr.h"
 #include "brave/components/infobars/core/brave_confirm_infobar_delegate.h"
@@ -38,6 +39,7 @@ class BraveObsoleteSystemInfoBarDelegate : public BraveConfirmInfoBarDelegate {
   GURL GetLinkURL() const override;
   std::u16string GetMessageText() const override;
   int GetButtons() const override;
+  std::vector<int> GetButtonsOrder() const override;
   bool ShouldExpire(const NavigationDetails& details) const override;
 
   void OnConfirmDialogClosing(bool suppress);

--- a/browser/ui/views/infobars/brave_confirm_infobar.cc
+++ b/browser/ui/views/infobars/brave_confirm_infobar.cc
@@ -5,12 +5,21 @@
 
 #include "brave/browser/ui/views/infobars/brave_confirm_infobar.h"
 
-#include <memory>
+#include <algorithm>
 #include <utility>
 
 #include "base/functional/bind.h"
+#include "build/build_config.h"
+#include "chrome/browser/ui/views/chrome_layout_provider.h"
 #include "ui/base/metadata/metadata_impl_macros.h"
+#include "ui/base/ui_base_features.h"
+#include "ui/base/window_open_disposition.h"
 #include "ui/views/controls/button/checkbox.h"
+#include "ui/views/controls/button/label_button.h"
+#include "ui/views/controls/button/md_text_button.h"
+#include "ui/views/controls/label.h"
+#include "ui/views/controls/link.h"
+#include "ui/views/view_class_properties.h"
 
 namespace {
 
@@ -25,14 +34,83 @@ std::unique_ptr<infobars::InfoBar> CreateBraveConfirmInfoBar(
 
 BraveConfirmInfoBar::BraveConfirmInfoBar(
     std::unique_ptr<BraveConfirmInfoBarDelegate> delegate)
-    : ConfirmInfoBar(std::move(delegate)) {
-  auto* delegate_ptr = GetBraveDelegate();
-  DCHECK(delegate_ptr);
+    : InfoBarView(std::move(delegate)) {
+  auto* delegate_ptr = GetDelegate();
+  label_ = AddChildView(CreateLabel(delegate_ptr->GetMessageText()));
+  label_->SetElideBehavior(delegate_ptr->GetMessageElideBehavior());
+
+  const auto create_button =
+      [this](ConfirmInfoBarDelegate::InfoBarButton type,
+             void (BraveConfirmInfoBar::*click_function)()) {
+        auto* button = AddChildView(std::make_unique<views::MdTextButton>(
+            base::BindRepeating(click_function, base::Unretained(this)),
+            GetDelegate()->GetButtonLabel(type)));
+        button->SetProperty(
+            views::kMarginsKey,
+            gfx::Insets::VH(ChromeLayoutProvider::Get()->GetDistanceMetric(
+                                DISTANCE_TOAST_CONTROL_VERTICAL),
+                            0));
+        return button;
+      };
+
+  const auto buttons = delegate_ptr->GetButtons();
+  if (buttons & ConfirmInfoBarDelegate::BUTTON_OK) {
+    ok_button_ = create_button(ConfirmInfoBarDelegate::BUTTON_OK,
+                               &BraveConfirmInfoBar::OkButtonPressed);
+    ok_button_->SetProminent(true);
+    ok_button_->SetImageModel(
+        views::Button::STATE_NORMAL,
+        delegate_ptr->GetButtonImage(ConfirmInfoBarDelegate::BUTTON_OK));
+    ok_button_->SetEnabled(
+        delegate_ptr->GetButtonEnabled(ConfirmInfoBarDelegate::BUTTON_OK));
+    ok_button_->SetTooltipText(
+        delegate_ptr->GetButtonTooltip(ConfirmInfoBarDelegate::BUTTON_OK));
+  }
+
+  if (buttons & ConfirmInfoBarDelegate::BUTTON_CANCEL) {
+    cancel_button_ = create_button(ConfirmInfoBarDelegate::BUTTON_CANCEL,
+                                   &BraveConfirmInfoBar::CancelButtonPressed);
+    if (features::IsChromeRefresh2023()) {
+      cancel_button_->SetStyle(ui::ButtonStyle::kTonal);
+    }
+    if (buttons == ConfirmInfoBarDelegate::BUTTON_CANCEL ||
+        delegate_ptr->IsProminent(ConfirmInfoBarDelegate::BUTTON_CANCEL)) {
+      cancel_button_->SetProminent(true);
+    }
+    cancel_button_->SetImageModel(
+        views::Button::STATE_NORMAL,
+        delegate_ptr->GetButtonImage(ConfirmInfoBarDelegate::BUTTON_CANCEL));
+    cancel_button_->SetEnabled(
+        delegate_ptr->GetButtonEnabled(ConfirmInfoBarDelegate::BUTTON_CANCEL));
+    cancel_button_->SetTooltipText(
+        delegate_ptr->GetButtonTooltip(ConfirmInfoBarDelegate::BUTTON_CANCEL));
+  }
+
+  if (buttons & ConfirmInfoBarDelegate::BUTTON_EXTRA) {
+    extra_button_ = create_button(ConfirmInfoBarDelegate::BUTTON_EXTRA,
+                                  &BraveConfirmInfoBar::ExtraButtonPressed);
+    if (features::IsChromeRefresh2023()) {
+      extra_button_->SetStyle(ui::ButtonStyle::kTonal);
+    }
+    if (buttons == ConfirmInfoBarDelegate::BUTTON_EXTRA ||
+        delegate_ptr->IsProminent(ConfirmInfoBarDelegate::BUTTON_EXTRA)) {
+      extra_button_->SetProminent(true);
+    }
+    extra_button_->SetImageModel(
+        views::Button::STATE_NORMAL,
+        delegate_ptr->GetButtonImage(ConfirmInfoBarDelegate::BUTTON_EXTRA));
+    extra_button_->SetEnabled(
+        delegate_ptr->GetButtonEnabled(ConfirmInfoBarDelegate::BUTTON_EXTRA));
+    extra_button_->SetTooltipText(
+        delegate_ptr->GetButtonTooltip(ConfirmInfoBarDelegate::BUTTON_EXTRA));
+  }
+
+  link_ = AddChildView(CreateLink(delegate_ptr->GetLinkText()));
 
   if (delegate_ptr->HasCheckbox()) {
     // We don't consider case where ok/cancel button and check box exist
     // together.
-    DCHECK(!ok_button_ && !cancel_button_);
+    // DCHECK(!ok_button_ && !cancel_button_);
     checkbox_ = AddChildView(std::make_unique<views::Checkbox>(
         delegate_ptr->GetCheckboxText(),
         base::BindRepeating(&BraveConfirmInfoBar::CheckboxPressed,
@@ -42,47 +120,143 @@ BraveConfirmInfoBar::BraveConfirmInfoBar(
 
 BraveConfirmInfoBar::~BraveConfirmInfoBar() = default;
 
-void BraveConfirmInfoBar::Layout() {
-  ConfirmInfoBar::Layout();
-
-  // Early return when checkbox is not used.
-  // This class is only valid when this infobar has checkbox now.
-  // NOTE: Revisit when we want to use other buttons together with checkbox.
-  if (!checkbox_)
-    return;
-
-  checkbox_->SizeToPreferredSize();
-
-  const int x = label_->bounds().right() + kCheckboxSpacing;
-  checkbox_->SetPosition(gfx::Point(x, OffsetY(checkbox_)));
+views::MdTextButton* BraveConfirmInfoBar::GetButtonById(int id) {
+  switch (id) {
+    case ConfirmInfoBarDelegate::BUTTON_OK:
+      return ok_button_;
+    case ConfirmInfoBarDelegate::BUTTON_CANCEL:
+      return cancel_button_;
+    case ConfirmInfoBarDelegate::BUTTON_EXTRA:
+      return extra_button_;
+    default:
+      NOTREACHED();
+      return nullptr;
+  }
 }
 
-BraveConfirmInfoBarDelegate* BraveConfirmInfoBar::GetBraveDelegate() {
-  return static_cast<BraveConfirmInfoBarDelegate*>(
-      ConfirmInfoBar::GetDelegate());
+void BraveConfirmInfoBar::Layout() {
+  InfoBarView::Layout();
+
+  if (ok_button_) {
+    ok_button_->SizeToPreferredSize();
+  }
+
+  if (cancel_button_) {
+    cancel_button_->SizeToPreferredSize();
+  }
+
+  if (extra_button_) {
+    extra_button_->SizeToPreferredSize();
+  }
+
+  int x = GetStartX();
+  Views views;
+  views.push_back(label_);
+  views.push_back(link_);
+  AssignWidths(&views, std::max(0, GetEndX() - x - NonLabelWidth()));
+
+  ChromeLayoutProvider* layout_provider = ChromeLayoutProvider::Get();
+
+  label_->SetPosition(gfx::Point(x, OffsetY(label_)));
+  if (!label_->GetText().empty()) {
+    x = label_->bounds().right() +
+        layout_provider->GetDistanceMetric(
+            DISTANCE_INFOBAR_HORIZONTAL_ICON_LABEL_PADDING);
+  }
+
+  auto order = GetDelegate()->GetButtonsOrder();
+  for (const auto& id : order) {
+    auto* current_button = GetButtonById(id);
+    current_button->SetPosition(gfx::Point(x, OffsetY(current_button)));
+    x = current_button->bounds().right() +
+        layout_provider->GetDistanceMetric(
+            views::DISTANCE_RELATED_BUTTON_HORIZONTAL);
+  }
+
+  // Place checkbox after latest button
+  if (checkbox_) {
+    checkbox_->SizeToPreferredSize();
+    x += kCheckboxSpacing;
+    checkbox_->SetPosition(gfx::Point(x, OffsetY(checkbox_)));
+  }
+
+  link_->SetPosition(gfx::Point(GetEndX() - link_->width(), OffsetY(link_)));
 }
 
 void BraveConfirmInfoBar::CheckboxPressed() {
-  GetBraveDelegate()->SetCheckboxChecked(checkbox_->GetChecked());
-}
-
-int BraveConfirmInfoBar::NonLabelWidth() const {
-  const int width = ConfirmInfoBar::NonLabelWidth();
-
-  // Early return when checkbox is not used.
-  // This class is only valid when this infobar has checkbox now.
-  if (!checkbox_)
-    return width;
-
-  return width + checkbox_->width() + kCheckboxSpacing;
+  GetDelegate()->SetCheckboxChecked(checkbox_->GetChecked());
 }
 
 void BraveConfirmInfoBar::CloseButtonPressed() {
-  if (GetBraveDelegate()->InterceptClosing())
+  if (GetDelegate()->InterceptClosing()) {
     return;
+  }
 
-  ConfirmInfoBar::CloseButtonPressed();
+  InfoBarView::CloseButtonPressed();
 }
 
-BEGIN_METADATA(BraveConfirmInfoBar, ConfirmInfoBar)
+void BraveConfirmInfoBar::OkButtonPressed() {
+  if (!owner()) {
+    return;  // We're closing; don't call anything, it might access the owner.
+  }
+  if (GetDelegate()->Accept()) {
+    RemoveSelf();
+  }
+}
+
+void BraveConfirmInfoBar::CancelButtonPressed() {
+  if (!owner()) {
+    return;  // We're closing; don't call anything, it might access the owner.
+  }
+  if (GetDelegate()->Cancel()) {
+    RemoveSelf();
+  }
+}
+
+void BraveConfirmInfoBar::ExtraButtonPressed() {
+  if (!owner()) {
+    return;  // We're closing; don't call anything, it might access the owner.
+  }
+  if (GetDelegate()->ExtraButtonPressed()) {
+    RemoveSelf();
+  }
+}
+
+BraveConfirmInfoBarDelegate* BraveConfirmInfoBar::GetDelegate() {
+  return reinterpret_cast<BraveConfirmInfoBarDelegate*>(delegate());
+}
+
+int BraveConfirmInfoBar::GetContentMinimumWidth() const {
+  return label_->GetMinimumSize().width() + link_->GetMinimumSize().width() +
+         NonLabelWidth();
+}
+
+int BraveConfirmInfoBar::NonLabelWidth() const {
+  ChromeLayoutProvider* layout_provider = ChromeLayoutProvider::Get();
+
+  const int label_spacing = layout_provider->GetDistanceMetric(
+      views::DISTANCE_RELATED_LABEL_HORIZONTAL);
+  const int button_spacing = layout_provider->GetDistanceMetric(
+      views::DISTANCE_RELATED_BUTTON_HORIZONTAL);
+
+  const int button_count =
+      (ok_button_ ? 1 : 0) + (cancel_button_ ? 1 : 0) + (extra_button_ ? 1 : 0);
+
+  int width =
+      (label_->GetText().empty() || button_count == 0) ? 0 : label_spacing;
+
+  width += std::max(0, button_spacing * (button_count - 1));
+
+  width += ok_button_ ? ok_button_->width() : 0;
+  width += cancel_button_ ? cancel_button_->width() : 0;
+  width += extra_button_ ? extra_button_->width() : 0;
+
+  if (checkbox_) {
+    width += checkbox_->width() + kCheckboxSpacing;
+  }
+
+  return width + ((link_->GetText().empty() || !width) ? 0 : label_spacing);
+}
+
+BEGIN_METADATA(BraveConfirmInfoBar, InfoBarView)
 END_METADATA

--- a/browser/ui/views/infobars/brave_confirm_infobar.h
+++ b/browser/ui/views/infobars/brave_confirm_infobar.h
@@ -3,8 +3,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-#ifndef BRAVE_BROWSER_UI_VIEWS_INFOBAR_BRAVE_CONFIRM_INFOBAR_
-#define BRAVE_BROWSER_UI_VIEWS_INFOBAR_BRAVE_CONFIRM_INFOBAR_
+#ifndef BRAVE_BROWSER_UI_VIEWS_INFOBARS_BRAVE_CONFIRM_INFOBAR_H_
+#define BRAVE_BROWSER_UI_VIEWS_INFOBARS_BRAVE_CONFIRM_INFOBAR_H_
 
 #include <memory>
 
@@ -36,15 +36,12 @@ class BraveConfirmInfoBar : public InfoBarView {
   // InfoBarView:
   void Layout() override;
 
-  BraveConfirmInfoBarDelegate* GetDelegate();
+  BraveConfirmInfoBarDelegate* GetDelegate() const;
 
-  views::MdTextButton* ok_button_for_testing() { return ok_button_; }
-
- protected:
+ private:
   // InfoBarView:
   int GetContentMinimumWidth() const override;
 
- private:
   void OkButtonPressed();
   void CancelButtonPressed();
   void ExtraButtonPressed();
@@ -63,6 +60,8 @@ class BraveConfirmInfoBar : public InfoBarView {
   raw_ptr<views::MdTextButton> extra_button_ = nullptr;
   raw_ptr<views::Link> link_ = nullptr;
   raw_ptr<views::Checkbox> checkbox_ = nullptr;
+
+  base::WeakPtrFactory<BraveConfirmInfoBar> weak_ptr_factory_{this};
 };
 
-#endif  // BRAVE_BROWSER_UI_VIEWS_INFOBAR_BRAVE_CONFIRM_INFOBAR_
+#endif  // BRAVE_BROWSER_UI_VIEWS_INFOBARS_BRAVE_CONFIRM_INFOBAR_H_

--- a/browser/ui/views/infobars/brave_confirm_infobar.h
+++ b/browser/ui/views/infobars/brave_confirm_infobar.h
@@ -3,42 +3,66 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-#ifndef BRAVE_BROWSER_UI_VIEWS_INFOBARS_BRAVE_CONFIRM_INFOBAR_H_
-#define BRAVE_BROWSER_UI_VIEWS_INFOBARS_BRAVE_CONFIRM_INFOBAR_H_
+#ifndef BRAVE_BROWSER_UI_VIEWS_INFOBAR_BRAVE_CONFIRM_INFOBAR_
+#define BRAVE_BROWSER_UI_VIEWS_INFOBAR_BRAVE_CONFIRM_INFOBAR_
 
 #include <memory>
 
 #include "base/memory/raw_ptr.h"
 #include "brave/components/infobars/core/brave_confirm_infobar_delegate.h"
-#include "chrome/browser/ui/views/infobars/confirm_infobar.h"
+#include "chrome/browser/ui/views/infobars/infobar_view.h"
 #include "ui/base/metadata/metadata_header_macros.h"
 
 namespace views {
 class Checkbox;
+class Label;
+class MdTextButton;
 }  // namespace views
 
-// Add checkbox to ConfirmInfoBar.
-// "Would you like to do X?  [Checkbox]       _Learn More_ [x]"
-class BraveConfirmInfoBar : public ConfirmInfoBar {
+// An infobar that shows a message, up to two optional buttons, and an optional,
+// right-aligned link.  This is commonly used to do things like:
+// "Would you like to do X?  [Yes]  [No]  [<custom button>]    _Learn More_ [x]"
+class BraveConfirmInfoBar : public InfoBarView {
  public:
   METADATA_HEADER(BraveConfirmInfoBar);
   explicit BraveConfirmInfoBar(
       std::unique_ptr<BraveConfirmInfoBarDelegate> delegate);
+
   BraveConfirmInfoBar(const BraveConfirmInfoBar&) = delete;
   BraveConfirmInfoBar& operator=(const BraveConfirmInfoBar&) = delete;
+
   ~BraveConfirmInfoBar() override;
 
-  // ConfirmInfoBar overrides:
+  // InfoBarView:
   void Layout() override;
-  int NonLabelWidth() const override;
-  void CloseButtonPressed() override;
+
+  BraveConfirmInfoBarDelegate* GetDelegate();
+
+  views::MdTextButton* ok_button_for_testing() { return ok_button_; }
+
+ protected:
+  // InfoBarView:
+  int GetContentMinimumWidth() const override;
 
  private:
-  BraveConfirmInfoBarDelegate* GetBraveDelegate();
-
+  void OkButtonPressed();
+  void CancelButtonPressed();
+  void ExtraButtonPressed();
+  void CloseButtonPressed() override;
   void CheckboxPressed();
 
+  views::MdTextButton* GetButtonById(int id);
+
+  // Returns the width of all content other than the label and link.  Layout()
+  // uses this to determine how much space the label and link can take.
+  int NonLabelWidth() const;
+
+  raw_ptr<views::Label> label_ = nullptr;
+  raw_ptr<views::MdTextButton> ok_button_ = nullptr;
+  raw_ptr<views::MdTextButton> cancel_button_ = nullptr;
+  raw_ptr<views::MdTextButton> extra_button_ = nullptr;
+  raw_ptr<views::Link> link_ = nullptr;
   raw_ptr<views::Checkbox> checkbox_ = nullptr;
 };
 
-#endif  // BRAVE_BROWSER_UI_VIEWS_INFOBARS_BRAVE_CONFIRM_INFOBAR_H_
+#endif  // BRAVE_BROWSER_UI_VIEWS_INFOBAR_BRAVE_CONFIRM_INFOBAR_

--- a/chromium_src/components/infobars/core/infobar_delegate.h
+++ b/chromium_src/components/infobars/core/infobar_delegate.h
@@ -18,7 +18,7 @@
   ANDROID_SYSTEM_SYNC_DISABLED_INFOBAR = 504, SYNC_CANNOT_RUN_INFOBAR = 505, \
   WEB_DISCOVERY_INFOBAR_DELEGATE = 506,                                      \
   BRAVE_SYNC_ACCOUNT_DELETED_INFOBAR = 507,                                  \
-  BRAVE_REQUEST_OTR_INFOBAR_DELEGATE,
+  BRAVE_REQUEST_OTR_INFOBAR_DELEGATE = 508, BRAVE_IPFS_INFOBAR_DELEGATE = 509,
 
 #include "src/components/infobars/core/infobar_delegate.h"  // IWYU pragma: export
 

--- a/components/infobars/core/brave_confirm_infobar_delegate.cc
+++ b/components/infobars/core/brave_confirm_infobar_delegate.cc
@@ -8,6 +8,18 @@
 BraveConfirmInfoBarDelegate::BraveConfirmInfoBarDelegate() = default;
 BraveConfirmInfoBarDelegate::~BraveConfirmInfoBarDelegate() = default;
 
+int BraveConfirmInfoBarDelegate::GetButtons() const {
+  return BUTTON_OK | BUTTON_CANCEL | BUTTON_EXTRA;
+}
+
+std::vector<int> BraveConfirmInfoBarDelegate::GetButtonsOrder() const {
+  return {BUTTON_OK | BUTTON_EXTRA | BUTTON_CANCEL};
+}
+
+bool BraveConfirmInfoBarDelegate::IsProminent(int id) const {
+  return id == BUTTON_OK;
+}
+
 bool BraveConfirmInfoBarDelegate::HasCheckbox() const {
   return false;
 }

--- a/components/infobars/core/brave_confirm_infobar_delegate.h
+++ b/components/infobars/core/brave_confirm_infobar_delegate.h
@@ -7,6 +7,7 @@
 #define BRAVE_COMPONENTS_INFOBARS_CORE_BRAVE_CONFIRM_INFOBAR_DELEGATE_H_
 
 #include <string>
+#include <vector>
 
 #include "components/infobars/core/confirm_infobar_delegate.h"
 
@@ -24,6 +25,10 @@ class BraveConfirmInfoBarDelegate : public ConfirmInfoBarDelegate {
   // Then closing will be cancelled and delegate should remove infobar
   // after doing something.
   virtual bool InterceptClosing();
+  virtual std::vector<int> GetButtonsOrder() const;
+  virtual bool IsProminent(int id) const;
+
+  int GetButtons() const override;
 
  protected:
   BraveConfirmInfoBarDelegate();

--- a/components/ipfs/ipfs_service.cc
+++ b/components/ipfs/ipfs_service.cc
@@ -189,6 +189,7 @@ void IpfsService::RegisterProfilePrefs(PrefRegistrySimple* registry) {
                                kDefaultIPFSNFTGateway);
   registry->RegisterFilePathPref(kIPFSBinaryPath, base::FilePath());
   registry->RegisterDictionaryPref(kIPFSPinnedCids);
+  registry->RegisterBooleanPref(kShowIPFSPromoInfobar, true);
 
   // Deprecated, kIPFSAutoRedirectToConfiguredGateway is used instead
   registry->RegisterBooleanPref(kIPFSAutoRedirectGateway, false);

--- a/components/ipfs/pref_names.cc
+++ b/components/ipfs/pref_names.cc
@@ -54,3 +54,6 @@ const char kIPFSPublicNFTGatewayAddress[] =
 
 // Stores list of CIDs that are pinned localy
 const char kIPFSPinnedCids[] = "brave.ipfs.local_pinned_cids";
+
+// Stores info whether IPFS promo infobar was shown yet
+const char kShowIPFSPromoInfobar[] = "brave.ipfs.show_ipfs_promo_infobar";

--- a/components/ipfs/pref_names.h
+++ b/components/ipfs/pref_names.h
@@ -17,6 +17,7 @@ extern const char kIPFSResolveMethod[];
 extern const char kIpfsStorageMax[];
 extern const char kIPFSPinnedCids[];
 extern const char kIPFSAutoFallbackToGateway[];
+extern const char kShowIPFSPromoInfobar[];
 
 // Deprecated, use kIPFSAutoRedirectToConfiguredGateway instead
 extern const char kIPFSAutoRedirectDNSLink[];


### PR DESCRIPTION
Resolves https://github.com/brave/brave-browser/issues/32010
Privacy review: https://github.com/brave/reviews/issues/1371
![image](https://github.com/brave/brave-core/assets/106654560/8403a904-9050-4bfd-be46-34fbcc5021bf)

New infobar is shown when user enters some page which can be loaded via ipfs:// (dnslink pages, gateway-like pages).
IpfsTabHelper creates infobar on expected conditions via BraveIpfsInfobarDelegate.
BraveConfirmInfobar is forked from ConfirmInfobar to allow reordering of buttons.

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-arm64, CI/skip-linux-x64, CI/skip-android, CI/skip-macos, CI/skip-ios, CI/skip-windows-arm64, CI/skip-windows-x64, CI/skip-windows-x86 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [ ] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
1) Open some ipfs-gateway like resource like "https://ipfs.io/ipfs/bafybeigdyrzt5sfp7udm7hu76uh7y26nf3efuylqabf3oclgtqy55fbzdi"
2) Check that infobar is shown
3) Press [x], check that infobar appears after re-enter the url
4) Press "Only this time" check that ipfs:// url is loaded but "Automatically redirect requests for IPFS network resources to the configured gateway."
5) Check that infobar is shown after re-enter the url
6) Press "Aways button" check that "Automatically redirect requests for IPFS network resources to the configured gateway." setting is enabled after and infobar is not shown again.
7) On fresh browser enter "https://ipfs.io/ipfs/bafybeigdyrzt5sfp7udm7hu76uh7y26nf3efuylqabf3oclgtqy55fbzdi" and check that after pressing "No Thanks" button infobar is not shown and page is not redirected to the ipfs://
8) Check that infobar is not shown on other sites(where purple button is not shown)

Also need to check obsolete system infobar https://github.com/brave/brave-browser/issues/32129