### PR TITLE
 Keep player alive while navigating playlist pages

### DIFF
--- a/components/playlist/browser/resources/components/app.v1.tsx
+++ b/components/playlist/browser/resources/components/app.v1.tsx
@@ -10,7 +10,13 @@ import styled from 'styled-components'
 // Components
 import Header from './header'
 import PlaylistsCatalog from './playlistsCatalog'
-import PlaylistPlayer from './playlistPlayer'
+import PlaylistFolder from './playlistFolder'
+import VideoFrame from './videoFrame'
+import {
+  PlaylistEditMode,
+  useLastPlayerState,
+  usePlaylistEditMode
+} from '../reducers/states'
 
 const HeaderWrapper = styled.header<{ isPlaylistPlayerPage: boolean }>`
   position: sticky;
@@ -22,6 +28,9 @@ const HeaderWrapper = styled.header<{ isPlaylistPlayerPage: boolean }>`
 `
 
 export default function App () {
+  const lastPlayerState = useLastPlayerState()
+  const editMode = usePlaylistEditMode()
+
   return (
     <>
       <Route
@@ -29,15 +38,24 @@ export default function App () {
         children={({ match }) => {
           const playlistId = match?.params.playlistId
           return (
-            <HeaderWrapper isPlaylistPlayerPage={!!playlistId}>
-              <Header playlistId={playlistId} />
-            </HeaderWrapper>
+            <>
+              <HeaderWrapper isPlaylistPlayerPage={!!playlistId}>
+                <Header playlistId={playlistId} />
+              </HeaderWrapper>
+              <VideoFrame
+                visible={
+                  !!lastPlayerState?.currentItem &&
+                  editMode !== PlaylistEditMode.BULK_EDIT
+                }
+                isMiniPlayer={lastPlayerState?.currentList?.id !== playlistId}
+              />
+            </>
           )
         }}
       />
       <section>
         <Switch>
-          <Route path='/playlist/:playlistId' component={PlaylistPlayer} />
+          <Route path='/playlist/:playlistId' component={PlaylistFolder} />
           <Route path='/' component={PlaylistsCatalog}></Route>
         </Switch>
       </section>

--- a/components/playlist/browser/resources/components/player.tsx
+++ b/components/playlist/browser/resources/components/player.tsx
@@ -17,28 +17,41 @@ import { getAllActions } from '../api/getAllActions'
 import PlayerControls from './playerControls'
 import { color, font } from '@brave/leo/tokens/css'
 import PlayerSeeker from './playerSeeker'
+import { playlistControlsAreaHeight } from '../constants/style'
 
 const StyledVideo = styled.video`
   width: 100vw;
   aspect-ratio: 16 / 9;
+  margin-bottom: 8px;
 `
 
 const PlayerContainer = styled.div`
+  width: 100vw;
+  height: 100vh;
   display: flex;
-  flex-direction: column;
+  flex-direction: column-reverse;
+  overflow: hidden;
   user-select: none; // In order to drag-and-drop on the seeker works well.
 `
 
 const ControlsContainer = styled.div`
+  ${playlistControlsAreaHeight}
+  height: var(--player-controls-area-height);
+
   display: flex;
   flex-direction: column;
-  padding: 24px 16px;
+  padding: 0px repeat(3, 16px);
   gap: 8px;
