### PR TITLE
Reset cached credentials on region change

### DIFF
--- a/components/brave_vpn/browser/connection/BUILD.gn
+++ b/components/brave_vpn/browser/connection/BUILD.gn
@@ -64,6 +64,9 @@ group("unit_tests") {
   testonly = true
   deps = []
   if (!is_android) {
-    deps += [ "ikev2:unit_tests" ]
+    deps += [
+      "ikev2:unit_tests",
+      "wireguard:unit_tests",
+    ]
   }
 }

--- a/components/brave_vpn/browser/connection/brave_vpn_os_connection_api.h
+++ b/components/brave_vpn/browser/connection/brave_vpn_os_connection_api.h
@@ -109,6 +109,8 @@ class BraveVPNOSConnectionAPI
   FRIEND_TEST_ALL_PREFIXES(BraveVPNOSConnectionAPIUnitTest,
                            IgnoreDisconnectedStateWhileConnecting);
   FRIEND_TEST_ALL_PREFIXES(BraveVPNOSConnectionAPIUnitTest, HostnamesTest);
+  FRIEND_TEST_ALL_PREFIXES(BraveVPNWireguardConnectionAPIUnitTest,
+                           SetSelectedRegion);
 
   void SetConnectionStateForTesting(mojom::ConnectionState state);
 

--- a/components/brave_vpn/browser/connection/wireguard/BUILD.gn
+++ b/components/brave_vpn/browser/connection/wireguard/BUILD.gn
@@ -24,3 +24,17 @@ source_set("wireguard") {
     "//services/network/public/cpp",
   ]
 }
+
+source_set("unit_tests") {
+  testonly = true
+  sources = [ "brave_vpn_wireguard_connection_api_unittest.cc" ]
+
+  deps = [
+    ":wireguard",
+    "//brave/components/brave_vpn/common",
+    "//components/sync_preferences:test_support",
+    "//content/test:test_support",
+    "//services/network:test_support",
+    "//testing/gtest",
+  ]
+}

--- a/components/brave_vpn/browser/connection/wireguard/brave_vpn_wireguard_connection_api_base.cc
+++ b/components/brave_vpn/browser/connection/wireguard/brave_vpn_wireguard_connection_api_base.cc
@@ -28,6 +28,7 @@ BraveVPNWireguardConnectionAPIBase::~BraveVPNWireguardConnectionAPIBase() {
 void BraveVPNWireguardConnectionAPIBase::SetSelectedRegion(
     const std::string& name) {
   GetRegionDataManager().SetSelectedRegion(name);
+  ResetConnectionInfo();
 }
 
 void BraveVPNWireguardConnectionAPIBase::OnWireguardKeypairGenerated(

--- a/components/brave_vpn/browser/connection/wireguard/brave_vpn_wireguard_connection_api_unittest.cc
+++ b/components/brave_vpn/browser/connection/wireguard/brave_vpn_wireguard_connection_api_unittest.cc
@@ -1,0 +1,86 @@
+/* Copyright (c) 2023 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "brave/components/brave_vpn/browser/connection/wireguard/brave_vpn_wireguard_connection_api_base.h"
+
+#include <memory>
+#include "brave/components/brave_vpn/common/brave_vpn_data_types.h"
+#include "brave/components/brave_vpn/common/brave_vpn_utils.h"
+#include "brave/components/brave_vpn/common/pref_names.h"
+#include "components/sync_preferences/testing_pref_service_syncable.h"
+#include "content/public/test/browser_task_environment.h"
+#include "services/network/public/cpp/weak_wrapper_shared_url_loader_factory.h"
+#include "services/network/test/test_url_loader_factory.h"
+#include "testing/gtest/include/gtest/gtest.h"
+
+namespace brave_vpn {
+
+namespace {
+class BraveVPNWireguardConnectionAPISim
+    : public BraveVPNWireguardConnectionAPIBase {
+ public:
+  BraveVPNWireguardConnectionAPISim(
+      scoped_refptr<network::SharedURLLoaderFactory> url_loader_factory,
+      PrefService* local_prefs)
+      : BraveVPNWireguardConnectionAPIBase(url_loader_factory, local_prefs) {}
+
+  ~BraveVPNWireguardConnectionAPISim() override {}
+
+  BraveVPNWireguardConnectionAPISim(const BraveVPNWireguardConnectionAPISim&) =
+      delete;
+  BraveVPNWireguardConnectionAPISim& operator=(
+      const BraveVPNWireguardConnectionAPISim&) = delete;
+
+  void Disconnect() override {}
+  void CheckConnection() override {}
+  void RequestNewProfileCredentials() override {}
+  void PlatformConnectImpl(
+      const wireguard::WireguardProfileCredentials& credentials) override {}
+};
+}  // namespace
+
+class BraveVPNWireguardConnectionAPIUnitTest : public testing::Test {
+ public:
+  BraveVPNWireguardConnectionAPIUnitTest()
+      : task_environment_(base::test::TaskEnvironment::TimeSource::MOCK_TIME) {}
+
+  void SetUp() override {
+    brave_vpn::RegisterLocalStatePrefs(local_pref_service_.registry());
+    connection_api_ = std::make_unique<BraveVPNWireguardConnectionAPISim>(
+        base::MakeRefCounted<network::WeakWrapperSharedURLLoaderFactory>(
+            &url_loader_factory_),
+        local_state());
+  }
+
+  BraveVPNWireguardConnectionAPIBase* GetBraveVPNWireguardConnectionAPIBase()
+      const {
+    return static_cast<BraveVPNWireguardConnectionAPIBase*>(
+        connection_api_.get());
+  }
+  PrefService* local_state() { return &local_pref_service_; }
+
+  BraveVPNOSConnectionAPI* GetConnectionAPI() { return connection_api_.get(); }
+
+ protected:
+  TestingPrefServiceSimple local_pref_service_;
+  network::TestURLLoaderFactory url_loader_factory_;
+  content::BrowserTaskEnvironment task_environment_;
+  std::unique_ptr<BraveVPNOSConnectionAPI> connection_api_;
+};
+
+TEST_F(BraveVPNWireguardConnectionAPIUnitTest, SetSelectedRegion) {
+  local_state()->SetString(prefs::kBraveVPNWireguardProfileCredentials,
+                           "region-a");
+  GetBraveVPNWireguardConnectionAPIBase()->hostname_ =
+      std::make_unique<Hostname>();
+  GetBraveVPNWireguardConnectionAPIBase()->hostname_->hostname = "test";
+  GetBraveVPNWireguardConnectionAPIBase()->SetSelectedRegion("region-b");
+  EXPECT_TRUE(local_state()
+                  ->GetString(prefs::kBraveVPNWireguardProfileCredentials)
+                  .empty());
+  EXPECT_EQ(GetBraveVPNWireguardConnectionAPIBase()->hostname_.get(), nullptr);
+}
+
+}  // namespace brave_vpn


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/32176

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-arm64, CI/skip-linux-x64, CI/skip-android, CI/skip-macos, CI/skip-ios, CI/skip-windows-arm64, CI/skip-windows-x64, CI/skip-windows-x86 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

- STR from the issue