### PR TITLE
Fixes invalid Rewards database in case of a crash.

### DIFF
--- a/components/brave_rewards/core/rewards_database.h
+++ b/components/brave_rewards/core/rewards_database.h
@@ -49,6 +49,10 @@ class RewardsDatabase {
   mojom::DBCommandResponse::Status Migrate(int32_t version,
                                            int32_t compatible_version);
 
+  bool ShouldCreateTables();
+
+  int GetTablesCount();
+
   void OnMemoryPressure(
       base::MemoryPressureListener::MemoryPressureLevel memory_pressure_level);
 


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/32588.

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-arm64, CI/skip-linux-x64, CI/skip-android, CI/skip-macos, CI/skip-ios, CI/skip-windows-arm64, CI/skip-windows-x64, CI/skip-windows-x86 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [ ] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

1. open the browser
2. join Rewards
3. make sure you see the database migration logs:
```
[29790:259:0829/135816.459048:VERBOSE1:database_migration.cc(150)] DB: Migrated to version 1
[29790:259:0829/135816.461797:VERBOSE1:database_migration.cc(150)] DB: Migrated to version 2
[29790:259:0829/135816.461832:VERBOSE1:database_migration.cc(150)] DB: Migrated to version 3
[29790:259:0829/135816.461853:VERBOSE1:database_migration.cc(150)] DB: Migrated to version 4
[29790:259:0829/135816.461873:VERBOSE1:database_migration.cc(150)] DB: Migrated to version 5
[29790:259:0829/135816.461896:VERBOSE1:database_migration.cc(150)] DB: Migrated to version 6
[29790:259:0829/135816.461916:VERBOSE1:database_migration.cc(150)] DB: Migrated to version 7
[29790:259:0829/135816.461942:VERBOSE1:database_migration.cc(150)] DB: Migrated to version 8
[29790:259:0829/135816.461963:VERBOSE1:database_migration.cc(150)] DB: Migrated to version 9
[29790:259:0829/135816.461982:VERBOSE1:database_migration.cc(150)] DB: Migrated to version 10
[29790:259:0829/135816.462004:VERBOSE1:database_migration.cc(150)] DB: Migrated to version 11
[29790:259:0829/135816.462024:VERBOSE1:database_migration.cc(150)] DB: Migrated to version 12
[29790:259:0829/135816.462046:VERBOSE1:database_migration.cc(150)] DB: Migrated to version 13
[29790:259:0829/135816.462067:VERBOSE1:database_migration.cc(150)] DB: Migrated to version 14
[29790:259:0829/135816.462090:VERBOSE1:database_migration.cc(150)] DB: Migrated to version 15
[29790:259:0829/135816.462111:VERBOSE1:database_migration.cc(150)] DB: Migrated to version 16
[29790:259:0829/135816.462131:VERBOSE1:database_migration.cc(150)] DB: Migrated to version 17
[29790:259:0829/135816.462153:VERBOSE1:database_migration.cc(150)] DB: Migrated to version 18
[29790:259:0829/135816.462174:VERBOSE1:database_migration.cc(150)] DB: Migrated to version 19
[29790:259:0829/135816.462192:VERBOSE1:database_migration.cc(150)] DB: Migrated to version 20
[29790:259:0829/135816.462210:VERBOSE1:database_migration.cc(150)] DB: Migrated to version 21
[29790:259:0829/135816.462228:VERBOSE1:database_migration.cc(150)] DB: Migrated to version 22
[29790:259:0829/135816.462247:VERBOSE1:database_migration.cc(150)] DB: Migrated to version 23
[29790:259:0829/135816.462265:VERBOSE1:database_migration.cc(150)] DB: Migrated to version 24
[29790:259:0829/135816.462283:VERBOSE1:database_migration.cc(150)] DB: Migrated to version 25
[29790:259:0829/135816.462303:VERBOSE1:database_migration.cc(150)] DB: Migrated to version 26
[29790:259:0829/135816.462323:VERBOSE1:database_migration.cc(150)] DB: Migrated to version 27
[29790:259:0829/135816.462342:VERBOSE1:database_migration.cc(150)] DB: Migrated to version 28
[29790:259:0829/135816.462361:VERBOSE1:database_migration.cc(150)] DB: Migrated to version 29
[29790:259:0829/135816.462379:VERBOSE1:database_migration.cc(150)] DB: Migrated to version 30
[29790:259:0829/135816.462397:VERBOSE1:database_migration.cc(150)] DB: Migrated to version 31
[29790:259:0829/135816.462418:VERBOSE1:database_migration.cc(150)] DB: Migrated to version 32
[29790:259:0829/135816.462439:VERBOSE1:database_migration.cc(150)] DB: Migrated to version 33
[29790:259:0829/135816.462458:VERBOSE1:database_migration.cc(150)] DB: Migrated to version 34
[29790:259:0829/135816.462477:VERBOSE1:database_migration.cc(150)] DB: Migrated to version 35
[29790:259:0829/135816.462495:VERBOSE1:database_migration.cc(150)] DB: Migrated to version 36
[29790:259:0829/135816.462514:VERBOSE1:database_migration.cc(150)] DB: Migrated to version 37
[29790:259:0829/135816.462532:VERBOSE1:database_migration.cc(150)] DB: Migrated to version 38
[29790:259:0829/135816.462550:VERBOSE1:database_migration.cc(150)] DB: Migrated to version 39
[29790:259:0829/135816.462569:VERBOSE1:database_migration.cc(150)] DB: Migrated to version 40
```
4. close the browser
5. open `publisher_info_db` in `DB Browser for SQLite`
6. execute:
```
PRAGMA writable_schema = 1;
DELETE FROM sqlite_master WHERE tbl_name IS NOT 'meta';
PRAGMA writable_schema = 0;
VACUUM;
```
7. close `DB Browser for SQLite`
8. open the browser
9. make sure you see the database migration logs (again)