### PR TITLE
Fixed vpn toolbar button has connected state for not purchased user

### DIFF
--- a/components/brave_vpn/browser/brave_vpn_service.cc
+++ b/components/brave_vpn/browser/brave_vpn_service.cc
@@ -184,6 +184,10 @@ mojom::ConnectionState BraveVpnService::GetConnectionState() const {
 }
 
 bool BraveVpnService::IsConnected() const {
+  if (!is_purchased_user()) {
+    return false;
+  }
+
   return GetConnectionState() == ConnectionState::CONNECTED;
 }
 

--- a/components/brave_vpn/browser/brave_vpn_service_unittest.cc
+++ b/components/brave_vpn/browser/brave_vpn_service_unittest.cc
@@ -722,6 +722,30 @@ TEST_F(BraveVPNServiceTest, ConnectionStateUpdateWithPurchasedStateTest) {
   EXPECT_EQ(ConnectionState::CONNECTED, observer.GetConnectionState());
 }
 
+TEST_F(BraveVPNServiceTest, IsConnectedWithPurchasedStateTest) {
+  auto* test_api = static_cast<BraveVPNOSConnectionAPISim*>(GetConnectionAPI());
+
+  TestBraveVPNServiceObserver observer;
+  AddObserver(observer.GetReceiver());
+  std::string env = skus::GetDefaultEnvironment();
+  SetPurchasedState(env, PurchasedState::PURCHASED);
+
+  // Prepare connected state.
+  test_api->SetConnectionStateForTesting(ConnectionState::CONNECTING);
+  base::RunLoop().RunUntilIdle();
+  test_api->SetConnectionStateForTesting(ConnectionState::CONNECTED);
+  base::RunLoop().RunUntilIdle();
+  EXPECT_EQ(ConnectionState::CONNECTED, observer.GetConnectionState());
+  // Gets connected for purchased user.
+  EXPECT_TRUE(service_->IsConnected());
+
+  // Check BraveVpnService gives false for IsConnected() when
+  // it's connected state but not purchased.
+  SetPurchasedState(env, PurchasedState::NOT_PURCHASED);
+  EXPECT_EQ(ConnectionState::CONNECTED, observer.GetConnectionState());
+  EXPECT_FALSE(service_->IsConnected());
+}
+
 TEST_F(BraveVPNServiceTest, DisconnectedIfDisabledByPolicy) {
   // Prepare valid connection info.
   auto* test_api = static_cast<BraveVPNOSConnectionAPISim*>(GetConnectionAPI());

--- a/components/brave_vpn/browser/connection/brave_vpn_os_connection_api.h
+++ b/components/brave_vpn/browser/connection/brave_vpn_os_connection_api.h
@@ -105,6 +105,8 @@ class BraveVPNOSConnectionAPI
   FRIEND_TEST_ALL_PREFIXES(BraveVPNServiceTest, ResetConnectionStateTest);
   FRIEND_TEST_ALL_PREFIXES(BraveVPNServiceTest,
                            ConnectionStateUpdateWithPurchasedStateTest);
+  FRIEND_TEST_ALL_PREFIXES(BraveVPNServiceTest,
+                           IsConnectedWithPurchasedStateTest);
   FRIEND_TEST_ALL_PREFIXES(BraveVPNServiceTest, DisconnectedIfDisabledByPolicy);
   FRIEND_TEST_ALL_PREFIXES(BraveVPNOSConnectionAPIUnitTest,
                            IgnoreDisconnectedStateWhileConnecting);


### PR DESCRIPTION
fix https://github.com/brave/brave-browser/issues/32542

VPN toolbar botton shoudn't have connected state for not purchased user.

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves 

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-arm64, CI/skip-linux-x64, CI/skip-android, CI/skip-macos, CI/skip-ios, CI/skip-windows-arm64, CI/skip-windows-x64, CI/skip-windows-x86 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

`BraveVPNServiceTest.IsConnectedWithPurchasedStateTest`

See the linked issue for manual test.