### PR TITLE
Enable split ABIs for bundle

### DIFF
--- a/android/brave_java_sources.gni
+++ b/android/brave_java_sources.gni
@@ -497,11 +497,16 @@ brave_browser_ui_android_toolbar_sources = [
 ]
 
 brave_java_base_sources = [
+  "//brave/android/java/org/chromium/base/BraveBundleUtils.java",
   "//brave/android/java/org/chromium/base/BraveCommandLineInitUtil.java",
   "//brave/android/java/org/chromium/base/BraveFeatureList.java",
   "//brave/android/java/org/chromium/base/BravePreferenceKeys.java",
   "//brave/android/java/org/chromium/base/BraveReflectionUtil.java",
+  "//brave/android/java/org/chromium/base/library_loader/BraveLibraryLoader.java",
 ]
+
+brave_java_base_jni_sources =
+    [ "//brave/android/java/org/chromium/base/BraveBundleUtils.java" ]
 
 brave_java_base_module_sources = [
   "//brave/android/java/org/chromium/chrome/browser/base/SplitCompatJobIntentService.java",

--- a/android/java/apk_for_test.flags
+++ b/android/java/apk_for_test.flags
@@ -804,3 +804,16 @@
 -keep class org.chromium.chrome.browser.externalnav.BraveExternalNavigationHandler {
     public <init>(...);
 }
+
+-keep class org.chromium.base.library_loader.LibraryLoader {
+    *** getInstance(...);
+    *** sInstance;
+    *** loadWithSystemLinkerAlreadyLocked(...);
+    *** preloadAlreadyLocked(...);
+}
+
+-keep class org.chromium.base.library_loader.BraveLibraryLoader {
+    *** getInstance(...);
+    *** sInstance;
+    *** loadWithSystemLinkerAlreadyLocked(...);
+}

--- a/android/java/org/chromium/base/BraveBundleUtils.java
+++ b/android/java/org/chromium/base/BraveBundleUtils.java
@@ -1,0 +1,72 @@
+/* Copyright (c) 2023 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+package org.chromium.base;
+
+import android.annotation.SuppressLint;
+import android.content.pm.ApplicationInfo;
+import android.os.Build;
+
+import androidx.annotation.Nullable;
+import androidx.annotation.RequiresApi;
+
+import org.chromium.base.annotations.CalledByNative;
+
+import java.util.Arrays;
+
+/**
+ * Brave's helpers for BundleUtils
+ */
+public class BraveBundleUtils {
+    public static String getSplitSuffixByCurrentAbi() {
+        assert Build.SUPPORTED_ABIS.length > 0;
+        String currentAbi = Build.SUPPORTED_ABIS[0];
+        switch (currentAbi) {
+            case "arm64-v8a":
+                return "config.arm64_v8a";
+            case "armeabi-v7a":
+                return "config.armeabi_v7a";
+            case "x86_64":
+                return "config.x86_64";
+            case "x86":
+                return "config.x86";
+            default:
+                assert false;
+                return "config.arm64_v8a";
+        }
+    }
+
+    @RequiresApi(api = Build.VERSION_CODES.O)
+    public static Boolean doesSplitExist(String splitName) {
+        ApplicationInfo appInfo = ContextUtils.getApplicationContext().getApplicationInfo();
+        if (appInfo.splitNames == null) {
+            return false;
+        }
+        int idx = Arrays.binarySearch(appInfo.splitNames, splitName);
+        return idx >= 0;
+    }
+
+    /* Returns absolute path to a native library in a feature module. */
+    @CalledByNative
+    @Nullable
+    @SuppressLint({"NewApi"})
+    public static String getNativeLibraryPathTrySplitAbi(String libraryName, String splitName) {
+        if (android.os.Build.VERSION.SDK_INT < android.os.Build.VERSION_CODES.O) {
+            // Fallback, as BundleUtils.getSplitApkPath works starting from Oreo
+            return BundleUtils.getNativeLibraryPath(libraryName, splitName);
+        }
+
+        // When bundle is built with abi split dimension, there is a separate split apk
+        // with a native lib, and if it is available, we must load library from there.
+        // Adjust split name with abi name and check whether it exists.
+        // This is required at least for VR module, but may also be required for others.
+        String splitNameWithAbi = splitName + "." + getSplitSuffixByCurrentAbi();
+        if (doesSplitExist(splitNameWithAbi)) {
+            return BundleUtils.getNativeLibraryPath(libraryName, splitNameWithAbi);
+        } else {
+            return BundleUtils.getNativeLibraryPath(libraryName, splitName);
+        }
+    }
+}

--- a/android/java/org/chromium/base/library_loader/BraveLibraryLoader.java
+++ b/android/java/org/chromium/base/library_loader/BraveLibraryLoader.java
@@ -1,0 +1,84 @@
+/* Copyright (c) 2023 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+package org.chromium.base.library_loader;
+
+import android.annotation.SuppressLint;
+import android.content.pm.ApplicationInfo;
+import android.os.Build;
+
+import androidx.annotation.RequiresApi;
+import androidx.annotation.VisibleForTesting;
+
+import org.chromium.base.BraveBundleUtils;
+import org.chromium.base.BundleUtils;
+import org.chromium.build.NativeLibraries;
+
+import java.util.Arrays;
+
+/**
+ * Class to override upstream's LibraryLoader.loadWithSystemLinkerAlreadyLocked
+ * See also BraveLibraryLoaderClassAdapter
+ */
+public class BraveLibraryLoader extends LibraryLoader {
+    @VisibleForTesting
+    public BraveLibraryLoader() {
+        super();
+    }
+
+    public static LibraryLoader sInstance = new BraveLibraryLoader();
+    public static LibraryLoader getInstance() {
+        return sInstance;
+    }
+
+    public void preloadAlreadyLocked(String packageName, boolean inZygote) {
+        assert false : "preloadAlreadyLocked should be redirected to parent in bytecode!";
+    }
+
+    public void loadWithSystemLinkerAlreadyLocked(ApplicationInfo appInfo, boolean inZygote) {
+        setEnvForNative();
+        preloadAlreadyLocked(appInfo.packageName, inZygote);
+        loadLibsfromSplits(appInfo, inZygote);
+    }
+
+    @SuppressLint({"UnsafeDynamicallyLoadedCode", "NewApi"})
+    private void loadLibsfromSplits(ApplicationInfo appInfo, boolean inZygote) {
+        assert !inZygote || android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.Q;
+
+        String splitName = BraveBundleUtils.getSplitSuffixByCurrentAbi();
+        if (inZygote && android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.O) {
+            String apkPath = getSplitApkPath(appInfo, splitName);
+            for (String library : NativeLibraries.LIBRARIES) {
+                System.load(getNativeLibraryPathUseAppInfo(library, apkPath, appInfo));
+            }
+        } else {
+            for (String library : NativeLibraries.LIBRARIES) {
+                System.load(BundleUtils.getNativeLibraryPath(library, splitName));
+            }
+        }
+    }
+
+    @RequiresApi(api = Build.VERSION_CODES.O)
+    private static String getSplitApkPath(ApplicationInfo appInfo, String splitName) {
+        String[] splitNames = appInfo.splitNames;
+        if (splitNames == null) {
+            return null;
+        }
+        int idx = Arrays.binarySearch(splitNames, splitName);
+        return idx < 0 ? null : appInfo.splitSourceDirs[idx];
+    }
+
+    @RequiresApi(api = Build.VERSION_CODES.O)
+    private String getNativeLibraryPathUseAppInfo(
+            String libraryName, String apkPath, ApplicationInfo appInfo) {
+        try {
+            String primaryCpuAbi =
+                    (String) appInfo.getClass().getField("primaryCpuAbi").get(appInfo);
+            return apkPath + "!/lib/" + primaryCpuAbi + "/" + System.mapLibraryName(libraryName);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/android/javatests/org/chromium/chrome/browser/BytecodeTest.java
+++ b/android/javatests/org/chromium/chrome/browser/BytecodeTest.java
@@ -518,6 +518,12 @@ public class BytecodeTest {
         Assert.assertTrue(
                 methodExists("org/chromium/chrome/browser/contextmenu/ChromeContextMenuPopulator",
                         "onItemSelected", true, boolean.class, int.class));
+        Assert.assertTrue(methodExists(
+                "org/chromium/base/library_loader/LibraryLoader", "getInstance", false, null));
+        Assert.assertTrue(methodExists("org/chromium/base/library_loader/LibraryLoader",
+                "preloadAlreadyLocked", false, null));
+        Assert.assertTrue(methodExists("org/chromium/base/library_loader/LibraryLoader",
+                "loadWithSystemLinkerAlreadyLocked", false, null));
     }
 
     @Test
@@ -1054,6 +1060,8 @@ public class BytecodeTest {
                 "mBookmarkManagerCoordinator"));
         Assert.assertTrue(
                 fieldExists("org/chromium/chrome/browser/flags/CachedFlag", "mDefaultValue"));
+        Assert.assertTrue(
+                fieldExists("org/chromium/base/library_loader/LibraryLoader", "sInstance"));
     }
 
     @Test

--- a/android/javatests/org/chromium/chrome/browser/BytecodeTest.java
+++ b/android/javatests/org/chromium/chrome/browser/BytecodeTest.java
@@ -1200,8 +1200,9 @@ public class BytecodeTest {
             if (f.getName().equals(fieldName)) {
                 if (checkTypes) {
                     if (fieldType != null && f.getType().equals(fieldType)) return true;
-                } else
+                } else {
                     return true;
+                }
             }
         }
         return false;

--- a/build/android/bytecode/BUILD.gn
+++ b/build/android/bytecode/BUILD.gn
@@ -52,6 +52,7 @@ java_binary("java_bytecode_rewriter") {
     "//brave/build/android/bytecode/java/org/brave/bytecode/BraveIntentHandlerClassAdapter.java",
     "//brave/build/android/bytecode/java/org/brave/bytecode/BraveLaunchIntentDispatcherClassAdapter.java",
     "//brave/build/android/bytecode/java/org/brave/bytecode/BraveLauncherActivityClassAdapter.java",
+    "//brave/build/android/bytecode/java/org/brave/bytecode/BraveLibraryLoaderClassAdapter.java",
     "//brave/build/android/bytecode/java/org/brave/bytecode/BraveLocationBarCoordinatorClassAdapter.java",
     "//brave/build/android/bytecode/java/org/brave/bytecode/BraveLocationBarLayoutClassAdapter.java",
     "//brave/build/android/bytecode/java/org/brave/bytecode/BraveLocationBarMediatorClassAdapter.java",

--- a/build/android/bytecode/bytecode_rewriter.gni
+++ b/build/android/bytecode/bytecode_rewriter.gni
@@ -42,12 +42,14 @@ brave_bytecode_jars = [
   "obj/components/sync/android/sync_java.javac.jar",
   "obj/content/public/android/content_full_java.javac.jar",
   "obj/content/public/android/content_main_dex_java.javac.jar",
+  "obj/testing/android/native_test/native_test_java.javac.jar",
   "obj/url/gurl_java.javac.jar",
 ]
 
 template("brave_bytecode_rewriter") {
   _rebased_build_config = rebase_path(invoker.build_config, root_build_dir)
   _java_bytecode_rewriter_input_jar = invoker._unprocessed_jar_path
+  forward_variables_from(invoker, [ "testonly" ])
 
   action_with_pydeps(target_name) {
     script = "//brave/build/android/gyp/bytecode_processor.py"

--- a/build/android/bytecode/bytecode_rewriter.gni
+++ b/build/android/bytecode/bytecode_rewriter.gni
@@ -6,6 +6,8 @@
 import("//build/config/python.gni")
 
 brave_bytecode_jars = [
+  "obj/android_webview/nonembedded/nonembedded_java.javac.jar",
+  "obj/base/base_java.javac.jar",
   "obj/brave/android/features/tab_ui/java.javac.jar",
   "obj/brave/android/java/org/chromium/chrome/browser/search_engines/java.javac.jar",
   "obj/brave/browser/notifications/java.javac.jar",
@@ -15,6 +17,7 @@ brave_bytecode_jars = [
   "obj/brave/components/browser_ui/site_settings/android/java.javac.jar",
   "obj/chrome/android/base_module_java.javac.jar",
   "obj/chrome/android/chrome_java.javac.jar",
+  "chrome/android/monochrome_java.javac.jar",
   "obj/chrome/android/features/tab_ui/java.javac.jar",
   "obj/chrome/browser/download/internal/android/java.javac.jar",
   "obj/chrome/browser/flags/java.javac.jar",
@@ -37,6 +40,9 @@ brave_bytecode_jars = [
   "obj/components/external_intents/android/java.javac.jar",
   "obj/components/permissions/android/java.javac.jar",
   "obj/components/sync/android/sync_java.javac.jar",
+  "obj/content/public/android/content_full_java.javac.jar",
+  "obj/content/public/android/content_main_dex_java.javac.jar",
+  "obj/url/gurl_java.javac.jar",
 ]
 
 template("brave_bytecode_rewriter") {

--- a/build/android/bytecode/java/org/brave/bytecode/BraveClassAdapter.java
+++ b/build/android/bytecode/java/org/brave/bytecode/BraveClassAdapter.java
@@ -7,6 +7,9 @@ package org.brave.bytecode;
 
 import org.objectweb.asm.ClassVisitor;
 
+/**
+ * Class responsible for applying Java assembly changes for Brave overrides
+ */
 public class BraveClassAdapter {
     public static ClassVisitor createAdapter(ClassVisitor chain) {
         chain = new BraveActivityClassAdapter(chain);
@@ -50,6 +53,7 @@ public class BraveClassAdapter {
         chain = new BraveIntentHandlerClassAdapter(chain);
         chain = new BraveLauncherActivityClassAdapter(chain);
         chain = new BraveLaunchIntentDispatcherClassAdapter(chain);
+        chain = new BraveLibraryLoaderClassAdapter(chain);
         chain = new BraveLocationBarCoordinatorClassAdapter(chain);
         chain = new BraveLocationBarLayoutClassAdapter(chain);
         chain = new BraveLocationBarMediatorClassAdapter(chain);

--- a/build/android/bytecode/java/org/brave/bytecode/BraveLibraryLoaderClassAdapter.java
+++ b/build/android/bytecode/java/org/brave/bytecode/BraveLibraryLoaderClassAdapter.java
@@ -1,0 +1,32 @@
+/* Copyright (c) 2023 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+package org.brave.bytecode;
+
+import org.objectweb.asm.ClassVisitor;
+
+/**
+ * Class for patch work on overriding upstream's
+ * LibraryLoader.loadWithSystemLinkerAlreadyLocked.
+ * See also BraveLibraryLoader
+ */
+public class BraveLibraryLoaderClassAdapter extends BraveClassVisitor {
+    static String sLibraryLoaderClassName = "org/chromium/base/library_loader/LibraryLoader";
+    static String sBraveLibraryLoaderClassName =
+            "org/chromium/base/library_loader/BraveLibraryLoader";
+
+    public BraveLibraryLoaderClassAdapter(ClassVisitor visitor) {
+        super(visitor);
+        changeMethodOwner(sLibraryLoaderClassName, "getInstance", sBraveLibraryLoaderClassName);
+
+        deleteField(sBraveLibraryLoaderClassName, "sInstance");
+        makeProtectedField(sLibraryLoaderClassName, "sInstance");
+
+        makePublicMethod(sLibraryLoaderClassName, "loadWithSystemLinkerAlreadyLocked");
+
+        deleteMethod(sBraveLibraryLoaderClassName, "preloadAlreadyLocked");
+        makePublicMethod(sLibraryLoaderClassName, "preloadAlreadyLocked");
+    }
+}

--- a/chromium_src/base/android/bundle_utils.cc
+++ b/chromium_src/base/android/bundle_utils.cc
@@ -1,0 +1,34 @@
+/* Copyright (c) 2023 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "base/android/jni_android.h"
+#include "base/android/jni_string.h"
+
+#include "base/base_jni/BraveBundleUtils_jni.h"
+#include "base/base_jni/BundleUtils_jni.h"
+
+namespace {
+
+// We need this just to avoid unused function
+// 'Java_BundleUtils_getNativeLibraryPath' error message.
+bool DummyBundleUtils() {
+  base::android::ScopedJavaLocalRef<jstring> java_path =
+      Java_BundleUtils_getNativeLibraryPath(
+          nullptr, base::android::ScopedJavaLocalRef<jstring>(),
+          base::android::ScopedJavaLocalRef<jstring>());
+  if (!java_path) {
+    return false;
+  }
+  return DummyBundleUtils();
+}
+
+}  // namespace
+
+#define Java_BundleUtils_getNativeLibraryPath \
+  Java_BraveBundleUtils_getNativeLibraryPathTrySplitAbi
+
+#include "src/base/android/bundle_utils.cc"
+
+#undef Java_BundleUtils_getNativeLibraryPath

--- a/patches/base-BUILD.gn.patch
+++ b/patches/base-BUILD.gn.patch
@@ -1,8 +1,16 @@
 diff --git a/base/BUILD.gn b/base/BUILD.gn
-index 304223b58a7062e3a6ae466d54b9e877708e5cb3..42d684f60658336b564a8754ecf51ec87a17ee27 100644
+index 304223b58a7062e3a6ae466d54b9e877708e5cb3..d93b29756810b8dafdad06788507e4e17e542bb5 100644
 --- a/base/BUILD.gn
 +++ b/base/BUILD.gn
-@@ -4433,6 +4433,7 @@ if (is_android) {
+@@ -4205,6 +4205,7 @@ if (is_android || is_robolectric) {
+       ":android_runtime_jni_headers",
+       ":android_runtime_unchecked_jni_headers",
+     ]
++    import("//brave/android/brave_java_sources.gni") sources += brave_java_base_jni_sources
+   }
+ 
+   generate_jar_jni("android_runtime_jni_headers") {
+@@ -4433,6 +4434,7 @@ if (is_android) {
        "android/java/src/org/chromium/base/task/ThreadPoolTaskExecutor.java",
        "android/java/src/org/chromium/base/task/UiThreadTaskExecutor.java",
      ]

--- a/patches/build-config-android-rules.gni.patch
+++ b/patches/build-config-android-rules.gni.patch
@@ -1,5 +1,5 @@
 diff --git a/build/config/android/rules.gni b/build/config/android/rules.gni
-index d12617a3c7a3a5b8216b8b7f471d7818ada7f809..de7302a1cef6f6dabeebdd8881540db929d72fe0 100644
+index d12617a3c7a3a5b8216b8b7f471d7818ada7f809..2cc9e84f2324dd0692b9ac2dc7de3378f4511fb1 100644
 --- a/build/config/android/rules.gni
 +++ b/build/config/android/rules.gni
 @@ -432,6 +432,7 @@ if (enable_java_templates && is_android) {
@@ -18,3 +18,11 @@ index d12617a3c7a3a5b8216b8b7f471d7818ada7f809..de7302a1cef6f6dabeebdd8881540db9
      action_with_pydeps(target_name) {
        forward_variables_from(invoker, TESTONLY_AND_VISIBILITY + [ "deps" ])
        inputs = [ invoker.input ]
+@@ -5112,6 +5114,7 @@ if (enable_java_templates && is_android) {
+     if (_enable_language_splits) {
+       _split_dimensions += [ "language" ]
+     }
++    _split_dimensions += [ "abi" ]
+ 
+     _keystore_path = android_keystore_path
+     _keystore_password = android_keystore_password


### PR DESCRIPTION
This PR enables [ABI split](https://developer.android.com/build/configure-apk-splits#configure-abi-split) for Brave Browser.

The main change is a patch at `rules.gni`.
The rest changes are done to deal with [OS Bugs => System.loadLibrary() Broken for Libraries in Splits ](https://source.chromium.org/chromium/chromium/src/+/main:docs/android_isolated_splits.md;l=128;drc=b27071598a6b291a7319d99ce7aa4af81ebc060f;bpv=0;bpt=0).
Also `BundleUtils` class relies on `ContextUtils.getApplicationContext()` which is unavailable for zygote process, so for zygote there is a duplicated methods to get lib path at `BraveLibraryLoader`.



<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/32468

Related issue: https://github.com/brave/brave-browser/issues/26792

From my tests split ABIs allow to decrease size 263 MB => 185 MB which is 78MB on arm. So only arm64 libs are installed and arm32 - are not.

Device&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;|before|after
---|---|---
Pixel&nbsp;6,&nbsp;Android&nbsp;14|![01-Pixel6-master-appsize](https://github.com/brave/brave-core/assets/24739341/703b7ce2-04d6-406f-b4a0-6b56b1f7b747)|![02-Pixel6-PR-appsize](https://github.com/brave/brave-core/assets/24739341/bd974576-a8eb-4cb3-82c3-3d0330b13044)
mi4c,&nbsp;Android&nbsp;9,&nbsp;app&nbsp;size|![03-mi4c-master-appsize](https://github.com/brave/brave-core/assets/24739341/f08c1f48-8f49-4fa3-9aeb-1028ee71330f)|![04-mi4c-PR-appsize](https://github.com/brave/brave-core/assets/24739341/723943ba-8702-46bc-98ad-32d96d4db584)
mi4c,&nbsp;Android&nbsp;9,&nbsp;/data/app&nbsp;folder|![05-mi4c-master-app-folder](https://github.com/brave/brave-core/assets/24739341/398c0972-80a0-4480-b406-94c0a22d2158)|![06-mi4c-PR-app-folder](https://github.com/brave/brave-core/assets/24739341/bf14fc56-b9af-46f4-8919-e621adadd87f)
App size in Google Play|![0f-GP-screenshots](https://github.com/brave/brave-core/assets/24739341/1e40a958-a191-41c5-a3af-6281fe208ceb)|to be updated

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-arm64, CI/skip-linux-x64, CI/skip-android, CI/skip-macos, CI/skip-ios, CI/skip-windows-arm64, CI/skip-windows-x64, CI/skip-windows-x86 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
The test plan is to ensure that:
1. app installed;
2. app didn't crash on launch. 


Script to install app from bundle is:
```
java -jar ./src/third_party/android_build_tools/bundletool/bundletool.jar  \
build-apks --connected-device                                                        \
--overwrite \
--bundle=./src/out/android_Release_arm64/apks/BraveMonoarm64.aab                     \
--output=./src/out/android_Release_arm64/apks/BraveMonoarm64.apks                    \
--adb=./src/third_party/android_sdk/public/platform-tools/adb                        \
--aapt2=./src/third_party/android_build_tools/aapt2/aapt2                            \


java -jar ./src/third_party/android_build_tools/bundletool/bundletool.jar  \
install-apks                                                                         \
--apks=./src/out/android_Release_arm64/apks/BraveMonoarm64.apks                      \
--adb=./src/third_party/android_sdk/public/platform-tools/adb
```








