### PR TITLE
Remove vertical tab strip related flags

### DIFF
--- a/browser/about_flags.cc
+++ b/browser/about_flags.cc
@@ -321,19 +321,6 @@
 #define BRAVE_COMMANDS_FEATURE_ENTRIES
 #endif
 
-#if defined(TOOLKIT_VIEWS)
-#define BRAVE_VERTICAL_TABS_STICKY_PINNED_TABS_FEATURE_ENTRY                  \
-  EXPAND_FEATURE_ENTRIES({                                                    \
-      "brave-vertical-tabs-stick-pinned-tabs",                                \
-      "Vertical tabs - sticky pinned tabs",                                   \
-      "Pinned tabs will be on top of unpinned tabs regardless scroll state",  \
-      kOsWin | kOsMac | kOsLinux,                                             \
-      FEATURE_VALUE_TYPE(tabs::features::kBraveVerticalTabsStickyPinnedTabs), \
-  })
-#else
-#define BRAVE_VERTICAL_TABS_STICKY_PINNED_TABS_FEATURE_ENTRY
-#endif
-
 #if BUILDFLAG(IS_LINUX)
 #define BRAVE_CHANGE_ACTIVE_TAB_ON_SCROLL_EVENT_FEATURE_ENTRIES               \
   EXPAND_FEATURE_ENTRIES({                                                    \
@@ -888,7 +875,6 @@
   BRAVE_FEDERATED_FEATURE_ENTRIES                                              \
   PLAYLIST_FEATURE_ENTRIES                                                     \
   BRAVE_COMMANDS_FEATURE_ENTRIES                                               \
-  BRAVE_VERTICAL_TABS_STICKY_PINNED_TABS_FEATURE_ENTRY                         \
   BRAVE_BACKGROUND_VIDEO_PLAYBACK_ANDROID                                      \
   BRAVE_SAFE_BROWSING_ANDROID                                                  \
   BRAVE_CHANGE_ACTIVE_TAB_ON_SCROLL_EVENT_FEATURE_ENTRIES                      \

--- a/browser/about_flags.cc
+++ b/browser/about_flags.cc
@@ -322,15 +322,6 @@
 #endif
 
 #if defined(TOOLKIT_VIEWS)
-#define BRAVE_VERTICAL_TABS_FEATURE_ENTRY                                \
-  EXPAND_FEATURE_ENTRIES({                                               \
-      "brave-vertical-tabs",                                             \
-      "Vertical tabs",                                                   \
-      "Move tab strip to be a vertical panel on the side of the window " \
-      "instead of horizontal at the top of the window.",                 \
-      kOsWin | kOsMac | kOsLinux,                                        \
-      FEATURE_VALUE_TYPE(tabs::features::kBraveVerticalTabs),            \
-  })
 #define BRAVE_VERTICAL_TABS_STICKY_PINNED_TABS_FEATURE_ENTRY                  \
   EXPAND_FEATURE_ENTRIES({                                                    \
       "brave-vertical-tabs-stick-pinned-tabs",                                \
@@ -340,7 +331,6 @@
       FEATURE_VALUE_TYPE(tabs::features::kBraveVerticalTabsStickyPinnedTabs), \
   })
 #else
-#define BRAVE_VERTICAL_TABS_FEATURE_ENTRY
 #define BRAVE_VERTICAL_TABS_STICKY_PINNED_TABS_FEATURE_ENTRY
 #endif
 
@@ -898,7 +888,6 @@
   BRAVE_FEDERATED_FEATURE_ENTRIES                                              \
   PLAYLIST_FEATURE_ENTRIES                                                     \
   BRAVE_COMMANDS_FEATURE_ENTRIES                                               \
-  BRAVE_VERTICAL_TABS_FEATURE_ENTRY                                            \
   BRAVE_VERTICAL_TABS_STICKY_PINNED_TABS_FEATURE_ENTRY                         \
   BRAVE_BACKGROUND_VIDEO_PLAYBACK_ANDROID                                      \
   BRAVE_SAFE_BROWSING_ANDROID                                                  \

--- a/browser/extensions/api/settings_private/brave_prefs_util.cc
+++ b/browser/extensions/api/settings_private/brave_prefs_util.cc
@@ -323,14 +323,12 @@ const PrefsUtil::TypedPrefMap& BravePrefsUtil::GetAllowlistedKeys() {
 
 #if defined(TOOLKIT_VIEWS)
   // Vertical tab strip prefs
-  if (base::FeatureList::IsEnabled(tabs::features::kBraveVerticalTabs)) {
     (*s_brave_allowlist)[brave_tabs::kVerticalTabsEnabled] =
         settings_api::PrefType::PREF_TYPE_BOOLEAN;
     (*s_brave_allowlist)[brave_tabs::kVerticalTabsFloatingEnabled] =
         settings_api::PrefType::PREF_TYPE_BOOLEAN;
     (*s_brave_allowlist)[brave_tabs::kVerticalTabsShowTitleOnWindow] =
         settings_api::PrefType::PREF_TYPE_BOOLEAN;
-  }
 #endif
   return *s_brave_allowlist;
 }

--- a/browser/extensions/api/settings_private/brave_prefs_util.cc
+++ b/browser/extensions/api/settings_private/brave_prefs_util.cc
@@ -322,12 +322,12 @@ const PrefsUtil::TypedPrefMap& BravePrefsUtil::GetAllowlistedKeys() {
 
 #if defined(TOOLKIT_VIEWS)
   // Vertical tab strip prefs
-    (*s_brave_allowlist)[brave_tabs::kVerticalTabsEnabled] =
-        settings_api::PrefType::PREF_TYPE_BOOLEAN;
-    (*s_brave_allowlist)[brave_tabs::kVerticalTabsFloatingEnabled] =
-        settings_api::PrefType::PREF_TYPE_BOOLEAN;
-    (*s_brave_allowlist)[brave_tabs::kVerticalTabsShowTitleOnWindow] =
-        settings_api::PrefType::PREF_TYPE_BOOLEAN;
+  (*s_brave_allowlist)[brave_tabs::kVerticalTabsEnabled] =
+      settings_api::PrefType::PREF_TYPE_BOOLEAN;
+  (*s_brave_allowlist)[brave_tabs::kVerticalTabsFloatingEnabled] =
+      settings_api::PrefType::PREF_TYPE_BOOLEAN;
+  (*s_brave_allowlist)[brave_tabs::kVerticalTabsShowTitleOnWindow] =
+      settings_api::PrefType::PREF_TYPE_BOOLEAN;
 #endif
   return *s_brave_allowlist;
 }

--- a/browser/extensions/api/settings_private/brave_prefs_util.cc
+++ b/browser/extensions/api/settings_private/brave_prefs_util.cc
@@ -8,7 +8,6 @@
 #include "base/feature_list.h"
 #include "brave/browser/ethereum_remote_client/buildflags/buildflags.h"
 #include "brave/browser/ui/tabs/brave_tab_prefs.h"
-#include "brave/browser/ui/tabs/features.h"
 #include "brave/components/ai_chat/common/buildflags/buildflags.h"
 #include "brave/components/brave_ads/core/public/prefs/pref_names.h"
 #include "brave/components/brave_news/common/pref_names.h"

--- a/browser/resources/settings/brave_appearance_page/tabs.html
+++ b/browser/resources/settings/brave_appearance_page/tabs.html
@@ -13,7 +13,6 @@
 <div class="cr-row">$i18n{appearanceSettingsTabsSection}</div>
 <div class="list-frame">
   <!-- Vertical Tab strip -->
-  <template is="dom-if" if="[[isVerticalTabStripFeatureEnabled()]]">
     <settings-toggle-button
       class="cr-row list-item"
       pref="{{prefs.brave.tabs.vertical_tabs_enabled}}"
@@ -37,7 +36,6 @@
           </settings-checkbox>
         </div>
     </template>  <!-- vertical_tabs_enabled.value -->
-  </template>  <!-- isVerticalTabStripFeatureEnabled()-->
 
   <!-- Tab search button visibility -->
   <settings-toggle-button

--- a/browser/resources/settings/brave_appearance_page/tabs.html
+++ b/browser/resources/settings/brave_appearance_page/tabs.html
@@ -13,29 +13,29 @@
 <div class="cr-row">$i18n{appearanceSettingsTabsSection}</div>
 <div class="list-frame">
   <!-- Vertical Tab strip -->
-    <settings-toggle-button
-      class="cr-row list-item"
-      pref="{{prefs.brave.tabs.vertical_tabs_enabled}}"
-      label="$i18n{appearanceSettingsTabsUseVerticalTabs}">
-    </settings-toggle-button>
-    <template
-      is="dom-if"
-      if="[[prefs.brave.tabs.vertical_tabs_enabled.value]]">
-        <div class="cr-row">
-          <settings-checkbox
-            class="cr-row list-item"
-            pref="{{prefs.brave.tabs.vertical_tabs_show_title_on_window}}"
-            label="$i18n{appearanceSettingsTabsShowWindowTitle}">
-          </settings-checkbox>
-        </div>
-        <div class="cr-row">
-          <settings-checkbox
-            class="cr-row list-item"
-            pref="{{prefs.brave.tabs.vertical_tabs_floating_enabled}}"
-            label="$i18n{appearanceSettingsTabsFloatOnMouseOver}">
-          </settings-checkbox>
-        </div>
-    </template>  <!-- vertical_tabs_enabled.value -->
+  <settings-toggle-button
+    class="cr-row list-item"
+    pref="{{prefs.brave.tabs.vertical_tabs_enabled}}"
+    label="$i18n{appearanceSettingsTabsUseVerticalTabs}">
+  </settings-toggle-button>
+  <template
+    is="dom-if"
+    if="[[prefs.brave.tabs.vertical_tabs_enabled.value]]">
+      <div class="cr-row">
+        <settings-checkbox
+          class="cr-row list-item"
+          pref="{{prefs.brave.tabs.vertical_tabs_show_title_on_window}}"
+          label="$i18n{appearanceSettingsTabsShowWindowTitle}">
+        </settings-checkbox>
+      </div>
+      <div class="cr-row">
+        <settings-checkbox
+          class="cr-row list-item"
+          pref="{{prefs.brave.tabs.vertical_tabs_floating_enabled}}"
+          label="$i18n{appearanceSettingsTabsFloatOnMouseOver}">
+        </settings-checkbox>
+      </div>
+  </template>  <!-- vertical_tabs_enabled.value -->
 
   <!-- Tab search button visibility -->
   <settings-toggle-button

--- a/browser/resources/settings/brave_appearance_page/tabs.ts
+++ b/browser/resources/settings/brave_appearance_page/tabs.ts
@@ -27,10 +27,6 @@ export class SettingsBraveAppearanceTabsElement extends SettingsBraveAppearanceT
     return getTemplate()
   }
 
-  private isVerticalTabStripFeatureEnabled() {
-    return loadTimeData.getBoolean('verticalTabStripFeatureEnabled')
-  }
-
   private tabTooltipModes_ = [
     { value: 1, name: this.i18n('appearanceSettingsTabHoverModeCard') },
     {

--- a/browser/ui/brave_browser_command_controller.cc
+++ b/browser/ui/brave_browser_command_controller.cc
@@ -192,15 +192,9 @@ void BraveBrowserCommandController::InitBraveCommandState() {
 #endif
   UpdateCommandEnabled(IDC_BRAVE_BOOKMARK_BAR_SUBMENU, true);
 
-  UpdateCommandEnabled(
-      IDC_TOGGLE_VERTICAL_TABS,
-      base::FeatureList::IsEnabled(tabs::features::kBraveVerticalTabs));
-  UpdateCommandEnabled(
-      IDC_TOGGLE_VERTICAL_TABS_WINDOW_TITLE,
-      base::FeatureList::IsEnabled(tabs::features::kBraveVerticalTabs));
-  UpdateCommandEnabled(
-      IDC_TOGGLE_VERTICAL_TABS_EXPANDED,
-      base::FeatureList::IsEnabled(tabs::features::kBraveVerticalTabs));
+  UpdateCommandEnabled(IDC_TOGGLE_VERTICAL_TABS, true);
+  UpdateCommandEnabled(IDC_TOGGLE_VERTICAL_TABS_WINDOW_TITLE, true);
+  UpdateCommandEnabled(IDC_TOGGLE_VERTICAL_TABS_EXPANDED, true);
 
   UpdateCommandEnabled(IDC_CONFIGURE_BRAVE_NEWS,
                        !browser_->profile()->IsOffTheRecord());

--- a/browser/ui/brave_browser_command_controller.cc
+++ b/browser/ui/brave_browser_command_controller.cc
@@ -16,7 +16,6 @@
 #include "brave/browser/ui/brave_pages.h"
 #include "brave/browser/ui/browser_commands.h"
 #include "brave/browser/ui/sidebar/sidebar_utils.h"
-#include "brave/browser/ui/tabs/features.h"
 #include "brave/components/brave_rewards/common/rewards_util.h"
 #include "brave/components/brave_vpn/common/buildflags/buildflags.h"
 #include "brave/components/brave_wallet/common/common_utils.h"

--- a/browser/ui/color/brave_color_mixer.cc
+++ b/browser/ui/color/brave_color_mixer.cc
@@ -12,7 +12,6 @@
 #include "brave/browser/ui/color/color_palette.h"
 #include "brave/browser/ui/color/leo/colors.h"
 #include "brave/browser/ui/tabs/brave_vertical_tab_color_mixer.h"
-#include "brave/browser/ui/tabs/features.h"
 #include "brave/components/brave_vpn/common/buildflags/buildflags.h"
 #include "brave/components/playlist/common/buildflags/buildflags.h"
 #include "brave/components/speedreader/common/buildflags/buildflags.h"

--- a/browser/ui/color/brave_color_mixer.cc
+++ b/browser/ui/color/brave_color_mixer.cc
@@ -474,7 +474,7 @@ void AddBraveDarkThemeColorMixer(ui::ColorProvider* provider,
   mixer[kColorFeaturePromoBubbleCloseButtonInkDrop] = {
       GetToolbarInkDropColor(mixer)};
 
-    tabs::AddBraveVerticalTabDarkThemeColorMixer(provider, key);
+  tabs::AddBraveVerticalTabDarkThemeColorMixer(provider, key);
 
 #if BUILDFLAG(ENABLE_PLAYLIST_WEBUI)
   if (base::FeatureList::IsEnabled(playlist::features::kPlaylist)) {

--- a/browser/ui/color/brave_color_mixer.cc
+++ b/browser/ui/color/brave_color_mixer.cc
@@ -385,9 +385,7 @@ void AddBraveLightThemeColorMixer(ui::ColorProvider* provider,
   mixer[kColorFeaturePromoBubbleCloseButtonInkDrop] = {
       GetToolbarInkDropColor(mixer)};
 
-  if (base::FeatureList::IsEnabled(tabs::features::kBraveVerticalTabs)) {
-    tabs::AddBraveVerticalTabLightThemeColorMixer(provider, key);
-  }
+  tabs::AddBraveVerticalTabLightThemeColorMixer(provider, key);
 
 #if BUILDFLAG(ENABLE_PLAYLIST_WEBUI)
   if (base::FeatureList::IsEnabled(playlist::features::kPlaylist)) {
@@ -477,9 +475,7 @@ void AddBraveDarkThemeColorMixer(ui::ColorProvider* provider,
   mixer[kColorFeaturePromoBubbleCloseButtonInkDrop] = {
       GetToolbarInkDropColor(mixer)};
 
-  if (base::FeatureList::IsEnabled(tabs::features::kBraveVerticalTabs)) {
     tabs::AddBraveVerticalTabDarkThemeColorMixer(provider, key);
-  }
 
 #if BUILDFLAG(ENABLE_PLAYLIST_WEBUI)
   if (base::FeatureList::IsEnabled(playlist::features::kPlaylist)) {

--- a/browser/ui/sidebar/sidebar_browsertest.cc
+++ b/browser/ui/sidebar/sidebar_browsertest.cc
@@ -794,18 +794,7 @@ IN_PROC_BROWSER_TEST_F(SidebarBrowserTestWithAIChat,
 }
 #endif  // BUILDFLAG(ENABLE_AI_CHAT)
 
-class SidebarBrowserTestWithVerticalTabs : public SidebarBrowserTest {
- public:
-  SidebarBrowserTestWithVerticalTabs() {
-    feature_list_.InitAndEnableFeature(tabs::features::kBraveVerticalTabs);
-  }
-  ~SidebarBrowserTestWithVerticalTabs() override = default;
-
-  base::test::ScopedFeatureList feature_list_;
-};
-
-IN_PROC_BROWSER_TEST_F(SidebarBrowserTestWithVerticalTabs,
-                       SidebarRightSideTest) {
+IN_PROC_BROWSER_TEST_F(SidebarBrowserTest, SidebarRightSideTest) {
   // Sidebar is on right by default
   EXPECT_FALSE(IsSidebarUIOnLeft());
 

--- a/browser/ui/tabs/brave_tab_menu_model.cc
+++ b/browser/ui/tabs/brave_tab_menu_model.cc
@@ -98,10 +98,6 @@ void BraveTabMenuModel::Build(int selected_tab_count) {
   AddItemWithStringId(CommandRestoreTab, GetRestoreTabCommandStringId());
   AddItemWithStringId(CommandBookmarkAllTabs, IDS_TAB_CXMENU_BOOKMARK_ALL_TABS);
 
-  if (!base::FeatureList::IsEnabled(tabs::features::kBraveVerticalTabs)) {
-    return;
-  }
-
   AddSeparator(ui::NORMAL_SEPARATOR);
   AddCheckItemWithStringId(CommandShowVerticalTabs,
                            IDS_TAB_CXMENU_SHOW_VERTICAL_TABS);

--- a/browser/ui/tabs/brave_tab_menu_model.cc
+++ b/browser/ui/tabs/brave_tab_menu_model.cc
@@ -9,7 +9,6 @@
 #include <vector>
 
 #include "brave/browser/ui/tabs/brave_tab_strip_model.h"
-#include "brave/browser/ui/tabs/features.h"
 #include "brave/grit/brave_generated_resources.h"
 #include "chrome/browser/profiles/profile.h"
 #include "chrome/browser/sessions/tab_restore_service_factory.h"

--- a/browser/ui/tabs/features.cc
+++ b/browser/ui/tabs/features.cc
@@ -7,10 +7,6 @@
 
 namespace tabs::features {
 
-BASE_FEATURE(kBraveVerticalTabs,
-             "BraveVerticalTabs",
-             base::FEATURE_ENABLED_BY_DEFAULT);
-
 BASE_FEATURE(kBraveVerticalTabsStickyPinnedTabs,
              "BraveVerticalTabsStickyPinnedTabs",
              base::FEATURE_ENABLED_BY_DEFAULT);

--- a/browser/ui/tabs/features.cc
+++ b/browser/ui/tabs/features.cc
@@ -7,10 +7,6 @@
 
 namespace tabs::features {
 
-BASE_FEATURE(kBraveVerticalTabsStickyPinnedTabs,
-             "BraveVerticalTabsStickyPinnedTabs",
-             base::FEATURE_ENABLED_BY_DEFAULT);
-
 #if BUILDFLAG(IS_LINUX)
 BASE_FEATURE(kBraveChangeActiveTabOnScrollEvent,
              "BraveChangeActiveTabOnScrollEvent",

--- a/browser/ui/tabs/features.h
+++ b/browser/ui/tabs/features.h
@@ -9,7 +9,6 @@
 #include "base/feature_list.h"
 namespace tabs::features {
 
-BASE_DECLARE_FEATURE(kBraveVerticalTabs);
 BASE_DECLARE_FEATURE(kBraveVerticalTabsStickyPinnedTabs);
 
 #if BUILDFLAG(IS_LINUX)

--- a/browser/ui/tabs/features.h
+++ b/browser/ui/tabs/features.h
@@ -9,8 +9,6 @@
 #include "base/feature_list.h"
 namespace tabs::features {
 
-BASE_DECLARE_FEATURE(kBraveVerticalTabsStickyPinnedTabs);
-
 #if BUILDFLAG(IS_LINUX)
 // This flag controls the behavior of browser_default::kScrollEventChangesTab,
 // which is true only when it's Linux.

--- a/browser/ui/views/brave_tab_search_bubble_host.cc
+++ b/browser/ui/views/brave_tab_search_bubble_host.cc
@@ -5,7 +5,6 @@
 
 #include "brave/browser/ui/views/brave_tab_search_bubble_host.h"
 
-#include "brave/browser/ui/tabs/features.h"
 #include "brave/browser/ui/views/tabs/vertical_tab_utils.h"
 #include "chrome/browser/ui/layout_constants.h"
 #include "chrome/browser/ui/views/frame/browser_view.h"

--- a/browser/ui/views/brave_tab_search_bubble_host.cc
+++ b/browser/ui/views/brave_tab_search_bubble_host.cc
@@ -13,18 +13,11 @@
 
 void BraveTabSearchBubbleHost::SetBubbleArrow(
     views::BubbleBorder::Arrow arrow) {
-  DCHECK(base::FeatureList::IsEnabled(tabs::features::kBraveVerticalTabs))
-      << "Should be called only when the vertical tab feature is enabled.";
   arrow_ = arrow;
 }
 
 bool BraveTabSearchBubbleHost::ShowTabSearchBubble(
     bool triggered_by_keyboard_shortcut) {
-  if (!base::FeatureList::IsEnabled(tabs::features::kBraveVerticalTabs)) {
-    return TabSearchBubbleHost::ShowTabSearchBubble(
-        triggered_by_keyboard_shortcut);
-  }
-
   bool result =
       TabSearchBubbleHost::ShowTabSearchBubble(triggered_by_keyboard_shortcut);
   if (!arrow_ || !result) {

--- a/browser/ui/views/frame/brave_browser_frame_mac.mm
+++ b/browser/ui/views/frame/brave_browser_frame_mac.mm
@@ -6,7 +6,6 @@
 #include "brave/browser/ui/views/frame/brave_browser_frame_mac.h"
 
 #include "brave/app/brave_command_ids.h"
-#include "brave/browser/ui/tabs/features.h"
 #include "brave/browser/ui/views/tabs/vertical_tab_utils.h"
 #include "chrome/browser/ui/tabs/tab_strip_model.h"
 #include "chrome/browser/ui/views/frame/browser_view.h"

--- a/browser/ui/views/frame/brave_browser_frame_mac.mm
+++ b/browser/ui/views/frame/brave_browser_frame_mac.mm
@@ -24,12 +24,6 @@ BraveBrowserFrameMac::~BraveBrowserFrameMac() = default;
 void BraveBrowserFrameMac::GetWindowFrameTitlebarHeight(
     bool* override_titlebar_height,
     float* titlebar_height) {
-  if (!base::FeatureList::IsEnabled(tabs::features::kBraveVerticalTabs)) {
-    BrowserFrameMac::GetWindowFrameTitlebarHeight(override_titlebar_height,
-                                                  titlebar_height);
-    return;
-  }
-
   if (tabs::utils::ShouldShowVerticalTabs(browser_)) {
     if (!tabs::utils::ShouldShowWindowTitleForVerticalTabs(browser_)) {
       // In this case, titlbar height should be the same as toolbar height.

--- a/browser/ui/views/frame/brave_browser_frame_view_linux_native.cc
+++ b/browser/ui/views/frame/brave_browser_frame_view_linux_native.cc
@@ -57,11 +57,6 @@ BraveBrowserFrameViewLinuxNative::BraveBrowserFrameViewLinuxNative(
 BraveBrowserFrameViewLinuxNative::~BraveBrowserFrameViewLinuxNative() = default;
 
 void BraveBrowserFrameViewLinuxNative::MaybeUpdateCachedFrameButtonImages() {
-  if (!base::FeatureList::IsEnabled(tabs::features::kBraveVerticalTabs)) {
-    BrowserFrameViewLinuxNative::MaybeUpdateCachedFrameButtonImages();
-    return;
-  }
-
   auto* browser = browser_view()->browser();
   DCHECK(browser);
 
@@ -116,9 +111,7 @@ void BraveBrowserFrameViewLinuxNative::MaybeUpdateCachedFrameButtonImages() {
 void BraveBrowserFrameViewLinuxNative::Layout() {
   BrowserFrameViewLinuxNative::Layout();
 
-  if (base::FeatureList::IsEnabled(tabs::features::kBraveVerticalTabs)) {
-    UpdateLeadingTrailingCaptionButtonWidth();
-  }
+  UpdateLeadingTrailingCaptionButtonWidth();
 }
 
 views::Button* BraveBrowserFrameViewLinuxNative::FrameButtonToButton(
@@ -137,8 +130,6 @@ views::Button* BraveBrowserFrameViewLinuxNative::FrameButtonToButton(
 
 void BraveBrowserFrameViewLinuxNative::
     UpdateLeadingTrailingCaptionButtonWidth() {
-  DCHECK(base::FeatureList::IsEnabled(tabs::features::kBraveVerticalTabs));
-
   auto* browser = browser_view()->browser();
   DCHECK(browser);
   std::pair<int, int> new_leading_trailing_caption_button_width;

--- a/browser/ui/views/frame/brave_browser_frame_view_linux_native.cc
+++ b/browser/ui/views/frame/brave_browser_frame_view_linux_native.cc
@@ -8,7 +8,6 @@
 #include <numeric>
 #include <string>
 
-#include "brave/browser/ui/tabs/features.h"
 #include "brave/browser/ui/views/tabs/vertical_tab_utils.h"
 #include "brave/browser/ui/views/toolbar/brave_toolbar_view.h"
 #include "chrome/browser/ui/layout_constants.h"

--- a/browser/ui/views/frame/brave_browser_frame_view_win.cc
+++ b/browser/ui/views/frame/brave_browser_frame_view_win.cc
@@ -24,18 +24,16 @@ BraveBrowserFrameViewWin::BraveBrowserFrameViewWin(BrowserFrame* frame,
   frame_graphic_.reset(
       new BraveWindowFrameGraphic(browser_view->browser()->profile()));
 
-    DCHECK(browser_view->browser());
-    auto* prefs = browser_view->browser()->profile()->GetPrefs();
-    using_vertical_tabs_.Init(
-        brave_tabs::kVerticalTabsEnabled, prefs,
-        base::BindRepeating(
-            &BraveBrowserFrameViewWin::OnVerticalTabsPrefsChanged,
-            base::Unretained(this)));
-    showing_window_title_for_vertical_tabs_.Init(
-        brave_tabs::kVerticalTabsShowTitleOnWindow, prefs,
-        base::BindRepeating(
-            &BraveBrowserFrameViewWin::OnVerticalTabsPrefsChanged,
-            base::Unretained(this)));
+  DCHECK(browser_view->browser());
+  auto* prefs = browser_view->browser()->profile()->GetPrefs();
+  using_vertical_tabs_.Init(
+      brave_tabs::kVerticalTabsEnabled, prefs,
+      base::BindRepeating(&BraveBrowserFrameViewWin::OnVerticalTabsPrefsChanged,
+                          base::Unretained(this)));
+  showing_window_title_for_vertical_tabs_.Init(
+      brave_tabs::kVerticalTabsShowTitleOnWindow, prefs,
+      base::BindRepeating(&BraveBrowserFrameViewWin::OnVerticalTabsPrefsChanged,
+                          base::Unretained(this)));
 }
 
 BraveBrowserFrameViewWin::~BraveBrowserFrameViewWin() = default;

--- a/browser/ui/views/frame/brave_browser_frame_view_win.cc
+++ b/browser/ui/views/frame/brave_browser_frame_view_win.cc
@@ -25,7 +25,6 @@ BraveBrowserFrameViewWin::BraveBrowserFrameViewWin(BrowserFrame* frame,
   frame_graphic_.reset(
       new BraveWindowFrameGraphic(browser_view->browser()->profile()));
 
-  if (base::FeatureList::IsEnabled(tabs::features::kBraveVerticalTabs)) {
     DCHECK(browser_view->browser());
     auto* prefs = browser_view->browser()->profile()->GetPrefs();
     using_vertical_tabs_.Init(
@@ -38,7 +37,6 @@ BraveBrowserFrameViewWin::BraveBrowserFrameViewWin(BrowserFrame* frame,
         base::BindRepeating(
             &BraveBrowserFrameViewWin::OnVerticalTabsPrefsChanged,
             base::Unretained(this)));
-  }
 }
 
 BraveBrowserFrameViewWin::~BraveBrowserFrameViewWin() = default;
@@ -74,10 +72,6 @@ void BraveBrowserFrameViewWin::OnPaint(gfx::Canvas* canvas) {
 }
 
 int BraveBrowserFrameViewWin::GetTopInset(bool restored) const {
-  if (!base::FeatureList::IsEnabled(tabs::features::kBraveVerticalTabs)) {
-    return BrowserFrameViewWin::GetTopInset(restored);
-  }
-
   if (auto* browser = browser_view()->browser();
       tabs::utils::ShouldShowVerticalTabs(browser) &&
       !tabs::utils::ShouldShowWindowTitleForVerticalTabs(browser)) {

--- a/browser/ui/views/frame/brave_browser_frame_view_win.cc
+++ b/browser/ui/views/frame/brave_browser_frame_view_win.cc
@@ -6,7 +6,6 @@
 #include "brave/browser/ui/views/frame/brave_browser_frame_view_win.h"
 
 #include "brave/browser/ui/tabs/brave_tab_prefs.h"
-#include "brave/browser/ui/tabs/features.h"
 #include "brave/browser/ui/views/frame/brave_non_client_hit_test_helper.h"
 #include "brave/browser/ui/views/frame/brave_window_frame_graphic.h"
 #include "brave/browser/ui/views/tabs/vertical_tab_utils.h"

--- a/browser/ui/views/frame/brave_browser_non_client_frame_view_mac.mm
+++ b/browser/ui/views/frame/brave_browser_non_client_frame_view_mac.mm
@@ -28,9 +28,6 @@ BraveBrowserNonClientFrameViewMac::BraveBrowserNonClientFrameViewMac(
   frame_graphic_ =
       std::make_unique<BraveWindowFrameGraphic>(browser->profile());
 
-  if (!base::FeatureList::IsEnabled(tabs::features::kBraveVerticalTabs))
-    return;
-
   if (tabs::utils::SupportsVerticalTabs(browser)) {
     auto* prefs = browser->profile()->GetOriginalProfile()->GetPrefs();
     show_vertical_tabs_.Init(
@@ -75,17 +72,11 @@ int BraveBrowserNonClientFrameViewMac::GetTopInset(bool restored) const {
 
 bool BraveBrowserNonClientFrameViewMac::ShouldShowWindowTitleForVerticalTabs()
     const {
-  if (!base::FeatureList::IsEnabled(tabs::features::kBraveVerticalTabs))
-    return false;
-
   return tabs::utils::ShouldShowWindowTitleForVerticalTabs(
       browser_view()->browser());
 }
 
 void BraveBrowserNonClientFrameViewMac::UpdateWindowTitleVisibility() {
-  DCHECK(base::FeatureList::IsEnabled(tabs::features::kBraveVerticalTabs))
-      << "This method should be called only when the flag is on.";
-
   if (!browser_view()->browser()->is_type_normal())
     return;
 
@@ -113,9 +104,6 @@ void BraveBrowserNonClientFrameViewMac::UpdateWindowTitleAndControls() {
 }
 
 gfx::Size BraveBrowserNonClientFrameViewMac::GetMinimumSize() const {
-  if (!base::FeatureList::IsEnabled(tabs::features::kBraveVerticalTabs))
-    return BrowserNonClientFrameViewMac::GetMinimumSize();
-
   if (tabs::utils::ShouldShowVerticalTabs(browser_view()->browser())) {
     // In order to ignore tab strip height, skip BrowserNonClientFrameViewMac's
     // implementation.

--- a/browser/ui/views/frame/brave_browser_non_client_frame_view_mac.mm
+++ b/browser/ui/views/frame/brave_browser_non_client_frame_view_mac.mm
@@ -8,7 +8,6 @@
 #include "brave/browser/ui/views/frame/brave_browser_non_client_frame_view_mac.h"
 
 #include "brave/browser/ui/tabs/brave_tab_prefs.h"
-#include "brave/browser/ui/tabs/features.h"
 #include "brave/browser/ui/views/frame/brave_non_client_hit_test_helper.h"
 #include "brave/browser/ui/views/frame/brave_window_frame_graphic.h"
 #include "brave/browser/ui/views/tabs/vertical_tab_utils.h"

--- a/browser/ui/views/frame/brave_browser_root_view.cc
+++ b/browser/ui/views/frame/brave_browser_root_view.cc
@@ -16,9 +16,6 @@ BraveBrowserRootView::BraveBrowserRootView(BrowserView* browser_view,
 BraveBrowserRootView::~BraveBrowserRootView() = default;
 
 bool BraveBrowserRootView::OnMouseWheel(const ui::MouseWheelEvent& event) {
-  if (!base::FeatureList::IsEnabled(tabs::features::kBraveVerticalTabs))
-    return BrowserRootView::OnMouseWheel(event);
-
     // Bypass BrowserRootView::OnMouseWheel() to avoid tab cycling feature.
 #if BUILDFLAG(IS_LINUX)
   if (!base::FeatureList::IsEnabled(

--- a/browser/ui/views/frame/brave_browser_view.cc
+++ b/browser/ui/views/frame/brave_browser_view.cc
@@ -24,7 +24,6 @@
 #include "brave/browser/ui/commands/accelerator_service.h"
 #include "brave/browser/ui/commands/accelerator_service_factory.h"
 #include "brave/browser/ui/sidebar/sidebar_utils.h"
-#include "brave/browser/ui/tabs/features.h"
 #include "brave/browser/ui/views/brave_actions/brave_actions_container.h"
 #include "brave/browser/ui/views/brave_actions/brave_shields_action_view.h"
 #include "brave/browser/ui/views/brave_rewards/tip_panel_bubble_host.h"

--- a/browser/ui/views/frame/brave_browser_view.cc
+++ b/browser/ui/views/frame/brave_browser_view.cc
@@ -196,7 +196,6 @@ BraveBrowserView::BraveBrowserView(std::unique_ptr<Browser> browser)
 #endif
 
   const bool supports_vertical_tabs =
-      base::FeatureList::IsEnabled(tabs::features::kBraveVerticalTabs) &&
       tabs::utils::SupportsVerticalTabs(browser_.get());
   if (supports_vertical_tabs) {
     vertical_tab_strip_host_view_ =
@@ -339,10 +338,6 @@ gfx::Rect BraveBrowserView::GetShieldsBubbleRect() {
 }
 
 bool BraveBrowserView::GetTabStripVisible() const {
-  if (!base::FeatureList::IsEnabled(tabs::features::kBraveVerticalTabs)) {
-    return BrowserView::GetTabStripVisible();
-  }
-
   if (tabs::utils::ShouldShowVerticalTabs(browser())) {
     return false;
   }
@@ -352,10 +347,6 @@ bool BraveBrowserView::GetTabStripVisible() const {
 
 #if BUILDFLAG(IS_WIN)
 bool BraveBrowserView::GetSupportsTitle() const {
-  if (!base::FeatureList::IsEnabled(tabs::features::kBraveVerticalTabs)) {
-    return BrowserView::GetSupportsTitle();
-  }
-
   if (tabs::utils::SupportsVerticalTabs(browser())) {
     return true;
   }
@@ -646,10 +637,6 @@ bool BraveBrowserView::ShouldShowWindowTitle() const {
     return true;
   }
 
-  if (!base::FeatureList::IsEnabled(tabs::features::kBraveVerticalTabs)) {
-    return false;
-  }
-
   if (tabs::utils::ShouldShowWindowTitleForVerticalTabs(browser())) {
     return true;
   }
@@ -667,8 +654,7 @@ void BraveBrowserView::OnThemeChanged() {
 }
 
 TabSearchBubbleHost* BraveBrowserView::GetTabSearchBubbleHost() {
-  if (!base::FeatureList::IsEnabled(tabs::features::kBraveVerticalTabs) ||
-      !tabs::utils::ShouldShowVerticalTabs(browser()) ||
+  if (!tabs::utils::ShouldShowVerticalTabs(browser()) ||
       WindowFrameUtil::IsWindowsTabSearchCaptionButtonEnabled(browser())) {
     return BrowserView::GetTabSearchBubbleHost();
   }

--- a/browser/ui/views/frame/brave_browser_view_layout.cc
+++ b/browser/ui/views/frame/brave_browser_view_layout.cc
@@ -7,7 +7,6 @@
 
 #include <vector>
 
-#include "brave/browser/ui/tabs/features.h"
 #include "brave/browser/ui/views/tabs/vertical_tab_utils.h"
 #include "chrome/browser/profiles/profile.h"
 #include "chrome/browser/ui/browser.h"

--- a/browser/ui/views/frame/brave_browser_view_layout.cc
+++ b/browser/ui/views/frame/brave_browser_view_layout.cc
@@ -24,9 +24,6 @@ void BraveBrowserViewLayout::Layout(views::View* host) {
   if (!vertical_tab_strip_host_.get())
     return;
 
-  CHECK(base::FeatureList::IsEnabled(tabs::features::kBraveVerticalTabs))
-      << "vertical_tab_strip_host_ should be set only when this flag is on";
-
   if (!tabs::utils::ShouldShowVerticalTabs(browser_view_->browser())) {
     vertical_tab_strip_host_->SetBorder(nullptr);
     vertical_tab_strip_host_->SetBoundsRect({});
@@ -77,9 +74,6 @@ void BraveBrowserViewLayout::LayoutSidePanelView(
 }
 
 int BraveBrowserViewLayout::LayoutTabStripRegion(int top) {
-  if (!base::FeatureList::IsEnabled(tabs::features::kBraveVerticalTabs))
-    return BrowserViewLayout::LayoutTabStripRegion(top);
-
   if (tabs::utils::ShouldShowVerticalTabs(browser_view_->browser())) {
     // In case we're using vertical tabstrip, we can decide the position
     // after we finish laying out views in top container.

--- a/browser/ui/views/frame/brave_non_client_hit_test_helper_browsertest.cc
+++ b/browser/ui/views/frame/brave_non_client_hit_test_helper_browsertest.cc
@@ -5,7 +5,6 @@
 
 #include "base/test/scoped_feature_list.h"
 #include "brave/browser/ui/browser_commands.h"
-#include "brave/browser/ui/tabs/features.h"
 #include "chrome/browser/ui/views/frame/browser_non_client_frame_view.h"
 #include "chrome/browser/ui/views/frame/browser_view.h"
 #include "chrome/browser/ui/views/toolbar/reload_button.h"

--- a/browser/ui/views/frame/brave_opaque_browser_frame_view.cc
+++ b/browser/ui/views/frame/brave_opaque_browser_frame_view.cc
@@ -50,8 +50,7 @@ void BraveOpaqueBrowserFrameView::OnPaint(gfx::Canvas* canvas) {
 }
 
 int BraveOpaqueBrowserFrameView::NonClientHitTest(const gfx::Point& point) {
-  if (base::FeatureList::IsEnabled(tabs::features::kBraveVerticalTabs) &&
-      tabs::utils::ShouldShowVerticalTabs(browser_view()->browser())) {
+  if (tabs::utils::ShouldShowVerticalTabs(browser_view()->browser())) {
     auto hit_test_caption_button = [](views::Button* button,
                                       const gfx::Point& point) {
       return button && button->GetVisible() &&
@@ -83,9 +82,6 @@ int BraveOpaqueBrowserFrameView::NonClientHitTest(const gfx::Point& point) {
 void BraveOpaqueBrowserFrameView::
     UpdateCaptionButtonPlaceholderContainerBackground() {
   OpaqueBrowserFrameView::UpdateCaptionButtonPlaceholderContainerBackground();
-  if (!base::FeatureList::IsEnabled(tabs::features::kBraveVerticalTabs)) {
-    return;
-  }
 
   DCHECK(browser_view());
   auto* browser = browser_view()->browser();
@@ -120,11 +116,6 @@ void BraveOpaqueBrowserFrameView::
 }
 
 void BraveOpaqueBrowserFrameView::PaintClientEdge(gfx::Canvas* canvas) const {
-  if (!base::FeatureList::IsEnabled(tabs::features::kBraveVerticalTabs)) {
-    OpaqueBrowserFrameView::PaintClientEdge(canvas);
-    return;
-  }
-
   // Don't draw client edge next to toolbar when it's in vertical tab stirp mode
   DCHECK(browser_view());
   auto* browser = browser_view()->browser();

--- a/browser/ui/views/frame/brave_opaque_browser_frame_view.cc
+++ b/browser/ui/views/frame/brave_opaque_browser_frame_view.cc
@@ -7,7 +7,6 @@
 
 #include <memory>
 
-#include "brave/browser/ui/tabs/features.h"
 #include "brave/browser/ui/views/frame/brave_non_client_hit_test_helper.h"
 #include "brave/browser/ui/views/frame/brave_window_frame_graphic.h"
 #include "brave/browser/ui/views/tabs/vertical_tab_utils.h"

--- a/browser/ui/views/frame/vertical_tab_strip_region_view.cc
+++ b/browser/ui/views/frame/vertical_tab_strip_region_view.cc
@@ -14,7 +14,6 @@
 #include "brave/browser/ui/brave_browser.h"
 #include "brave/browser/ui/color/brave_color_id.h"
 #include "brave/browser/ui/tabs/brave_tab_prefs.h"
-#include "brave/browser/ui/tabs/features.h"
 #include "brave/browser/ui/views/tabs/brave_new_tab_button.h"
 #include "brave/browser/ui/views/tabs/brave_tab_search_button.h"
 #include "brave/browser/ui/views/tabs/brave_tab_strip_layout_helper.h"

--- a/browser/ui/views/frame/vertical_tab_strip_region_view.cc
+++ b/browser/ui/views/frame/vertical_tab_strip_region_view.cc
@@ -596,9 +596,6 @@ VerticalTabStripRegionView::VerticalTabStripRegionView(
       browser_(browser_view->browser()),
       original_region_view_(region_view),
       tab_style_(TabStyle::Get()) {
-  CHECK(base::FeatureList::IsEnabled(tabs::features::kBraveVerticalTabs))
-      << "This view should be created only when this flag is on";
-
   browser_->tab_strip_model()->AddObserver(this);
 
   SetNotifyEnterExitOnChild(true);

--- a/browser/ui/views/frame/vertical_tab_strip_region_view.cc
+++ b/browser/ui/views/frame/vertical_tab_strip_region_view.cc
@@ -596,15 +596,11 @@ VerticalTabStripRegionView::VerticalTabStripRegionView(
       browser_(browser_view->browser()),
       original_region_view_(region_view),
       tab_style_(TabStyle::Get()) {
-  browser_->tab_strip_model()->AddObserver(this);
-
   SetNotifyEnterExitOnChild(true);
 
   // The default state is kExpanded, so reset animation state to 1.0.
   width_animation_.Reset(1.0);
 
-  if (base::FeatureList::IsEnabled(
-          tabs::features::kBraveVerticalTabsStickyPinnedTabs)) {
     header_view_ = AddChildView(std::make_unique<HeaderView>(
         base::BindRepeating(
             [](VerticalTabStripRegionView* container, const ui::Event& event) {
@@ -623,33 +619,6 @@ VerticalTabStripRegionView::VerticalTabStripRegionView(
     contents_view_ =
         AddChildView(std::make_unique<VerticalTabStripScrollContentsView>(
             this, original_region_view_->tab_strip_));
-  } else {
-    scroll_view_ = AddChildView(std::make_unique<CustomScrollView>());
-    scroll_view_->SetDrawOverflowIndicator(false);
-    header_view_ = scroll_view_->SetHeader(std::make_unique<HeaderView>(
-        base::BindRepeating(
-            [](VerticalTabStripRegionView* container, const ui::Event& event) {
-              // Note that Calling SetValue() doesn't trigger
-              // OnCollapsedPrefChanged() for this view.
-              if (container->state_ == State::kExpanded) {
-                container->collapsed_pref_.SetValue(true);
-                container->SetState(State::kCollapsed);
-              } else {
-                container->collapsed_pref_.SetValue(false);
-                container->SetState(State::kExpanded);
-              }
-            },
-            this),
-        this));
-
-    contents_view_ = scroll_view_->SetContents(
-        std::make_unique<VerticalTabStripScrollContentsView>(
-            this, original_region_view_->tab_strip_));
-    scroll_view_->SetVerticalScrollBarMode(
-        base::FeatureList::IsEnabled(features::kScrollableTabStrip)
-            ? views::ScrollView::ScrollBarMode::kDisabled
-            : views::ScrollView::ScrollBarMode::kHiddenButEnabled);
-  }
   header_view_->toggle_button()->SetHighlighted(state_ == State::kExpanded);
 
   new_tab_button_ = AddChildView(std::make_unique<VerticalTabNewTabButton>(
@@ -825,8 +794,6 @@ void VerticalTabStripRegionView::Layout() {
       {contents_bounds.x(),
        contents_bounds.bottom() - new_tab_button_->height()});
 
-  if (base::FeatureList::IsEnabled(
-          tabs::features::kBraveVerticalTabsStickyPinnedTabs)) {
     const gfx::Size header_size{contents_bounds.width(),
                                 tabs::kVerticalTabHeight + kHeaderInset * 2};
     header_view_->SetPosition(contents_bounds.origin());
@@ -844,45 +811,6 @@ void VerticalTabStripRegionView::Layout() {
     constexpr int kResizeAreaWidth = 4;
     resize_area_->SetBounds(width() - kResizeAreaWidth, contents_bounds.y(),
                             kResizeAreaWidth, contents_bounds.height());
-    return;
-  }
-
-  // 2. ScrollView takes the rest of space.
-  // Set preferred size for scroll view to know this.
-  const gfx::Size header_size{contents_bounds.width(),
-                              tabs::kVerticalTabHeight + kHeaderInset * 2};
-  header_view_->SetPreferredSize(header_size);
-  header_view_->SetSize(header_size);
-
-  scroll_view_->SetSize({contents_bounds.width(),
-                         contents_bounds.height() - new_tab_button_->height()});
-  scroll_view_->SetPosition(contents_bounds.origin());
-
-  auto scroll_viewport_height = scroll_view_->height() - header_size.height();
-  if (scroll_view_->GetMaxHeight() != scroll_viewport_height) {
-    scroll_view_->ClipHeightTo(0, scroll_viewport_height);
-  }
-
-  if (base::FeatureList::IsEnabled(features::kScrollableTabStrip) &&
-      tabs::utils::ShouldShowVerticalTabs(browser_)) {
-    contents_view_->SetSize({scroll_view_->width(), scroll_view_->height()});
-    auto* nested_scroll_view = GetTabStripScrollContainer()->scroll_view_.get();
-    nested_scroll_view->SetSize(
-        {scroll_view_->width(), scroll_viewport_height});
-    nested_scroll_view->ClipHeightTo(0, scroll_viewport_height);
-  } else {
-    contents_view_->SetSize(
-        {scroll_view_->width(),
-         std::max(scroll_viewport_height,
-                  contents_view_->GetPreferredSize().height())});
-  }
-
-  UpdateOriginalTabSearchButtonVisibility();
-
-  // Put resize area on the right side, overlapped with contents.
-  constexpr int kResizeAreaWidth = 4;
-  resize_area_->SetBounds(width() - kResizeAreaWidth, contents_bounds.y(),
-                          kResizeAreaWidth, contents_bounds.height());
 }
 
 void VerticalTabStripRegionView::OnShowVerticalTabsPrefChanged() {
@@ -949,12 +877,6 @@ void VerticalTabStripRegionView::OnThemeChanged() {
 
   const auto background_color = cp->GetColor(kColorToolbar);
   SetBackground(views::CreateSolidBackground(background_color));
-
-  // TODO(sko) Remove this once the "sticky pinned tabs" is enabled by default.
-  // https://github.com/brave/brave-browser/issues/29935
-  if (scroll_view_) {
-    scroll_view_->SetBackgroundColor(background_color);
-  }
 
   new_tab_button_->FrameColorsChanged();
 
@@ -1031,12 +953,6 @@ void VerticalTabStripRegionView::OnBoundsChanged(
       tab_strip()->tab_container_->InvalidateIdealBounds();
       tab_strip()->tab_container_->CompleteAnimationAndLayout();
     }
-
-    // TODO(sko) Remove this once the "sticky pinned tabs" is enabled by
-    // default. https://github.com/brave/brave-browser/issues/29935
-    if (scroll_view_) {
-      ScrollActiveTabToBeVisible();
-    }
   }
 
 #if DCHECK_IS_ON()
@@ -1055,22 +971,6 @@ void VerticalTabStripRegionView::PreferredSizeChanged() {
 void VerticalTabStripRegionView::AddedToWidget() {
   View::AddedToWidget();
   mouse_watcher_ = std::make_unique<MouseWatcher>(this);
-}
-
-void VerticalTabStripRegionView::OnTabStripModelChanged(
-    TabStripModel* tab_strip_model,
-    const TabStripModelChange& change,
-    const TabStripSelectionChange& selection) {
-  if (base::FeatureList::IsEnabled(
-          tabs::features::kBraveVerticalTabsStickyPinnedTabs)) {
-    return;
-  }
-
-  if (!selection.active_tab_changed()) {
-    return;
-  }
-
-  ScrollActiveTabToBeVisible();
 }
 
 void VerticalTabStripRegionView::OnResize(int resize_amount,
@@ -1249,56 +1149,6 @@ void VerticalTabStripRegionView::ScheduleFloatingModeTimer() {
         FROM_HERE, base::Milliseconds(400),
         base::BindOnce(&VerticalTabStripRegionView::SetState,
                        base::Unretained(this), State::kFloating));
-  }
-}
-
-void VerticalTabStripRegionView::ScrollActiveTabToBeVisible() {
-  if (!tabs::utils::ShouldShowVerticalTabs(browser_)) {
-    return;
-  }
-
-  DCHECK(scroll_view_);
-
-  auto active_index = browser_->tab_strip_model()->active_index();
-  if (active_index == TabStripModel::kNoTab) {
-    // This could happen on destruction.
-    return;
-  }
-
-  auto* active_tab = original_region_view_->tab_strip_->tab_at(active_index);
-  CHECK(active_tab);
-
-  if (!contents_view_->Contains(active_tab)) {
-    // Reportedly, contents_view_ and active sometimes tab belong to different
-    // view trees and it causes CHECK failure while converting coordinates.
-    // https://github.com/brave/brave-browser/issues/32183
-    return;
-  }
-
-  gfx::RectF tab_bounds_in_contents_view(active_tab->GetLocalBounds());
-  views::View::ConvertRectToTarget(active_tab, contents_view_,
-                                   &tab_bounds_in_contents_view);
-
-  auto visible_rect = scroll_view_->GetVisibleRect();
-  if (visible_rect.Contains(gfx::Rect(0, tab_bounds_in_contents_view.y(),
-                                      1 /*in order to ignore width */,
-                                      tab_bounds_in_contents_view.height()))) {
-    return;
-  }
-
-  // Unfortunately, ScrollView's API doesn't work well for us. So we manually
-  // adjust scroll offset. Note that we change contents view's position as
-  // we disabled layered scroll view.
-  if (visible_rect.CenterPoint().y() >=
-      tab_bounds_in_contents_view.CenterPoint().y()) {
-    scroll_view_->contents()->SetPosition(
-        {0, -static_cast<int>(tab_bounds_in_contents_view.y())});
-  } else {
-    scroll_view_->contents()->SetPosition(
-        {0, std::min(0, scroll_view_->height() -
-                            static_cast<int>(
-                                tab_bounds_in_contents_view.bottom() +
-                                tabs::kMarginForVerticalTabContainers))});
   }
 }
 

--- a/browser/ui/views/frame/vertical_tab_strip_region_view.cc
+++ b/browser/ui/views/frame/vertical_tab_strip_region_view.cc
@@ -600,24 +600,24 @@ VerticalTabStripRegionView::VerticalTabStripRegionView(
   // The default state is kExpanded, so reset animation state to 1.0.
   width_animation_.Reset(1.0);
 
-    header_view_ = AddChildView(std::make_unique<HeaderView>(
-        base::BindRepeating(
-            [](VerticalTabStripRegionView* container, const ui::Event& event) {
-              // Note that Calling SetValue() doesn't trigger
-              // OnCollapsedPrefChanged() for this view.
-              if (container->state_ == State::kExpanded) {
-                container->collapsed_pref_.SetValue(true);
-                container->SetState(State::kCollapsed);
-              } else {
-                container->collapsed_pref_.SetValue(false);
-                container->SetState(State::kExpanded);
-              }
-            },
-            this),
-        this));
-    contents_view_ =
-        AddChildView(std::make_unique<VerticalTabStripScrollContentsView>(
-            this, original_region_view_->tab_strip_));
+  header_view_ = AddChildView(std::make_unique<HeaderView>(
+      base::BindRepeating(
+          [](VerticalTabStripRegionView* container, const ui::Event& event) {
+            // Note that Calling SetValue() doesn't trigger
+            // OnCollapsedPrefChanged() for this view.
+            if (container->state_ == State::kExpanded) {
+              container->collapsed_pref_.SetValue(true);
+              container->SetState(State::kCollapsed);
+            } else {
+              container->collapsed_pref_.SetValue(false);
+              container->SetState(State::kExpanded);
+            }
+          },
+          this),
+      this));
+  contents_view_ =
+      AddChildView(std::make_unique<VerticalTabStripScrollContentsView>(
+          this, original_region_view_->tab_strip_));
   header_view_->toggle_button()->SetHighlighted(state_ == State::kExpanded);
 
   new_tab_button_ = AddChildView(std::make_unique<VerticalTabNewTabButton>(
@@ -793,23 +793,23 @@ void VerticalTabStripRegionView::Layout() {
       {contents_bounds.x(),
        contents_bounds.bottom() - new_tab_button_->height()});
 
-    const gfx::Size header_size{contents_bounds.width(),
-                                tabs::kVerticalTabHeight + kHeaderInset * 2};
-    header_view_->SetPosition(contents_bounds.origin());
-    header_view_->SetSize(header_size);
+  const gfx::Size header_size{contents_bounds.width(),
+                              tabs::kVerticalTabHeight + kHeaderInset * 2};
+  header_view_->SetPosition(contents_bounds.origin());
+  header_view_->SetSize(header_size);
 
-    contents_view_->SetSize(
-        {contents_bounds.width(), contents_bounds.height() -
-                                      new_tab_button_->height() -
-                                      header_view_->height()});
-    contents_view_->SetPosition({contents_bounds.origin().x(),
-                                 header_view_->y() + header_view_->height()});
-    UpdateOriginalTabSearchButtonVisibility();
+  contents_view_->SetSize(
+      {contents_bounds.width(), contents_bounds.height() -
+                                    new_tab_button_->height() -
+                                    header_view_->height()});
+  contents_view_->SetPosition({contents_bounds.origin().x(),
+                               header_view_->y() + header_view_->height()});
+  UpdateOriginalTabSearchButtonVisibility();
 
-    // Put resize area on the right side, overlapped with contents.
-    constexpr int kResizeAreaWidth = 4;
-    resize_area_->SetBounds(width() - kResizeAreaWidth, contents_bounds.y(),
-                            kResizeAreaWidth, contents_bounds.height());
+  // Put resize area on the right side, overlapped with contents.
+  constexpr int kResizeAreaWidth = 4;
+  resize_area_->SetBounds(width() - kResizeAreaWidth, contents_bounds.y(),
+                          kResizeAreaWidth, contents_bounds.height());
 }
 
 void VerticalTabStripRegionView::OnShowVerticalTabsPrefChanged() {

--- a/browser/ui/views/frame/vertical_tab_strip_region_view.h
+++ b/browser/ui/views/frame/vertical_tab_strip_region_view.h
@@ -18,7 +18,6 @@
 #include "ui/views/controls/resize_area_delegate.h"
 
 namespace views {
-class ScrollView;
 class ResizeArea;
 }  // namespace views
 

--- a/browser/ui/views/frame/vertical_tab_strip_region_view.h
+++ b/browser/ui/views/frame/vertical_tab_strip_region_view.h
@@ -13,7 +13,6 @@
 #include "base/memory/weak_ptr.h"
 #include "base/timer/timer.h"
 #include "base/types/pass_key.h"
-#include "chrome/browser/ui/tabs/tab_strip_model_observer.h"
 #include "chrome/browser/ui/views/frame/tab_strip_region_view.h"
 #include "components/prefs/pref_member.h"
 #include "ui/views/controls/resize_area_delegate.h"
@@ -30,7 +29,6 @@ class VerticalTabStripScrollContentsView;
 
 // Wraps TabStripRegion and show it vertically.
 class VerticalTabStripRegionView : public views::View,
-                                   public TabStripModelObserver,
                                    public views::ResizeAreaDelegate,
                                    public views::AnimationDelegateViews,
                                    public views::WidgetObserver {
@@ -100,14 +98,6 @@ class VerticalTabStripRegionView : public views::View,
   void PreferredSizeChanged() override;
   void AddedToWidget() override;
 
-  // TabStripModelObserver:
-  // TODO(sko) Remove this once the "sticky pinned tabs" is enabled by default.
-  // https://github.com/brave/brave-browser/issues/29935
-  void OnTabStripModelChanged(
-      TabStripModel* tab_strip_model,
-      const TabStripModelChange& change,
-      const TabStripSelectionChange& selection) override;
-
   // views::ResizeAreaDelegate
   void OnResize(int resize_amount, bool done_resizing) override;
 
@@ -157,21 +147,12 @@ class VerticalTabStripRegionView : public views::View,
   // Returns valid object only when the related flag is enabled.
   TabStripScrollContainer* GetTabStripScrollContainer();
 
-  // TODO(sko) Remove this once the "sticky pinned tabs" is enabled by default.
-  // https://github.com/brave/brave-browser/issues/29935
-  void ScrollActiveTabToBeVisible();
-
   std::u16string GetShortcutTextForNewTabButton(BrowserView* browser_view);
 
   raw_ptr<Browser> browser_ = nullptr;
 
   raw_ptr<views::View> original_parent_of_region_view_ = nullptr;
   raw_ptr<TabStripRegionView> original_region_view_ = nullptr;
-
-  // Contains TabStripRegion.
-  // TODO(sko) Remove this once the "sticky pinned tabs" is enabled by default.
-  // https://github.com/brave/brave-browser/issues/29935
-  raw_ptr<views::ScrollView> scroll_view_ = nullptr;
 
   raw_ptr<HeaderView> header_view_ = nullptr;
   raw_ptr<views::View> contents_view_ = nullptr;

--- a/browser/ui/views/omnibox/brave_omnibox_popup_view_views.cc
+++ b/browser/ui/views/omnibox/brave_omnibox_popup_view_views.cc
@@ -5,7 +5,6 @@
 
 #include "brave/browser/ui/views/omnibox/brave_omnibox_popup_view_views.h"
 
-#include "brave/browser/ui/tabs/features.h"
 #include "brave/browser/ui/views/tabs/vertical_tab_utils.h"
 #include "chrome/browser/ui/views/location_bar/location_bar_view.h"
 #include "chrome/browser/ui/views/omnibox/rounded_omnibox_results_frame.h"

--- a/browser/ui/views/omnibox/brave_omnibox_popup_view_views.cc
+++ b/browser/ui/views/omnibox/brave_omnibox_popup_view_views.cc
@@ -15,10 +15,6 @@ BraveOmniboxPopupViewViews::~BraveOmniboxPopupViewViews() = default;
 
 gfx::Rect BraveOmniboxPopupViewViews::GetTargetBounds() const {
   auto bounds = OmniboxPopupViewViews::GetTargetBounds();
-  if (!base::FeatureList::IsEnabled(tabs::features::kBraveVerticalTabs)) {
-    return bounds;
-  }
-
   if (auto* browser = location_bar_view_->browser();
       tabs::utils::ShouldShowVerticalTabs(browser) &&
       !tabs::utils::ShouldShowWindowTitleForVerticalTabs(browser)) {

--- a/browser/ui/views/omnibox/brave_rounded_omnibox_results_frame.cc
+++ b/browser/ui/views/omnibox/brave_rounded_omnibox_results_frame.cc
@@ -9,7 +9,6 @@
 #include <utility>
 
 #include "brave/browser/ui/tabs/brave_tab_prefs.h"
-#include "brave/browser/ui/tabs/features.h"
 #include "brave/browser/ui/views/tabs/vertical_tab_utils.h"
 #include "chrome/browser/profiles/profile.h"
 #include "chrome/browser/ui/browser.h"

--- a/browser/ui/views/omnibox/brave_rounded_omnibox_results_frame.cc
+++ b/browser/ui/views/omnibox/brave_rounded_omnibox_results_frame.cc
@@ -21,9 +21,6 @@ BraveRoundedOmniboxResultsFrame::BraveRoundedOmniboxResultsFrame(
     LocationBarView* location_bar)
     : RoundedOmniboxResultsFrame(contents, location_bar),
       browser_(location_bar->browser()) {
-  if (!base::FeatureList::IsEnabled(tabs::features::kBraveVerticalTabs))
-    return;
-
   UpdateShadowBorder();
 
   show_vertical_tabs_.Init(
@@ -41,8 +38,6 @@ BraveRoundedOmniboxResultsFrame::BraveRoundedOmniboxResultsFrame(
 BraveRoundedOmniboxResultsFrame::~BraveRoundedOmniboxResultsFrame() = default;
 
 void BraveRoundedOmniboxResultsFrame::UpdateShadowBorder() {
-  DCHECK(base::FeatureList::IsEnabled(tabs::features::kBraveVerticalTabs));
-
   int corner_radius = views::LayoutProvider::Get()->GetCornerRadiusMetric(
       views::Emphasis::kHigh);
 

--- a/browser/ui/views/tabs/brave_compound_tab_container.cc
+++ b/browser/ui/views/tabs/brave_compound_tab_container.cc
@@ -93,9 +93,6 @@ BraveCompoundTabContainer::BraveCompoundTabContainer(
 void BraveCompoundTabContainer::SetAvailableWidthCallback(
     base::RepeatingCallback<int()> available_width_callback) {
   CompoundTabContainer::SetAvailableWidthCallback(available_width_callback);
-  if (!base::FeatureList::IsEnabled(tabs::features::kBraveVerticalTabs))
-    return;
-
   if (tabs::utils::ShouldShowVerticalTabs(tab_slot_controller_->GetBrowser()) &&
       available_width_callback) {
     pinned_tab_container_->SetAvailableWidthCallback(
@@ -302,8 +299,7 @@ Tab* BraveCompoundTabContainer::AddTab(std::unique_ptr<Tab> tab,
                                        TabPinned pinned) {
   auto* new_tab =
       CompoundTabContainer::AddTab(std::move(tab), model_index, pinned);
-  if (!base::FeatureList::IsEnabled(tabs::features::kBraveVerticalTabs) ||
-      !tabs::utils::ShouldShowVerticalTabs(
+  if (!tabs::utils::ShouldShowVerticalTabs(
           tab_slot_controller_->GetBrowser())) {
     return new_tab;
   }
@@ -426,9 +422,8 @@ gfx::Rect BraveCompoundTabContainer::ConvertUnpinnedContainerIdealBoundsToLocal(
 }
 
 bool BraveCompoundTabContainer::ShouldShowVerticalTabs() const {
-  return base::FeatureList::IsEnabled(tabs::features::kBraveVerticalTabs) &&
-         tabs::utils::ShouldShowVerticalTabs(
-             tab_slot_controller_->GetBrowser());
+  return tabs::utils::ShouldShowVerticalTabs(
+      tab_slot_controller_->GetBrowser());
 }
 
 void BraveCompoundTabContainer::UpdateUnpinnedContainerSize() {

--- a/browser/ui/views/tabs/brave_compound_tab_container.cc
+++ b/browser/ui/views/tabs/brave_compound_tab_container.cc
@@ -12,7 +12,6 @@
 
 #include "brave/browser/ui/color/brave_color_id.h"
 #include "brave/browser/ui/tabs/brave_tab_prefs.h"
-#include "brave/browser/ui/tabs/features.h"
 #include "brave/browser/ui/views/frame/vertical_tab_strip_region_view.h"
 #include "brave/browser/ui/views/tabs/brave_tab_container.h"
 #include "brave/browser/ui/views/tabs/vertical_tab_utils.h"

--- a/browser/ui/views/tabs/brave_tab.cc
+++ b/browser/ui/views/tabs/brave_tab.cc
@@ -152,16 +152,10 @@ void BraveTab::ActiveStateChanged() {
   // https://github.com/brave/brave-browser/issues/23476/
   alert_indicator_button_->UpdateEnabledForMuteToggle();
 
-  if (base::FeatureList::IsEnabled(tabs::features::kBraveVerticalTabs)) {
-    UpdateShadowForActiveTab();
-  }
+  UpdateShadowForActiveTab();
 }
 
 absl::optional<SkColor> BraveTab::GetGroupColor() const {
-  if (!base::FeatureList::IsEnabled(tabs::features::kBraveVerticalTabs)) {
-    return Tab::GetGroupColor();
-  }
-
   // Hide tab border with group color as it doesn't go well with vertical tabs.
   if (tabs::utils::ShouldShowVerticalTabs(controller()->GetBrowser())) {
     return {};
@@ -208,10 +202,6 @@ void BraveTab::OnLayerBoundsChanged(const gfx::Rect& old_bounds,
                                     ui::PropertyChangeReason reason) {
   Tab::OnLayerBoundsChanged(old_bounds, reason);
 
-  if (!base::FeatureList::IsEnabled(tabs::features::kBraveVerticalTabs)) {
-    return;
-  }
-
   if (shadow_layer_ && shadow_layer_->parent() &&
       shadow_layer_->parent() == layer()->parent()) {
     LayoutShadowLayer();
@@ -255,10 +245,6 @@ gfx::Insets BraveTab::GetInsets() const {
 void BraveTab::ReorderChildLayers(ui::Layer* parent_layer) {
   Tab::ReorderChildLayers(parent_layer);
 
-  if (!base::FeatureList::IsEnabled(tabs::features::kBraveVerticalTabs)) {
-    return;
-  }
-
   if (!layer() || layer()->parent() != parent_layer || !shadow_layer_) {
     return;
   }
@@ -278,8 +264,7 @@ void BraveTab::ReorderChildLayers(ui::Layer* parent_layer) {
 
 void BraveTab::MaybeAdjustLeftForPinnedTab(gfx::Rect* bounds,
                                            int visual_width) const {
-  if (!base::FeatureList::IsEnabled(tabs::features::kBraveVerticalTabs) ||
-      !tabs::utils::ShouldShowVerticalTabs(controller()->GetBrowser())) {
+  if (!tabs::utils::ShouldShowVerticalTabs(controller()->GetBrowser())) {
     Tab::MaybeAdjustLeftForPinnedTab(bounds, visual_width);
     return;
   }
@@ -299,16 +284,11 @@ bool BraveTab::ShouldRenderAsNormalTab() const {
 }
 
 bool BraveTab::IsAtMinWidthForVerticalTabStrip() const {
-  if (!base::FeatureList::IsEnabled(tabs::features::kBraveVerticalTabs)) {
-    return false;
-  }
-
   return tabs::utils::ShouldShowVerticalTabs(controller()->GetBrowser()) &&
          width() <= tabs::kVerticalTabMinWidth;
 }
 
 void BraveTab::UpdateShadowForActiveTab() {
-  CHECK(base::FeatureList::IsEnabled(tabs::features::kBraveVerticalTabs));
   if (IsActive() &&
       tabs::utils::ShouldShowVerticalTabs(controller()->GetBrowser())) {
     shadow_layer_ = CreateShadowLayer();

--- a/browser/ui/views/tabs/brave_tab.cc
+++ b/browser/ui/views/tabs/brave_tab.cc
@@ -8,7 +8,6 @@
 #include <algorithm>
 
 #include "brave/browser/ui/tabs/brave_tab_prefs.h"
-#include "brave/browser/ui/tabs/features.h"
 #include "brave/browser/ui/views/frame/brave_browser_view.h"
 #include "brave/browser/ui/views/frame/vertical_tab_strip_region_view.h"
 #include "brave/browser/ui/views/frame/vertical_tab_strip_widget_delegate_view.h"

--- a/browser/ui/views/tabs/brave_tab_container.cc
+++ b/browser/ui/views/tabs/brave_tab_container.cc
@@ -37,9 +37,6 @@ BraveTabContainer::BraveTabContainer(
                        scroll_contents_view),
       drag_context_(static_cast<TabDragContext*>(drag_context)),
       tab_style_(TabStyle::Get()) {
-  if (!base::FeatureList::IsEnabled(tabs::features::kBraveVerticalTabs))
-    return;
-
   auto* browser = tab_slot_controller_->GetBrowser();
   if (!browser) {
     CHECK_IS_TEST();
@@ -68,9 +65,6 @@ BraveTabContainer::BraveTabContainer(
 }
 
 BraveTabContainer::~BraveTabContainer() {
-  if (!base::FeatureList::IsEnabled(tabs::features::kBraveVerticalTabs))
-    return;
-
   // When the last tab is closed and tab strip is being destructed, the
   // animation for the last removed tab could have been scheduled but not
   // finished yet. In this case, stop the animation before checking if all
@@ -82,9 +76,6 @@ BraveTabContainer::~BraveTabContainer() {
 }
 
 base::OnceClosure BraveTabContainer::LockLayout() {
-  DCHECK(base::FeatureList::IsEnabled(tabs::features::kBraveVerticalTabs))
-      << "This method should be called only when the flag is on.";
-
   DCHECK(!layout_locked_) << "LockLayout() doesn't allow reentrance";
   layout_locked_ = true;
   return base::BindOnce(&BraveTabContainer::OnUnlockLayout,
@@ -92,9 +83,6 @@ base::OnceClosure BraveTabContainer::LockLayout() {
 }
 
 gfx::Size BraveTabContainer::CalculatePreferredSize() const {
-  if (!base::FeatureList::IsEnabled(tabs::features::kBraveVerticalTabs))
-    return TabContainerImpl::CalculatePreferredSize();
-
   // Note that we check this before checking currently we're in vertical tab
   // strip mode. We might be in the middle of changing orientation.
   if (layout_locked_)
@@ -146,11 +134,6 @@ gfx::Size BraveTabContainer::CalculatePreferredSize() const {
 
 void BraveTabContainer::UpdateClosingModeOnRemovedTab(int model_index,
                                                       bool was_active) {
-  if (!base::FeatureList::IsEnabled(tabs::features::kBraveVerticalTabs)) {
-    TabContainerImpl::UpdateClosingModeOnRemovedTab(model_index, was_active);
-    return;
-  }
-
   // Don't shrink vertical tab strip's width
   if (tabs::utils::ShouldShowVerticalTabs(tab_slot_controller_->GetBrowser())) {
     return;
@@ -162,11 +145,6 @@ void BraveTabContainer::UpdateClosingModeOnRemovedTab(int model_index,
 gfx::Rect BraveTabContainer::GetTargetBoundsForClosingTab(
     Tab* tab,
     int former_model_index) const {
-  if (!base::FeatureList::IsEnabled(tabs::features::kBraveVerticalTabs)) {
-    return TabContainerImpl::GetTargetBoundsForClosingTab(tab,
-                                                          former_model_index);
-  }
-
   if (!tabs::utils::ShouldShowVerticalTabs(
           tab_slot_controller_->GetBrowser())) {
     return TabContainerImpl::GetTargetBoundsForClosingTab(tab,
@@ -188,11 +166,6 @@ gfx::Rect BraveTabContainer::GetTargetBoundsForClosingTab(
 
 void BraveTabContainer::EnterTabClosingMode(absl::optional<int> override_width,
                                             CloseTabSource source) {
-  if (!base::FeatureList::IsEnabled(tabs::features::kBraveVerticalTabs)) {
-    TabContainerImpl::EnterTabClosingMode(override_width, source);
-    return;
-  }
-
   // Don't shrink vertical tab strip's width
   if (tabs::utils::ShouldShowVerticalTabs(tab_slot_controller_->GetBrowser())) {
     return;
@@ -202,9 +175,6 @@ void BraveTabContainer::EnterTabClosingMode(absl::optional<int> override_width,
 }
 
 bool BraveTabContainer::ShouldTabBeVisible(const Tab* tab) const {
-  if (!base::FeatureList::IsEnabled(tabs::features::kBraveVerticalTabs))
-    return TabContainerImpl::ShouldTabBeVisible(tab);
-
   // We don't have to clip tabs out of bounds. Scroll view will handle it.
   if (tabs::utils::ShouldShowVerticalTabs(tab_slot_controller_->GetBrowser())) {
     return true;
@@ -214,11 +184,6 @@ bool BraveTabContainer::ShouldTabBeVisible(const Tab* tab) const {
 }
 
 void BraveTabContainer::StartInsertTabAnimation(int model_index) {
-  if (!base::FeatureList::IsEnabled(tabs::features::kBraveVerticalTabs)) {
-    TabContainerImpl::StartInsertTabAnimation(model_index);
-    return;
-  }
-
   // Note that we check this before checking currently we're in vertical tab
   // strip mode. We might be in the middle of changing orientation.
   if (layout_locked_)
@@ -250,11 +215,6 @@ void BraveTabContainer::StartInsertTabAnimation(int model_index) {
 }
 
 void BraveTabContainer::RemoveTab(int index, bool was_active) {
-  if (!base::FeatureList::IsEnabled(tabs::features::kBraveVerticalTabs)) {
-    TabContainerImpl::RemoveTab(index, was_active);
-    return;
-  }
-
   if (tabs::utils::ShouldShowVerticalTabs(tab_slot_controller_->GetBrowser())) {
     closing_tabs_.insert(tabs_view_model_.view_at(index));
   }
@@ -263,11 +223,6 @@ void BraveTabContainer::RemoveTab(int index, bool was_active) {
 }
 
 void BraveTabContainer::OnTabCloseAnimationCompleted(Tab* tab) {
-  if (!base::FeatureList::IsEnabled(tabs::features::kBraveVerticalTabs)) {
-    TabContainerImpl::OnTabCloseAnimationCompleted(tab);
-    return;
-  }
-
   if (tabs::utils::ShouldShowVerticalTabs(tab_slot_controller_->GetBrowser())) {
     closing_tabs_.erase(tab);
   }
@@ -280,9 +235,6 @@ void BraveTabContainer::OnTabCloseAnimationCompleted(Tab* tab) {
 }
 
 void BraveTabContainer::UpdateLayoutOrientation() {
-  DCHECK(base::FeatureList::IsEnabled(tabs::features::kBraveVerticalTabs))
-      << "This method should be called only when the flag is on.";
-
   layout_helper_->set_use_vertical_tabs(
       tabs::utils::ShouldShowVerticalTabs(tab_slot_controller_->GetBrowser()));
   layout_helper_->set_tab_strip(
@@ -291,9 +243,6 @@ void BraveTabContainer::UpdateLayoutOrientation() {
 }
 
 void BraveTabContainer::OnUnlockLayout() {
-  DCHECK(base::FeatureList::IsEnabled(tabs::features::kBraveVerticalTabs))
-      << "This method should be called only when the flag is on.";
-
   layout_locked_ = false;
 
   InvalidateIdealBounds();
@@ -302,11 +251,6 @@ void BraveTabContainer::OnUnlockLayout() {
 }
 
 void BraveTabContainer::CompleteAnimationAndLayout() {
-  if (!base::FeatureList::IsEnabled(tabs::features::kBraveVerticalTabs)) {
-    TabContainerImpl::CompleteAnimationAndLayout();
-    return;
-  }
-
   // Note that we check this before checking currently we're in vertical tab
   // strip mode. We might be in the middle of changing orientation.
   if (layout_locked_)
@@ -320,11 +264,6 @@ void BraveTabContainer::CompleteAnimationAndLayout() {
 }
 
 void BraveTabContainer::OnPaintBackground(gfx::Canvas* canvas) {
-  if (!base::FeatureList::IsEnabled(tabs::features::kBraveVerticalTabs)) {
-    TabContainerImpl::OnPaintBackground(canvas);
-    return;
-  }
-
   if (!tabs::utils::ShouldShowVerticalTabs(
           tab_slot_controller_->GetBrowser())) {
     TabContainerImpl::OnPaintBackground(canvas);
@@ -335,11 +274,6 @@ void BraveTabContainer::OnPaintBackground(gfx::Canvas* canvas) {
 }
 
 void BraveTabContainer::PaintChildren(const views::PaintInfo& paint_info) {
-  if (!base::FeatureList::IsEnabled(tabs::features::kBraveVerticalTabs)) {
-    TabContainerImpl::PaintChildren(paint_info);
-    return;
-  }
-
   // Exclude tabs that own layer.
   std::vector<ZOrderableTabContainerElement> orderable_children;
   for (views::View* child : children()) {

--- a/browser/ui/views/tabs/brave_tab_container.cc
+++ b/browser/ui/views/tabs/brave_tab_container.cc
@@ -10,7 +10,6 @@
 
 #include "base/check_is_test.h"
 #include "brave/browser/ui/tabs/brave_tab_prefs.h"
-#include "brave/browser/ui/tabs/features.h"
 #include "brave/browser/ui/views/tabs/brave_tab_group_header.h"
 #include "brave/browser/ui/views/tabs/brave_tab_strip.h"
 #include "brave/browser/ui/views/tabs/vertical_tab_utils.h"

--- a/browser/ui/views/tabs/brave_tab_context_menu_contents.cc
+++ b/browser/ui/views/tabs/brave_tab_context_menu_contents.cc
@@ -14,7 +14,6 @@
 #include "brave/browser/ui/tabs/brave_tab_menu_model.h"
 #include "brave/browser/ui/tabs/brave_tab_prefs.h"
 #include "brave/browser/ui/tabs/brave_tab_strip_model.h"
-#include "brave/browser/ui/tabs/features.h"
 #include "brave/browser/ui/views/tabs/brave_browser_tab_strip_controller.h"
 #include "brave/browser/ui/views/tabs/vertical_tab_utils.h"
 #include "chrome/browser/defaults.h"

--- a/browser/ui/views/tabs/brave_tab_context_menu_contents.cc
+++ b/browser/ui/views/tabs/brave_tab_context_menu_contents.cc
@@ -39,7 +39,6 @@ BraveTabContextMenuContents::BraveTabContextMenuContents(
       browser_(const_cast<Browser*>(controller->browser())),
       controller_(controller) {
   const bool is_vertical_tab =
-      base::FeatureList::IsEnabled(tabs::features::kBraveVerticalTabs) &&
       tabs::utils::ShouldShowVerticalTabs(browser_);
 
   model_ = std::make_unique<BraveTabMenuModel>(
@@ -66,10 +65,6 @@ void BraveTabContextMenuContents::RunMenuAt(const gfx::Point& point,
 }
 
 bool BraveTabContextMenuContents::IsCommandIdChecked(int command_id) const {
-  if (!base::FeatureList::IsEnabled(tabs::features::kBraveVerticalTabs)) {
-    return ui::SimpleMenuModel::Delegate::IsCommandIdChecked(command_id);
-  }
-
   if (command_id == BraveTabMenuModel::CommandShowVerticalTabs) {
     return tabs::utils::ShouldShowVerticalTabs(browser_);
   }
@@ -86,10 +81,6 @@ bool BraveTabContextMenuContents::IsCommandIdEnabled(int command_id) const {
 }
 
 bool BraveTabContextMenuContents::IsCommandIdVisible(int command_id) const {
-  if (!base::FeatureList::IsEnabled(tabs::features::kBraveVerticalTabs)) {
-    return ui::SimpleMenuModel::Delegate::IsCommandIdVisible(command_id);
-  }
-
   if (command_id == BraveTabMenuModel::CommandShowVerticalTabs) {
     return tabs::utils::SupportsVerticalTabs(browser_);
   }

--- a/browser/ui/views/tabs/brave_tab_group_header.cc
+++ b/browser/ui/views/tabs/brave_tab_group_header.cc
@@ -24,9 +24,6 @@ namespace {
 SkColor GetGroupBackgroundColorForVerticalTabs(
     const tab_groups::TabGroupId& group_id,
     TabSlotController* controller) {
-  DCHECK(base::FeatureList::IsEnabled(tabs::features::kBraveVerticalTabs))
-      << "This should be called only when the flag is on.";
-
   if (!controller->GetBrowser()
            ->tab_strip_model()
            ->group_model()
@@ -92,18 +89,11 @@ void BraveTabGroupHeader::Layout() {
 }
 
 bool BraveTabGroupHeader::ShouldShowVerticalTabs() const {
-  if (!base::FeatureList::IsEnabled(tabs::features::kBraveVerticalTabs)) {
-    return false;
-  }
-
   return tabs::utils::ShouldShowVerticalTabs(
       tab_slot_controller_->GetBrowser());
 }
 
 void BraveTabGroupHeader::LayoutTitleChip() {
-  DCHECK(base::FeatureList::IsEnabled(tabs::features::kBraveVerticalTabs))
-      << "This should be called only when the flag is on.";
-
   auto title_bounds = GetContentsBounds();
   title_bounds.Inset(gfx::Insets(kPaddingForGroup * 2));
   title_chip_->SetBoundsRect(title_bounds);

--- a/browser/ui/views/tabs/brave_tab_group_header.cc
+++ b/browser/ui/views/tabs/brave_tab_group_header.cc
@@ -5,7 +5,6 @@
 
 #include "brave/browser/ui/views/tabs/brave_tab_group_header.h"
 
-#include "brave/browser/ui/tabs/features.h"
 #include "brave/browser/ui/views/tabs/vertical_tab_utils.h"
 #include "chrome/browser/ui/browser.h"
 #include "chrome/browser/ui/tabs/tab_group_model.h"

--- a/browser/ui/views/tabs/brave_tab_group_highlight.cc
+++ b/browser/ui/views/tabs/brave_tab_group_highlight.cc
@@ -13,9 +13,6 @@
 BraveTabGroupHighlight::~BraveTabGroupHighlight() = default;
 
 SkPath BraveTabGroupHighlight::GetPath() const {
-  if (!base::FeatureList::IsEnabled(tabs::features::kBraveVerticalTabs))
-    return TabGroupHighlight::GetPath();
-
   if (!tabs::utils::ShouldShowVerticalTabs(tab_group_views_->GetBrowser())) {
     return TabGroupHighlight::GetPath();
   }

--- a/browser/ui/views/tabs/brave_tab_group_highlight.cc
+++ b/browser/ui/views/tabs/brave_tab_group_highlight.cc
@@ -5,7 +5,6 @@
 
 #include "brave/browser/ui/views/tabs/brave_tab_group_highlight.h"
 
-#include "brave/browser/ui/tabs/features.h"
 #include "brave/browser/ui/views/tabs/brave_tab_group_header.h"
 #include "brave/browser/ui/views/tabs/vertical_tab_utils.h"
 #include "chrome/browser/ui/views/tabs/tab_group_views.h"

--- a/browser/ui/views/tabs/brave_tab_group_underline.cc
+++ b/browser/ui/views/tabs/brave_tab_group_underline.cc
@@ -81,8 +81,5 @@ gfx::Rect BraveTabGroupUnderline::CalculateTabGroupUnderlineBounds(
 }
 
 bool BraveTabGroupUnderline::ShouldShowVerticalTabs() const {
-  if (!base::FeatureList::IsEnabled(tabs::features::kBraveVerticalTabs))
-    return false;
-
   return tabs::utils::ShouldShowVerticalTabs(tab_group_views_->GetBrowser());
 }

--- a/browser/ui/views/tabs/brave_tab_group_underline.cc
+++ b/browser/ui/views/tabs/brave_tab_group_underline.cc
@@ -7,7 +7,6 @@
 
 #include <algorithm>
 
-#include "brave/browser/ui/tabs/features.h"
 #include "brave/browser/ui/views/tabs/brave_tab_group_header.h"
 #include "brave/browser/ui/views/tabs/vertical_tab_utils.h"
 #include "cc/paint/paint_flags.h"

--- a/browser/ui/views/tabs/brave_tab_strip.cc
+++ b/browser/ui/views/tabs/brave_tab_strip.cc
@@ -162,9 +162,6 @@ void BraveTabStrip::MaybeStartDrag(
 
 void BraveTabStrip::AddedToWidget() {
   TabStrip::AddedToWidget();
-  if (!base::FeatureList::IsEnabled(tabs::features::kBraveVerticalTabs)) {
-    return;
-  }
 
   if (BrowserView::GetBrowserViewForBrowser(GetBrowser())) {
     UpdateTabContainer();
@@ -226,9 +223,6 @@ absl::optional<int> BraveTabStrip::GetCustomBackgroundId(
 }
 
 void BraveTabStrip::UpdateTabContainer() {
-  DCHECK(base::FeatureList::IsEnabled(tabs::features::kBraveVerticalTabs))
-      << "This should be called only when the flag is on.";
-
   const bool using_vertical_tabs = ShouldShowVerticalTabs();
   const bool should_use_compound_tab_container =
       using_vertical_tabs ||
@@ -397,10 +391,6 @@ void BraveTabStrip::UpdateTabContainer() {
 }
 
 bool BraveTabStrip::ShouldShowVerticalTabs() const {
-  if (!base::FeatureList::IsEnabled(tabs::features::kBraveVerticalTabs)) {
-    return false;
-  }
-
   return tabs::utils::ShouldShowVerticalTabs(GetBrowser());
 }
 

--- a/browser/ui/views/tabs/brave_tab_strip.cc
+++ b/browser/ui/views/tabs/brave_tab_strip.cc
@@ -253,12 +253,12 @@ void BraveTabStrip::UpdateTabContainer() {
       layout_lock =
           base::ScopedClosureRunner(brave_tab_container->LockLayout());
 
-        brave_tab_container->SetScrollEnabled(using_vertical_tabs);
+      brave_tab_container->SetScrollEnabled(using_vertical_tabs);
 
-        // Make dragged views on top of container's layer.
-        drag_context->SetPaintToLayer();
-        drag_context->layer()->SetFillsBoundsOpaquely(false);
-        drag_context->parent()->ReorderChildView(drag_context, -1);
+      // Make dragged views on top of container's layer.
+      drag_context->SetPaintToLayer();
+      drag_context->layer()->SetFillsBoundsOpaquely(false);
+      drag_context->parent()->ReorderChildView(drag_context, -1);
     } else {
       // Container should be attached before TabDragContext so that dragged
       // views can be atop container.
@@ -271,7 +271,7 @@ void BraveTabStrip::UpdateTabContainer() {
       layout_lock =
           base::ScopedClosureRunner(brave_tab_container->LockLayout());
 
-        GetDragContext()->DestroyLayer();
+      GetDragContext()->DestroyLayer();
     }
 
     // Resets TabSlotViews for the new TabContainer.

--- a/browser/ui/views/tabs/brave_tab_strip.cc
+++ b/browser/ui/views/tabs/brave_tab_strip.cc
@@ -230,8 +230,6 @@ void BraveTabStrip::UpdateTabContainer() {
   const bool is_using_compound_tab_container =
       tab_container_->GetClassName() ==
       BraveCompoundTabContainer::kViewClassName;
-  const bool using_sticky_pinned_tabs = base::FeatureList::IsEnabled(
-      tabs::features::kBraveVerticalTabsStickyPinnedTabs);
 
   base::ScopedClosureRunner layout_lock;
   if (should_use_compound_tab_container != is_using_compound_tab_container) {
@@ -255,14 +253,12 @@ void BraveTabStrip::UpdateTabContainer() {
       layout_lock =
           base::ScopedClosureRunner(brave_tab_container->LockLayout());
 
-      if (using_sticky_pinned_tabs) {
         brave_tab_container->SetScrollEnabled(using_vertical_tabs);
 
         // Make dragged views on top of container's layer.
         drag_context->SetPaintToLayer();
         drag_context->layer()->SetFillsBoundsOpaquely(false);
         drag_context->parent()->ReorderChildView(drag_context, -1);
-      }
     } else {
       // Container should be attached before TabDragContext so that dragged
       // views can be atop container.
@@ -275,9 +271,7 @@ void BraveTabStrip::UpdateTabContainer() {
       layout_lock =
           base::ScopedClosureRunner(brave_tab_container->LockLayout());
 
-      if (using_sticky_pinned_tabs) {
         GetDragContext()->DestroyLayer();
-      }
     }
 
     // Resets TabSlotViews for the new TabContainer.
@@ -351,15 +345,6 @@ void BraveTabStrip::UpdateTabContainer() {
       SetAvailableWidthCallback(base::BindRepeating(
           &VerticalTabStripRegionView::GetAvailableWidthForTabContainer,
           base::Unretained(vertical_region_view)));
-    }
-
-    if (!using_sticky_pinned_tabs) {
-      tab_container_->SetLayoutManager(std::make_unique<views::FlexLayout>())
-          ->SetOrientation(views::LayoutOrientation::kVertical)
-          .SetDefault(views::kFlexBehaviorKey,
-                      views::FlexSpecification(
-                          views::MinimumFlexSizeRule::kScaleToMinimumSnapToZero,
-                          views::MaximumFlexSizeRule::kPreferred));
     }
   } else {
     if (base::FeatureList::IsEnabled(features::kScrollableTabStrip)) {

--- a/browser/ui/views/tabs/brave_tab_style_views.inc.cc
+++ b/browser/ui/views/tabs/brave_tab_style_views.inc.cc
@@ -75,8 +75,6 @@ class BraveVerticalTabStyle : public BraveGM2TabStyle {
 };
 
 BraveVerticalTabStyle::BraveVerticalTabStyle(Tab* tab) : BraveGM2TabStyle(tab) {
-  CHECK(base::FeatureList::IsEnabled(tabs::features::kBraveVerticalTabs))
-      << "This class should be used only when the flag is on.";
 }
 
 SkPath BraveVerticalTabStyle::GetPath(
@@ -210,9 +208,5 @@ bool BraveVerticalTabStyle::ShouldShowVerticalTabs() const {
 }  // namespace
 
 std::unique_ptr<TabStyleViews> TabStyleViews::CreateForTab(Tab* tab) {
-  if (base::FeatureList::IsEnabled(tabs::features::kBraveVerticalTabs)) {
     return std::make_unique<BraveVerticalTabStyle>(tab);
-  }
-
-  return std::make_unique<BraveGM2TabStyle>(tab);
 }

--- a/browser/ui/views/tabs/brave_tab_style_views.inc.cc
+++ b/browser/ui/views/tabs/brave_tab_style_views.inc.cc
@@ -208,5 +208,5 @@ bool BraveVerticalTabStyle::ShouldShowVerticalTabs() const {
 }  // namespace
 
 std::unique_ptr<TabStyleViews> TabStyleViews::CreateForTab(Tab* tab) {
-    return std::make_unique<BraveVerticalTabStyle>(tab);
+  return std::make_unique<BraveVerticalTabStyle>(tab);
 }

--- a/browser/ui/views/tabs/tab_drag_controller.cc
+++ b/browser/ui/views/tabs/tab_drag_controller.cc
@@ -66,10 +66,6 @@ void TabDragController::Init(TabDragContext* source_context,
     }
   }
 
-  if (!base::FeatureList::IsEnabled(tabs::features::kBraveVerticalTabs)) {
-    return;
-  }
-
   auto* widget = source_view->GetWidget();
   DCHECK(widget);
   const auto* browser =

--- a/browser/ui/views/tabs/vertical_tab_strip_browsertest.cc
+++ b/browser/ui/views/tabs/vertical_tab_strip_browsertest.cc
@@ -114,9 +114,7 @@ void FullscreenNotificationObserver::Wait() {
 
 class VerticalTabStripBrowserTest : public InProcessBrowserTest {
  public:
-  VerticalTabStripBrowserTest()
-      : feature_list_(tabs::features::kBraveVerticalTabs) {}
-
+  VerticalTabStripBrowserTest() = default;
   ~VerticalTabStripBrowserTest() override = default;
 
   const BraveBrowserView* browser_view() const {

--- a/browser/ui/views/tabs/vertical_tab_strip_browsertest.cc
+++ b/browser/ui/views/tabs/vertical_tab_strip_browsertest.cc
@@ -202,8 +202,6 @@ class VerticalTabStripBrowserTest : public InProcessBrowserTest {
   }
 
  private:
-  base::test::ScopedFeatureList feature_list_;
-
   std::unique_ptr<base::RunLoop> run_loop_;
 };
 

--- a/browser/ui/views/tabs/vertical_tab_strip_browsertest.cc
+++ b/browser/ui/views/tabs/vertical_tab_strip_browsertest.cc
@@ -8,7 +8,6 @@
 #include "brave/browser/ui/browser_commands.h"
 #include "brave/browser/ui/tabs/brave_tab_menu_model.h"
 #include "brave/browser/ui/tabs/brave_tab_prefs.h"
-#include "brave/browser/ui/tabs/features.h"
 #include "brave/browser/ui/views/frame/brave_browser_view.h"
 #include "brave/browser/ui/views/frame/vertical_tab_strip_region_view.h"
 #include "brave/browser/ui/views/frame/vertical_tab_strip_widget_delegate_view.h"

--- a/browser/ui/views/tabs/vertical_tab_utils.cc
+++ b/browser/ui/views/tabs/vertical_tab_utils.cc
@@ -35,9 +35,6 @@
 namespace tabs::utils {
 
 bool SupportsVerticalTabs(const Browser* browser) {
-  DCHECK(base::FeatureList::IsEnabled(tabs::features::kBraveVerticalTabs))
-      << "Don't call this before checking the feature flag.";
-
   if (!browser) {
     // During unit tests, |browser| can be null.
     CHECK_IS_TEST();

--- a/browser/ui/views/tabs/vertical_tab_utils.cc
+++ b/browser/ui/views/tabs/vertical_tab_utils.cc
@@ -7,7 +7,6 @@
 
 #include "base/check_is_test.h"
 #include "brave/browser/ui/tabs/brave_tab_prefs.h"
-#include "brave/browser/ui/tabs/features.h"
 #include "chrome/browser/profiles/profile.h"
 #include "chrome/browser/ui/browser.h"
 #include "components/prefs/pref_service.h"

--- a/browser/ui/views/toolbar/brave_toolbar_view.cc
+++ b/browser/ui/views/toolbar/brave_toolbar_view.cc
@@ -159,8 +159,7 @@ void BraveToolbarView::Init() {
       base::BindRepeating(&BraveToolbarView::OnLocationBarIsWideChanged,
                           base::Unretained(this)));
 
-  if (base::FeatureList::IsEnabled(tabs::features::kBraveVerticalTabs) &&
-      tabs::utils::SupportsVerticalTabs(browser_)) {
+  if (tabs::utils::SupportsVerticalTabs(browser_)) {
     show_vertical_tabs_.Init(
         brave_tabs::kVerticalTabsEnabled,
         profile->GetOriginalProfile()->GetPrefs(),
@@ -316,8 +315,6 @@ void BraveToolbarView::UpdateBookmarkVisibility() {
 }
 
 void BraveToolbarView::UpdateHorizontalPadding() {
-  DCHECK(base::FeatureList::IsEnabled(tabs::features::kBraveVerticalTabs));
-
   if (!brave_initialized_) {
     return;
   }

--- a/browser/ui/views/toolbar/brave_toolbar_view.cc
+++ b/browser/ui/views/toolbar/brave_toolbar_view.cc
@@ -13,7 +13,6 @@
 #include "brave/app/brave_command_ids.h"
 #include "brave/browser/brave_wallet/brave_wallet_context_utils.h"
 #include "brave/browser/ui/tabs/brave_tab_prefs.h"
-#include "brave/browser/ui/tabs/features.h"
 #include "brave/browser/ui/views/tabs/vertical_tab_utils.h"
 #include "brave/browser/ui/views/toolbar/bookmark_button.h"
 #include "brave/browser/ui/views/toolbar/wallet_button.h"

--- a/browser/ui/webui/brave_settings_ui.cc
+++ b/browser/ui/webui/brave_settings_ui.cc
@@ -18,7 +18,6 @@
 #include "brave/browser/resources/settings/shortcuts_page/grit/commands_generated_map.h"
 #include "brave/browser/shell_integrations/buildflags/buildflags.h"
 #include "brave/browser/ui/commands/accelerator_service_factory.h"
-#include "brave/browser/ui/tabs/features.h"
 #include "brave/browser/ui/webui/navigation_bar_data_provider.h"
 #include "brave/browser/ui/webui/settings/brave_adblock_handler.h"
 #include "brave/browser/ui/webui/settings/brave_appearance_handler.h"

--- a/browser/ui/webui/brave_settings_ui.cc
+++ b/browser/ui/webui/brave_settings_ui.cc
@@ -189,11 +189,6 @@ void BraveSettingsUI::AddResources(content::WebUIDataSource* html_source,
 
   html_source->AddBoolean("extensionsManifestV2Feature",
                           base::FeatureList::IsEnabled(kExtensionsManifestV2));
-#if defined(TOOLKIT_VIEWS)
-  html_source->AddBoolean(
-      "verticalTabStripFeatureEnabled",
-      base::FeatureList::IsEnabled(tabs::features::kBraveVerticalTabs));
-#endif
 
 #if BUILDFLAG(ENABLE_AI_CHAT)
   html_source->AddBoolean("isLeoAssistantAllowed",

--- a/chromium_src/chrome/browser/ui/views/frame/browser_frame_view_layout_linux.cc
+++ b/chromium_src/chrome/browser/ui/views/frame/browser_frame_view_layout_linux.cc
@@ -6,7 +6,6 @@
 #include "src/chrome/browser/ui/views/frame/browser_frame_view_layout_linux.cc"
 
 #include "base/check_is_test.h"
-#include "brave/browser/ui/tabs/features.h"
 #include "brave/browser/ui/views/tabs/vertical_tab_utils.h"
 #include "chrome/browser/ui/views/frame/browser_view.h"
 #include "chrome/browser/ui/views/toolbar/toolbar_view.h"

--- a/chromium_src/chrome/browser/ui/views/frame/browser_frame_view_layout_linux.cc
+++ b/chromium_src/chrome/browser/ui/views/frame/browser_frame_view_layout_linux.cc
@@ -18,10 +18,6 @@ void BrowserFrameViewLayoutLinux::SetBoundsForButton(
     views::Button* button,
     ButtonAlignment align) {
   OpaqueBrowserFrameViewLayout::SetBoundsForButton(button_id, button, align);
-  if (!base::FeatureList::IsEnabled(tabs::features::kBraveVerticalTabs)) {
-    return;
-  }
-
   if (!view_) {
     CHECK_IS_TEST();
     return;

--- a/chromium_src/chrome/browser/ui/views/frame/browser_root_view.cc
+++ b/chromium_src/chrome/browser/ui/views/frame/browser_root_view.cc
@@ -9,7 +9,6 @@
 
 #define ConvertPointToTarget(THIS, TARGET_GETTER, POINT)                  \
   if (views::View* target_v = TARGET_GETTER;                              \
-      base::FeatureList::IsEnabled(tabs::features::kBraveVerticalTabs) && \
       tabs::utils::ShouldShowVerticalTabs(browser_view_->browser()) &&    \
       (target_v == tabstrip() || !THIS->Contains(target_v))) {            \
     ConvertPointToScreen(target_v, POINT);                                \

--- a/chromium_src/chrome/browser/ui/views/frame/browser_root_view.cc
+++ b/chromium_src/chrome/browser/ui/views/frame/browser_root_view.cc
@@ -3,7 +3,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-#include "brave/browser/ui/tabs/features.h"
 #include "brave/browser/ui/views/tabs/vertical_tab_utils.h"
 #include "ui/views/view.h"
 

--- a/chromium_src/chrome/browser/ui/views/frame/browser_view.cc
+++ b/chromium_src/chrome/browser/ui/views/frame/browser_view.cc
@@ -7,7 +7,6 @@
 // therefore avoid undef before use.
 #include "chrome/browser/ui/views/frame/browser_view.h"
 
-#include "brave/browser/ui/tabs/features.h"
 #include "brave/browser/ui/views/frame/brave_browser_view_layout.h"
 #include "brave/browser/ui/views/infobars/brave_infobar_container_view.h"
 #include "brave/browser/ui/views/side_panel/brave_side_panel.h"

--- a/chromium_src/chrome/browser/ui/views/tabs/tab_drag_controller.cc
+++ b/chromium_src/chrome/browser/ui/views/tabs/tab_drag_controller.cc
@@ -23,14 +23,13 @@
       : source->GetWidget()->GetTopLevelWidget()->non_client_view()
 
 // Remove drag threshold when it's vertical tab strip
-#define GetHorizontalDragThreshold()                                       \
-  GetHorizontalDragThreshold() -                                           \
-      (base::FeatureList::IsEnabled(tabs::features::kBraveVerticalTabs) && \
-               tabs::utils::ShouldShowVerticalTabs(                        \
-                   BrowserView::GetBrowserViewForNativeWindow(             \
-                       GetAttachedBrowserWidget()->GetNativeWindow())      \
-                       ->browser())                                        \
-           ? attached_context_->GetHorizontalDragThreshold()               \
+#define GetHorizontalDragThreshold()                          \
+  GetHorizontalDragThreshold() -                              \
+      (tabs::utils::ShouldShowVerticalTabs(                   \
+           BrowserView::GetBrowserViewForNativeWindow(        \
+               GetAttachedBrowserWidget()->GetNativeWindow()) \
+               ->browser())                                   \
+           ? attached_context_->GetHorizontalDragThreshold()  \
            : 0)
 
 #include "src/chrome/browser/ui/views/tabs/tab_drag_controller.cc"

--- a/chromium_src/chrome/browser/ui/views/tabs/tab_drag_controller.cc
+++ b/chromium_src/chrome/browser/ui/views/tabs/tab_drag_controller.cc
@@ -5,7 +5,6 @@
 
 #include "chrome/browser/ui/views/tabs/tab_drag_controller.h"
 
-#include "brave/browser/ui/tabs/features.h"
 #include "brave/browser/ui/views/frame/brave_browser_view.h"
 #include "brave/browser/ui/views/frame/vertical_tab_strip_widget_delegate_view.h"
 #include "brave/browser/ui/views/tabs/vertical_tab_utils.h"

--- a/chromium_src/chrome/browser/ui/views/tabs/tab_group_style.cc
+++ b/chromium_src/chrome/browser/ui/views/tabs/tab_group_style.cc
@@ -50,10 +50,6 @@ SkPath TabGroupStyle::GetUnderlinePath(gfx::Rect local_bounds) const {
 }
 
 bool TabGroupStyle::ShouldShowVerticalTabs() const {
-  if (!base::FeatureList::IsEnabled(tabs::features::kBraveVerticalTabs)) {
-    return false;
-  }
-
   return tabs::utils::ShouldShowVerticalTabs(tab_group_views_->GetBrowser());
 }
 

--- a/chromium_src/chrome/browser/ui/views/tabs/tab_group_style.cc
+++ b/chromium_src/chrome/browser/ui/views/tabs/tab_group_style.cc
@@ -5,7 +5,6 @@
 
 #include "chrome/browser/ui/views/tabs/tab_group_style.h"
 
-#include "brave/browser/ui/tabs/features.h"
 #include "brave/browser/ui/views/tabs/vertical_tab_utils.h"
 
 #define TabGroupStyle TabGroupStyle_ChromiumImpl

--- a/chromium_src/chrome/browser/ui/views/tabs/tab_group_views.cc
+++ b/chromium_src/chrome/browser/ui/views/tabs/tab_group_views.cc
@@ -3,7 +3,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-#include "brave/browser/ui/tabs/features.h"
 #include "brave/browser/ui/views/tabs/brave_tab_group_header.h"
 #include "brave/browser/ui/views/tabs/brave_tab_group_highlight.h"
 #include "brave/browser/ui/views/tabs/brave_tab_group_underline.h"

--- a/chromium_src/chrome/browser/ui/views/tabs/tab_group_views.cc
+++ b/chromium_src/chrome/browser/ui/views/tabs/tab_group_views.cc
@@ -17,8 +17,7 @@
 
 // TabGroupViews destructor is not virtual, so we can't override the method.
 #define BRAVE_TAB_GROUP_VIEWS_GET_LEADING_TRAILING_GROUP_VIEWS                 \
-  if (base::FeatureList::IsEnabled(tabs::features::kBraveVerticalTabs) &&      \
-      tabs::utils::ShouldShowVerticalTabs(                                     \
+  if (tabs::utils::ShouldShowVerticalTabs(                                     \
           tab_slot_controller_->GetBrowser())) {                               \
     std::vector<views::View*> children_in_same_group;                          \
     base::ranges::copy_if(                                                     \

--- a/chromium_src/chrome/browser/ui/views/tabs/tab_strip.cc
+++ b/chromium_src/chrome/browser/ui/views/tabs/tab_strip.cc
@@ -35,8 +35,7 @@
 // seems to be the most efficient way for now. If we could split this into
 // another file or child class, that'd be great.
 #define BRAVE_TAB_DRAG_CONTEXT_IMPL_CALCULATE_INSERTION_INDEX                \
-  if (base::FeatureList::IsEnabled(tabs::features::kBraveVerticalTabs) &&    \
-      tabs::utils::ShouldShowVerticalTabs(tab_strip_->GetBrowser())) {       \
+  if (tabs::utils::ShouldShowVerticalTabs(tab_strip_->GetBrowser())) {       \
     tabs::UpdateInsertionIndexForVerticalTabs(                               \
         dragged_bounds, first_dragged_tab_index, num_dragged_tabs,           \
         dragged_group, candidate_index, tab_strip_->controller_.get(),       \
@@ -46,14 +45,12 @@
   }
 
 #define BRAVE_TAB_DRAG_CONTEXT_IMPL_CALCULATE_BOUNDS_FOR_DRAGGED_VIEWS      \
-  if (base::FeatureList::IsEnabled(tabs::features::kBraveVerticalTabs) &&   \
-      tabs::utils::ShouldShowVerticalTabs(tab_strip_->GetBrowser())) {      \
+  if (tabs::utils::ShouldShowVerticalTabs(tab_strip_->GetBrowser())) {      \
     return tabs::CalculateBoundsForVerticalDraggedViews(views, tab_strip_); \
   }
 
 #define BRAVE_TAB_DRAG_CONTEXT_IMPL_PAINT_CHILDREN                        \
-  if (base::FeatureList::IsEnabled(tabs::features::kBraveVerticalTabs) && \
-      tabs::utils::ShouldShowVerticalTabs(tab_strip_->GetBrowser())) {    \
+  if (tabs::utils::ShouldShowVerticalTabs(tab_strip_->GetBrowser())) {    \
     for (const ZOrderableTabContainerElement& child : orderable_children) \
       if (!child.view()->layer()) {                                       \
         child.view()->Paint(paint_info);                                  \

--- a/chromium_src/chrome/browser/ui/views/tabs/tab_strip.cc
+++ b/chromium_src/chrome/browser/ui/views/tabs/tab_strip.cc
@@ -7,7 +7,6 @@
 
 #include <cmath>
 
-#include "brave/browser/ui/tabs/features.h"
 #include "brave/browser/ui/views/tabs/brave_compound_tab_container.h"
 #include "brave/browser/ui/views/tabs/brave_tab.h"
 #include "brave/browser/ui/views/tabs/brave_tab_group_header.h"

--- a/chromium_src/chrome/browser/ui/views/tabs/tab_style_views.cc
+++ b/chromium_src/chrome/browser/ui/views/tabs/tab_style_views.cc
@@ -5,7 +5,6 @@
 
 #include "chrome/browser/ui/views/tabs/tab_style_views.h"
 #include "brave/browser/ui/color/brave_color_id.h"
-#include "brave/browser/ui/tabs/features.h"
 #include "brave/browser/ui/views/tabs/brave_tab_group_header.h"
 #include "brave/browser/ui/views/tabs/vertical_tab_utils.h"
 #include "chrome/browser/ui/views/tabs/tab_slot_controller.h"


### PR DESCRIPTION
We've enabled `Vertical tabs` and `sticky pinned tabs` by default and been through a few versions without big problems. Now we can remove the flags. There's no intended behavior changes in this PR, so everything should work as is.

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/30662

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-arm64, CI/skip-linux-x64, CI/skip-android, CI/skip-macos, CI/skip-ios, CI/skip-windows-arm64, CI/skip-windows-x64, CI/skip-windows-x86 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [ ] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

