### PR TITLE
Add terms of service to Rewards onboarding

### DIFF
--- a/components/brave_rewards/resources/shared/components/newtab/rewards_card.style.ts
+++ b/components/brave_rewards/resources/shared/components/newtab/rewards_card.style.ts
@@ -103,7 +103,7 @@ export const optInLearnMore = styled.div.attrs({
   'data-theme': 'dark'
 })`
   margin-top: 12px;
-  margin-bottom: 8px;
+  margin-bottom: 20px;
   text-align: center;
 
   a {
@@ -112,6 +112,20 @@ export const optInLearnMore = styled.div.attrs({
     font-size: 13px;
     line-height: 20px;
     letter-spacing: 0.03em;
+    text-decoration: none;
+  }
+`
+
+export const optInTerms = styled.div.attrs({
+  'data-theme': 'dark'
+})`
+  color: ${leo.color.text.tertiary};
+  text-align: center;
+  font-size: 11px;
+  line-height: 16px;
+
+  a {
+    color: ${leo.color.text.interactive};
     text-decoration: none;
   }
 `

--- a/components/brave_rewards/resources/shared/components/newtab/rewards_card.tsx
+++ b/components/brave_rewards/resources/shared/components/newtab/rewards_card.tsx
@@ -21,6 +21,7 @@ import { EarningsRange } from '../earnings_range'
 import { TokenAmount } from '../token_amount'
 import { ExchangeAmount } from '../exchange_amount'
 import { NewTabLink } from '../new_tab_link'
+import { TermsOfService } from '../terms_of_service'
 import { GrantOverlay } from './grant_overlay'
 import { SelectCountryCard } from './select_country_card'
 import { PaymentStatusView } from '../payment_status_view'
@@ -245,6 +246,9 @@ export function RewardsCard (props: Props) {
             {getString('rewardsHowDoesItWork')}
           </NewTabLink>
         </style.optInLearnMore>
+        <style.optInTerms>
+          <TermsOfService text={getString('rewardsOptInTerms')} />
+        </style.optInTerms>
       </style.root>
     )
   }

