### PR TITLE
ipfs:// and ipns:// are not preserved in address bar when clicking on a relative link

### DIFF
--- a/browser/ipfs/content_browser_client_helper.cc
+++ b/browser/ipfs/content_browser_client_helper.cc
@@ -120,9 +120,11 @@ bool HandleIPFSURLReverseRewrite(GURL* url,
   if (ipfs_pos == std::string::npos && ipns_pos == std::string::npos)
     return false;
 
-  auto cid_end = (ipfs_pos == std::string::npos) ? ipns_pos : ipfs_pos;
-  if (!ipfs::IsValidCIDOrDomain(url->host().substr(0, cid_end)))
+  if (auto cid_end = (ipfs_pos == std::string::npos) ? ipns_pos : ipfs_pos;
+      !ipfs::IsValidCIDOrDomain(
+          ipfs::DecodeSingleLabelForm((url->host().substr(0, cid_end))))) {
     return false;
+  }
 
   GURL configured_gateway = GetConfiguredBaseGateway(
       user_prefs::UserPrefs::Get(browser_context), chrome::GetChannel());

--- a/browser/ipfs/content_browser_client_helper_unittest.cc
+++ b/browser/ipfs/content_browser_client_helper_unittest.cc
@@ -257,6 +257,12 @@ TEST_F(ContentBrowserClientHelperUnitTest, HandleIPFSURLReverseRewriteLocal) {
   ASSERT_TRUE(HandleIPFSURLReverseRewrite(&ipns_uri, browser_context()));
   ASSERT_EQ(ipns_uri.spec(), "ipns://test.com/#ref");
 
+  source = "http://en-wikipedia--on--ipfs-org.ipns.localhost/wiki/Architecture";
+  ipns_uri = GURL(source).ReplaceComponents(replacements);
+  ASSERT_TRUE(HandleIPFSURLReverseRewrite(&ipns_uri, browser_context()));
+  ASSERT_EQ(ipns_uri.spec(),
+            "ipns://en-wikipedia--on--ipfs-org/wiki/Architecture");
+
   source = "http://test.com.ipns.localhost:8000/";
   ipns_uri = GURL(source);
   ASSERT_FALSE(HandleIPFSURLReverseRewrite(&ipns_uri, browser_context()));
@@ -314,6 +320,11 @@ TEST_F(ContentBrowserClientHelperUnitTest, HandleIPFSURLReverseRewriteGateway) {
   ASSERT_EQ(ipns_uri.spec(), "ipns://test.com/#some-ref");
 
   source = "https://wrongcidandbaddomain.ipns.localhost:8080/";
+  ipns_uri = GURL(source);
+  ASSERT_FALSE(HandleIPFSURLReverseRewrite(&ipns_uri, browser_context()));
+  ASSERT_EQ(ipns_uri.spec(), source);
+
+  source = "http://en-wikipedia--on--ipfs-org.ipns.localhost:48080/wiki/";
   ipns_uri = GURL(source);
   ASSERT_FALSE(HandleIPFSURLReverseRewrite(&ipns_uri, browser_context()));
   ASSERT_EQ(ipns_uri.spec(), source);


### PR DESCRIPTION
Added decoding single label form before value validation to prevent failing `HandleIPFSURLReverseRewrite` method
Results on video: 
https://github.com/brave/brave-core/assets/118171981/607a1fd4-f016-499d-9ec9-f2ca60e87f61


<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/32883

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-arm64, CI/skip-linux-x64, CI/skip-android, CI/skip-macos, CI/skip-ios, CI/skip-windows-arm64, CI/skip-windows-x64, CI/skip-windows-x86 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

