### PR TITLE
Don't show hide icon/button menu from vpn app menu

### DIFF
--- a/app/brave_generated_resources.grd
+++ b/app/brave_generated_resources.grd
@@ -1012,9 +1012,6 @@ Or change later at <ph name="SETTINGS_EXTENIONS_LINK">$2<ex>brave://settings/ext
           <message name="IDS_BRAVE_VPN_SHOW_VPN_TRAY_ICON_MENU_ITEM" desc="The menu item for showing vpn tray icon in windows">
             Show VPN Tray Icon
           </message>
-          <message name="IDS_BRAVE_VPN_HIDE_VPN_TRAY_ICON_MENU_ITEM" desc="The menu item for hiding vpn tray icon in windows">
-            Hide VPN Tray Icon
-          </message>
           <message name="IDS_BRAVE_VPN_SHOW_FEEDBACK_MENU_ITEM" desc="The menu item for sending feedback">
             Send Feedback
           </message>
@@ -1031,9 +1028,6 @@ Or change later at <ph name="SETTINGS_EXTENIONS_LINK">$2<ex>brave://settings/ext
           </message>
           <message name="IDS_BRAVE_VPN_SHOW_VPN_TRAY_ICON_MENU_ITEM" desc="The menu item for showing vpn tray icon in windows">
             Show VPN tray icon
-          </message>
-          <message name="IDS_BRAVE_VPN_HIDE_VPN_TRAY_ICON_MENU_ITEM" desc="The menu item for hiding vpn tray icon in windows">
-            Hide VPN tray icon
           </message>
           <message name="IDS_BRAVE_VPN_SHOW_FEEDBACK_MENU_ITEM" desc="The menu item for sending feedback">
             Send feedback

--- a/browser/ui/toolbar/brave_vpn_menu_model.cc
+++ b/browser/ui/toolbar/brave_vpn_menu_model.cc
@@ -31,15 +31,15 @@ BraveVPNMenuModel::~BraveVPNMenuModel() = default;
 void BraveVPNMenuModel::Build() {
   AddItemWithStringId(IDC_TOGGLE_BRAVE_VPN, IDS_BRAVE_VPN_MENU);
   AddSeparator(ui::NORMAL_SEPARATOR);
-  AddItemWithStringId(IDC_TOGGLE_BRAVE_VPN_TOOLBAR_BUTTON,
-                      IsBraveVPNButtonVisible()
-                          ? IDS_BRAVE_VPN_HIDE_VPN_BUTTON_MENU_ITEM
-                          : IDS_BRAVE_VPN_SHOW_VPN_BUTTON_MENU_ITEM);
+  if (!IsBraveVPNButtonVisible()) {
+    AddItemWithStringId(IDC_TOGGLE_BRAVE_VPN_TOOLBAR_BUTTON,
+                        IDS_BRAVE_VPN_SHOW_VPN_BUTTON_MENU_ITEM);
+  }
 #if BUILDFLAG(IS_WIN)
-  AddItemWithStringId(IDC_TOGGLE_BRAVE_VPN_TRAY_ICON,
-                      IsTrayIconEnabled()
-                          ? IDS_BRAVE_VPN_HIDE_VPN_TRAY_ICON_MENU_ITEM
-                          : IDS_BRAVE_VPN_SHOW_VPN_TRAY_ICON_MENU_ITEM);
+  if (!IsTrayIconEnabled()) {
+    AddItemWithStringId(IDC_TOGGLE_BRAVE_VPN_TRAY_ICON,
+                        IDS_BRAVE_VPN_SHOW_VPN_TRAY_ICON_MENU_ITEM);
+  }
 #endif  // BUILDFLAG(IS_WIN)
   AddItemWithStringId(IDC_SEND_BRAVE_VPN_FEEDBACK,
                       IDS_BRAVE_VPN_SHOW_FEEDBACK_MENU_ITEM);

--- a/browser/ui/toolbar/brave_vpn_menu_model_unittest.cc
+++ b/browser/ui/toolbar/brave_vpn_menu_model_unittest.cc
@@ -58,12 +58,9 @@ TEST_F(BraveVPNMenuModelUnitTest, TrayIconEnabled) {
   menu_model.Build();
   EXPECT_NE(menu_model.GetItemCount(), 0u);
   {
-    auto tray_index =
-        menu_model.GetIndexOfCommandId(IDC_TOGGLE_BRAVE_VPN_TRAY_ICON);
-    EXPECT_TRUE(tray_index);
-    EXPECT_EQ(
-        menu_model.GetLabelAt(tray_index.value()),
-        l10n_util::GetStringUTF16(IDS_BRAVE_VPN_HIDE_VPN_TRAY_ICON_MENU_ITEM));
+    // Don't show toggle menu when tray icon is visible.
+    EXPECT_FALSE(
+        menu_model.GetIndexOfCommandId(IDC_TOGGLE_BRAVE_VPN_TRAY_ICON));
   }
 
   // Wireguard protocol disbled in the setting.
@@ -73,7 +70,9 @@ TEST_F(BraveVPNMenuModelUnitTest, TrayIconEnabled) {
   menu_model.Build();
   EXPECT_NE(menu_model.GetItemCount(), 0u);
   {
-    EXPECT_TRUE(menu_model.GetIndexOfCommandId(IDC_TOGGLE_BRAVE_VPN_TRAY_ICON));
+    // Still toggle menu is hidden.
+    EXPECT_FALSE(
+        menu_model.GetIndexOfCommandId(IDC_TOGGLE_BRAVE_VPN_TRAY_ICON));
   }
 
   // Cases with Disabled value.
@@ -107,12 +106,9 @@ TEST_F(BraveVPNMenuModelUnitTest, ToolbarVPNButton) {
   menu_model.Build();
   EXPECT_NE(menu_model.GetItemCount(), 0u);
   {
-    auto toolbar_index =
-        menu_model.GetIndexOfCommandId(IDC_TOGGLE_BRAVE_VPN_TOOLBAR_BUTTON);
-    EXPECT_TRUE(toolbar_index);
-    EXPECT_EQ(
-        menu_model.GetLabelAt(toolbar_index.value()),
-        l10n_util::GetStringUTF16(IDS_BRAVE_VPN_HIDE_VPN_BUTTON_MENU_ITEM));
+    // Don't show toggle menu when button is visible.
+    EXPECT_FALSE(
+        menu_model.GetIndexOfCommandId(IDC_TOGGLE_BRAVE_VPN_TOOLBAR_BUTTON));
   }
 
   // Cases with Disabled value.


### PR DESCRIPTION
fix https://github.com/brave/brave-browser/issues/33027

Hide can be done via UI.

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves 

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-arm64, CI/skip-linux-x64, CI/skip-android, CI/skip-macos, CI/skip-ios, CI/skip-windows-arm64, CI/skip-windows-x64, CI/skip-windows-x86 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

Check that hide menu entry is not shown when vpn button or try icon is visible