### PR TITLE
Extend obsolete OS version infobar to macOS. (uplift to 1.58.x)

### DIFF
--- a/app/brave_generated_resources.grd
+++ b/app/brave_generated_resources.grd
@@ -629,14 +629,23 @@ Or change later at <ph name="SETTINGS_EXTENIONS_LINK">$2<ex>brave://settings/ext
           No thanks
         </message>
         <!-- obsolete system InfoBar -->
-        <if expr="is_win">
+        <if expr="is_win or is_macosx">
           <message name="IDS_OBSOLETE_SYSTEM_INFOBAR_DONT_SHOW_BUTTON" desc="The text for don't show again button">
             Don't show again
           </message>
+        </if>
+        <if expr="is_win">
           <message name="IDS_OBSOLETE_SYSTEM_CONFIRM_DIALOG_CONTENT" desc="The text for obsolete system confirm dialog">
             By clicking OK, you acknowledge that your installation of Brave will NOT receive critical security fixes until you update to Windows 10 or later. This warning will NOT show again.
           </message>
         </if>
+        <if expr="is_macosx">
+          <message name="IDS_OBSOLETE_SYSTEM_CONFIRM_DIALOG_CONTENT" desc="The text for obsolete system confirm dialog">
+            By clicking OK, you acknowledge that your installation of Brave will NOT receive critical security fixes until you update to macOS 10.15 or later. This warning will NOT show again.
+          </message>
+        </if>
+
+        <!-- Download bubble -->
         <message name="IDS_DOWNLOAD_BUBBLE_ITEM_CTX_MENU_REMOVE_ITEM" desc="Text for the download bubble context menu item for removing item from the list">
           Remove from list
         </message>

--- a/browser/ui/BUILD.gn
+++ b/browser/ui/BUILD.gn
@@ -425,8 +425,8 @@ source_set("ui") {
     ]
   }
 
-  # brave's obsolete infobar is only used on Windows now.
-  if (is_win) {
+  # brave's obsolete infobar is only used on Windows and Mac now.
+  if (is_win || is_mac) {
     sources += [
       "startup/brave_obsolete_system_infobar_delegate.cc",
       "startup/brave_obsolete_system_infobar_delegate.h",

--- a/chromium_src/chrome/browser/ui/startup/infobar_utils.cc
+++ b/chromium_src/chrome/browser/ui/startup/infobar_utils.cc
@@ -9,7 +9,7 @@
 #include "chrome/browser/ui/startup/google_api_keys_infobar_delegate.h"
 #include "components/infobars/content/content_infobar_manager.h"
 
-#if BUILDFLAG(IS_WIN)
+#if BUILDFLAG(IS_WIN) || BUILDFLAG(IS_MAC)
 #include "chrome/browser/ui/startup/obsolete_system_infobar_delegate.h"
 #endif
 
@@ -23,13 +23,13 @@ class BraveGoogleKeysInfoBarDelegate {
 #define ShowIfNotOffTheRecordProfile ShowIfNotOffTheRecordProfileBrave
 #define GoogleApiKeysInfoBarDelegate BraveGoogleKeysInfoBarDelegate
 
-#if BUILDFLAG(IS_WIN)
+#if BUILDFLAG(IS_WIN) || BUILDFLAG(IS_MAC)
 #define ObsoleteSystemInfoBarDelegate BraveObsoleteSystemInfoBarDelegate
 #endif
 
 #include "src/chrome/browser/ui/startup/infobar_utils.cc"
 
-#if BUILDFLAG(IS_WIN)
+#if BUILDFLAG(IS_WIN) || BUILDFLAG(IS_MAC)
 #undef ObsoleteSystemInfoBarDelegate
 #endif
 

--- a/chromium_src/chrome/common/url_constants.cc
+++ b/chromium_src/chrome/common/url_constants.cc
@@ -246,7 +246,7 @@ const char kChromeEnterpriseSignInLearnMoreURL[] =
 
 const char kMacOsObsoleteURL[] =
     "https://support.brave.com/hc/en-us/articles/"
-    "360025390311-How-do-I-download-and-install-Brave-";
+    "18347246446733-Changes-to-macOS-desktop-browser-requirements";
 #endif
 
 #if BUILDFLAG(IS_WIN)


### PR DESCRIPTION
Uplift of #19618
Resolves https://github.com/brave/brave-browser/issues/32129

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.