### PR TITLE
Add IKEv2 support for status tray icon

### DIFF
--- a/browser/brave_vpn/win/brave_vpn_wireguard_observer_service_win.cc
+++ b/browser/brave_vpn/win/brave_vpn_wireguard_observer_service_win.cc
@@ -37,7 +37,7 @@ bool BraveVpnWireguardObserverService::ShouldShowFallbackDialog() const {
     return should_fallback_for_testing_.value();
   }
 
-  return wireguard::ShouldFallbackToIKEv2();
+  return ShouldFallbackToIKEv2();
 }
 
 }  // namespace brave_vpn

--- a/browser/brave_vpn/win/brave_vpn_wireguard_observer_service_win.cc
+++ b/browser/brave_vpn/win/brave_vpn_wireguard_observer_service_win.cc
@@ -24,7 +24,6 @@ void BraveVpnWireguardObserverService::ShowFallbackDialog() {
 
 void BraveVpnWireguardObserverService::OnConnectionStateChanged(
     brave_vpn::mojom::ConnectionState state) {
-  wireguard::WriteConnectionState(static_cast<int>(state));
   if (state == brave_vpn::mojom::ConnectionState::DISCONNECTED ||
       state == brave_vpn::mojom::ConnectionState::CONNECT_FAILED) {
     if (ShouldShowFallbackDialog()) {

--- a/browser/brave_vpn/win/brave_vpn_wireguard_service/service/BUILD.gn
+++ b/browser/brave_vpn/win/brave_vpn_wireguard_service/service/BUILD.gn
@@ -13,8 +13,6 @@ source_set("service") {
     "brave_wireguard_manager.h",
     "install_utils.cc",
     "install_utils.h",
-    "process_utils.cc",
-    "process_utils.h",
     "wireguard_service_runner.cc",
     "wireguard_service_runner.h",
     "wireguard_tunnel_service.cc",

--- a/browser/brave_vpn/win/brave_vpn_wireguard_service/service/wireguard_tunnel_service.cc
+++ b/browser/brave_vpn/win/brave_vpn_wireguard_service/service/wireguard_tunnel_service.cc
@@ -22,9 +22,9 @@
 #include "base/win/security_descriptor.h"
 #include "base/win/sid.h"
 #include "base/win/windows_types.h"
-#include "brave/browser/brave_vpn/win/brave_vpn_wireguard_service/service/process_utils.h"
 #include "brave/components/brave_vpn/common/win/scoped_sc_handle.h"
 #include "brave/components/brave_vpn/common/win/utils.h"
+#include "brave/components/brave_vpn/common/wireguard/win/service_commands.h"
 #include "brave/components/brave_vpn/common/wireguard/win/service_constants.h"
 #include "brave/components/brave_vpn/common/wireguard/win/service_details.h"
 #include "brave/components/brave_vpn/common/wireguard/win/storage_utils.h"
@@ -302,10 +302,6 @@ bool CreateAndRunBraveWireguardService(const std::wstring& encoded_config) {
       !UpdateLastUsedConfigPath(config_file_path.value())) {
     VLOG(1) << "Failed to save last used config path";
   }
-  // Run tray process each time we establish connection. System tray icon
-  // manages self state to be visible/hidden due to settings.
-  brave_vpn::RunWireGuardCommandForUsers(
-      brave_vpn::kBraveVpnWireguardServiceInteractiveSwitchName);
   return true;
 }
 

--- a/browser/brave_vpn/win/brave_vpn_wireguard_service/status_tray/BUILD.gn
+++ b/browser/brave_vpn/win/brave_vpn_wireguard_service/status_tray/BUILD.gn
@@ -13,12 +13,13 @@ source_set("status_tray") {
   ]
   public_deps = [ "status_icon" ]
   deps = [
+    "ras",
     "resources",
     "wireguard",
     "//base",
     "//brave/components/brave_vpn/common",
     "//brave/components/brave_vpn/common/mojom",
-    "//brave/components/brave_vpn/common/win",
+    "//brave/components/brave_vpn/common/win/ras",
     "//brave/components/brave_vpn/common/wireguard/win",
     "//brave/components/resources:strings_grit",
     "//ui/base",

--- a/browser/brave_vpn/win/brave_vpn_wireguard_service/status_tray/ras/BUILD.gn
+++ b/browser/brave_vpn/win/brave_vpn_wireguard_service/status_tray/ras/BUILD.gn
@@ -1,0 +1,16 @@
+# Copyright (c) 2023 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+
+source_set("ras") {
+  sources = [
+    "ras_utils.cc",
+    "ras_utils.h",
+  ]
+  deps = [
+    "//brave/components/brave_vpn/browser/connection/ikev2/win:ras_utils",
+    "//brave/components/brave_vpn/common",
+    "//chrome/common:channel_info",
+  ]
+}

--- a/browser/brave_vpn/win/brave_vpn_wireguard_service/status_tray/ras/ras_utils.cc
+++ b/browser/brave_vpn/win/brave_vpn_wireguard_service/status_tray/ras/ras_utils.cc
@@ -1,0 +1,36 @@
+/* Copyright (c) 2023 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "brave/browser/brave_vpn/win/brave_vpn_wireguard_service/status_tray/ras/ras_utils.h"
+
+#include "base/strings/utf_string_conversions.h"
+#include "brave/components/brave_vpn/browser/connection/ikev2/win/ras_utils.h"
+#include "brave/components/brave_vpn/common/brave_vpn_utils.h"
+#include "chrome/common/channel_info.h"
+
+namespace brave_vpn {
+namespace ras {
+
+namespace {
+std::wstring GetConnectionEntryName() {
+  return base::UTF8ToWide(GetBraveVPNEntryName(chrome::GetChannel()));
+}
+}  // namespace
+
+bool IsRasConnected() {
+  return (ras::CheckConnection(GetConnectionEntryName()) ==
+          ras::CheckConnectionResult::CONNECTED);
+}
+
+bool ConnectRasEntry() {
+  return ConnectEntry(GetConnectionEntryName()).success;
+}
+
+bool DisconnectRasEntry() {
+  return DisconnectEntry(GetConnectionEntryName()).success;
+}
+
+}  // namespace ras
+}  // namespace brave_vpn

--- a/browser/brave_vpn/win/brave_vpn_wireguard_service/status_tray/ras/ras_utils.h
+++ b/browser/brave_vpn/win/brave_vpn_wireguard_service/status_tray/ras/ras_utils.h
@@ -1,0 +1,19 @@
+/* Copyright (c) 2023 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_BROWSER_BRAVE_VPN_WIN_BRAVE_VPN_WIREGUARD_SERVICE_STATUS_TRAY_RAS_RAS_UTILS_H_
+#define BRAVE_BROWSER_BRAVE_VPN_WIN_BRAVE_VPN_WIREGUARD_SERVICE_STATUS_TRAY_RAS_RAS_UTILS_H_
+
+namespace brave_vpn {
+namespace ras {
+
+bool IsRasConnected();
+bool ConnectRasEntry();
+bool DisconnectRasEntry();
+
+}  // namespace ras
+}  // namespace brave_vpn
+
+#endif  // BRAVE_BROWSER_BRAVE_VPN_WIN_BRAVE_VPN_WIREGUARD_SERVICE_STATUS_TRAY_RAS_RAS_UTILS_H_

--- a/browser/brave_vpn/win/brave_vpn_wireguard_service/status_tray/status_tray_runner.cc
+++ b/browser/brave_vpn/win/brave_vpn_wireguard_service/status_tray/status_tray_runner.cc
@@ -119,7 +119,7 @@ void StatusTrayRunner::ConnectVPN() {
         "", base::BindOnce(&StatusTrayRunner::OnConnected,
                            weak_factory_.GetWeakPtr()));
   } else {
-    StatusTrayRunner::OnConnected(ras::ConnectRasEntry());
+   OnConnected(ras::ConnectRasEntry());
   }
 }
 

--- a/browser/brave_vpn/win/brave_vpn_wireguard_service/status_tray/status_tray_runner.cc
+++ b/browser/brave_vpn/win/brave_vpn_wireguard_service/status_tray/status_tray_runner.cc
@@ -128,7 +128,7 @@ void StatusTrayRunner::DisconnectVPN() {
     wireguard::DisableBraveVpnWireguardService(base::BindOnce(
         &StatusTrayRunner::OnDisconnected, weak_factory_.GetWeakPtr()));
   } else {
-    StatusTrayRunner::OnDisconnected(ras::DisconnectRasEntry());
+    OnDisconnected(ras::DisconnectRasEntry());
   }
 }
 

--- a/browser/brave_vpn/win/brave_vpn_wireguard_service/status_tray/status_tray_runner.cc
+++ b/browser/brave_vpn/win/brave_vpn_wireguard_service/status_tray/status_tray_runner.cc
@@ -19,6 +19,7 @@
 #include "base/task/single_thread_task_executor.h"
 #include "base/task/thread_pool/thread_pool_instance.h"
 #include "brave/browser/brave_vpn/win/brave_vpn_wireguard_service/status_tray/brave_vpn_tray_command_ids.h"
+#include "brave/browser/brave_vpn/win/brave_vpn_wireguard_service/status_tray/ras/ras_utils.h"
 #include "brave/browser/brave_vpn/win/brave_vpn_wireguard_service/status_tray/resources/resource.h"
 #include "brave/browser/brave_vpn/win/brave_vpn_wireguard_service/status_tray/status_icon/icon_utils.h"
 #include "brave/browser/brave_vpn/win/brave_vpn_wireguard_service/status_tray/status_icon/status_icon.h"
@@ -102,9 +103,38 @@ StatusTrayRunner::StatusTrayRunner() = default;
 
 StatusTrayRunner::~StatusTrayRunner() = default;
 
+bool StatusTrayRunner::IsVPNConnected() const {
+  if (vpn_connected_for_testing_.has_value()) {
+    return vpn_connected_for_testing_.value();
+  }
+
+  return wireguard::IsWireguardActive()
+             ? wireguard::IsBraveVPNWireguardTunnelServiceRunning()
+             : ras::IsRasConnected();
+}
+
+void StatusTrayRunner::ConnectVPN() {
+  if (wireguard::IsWireguardActive()) {
+    wireguard::EnableBraveVpnWireguardService(
+        "", base::BindOnce(&StatusTrayRunner::OnConnected,
+                           weak_factory_.GetWeakPtr()));
+  } else {
+    StatusTrayRunner::OnConnected(ras::ConnectRasEntry());
+  }
+}
+
+void StatusTrayRunner::DisconnectVPN() {
+  if (wireguard::IsWireguardActive()) {
+    wireguard::DisableBraveVpnWireguardService(base::BindOnce(
+        &StatusTrayRunner::OnDisconnected, weak_factory_.GetWeakPtr()));
+  } else {
+    StatusTrayRunner::OnDisconnected(ras::DisconnectRasEntry());
+  }
+}
+
 void StatusTrayRunner::SetupStatusIcon() {
   status_tray_ = std::make_unique<StatusTray>();
-  current_state_ = IsTunnelServiceRunning()
+  current_state_ = IsVPNConnected()
                        ? brave_vpn::mojom::ConnectionState::CONNECTED
                        : brave_vpn::mojom::ConnectionState::DISCONNECTED;
   status_tray_->CreateStatusIcon(
@@ -114,9 +144,7 @@ void StatusTrayRunner::SetupStatusIcon() {
   if (status_icon) {
     status_icon->SetContextMenu(std::make_unique<TrayMenuModel>(this));
   }
-  SubscribeForWireguardNotifications(
-      IsTunnelServiceRunning() ? GetBraveVpnWireguardTunnelServiceName()
-                               : GetBraveVpnWireguardServiceName());
+
   UpdateConnectionState();
 }
 
@@ -127,13 +155,10 @@ void StatusTrayRunner::ExecuteCommand(int command_id, int event_flags) {
       SignalExit();
       break;
     case IDC_BRAVE_VPN_TRAY_CONNECT_VPN_ITEM:
-      wireguard::EnableBraveVpnWireguardService(
-          "", base::BindOnce(&StatusTrayRunner::OnConnected,
-                             weak_factory_.GetWeakPtr()));
+      ConnectVPN();
       break;
     case IDC_BRAVE_VPN_TRAY_DISCONNECT_VPN_ITEM:
-      wireguard::DisableBraveVpnWireguardService(base::BindOnce(
-          &StatusTrayRunner::OnDisconnected, weak_factory_.GetWeakPtr()));
+      DisconnectVPN();
       break;
     case IDC_BRAVE_VPN_TRAY_MANAGE_ACCOUNT_ITEM:
       OpenURLInBrowser(kManageUrlProd);
@@ -144,15 +169,8 @@ void StatusTrayRunner::ExecuteCommand(int command_id, int event_flags) {
   }
 }
 
-bool StatusTrayRunner::IsTunnelServiceRunning() const {
-  if (service_running_for_testing_.has_value()) {
-    return service_running_for_testing_.value();
-  }
-  return wireguard::IsBraveVPNWireguardTunnelServiceRunning();
-}
-
 void StatusTrayRunner::OnMenuWillShow(ui::SimpleMenuModel* source) {
-  auto connected = IsTunnelServiceRunning();
+  auto connected = IsVPNConnected();
   source->Clear();
   source->AddItem(IDC_BRAVE_VPN_TRAY_STATUS_ITEM, GetVpnStatusLabel(connected));
   source->SetEnabledAt(0, false);
@@ -180,10 +198,11 @@ void StatusTrayRunner::OnMenuWillShow(ui::SimpleMenuModel* source) {
 
 void StatusTrayRunner::OnConnected(bool success) {
   VLOG(1) << __func__ << ":" << success;
+  UpdateConnectionState();
 }
 
 brave_vpn::mojom::ConnectionState StatusTrayRunner::GetConnectionState() {
-  if (IsTunnelServiceRunning()) {
+  if (IsVPNConnected()) {
     return brave_vpn::mojom::ConnectionState::CONNECTED;
   }
 
@@ -204,9 +223,8 @@ void StatusTrayRunner::UpdateConnectionState() {
   auto state = GetConnectionState();
   if (state == brave_vpn::mojom::ConnectionState::CONNECTED) {
     // Check if we have obsolete connected state in storage.
-    state = IsTunnelServiceRunning()
-                ? state
-                : brave_vpn::mojom::ConnectionState::DISCONNECTED;
+    state = IsVPNConnected() ? state
+                             : brave_vpn::mojom::ConnectionState::DISCONNECTED;
     // if Tunnel service launched it means we have connected state and should
     // reset storage states because it could be expired from closed browser.
     wireguard::WriteConnectionState(static_cast<int>(state));
@@ -215,6 +233,7 @@ void StatusTrayRunner::UpdateConnectionState() {
   if (current_state_ == state) {
     return;
   }
+  VLOG(1) << __func__ << ":" << state;
   current_state_ = state;
   SetIconState(GetStatusTrayIcon(state), GetStatusIconTooltip(state));
 }
@@ -233,15 +252,21 @@ void StatusTrayRunner::SetIconState(int icon_id, int tooltip_id) {
       l10n_util::GetStringUTF16(tooltip_id));
 }
 
+void StatusTrayRunner::OnRasConnectionStateChanged() {
+  UpdateConnectionState();
+  SetupConnectionObserver();
+}
+
 void StatusTrayRunner::OnWireguardServiceStateChanged(int mask) {
   UpdateConnectionState();
   SubscribeForWireguardNotifications(
-      IsTunnelServiceRunning() ? GetBraveVpnWireguardTunnelServiceName()
-                               : GetBraveVpnWireguardServiceName());
+      IsVPNConnected() ? GetBraveVpnWireguardTunnelServiceName()
+                       : GetBraveVpnWireguardServiceName());
 }
 
 void StatusTrayRunner::OnDisconnected(bool success) {
   VLOG(1) << __func__ << ":" << success;
+  UpdateConnectionState();
 }
 
 void StatusTrayRunner::OnStorageUpdated() {
@@ -251,12 +276,10 @@ void StatusTrayRunner::OnStorageUpdated() {
     SignalExit();
   }
 
-  // Checks if wireguard protocol activated in brave://settings/system.
-  if (!wireguard::IsWireguardActive()) {
-    SignalExit();
-  }
+  SetupConnectionObserver();
 
   UpdateConnectionState();
+
   storage_.StartWatching(base::BindRepeating(
       &StatusTrayRunner::OnStorageUpdated, weak_factory_.GetWeakPtr()));
 }
@@ -272,22 +295,44 @@ void StatusTrayRunner::SubscribeForStorageUpdates() {
       &StatusTrayRunner::OnStorageUpdated, weak_factory_.GetWeakPtr()));
 }
 
-HRESULT StatusTrayRunner::Run() {
-  if (!wireguard::GetLastUsedConfigPath().has_value()) {
-    VLOG(1) << "Last used config not found.";
-    return S_OK;
+void StatusTrayRunner::SetupConnectionObserver() {
+  if (wireguard::IsWireguardActive()) {
+    if (IsWireguardObserverActive()) {
+      return;
+    }
+    if (IsRasConnectionObserverActive()) {
+      StopRasConnectionChangeMonitoring();
+    }
+    SubscribeForWireguardNotifications(
+        IsVPNConnected() ? GetBraveVpnWireguardTunnelServiceName()
+                         : GetBraveVpnWireguardServiceName());
+    return;
   }
+
+  if (IsWireguardObserverActive()) {
+    StopWireguardObserver();
+  }
+
+  if (IsRasConnectionObserverActive()) {
+    StopRasConnectionChangeMonitoring();
+  }
+  StartRasConnectionChangeMonitoring();
+}
+
+HRESULT StatusTrayRunner::Run() {
   if (!wireguard::IsVPNTrayIconEnabled()) {
     VLOG(1) << "Tray icon was hidden by user.";
-    return S_OK;
-  }
-  if (!wireguard::IsWireguardActive()) {
-    VLOG(1) << "Wireguard VPN is not enabled in settings.";
     return S_OK;
   }
 
   if (StatusTray::IconWindowExists()) {
     VLOG(1) << "Tray icon is already visible.";
+    return S_OK;
+  }
+
+  if (wireguard::IsWireguardActive() &&
+      !wireguard::GetLastUsedConfigPath().has_value()) {
+    VLOG(1) << "Last used config not found.";
     return S_OK;
   }
 
@@ -297,6 +342,7 @@ HRESULT StatusTrayRunner::Run() {
 
   SetupStatusIcon();
   SubscribeForStorageUpdates();
+  SetupConnectionObserver();
 
   base::RunLoop loop;
   quit_ = loop.QuitClosure();

--- a/browser/brave_vpn/win/brave_vpn_wireguard_service/status_tray/status_tray_runner_unittest.cc
+++ b/browser/brave_vpn/win/brave_vpn_wireguard_service/status_tray/status_tray_runner_unittest.cc
@@ -79,17 +79,17 @@ TEST_F(StatusTrayRunnerTest, RebuildMenu) {
   EXPECT_EQ(menu_model.GetItemCount(), 0u);
 
   // connected state
-  StatusTrayRunner::GetInstance()->SetTunnelServiceRunningForTesting(true);
+  StatusTrayRunner::GetInstance()->SetVPNConnectedForTesting(true);
   menu_model.MenuWillShow();
   CheckConnectedMenuState(&menu_model);
 
   // disconnected state
-  StatusTrayRunner::GetInstance()->SetTunnelServiceRunningForTesting(false);
+  StatusTrayRunner::GetInstance()->SetVPNConnectedForTesting(false);
   menu_model.MenuWillShow();
   CheckDisconnectedMenuState(&menu_model);
 
   // back to connected state
-  StatusTrayRunner::GetInstance()->SetTunnelServiceRunningForTesting(true);
+  StatusTrayRunner::GetInstance()->SetVPNConnectedForTesting(true);
   menu_model.MenuWillShow();
   CheckConnectedMenuState(&menu_model);
 }
@@ -102,7 +102,7 @@ TEST_F(StatusTrayRunnerTest, UpdateConnectionState) {
   EXPECT_TRUE(ui::NativeTheme::GetInstanceForNativeUi()->ShouldUseDarkColors());
 
   // Tunnel service stopped, state disconnected, no info in registry.
-  StatusTrayRunner::GetInstance()->SetTunnelServiceRunningForTesting(false);
+  StatusTrayRunner::GetInstance()->SetVPNConnectedForTesting(false);
   WaitIconStateChangedTo(
       IDR_BRAVE_VPN_TRAY_LIGHT,
       IDS_BRAVE_VPN_WIREGUARD_TRAY_ICON_TOOLTIP_DISCONNECTED);
@@ -158,7 +158,7 @@ TEST_F(StatusTrayRunnerTest, UpdateConnectionState) {
       static_cast<int>(brave_vpn::mojom::ConnectionState::CONNECT_FAILED));
 
   // Service is working, state connected.
-  StatusTrayRunner::GetInstance()->SetTunnelServiceRunningForTesting(true);
+  StatusTrayRunner::GetInstance()->SetVPNConnectedForTesting(true);
   WaitIconStateChangedTo(IDR_BRAVE_VPN_TRAY_LIGHT_CONNECTED,
                          IDS_BRAVE_VPN_WIREGUARD_TRAY_ICON_TOOLTIP_CONNECTED);
   EXPECT_EQ(brave_vpn::wireguard::GetConnectionState().value(),

--- a/browser/brave_vpn/win/brave_vpn_wireguard_service/status_tray/status_tray_runner_unittest.cc
+++ b/browser/brave_vpn/win/brave_vpn_wireguard_service/status_tray/status_tray_runner_unittest.cc
@@ -106,20 +106,20 @@ TEST_F(StatusTrayRunnerTest, UpdateConnectionState) {
   WaitIconStateChangedTo(
       IDR_BRAVE_VPN_TRAY_LIGHT,
       IDS_BRAVE_VPN_WIREGUARD_TRAY_ICON_TOOLTIP_DISCONNECTED);
-  EXPECT_FALSE(brave_vpn::wireguard::GetConnectionState().has_value());
+  EXPECT_FALSE(brave_vpn::GetConnectionState().has_value());
 
   // Tunnel service stopped, registry state as "connecting"
-  wireguard::WriteConnectionState(
+  WriteConnectionState(
       static_cast<int>(brave_vpn::mojom::ConnectionState::CONNECTING));
   WaitIconStateChangedTo(IDR_BRAVE_VPN_TRAY_LIGHT_CONNECTING,
                          IDS_BRAVE_VPN_WIREGUARD_TRAY_ICON_TOOLTIP_CONNECTING);
-  EXPECT_EQ(brave_vpn::wireguard::GetConnectionState().value(),
+  EXPECT_EQ(brave_vpn::GetConnectionState().value(),
             static_cast<int>(brave_vpn::mojom::ConnectionState::CONNECTING));
 
   // Tunnel service stopped, registry state as "connected"
-  wireguard::WriteConnectionState(
+  WriteConnectionState(
       static_cast<int>(brave_vpn::mojom::ConnectionState::CONNECTED));
-  EXPECT_EQ(brave_vpn::wireguard::GetConnectionState().value(),
+  EXPECT_EQ(brave_vpn::GetConnectionState().value(),
             static_cast<int>(brave_vpn::mojom::ConnectionState::CONNECTED));
   // State should not be shown as connected because tunnel service is not
   // launched.
@@ -127,41 +127,41 @@ TEST_F(StatusTrayRunnerTest, UpdateConnectionState) {
       IDR_BRAVE_VPN_TRAY_LIGHT,
       IDS_BRAVE_VPN_WIREGUARD_TRAY_ICON_TOOLTIP_DISCONNECTED);
   // Registry state was reset because the service wasn't running.
-  EXPECT_EQ(brave_vpn::wireguard::GetConnectionState().value(),
+  EXPECT_EQ(brave_vpn::GetConnectionState().value(),
             static_cast<int>(brave_vpn::mojom::ConnectionState::DISCONNECTED));
 
   // Tunnel service stopped, registry state as "disconnecting"
-  wireguard::WriteConnectionState(
+  WriteConnectionState(
       static_cast<int>(brave_vpn::mojom::ConnectionState::DISCONNECTING));
   WaitIconStateChangedTo(
       IDR_BRAVE_VPN_TRAY_LIGHT,
       IDS_BRAVE_VPN_WIREGUARD_TRAY_ICON_TOOLTIP_DISCONNECTING);
-  EXPECT_EQ(brave_vpn::wireguard::GetConnectionState().value(),
+  EXPECT_EQ(brave_vpn::GetConnectionState().value(),
             static_cast<int>(brave_vpn::mojom::ConnectionState::DISCONNECTING));
 
   // Tunnel service stopped, registry state as "CONNECT_NOT_ALLOWED"
-  wireguard::WriteConnectionState(
+  WriteConnectionState(
       static_cast<int>(brave_vpn::mojom::ConnectionState::CONNECT_NOT_ALLOWED));
   WaitIconStateChangedTo(IDR_BRAVE_VPN_TRAY_LIGHT_ERROR,
                          IDS_BRAVE_VPN_WIREGUARD_TRAY_ICON_TOOLTIP_ERROR);
   EXPECT_EQ(
-      brave_vpn::wireguard::GetConnectionState().value(),
+      brave_vpn::GetConnectionState().value(),
       static_cast<int>(brave_vpn::mojom::ConnectionState::CONNECT_NOT_ALLOWED));
 
   // Tunnel service stopped, registry state as "CONNECT_FAILED"
-  wireguard::WriteConnectionState(
+  WriteConnectionState(
       static_cast<int>(brave_vpn::mojom::ConnectionState::CONNECT_FAILED));
   WaitIconStateChangedTo(IDR_BRAVE_VPN_TRAY_LIGHT_ERROR,
                          IDS_BRAVE_VPN_WIREGUARD_TRAY_ICON_TOOLTIP_ERROR);
   EXPECT_EQ(
-      brave_vpn::wireguard::GetConnectionState().value(),
+      brave_vpn::GetConnectionState().value(),
       static_cast<int>(brave_vpn::mojom::ConnectionState::CONNECT_FAILED));
 
   // Service is working, state connected.
   StatusTrayRunner::GetInstance()->SetVPNConnectedForTesting(true);
   WaitIconStateChangedTo(IDR_BRAVE_VPN_TRAY_LIGHT_CONNECTED,
                          IDS_BRAVE_VPN_WIREGUARD_TRAY_ICON_TOOLTIP_CONNECTED);
-  EXPECT_EQ(brave_vpn::wireguard::GetConnectionState().value(),
+  EXPECT_EQ(brave_vpn::GetConnectionState().value(),
             static_cast<int>(brave_vpn::mojom::ConnectionState::CONNECTED));
 }
 

--- a/browser/ui/brave_browser_command_controller.cc
+++ b/browser/ui/brave_browser_command_controller.cc
@@ -39,7 +39,6 @@
 #include "brave/browser/brave_vpn/brave_vpn_service_factory.h"
 #include "brave/browser/brave_vpn/vpn_utils.h"
 #include "brave/components/brave_vpn/browser/brave_vpn_service.h"
-#include "brave/components/brave_vpn/common/brave_vpn_utils.h"
 #include "brave/components/brave_vpn/common/pref_names.h"
 #endif
 
@@ -262,9 +261,7 @@ void BraveBrowserCommandController::UpdateCommandForBraveVPN() {
   UpdateCommandEnabled(IDC_SHOW_BRAVE_VPN_PANEL, true);
   UpdateCommandEnabled(IDC_TOGGLE_BRAVE_VPN_TOOLBAR_BUTTON, true);
 #if BUILDFLAG(IS_WIN)
-  UpdateCommandEnabled(
-      IDC_TOGGLE_BRAVE_VPN_TRAY_ICON,
-      brave_vpn::IsBraveVPNWireguardEnabled(g_browser_process->local_state()));
+  UpdateCommandEnabled(IDC_TOGGLE_BRAVE_VPN_TRAY_ICON, true);
 #endif
   UpdateCommandEnabled(IDC_SEND_BRAVE_VPN_FEEDBACK, true);
   UpdateCommandEnabled(IDC_ABOUT_BRAVE_VPN, true);

--- a/browser/ui/browser_commands.cc
+++ b/browser/ui/browser_commands.cc
@@ -8,9 +8,6 @@
 #include <string>
 #include <vector>
 
-#include "base/command_line.h"
-#include "base/files/file_path.h"
-#include "base/process/launch.h"
 #include "base/strings/utf_string_conversions.h"
 #include "brave/app/brave_command_ids.h"
 #include "brave/browser/debounce/debounce_service_factory.h"
@@ -73,9 +70,8 @@
 #include "brave/components/brave_vpn/common/pref_names.h"
 
 #if BUILDFLAG(IS_WIN)
-#include "brave/components/brave_vpn/common/wireguard/win/service_constants.h"
-#include "brave/components/brave_vpn/common/wireguard/win/service_details.h"
 #include "brave/components/brave_vpn/common/wireguard/win/storage_utils.h"
+#include "brave/components/brave_vpn/common/wireguard/win/wireguard_utils.h"
 #endif  // BUILDFLAG(ENABLE_BRAVE_VPN)
 
 #endif  // BUILDFLAG(ENABLE_BRAVE_VPN)
@@ -88,19 +84,6 @@
 using content::WebContents;
 
 namespace brave {
-namespace {
-#if BUILDFLAG(ENABLE_BRAVE_VPN) && BUILDFLAG(IS_WIN)
-void LaunchBraveVpnWireguardInInteractiveMode() {
-  auto executable_path = brave_vpn::GetBraveVPNWireguardServiceExecutablePath();
-  base::CommandLine interactive_cmd(executable_path);
-  interactive_cmd.AppendSwitch(
-      brave_vpn::kBraveVpnWireguardServiceInteractiveSwitchName);
-  if (!base::LaunchProcess(interactive_cmd, base::LaunchOptions()).IsValid()) {
-    VLOG(1) << "Interactive process launch failed";
-  }
-}
-#endif
-}  // namespace
 void NewOffTheRecordWindowTor(Browser* browser) {
   CHECK(browser);
   if (browser->profile()->IsTor()) {
@@ -149,7 +132,7 @@ void ToggleBraveVPNTrayIcon() {
   brave_vpn::wireguard::EnableVPNTrayIcon(
       !brave_vpn::wireguard::IsVPNTrayIconEnabled());
   if (brave_vpn::wireguard::IsVPNTrayIconEnabled()) {
-    LaunchBraveVpnWireguardInInteractiveMode();
+    brave_vpn::wireguard::ShowBraveVpnStatusTrayIcon();
   }
 #endif
 }

--- a/browser/ui/browser_commands.cc
+++ b/browser/ui/browser_commands.cc
@@ -129,9 +129,8 @@ void ShowBraveVPNBubble(Browser* browser) {
 
 void ToggleBraveVPNTrayIcon() {
 #if BUILDFLAG(ENABLE_BRAVE_VPN) && BUILDFLAG(IS_WIN)
-  brave_vpn::wireguard::EnableVPNTrayIcon(
-      !brave_vpn::wireguard::IsVPNTrayIconEnabled());
-  if (brave_vpn::wireguard::IsVPNTrayIconEnabled()) {
+  brave_vpn::EnableVPNTrayIcon(!brave_vpn::IsVPNTrayIconEnabled());
+  if (brave_vpn::IsVPNTrayIconEnabled()) {
     brave_vpn::wireguard::ShowBraveVpnStatusTrayIcon();
   }
 #endif

--- a/browser/ui/toolbar/brave_vpn_menu_model.cc
+++ b/browser/ui/toolbar/brave_vpn_menu_model.cc
@@ -36,12 +36,10 @@ void BraveVPNMenuModel::Build() {
                           ? IDS_BRAVE_VPN_HIDE_VPN_BUTTON_MENU_ITEM
                           : IDS_BRAVE_VPN_SHOW_VPN_BUTTON_MENU_ITEM);
 #if BUILDFLAG(IS_WIN)
-  if (brave_vpn::IsBraveVPNWireguardEnabled(g_browser_process->local_state())) {
-    AddItemWithStringId(IDC_TOGGLE_BRAVE_VPN_TRAY_ICON,
-                        IsTrayIconEnabled()
-                            ? IDS_BRAVE_VPN_HIDE_VPN_TRAY_ICON_MENU_ITEM
-                            : IDS_BRAVE_VPN_SHOW_VPN_TRAY_ICON_MENU_ITEM);
-  }
+  AddItemWithStringId(IDC_TOGGLE_BRAVE_VPN_TRAY_ICON,
+                      IsTrayIconEnabled()
+                          ? IDS_BRAVE_VPN_HIDE_VPN_TRAY_ICON_MENU_ITEM
+                          : IDS_BRAVE_VPN_SHOW_VPN_TRAY_ICON_MENU_ITEM);
 #endif  // BUILDFLAG(IS_WIN)
   AddItemWithStringId(IDC_SEND_BRAVE_VPN_FEEDBACK,
                       IDS_BRAVE_VPN_SHOW_FEEDBACK_MENU_ITEM);

--- a/browser/ui/toolbar/brave_vpn_menu_model.cc
+++ b/browser/ui/toolbar/brave_vpn_menu_model.cc
@@ -62,6 +62,6 @@ bool BraveVPNMenuModel::IsTrayIconEnabled() const {
     return tray_icon_enabled_for_testing_.value();
   }
 
-  return brave_vpn::wireguard::IsVPNTrayIconEnabled();
+  return brave_vpn::IsVPNTrayIconEnabled();
 }
 #endif

--- a/browser/ui/toolbar/brave_vpn_menu_model_unittest.cc
+++ b/browser/ui/toolbar/brave_vpn_menu_model_unittest.cc
@@ -67,21 +67,18 @@ TEST_F(BraveVPNMenuModelUnitTest, TrayIconEnabled) {
   }
 
   // Wireguard protocol disbled in the setting.
-  local_state()->SetBoolean(brave_vpn::prefs::kBraveVPNWireguardEnabled, false);
   EXPECT_TRUE(menu_model.IsTrayIconEnabled());
   menu_model.Clear();
   EXPECT_EQ(menu_model.GetItemCount(), 0u);
   menu_model.Build();
   EXPECT_NE(menu_model.GetItemCount(), 0u);
   {
-    EXPECT_FALSE(
-        menu_model.GetIndexOfCommandId(IDC_TOGGLE_BRAVE_VPN_TRAY_ICON));
+    EXPECT_TRUE(menu_model.GetIndexOfCommandId(IDC_TOGGLE_BRAVE_VPN_TRAY_ICON));
   }
 
   // Cases with Disabled value.
   menu_model.SetTrayIconEnabledForTesting(false);
   prefs()->SetBoolean(brave_vpn::prefs::kBraveVPNShowButton, false);
-  local_state()->SetBoolean(brave_vpn::prefs::kBraveVPNWireguardEnabled, true);
   EXPECT_FALSE(menu_model.IsTrayIconEnabled());
   menu_model.Clear();
   EXPECT_EQ(menu_model.GetItemCount(), 0u);
@@ -95,22 +92,6 @@ TEST_F(BraveVPNMenuModelUnitTest, TrayIconEnabled) {
         menu_model.GetLabelAt(tray_index.value()),
         l10n_util::GetStringUTF16(IDS_BRAVE_VPN_SHOW_VPN_TRAY_ICON_MENU_ITEM));
   }
-}
-TEST_F(BraveVPNMenuModelUnitTest, TrayIconDisabled) {
-  local_state()->SetBoolean(brave_vpn::prefs::kBraveVPNWireguardEnabled, false);
-
-  BraveVPNMenuModel menu_model(nullptr, prefs());
-
-  // Cases with Enabled value.
-  menu_model.SetTrayIconEnabledForTesting(true);
-  prefs()->SetBoolean(brave_vpn::prefs::kBraveVPNShowButton, true);
-
-  EXPECT_TRUE(menu_model.IsTrayIconEnabled());
-  menu_model.Clear();
-  EXPECT_EQ(menu_model.GetItemCount(), 0u);
-  menu_model.Build();
-  EXPECT_NE(menu_model.GetItemCount(), 0u);
-  EXPECT_FALSE(menu_model.GetIndexOfCommandId(IDC_TOGGLE_BRAVE_VPN_TRAY_ICON));
 }
 #endif  // BUILDFLAG(IS_WIN)
 

--- a/browser/ui/webui/settings/brave_vpn/brave_vpn_handler.cc
+++ b/browser/ui/webui/settings/brave_vpn/brave_vpn_handler.cc
@@ -70,7 +70,7 @@ void BraveVpnHandler::RegisterMessages() {
 void BraveVpnHandler::OnProtocolChanged() {
   auto enabled =
       brave_vpn::IsBraveVPNWireguardEnabled(g_browser_process->local_state());
-  brave_vpn::wireguard::SetWireguardActive(enabled);
+  brave_vpn::SetWireguardActive(enabled);
 }
 
 void BraveVpnHandler::HandleRegisterWireguardService(

--- a/components/brave_vpn/browser/BUILD.gn
+++ b/components/brave_vpn/browser/BUILD.gn
@@ -40,6 +40,9 @@ static_library("browser") {
     "//ui/base",
     "//url",
   ]
+  if (is_win) {
+    deps += [ "//brave/components/brave_vpn/common/wireguard/win" ]
+  }
 }
 
 source_set("unit_tests") {

--- a/components/brave_vpn/browser/brave_vpn_service.cc
+++ b/components/brave_vpn/browser/brave_vpn_service.cc
@@ -137,7 +137,7 @@ void BraveVpnService::OnConnectionStateChanged(mojom::ConnectionState state) {
   DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
   VLOG(2) << __func__ << " " << state;
 #if BUILDFLAG(IS_WIN)
-  wireguard::WriteConnectionState(static_cast<int>(state));
+  WriteConnectionState(static_cast<int>(state));
 #endif
   // Ignore connection state change request for non purchased user.
   // This can be happened when user controls vpn via os settings.

--- a/components/brave_vpn/browser/connection/ikev2/win/brave_vpn_helper/BUILD.gn
+++ b/components/brave_vpn/browser/connection/ikev2/win/brave_vpn_helper/BUILD.gn
@@ -52,6 +52,7 @@ source_set("lib") {
     "//brave/components/brave_vpn/browser/connection/ikev2/win:ras_utils",
     "//brave/components/brave_vpn/common",
     "//brave/components/brave_vpn/common/win",
+    "//brave/components/brave_vpn/common/wireguard/win",
     "//third_party/abseil-cpp:absl",
   ]
 

--- a/components/brave_vpn/browser/connection/ikev2/win/brave_vpn_helper/vpn_dns_handler.cc
+++ b/components/brave_vpn/browser/connection/ikev2/win/brave_vpn_helper/vpn_dns_handler.cc
@@ -15,7 +15,8 @@
 #include "brave/components/brave_vpn/browser/connection/ikev2/win/brave_vpn_helper/brave_vpn_helper_state.h"
 #include "brave/components/brave_vpn/browser/connection/ikev2/win/brave_vpn_helper/vpn_utils.h"
 #include "brave/components/brave_vpn/browser/connection/ikev2/win/ras_utils.h"
-#include "brave/components/brave_vpn/common/brave_vpn_constants.h"
+#include "brave/components/brave_vpn/common/wireguard/win/service_commands.h"
+#include "brave/components/brave_vpn/common/wireguard/win/service_constants.h"
 
 namespace brave_vpn {
 
@@ -86,6 +87,11 @@ bool VpnDnsHandler::SetFilters(const std::wstring& connection_name) {
     }
     return false;
   }
+
+  // Show system notification about connected vpn.
+  brave_vpn::RunWireGuardCommandForUsers(
+      brave_vpn::kBraveVpnWireguardServiceNotifyConnectedSwitchName);
+
   return true;
 }
 

--- a/components/brave_vpn/common/wireguard/win/BUILD.gn
+++ b/components/brave_vpn/common/wireguard/win/BUILD.gn
@@ -18,6 +18,8 @@ midl("brave_wireguard_manager_idl") {
 
 source_set("win") {
   sources = [
+    "service_commands.cc",
+    "service_commands.h",
     "service_constants.h",
     "service_details.cc",
     "service_details.h",

--- a/components/brave_vpn/common/wireguard/win/service_commands.cc
+++ b/components/brave_vpn/common/wireguard/win/service_commands.cc
@@ -3,7 +3,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-#include "brave/browser/brave_vpn/win/brave_vpn_wireguard_service/service/process_utils.h"
+#include "brave/components/brave_vpn/common/wireguard/win/service_commands.h"
 
 #include "base/command_line.h"
 #include "base/files/file_path.h"

--- a/components/brave_vpn/common/wireguard/win/service_commands.h
+++ b/components/brave_vpn/common/wireguard/win/service_commands.h
@@ -3,8 +3,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-#ifndef BRAVE_BROWSER_BRAVE_VPN_WIN_BRAVE_VPN_WIREGUARD_SERVICE_SERVICE_PROCESS_UTILS_H_
-#define BRAVE_BROWSER_BRAVE_VPN_WIN_BRAVE_VPN_WIREGUARD_SERVICE_SERVICE_PROCESS_UTILS_H_
+#ifndef BRAVE_COMPONENTS_BRAVE_VPN_COMMON_WIREGUARD_WIN_SERVICE_COMMANDS_H_
+#define BRAVE_COMPONENTS_BRAVE_VPN_COMMON_WIREGUARD_WIN_SERVICE_COMMANDS_H_
 
 #include <string>
 
@@ -12,4 +12,4 @@ namespace brave_vpn {
 void RunWireGuardCommandForUsers(const std::string& command);
 }  // namespace brave_vpn
 
-#endif  // BRAVE_BROWSER_BRAVE_VPN_WIN_BRAVE_VPN_WIREGUARD_SERVICE_SERVICE_PROCESS_UTILS_H_
+#endif  // BRAVE_COMPONENTS_BRAVE_VPN_COMMON_WIREGUARD_WIN_SERVICE_COMMANDS_H_

--- a/components/brave_vpn/common/wireguard/win/storage_utils.h
+++ b/components/brave_vpn/common/wireguard/win/storage_utils.h
@@ -12,8 +12,11 @@
 namespace brave_vpn {
 
 namespace wireguard {
-
 std::wstring GetBraveVpnWireguardServiceRegistryStoragePath();
+absl::optional<base::FilePath> GetLastUsedConfigPath();
+bool UpdateLastUsedConfigPath(const base::FilePath& config_path);
+void RemoveStorageKey();
+}  // namespace wireguard
 
 bool IsVPNTrayIconEnabled();
 void EnableVPNTrayIcon(bool value);
@@ -21,18 +24,13 @@ void EnableVPNTrayIcon(bool value);
 void SetWireguardActive(bool value);
 bool IsWireguardActive();
 
-absl::optional<base::FilePath> GetLastUsedConfigPath();
-bool UpdateLastUsedConfigPath(const base::FilePath& config_path);
-
 bool ShouldFallbackToIKEv2();
 void IncrementWireguardTunnelUsageFlag();
 void ResetWireguardTunnelUsageFlag();
 
-void RemoveStorageKey();
-
 void WriteConnectionState(int state);
 absl::optional<int32_t> GetConnectionState();
-}  // namespace wireguard
+
 }  // namespace brave_vpn
 
 #endif  // BRAVE_COMPONENTS_BRAVE_VPN_COMMON_WIREGUARD_WIN_STORAGE_UTILS_H_

--- a/components/brave_vpn/common/wireguard/win/storage_utils_unittest.cc
+++ b/components/brave_vpn/common/wireguard/win/storage_utils_unittest.cc
@@ -11,7 +11,6 @@
 #include "testing/gtest/include/gtest/gtest.h"
 
 namespace brave_vpn {
-namespace wireguard {
 
 TEST(StorageUtilsUnitTest, IsVPNTrayIconEnabled) {
   registry_util::RegistryOverrideManager registry_overrides;
@@ -38,14 +37,14 @@ TEST(StorageUtilsUnitTest, IsWireguardActive) {
 TEST(StorageUtilsUnitTest, GetLastUsedConfigPath) {
   registry_util::RegistryOverrideManager registry_overrides;
   registry_overrides.OverrideRegistry(HKEY_LOCAL_MACHINE);
-  EXPECT_FALSE(GetLastUsedConfigPath());
+  EXPECT_FALSE(wireguard::GetLastUsedConfigPath());
 
-  EXPECT_TRUE(UpdateLastUsedConfigPath(base::FilePath()));
-  EXPECT_FALSE(GetLastUsedConfigPath());
+  EXPECT_TRUE(wireguard::UpdateLastUsedConfigPath(base::FilePath()));
+  EXPECT_FALSE(wireguard::GetLastUsedConfigPath());
 
   base::FilePath test_config_path(L"C:\\value");
-  EXPECT_TRUE(UpdateLastUsedConfigPath(test_config_path));
-  auto last_config = GetLastUsedConfigPath();
+  EXPECT_TRUE(wireguard::UpdateLastUsedConfigPath(test_config_path));
+  auto last_config = wireguard::GetLastUsedConfigPath();
   EXPECT_TRUE(last_config.has_value());
   EXPECT_EQ(last_config.value(), test_config_path);
 }
@@ -53,7 +52,7 @@ TEST(StorageUtilsUnitTest, GetLastUsedConfigPath) {
 TEST(StorageUtilsUnitTest, ShouldFallbackToIKEv2) {
   registry_util::RegistryOverrideManager registry_overrides;
   registry_overrides.OverrideRegistry(HKEY_LOCAL_MACHINE);
-  SetWireguardServiceRegisteredForTesting(true);
+  wireguard::SetWireguardServiceRegisteredForTesting(true);
   EXPECT_FALSE(ShouldFallbackToIKEv2());
 
   // By default we have limitations in 3 attempts.
@@ -65,7 +64,7 @@ TEST(StorageUtilsUnitTest, ShouldFallbackToIKEv2) {
   EXPECT_TRUE(ShouldFallbackToIKEv2());
   ResetWireguardTunnelUsageFlag();
   EXPECT_FALSE(ShouldFallbackToIKEv2());
-  SetWireguardServiceRegisteredForTesting(false);
+  wireguard::SetWireguardServiceRegisteredForTesting(false);
   EXPECT_TRUE(ShouldFallbackToIKEv2());
 }
 
@@ -80,5 +79,4 @@ TEST(StorageUtilsUnitTest, WriteConnectionState) {
   EXPECT_EQ(value.value(), 1);
 }
 
-}  // namespace wireguard
 }  // namespace brave_vpn

--- a/components/brave_vpn/common/wireguard/win/wireguard_utils.cc
+++ b/components/brave_vpn/common/wireguard/win/wireguard_utils.cc
@@ -11,7 +11,10 @@
 #include <utility>
 
 #include "base/base64.h"
+#include "base/command_line.h"
+#include "base/files/file_path.h"
 #include "base/logging.h"
+#include "base/process/launch.h"
 #include "base/strings/string_util.h"
 #include "base/strings/utf_string_conversions.h"
 #include "base/task/single_thread_task_runner.h"
@@ -20,6 +23,7 @@
 #include "base/win/scoped_bstr.h"
 #include "brave/components/brave_vpn/common/win/utils.h"
 #include "brave/components/brave_vpn/common/wireguard/win/brave_wireguard_manager_idl.h"
+#include "brave/components/brave_vpn/common/wireguard/win/service_constants.h"
 #include "brave/components/brave_vpn/common/wireguard/win/service_details.h"
 #include "third_party/abseil-cpp/absl/types/optional.h"
 
@@ -223,6 +227,16 @@ void WireguardGenerateKeypair(
       ->PostTaskAndReplyWithResult(
           FROM_HERE, base::BindOnce(&WireguardGenerateKeypairImpl),
           std::move(callback));
+}
+
+void ShowBraveVpnStatusTrayIcon() {
+  auto executable_path = brave_vpn::GetBraveVPNWireguardServiceExecutablePath();
+  base::CommandLine interactive_cmd(executable_path);
+  interactive_cmd.AppendSwitch(
+      brave_vpn::kBraveVpnWireguardServiceInteractiveSwitchName);
+  if (!base::LaunchProcess(interactive_cmd, base::LaunchOptions()).IsValid()) {
+    VLOG(1) << "Interactive process launch failed";
+  }
 }
 
 }  // namespace wireguard

--- a/components/brave_vpn/common/wireguard/win/wireguard_utils.h
+++ b/components/brave_vpn/common/wireguard/win/wireguard_utils.h
@@ -30,6 +30,8 @@ void EnableBraveVpnWireguardService(const std::string& config,
 void DisableBraveVpnWireguardService(BooleanCallback callback);
 
 void SetWireguardServiceRegisteredForTesting(bool value);
+void ShowBraveVpnStatusTrayIcon();
+
 }  // namespace wireguard
 
 }  // namespace brave_vpn


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/32143

- Added IKEv2 support for status tray icon
- Status tray icon launched if any of BraveVPN protocols connected
- Show system notifications if brave IKEv2 vpn connected (only if dns helper started)

https://github.com/brave/brave-core/assets/2965009/141fa44a-85bc-4125-aee5-d3e82fe7c6b6


<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-arm64, CI/skip-linux-x64, CI/skip-android, CI/skip-macos, CI/skip-ios, CI/skip-windows-arm64, CI/skip-windows-x64, CI/skip-windows-x86 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

- Check that Brave VPN status tray icon allow to manage both BraveVPN protocols, Ras/Wireguard
- Check if users enable vpn using system Brave VPN RAS connection entry, the tray icons shows and updates connection status correctly
- Check that the icon becomes visible if it was not visible and IKEv2 connected.
- Check that browser shows system notifications if Brave IKEv2 vpn connected (only if dns helper started)