### PR TITLE
fix(wallet): Market Tab Empty State

### DIFF
--- a/components/brave_wallet_ui/components/shared/market-grid/market-grid.style.ts
+++ b/components/brave_wallet_ui/components/shared/market-grid/market-grid.style.ts
@@ -10,7 +10,7 @@ import {
   layoutPanelWidth,
   layoutSmallWidth
 } from '../../desktop/wallet-page-wrapper/wallet-page-wrapper.style'
-import { WalletButton } from '../style'
+import { WalletButton, Text } from '../style'
 
 export const breakpoints = {
   panel: `${layoutPanelWidth}px`,
@@ -84,7 +84,7 @@ export const GridRowsWrapper = styled.div`
     display: none;
   }
 `
-export const Row = styled.div<{ templateColumns: string }>`
+export const GridRow = styled.div<{ templateColumns: string }>`
   display: grid;
   grid-template-columns: ${({ templateColumns }) => templateColumns};
   gap: 5px;
@@ -195,4 +195,8 @@ export const ActionButton = styled(WalletButton)`
   line-height: 16px;
   letter-spacing: 0.36px;
   color: ${leo.color.text.interactive};
+`
+
+export const EmptyStateText = styled(Text)`
+  color: ${leo.color.text.secondary};
 `

--- a/components/brave_wallet_ui/components/shared/market-grid/market-grid.tsx
+++ b/components/brave_wallet_ui/components/shared/market-grid/market-grid.tsx
@@ -29,11 +29,13 @@ import {
   GridContainer,
   Header,
   HeaderItem,
-  Row,
+  GridRow,
   GridRowsWrapper,
   SortIcon,
-  StyledWrapper
+  StyledWrapper,
+  EmptyStateText
 } from './market-grid.style'
+import { Row } from '../style'
 
 export type MarketGridProps = {
   headers: MarketGridHeader[]
@@ -134,7 +136,7 @@ export const MarketGrid = ({
     ({ index, style }: { index: number; style: React.CSSProperties }) => {
       const row = rows[index]
       return (
-        <Row
+        <GridRow
           key={row.id}
           templateColumns={gridTemplateColumns}
           style={style}
@@ -150,7 +152,7 @@ export const MarketGrid = ({
               {cell.content}
             </Cell>
           ))}
-        </Row>
+        </GridRow>
       )
     },
     [rows, gridTemplateColumns]
@@ -195,18 +197,31 @@ export const MarketGrid = ({
             </HeaderItem>
           ))}
         </Header>
-        <FixedSizeList
-          height={visibleRows * rowHeight}
-          itemCount={rows.length}
-          itemSize={rowHeight}
-          overscanCount={overScanCount}
-          width='100%'
-          outerElementType={GridRowsWrapper}
-        >
-          {renderRows}
-        </FixedSizeList>
+        {showEmptyState ? (
+          <Row
+            margin='30px 0px'
+          >
+            <EmptyStateText
+              isBold={true}
+              textSize='14px'
+            >
+              {getLocale('braveWalletMarketDataNoAssetsFound')}
+            </EmptyStateText>
+          </Row>
+        ) : (
+          <FixedSizeList
+            height={visibleRows * rowHeight}
+            itemCount={rows.length}
+            itemSize={rowHeight}
+            overscanCount={overScanCount}
+            width='100%'
+            outerElementType={GridRowsWrapper}
+          >
+            {renderRows}
+          </FixedSizeList>
+        )}
+
       </GridContainer>
-      {showEmptyState && getLocale('braveWalletMarketDataNoAssetsFound')}
       <CoinGeckoText>
         {getLocale('braveWalletPoweredByCoinGecko')}
       </CoinGeckoText>

--- a/components/brave_wallet_ui/market/market.tsx
+++ b/components/brave_wallet_ui/market/market.tsx
@@ -200,7 +200,7 @@ const App = () => {
           <MarketGrid
             headers={marketGridHeaders}
             coinMarketData={visibleCoinMarkets}
-            showEmptyState={searchTerm !== '' || currentFilter !== 'all'}
+            showEmptyState={visibleCoinMarkets.length === 0}
             fiatCurrency={defaultCurrencies?.fiat ?? 'USD'}
             sortedBy={sortByColumnId}
             sortOrder={sortOrder}


### PR DESCRIPTION
## Description 
Fixes a bug where the `Empty State` text was being shown when there wasn't empty state on the `Market` tab

<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves <https://github.com/brave/brave-browser/issues/32750>

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-arm64, CI/skip-linux-x64, CI/skip-android, CI/skip-macos, CI/skip-ios, CI/skip-windows-arm64, CI/skip-windows-x64, CI/skip-windows-x86 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
1. Open the `Panel` and go to the `Market` tab
2. Search for `ETH` and scroll to the bottom, you should not see the `Empty State` text
3. Search for something that doesn't exist, you should see the `Empty State` text.

Before:

https://github.com/brave/brave-core/assets/40611140/fd849e43-738c-4e12-8243-91bbd46d68a9

After:

https://github.com/brave/brave-core/assets/40611140/3d33da7b-9a4f-4fee-9473-716aaa9bdcb6
