### PR TITLE
[Commander]: Add custom icon

### DIFF
--- a/chromium_src/components/omnibox/browser/autocomplete_match.cc
+++ b/chromium_src/components/omnibox/browser/autocomplete_match.cc
@@ -1,0 +1,24 @@
+// Copyright (c) 2023 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#include "components/omnibox/browser/autocomplete_match.h"
+
+#include "brave/components/omnibox/browser/commander_provider.h"
+#include "brave/components/vector_icons/vector_icons.h"
+
+#define GetVectorIcon GetVectorIcon_Chromium
+
+#include "src/components/omnibox/browser/autocomplete_match.cc"
+
+#undef GetVectorIcon
+
+const gfx::VectorIcon& AutocompleteMatch::GetVectorIcon(
+    bool is_bookmark,
+    const TemplateURL* turl) const {
+  if (!GetAdditionalInfo(commander::kCommanderMatchMarker).empty()) {
+    return kLeoCaratRightIcon;
+  }
+  return GetVectorIcon_Chromium(is_bookmark, turl);
+}

--- a/chromium_src/components/omnibox/browser/autocomplete_match.cc
+++ b/chromium_src/components/omnibox/browser/autocomplete_match.cc
@@ -10,7 +10,7 @@
 
 #define GetVectorIcon GetVectorIcon_Chromium
 
-#include "src/components/omnibox/browser/autocomplete_match.cc"
+#include "src/components/omnibox/browser/autocomplete_match.cc"  // IWYU pragma: export
 
 #undef GetVectorIcon
 

--- a/chromium_src/components/omnibox/browser/autocomplete_match.cc
+++ b/chromium_src/components/omnibox/browser/autocomplete_match.cc
@@ -8,12 +8,7 @@
 #include "brave/components/omnibox/browser/commander_provider.h"
 #include "brave/components/vector_icons/vector_icons.h"
 
-#define GetVectorIcon GetVectorIcon_Chromium
-
-#include "src/components/omnibox/browser/autocomplete_match.cc"  // IWYU pragma: export
-
-#undef GetVectorIcon
-
+#if (!BUILDFLAG(IS_ANDROID) || BUILDFLAG(ENABLE_VR)) && !BUILDFLAG(IS_IOS)
 const gfx::VectorIcon& AutocompleteMatch::GetVectorIcon(
     bool is_bookmark,
     const TemplateURL* turl) const {
@@ -22,3 +17,10 @@ const gfx::VectorIcon& AutocompleteMatch::GetVectorIcon(
   }
   return GetVectorIcon_Chromium(is_bookmark, turl);
 }
+
+#define GetVectorIcon GetVectorIcon_Chromium
+#endif
+
+#include "src/components/omnibox/browser/autocomplete_match.cc"  // IWYU pragma: export
+
+#undef GetVectorIcon

--- a/chromium_src/components/omnibox/browser/autocomplete_match.h
+++ b/chromium_src/components/omnibox/browser/autocomplete_match.h
@@ -1,0 +1,17 @@
+// Copyright (c) 2023 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#ifndef BRAVE_CHROMIUM_SRC_COMPONENTS_OMNIBOX_BROWSER_AUTOCOMPLETE_MATCH_H_
+#define BRAVE_CHROMIUM_SRC_COMPONENTS_OMNIBOX_BROWSER_AUTOCOMPLETE_MATCH_H_
+
+#define GetVectorIcon                                                      \
+  GetVectorIcon_Chromium(bool is_bookmark, const TemplateURL* turl) const; \
+  const gfx::VectorIcon& GetVectorIcon
+
+#include "src/components/omnibox/browser/autocomplete_match.h"
+
+#undef GetVectorIcon
+
+#endif  // BRAVE_CHROMIUM_SRC_COMPONENTS_OMNIBOX_BROWSER_AUTOCOMPLETE_MATCH_H_

--- a/chromium_src/components/omnibox/browser/autocomplete_match.h
+++ b/chromium_src/components/omnibox/browser/autocomplete_match.h
@@ -6,9 +6,14 @@
 #ifndef BRAVE_CHROMIUM_SRC_COMPONENTS_OMNIBOX_BROWSER_AUTOCOMPLETE_MATCH_H_
 #define BRAVE_CHROMIUM_SRC_COMPONENTS_OMNIBOX_BROWSER_AUTOCOMPLETE_MATCH_H_
 
