### PR TITLE
Add permission duration to connect from panel on desktop

### DIFF
--- a/android/java/org/chromium/chrome/browser/crypto_wallet/fragments/dapps/ConnectAccountFragment.java
+++ b/android/java/org/chromium/chrome/browser/crypto_wallet/fragments/dapps/ConnectAccountFragment.java
@@ -201,7 +201,6 @@ public class ConnectAccountFragment extends BaseDAppsFragment
 
     private static void setConnectAccountPendingData(
             String accountAddress, int permissionLifetimeOption) {
-        assert sConnectAccountPendingData == null;
         sConnectAccountPendingData =
                 new ConnectAccountPendingData(accountAddress, permissionLifetimeOption);
     }
@@ -277,10 +276,12 @@ public class ConnectAccountFragment extends BaseDAppsFragment
         }
         return GURL.emptyGURL();
     }
+
     @CalledByNative
     private static void onConnectAccountDone(Callback<Boolean> callback, Boolean result) {
         callback.onResult(result);
     }
+
     @NativeMethods
     interface Natives {
         void connectAccount(String accountAddress, int accountIdCoin, WebContents webContents,

--- a/android/java/org/chromium/chrome/browser/crypto_wallet/permission/BraveDappPermissionPromptDialog.java
+++ b/android/java/org/chromium/chrome/browser/crypto_wallet/permission/BraveDappPermissionPromptDialog.java
@@ -26,12 +26,14 @@ import org.chromium.brave_wallet.mojom.AccountInfo;
 import org.chromium.brave_wallet.mojom.BraveWalletService;
 import org.chromium.brave_wallet.mojom.CoinType;
 import org.chromium.brave_wallet.mojom.KeyringService;
+import org.chromium.brave_wallet.mojom.PermissionLifetimeOption;
 import org.chromium.chrome.R;
 import org.chromium.chrome.browser.app.BraveActivity;
 import org.chromium.chrome.browser.app.domain.WalletModel;
 import org.chromium.chrome.browser.app.helpers.ImageLoader;
 import org.chromium.chrome.browser.crypto_wallet.BraveWalletServiceFactory;
 import org.chromium.chrome.browser.crypto_wallet.KeyringServiceFactory;
+import org.chromium.chrome.browser.crypto_wallet.fragments.dapps.ConnectAccountFragment;
 import org.chromium.chrome.browser.crypto_wallet.util.Utils;
 import org.chromium.chrome.browser.crypto_wallet.util.WalletConstants;
 import org.chromium.components.browser_ui.modaldialog.ModalDialogView;
@@ -50,6 +52,9 @@ import org.chromium.ui.modelutil.PropertyModel;
 import java.lang.ref.WeakReference;
 import java.util.List;
 
+/**
+ * Dialog to grant website permissions to use Dapps
+ */
 public class BraveDappPermissionPromptDialog
         implements ModalDialogProperties.Controller, ConnectionErrorHandler {
     private static final String TAG = "BraveDappPermission";
@@ -113,7 +118,7 @@ public class BraveDappPermissionPromptDialog
         setFavIcon();
         mRecyclerView = customView.findViewById(R.id.accounts_list);
 
-        InitBraveWalletService();
+        initBraveWalletService();
         TextView domain = customView.findViewById(R.id.domain);
         mBraveWalletService.getActiveOrigin(
                 originInfo -> { domain.setText(Utils.geteTldSpanned(originInfo)); });
@@ -131,7 +136,7 @@ public class BraveDappPermissionPromptDialog
                         .with(ModalDialogProperties.FILTER_TOUCH_FOR_SECURITY, true)
                         .build();
         mModalDialogManager.showDialog(mPropertyModel, ModalDialogType.APP);
-        InitKeyringService();
+        initKeyringService();
         try {
             BraveActivity activity = BraveActivity.getBraveActivity();
             activity.dismissWalletPanelOrDialog();
@@ -150,6 +155,11 @@ public class BraveDappPermissionPromptDialog
         initAccounts();
     }
 
+    @PermissionLifetimeOption.EnumType
+    int getPermissionLifetimeOption() {
+        return PermissionLifetimeOption.FOREVER;
+    }
+
     @NonNull
     private ViewGroup getPermissionModalViewContainer(View customView) {
         ViewParent viewParent = customView.getParent();
@@ -162,7 +172,7 @@ public class BraveDappPermissionPromptDialog
         return (ViewGroup) viewParent;
     }
 
-    private void InitBraveWalletService() {
+    private void initBraveWalletService() {
         if (mBraveWalletService != null) {
             return;
         }
@@ -198,6 +208,18 @@ public class BraveDappPermissionPromptDialog
                         }
                     }
                     mAccountsListAdapter.notifyDataSetChanged();
+
+                    // We are on the flow from ConnectAccountFragment.connectAccount
+                    ConnectAccountFragment.ConnectAccountPendingData capd =
+                            ConnectAccountFragment.getAndResetConnectAccountPendingData();
+                    if (capd != null) {
+                        final String[] selectedAccounts = {capd.accountAddress};
+                        BraveDappPermissionPromptDialogJni.get().onPrimaryButtonClicked(
+                                mNativeDialogController, selectedAccounts,
+                                capd.permissionLifetimeOption);
+                        mModalDialogManager.dismissDialog(
+                                mPropertyModel, DialogDismissalCause.POSITIVE_BUTTON_CLICKED);
+                    }
                 });
     }
 
