### PR TITLE
Disable kPermissionsStorageAccessAPI on Android also (uplift to 1.58.x)

### DIFF
--- a/app/brave_main_delegate_browsertest.cc
+++ b/app/brave_main_delegate_browsertest.cc
@@ -244,10 +244,10 @@ IN_PROC_BROWSER_TEST_F(BraveMainDelegateBrowserTest, DisabledFeatures) {
 #if !BUILDFLAG(IS_ANDROID)
     &page_info::kPageInfoCookiesSubpage,
     &permissions::features::kPermissionsPromptSurvey,
-    &permissions::features::kPermissionStorageAccessAPI,
     &permissions::features::kRecordPermissionExpirationTimestamps,
 #endif
     &permissions::features::kPermissionOnDeviceNotificationPredictions,
+    &permissions::features::kPermissionStorageAccessAPI,
     &privacy_sandbox::kOverridePrivacySandboxSettingsLocalTesting,
     &privacy_sandbox::kEnforcePrivacySandboxAttestations,
     &privacy_sandbox::kPrivacySandboxSettings3,

--- a/chromium_src/components/permissions/features.cc
+++ b/chromium_src/components/permissions/features.cc
@@ -20,9 +20,9 @@ OVERRIDE_FEATURE_DEFAULT_STATES({{
      base::FEATURE_DISABLED_BY_DEFAULT},
 #if !BUILDFLAG(IS_ANDROID)
     {kPermissionsPromptSurvey, base::FEATURE_DISABLED_BY_DEFAULT},
-    {kPermissionStorageAccessAPI, base::FEATURE_DISABLED_BY_DEFAULT},
     {kRecordPermissionExpirationTimestamps, base::FEATURE_DISABLED_BY_DEFAULT},
 #endif
+    {kPermissionStorageAccessAPI, base::FEATURE_DISABLED_BY_DEFAULT},
 }});
 
 }  // namespace features


### PR DESCRIPTION
Uplift of #19848
Resolves https://github.com/brave/brave-browser/issues/32485

Pre-approval checklist: 
- [ ] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.