### PR TITLE
perf: reducer renders of pending transactions hook

### DIFF
--- a/components/brave_wallet_ui/components/extension/confirm-transaction-panel/common/queue.tsx
+++ b/components/brave_wallet_ui/components/extension/confirm-transaction-panel/common/queue.tsx
@@ -11,13 +11,15 @@ import { getLocale } from '../../../../../common/locale'
 // Styled components
 import { QueueStepButton, QueueStepRow, QueueStepText } from './style'
 
-// Hooks
-import { usePendingTransactions } from '../../../../common/hooks/use-pending-transaction'
-
-export function TransactionQueueStep () {
-  const { transactionsQueueLength, transactionQueueNumber, queueNextTransaction } =
-    usePendingTransactions()
-
+export function TransactionQueueSteps({
+  transactionsQueueLength,
+  transactionQueueNumber,
+  queueNextTransaction
+}: {
+  transactionsQueueLength: number
+  transactionQueueNumber: number
+  queueNextTransaction: () => void
+}) {
   if (transactionsQueueLength <= 1) {
     return null
   }
@@ -25,7 +27,8 @@ export function TransactionQueueStep () {
   return (
     <QueueStepRow>
       <QueueStepText>
-        {transactionQueueNumber} {getLocale('braveWalletQueueOf')} {transactionsQueueLength}
+        {transactionQueueNumber} {getLocale('braveWalletQueueOf')}{' '}
+        {transactionsQueueLength}
       </QueueStepText>
       <QueueStepButton onClick={queueNextTransaction}>
         {transactionQueueNumber === transactionsQueueLength

--- a/components/brave_wallet_ui/components/extension/confirm-transaction-panel/confirm-solana-transaction-panel.tsx
+++ b/components/brave_wallet_ui/components/extension/confirm-transaction-panel/confirm-solana-transaction-panel.tsx
@@ -25,6 +25,8 @@ import CreateSiteOrigin from '../../shared/create-site-origin/index'
 import PanelTab from '../panel-tab'
 import { TransactionInfo } from './transaction-info'
 import { SolanaTransactionDetailBox } from '../transaction-box/solana-transaction-detail-box'
+import { TransactionQueueSteps } from './common/queue'
+import { Footer } from './common/footer'
 
 // Styles
 import { Skeleton } from '../../shared/loading-skeleton/styles'
@@ -58,8 +60,6 @@ import {
   SmallLoadIcon
 } from './style'
 import { StatusBubble } from '../../shared/style'
-import { TransactionQueueStep } from './common/queue'
-import { Footer } from './common/footer'
 
 type confirmPanelTabs = 'transaction' | 'details'
 
@@ -93,7 +93,10 @@ export const ConfirmSolanaTransactionPanel = () => {
     selectedPendingTransactionGroupIndex,
     selectedPendingTransaction,
     onConfirm,
-    onReject
+    onReject,
+    queueNextTransaction,
+    transactionQueueNumber,
+    transactionsQueueLength
   } = usePendingTransactions()
   const originInfo = selectedPendingTransaction?.originInfo ?? activeOrigin
 
@@ -123,7 +126,11 @@ export const ConfirmSolanaTransactionPanel = () => {
 
       <TopRow>
         <NetworkText>{transactionsNetwork.chainName}</NetworkText>
-        <TransactionQueueStep />
+        <TransactionQueueSteps
+          queueNextTransaction={queueNextTransaction}
+          transactionQueueNumber={transactionQueueNumber}
+          transactionsQueueLength={transactionsQueueLength}
+        />
       </TopRow>
 
       <AccountCircleWrapper>

--- a/components/brave_wallet_ui/components/extension/confirm-transaction-panel/confirm-transaction-panel.tsx
+++ b/components/brave_wallet_ui/components/extension/confirm-transaction-panel/confirm-transaction-panel.tsx
@@ -26,8 +26,6 @@ import {
 import CreateSiteOrigin from '../../shared/create-site-origin/index'
 import Tooltip from '../../shared/tooltip/index'
 import withPlaceholderIcon from '../../shared/create-placeholder-icon'
-
-// Components
 import { PanelTab } from '../panel-tab/index'
 import { TransactionDetailBox } from '../transaction-box/index'
 import EditAllowance from '../edit-allowance'
@@ -36,6 +34,10 @@ import AdvancedTransactionSettings from '../advanced-transaction-settings'
 import { Erc20ApproveTransactionInfo } from './erc-twenty-transaction-info'
 import { TransactionInfo } from './transaction-info'
 import { NftIcon } from '../../shared/nft-icon/nft-icon'
+import { Footer } from './common/footer'
+import { TransactionQueueSteps } from './common/queue'
+import { Origin } from './common/origin'
+import { EditPendingTransactionGas } from './common/gas'
 
 // Styled Components
 import {
@@ -72,11 +74,6 @@ import {
   WarningBoxTitleRow
 } from '../shared-panel-styles'
 import { Column, Row } from '../../shared/style'
-
-import { Footer } from './common/footer'
-import { TransactionQueueStep } from './common/queue'
-import { Origin } from './common/origin'
-import { EditPendingTransactionGas } from './common/gas'
 
 type confirmPanelTabs = 'transaction' | 'details'
 
@@ -123,7 +120,10 @@ export const ConfirmTransactionPanel = () => {
     onReject,
     gasFee,
     insufficientFundsError,
-    insufficientFundsForGasError
+    insufficientFundsForGasError,
+    queueNextTransaction,
+    transactionQueueNumber,
+    transactionsQueueLength
   } = usePendingTransactions()
 
   // queries
@@ -214,7 +214,11 @@ export const ConfirmTransactionPanel = () => {
           </AddressAndOrb>
         )}
 
-        <TransactionQueueStep />
+        <TransactionQueueSteps
+          queueNextTransaction={queueNextTransaction}
+          transactionQueueNumber={transactionQueueNumber}
+          transactionsQueueLength={transactionsQueueLength}
+        />
       </TopRow>
 
       {isERC20Approve ? (

--- a/components/brave_wallet_ui/components/extension/confirm-transaction-panel/swap.tsx
+++ b/components/brave_wallet_ui/components/extension/confirm-transaction-panel/swap.tsx
@@ -43,7 +43,7 @@ import { Origin } from './common/origin'
 import { EditPendingTransactionGas } from './common/gas'
 
 // Components
-import { TransactionQueueStep } from './common/queue'
+import { TransactionQueueSteps } from './common/queue'
 import { Footer } from './common/footer'
 import AdvancedTransactionSettings from '../advanced-transaction-settings'
 import {
@@ -78,7 +78,10 @@ export function ConfirmSwapTransaction () {
     updateUnapprovedTransactionNonce,
     selectedPendingTransaction,
     onConfirm,
-    onReject
+    onReject,
+    queueNextTransaction,
+    transactionQueueNumber,
+    transactionsQueueLength
   } = usePendingTransactions()
 
   // queries
@@ -124,7 +127,11 @@ export function ConfirmSwapTransaction () {
     <StyledWrapper>
       <TopRow>
         <NetworkText />
-        <TransactionQueueStep />
+        <TransactionQueueSteps
+          queueNextTransaction={queueNextTransaction}
+          transactionQueueNumber={transactionQueueNumber}
+          transactionsQueueLength={transactionsQueueLength}
+        />
       </TopRow>
 
       <HeaderTitle>{getLocale('braveWalletSwapReviewHeader')}</HeaderTitle>


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/32766

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-arm64, CI/skip-linux-x64, CI/skip-android, CI/skip-macos, CI/skip-ios, CI/skip-windows-arm64, CI/skip-windows-x64, CI/skip-windows-x86 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
Pending-Transactions queue should continue to operate as expected without regressions.
