### PR TITLE
Removed the assumption that new sidebar item is added at last

### DIFF
--- a/browser/ui/views/sidebar/sidebar_items_contents_view.cc
+++ b/browser/ui/views/sidebar/sidebar_items_contents_view.cc
@@ -7,7 +7,9 @@
 
 #include <string>
 
+#include "base/check_is_test.h"
 #include "base/functional/bind.h"
+#include "base/functional/callback.h"
 #include "base/i18n/case_conversion.h"
 #include "base/notreached.h"
 #include "base/strings/string_util.h"
@@ -332,6 +334,13 @@ void SidebarItemsContentsView::ShowItemAddedFeedbackBubble(
   // Only launch feedback bubble for active browser window.
   DCHECK_EQ(browser_, BrowserList::GetInstance()->GetLastActive());
   DCHECK(!observation_.IsObserving());
+
+  if (item_added_bubble_launched_for_test_) {
+    // Early return w/o launching actual bubble for quick test.
+    CHECK_IS_TEST();
+    item_added_bubble_launched_for_test_.Run(anchor_view);
+    return;
+  }
 
   auto* bubble = SidebarItemAddedFeedbackBubble::Create(anchor_view, this);
   observation_.Observe(bubble);

--- a/browser/ui/views/sidebar/sidebar_items_contents_view.cc
+++ b/browser/ui/views/sidebar/sidebar_items_contents_view.cc
@@ -312,7 +312,8 @@ void SidebarItemsContentsView::UpdateItem(
   }
 }
 
-void SidebarItemsContentsView::ShowItemAddedFeedbackBubble() {
+void SidebarItemsContentsView::ShowItemAddedFeedbackBubble(
+    size_t item_added_index) {
   auto* prefs = browser_->profile()->GetPrefs();
   const int current_count =
       prefs->GetInteger(sidebar::kSidebarItemAddedFeedbackBubbleShowCount);
@@ -321,8 +322,8 @@ void SidebarItemsContentsView::ShowItemAddedFeedbackBubble() {
     return;
   prefs->SetInteger(sidebar::kSidebarItemAddedFeedbackBubbleShowCount,
                     current_count + 1);
-
-  auto* lastly_added_view = children()[children().size() - 1];
+  CHECK_LT(item_added_index, children().size());
+  auto* lastly_added_view = children()[item_added_index];
   ShowItemAddedFeedbackBubble(lastly_added_view);
 }
 

--- a/browser/ui/views/sidebar/sidebar_items_contents_view.h
+++ b/browser/ui/views/sidebar/sidebar_items_contents_view.h
@@ -8,6 +8,7 @@
 
 #include <memory>
 
+#include "base/functional/callback_forward.h"
 #include "base/memory/raw_ptr.h"
 #include "base/scoped_observation.h"
 #include "brave/browser/ui/sidebar/sidebar_model.h"
@@ -127,6 +128,8 @@ class SidebarItemsContentsView : public views::View,
   raw_ptr<sidebar::SidebarModel> sidebar_model_ = nullptr;
   std::unique_ptr<ui::SimpleMenuModel> context_menu_model_;
   std::unique_ptr<views::MenuRunner> context_menu_runner_;
+  base::RepeatingCallback<void(views::View*)>
+      item_added_bubble_launched_for_test_;
   // Observe to know whether item added feedback bubble is visible or not.
   base::ScopedObservation<views::Widget, views::WidgetObserver> observation_{
       this};

--- a/browser/ui/views/sidebar/sidebar_items_contents_view.h
+++ b/browser/ui/views/sidebar/sidebar_items_contents_view.h
@@ -67,7 +67,7 @@ class SidebarItemsContentsView : public views::View,
   void OnActiveIndexChanged(absl::optional<size_t> old_index,
                             absl::optional<size_t> new_index);
 
-  void ShowItemAddedFeedbackBubble();
+  void ShowItemAddedFeedbackBubble(size_t added_item_index);
 
   void SetImageForItem(const sidebar::SidebarItem& item,
                        const gfx::ImageSkia& image);

--- a/browser/ui/views/sidebar/sidebar_items_scroll_view.h
+++ b/browser/ui/views/sidebar/sidebar_items_scroll_view.h
@@ -14,6 +14,7 @@
 #include "base/scoped_multi_source_observation.h"
 #include "base/scoped_observation.h"
 #include "brave/browser/ui/sidebar/sidebar_model.h"
+#include "third_party/abseil-cpp/absl/types/optional.h"
 #include "ui/base/clipboard/clipboard.h"
 #include "ui/views/animation/bounds_animator.h"
 #include "ui/views/animation/bounds_animator_observer.h"
@@ -110,6 +111,13 @@ class SidebarItemsScrollView : public views::View,
   gfx::Rect GetTargetScrollContentsViewRectTo(bool top);
   void ScrollContentsViewBy(int offset, bool animate);
 
+  // Returns true when needs scroll for showing an item at |index|.
+  bool NeedScrollForItemAt(size_t index) const;
+
+  // Get bounds for |contents_view_| to make item at |index| visible in
+  // scroll view.
+  gfx::Rect GetTargetScrollContentsViewRectForItemAt(size_t index) const;
+
   // Put NOLINT here because our cpp linter complains -
   // "make const or use a pointer: ui::mojom::DragOperation& output_drag_op"
   // But can't avoid because View::DropCallback uses non const refererence
@@ -122,6 +130,7 @@ class SidebarItemsScrollView : public views::View,
   bool IsInVisibleContentsViewBounds(const gfx::Point& position) const;
   void ClearDragIndicator();
 
+  absl::optional<size_t> lastly_added_item_index_;
   raw_ptr<BraveBrowser> browser_ = nullptr;
   raw_ptr<views::ImageButton> up_arrow_ = nullptr;
   raw_ptr<views::ImageButton> down_arrow_ = nullptr;

--- a/components/sidebar/sidebar_service.cc
+++ b/components/sidebar/sidebar_service.cc
@@ -659,4 +659,17 @@ void SidebarService::OnPreferenceChanged(const std::string& pref_name) {
   }
 }
 
+void SidebarService::AddItemAtForTesting(const SidebarItem& item,
+                                         size_t index) {
+  // Assueme that |index| is valid now in test.
+  CHECK_IS_TEST();
+
+  items_.insert(items_.begin() + index, item);
+  for (Observer& obs : observers_) {
+    obs.OnItemAdded(item, index);
+  }
+
+  UpdateSidebarItemsToPrefStore();
+}
+
 }  // namespace sidebar

