### PR TITLE
Use scope URL for service worker instead of StorageKey.

### DIFF
--- a/patches/content-browser-renderer_host-render_process_host_impl.cc.patch
+++ b/patches/content-browser-renderer_host-render_process_host_impl.cc.patch
@@ -1,0 +1,30 @@
+diff --git a/content/browser/renderer_host/render_process_host_impl.cc b/content/browser/renderer_host/render_process_host_impl.cc
+index 15dc38f75fd7f967bbc045c9b53b2d1f3d896ff9..0055e7453ab73608ce58d604ef80ba22f96661a3 100644
+--- a/content/browser/renderer_host/render_process_host_impl.cc
++++ b/content/browser/renderer_host/render_process_host_impl.cc
+@@ -2136,7 +2136,11 @@ void RenderProcessHostImpl::BindRestrictedCookieManagerForServiceWorker(
+   // overrides for a service worker.
+   storage_partition_impl_->CreateRestrictedCookieManager(
+       network::mojom::RestrictedCookieManagerRole::SCRIPT, storage_key.origin(),
+-      storage_key.ToPartialNetIsolationInfo(),
++      net::IsolationInfo::Create(
++          net::IsolationInfo::RequestType::kOther,
++          url::Origin::Create(storage_key.top_level_site().GetURL()),
++          storage_key.origin(), storage_key.ToNetSiteForCookies(),
++          /*party_context=*/absl::nullopt, storage_key.nonce()),
+       /*is_service_worker=*/true, GetID(), MSG_ROUTING_NONE,
+       net::CookieSettingOverrides(), std::move(receiver),
+       storage_partition_impl_->CreateCookieAccessObserverForServiceWorker());
+@@ -2243,7 +2247,11 @@ void RenderProcessHostImpl::CreateWebSocketConnector(
+   mojo::MakeSelfOwnedReceiver(
+       std::make_unique<WebSocketConnectorImpl>(
+           GetID(), MSG_ROUTING_NONE, storage_key.origin(),
+-          storage_key.ToPartialNetIsolationInfo()),
++          net::IsolationInfo::Create(
++              net::IsolationInfo::RequestType::kOther,
++              url::Origin::Create(storage_key.top_level_site().GetURL()),
++              storage_key.origin(), storage_key.ToNetSiteForCookies(),
++              /*party_context=*/absl::nullopt, storage_key.nonce())),
+       std::move(receiver));
+ }
+ 

--- a/patches/third_party-blink-renderer-modules-cookie_store-cookie_store.cc.patch
+++ b/patches/third_party-blink-renderer-modules-cookie_store-cookie_store.cc.patch
@@ -1,0 +1,34 @@
+diff --git a/third_party/blink/renderer/modules/cookie_store/cookie_store.cc b/third_party/blink/renderer/modules/cookie_store/cookie_store.cc
+index 9bc407fa19e0431afa1b18c4cdd5560c4bb38a92..baec2c886c7eca647c892c7db260891d03dc3c03 100644
+--- a/third_party/blink/renderer/modules/cookie_store/cookie_store.cc
++++ b/third_party/blink/renderer/modules/cookie_store/cookie_store.cc
+@@ -231,11 +231,7 @@ net::SiteForCookies DefaultSiteForCookies(ExecutionContext* execution_context) {
+     return window->document()->SiteForCookies();
+ 
+   auto* scope = To<ServiceWorkerGlobalScope>(execution_context);
+-  const blink::BlinkStorageKey& key = scope->storage_key();
+-  if (key.IsFirstPartyContext()) {
+-    return net::SiteForCookies::FromUrl(GURL(scope->Url()));
+-  }
+-  return net::SiteForCookies();
++  return net::SiteForCookies::FromUrl(GURL(scope->Url()));
+ }
+ 
+ const scoped_refptr<const SecurityOrigin> DefaultTopFrameOrigin(
+@@ -248,13 +244,9 @@ const scoped_refptr<const SecurityOrigin> DefaultTopFrameOrigin(
+     return window->document()->TopFrameOrigin()->IsolatedCopy();
+   }
+ 
+-  const BlinkStorageKey& key =
+-      To<ServiceWorkerGlobalScope>(execution_context)->storage_key();
+-  if (key.IsFirstPartyContext()) {
+-    return key.GetSecurityOrigin();
+-  }
+-  return SecurityOrigin::CreateFromUrlOrigin(
+-      url::Origin::Create(net::SchemefulSite(key.GetTopLevelSite()).GetURL()));
++  auto* scope = To<ServiceWorkerGlobalScope>(execution_context);
++  return SecurityOrigin::CreateFromUrlOrigin(url::Origin::Create(
++      net::SchemefulSite(scope->GetSecurityOrigin()->ToUrlOrigin()).GetURL()));
+ }
+ 
+ }  // namespace


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Partial revert of
https://chromium-review.googlesource.com/c/chromium/src/+/4420046
https://chromium-review.googlesource.com/c/chromium/src/+/4506477

Resolves 

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-arm64, CI/skip-linux-x64, CI/skip-android, CI/skip-macos, CI/skip-ios, CI/skip-windows-arm64, CI/skip-windows-x64, CI/skip-windows-x86 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [ ] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

