### PR TITLE
Fixed vpn toggle menu item is not visible in app menu

### DIFF
--- a/browser/ui/brave_browser_command_controller.h
+++ b/browser/ui/brave_browser_command_controller.h
@@ -19,6 +19,7 @@
 #endif
 
 class BraveAppMenuBrowserTest;
+class BraveAppMenuModelBrowserTest;
 class BraveBrowserCommandControllerTest;
 
 // This namespace is needed for a chromium_src override
@@ -43,6 +44,7 @@ class BraveBrowserCommandController : public chrome::BrowserCommandController
 
  private:
   friend class ::BraveAppMenuBrowserTest;
+  friend class ::BraveAppMenuModelBrowserTest;
   friend class ::BraveBrowserCommandControllerTest;
 
   // Overriden from CommandUpdater:

--- a/browser/ui/toolbar/brave_app_menu_model.h
+++ b/browser/ui/toolbar/brave_app_menu_model.h
@@ -36,7 +36,7 @@ class BraveAppMenuModel : public AppMenuModel {
   BraveAppMenuModel& operator=(const BraveAppMenuModel&) = delete;
 
  private:
-  FRIEND_TEST_ALL_PREFIXES(BraveAppMenuBrowserTest, BraveIpfsMenuTest);
+  FRIEND_TEST_ALL_PREFIXES(BraveAppMenuModelBrowserTest, BraveIpfsMenuTest);
 
   // AppMenuModel overrides:
   void Build() override;

--- a/browser/ui/toolbar/brave_app_menu_model_browsertest.cc
+++ b/browser/ui/toolbar/brave_app_menu_model_browsertest.cc
@@ -45,9 +45,9 @@
 #include "brave/components/ipfs/keys/ipns_keys_manager.h"
 #endif
 
-class BraveAppMenuBrowserTest : public InProcessBrowserTest {
+class BraveAppMenuModelBrowserTest : public InProcessBrowserTest {
  public:
-  BraveAppMenuBrowserTest() {
+  BraveAppMenuModelBrowserTest() {
 #if BUILDFLAG(ENABLE_BRAVE_VPN)
     scoped_feature_list_.InitWithFeatures(
         {skus::features::kSkusFeature, brave_vpn::features::kBraveVPN}, {});
@@ -191,7 +191,7 @@ void CheckHistoryCommandsAreInOrderInMenuModel(
 // Brave menu is inserted based on corresponding commands enable status.
 // So, this doesn't test for each profiles(normal, private, tor and guest).
 // Instead, BraveBrowserCommandControllerTest will do that.
-IN_PROC_BROWSER_TEST_F(BraveAppMenuBrowserTest, MenuOrderTest) {
+IN_PROC_BROWSER_TEST_F(BraveAppMenuModelBrowserTest, MenuOrderTest) {
   std::vector<int> commands_in_order_for_normal_profile = {
     IDC_NEW_TAB,
     IDC_NEW_WINDOW,
@@ -379,7 +379,7 @@ IN_PROC_BROWSER_TEST_F(BraveAppMenuBrowserTest, MenuOrderTest) {
 
 #if BUILDFLAG(ENABLE_BRAVE_VPN)
 // Check vpn menu based on purchased status.
-IN_PROC_BROWSER_TEST_F(BraveAppMenuBrowserTest, BraveVPNMenuTest) {
+IN_PROC_BROWSER_TEST_F(BraveAppMenuModelBrowserTest, BraveVPNMenuTest) {
   std::vector<int> commands_enabled_for_non_purchased = {
       IDC_SHOW_BRAVE_VPN_PANEL,
   };
@@ -408,7 +408,7 @@ IN_PROC_BROWSER_TEST_F(BraveAppMenuBrowserTest, BraveVPNMenuTest) {
 #endif
 
 #if BUILDFLAG(ENABLE_IPFS_LOCAL_NODE)
-IN_PROC_BROWSER_TEST_F(BraveAppMenuBrowserTest, BraveIpfsMenuTest) {
+IN_PROC_BROWSER_TEST_F(BraveAppMenuModelBrowserTest, BraveIpfsMenuTest) {
   CheckIpfsCommandsAreDisabledForMode(
       browser(), ipfs::IPFSResolveMethodTypes::IPFS_GATEWAY);
   CheckIpfsCommandsAreDisabledForMode(browser(),

--- a/browser/ui/views/toolbar/brave_app_menu.cc
+++ b/browser/ui/views/toolbar/brave_app_menu.cc
@@ -30,6 +30,7 @@ BraveAppMenu::BraveAppMenu(Browser* browser,
       menu_metrics_(
           g_brave_browser_process->process_misc_metrics()->menu_metrics()) {
   DCHECK(menu_metrics_);
+  UpdateMenuItemView();
 }
 
 BraveAppMenu::~BraveAppMenu() = default;
@@ -49,24 +50,6 @@ void BraveAppMenu::OnMenuClosed(views::MenuItemView* menu) {
   if (menu == nullptr) {
     menu_metrics_->RecordMenuDismiss();
   }
-}
-
-MenuItemView* BraveAppMenu::AddMenuItem(views::MenuItemView* parent,
-                                        size_t menu_index,
-                                        ui::MenuModel* model,
-                                        size_t model_index,
-                                        ui::MenuModel::ItemType menu_type) {
-  MenuItemView* menu_item =
-      AppMenu::AddMenuItem(parent, menu_index, model, model_index, menu_type);
-
-#if BUILDFLAG(ENABLE_BRAVE_VPN)
-  if (menu_item && model->GetCommandIdAt(model_index) == IDC_TOGGLE_BRAVE_VPN) {
-    menu_item->AddChildView(std::make_unique<BraveVPNStatusLabel>(browser_));
-    menu_item->AddChildView(std::make_unique<BraveVPNToggleButton>(browser_));
-  }
-#endif
-
-  return menu_item;
 }
 
 void BraveAppMenu::RecordMenuUsage(int command_id) {
@@ -104,4 +87,15 @@ void BraveAppMenu::RecordMenuUsage(int command_id) {
       }
   }
   menu_metrics_->RecordMenuGroupAction(group);
+}
+
+void BraveAppMenu::UpdateMenuItemView() {
+#if BUILDFLAG(ENABLE_BRAVE_VPN)
+  CHECK(root_menu_item());
+  if (auto* menu_item =
+          root_menu_item()->GetMenuItemByID(IDC_TOGGLE_BRAVE_VPN)) {
+    menu_item->AddChildView(std::make_unique<BraveVPNStatusLabel>(browser_));
+    menu_item->AddChildView(std::make_unique<BraveVPNToggleButton>(browser_));
+  }
+#endif
 }

--- a/browser/ui/views/toolbar/brave_app_menu.h
+++ b/browser/ui/views/toolbar/brave_app_menu.h
@@ -18,21 +18,16 @@ class BraveAppMenu : public AppMenu {
   BraveAppMenu(const BraveAppMenu&) = delete;
   BraveAppMenu& operator=(const BraveAppMenu&) = delete;
 
+  // AppMenu overrides:
   void RunMenu(views::MenuButtonController* host) override;
-
   void ExecuteCommand(int command_id, int mouse_event_flags) override;
-
   void OnMenuClosed(views::MenuItemView* menu) override;
 
  private:
-  // AppMenu overrides:
-  views::MenuItemView* AddMenuItem(views::MenuItemView* parent,
-                                   size_t menu_index,
-                                   ui::MenuModel* model,
-                                   size_t model_index,
-                                   ui::MenuModel::ItemType menu_type) override;
-
   void RecordMenuUsage(int command_id);
+
+  // Update item's view as brave style.
+  void UpdateMenuItemView();
 
   base::raw_ptr<misc_metrics::MenuMetrics> menu_metrics_;
 };

--- a/browser/ui/views/toolbar/brave_app_menu_browsertest.cc
+++ b/browser/ui/views/toolbar/brave_app_menu_browsertest.cc
@@ -1,0 +1,88 @@
+/* Copyright (c) 2023 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "base/test/scoped_feature_list.h"
+#include "brave/app/brave_command_ids.h"
+#include "brave/browser/ui/brave_browser_command_controller.h"
+#include "brave/components/brave_vpn/common/buildflags/buildflags.h"
+#include "brave/components/skus/common/features.h"
+#include "chrome/browser/ui/views/frame/browser_view.h"
+#include "chrome/browser/ui/views/toolbar/app_menu.h"
+#include "chrome/browser/ui/views/toolbar/browser_app_menu_button.h"
+#include "chrome/browser/ui/views/toolbar/toolbar_view.h"
+#include "chrome/test/base/in_process_browser_test.h"
+#include "chrome/test/base/ui_test_utils.h"
+#include "content/public/test/browser_test.h"
+#include "content/public/test/test_utils.h"
+#include "ui/views/controls/button/toggle_button.h"
+#include "ui/views/controls/menu/menu_item_view.h"
+#include "ui/views/controls/menu/menu_runner.h"
+#include "ui/views/view_utils.h"
+
+#if BUILDFLAG(ENABLE_BRAVE_VPN)
+#include "brave/browser/brave_vpn/brave_vpn_service_factory.h"
+#include "brave/components/brave_vpn/browser/brave_vpn_service.h"
+#include "brave/components/brave_vpn/common/features.h"
+#endif
+
+class BraveAppMenuBrowserTest : public InProcessBrowserTest {
+ public:
+  BraveAppMenuBrowserTest() {
+#if BUILDFLAG(ENABLE_BRAVE_VPN)
+    scoped_feature_list_.InitWithFeatures(
+        {skus::features::kSkusFeature, brave_vpn::features::kBraveVPN}, {});
+#endif
+  }
+
+  ~BraveAppMenuBrowserTest() override = default;
+
+  BrowserAppMenuButton* menu_button() {
+    return BrowserView::GetBrowserViewForBrowser(browser())
+        ->toolbar()
+        ->app_menu_button();
+  }
+
+#if BUILDFLAG(ENABLE_BRAVE_VPN)
+  void SetPurchasedUserForBraveVPN(Browser* browser, bool purchased) {
+    auto* service =
+        brave_vpn::BraveVpnServiceFactory::GetForProfile(browser->profile());
+    ASSERT_TRUE(!!service);
+    auto target_state = purchased
+                            ? brave_vpn::mojom::PurchasedState::PURCHASED
+                            : brave_vpn::mojom::PurchasedState::NOT_PURCHASED;
+    service->SetPurchasedState(skus::GetDefaultEnvironment(), target_state);
+    // Call explicitely to update vpn commands status because mojo works in
+    // async way.
+    static_cast<chrome::BraveBrowserCommandController*>(
+        browser->command_controller())
+        ->OnPurchasedStateChanged(target_state, absl::nullopt);
+  }
+
+  base::test::ScopedFeatureList scoped_feature_list_;
+#endif
+};
+
+#if BUILDFLAG(ENABLE_BRAVE_VPN)
+// Check toggle menu item has additional toggle button for purchased user.
+IN_PROC_BROWSER_TEST_F(BraveAppMenuBrowserTest, PurchasedVPN) {
+  SetPurchasedUserForBraveVPN(browser(), true);
+  menu_button()->ShowMenu(views::MenuRunner::NO_FLAGS);
+  views::MenuItemView* menu_root = menu_button()->app_menu()->root_menu_item();
+  auto* toggle_menu_item = menu_root->GetMenuItemByID(IDC_TOGGLE_BRAVE_VPN);
+  ASSERT_TRUE(!!toggle_menu_item);
+  const int last_item_index = toggle_menu_item->children().size() - 1;
+  auto* toggle_button = views::AsViewClass<views::ToggleButton>(
+      toggle_menu_item->children()[last_item_index]);
+  ASSERT_NE(nullptr, toggle_button);
+}
+
+// Check app menu has show vpn panel menu item for not purchased user.
+IN_PROC_BROWSER_TEST_F(BraveAppMenuBrowserTest, NotPurchasedVPN) {
+  SetPurchasedUserForBraveVPN(browser(), false);
+  menu_button()->ShowMenu(views::MenuRunner::NO_FLAGS);
+  views::MenuItemView* menu_root = menu_button()->app_menu()->root_menu_item();
+  EXPECT_TRUE(!!menu_root->GetMenuItemByID(IDC_SHOW_BRAVE_VPN_PANEL));
+}
+#endif

--- a/chromium_src/chrome/browser/ui/views/toolbar/app_menu.h
+++ b/chromium_src/chrome/browser/ui/views/toolbar/app_menu.h
@@ -6,18 +6,13 @@
 #ifndef BRAVE_CHROMIUM_SRC_CHROME_BROWSER_UI_VIEWS_TOOLBAR_APP_MENU_H_
 #define BRAVE_CHROMIUM_SRC_CHROME_BROWSER_UI_VIEWS_TOOLBAR_APP_MENU_H_
 
-#define RunMenu      \
-  UnusedMethod1() {} \
+#define RunMenu              \
+  UnusedMethod1() {}         \
+  friend class BraveAppMenu; \
   virtual void RunMenu
-
-#define AddMenuItem                   \
-  UnusedMethod2() { return nullptr; } \
-  friend class BraveAppMenu;          \
-  virtual views::MenuItemView* AddMenuItem
 
 #include "src/chrome/browser/ui/views/toolbar/app_menu.h"  // IWYU pragma: export
 
 #undef RunMenu
-#undef AddMenuItem
 
 #endif  // BRAVE_CHROMIUM_SRC_CHROME_BROWSER_UI_VIEWS_TOOLBAR_APP_MENU_H_

--- a/components/brave_vpn/browser/brave_vpn_service.h
+++ b/components/brave_vpn/browser/brave_vpn_service.h
@@ -41,6 +41,7 @@ class PrefService;
 
 #if !BUILDFLAG(IS_ANDROID)
 class BraveAppMenuBrowserTest;
+class BraveAppMenuModelBrowserTest;
 class BraveBrowserCommandControllerTest;
 #endif  // !BUILDFLAG(IS_ANDROID)
 
@@ -159,6 +160,7 @@ class BraveVpnService :
 
 #if !BUILDFLAG(IS_ANDROID)
   friend class ::BraveAppMenuBrowserTest;
+  friend class ::BraveAppMenuModelBrowserTest;
   friend class ::BraveBrowserCommandControllerTest;
 
   // BraveVPNOSConnectionAPI::Observer overrides:

--- a/test/BUILD.gn
+++ b/test/BUILD.gn
@@ -1090,6 +1090,7 @@ test("brave_browser_tests") {
       "//brave/browser/ui/views/profiles/brave_profile_menu_view_browsertest.cc",
       "//brave/browser/ui/views/tabs/brave_tab_context_menu_contents_browsertest.cc",
       "//brave/browser/ui/views/tabs/vertical_tab_strip_browsertest.cc",
+      "//brave/browser/ui/views/toolbar/brave_app_menu_browsertest.cc",
       "//brave/browser/ui/views/toolbar/brave_toolbar_view_browsertest.cc",
       "//brave/browser/ui/views/toolbar/wallet_button_browsertest.cc",
     ]


### PR DESCRIPTION
fix https://github.com/brave/brave-browser/issues/32703

As AddMenuItem() is called in base class' ctor, our overridden method is not called.
Fixed by updating that menu item after menu build is finished in ctor.

https://chromium-review.googlesource.com/c/chromium/src/+/4563503 made this regression.
AddMenuItem() was called by another Init() but called in ctor now.

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves 

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-arm64, CI/skip-linux-x64, CI/skip-android, CI/skip-macos, CI/skip-ios, CI/skip-windows-arm64, CI/skip-windows-x64, CI/skip-windows-x86 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

`BraveAppMenuBrowserTest.*`

See the linked issue for manu test