### PR TITLE
Only show the BraveVpnPageElement on Windows

### DIFF
--- a/browser/resources/settings/brave_overrides/system_page.ts
+++ b/browser/resources/settings/brave_overrides/system_page.ts
@@ -10,7 +10,9 @@ import {
 } from 'chrome://resources/brave/polymer_overriding.js'
 import { loadTimeData } from '../i18n_setup.js'
 import '../brave_system_page/brave_performance_page.js'
+// <if expr="is_win">
 import '../brave_system_page/brave_vpn_page.js'
+// </if>
 import '../shortcuts_page/shortcuts_page.js'
 import { Router } from '../router.js'
 
@@ -77,10 +79,20 @@ RegisterPolymerTemplateModifications({
           label="${loadTimeData.getString('braveHelpTipsClosingLastTab')}"
         >
         </settings-toggle-button>
+      `
+    )
 
+    // <if expr="is_win">
+    templateContent.appendChild(
+      html`
         <settings-brave-vpn-page prefs="{{prefs}}">
         </settings-brave-vpn-page>
+      `
+    )
+    // </if>
 
+    templateContent.appendChild(
+      html`
         <settings-brave-performance-page prefs="{{prefs}}">
         </settings-brave-performance-page>
       `

--- a/browser/resources/settings/brave_overrides/system_page.ts
+++ b/browser/resources/settings/brave_overrides/system_page.ts
@@ -10,7 +10,7 @@ import {
 } from 'chrome://resources/brave/polymer_overriding.js'
 import { loadTimeData } from '../i18n_setup.js'
 import '../brave_system_page/brave_performance_page.js'
-// <if expr="is_win">
+// <if expr="enable_brave_vpn and is_win">
 import '../brave_system_page/brave_vpn_page.js'
 // </if>
 import '../shortcuts_page/shortcuts_page.js'
@@ -82,7 +82,7 @@ RegisterPolymerTemplateModifications({
       `
     )
 
-    // <if expr="is_win">
+    // <if expr="enable_brave_vpn and is_win">
     templateContent.appendChild(
       html`
         <settings-brave-vpn-page prefs="{{prefs}}">

--- a/browser/resources/settings/sources.gni
+++ b/browser/resources/settings/sources.gni
@@ -4,6 +4,7 @@
 # you can obtain one at http://mozilla.org/MPL/2.0/.
 
 import("//brave/browser/shell_integrations/buildflags/buildflags.gni")
+import("//brave/components/brave_vpn/common/buildflags/buildflags.gni")
 
 # Provide our file list to chromium's settings page build
 # Since our components start in a different path, we'll do the first step (move them to
@@ -42,7 +43,6 @@ brave_settings_web_component_files = [
   "brave_sync_page/brave_sync_setup.ts",
   "brave_sync_page/brave_sync_subpage.ts",
   "brave_system_page/brave_performance_page.ts",
-  "brave_system_page/brave_vpn_page.ts",
   "brave_tor_page/brave_tor_bridges_dialog.ts",
   "brave_tor_page/brave_tor_snowflake_install_failed_dialog.ts",
   "brave_tor_page/brave_tor_subpage.ts",
@@ -66,7 +66,6 @@ brave_settings_non_web_component_files = [
   "brave_add_site_dialog/brave_add_site_dialog.ts",
   "brave_default_extensions_page/brave_default_extensions_browser_proxy.ts",
   "brave_ipfs_page/brave_ipfs_browser_proxy.ts",
-  "brave_system_page/brave_vpn_browser_proxy.ts",
   "brave_new_tab_page/brave_new_tab_browser_proxy.ts",
   "brave_leo_assistant_page/brave_leo_assistant_browser_proxy.ts",
   "brave_overrides/about_page.ts",
@@ -119,6 +118,13 @@ brave_settings_non_web_component_files = [
   "default_brave_shields_page/default_brave_shields_browser_proxy.ts",
   "shortcuts_page/shortcuts_page.ts",
 ]
+
+if (enable_brave_vpn && is_win) {
+  brave_settings_web_component_files +=
+      [ "brave_system_page/brave_vpn_page.ts" ]
+  brave_settings_non_web_component_files +=
+      [ "brave_system_page/brave_vpn_browser_proxy.ts" ]
+}
 
 if (enable_pin_shortcut) {
   brave_settings_web_component_files +=


### PR DESCRIPTION
It uses a Window-only preference. We can remove guards once WireGuard is available on other platforms.

Fixes https://github.com/brave/brave-browser/issues/32213

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-arm64, CI/skip-linux-x64, CI/skip-android, CI/skip-macos, CI/skip-ios, CI/skip-windows-arm64, CI/skip-windows-x64, CI/skip-windows-x86 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

