### PR TITLE
Share code to generate Brave VPN Wireguard keys between Windows and OSX

### DIFF
--- a/components/brave_vpn/browser/connection/wireguard/brave_vpn_wireguard_connection_api_base.cc
+++ b/components/brave_vpn/browser/connection/wireguard/brave_vpn_wireguard_connection_api_base.cc
@@ -8,6 +8,7 @@
 #include "brave/components/brave_vpn/common/brave_vpn_utils.h"
 #include "brave/components/brave_vpn/common/mojom/brave_vpn.mojom.h"
 #include "brave/components/brave_vpn/common/pref_names.h"
+#include "brave/components/brave_vpn/common/wireguard/wireguard_utils.h"
 #include "components/prefs/pref_service.h"
 
 namespace brave_vpn {
@@ -31,7 +32,7 @@ void BraveVPNWireguardConnectionAPIBase::SetSelectedRegion(
   ResetConnectionInfo();
 }
 
-void BraveVPNWireguardConnectionAPIBase::OnWireguardKeypairGenerated(
+void BraveVPNWireguardConnectionAPIBase::RequestNewProfileCredentials(
     brave_vpn::wireguard::WireguardKeyPair key_pair) {
   if (!key_pair.has_value()) {
     VLOG(1) << __func__ << " : failed to get keypair";
@@ -104,7 +105,7 @@ void BraveVPNWireguardConnectionAPIBase::FetchProfileCredentials() {
           local_prefs()->GetString(
               prefs::kBraveVPNWireguardProfileCredentials));
   if (!existing_credentials.has_value()) {
-    RequestNewProfileCredentials();
+    RequestNewProfileCredentials(wireguard::GenerateNewX25519Keypair());
     return;
   }
   GetAPIRequest()->VerifyCredentials(
@@ -132,7 +133,7 @@ void BraveVPNWireguardConnectionAPIBase::OnVerifyCredentials(
   if (!success || !existing_credentials.has_value()) {
     VLOG(1) << __func__ << " : credentials verification failed ( " << result
             << " ), request new";
-    RequestNewProfileCredentials();
+    RequestNewProfileCredentials(wireguard::GenerateNewX25519Keypair());
     return;
   }
   PlatformConnectImpl(existing_credentials.value());

--- a/components/brave_vpn/browser/connection/wireguard/brave_vpn_wireguard_connection_api_base.h
+++ b/components/brave_vpn/browser/connection/wireguard/brave_vpn_wireguard_connection_api_base.h
@@ -36,7 +36,6 @@ class BraveVPNWireguardConnectionAPIBase
   void Connect() override;
 
   // Platform dependent APIs.
-  virtual void RequestNewProfileCredentials() = 0;
   virtual void PlatformConnectImpl(
       const wireguard::WireguardProfileCredentials& credentials) = 0;
 
@@ -45,7 +44,7 @@ class BraveVPNWireguardConnectionAPIBase
 
  protected:
   void OnDisconnected(bool success);
-  void OnWireguardKeypairGenerated(
+  void RequestNewProfileCredentials(
       brave_vpn::wireguard::WireguardKeyPair key_pair);
   void OnGetProfileCredentials(const std::string& client_private_key,
                                const std::string& profile_credential,

--- a/components/brave_vpn/browser/connection/wireguard/brave_vpn_wireguard_connection_api_unittest.cc
+++ b/components/brave_vpn/browser/connection/wireguard/brave_vpn_wireguard_connection_api_unittest.cc
@@ -35,7 +35,6 @@ class BraveVPNWireguardConnectionAPISim
 
   void Disconnect() override {}
   void CheckConnection() override {}
-  void RequestNewProfileCredentials() override {}
   void PlatformConnectImpl(
       const wireguard::WireguardProfileCredentials& credentials) override {}
 };

--- a/components/brave_vpn/browser/connection/wireguard/mac/brave_vpn_wireguard_connection_api_mac.h
+++ b/components/brave_vpn/browser/connection/wireguard/mac/brave_vpn_wireguard_connection_api_mac.h
@@ -30,7 +30,6 @@ class WireguardOSConnectionAPIMac : public BraveVPNWireguardConnectionAPIBase {
   void CheckConnection() override;
 
   // BraveVPNWireguardConnectionAPIBase overrides:
-  void RequestNewProfileCredentials() override;
   void PlatformConnectImpl(
       const wireguard::WireguardProfileCredentials& credentials) override;
 };

--- a/components/brave_vpn/browser/connection/wireguard/mac/brave_vpn_wireguard_connection_api_mac.mm
+++ b/components/brave_vpn/browser/connection/wireguard/mac/brave_vpn_wireguard_connection_api_mac.mm
@@ -29,10 +29,6 @@ WireguardOSConnectionAPIMac::WireguardOSConnectionAPIMac(
 
 WireguardOSConnectionAPIMac::~WireguardOSConnectionAPIMac() = default;
 
-void WireguardOSConnectionAPIMac::RequestNewProfileCredentials() {
-  NOTIMPLEMENTED();
-}
-
 void WireguardOSConnectionAPIMac::PlatformConnectImpl(
     const wireguard::WireguardProfileCredentials& credentials) {
   if (credentials.IsValid()) {

--- a/components/brave_vpn/browser/connection/wireguard/win/brave_vpn_wireguard_connection_api.cc
+++ b/components/brave_vpn/browser/connection/wireguard/win/brave_vpn_wireguard_connection_api.cc
@@ -58,12 +58,6 @@ void BraveVPNWireguardConnectionAPI::CheckConnection() {
   UpdateAndNotifyConnectionStateChange(state);
 }
 
-void BraveVPNWireguardConnectionAPI::RequestNewProfileCredentials() {
-  brave_vpn::wireguard::WireguardGenerateKeypair(base::BindOnce(
-      &BraveVPNWireguardConnectionAPI::OnWireguardKeypairGenerated,
-      weak_factory_.GetWeakPtr()));
-}
-
 void BraveVPNWireguardConnectionAPI::PlatformConnectImpl(
     const wireguard::WireguardProfileCredentials& credentials) {
   auto vpn_server_hostname = GetHostname();

--- a/components/brave_vpn/browser/connection/wireguard/win/brave_vpn_wireguard_connection_api.h
+++ b/components/brave_vpn/browser/connection/wireguard/win/brave_vpn_wireguard_connection_api.h
@@ -41,7 +41,6 @@ class BraveVPNWireguardConnectionAPI
 
  protected:
   // BraveVPNWireguardConnectionAPIBase
-  void RequestNewProfileCredentials() override;
   void PlatformConnectImpl(
       const wireguard::WireguardProfileCredentials& credentials) override;
 

--- a/components/brave_vpn/common/wireguard/BUILD.gn
+++ b/components/brave_vpn/common/wireguard/BUILD.gn
@@ -14,6 +14,8 @@ source_set("wireguard") {
   ]
   deps = [
     "//base",
+    "//crypto",
     "//third_party/abseil-cpp:absl",
+    "//third_party/boringssl",
   ]
 }

--- a/components/brave_vpn/common/wireguard/DEPS
+++ b/components/brave_vpn/common/wireguard/DEPS
@@ -1,0 +1,4 @@
+include_rules = [
+  "+crypto",
+  "+third_party/boringssl",
+]

--- a/components/brave_vpn/common/wireguard/wireguard_utils.cc
+++ b/components/brave_vpn/common/wireguard/wireguard_utils.cc
@@ -5,9 +5,13 @@
 
 #include "brave/components/brave_vpn/common/wireguard/wireguard_utils.h"
 
+#include <stdint.h>
+#include <vector>
+
 #include "base/base64.h"
 #include "base/strings/string_util.h"
 #include "crypto/openssl_util.h"
+#include "third_party/boringssl/src/include/openssl/base64.h"
 #include "third_party/boringssl/src/include/openssl/curve25519.h"
 
 namespace brave_vpn {
@@ -15,6 +19,20 @@ namespace brave_vpn {
 namespace wireguard {
 
 namespace {
+std::string EncodeBase64(const std::vector<uint8_t>& in) {
+  std::string res;
+  size_t size = 0;
+  if (!EVP_EncodedLength(&size, in.size())) {
+    DCHECK(false);
+    return "";
+  }
+  std::vector<uint8_t> out(size);
+  size_t numEncBytes = EVP_EncodeBlock(&out.front(), &in.front(), in.size());
+  DCHECK_NE(numEncBytes, 0u);
+  res = reinterpret_cast<char*>(&out.front());
+  return res;
+}
+
 constexpr char kCloudflareIPv4[] = "1.1.1.1";
 // Template for wireguard config generation.
 constexpr char kWireguardConfigTemplate[] = R"(
@@ -53,12 +71,13 @@ absl::optional<std::string> CreateWireguardConfig(
   return config;
 }
 
-wireguard::WireguardKeyPair GenerateNewX25519Keypair() {
+WireguardKeyPair GenerateNewX25519Keypair() {
   crypto::EnsureOpenSSLInit();
   uint8_t pubkey[32] = {}, privkey[32] = {};
   X25519_keypair(pubkey, privkey);
-  return std::make_tuple(base::Base64Encode(pubkey),
-                         base::Base64Encode(privkey));
+  return std::make_tuple(
+      EncodeBase64(std::vector<uint8_t>(pubkey, pubkey + 32)),
+      EncodeBase64(std::vector<uint8_t>(privkey, privkey + 32)));
 }
 
 }  // namespace wireguard

--- a/components/brave_vpn/common/wireguard/wireguard_utils.cc
+++ b/components/brave_vpn/common/wireguard/wireguard_utils.cc
@@ -5,7 +5,10 @@
 
 #include "brave/components/brave_vpn/common/wireguard/wireguard_utils.h"
 
+#include "base/base64.h"
 #include "base/strings/string_util.h"
+#include "crypto/openssl_util.h"
+#include "third_party/boringssl/src/include/openssl/curve25519.h"
 
 namespace brave_vpn {
 
@@ -48,6 +51,14 @@ absl::optional<std::string> CreateWireguardConfig(
   base::ReplaceSubstringsAfterOffset(&config, 0, "{dns_servers}",
                                      kCloudflareIPv4);
   return config;
+}
+
+wireguard::WireguardKeyPair GenerateNewX25519Keypair() {
+  crypto::EnsureOpenSSLInit();
+  uint8_t pubkey[32] = {}, privkey[32] = {};
+  X25519_keypair(pubkey, privkey);
+  return std::make_tuple(base::Base64Encode(pubkey),
+                         base::Base64Encode(privkey));
 }
 
 }  // namespace wireguard

--- a/components/brave_vpn/common/wireguard/wireguard_utils.h
+++ b/components/brave_vpn/common/wireguard/wireguard_utils.h
@@ -27,6 +27,8 @@ absl::optional<std::string> CreateWireguardConfig(
     const std::string& vpn_server_hostname,
     const std::string& mapped_ipv4_address);
 
+WireguardKeyPair GenerateNewX25519Keypair();
+
 }  // namespace wireguard
 
 }  // namespace brave_vpn


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/32937
Security review https://github.com/brave/reviews/issues/1399

Previously we used `WireGuardGenerateKeypair` from [tunnel.dll](https://github.com/WireGuard/wireguard-windows/blob/dcc0eb72a04ba2c0c83d29bd621a7f66acce0a23/embeddable-dll-service/main.go#L35).  Changed to `X25519_keypair` from [curve25519](https://source.chromium.org/chromium/chromium/src/+/main:third_party/boringssl/src/crypto/curve25519/curve25519.c;l=2092?q=X25519_keypair&sq=&ss=chromium). This allow us to reuse same code in OSX implementation where used [same code](https://github.com/WireGuard/wireguard-apple/blob/2fec12a6e1f6e3460b6ee483aa00ad29cddadab1/Sources/WireGuardKitC/x25519.c#L173)

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-arm64, CI/skip-linux-x64, CI/skip-android, CI/skip-macos, CI/skip-ios, CI/skip-windows-arm64, CI/skip-windows-x64, CI/skip-windows-x86 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

- Check Brave VPN Wireguard can be successfully connected