### PR TITLE
Added copy to clipboard and download button on brave://skus-internals

### DIFF
--- a/browser/ui/webui/skus_internals_ui.h
+++ b/browser/ui/webui/skus_internals_ui.h
@@ -12,11 +12,13 @@
 #include "base/values.h"
 #include "brave/components/skus/common/skus_internals.mojom.h"
 #include "content/public/browser/web_ui_controller.h"
+#include "ui/shell_dialogs/select_file_dialog.h"
 
 class PrefService;
 
 class SkusInternalsUI : public content::WebUIController,
-                        public skus::mojom::SkusInternals {
+                        public skus::mojom::SkusInternals,
+                        public ui::SelectFileDialog::Listener {
  public:
   SkusInternalsUI(content::WebUI* web_ui, const std::string& host);
   ~SkusInternalsUI() override;
@@ -32,11 +34,21 @@ class SkusInternalsUI : public content::WebUIController,
   void GetSkusState(GetSkusStateCallback callback) override;
   void GetVpnState(GetVpnStateCallback callback) override;
   void ResetSkusState() override;
+  void CopySkusStateToClipboard() override;
+  void DownloadSkusState() override;
+
+  // SelectFileDialog::Listener overrides:
+  void FileSelected(const base::FilePath& path,
+                    int index,
+                    void* params) override;
+  void FileSelectionCanceled(void* params) override;
 
   std::string GetLastVPNConnectionError() const;
   base::Value::Dict GetVPNOrderInfo() const;
+  std::string GetSkusStateAsString() const;
 
   raw_ptr<PrefService> local_state_ = nullptr;
+  scoped_refptr<ui::SelectFileDialog> select_file_dialog_ = nullptr;
   mojo::Receiver<skus::mojom::SkusInternals> skus_internals_receiver_{this};
 
   WEB_UI_CONTROLLER_TYPE_DECL();

--- a/components/skus/browser/resources/skus_internals.tsx
+++ b/components/skus/browser/resources/skus_internals.tsx
@@ -71,6 +71,8 @@ function App() {
       </StateContainer>
       <StateContainer>
         <b>SKUs State:</b>
+        <button onClick={() => API.copySkusStateToClipboard()}>Copy</button>
+        <button onClick={() => API.downloadSkusState()}>Download</button>
         <JsonView data={skusState} shouldInitiallyExpand={(level) => true} />
       </StateContainer>
     </Container>

--- a/components/skus/common/skus_internals.mojom
+++ b/components/skus/common/skus_internals.mojom
@@ -9,5 +9,7 @@ interface SkusInternals {
   GetEventLog() => (string response);
   GetSkusState() => (string response);
   GetVpnState() => (string response);
+  CopySkusStateToClipboard();
+  DownloadSkusState();
   ResetSkusState();
 };


### PR DESCRIPTION
fix https://github.com/brave/brave-browser/issues/32884

<img width="468" alt="image" src="https://github.com/brave/brave-core/assets/6786187/b9617452-30a4-4473-aee5-102e3f492b4e">


<!-- Add brave-browser issue below that this PR will resolve -->
Resolves 

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-arm64, CI/skip-linux-x64, CI/skip-android, CI/skip-macos, CI/skip-ios, CI/skip-windows-arm64, CI/skip-windows-x64, CI/skip-windows-x86 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

1. Click `Copy` button and check skus state is copied to clipboard
2. Click `Download` button and check skus state is downloaded as a file