+  flex-shrink: 0;
+  justify-content: center;
 `
 
-const StyledTitle = styled.span`
+const StyledTitle = styled.div`
   color: ${color.text.primary};
-  font: ${font.primary.xSmall.regular};
+  font: ${font.primary.large.semibold};
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 `
 
 const StyledPlayerControls = styled(PlayerControls)`
@@ -79,6 +92,11 @@ export default function Player () {
 
   return (
     <PlayerContainer>
+      <ControlsContainer>
+        <StyledTitle>{currentItem?.name}</StyledTitle>
+        <PlayerSeeker videoElement={videoElement} />
+        <StyledPlayerControls videoElement={videoElement} />
+      </ControlsContainer>
       <StyledVideo
         ref={setVideoElement}
         autoPlay
@@ -94,11 +112,6 @@ export default function Player () {
             : currentItem?.mediaPath.url
         }
       />
-      <ControlsContainer>
-        <StyledTitle>{currentItem?.name}</StyledTitle>
-        <PlayerSeeker videoElement={videoElement} />
-        <StyledPlayerControls videoElement={videoElement} />
-      </ControlsContainer>
     </PlayerContainer>
   )
 }

--- a/components/playlist/browser/resources/components/playlistFolder.tsx
+++ b/components/playlist/browser/resources/components/playlistFolder.tsx
@@ -4,19 +4,16 @@
 // You can obtain one at https://mozilla.org/MPL/2.0/.
 
 import * as React from 'react'
-import { useSelector } from 'react-redux'
 import { RouteComponentProps, Redirect } from 'react-router-dom'
 import styled from 'styled-components'
 
 import { color } from '@brave/leo/tokens/css'
 import LeoButton from '@brave/leo/react/button'
 
-import VideoFrame from './videoFrame'
 import PlaylistItem from './playlistItem'
 import {
-  ApplicationState,
-  PlayerState,
   PlaylistEditMode,
+  useLastPlayerState,
   usePlaylist,
   usePlaylistEditMode
 } from '../reducers/states'
@@ -98,25 +95,22 @@ function EditActionsContainer ({
   )
 }
 
-export default function PlaylistPlayer ({
+export default function PlaylistFolder ({
   match
 }: RouteComponentProps<MatchParams>) {
   const playlist = usePlaylist(match.params.playlistId)
-  const lastPlayerState = useSelector<
-    ApplicationState,
-    PlayerState | undefined
-  >(applicationState => applicationState.playlistData?.lastPlayerState)
+  const lastPlayerState = useLastPlayerState()
 
   React.useEffect(() => {
     // When playlist updated and player is working, notify that the current
     // list has changed.
-    if (playlist && lastPlayerState) {
+    if (playlist && playlist?.id === lastPlayerState?.currentList?.id) {
       postMessageToPlayer({
         actionType: types.SELECTED_PLAYLIST_UPDATED,
         currentList: playlist
       })
     }
-  }, [playlist])
+  }, [playlist, lastPlayerState])
 
   const [selectedSet, setSelectedSet] = React.useState(new Set<string>())
   const editMode = usePlaylistEditMode()
@@ -159,7 +153,6 @@ export default function PlaylistPlayer ({
 
   return (
     <>
-      <VideoFrame visible={!!lastPlayerState?.currentItem && !editMode} />
       {editMode === PlaylistEditMode.BULK_EDIT && (
         <EditActionsContainer
           playlistId={playlist.id!}

--- a/components/playlist/browser/resources/components/videoFrame.tsx
+++ b/components/playlist/browser/resources/components/videoFrame.tsx
@@ -6,15 +6,35 @@
 import * as React from 'react'
 import styled, { css } from 'styled-components'
 
+import { color } from '@brave/leo/tokens/css'
+
+import { playlistControlsAreaHeight } from '../constants/style'
+
 interface Props {
   visible: boolean
+  isMiniPlayer: boolean
 }
 
 const StyledVideoFrame = styled.iframe<Props>`
+  ${playlistControlsAreaHeight}
+
   width: 100vw;
-  // 16:9 aspect ratio for video and fixed height for the controls area
-  height: calc(56vw + 160px);
   border: none;
+  ${p =>
+    p.isMiniPlayer
+      ? css`
+          position: fixed;
+          bottom: 0;
+          height: var(--player-controls-area-height);
+          z-index: 1;
+          border-top: 1px solid ${color.divider.subtle};
+        `
+      : css`
+          // 16:9 aspect ratio for video and fixed height for the controls area
+          height: calc(56vw + var(--player-controls-area-height));
+          margin-bottom: 8px;
+        `}
+
   ${({ visible }) =>
     !visible &&
     css`
@@ -22,7 +42,7 @@ const StyledVideoFrame = styled.iframe<Props>`
     `}
 `
 
-export default function VideoFrame ({ visible }: Props) {
+export default function VideoFrame (props: Props) {
   return (
     <StyledVideoFrame
       id='player'
@@ -34,7 +54,7 @@ export default function VideoFrame ({ visible }: Props) {
       allow='autoplay; fullscreen;'
       scrolling='no'
       sandbox='allow-scripts allow-same-origin'
-      visible={visible}
+      {...props}
     />
   )
 }

--- a/components/playlist/browser/resources/constants/style.ts
+++ b/components/playlist/browser/resources/constants/style.ts
@@ -1,0 +1,10 @@
+// Copyright (c) 2023 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import { css } from 'styled-components'
+
+export const playlistControlsAreaHeight = css`
+  --player-controls-area-height: 148px;
+`

--- a/components/playlist/browser/resources/reducers/states.ts
+++ b/components/playlist/browser/resources/reducers/states.ts
@@ -80,3 +80,9 @@ export function usePlaylistEditMode () {
     applicationState => applicationState.playlistData?.playlistEditMode
   )
 }
+
+export function useLastPlayerState () {
+  return useSelector<ApplicationState, PlayerState | undefined>(
+    applicationState => applicationState.playlistData?.lastPlayerState
+  )
+}

--- a/components/playlist/browser/resources/video_frame_contents.html
+++ b/components/playlist/browser/resources/video_frame_contents.html
@@ -8,6 +8,7 @@
 <head>
 <meta charset="utf-8">
 <title>Brave Playlist Player</title>
+<link rel="stylesheet" href="chrome-untrusted://resources/brave/fonts/poppins.css">
 <script src="/videoFrameContents.bundle.js"></script>
 </head>
 <style>


### PR DESCRIPTION
Previously, we rendered playlist player only when
user is in the playlist folder page.

This PR extract video frame to top-most component,
and keep video player alive, so that users can enjoy
the video and browse playlist at the same time.


https://github.com/brave/brave-core/assets/5474642/b9c01e0f-9cb3-495a-9f29-1ed31550c9d4


<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/32331

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-arm64, CI/skip-linux-x64, CI/skip-android, CI/skip-macos, CI/skip-ios, CI/skip-windows-arm64, CI/skip-windows-x64, CI/skip-windows-x86 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [ ] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

