### PR TITLE
Fixes the balance tooltip on the NTP widget. (uplift to 1.58.x)

### DIFF
--- a/components/brave_rewards/resources/shared/components/newtab/rewards_card.style.ts
+++ b/components/brave_rewards/resources/shared/components/newtab/rewards_card.style.ts
@@ -197,12 +197,27 @@ export const balanceInfo = styled.div`
   margin-top: 18px;
 
   .tooltip {
-    position: absolute;
-    right: -93px;
-    width: 260px;
-    padding-top: 8px;
     visibility: hidden;
     transition: visibility 0s linear 300ms;
+  }
+
+  .tooltip-arrow {
+    content: '';
+    position: absolute;
+    top: 29px;
+    left: 4px;
+    background: ${leo.color.white};
+    height: 15px;
+    width: 15px;
+    transform: rotate(45deg);
+    z-index: 2;
+  }
+
+  .tooltip-bubble {
+    position: fixed;
+    right: 12px;
+    width: 260px;
+    padding-top: 8px;
     z-index: 1;
   }
 
@@ -221,17 +236,6 @@ export const balanceTooltip = styled.div`
   font-size: 12px;
   line-height: 18px;
   font-weight: 400;
-
-  &:before {
-    content: '';
-    position: absolute;
-    top: -3px;
-    left: 147px;
-    background: inherit;
-    height: 15px;
-    width: 15px;
-    transform: rotate(45deg);
-  }
 `
 
 export const balanceExchange = styled.div`

--- a/components/brave_rewards/resources/shared/components/newtab/rewards_card.tsx
+++ b/components/brave_rewards/resources/shared/components/newtab/rewards_card.tsx
@@ -175,9 +175,12 @@ export function RewardsCard (props: Props) {
                     <style.balanceInfo>
                       <Icon name='help-outline' />
                       <div className='tooltip'>
-                        <style.balanceTooltip>
-                          {getString('rewardsBalanceInfoText')}
-                        </style.balanceTooltip>
+                        <div className='tooltip-arrow' />
+                        <div className='tooltip-bubble'>
+                          <style.balanceTooltip>
+                            {getString('rewardsBalanceInfoText')}
+                          </style.balanceTooltip>
+                        </div>
                       </div>
                     </style.balanceInfo>
                   }


### PR DESCRIPTION
Uplift of #19846
Resolves https://github.com/brave/brave-browser/issues/32470

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.