### PR TITLE
Avoid dangling pointer in `NTPBackgroundImagesServiceTest`

### DIFF
--- a/components/ntp_background_images/browser/ntp_background_images_service_unittest.cc
+++ b/components/ntp_background_images/browser/ntp_background_images_service_unittest.cc
@@ -268,26 +268,26 @@ TEST_F(NTPBackgroundImagesServiceTest, InternalDataTest) {
   EXPECT_EQ(nullptr, service_->GetBackgroundImagesData());
 
   // Check with json file with empty object.
+  observer.si_data_ = nullptr;
   service_->si_images_data_.reset();
   observer.on_si_updated_ = false;
-  observer.si_data_ = nullptr;
   service_->OnGetSponsoredComponentJsonData(false, kTestEmptyComponent);
   auto* si_data = service_->GetBrandedImagesData(false);
   EXPECT_EQ(si_data, nullptr);
   EXPECT_TRUE(observer.on_si_updated_);
   EXPECT_TRUE(observer.si_data_->campaigns.empty());
+  observer.bi_data_ = nullptr;
   service_->bi_images_data_.reset();
   observer.on_bi_updated_ = false;
-  observer.bi_data_ = nullptr;
   service_->OnGetComponentJsonData(kTestEmptyComponent);
   auto* bi_data = service_->GetBackgroundImagesData();
   EXPECT_EQ(bi_data, nullptr);
   EXPECT_TRUE(observer.on_bi_updated_);
   EXPECT_FALSE(observer.bi_data_->IsValid());
 
+  observer.si_data_ = nullptr;
   service_->si_images_data_.reset();
   observer.on_si_updated_ = false;
-  observer.si_data_ = nullptr;
   service_->OnGetSponsoredComponentJsonData(false, kTestSponsoredImages);
   // Mark this is not SR to get SI data.
   service_->MarkThisInstallIsNotSuperReferralForever();
@@ -329,9 +329,9 @@ TEST_F(NTPBackgroundImagesServiceTest, InternalDataTest) {
       *si_data->GetBackgroundAt(0, 1)->FindStringByDottedPath(kLogoImagePath));
 
   // Test BI data loading
+  observer.bi_data_ = nullptr;
   service_->bi_images_data_.reset();
   observer.on_bi_updated_ = false;
-  observer.bi_data_ = nullptr;
   service_->OnGetComponentJsonData(kTestBackgroundImages);
   bi_data = service_->GetBackgroundImagesData();
   EXPECT_TRUE(bi_data);
@@ -378,9 +378,9 @@ TEST_F(NTPBackgroundImagesServiceTest, InternalDataTest) {
             }
         ]
     })";
+  observer.si_data_ = nullptr;
   service_->si_images_data_.reset();
   observer.on_si_updated_ = false;
-  observer.si_data_ = nullptr;
   service_->OnGetSponsoredComponentJsonData(false,
                                             test_json_string_higher_schema);
   si_data = service_->GetBrandedImagesData(false);
@@ -400,9 +400,9 @@ TEST_F(NTPBackgroundImagesServiceTest, InternalDataTest) {
       }
     ]
   })";
+  observer.bi_data_ = nullptr;
   service_->bi_images_data_.reset();
   observer.on_bi_updated_ = false;
-  observer.bi_data_ = nullptr;
   service_->OnGetComponentJsonData(test_background_json_string_higher_schema);
   bi_data = service_->GetBackgroundImagesData();
   EXPECT_FALSE(bi_data);
@@ -418,9 +418,9 @@ TEST_F(NTPBackgroundImagesServiceTest, MultipleCampaignsTest) {
   pref_service_.SetBoolean(kReferralCheckedForPromoCodeFile, true);
   pref_service_.SetBoolean(kReferralInitialization, true);
 
+  observer.si_data_ = nullptr;
   service_->si_images_data_.reset();
   observer.on_si_updated_ = false;
-  observer.si_data_ = nullptr;
   service_->OnGetSponsoredComponentJsonData(
       false, kTestSponsoredImagesWithMultipleCampaigns);
   // Mark this is not SR to get SI data.


### PR DESCRIPTION
In these tests, the instance `TestObserver` has subobjects and references to them that will dangle depending in which order they are being reset. This change reorders those assignments to make sure pointer fields do not dangle as a result.

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/32440

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-arm64, CI/skip-linux-x64, CI/skip-android, CI/skip-macos, CI/skip-ios, CI/skip-windows-arm64, CI/skip-windows-x64, CI/skip-windows-x86 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [ ] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

