### PR TITLE
Disable network::features::kFledgePST feature. (uplift to 1.59.x)

### DIFF
--- a/app/brave_main_delegate_browsertest.cc
+++ b/app/brave_main_delegate_browsertest.cc
@@ -243,6 +243,7 @@ IN_PROC_BROWSER_TEST_F(BraveMainDelegateBrowserTest, DisabledFeatures) {
     &net::features::kEnableWebTransportDraft07,
     &net::features::kNoncedPartitionedCookies,
     &net::features::kPartitionedCookies,
+    &network::features::kFledgePst,
     &network::features::kPrivateStateTokens,
     &network_time::kNetworkTimeServiceQuerying,
     &ntp_features::kNtpAlphaBackgroundCollections,

--- a/chromium_src/services/network/public/cpp/features.cc
+++ b/chromium_src/services/network/public/cpp/features.cc
@@ -11,6 +11,7 @@ namespace network {
 namespace features {
 
 OVERRIDE_FEATURE_DEFAULT_STATES({{
+    {kFledgePst, base::FEATURE_DISABLED_BY_DEFAULT},
     {kPrivateStateTokens, base::FEATURE_DISABLED_BY_DEFAULT},
 }});
 


### PR DESCRIPTION
Uplift of #20143
Resolves https://github.com/brave/brave-browser/issues/32962

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.