### PR TITLE
[Uplift 1.59]: Add missing open in PWA icon (#20084)

### DIFF
--- a/browser/ui/toolbar/app_menu_icons.cc
+++ b/browser/ui/toolbar/app_menu_icons.cc
@@ -82,6 +82,7 @@ const std::map<int, const gfx::VectorIcon&>& GetCommandIcons() {
           {IDC_SHOW_BRAVE_SYNC, kLeoProductSyncIcon},
           {IDC_ROUTE_MEDIA, kLeoChromeCastIcon},
           {IDC_INSTALL_PWA, kLeoPwaInstallIcon},
+          {IDC_OPEN_IN_PWA_WINDOW, kLeoLaunchIcon},
           {IDC_SIDEBAR_SHOW_OPTION_MENU, kLeoBrowserSidebarRightIcon},
       });
   return *kCommandIcons.get();


### PR DESCRIPTION
Uplift https://github.com/brave/brave-core/pull/20084 which fixes https://github.com/brave/brave-browser/issues/32893 to 1.59.x