--- a/components/sidebar/sidebar_service.h
+++ b/components/sidebar/sidebar_service.h
@@ -107,6 +107,8 @@ class SidebarService : public KeyedService {
 
  private:
   FRIEND_TEST_ALL_PREFIXES(SidebarServiceTest, AddRemoveItems);
+  FRIEND_TEST_ALL_PREFIXES(SidebarBrowserTest, ItemAddedBubbleAnchorViewTest);
+  FRIEND_TEST_ALL_PREFIXES(SidebarBrowserTest, ItemAddedScrollTest);
 
   void LoadSidebarItems();
   void UpdateSidebarItemsToPrefStore();
@@ -117,6 +119,8 @@ class SidebarService : public KeyedService {
   void OnPreferenceChanged(const std::string& pref_name);
   void MigrateSidebarShowOptions();
   void MigratePrefSidebarBuiltInItemsToHidden();
+
+  void AddItemAtForTesting(const SidebarItem& item, size_t index);
 
   raw_ptr<PrefService> prefs_ = nullptr;
 


### PR DESCRIPTION
Whenever new item is added to any place, scroll should be done to make new item visible.
and item added bubble should be anchored to new item always.

No behavioral change as new item is still added at last.

With this change, https://github.com/brave/brave-core/pull/19637/ will also work well.

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/32637

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-arm64, CI/skip-linux-x64, CI/skip-android, CI/skip-macos, CI/skip-ios, CI/skip-windows-arm64, CI/skip-windows-x64, CI/skip-windows-x86 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

`SidebarBrowserTest.ItemAddedBubbleAnchorViewTest`
`SidebarBrowserTest.ItemAddedScrollTest`

Manual test - As this PR doesn't change any current behavior,
it would be sufficient to test for this PR by doing basic sidebar test like below.

1. Launch clean profile and add some items and check item added feedback bubble is launched properly
2. Add many items to make sidebar area scrollable and add more items and check sidebar UI is scrolled to make new item visible