### PR TITLE
[Android] Fix for crash on capturing bottom toolbar state (uplift to 1.58.x)

### DIFF
--- a/android/java/org/chromium/chrome/browser/toolbar/bottom/BraveScrollingBottomViewResourceFrameLayout.java
+++ b/android/java/org/chromium/chrome/browser/toolbar/bottom/BraveScrollingBottomViewResourceFrameLayout.java
@@ -152,12 +152,15 @@ public class BraveScrollingBottomViewResourceFrameLayout
         }
     }
 
+    @SuppressLint("VisibleForTests")
     public void triggerBitmapCapture(boolean dropCachedBitmap) {
         synchronized (mCallbackController) {
             if (dropCachedBitmap) {
                 getResourceAdapter().dropCachedBitmap();
             }
-            getResourceAdapter().triggerBitmapCapture();
+            if (!getResourceAdapter().getDirtyRect().isEmpty()) {
+                getResourceAdapter().triggerBitmapCapture();
+            }
         }
     }
 }


### PR DESCRIPTION
Uplift of #19742
Resolves https://github.com/brave/brave-browser/issues/32334

Pre-approval checklist: 
- [ ] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.