### PR TITLE
Try all Linux password storage backends when detection fails

### DIFF
--- a/chromium_src/components/os_crypt/sync/key_storage_linux.cc
+++ b/chromium_src/components/os_crypt/sync/key_storage_linux.cc
@@ -9,6 +9,28 @@
   const char KeyStorageLinux::kFolderName[] = "Brave Keys"; \
   const char KeyStorageLinux::kKey[] = "Brave Safe Storage";
 
+#define BRAVE_KEY_STORAGE_LINUX_CREATE_SERVICE                          \
+  if (use_backend && config.store.empty() &&                            \
+      selected_backend == os_crypt::SelectedLinuxBackend::BASIC_TEXT) { \
+    VLOG(1) << "Trying to find a working backend manually.";            \
+    for (const auto fallback_backend : {                                \
+             os_crypt::SelectedLinuxBackend::GNOME_LIBSECRET,           \
+             os_crypt::SelectedLinuxBackend::KWALLET6,                  \
+             os_crypt::SelectedLinuxBackend::KWALLET5,                  \
+             os_crypt::SelectedLinuxBackend::KWALLET,                   \
+         }) {                                                           \
+      key_storage = CreateServiceInternal(fallback_backend, config);    \
+      if (key_storage) {                                                \
+        VLOG(1) << "Successfully found a working backend: "             \
+                << SelectedLinuxBackendToString(fallback_backend);      \
+        break;                                                          \
+      }                                                                 \
+    }                                                                   \
+    if (!key_storage) {                                                 \
+      VLOG(1) << "Did not find a working backend.";                     \
+    }                                                                   \
+  }
+
 // clang-format off
 #define BRAVE_KEY_STORAGE_LINUX_CREATE_SERVICE_INTERNAL                       \
   static const base::NoDestructor<std::string> kDefaultApplicationName("brave");
@@ -16,4 +38,5 @@
 
 #include "src/components/os_crypt/sync/key_storage_linux.cc"
 #undef BRAVE_KEY_STORAGE_LINUX_CREATE_SERVICE_INTERNAL
+#undef BRAVE_KEY_STORAGE_LINUX_CREATE_SERVICE
 #undef BRAVE_KEY_STORAGE_LINUX

--- a/patches/components-os_crypt-sync-key_storage_linux.cc.patch
+++ b/patches/components-os_crypt-sync-key_storage_linux.cc.patch
@@ -1,5 +1,5 @@
 diff --git a/components/os_crypt/sync/key_storage_linux.cc b/components/os_crypt/sync/key_storage_linux.cc
-index 1fb350f826902270165123ac0dcac39ef113bfed..3212dc85803324151629d2aec53e9c8d0760b74d 100644
+index 1fb350f826902270165123ac0dcac39ef113bfed..3425a8b6f644b139823467ca25cbf3c6939d0497 100644
 --- a/components/os_crypt/sync/key_storage_linux.cc
 +++ b/components/os_crypt/sync/key_storage_linux.cc
 @@ -29,8 +29,7 @@
@@ -12,7 +12,15 @@ index 1fb350f826902270165123ac0dcac39ef113bfed..3212dc85803324151629d2aec53e9c8d
  #endif
  
  namespace {
-@@ -145,7 +144,7 @@ std::unique_ptr<KeyStorageLinux> KeyStorageLinux::CreateServiceInternal(
+@@ -126,6 +125,7 @@ std::unique_ptr<KeyStorageLinux> KeyStorageLinux::CreateService(
+   std::unique_ptr<KeyStorageLinux> key_storage;
+ #if defined(USE_LIBSECRET) || defined(USE_KWALLET)
+   key_storage = CreateServiceInternal(selected_backend, config);
++  BRAVE_KEY_STORAGE_LINUX_CREATE_SERVICE
+ #endif  // defined(USE_LIBSECRET) || defined(USE_KWALLET)
+ 
+   UMA_HISTOGRAM_ENUMERATION(
+@@ -145,7 +145,7 @@ std::unique_ptr<KeyStorageLinux> KeyStorageLinux::CreateServiceInternal(
  #if BUILDFLAG(GOOGLE_CHROME_BRANDING)
    static const base::NoDestructor<std::string> kDefaultApplicationName("chrome");
  #else


### PR DESCRIPTION
Fixes brave/brave-browser#32314
Security review: https://github.com/brave/reviews/issues/1373

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

Using Brave nightly **without this PR**:

1. Create a new browser profile
2. Use an Ubuntu 22.04 Linux VM and login with the default window manager.
3. Start Brave with `--enable-logging=stderr --vmodule=key_storage_linux=1,key_storage_util_linux=1`.
4. You should see _"OSCrypt using Libsecret as backend."_.
5. Go to https://www.libravatar.org/accounts/new/ and register an account
   called something like `username-gnome` and then save the password in the
   password manager.
6. Open `brave://settings/passwords` to verify that the password is saved.
7. Close the browser.
8. `apt install kwalletmanager`
9. Start Brave with `--password-store=kwallet5`.
10. Open `brave://settings/passwords` and confirm that the password saved
    earlier is not visible.
11. Go to https://www.libravatar.org/accounts/new/ and register an account
    like `username-kwallet5` and then save the password in the password
    manager.
12. Open `brave://settings/passwords` to verify that the password is saved.
13. Close Brave.
14. Start Brave with `--password-store=basic`.
15. Open `brave://settings/passwords` to verify that none of the earlier
    passwords are available.
16. Go to https://www.libravatar.org/accounts/new/ and register an account
    like `username-peanuts` and then save the password in the password
    manager.
17. Open `brave://settings/passwords` to verify that the password is saved.
18. `apt install i3`
19. Logout and log back in using the i3 window manager (click the gear icon
    on the login screen to change this).
20. Open a terminal using `Windows+Enter` or `Alt+Enter`.
21. Start Brave with `--enable-logging=stderr --vmodule=key_storage_linux=1,key_storage_util_linux=1`.
22. You should see _"OSCrypt did not initialize a backend."_.
23. Open `brave://settings/passwords` to verify that only the `-peanuts`
    password is available.

Now, using the version of Brave **from this PR**:

1. Log in using the i3 window manager.
2. Start Brave with `--enable-logging=stderr --vmodule=key_storage_linux=1,key_storage_util_linux=1`.
3. You should see _"OSCrypt using Libsecret as backend."_.
4. Open `brave://settings/passwords` to verify that both the `-peanuts`
   and the `-gnome` passwords are available.
5. Close Brave and logout.
6. Log back in using the default window manager.
7. Start Brave with `--enable-logging=stderr --vmodule=key_storage_linux=1,key_storage_util_linux=1`.
8. You should see _"OSCrypt using Libsecret as backend."_.
9. Open `brave://settings/passwords` to verify that both the `-peanuts`
   and the `-gnome` passwords are available as we saw with the i3 window
   manager.
10. Start Brave with `--password-store=kwallet5`.
11. You should see _"OSCrypt using KWallet as backend."_.
12. Open `brave://settings/passwords` to verify that both the `-peanuts`
    and the `-kde` passwords are available, but not the `-gnome` one.