### PR TITLE
Fix "Open playlist" flakiness

### DIFF
--- a/browser/ui/views/playlist/playlist_action_bubble_view.cc
+++ b/browser/ui/views/playlist/playlist_action_bubble_view.cc
@@ -256,7 +256,16 @@ void ConfirmBubble::OpenInPlaylist() {
       PlaylistSidePanelCoordinator::FromBrowser(browser_);
   CHECK(side_panel_coordinator);
   side_panel_coordinator->ActivatePanel();
+
+  // TODO(sko) Calling this will reload the web ui and we'll lose the video
+  // being played if there's. So the panel has been already activated and has
+  // something loaded, we should call web ui API and handle this from the web ui
+  // side.
   side_panel_coordinator->LoadPlaylist(playlist_id, item_id);
+
+  // Before closing widget, try resetting observer to avoid crash on Win11
+  playlist_tab_helper_observation_.Reset();
+  GetWidget()->Close();
 }
 
 void ConfirmBubble::ChangeFolder() {

--- a/browser/ui/views/playlist/playlist_action_bubble_view.cc
+++ b/browser/ui/views/playlist/playlist_action_bubble_view.cc
@@ -258,9 +258,9 @@ void ConfirmBubble::OpenInPlaylist() {
   side_panel_coordinator->ActivatePanel();
 
   // TODO(sko) Calling this will reload the web ui and we'll lose the video
-  // being played if there's. So the panel has been already activated and has
-  // something loaded, we should call web ui API and handle this from the web ui
-  // side.
+  // being played if there is one. So if the panel has been already activated
+  // and has something loaded, we should call web ui API and handle this from
+  // the web ui side.
   side_panel_coordinator->LoadPlaylist(playlist_id, item_id);
 
   // Before closing widget, try resetting observer to avoid crash on Win11

--- a/browser/ui/views/side_panel/playlist/playlist_side_panel_coordinator.cc
+++ b/browser/ui/views/side_panel/playlist/playlist_side_panel_coordinator.cc
@@ -71,10 +71,10 @@ void PlaylistSidePanelCoordinator::LoadPlaylist(const std::string& playlist_id,
   CHECK(web_contents);
 
   CHECK(!playlist_id.empty());
-  web_contents->GetController().LoadURL(
+  CHECK(web_contents->GetController().LoadURL(
       GURL("chrome-untrusted://playlist/playlist/" + playlist_id + "#" +
            item_id),
-      {}, ui::PageTransition::PAGE_TRANSITION_AUTO_BOOKMARK, {});
+      {}, ui::PageTransition::PAGE_TRANSITION_AUTO_BOOKMARK, {}));
 }
 
 std::unique_ptr<views::View> PlaylistSidePanelCoordinator::CreateWebView() {

--- a/components/playlist/browser/resources/components/playlistFolder.tsx
+++ b/components/playlist/browser/resources/components/playlistFolder.tsx
@@ -116,11 +116,11 @@ function EditActionsContainer ({
 }
 
 function useItemIdFromHash () {
-  const getId = () => window.location.hash.replace('#', '')
-  let [idFromHash, setIdFromHash] = React.useState<string>('')
-  const updateId = () => setIdFromHash(getId())
+  const [idFromHash, setIdFromHash] = React.useState<string>('')
 
   React.useEffect(() => {
+    const getId = () => window.location.hash.replace('#', '')
+    const updateId = () => setIdFromHash(getId())
     updateId()
     window.addEventListener('hashchange', updateId)
     return () => window.removeEventListener('hashchange', updateId)
@@ -129,16 +129,13 @@ function useItemIdFromHash () {
 }
 
 function useScrollToItem (itemId: string | undefined) {
-  const ref = React.useRef<HTMLAnchorElement>(null)
-  const scrollToElement = () => {
-    if (ref.current) {
-      window.scrollTo({ top: ref.current.offsetTop })
-    }
-  }
+  const [el, setEl] = React.useState<HTMLAnchorElement | null>(null)
 
-  React.useEffect(() => scrollToElement(), [itemId, ref.current])
+  React.useEffect(() => {
+    if (el) window.scrollTo({ top: el.offsetTop })
+  }, [el, itemId])
 
-  return ref
+  return setEl
 }
 
 export default function PlaylistFolder ({

--- a/components/playlist/browser/resources/components/playlistFolder.tsx
+++ b/components/playlist/browser/resources/components/playlistFolder.tsx
@@ -26,6 +26,7 @@ import { PlaylistItem as PlaylistItemMojo } from 'gen/brave/components/playlist/
 import { SortablePlaylistItem, PlaylistItem } from './playlistItem'
 import {
   PlaylistEditMode,
+  useInitialized,
   useLastPlayerState,
   usePlaylist,
   usePlaylistEditMode
@@ -119,6 +120,7 @@ export default function PlaylistFolder ({
 }: RouteComponentProps<MatchParams>) {
   const playlist = usePlaylist(match.params.playlistId)
   const lastPlayerState = useLastPlayerState()
+  const initialized = useInitialized()
 
   React.useEffect(() => {
     // When playlist updated and player is working, notify that the current
@@ -170,6 +172,13 @@ export default function PlaylistFolder ({
   const sensors = useSensorsWithThreshold()
 
   if (!playlist) {
+    if (!initialized) {
+      // When Playlist web ui is loaded with a certain folder in the path, e.g.
+      // chrome://playlist/playlist/{playlist_id}, the App state could be uninitialized yet.
+      // We should wait for it to be loaded rather than redirect to the index page.
+      return null
+    }
+
     // After deleting a playlist from header, this could happen. In this case,
     // redirect to the index page.
     return <Redirect to='/' />

--- a/components/playlist/browser/resources/components/playlistItem.tsx
+++ b/components/playlist/browser/resources/components/playlistItem.tsx
@@ -343,7 +343,7 @@ export function PlaylistItem ({
 export const SortablePlaylistItem = React.forwardRef(
   function SortablePlaylistItem (
     props: Props,
-    forwardedRef: React.ForwardedRef<HTMLAnchorElement>
+    forwardedRef?: React.ForwardedRef<HTMLAnchorElement>
   ) {
     const itemId = props.item.id
     const { attributes, listeners, setNodeRef, style } = useVerticallySortable({

--- a/components/playlist/browser/resources/components/playlistItem.tsx
+++ b/components/playlist/browser/resources/components/playlistItem.tsx
@@ -33,6 +33,7 @@ interface Props {
   item: PlaylistItemMojo
   isEditing: boolean
   isSelected?: boolean
+  isHighlighted?: boolean
   canReorder: boolean
   shouldBeHidden: boolean
   onClick: (item: PlaylistItemMojo) => void
@@ -74,8 +75,18 @@ const DefaultThumbnail = styled.div`
 
 const PlaylistItemContainer = styled.li<{
   isActive: boolean
+  isHighlighted?: boolean
   shouldBeHidden: boolean
 }>`
+  @keyframes highlightBackground {
+    0% {
+      background-color: none;
+    }
+    100% {
+      background-color: ${color.container.interactive};
+    }
+  }
+
   display: flex;
   position: relative;
   padding: ${spacing.m} ${spacing.xl} ${spacing.m} ${spacing.m};
@@ -98,6 +109,12 @@ const PlaylistItemContainer = styled.li<{
     p.isActive &&
     css`
       background: ${color.container.interactive};
+    `}
+
+  ${p =>
+    p.isHighlighted &&
+    css`
+      animation: highlightBackground 500ms 4 alternate;
     `}
 `
 
@@ -206,6 +223,7 @@ export function PlaylistItem ({
   item,
   isEditing,
   isSelected,
+  isHighlighted,
   shouldBeHidden,
   onClick
 }: Props) {
@@ -217,24 +235,6 @@ export function PlaylistItem ({
     duration,
     thumbnailPath: { url: thumbnailUrl }
   } = item
-
-  const anchorElem = React.useRef<HTMLAnchorElement>(null)
-
-  const scrollToThisIfNeeded = React.useCallback(() => {
-    if (window.location.hash.replace('#', '') !== id) return
-
-    if (anchorElem.current)
-      window.scrollTo({ top: anchorElem.current.offsetTop })
-  }, [id])
-
-  React.useEffect(() => {
-    window.addEventListener('hashchange', scrollToThisIfNeeded)
-    return () => {
-      window.removeEventListener('hashchange', scrollToThisIfNeeded)
-    }
-  }, [scrollToThisIfNeeded])
-
-  React.useEffect(() => scrollToThisIfNeeded(), [])
 
   const [hovered, setHovered] = React.useState(false)
   const [showingMenu, setShowingMenu] = React.useState(false)
@@ -255,10 +255,10 @@ export function PlaylistItem ({
       onMouseEnter={() => setHovered(true)}
       onMouseLeave={() => setHovered(false)}
       isActive={(isEditing && isSelected) || isPlaying}
+      isHighlighted={isHighlighted}
       shouldBeHidden={shouldBeHidden}
       onClick={() => onClick(item)}
     >
-      <a ref={anchorElem} href={`#${id}`} />
       {isEditing && (
         <StyledCheckBox
           checked={!!isSelected}
@@ -340,15 +340,22 @@ export function PlaylistItem ({
   )
 }
 
-export function SortablePlaylistItem (props: Props) {
-  const { attributes, listeners, setNodeRef, style } = useVerticallySortable({
-    id: props.item.id,
-    disabled: !props.canReorder
-  })
+export const SortablePlaylistItem = React.forwardRef(
+  function SortablePlaylistItem (
+    props: Props,
+    forwardedRef: React.ForwardedRef<HTMLAnchorElement>
+  ) {
+    const itemId = props.item.id
+    const { attributes, listeners, setNodeRef, style } = useVerticallySortable({
+      id: itemId,
+      disabled: !props.canReorder
+    })
 
-  return (
-    <div ref={setNodeRef} style={style} {...attributes} {...listeners}>
-      <PlaylistItem {...props} />
-    </div>
-  )
-}
+    return (
+      <div ref={setNodeRef} style={style} {...attributes} {...listeners}>
+        <a ref={forwardedRef} href={`#${itemId}`} />
+        <PlaylistItem {...props} />
+      </div>
+    )
+  }
+)

--- a/components/playlist/browser/resources/reducers/states.ts
+++ b/components/playlist/browser/resources/reducers/states.ts
@@ -102,3 +102,9 @@ export function useAutoPlayEnabled () {
     applicationState => applicationState.playerState?.autoPlayEnabled
   )
 }
+
+export function useInitialized() {
+  return useSelector<ApplicationState, boolean>(
+    applicationState => !!applicationState.playlistData?.lists.length
+  )
+}


### PR DESCRIPTION
* Don't redirect to the 'index' page if the app isn't initialized yet
* Fix scroll behavior - scroll after all playlist items are rendered.
* Add highlighting effect

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/32922

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-arm64, CI/skip-linux-x64, CI/skip-android, CI/skip-macos, CI/skip-ios, CI/skip-windows-arm64, CI/skip-windows-x64, CI/skip-windows-x86 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [ ] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
* Add a media from any site.
* Click playlist action and click 'Open in Playlist'
* Sidebar should be opened and the item should be highglighted.
  * This should work regardless of playlist webui's location.
  * The location could be the index page or any folders, and clicking the item should load the specified folder and item.
