### PR TITLE
Improve view pager instance recreation and bottom navigation view indicator

### DIFF
--- a/android/java/org/chromium/chrome/browser/crypto_wallet/activities/BraveWalletActivity.java
+++ b/android/java/org/chromium/chrome/browser/crypto_wallet/activities/BraveWalletActivity.java
@@ -81,6 +81,7 @@ public class BraveWalletActivity extends BraveWalletBaseActivity implements OnNe
     private ModalDialogManager mModalDialogManager;
     private CryptoWalletOnboardingPagerAdapter mCryptoWalletOnboardingPagerAdapter;
     private BottomNavigationViewWithIndicator mBottomNavigationView;
+    private ViewPager2 mViewPager;
     private boolean mShowBiometricPrompt;
     private boolean mIsFromDapps;
     private WalletModel mWalletModel;
@@ -200,6 +201,9 @@ public class BraveWalletActivity extends BraveWalletBaseActivity implements OnNe
         mModalDialogManager = new ModalDialogManager(
                 new AppModalPresenter(this), ModalDialogManager.ModalDialogType.APP);
 
+        mViewPager = findViewById(R.id.navigation_view_pager);
+        mViewPager.setUserInputEnabled(false);
+
         onInitialLayoutInflationComplete();
     }
 
@@ -216,6 +220,16 @@ public class BraveWalletActivity extends BraveWalletBaseActivity implements OnNe
                     setCryptoLayout();
                 }
             });
+        }
+    }
+
+    @Override
+    public void onStartWithNative() {
+        super.onStartWithNative();
+        if (mCryptoFragmentPageAdapter == null) {
+            mCryptoFragmentPageAdapter = new CryptoFragmentPageAdapter(this);
+            mViewPager.setAdapter(mCryptoFragmentPageAdapter);
+            mViewPager.setOffscreenPageLimit(mCryptoFragmentPageAdapter.getItemCount() - 1);
         }
     }
 
@@ -323,12 +337,6 @@ public class BraveWalletActivity extends BraveWalletBaseActivity implements OnNe
 
         mCryptoOnboardingLayout.setVisibility(View.GONE);
         mCryptoLayout.setVisibility(View.VISIBLE);
-
-        ViewPager2 viewPager = findViewById(R.id.navigation_view_pager);
-        viewPager.setUserInputEnabled(false);
-        mCryptoFragmentPageAdapter = new CryptoFragmentPageAdapter(this);
-        viewPager.setAdapter(mCryptoFragmentPageAdapter);
-        viewPager.setOffscreenPageLimit(mCryptoFragmentPageAdapter.getItemCount() - 1);
 
         mBottomNavigationView.setOnItemSelectedListener(menuItem -> {
             final int menuItemId = menuItem.getItemId();

--- a/android/java/org/chromium/chrome/browser/crypto_wallet/activities/BraveWalletActivity.java
+++ b/android/java/org/chromium/chrome/browser/crypto_wallet/activities/BraveWalletActivity.java
@@ -217,7 +217,7 @@ public class BraveWalletActivity extends BraveWalletBaseActivity implements OnNe
                 if (isLocked) {
                     setNavigationFragments(UNLOCK_WALLET_ACTION);
                 } else {
-                    setCryptoLayout();
+                    showMainLayout();
                 }
             });
         }
@@ -332,7 +332,7 @@ public class BraveWalletActivity extends BraveWalletBaseActivity implements OnNe
         }
     }
 
-    private void setCryptoLayout() {
+    private void showMainLayout() {
         addRemoveSecureFlag(false);
 
         mCryptoOnboardingLayout.setVisibility(View.GONE);
@@ -341,15 +341,15 @@ public class BraveWalletActivity extends BraveWalletBaseActivity implements OnNe
         mBottomNavigationView.setOnItemSelectedListener(menuItem -> {
             final int menuItemId = menuItem.getItemId();
             if (menuItemId == R.id.action_wallet_portfolio) {
-                viewPager.setCurrentItem(PORTFOLIO_FRAGMENT_POSITION, true);
+                mViewPager.setCurrentItem(PORTFOLIO_FRAGMENT_POSITION, true);
             } else if (menuItemId == R.id.action_wallet_nfts) {
-                viewPager.setCurrentItem(NFT_GRID_FRAGMENT_POSITION, true);
+                mViewPager.setCurrentItem(NFT_GRID_FRAGMENT_POSITION, true);
             } else if (menuItemId == R.id.action_wallet_activity) {
-                viewPager.setCurrentItem(TRANSACTIONS_ACTIVITY_FRAGMENT_POSITION, true);
+                mViewPager.setCurrentItem(TRANSACTIONS_ACTIVITY_FRAGMENT_POSITION, true);
             } else if (menuItemId == R.id.action_wallet_accounts) {
-                viewPager.setCurrentItem(ACCOUNTS_FRAGMENT_POSITION, true);
+                mViewPager.setCurrentItem(ACCOUNTS_FRAGMENT_POSITION, true);
             } else if (menuItemId == R.id.action_wallet_explore) {
-                viewPager.setCurrentItem(MARKET_FRAGMENT_POSITION, true);
+                mViewPager.setCurrentItem(MARKET_FRAGMENT_POSITION, true);
             }
             return true;
         });
@@ -384,7 +384,7 @@ public class BraveWalletActivity extends BraveWalletBaseActivity implements OnNe
                         verifyRecoveryPhraseFragment));
     }
 