@@ -227,7 +249,7 @@ public class BraveDappPermissionPromptDialog
     public void onClick(PropertyModel model, @ButtonType int buttonType) {
         if (buttonType == ButtonType.POSITIVE) {
             BraveDappPermissionPromptDialogJni.get().onPrimaryButtonClicked(
-                    mNativeDialogController, getSelectedAccounts());
+                    mNativeDialogController, getSelectedAccounts(), getPermissionLifetimeOption());
             mModalDialogManager.dismissDialog(
                     mPropertyModel, DialogDismissalCause.POSITIVE_BUTTON_CLICKED);
         } else if (buttonType == ButtonType.NEGATIVE) {
@@ -240,7 +262,7 @@ public class BraveDappPermissionPromptDialog
 
     @Override
     public void onDismiss(PropertyModel model, int dismissalCause) {
-        DisconnectMojoServices();
+        disconnectMojoServices();
         BraveDappPermissionPromptDialogJni.get().onDialogDismissed(mNativeDialogController);
         mNativeDialogController = 0;
     }
@@ -250,7 +272,7 @@ public class BraveDappPermissionPromptDialog
         mModalDialogManager.dismissDialog(mPropertyModel, DialogDismissalCause.DISMISSED_BY_NATIVE);
     }
 
-    public void DisconnectMojoServices() {
+    public void disconnectMojoServices() {
         mMojoServicesClosed = true;
         if (mKeyringService != null) {
             mKeyringService.close();
@@ -269,10 +291,10 @@ public class BraveDappPermissionPromptDialog
         }
         mKeyringService.close();
         mKeyringService = null;
-        InitKeyringService();
+        initKeyringService();
     }
 
-    protected void InitKeyringService() {
+    protected void initKeyringService() {
         if (mKeyringService != null) {
             return;
         }
@@ -282,8 +304,8 @@ public class BraveDappPermissionPromptDialog
 
     @NativeMethods
     interface Natives {
-        void onPrimaryButtonClicked(
-                long nativeBraveDappPermissionPromptDialogController, String[] accounts);
+        void onPrimaryButtonClicked(long nativeBraveDappPermissionPromptDialogController,
+                String[] accounts, int permissionLifetimeOption);
         void onNegativeButtonClicked(long nativeBraveDappPermissionPromptDialogController);
         void onDialogDismissed(long nativeBraveDappPermissionPromptDialogController);
     }

--- a/browser/brave_wallet/android/sources.gni
+++ b/browser/brave_wallet/android/sources.gni
@@ -17,6 +17,7 @@ brave_browser_brave_wallet_android_sources = [
   "//brave/browser/permissions/brave_dapp_permission_prompt_dialog_controller_android.h",
   "//brave/browser/permissions/brave_wallet_permission_prompt_android.cc",
   "//brave/browser/permissions/brave_wallet_permission_prompt_android.h",
+  "//brave/browser/permissions/connect_account_android.cc",
 ]
 
 brave_browser_brave_wallet_android_deps = [

--- a/browser/brave_wallet/brave_wallet_provider_delegate_impl.cc
+++ b/browser/brave_wallet/brave_wallet_provider_delegate_impl.cc
@@ -57,18 +57,6 @@ void OnRequestPermissions(
   }
 }
 
-absl::optional<permissions::RequestType> CoinTypeToPermissionRequestType(
-    mojom::CoinType coin_type) {
-  switch (coin_type) {
-    case mojom::CoinType::ETH:
-      return permissions::RequestType::kBraveEthereum;
-    case mojom::CoinType::SOL:
-      return permissions::RequestType::kBraveSolana;
-    default:
-      return absl::nullopt;
-  }
-}
-
 }  // namespace
 
 BraveWalletProviderDelegateImpl::BraveWalletProviderDelegateImpl(

--- a/browser/brave_wallet/brave_wallet_service_delegate_impl.cc
+++ b/browser/brave_wallet/brave_wallet_service_delegate_impl.cc
@@ -149,18 +149,6 @@ void BraveWalletServiceDelegateImpl::ContinueGetImportInfoFromExternalWallet(
   }
 }
 
-bool BraveWalletServiceDelegateImpl::AddPermission(mojom::CoinType coin,
-                                                   const url::Origin& origin,
-                                                   const std::string& account) {
-  auto type = CoinTypeToPermissionType(coin);
-  if (!type) {
-    return false;
-  }
-
-  return permissions::BraveWalletPermissionContext::AddPermission(
-      *type, context_, origin, account);
-}
-
 bool BraveWalletServiceDelegateImpl::HasPermission(mojom::CoinType coin,
                                                    const url::Origin& origin,
                                                    const std::string& account) {

--- a/browser/brave_wallet/brave_wallet_service_delegate_impl.h
+++ b/browser/brave_wallet/brave_wallet_service_delegate_impl.h
@@ -50,9 +50,6 @@ class BraveWalletServiceDelegateImpl : public BraveWalletServiceDelegate,
                                        const std::string& password,
                                        GetImportInfoCallback callback) override;
 
-  bool AddPermission(mojom::CoinType coin,
-                     const url::Origin& origin,
-                     const std::string& account) override;
   bool HasPermission(mojom::CoinType coin,
                      const url::Origin& origin,
                      const std::string& account) override;

--- a/browser/brave_wallet/ethereum_provider_impl_unittest.cc
+++ b/browser/brave_wallet/ethereum_provider_impl_unittest.cc
@@ -44,6 +44,7 @@
 #include "brave/components/brave_wallet/common/brave_wallet.mojom.h"
 #include "brave/components/brave_wallet/common/hex_utils.h"
 #include "brave/components/permissions/brave_permission_manager.h"
+#include "brave/components/permissions/contexts/brave_wallet_permission_context.h"
 #include "brave/components/version_info/version_info.h"
 #include "chrome/browser/content_settings/host_content_settings_map_factory.h"
 #include "chrome/browser/permissions/permission_manager_factory.h"
@@ -455,13 +456,9 @@ class EthereumProviderImplUnitTest : public testing::Test {
   }
 
   void AddEthereumPermission(const mojom::AccountIdPtr& account_id) {
-    base::RunLoop run_loop;
-    brave_wallet_service_->AddPermission(
-        account_id.Clone(), base::BindLambdaForTesting([&](bool success) {
-          EXPECT_TRUE(success);
-          run_loop.Quit();
-        }));
-    run_loop.Run();
+    EXPECT_TRUE(permissions::BraveWalletPermissionContext::AddPermission(
+        blink::PermissionType::BRAVE_ETHEREUM, browser_context(), GetOrigin(),
+        account_id->address));
   }
 
   void ResetEthereumPermission(const mojom::AccountIdPtr& account_id) {

--- a/browser/brave_wallet/send_or_sign_transaction_browsertest.cc
+++ b/browser/brave_wallet/send_or_sign_transaction_browsertest.cc
@@ -11,12 +11,10 @@
 #include "base/strings/stringprintf.h"
 #include "base/test/bind.h"
 #include "base/test/scoped_feature_list.h"
-#include "brave/browser/brave_wallet/brave_wallet_service_factory.h"
 #include "brave/browser/brave_wallet/brave_wallet_tab_helper.h"
 #include "brave/browser/brave_wallet/json_rpc_service_factory.h"
 #include "brave/browser/brave_wallet/keyring_service_factory.h"
 #include "brave/browser/brave_wallet/tx_service_factory.h"
-#include "brave/components/brave_wallet/browser/brave_wallet_service.h"
 #include "brave/components/brave_wallet/browser/brave_wallet_utils.h"
 #include "brave/components/brave_wallet/browser/json_rpc_service.h"
 #include "brave/components/brave_wallet/browser/keyring_service.h"
@@ -191,9 +189,6 @@ class SendOrSignTransactionBrowserTest : public InProcessBrowserTest {
     https_server_for_files()->ServeFilesFromDirectory(test_data_dir);
     ASSERT_TRUE(https_server_for_files()->Start());
 
-    brave_wallet_service_ =
-        brave_wallet::BraveWalletServiceFactory::GetServiceForContext(
-            browser()->profile());
     keyring_service_ =
         KeyringServiceFactory::GetServiceForContext(browser()->profile());
     tx_service_ = TxServiceFactory::GetServiceForContext(browser()->profile());
@@ -332,13 +327,10 @@ class SendOrSignTransactionBrowserTest : public InProcessBrowserTest {
   }
 
   void AddEthereumPermission(const mojom::AccountIdPtr& account_id) {
-    base::RunLoop run_loop;
-    brave_wallet_service_->AddPermission(
-        account_id.Clone(), base::BindLambdaForTesting([&](bool success) {
-          EXPECT_TRUE(success);
-          run_loop.Quit();
-        }));
-    run_loop.Run();
+    EXPECT_TRUE(permissions::BraveWalletPermissionContext::AddPermission(
+        blink::PermissionType::BRAVE_ETHEREUM, browser()->profile(),
+        web_contents()->GetPrimaryMainFrame()->GetLastCommittedOrigin(),
+        account_id->address));
   }
 
   const mojom::AccountInfoPtr& default_account() const {
@@ -596,7 +588,6 @@ class SendOrSignTransactionBrowserTest : public InProcessBrowserTest {
   }
 
  protected:
-  raw_ptr<BraveWalletService> brave_wallet_service_ = nullptr;
   mojom::AccountInfoPtr default_account_;
 
  private:

--- a/browser/brave_wallet/solana_provider_impl_unittest.cc
+++ b/browser/brave_wallet/solana_provider_impl_unittest.cc
@@ -33,6 +33,7 @@
 #include "brave/components/brave_wallet/common/features.h"
 #include "brave/components/brave_wallet/common/solana_utils.h"
 #include "brave/components/permissions/brave_permission_manager.h"
+#include "brave/components/permissions/contexts/brave_wallet_permission_context.h"
 #include "chrome/browser/content_settings/host_content_settings_map_factory.h"
 #include "chrome/browser/permissions/permission_manager_factory.h"
 #include "chrome/test/base/scoped_testing_local_state.h"
@@ -270,13 +271,9 @@ class SolanaProviderImplUnitTest : public testing::Test {
   }
 
   void AddSolanaPermission(const mojom::AccountIdPtr& account_id) {
-    base::RunLoop run_loop;
-    brave_wallet_service_->AddPermission(
-        account_id.Clone(), base::BindLambdaForTesting([&](bool success) {
-          EXPECT_TRUE(success);
-          run_loop.Quit();
-        }));
-    run_loop.Run();
+    EXPECT_TRUE(permissions::BraveWalletPermissionContext::AddPermission(
+        blink::PermissionType::BRAVE_SOLANA, browser_context(), GetOrigin(),
+        account_id->address));
   }
 
   std::string Connect(absl::optional<base::Value::Dict> arg,

--- a/browser/permissions/brave_dapp_permission_prompt_dialog_controller_android.cc
+++ b/browser/permissions/brave_dapp_permission_prompt_dialog_controller_android.cc
@@ -52,11 +52,12 @@ void BraveDappPermissionPromptDialogController::ShowDialog() {
 
 void BraveDappPermissionPromptDialogController::OnPrimaryButtonClicked(
     JNIEnv* env,
-    const base::android::JavaParamRef<jobjectArray>& accounts) {
+    const base::android::JavaParamRef<jobjectArray>& accounts,
+    int permission_lifetime_option) {
   std::vector<std::string> allowedAccounts;
   base::android::AppendJavaStringArrayToStringVector(env, accounts,
                                                      &allowedAccounts);
-  delegate_->ConnectToSite(allowedAccounts);
+  delegate_->ConnectToSite(allowedAccounts, permission_lifetime_option);
 }
 
 void BraveDappPermissionPromptDialogController::OnNegativeButtonClicked(

--- a/browser/permissions/brave_dapp_permission_prompt_dialog_controller_android.h
+++ b/browser/permissions/brave_dapp_permission_prompt_dialog_controller_android.h
@@ -23,7 +23,8 @@ class BraveDappPermissionPromptDialogController {
   class Delegate {
    public:
     virtual void OnDialogDismissed() = 0;
-    virtual void ConnectToSite(const std::vector<std::string>& accounts) = 0;
+    virtual void ConnectToSite(const std::vector<std::string>& accounts,
+                               int permission_lifetime_option) = 0;
     virtual void CancelConnectToSite() = 0;
   };
 
@@ -39,7 +40,8 @@ class BraveDappPermissionPromptDialogController {
 
   void OnPrimaryButtonClicked(
       JNIEnv* env,
-      const base::android::JavaParamRef<jobjectArray>& accounts);
+      const base::android::JavaParamRef<jobjectArray>& accounts,
+      int permission_lifetime_option);
   void OnNegativeButtonClicked(JNIEnv* env);
   void OnDialogDismissed(JNIEnv* env);
 

--- a/browser/permissions/brave_wallet_permission_prompt_android.cc
+++ b/browser/permissions/brave_wallet_permission_prompt_android.cc
@@ -27,7 +27,8 @@ BraveWalletPermissionPrompt::BraveWalletPermissionPrompt(
 BraveWalletPermissionPrompt::~BraveWalletPermissionPrompt() {}
 
 void BraveWalletPermissionPrompt::ConnectToSite(
-    const std::vector<std::string>& accounts) {
+    const std::vector<std::string>& accounts,
+    int permission_lifetime_option) {
   has_interacted_with_dialog_ = true;
   dialog_controller_.reset();
   // TODO(SergeyZhukovsky): Use the real option that the user chooses, using

--- a/browser/permissions/brave_wallet_permission_prompt_android.h
+++ b/browser/permissions/brave_wallet_permission_prompt_android.h
@@ -47,7 +47,8 @@ class BraveWalletPermissionPrompt
  protected:
   // BraveDappPermissionPromptDialogController::Delegate:
   void OnDialogDismissed() override;
-  void ConnectToSite(const std::vector<std::string>& accounts) override;
+  void ConnectToSite(const std::vector<std::string>& accounts,
+                     int permission_lifetime_option) override;
   void CancelConnectToSite() override;
 
  private:

--- a/browser/permissions/connect_account_android.cc
+++ b/browser/permissions/connect_account_android.cc
@@ -1,0 +1,97 @@
+/* Copyright (c) 2023 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "base/android/jni_android.h"
+#include "base/android/jni_array.h"
+#include "base/android/jni_string.h"
+#include "brave/build/android/jni_headers/ConnectAccountFragment_jni.h"
+#include "brave/components/brave_wallet/browser/permission_utils.h"
+#include "brave/components/brave_wallet/common/brave_wallet.mojom-shared.h"
+#include "brave/components/permissions/contexts/brave_wallet_permission_context.h"
+#include "content/public/browser/web_contents.h"
+
+#include "base/functional/callback.h"
+#include "content/public/browser/render_frame_host.h"
+
+namespace {
+
+base::android::ScopedJavaLocalRef<jobject> GetJavaBoolean(
+    JNIEnv* env,
+    const bool& native_bool) {
+  jclass booleanClass = env->FindClass("java/lang/Boolean");
+  jmethodID methodID = env->GetMethodID(booleanClass, "<init>", "(Z)V");
+  jobject booleanObject = env->NewObject(booleanClass, methodID, native_bool);
+
+  return base::android::ScopedJavaLocalRef<jobject>(env, booleanObject);
+}
+
+void PlainCallConnectAccountCallback(
+    JNIEnv* env,
+    base::android::ScopedJavaGlobalRef<jobject> java_callback,
+    bool value_result) {
+  Java_ConnectAccountFragment_onConnectAccountDone(
+      env, java_callback, GetJavaBoolean(env, value_result));
+}
+
+}  // namespace
+
+static void JNI_ConnectAccountFragment_ConnectAccount(
+    JNIEnv* env,
+    const base::android::JavaParamRef<jstring>& java_account_address,
+    jint account_id_coin,
+    const base::android::JavaParamRef<jobject>& java_web_contents,
+    const base::android::JavaParamRef<jobject>& callback) {
+  base::android::ScopedJavaGlobalRef<jobject> java_callback;
+  java_callback.Reset(env, callback);
+
+  content::WebContents* web_contents =
+      content::WebContents::FromJavaWebContents(java_web_contents);
+
+  if (web_contents == nullptr) {
+    PlainCallConnectAccountCallback(env, java_callback, false);
+    return;
+  }
+
+  std::string account_address =
+      base::android::ConvertJavaStringToUTF8(java_account_address);
+
+  content::RenderFrameHost* rfh = web_contents->GetFocusedFrame();
+  if (rfh == nullptr) {
+    PlainCallConnectAccountCallback(env, java_callback, false);
+    return;
+  }
+
+  brave_wallet::mojom::CoinType coin =
+      static_cast<brave_wallet::mojom::CoinType>(account_id_coin);
+  CHECK(brave_wallet::mojom::IsKnownEnumValue(coin));
+
+  auto request_type = brave_wallet::CoinTypeToPermissionRequestType(coin);
+  auto permission = brave_wallet::CoinTypeToPermissionType(coin);
+
+  if (!request_type || !permission) {
+    PlainCallConnectAccountCallback(env, java_callback, false);
+    return;
+  }
+
+  if (permissions::BraveWalletPermissionContext::HasRequestsInProgress(
+          rfh, *request_type)) {
+    PlainCallConnectAccountCallback(env, java_callback, false);
+    return;
+  }
+
+  permissions::BraveWalletPermissionContext::RequestPermissions(
+      *permission, rfh, {account_address},
+      base::BindOnce(
+          [](JNIEnv* env,
+             base::android::ScopedJavaGlobalRef<jobject> java_callback,
+             const std::vector<blink::mojom::PermissionStatus>& responses) {
+            if (responses.empty() || responses.size() != 1u) {
+              PlainCallConnectAccountCallback(env, java_callback, false);
+            } else {
+              PlainCallConnectAccountCallback(env, java_callback, true);
+            }
+          },
+          env, std::move(java_callback)));
+}

--- a/browser/permissions/connect_account_android.cc
+++ b/browser/permissions/connect_account_android.cc
@@ -17,9 +17,8 @@
 
 namespace {
 
-base::android::ScopedJavaLocalRef<jobject> GetJavaBoolean(
-    JNIEnv* env,
-    const bool& native_bool) {
+base::android::ScopedJavaLocalRef<jobject> GetJavaBoolean(JNIEnv* env,
+                                                          bool native_bool) {
   jclass booleanClass = env->FindClass("java/lang/Boolean");
   jmethodID methodID = env->GetMethodID(booleanClass, "<init>", "(Z)V");
   jobject booleanObject = env->NewObject(booleanClass, methodID, native_bool);

--- a/browser/ui/webui/brave_wallet/panel_handler/BUILD.gn
+++ b/browser/ui/webui/brave_wallet/panel_handler/BUILD.gn
@@ -12,6 +12,7 @@ source_set("panel_handler") {
     "//brave/browser/brave_wallet",
     "//brave/browser/brave_wallet:tab_helper",
     "//brave/components/brave_wallet/browser",
+    "//brave/components/brave_wallet/browser:permission_utils",
     "//brave/components/brave_wallet/common:mojom",
     "//chrome/browser/profiles:profile",
     "//components/permissions",

--- a/browser/ui/webui/brave_wallet/panel_handler/wallet_panel_handler.h
+++ b/browser/ui/webui/brave_wallet/panel_handler/wallet_panel_handler.h
@@ -44,6 +44,8 @@ class WalletPanelHandler : public brave_wallet::mojom::PanelHandler {
   void IsSolanaAccountConnected(
       const std::string& account,
       IsSolanaAccountConnectedCallback callback) override;
+  void RequestPermission(brave_wallet::mojom::AccountIdPtr account_id,
+                         RequestPermissionCallback callback) override;
 
  private:
   mojo::Receiver<brave_wallet::mojom::PanelHandler> receiver_;

--- a/build/android/BUILD.gn
+++ b/build/android/BUILD.gn
@@ -221,6 +221,7 @@ generate_jni("jni_headers") {
     "//brave/android/java/org/chromium/chrome/browser/crypto_wallet/KeyringServiceFactory.java",
     "//brave/android/java/org/chromium/chrome/browser/crypto_wallet/SwapServiceFactory.java",
     "//brave/android/java/org/chromium/chrome/browser/crypto_wallet/TxServiceFactory.java",
+    "//brave/android/java/org/chromium/chrome/browser/crypto_wallet/fragments/dapps/ConnectAccountFragment.java",
     "//brave/android/java/org/chromium/chrome/browser/crypto_wallet/permission/BraveDappPermissionPromptDialog.java",
     "//brave/android/java/org/chromium/chrome/browser/crypto_wallet/util/WalletDataFilesInstaller.java",
     "//brave/android/java/org/chromium/chrome/browser/crypto_wallet/util/WalletDataFilesInstallerUtil.java",

--- a/build/android/config.gni
+++ b/build/android/config.gni
@@ -120,6 +120,7 @@ brave_jni_headers_sources = [
   "//brave/android/java/org/chromium/chrome/browser/crypto_wallet/KeyringServiceFactory.java",
   "//brave/android/java/org/chromium/chrome/browser/crypto_wallet/SwapServiceFactory.java",
   "//brave/android/java/org/chromium/chrome/browser/crypto_wallet/TxServiceFactory.java",
+  "//brave/android/java/org/chromium/chrome/browser/crypto_wallet/fragments/dapps/ConnectAccountFragment.java",
   "//brave/android/java/org/chromium/chrome/browser/crypto_wallet/permission/BraveDappPermissionPromptDialog.java",
   "//brave/android/java/org/chromium/chrome/browser/crypto_wallet/util/WalletDataFilesInstaller.java",
   "//brave/android/java/org/chromium/chrome/browser/crypto_wallet/util/WalletNativeUtils.java",

--- a/components/brave_wallet/browser/brave_wallet_service.cc
+++ b/components/brave_wallet/browser/brave_wallet_service.cc
@@ -935,18 +935,6 @@ void BraveWalletService::OnBraveWalletNftDiscoveryEnabled() {
   }
 }
 
-void BraveWalletService::AddPermission(mojom::AccountIdPtr account_id,
-                                       AddPermissionCallback callback) {
-  auto origin = delegate_->GetActiveOrigin();
-  if (!origin) {
-    std::move(callback).Run(false);
-    return;
-  }
-
-  std::move(callback).Run(
-      delegate_->AddPermission(account_id->coin, *origin, account_id->address));
-}
-
 void BraveWalletService::HasPermission(
     std::vector<mojom::AccountIdPtr> accounts,
     HasPermissionCallback callback) {

--- a/components/brave_wallet/browser/brave_wallet_service.h
+++ b/components/brave_wallet/browser/brave_wallet_service.h
@@ -173,8 +173,6 @@ class BraveWalletService : public KeyedService,
   void SetNetworkForSelectedAccountOnActiveOrigin(
       const std::string& chain_id,
       SetNetworkForSelectedAccountOnActiveOriginCallback callback) override;
-  void AddPermission(mojom::AccountIdPtr account_id,
-                     AddPermissionCallback callback) override;
   void HasPermission(std::vector<mojom::AccountIdPtr> accounts,
                      HasPermissionCallback callback) override;
   void ResetPermission(mojom::AccountIdPtr account_id,

--- a/components/brave_wallet/browser/permission_utils.cc
+++ b/components/brave_wallet/browser/permission_utils.cc
@@ -218,4 +218,16 @@ absl::optional<blink::PermissionType> CoinTypeToPermissionType(
   }
 }
 
+absl::optional<permissions::RequestType> CoinTypeToPermissionRequestType(
+    mojom::CoinType coin_type) {
+  switch (coin_type) {
+    case mojom::CoinType::ETH:
+      return permissions::RequestType::kBraveEthereum;
+    case mojom::CoinType::SOL:
+      return permissions::RequestType::kBraveSolana;
+    default:
+      return absl::nullopt;
+  }
+}
+
 }  // namespace brave_wallet

--- a/components/brave_wallet/browser/permission_utils.h
+++ b/components/brave_wallet/browser/permission_utils.h
@@ -81,6 +81,9 @@ GURL GetConnectWithSiteWebUIURL(const GURL& webui_base_url,
 absl::optional<blink::PermissionType> CoinTypeToPermissionType(
     mojom::CoinType coin_type);
 
+absl::optional<permissions::RequestType> CoinTypeToPermissionRequestType(
+    mojom::CoinType coin_type);
+
 }  // namespace brave_wallet
 
 #endif  // BRAVE_COMPONENTS_BRAVE_WALLET_BROWSER_PERMISSION_UTILS_H_

--- a/components/brave_wallet/browser/permission_utils_unittest.cc
+++ b/components/brave_wallet/browser/permission_utils_unittest.cc
@@ -373,4 +373,26 @@ TEST(PermissionUtilsUnitTest, SyncingWithCreatePermissionLifetimeOptions) {
       absl::nullopt);
 }
 
+TEST(PermissionUtilsUnitTest, CoinTypeToPermissionType) {
+  auto type = CoinTypeToPermissionType(mojom::CoinType::ETH);
+  ASSERT_TRUE(type);
+  EXPECT_EQ(*type, blink::PermissionType::BRAVE_ETHEREUM);
+  type = CoinTypeToPermissionType(mojom::CoinType::SOL);
+  ASSERT_TRUE(type);
+  EXPECT_EQ(*type, blink::PermissionType::BRAVE_SOLANA);
+  EXPECT_FALSE(CoinTypeToPermissionType(mojom::CoinType::FIL));
+  EXPECT_FALSE(CoinTypeToPermissionType(mojom::CoinType::BTC));
+}
+
+TEST(PermissionUtilsUnitTest, CoinTypeToPermissionRequestType) {
+  auto request = CoinTypeToPermissionRequestType(mojom::CoinType::ETH);
+  ASSERT_TRUE(request);
+  EXPECT_EQ(*request, permissions::RequestType::kBraveEthereum);
+  request = CoinTypeToPermissionRequestType(mojom::CoinType::SOL);
+  ASSERT_TRUE(request);
+  EXPECT_EQ(*request, permissions::RequestType::kBraveSolana);
+  EXPECT_FALSE(CoinTypeToPermissionType(mojom::CoinType::FIL));
+  EXPECT_FALSE(CoinTypeToPermissionType(mojom::CoinType::BTC));
+}
+
 }  // namespace brave_wallet

--- a/components/brave_wallet/common/brave_wallet.mojom
+++ b/components/brave_wallet/common/brave_wallet.mojom
@@ -401,6 +401,13 @@ interface PanelHandler {
   Focus();
 
   IsSolanaAccountConnected(string account) => (bool connected);
+
+  // Create a permission request for users based on active web contents.
+  // The flow will be similar to dapp request permission except it is initiated
+  // from panel. Desktop front end will be opened with same #connectWitSite ref
+  // and we need to call ConnectToSite or CancelConnectToSite based on user
+  // decision.
+  RequestPermission(AccountId account_id) => (bool success);
 };
 
 // Browser-side handler for requests from WebUI page.
@@ -1867,10 +1874,6 @@ interface BraveWalletService {
   // currently selected account does not support it.
   GetNetworkForSelectedAccountOnActiveOrigin() => (NetworkInfo? network);
   SetNetworkForSelectedAccountOnActiveOrigin(string chain_id) => (bool success);
-
-  // Adds the permission for the account on active origin.
-  AddPermission(AccountId account_id)
-    => (bool success);
 
   // Filters accounts with permissions on active origin.
   HasPermission(array<AccountId> accounts)

--- a/components/brave_wallet_ui/common/actions/wallet_actions.ts
+++ b/components/brave_wallet_ui/common/actions/wallet_actions.ts
@@ -11,7 +11,6 @@ export const {
   activeOriginChanged,
   addAccount,
   addFavoriteApp,
-  addSitePermission,
   addUserAsset,
   addUserAssetError,
   autoLockMinutesChanged,

--- a/components/brave_wallet_ui/common/async/handlers.ts
+++ b/components/brave_wallet_ui/common/async/handlers.ts
@@ -8,7 +8,6 @@ import { mapLimit } from 'async'
 import AsyncActionHandler from '../../../common/AsyncActionHandler'
 import * as WalletActions from '../actions/wallet_actions'
 import {
-  AddSitePermissionPayloadType,
   RemoveSitePermissionPayloadType,
   SetUserAssetVisiblePayloadType,
   UnlockWalletPayloadType,
@@ -315,12 +314,6 @@ handler.on(WalletActions.selectPortfolioTimeline.type, async (store: Store, payl
 handler.on(WalletActions.removeSitePermission.type, async (store: Store, payload: RemoveSitePermissionPayloadType) => {
   const braveWalletService = getAPIProxy().braveWalletService
   await braveWalletService.resetPermission(payload.accountId)
-  await refreshWalletInfo(store)
-})
-
-handler.on(WalletActions.addSitePermission.type, async (store: Store, payload: AddSitePermissionPayloadType) => {
-  const braveWalletService = getAPIProxy().braveWalletService
-  await braveWalletService.addPermission(payload.accountId)
   await refreshWalletInfo(store)
 })
 

--- a/components/brave_wallet_ui/common/constants/action_types.ts
+++ b/components/brave_wallet_ui/common/constants/action_types.ts
@@ -89,10 +89,6 @@ export type RemoveSitePermissionPayloadType = {
   accountId: BraveWallet.AccountId
 }
 
-export type AddSitePermissionPayloadType = {
-  accountId: BraveWallet.AccountId
-}
-
 export type GetCoinMarketPayload = {
   vsAsset: string
   limit: number

--- a/components/brave_wallet_ui/common/slices/wallet.slice.ts
+++ b/components/brave_wallet_ui/common/slices/wallet.slice.ts
@@ -15,7 +15,6 @@ import {
   ImportAccountErrorType
 } from '../../constants/types'
 import {
-  AddSitePermissionPayloadType,
   DefaultBaseCryptocurrencyChanged,
   DefaultBaseCurrencyChanged,
   DefaultEthereumWalletChanged,
@@ -196,8 +195,6 @@ export const WalletAsyncActions = {
   removeSitePermission: createAction<RemoveSitePermissionPayloadType>(
     'removeSitePermission'
   ),
-  addSitePermission:
-    createAction<AddSitePermissionPayloadType>('addSitePermission'),
   refreshNetworksAndTokens:
     createAction<RefreshOpts>('refreshNetworksAndTokens'),
   expandWalletNetworks: createAction('expandWalletNetworks'), // replace with chrome.tabs.create helper

--- a/components/brave_wallet_ui/components/extension/connected-account-item/index.tsx
+++ b/components/brave_wallet_ui/components/extension/connected-account-item/index.tsx
@@ -7,6 +7,7 @@ import * as React from 'react'
 import { useDispatch } from 'react-redux'
 
 // Actions
+import { PanelActions } from '../../../panel/actions'
 import { WalletActions } from '../../../common/actions'
 
 // Types
@@ -83,7 +84,8 @@ export const ConnectedAccountItem = (props: Props) => {
 
   // methods
   const onClickConnect = React.useCallback(() => {
-    dispatch(WalletActions.addSitePermission({ accountId: account.accountId }))
+    dispatch(PanelActions
+      .requestSitePermission({ accountId: account.accountId }))
     if (selectedCoin !== BraveWallet.CoinType.SOL) {
       setSelectedAccount(account.accountId)
     }

--- a/components/brave_wallet_ui/components/extension/dapp-connection-settings/change-account-button.tsx
+++ b/components/brave_wallet_ui/components/extension/dapp-connection-settings/change-account-button.tsx
@@ -8,6 +8,8 @@ import Button from '@brave/leo/react/button'
 import { useDispatch } from 'react-redux'
 
 // Actions
+import { PanelActions } from '../../../panel/actions'
+
 import {
   WalletActions
 } from '../../../common/actions'
@@ -120,8 +122,8 @@ export const ChangeAccountButton = (props: Props) => {
   // Methods
   const onClickConnect = React.useCallback(() => {
     dispatch(
-      WalletActions
-        .addSitePermission({ accountId: account.accountId })
+      PanelActions
+        .requestSitePermission({ accountId: account.accountId })
     )
     if (selectedCoin !== BraveWallet.CoinType.SOL) {
       setSelectedAccount(account.accountId)

--- a/components/brave_wallet_ui/components/extension/dapp-connection-settings/change-account-button.tsx
+++ b/components/brave_wallet_ui/components/extension/dapp-connection-settings/change-account-button.tsx
@@ -51,13 +51,15 @@ import {
 
 // Styled Components
 import {
+  ActiveIndicator,
   DescriptionText,
   NameText
 } from './dapp-connection-settings.style'
 import {
   Row,
   Column,
-  VerticalSpace
+  VerticalSpace,
+  HorizontalSpace
 } from '../../shared/style'
 
 interface Props {
@@ -184,12 +186,25 @@ export const ChangeAccountButton = (props: Props) => {
           >
             {account.name}
           </NameText>
-          <DescriptionText
-            textSize='12px'
-            isBold={false}
+          <Row
+            width='unset'
+            justifyContent='flex-start'
           >
-            {reduceAddress(account.accountId.address)}
-          </DescriptionText>
+            <DescriptionText
+              textSize='12px'
+              isBold={false}
+            >
+              {reduceAddress(account.accountId.address)}
+            </DescriptionText>
+            {isActive &&
+              <>
+                <HorizontalSpace space='8px' />
+                <ActiveIndicator>
+                  {getLocale('braveWalletActive')}
+                </ActiveIndicator>
+              </>
+            }
+          </Row>
           {accountFiatValue.isUndefined() ? (
             <>
               <VerticalSpace space='3px' />

--- a/components/brave_wallet_ui/components/extension/dapp-connection-settings/dapp-connection-main.tsx
+++ b/components/brave_wallet_ui/components/extension/dapp-connection-settings/dapp-connection-main.tsx
@@ -8,6 +8,8 @@ import Button from '@brave/leo/react/button'
 import { useDispatch } from 'react-redux'
 
 // Actions
+import { PanelActions } from '../../../panel/actions'
+
 import {
   WalletActions
 } from '../../../common/actions'
@@ -124,8 +126,8 @@ export const DAppConnectionMain = (props: Props) => {
       return
     }
     dispatch(
-      WalletActions
-        .addSitePermission(
+      PanelActions
+        .requestSitePermission(
           { accountId: selectedAccount.accountId }
         )
     )

--- a/components/brave_wallet_ui/panel/actions/wallet_panel_actions.ts
+++ b/components/brave_wallet_ui/panel/actions/wallet_panel_actions.ts
@@ -10,6 +10,7 @@ import {
   DecryptProcessedPayload,
   ShowConnectToSitePayload,
   EthereumChainRequestPayload,
+  RequestSitePermissionPayloadType,
   SignMessageProcessedPayload,
   SignAllTransactionsProcessedPayload,
   SwitchEthereumChainProcessedPayload,
@@ -25,6 +26,8 @@ import { HardwareWalletResponseCodeType } from '../../common/hardware/types'
 
 export const connectToSite = createAction<ConnectWithSitePayloadType>('connectToSite')
 export const cancelConnectToSite = createAction('cancelConnectToSite')
+export const requestSitePermission
+  = createAction<RequestSitePermissionPayloadType>('requestSitePermission')
 export const visibilityChanged = createAction<boolean>('visibilityChanged')
 export const showConnectToSite = createAction<ShowConnectToSitePayload>('showConnectToSite')
 export const addEthereumChain = createAction<BraveWallet.AddChainRequest>('addEthereumChain')

--- a/components/brave_wallet_ui/panel/async/wallet_panel_async_handler.ts
+++ b/components/brave_wallet_ui/panel/async/wallet_panel_async_handler.ts
@@ -18,6 +18,7 @@ import {
   ConnectWithSitePayloadType,
   ShowConnectToSitePayload,
   EthereumChainRequestPayload,
+  RequestSitePermissionPayloadType,
   SignMessageProcessedPayload,
   SignAllTransactionsProcessedPayload,
   SwitchEthereumChainProcessedPayload,
@@ -183,6 +184,12 @@ handler.on(PanelActions.connectToSite.type, async (store: Store, payload: Connec
   const apiProxy = getWalletPanelApiProxy()
   apiProxy.panelHandler.connectToSite([payload.addressToConnect], payload.duration)
   apiProxy.panelHandler.closeUI()
+})
+
+handler.on(PanelActions.requestSitePermission.type,
+           async(store: Store, payload: RequestSitePermissionPayloadType) => {
+  const apiProxy = getWalletPanelApiProxy()
+  await apiProxy.panelHandler.requestPermission(payload.accountId)
 })
 
 handler.on(PanelActions.visibilityChanged.type, async (store: Store, isVisible) => {

--- a/components/brave_wallet_ui/panel/constants/action_types.ts
+++ b/components/brave_wallet_ui/panel/constants/action_types.ts
@@ -9,6 +9,10 @@ export type AccountPayloadType = {
   selectedAccounts: BraveWallet.AccountInfo[]
 }
 
+export type RequestSitePermissionPayloadType = {
+  accountId: BraveWallet.AccountId,
+}
+
 export type ConnectWithSitePayloadType = {
   addressToConnect: string,
   duration: BraveWallet.PermissionLifetimeOption


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/32643

When users click on connect, we will create a permission request same as dapp request permission and rest of the flow is the same.
This also deprecates AddPermission API to prevent permission is being added without permission duration tracking.

@AlexeyBarabash addressed `AddPermission` deprecation on Android
@Douglashdaniel added active account indicator to v2 panel on desktop

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-arm64, CI/skip-linux-x64, CI/skip-android, CI/skip-macos, CI/skip-ios, CI/skip-windows-arm64, CI/skip-windows-x64, CI/skip-windows-x86 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
### Panel Permission duration
1. Make sure there is nothing blocked in Ethereum/Solana content setting
2. Navigate to https://example.com/
3. Open panel and select Ethereum network and click "Connect"
4. After selecting account to connect, we should be able to select permission duration
5. Select "Until I close this site"
6. Navigate to brave://settings/content/ethereum and permission should be set
7. Repeat step 3-6 with Solana
8. Close the example.com tab
9. Open both brave://settings/content/ethereum and brave://settings/content/solana 
10. Wait approximately 30s, the previous granted permissions should be gone.

### Active account indicator
1. Go to https://bbondy.github.io/eth-manual-tests/request.html and connect a bunch of accounts
2. Open the Wallet `Panel` and then open `DApp Connection Settings`
3. Click on the `Account` selector.
4. There should be an `Active` indicator for the current selected account
5. Test switching between account, the `Active` indicator should update correctly.

https://github.com/brave/brave-core/assets/40611140/70c7972a-fef6-4e03-8667-0ab1caae7c8e


