### PR TITLE
Disable Omnibox shape modification features (uplift to 1.59.x)

### DIFF
--- a/app/brave_main_delegate_browsertest.cc
+++ b/app/brave_main_delegate_browsertest.cc
@@ -253,6 +253,8 @@ IN_PROC_BROWSER_TEST_F(BraveMainDelegateBrowserTest, DisabledFeatures) {
     &omnibox::kInspireMe,
     &omnibox::kDocumentProviderNoSetting,
     &omnibox::kDocumentProviderNoSyncRequirement,
+    &omnibox::kExpandedStateHeight,
+    &omnibox::kExpandedStateShape,
     &omnibox::kOmniboxMostVisitedTilesOnSrp,
     &omnibox::kOmniboxSteadyStateHeight,
     &omnibox::kRichAutocompletion,

--- a/chromium_src/components/omnibox/common/omnibox_features.cc
+++ b/chromium_src/components/omnibox/common/omnibox_features.cc
@@ -13,6 +13,8 @@ OVERRIDE_FEATURE_DEFAULT_STATES({{
     {kInspireMe, base::FEATURE_DISABLED_BY_DEFAULT},
     {kDocumentProviderNoSetting, base::FEATURE_DISABLED_BY_DEFAULT},
     {kDocumentProviderNoSyncRequirement, base::FEATURE_DISABLED_BY_DEFAULT},
+    {kExpandedStateHeight, base::FEATURE_DISABLED_BY_DEFAULT},
+    {kExpandedStateShape, base::FEATURE_DISABLED_BY_DEFAULT},
     {kOmniboxMostVisitedTilesOnSrp, base::FEATURE_DISABLED_BY_DEFAULT},
     {kOmniboxSteadyStateHeight, base::FEATURE_DISABLED_BY_DEFAULT},
     {kRichAutocompletion, base::FEATURE_DISABLED_BY_DEFAULT},


### PR DESCRIPTION
Uplift of #20076
Resolves https://github.com/brave/brave-browser/issues/32874

Pre-approval checklist: 
- [ ] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.