### PR TITLE
Make #brave-adblock-cookie-list-default enabled by default (uplift to 1.58.x)

### DIFF
--- a/browser/brave_shields/ad_block_service_browsertest.cc
+++ b/browser/brave_shields/ad_block_service_browsertest.cc
@@ -84,7 +84,6 @@ const char kRegionalAdBlockComponentTest64PublicKey[] =
 
 using brave_shields::features::kBraveAdblockCnameUncloaking;
 using brave_shields::features::kBraveAdblockCollapseBlockedElements;
-using brave_shields::features::kBraveAdblockCookieListDefault;
 using brave_shields::features::kBraveAdblockCosmeticFiltering;
 using brave_shields::features::kBraveAdblockDefault1pBlocking;
 using brave_shields::features::kBraveAdblockScriptletDebugLogs;
@@ -2468,16 +2467,6 @@ IN_PROC_BROWSER_TEST_F(AdBlockServiceTest,
   EXPECT_EQ(base::Value(true), result_first.value);
 }
 
-class DefaultCookieListFlagEnabledTest : public AdBlockServiceTest {
- public:
-  DefaultCookieListFlagEnabledTest() {
-    feature_list_.InitAndEnableFeature(kBraveAdblockCookieListDefault);
-  }
-
- private:
-  base::test::ScopedFeatureList feature_list_;
-};
-
 class CookieListPrefObserver {
  public:
   explicit CookieListPrefObserver(PrefService* local_state) {
@@ -2504,7 +2493,7 @@ class CookieListPrefObserver {
 
 // Test that the `brave-adblock-default-1p-blocking` flag forces the Cookie
 // List UUID to be enabled, until manually enabled and then disabled again.
-IN_PROC_BROWSER_TEST_F(DefaultCookieListFlagEnabledTest, ListEnabled) {
+IN_PROC_BROWSER_TEST_F(AdBlockServiceTest, ListEnabled) {
   ASSERT_TRUE(
       InstallRegionalAdBlockExtension(brave_shields::kCookieListUuid, false));
 

--- a/browser/ui/views/brave_shields/cookie_list_opt_in_browsertest.cc
+++ b/browser/ui/views/brave_shields/cookie_list_opt_in_browsertest.cc
@@ -90,7 +90,8 @@ class CookieListOptInBrowserTest : public InProcessBrowserTest {
   explicit CookieListOptInBrowserTest(bool enable_feature) {
     if (enable_feature) {
       scoped_feature_list_.InitWithFeatures(
-          {features::kBraveAdblockCookieListOptIn}, {});
+          {features::kBraveAdblockCookieListOptIn},
+          {features::kBraveAdblockCookieListDefault});
     } else {
       scoped_feature_list_.InitWithFeatures(
           {}, {features::kBraveAdblockCookieListOptIn});
@@ -278,7 +279,7 @@ class CookieListOptInFeatureOffBrowserTest : public CookieListOptInBrowserTest {
 IN_PROC_BROWSER_TEST_F(CookieListOptInFeatureOffBrowserTest, FeatureOff) {
   WaitForSessionRestore();
   EXPECT_FALSE(GetBubbleWebContents());
-  EXPECT_FALSE(IsCookieListFilterEnabled());
+  EXPECT_TRUE(IsCookieListFilterEnabled());
   EXPECT_FALSE(g_browser_process->local_state()->GetBoolean(
       prefs::kAdBlockCookieListOptInShown));
 }

--- a/components/brave_shields/common/features.cc
+++ b/components/brave_shields/common/features.cc
@@ -32,7 +32,7 @@ BASE_FEATURE(kBraveAdblockCollapseBlockedElements,
 // overridden by a locally set preference.
 BASE_FEATURE(kBraveAdblockCookieListDefault,
              "BraveAdblockCookieListDefault",
-             base::FEATURE_DISABLED_BY_DEFAULT);
+             base::FEATURE_ENABLED_BY_DEFAULT);
 // When enabled, Brave will display a bubble inviting the user to turn on the
 // "Easylist-Cookie List" filter.
 BASE_FEATURE(kBraveAdblockCookieListOptIn,


### PR DESCRIPTION
Uplift of #19754
Resolves https://github.com/brave/brave-browser/issues/29986

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.