### PR TITLE
Don't do `$removeparam` in default blocking mode (uplift to 1.58.x)

### DIFF
--- a/browser/net/brave_ad_block_tp_network_delegate_helper.cc
+++ b/browser/net/brave_ad_block_tp_network_delegate_helper.cc
@@ -201,7 +201,8 @@ EngineFlags ShouldBlockRequestOnTaskRunner(
   if (adblock_result.rewritten_url.has_value &&
       GURL(std::string(adblock_result.rewritten_url.value)).is_valid() &&
       (ctx->method == "GET" || ctx->method == "HEAD" ||
-       ctx->method == "OPTIONS")) {
+       ctx->method == "OPTIONS") &&
+      ctx->aggressive_blocking) {
     ctx->new_url_spec = std::string(adblock_result.rewritten_url.value);
   }
 


### PR DESCRIPTION
Uplift of #19954
Resolves https://github.com/brave/brave-browser/issues/32462

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.