### PR TITLE
Replace chrome:// with brave:// in PWA confirmation bubble. (uplift to 1.58.x)

### DIFF
--- a/chromium_src/chrome/browser/ui/views/web_apps/web_app_views_utils.cc
+++ b/chromium_src/chrome/browser/ui/views/web_apps/web_app_views_utils.cc
@@ -1,0 +1,22 @@
+// Copyright (c) 2023 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#include "chrome/browser/ui/views/web_apps/web_app_views_utils.h"
+
+#define CreateOriginLabel CreateOriginLabel_ChromiumImpl
+#include "src/chrome/browser/ui/views/web_apps/web_app_views_utils.cc"
+#undef CreateOriginLabel
+
+namespace web_app {
+
+std::unique_ptr<views::Label> CreateOriginLabel(const url::Origin& origin,
+                                                bool is_primary_text) {
+  const url::Origin updated_origin = url::Origin::CreateFromNormalizedTuple(
+      origin.scheme() == "chrome" ? "brave" : origin.scheme(), origin.host(),
+      origin.port());
+  return CreateOriginLabel_ChromiumImpl(updated_origin, is_primary_text);
+}
+
+}  // namespace web_app


### PR DESCRIPTION
Uplift of #20049
Resolves https://github.com/brave/brave-browser/issues/32827

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.