### PR TITLE
Fixes redeeming of payment tokens sometimes is not triggered with ShouldAlwaysRunBraveAdsService - 1.58.x

### DIFF
--- a/components/brave_ads/core/internal/account/account.cc
+++ b/components/brave_ads/core/internal/account/account.cc
@@ -353,7 +353,7 @@ void Account::OnNotifyRewardsWalletDidUpdate(const std::string& payment_id,
                                              const std::string& recovery_seed) {
   SetWallet(payment_id, recovery_seed);
 
-  MaybeTopUpUnblindedTokens();
+  Initialize();
 }
 
 void Account::OnNotifyDidSolveAdaptiveCaptcha() {


### PR DESCRIPTION
Uplift of https://github.com/brave/brave-core/pull/20176
Resolves https://github.com/brave/brave-browser/issues/32991

- [ ] You have checked CI and the builds, lint, and tests all pass or are not related to your PR.
- [ ] You have tested your change on Nightly. 
- [x] The PR milestones match the branch they are landing to. 

After you merge: 
- [ ] The associated issue milestone is set to the smallest version that the changes is landed on.

