### PR TITLE
Add rounded corners to navigation bar panels

### DIFF
--- a/browser/ui/BUILD.gn
+++ b/browser/ui/BUILD.gn
@@ -287,6 +287,7 @@ source_set("ui") {
       "views/brave_shields/cookie_list_opt_in_bubble_host.h",
       "views/brave_tab_search_bubble_host.cc",
       "views/brave_tab_search_bubble_host.h",
+      "views/bubble/brave_webui_bubble_manager.h",
       "views/commands/default_accelerators_views.cc",
       "views/crash_report_permission_ask_dialog_view.cc",
       "views/crash_report_permission_ask_dialog_view.h",

--- a/browser/ui/views/brave_actions/brave_shields_action_view.cc
+++ b/browser/ui/views/brave_actions/brave_shields_action_view.cc
@@ -11,6 +11,7 @@
 
 #include "base/memory/weak_ptr.h"
 #include "brave/browser/ui/brave_icon_with_badge_image_source.h"
+#include "brave/browser/ui/views/bubble/brave_webui_bubble_manager.h"
 #include "brave/components/constants/pref_names.h"
 #include "brave/components/constants/url_constants.h"
 #include "brave/components/constants/webui_url_constants.h"
@@ -200,7 +201,7 @@ void BraveShieldsActionView::ButtonPressed() {
 
   if (!webui_bubble_manager_) {
     webui_bubble_manager_ =
-        std::make_unique<WebUIBubbleManagerT<ShieldsPanelUI>>(
+        std::make_unique<BraveWebUIBubbleManager<ShieldsPanelUI>>(
             this, &*profile_, GURL(kShieldsPanelURL), IDS_BRAVE_SHIELDS);
   }
 

--- a/browser/ui/views/brave_layout_provider.cc
+++ b/browser/ui/views/brave_layout_provider.cc
@@ -13,8 +13,9 @@ int BraveLayoutProvider::GetCornerRadiusMetric(views::Emphasis emphasis,
     case views::Emphasis::kNone:
       return 0;
     case views::Emphasis::kLow:
-    case views::Emphasis::kMedium:
       return 2;
+    case views::Emphasis::kMedium:
+      return 8;
     case views::Emphasis::kHigh:
     case views::Emphasis::kMaximum:
       return 4;

--- a/browser/ui/views/bubble/brave_webui_bubble_manager.h
+++ b/browser/ui/views/bubble/brave_webui_bubble_manager.h
@@ -1,0 +1,36 @@
+/* Copyright (c) 2023 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_BROWSER_UI_VIEWS_BUBBLE_BRAVE_WEBUI_BUBBLE_MANAGER_H_
+#define BRAVE_BROWSER_UI_VIEWS_BUBBLE_BRAVE_WEBUI_BUBBLE_MANAGER_H_
+
+#include "chrome/browser/ui/views/bubble/webui_bubble_manager.h"
+
+// A subclass of WebUIBubbleManagerT that allows customization of the bubble
+// border radius and other aspects of the rendered bubble view. Use exactly like
+// WebUIBubbleManagerT, or subclass if a different customization behavior is
+// required.
+template <typename T>
+class BraveWebUIBubbleManager : public WebUIBubbleManagerT<T> {
+ public:
+  using WebUIBubbleManagerT<T>::WebUIBubbleManagerT;
+
+  ~BraveWebUIBubbleManager() override = default;
+
+ protected:
+  // Allows customization of the rendered bubble dialog view.
+  virtual void CustomizeBubbleDialogView(WebUIBubbleDialogView& bubble_view) {}
+
+ private:
+  void BraveCustomizeBubbleDialogView(
+      WebUIBubbleDialogView& bubble_view) override {
+    bubble_view.SetPaintClientToLayer(true);
+    bubble_view.set_use_round_corners(true);
+    bubble_view.set_corner_radius(16);
+    CustomizeBubbleDialogView(bubble_view);
+  }
+};
+
+#endif  // BRAVE_BROWSER_UI_VIEWS_BUBBLE_BRAVE_WEBUI_BUBBLE_MANAGER_H_

--- a/browser/ui/views/toolbar/brave_vpn_panel_controller.cc
+++ b/browser/ui/views/toolbar/brave_vpn_panel_controller.cc
@@ -5,6 +5,7 @@
 
 #include "brave/browser/ui/views/toolbar/brave_vpn_panel_controller.h"
 
+#include "brave/browser/ui/views/bubble/brave_webui_bubble_manager.h"
 #include "brave/browser/ui/views/frame/brave_browser_view.h"
 #include "brave/components/constants/webui_url_constants.h"
 #include "chrome/browser/profiles/profile.h"
@@ -26,8 +27,9 @@ void BraveVPNPanelController::ShowBraveVPNPanel() {
 
   if (!webui_bubble_manager_) {
     auto* profile = browser_view_->browser()->profile();
-    webui_bubble_manager_ = std::make_unique<WebUIBubbleManagerT<VPNPanelUI>>(
-        anchor_view, profile, GURL(kVPNPanelURL), IDS_BRAVE_VPN_PANEL_NAME);
+    webui_bubble_manager_ =
+        std::make_unique<BraveWebUIBubbleManager<VPNPanelUI>>(
+            anchor_view, profile, GURL(kVPNPanelURL), IDS_BRAVE_VPN_PANEL_NAME);
   }
 
   if (webui_bubble_manager_->GetBubbleWidget()) {

--- a/browser/ui/wallet_bubble_manager_delegate_impl.h
+++ b/browser/ui/wallet_bubble_manager_delegate_impl.h
@@ -17,8 +17,7 @@
 
 namespace brave_wallet {
 
-template <typename T>
-class BraveWebUIBubbleManagerT;
+class WalletWebUIBubbleManager;
 
 class WalletBubbleManagerDelegateImpl : public WalletBubbleManagerDelegate {
  public:
@@ -41,8 +40,7 @@ class WalletBubbleManagerDelegateImpl : public WalletBubbleManagerDelegate {
  private:
   raw_ptr<content::WebContents> web_contents_ = nullptr;
   GURL webui_url_;
-  std::unique_ptr<BraveWebUIBubbleManagerT<WalletPanelUI>>
-      webui_bubble_manager_;
+  std::unique_ptr<WalletWebUIBubbleManager> webui_bubble_manager_;
 };
 
 }  // namespace brave_wallet

--- a/chromium_src/chrome/browser/ui/views/bubble/webui_bubble_manager.h
+++ b/chromium_src/chrome/browser/ui/views/bubble/webui_bubble_manager.h
@@ -1,0 +1,29 @@
+/* Copyright (c) 2023 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_CHROMIUM_SRC_CHROME_BROWSER_UI_VIEWS_BUBBLE_WEBUI_BUBBLE_MANAGER_H_
+#define BRAVE_CHROMIUM_SRC_CHROME_BROWSER_UI_VIEWS_BUBBLE_WEBUI_BUBBLE_MANAGER_H_
+
+// `WebUIBubbleManager` is patched to include a new virtual method that is
+// called after a `WebUIBubbleDialogView` is created and before it is supplied
+// to `views::BubbleDialogDelegateView::CreateBubble`. This allows us to
+// customize the view appropriately (e.g. by setting the border radius) prior to
+// rendering. For a class that uses this method, see `BraveWebUIBubbleManager`.
+
+#define DisableCloseBubbleHelperForTesting()    \
+  DisableCloseBubbleHelperForTesting_NotUsed(); \
+  virtual void BraveCustomizeBubbleDialogView(  \
+      WebUIBubbleDialogView& bubble_view) {}    \
+  void DisableCloseBubbleHelperForTesting()
+
+#define BRAVE_WEBUI_BUBBLE_MANAGER_T_CREATE_WEB_UI_BUBBLE_DIALOG \
+  BraveCustomizeBubbleDialogView(*bubble_view);
+
+#include "src/chrome/browser/ui/views/bubble/webui_bubble_manager.h"  // IWYU pragma: export
+
+#undef BRAVE_WEBUI_BUBBLE_MANAGER_T_CREATE_WEB_UI_BUBBLE_DIALOG
+#undef DisableCloseBubbleHelperForTesting
+
+#endif  // BRAVE_CHROMIUM_SRC_CHROME_BROWSER_UI_VIEWS_BUBBLE_WEBUI_BUBBLE_MANAGER_H_

--- a/patches/chrome-browser-ui-views-bubble-webui_bubble_manager.h.patch
+++ b/patches/chrome-browser-ui-views-bubble-webui_bubble_manager.h.patch
@@ -1,0 +1,12 @@
+diff --git a/chrome/browser/ui/views/bubble/webui_bubble_manager.h b/chrome/browser/ui/views/bubble/webui_bubble_manager.h
+index 1bccdbfc4895a5aa4f69aaa1b7bc71810d4ac31f..78730cb3abbd2ab7757c0bd9972d6beb396e67be 100644
+--- a/chrome/browser/ui/views/bubble/webui_bubble_manager.h
++++ b/chrome/browser/ui/views/bubble/webui_bubble_manager.h
+@@ -165,6 +165,7 @@ class WebUIBubbleManagerT : public WebUIBubbleManager {
+ 
+     auto bubble_view = std::make_unique<WebUIBubbleDialogView>(
+         anchor_view_, contents_wrapper, anchor, arrow);
++    BRAVE_WEBUI_BUBBLE_MANAGER_T_CREATE_WEB_UI_BUBBLE_DIALOG
+     auto weak_ptr = bubble_view->GetWeakPtr();
+     views::BubbleDialogDelegateView::CreateBubble(std::move(bubble_view));
+     return weak_ptr;


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/32150
Resolves https://github.com/brave/brave-browser/issues/31858

* Feature panels (e.g. Shields, Wallet, and VPN) have been given 16px corners.
* Dialogs have been given 8px corners.

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-arm64, CI/skip-linux-x64, CI/skip-android, CI/skip-macos, CI/skip-ios, CI/skip-windows-arm64, CI/skip-windows-x64, CI/skip-windows-x86 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [ ] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

### Feature Panels

<img width="399" alt="Screenshot 2023-08-24 at 4 37 47 PM" src="https://github.com/brave/brave-core/assets/5995084/3c6b4331-44b1-4b5d-ba4f-d3652b3b0bf6">

<img width="326" alt="Screenshot 2023-08-24 at 4 43 22 PM" src="https://github.com/brave/brave-core/assets/5995084/70baaaa8-4835-4f0e-b75f-38fc90f6be4a">

<img width="329" alt="Screenshot 2023-08-24 at 4 43 39 PM" src="https://github.com/brave/brave-core/assets/5995084/60baac97-4ec3-4cf8-a328-69bbf0816c9f">

### Dialog Bubbles

<img width="330" alt="Screenshot 2023-08-24 at 4 38 00 PM" src="https://github.com/brave/brave-core/assets/5995084/a0d2ff66-8a4d-4f77-8600-5b5a11e67fc0">
<img width="328" alt="Screenshot 2023-08-24 at 4 38 10 PM" src="https://github.com/brave/brave-core/assets/5995084/c6368302-f246-4762-90e5-1708b41c9d7d">
<img width="329" alt="Screenshot 2023-08-24 at 4 38 18 PM" src="https://github.com/brave/brave-core/assets/5995084/2af403ba-2a59-4fa3-9513-bcab9671e4d2">
<img width="365" alt="Screenshot 2023-08-24 at 4 38 30 PM" src="https://github.com/brave/brave-core/assets/5995084/b5297f96-a96d-45a9-9c10-012f353612e3">
<img width="331" alt="Screenshot 2023-08-24 at 4 38 54 PM" src="https://github.com/brave/brave-core/assets/5995084/7c1d77e9-f4fb-46fa-87fb-47ea4b6a36df">
<img width="327" alt="Screenshot 2023-08-24 at 4 40 20 PM" src="https://github.com/brave/brave-core/assets/5995084/a87c1f0b-9312-43fd-80c0-900aae9b3edd">
<img width="328" alt="Screenshot 2023-08-24 at 4 41 51 PM" src="https://github.com/brave/brave-core/assets/5995084/dc9d0b9f-cafe-4041-aaf6-84bb68e70540">
