### PR TITLE
Fixes crash in `DatabaseRecurringTip::GetNextMonthlyContributionTime()`. (uplift to 1.58.x)

### DIFF
--- a/components/brave_rewards/core/database/database_recurring_tip.cc
+++ b/components/brave_rewards/core/database/database_recurring_tip.cc
@@ -167,7 +167,9 @@ void DatabaseRecurringTip::GetNextMonthlyContributionTime(
       [](base::OnceCallback<void(absl::optional<base::Time>)> callback,
          mojom::DBCommandResponsePtr response) {
         base::Time time;
-        if (response && !response->result->get_records().empty()) {
+        if (response &&
+            response->status == mojom::DBCommandResponse::Status::RESPONSE_OK &&
+            response->result && !response->result->get_records().empty()) {
           const auto& record = response->result->get_records().front();
           int64_t timestamp = GetInt64Column(record.get(), 0);
           if (timestamp > 0) {


### PR DESCRIPTION
Uplift of #19627
Resolves https://github.com/brave/brave-browser/issues/32151

Pre-approval checklist: 
- [ ] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.