### PR TITLE
Fix permission bubble Allow/Block action after lifetime option change. (uplift to 1.57.x)

### DIFF
--- a/chromium_src/ui/views/input_event_activation_protector.cc
+++ b/chromium_src/ui/views/input_event_activation_protector.cc
@@ -1,0 +1,29 @@
+/* Copyright (c) 2023 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "ui/views/input_event_activation_protector.h"
+
+#define OnWindowStationaryStateChanged(...) \
+  OnWindowStationaryStateChanged_ChromiumImpl(__VA_ARGS__)
+
+#include "src/ui/views/input_event_activation_protector.cc"
+
+#undef OnWindowStationaryStateChanged
+
+namespace views {
+
+void InputEventActivationProtector::IgnoreNextWindowStationaryStateChanged() {
+  ignore_next_window_stationary_state_changed_ = true;
+}
+
+void InputEventActivationProtector::OnWindowStationaryStateChanged() {
+  if (ignore_next_window_stationary_state_changed_) {
+    ignore_next_window_stationary_state_changed_ = false;
+    return;
+  }
+  OnWindowStationaryStateChanged_ChromiumImpl();
+}
+
+}  // namespace views

--- a/chromium_src/ui/views/input_event_activation_protector.h
+++ b/chromium_src/ui/views/input_event_activation_protector.h
@@ -1,0 +1,25 @@
+/* Copyright (c) 2023 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_CHROMIUM_SRC_UI_VIEWS_INPUT_EVENT_ACTIVATION_PROTECTOR_H_
+#define BRAVE_CHROMIUM_SRC_UI_VIEWS_INPUT_EVENT_ACTIVATION_PROTECTOR_H_
+
+#include "ui/views/windows_stationarity_monitor.h"
+
+#define OnWindowStationaryStateChanged(...)                  \
+  OnWindowStationaryStateChanged_ChromiumImpl(__VA_ARGS__);  \
+  void IgnoreNextWindowStationaryStateChanged();             \
+                                                             \
+ private:                                                    \
+  bool ignore_next_window_stationary_state_changed_ = false; \
+                                                             \
+ public:                                                     \
+  void OnWindowStationaryStateChanged(__VA_ARGS__)
+
+#include "src/ui/views/input_event_activation_protector.h"  // IWYU pragma: export
+
+#undef OnWindowStationaryStateChanged
+
+#endif  // BRAVE_CHROMIUM_SRC_UI_VIEWS_INPUT_EVENT_ACTIVATION_PROTECTOR_H_

--- a/chromium_src/ui/views/window/dialog_client_view.cc
+++ b/chromium_src/ui/views/window/dialog_client_view.cc
@@ -21,4 +21,9 @@ void DialogClientView::SetupButtonsLayoutVertically() {
       kVerticalButtonsSpacing));
 }
 
+void DialogClientView::IgnoreNextWindowStationaryStateChanged() {
+  DCHECK(input_protector_);
+  input_protector_->IgnoreNextWindowStationaryStateChanged();
+}
+
 }  // namespace views

--- a/chromium_src/ui/views/window/dialog_client_view.h
+++ b/chromium_src/ui/views/window/dialog_client_view.h
@@ -8,10 +8,15 @@
 
 class WebDiscoveryDialogClientView;
 
-#define SetupLayout                            \
-  SetupLayout_UnUsed() {}                      \
-  friend class ::WebDiscoveryDialogClientView; \
-  void SetupButtonsLayoutVertically();         \
+#define SetupLayout                              \
+  SetupLayout_UnUsed() {}                        \
+  friend class ::WebDiscoveryDialogClientView;   \
+  void SetupButtonsLayoutVertically();           \
+                                                 \
+ public:                                         \
+  void IgnoreNextWindowStationaryStateChanged(); \
+                                                 \
+ private:                                        \
   virtual void SetupLayout
 
 #include "src/ui/views/window/dialog_client_view.h"  // IWYU pragma: export


### PR DESCRIPTION
Uplift of #19694
Resolves https://github.com/brave/brave-browser/issues/32258

Pre-approval checklist: 
- [ ] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.