### PR TITLE
Add menu item to NTP Rewards widget menu to open Rewards panel

### DIFF
--- a/browser/ui/webui/brave_webui_source.cc
+++ b/browser/ui/webui/brave_webui_source.cc
@@ -180,6 +180,7 @@ void CustomizeWebUIHTMLSource(content::WebUI* web_ui,
         { "solidColorTitle", IDS_BRAVE_NEW_TAB_SOLID_COLOR},
         { "gradientColorTitle", IDS_BRAVE_NEW_TAB_GRADIENT_COLOR},
         { "refreshBackgroundOnNewTab", IDS_BRAVE_NEW_TAB_REFRESH_BACKGROUND_ON_NEW_TAB},  // NOLINT
+        { "rewardsOpenPanel", IDS_BRAVE_NEW_TAB_REWARDS_OPEN_PANEL },
 
         // search promotion
         { "searchPromotionNTPPopupTitle1", IDS_BRAVE_NEW_TAB_SEARCH_PROMOTION_POPUP_TITLE_1},  // NOLINT

--- a/components/brave_new_tab_ui/components/default/widget/index.tsx
+++ b/components/brave_new_tab_ui/components/default/widget/index.tsx
@@ -4,7 +4,7 @@
 
 import * as React from 'react'
 import { StyledWidget, StyledWidgetContainer } from './styles'
-import WidgetMenu from './widgetMenu'
+import WidgetMenu, { WidgetMenuCustomItem } from './widgetMenu'
 
 type HideWidgetFunction = () => void
 
@@ -23,6 +23,7 @@ export interface WidgetProps {
   onAddSite?: () => void
   customLinksEnabled?: boolean
   onToggleCustomLinksEnabled?: () => void
+  customMenuItems?: WidgetMenuCustomItem[]
 }
 
 export interface WidgetState {
@@ -44,6 +45,7 @@ export function Widget ({
   onAddSite,
   customLinksEnabled,
   onToggleCustomLinksEnabled,
+  customMenuItems,
   children
 }: WidgetProps & { children: React.ReactNode }) {
   const [widgetMenuPersist, setWidgetMenuPersist] = React.useState(!!isForeground)
@@ -63,6 +65,7 @@ export function Widget ({
         onAddSite={onAddSite}
         customLinksEnabled={customLinksEnabled}
         onToggleCustomLinksEnabled={onToggleCustomLinksEnabled}
+        customMenuItems={customMenuItems}
         isForeground={isForeground}
         widgetMenuPersist={widgetMenuPersist}
         textDirection={textDirection}

--- a/components/brave_new_tab_ui/components/default/widget/widgetMenu.tsx
+++ b/components/brave_new_tab_ui/components/default/widget/widgetMenu.tsx
@@ -15,6 +15,12 @@ import LearnMoreIcon from './assets/learn-more'
 import FavoritesIcon from './assets/favorites'
 import { getLocale } from '../../../../common/locale'
 
+export interface WidgetMenuCustomItem {
+  label: string
+  renderIcon: () => React.ReactNode
+  onClick: () => void
+}
+
 interface Props {
   menuPosition: 'right' | 'left'
   hideWidget: () => void
@@ -28,6 +34,7 @@ interface Props {
   onAddSite?: () => void
   customLinksEnabled?: boolean
   onToggleCustomLinksEnabled?: () => void
+  customMenuItems?: WidgetMenuCustomItem[]
   paddingType: 'none' | 'right' | 'default'
 }
 
@@ -88,6 +95,32 @@ export default class WidgetMenu extends React.PureComponent<Props, State> {
     this.closeMenu()
   }
 
+  renderCustomMenuItems () {
+    const { customMenuItems } = this.props
+
+    if (!customMenuItems) {
+      return null
+    }
+
+    return (
+      <>
+        {
+          customMenuItems.map((item, index) => {
+            return (
+              <StyledWidgetLink
+                key={index}
+                onClick={this.closeMenuWidget.bind(this, item.onClick)}
+              >
+                <StyledWidgetIcon>{item.renderIcon()}</StyledWidgetIcon>
+                <StyledSpan>{getLocale(item.label)}</StyledSpan>
+              </StyledWidgetLink>
+            )
+          })
+        }
+      </>
+    )
+  }
+
   render () {
     const {
       menuPosition,
@@ -99,7 +132,8 @@ export default class WidgetMenu extends React.PureComponent<Props, State> {
       onLearnMore,
       onAddSite,
       onToggleCustomLinksEnabled,
-      customLinksEnabled
+      customLinksEnabled,
+      customMenuItems
     } = this.props
     const { showMenu } = this.state
     const hideString = widgetTitle ? `${getLocale('hide')} ${widgetTitle}` : getLocale('hide')
@@ -116,6 +150,7 @@ export default class WidgetMenu extends React.PureComponent<Props, State> {
           menuPosition={menuPosition}
           widgetMenuPersist={widgetMenuPersist}
         >
+          { customMenuItems ? this.renderCustomMenuItems() : null }
           {
             onLearnMore
             ? <StyledWidgetLink

--- a/components/brave_new_tab_ui/containers/newTab/index.tsx
+++ b/components/brave_new_tab_ui/containers/newTab/index.tsx
@@ -38,8 +38,10 @@ import BraveNewsHint from '../../components/default/braveNews/hint'
 import GridWidget from './gridWidget'
 import SponsoredImageClickArea from '../../components/default/sponsoredImage/sponsoredImageClickArea'
 
-import { setIconBasePath } from '@brave/leo/react/icon'
+import Icon, { setIconBasePath } from '@brave/leo/react/icon'
 setIconBasePath('chrome://resources/brave-icons')
+
+import * as style from './style'
 
 interface Props {
   newTabData: NewTab.State
@@ -495,6 +497,20 @@ class NewTabPage extends React.Component<Props, State> {
       return null
     }
 
+    const customMenuItems = [
+      {
+        label: 'rewardsOpenPanel',
+        renderIcon: () => {
+          return (
+            <style.batIcon>
+              <Icon name='product-bat-outline' />
+            </style.batIcon>
+          )
+        },
+        onClick: () => { chrome.braveRewards.openRewardsPanel() }
+      }
+    ]
+
     return (
       <Rewards
         {...rewardsState}
@@ -512,6 +528,7 @@ class NewTabPage extends React.Component<Props, State> {
         showContent={showContent}
         onShowContent={this.setForegroundStackWidget.bind(this, 'rewards')}
         onDismissNotification={this.dismissNotification}
+        customMenuItems={customMenuItems}
       />
     )
   }

--- a/components/brave_new_tab_ui/containers/newTab/style.ts
+++ b/components/brave_new_tab_ui/containers/newTab/style.ts
@@ -1,0 +1,11 @@
+/* Copyright (c) 2023 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import styled from 'styled-components'
+
+export const batIcon = styled.div`
+  --leo-icon-size: 20px;
+  margin-left: 2px;
+`

--- a/components/resources/brave_components_strings.grd
+++ b/components/resources/brave_components_strings.grd
@@ -272,6 +272,7 @@
       <message name="IDS_BRAVE_NEW_TAB_SOLID_COLOR" desc="Solid background colors title">Solid colors</message>
       <message name="IDS_BRAVE_NEW_TAB_GRADIENT_COLOR" desc="Gradient background colors title">Gradients</message>
       <message name="IDS_BRAVE_NEW_TAB_REFRESH_BACKGROUND_ON_NEW_TAB" desc="Label for random toggle button">Refresh on every new tab</message>
+      <message name="IDS_BRAVE_NEW_TAB_REWARDS_OPEN_PANEL" desc="Label for menu item to open the Rewards panel">Open Rewards panel</message>
 
       <message name="IDS_BRAVE_TALK_PROMPT_TITLE" desc="Title for prompt about Brave Talk">
         You can start a private call in Brave.


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/30432

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-arm64, CI/skip-linux-x64, CI/skip-android, CI/skip-macos, CI/skip-ios, CI/skip-windows-arm64, CI/skip-windows-x64, CI/skip-windows-x86 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [ ] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## UI:

![Screenshot 2023-08-16 112239](https://github.com/brave/brave-core/assets/5033691/856e527c-89a4-4181-907d-b2fd992c4a9c)

## Test Plan:

- New profile
- Enable Rewards
- Create new tab
- Click ... menu in Rewards widget in NTP
- Verify that `Open Rewards panel` menu item appears with BAT icon
- Click `Open Rewards panel` menu item and verify that the Rewards panel opens
- Verify that other widgets do _not_ have this menu item
- Verify that this menu item works even when `Hide Rewards URL button` is enabled in brave://settings/rewards