### PR TITLE
Avoid dangling pointers in `BravePrefProviderTest`

### DIFF
--- a/components/content_settings/core/browser/brave_content_settings_pref_provider_unittest.cc
+++ b/components/content_settings/core/browser/brave_content_settings_pref_provider_unittest.cc
@@ -528,12 +528,13 @@ TEST_F(BravePrefProviderTest, TestShieldsSettingsMigrationFromResourceIDs) {
 
   // Manually write settings under the PLUGINS type using the no longer existing
   // ResourceIdentifier names, and then perform the migration.
-  ScopedDictPrefUpdate plugins(pref_service, kUserProfilePluginsPath);
+  absl::optional<ScopedDictPrefUpdate> plugins(absl::in_place, pref_service,
+                                               kUserProfilePluginsPath);
 
   base::Time expected_last_modified = base::Time::Now();
 
   // Seed global shield settings with non-default values.
-  base::Value::Dict* global_settings = plugins->EnsureDict("*,*");
+  base::Value::Dict* global_settings = plugins.value()->EnsureDict("*,*");
 
   const int expected_global_settings_value = 1;
   InitializeAllShieldSettingsInDictionary(
@@ -541,7 +542,7 @@ TEST_F(BravePrefProviderTest, TestShieldsSettingsMigrationFromResourceIDs) {
 
   // Change all of those global settings for www.example.com.
   base::Value::Dict* example_settings =
-      plugins->EnsureDict("www.example.com,*");
+      plugins.value()->EnsureDict("www.example.com,*");
 
   const int expected_example_com_settings_value = 1;
   InitializeAllShieldSettingsInDictionary(example_settings,
@@ -549,12 +550,17 @@ TEST_F(BravePrefProviderTest, TestShieldsSettingsMigrationFromResourceIDs) {
                                           expected_example_com_settings_value);
 
   // Disable Brave Shields for www.brave.com.
-  base::Value::Dict* brave_settings = plugins->EnsureDict("www.brave.com,*");
+  base::Value::Dict* brave_settings =
+      plugins.value()->EnsureDict("www.brave.com,*");
 
   const int expected_brave_com_settings_value = 1;
   InitializeBraveShieldsSettingInDictionary(brave_settings,
                                             expected_last_modified,
                                             expected_brave_com_settings_value);
+
+  // Destroying `plugins` at this point, as otherwise it will be holding a
+  // dangling pointer, after `MigrateShieldsSettingsFromResourceIds()`.
+  plugins = absl::nullopt;
 
   provider.MigrateShieldsSettingsFromResourceIds();
 
@@ -591,7 +597,8 @@ TEST_F(BravePrefProviderTest, TestShieldsSettingsMigrationFromUnknownSettings) {
 
   // Manually write invalid settings under the PLUGINS type using the no longer
   // existing ResourceIdentifier names, to attempt the migration.
-  ScopedDictPrefUpdate plugins(pref_service, kUserProfilePluginsPath);
+  absl::optional<ScopedDictPrefUpdate> plugins(absl::in_place, pref_service,
+                                               kUserProfilePluginsPath);
 
   // Seed both global and per-site shield settings preferences using unsupported
   // names, so that we can test that Brave doesn't crash while attempting the
@@ -600,13 +607,17 @@ TEST_F(BravePrefProviderTest, TestShieldsSettingsMigrationFromUnknownSettings) {
   // For a list of supported names, see |kBraveContentSettingstypes| inside the
   // components/content_settings/core/browser/content_settings_registry.cc
   // override, in the chromium_src/ directory.
-  base::Value::Dict* global_settings = plugins->EnsureDict("*,*");
+  base::Value::Dict* global_settings = plugins.value()->EnsureDict("*,*");
   InitializeUnsupportedShieldSettingInDictionary(global_settings,
                                                  base::Time::Now());
   base::Value::Dict* example_settings =
-      plugins->EnsureDict("www.example.com,*");
+      plugins.value()->EnsureDict("www.example.com,*");
   InitializeUnsupportedShieldSettingInDictionary(example_settings,
                                                  base::Time::Now());
+
+  // Destroying `plugins` at this point, as otherwise it will be holding a
+  // dangling pointer, after `MigrateShieldsSettingsFromResourceIds()`.
+  plugins = absl::nullopt;
 
   // Doing the migration below should NOT get a crash due to invalid settings.
   provider.MigrateShieldsSettingsFromResourceIds();


### PR DESCRIPTION
When using `ScopedDictPrefUpdate` to create dictionaries, a raw ptr is used to keep track of it. However, these prefs end up getting destroyed when these tests eventually call
`MigrateShieldsSettingsFromResourceIds`.

This change makes sure that the `ScopedDictPrefUpdate` instance is dropped as soon as it is not needed anymore, to avoid the internal pointer in that instance to dangle, as the pref it is referring to gets destroyed.

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves 

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-arm64, CI/skip-linux-x64, CI/skip-android, CI/skip-macos, CI/skip-ios, CI/skip-windows-arm64, CI/skip-windows-x64, CI/skip-windows-x86 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [ ] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

