### PR TITLE
[iOS] - Fix #32840: Disable Chromium Session-Restore for WebState and WebViews (uplift to 1.59.x)

### DIFF
--- a/ios/browser/api/web/web_state/web_state_native.mm
+++ b/ios/browser/api/web/web_state/web_state_native.mm
@@ -39,18 +39,6 @@ NativeWebState::NativeWebState(Browser* browser, bool off_the_record)
   session_id_ =
       SyncedWindowDelegateBrowserAgent::FromBrowser(browser_)->GetSessionId();
 
-  // Create session storage with an empty item storage
-  NSMutableArray<CRWNavigationItemStorage*>* item_storages =
-      [[NSMutableArray alloc] init];
-  CRWNavigationItemStorage* item = [[CRWNavigationItemStorage alloc] init];
-  [item_storages addObject:item];
-
-  CRWSessionStorage* session_storage = [[CRWSessionStorage alloc] init];
-  session_storage.stableIdentifier = [[NSUUID UUID] UUIDString];
-  session_storage.uniqueIdentifier = SessionID::NewUnique();
-  session_storage.itemStorages = [item_storages copy];
-  session_storage.userAgentType = web::UserAgentType::MOBILE;
-
   // Create BrowserState
   ChromeBrowserState* browser_state = browser->GetBrowserState();
   if (off_the_record) {
@@ -60,8 +48,7 @@ NativeWebState::NativeWebState(Browser* browser, bool off_the_record)
   // Create WebState with parameters
   web::WebState::CreateParams create_params(browser_state);
   create_params.last_active_time = base::Time::Now();
-  auto web_state =
-      web::WebState::CreateWithStorageSession(create_params, session_storage);
+  auto web_state = web::WebState::Create(create_params);
   web_state->ForceRealized();
 
   // Setup Observers of the WebState


### PR DESCRIPTION
Uplift of #20047
Resolves https://github.com/brave/brave-browser/issues/32840

Pre-approval checklist: 
- [ ] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.