### PR TITLE
Do not show `new` label for Password Manager app menu item. (uplift to 1.59.x)

### DIFF
--- a/browser/brave_profile_prefs.cc
+++ b/browser/brave_profile_prefs.cc
@@ -395,6 +395,11 @@ void RegisterProfilePrefs(user_prefs::PrefRegistrySyncable* registry) {
 
   omnibox::RegisterBraveProfilePrefs(registry);
 
+  // Do not mark Password Manager app menu item as new
+  registry->SetDefaultPrefValue(
+      password_manager::prefs::kPasswordsPrefWithNewLabelUsed,
+      base::Value(true));
+
   // Password leak detection should be disabled
   registry->SetDefaultPrefValue(
       password_manager::prefs::kPasswordLeakDetectionEnabled,


### PR DESCRIPTION
Uplift of #20075
Resolves https://github.com/brave/brave-browser/issues/32873

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.