### PR TITLE
Enable Wireguard vpn service by default

### DIFF
--- a/browser/ui/webui/settings/brave_vpn/brave_vpn_handler.cc
+++ b/browser/ui/webui/settings/brave_vpn/brave_vpn_handler.cc
@@ -16,10 +16,10 @@
 #include "brave/components/brave_vpn/browser/brave_vpn_service.h"
 #include "brave/components/brave_vpn/common/brave_vpn_utils.h"
 #include "brave/components/brave_vpn/common/pref_names.h"
-#include "brave/components/brave_vpn/common/win/utils.h"
 #include "brave/components/brave_vpn/common/wireguard/win/service_constants.h"
 #include "brave/components/brave_vpn/common/wireguard/win/service_details.h"
 #include "brave/components/brave_vpn/common/wireguard/win/storage_utils.h"
+#include "brave/components/brave_vpn/common/wireguard/win/wireguard_utils.h"
 #include "chrome/browser/browser_process.h"
 #include "components/prefs/pref_service.h"
 #include "components/version_info/version_info.h"
@@ -95,10 +95,9 @@ void BraveVpnHandler::HandleIsWireguardServiceRegistered(
     const base::Value::List& args) {
   AllowJavascript();
 
-  auto status = brave_vpn::GetWindowsServiceStatus(
-      brave_vpn::GetBraveVpnWireguardServiceName());
-
-  ResolveJavascriptCallback(args[0], base::Value(status.has_value()));
+  ResolveJavascriptCallback(
+      args[0],
+      base::Value(brave_vpn::wireguard::IsWireguardServiceRegistered()));
 }
 
 void BraveVpnHandler::HandleIsBraveVpnConnected(const base::Value::List& args) {

--- a/components/brave_vpn/common/BUILD.gn
+++ b/components/brave_vpn/common/BUILD.gn
@@ -28,6 +28,9 @@ source_set("common") {
     "//components/version_info",
     "//net",
   ]
+  if (is_win) {
+    deps += [ "//brave/components/brave_vpn/common/wireguard/win" ]
+  }
 }
 
 source_set("unit_tests") {

--- a/components/brave_vpn/common/brave_vpn_utils.cc
+++ b/components/brave_vpn/common/brave_vpn_utils.cc
@@ -24,6 +24,10 @@
 #include "components/prefs/pref_service.h"
 #include "components/version_info/channel.h"
 
+#if BUILDFLAG(IS_WIN)
+#include "brave/components/brave_vpn/common/wireguard/win/wireguard_utils.h"
+#endif
+
 namespace brave_vpn {
 
 namespace {
@@ -61,7 +65,9 @@ void MigrateWireguardFeatureFlag(PrefService* local_prefs) {
   auto* wireguard_enabled_pref =
       local_prefs->FindPreference(prefs::kBraveVPNWireguardEnabled);
   if (wireguard_enabled_pref && wireguard_enabled_pref->IsDefaultValue()) {
-    local_prefs->SetBoolean(prefs::kBraveVPNWireguardEnabled, true);
+    local_prefs->SetBoolean(
+        prefs::kBraveVPNWireguardEnabled,
+        brave_vpn::wireguard::IsWireguardServiceRegistered());
   }
 }
 #endif

--- a/components/brave_vpn/common/features.cc
+++ b/components/brave_vpn/common/features.cc
@@ -31,7 +31,7 @@ BASE_FEATURE(kBraveVPNDnsProtection,
              base::FEATURE_ENABLED_BY_DEFAULT);
 BASE_FEATURE(kBraveVPNUseWireguardService,
              "BraveVPNUseWireguardService",
-             base::FEATURE_DISABLED_BY_DEFAULT);
+             base::FEATURE_ENABLED_BY_DEFAULT);
 #endif
 }  // namespace features
 

--- a/components/brave_vpn/common/wireguard/win/wireguard_utils.cc
+++ b/components/brave_vpn/common/wireguard/win/wireguard_utils.cc
@@ -43,6 +43,12 @@ constexpr char kWireguardConfigTemplate[] = R"(
 
 namespace wireguard {
 
+bool IsWireguardServiceRegistered() {
+  return brave_vpn::GetWindowsServiceStatus(
+             brave_vpn::GetBraveVpnWireguardServiceName())
+      .has_value();
+}
+
 bool IsBraveVPNWireguardTunnelServiceRunning() {
   auto status =
       GetWindowsServiceStatus(GetBraveVpnWireguardTunnelServiceName());

--- a/components/brave_vpn/common/wireguard/win/wireguard_utils.h
+++ b/components/brave_vpn/common/wireguard/win/wireguard_utils.h
@@ -17,7 +17,7 @@ namespace brave_vpn {
 namespace wireguard {
 
 bool IsBraveVPNWireguardTunnelServiceRunning();
-
+bool IsWireguardServiceRegistered();
 void WireguardGenerateKeypair(WireguardGenerateKeypairCallback callback);
 absl::optional<std::string> CreateWireguardConfig(
     const std::string& client_private_key,


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/32280

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-arm64, CI/skip-linux-x64, CI/skip-android, CI/skip-macos, CI/skip-ios, CI/skip-windows-arm64, CI/skip-windows-x64, CI/skip-windows-x86 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [x] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [x] New files have MPL-2.0 license header
- [x] Adequate test coverage exists to prevent regressions
- [x] Major classes, functions and non-trivial code blocks are well-commented
- [x] Changes in component dependencies are properly reflected in `gn`
- [x] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [x] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
1)
- Clean install
- Buy VPN
- Connect
- WireGuard VPN should be connected and enabled in brave://settings/system

2)
- Install previous version of browser
- Set the WireGuard experiment explicitly to false
- Update to current version
- IKEv2 should be used after update
