### PR TITLE
feat(wallet): Enable Panel V2 by Default

### DIFF
--- a/browser/ui/webui/brave_wallet/wallet_panel_ui_browsertest.cc
+++ b/browser/ui/webui/brave_wallet/wallet_panel_ui_browsertest.cc
@@ -75,6 +75,10 @@ std::string NeonEVMNetworkChainName() {
   return NeonEVMNetwork() + " .chainName";
 }
 
+std::string DAppSettingsButton() {
+  return R"([data-test-id='dapp-settings-button'])";
+}
+
 std::string NetworksButton() {
   return R"([data-test-id='select-network-button'])";
 }
@@ -108,11 +112,16 @@ bool WaitFor(content::WebContents* web_contents, const std::string& selector) {
 
 bool WaitAndClickElement(content::WebContents* web_contents,
                          const std::string& selector) {
-  if (!WaitFor(web_contents, selector)) {
-    return false;
+  for (int i = 0; i < 10; ++i) {
+    if (!WaitFor(web_contents, selector)) {
+      return false;
+    }
+    auto result = EvalJs(web_contents, selector + ".click()");
+    if (result.value.is_none() && result.error.empty()) {
+      return true;
+    }
   }
-
-  return EvalJs(web_contents, selector + ".click()").value.is_none();
+  return false;
 }
 
 }  // namespace
@@ -248,6 +257,9 @@ IN_PROC_BROWSER_TEST_F(WalletPanelUIBrowserTest, InitialUIRendered) {
 #endif
 IN_PROC_BROWSER_TEST_F(WalletPanelUIBrowserTest, MAYBE_HideNetworkInSettings) {
   ActivateWalletTab();
+  // Wait and click on DApp settings button.
+  ASSERT_TRUE(
+      WaitAndClickElement(wallet(), QuerySelectorJS(DAppSettingsButton())));
   // Wait and click on select network button.
   ASSERT_TRUE(WaitAndClickElement(wallet(), QuerySelectorJS(NetworksButton())));
 
@@ -266,6 +278,9 @@ IN_PROC_BROWSER_TEST_F(WalletPanelUIBrowserTest, MAYBE_HideNetworkInSettings) {
 
   ActivateWalletTab();
   wallet()->GetController().Reload(content::ReloadType::NORMAL, true);
+  // Wait and click on DApp settings button.
+  ASSERT_TRUE(
+      WaitAndClickElement(wallet(), QuerySelectorJS(DAppSettingsButton())));
   // Wait and click on select network button.
   ASSERT_TRUE(WaitAndClickElement(wallet(), QuerySelectorJS(NetworksButton())));
 
@@ -281,6 +296,9 @@ IN_PROC_BROWSER_TEST_F(WalletPanelUIBrowserTest, CustomNetworkInSettings) {
   CreateSettingsTab();
 
   ActivateWalletTab();
+  // Wait and click on DApp settings button.
+  ASSERT_TRUE(
+      WaitAndClickElement(wallet(), QuerySelectorJS(DAppSettingsButton())));
   // Wait and click on select network button.
   ASSERT_TRUE(WaitAndClickElement(wallet(), QuerySelectorJS(NetworksButton())));
 

--- a/components/brave_wallet/common/features.cc
+++ b/components/brave_wallet/common/features.cc
@@ -54,7 +54,7 @@ BASE_FEATURE(kBraveWalletNftPinningFeature,
 
 BASE_FEATURE(kBraveWalletPanelV2Feature,
              "BraveWalletPanelV2",
-             base::FEATURE_DISABLED_BY_DEFAULT);
+             base::FEATURE_ENABLED_BY_DEFAULT);
 
 BASE_FEATURE(kBraveWalletBitcoinFeature,
              "BraveWalletBitcoin",

--- a/components/brave_wallet_ui/components/extension/dapp-connection-settings/change-network-button.tsx
+++ b/components/brave_wallet_ui/components/extension/dapp-connection-settings/change-network-button.tsx
@@ -26,7 +26,7 @@ import {
 // Styled Components
 import {
   NetworkButton,
-  NameText,
+  NetworkName,
   ActiveIndicator
 } from './dapp-connection-settings.style'
 import {
@@ -55,6 +55,7 @@ export const ChangeNetworkButton = (props: Props) => {
   return (
     <NetworkButton
       onClick={onClick}
+      data-test-chain-id={'chain-' + network.chainId}
     >
       <Row
         width='unset'
@@ -64,12 +65,9 @@ export const ChangeNetworkButton = (props: Props) => {
           marginRight={8}
           size='big'
         />
-        <NameText
-          textSize='14px'
-          isBold={false}
-        >
+        <NetworkName>
           {network.chainName}
-        </NameText>
+        </NetworkName>
       </Row>
       {selectedNetwork?.chainId === network.chainId &&
         <ActiveIndicator>

--- a/components/brave_wallet_ui/components/extension/dapp-connection-settings/dapp-connection-main.tsx
+++ b/components/brave_wallet_ui/components/extension/dapp-connection-settings/dapp-connection-main.tsx
@@ -287,6 +287,7 @@ export const DAppConnectionMain = (props: Props) => {
       <VerticalSpace space='8px' />
       <SectionButton
         onClick={() => onSelectOption('networks')}
+        data-test-id='select-network-button'
       >
         <Row
           width='unset'

--- a/components/brave_wallet_ui/components/extension/dapp-connection-settings/dapp-connection-settings.style.ts
+++ b/components/brave_wallet_ui/components/extension/dapp-connection-settings/dapp-connection-settings.style.ts
@@ -22,6 +22,7 @@ export const SettingsButton = styled(WalletButton)`
   margin-right: 16px;
   background-color: transparent;
   position: relative;
+  z-index: 10;
 `
 
 export const ConnectedIcon = styled(Icon) <{
@@ -45,6 +46,16 @@ export const ConnectedText = styled(Text) <{
       : leo.color.icon.default
   };
   line-height: 24px;
+`
+
+export const OverlapForClick = styled.div`
+  display: flex;
+  position: fixed;
+  top: 0px;
+  left: 0px;
+  right: 0px;
+  bottom: 0px;
+  z-index: 11;
 `
 
 export const SettingsBubbleWrapper = styled.div`
@@ -150,6 +161,18 @@ export const NameText = styled(Text)`
   line-height: 24px;
   word-break: break-all;
   text-align: left;
+`
+
+export const NetworkName = styled.span`
+  font-family: 'Poppins';
+  color: ${leo.color.text.primary};
+  line-height: 24px;
+  word-wrap: wrap;
+  word-break: break-all;
+  text-align: left;
+  font-size: 14px;
+  font-weight: 400;
+  letter-spacing: 0.02em;
 `
 
 export const DescriptionText = styled(Text)`

--- a/components/brave_wallet_ui/components/extension/dapp-connection-settings/dapp-connection-settings.tsx
+++ b/components/brave_wallet_ui/components/extension/dapp-connection-settings/dapp-connection-settings.tsx
@@ -86,7 +86,8 @@ import {
   PointerShadow,
   BackgroundBlur,
   FavIcon,
-  NetworkIconWrapper
+  NetworkIconWrapper,
+  OverlapForClick
 } from './dapp-connection-settings.style'
 
 export type DAppConnectionOptionsType =
@@ -295,7 +296,8 @@ export const DAppConnectionSettings = () => {
   return (
     <>
       <SettingsButton
-        onMouseDown={() => setShowSettings(prev => !prev)}
+        onClick={() => setShowSettings(prev => !prev)}
+        data-test-id='dapp-settings-button'
       >
         <ConnectedIcon
           name={
@@ -321,6 +323,7 @@ export const DAppConnectionSettings = () => {
       </SettingsButton>
       {showSettings &&
         <>
+          <OverlapForClick />
           <SettingsBubbleWrapper>
             <Pointer />
             <PointerShadow />


### PR DESCRIPTION
## Description 
Enables the `Panel V2` feature by default

<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves <https://github.com/brave/brave-browser/issues/32352>

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-arm64, CI/skip-linux-x64, CI/skip-android, CI/skip-macos, CI/skip-ios, CI/skip-windows-arm64, CI/skip-windows-x64, CI/skip-windows-x86 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
1. Go to brave://flags and make sure that `Enable Panel v2` is `Default (Enabled)`
2. Open the Wallet `Panel`, it should be the new `V2` design

![Screenshot 3](https://github.com/brave/brave-core/assets/40611140/366785d6-faab-41a2-9980-25b21b958033)

![Screenshot 4](https://github.com/brave/brave-core/assets/40611140/49a93024-326f-480b-a2f5-1a58bf2ce665)