--- a/components/brave_rewards/resources/shared/components/newtab/stories/index.tsx
+++ b/components/brave_rewards/resources/shared/components/newtab/stories/index.tsx
@@ -35,7 +35,7 @@ export function Card () {
       <WithThemeVariables>
         <div style={{ width: '284px' }}>
           <RewardsCard
-            rewardsEnabled={true}
+            rewardsEnabled={false}
             isGrandfatheredUser={false}
             userType='connected'
             vbatDeadline={Date.parse('2023-01-01T00:00:00-05:00')}

--- a/components/brave_rewards/resources/shared/components/onboarding/rewards_opt_in.style.ts
+++ b/components/brave_rewards/resources/shared/components/onboarding/rewards_opt_in.style.ts
@@ -57,7 +57,7 @@ export const optInText = styled.div`
 
 export const learnMore = styled.div`
   margin-top: 8px;
-  margin-bottom: 29px;
+  margin-bottom: 37px;
   text-align: center;
 
   &.learn-more-success {
@@ -71,6 +71,19 @@ export const learnMore = styled.div`
     font-size: 13px;
     line-height: 20px;
     letter-spacing: 0.03em;
+    text-decoration: none;
+  }
+`
+
+export const terms = styled.div`
+  color: ${leo.color.text.tertiary};
+  font-size: 11px;
+  line-height: 16px;
+  margin-bottom: -8px;
+  padding: 0 10px;
+
+  a {
+    color: ${leo.color.text.interactive};
     text-decoration: none;
   }
 `

--- a/components/brave_rewards/resources/shared/components/onboarding/rewards_opt_in.tsx
+++ b/components/brave_rewards/resources/shared/components/onboarding/rewards_opt_in.tsx
@@ -7,6 +7,7 @@ import * as React from 'react'
 
 import { LocaleContext, formatMessage } from '../../lib/locale_context'
 import { NewTabLink } from '../new_tab_link'
+import { TermsOfService } from '../terms_of_service'
 import { LoadingIcon } from '../icons/loading_icon'
 import { ErrorIcon } from './icons/error_icon'
 import { CountrySelect } from './country_select'
@@ -181,6 +182,9 @@ export function RewardsOptIn (props: Props) {
           {getString('onboardingHowDoesItWork')}
         </NewTabLink>
       </style.learnMore>
+      <style.terms>
+        <TermsOfService />
+      </style.terms>
     </style.root>
   )
 }

--- a/components/brave_rewards/resources/shared/components/onboarding/settings_opt_in_form.style.ts
+++ b/components/brave_rewards/resources/shared/components/onboarding/settings_opt_in_form.style.ts
@@ -9,7 +9,7 @@ import * as leo from '@brave/leo/tokens/css'
 
 export const root = styled.div`
   background-color: ${leo.color.white};
-  border-radius: 4px;
+  border-radius: 16px;
   font-family: var(--brave-font-heading);
   text-align: center;
   padding: 44px;
@@ -79,7 +79,7 @@ export const enable = styled.div.attrs({
 export const learnMore = styled.div.attrs({
   'data-theme': 'light'
 })`
-  margin: 20px 0 8px;
+  margin: 20px 0 37px;
   text-align: center;
 
   a {
@@ -88,6 +88,20 @@ export const learnMore = styled.div.attrs({
     font-size: 13px;
     line-height: 20px;
     letter-spacing: 0.03em;
+    text-decoration: none;
+  }
+`
+
+export const terms = styled.div.attrs({
+  'data-theme': 'light'
+})`
+  color: ${leo.color.text.tertiary};
+  font-size: 11px;
+  line-height: 16px;
+  margin-bottom: -8px;
+
+  a {
+    color: ${leo.color.text.interactive};
     text-decoration: none;
   }
 `

--- a/components/brave_rewards/resources/shared/components/onboarding/settings_opt_in_form.tsx
+++ b/components/brave_rewards/resources/shared/components/onboarding/settings_opt_in_form.tsx
@@ -6,6 +6,7 @@ import * as React from 'react'
 
 import { LocaleContext, formatMessage } from '../../lib/locale_context'
 import { NewTabLink } from '../new_tab_link'
+import { TermsOfService } from '../terms_of_service'
 import { BatIcon } from '../icons/bat_icon'
 import { OptInIcon } from './icons/optin_icon'
 import { MainButton } from './main_button'
@@ -47,6 +48,9 @@ export function SettingsOptInForm (props: Props) {
           {getString('rewardsLearnMore')}
         </NewTabLink>
       </style.learnMore>
+      <style.terms>
+        <TermsOfService />
+      </style.terms>
     </style.root>
   )
 }

--- a/components/brave_rewards/resources/shared/components/onboarding/stories/index.tsx
+++ b/components/brave_rewards/resources/shared/components/onboarding/stories/index.tsx
@@ -4,6 +4,7 @@
  * You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 import * as React from 'react'
+import styled from 'styled-components';
 
 import { LocaleContext, createLocaleContextForTesting } from '../../../lib/locale_context'
 import { WithThemeVariables } from '../../with_theme_variables'
@@ -26,13 +27,21 @@ interface StoryWrapperProps {
   children: React.ReactNode
 }
 
+const style = {
+  wrapper: styled.div`
+    border-radius: 8px;
+    box-shadow: 0px 0px 24px rgba(99, 105, 110, 0.36);
+    width: 410px;
+  `
+}
+
 function StoryWrapper (props: StoryWrapperProps) {
   return (
     <LocaleContext.Provider value={localeContext}>
       <WithThemeVariables>
-        <div style={props.style || {}}>
+        <style.wrapper style={{...props.style || {}}}>
           {props.children}
-        </div>
+        </style.wrapper>
       </WithThemeVariables>
     </LocaleContext.Provider>
   )
@@ -144,7 +153,7 @@ OptInError3.storyName = 'Opt In (Error: unexpected error)'
 
 export function SettingsOptIn () {
   return (
-    <StoryWrapper style={{ width: '619px' }}>
+    <StoryWrapper style={{ width: '600px' }}>
       <SettingsOptInForm
         onEnable={actionLogger('onEnable')}
       />


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/32762

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-arm64, CI/skip-linux-x64, CI/skip-android, CI/skip-macos, CI/skip-ios, CI/skip-windows-arm64, CI/skip-windows-x64, CI/skip-windows-x86 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [ ] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

<img width="425" alt="Screenshot 2023-09-05 at 3 05 49 PM" src="https://github.com/brave/brave-core/assets/5995084/59741f0b-afa0-4212-8192-664d5ac599d7">
<img width="621" alt="Screenshot 2023-09-05 at 3 06 04 PM" src="https://github.com/brave/brave-core/assets/5995084/60b3e215-4447-44aa-845a-28ccd4467d90">
<img width="294" alt="Screenshot 2023-09-05 at 3 06 29 PM" src="https://github.com/brave/brave-core/assets/5995084/1b35e04c-01a3-4bc1-ab37-77f4ed840f90">
