### PR TITLE
Fix gn_check error (uplift to 1.59.x)

### DIFF
--- a/test/BUILD.gn
+++ b/test/BUILD.gn
@@ -1036,14 +1036,12 @@ test("brave_browser_tests") {
   if (enable_speedreader) {
     sources += [ "//brave/browser/speedreader/speedreader_browsertest.cc" ]
     deps += [
+      "//brave/components/ai_chat/common/buildflags",
       "//brave/components/speedreader",
       "//brave/components/speedreader/common:mojom",
     ]
     if (enable_ai_chat) {
-      deps += [
-        "//brave/components/ai_chat/common:common",
-        "//brave/components/ai_chat/common/buildflags:buildflags",
-      ]
+      deps += [ "//brave/components/ai_chat/common" ]
     }
   }
 


### PR DESCRIPTION
Uplift of #20039
fix https://github.com/brave/brave-browser/issues/32833

Pre-approval checklist: 
- [ ] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.