### PR TITLE
Fixes crash when conversion has empty segment in conversion queue (uplift to 1.58.x)

### DIFF
--- a/components/brave_ads/core/internal/conversions/conversion/conversion_info.cc
+++ b/components/brave_ads/core/internal/conversions/conversion/conversion_info.cc
@@ -26,7 +26,7 @@ ConversionInfo::~ConversionInfo() = default;
 bool ConversionInfo::IsValid() const {
   return ad_type != AdType::kUndefined && !creative_instance_id.empty() &&
          !creative_set_id.empty() && !campaign_id.empty() &&
-         !advertiser_id.empty() && !segment.empty() &&
+         !advertiser_id.empty() &&
          action_type != ConversionActionType::kUndefined;
 }
 


### PR DESCRIPTION
Uplift of #19917
Resolves https://github.com/brave/brave-browser/issues/32583

Pre-approval checklist: 
- [ ] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [ ] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [ ] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [ ] The associated issue milestone is set to the smallest version that the changes is landed on.