### PR TITLE
fix(wallet): NFT Header Title Text Wrap

### DIFF
--- a/components/brave_wallet_ui/components/desktop/card-headers/nft-asset-header.tsx
+++ b/components/brave_wallet_ui/components/desktop/card-headers/nft-asset-header.tsx
@@ -50,6 +50,7 @@ export const NftAssetHeader = ({ assetName, tokenId, showSendButton, onBack, onS
     >
       <Row
         justifyContent='flex-start'
+        margin='0px 6px 0px 0px'
       >
         <CircleButton
           size={28}

--- a/components/brave_wallet_ui/components/desktop/card-headers/shared-card-headers.style.ts
+++ b/components/brave_wallet_ui/components/desktop/card-headers/shared-card-headers.style.ts
@@ -17,6 +17,7 @@ export const HeaderTitle = styled.span<{
   font-weight: ${(p) => p.isPanel ? 600 : 500};
   line-height: ${(p) => p.isPanel ? 24 : 40}px;
   color: ${leo.color.text.primary};
+  word-break: break-all;
 `
 
 export const MenuWrapper = styled.div`
@@ -63,7 +64,6 @@ export const SendButton = styled(WalletButton)`
   flex-direction: row;
   justify-content: center;
   align-items: center;
-  align-self: flex-end;
   padding: 12px 16px;
   background: ${leo.color.button.background};
   border-radius: 1000px;


### PR DESCRIPTION
## Description 
Fixes a bug where long `NFT` names were pushing the `Send` button out of view.

<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves <https://github.com/brave/brave-browser/issues/32754>

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-arm64, CI/skip-linux-x64, CI/skip-android, CI/skip-macos, CI/skip-ios, CI/skip-windows-arm64, CI/skip-windows-x64, CI/skip-windows-x86 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
1. Add an `Unstoppable Domain` or an `NFT` with a really long name to your `Portfolio`
2. Open that `NFT` on the `Desktop View` or in the `Panel`
3. The name should `wrap` and not push the `Send` button out of view

Before:

![Screenshot 66](https://github.com/brave/brave-core/assets/40611140/707a15f7-b65c-400b-ae8d-06cd0f32bfee)

After:

![Screenshot 68](https://github.com/brave/brave-core/assets/40611140/d314535a-1ed2-48b4-a8ee-c93e704fb144)
