### PR TITLE
Revert "Hide Vertical tab strip even when it's browser fullscreen"

### DIFF
--- a/browser/ui/views/frame/vertical_tab_strip_region_view.cc
+++ b/browser/ui/views/frame/vertical_tab_strip_region_view.cc
@@ -685,9 +685,19 @@ void VerticalTabStripRegionView::OnWidgetDestroying(views::Widget* widget) {
   widget_observation_.Reset();
 }
 
-bool VerticalTabStripRegionView::IsFullscreen() const {
-  auto* widget = GetWidget();
-  return widget && widget->GetTopLevelWidget()->IsFullscreen();
+bool VerticalTabStripRegionView::IsTabFullscreen() const {
+  auto* exclusive_access_manager = browser_->exclusive_access_manager();
+  if (!exclusive_access_manager) {
+    return false;
+  }
+
+  auto* fullscreen_controller =
+      exclusive_access_manager->fullscreen_controller();
+  if (!fullscreen_controller) {
+    return false;
+  }
+
+  return fullscreen_controller->IsWindowFullscreenForTabOrPending();
 }
 
 void VerticalTabStripRegionView::SetState(State state) {
@@ -1080,7 +1090,7 @@ gfx::Size VerticalTabStripRegionView::GetPreferredSizeForState(
     return {};
   }
 
-  if (IsFullscreen()) {
+  if (IsTabFullscreen()) {
     return {};
   }
 

--- a/browser/ui/views/frame/vertical_tab_strip_region_view.h
+++ b/browser/ui/views/frame/vertical_tab_strip_region_view.h
@@ -19,7 +19,7 @@
 
 namespace views {
 class ResizeArea;
-}  // namespace views
+}
 
 class BraveNewTabButton;
 class BrowserView;
@@ -116,7 +116,7 @@ class VerticalTabStripRegionView : public views::View,
   FRIEND_TEST_ALL_PREFIXES(VerticalTabStripBrowserTest,
                            OriginalTabSearchButton);
 
-  bool IsFullscreen() const;
+  bool IsTabFullscreen() const;
 
   void SetState(State state);
 

--- a/browser/ui/views/tabs/vertical_tab_strip_browsertest.cc
+++ b/browser/ui/views/tabs/vertical_tab_strip_browsertest.cc
@@ -391,6 +391,40 @@ IN_PROC_BROWSER_TEST_F(VerticalTabStripBrowserTest, MAYBE_Fullscreen) {
     observer.Wait();
   }
 
+  // Vertical tab strip should be visible on browser fullscreen.
+  ASSERT_TRUE(fullscreen_controller->IsFullscreenForBrowser());
+  ASSERT_TRUE(browser_view()->IsFullscreen());
+  EXPECT_TRUE(browser_view()
+                  ->vertical_tab_strip_host_view_->GetPreferredSize()
+                  .width());
+
+  {
+    auto observer = FullscreenNotificationObserver(browser());
+    fullscreen_controller->ToggleBrowserFullscreenMode();
+    observer.Wait();
+  }
+  ASSERT_FALSE(fullscreen_controller->IsFullscreenForBrowser());
+  ASSERT_FALSE(browser_view()->IsFullscreen());
+
+  {
+    auto observer = FullscreenNotificationObserver(browser());
+    // Vertical tab strip should become invisible on tab fullscreen.
+    fullscreen_controller->EnterFullscreenModeForTab(
+        browser_view()
+            ->browser()
+            ->tab_strip_model()
+            ->GetActiveWebContents()
+            ->GetPrimaryMainFrame());
+
+    observer.Wait();
+  }
+  ASSERT_TRUE(fullscreen_controller->IsTabFullscreen());
+  if (!browser_view()
+           ->vertical_tab_strip_host_view_->GetPreferredSize()
+           .width()) {
+    return;
+  }
+
   base::RunLoop run_loop;
   auto wait_until = base::BindLambdaForTesting(
       [&](base::RepeatingCallback<bool()> predicate) {
@@ -403,47 +437,15 @@ IN_PROC_BROWSER_TEST_F(VerticalTabStripBrowserTest, MAYBE_Fullscreen) {
                         base::BindLambdaForTesting([&]() {
                           if (predicate.Run()) {
                             run_loop.Quit();
+                          } else {
+                            LOG(ERROR) << browser_view()
+                                              ->vertical_tab_strip_host_view_
+                                              ->GetPreferredSize()
+                                              .width();
                           }
                         }));
         run_loop.Run();
       });
-
-  // Vertical tab strip should be invisible on browser fullscreen.
-  ASSERT_TRUE(fullscreen_controller->IsFullscreenForBrowser());
-  ASSERT_TRUE(browser_view()->IsFullscreen());
-  wait_until.Run(base::BindLambdaForTesting([&]() {
-    return !browser_view()
-                ->vertical_tab_strip_host_view_->GetPreferredSize()
-                .width();
-  }));
-
-  {
-    auto observer = FullscreenNotificationObserver(browser());
-    fullscreen_controller->ToggleBrowserFullscreenMode();
-    observer.Wait();
-  }
-  ASSERT_FALSE(fullscreen_controller->IsFullscreenForBrowser());
-  ASSERT_FALSE(browser_view()->IsFullscreen());
-
-  {
-    auto observer = FullscreenNotificationObserver(browser());
-    fullscreen_controller->EnterFullscreenModeForTab(
-        browser_view()
-            ->browser()
-            ->tab_strip_model()
-            ->GetActiveWebContents()
-            ->GetPrimaryMainFrame());
-
-    observer.Wait();
-  }
-
-  // Vertical tab strip should be invisible on tab fullscreen.
-  ASSERT_TRUE(fullscreen_controller->IsTabFullscreen());
-  if (!browser_view()
-           ->vertical_tab_strip_host_view_->GetPreferredSize()
-           .width()) {
-    return;
-  }
 
   wait_until.Run(base::BindLambdaForTesting([&]() {
     return !browser_view()


### PR DESCRIPTION
Reverts brave/brave-core#19802

Fix https://github.com/brave/brave-browser/issues/33106