### PR TITLE
[iOS] Remove breaking `enable_arc` build configs (uplift to 1.59.x)

### DIFF
--- a/ios/browser/api/url_sanitizer/BUILD.gn
+++ b/ios/browser/api/url_sanitizer/BUILD.gn
@@ -4,7 +4,6 @@
 # You can obtain one at https://mozilla.org/MPL/2.0/.
 
 source_set("url_sanitizer") {
-  configs += [ "//build/config/compiler:enable_arc" ]
   sources = [
     "url_sanitizer_service+private.h",
     "url_sanitizer_service.h",

--- a/ios/browser/browser_state/BUILD.gn
+++ b/ios/browser/browser_state/BUILD.gn
@@ -7,7 +7,6 @@ import("//build/config/ios/rules.gni")
 import("//ios/build/config.gni")
 
 source_set("browser_state") {
-  configs += [ "//build/config/compiler:enable_arc" ]
   sources = [
     "brave_browser_state_keyed_service_factories.h",
     "brave_browser_state_keyed_service_factories.mm",

--- a/ios/browser/url_sanitizer/BUILD.gn
+++ b/ios/browser/url_sanitizer/BUILD.gn
@@ -4,7 +4,6 @@
 # You can obtain one at https://mozilla.org/MPL/2.0/.
 
 source_set("url_sanitizer") {
-  configs += [ "//build/config/compiler:enable_arc" ]
   sources = [
     "url_sanitizer_service_factory+private.h",
     "url_sanitizer_service_factory.h",


### PR DESCRIPTION
Uplift of #20022

Pre-approval checklist: 
- [ ] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.