### PR TITLE
Fixed NTP shows same background images

### DIFF
--- a/components/ntp_background_images/browser/view_counter_model.cc
+++ b/components/ntp_background_images/browser/view_counter_model.cc
@@ -118,8 +118,10 @@ void ViewCounterModel::RegisterPageViewForBackgroundImages() {
     return;
 
   // Don't count when SI will be visible.
-  if (show_branded_wallpaper_ && count_to_branded_wallpaper_ == 0)
+  if (show_branded_wallpaper_ && total_campaign_count_ != 0 &&
+      count_to_branded_wallpaper_ == 0) {
     return;
+  }
 
   // Increase background image index
   current_wallpaper_image_index_++;

--- a/components/ntp_background_images/browser/view_counter_model.h
+++ b/components/ntp_background_images/browser/view_counter_model.h
@@ -55,7 +55,10 @@ class ViewCounterModel {
   FRIEND_TEST_ALL_PREFIXES(ViewCounterModelTest,
                            NTPSponsoredImagesCountToBrandedWallpaperTest);
   FRIEND_TEST_ALL_PREFIXES(ViewCounterModelTest, NTPBackgroundImagesTest);
-  FRIEND_TEST_ALL_PREFIXES(ViewCounterModelTest, NTPBackgroundImagesOnlyTest);
+  FRIEND_TEST_ALL_PREFIXES(ViewCounterModelTest,
+                           NTPBackgroundImagesWithSIDisabledTest);
+  FRIEND_TEST_ALL_PREFIXES(ViewCounterModelTest,
+                           NTPBackgroundImagesWithEmptyCampaignTest);
   FRIEND_TEST_ALL_PREFIXES(ViewCounterModelTest,
                            NTPFailedToLoadSponsoredImagesTest);
   FRIEND_TEST_ALL_PREFIXES(NTPBackgroundImagesViewCounterTest, ModelTest);

--- a/components/ntp_background_images/browser/view_counter_model_unittest.cc
+++ b/components/ntp_background_images/browser/view_counter_model_unittest.cc
@@ -144,8 +144,8 @@ TEST_F(ViewCounterModelTest, NTPBackgroundImagesTest) {
   }
 }
 
-// Test for background images only case (SI not active)
-TEST_F(ViewCounterModelTest, NTPBackgroundImagesOnlyTest) {
+// Test for background images only case (SI option is disabled)
+TEST_F(ViewCounterModelTest, NTPBackgroundImagesWithSIDisabledTest) {
   ViewCounterModel model(prefs());
 
   model.set_total_image_count(kTestImageCount);
@@ -173,6 +173,25 @@ TEST_F(ViewCounterModelTest, NTPBackgroundImagesOnlyTest) {
   model.set_show_wallpaper(false);
   for (int i = 0; i < kTestPageViewCount; ++i) {
     EXPECT_EQ(latest_wallpaper_index, model.current_wallpaper_image_index());
+    model.RegisterPageView();
+  }
+}
+
+// Test for background images only case (SI option is enabled but no campaign)
+TEST_F(ViewCounterModelTest, NTPBackgroundImagesWithEmptyCampaignTest) {
+  ViewCounterModel model(prefs());
+
+  // Check background wallpaper index is properly updated when SI option is
+  // enabled but there is no campaign.
+  model.Reset();
+  model.set_total_image_count(kTestImageCount);
+  model.set_show_branded_wallpaper(true);
+  model.count_to_branded_wallpaper_ = 0;
+
+  constexpr int kTestPageViewCount = 30;
+  for (int i = 0; i < kTestPageViewCount; ++i) {
+    EXPECT_EQ(i % model.total_image_count_,
+              model.current_wallpaper_image_index());
     model.RegisterPageView();
   }
 }


### PR DESCRIPTION
fix https://github.com/brave/brave-browser/issues/32359

Sometimes we could meet the condition that
ViewCounterModel::count_to_branded_wallpaper_ is zero and no SI campaign.
When this happens, we didn't increase background wallpaper index.
This caused showing same background image till new campaign starts.
We should increase background images index in this situation also.

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves 

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-arm64, CI/skip-linux-x64, CI/skip-android, CI/skip-macos, CI/skip-ios, CI/skip-windows-arm64, CI/skip-windows-x64, CI/skip-windows-x86 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

`ViewCounterModelTest.NTPBackgroundImagesWithEmptyCampaignTest`

Manual test.
1. Launch browser and current region has SI campaign.
2. Open NTP reload multiple times till SI is shown and reload three times.
    With this condition, NTP SI will be shown at next NTP reloading or opening
3. Close all NTP to prevent opening NTP at next startup
4. Shutdown browser and change to another region that doesn't have SI campaign
5. Launch Browser and make sure there is no NTP tab
6. Load brave://components and update NTP SI components to get empty campaign
7. Open NTP and reload
8. Check different NTP background images are shown whenever reloading

To test more easily, we could edit `Preferences` file manually instead of above step
1. Launch browser and close all NTP to prevent NTP opening after next startup
2. Shutdown browser
3. Change to another region that doesn't have SI campaign
4. Set  zero to `count_to_branded_wallpaper` value in user dir's `Preferences` file
5. Launch browser and make sure there is no NTP and update NTP SI campaigns from brave://components to get empty NTP SI
6. Open NTP and reload
7. Check different NTP background images are shown whenever reloading