### PR TITLE
Revert "Hide Vertical tab strip even when it's browser fullscreen" (uplift to 1.58.x)

### DIFF
--- a/browser/ui/views/frame/vertical_tab_strip_region_view.cc
+++ b/browser/ui/views/frame/vertical_tab_strip_region_view.cc
@@ -720,9 +720,19 @@ void VerticalTabStripRegionView::OnWidgetDestroying(views::Widget* widget) {
   widget_observation_.Reset();
 }
 
-bool VerticalTabStripRegionView::IsFullscreen() const {
-  auto* widget = GetWidget();
-  return widget && widget->GetTopLevelWidget()->IsFullscreen();
+bool VerticalTabStripRegionView::IsTabFullscreen() const {
+  auto* exclusive_access_manager = browser_->exclusive_access_manager();
+  if (!exclusive_access_manager) {
+    return false;
+  }
+
+  auto* fullscreen_controller =
+      exclusive_access_manager->fullscreen_controller();
+  if (!fullscreen_controller) {
+    return false;
+  }
+
+  return fullscreen_controller->IsWindowFullscreenForTabOrPending();
 }
 
 void VerticalTabStripRegionView::SetState(State state) {
@@ -1184,7 +1194,7 @@ gfx::Size VerticalTabStripRegionView::GetPreferredSizeForState(
     return {};
   }
 
-  if (IsFullscreen()) {
+  if (IsTabFullscreen()) {
     return {};
   }
 

--- a/browser/ui/views/frame/vertical_tab_strip_region_view.h
+++ b/browser/ui/views/frame/vertical_tab_strip_region_view.h
@@ -127,7 +127,7 @@ class VerticalTabStripRegionView : public views::View,
   FRIEND_TEST_ALL_PREFIXES(VerticalTabStripBrowserTest,
                            OriginalTabSearchButton);
 
-  bool IsFullscreen() const;
+  bool IsTabFullscreen() const;
 
   void SetState(State state);
 


### PR DESCRIPTION
Uplift of #20208
Fix https://github.com/brave/brave-browser/issues/33106

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.