### PR TITLE
[Brave News]: Setup model for FeedV2

### DIFF
--- a/components/brave_new_tab_ui/stories/default/data/mockBraveNewsController.ts
+++ b/components/brave_new_tab_ui/stories/default/data/mockBraveNewsController.ts
@@ -192,6 +192,7 @@ export const feed: BraveNews.Feed = {
     promotedArticle: undefined,
     deal: undefined,
     article: {
+      isDiscover: true,
       data: {
         categoryName: 'Top News',
         description: 'Here\'s everything you need to know about the Haunted Hallows event, including how to unlock the Batmobile.',
@@ -217,6 +218,7 @@ export const feed: BraveNews.Feed = {
               promotedArticle: undefined,
               deal: undefined,
               article: {
+                isDiscover: true,
                 'data': {
                   'categoryName': 'Sports',
                   'publishTime': {
@@ -250,6 +252,7 @@ export const feed: BraveNews.Feed = {
               promotedArticle: undefined,
               deal: undefined,
               article: {
+                isDiscover: true,
                 'data': {
                   'categoryName': 'Sports',
                   'publishTime': {
@@ -283,6 +286,7 @@ export const feed: BraveNews.Feed = {
               promotedArticle: undefined,
               deal: undefined,
               article: {
+                isDiscover: true,
                 'data': {
                   'categoryName': 'Technology',
                   'publishTime': {
@@ -311,6 +315,7 @@ export const feed: BraveNews.Feed = {
               promotedArticle: undefined,
               deal: undefined,
               article: {
+                isDiscover: true,
                 'data': {
                   'categoryName': 'Science',
                   'publishTime': {
@@ -378,6 +383,7 @@ export const feed: BraveNews.Feed = {
               promotedArticle: undefined,
               deal: undefined,
               article: {
+                isDiscover: true,
                 'data': {
                   'categoryName': 'Top News',
                   'publishTime': {
@@ -406,6 +412,7 @@ export const feed: BraveNews.Feed = {
               promotedArticle: undefined,
               deal: undefined,
               article: {
+                isDiscover: true,
                 'data': {
                   'categoryName': 'Top News',
                   'publishTime': {
@@ -434,6 +441,7 @@ export const feed: BraveNews.Feed = {
               promotedArticle: undefined,
               deal: undefined,
               article: {
+                isDiscover: true,
                 'data': {
                   'categoryName': 'Top News',
                   'publishTime': {
@@ -467,6 +475,7 @@ export const feed: BraveNews.Feed = {
               promotedArticle: undefined,
               deal: undefined,
               article: {
+                isDiscover: true,
                 'data': {
                   'categoryName': 'Business',
                   'publishTime': {
@@ -500,6 +509,7 @@ export const feed: BraveNews.Feed = {
               promotedArticle: undefined,
               deal: undefined,
               article: {
+                isDiscover: true,
                 'data': {
                   'categoryName': 'Cars',
                   'publishTime': {
@@ -533,6 +543,7 @@ export const feed: BraveNews.Feed = {
               promotedArticle: undefined,
               deal: undefined,
               article: {
+                isDiscover: true,
                 'data': {
                   'categoryName': 'Home',
                   'publishTime': {
@@ -561,6 +572,7 @@ export const feed: BraveNews.Feed = {
               promotedArticle: undefined,
               deal: undefined,
               article: {
+                isDiscover: true,
                 'data': {
                   'categoryName': 'Entertainment',
                   'publishTime': {
@@ -594,6 +606,7 @@ export const feed: BraveNews.Feed = {
               promotedArticle: undefined,
               deal: undefined,
               article: {
+                isDiscover: true,
                 'data': {
                   'categoryName': 'Entertainment',
                   'publishTime': {
@@ -622,6 +635,7 @@ export const feed: BraveNews.Feed = {
               promotedArticle: undefined,
               deal: undefined,
               article: {
+                isDiscover: true,
                 'data': {
                   'categoryName': 'Entertainment',
                   'publishTime': {
@@ -659,6 +673,7 @@ export const feed: BraveNews.Feed = {
               promotedArticle: undefined,
               deal: undefined,
               article: {
+                isDiscover: true,
                 'data': {
                   'categoryName': 'Science',
                   'publishTime': {
@@ -692,6 +707,7 @@ export const feed: BraveNews.Feed = {
               promotedArticle: undefined,
               deal: undefined,
               article: {
+                isDiscover: true,
                 'data': {
                   'categoryName': 'Sports',
                   'publishTime': {
@@ -725,6 +741,7 @@ export const feed: BraveNews.Feed = {
               promotedArticle: undefined,
               deal: undefined,
               article: {
+                isDiscover: true,
                 'data': {
                   'categoryName': 'Entertainment',
                   'publishTime': {
@@ -753,6 +770,7 @@ export const feed: BraveNews.Feed = {
               promotedArticle: undefined,
               deal: undefined,
               article: {
+                isDiscover: true,
                 'data': {
                   'categoryName': 'Entertainment',
                   'publishTime': {
@@ -781,6 +799,7 @@ export const feed: BraveNews.Feed = {
               promotedArticle: undefined,
               deal: undefined,
               article: {
+                isDiscover: true,
                 'data': {
                   'categoryName': 'Entertainment',
                   'publishTime': {
@@ -814,6 +833,7 @@ export const feed: BraveNews.Feed = {
               promotedArticle: undefined,
               deal: undefined,
               article: {
+                isDiscover: true,
                 'data': {
                   'categoryName': 'Technology',
                   'publishTime': {
@@ -842,6 +862,7 @@ export const feed: BraveNews.Feed = {
               promotedArticle: undefined,
               deal: undefined,
               article: {
+                isDiscover: true,
                 'data': {
                   'categoryName': 'Technology',
                   'publishTime': {
@@ -875,6 +896,7 @@ export const feed: BraveNews.Feed = {
               promotedArticle: undefined,
               deal: undefined,
               article: {
+                isDiscover: true,
                 'data': {
                   'categoryName': 'Technology',
                   'publishTime': {
@@ -1000,6 +1022,7 @@ export const feed: BraveNews.Feed = {
               promotedArticle: undefined,
               deal: undefined,
               article: {
+                isDiscover: true,
                 'data': {
                   'categoryName': 'Top News',
                   'publishTime': {
@@ -1033,6 +1056,7 @@ export const feed: BraveNews.Feed = {
               promotedArticle: undefined,
               deal: undefined,
               article: {
+                isDiscover: true,
                 'data': {
                   'categoryName': 'Health',
                   'publishTime': {
@@ -1061,6 +1085,7 @@ export const feed: BraveNews.Feed = {
               promotedArticle: undefined,
               deal: undefined,
               article: {
+                isDiscover: true,
                 'data': {
                   'categoryName': 'Entertainment',
                   'publishTime': {
@@ -1098,6 +1123,7 @@ export const feed: BraveNews.Feed = {
               promotedArticle: undefined,
               deal: undefined,
               article: {
+                isDiscover: true,
                 'data': {
                   'categoryName': 'Sports',
                   'publishTime': {
@@ -1131,6 +1157,7 @@ export const feed: BraveNews.Feed = {
               promotedArticle: undefined,
               deal: undefined,
               article: {
+                isDiscover: true,
                 'data': {
                   'categoryName': 'Culture',
                   'publishTime': {
@@ -1164,6 +1191,7 @@ export const feed: BraveNews.Feed = {
               promotedArticle: undefined,
               deal: undefined,
               article: {
+                isDiscover: true,
                 'data': {
                   'categoryName': 'Business',
                   'publishTime': {
@@ -1192,6 +1220,7 @@ export const feed: BraveNews.Feed = {
               promotedArticle: undefined,
               deal: undefined,
               article: {
+                isDiscover: true,
                 'data': {
                   'categoryName': 'Sports',
                   'publishTime': {
@@ -1259,6 +1288,7 @@ export const feed: BraveNews.Feed = {
               promotedArticle: undefined,
               deal: undefined,
               article: {
+                isDiscover: true,
                 'data': {
                   'categoryName': 'Brave',
                   'publishTime': {
@@ -1287,6 +1317,7 @@ export const feed: BraveNews.Feed = {
               promotedArticle: undefined,
               deal: undefined,
               article: {
+                isDiscover: true,
                 'data': {
                   'categoryName': 'Brave',
                   'publishTime': {
@@ -1315,6 +1346,7 @@ export const feed: BraveNews.Feed = {
               promotedArticle: undefined,
               deal: undefined,
               article: {
+                isDiscover: true,
                 'data': {
                   'categoryName': 'Brave',
                   'publishTime': {
@@ -1348,6 +1380,7 @@ export const feed: BraveNews.Feed = {
               promotedArticle: undefined,
               deal: undefined,
               article: {
+                isDiscover: true,
                 'data': {
                   'categoryName': 'Entertainment',
                   'publishTime': {
@@ -1381,6 +1414,7 @@ export const feed: BraveNews.Feed = {
               promotedArticle: undefined,
               deal: undefined,
               article: {
+                isDiscover: true,
                 'data': {
                   'categoryName': 'Business',
                   'publishTime': {
@@ -1414,6 +1448,7 @@ export const feed: BraveNews.Feed = {
               promotedArticle: undefined,
               deal: undefined,
               article: {
+                isDiscover: true,
                 'data': {
                   'categoryName': 'Top News',
                   'publishTime': {
@@ -1442,6 +1477,7 @@ export const feed: BraveNews.Feed = {
               promotedArticle: undefined,
               deal: undefined,
               article: {
+                isDiscover: true,
                 'data': {
                   'categoryName': 'Health',
                   'publishTime': {
@@ -1475,6 +1511,7 @@ export const feed: BraveNews.Feed = {
               promotedArticle: undefined,
               deal: undefined,
               article: {
+                isDiscover: true,
                 'data': {
                   'categoryName': 'Business',
                   'publishTime': {
@@ -1503,6 +1540,7 @@ export const feed: BraveNews.Feed = {
               promotedArticle: undefined,
               deal: undefined,
               article: {
+                isDiscover: true,
                 'data': {
                   'categoryName': 'Top News',
                   'publishTime': {
@@ -1540,6 +1578,7 @@ export const feed: BraveNews.Feed = {
               promotedArticle: undefined,
               deal: undefined,
               article: {
+                isDiscover: true,
                 'data': {
                   'categoryName': 'Technology',
                   'publishTime': {
@@ -1573,6 +1612,7 @@ export const feed: BraveNews.Feed = {
               promotedArticle: undefined,
               deal: undefined,
               article: {
+                isDiscover: true,
                 'data': {
                   'categoryName': 'Business',
                   'publishTime': {
@@ -1606,6 +1646,7 @@ export const feed: BraveNews.Feed = {
               promotedArticle: undefined,
               deal: undefined,
               article: {
+                isDiscover: true,
                 'data': {
                   'categoryName': 'Culture',
                   'publishTime': {
@@ -1634,6 +1675,7 @@ export const feed: BraveNews.Feed = {
               promotedArticle: undefined,
               deal: undefined,
               article: {
+                isDiscover: true,
                 'data': {
                   'categoryName': 'Culture',
                   'publishTime': {
@@ -1662,6 +1704,7 @@ export const feed: BraveNews.Feed = {
               promotedArticle: undefined,
               deal: undefined,
               article: {
+                isDiscover: true,
                 'data': {
                   'categoryName': 'Culture',
                   'publishTime': {
@@ -1695,6 +1738,7 @@ export const feed: BraveNews.Feed = {
               promotedArticle: undefined,
               deal: undefined,
               article: {
+                isDiscover: true,
                 'data': {
                   'categoryName': 'Sports',
                   'publishTime': {
@@ -1723,6 +1767,7 @@ export const feed: BraveNews.Feed = {
               promotedArticle: undefined,
               deal: undefined,
               article: {
+                isDiscover: true,
                 'data': {
                   'categoryName': 'Top News',
                   'publishTime': {
@@ -1756,6 +1801,7 @@ export const feed: BraveNews.Feed = {
               promotedArticle: undefined,
               deal: undefined,
               article: {
+                isDiscover: true,
                 'data': {
                   'categoryName': 'Technology',
                   'publishTime': {
@@ -1881,6 +1927,7 @@ export const feed: BraveNews.Feed = {
               promotedArticle: undefined,
               deal: undefined,
               article: {
+                isDiscover: true,
                 'data': {
                   'categoryName': 'Cars',
                   'publishTime': {
@@ -1914,6 +1961,7 @@ export const feed: BraveNews.Feed = {
               promotedArticle: undefined,
               deal: undefined,
               article: {
+                isDiscover: true,
                 'data': {
                   'categoryName': 'Business',
                   'publishTime': {
@@ -1942,6 +1990,7 @@ export const feed: BraveNews.Feed = {
               promotedArticle: undefined,
               deal: undefined,
               article: {
+                isDiscover: true,
                 'data': {
                   'categoryName': 'Top News',
                   'publishTime': {
@@ -1974,19 +2023,19 @@ export const feed: BraveNews.Feed = {
 }
 
 export const mockBraveNewsController: Partial<BraveNewsControllerRemote> = {
-  async getLocale () {
+  async getLocale() {
     return { locale: 'en-US' }
   },
 
-  async getFeed () {
+  async getFeed() {
     return { feed }
   },
 
-  async getPublishers () {
+  async getPublishers() {
     return { publishers }
   },
 
-  async getChannels () {
+  async getChannels() {
     const channelNames = Object.values(publishers).reduce((prev, next) => {
       for (const locale of next.locales) {
         for (const channel of locale.channels) {
@@ -2002,19 +2051,19 @@ export const mockBraveNewsController: Partial<BraveNewsControllerRemote> = {
     }
   },
 
-  async setChannelSubscribed (channelId, subscribed) {
+  async setChannelSubscribed(channelId, subscribed) {
     return { updated: { ...(await mockBraveNewsController.getChannels!())[channelId], subscribed } }
   },
 
-  async findFeeds () {
+  async findFeeds() {
     return { results: [] }
   },
 
-  async subscribeToNewDirectFeed () {
+  async subscribeToNewDirectFeed() {
     return { isValidFeed: false, isDuplicate: false, publishers: await mockBraveNewsController.getChannels!() }
   },
 
-  async setPublisherPref (publisherId, newStatus) {
+  async setPublisherPref(publisherId, newStatus) {
     publishers[publisherId].userEnabledStatus = newStatus
     return {
       newStatus

--- a/components/brave_news/browser/BUILD.gn
+++ b/components/brave_news/browser/BUILD.gn
@@ -26,6 +26,8 @@ static_library("browser") {
     "feed_controller.h",
     "feed_fetcher.cc",
     "feed_fetcher.h",
+    "feed_v2_builder.cc",
+    "feed_v2_builder.h",
     "html_parsing.cc",
     "html_parsing.h",
     "locales_helper.cc",

--- a/components/brave_news/browser/brave_news_controller.cc
+++ b/components/brave_news/browser/brave_news_controller.cc
@@ -92,6 +92,7 @@ BraveNewsController::BraveNewsController(
       api_request_helper_(GetNetworkTrafficAnnotationTag(), url_loader_factory),
       private_cdn_request_helper_(GetNetworkTrafficAnnotationTag(),
                                   url_loader_factory),
+      url_loader_factory_(url_loader_factory),
       direct_feed_controller_(prefs_, url_loader_factory),
       unsupported_publisher_migrator_(prefs_,
                                       &direct_feed_controller_,
@@ -107,9 +108,6 @@ BraveNewsController::BraveNewsController(
                        history_service,
                        url_loader_factory,
                        prefs_),
-      feed_v2_builder_(publishers_controller_,
-                       channels_controller_,
-                       url_loader_factory),
       suggestions_controller_(prefs_,
                               &publishers_controller_,
                               &api_request_helper_,
@@ -183,7 +181,12 @@ void BraveNewsController::GetFeedV2(GetFeedV2Callback callback) {
     return;
   }
 
-  feed_v2_builder_.Build(std::move(callback));
+  if (!feed_v2_builder_) {
+    feed_v2_builder_ = std::make_unique<FeedV2Builder>(
+        publishers_controller_, channels_controller_, url_loader_factory_);
+  }
+
+  feed_v2_builder_->Build(std::move(callback));
 }
 
 void BraveNewsController::GetPublishers(GetPublishersCallback callback) {

--- a/components/brave_news/browser/brave_news_controller.cc
+++ b/components/brave_news/browser/brave_news_controller.cc
@@ -26,6 +26,7 @@
 #include "brave/components/brave_news/browser/brave_news_p3a.h"
 #include "brave/components/brave_news/browser/channels_controller.h"
 #include "brave/components/brave_news/browser/direct_feed_controller.h"
+#include "brave/components/brave_news/browser/feed_v2_builder.h"
 #include "brave/components/brave_news/browser/locales_helper.h"
 #include "brave/components/brave_news/browser/network.h"
 #include "brave/components/brave_news/browser/publishers_controller.h"
@@ -33,6 +34,7 @@
 #include "brave/components/brave_news/browser/suggestions_controller.h"
 #include "brave/components/brave_news/browser/unsupported_publisher_migrator.h"
 #include "brave/components/brave_news/common/brave_news.mojom.h"
+#include "brave/components/brave_news/common/features.h"
 #include "brave/components/brave_news/common/pref_names.h"
 #include "brave/components/brave_private_cdn/private_cdn_helper.h"
 #include "brave/components/brave_private_cdn/private_cdn_request_helper.h"
@@ -105,6 +107,9 @@ BraveNewsController::BraveNewsController(
                        history_service,
                        url_loader_factory,
                        prefs_),
+      feed_v2_builder_(publishers_controller_,
+                       channels_controller_,
+                       url_loader_factory),
       suggestions_controller_(prefs_,
                               &publishers_controller_,
                               &api_request_helper_,
@@ -168,6 +173,17 @@ void BraveNewsController::GetFeed(GetFeedCallback callback) {
     return;
   }
   feed_controller_.GetOrFetchFeed(std::move(callback));
+}
+
+void BraveNewsController::GetFeedV2(GetFeedV2Callback callback) {
+  if (!GetIsEnabled(prefs_) ||
+      !base::FeatureList::IsEnabled(
+          brave_news::features::kBraveNewsFeedUpdate)) {
+    std::move(callback).Run(mojom::FeedV2::New());
+    return;
+  }
+
+  feed_v2_builder_.Build(std::move(callback));
 }
 
 void BraveNewsController::GetPublishers(GetPublishersCallback callback) {

--- a/components/brave_news/browser/brave_news_controller.h
+++ b/components/brave_news/browser/brave_news_controller.h
@@ -20,6 +20,7 @@
 #include "brave/components/brave_news/browser/channels_controller.h"
 #include "brave/components/brave_news/browser/direct_feed_controller.h"
 #include "brave/components/brave_news/browser/feed_controller.h"
+#include "brave/components/brave_news/browser/feed_v2_builder.h"
 #include "brave/components/brave_news/browser/publishers_controller.h"
 #include "brave/components/brave_news/browser/suggestions_controller.h"
 #include "brave/components/brave_news/browser/unsupported_publisher_migrator.h"
@@ -88,6 +89,7 @@ class BraveNewsController : public KeyedService,
   // mojom::BraveNewsController
   void GetLocale(GetLocaleCallback callback) override;
   void GetFeed(GetFeedCallback callback) override;
+  void GetFeedV2(GetFeedV2Callback callback) override;
   void GetPublishers(GetPublishersCallback callback) override;
   void AddPublishersListener(
       mojo::PendingRemote<mojom::PublishersListener> listener) override;
@@ -154,6 +156,7 @@ class BraveNewsController : public KeyedService,
   PublishersController publishers_controller_;
   ChannelsController channels_controller_;
   FeedController feed_controller_;
+  FeedV2Builder feed_v2_builder_;
   SuggestionsController suggestions_controller_;
 
   PrefChangeRegistrar pref_change_registrar_;

--- a/components/brave_news/browser/brave_news_controller.h
+++ b/components/brave_news/browser/brave_news_controller.h
@@ -13,6 +13,7 @@
 #include "base/containers/flat_map.h"
 #include "base/functional/callback_forward.h"
 #include "base/memory/raw_ptr.h"
+#include "base/memory/scoped_refptr.h"
 #include "base/scoped_observation.h"
 #include "base/task/cancelable_task_tracker.h"
 #include "base/timer/timer.h"
@@ -36,6 +37,7 @@
 #include "mojo/public/cpp/bindings/receiver_set.h"
 #include "mojo/public/cpp/bindings/remote.h"
 #include "mojo/public/cpp/bindings/remote_set.h"
+#include "services/network/public/cpp/shared_url_loader_factory.h"
 
 class PrefRegistrySimple;
 class PrefService;
@@ -150,14 +152,15 @@ class BraveNewsController : public KeyedService,
   raw_ptr<brave_ads::AdsService> ads_service_ = nullptr;
   api_request_helper::APIRequestHelper api_request_helper_;
   brave_private_cdn::PrivateCDNRequestHelper private_cdn_request_helper_;
+  scoped_refptr<network::SharedURLLoaderFactory> url_loader_factory_;
 
   DirectFeedController direct_feed_controller_;
   UnsupportedPublisherMigrator unsupported_publisher_migrator_;
   PublishersController publishers_controller_;
   ChannelsController channels_controller_;
   FeedController feed_controller_;
-  FeedV2Builder feed_v2_builder_;
   SuggestionsController suggestions_controller_;
+  std::unique_ptr<FeedV2Builder> feed_v2_builder_;
 
   PrefChangeRegistrar pref_change_registrar_;
   base::OneShotTimer timer_prefetch_;

--- a/components/brave_news/browser/feed_building_unittest.cc
+++ b/components/brave_news/browser/feed_building_unittest.cc
@@ -232,14 +232,15 @@ TEST_F(BraveNewsFeedBuildingTest, DirectFeedsShouldAlwaysBeDisplayed) {
   publisher->type = mojom::PublisherType::DIRECT_SOURCE;
   publisher->user_enabled_status = mojom::UserEnabled::NOT_MODIFIED;
 
-  auto feed_item = mojom::FeedItem::NewArticle(
-      mojom::Article::New(mojom::FeedItemMetadata::New(
+  auto feed_item = mojom::FeedItem::NewArticle(mojom::Article::New(
+      mojom::FeedItemMetadata::New(
           "Technology", base::Time::Now(), "Title", "Description",
           GURL("https://example.com/article"),
           "7bb5d8b3e2eee9d317f0568dcb094850fdf2862b2ed6d583c62b2245ea507ab8",
           mojom::Image::NewPaddedImageUrl(
               GURL("https://example.com/article/image")),
-          publisher->publisher_id, "Source", 10, "a minute ago")));
+          publisher->publisher_id, "Source", 10, "a minute ago"),
+      false));
   EXPECT_TRUE(ShouldDisplayFeedItem(feed_item, &publisher_list, channels));
 
   publisher->locales = std::vector<mojom::LocaleInfoPtr>();
@@ -257,8 +258,8 @@ TEST_F(BraveNewsFeedBuildingTest, RemovesUserDisabledItems) {
   publisher_list.at(publisher_id_to_hide)->user_enabled_status =
       mojom::UserEnabled::DISABLED;
 
-  auto feed_item = mojom::FeedItem::NewArticle(
-      mojom::Article::New(mojom::FeedItemMetadata::New(
+  auto feed_item = mojom::FeedItem::NewArticle(mojom::Article::New(
+      mojom::FeedItemMetadata::New(
           "Technology", base::Time::Now(),
           "Expecting First Transfer Talk: How a busy Deadline Day unfolded",
           "The transfer window is closed and Saul Niguez is on his way to "
@@ -274,7 +275,8 @@ TEST_F(BraveNewsFeedBuildingTest, RemovesUserDisabledItems) {
                    "85fb134433369025b46b861a00408e61223678f55620612d980533fa6ce"
                    "0a815.jpg.pad")),
           publisher_id_to_hide, "ESPN - Football", 14.525910905005045,
-          "a minute ago")));
+          "a minute ago"),
+      false));
 
   Channels channels;
   ASSERT_FALSE(ShouldDisplayFeedItem(feed_item, &publisher_list, channels));
@@ -292,8 +294,8 @@ TEST_F(BraveNewsFeedBuildingTest, IncludesUserEnabledItems) {
   publisher_list.at(publisher_id_to_hide)->user_enabled_status =
       mojom::UserEnabled::ENABLED;
 
-  auto feed_item = mojom::FeedItem::NewArticle(
-      mojom::Article::New(mojom::FeedItemMetadata::New(
+  auto feed_item = mojom::FeedItem::NewArticle(mojom::Article::New(
+      mojom::FeedItemMetadata::New(
           "Technology", base::Time::Now(),
           "Expecting First Transfer Talk: How a busy Deadline Day unfolded",
           "The transfer window is closed and Saul Niguez is on his way to "
@@ -309,7 +311,8 @@ TEST_F(BraveNewsFeedBuildingTest, IncludesUserEnabledItems) {
                    "85fb134433369025b46b861a00408e61223678f55620612d980533fa6ce"
                    "0a815.jpg.pad")),
           publisher_id_to_hide, "ESPN - Football", 14.525910905005045,
-          "a minute ago")));
+          "a minute ago"),
+      false));
 
   Channels channels;
   ASSERT_TRUE(ShouldDisplayFeedItem(feed_item, &publisher_list, channels));
@@ -326,14 +329,15 @@ TEST_F(BraveNewsFeedBuildingTest, ChannelIsUsed) {
                        "Top News", std::vector<std::string>{"en_US"})});
   auto* channel = channels["Top News"].get();
 
-  auto feed_item = mojom::FeedItem::NewArticle(
-      mojom::Article::New(mojom::FeedItemMetadata::New(
+  auto feed_item = mojom::FeedItem::NewArticle(mojom::Article::New(
+      mojom::FeedItemMetadata::New(
           "Technology", base::Time::Now(), "Title", "Description",
           GURL("https://example.com/article"),
           "7bb5d8b3e2eee9d317f0568dcb094850fdf2862b2ed6d583c62b2245ea507ab8",
           mojom::Image::NewPaddedImageUrl(
               GURL("https://example.com/article/image")),
-          publisher->publisher_id, "Source", 10, "a minute ago")));
+          publisher->publisher_id, "Source", 10, "a minute ago"),
+      false));
 
   // Publisher: NOT_MODIFIED, Channel: Subscribed, Should display.
   EXPECT_TRUE(ShouldDisplayFeedItem(feed_item, &publisher_list, channels));

--- a/components/brave_news/browser/feed_v2_builder.cc
+++ b/components/brave_news/browser/feed_v2_builder.cc
@@ -1,0 +1,64 @@
+// Copyright (c) 2023 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#include "brave/components/brave_news/browser/feed_v2_builder.h"
+
+#include <iterator>
+#include <locale>
+#include <utility>
+#include <vector>
+
+#include "base/functional/bind.h"
+#include "base/memory/scoped_refptr.h"
+#include "base/ranges/algorithm.h"
+#include "brave/components/brave_news/browser/channels_controller.h"
+#include "brave/components/brave_news/browser/feed_fetcher.h"
+#include "brave/components/brave_news/browser/publishers_controller.h"
+#include "brave/components/brave_news/common/brave_news.mojom-forward.h"
+#include "services/network/public/cpp/shared_url_loader_factory.h"
+
+namespace brave_news {
+
+FeedV2Builder::FeedV2Builder(
+    PublishersController& publishers_controller,
+    ChannelsController& channels_controller,
+    scoped_refptr<network::SharedURLLoaderFactory> url_loader_factory)
+    : fetcher_(publishers_controller, channels_controller, url_loader_factory) {
+
+}
+
+FeedV2Builder::~FeedV2Builder() = default;
+
+void FeedV2Builder::Build(BuildFeedCallback callback) {
+  if (articles_.size()) {
+    BuildFeedFromArticles(std::move(callback));
+    return;
+  }
+
+  fetcher_.FetchFeed(base::BindOnce(
+      [](FeedV2Builder* builder, BuildFeedCallback callback, FeedItems items,
+         ETags tags) {
+        std::vector<mojom::ArticlePtr> articles;
+        for (const auto& item : items) {
+          if (item->is_article()) {
+            articles.push_back(std::move(item->get_article()));
+          }
+        }
+        builder->articles_ = std::move(articles);
+        builder->BuildFeedFromArticles(std::move(callback));
+      },
+      // Unretained is safe here because the FeedFetcher is owned by this and
+      // uses weak pointers internally.
+      base::Unretained(this), std::move(callback)));
+}
+
+void FeedV2Builder::BuildFeedFromArticles(BuildFeedCallback callback) {
+  std::vector<mojom::ArticlePtr> articles;
+  base::ranges::transform(articles_, std::back_inserter(articles),
+                          [](const auto& article) { return article->Clone(); });
+  std::move(callback).Run(std::move(articles));
+}
+
+}  // namespace brave_news

--- a/components/brave_news/browser/feed_v2_builder.cc
+++ b/components/brave_news/browser/feed_v2_builder.cc
@@ -27,7 +27,6 @@ FeedV2Builder::FeedV2Builder(
     ChannelsController& channels_controller,
     scoped_refptr<network::SharedURLLoaderFactory> url_loader_factory)
     : fetcher_(publishers_controller, channels_controller, url_loader_factory) {
-
 }
 
 FeedV2Builder::~FeedV2Builder() = default;

--- a/components/brave_news/browser/feed_v2_builder.h
+++ b/components/brave_news/browser/feed_v2_builder.h
@@ -1,7 +1,10 @@
+// Copyright (c) 2023 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
 #ifndef BRAVE_COMPONENTS_BRAVE_NEWS_BROWSER_FEED_V2_BUILDER_H_
 #define BRAVE_COMPONENTS_BRAVE_NEWS_BROWSER_FEED_V2_BUILDER_H_
-
-#include <vector>
 
 #include "base/memory/scoped_refptr.h"
 #include "brave/components/brave_news/browser/channels_controller.h"
@@ -31,7 +34,7 @@ class FeedV2Builder {
 
   FeedFetcher fetcher_;
 
-  FeedItems raw_feed_items_{};
+  FeedItems raw_feed_items_;
 };
 
 }  // namespace brave_news

--- a/components/brave_news/browser/feed_v2_builder.h
+++ b/components/brave_news/browser/feed_v2_builder.h
@@ -1,0 +1,39 @@
+#ifndef BRAVE_COMPONENTS_BRAVE_NEWS_BROWSER_FEED_V2_BUILDER_H_
+#define BRAVE_COMPONENTS_BRAVE_NEWS_BROWSER_FEED_V2_BUILDER_H_
+
+#include <vector>
+#include "base/functional/callback_forward.h"
+#include "base/memory/scoped_refptr.h"
+#include "brave/components/brave_news/browser/channels_controller.h"
+#include "brave/components/brave_news/browser/feed_fetcher.h"
+#include "brave/components/brave_news/browser/publishers_controller.h"
+#include "brave/components/brave_news/common/brave_news.mojom-forward.h"
+#include "services/network/public/cpp/shared_url_loader_factory.h"
+namespace brave_news {
+
+using BuildFeedCallback =
+    base::OnceCallback<void(std::vector<mojom::ArticlePtr>)>;
+
+class FeedV2Builder {
+ public:
+  FeedV2Builder(
+      PublishersController& publishers_controller,
+      ChannelsController& channels_controller,
+      scoped_refptr<network::SharedURLLoaderFactory> url_loader_factory);
+  FeedV2Builder(const FeedV2Builder&) = delete;
+  FeedV2Builder& operator=(const FeedV2Builder&) = delete;
+  ~FeedV2Builder();
+
+  void Build(BuildFeedCallback callback);
+
+ private:
+  void BuildFeedFromArticles(BuildFeedCallback callback);
+
+  FeedFetcher fetcher_;
+
+  std::vector<mojom::ArticlePtr> articles_{};
+};
+
+}  // namespace brave_news
+
+#endif  // BRAVE_COMPONENTS_BRAVE_NEWS_BROWSER_FEED_V2_BUILDER_H_

--- a/components/brave_news/browser/feed_v2_builder.h
+++ b/components/brave_news/browser/feed_v2_builder.h
@@ -2,17 +2,17 @@
 #define BRAVE_COMPONENTS_BRAVE_NEWS_BROWSER_FEED_V2_BUILDER_H_
 
 #include <vector>
-#include "base/functional/callback_forward.h"
+
 #include "base/memory/scoped_refptr.h"
 #include "brave/components/brave_news/browser/channels_controller.h"
 #include "brave/components/brave_news/browser/feed_fetcher.h"
 #include "brave/components/brave_news/browser/publishers_controller.h"
-#include "brave/components/brave_news/common/brave_news.mojom-forward.h"
+#include "brave/components/brave_news/common/brave_news.mojom.h"
 #include "services/network/public/cpp/shared_url_loader_factory.h"
+
 namespace brave_news {
 
-using BuildFeedCallback =
-    base::OnceCallback<void(std::vector<mojom::ArticlePtr>)>;
+using BuildFeedCallback = mojom::BraveNewsController::GetFeedV2Callback;
 
 class FeedV2Builder {
  public:
@@ -31,7 +31,7 @@ class FeedV2Builder {
 
   FeedFetcher fetcher_;
 
-  std::vector<mojom::ArticlePtr> articles_{};
+  FeedItems raw_feed_items_{};
 };
 
 }  // namespace brave_news

--- a/components/brave_news/browser/resources/FeedPage.tsx
+++ b/components/brave_news/browser/resources/FeedPage.tsx
@@ -4,12 +4,47 @@
 // You can obtain one at https://mozilla.org/MPL/2.0/.
 
 import * as React from 'react';
+import { useInspectContext } from './context';
+import Advert from './feed/Ad';
+import Article from './feed/Article';
+import Cluster from './feed/Cluster';
+import Discover from './feed/Discover'
+import HeroArticle from './feed/Hero';
+import styled from 'styled-components';
 
 interface Props {
 }
 
-export default function FeedPage (props: Props) {
-    return <div>
-      The Feed
-    </div>
+const FeedContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+`
+
+export default function FeedPage(props: Props) {
+  const { feed } = useInspectContext();
+  return <div>
+    The Feed ({feed?.items.length} items. Truncated at 100)
+    <FeedContainer>
+      {feed?.items.slice(0, 100).map((item, index) => {
+        if (item.advert) {
+          return <Advert info={item.advert} key={item.advert.creativeInstanceId} />
+        }
+        if (item.article) {
+          return <Article info={item.article} key={item.article.data.urlHash} />
+        }
+        if (item.cluster) {
+          return <Cluster info={item.cluster} key={index} />
+        }
+        if (item.discover) {
+          return <Discover info={item.discover} key={index} />
+        }
+        if (item.hero) {
+          return <HeroArticle info={item.hero} key={item.hero.data.urlHash} />
+        }
+
+        throw new Error("Invalid item!" + JSON.stringify(item))
+      })}
+    </FeedContainer>
+  </div>
 }

--- a/components/brave_news/browser/resources/context.tsx
+++ b/components/brave_news/browser/resources/context.tsx
@@ -42,7 +42,7 @@ export const useInspectContext = () => {
 export default function InspectContext(props: React.PropsWithChildren<{}>) {
   const { result: publishers } = usePromise(() => api.getPublishers().then(p => p.publishers as { [key: string]: Publisher }), [])
   const { result: channels } = usePromise(() => api.getChannels().then(c => c.channels as { [key: string]: Channel }), [])
-  const { result: feed } = usePromise(() => api.getFeedV2().then(r => r.feed as FeedV2), [])
+  const { result: feed } = usePromise(() => api.getFeedV2().then(r => r.feed ), [])
   const [page, setPage] = React.useState<Page>('feed')
   const [locale, setLocale] = React.useState<string>('en_US')
 

--- a/components/brave_news/browser/resources/context.tsx
+++ b/components/brave_news/browser/resources/context.tsx
@@ -4,7 +4,7 @@
 // You can obtain one at https://mozilla.org/MPL/2.0/.
 
 import {
-  BraveNewsController, Channel, Publisher
+  BraveNewsController, Channel, FeedV2, Publisher
 } from 'gen/brave/components/brave_news/common/brave_news.mojom.m'
 import * as React from 'react'
 import usePromise from '../../../brave_new_tab_ui/hooks/usePromise'
@@ -14,6 +14,7 @@ export const pages = ['feed', 'signals'] as const;
 export type Page = (typeof pages)[number]
 
 export interface InspectContext {
+  feed: FeedV2 | undefined,
   publishers: { [key: string]: Publisher },
   channels: { [key: string]: Channel },
   page: Page,
@@ -30,7 +31,8 @@ const Context = React.createContext<InspectContext>({
   page: 'feed',
   setPage: () => { },
   locale: 'en_US',
-  setLocale: () => { }
+  setLocale: () => { },
+  feed: undefined,
 })
 
 export const useInspectContext = () => {
@@ -40,6 +42,7 @@ export const useInspectContext = () => {
 export default function InspectContext(props: React.PropsWithChildren<{}>) {
   const { result: publishers } = usePromise(() => api.getPublishers().then(p => p.publishers as { [key: string]: Publisher }), [])
   const { result: channels } = usePromise(() => api.getChannels().then(c => c.channels as { [key: string]: Channel }), [])
+  const { result: feed } = usePromise(() => api.getFeedV2().then(r => r.feed as FeedV2), [])
   const [page, setPage] = React.useState<Page>('feed')
   const [locale, setLocale] = React.useState<string>('en_US')
 
@@ -49,8 +52,9 @@ export default function InspectContext(props: React.PropsWithChildren<{}>) {
     page,
     setPage,
     locale,
-    setLocale
-  }), [publishers, channels, page, locale])
+    setLocale,
+    feed
+  }), [publishers, channels, page, locale, feed])
 
   return <Context.Provider value={context}>
     {props.children}

--- a/components/brave_news/browser/resources/feed/Ad.tsx
+++ b/components/brave_news/browser/resources/feed/Ad.tsx
@@ -1,0 +1,17 @@
+// Copyright (c) 2023 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+import * as React from 'react';
+import Card from './Card';
+import { PromotedArticle } from 'gen/brave/components/brave_news/common/brave_news.mojom.m';
+
+interface Props {
+  info: PromotedArticle
+}
+
+export default function Advert(props: Props) {
+  return <Card>
+    This is a useful & relevant advert
+  </Card>
+}

--- a/components/brave_news/browser/resources/feed/Article.tsx
+++ b/components/brave_news/browser/resources/feed/Article.tsx
@@ -1,0 +1,18 @@
+// Copyright (c) 2023 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+import * as React from 'react';
+import Card from './Card';
+import { Article as Info } from 'gen/brave/components/brave_news/common/brave_news.mojom.m';
+
+interface Props {
+  info: Info
+}
+
+export default function Article({ info }: Props) {
+  return <Card onClick={() => window.open(info.data.url.url, '_blank', 'noopener noreferrer')}>
+    <h4>{info.data.title}{info.isDiscover && " (discovering)"}</h4>
+    <div>{info.data.description}</div>
+  </Card>
+}

--- a/components/brave_news/browser/resources/feed/Card.tsx
+++ b/components/brave_news/browser/resources/feed/Card.tsx
@@ -1,0 +1,15 @@
+// Copyright (c) 2023 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+import styled from "styled-components";
+import { color, effect, radius, spacing } from '@brave/leo/tokens/css'
+
+export default styled.div`
+  background: ${color.container.background};
+  box-shadow: ${effect.elevation[7]};
+  border-radius: ${radius[8]};
+  border: 1px solid ${color.gray[20]};
+  color: ${color.text.primary};
+  padding: ${spacing[8]};
+`

--- a/components/brave_news/browser/resources/feed/Cluster.tsx
+++ b/components/brave_news/browser/resources/feed/Cluster.tsx
@@ -1,0 +1,17 @@
+// Copyright (c) 2023 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+import * as React from 'react';
+import { Cluster as Info } from 'gen/brave/components/brave_news/common/brave_news.mojom.m';
+import Card from './Card';
+
+interface Props {
+  info: Info
+}
+
+export default function Cluster({info}: Props) {
+  return <Card>
+    Cluster: {info.type} {info.id}
+  </Card>
+}

--- a/components/brave_news/browser/resources/feed/Discover.tsx
+++ b/components/brave_news/browser/resources/feed/Discover.tsx
@@ -1,0 +1,27 @@
+// Copyright (c) 2023 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+import * as React from 'react';
+import { Discover as Info } from 'gen/brave/components/brave_news/common/brave_news.mojom.m';
+import styled from 'styled-components';
+import Card from './Card';
+
+const Row = styled.div`
+  display: flex;
+  flex-direction: row;
+  gap: 8px;
+  justify-content: space-between;
+`
+
+interface Props {
+  info: Info
+}
+
+export default function Component({ info }: Props) {
+  return <Row>
+    {info.publishers.map(p => <Card key={p.publisherId}>
+      {p.publisherName}
+    </Card>)}
+  </Row>
+}

--- a/components/brave_news/browser/resources/feed/Hero.tsx
+++ b/components/brave_news/browser/resources/feed/Hero.tsx
@@ -1,0 +1,18 @@
+// Copyright (c) 2023 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+import * as React from 'react';
+import Card from './Card';
+import { HeroArticle as Info } from 'gen/brave/components/brave_news/common/brave_news.mojom.m';
+
+interface Props {
+  info: Info
+}
+
+export default function HeroArticle({ info }: Props) {
+  return <Card onClick={() => window.open(info.data.url.url, '_blank', 'noopener noreferrer')}>
+    <h2>Hero: {info.data.title}</h2>
+    <div>{info.data.description}</div>
+  </Card>
+}

--- a/components/brave_news/common/brave_news.mojom
+++ b/components/brave_news/common/brave_news.mojom
@@ -40,6 +40,7 @@ struct FeedItemMetadata {
 
 struct Article {
   FeedItemMetadata data;
+  bool is_discover;
 };
 
 struct PromotedArticle {
@@ -140,6 +141,36 @@ struct Publisher {
   UserEnabled user_enabled_status = UserEnabled.NOT_MODIFIED;
 };
 
+struct HeroArticle {
+  FeedItemMetadata data;
+};
+
+union ArticleElements {
+  Article article;
+  HeroArticle hero;
+};
+
+struct Discover {
+  array<Publisher> publishers;
+};
+
+struct Cluster {
+  string type;
+  array<ArticleElements> articles;
+};
+
+union FeedItemV2 {
+  Article article;
+  HeroArticle hero;
+  PromotedArticle advert;
+  Discover discover;
+  Cluster cluster;
+};
+
+struct FeedV2 {
+  array<FeedItemV2> items;
+};
+
 struct DisplayAd {
   string uuid;
   string creative_instance_id;
@@ -184,6 +215,7 @@ interface BraveNewsController {
   GetLocale() => (string locale);
 
   GetFeed() => (Feed feed);
+  GetFeedV2() => (FeedV2 feed);
 
   // Deprecated by https://github.com/brave/brave-core/pull/16038. Use
   // |AddPublishersListener| instead.

--- a/components/brave_news/common/brave_news.mojom
+++ b/components/brave_news/common/brave_news.mojom
@@ -156,6 +156,7 @@ struct Discover {
 
 struct Cluster {
   string type;
+  string id;
   array<ArticleElements> articles;
 };
 


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/32171

**Note:** We don't actually do any feed building/filtering yet, we just return all the articles/adverts from the server in a giant feed. That will be done as a followup PR.

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-arm64, CI/skip-linux-x64, CI/skip-android, CI/skip-macos, CI/skip-ios, CI/skip-windows-arm64, CI/skip-windows-x64, CI/skip-windows-x86 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [ ] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

This is QA/No for now - it's an internal page, behind a flag & the feature is a work in progress