### PR TITLE
fix(wallet): Fix overflowing asset name in the market grid

### DIFF
--- a/components/brave_wallet_ui/components/asset-name-and-icon/index.tsx
+++ b/components/brave_wallet_ui/components/asset-name-and-icon/index.tsx
@@ -5,7 +5,13 @@
 
 import * as React from 'react'
 
-import { StyledWrapper, NameAndSymbolWrapper, AssetName, AssetSymbol, AssetIcon } from './style'
+import {
+  StyledWrapper,
+  NameAndSymbolWrapper,
+  AssetName,
+  AssetSymbol,
+  AssetIcon
+} from './style'
 
 export interface Props {
   symbol: string
@@ -14,15 +20,11 @@ export interface Props {
 }
 
 export const AssetNameAndIcon = (props: Props) => {
-  const {
-    assetLogo,
-    assetName,
-    symbol
-  } = props
+  const { assetLogo, assetName, symbol } = props
 
   return (
     <StyledWrapper>
-      <AssetIcon src={assetLogo} loading="lazy" />
+      <AssetIcon src={assetLogo} loading='lazy' />
       <NameAndSymbolWrapper>
         <AssetName>{assetName}</AssetName>
         <AssetSymbol>{symbol}</AssetSymbol>

--- a/components/brave_wallet_ui/components/asset-name-and-icon/style.ts
+++ b/components/brave_wallet_ui/components/asset-name-and-icon/style.ts
@@ -23,6 +23,7 @@ export const NameAndSymbolWrapper = styled.div`
   display: flex;
   flex-direction: column;
   justify-content: space-between;
+  align-items: flex-start;
   height: 100%;
   padding: 1px 0;
 `
@@ -34,6 +35,11 @@ export const AssetName = styled.span`
   font-style: normal;
   font-weight: 600;
   line-height: 24px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  width: 160px;
+  text-align: left;
 `
 
 export const AssetSymbol = styled.span`
@@ -44,4 +50,5 @@ export const AssetSymbol = styled.span`
   font-weight: 500;
   line-height: 18px;
   text-transform: uppercase;
+  text-align: left;
 `


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/32544

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-arm64, CI/skip-linux-x64, CI/skip-android, CI/skip-macos, CI/skip-ios, CI/skip-windows-arm64, CI/skip-windows-x64, CI/skip-windows-x86 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
<img width="799" alt="Screenshot 2023-09-19 at 13 03 07" src="https://github.com/brave/brave-core/assets/48117473/14b8438b-1544-49f5-bbca-889aaf292960">
