### PR TITLE
[Android] remove redirect for filter settings (uplift to 1.59.x)

### DIFF
--- a/android/java/org/chromium/chrome/browser/app/BraveActivity.java
+++ b/android/java/org/chromium/chrome/browser/app/BraveActivity.java
@@ -150,7 +150,6 @@ import org.chromium.chrome.browser.settings.SettingsLauncherImpl;
 import org.chromium.chrome.browser.settings.developer.BraveQAPreferences;
 import org.chromium.chrome.browser.share.ShareDelegate;
 import org.chromium.chrome.browser.share.ShareDelegate.ShareOrigin;
-import org.chromium.chrome.browser.shields.ContentFilteringFragment;
 import org.chromium.chrome.browser.site_settings.BraveWalletEthereumConnectedSites;
 import org.chromium.chrome.browser.speedreader.BraveSpeedReaderUtils;
 import org.chromium.chrome.browser.tab.Tab;
@@ -1318,10 +1317,12 @@ public abstract class BraveActivity extends ChromeActivity
         settingsLauncher.launchSettingsActivity(this, BraveNewsPreferencesV2.class);
     }
 
-    public void openBraveContentFilteringSettings() {
+    // TODO: Once we have a ready for https://github.com/brave/brave-browser/issues/33015, We'll use
+    // this code
+    /*public void openBraveContentFilteringSettings() {
         SettingsLauncher settingsLauncher = new SettingsLauncherImpl();
         settingsLauncher.launchSettingsActivity(this, ContentFilteringFragment.class);
-    }
+    }*/
 
     public void openBraveWalletSettings() {
         SettingsLauncher settingsLauncher = new SettingsLauncherImpl();

--- a/android/java/org/chromium/chrome/browser/externalnav/BraveExternalNavigationHandler.java
+++ b/android/java/org/chromium/chrome/browser/externalnav/BraveExternalNavigationHandler.java
@@ -8,9 +8,7 @@ package org.chromium.chrome.browser.externalnav;
 import android.content.Intent;
 
 import org.chromium.base.ContextUtils;
-import org.chromium.base.Log;
 import org.chromium.chrome.browser.BraveWalletProvider;
-import org.chromium.chrome.browser.app.BraveActivity;
 import org.chromium.chrome.browser.privacy.settings.BravePrivacySettings;
 import org.chromium.components.external_intents.ExternalNavigationDelegate;
 import org.chromium.components.external_intents.ExternalNavigationHandler;
@@ -22,7 +20,7 @@ import org.chromium.url.GURL;
  * Extends Chromium's ExternalNavigationHandler
  */
 public class BraveExternalNavigationHandler extends ExternalNavigationHandler {
-    private static final String TAG = "BraveUrlHandler";
+    // private static final String TAG = "BraveUrlHandler";
     private BraveWalletProvider mBraveWalletProvider;
 
     public BraveExternalNavigationHandler(ExternalNavigationDelegate delegate) {
@@ -31,22 +29,25 @@ public class BraveExternalNavigationHandler extends ExternalNavigationHandler {
 
     @Override
     public OverrideUrlLoadingResult shouldOverrideUrlLoading(ExternalNavigationParams params) {
-        String originalUrl = params.getUrl().getSpec();
         if (isWalletProviderOverride(params)) {
+            String originalUrl = params.getUrl().getSpec();
             String url = originalUrl.replaceFirst("^rewards://", "brave://rewards/");
             GURL browserFallbackGURL = new GURL(url);
             if (params.getRedirectHandler() != null) {
                 params.getRedirectHandler().setShouldNotOverrideUrlLoadingOnCurrentRedirectChain();
             }
             return OverrideUrlLoadingResult.forNavigateTab(browserFallbackGURL, params);
-        } else if (originalUrl.equalsIgnoreCase("chrome://adblock/")) {
+        }
+        // TODO: Once we have a ready for https://github.com/brave/brave-browser/issues/33015, We'll
+        // use this code
+        /*else if (originalUrl.equalsIgnoreCase("chrome://adblock/")) {
             try {
                 BraveActivity.getBraveActivity().openBraveContentFilteringSettings();
             } catch (BraveActivity.BraveActivityNotFoundException e) {
                 Log.e(TAG, "adblock url " + e);
             }
             return OverrideUrlLoadingResult.forExternalIntent();
-        }
+        }*/
         return super.shouldOverrideUrlLoading(params);
     }
 


### PR DESCRIPTION
Uplift of #20212
Resolves https://github.com/brave/brave-browser/issues/33091

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.