### PR TITLE
Added a retry button to the error limit UI state

### DIFF
--- a/components/ai_chat/browser/ai_chat_tab_helper.cc
+++ b/components/ai_chat/browser/ai_chat_tab_helper.cc
@@ -259,6 +259,7 @@ void AIChatTabHelper::CleanUp() {
   has_generated_questions_ = false;
   should_page_content_be_disconnected_ = false;
   OnSuggestedQuestionsChanged();
+  SetAPIError(mojom::APIError::None);
   ai_chat_api_->ClearAllQueries();
 
   // Trigger an observer update to refresh the UI.

--- a/components/ai_chat/resources/page/chat_ui.tsx
+++ b/components/ai_chat/resources/page/chat_ui.tsx
@@ -102,7 +102,11 @@ function App () {
     }
 
     if (apiHasError && model.currentError === APIError.RateLimitReached) {
-      currentErrorElement = <ErrorRateLimit />
+      currentErrorElement = (
+        <ErrorRateLimit
+          onRetry={() => getPageHandlerInstance().pageHandler.retryAPIRequest()}
+        />
+      )
     }
   }
 

--- a/components/ai_chat/resources/page/components/error_rate_limit/index.tsx
+++ b/components/ai_chat/resources/page/components/error_rate_limit/index.tsx
@@ -6,15 +6,25 @@
 import * as React from 'react'
 import { getLocale } from '$web-common/locale'
 import Icon from '@brave/leo/react/icon'
+import Button from '@brave/leo/react/button'
 
 import styles from './style.module.scss'
 
-function ErrorRateLimit () {
+interface ErrorRateLimit {
+  onRetry?: () => void
+}
+
+function ErrorRateLimit (props: ErrorRateLimit) {
   return (
     <div className={styles.box}>
-      <Icon name="warning-circle-filled" className={styles.icon} />
+      <Icon name="warning-triangle-filled" className={styles.icon} />
       <div>
-        <p>{getLocale('errorRateLimit')}.</p>
+        <p>{getLocale('errorRateLimit')}</p>
+        <div className={styles.actionsBox}>
+          <Button onClick={props.onRetry}>
+            {getLocale('retryButtonLabel')}
+          </Button>
+        </div>
       </div>
     </div>
   )

--- a/components/ai_chat/resources/page/components/error_rate_limit/style.module.scss
+++ b/components/ai_chat/resources/page/components/error_rate_limit/style.module.scss
@@ -5,7 +5,7 @@
 
 .box {
   width: 100%;
-  background: var(--leo-color-systemfeedback-error-background);
+  background: var(--leo-color-systemfeedback-warning-background);
   border-radius: 16px;
   padding: 16px;
   margin-bottom: 16px;
@@ -19,14 +19,14 @@
   }
 
   p {
-    margin: 0;
+    margin: 0 0 12px 0;
     font: var(--leo-font-primary-default-regular);
   }
 }
 
 .icon {
   --leo-icon-size: 18px;
-  color: var(--leo-color-systemfeedback-error-icon);
+  color: var(--leo-color-systemfeedback-warning-icon);
 }
 
 .actionsBox {

--- a/components/ai_chat/resources/page/stories/locale.ts
+++ b/components/ai_chat/resources/page/stories/locale.ts
@@ -19,6 +19,6 @@ provideStrings({
   acceptButtonLabel: 'Accept and begin',
   pageContentWarning: 'Disconnect to stop sending this page content to Leo, and start a new conversation',
   errorNetworkLabel: 'There was a network issue connecting to Leo, check your connection and try again.',
-  errorRateLimit: 'You\'ve reached the maximum number of questions for Leo. Please try again in a few hours.',
+  errorRateLimit: 'Leo is too busy right now. Please try again in a few minutes.',
   retryButtonLabel: 'Retry'
 })


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/32602

<img width="321" alt="image" src="https://github.com/brave/brave-core/assets/8665427/0fb9234c-a1f3-4687-b1b1-231385ad87e2">


This PR adds a button to the error limit UI. Additionally, it fixes a crash. When the user is in an error state, clearing the conversation or disconnecting the page contents resets all state except the error. Upon retry, it crashes because there is now an empty history vector, which is used in the retry logic.

stack trace for the crash:
```
[49308:259:0830/133221.156741:FATAL:ai_chat_tab_helper.cc(700)] Check failed: !chat_history_.empty(). 
0   libbase.dylib                       0x00000001010e8aa8 base::debug::CollectStackTrace(void**, unsigned long) + 28
1   libbase.dylib                       0x00000001010d0418 base::debug::StackTrace::StackTrace() + 24
2   libbase.dylib                       0x0000000100fd248c logging::LogMessage::~LogMessage() + 156
3   libbase.dylib                       0x0000000100fb50b8 logging::(anonymous namespace)::DCheckLogMessage::~DCheckLogMessage() + 60
4   libbase.dylib                       0x0000000100fb4df4 logging::CheckError::~CheckError() + 40
5   libbase.dylib                       0x0000000100fb4e24 logging::CheckError::~CheckError() + 12
6   libchrome_dll.dylib                 0x000000010db92bf8 ai_chat::AIChatTabHelper::RetryAPIRequest() + 488
7   libchrome_dll.dylib                 0x000000010b784698 ai_chat::mojom::PageHandlerStubDispatch::Accept(ai_chat::mojom::PageHandler*, mojo::Message*) + 628
8   libmojo_public_cpp_bindings.dylib   0x00000001015c25e4 mojo::InterfaceEndpointClient::HandleValidatedMessage(mojo::Message*) + 1104
9   libmojo_public_cpp_bindings.dylib   0x00000001015c9310 mojo::MessageDispatcher::Accept(mojo::Message*) + 236
```

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-arm64, CI/skip-linux-x64, CI/skip-android, CI/skip-macos, CI/skip-ios, CI/skip-windows-arm64, CI/skip-windows-x64, CI/skip-windows-x86 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [ ] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

