### PR TITLE
fix(wallet): Infinite Loading for New Wallets

### DIFF
--- a/components/brave_wallet_ui/components/desktop/account-list-item/index.tsx
+++ b/components/brave_wallet_ui/components/desktop/account-list-item/index.tsx
@@ -269,7 +269,7 @@ export const AccountListItem = ({
         </AccountAndAddress>
       </NameAndIcon>
       <Row width='unset'>
-        {!isPanel ? (
+        {!isPanel && !accountsFiatValue.isZero() ? (
           tokensWithBalances.length ? (
             <TokenIconsStack tokens={tokensWithBalances} />
           ) : (

--- a/components/brave_wallet_ui/components/desktop/views/accounts/account.tsx
+++ b/components/brave_wallet_ui/components/desktop/views/accounts/account.tsx
@@ -203,6 +203,7 @@ export const Account = () => {
 
   const {
     data: tokenBalancesRegistry,
+    isLoading: isLoadingBalances
   } = useBalancesFetcher(selectedAccount && networkList
     ? {
         accounts: [selectedAccount],
@@ -368,14 +369,24 @@ export const Account = () => {
               action={() => onSelectAsset(asset)}
               account={selectedAccount}
               assetBalance={
-                getBalance(selectedAccount.accountId, asset, tokenBalancesRegistry)
+                isLoadingBalances
+                  ? ''
+                  : getBalance(
+                    selectedAccount.accountId,
+                    asset,
+                    tokenBalancesRegistry
+                  )
               }
               token={asset}
               spotPrice={
                 spotPriceRegistry && !isLoadingSpotPrices
                   ? getTokenPriceAmountFromRegistry(spotPriceRegistry, asset)
                     .format()
-                  : ''
+                  : !spotPriceRegistry &&
+                    !isLoadingSpotPrices &&
+                    !isLoadingBalances
+                    ? '0'
+                    : ''
               }
             />
           )}

--- a/components/brave_wallet_ui/components/desktop/views/portfolio/portfolio-overview.tsx
+++ b/components/brave_wallet_ui/components/desktop/views/portfolio/portfolio-overview.tsx
@@ -308,7 +308,7 @@ export const PortfolioOverview = () => {
       return Amount.empty()
     }
 
-    if (isLoadingSpotPrices) {
+    if (isLoadingSpotPrices || isLoadingBalances) {
       return Amount.empty()
     }
 
@@ -331,7 +331,8 @@ export const PortfolioOverview = () => {
       visibleAssetOptions,
       spotPriceRegistry,
       isLoadingSpotPrices,
-      usersFilteredAccounts.length
+      usersFilteredAccounts.length,
+      isLoadingBalances
     ])
 
   const formattedFullPortfolioFiatBalance = React.useMemo(() => {
@@ -375,8 +376,16 @@ export const PortfolioOverview = () => {
       return ''
     }
 
+    if (
+      !isFetchingPortfolioPriceHistory &&
+      oldestValue.isZero() &&
+      difference.isZero()
+    ) {
+      return '0'
+    }
+
     return `${difference.div(oldestValue).times(100).format(2)}`
-  }, [change])
+  }, [change, isFetchingPortfolioPriceHistory])
 
   const fiatValueChange = React.useMemo(() => {
     const { difference, oldestValue } = change
@@ -452,10 +461,16 @@ export const PortfolioOverview = () => {
           action={() => onSelectAsset(item.asset)}
           key={getAssetIdKey(item.asset)}
           assetBalance={
-            selectedGroupAssetsByItem ===
-              AccountsGroupByOption.id
-              ? getBalance(account?.accountId, item.asset, tokenBalancesRegistry)
-              : item.assetBalance
+            isLoadingBalances
+              ? ''
+              : selectedGroupAssetsByItem ===
+                AccountsGroupByOption.id
+                ? getBalance(
+                  account?.accountId,
+                  item.asset,
+                  tokenBalancesRegistry
+                )
+                : item.assetBalance
           }
           account={
             selectedGroupAssetsByItem ===
@@ -471,7 +486,11 @@ export const PortfolioOverview = () => {
                 spotPriceRegistry,
                 item.asset
               ).format()
-              : ''
+              : !spotPriceRegistry &&
+                !isLoadingSpotPrices &&
+                !isLoadingBalances
+                ? '0'
+                : ''
           }
         />
       }
@@ -486,7 +505,8 @@ export const PortfolioOverview = () => {
     hidePortfolioBalances,
     spotPriceRegistry,
     isLoadingSpotPrices,
-    tokenBalancesRegistry
+    tokenBalancesRegistry,
+    isLoadingBalances
   ])
 
   // effects

--- a/components/brave_wallet_ui/utils/pricing-utils.ts
+++ b/components/brave_wallet_ui/utils/pricing-utils.ts
@@ -50,6 +50,10 @@ export const computeFiatAmount = ({ spotPriceRegistry, value, token }: {
     | 'decimals'
   >
 }): Amount => {
+  if (!spotPriceRegistry && value === '0') {
+    return Amount.zero()
+  }
+
   if (!spotPriceRegistry || !value) {
     return Amount.empty()
   }


### PR DESCRIPTION
## Description 
Fixes a bug where the `Portfolio` and `Account` screens would never finish loading for `New` wallets.

<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves <https://github.com/brave/brave-browser/issues/32135>

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-arm64, CI/skip-linux-x64, CI/skip-android, CI/skip-macos, CI/skip-ios, CI/skip-windows-arm64, CI/skip-windows-x64, CI/skip-windows-x86 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

   1. Create a brand new `Wallet`
   2. Go to the `Portfolio` page, the balances should finish loading
   3. Go to the `Accounts` page, the balances should finish loading
   4. Go to an `Accounts` details page, the balances should finish loading

Before:

https://github.com/brave/brave-browser/assets/40611140/190e83b6-b2cc-4eae-adc8-a526c1e8ae0f

After:

https://github.com/brave/brave-core/assets/40611140/bc20f2fe-ffa3-48b5-8457-5ec8b386930e
