### PR TITLE
Fixes crash in brave_ads::*AdHandler::TriggerEvent (uplift to 1.58.x)

### DIFF
--- a/components/brave_ads/core/internal/ads/inline_content_ad_handler.cc
+++ b/components/brave_ads/core/internal/ads/inline_content_ad_handler.cc
@@ -81,8 +81,10 @@ void InlineContentAdHandler::TriggerEvent(
   CHECK_NE(mojom::InlineContentAdEventType::kServed, event_type)
       << "Should not be called with kServed as this event is handled when "
          "calling MaybeServe";
-  CHECK(UserHasOptedInToBraveNewsAds())
-      << "Should only be called if the user has opted-in to Brave News Ads";
+
+  if (!UserHasOptedInToBraveNewsAds()) {
+    return std::move(callback).Run(/*success*/ false);
+  }
 
   event_handler_.FireEvent(
       placement_id, creative_instance_id, event_type,

--- a/components/brave_ads/core/internal/ads/new_tab_page_ad_handler.cc
+++ b/components/brave_ads/core/internal/ads/new_tab_page_ad_handler.cc
@@ -80,6 +80,10 @@ void NewTabPageAdHandler::TriggerEvent(
     TriggerAdEventCallback callback) {
   CHECK(mojom::IsKnownEnumValue(event_type));
 
+  if (!UserHasOptedInToNewTabPageAds()) {
+    return std::move(callback).Run(/*success*/ false);
+  }
+
   if (!UserHasJoinedBraveRewards() &&
       !ShouldAlwaysTriggerNewTabPageAdEvents()) {
     return std::move(callback).Run(/*success*/ false);

--- a/components/brave_ads/core/internal/ads/notification_ad_handler.cc
+++ b/components/brave_ads/core/internal/ads/notification_ad_handler.cc
@@ -93,8 +93,10 @@ void NotificationAdHandler::TriggerEvent(
   CHECK_NE(mojom::NotificationAdEventType::kServed, event_type)
       << "Should not be called with kServed as this event is handled when "
          "calling TriggerEvent with kViewed";
-  CHECK(UserHasJoinedBraveRewards())
-      << "Should only be called if user has joined Brave Rewards";
+
+  if (!UserHasOptedInToNotificationAds()) {
+    return std::move(callback).Run(/*success*/ false);
+  }
 
   if (event_type == mojom::NotificationAdEventType::kViewed) {
     return event_handler_.FireEvent(

--- a/components/brave_ads/core/internal/ads/promoted_content_ad_handler.cc
+++ b/components/brave_ads/core/internal/ads/promoted_content_ad_handler.cc
@@ -10,6 +10,7 @@
 #include "base/check.h"
 #include "brave/components/brave_ads/core/confirmation_type.h"
 #include "brave/components/brave_ads/core/internal/account/account.h"
+#include "brave/components/brave_ads/core/internal/account/account_util.h"
 #include "brave/components/brave_ads/core/internal/common/logging_util.h"
 #include "brave/components/brave_ads/core/internal/history/history_manager.h"
 #include "brave/components/brave_ads/core/internal/transfer/transfer.h"
@@ -45,6 +46,10 @@ void PromotedContentAdHandler::TriggerEvent(
   CHECK_NE(mojom::PromotedContentAdEventType::kServed, event_type)
       << "Should not be called with kServed as this event is handled when "
          "calling TriggerEvent with kViewed";
+
+  if (!UserHasOptedInToBraveNewsAds()) {
+    return std::move(callback).Run(/*success*/ false);
+  }
 
   if (event_type == mojom::PromotedContentAdEventType::kViewed) {
     return event_handler_.FireEvent(

--- a/components/brave_ads/core/internal/ads/serving/permission_rules/command_line_permission_rule.cc
+++ b/components/brave_ads/core/internal/ads/serving/permission_rules/command_line_permission_rule.cc
@@ -18,7 +18,7 @@ bool DoesRespectCap() {
     return true;
   }
 
-  return IsProductionEnvironment() && !DidOverrideCommandLine();
+  return !DidOverrideCommandLine();
 }
 
 }  // namespace


### PR DESCRIPTION
Uplift of #19859
Resolves https://github.com/brave/brave-browser/issues/31472

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.