+#include "build/build_config.h"
+#include "components/omnibox/browser/buildflags.h"
+
+#if (!BUILDFLAG(IS_ANDROID) || BUILDFLAG(ENABLE_VR)) && !BUILDFLAG(IS_IOS)
 #define GetVectorIcon                                                      \
   GetVectorIcon_Chromium(bool is_bookmark, const TemplateURL* turl) const; \
   const gfx::VectorIcon& GetVectorIcon
+#endif
 
 #include "src/components/omnibox/browser/autocomplete_match.h"  // IWYU pragma: export
 

--- a/chromium_src/components/omnibox/browser/autocomplete_match.h
+++ b/chromium_src/components/omnibox/browser/autocomplete_match.h
@@ -6,14 +6,9 @@
 #ifndef BRAVE_CHROMIUM_SRC_COMPONENTS_OMNIBOX_BROWSER_AUTOCOMPLETE_MATCH_H_
 #define BRAVE_CHROMIUM_SRC_COMPONENTS_OMNIBOX_BROWSER_AUTOCOMPLETE_MATCH_H_
 
-#include "build/build_config.h"
-#include "components/omnibox/browser/buildflags.h"
-
-#if (!BUILDFLAG(IS_ANDROID) || BUILDFLAG(ENABLE_VR)) && !BUILDFLAG(IS_IOS)
 #define GetVectorIcon                                                      \
   GetVectorIcon_Chromium(bool is_bookmark, const TemplateURL* turl) const; \
   const gfx::VectorIcon& GetVectorIcon
-#endif
 
 #include "src/components/omnibox/browser/autocomplete_match.h"  // IWYU pragma: export
 

--- a/chromium_src/components/omnibox/browser/autocomplete_match.h
+++ b/chromium_src/components/omnibox/browser/autocomplete_match.h
@@ -10,7 +10,7 @@
   GetVectorIcon_Chromium(bool is_bookmark, const TemplateURL* turl) const; \
   const gfx::VectorIcon& GetVectorIcon
 
-#include "src/components/omnibox/browser/autocomplete_match.h"
+#include "src/components/omnibox/browser/autocomplete_match.h"  // IWYU pragma: export
 
 #undef GetVectorIcon
 

--- a/components/omnibox/browser/BUILD.gn
+++ b/components/omnibox/browser/BUILD.gn
@@ -48,6 +48,9 @@ source_set("unit_tests") {
     sources +=
         [ "//brave/components/omnibox/browser/commander_provider_unittest.cc" ]
 
-    deps += [ "//brave/components/commander/browser" ]
+    deps += [
+      "//brave/components/commander/browser",
+      "//brave/components/vector_icons",
+    ]
   }
 }

--- a/components/omnibox/browser/commander_provider.h
+++ b/components/omnibox/browser/commander_provider.h
@@ -17,6 +17,13 @@ class AutocompleteProviderClient;
 class AutocompleteProviderListener;
 
 namespace commander {
+
+// Used to distinguish matches for command items from regular
+// AutocompleteMatches. Other match types are defined in an enum, but to avoid
+// patching as much as possible, we're just using this marker in the
+// additional_info lookup to determine whether to show our custom icon.
+constexpr char kCommanderMatchMarker[] = "command-match";
+
 class CommanderProvider
     : public AutocompleteProvider,
       public commander::CommanderFrontendDelegate::Observer {

--- a/components/vector_icons/BUILD.gn
+++ b/components/vector_icons/BUILD.gn
@@ -24,6 +24,7 @@ aggregate_vector_icons("brave_components_vector_icons") {
     "leo_browser_bookmark_plural.icon",
     "leo_browser_extensions.icon",
     "leo_browser_sidebar_right.icon",
+    "leo_carat_right.icon",
     "leo_check_circle_filled.icon",
     "leo_check_circle_outline.icon",
     "leo_chrome_cast.icon",


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/32744

Adds a custom icon and removes the `:>` prefix from commands.

Before:
![image](https://github.com/brave/brave-core/assets/7678024/dda4b90d-c512-420a-b5d9-77ef8784ea88)

After:
![image](https://github.com/brave/brave-core/assets/7678024/988b1cc7-2bd5-489c-a496-f389ee6ad9e3)


<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-arm64, CI/skip-linux-x64, CI/skip-android, CI/skip-macos, CI/skip-ios, CI/skip-windows-arm64, CI/skip-windows-x64, CI/skip-windows-x86 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [ ] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

