### PR TITLE
fix(wallet) Use image_url field in NFTs

### DIFF
--- a/components/brave_wallet_ui/common/slices/api.slice.ts
+++ b/components/brave_wallet_ui/common/slices/api.slice.ts
@@ -645,7 +645,7 @@ export function createWalletApi () {
             ).unwrap()
 
             if (metadata?.image) {
-              tokenArg.logo = metadata?.image || tokenArg.logo
+              tokenArg.logo = metadata?.image || metadata?.image_url || tokenArg.logo
             }
           }
 

--- a/components/brave_wallet_ui/common/slices/endpoints/nfts.endpoints.ts
+++ b/components/brave_wallet_ui/common/slices/endpoints/nfts.endpoints.ts
@@ -30,6 +30,7 @@ export interface CommonNftMetadata {
   attributes?: any[]
   description?: string
   image?: string
+  image_url?: string
   name?: string
 }
 
@@ -142,9 +143,10 @@ export const nftsEndpoints = ({
             ? (JSON.parse(result.response) as CommonNftMetadata)
             : undefined
 
-          const imageURL = response?.image?.startsWith('data:image/')
-            ? response.image
-            : await cache.getIpfsGatewayTranslatedNftUrl(response?.image || '')
+          const responseImageUrl = response?.image || response?.image_url
+          const imageURL = responseImageUrl?.startsWith('data:image/')
+            ? responseImageUrl
+            : await cache.getIpfsGatewayTranslatedNftUrl(responseImageUrl || '')
 
           const attributes = Array.isArray(response?.attributes)
             ? response?.attributes.map(

--- a/components/brave_wallet_ui/constants/types.ts
+++ b/components/brave_wallet_ui/constants/types.ts
@@ -1005,7 +1005,8 @@ export enum TokenStandards {
 }
 
 export type ERC721Metadata = {
-  image?: string
+  image?: string,
+  image_url?: string
 }
 
 export type AddressMessageInfo = {


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/31763

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-arm64, CI/skip-linux-x64, CI/skip-android, CI/skip-macos, CI/skip-ios, CI/skip-windows-arm64, CI/skip-windows-x64, CI/skip-windows-x86 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
- Add an NFT that has `image_url` in the metadata e.g token ID - 6188775
contract address - 0x22c1f6050e56d2876009903609a2cc3fef83b415
chain - gnosis
- The NFT should the correct image in the icon and in the NFT details screen

<img width="828" alt="Screenshot 2023-08-10 at 21 41 29" src="https://github.com/brave/brave-core/assets/48117473/dc055d39-5103-4531-b048-47a5b2f3fc2a">