-    public void backupBannerOnClick() {
+    public void showOnboardingLayout() {
         addRemoveSecureFlag(true);
         mCryptoOnboardingLayout.setVisibility(View.VISIBLE);
         mCryptoLayout.setVisibility(View.GONE);
@@ -401,9 +401,9 @@ public class BraveWalletActivity extends BraveWalletBaseActivity implements OnNe
     }
 
     private void showWalletBackupBanner() {
-        final ViewGroup backupTopBannerLayout = (ViewGroup) findViewById(R.id.wallet_backup_banner);
+        final ViewGroup backupTopBannerLayout = findViewById(R.id.wallet_backup_banner);
         backupTopBannerLayout.setVisibility(View.VISIBLE);
-        backupTopBannerLayout.setOnClickListener(view -> backupBannerOnClick());
+        backupTopBannerLayout.setOnClickListener(view -> showOnboardingLayout());
         ImageView bannerClose = backupTopBannerLayout.findViewById(R.id.backup_banner_close);
         bannerClose.setOnClickListener(view -> backupTopBannerLayout.setVisibility(View.GONE));
     }
@@ -435,11 +435,11 @@ public class BraveWalletActivity extends BraveWalletBaseActivity implements OnNe
                     BraveActivity activity = BraveActivity.getBraveActivity();
                     activity.showWalletPanel(true);
                 } catch (BraveActivity.BraveActivityNotFoundException e) {
-                    Log.e(TAG, "gotoNextPage " + e);
+                    Log.e(TAG, "gotoNextPage", e);
                 }
                 return;
             }
-            setCryptoLayout();
+            showMainLayout();
         } else {
             if (mCryptoWalletOnboardingViewPager != null) {
                 mCryptoWalletOnboardingViewPager.setCurrentItem(

--- a/android/java/org/chromium/chrome/browser/crypto_wallet/adapters/CryptoFragmentPageAdapter.java
+++ b/android/java/org/chromium/chrome/browser/crypto_wallet/adapters/CryptoFragmentPageAdapter.java
@@ -41,7 +41,7 @@ public class CryptoFragmentPageAdapter extends FragmentStateAdapter {
     public CryptoFragmentPageAdapter(@NonNull final FragmentActivity activity) {
         super(activity);
         Resources resources = activity.getResources();
-        mTitles = new ArrayList<>(Arrays.asList(resources.getString(R.string.portfolio),
+        mTitles = new ArrayList<String>(Arrays.asList(resources.getString(R.string.portfolio),
                 resources.getString(R.string.brave_wallet_nfts),
                 resources.getString(R.string.brave_wallet_activity),
                 resources.getString(R.string.accounts), resources.getString(R.string.explore)));

--- a/android/java/org/chromium/chrome/browser/crypto_wallet/fragments/AccountsFragment.java
+++ b/android/java/org/chromium/chrome/browser/crypto_wallet/fragments/AccountsFragment.java
@@ -86,7 +86,7 @@ public class AccountsFragment extends Fragment implements OnWalletListItemClick 
 
         TextView backupBtn = view.findViewById(R.id.accounts_backup);
         backupBtn.setOnClickListener(
-                v -> { ((BraveWalletActivity) getActivity()).backupBannerOnClick(); });
+                v -> { ((BraveWalletActivity) getActivity()).showOnboardingLayout(); });
 
         AppCompatImageView settingsBtn = view.findViewById(R.id.accounts_settings);
         settingsBtn.setOnClickListener(v -> {

--- a/android/java/org/chromium/chrome/browser/custom_layout/BottomNavigationViewWithIndicator.java
+++ b/android/java/org/chromium/chrome/browser/custom_layout/BottomNavigationViewWithIndicator.java
@@ -123,7 +123,7 @@ public class BottomNavigationViewWithIndicator
     @Override
     protected void dispatchDraw(Canvas canvas) {
         super.dispatchDraw(canvas);
-        if (isLaidOut()) {
+        if (isAttachedToWindow()) {
             mIndicator.roundOut(mBounds);
             mShape.setBounds(mBounds);
             mShape.draw(canvas);
@@ -131,7 +131,7 @@ public class BottomNavigationViewWithIndicator
     }
 
     private void onItemSelected(int itemId, boolean animate) {
-        if (!isLaidOut()) return;
+        if (!isAttachedToWindow()) return;
 
         // Interrupt any current animation, but don't set the end values,
         // if it's in the middle of a movement we want it to start from


### PR DESCRIPTION
## Resolves https://github.com/brave/brave-browser/issues/32256

Improve view pager creation, saving device memory and offering a faster experience without the black screen when an onboarding fragment is dismissed.


<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-arm64, CI/skip-linux-x64, CI/skip-android, CI/skip-macos, CI/skip-ios, CI/skip-windows-arm64, CI/skip-windows-x64, CI/skip-windows-x86 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [X] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
* Navigate to Brave Wallet
* Tap on the banner "Back up your crypto wallet"
* Tap Skip
* Observe the Portfolio section is shown immediately, no loading times, no black screen and no flickering
* Tap on Accounts section
* Tap again on the banner "Back up your crypto wallet"
* Tap Skip
* Observe the Accounts (and not Portfolio) section is shown immediately, no loading times, no black screen and no flickering
