### PR TITLE
Fix permission bubble Allow/Block action after lifetime option change.

### DIFF
--- a/chromium_src/ui/views/input_event_activation_protector.cc
+++ b/chromium_src/ui/views/input_event_activation_protector.cc
@@ -1,0 +1,29 @@
+/* Copyright (c) 2023 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "ui/views/input_event_activation_protector.h"
+
+#define OnWindowStationaryStateChanged(...) \
+  OnWindowStationaryStateChanged_ChromiumImpl(__VA_ARGS__)
+
+#include "src/ui/views/input_event_activation_protector.cc"
+
+#undef OnWindowStationaryStateChanged
+
+namespace views {
+
+void InputEventActivationProtector::IgnoreNextWindowStationaryStateChanged() {
+  ignore_next_window_stationary_state_changed_ = true;
+}
+
+void InputEventActivationProtector::OnWindowStationaryStateChanged() {
+  if (ignore_next_window_stationary_state_changed_) {
+    ignore_next_window_stationary_state_changed_ = false;
+    return;
+  }
+  OnWindowStationaryStateChanged_ChromiumImpl();
+}
+
+}  // namespace views

--- a/chromium_src/ui/views/input_event_activation_protector.h
+++ b/chromium_src/ui/views/input_event_activation_protector.h
@@ -1,0 +1,25 @@
+/* Copyright (c) 2023 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_CHROMIUM_SRC_UI_VIEWS_INPUT_EVENT_ACTIVATION_PROTECTOR_H_
+#define BRAVE_CHROMIUM_SRC_UI_VIEWS_INPUT_EVENT_ACTIVATION_PROTECTOR_H_
+
+#include "ui/views/windows_stationarity_monitor.h"
+
+#define OnWindowStationaryStateChanged(...)                  \
+  OnWindowStationaryStateChanged_ChromiumImpl(__VA_ARGS__);  \
+  void IgnoreNextWindowStationaryStateChanged();             \
+                                                             \
+ private:                                                    \
+  bool ignore_next_window_stationary_state_changed_ = false; \
+                                                             \
+ public:                                                     \
+  void OnWindowStationaryStateChanged(__VA_ARGS__)
+
+#include "src/ui/views/input_event_activation_protector.h"  // IWYU pragma: export
+
+#undef OnWindowStationaryStateChanged
+
+#endif  // BRAVE_CHROMIUM_SRC_UI_VIEWS_INPUT_EVENT_ACTIVATION_PROTECTOR_H_

--- a/chromium_src/ui/views/window/dialog_client_view.cc
+++ b/chromium_src/ui/views/window/dialog_client_view.cc
@@ -21,4 +21,9 @@ void DialogClientView::SetupButtonsLayoutVertically() {
       kVerticalButtonsSpacing));
 }
 
+void DialogClientView::IgnoreNextWindowStationaryStateChanged() {
+  DCHECK(input_protector_);
+  input_protector_->IgnoreNextWindowStationaryStateChanged();
+}
+
 }  // namespace views

--- a/chromium_src/ui/views/window/dialog_client_view.h
+++ b/chromium_src/ui/views/window/dialog_client_view.h
@@ -8,10 +8,15 @@
 
 class WebDiscoveryDialogClientView;
 
-#define SetupLayout                            \
-  SetupLayout_UnUsed() {}                      \
-  friend class ::WebDiscoveryDialogClientView; \
-  void SetupButtonsLayoutVertically();         \
+#define SetupLayout                              \
+  SetupLayout_UnUsed() {}                        \
+  friend class ::WebDiscoveryDialogClientView;   \
+  void SetupButtonsLayoutVertically();           \
+                                                 \
+ public:                                         \
+  void IgnoreNextWindowStationaryStateChanged(); \
+                                                 \
+ private:                                        \
   virtual void SetupLayout
 
 #include "src/ui/views/window/dialog_client_view.h"  // IWYU pragma: export


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
A combobox close is treated as a window close. This lead to an issue when bubble buttons become no-op for 500ms after selecting an item in the combobox (see [1]). This got worse after [2] was landed, because a quick repeating button press also became no-op (see video in the issue).

This PR adds a workaround that prevents `InputEventActivationProtector::OnWindowStationaryStateChanged` to update `view_protected_time_stamp_` once a permission lifetime combobox is closed.

1. https://github.com/chromium/chromium/commit/c5119cd03d4078afaa280d2398d7faf3157db980
2. https://github.com/chromium/chromium/commit/f3c34f8e7b61909e683114ce13c2f1e769027cd4

Resolves https://github.com/brave/brave-browser/issues/32258

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-arm64, CI/skip-linux-x64, CI/skip-android, CI/skip-macos, CI/skip-ios, CI/skip-windows-arm64, CI/skip-windows-x64, CI/skip-windows-x86 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

