### PR TITLE
AI Chat: refactor prompt building and engine calling to EngineConsumer implementations

### DIFF
--- a/browser/ui/webui/ai_chat/ai_chat_ui_page_handler.cc
+++ b/browser/ui/webui/ai_chat/ai_chat_ui_page_handler.cc
@@ -80,22 +80,10 @@ void AIChatUIPageHandler::SetClientPage(
 
 void AIChatUIPageHandler::SubmitHumanConversationEntry(
     const std::string& input) {
-  // TODO(nullhook): Avoid copy
-  std::string input_copy = input;
-
-  // Prevent indirect prompt injections being sent to the AI model.
-  // TODO(nullhook): Abstract prompt injection cleanups to a central place
-  base::ReplaceSubstringsAfterOffset(&input_copy, 0, ai_chat::kHumanPrompt, "");
-  base::ReplaceSubstringsAfterOffset(&input_copy, 0, ai_chat::kAIPrompt, "");
-  base::ReplaceSubstringsAfterOffset(&input_copy, 0, "<article>", "");
-  base::ReplaceSubstringsAfterOffset(&input_copy, 0, "</article>", "");
-  base::ReplaceSubstringsAfterOffset(&input_copy, 0, "<history>", "");
-  base::ReplaceSubstringsAfterOffset(&input_copy, 0, "</history>", "");
-  base::ReplaceSubstringsAfterOffset(&input_copy, 0, "<question>", "");
-  base::ReplaceSubstringsAfterOffset(&input_copy, 0, "</question>", "");
-
+  mojom::ConversationTurn turn = {CharacterType::HUMAN,
+                                  ConversationTurnVisibility::VISIBLE, input};
   active_chat_tab_helper_->MakeAPIRequestWithConversationHistoryUpdate(
-      {CharacterType::HUMAN, ConversationTurnVisibility::VISIBLE, input_copy});
+      std::move(turn));
 }
 
 void AIChatUIPageHandler::GetConversationHistory(

--- a/components/ai_chat/browser/BUILD.gn
+++ b/components/ai_chat/browser/BUILD.gn
@@ -19,15 +19,15 @@ static_library("browser") {
     "ai_chat_tab_helper.h",
     "constants.cc",
     "constants.h",
-    "page_content_fetcher.cc",
-    "page_content_fetcher.h",
+    "engine/engine_consumer.h",
     "engine/engine_consumer_claude.cc",
     "engine/engine_consumer_claude.h",
     "engine/engine_consumer_llama.cc",
     "engine/engine_consumer_llama.h",
-    "engine/engine_consumer.h",
     "engine/remote_completion_client.cc",
     "engine/remote_completion_client.h",
+    "page_content_fetcher.cc",
+    "page_content_fetcher.h",
   ]
 
   deps = [

--- a/components/ai_chat/browser/BUILD.gn
+++ b/components/ai_chat/browser/BUILD.gn
@@ -23,6 +23,11 @@ static_library("browser") {
     "constants.h",
     "page_content_fetcher.cc",
     "page_content_fetcher.h",
+    "engine/engine_consumer_claude.cc",
+    "engine/engine_consumer_claude.h",
+    "engine/engine_consumer_llama.cc",
+    "engine/engine_consumer_llama.h",
+    "engine/engine_consumer.h",
   ]
 
   deps = [

--- a/components/ai_chat/browser/BUILD.gn
+++ b/components/ai_chat/browser/BUILD.gn
@@ -13,8 +13,6 @@ if (is_official_build) {
 
 static_library("browser") {
   sources = [
-    "ai_chat_api.cc",
-    "ai_chat_api.h",
     "ai_chat_metrics.cc",
     "ai_chat_metrics.h",
     "ai_chat_tab_helper.cc",
@@ -28,6 +26,8 @@ static_library("browser") {
     "engine/engine_consumer_llama.cc",
     "engine/engine_consumer_llama.h",
     "engine/engine_consumer.h",
+    "engine/remote_completion_client.cc",
+    "engine/remote_completion_client.h",
   ]
 
   deps = [

--- a/components/ai_chat/browser/DEPS
+++ b/components/ai_chat/browser/DEPS
@@ -3,5 +3,6 @@ include_rules = [
   "+services/data_decoder/public",
   "+services/network/public",
   "+services/service_manager/public",
+  "+absl/types/optional.h",
   "+ui",
 ]

--- a/components/ai_chat/browser/ai_chat_api.h
+++ b/components/ai_chat/browser/ai_chat_api.h
@@ -16,9 +16,20 @@ namespace network {
 class SharedURLLoaderFactory;
 }  // namespace network
 
+namespace ai_chat {
+
+// TODO(petemill): Is this meant to be shared by both Claude and Llama? It's not
+// used to start the llama prompts but it is for Claude, but it's set for both
+// as a stop sequence (and currently the only stop sequence used by the
+// conversation prompts.
+constexpr char kHumanPrompt[] = "Human:";
+
 class AIChatAPI {
  public:
+  static std::string GetHumanPromptSegment();
+
   explicit AIChatAPI(
+      std::string model_name,
       scoped_refptr<network::SharedURLLoaderFactory> url_loader_factory);
   AIChatAPI(const AIChatAPI&) = delete;
   AIChatAPI& operator=(const AIChatAPI&) = delete;
@@ -27,7 +38,7 @@ class AIChatAPI {
   // This function queries both types of APIs: SSE and non-SSE.
   // In non-SSE cases, only the data_completed_callback will be triggered.
   void QueryPrompt(const std::string& prompt,
-                   const std::vector<std::string> extra_stop_sequences,
+                   const std::vector<std::string> stop_sequences,
                    api_request_helper::APIRequestHelper::ResultCallback
                        data_completed_callback,
                    api_request_helper::APIRequestHelper::DataReceivedCallback
@@ -36,7 +47,11 @@ class AIChatAPI {
   void ClearAllQueries();
 
  private:
+  std::string model_name_;
+  std::vector<std::string> default_stop_sequences_;
   api_request_helper::APIRequestHelper api_request_helper_;
 };
+
+}  // namespace ai_chat
 
 #endif  // BRAVE_COMPONENTS_AI_CHAT_BROWSER_AI_CHAT_API_H_

--- a/components/ai_chat/browser/ai_chat_tab_helper.cc
+++ b/components/ai_chat/browser/ai_chat_tab_helper.cc
@@ -14,8 +14,6 @@
 #include "base/functional/bind.h"
 #include "base/memory/weak_ptr.h"
 #include "base/ranges/algorithm.h"
-#include "base/strings/strcat.h"
-#include "base/strings/string_split.h"
 #include "base/strings/string_util.h"
 #include "brave/components/ai_chat/browser/ai_chat_metrics.h"
 #include "brave/components/ai_chat/browser/constants.h"
@@ -34,7 +32,6 @@
 #include "content/public/browser/browser_context.h"
 #include "content/public/browser/navigation_entry.h"
 #include "content/public/browser/storage_partition.h"
-#include "net/http/http_status_code.h"
 #include "ui/base/l10n/l10n_util.h"
 
 using ai_chat::mojom::CharacterType;
@@ -381,8 +378,8 @@ void AIChatTabHelper::MakeAPIRequestWithConversationHistoryUpdate(
                             : chat_history_;
 
   auto data_received_callback = base::BindRepeating(
-    &AIChatTabHelper::OnEngineCompletionDataReceived, weak_ptr_factory_.GetWeakPtr(),
-    current_navigation_id_);
+      &AIChatTabHelper::OnEngineCompletionDataReceived,
+      weak_ptr_factory_.GetWeakPtr(), current_navigation_id_);
 
   auto data_completed_callback =
       base::BindOnce(&AIChatTabHelper::OnEngineCompletionComplete,
@@ -420,9 +417,8 @@ bool AIChatTabHelper::IsRequestInProgress() {
   return is_request_in_progress_;
 }
 
-void AIChatTabHelper::OnEngineCompletionDataReceived(
-    int64_t for_navigation_id,
-    std::string result) {
+void AIChatTabHelper::OnEngineCompletionDataReceived(int64_t for_navigation_id,
+                                                     std::string result) {
   if (for_navigation_id != current_navigation_id_) {
     VLOG(1) << __func__ << " for a different navigation. Ignoring.";
     return;

--- a/components/ai_chat/browser/ai_chat_tab_helper.cc
+++ b/components/ai_chat/browser/ai_chat_tab_helper.cc
@@ -12,19 +12,20 @@
 #include "base/containers/contains.h"
 #include "base/containers/fixed_flat_set.h"
 #include "base/functional/bind.h"
-#include "base/i18n/time_formatting.h"
 #include "base/memory/weak_ptr.h"
 #include "base/ranges/algorithm.h"
 #include "base/strings/strcat.h"
 #include "base/strings/string_split.h"
 #include "base/strings/string_util.h"
-#include "base/strings/utf_string_conversions.h"
-#include "base/time/time.h"
 #include "brave/components/ai_chat/browser/ai_chat_metrics.h"
 #include "brave/components/ai_chat/browser/constants.h"
+#include "brave/components/ai_chat/browser/engine/engine_consumer.h"
+#include "brave/components/ai_chat/browser/engine/engine_consumer_claude.h"
+#include "brave/components/ai_chat/browser/engine/engine_consumer_llama.h"
 #include "brave/components/ai_chat/browser/page_content_fetcher.h"
 #include "brave/components/ai_chat/common/features.h"
 #include "brave/components/ai_chat/common/mojom/ai_chat.mojom-shared.h"
+#include "brave/components/ai_chat/common/mojom/ai_chat.mojom.h"
 #include "brave/components/ai_chat/common/pref_names.h"
 #include "components/favicon/content/content_favicon_driver.h"
 #include "components/grit/brave_components_strings.h"
@@ -65,10 +66,21 @@ AIChatTabHelper::AIChatTabHelper(content::WebContents* web_contents,
       base::BindRepeating(
           &AIChatTabHelper::OnPermissionChangedAutoGenerateQuestions,
           weak_ptr_factory_.GetWeakPtr()));
-  ai_chat_api_ =
-      std::make_unique<AIChatAPI>(web_contents->GetBrowserContext()
-                                      ->GetDefaultStoragePartition()
-                                      ->GetURLLoaderFactoryForBrowserProcess());
+  // TODO(petemill): Engines and model names should be selectable
+  // per conversation, not static.
+  if (UsesLlama2PromptTemplate(features::kAIModelName.Get())) {
+    VLOG(1) << "Started tab helper for AI engine: llama";
+    engine_ = std::make_unique<EngineConsumerLlamaRemote>(
+        web_contents->GetBrowserContext()
+            ->GetDefaultStoragePartition()
+            ->GetURLLoaderFactoryForBrowserProcess());
+  } else {
+    VLOG(1) << "Started tab helper for AI engine: claude";
+    engine_ = std::make_unique<EngineConsumerClaudeRemote>(
+        web_contents->GetBrowserContext()
+            ->GetDefaultStoragePartition()
+            ->GetURLLoaderFactoryForBrowserProcess());
+  }
   favicon::ContentFaviconDriver::FromWebContents(web_contents)
       ->AddObserver(this);
 }
@@ -101,20 +113,8 @@ void AIChatTabHelper::OnPermissionChangedAutoGenerateQuestions() {
   MaybeGenerateQuestions();
 }
 
-std::string AIChatTabHelper::GetConversationHistoryString() {
-  std::vector<std::string> turn_strings;
-  for (const ConversationTurn& turn : chat_history_) {
-    turn_strings.push_back((turn.character_type == CharacterType::HUMAN
-                                ? ai_chat::kHumanPromptPlaceholder
-                                : ai_chat::kAIPromptPlaceholder) +
-                           turn.text);
-  }
-
-  return base::JoinString(turn_strings, "");
-}
-
-void AIChatTabHelper::AddToConversationHistory(const ConversationTurn& turn) {
-  chat_history_.push_back(turn);
+void AIChatTabHelper::AddToConversationHistory(mojom::ConversationTurn turn) {
+  chat_history_.push_back(std::move(turn));
 
   for (auto& obs : observers_) {
     obs.OnHistoryUpdate();
@@ -223,19 +223,9 @@ void AIChatTabHelper::OnTabContentRetrieved(int64_t for_navigation_id,
 
   is_video_ = is_video;
   article_text_ = contents_text;
+  engine_->SanitizeInput(article_text_);
 
   OnPageHasContentChanged();
-
-  // Prevent indirect prompt injections being sent to the AI model.
-  base::ReplaceSubstringsAfterOffset(&contents_text, 0, ai_chat::kHumanPrompt,
-                                     "");
-  base::ReplaceSubstringsAfterOffset(&contents_text, 0, ai_chat::kAIPrompt, "");
-  base::ReplaceSubstringsAfterOffset(&contents_text, 0, "<article>", "");
-  base::ReplaceSubstringsAfterOffset(&contents_text, 0, "</article>", "");
-  base::ReplaceSubstringsAfterOffset(&contents_text, 0, "<history>", "");
-  base::ReplaceSubstringsAfterOffset(&contents_text, 0, "</history>", "");
-  base::ReplaceSubstringsAfterOffset(&contents_text, 0, "<question>", "");
-  base::ReplaceSubstringsAfterOffset(&contents_text, 0, "</question>", "");
 
   // Now that we have article text, we can suggest to summarize it
   DCHECK(suggested_questions_.empty())
@@ -263,7 +253,7 @@ void AIChatTabHelper::CleanUp() {
   should_page_content_be_disconnected_ = false;
   OnSuggestedQuestionsChanged();
   SetAPIError(mojom::APIError::None);
-  ai_chat_api_->ClearAllQueries();
+  engine_->ClearAllQueries();
 
   // Trigger an observer update to refresh the UI.
   for (auto& obs : observers_) {
@@ -294,7 +284,7 @@ void AIChatTabHelper::DisconnectPageContents() {
 
 void AIChatTabHelper::ClearConversationHistory() {
   chat_history_.clear();
-  ai_chat_api_->ClearAllQueries();
+  engine_->ClearAllQueries();
 
   // Trigger an observer update to refresh the UI.
   for (auto& obs : observers_) {
@@ -323,342 +313,36 @@ void AIChatTabHelper::GenerateQuestions() {
 
   has_generated_questions_ = true;
   OnSuggestedQuestionsChanged();
-
-  std::string prompt;
-  std::vector<std::string> stop_sequences;
-  if (UsesLlama2PromptTemplate(ai_chat::features::kAIModelName.Get())) {
-    prompt = BuildLlama2GenerateQuestionsPrompt(is_video_, article_text_);
-    stop_sequences.push_back(ai_chat::kLlama2Eos);
-    stop_sequences.push_back("</ul>");
-  } else {
-    prompt = base::StrCat(
-        {GetHumanPromptSegment(),
-         base::ReplaceStringPlaceholders(
-             l10n_util::GetStringUTF8(is_video_
-                                          ? IDS_AI_CHAT_VIDEO_PROMPT_SEGMENT
-                                          : IDS_AI_CHAT_ARTICLE_PROMPT_SEGMENT),
-             {article_text_}, nullptr),
-         "\n\n", l10n_util::GetStringUTF8(IDS_AI_CHAT_QUESTION_PROMPT_SEGMENT),
-         GetAssistantPromptSegment(), " <response>"});
-    stop_sequences.push_back("</response>");
-  }
   // Make API request for questions.
   // Do not call SetRequestInProgress, this progress
   // does not need to be shown to the UI.
   auto navigation_id_for_query = current_navigation_id_;
-  ai_chat_api_->QueryPrompt(
-      prompt, stop_sequences,
-      base::BindOnce(&AIChatTabHelper::OnAPISuggestedQuestionsResponse,
+  engine_->GenerateQuestionSuggestions(
+      is_video_, article_text_,
+      base::BindOnce(&AIChatTabHelper::OnSuggestedQuestionsResponse,
                      weak_ptr_factory_.GetWeakPtr(),
                      std::move(navigation_id_for_query)));
 }
 
-void AIChatTabHelper::OnAPISuggestedQuestionsResponse(
+void AIChatTabHelper::OnSuggestedQuestionsResponse(
     int64_t for_navigation_id,
-    api_request_helper::APIRequestResult result) {
+    std::vector<std::string> result) {
   // We might have navigated away whilst this async operation is in
   // progress, so check if we're the same navigation.
   if (for_navigation_id != current_navigation_id_) {
     VLOG(1) << __func__ << " for a different navigation. Ignoring.";
     return;
   }
-  auto success = result.Is2XXResponseCode();
-  if (!success) {
-    LOG(ERROR) << "Error getting question suggestions. Code: "
-               << result.response_code();
-    return;
-  }
-  // Validate
-  if (!result.value_body().is_dict()) {
-    DVLOG(1) << "Expected dictionary for question suggestion result"
-             << " but got: " << result.value_body().DebugString();
-    return;
-  }
-  const std::string* completion =
-      result.value_body().GetDict().FindString("completion");
-  if (!completion || completion->empty()) {
-    DVLOG(1) << "Expected completion param for question suggestion"
-             << " result but got: " << result.value_body().DebugString();
-    return;
-  }
 
-  DVLOG(2) << "Received " << (success ? "success" : "failed")
-           << " suggested questions response: " << completion;
-
-  std::vector<std::string> questions;
-  if (UsesLlama2PromptTemplate(ai_chat::features::kAIModelName.Get())) {
-    // Llama 2 results look something like this:
-    // Can ChatGPT actually summarize a seven-hour video in under a minute?</li>
-    // <li>What are the limitations of ChatGPT's browsing capabilities, and how
-    // does it affect its ability to provide accurate information?</li> <li>Can
-    // ChatGPT's tonewood research be applied to other areas of scientific
-    // inquiry beyond guitar making?</li>  These questions capture interesting
-    // aspects of the video, such as the AI's ability to summarize long content,
-    // its limitations, and its potential applications beyond the specific use
-    // case presented in the video.
-
-    // Split out the questions using </li>
-    questions = base::SplitStringUsingSubstr(
-        *completion, "</li>", base::TRIM_WHITESPACE, base::SPLIT_WANT_NONEMPTY);
-
-    // Remove the last entry in questions if it doesn't contain an <li> tag
-    // which means its not an actually a question
-    if (questions.size() > 1) {
-      if (questions.back().find("<li>") == std::string::npos) {
-        questions.pop_back();
-      }
-    }
-
-    // Remove leading <li> from each question
-    for (auto& question : questions) {
-      auto parts = base::SplitStringUsingSubstr(
-          question, "<li>", base::TRIM_WHITESPACE, base::SPLIT_WANT_NONEMPTY);
-      if (!parts.empty()) {
-        question = parts.back();  // If there's an <li>, parts will contain an
-                                  // empty string and then the question. We take
-                                  // the last element.
-      }
-    }
-  } else {
-    questions = base::SplitString(*completion, "|",
-                                  base::WhitespaceHandling::TRIM_WHITESPACE,
-                                  base::SplitResult::SPLIT_WANT_NONEMPTY);
-  }
-
-  suggested_questions_.insert(suggested_questions_.end(), questions.begin(),
-                              questions.end());
+  suggested_questions_.insert(suggested_questions_.end(), result.begin(),
+                              result.end());
   // Notify observers
   OnSuggestedQuestionsChanged();
   DVLOG(2) << "Got questions:" << base::JoinString(suggested_questions_, "\n");
 }
 
-std::string AIChatTabHelper::BuildClaudePrompt(const std::string& question_part,
-                                               bool is_suggested_question) {
-  auto prompt_segment_article =
-      article_text_.empty()
-          ? ""
-          : base::StrCat(
-                {base::ReplaceStringPlaceholders(
-                     l10n_util::GetStringUTF8(
-                         is_video_ ? IDS_AI_CHAT_VIDEO_PROMPT_SEGMENT
-                                   : IDS_AI_CHAT_ARTICLE_PROMPT_SEGMENT),
-                     {article_text_}, nullptr),
-                 "\n\n"});
-
-  auto prompt_segment_history =
-      (chat_history_.empty() || is_suggested_question)
-          ? ""
-          : base::ReplaceStringPlaceholders(
-                l10n_util::GetStringUTF8(
-                    IDS_AI_CHAT_ASSISTANT_HISTORY_PROMPT_SEGMENT),
-                {GetConversationHistoryString()}, nullptr);
-
-  std::string prompt = base::StrCat(
-      {GetHumanPromptSegment(), prompt_segment_article,
-       base::ReplaceStringPlaceholders(
-           l10n_util::GetStringUTF8(IDS_AI_CHAT_ASSISTANT_PROMPT_SEGMENT),
-           {prompt_segment_history, question_part}, nullptr),
-       GetAssistantPromptSegment(), " <response>\n"});
-
-  return prompt;
-}
-
-std::string AIChatTabHelper::BuildLlama2Prompt(std::string user_message) {
-  // Always use a generic system message
-  std::string system_message =
-      l10n_util::GetStringUTF8(IDS_AI_CHAT_LLAMA2_SYSTEM_MESSAGE_GENERIC);
-  std::string date_and_time_string =
-      base::UTF16ToUTF8(TimeFormatFriendlyDateAndTime(base::Time::Now()));
-  std::string today_system_message = base::ReplaceStringPlaceholders(
-      system_message, {date_and_time_string}, nullptr);
-
-  auto conversation_history = GetConversationHistory();
-
-  // Get the raw first user message, which is in the chat history if this is
-  // the first sequence.
-  std::string raw_first_user_message;
-  if (conversation_history.size() > 0) {
-    raw_first_user_message = conversation_history[0].text;
-  } else {
-    raw_first_user_message = user_message;
-  }
-
-  // Build first_user_message, the first complete message sent to the AI model,
-  // which may or may not include injected contents such as article text.
-  std::string first_user_message;
-  if (!article_text_.empty()) {
-    std::string first_message_template;
-    if (is_video_) {
-      first_message_template =
-          l10n_util::GetStringUTF8(IDS_AI_CHAT_VIDEO_PROMPT_SEGMENT_LLAMA2);
-    } else {
-      first_message_template =
-          l10n_util::GetStringUTF8(IDS_AI_CHAT_ARTICLE_PROMPT_SEGMENT_LLAMA2);
-    }
-
-    first_user_message = base::ReplaceStringPlaceholders(
-        first_message_template, {article_text_, raw_first_user_message},
-        nullptr);
-  } else {
-    // If there's no article or video context, just use the raw first user
-    // message.
-    first_user_message = raw_first_user_message;
-  }
-
-  // If there's no conversation history, then we just send a (partial)
-  // first sequence.
-  if (conversation_history.empty() || conversation_history.size() <= 1) {
-    return BuildLlama2FirstSequence(
-        today_system_message, first_user_message, absl::nullopt,
-        l10n_util::GetStringUTF8(IDS_AI_CHAT_LLAMA2_GENERAL_SEED));
-  }
-
-  // Use the first two messages to build the first sequence,
-  // which includes the system prompt.
-  std::string prompt =
-      BuildLlama2FirstSequence(today_system_message, first_user_message,
-                               conversation_history[1].text, absl::nullopt);
-
-  // Loop through the rest of the history two at a time building subsequent
-  // sequences.
-  for (size_t i = 2; i + 1 < conversation_history.size(); i += 2) {
-    const std::string& prev_user_message = conversation_history[i].text;
-    const std::string& assistant_message = conversation_history[i + 1].text;
-    prompt += BuildLlama2SubsequentSequence(prev_user_message,
-                                            assistant_message, absl::nullopt);
-  }
-
-  // Build the final subsequent exchange using the current turn.
-  prompt += BuildLlama2SubsequentSequence(
-      user_message, absl::nullopt,
-      l10n_util::GetStringUTF8(IDS_AI_CHAT_LLAMA2_GENERAL_SEED));
-
-  // Trimming recommended by Meta
-  // https://huggingface.co/meta-llama/Llama-2-13b-chat#intended-use
-  prompt = base::TrimWhitespaceASCII(prompt, base::TRIM_ALL);
-  return prompt;
-}
-
-std::string AIChatTabHelper::BuildLlama2InstructionPrompt(
-    const std::string& instruction) {
-  return base::ReplaceStringPlaceholders(
-      R"($1 $2 $3 )", {ai_chat::kLlama2BIns, instruction, ai_chat::kLlama2EIns},
-      nullptr);
-}
-
-std::string AIChatTabHelper::BuildLlama2GenerateQuestionsPrompt(
-    bool is_video,
-    const std::string content) {
-  std::string content_template;
-  if (is_video) {
-    content_template =
-        l10n_util::GetStringUTF8(IDS_AI_CHAT_LLAMA2_GENERATE_QUESTIONS_VIDEO);
-  } else {
-    content_template =
-        l10n_util::GetStringUTF8(IDS_AI_CHAT_LLAMA2_GENERATE_QUESTIONS_ARTICLE);
-  }
-
-  const std::string& user_message =
-      base::ReplaceStringPlaceholders(content_template, {content}, nullptr);
-
-  return BuildLlama2FirstSequence(
-      l10n_util::GetStringUTF8(
-          IDS_AI_CHAT_LLAMA2_SYSTEM_MESSAGE_GENERATE_QUESTIONS),
-      user_message, absl::nullopt,
-      l10n_util::GetStringUTF8(
-          IDS_AI_CHAT_LLAMA2_SYSTEM_MESSAGE_GENERATE_QUESTIONS_RESPONSE_SEED));
-}
-
-std::string AIChatTabHelper::BuildLlama2FirstSequence(
-    const std::string& system_message,
-    const std::string& user_message,
-    absl::optional<std::string> assistant_response,
-    absl::optional<std::string> assistant_response_seed) {
-  // Generates a partial sequence if there is no assistant_response:
-
-  // <s> [INST] <<SYS>>
-  // You will be acting as an assistant named Leo created by the company Brave.
-  // Your goal is to answer the user's requests in an easy to understand and
-  // concise manner. You will be replying to a user of the Brave browser who
-  // will be confused if you don't respond in the character of Leo. Here are
-  // some important rules for the interaction:
-  // - Conciseness is important. Your responses should not exceed 6 sentences.
-  // - Always respond in a neutral tone.
-  // - Always stay in character, as Leo, an AI from Brave.
-  // <</SYS>>
-  //
-  // How's it going? [/INST]
-
-  // Or, if there is an assistant_response:
-
-  // <s> [INST] <<SYS>>
-  // You will be acting as an assistant named Leo created by the company Brave.
-  // Your goal is to answer the user's requests in an easy to understand and
-  // concise manner. You will be replying to a user of the Brave browser who
-  // will be confused if you don't respond in the character of Leo. Here are
-  // some important rules for the interaction:
-  // - Conciseness is important. Your responses should not exceed 6 sentences.
-  // - Always respond in a neutral tone.
-  // - Always stay in character, as Leo, an AI from Brave.
-  // <</SYS>>
-  //
-  // How's it going? [/INST] Hey there! I'm Leo, your AI assistant here to help
-  // you out. I'm here to answer any questions you have, so feel free to ask me
-  // anything! What's up?</s>
-
-  // Create the system prompt through the first user message.
-  std::string system_prompt =
-      base::StrCat({ai_chat::kLlama2BSys, system_message, ai_chat::kLlama2ESys,
-                    user_message});
-
-  // Wrap in [INST] [/INST] tags.
-  std::string instruction_prompt = BuildLlama2InstructionPrompt(system_prompt);
-
-  if (!assistant_response) {
-    // Prepend just <s> if there's no assistant_response ( it will be completed
-    // by the model).
-    if (assistant_response_seed) {
-      return base::StrCat(
-          {ai_chat::kLlama2Bos, instruction_prompt, *assistant_response_seed});
-    }
-    return base::StrCat({ai_chat::kLlama2Bos, instruction_prompt});
-  }
-
-  // Add assistant response and wrap in <s> </s> tags.
-  return base::StrCat({ai_chat::kLlama2Bos, instruction_prompt,
-                       *assistant_response, ai_chat::kLlama2Eos});
-}
-
-std::string AIChatTabHelper::BuildLlama2SubsequentSequence(
-    std::string user_message,
-    absl::optional<std::string> assistant_response,
-    absl::optional<std::string> assistant_response_seed) {
-  // Builds a prompt segment that looks like this:
-  // <s> [INST] Give me the first few numbers in the fibonacci sequence [/INST]
-
-  // or, if there's an assistant_response:
-
-  // <s> [INST] Give me the first few numbers in the fibonacci sequence [/INST]
-  // Hey there! Sure thing! The first few numbers in the Fibonacci sequence are:
-  // 1, 1, 2, 3, 5, 8, 13, and so on. </s>
-
-  user_message = BuildLlama2InstructionPrompt(user_message);
-
-  if (assistant_response_seed) {
-    return base::StrCat(
-        {ai_chat::kLlama2Bos, user_message, *assistant_response_seed});
-  }
-
-  if (!assistant_response) {
-    return base::StrCat({ai_chat::kLlama2Bos, user_message});
-  }
-
-  return base::StrCat({ai_chat::kLlama2Bos, user_message, *assistant_response,
-                       ai_chat::kLlama2Eos});
-}
-
 void AIChatTabHelper::MakeAPIRequestWithConversationHistoryUpdate(
-    const ConversationTurn& turn) {
+    mojom::ConversationTurn turn) {
   // This function should not be presented in the UI if the user has not
   // opted-in yet.
   DCHECK(HasUserOptedIn());
@@ -677,6 +361,9 @@ void AIChatTabHelper::MakeAPIRequestWithConversationHistoryUpdate(
     OnSuggestedQuestionsChanged();
   }
 
+  // Directly modify Entry's text to remove engine-breaking substrings
+  engine_->SanitizeInput(turn.text);
+
   // TODO(petemill): Tokenize the summary question so that we
   // don't have to do this weird substitution.
   std::string question_part;
@@ -687,30 +374,28 @@ void AIChatTabHelper::MakeAPIRequestWithConversationHistoryUpdate(
     question_part = turn.text;
   }
 
-  std::string prompt;
-  if (UsesLlama2PromptTemplate(ai_chat::features::kAIModelName.Get())) {
-    prompt = BuildLlama2Prompt(question_part);
-  } else {
-    prompt = BuildClaudePrompt(question_part, is_suggested_question);
-  }
+  // Suggested questions were based on only the initial prompt (with content),
+  // so no need to submit all conversation history when they are used.
+  std::vector<mojom::ConversationTurn> history =
+      is_suggested_question ? std::vector<mojom::ConversationTurn>()
+                            : chat_history_;
 
-  if (turn.visibility != ConversationTurnVisibility::HIDDEN) {
-    AddToConversationHistory(turn);
-  }
-
-  DCHECK(ai_chat_api_);
   auto data_received_callback = base::BindRepeating(
-      &AIChatTabHelper::OnAPIStreamDataReceived, weak_ptr_factory_.GetWeakPtr(),
-      current_navigation_id_);
+    &AIChatTabHelper::OnEngineCompletionDataReceived, weak_ptr_factory_.GetWeakPtr(),
+    current_navigation_id_);
 
   auto data_completed_callback =
-      base::BindOnce(&AIChatTabHelper::OnAPIStreamDataComplete,
+      base::BindOnce(&AIChatTabHelper::OnEngineCompletionComplete,
                      weak_ptr_factory_.GetWeakPtr(), current_navigation_id_);
 
+  engine_->SubmitHumanInput(is_video_, article_text_, history, question_part,
+                            std::move(data_received_callback),
+                            std::move(data_completed_callback));
+
+  // Add the human part to the conversation
+  AddToConversationHistory(std::move(turn));
+
   is_request_in_progress_ = true;
-  ai_chat_api_->QueryPrompt(std::move(prompt), {"</response>"},
-                            std::move(data_completed_callback),
-                            std::move(data_received_callback));
 }
 
 void AIChatTabHelper::RetryAPIRequest() {
@@ -732,66 +417,43 @@ void AIChatTabHelper::RetryAPIRequest() {
 }
 
 bool AIChatTabHelper::IsRequestInProgress() {
-  DCHECK(ai_chat_api_);
-
   return is_request_in_progress_;
 }
 
-void AIChatTabHelper::OnAPIStreamDataReceived(
+void AIChatTabHelper::OnEngineCompletionDataReceived(
     int64_t for_navigation_id,
-    data_decoder::DataDecoder::ValueOrError result) {
+    std::string result) {
   if (for_navigation_id != current_navigation_id_) {
     VLOG(1) << __func__ << " for a different navigation. Ignoring.";
     return;
   }
-  if (!result.has_value() || !result->is_dict()) {
-    return;
-  }
 
-  if (const std::string* completion =
-          result->GetDict().FindString("completion")) {
-    UpdateOrCreateLastAssistantEntry(*completion);
+  UpdateOrCreateLastAssistantEntry(result);
 
-    // Trigger an observer update to refresh the UI.
-    for (auto& obs : observers_) {
-      obs.OnAPIRequestInProgress(IsRequestInProgress());
-    }
+  // Trigger an observer update to refresh the UI.
+  for (auto& obs : observers_) {
+    obs.OnAPIRequestInProgress(IsRequestInProgress());
   }
 }
 
-void AIChatTabHelper::OnAPIStreamDataComplete(
+void AIChatTabHelper::OnEngineCompletionComplete(
     int64_t for_navigation_id,
-    api_request_helper::APIRequestResult result) {
+    EngineConsumer::AssistantResponseResult result) {
   if (for_navigation_id != current_navigation_id_) {
     VLOG(1) << __func__ << " for a different navigation. Ignoring.";
     return;
   }
-  const bool success = result.Is2XXResponseCode();
-  if (success) {
-    // We're checking for a value body in case for non-streaming API results.
-    if (result.value_body().is_dict()) {
-      if (const std::string* completion =
-              result.value_body().GetDict().FindString("completion")) {
-        // Trimming necessary for Llama 2 which prepends responses with a " ".
-        const std::string& trimmed =
-            std::string(base::TrimWhitespaceASCII(*completion, base::TRIM_ALL));
-        AddToConversationHistory(
-            ConversationTurn{CharacterType::ASSISTANT,
-                             ConversationTurnVisibility::VISIBLE, trimmed});
-      }
-    }
-  }
-
-  if (!success) {
-    if (net::HTTP_TOO_MANY_REQUESTS == result.response_code()) {
-      SetAPIError(mojom::APIError::RateLimitReached);
-    } else {
-      SetAPIError(mojom::APIError::ConnectionIssue);
-    }
-  }
-
   is_request_in_progress_ = false;
-
+  if (result.has_value()) {
+    // Handle success, which might mean do nothing much since all
+    // data was passed in the streaming "received" callback.
+    if (!result->empty()) {
+      UpdateOrCreateLastAssistantEntry(*result);
+    }
+  } else {
+    // handle failure
+    SetAPIError(std::move(result.error()));
+  }
   // Trigger an observer update to refresh the UI.
   for (auto& obs : observers_) {
     obs.OnAPIRequestInProgress(IsRequestInProgress());

--- a/components/ai_chat/browser/ai_chat_tab_helper.cc
+++ b/components/ai_chat/browser/ai_chat_tab_helper.cc
@@ -385,9 +385,9 @@ void AIChatTabHelper::MakeAPIRequestWithConversationHistoryUpdate(
       base::BindOnce(&AIChatTabHelper::OnEngineCompletionComplete,
                      weak_ptr_factory_.GetWeakPtr(), current_navigation_id_);
 
-  engine_->SubmitHumanInput(is_video_, article_text_, history, question_part,
-                            std::move(data_received_callback),
-                            std::move(data_completed_callback));
+  engine_->GenerateAssistantResponse(
+      is_video_, article_text_, history, question_part,
+      std::move(data_received_callback), std::move(data_completed_callback));
 
   // Add the human part to the conversation
   AddToConversationHistory(std::move(turn));
@@ -434,7 +434,7 @@ void AIChatTabHelper::OnEngineCompletionDataReceived(int64_t for_navigation_id,
 
 void AIChatTabHelper::OnEngineCompletionComplete(
     int64_t for_navigation_id,
-    EngineConsumer::CompletionResult result) {
+    EngineConsumer::GenerationResult result) {
   if (for_navigation_id != current_navigation_id_) {
     VLOG(1) << __func__ << " for a different navigation. Ignoring.";
     return;

--- a/components/ai_chat/browser/ai_chat_tab_helper.cc
+++ b/components/ai_chat/browser/ai_chat_tab_helper.cc
@@ -434,7 +434,7 @@ void AIChatTabHelper::OnEngineCompletionDataReceived(int64_t for_navigation_id,
 
 void AIChatTabHelper::OnEngineCompletionComplete(
     int64_t for_navigation_id,
-    EngineConsumer::AssistantResponseResult result) {
+    EngineConsumer::CompletionResult result) {
   if (for_navigation_id != current_navigation_id_) {
     VLOG(1) << __func__ << " for a different navigation. Ignoring.";
     return;

--- a/components/ai_chat/browser/ai_chat_tab_helper.h
+++ b/components/ai_chat/browser/ai_chat_tab_helper.h
@@ -104,9 +104,8 @@ class AIChatTabHelper : public content::WebContentsObserver,
                              bool is_video = false);
   void OnEngineCompletionDataReceived(int64_t for_navigation_id,
                                       std::string result);
-  void OnEngineCompletionComplete(
-      int64_t for_navigation_id,
-      EngineConsumer::AssistantResponseResult result);
+  void OnEngineCompletionComplete(int64_t for_navigation_id,
+                                  EngineConsumer::CompletionResult result);
   void OnSuggestedQuestionsResponse(int64_t for_navigation_id,
                                     std::vector<std::string> result);
   void OnSuggestedQuestionsChanged();

--- a/components/ai_chat/browser/ai_chat_tab_helper.h
+++ b/components/ai_chat/browser/ai_chat_tab_helper.h
@@ -12,7 +12,6 @@
 
 #include "base/memory/raw_ptr.h"
 #include "base/observer_list.h"
-#include "brave/components/ai_chat/browser/ai_chat_api.h"
 #include "brave/components/ai_chat/browser/engine/engine_consumer.h"
 #include "brave/components/ai_chat/common/mojom/ai_chat.mojom.h"
 #include "components/favicon/core/favicon_driver_observer.h"

--- a/components/ai_chat/browser/ai_chat_tab_helper.h
+++ b/components/ai_chat/browser/ai_chat_tab_helper.h
@@ -107,9 +107,8 @@ class AIChatTabHelper : public content::WebContentsObserver,
   void OnEngineCompletionComplete(
       int64_t for_navigation_id,
       EngineConsumer::AssistantResponseResult result);
-  void OnSuggestedQuestionsResponse(
-      int64_t for_navigation_id,
-      std::vector<std::string> result);
+  void OnSuggestedQuestionsResponse(int64_t for_navigation_id,
+                                    std::vector<std::string> result);
   void OnSuggestedQuestionsChanged();
   void OnPageHasContentChanged();
 

--- a/components/ai_chat/browser/ai_chat_tab_helper.h
+++ b/components/ai_chat/browser/ai_chat_tab_helper.h
@@ -105,7 +105,7 @@ class AIChatTabHelper : public content::WebContentsObserver,
   void OnEngineCompletionDataReceived(int64_t for_navigation_id,
                                       std::string result);
   void OnEngineCompletionComplete(int64_t for_navigation_id,
-                                  EngineConsumer::CompletionResult result);
+                                  EngineConsumer::GenerationResult result);
   void OnSuggestedQuestionsResponse(int64_t for_navigation_id,
                                     std::vector<std::string> result);
   void OnSuggestedQuestionsChanged();

--- a/components/ai_chat/browser/constants.cc
+++ b/components/ai_chat/browser/constants.cc
@@ -8,21 +8,6 @@
 
 namespace ai_chat {
 
-// Note the blank space intentionally added
-constexpr char kHumanPrompt[] = "Human:";
-constexpr char kHumanPromptPlaceholder[] = "\nH: ";
-constexpr char kAIPrompt[] = "Assistant:";
-constexpr char kAIPromptPlaceholder[] = "\n\nA: ";
-
-constexpr char kLlama2Bos[] = "<s>";
-constexpr char kLlama2Eos[] = "</s>";
-constexpr char kLlama2BIns[] = "[INST]";
-constexpr char kLlama2EIns[] = "[/INST]";
-constexpr char kLlama2BSys[] = "<<SYS>>\n";
-constexpr char kLlama2ESys[] = "\n<</SYS>>\n\n";
-
-constexpr char kAIChatCompletionPath[] = "v1/complete";
-
 base::span<const webui::LocalizedString> GetLocalizedStrings() {
   constexpr webui::LocalizedString kLocalizedStrings[] = {
       {"siteTitle", IDS_CHAT_UI_TITLE},
@@ -43,14 +28,6 @@ base::span<const webui::LocalizedString> GetLocalizedStrings() {
       {"retryButtonLabel", IDS_CHAT_UI_RETRY_BUTTON_LABEL}};
 
   return kLocalizedStrings;
-}
-
-std::string GetHumanPromptSegment() {
-  return base::StrCat({"\n\n", kHumanPrompt, " "});
-}
-
-std::string GetAssistantPromptSegment() {
-  return base::StrCat({"\n\n", kAIPrompt});
 }
 
 bool UsesLlama2PromptTemplate(const std::string& model) {

--- a/components/ai_chat/browser/constants.h
+++ b/components/ai_chat/browser/constants.h
@@ -13,29 +13,7 @@
 
 namespace ai_chat {
 
-// Claude
-// prefix for for user input
-extern const char kHumanPrompt[];
-extern const char kHumanPromptPlaceholder[];
-// prefix for AI assistant output
-extern const char kAIPrompt[];
-extern const char kAIPromptPlaceholder[];
-
-// Llama 2
-extern const char kLlama2Bos[];
-extern const char kLlama2Eos[];
-extern const char kLlama2BIns[];
-extern const char kLlama2EIns[];
-extern const char kLlama2BSys[];
-extern const char kLlama2ESys[];
-extern const char kLlama2DefaultSystemMessage[];
-
-extern const char kAIChatCompletionPath[];
-
 base::span<const webui::LocalizedString> GetLocalizedStrings();
-
-std::string GetHumanPromptSegment();
-std::string GetAssistantPromptSegment();
 
 bool UsesLlama2PromptTemplate(const std::string& model);
 

--- a/components/ai_chat/browser/engine/engine_consumer.h
+++ b/components/ai_chat/browser/engine/engine_consumer.h
@@ -11,25 +11,24 @@
 
 #include "base/functional/callback_forward.h"
 #include "base/types/expected.h"
-#include "brave/components/ai_chat/common/mojom/ai_chat.mojom.h"
+#include "brave/components/ai_chat/common/mojom/ai_chat.mojom-forward.h"
 
 namespace ai_chat {
 
-// Abstract class for using AI engines to generate various specifi styles of
-// completion. The engines could be local (invoked directly via a subclass) or
-// remote (invoked via network requests).
+// Abstract class for using AI completion engines to generate various specific
+// styles of completion. The engines could be local (invoked directly via a
+// subclass) or remote (invoked via network requests).
 class EngineConsumer {
  public:
   using SuggestedQuestionsCallback =
       base::OnceCallback<void(std::vector<std::string>)>;
 
-  using CompletionResult = base::expected<std::string, mojom::APIError>;
+  using GenerationResult = base::expected<std::string, mojom::APIError>;
 
-  using CompletionDataReceivedCallback =
-      base::RepeatingCallback<void(std::string)>;
+  using GenerationDataCallback = base::RepeatingCallback<void(std::string)>;
 
-  using CompletionCompletedCallback =
-      base::OnceCallback<void(CompletionResult)>;
+  using GenerationCompletedCallback =
+      base::OnceCallback<void(GenerationResult)>;
 
   using ConversationHistory = std::vector<mojom::ConversationTurn>;
 
@@ -42,14 +41,20 @@ class EngineConsumer {
       const bool& is_video,
       const std::string& page_content,
       SuggestedQuestionsCallback callback) = 0;
-  virtual void SubmitHumanInput(
+
+  virtual void GenerateAssistantResponse(
       const bool& is_video,
       const std::string& page_content,
       const ConversationHistory& conversation_history,
       const std::string& human_input,
-      CompletionDataReceivedCallback data_received_callback,
-      CompletionCompletedCallback completed_callback) = 0;
+      GenerationDataCallback data_received_callback,
+      GenerationCompletedCallback completed_callback) = 0;
+
+  // Prevent indirect prompt injections being sent to the AI model.
+  // Include break-out strings contained in prompts, as well as the base
+  // model command separators.
   virtual void SanitizeInput(std::string& input) = 0;
+
   virtual void ClearAllQueries() = 0;
 };
 

--- a/components/ai_chat/browser/engine/engine_consumer.h
+++ b/components/ai_chat/browser/engine/engine_consumer.h
@@ -6,12 +6,11 @@
 #ifndef BRAVE_COMPONENTS_AI_CHAT_BROWSER_ENGINE_ENGINE_CONSUMER_H_
 #define BRAVE_COMPONENTS_AI_CHAT_BROWSER_ENGINE_ENGINE_CONSUMER_H_
 
+#include <string>
+#include <vector>
+
 #include "base/functional/callback_forward.h"
-
 #include "base/types/expected.h"
-#include "string"
-#include "vector"
-
 #include "base/values.h"
 #include "brave/components/ai_chat/common/mojom/ai_chat.mojom.h"
 
@@ -22,10 +21,13 @@ namespace ai_chat {
 // remote (invoked via network requests).
 class EngineConsumer {
  public:
-  using SuggestedQuestionsCallback = base::OnceCallback<void(std::vector<std::string>)>;
+  using SuggestedQuestionsCallback =
+      base::OnceCallback<void(std::vector<std::string>)>;
   using AssistantResponseResult = base::expected<std::string, mojom::APIError>;
-  using SubmitHumanInputDataReceivedCallback = base::RepeatingCallback<void(std::string)>;
-  using SubmitHumanInputCompletedCallback = base::OnceCallback<void(AssistantResponseResult)>;
+  using SubmitHumanInputDataReceivedCallback =
+      base::RepeatingCallback<void(std::string)>;
+  using SubmitHumanInputCompletedCallback =
+      base::OnceCallback<void(AssistantResponseResult)>;
   using ConversationHistory = std::vector<mojom::ConversationTurn>;
 
   EngineConsumer() = default;
@@ -37,12 +39,13 @@ class EngineConsumer {
       const bool& is_video,
       const std::string& page_content,
       SuggestedQuestionsCallback callback) = 0;
-  virtual void SubmitHumanInput(const bool& is_video,
-                                const std::string& page_content,
-                                const ConversationHistory& conversation_history,
-                                const std::string& human_input,
-                                SubmitHumanInputDataReceivedCallback data_received_callback,
-                                SubmitHumanInputCompletedCallback completed_callback) = 0;
+  virtual void SubmitHumanInput(
+      const bool& is_video,
+      const std::string& page_content,
+      const ConversationHistory& conversation_history,
+      const std::string& human_input,
+      SubmitHumanInputDataReceivedCallback data_received_callback,
+      SubmitHumanInputCompletedCallback completed_callback) = 0;
   virtual void SanitizeInput(std::string& input) = 0;
   virtual void ClearAllQueries() = 0;
 };

--- a/components/ai_chat/browser/engine/engine_consumer.h
+++ b/components/ai_chat/browser/engine/engine_consumer.h
@@ -11,7 +11,6 @@
 
 #include "base/functional/callback_forward.h"
 #include "base/types/expected.h"
-#include "base/values.h"
 #include "brave/components/ai_chat/common/mojom/ai_chat.mojom.h"
 
 namespace ai_chat {
@@ -23,11 +22,15 @@ class EngineConsumer {
  public:
   using SuggestedQuestionsCallback =
       base::OnceCallback<void(std::vector<std::string>)>;
-  using AssistantResponseResult = base::expected<std::string, mojom::APIError>;
-  using SubmitHumanInputDataReceivedCallback =
+
+  using CompletionResult = base::expected<std::string, mojom::APIError>;
+
+  using CompletionDataReceivedCallback =
       base::RepeatingCallback<void(std::string)>;
-  using SubmitHumanInputCompletedCallback =
-      base::OnceCallback<void(AssistantResponseResult)>;
+
+  using CompletionCompletedCallback =
+      base::OnceCallback<void(CompletionResult)>;
+
   using ConversationHistory = std::vector<mojom::ConversationTurn>;
 
   EngineConsumer() = default;
@@ -44,8 +47,8 @@ class EngineConsumer {
       const std::string& page_content,
       const ConversationHistory& conversation_history,
       const std::string& human_input,
-      SubmitHumanInputDataReceivedCallback data_received_callback,
-      SubmitHumanInputCompletedCallback completed_callback) = 0;
+      CompletionDataReceivedCallback data_received_callback,
+      CompletionCompletedCallback completed_callback) = 0;
   virtual void SanitizeInput(std::string& input) = 0;
   virtual void ClearAllQueries() = 0;
 };

--- a/components/ai_chat/browser/engine/engine_consumer.h
+++ b/components/ai_chat/browser/engine/engine_consumer.h
@@ -1,0 +1,52 @@
+// Copyright (c) 2023 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#ifndef BRAVE_COMPONENTS_AI_CHAT_BROWSER_ENGINE_ENGINE_CONSUMER_H_
+#define BRAVE_COMPONENTS_AI_CHAT_BROWSER_ENGINE_ENGINE_CONSUMER_H_
+
+#include "base/functional/callback_forward.h"
+
+#include "base/types/expected.h"
+#include "string"
+#include "vector"
+
+#include "base/values.h"
+#include "brave/components/ai_chat/common/mojom/ai_chat.mojom.h"
+
+namespace ai_chat {
+
+// Abstract class for using AI engines to generate various specifi styles of
+// completion. The engines could be local (invoked directly via a subclass) or
+// remote (invoked via network requests).
+class EngineConsumer {
+ public:
+  using SuggestedQuestionsCallback = base::OnceCallback<void(std::vector<std::string>)>;
+  using AssistantResponseResult = base::expected<std::string, mojom::APIError>;
+  using SubmitHumanInputDataReceivedCallback = base::RepeatingCallback<void(std::string)>;
+  using SubmitHumanInputCompletedCallback = base::OnceCallback<void(AssistantResponseResult)>;
+  using ConversationHistory = std::vector<mojom::ConversationTurn>;
+
+  EngineConsumer() = default;
+  EngineConsumer(const EngineConsumer&) = delete;
+  EngineConsumer& operator=(const EngineConsumer&) = delete;
+  virtual ~EngineConsumer() = default;
+
+  virtual void GenerateQuestionSuggestions(
+      const bool& is_video,
+      const std::string& page_content,
+      SuggestedQuestionsCallback callback) = 0;
+  virtual void SubmitHumanInput(const bool& is_video,
+                                const std::string& page_content,
+                                const ConversationHistory& conversation_history,
+                                const std::string& human_input,
+                                SubmitHumanInputDataReceivedCallback data_received_callback,
+                                SubmitHumanInputCompletedCallback completed_callback) = 0;
+  virtual void SanitizeInput(std::string& input) = 0;
+  virtual void ClearAllQueries() = 0;
+};
+
+}  // namespace ai_chat
+
+#endif  // BRAVE_COMPONENTS_AI_CHAT_BROWSER_ENGINE_ENGINE_CONSUMER_H_

--- a/components/ai_chat/browser/engine/engine_consumer_claude.cc
+++ b/components/ai_chat/browser/engine/engine_consumer_claude.cc
@@ -8,6 +8,7 @@
 #include <memory>
 #include <string>
 #include <utility>
+#include <vector>
 
 #include "base/functional/bind.h"
 #include "base/memory/raw_ptr.h"
@@ -94,10 +95,8 @@ void CheckPrompt(std::string& prompt) {
   // All queries must have the "Human" and "AI" prompt markers. We do not
   // prepend / append them here since callers may want to put them in
   // custom positions.
-  DCHECK(base::MatchPattern(prompt,
-                            base::StrCat({"*", kHumanPrompt, "*"})));
-  DCHECK(base::MatchPattern(prompt,
-                            base::StrCat({"*", kAIPrompt, "*"})));
+  DCHECK(base::MatchPattern(prompt, base::StrCat({"*", kHumanPrompt, "*"})));
+  DCHECK(base::MatchPattern(prompt, base::StrCat({"*", kAIPrompt, "*"})));
 }
 
 }  // namespace
@@ -109,7 +108,8 @@ EngineConsumerClaudeRemote::EngineConsumerClaudeRemote(
   // likley it will be chosen by the server and the general string "claude"
   // provided here.
   const auto model_name = ai_chat::features::kAIModelName.Get();
-  api_ = std::make_unique<RemoteCompletionClient>(model_name, url_loader_factory);
+  api_ =
+      std::make_unique<RemoteCompletionClient>(model_name, url_loader_factory);
 }
 
 EngineConsumerClaudeRemote::~EngineConsumerClaudeRemote() = default;
@@ -158,7 +158,8 @@ void EngineConsumerClaudeRemote::OnGenerateQuestionSuggestionsResponse(
              << " but got: " << result.value_body().DebugString();
     return;
   }
-  // TODO(petemill): move common completion basic value lookup to RemoteCompletionClient
+  // TODO(petemill): move common completion basic value lookup to
+  // RemoteCompletionClient
   const std::string* completion =
       result.value_body().GetDict().FindString("completion");
   if (!completion || completion->empty()) {
@@ -193,7 +194,7 @@ void EngineConsumerClaudeRemote::SubmitHumanInput(
       &EngineConsumerClaudeRemote::OnCompletionCompleted,
       weak_ptr_factory_.GetWeakPtr(), std::move(completed_callback));
   api_->QueryPrompt(prompt, {"</response>"}, std::move(on_complete),
-    std::move(on_data_received));
+                    std::move(on_data_received));
 }
 
 void EngineConsumerClaudeRemote::OnCompletionDataReceived(

--- a/components/ai_chat/browser/engine/engine_consumer_claude.cc
+++ b/components/ai_chat/browser/engine/engine_consumer_claude.cc
@@ -1,0 +1,254 @@
+// Copyright (c) 2023 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#include "brave/components/ai_chat/browser/engine/engine_consumer_claude.h"
+
+#include <memory>
+#include <string>
+#include <utility>
+
+#include "base/functional/bind.h"
+#include "base/memory/raw_ptr.h"
+#include "base/memory/weak_ptr.h"
+#include "base/strings/pattern.h"
+#include "base/strings/strcat.h"
+#include "base/strings/string_split.h"
+#include "base/strings/string_util.h"
+#include "base/types/expected.h"
+#include "brave/components/ai_chat/browser/ai_chat_api.h"
+#include "brave/components/ai_chat/common/features.h"
+#include "brave/components/ai_chat/common/mojom/ai_chat.mojom.h"
+#include "components/grit/brave_components_strings.h"
+#include "net/http/http_status_code.h"
+#include "services/network/public/cpp/shared_url_loader_factory.h"
+#include "ui/base/l10n/l10n_util.h"
+
+namespace ai_chat {
+
+namespace {
+
+using mojom::CharacterType;
+using mojom::ConversationTurn;
+
+// Note the blank spaces intentionally added
+
+constexpr char kHumanPromptPlaceholder[] = "\nH: ";
+constexpr char kAIPrompt[] = "Assistant:";
+constexpr char kAIPromptPlaceholder[] = "\n\nA: ";
+
+std::string GetAssistantPromptSegment() {
+  return base::StrCat({"\n\n", kAIPrompt});
+}
+
+std::string GetConversationHistoryString(
+    const std::vector<ConversationTurn>& conversation_history) {
+  std::vector<std::string> turn_strings;
+  for (const ConversationTurn& turn : conversation_history) {
+    turn_strings.push_back((turn.character_type == CharacterType::HUMAN
+                                ? kHumanPromptPlaceholder
+                                : kAIPromptPlaceholder) +
+                           turn.text);
+  }
+
+  return base::JoinString(turn_strings, "");
+}
+
+std::string BuildClaudePrompt(
+    const std::string& question_part,
+    const std::string& page_content,
+    const bool& is_video,
+    const std::vector<ConversationTurn>& conversation_history) {
+  auto prompt_segment_article =
+      page_content.empty()
+          ? ""
+          : base::StrCat(
+                {base::ReplaceStringPlaceholders(
+                     l10n_util::GetStringUTF8(
+                         is_video ? IDS_AI_CHAT_VIDEO_PROMPT_SEGMENT
+                                  : IDS_AI_CHAT_ARTICLE_PROMPT_SEGMENT),
+                     {page_content}, nullptr),
+                 "\n\n"});
+
+  auto prompt_segment_history =
+      (conversation_history.empty())
+          ? ""
+          : base::ReplaceStringPlaceholders(
+                l10n_util::GetStringUTF8(
+                    IDS_AI_CHAT_ASSISTANT_HISTORY_PROMPT_SEGMENT),
+                {GetConversationHistoryString(conversation_history)}, nullptr);
+
+  std::string prompt = base::StrCat(
+      {AIChatAPI::GetHumanPromptSegment(), prompt_segment_article,
+       base::ReplaceStringPlaceholders(
+           l10n_util::GetStringUTF8(IDS_AI_CHAT_ASSISTANT_PROMPT_SEGMENT),
+           {prompt_segment_history, question_part}, nullptr),
+       GetAssistantPromptSegment(), " <response>\n"});
+
+  return prompt;
+}
+
+void CheckPrompt(std::string& prompt) {
+  // TODO(petemill): Perform similar DCHECKs for llama models
+  // All queries must have the "Human" and "AI" prompt markers. We do not
+  // prepend / append them here since callers may want to put them in
+  // custom positions.
+  DCHECK(base::MatchPattern(prompt,
+                            base::StrCat({"*", kHumanPrompt, "*"})));
+  DCHECK(base::MatchPattern(prompt,
+                            base::StrCat({"*", kAIPrompt, "*"})));
+}
+
+}  // namespace
+
+EngineConsumerClaudeRemote::EngineConsumerClaudeRemote(
+    scoped_refptr<network::SharedURLLoaderFactory> url_loader_factory) {
+  // TODO(petemill): In multi-model mode, this model name will always be a
+  // specific claude version - either static or dynamic via some mechanism. Most
+  // likley it will be chosen by the server and the general string "claude"
+  // provided here.
+  const auto model_name = ai_chat::features::kAIModelName.Get();
+  api_ = std::make_unique<AIChatAPI>(model_name, url_loader_factory);
+}
+
+EngineConsumerClaudeRemote::~EngineConsumerClaudeRemote() = default;
+
+void EngineConsumerClaudeRemote::ClearAllQueries() {
+  api_->ClearAllQueries();
+}
+
+void EngineConsumerClaudeRemote::GenerateQuestionSuggestions(
+    const bool& is_video,
+    const std::string& page_content,
+    SuggestedQuestionsCallback callback) {
+  std::string prompt;
+  std::vector<std::string> stop_sequences;
+  prompt = base::StrCat(
+      {AIChatAPI::GetHumanPromptSegment(),
+       base::ReplaceStringPlaceholders(
+           l10n_util::GetStringUTF8(is_video
+                                        ? IDS_AI_CHAT_VIDEO_PROMPT_SEGMENT
+                                        : IDS_AI_CHAT_ARTICLE_PROMPT_SEGMENT),
+           {page_content}, nullptr),
+       "\n\n", l10n_util::GetStringUTF8(IDS_AI_CHAT_QUESTION_PROMPT_SEGMENT),
+       GetAssistantPromptSegment(), " <response>"});
+  CheckPrompt(prompt);
+  stop_sequences.push_back("</response>");
+
+  api_->QueryPrompt(
+      prompt, stop_sequences,
+      base::BindOnce(
+          &EngineConsumerClaudeRemote::OnGenerateQuestionSuggestionsResponse,
+          weak_ptr_factory_.GetWeakPtr(), std::move(callback)));
+}
+
+void EngineConsumerClaudeRemote::OnGenerateQuestionSuggestionsResponse(
+    SuggestedQuestionsCallback callback,
+    APIRequestResult result) {
+  auto success = result.Is2XXResponseCode();
+  if (!success) {
+    LOG(ERROR) << "Error getting question suggestions. Code: "
+               << result.response_code();
+    return;
+  }
+  // Validate
+  if (!result.value_body().is_dict()) {
+    DVLOG(1) << "Expected dictionary for question suggestion result"
+             << " but got: " << result.value_body().DebugString();
+    return;
+  }
+  // TODO(petemill): move common completion basic value lookup to AIChatAPI
+  const std::string* completion =
+      result.value_body().GetDict().FindString("completion");
+  if (!completion || completion->empty()) {
+    DVLOG(1) << "Expected completion param for question suggestion"
+             << " result but got: " << result.value_body().DebugString();
+    return;
+  }
+
+  DVLOG(2) << "Received " << (success ? "success" : "failed")
+           << " suggested questions response: " << completion;
+
+  std::vector<std::string> questions = base::SplitString(
+      *completion, "|", base::WhitespaceHandling::TRIM_WHITESPACE,
+      base::SplitResult::SPLIT_WANT_NONEMPTY);
+  std::move(callback).Run(std::move(questions));
+}
+
+void EngineConsumerClaudeRemote::SubmitHumanInput(
+    const bool& is_video,
+    const std::string& page_content,
+    const ConversationHistory& conversation_history,
+    const std::string& human_input,
+    SubmitHumanInputDataReceivedCallback data_received_callback,
+    SubmitHumanInputCompletedCallback completed_callback) {
+  std::string prompt = BuildClaudePrompt(human_input, page_content, is_video,
+                                         conversation_history);
+  CheckPrompt(prompt);
+  auto on_data_received = base::BindRepeating(
+      &EngineConsumerClaudeRemote::OnCompletionDataReceived,
+      weak_ptr_factory_.GetWeakPtr(), std::move(data_received_callback));
+  auto on_complete = base::BindOnce(
+      &EngineConsumerClaudeRemote::OnCompletionCompleted,
+      weak_ptr_factory_.GetWeakPtr(), std::move(completed_callback));
+  api_->QueryPrompt(prompt, {"</response>"}, std::move(on_complete),
+    std::move(on_data_received));
+}
+
+void EngineConsumerClaudeRemote::OnCompletionDataReceived(
+    SubmitHumanInputDataReceivedCallback callback,
+    base::expected<base::Value, std::string> result) {
+  if (!result.has_value() || !result->is_dict()) {
+    return;
+  }
+
+  if (const std::string* completion =
+          result->GetDict().FindString("completion")) {
+    callback.Run(std::move(*completion));
+  }
+}
+
+void EngineConsumerClaudeRemote::OnCompletionCompleted(
+    SubmitHumanInputCompletedCallback callback,
+    APIRequestResult result) {
+  const bool success = result.Is2XXResponseCode();
+  // Handle successful request
+  if (success) {
+    std::string completion = "";
+    // We're checking for a value body in case for non-streaming API results.
+    if (result.value_body().is_dict()) {
+      if (const std::string* completion_raw =
+              result.value_body().GetDict().FindString("completion")) {
+        // Trimming necessary for Llama 2 which prepends responses with a " ".
+        completion = base::TrimWhitespaceASCII(*completion_raw, base::TRIM_ALL);
+      }
+    }
+    std::move(callback).Run(base::ok(std::move(completion)));
+    return;
+  }
+  // Handle error
+  mojom::APIError error =
+      (net::HTTP_TOO_MANY_REQUESTS == result.response_code())
+          ? mojom::APIError::RateLimitReached
+          : mojom::APIError::ConnectionIssue;
+  std::move(callback).Run(base::unexpected(std::move(error)));
+}
+
+void EngineConsumerClaudeRemote::SanitizeInput(std::string& input) {
+  // Prevent indirect prompt injections being sent to the AI model.
+  // Include break-out strings contained in prompts, as well as the base
+  // model command separators.
+  base::ReplaceSubstringsAfterOffset(&input, 0, kHumanPrompt, "");
+  // TODO(petemill): Do we need to strip the versions of these without newlines?
+  base::ReplaceSubstringsAfterOffset(&input, 0, kHumanPromptPlaceholder, "");
+  base::ReplaceSubstringsAfterOffset(&input, 0, kAIPromptPlaceholder, "");
+  base::ReplaceSubstringsAfterOffset(&input, 0, "<article>", "");
+  base::ReplaceSubstringsAfterOffset(&input, 0, "</article>", "");
+  base::ReplaceSubstringsAfterOffset(&input, 0, "<history>", "");
+  base::ReplaceSubstringsAfterOffset(&input, 0, "</history>", "");
+  base::ReplaceSubstringsAfterOffset(&input, 0, "<question>", "");
+  base::ReplaceSubstringsAfterOffset(&input, 0, "</question>", "");
+}
+
+}  // namespace ai_chat

--- a/components/ai_chat/browser/engine/engine_consumer_claude.cc
+++ b/components/ai_chat/browser/engine/engine_consumer_claude.cc
@@ -145,7 +145,7 @@ void EngineConsumerClaudeRemote::GenerateQuestionSuggestions(
 
 void EngineConsumerClaudeRemote::OnGenerateQuestionSuggestionsResponse(
     SuggestedQuestionsCallback callback,
-    CompletionResult result) {
+    GenerationResult result) {
   if (!result.has_value() || result->empty()) {
     // Query resulted in error
     LOG(ERROR) << "Error getting question suggestions.";
@@ -159,13 +159,13 @@ void EngineConsumerClaudeRemote::OnGenerateQuestionSuggestionsResponse(
   std::move(callback).Run(std::move(questions));
 }
 
-void EngineConsumerClaudeRemote::SubmitHumanInput(
+void EngineConsumerClaudeRemote::GenerateAssistantResponse(
     const bool& is_video,
     const std::string& page_content,
     const ConversationHistory& conversation_history,
     const std::string& human_input,
-    CompletionDataReceivedCallback data_received_callback,
-    CompletionCompletedCallback completed_callback) {
+    GenerationDataCallback data_received_callback,
+    GenerationCompletedCallback completed_callback) {
   std::string prompt = BuildClaudePrompt(human_input, page_content, is_video,
                                          conversation_history);
   CheckPrompt(prompt);
@@ -174,9 +174,6 @@ void EngineConsumerClaudeRemote::SubmitHumanInput(
 }
 
 void EngineConsumerClaudeRemote::SanitizeInput(std::string& input) {
-  // Prevent indirect prompt injections being sent to the AI model.
-  // Include break-out strings contained in prompts, as well as the base
-  // model command separators.
   base::ReplaceSubstringsAfterOffset(&input, 0, kHumanPrompt, "");
   // TODO(petemill): Do we need to strip the versions of these without newlines?
   base::ReplaceSubstringsAfterOffset(&input, 0, kHumanPromptPlaceholder, "");

--- a/components/ai_chat/browser/engine/engine_consumer_claude.h
+++ b/components/ai_chat/browser/engine/engine_consumer_claude.h
@@ -9,8 +9,7 @@
 #include <string>
 
 #include "brave/components/ai_chat/browser/engine/engine_consumer.h"
-#include "brave/components/ai_chat/browser/ai_chat_api.h"
-#include "brave/components/ai_chat/common/mojom/ai_chat.mojom.h"
+#include "brave/components/ai_chat/browser/engine/remote_completion_client.h"
 
 namespace api_request_helper {
   class APIRequestResult;
@@ -60,7 +59,7 @@ namespace ai_chat {
    void OnCompletionCompleted(SubmitHumanInputCompletedCallback callback,
                               APIRequestResult result);
 
-   std::unique_ptr<AIChatAPI> api_ = nullptr;
+   std::unique_ptr<RemoteCompletionClient> api_ = nullptr;
 
    base::WeakPtrFactory<EngineConsumerClaudeRemote> weak_ptr_factory_{this};
 

--- a/components/ai_chat/browser/engine/engine_consumer_claude.h
+++ b/components/ai_chat/browser/engine/engine_consumer_claude.h
@@ -45,20 +45,15 @@ class EngineConsumerClaudeRemote : public EngineConsumer {
       const std::string& page_content,
       const ConversationHistory& conversation_history,
       const std::string& human_input,
-      SubmitHumanInputDataReceivedCallback data_received_callback,
-      SubmitHumanInputCompletedCallback completed_callback) override;
+      CompletionDataReceivedCallback data_received_callback,
+      CompletionCompletedCallback completed_callback) override;
   void SanitizeInput(std::string& input) override;
   void ClearAllQueries() override;
 
  private:
   void OnGenerateQuestionSuggestionsResponse(
       SuggestedQuestionsCallback callback,
-      APIRequestResult result);
-  void OnCompletionDataReceived(
-      SubmitHumanInputDataReceivedCallback callback,
-      base::expected<base::Value, std::string> result);
-  void OnCompletionCompleted(SubmitHumanInputCompletedCallback callback,
-                             APIRequestResult result);
+      CompletionResult result);
 
   std::unique_ptr<RemoteCompletionClient> api_ = nullptr;
 

--- a/components/ai_chat/browser/engine/engine_consumer_claude.h
+++ b/components/ai_chat/browser/engine/engine_consumer_claude.h
@@ -1,0 +1,71 @@
+// Copyright (c) 2023 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#ifndef BRAVE_COMPONENTS_AI_CHAT_BROWSER_ENGINE_ENGINE_CONSUMER_CLAUDE_H_
+#define BRAVE_COMPONENTS_AI_CHAT_BROWSER_ENGINE_ENGINE_CONSUMER_CLAUDE_H_
+
+#include <string>
+
+#include "brave/components/ai_chat/browser/engine/engine_consumer.h"
+#include "brave/components/ai_chat/browser/ai_chat_api.h"
+#include "brave/components/ai_chat/common/mojom/ai_chat.mojom.h"
+
+namespace api_request_helper {
+  class APIRequestResult;
+}  // namespace api_request_helper
+
+namespace network {
+class SharedURLLoaderFactory;
+}  // namespace network
+
+namespace ai_chat {
+
+ using api_request_helper::APIRequestResult;
+
+ // An AI Chat engine consumer that uses the Claude-style remote HTTP completion
+ // API and builds prompts tailored to the Claude models.
+ class EngineConsumerClaudeRemote : public EngineConsumer {
+  public:
+   explicit EngineConsumerClaudeRemote(
+       scoped_refptr<network::SharedURLLoaderFactory> url_loader_factory);
+   EngineConsumerClaudeRemote(const EngineConsumerClaudeRemote&) = delete;
+   EngineConsumerClaudeRemote& operator=(const EngineConsumerClaudeRemote&) =
+       delete;
+   ~EngineConsumerClaudeRemote() override;
+
+   // EngineConsumer
+   void GenerateQuestionSuggestions(
+       const bool& is_video,
+       const std::string& page_content,
+       SuggestedQuestionsCallback callback) override;
+   void SubmitHumanInput(
+       const bool& is_video,
+       const std::string& page_content,
+       const ConversationHistory& conversation_history,
+       const std::string& human_input,
+       SubmitHumanInputDataReceivedCallback data_received_callback,
+       SubmitHumanInputCompletedCallback completed_callback) override;
+   void SanitizeInput(std::string& input) override;
+   void ClearAllQueries() override;
+
+  private:
+   void OnGenerateQuestionSuggestionsResponse(
+       SuggestedQuestionsCallback callback,
+       APIRequestResult result);
+   void OnCompletionDataReceived(
+       SubmitHumanInputDataReceivedCallback callback,
+       base::expected<base::Value, std::string> result);
+   void OnCompletionCompleted(SubmitHumanInputCompletedCallback callback,
+                              APIRequestResult result);
+
+   std::unique_ptr<AIChatAPI> api_ = nullptr;
+
+   base::WeakPtrFactory<EngineConsumerClaudeRemote> weak_ptr_factory_{this};
+
+};
+
+}  // namespace ai_chat
+
+#endif  // BRAVE_COMPONENTS_AI_CHAT_BROWSER_ENGINE_ENGINE_CONSUMER_CLAUDE_H_

--- a/components/ai_chat/browser/engine/engine_consumer_claude.h
+++ b/components/ai_chat/browser/engine/engine_consumer_claude.h
@@ -6,13 +6,14 @@
 #ifndef BRAVE_COMPONENTS_AI_CHAT_BROWSER_ENGINE_ENGINE_CONSUMER_CLAUDE_H_
 #define BRAVE_COMPONENTS_AI_CHAT_BROWSER_ENGINE_ENGINE_CONSUMER_CLAUDE_H_
 
+#include <memory>
 #include <string>
 
 #include "brave/components/ai_chat/browser/engine/engine_consumer.h"
 #include "brave/components/ai_chat/browser/engine/remote_completion_client.h"
 
 namespace api_request_helper {
-  class APIRequestResult;
+class APIRequestResult;
 }  // namespace api_request_helper
 
 namespace network {
@@ -21,48 +22,47 @@ class SharedURLLoaderFactory;
 
 namespace ai_chat {
 
- using api_request_helper::APIRequestResult;
+using api_request_helper::APIRequestResult;
 
- // An AI Chat engine consumer that uses the Claude-style remote HTTP completion
- // API and builds prompts tailored to the Claude models.
- class EngineConsumerClaudeRemote : public EngineConsumer {
-  public:
-   explicit EngineConsumerClaudeRemote(
-       scoped_refptr<network::SharedURLLoaderFactory> url_loader_factory);
-   EngineConsumerClaudeRemote(const EngineConsumerClaudeRemote&) = delete;
-   EngineConsumerClaudeRemote& operator=(const EngineConsumerClaudeRemote&) =
-       delete;
-   ~EngineConsumerClaudeRemote() override;
+// An AI Chat engine consumer that uses the Claude-style remote HTTP completion
+// API and builds prompts tailored to the Claude models.
+class EngineConsumerClaudeRemote : public EngineConsumer {
+ public:
+  explicit EngineConsumerClaudeRemote(
+      scoped_refptr<network::SharedURLLoaderFactory> url_loader_factory);
+  EngineConsumerClaudeRemote(const EngineConsumerClaudeRemote&) = delete;
+  EngineConsumerClaudeRemote& operator=(const EngineConsumerClaudeRemote&) =
+      delete;
+  ~EngineConsumerClaudeRemote() override;
 
-   // EngineConsumer
-   void GenerateQuestionSuggestions(
-       const bool& is_video,
-       const std::string& page_content,
-       SuggestedQuestionsCallback callback) override;
-   void SubmitHumanInput(
-       const bool& is_video,
-       const std::string& page_content,
-       const ConversationHistory& conversation_history,
-       const std::string& human_input,
-       SubmitHumanInputDataReceivedCallback data_received_callback,
-       SubmitHumanInputCompletedCallback completed_callback) override;
-   void SanitizeInput(std::string& input) override;
-   void ClearAllQueries() override;
+  // EngineConsumer
+  void GenerateQuestionSuggestions(
+      const bool& is_video,
+      const std::string& page_content,
+      SuggestedQuestionsCallback callback) override;
+  void SubmitHumanInput(
+      const bool& is_video,
+      const std::string& page_content,
+      const ConversationHistory& conversation_history,
+      const std::string& human_input,
+      SubmitHumanInputDataReceivedCallback data_received_callback,
+      SubmitHumanInputCompletedCallback completed_callback) override;
+  void SanitizeInput(std::string& input) override;
+  void ClearAllQueries() override;
 
-  private:
-   void OnGenerateQuestionSuggestionsResponse(
-       SuggestedQuestionsCallback callback,
-       APIRequestResult result);
-   void OnCompletionDataReceived(
-       SubmitHumanInputDataReceivedCallback callback,
-       base::expected<base::Value, std::string> result);
-   void OnCompletionCompleted(SubmitHumanInputCompletedCallback callback,
-                              APIRequestResult result);
+ private:
+  void OnGenerateQuestionSuggestionsResponse(
+      SuggestedQuestionsCallback callback,
+      APIRequestResult result);
+  void OnCompletionDataReceived(
+      SubmitHumanInputDataReceivedCallback callback,
+      base::expected<base::Value, std::string> result);
+  void OnCompletionCompleted(SubmitHumanInputCompletedCallback callback,
+                             APIRequestResult result);
 
-   std::unique_ptr<RemoteCompletionClient> api_ = nullptr;
+  std::unique_ptr<RemoteCompletionClient> api_ = nullptr;
 
-   base::WeakPtrFactory<EngineConsumerClaudeRemote> weak_ptr_factory_{this};
-
+  base::WeakPtrFactory<EngineConsumerClaudeRemote> weak_ptr_factory_{this};
 };
 
 }  // namespace ai_chat

--- a/components/ai_chat/browser/engine/engine_consumer_claude.h
+++ b/components/ai_chat/browser/engine/engine_consumer_claude.h
@@ -40,20 +40,20 @@ class EngineConsumerClaudeRemote : public EngineConsumer {
       const bool& is_video,
       const std::string& page_content,
       SuggestedQuestionsCallback callback) override;
-  void SubmitHumanInput(
+  void GenerateAssistantResponse(
       const bool& is_video,
       const std::string& page_content,
       const ConversationHistory& conversation_history,
       const std::string& human_input,
-      CompletionDataReceivedCallback data_received_callback,
-      CompletionCompletedCallback completed_callback) override;
+      GenerationDataCallback data_received_callback,
+      GenerationCompletedCallback completed_callback) override;
   void SanitizeInput(std::string& input) override;
   void ClearAllQueries() override;
 
  private:
   void OnGenerateQuestionSuggestionsResponse(
       SuggestedQuestionsCallback callback,
-      CompletionResult result);
+      GenerationResult result);
 
   std::unique_ptr<RemoteCompletionClient> api_ = nullptr;
 

--- a/components/ai_chat/browser/engine/engine_consumer_llama.cc
+++ b/components/ai_chat/browser/engine/engine_consumer_llama.cc
@@ -8,6 +8,7 @@
 #include <memory>
 #include <string>
 #include <utility>
+#include <vector>
 
 #include "absl/types/optional.h"
 #include "base/functional/bind.h"
@@ -239,7 +240,8 @@ EngineConsumerLlamaRemote::EngineConsumerLlamaRemote(
   // likely it will be chosen by the server and the general string "leo"
   // provided here.
   const auto model_name = ai_chat::features::kAIModelName.Get();
-  api_ = std::make_unique<RemoteCompletionClient>(model_name, url_loader_factory);
+  api_ =
+      std::make_unique<RemoteCompletionClient>(model_name, url_loader_factory);
 }
 
 EngineConsumerLlamaRemote::~EngineConsumerLlamaRemote() = default;
@@ -280,7 +282,8 @@ void EngineConsumerLlamaRemote::OnGenerateQuestionSuggestionsResponse(
              << " but got: " << result.value_body().DebugString();
     return;
   }
-  // TODO(petemill): move common completion basic value lookup to RemoteCompletionClient
+  // TODO(petemill): move common completion basic value lookup to
+  // RemoteCompletionClient
   const std::string* completion =
       result.value_body().GetDict().FindString("completion");
   if (!completion || completion->empty()) {

--- a/components/ai_chat/browser/engine/engine_consumer_llama.cc
+++ b/components/ai_chat/browser/engine/engine_consumer_llama.cc
@@ -1,0 +1,408 @@
+// Copyright (c) 2023 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#include "brave/components/ai_chat/browser/engine/engine_consumer_llama.h"
+
+#include <memory>
+#include <string>
+#include <utility>
+
+#include "absl/types/optional.h"
+#include "base/functional/bind.h"
+#include "base/i18n/time_formatting.h"
+#include "base/memory/raw_ptr.h"
+#include "base/memory/weak_ptr.h"
+#include "base/strings/strcat.h"
+#include "base/strings/string_split.h"
+#include "base/strings/string_util.h"
+#include "base/strings/utf_string_conversions.h"
+#include "base/time/time.h"
+#include "brave/components/ai_chat/browser/ai_chat_api.h"
+#include "brave/components/ai_chat/common/features.h"
+#include "brave/components/ai_chat/common/mojom/ai_chat.mojom.h"
+#include "components/grit/brave_components_strings.h"
+#include "net/http/http_status_code.h"
+#include "services/network/public/cpp/shared_url_loader_factory.h"
+#include "ui/base/l10n/l10n_util.h"
+
+namespace {
+
+using ai_chat::mojom::ConversationTurn;
+
+constexpr char kLlama2Bos[] = "<s>";
+constexpr char kLlama2Eos[] = "</s>";
+constexpr char kLlama2BIns[] = "[INST]";
+constexpr char kLlama2EIns[] = "[/INST]";
+constexpr char kLlama2BSys[] = "<<SYS>>\n";
+constexpr char kLlama2ESys[] = "\n<</SYS>>\n\n";
+
+std::string BuildLlama2InstructionPrompt(const std::string& instruction) {
+  return base::ReplaceStringPlaceholders(
+      R"($1 $2 $3 )", {kLlama2BIns, instruction, kLlama2EIns}, nullptr);
+}
+
+std::string BuildLlama2FirstSequence(
+    const std::string& system_message,
+    const std::string& user_message,
+    absl::optional<std::string> assistant_response,
+    absl::optional<std::string> assistant_response_seed) {
+  // Generates a partial sequence if there is no assistant_response:
+
+  // <s> [INST] <<SYS>>
+  // You will be acting as an assistant named Leo created by the company Brave.
+  // Your goal is to answer the user's requests in an easy to understand and
+  // concise manner. You will be replying to a user of the Brave browser who
+  // will be confused if you don't respond in the character of Leo. Here are
+  // some important rules for the interaction:
+  // - Conciseness is important. Your responses should not exceed 6 sentences.
+  // - Always respond in a neutral tone.
+  // - Always stay in character, as Leo, an AI from Brave.
+  // <</SYS>>
+  //
+  // How's it going? [/INST]
+
+  // Or, if there is an assistant_response:
+
+  // <s> [INST] <<SYS>>
+  // You will be acting as an assistant named Leo created by the company Brave.
+  // Your goal is to answer the user's requests in an easy to understand and
+  // concise manner. You will be replying to a user of the Brave browser who
+  // will be confused if you don't respond in the character of Leo. Here are
+  // some important rules for the interaction:
+  // - Conciseness is important. Your responses should not exceed 6 sentences.
+  // - Always respond in a neutral tone.
+  // - Always stay in character, as Leo, an AI from Brave.
+  // <</SYS>>
+  //
+  // How's it going? [/INST] Hey there! I'm Leo, your AI assistant here to help
+  // you out. I'm here to answer any questions you have, so feel free to ask me
+  // anything! What's up?</s>
+
+  // Create the system prompt through the first user message.
+  std::string system_prompt =
+      base::StrCat({kLlama2BSys, system_message, kLlama2ESys, user_message});
+
+  // Wrap in [INST] [/INST] tags.
+  std::string instruction_prompt = BuildLlama2InstructionPrompt(system_prompt);
+
+  if (!assistant_response) {
+    // Prepend just <s> if there's no assistant_response ( it will be completed
+    // by the model).
+    if (assistant_response_seed) {
+      return base::StrCat(
+          {kLlama2Bos, instruction_prompt, *assistant_response_seed});
+    }
+    return base::StrCat({kLlama2Bos, instruction_prompt});
+  }
+
+  // Add assistant response and wrap in <s> </s> tags.
+  return base::StrCat(
+      {kLlama2Bos, instruction_prompt, *assistant_response, kLlama2Eos});
+}
+
+std::string BuildLlama2SubsequentSequence(
+    std::string user_message,
+    absl::optional<std::string> assistant_response,
+    absl::optional<std::string> assistant_response_seed) {
+  // Builds a prompt segment that looks like this:
+  // <s> [INST] Give me the first few numbers in the fibonacci sequence [/INST]
+
+  // or, if there's an assistant_response:
+
+  // <s> [INST] Give me the first few numbers in the fibonacci sequence [/INST]
+  // Hey there! Sure thing! The first few numbers in the Fibonacci sequence are:
+  // 1, 1, 2, 3, 5, 8, 13, and so on. </s>
+
+  user_message = BuildLlama2InstructionPrompt(user_message);
+
+  if (assistant_response_seed) {
+    return base::StrCat({kLlama2Bos, user_message, *assistant_response_seed});
+  }
+
+  if (!assistant_response) {
+    return base::StrCat({kLlama2Bos, user_message});
+  }
+
+  return base::StrCat(
+      {kLlama2Bos, user_message, *assistant_response, kLlama2Eos});
+}
+
+std::string BuildLlama2GenerateQuestionsPrompt(bool is_video,
+                                               const std::string content) {
+  std::string content_template;
+  if (is_video) {
+    content_template =
+        l10n_util::GetStringUTF8(IDS_AI_CHAT_LLAMA2_GENERATE_QUESTIONS_VIDEO);
+  } else {
+    content_template =
+        l10n_util::GetStringUTF8(IDS_AI_CHAT_LLAMA2_GENERATE_QUESTIONS_ARTICLE);
+  }
+
+  const std::string& user_message =
+      base::ReplaceStringPlaceholders(content_template, {content}, nullptr);
+
+  return BuildLlama2FirstSequence(
+      l10n_util::GetStringUTF8(
+          IDS_AI_CHAT_LLAMA2_SYSTEM_MESSAGE_GENERATE_QUESTIONS),
+      user_message, absl::nullopt,
+      l10n_util::GetStringUTF8(
+          IDS_AI_CHAT_LLAMA2_SYSTEM_MESSAGE_GENERATE_QUESTIONS_RESPONSE_SEED));
+}
+
+std::string BuildLlama2Prompt(
+    const std::vector<ConversationTurn>& conversation_history,
+    std::string page_content,
+    const bool& is_video,
+    const std::string user_message) {
+  // Always use a generic system message
+  std::string system_message =
+      l10n_util::GetStringUTF8(IDS_AI_CHAT_LLAMA2_SYSTEM_MESSAGE_GENERIC);
+  std::string date_and_time_string =
+      base::UTF16ToUTF8(TimeFormatFriendlyDateAndTime(base::Time::Now()));
+  std::string today_system_message = base::ReplaceStringPlaceholders(
+      system_message, {date_and_time_string}, nullptr);
+
+  // Get the raw first user message, which is in the chat history if this is
+  // the first sequence.
+  std::string raw_first_user_message;
+  if (conversation_history.size() > 0) {
+    raw_first_user_message = conversation_history[0].text;
+  } else {
+    raw_first_user_message = user_message;
+  }
+
+  // Build first_user_message, the first complete message sent to the AI model,
+  // which may or may not include injected contents such as article text.
+  std::string first_user_message;
+  if (!page_content.empty()) {
+    std::string first_message_template;
+    if (is_video) {
+      first_message_template =
+          l10n_util::GetStringUTF8(IDS_AI_CHAT_VIDEO_PROMPT_SEGMENT_LLAMA2);
+    } else {
+      first_message_template =
+          l10n_util::GetStringUTF8(IDS_AI_CHAT_ARTICLE_PROMPT_SEGMENT_LLAMA2);
+    }
+    first_user_message = base::ReplaceStringPlaceholders(
+        first_message_template, {page_content, raw_first_user_message},
+        nullptr);
+  } else {
+    // If there's no article or video context, just use the raw first user
+    // message.
+    first_user_message = raw_first_user_message;
+  }
+
+  // If there's no conversation history, then we just send a (partial)
+  // first sequence.
+  if (conversation_history.empty() || conversation_history.size() <= 1) {
+    return BuildLlama2FirstSequence(
+        today_system_message, first_user_message, absl::nullopt,
+        l10n_util::GetStringUTF8(IDS_AI_CHAT_LLAMA2_GENERAL_SEED));
+  }
+
+  // Use the first two messages to build the first sequence,
+  // which includes the system prompt.
+  std::string prompt =
+      BuildLlama2FirstSequence(today_system_message, first_user_message,
+                               conversation_history[1].text, absl::nullopt);
+
+  // Loop through the rest of the history two at a time building subsequent
+  // sequences.
+  for (size_t i = 2; i + 1 < conversation_history.size(); i += 2) {
+    const std::string& prev_user_message = conversation_history[i].text;
+    const std::string& assistant_message = conversation_history[i + 1].text;
+    prompt += BuildLlama2SubsequentSequence(prev_user_message,
+                                            assistant_message, absl::nullopt);
+  }
+
+  // Build the final subsequent exchange using the current turn.
+  prompt += BuildLlama2SubsequentSequence(
+      user_message, absl::nullopt,
+      l10n_util::GetStringUTF8(IDS_AI_CHAT_LLAMA2_GENERAL_SEED));
+
+  // Trimming recommended by Meta
+  // https://huggingface.co/meta-llama/Llama-2-13b-chat#intended-use
+  prompt = base::TrimWhitespaceASCII(prompt, base::TRIM_ALL);
+  return prompt;
+}
+
+}  // namespace
+
+namespace ai_chat {
+
+EngineConsumerLlamaRemote::EngineConsumerLlamaRemote(
+    scoped_refptr<network::SharedURLLoaderFactory> url_loader_factory) {
+  // TODO(petemill): In multi-model mode, this model name will always be a
+  // specific llama version - either static or dynamic via some mechanism. Most
+  // likely it will be chosen by the server and the general string "leo"
+  // provided here.
+  const auto model_name = ai_chat::features::kAIModelName.Get();
+  api_ = std::make_unique<AIChatAPI>(model_name, url_loader_factory);
+}
+
+EngineConsumerLlamaRemote::~EngineConsumerLlamaRemote() = default;
+
+void EngineConsumerLlamaRemote::ClearAllQueries() {
+  api_->ClearAllQueries();
+}
+
+void EngineConsumerLlamaRemote::GenerateQuestionSuggestions(
+    const bool& is_video,
+    const std::string& page_content,
+    SuggestedQuestionsCallback callback) {
+  std::string prompt;
+  std::vector<std::string> stop_sequences;
+  prompt = BuildLlama2GenerateQuestionsPrompt(is_video, page_content);
+  stop_sequences.push_back(kLlama2Eos);
+  stop_sequences.push_back("</ul>");
+  DCHECK(api_);
+  api_->QueryPrompt(
+      prompt, stop_sequences,
+      base::BindOnce(
+          &EngineConsumerLlamaRemote::OnGenerateQuestionSuggestionsResponse,
+          weak_ptr_factory_.GetWeakPtr(), std::move(callback)));
+}
+
+void EngineConsumerLlamaRemote::OnGenerateQuestionSuggestionsResponse(
+    SuggestedQuestionsCallback callback,
+    APIRequestResult result) {
+  auto success = result.Is2XXResponseCode();
+  if (!success) {
+    LOG(ERROR) << "Error getting question suggestions. Code: "
+               << result.response_code();
+    return;
+  }
+  // Validate
+  if (!result.value_body().is_dict()) {
+    DVLOG(1) << "Expected dictionary for question suggestion result"
+             << " but got: " << result.value_body().DebugString();
+    return;
+  }
+  // TODO(petemill): move common completion basic value lookup to AIChatAPI
+  const std::string* completion =
+      result.value_body().GetDict().FindString("completion");
+  if (!completion || completion->empty()) {
+    DVLOG(1) << "Expected completion param for question suggestion"
+             << " result but got: " << result.value_body().DebugString();
+    return;
+  }
+
+  DVLOG(2) << "Received " << (success ? "success" : "failed")
+           << " suggested questions response: " << completion;
+
+  // Llama 2 results look something like this:
+  // Can ChatGPT actually summarize a seven-hour video in under a minute?</li>
+  // <li>What are the limitations of ChatGPT's browsing capabilities, and how
+  // does it affect its ability to provide accurate information?</li> <li>Can
+  // ChatGPT's tonewood research be applied to other areas of scientific
+  // inquiry beyond guitar making?</li>  These questions capture interesting
+  // aspects of the video, such as the AI's ability to summarize long content,
+  // its limitations, and its potential applications beyond the specific use
+  // case presented in the video.
+
+  // Split out the questions using </li>
+  std::vector<std::string> questions = base::SplitStringUsingSubstr(
+      *completion, "</li>", base::TRIM_WHITESPACE, base::SPLIT_WANT_NONEMPTY);
+
+  // Remove the last entry in questions if it doesn't contain an <li> tag
+  // which means its not an actually a question
+  if (questions.size() > 1) {
+    if (questions.back().find("<li>") == std::string::npos) {
+      questions.pop_back();
+    }
+  }
+
+  // Remove leading <li> from each question
+  for (auto& question : questions) {
+    auto parts = base::SplitStringUsingSubstr(
+        question, "<li>", base::TRIM_WHITESPACE, base::SPLIT_WANT_NONEMPTY);
+    if (!parts.empty()) {
+      question = parts.back();  // If there's an <li>, parts will contain an
+                                // empty string and then the question. We take
+                                // the last element.
+    }
+  }
+
+  std::move(callback).Run(std::move(questions));
+}
+
+void EngineConsumerLlamaRemote::SubmitHumanInput(
+    const bool& is_video,
+    const std::string& page_content,
+    const ConversationHistory& conversation_history,
+    const std::string& human_input,
+    SubmitHumanInputDataReceivedCallback data_received_callback,
+    SubmitHumanInputCompletedCallback completed_callback) {
+  std::string prompt = BuildLlama2Prompt(conversation_history, page_content,
+                                         is_video, human_input);
+  auto on_data_received = base::BindRepeating(
+      &EngineConsumerLlamaRemote::OnCompletionDataReceived,
+      weak_ptr_factory_.GetWeakPtr(), std::move(data_received_callback));
+  auto on_complete = base::BindOnce(
+      &EngineConsumerLlamaRemote::OnCompletionCompleted,
+      weak_ptr_factory_.GetWeakPtr(), std::move(completed_callback));
+  DCHECK(api_);
+  api_->QueryPrompt(prompt, {"</response>"}, std::move(on_complete),
+                    std::move(on_data_received));
+}
+
+void EngineConsumerLlamaRemote::OnCompletionDataReceived(
+    SubmitHumanInputDataReceivedCallback callback,
+    base::expected<base::Value, std::string> result) {
+  // TODO(petemill): Have all of this handled by common AI API helper class
+  if (!result.has_value() || !result->is_dict()) {
+    return;
+  }
+
+  if (const std::string* completion =
+          result->GetDict().FindString("completion")) {
+    callback.Run(std::move(*completion));
+  }
+}
+
+void EngineConsumerLlamaRemote::OnCompletionCompleted(
+    SubmitHumanInputCompletedCallback callback,
+    APIRequestResult result) {
+  // TODO(petemill): Have all of this handled by common AI API helper class
+  const bool success = result.Is2XXResponseCode();
+  // Handle successful request
+  if (success) {
+    std::string completion;
+    // We're checking for a value body in case for non-streaming API results.
+    if (result.value_body().is_dict()) {
+      completion = *result.value_body().GetDict().FindString("completion");
+      // Trimming necessary for Llama 2 which prepends responses with a " ".
+      completion = base::TrimWhitespaceASCII(completion, base::TRIM_ALL);
+    } else {
+      completion = "";
+    }
+    std::move(callback).Run(base::ok(std::move(completion)));
+  }
+  // Handle error
+  mojom::APIError error =
+      (net::HTTP_TOO_MANY_REQUESTS == result.response_code())
+          ? mojom::APIError::RateLimitReached
+          : mojom::APIError::ConnectionIssue;
+  std::move(callback).Run(base::unexpected(std::move(error)));
+}
+
+void EngineConsumerLlamaRemote::SanitizeInput(std::string& input) {
+  base::ReplaceSubstringsAfterOffset(&input, 0, kLlama2Bos, "");
+  base::ReplaceSubstringsAfterOffset(&input, 0, kLlama2Eos, "");
+  base::ReplaceSubstringsAfterOffset(&input, 0, kLlama2BIns, "");
+  base::ReplaceSubstringsAfterOffset(&input, 0, kLlama2EIns, "");
+  base::ReplaceSubstringsAfterOffset(&input, 0, kLlama2BSys, "");
+  base::ReplaceSubstringsAfterOffset(&input, 0, kLlama2ESys, "");
+  // TODO(petemill): Case-sensitive?
+  base::ReplaceSubstringsAfterOffset(&input, 0, "<SYS>", "");
+  base::ReplaceSubstringsAfterOffset(&input, 0, "<article>", "");
+  base::ReplaceSubstringsAfterOffset(&input, 0, "</article>", "");
+  base::ReplaceSubstringsAfterOffset(&input, 0, "<history>", "");
+  base::ReplaceSubstringsAfterOffset(&input, 0, "</history>", "");
+  base::ReplaceSubstringsAfterOffset(&input, 0, "<question>", "");
+  base::ReplaceSubstringsAfterOffset(&input, 0, "</question>", "");
+}
+
+}  // namespace ai_chat

--- a/components/ai_chat/browser/engine/engine_consumer_llama.cc
+++ b/components/ai_chat/browser/engine/engine_consumer_llama.cc
@@ -269,7 +269,7 @@ void EngineConsumerLlamaRemote::GenerateQuestionSuggestions(
 
 void EngineConsumerLlamaRemote::OnGenerateQuestionSuggestionsResponse(
     SuggestedQuestionsCallback callback,
-    CompletionResult result) {
+    GenerationResult result) {
   if (!result.has_value() || result->empty()) {
     // Query resulted in error
     LOG(ERROR) << "Error getting question suggestions.";
@@ -313,13 +313,13 @@ void EngineConsumerLlamaRemote::OnGenerateQuestionSuggestionsResponse(
   std::move(callback).Run(std::move(questions));
 }
 
-void EngineConsumerLlamaRemote::SubmitHumanInput(
+void EngineConsumerLlamaRemote::GenerateAssistantResponse(
     const bool& is_video,
     const std::string& page_content,
     const ConversationHistory& conversation_history,
     const std::string& human_input,
-    CompletionDataReceivedCallback data_received_callback,
-    CompletionCompletedCallback completed_callback) {
+    GenerationDataCallback data_received_callback,
+    GenerationCompletedCallback completed_callback) {
   std::string prompt = BuildLlama2Prompt(conversation_history, page_content,
                                          is_video, human_input);
   DCHECK(api_);

--- a/components/ai_chat/browser/engine/engine_consumer_llama.cc
+++ b/components/ai_chat/browser/engine/engine_consumer_llama.cc
@@ -19,7 +19,7 @@
 #include "base/strings/string_util.h"
 #include "base/strings/utf_string_conversions.h"
 #include "base/time/time.h"
-#include "brave/components/ai_chat/browser/ai_chat_api.h"
+#include "brave/components/ai_chat/browser/engine/remote_completion_client.h"
 #include "brave/components/ai_chat/common/features.h"
 #include "brave/components/ai_chat/common/mojom/ai_chat.mojom.h"
 #include "components/grit/brave_components_strings.h"
@@ -239,7 +239,7 @@ EngineConsumerLlamaRemote::EngineConsumerLlamaRemote(
   // likely it will be chosen by the server and the general string "leo"
   // provided here.
   const auto model_name = ai_chat::features::kAIModelName.Get();
-  api_ = std::make_unique<AIChatAPI>(model_name, url_loader_factory);
+  api_ = std::make_unique<RemoteCompletionClient>(model_name, url_loader_factory);
 }
 
 EngineConsumerLlamaRemote::~EngineConsumerLlamaRemote() = default;
@@ -280,7 +280,7 @@ void EngineConsumerLlamaRemote::OnGenerateQuestionSuggestionsResponse(
              << " but got: " << result.value_body().DebugString();
     return;
   }
-  // TODO(petemill): move common completion basic value lookup to AIChatAPI
+  // TODO(petemill): move common completion basic value lookup to RemoteCompletionClient
   const std::string* completion =
       result.value_body().GetDict().FindString("completion");
   if (!completion || completion->empty()) {

--- a/components/ai_chat/browser/engine/engine_consumer_llama.h
+++ b/components/ai_chat/browser/engine/engine_consumer_llama.h
@@ -9,7 +9,7 @@
 #include <string>
 
 #include "brave/components/ai_chat/browser/engine/engine_consumer.h"
-#include "brave/components/ai_chat/browser/ai_chat_api.h"
+#include "brave/components/ai_chat/browser/engine/remote_completion_client.h"
 
 namespace api_request_helper {
   class APIRequestResult;
@@ -57,7 +57,7 @@ class EngineConsumerLlamaRemote : public EngineConsumer {
   void OnCompletionCompleted(SubmitHumanInputCompletedCallback callback,
                             APIRequestResult result);
 
-  std::unique_ptr<AIChatAPI> api_ = nullptr;
+  std::unique_ptr<RemoteCompletionClient> api_ = nullptr;
 
   base::WeakPtrFactory<EngineConsumerLlamaRemote> weak_ptr_factory_{this};
 

--- a/components/ai_chat/browser/engine/engine_consumer_llama.h
+++ b/components/ai_chat/browser/engine/engine_consumer_llama.h
@@ -40,20 +40,20 @@ class EngineConsumerLlamaRemote : public EngineConsumer {
       const bool& is_video,
       const std::string& page_content,
       SuggestedQuestionsCallback callback) override;
-  void SubmitHumanInput(
+  void GenerateAssistantResponse(
       const bool& is_video,
       const std::string& page_content,
       const ConversationHistory& conversation_history,
       const std::string& human_input,
-      CompletionDataReceivedCallback data_received_callback,
-      CompletionCompletedCallback completed_callback) override;
+      GenerationDataCallback data_received_callback,
+      GenerationCompletedCallback completed_callback) override;
   void SanitizeInput(std::string& input) override;
   void ClearAllQueries() override;
 
  private:
   void OnGenerateQuestionSuggestionsResponse(
       SuggestedQuestionsCallback callback,
-      CompletionResult result);
+      GenerationResult result);
 
   std::unique_ptr<RemoteCompletionClient> api_ = nullptr;
 

--- a/components/ai_chat/browser/engine/engine_consumer_llama.h
+++ b/components/ai_chat/browser/engine/engine_consumer_llama.h
@@ -1,0 +1,68 @@
+// Copyright (c) 2023 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#ifndef BRAVE_COMPONENTS_AI_CHAT_BROWSER_ENGINE_ENGINE_CONSUMER_LLAMA_H_
+#define BRAVE_COMPONENTS_AI_CHAT_BROWSER_ENGINE_ENGINE_CONSUMER_LLAMA_H_
+
+#include <string>
+
+#include "brave/components/ai_chat/browser/engine/engine_consumer.h"
+#include "brave/components/ai_chat/browser/ai_chat_api.h"
+
+namespace api_request_helper {
+  class APIRequestResult;
+}  // namespace api_request_helper
+
+namespace network {
+class SharedURLLoaderFactory;
+}  // namespace network
+
+namespace ai_chat {
+
+ using api_request_helper::APIRequestResult;
+
+// An AI Chat engine consumer that uses the Claude-style remote HTTP completion
+// API and builds prompts tailored to the Brave Leo model.
+class EngineConsumerLlamaRemote : public EngineConsumer {
+ public:
+  explicit EngineConsumerLlamaRemote(scoped_refptr<network::SharedURLLoaderFactory> url_loader_factory);
+  EngineConsumerLlamaRemote(const EngineConsumerLlamaRemote&) = delete;
+  EngineConsumerLlamaRemote& operator=(const EngineConsumerLlamaRemote&) = delete;
+  ~EngineConsumerLlamaRemote() override;
+
+  // EngineConsumer
+  void GenerateQuestionSuggestions(
+      const bool& is_video,
+      const std::string& page_content,
+      SuggestedQuestionsCallback callback) override;
+  void SubmitHumanInput(
+      const bool& is_video,
+      const std::string& page_content,
+      const ConversationHistory& conversation_history,
+      const std::string& human_input,
+      SubmitHumanInputDataReceivedCallback data_received_callback,
+      SubmitHumanInputCompletedCallback completed_callback) override;
+  void SanitizeInput(std::string& input) override;
+  void ClearAllQueries() override;
+
+ private:
+  void OnGenerateQuestionSuggestionsResponse(
+      SuggestedQuestionsCallback callback,
+      APIRequestResult result);
+  void OnCompletionDataReceived(
+      SubmitHumanInputDataReceivedCallback callback,
+      base::expected<base::Value, std::string> result);
+  void OnCompletionCompleted(SubmitHumanInputCompletedCallback callback,
+                            APIRequestResult result);
+
+  std::unique_ptr<AIChatAPI> api_ = nullptr;
+
+  base::WeakPtrFactory<EngineConsumerLlamaRemote> weak_ptr_factory_{this};
+
+};
+
+}  // namespace ai_chat
+
+#endif  // BRAVE_COMPONENTS_AI_CHAT_BROWSER_ENGINE_ENGINE_CONSUMER_LLAMA_H_

--- a/components/ai_chat/browser/engine/engine_consumer_llama.h
+++ b/components/ai_chat/browser/engine/engine_consumer_llama.h
@@ -6,13 +6,14 @@
 #ifndef BRAVE_COMPONENTS_AI_CHAT_BROWSER_ENGINE_ENGINE_CONSUMER_LLAMA_H_
 #define BRAVE_COMPONENTS_AI_CHAT_BROWSER_ENGINE_ENGINE_CONSUMER_LLAMA_H_
 
+#include <memory>
 #include <string>
 
 #include "brave/components/ai_chat/browser/engine/engine_consumer.h"
 #include "brave/components/ai_chat/browser/engine/remote_completion_client.h"
 
 namespace api_request_helper {
-  class APIRequestResult;
+class APIRequestResult;
 }  // namespace api_request_helper
 
 namespace network {
@@ -21,15 +22,17 @@ class SharedURLLoaderFactory;
 
 namespace ai_chat {
 
- using api_request_helper::APIRequestResult;
+using api_request_helper::APIRequestResult;
 
 // An AI Chat engine consumer that uses the Claude-style remote HTTP completion
 // API and builds prompts tailored to the Brave Leo model.
 class EngineConsumerLlamaRemote : public EngineConsumer {
  public:
-  explicit EngineConsumerLlamaRemote(scoped_refptr<network::SharedURLLoaderFactory> url_loader_factory);
+  explicit EngineConsumerLlamaRemote(
+      scoped_refptr<network::SharedURLLoaderFactory> url_loader_factory);
   EngineConsumerLlamaRemote(const EngineConsumerLlamaRemote&) = delete;
-  EngineConsumerLlamaRemote& operator=(const EngineConsumerLlamaRemote&) = delete;
+  EngineConsumerLlamaRemote& operator=(const EngineConsumerLlamaRemote&) =
+      delete;
   ~EngineConsumerLlamaRemote() override;
 
   // EngineConsumer
@@ -55,12 +58,11 @@ class EngineConsumerLlamaRemote : public EngineConsumer {
       SubmitHumanInputDataReceivedCallback callback,
       base::expected<base::Value, std::string> result);
   void OnCompletionCompleted(SubmitHumanInputCompletedCallback callback,
-                            APIRequestResult result);
+                             APIRequestResult result);
 
   std::unique_ptr<RemoteCompletionClient> api_ = nullptr;
 
   base::WeakPtrFactory<EngineConsumerLlamaRemote> weak_ptr_factory_{this};
-
 };
 
 }  // namespace ai_chat

--- a/components/ai_chat/browser/engine/engine_consumer_llama.h
+++ b/components/ai_chat/browser/engine/engine_consumer_llama.h
@@ -45,20 +45,15 @@ class EngineConsumerLlamaRemote : public EngineConsumer {
       const std::string& page_content,
       const ConversationHistory& conversation_history,
       const std::string& human_input,
-      SubmitHumanInputDataReceivedCallback data_received_callback,
-      SubmitHumanInputCompletedCallback completed_callback) override;
+      CompletionDataReceivedCallback data_received_callback,
+      CompletionCompletedCallback completed_callback) override;
   void SanitizeInput(std::string& input) override;
   void ClearAllQueries() override;
 
  private:
   void OnGenerateQuestionSuggestionsResponse(
       SuggestedQuestionsCallback callback,
-      APIRequestResult result);
-  void OnCompletionDataReceived(
-      SubmitHumanInputDataReceivedCallback callback,
-      base::expected<base::Value, std::string> result);
-  void OnCompletionCompleted(SubmitHumanInputCompletedCallback callback,
-                             APIRequestResult result);
+      CompletionResult result);
 
   std::unique_ptr<RemoteCompletionClient> api_ = nullptr;
 

--- a/components/ai_chat/browser/engine/remote_completion_client.cc
+++ b/components/ai_chat/browser/engine/remote_completion_client.cc
@@ -3,7 +3,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-#include "brave/components/ai_chat/browser/ai_chat_api.h"
+#include "brave/components/ai_chat/browser/engine/remote_completion_client.h"
 
 #include <base/containers/flat_map.h>
 
@@ -57,7 +57,7 @@ base::Value::Dict CreateApiParametersDict(
   base::Value::Dict dict;
 
   base::Value::List stop_sequences;
-  stop_sequences.Append(AIChatAPI::GetHumanPromptSegment());
+  stop_sequences.Append(RemoteCompletionClient::GetHumanPromptSegment());
   for (auto& item : additional_stop_sequences) {
     stop_sequences.Append(item);
   }
@@ -105,11 +105,11 @@ const GURL GetEndpointBaseUrl() {
 }  // namespace
 
 // static
-std::string AIChatAPI::GetHumanPromptSegment() {
+std::string RemoteCompletionClient::GetHumanPromptSegment() {
   return base::StrCat({"\n\n", kHumanPrompt, " "});
 }
 
-AIChatAPI::AIChatAPI(
+RemoteCompletionClient::RemoteCompletionClient(
     std::string model_name,
     scoped_refptr<network::SharedURLLoaderFactory> url_loader_factory)
     : model_name_(model_name),
@@ -125,9 +125,9 @@ AIChatAPI::AIChatAPI(
   }
 }
 
-AIChatAPI::~AIChatAPI() = default;
+RemoteCompletionClient::~RemoteCompletionClient() = default;
 
-void AIChatAPI::QueryPrompt(
+void RemoteCompletionClient::QueryPrompt(
     const std::string& prompt,
     const std::vector<std::string> extra_stop_sequences,
     api_request_helper::APIRequestHelper::ResultCallback
@@ -173,7 +173,7 @@ void AIChatAPI::QueryPrompt(
   }
 }
 
-void AIChatAPI::ClearAllQueries() {
+void RemoteCompletionClient::ClearAllQueries() {
   // TODO(nullhook): Keep track of in-progress requests and cancel them
   // individually. This would be useful to keep some in-progress requests alive.
   api_request_helper_.CancelAll();

--- a/components/ai_chat/browser/engine/remote_completion_client.cc
+++ b/components/ai_chat/browser/engine/remote_completion_client.cc
@@ -132,8 +132,8 @@ RemoteCompletionClient::~RemoteCompletionClient() = default;
 void RemoteCompletionClient::QueryPrompt(
     const std::string& prompt,
     const std::vector<std::string> extra_stop_sequences,
-    EngineConsumer::CompletionCompletedCallback data_completed_callback,
-    EngineConsumer::CompletionDataReceivedCallback
+    EngineConsumer::GenerationCompletedCallback data_completed_callback,
+    EngineConsumer::GenerationDataCallback
         data_received_callback /* = base::NullCallback() */) {
   const GURL api_base_url = GetEndpointBaseUrl();
 
@@ -182,7 +182,7 @@ void RemoteCompletionClient::ClearAllQueries() {
 }
 
 void RemoteCompletionClient::OnQueryDataReceived(
-    EngineConsumer::CompletionDataReceivedCallback callback,
+    EngineConsumer::GenerationDataCallback callback,
     base::expected<base::Value, std::string> result) {
   if (!result.has_value() || !result->is_dict()) {
     return;
@@ -195,7 +195,7 @@ void RemoteCompletionClient::OnQueryDataReceived(
 }
 
 void RemoteCompletionClient::OnQueryCompleted(
-    EngineConsumer::CompletionCompletedCallback callback,
+    EngineConsumer::GenerationCompletedCallback callback,
     APIRequestResult result) {
   const bool success = result.Is2XXResponseCode();
   // Handle successful request

--- a/components/ai_chat/browser/engine/remote_completion_client.h
+++ b/components/ai_chat/browser/engine/remote_completion_client.h
@@ -3,8 +3,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-#ifndef BRAVE_COMPONENTS_AI_CHAT_BROWSER_AI_CHAT_API_H_
-#define BRAVE_COMPONENTS_AI_CHAT_BROWSER_AI_CHAT_API_H_
+#ifndef BRAVE_COMPONENTS_AI_CHAT_BROWSER_ENGINE_REMOTE_COMPLETION_CLIENT_H_
+#define BRAVE_COMPONENTS_AI_CHAT_BROWSER_ENGINE_REMOTE_COMPLETION_CLIENT_H_
 
 #include <memory>
 #include <string>
@@ -24,16 +24,16 @@ namespace ai_chat {
 // conversation prompts.
 constexpr char kHumanPrompt[] = "Human:";
 
-class AIChatAPI {
+class RemoteCompletionClient {
  public:
   static std::string GetHumanPromptSegment();
 
-  explicit AIChatAPI(
+  explicit RemoteCompletionClient(
       std::string model_name,
       scoped_refptr<network::SharedURLLoaderFactory> url_loader_factory);
-  AIChatAPI(const AIChatAPI&) = delete;
-  AIChatAPI& operator=(const AIChatAPI&) = delete;
-  ~AIChatAPI();
+  RemoteCompletionClient(const RemoteCompletionClient&) = delete;
+  RemoteCompletionClient& operator=(const RemoteCompletionClient&) = delete;
+  ~RemoteCompletionClient();
 
   // This function queries both types of APIs: SSE and non-SSE.
   // In non-SSE cases, only the data_completed_callback will be triggered.
@@ -54,4 +54,4 @@ class AIChatAPI {
 
 }  // namespace ai_chat
 
-#endif  // BRAVE_COMPONENTS_AI_CHAT_BROWSER_AI_CHAT_API_H_
+#endif  // BRAVE_COMPONENTS_AI_CHAT_BROWSER_ENGINE_REMOTE_COMPLETION_CLIENT_H_

--- a/components/ai_chat/browser/engine/remote_completion_client.h
+++ b/components/ai_chat/browser/engine/remote_completion_client.h
@@ -10,8 +10,10 @@
 #include <string>
 #include <vector>
 
+#include "base/containers/flat_set.h"
 #include "base/functional/callback_forward.h"
 #include "base/memory/weak_ptr.h"
+#include "base/strings/string_piece_forward.h"
 #include "base/types/expected.h"
 #include "brave/components/ai_chat/browser/engine/engine_consumer.h"
 #include "brave/components/ai_chat/common/mojom/ai_chat.mojom.h"
@@ -25,19 +27,13 @@ namespace ai_chat {
 
 using api_request_helper::APIRequestResult;
 
-// TODO(petemill): Is this meant to be shared by both Claude and Llama? It's not
-// used to start the llama prompts but it is for Claude, but it's set for both
-// as a stop sequence (and currently the only stop sequence used by the
-// conversation prompts.
-constexpr char kHumanPrompt[] = "Human:";
-
 class RemoteCompletionClient {
  public:
-  static std::string GetHumanPromptSegment();
-
-  explicit RemoteCompletionClient(
+  RemoteCompletionClient(
       std::string model_name,
+      const base::flat_set<base::StringPiece>& stop_sequences,
       scoped_refptr<network::SharedURLLoaderFactory> url_loader_factory);
+
   RemoteCompletionClient(const RemoteCompletionClient&) = delete;
   RemoteCompletionClient& operator=(const RemoteCompletionClient&) = delete;
   ~RemoteCompletionClient();
@@ -60,7 +56,7 @@ class RemoteCompletionClient {
                         APIRequestResult result);
 
   std::string model_name_;
-  std::vector<std::string> default_stop_sequences_;
+  const base::flat_set<base::StringPiece> stop_sequences_;
   api_request_helper::APIRequestHelper api_request_helper_;
 
   base::WeakPtrFactory<RemoteCompletionClient> weak_ptr_factory_{this};

--- a/components/ai_chat/browser/engine/remote_completion_client.h
+++ b/components/ai_chat/browser/engine/remote_completion_client.h
@@ -47,17 +47,16 @@ class RemoteCompletionClient {
   void QueryPrompt(
       const std::string& prompt,
       const std::vector<std::string> stop_sequences,
-      EngineConsumer::CompletionCompletedCallback data_completed_callback,
-      EngineConsumer::CompletionDataReceivedCallback data_received_callback =
+      EngineConsumer::GenerationCompletedCallback data_completed_callback,
+      EngineConsumer::GenerationDataCallback data_received_callback =
           base::NullCallback());
   // Clears all in-progress requests
   void ClearAllQueries();
 
  private:
-  void OnQueryDataReceived(
-      EngineConsumer::CompletionDataReceivedCallback callback,
-      base::expected<base::Value, std::string> result);
-  void OnQueryCompleted(EngineConsumer::CompletionCompletedCallback callback,
+  void OnQueryDataReceived(EngineConsumer::GenerationDataCallback callback,
+                           base::expected<base::Value, std::string> result);
+  void OnQueryCompleted(EngineConsumer::GenerationCompletedCallback callback,
                         APIRequestResult result);
 
   std::string model_name_;

--- a/components/ai_chat/browser/engine/remote_completion_client_unittest.cc
+++ b/components/ai_chat/browser/engine/remote_completion_client_unittest.cc
@@ -3,7 +3,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-#include "brave/components/ai_chat/browser/ai_chat_api.h"
+#include "brave/components/ai_chat/browser/engine/remote_completion_client.h"
 
 #include <memory>
 #include <utility>
@@ -17,25 +17,25 @@
 
 namespace ai_chat {
 
-class AIChatAPIUnitTest : public testing::Test {
+class RemoteCompletionClientUnitTest : public testing::Test {
  public:
-  AIChatAPIUnitTest()
+  RemoteCompletionClientUnitTest()
       : shared_url_loader_factory_(
             base::MakeRefCounted<network::WeakWrapperSharedURLLoaderFactory>(
                 &url_loader_factory_)) {
-    ai_chat_api_ = std::make_unique<AIChatAPI>(shared_url_loader_factory_);
+    ai_chat_api_ = std::make_unique<RemoteCompletionClient>(shared_url_loader_factory_);
   }
 
-  ~AIChatAPIUnitTest() override = default;
+  ~RemoteCompletionClientUnitTest() override = default;
 
-  void SendMesage(AIChatAPI::ResponseCallback callback,
+  void SendMesage(RemoteCompletionClient::ResponseCallback callback,
                   const std::string& text) {
     ai_chat_api_->set_response_callback_for_testing(callback);
     ai_chat_api_->SendDataForTesting(text);
   }
 
  protected:
-  std::unique_ptr<AIChatAPI> ai_chat_api_ = nullptr;
+  std::unique_ptr<RemoteCompletionClient> ai_chat_api_ = nullptr;
 
  private:
   base::test::TaskEnvironment task_environment_;
@@ -44,7 +44,7 @@ class AIChatAPIUnitTest : public testing::Test {
   data_decoder::test::InProcessDataDecoder in_process_data_decoder_;
 };
 
-TEST_F(AIChatAPIUnitTest, ParseJson) {
+TEST_F(RemoteCompletionClientUnitTest, ParseJson) {
   base::RunLoop run_loop;
   SendMesage(base::BindRepeating(
                  [](base::RunLoop* run_loop, const std::string& response) {

--- a/components/ai_chat/browser/engine/remote_completion_client_unittest.cc
+++ b/components/ai_chat/browser/engine/remote_completion_client_unittest.cc
@@ -23,7 +23,8 @@ class RemoteCompletionClientUnitTest : public testing::Test {
       : shared_url_loader_factory_(
             base::MakeRefCounted<network::WeakWrapperSharedURLLoaderFactory>(
                 &url_loader_factory_)) {
-    ai_chat_api_ = std::make_unique<RemoteCompletionClient>(shared_url_loader_factory_);
+    ai_chat_api_ =
+        std::make_unique<RemoteCompletionClient>(shared_url_loader_factory_);
   }
 
   ~RemoteCompletionClientUnitTest() override = default;


### PR DESCRIPTION
Moves all prompt building from the single AIChatTabHelper class to either `EngineConsumerLlama` or `EngineConsumerClaude` with shared functionality in `RemoteCompletionClient` (was `AIChatAPI`).

The drivers for this are:
- Make the `AIChatTabHelper` more readable - adding llama prompt building added a lot of noise to it.
- Allow the prompt building and API calling to be implemented once and shared with iOS, which can't use TabHelpers.
- Make prompt building and API use more testable
- Perform some ground-work for model/engine choice per-Conversation

Resolves https://github.com/brave/brave-browser/issues/31821

Some of this will be further refactored when prompt generation is moved to an API.

Also fixes that input sanitization was not happening when using the llama models.
Resolves https://github.com/brave/brave-browser/issues/32787

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-arm64, CI/skip-linux-x64, CI/skip-android, CI/skip-macos, CI/skip-ios, CI/skip-windows-arm64, CI/skip-windows-x64, CI/skip-windows-x86 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

For both llama and claude models:
- Page-connected conversations still work
- Responses are streamed
- Disconnected conversations still work
- Suggested questions still work
