### PR TITLE
fix(wallet): Selecting Hidden NFTs

### DIFF
--- a/components/brave_wallet_ui/components/desktop/views/portfolio/portfolio-nft-asset.tsx
+++ b/components/brave_wallet_ui/components/desktop/views/portfolio/portfolio-nft-asset.tsx
@@ -51,16 +51,27 @@ export const PortfolioNftAsset = () => {
   const userVisibleTokensInfo = useUnsafeWalletSelector(
     WalletSelectors.userVisibleTokensInfo
   )
+  const hiddenNfts =
+    useUnsafeWalletSelector(WalletSelectors.removedNonFungibleTokens)
 
   const selectedAssetFromParams = React.useMemo(() => {
-    const userToken = userVisibleTokensInfo.find((token) =>
-      tokenId
-        ? token.tokenId === tokenId &&
-          token.contractAddress.toLowerCase() === contractAddress.toLowerCase()
-        : token.contractAddress.toLowerCase() === contractAddress.toLowerCase()
-    )
+    const userToken =
+      [...userVisibleTokensInfo, ...hiddenNfts]
+        .find((token) =>
+          tokenId
+            ? token.tokenId === tokenId &&
+            token.contractAddress.toLowerCase() ===
+            contractAddress.toLowerCase()
+            : token.contractAddress.toLowerCase() ===
+            contractAddress.toLowerCase()
+        )
     return userToken
-  }, [userVisibleTokensInfo, contractAddress, tokenId])
+  }, [
+    userVisibleTokensInfo,
+    contractAddress,
+    tokenId,
+    hiddenNfts
+  ])
 
   const accounts = useUnsafeWalletSelector(WalletSelectors.accounts)
   const { data: selectedAssetNetwork } = useGetNetworkQuery(


### PR DESCRIPTION
## Description 
Re-Fixes a bug where you were not able to view a `Hidden` NFT

<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves <https://github.com/brave/brave-browser/issues/32646>

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-arm64, CI/skip-linux-x64, CI/skip-android, CI/skip-macos, CI/skip-ios, CI/skip-windows-arm64, CI/skip-windows-x64, CI/skip-windows-x86 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

   1. Open the `Wallet` and go to the `NFT's` tab
   2. Hide an `NFT` and then try to open it
   3. It shouldn't redirect to the `Portfolio` page and you should be able to view it.

https://github.com/brave/brave-core/assets/40611140/21952063-acb1-4cc0-a768-adc2de490a00
