### PR TITLE
Remove uses of `StringPiece` and its variants

### DIFF
--- a/PRESUBMIT.py
+++ b/PRESUBMIT.py
@@ -16,7 +16,7 @@ import override_utils
 USE_PYTHON3 = True
 PRESUBMIT_VERSION = '2.0.0'
 
-# pylint: disable=line-too-long,protected-access
+# pylint: disable=line-too-long,protected-access,undefined-variable
 
 
 # Adds support for chromium_presubmit_config.json5 and some helpers.
@@ -283,6 +283,14 @@ def CheckLicense(input_api, output_api):
 # executed first.
 chromium_presubmit_overrides.inline_presubmit_from_src('PRESUBMIT.py',
                                                        globals(), locals())
+
+_BANNED_CPP_FUNCTIONS += (
+    BanRule(
+        r'/\bStringPiece',
+        ('Use std::string_view instead', ),
+        True,
+        [_THIRD_PARTY_EXCEPT_BLINK],  # Don't warn in third_party folders.
+    ), )
 
 
 # Extend BanRule exclude lists with Brave-specific paths.

--- a/browser/brave_ads/application_state/notification_helper/notification_helper_impl_win.cc
+++ b/browser/brave_ads/application_state/notification_helper/notification_helper_impl_win.cc
@@ -7,6 +7,8 @@
 
 #include <Windows.h>
 
+#include <string_view>
+
 #include "base/feature_list.h"
 #include "base/logging.h"
 #include "base/win/core_winrt_util.h"
@@ -241,8 +243,8 @@ HRESULT NotificationHelperImplWin::CreateActivationFactory(
     wchar_t const (&class_name)[size],
     const IID& iid,
     void** factory) const {
-  auto ref_class_name = base::win::ScopedHString::Create(
-      base::WStringPiece(class_name, size - 1));
+  auto ref_class_name =
+      base::win::ScopedHString::Create(std::wstring_view(class_name, size - 1));
 
   return base::win::RoGetActivationFactory(ref_class_name.get(), iid, factory);
 }

--- a/browser/brave_shields/eventsource_pool_limit_browsertest.cc
+++ b/browser/brave_shields/eventsource_pool_limit_browsertest.cc
@@ -4,6 +4,7 @@
  * You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 #include <string>
+#include <string_view>
 
 #include "base/path_service.h"
 #include "brave/components/brave_shields/browser/brave_shields_util.h"
@@ -127,7 +128,7 @@ class EventSourcePoolLimitBrowserTest : public InProcessBrowserTest {
   }
 
   void OpenEventSources(content::RenderFrameHost* rfh,
-                        base::StringPiece script_template,
+                        std::string_view script_template,
                         int count) {
     const std::string& es_open_script =
         content::JsReplace(script_template, es_url_);
@@ -137,7 +138,7 @@ class EventSourcePoolLimitBrowserTest : public InProcessBrowserTest {
   }
 
   void ExpectEventSourcesAreLimited(content::RenderFrameHost* rfh,
-                                    base::StringPiece script_template) {
+                                    std::string_view script_template) {
     const std::string& es_open_script =
         content::JsReplace(script_template, es_url_);
     for (int i = 0; i < 5; ++i) {
@@ -146,7 +147,7 @@ class EventSourcePoolLimitBrowserTest : public InProcessBrowserTest {
   }
 
   void CloseEventSources(content::RenderFrameHost* rfh,
-                         base::StringPiece script_template,
+                         std::string_view script_template,
                          int count) {
     for (int i = 0; i < count; ++i) {
       EXPECT_TRUE(content::ExecJs(rfh, content::JsReplace(script_template, i)));
@@ -154,7 +155,7 @@ class EventSourcePoolLimitBrowserTest : public InProcessBrowserTest {
   }
 
   void OpenEventSourcesAndExpectLimited(content::RenderFrameHost* rfh,
-                                        base::StringPiece script_template,
+                                        std::string_view script_template,
                                         int count) {
     OpenEventSources(rfh, script_template, count);
     ExpectEventSourcesAreLimited(rfh, script_template);
@@ -182,7 +183,7 @@ class EventSourcePoolLimitBrowserTest : public InProcessBrowserTest {
   // Makes use of Cross Site Redirector
   content::RenderFrameHost* GetNthChildFrameWithHost(
       content::RenderFrameHost* main,
-      base::StringPiece host,
+      std::string_view host,
       size_t n = 0) {
     size_t child_idx = 0;
     while (true) {

--- a/browser/brave_shields/websockets_pool_limit_browsertest.cc
+++ b/browser/brave_shields/websockets_pool_limit_browsertest.cc
@@ -3,6 +3,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+#include <string_view>
+
 #include "base/path_service.h"
 #include "brave/components/brave_shields/browser/brave_shields_util.h"
 #include "brave/components/constants/brave_paths.h"
@@ -125,7 +127,7 @@ class WebSocketsPoolLimitBrowserTest : public InProcessBrowserTest {
 
   content::RenderFrameHost* GetNthChildFrameWithHost(
       content::RenderFrameHost* main,
-      base::StringPiece host,
+      std::string_view host,
       size_t n = 0) {
     size_t child_idx = 0;
     while (true) {
@@ -142,7 +144,7 @@ class WebSocketsPoolLimitBrowserTest : public InProcessBrowserTest {
   }
 
   void OpenWebSockets(content::RenderFrameHost* rfh,
-                      base::StringPiece script_template,
+                      std::string_view script_template,
                       int count) {
     const std::string& ws_open_script =
         content::JsReplace(script_template, ws_url_);
@@ -152,7 +154,7 @@ class WebSocketsPoolLimitBrowserTest : public InProcessBrowserTest {
   }
 
   void ExpectWebSocketsAreLimited(content::RenderFrameHost* rfh,
-                                  base::StringPiece script_template) {
+                                  std::string_view script_template) {
     const std::string& ws_open_script =
         content::JsReplace(script_template, ws_url_);
     for (int i = 0; i < 5; ++i) {
@@ -161,7 +163,7 @@ class WebSocketsPoolLimitBrowserTest : public InProcessBrowserTest {
   }
 
   void CloseWebSockets(content::RenderFrameHost* rfh,
-                       base::StringPiece script_template,
+                       std::string_view script_template,
                        int count) {
     for (int i = 0; i < count; ++i) {
       EXPECT_TRUE(content::ExecJs(rfh, content::JsReplace(script_template, i)));
@@ -169,7 +171,7 @@ class WebSocketsPoolLimitBrowserTest : public InProcessBrowserTest {
   }
 
   void OpenWebSocketsAndExpectLimited(content::RenderFrameHost* rfh,
-                                      base::StringPiece script_template,
+                                      std::string_view script_template,
                                       int count) {
     OpenWebSockets(rfh, script_template, count);
     ExpectWebSocketsAreLimited(rfh, script_template);

--- a/browser/brave_vpn/win/brave_vpn_wireguard_service/notifications/notification_utils.cc
+++ b/browser/brave_vpn/win/brave_vpn_wireguard_service/notifications/notification_utils.cc
@@ -10,6 +10,8 @@
 #include <wrl/client.h>
 #include <wrl/event.h>
 
+#include <string_view>
+
 #include "base/functional/bind.h"
 #include "base/logging.h"
 #include "base/strings/string_util.h"
@@ -36,8 +38,8 @@ template <unsigned int size>
 HRESULT CreateActivationFactory(wchar_t const (&class_name)[size],
                                 const IID& iid,
                                 void** factory) {
-  base::win::ScopedHString ref_class_name = base::win::ScopedHString::Create(
-      base::WStringPiece(class_name, size - 1));
+  base::win::ScopedHString ref_class_name =
+      base::win::ScopedHString::Create(std::wstring_view(class_name, size - 1));
   return base::win::RoGetActivationFactory(ref_class_name.get(), iid, factory);
 }
 

--- a/browser/brave_wallet/asset_discovery_task_unittest.cc
+++ b/browser/brave_wallet/asset_discovery_task_unittest.cc
@@ -5,6 +5,8 @@
 
 #include "brave/components/brave_wallet/browser/asset_discovery_task.h"
 
+#include <string_view>
+
 #include "base/base64.h"
 #include "base/json/json_reader.h"
 #include "base/memory/raw_ptr.h"
@@ -233,11 +235,10 @@ class AssetDiscoveryTaskUnitTest : public testing::Test {
     url_loader_factory_.SetInterceptor(base::BindLambdaForTesting(
         [&, intended_url, requests](const network::ResourceRequest& request) {
           if (request.url.spec() == intended_url) {
-            base::StringPiece request_string(
-                request.request_body->elements()
-                    ->at(0)
-                    .As<network::DataElementBytes>()
-                    .AsStringPiece());
+            std::string_view request_string(request.request_body->elements()
+                                                ->at(0)
+                                                .As<network::DataElementBytes>()
+                                                .AsStringPiece());
             std::string response;
             for (auto const& [key, val] : requests) {
               if (request_string.find(key) != std::string::npos) {
@@ -262,7 +263,7 @@ class AssetDiscoveryTaskUnitTest : public testing::Test {
         [&, requests](const network::ResourceRequest& request) {
           for (auto const& [url, address_response_map] : requests) {
             if (request.url.spec() == url.spec()) {
-              base::StringPiece request_string;
+              std::string_view request_string;
               if (request.request_body) {
                 request_string = request.request_body->elements()
                                      ->at(0)

--- a/browser/brave_wallet/blockchain_images_source_unittest.cc
+++ b/browser/brave_wallet/blockchain_images_source_unittest.cc
@@ -6,6 +6,7 @@
 #include "brave/browser/brave_wallet/blockchain_images_source.h"
 
 #include <memory>
+#include <string_view>
 #include <utility>
 
 #include "base/files/file_path.h"
@@ -60,7 +61,7 @@ class BlockchainImagesSourceTest : public testing::Test {
   void OnDataReceived(scoped_refptr<base::RefCountedMemory> bytes) {
     data_received_ = true;
     if (bytes) {
-      data_ = std::string(base::StringPiece(
+      data_ = std::string(std::string_view(
           reinterpret_cast<const char*>(bytes->front()), bytes->size()));
     }
   }

--- a/browser/brave_wallet/brave_wallet_service_unittest.cc
+++ b/browser/brave_wallet/brave_wallet_service_unittest.cc
@@ -4,8 +4,10 @@
  * You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 #include "brave/components/brave_wallet/browser/brave_wallet_service.h"
+
 #include <memory>
 #include <string>
+#include <string_view>
 
 #include "base/json/json_reader.h"
 #include "base/memory/raw_ptr.h"
@@ -444,10 +446,10 @@ class BraveWalletServiceUnitTest : public testing::Test {
         [&, expected_url,
          interface_id_to_response](const network::ResourceRequest& request) {
           EXPECT_EQ(request.url, expected_url);
-          base::StringPiece request_string(request.request_body->elements()
-                                               ->at(0)
-                                               .As<network::DataElementBytes>()
-                                               .AsStringPiece());
+          std::string_view request_string(request.request_body->elements()
+                                              ->at(0)
+                                              .As<network::DataElementBytes>()
+                                              .AsStringPiece());
           // Check if any of the interface ids are in the request
           // if so, return the response for that interface id
           // if not, do nothing

--- a/browser/brave_wallet/eth_allowance_manager_unittest.cc
+++ b/browser/brave_wallet/eth_allowance_manager_unittest.cc
@@ -163,7 +163,7 @@ using AllowancesMapCallback = base::OnceCallback<void(const AllowancesMap&)>;
 using OnDiscoverEthAllowancesCompletedValidation =
     base::RepeatingCallback<void(const std::vector<mojom::AllowanceInfoPtr>&)>;
 
-base::Value::Dict ParseTestJson(const std::string_view& json) {
+base::Value::Dict ParseTestJson(const std::string_view json) {
   absl::optional<base::Value> potential_response_dict_val =
       base::JSONReader::Read(json, base::JSON_PARSE_CHROMIUM_EXTENSIONS |
                                        base::JSONParserOptions::JSON_PARSE_RFC);
@@ -483,7 +483,7 @@ class EthAllowanceManagerUnitTest : public testing::Test {
   }
 
   std::map<GURL, std::map<std::string, std::string>> PrepareResponses(
-      const std::string_view& response_json,
+      const std::string_view response_json,
       const std::vector<std::string>& eth_account_address,
       const TokenListMap& token_list_map,
       base::RepeatingCallback<void(base::Value::Dict,

--- a/browser/brave_wallet/eth_allowance_manager_unittest.cc
+++ b/browser/brave_wallet/eth_allowance_manager_unittest.cc
@@ -7,6 +7,7 @@
 
 #include <map>
 #include <memory>
+#include <string_view>
 #include <utility>
 
 #include "base/json/json_reader.h"
@@ -47,7 +48,7 @@ namespace brave_wallet {
 
 namespace {
 
-constexpr base::StringPiece eth_allowance_detected_response = R"({
+constexpr std::string_view eth_allowance_detected_response = R"({
     "jsonrpc": "2.0",
     "id": 1,
     "result": [
@@ -69,7 +70,7 @@ constexpr base::StringPiece eth_allowance_detected_response = R"({
     ]
 })";
 
-constexpr base::StringPiece eth_allowance_error_response = R"({
+constexpr std::string_view eth_allowance_error_response = R"({
                   "error": {
                     "code": -32000,
 "message": "requested too many blocks from 0
@@ -162,7 +163,7 @@ using AllowancesMapCallback = base::OnceCallback<void(const AllowancesMap&)>;
 using OnDiscoverEthAllowancesCompletedValidation =
     base::RepeatingCallback<void(const std::vector<mojom::AllowanceInfoPtr>&)>;
 
-base::Value::Dict ParseTestJson(const base::StringPiece& json) {
+base::Value::Dict ParseTestJson(const std::string_view& json) {
   absl::optional<base::Value> potential_response_dict_val =
       base::JSONReader::Read(json, base::JSON_PARSE_CHROMIUM_EXTENSIONS |
                                        base::JSONParserOptions::JSON_PARSE_RFC);
@@ -482,7 +483,7 @@ class EthAllowanceManagerUnitTest : public testing::Test {
   }
 
   std::map<GURL, std::map<std::string, std::string>> PrepareResponses(
-      const base::StringPiece& response_json,
+      const std::string_view& response_json,
       const std::vector<std::string>& eth_account_address,
       const TokenListMap& token_list_map,
       base::RepeatingCallback<void(base::Value::Dict,

--- a/browser/brave_wallet/ethereum_provider_impl_unittest.cc
+++ b/browser/brave_wallet/ethereum_provider_impl_unittest.cc
@@ -7,6 +7,7 @@
 
 #include <algorithm>
 #include <memory>
+#include <string_view>
 #include <utility>
 #include <vector>
 
@@ -121,10 +122,10 @@ std::vector<uint8_t> DecodeHexHash(const std::string& hash_hex) {
 }
 
 absl::optional<base::Value> ToValue(const network::ResourceRequest& request) {
-  base::StringPiece request_string(request.request_body->elements()
-                                       ->at(0)
-                                       .As<network::DataElementBytes>()
-                                       .AsStringPiece());
+  std::string_view request_string(request.request_body->elements()
+                                      ->at(0)
+                                      .As<network::DataElementBytes>()
+                                      .AsStringPiece());
   return base::JSONReader::Read(request_string,
                                 base::JSONParserOptions::JSON_PARSE_RFC);
 }

--- a/browser/brave_wallet/keyring_service_unittest.cc
+++ b/browser/brave_wallet/keyring_service_unittest.cc
@@ -5,6 +5,7 @@
 
 #include "brave/components/brave_wallet/browser/keyring_service.h"
 
+#include <string_view>
 #include <utility>
 
 #include "base/base64.h"
@@ -3993,10 +3994,10 @@ class KeyringServiceAccountDiscoveryUnitTest : public KeyringServiceUnitTest {
 
   void Interceptor(const network::ResourceRequest& request) {
     url_loader_factory().ClearResponses();
-    base::StringPiece request_string(request.request_body->elements()
-                                         ->at(0)
-                                         .As<network::DataElementBytes>()
-                                         .AsStringPiece());
+    std::string_view request_string(request.request_body->elements()
+                                        ->at(0)
+                                        .As<network::DataElementBytes>()
+                                        .AsStringPiece());
     base::Value::Dict dict = base::test::ParseJsonDict(request_string);
     std::string* method = dict.FindString("method");
     ASSERT_TRUE(method);

--- a/browser/default_protocol_handler_utils_win.h
+++ b/browser/default_protocol_handler_utils_win.h
@@ -9,19 +9,18 @@
 #include <windows.h>
 
 #include <string>
-
-#include "base/strings/string_piece_forward.h"
+#include <string_view>
 
 namespace protocol_handler_utils {
 
 // Exported for testing.
-std::wstring GenerateUserChoiceHash(base::WStringPiece ext,
-                                    base::WStringPiece sid,
-                                    base::WStringPiece prog_id,
+std::wstring GenerateUserChoiceHash(std::wstring_view ext,
+                                    std::wstring_view sid,
+                                    std::wstring_view prog_id,
                                     SYSTEMTIME timestamp);
 
-bool SetDefaultProtocolHandlerFor(base::WStringPiece protocol);
-bool IsDefaultProtocolHandlerFor(base::WStringPiece protocol);
+bool SetDefaultProtocolHandlerFor(std::wstring_view protocol);
+bool IsDefaultProtocolHandlerFor(std::wstring_view protocol);
 
 }  // namespace protocol_handler_utils
 

--- a/browser/default_protocol_handler_utils_win_unittest.cc
+++ b/browser/default_protocol_handler_utils_win_unittest.cc
@@ -5,7 +5,6 @@
 
 #include "brave/browser/default_protocol_handler_utils_win.h"
 
-#include "base/strings/string_piece.h"
 #include "testing/gtest/include/gtest/gtest.h"
 
 // Below test cases are copied from

--- a/browser/ephemeral_storage/blob_url_browsertest.cc
+++ b/browser/ephemeral_storage/blob_url_browsertest.cc
@@ -3,6 +3,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+#include <string_view>
+
 #include "base/memory/raw_ptr.h"
 #include "base/strings/pattern.h"
 #include "brave/browser/ephemeral_storage/ephemeral_storage_browsertest.h"
@@ -75,7 +77,7 @@ class BlobUrlBrowserTestBase : public EphemeralStorageBrowserTest {
   }
 
   static GURL RegisterBlob(content::RenderFrameHost* render_frame_host,
-                           base::StringPiece content) {
+                           std::string_view content) {
     return GURL(EvalJs(render_frame_host,
                        content::JsReplace(kCreateBlobScript, content))
                     .ExtractString());

--- a/browser/ephemeral_storage/ephemeral_storage_browsertest.cc
+++ b/browser/ephemeral_storage/ephemeral_storage_browsertest.cc
@@ -6,6 +6,7 @@
 #include "brave/browser/ephemeral_storage/ephemeral_storage_browsertest.h"
 
 #include <memory>
+#include <string_view>
 
 #include "base/memory/raw_ptr.h"
 #include "base/path_service.h"
@@ -342,7 +343,7 @@ void EphemeralStorageBrowserTest::CreateBroadcastChannel(
 
 void EphemeralStorageBrowserTest::SendBroadcastMessage(
     RenderFrameHost* frame,
-    base::StringPiece message) {
+    std::string_view message) {
   EXPECT_TRUE(content::ExecJs(
       frame, content::JsReplace("(async () => {"
                                 "  self.bc.postMessage($1);"

--- a/browser/ephemeral_storage/ephemeral_storage_browsertest.h
+++ b/browser/ephemeral_storage/ephemeral_storage_browsertest.h
@@ -7,6 +7,7 @@
 #define BRAVE_BROWSER_EPHEMERAL_STORAGE_EPHEMERAL_STORAGE_BROWSERTEST_H_
 
 #include <string>
+#include <string_view>
 #include <vector>
 
 #include "base/thread_annotations.h"
@@ -93,7 +94,7 @@ class EphemeralStorageBrowserTest : public InProcessBrowserTest {
 
   void CreateBroadcastChannel(content::RenderFrameHost* frame);
   void SendBroadcastMessage(content::RenderFrameHost* frame,
-                            base::StringPiece message);
+                            std::string_view message);
   void ClearBroadcastMessage(content::RenderFrameHost* frame);
   content::EvalJsResult GetBroadcastMessage(content::RenderFrameHost* frame,
                                             bool wait_for_non_empty);

--- a/browser/ethereum_remote_client/ethereum_remote_client_service.cc
+++ b/browser/ethereum_remote_client/ethereum_remote_client_service.cc
@@ -6,6 +6,7 @@
 #include "brave/browser/ethereum_remote_client/ethereum_remote_client_service.h"
 
 #include <string>
+#include <string_view>
 #include <utility>
 
 #include "base/base64.h"
@@ -60,8 +61,8 @@ const size_t EthereumRemoteClientService::kSeedByteLength = 32;
 std::string
 EthereumRemoteClientService::GetEthereumRemoteClientSeedFromRootSeed(
     const std::string& seed) {
-  base::StringPiece salt("brave-ethwallet-salt");
-  base::StringPiece info("ethwallet");
+  std::string_view salt("brave-ethwallet-salt");
+  std::string_view info("ethwallet");
   return crypto::HkdfSha256(base::MakeStringPiece(seed.begin(), seed.end()),
                             salt, info, kSeedByteLength);
 }
@@ -90,7 +91,7 @@ bool EthereumRemoteClientService::OpenSeed(const std::string& cipher_seed,
                                            std::string* seed) {
   crypto::Aead aes_256_gcm_siv(crypto::Aead::AES_256_GCM_SIV);
   aes_256_gcm_siv.Init(&key);
-  return aes_256_gcm_siv.Open(cipher_seed, nonce, base::StringPiece(""), seed);
+  return aes_256_gcm_siv.Open(cipher_seed, nonce, std::string_view(""), seed);
 }
 
 // Generate a new random nonce
@@ -119,7 +120,7 @@ bool EthereumRemoteClientService::SealSeed(const std::string& seed,
   crypto::Aead aes_256_gcm_siv(crypto::Aead::AES_256_GCM_SIV);
   aes_256_gcm_siv.Init(&key);
   return aes_256_gcm_siv.Seal(base::MakeStringPiece(seed.begin(), seed.end()),
-                              nonce, base::StringPiece(""), cipher_seed);
+                              nonce, std::string_view(""), cipher_seed);
 }
 
 // Store the seed in preferences, binary pref strings need to be

--- a/browser/extensions/api/brave_extensions_api_client.cc
+++ b/browser/extensions/api/brave_extensions_api_client.cc
@@ -5,7 +5,8 @@
 
 #include "brave/browser/extensions/api/brave_extensions_api_client.h"
 
-#include "base/strings/string_piece.h"
+#include <string_view>
+
 #include "brave/components/constants/url_constants.h"
 #include "extensions/common/permissions/permissions_data.h"
 #include "extensions/common/url_pattern.h"
@@ -17,7 +18,7 @@ bool BraveExtensionsAPIClient::ShouldHideBrowserNetworkRequest(
     content::BrowserContext* context,
     const WebRequestInfo& request) const {
   const url::Origin origin = url::Origin::Create(request.url);
-  const base::StringPiece path = request.url.path_piece();
+  const std::string_view path = request.url.path_piece();
   if (((origin.DomainIs("wallet-sandbox.uphold.com") ||
         origin.DomainIs("uphold.com")) &&
        base::StartsWith(path, "/authorize/",

--- a/browser/extensions/api/identity/brave_web_auth_flow.cc
+++ b/browser/extensions/api/identity/brave_web_auth_flow.cc
@@ -9,7 +9,6 @@
 #include <utility>
 #include <vector>
 
-#include "base/strings/string_piece.h"
 #include "base/strings/string_split.h"
 #include "base/strings/string_util.h"
 #include "chrome/browser/extensions/api/identity/identity_api.h"

--- a/browser/farbling/brave_font_whitelist_browsertest.cc
+++ b/browser/farbling/brave_font_whitelist_browsertest.cc
@@ -3,6 +3,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+#include <string_view>
+
 #include "base/test/scoped_feature_list.h"
 #include "brave/components/brave_shields/common/features.h"
 #include "brave/components/content_settings/renderer/brave_content_settings_agent_impl.h"
@@ -70,7 +72,7 @@ TEST_F(BraveFontWhitelistRenderViewTest, MAYBE_FontLocalSource) {
   // on the font whitelist.
   brave::set_font_whitelist_for_testing(
       true,
-      base::MakeFlatSet<base::StringPiece>(std::vector<base::StringPiece>{}));
+      base::MakeFlatSet<std::string_view>(std::vector<std::string_view>{}));
 
   // Use mock content settings agent that unconditionally enables font
   // whitelisting.

--- a/browser/net/brave_proxying_url_loader_factory.cc
+++ b/browser/net/brave_proxying_url_loader_factory.cc
@@ -5,6 +5,7 @@
 
 #include "brave/browser/net/brave_proxying_url_loader_factory.h"
 
+#include <string_view>
 #include <utility>
 
 #include "base/feature_list.h"
@@ -377,7 +378,7 @@ void BraveProxyingURLLoaderFactory::InProgressRequest::
     write_data->producer =
         std::make_unique<mojo::DataPipeProducer>(std::move(producer));
 
-    base::StringPiece string_piece(write_data->data);
+    std::string_view string_piece(write_data->data);
     WriteData* write_data_ptr = write_data.get();
     write_data_ptr->producer->Write(
         std::make_unique<mojo::StringDataSource>(

--- a/browser/net/brave_reduce_language_network_delegate_helper.cc
+++ b/browser/net/brave_reduce_language_network_delegate_helper.cc
@@ -7,6 +7,7 @@
 
 #include <array>
 #include <string>
+#include <string_view>
 #include <vector>
 
 #include "base/containers/fixed_flat_set.h"
@@ -32,7 +33,7 @@ constexpr char kAcceptLanguageMax[] = "en-US,en;q=0.9";
 const std::array<std::string, 5> kFakeQValues = {";q=0.5", ";q=0.6", ";q=0.7",
                                                  ";q=0.8", ";q=0.9"};
 static constexpr auto kFarbleAcceptLanguageExceptions =
-    base::MakeFixedFlatSet<base::StringPiece>(
+    base::MakeFixedFlatSet<std::string_view>(
         {// https://github.com/brave/brave-browser/issues/25309
          "ulta.com", "www.ulta.com",
          // https://github.com/brave/brave-browser/issues/26325
@@ -86,7 +87,7 @@ int OnBeforeStartTransaction_ReduceLanguageWork(
                                              profile->GetPrefs())) {
     return net::OK;
   }
-  base::StringPiece origin_host(origin_url.host_piece());
+  std::string_view origin_host(origin_url.host_piece());
   if (kFarbleAcceptLanguageExceptions.contains(origin_host)) {
     return net::OK;
   }

--- a/browser/net/brave_site_hacks_network_delegate_helper_browsertest.cc
+++ b/browser/net/brave_site_hacks_network_delegate_helper_browsertest.cc
@@ -131,7 +131,7 @@ class BraveSiteHacksNetworkDelegateBrowserTest : public InProcessBrowserTest {
     return navigation_url.ReplaceComponents(replacement);
   }
 
-  GURL landing_url(const std::string_view& query, const GURL& landing_url) {
+  GURL landing_url(const std::string_view query, const GURL& landing_url) {
     GURL::Replacements replacement;
     if (!query.empty()) {
       replacement.SetQueryStr(query);

--- a/browser/net/brave_site_hacks_network_delegate_helper_browsertest.cc
+++ b/browser/net/brave_site_hacks_network_delegate_helper_browsertest.cc
@@ -3,6 +3,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+#include <string_view>
+
 #include "base/base64url.h"
 #include "base/path_service.h"
 #include "base/strings/stringprintf.h"
@@ -129,7 +131,7 @@ class BraveSiteHacksNetworkDelegateBrowserTest : public InProcessBrowserTest {
     return navigation_url.ReplaceComponents(replacement);
   }
 
-  GURL landing_url(const base::StringPiece& query, const GURL& landing_url) {
+  GURL landing_url(const std::string_view& query, const GURL& landing_url) {
     GURL::Replacements replacement;
     if (!query.empty()) {
       replacement.SetQueryStr(query);

--- a/browser/net/brave_static_redirect_network_delegate_helper.cc
+++ b/browser/net/brave_static_redirect_network_delegate_helper.cc
@@ -8,9 +8,9 @@
 #include <algorithm>
 #include <memory>
 #include <string>
+#include <string_view>
 #include <vector>
 
-#include "base/strings/string_piece_forward.h"
 #include "brave/browser/net/brave_geolocation_buildflags.h"
 #include "brave/browser/safebrowsing/buildflags.h"
 #include "brave/components/constants/network_constants.h"
@@ -26,7 +26,7 @@ namespace {
 
 bool g_safebrowsing_api_endpoint_for_testing_ = false;
 
-base::StringPiece GetSafeBrowsingEndpoint() {
+std::string_view GetSafeBrowsingEndpoint() {
   if (g_safebrowsing_api_endpoint_for_testing_)
     return kSafeBrowsingTestingEndpoint;
   return BUILDFLAG(SAFEBROWSING_ENDPOINT);

--- a/browser/net/brave_stp_util.cc
+++ b/browser/net/brave_stp_util.cc
@@ -6,15 +6,16 @@
 #include "brave/browser/net/brave_stp_util.h"
 
 #include <string>
+#include <string_view>
 
 #include "base/no_destructor.h"
 #include "net/base/registry_controlled_domains/registry_controlled_domain.h"
 
 namespace brave {
 
-base::flat_set<base::StringPiece>* TrackableSecurityHeaders() {
-  static base::NoDestructor<base::flat_set<base::StringPiece>>
-      kTrackableSecurityHeaders(base::flat_set<base::StringPiece>{
+base::flat_set<std::string_view>* TrackableSecurityHeaders() {
+  static base::NoDestructor<base::flat_set<std::string_view>>
+      kTrackableSecurityHeaders(base::flat_set<std::string_view>{
           "Strict-Transport-Security", "Expect-CT", "Public-Key-Pins",
           "Public-Key-Pins-Report-Only"});
   return kTrackableSecurityHeaders.get();

--- a/browser/net/brave_stp_util.h
+++ b/browser/net/brave_stp_util.h
@@ -6,15 +6,16 @@
 #ifndef BRAVE_BROWSER_NET_BRAVE_STP_UTIL_H_
 #define BRAVE_BROWSER_NET_BRAVE_STP_UTIL_H_
 
+#include <string_view>
+
 #include "base/containers/flat_set.h"
-#include "base/strings/string_piece.h"
 #include "net/http/http_response_headers.h"
 #include "url/gurl.h"
 #include "url/origin.h"
 
 namespace brave {
 
-base::flat_set<base::StringPiece>* TrackableSecurityHeaders();
+base::flat_set<std::string_view>* TrackableSecurityHeaders();
 
 void RemoveTrackableSecurityHeadersForThirdParty(
     const GURL& request_url, const url::Origin& top_frame_origin,

--- a/browser/permissions/permission_lifetime_manager_unittest.cc
+++ b/browser/permissions/permission_lifetime_manager_unittest.cc
@@ -5,6 +5,8 @@
 
 #include "brave/components/permissions/permission_lifetime_manager.h"
 
+#include <string_view>
+
 #include "base/memory/raw_ptr.h"
 #include "base/run_loop.h"
 #include "base/stl_util.h"
@@ -40,7 +42,7 @@ namespace {
 
 using PermissionDecidedCallback = PermissionRequest::PermissionDecidedCallback;
 
-constexpr base::StringPiece kOneTypeOneExpirationPrefValue = R"({
+constexpr std::string_view kOneTypeOneExpirationPrefValue = R"({
   "$1": {
     "$2": [
       {"ro": "$3", "cs": 1}
@@ -48,7 +50,7 @@ constexpr base::StringPiece kOneTypeOneExpirationPrefValue = R"({
   }
 })";
 
-constexpr base::StringPiece kOneTypeOneExpirationWithCsPrefValue = R"({
+constexpr std::string_view kOneTypeOneExpirationWithCsPrefValue = R"({
   "$1": {
     "$2": [
       {"ro": "$3", "cs": $4}
@@ -56,7 +58,7 @@ constexpr base::StringPiece kOneTypeOneExpirationWithCsPrefValue = R"({
   }
 })";
 
-constexpr base::StringPiece kOneTypeSameTimeExpirationsPrefValue = R"({
+constexpr std::string_view kOneTypeSameTimeExpirationsPrefValue = R"({
   "$1": {
     "$2": [
       {"ro": "$3", "cs": 1},
@@ -65,7 +67,7 @@ constexpr base::StringPiece kOneTypeSameTimeExpirationsPrefValue = R"({
   }
 })";
 
-constexpr base::StringPiece kOneTypeTwoExpirationsPrefValue = R"({
+constexpr std::string_view kOneTypeTwoExpirationsPrefValue = R"({
   "$1": {
     "$2": [
       {"ro": "$3", "cs": 1}
@@ -76,7 +78,7 @@ constexpr base::StringPiece kOneTypeTwoExpirationsPrefValue = R"({
   }
 })";
 
-constexpr base::StringPiece kTwoTypesOneExpirationPrefValue = R"({
+constexpr std::string_view kTwoTypesOneExpirationPrefValue = R"({
   "$1": {
     "$2": [
       {"ro": "$3", "cs": 1}
@@ -216,7 +218,7 @@ class PermissionLifetimeManagerTest : public testing::Test {
   }
 
   void CheckExpirationsPref(const base::Location& location,
-                            base::StringPiece pref_value_template,
+                            std::string_view pref_value_template,
                             const std::vector<std::string>& subst = {}) {
     SCOPED_TRACE(testing::Message() << location.ToString());
     const auto& expirations =

--- a/browser/speedreader/speedreader_browsertest.cc
+++ b/browser/speedreader/speedreader_browsertest.cc
@@ -3,12 +3,13 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+#include <string_view>
+
 #include "base/command_line.h"
 #include "base/functional/bind.h"
 #include "base/path_service.h"
 #include "base/run_loop.h"
 #include "base/strings/escape.h"
-#include "base/strings/string_piece_forward.h"
 #include "base/strings/string_util.h"
 #include "base/strings/utf_string_conversions.h"
 #include "base/test/bind.h"
@@ -204,7 +205,7 @@ class SpeedReaderBrowserTest : public InProcessBrowserTest {
   }
 
   void NavigateToPageSynchronously(
-      base::StringPiece path,
+      std::string_view path,
       WindowOpenDisposition disposition =
           WindowOpenDisposition::NEW_FOREGROUND_TAB) {
     const GURL url = https_server_.GetURL(kTestHost, path);

--- a/browser/speedreader/speedreader_tab_helper.cc
+++ b/browser/speedreader/speedreader_tab_helper.cc
@@ -7,13 +7,13 @@
 
 #include <initializer_list>
 #include <string>
+#include <string_view>
 #include <utility>
 
 #include "base/feature_list.h"
 #include "base/functional/bind.h"
 #include "base/no_destructor.h"
 #include "base/strings/strcat.h"
-#include "base/strings/string_piece.h"
 #include "base/strings/string_util.h"
 #include "base/strings/utf_string_conversions.h"
 #include "brave/browser/brave_browser_process.h"
@@ -50,7 +50,7 @@
 namespace speedreader {
 
 std::u16string GetSpeedreaderData(
-    std::initializer_list<std::pair<base::StringPiece, int>> resources) {
+    std::initializer_list<std::pair<std::string_view, int>> resources) {
   std::u16string result = u"speedreaderData = {";
 
   if (kSpeedreaderTTS.Get()) {

--- a/browser/ssl/certificate_transparency_browsertest.cc
+++ b/browser/ssl/certificate_transparency_browsertest.cc
@@ -11,6 +11,8 @@
 //   Use of this source code is governed by a BSD-style license that can be
 //   found in the LICENSE file.
 
+#include <string_view>
+
 #include "base/run_loop.h"
 #include "chrome/browser/net/system_network_context_manager.h"
 #include "chrome/browser/profiles/profile.h"
@@ -38,7 +40,7 @@ namespace {
 
 // Returns the Sha256 hash of the SPKI of |cert|.
 net::HashValue GetSPKIHash(const CRYPTO_BUFFER* cert) {
-  base::StringPiece spki_bytes;
+  std::string_view spki_bytes;
   EXPECT_TRUE(net::asn1::ExtractSPKIFromDERCert(
       net::x509_util::CryptoBufferAsStringPiece(cert), &spki_bytes));
   net::HashValue sha256(net::HASH_VALUE_SHA256);

--- a/browser/ui/webui/brave_rewards/tip_panel_handler.cc
+++ b/browser/ui/webui/brave_rewards/tip_panel_handler.cc
@@ -9,7 +9,6 @@
 #include <vector>
 
 #include "base/functional/bind.h"
-#include "base/strings/string_piece.h"
 #include "brave/browser/brave_rewards/rewards_service_factory.h"
 #include "brave/browser/ui/brave_rewards/tip_panel_coordinator.h"
 #include "brave/components/brave_rewards/browser/rewards_service.h"

--- a/browser/ui/webui/brave_wallet/wallet_panel_ui_browsertest.cc
+++ b/browser/ui/webui/brave_wallet/wallet_panel_ui_browsertest.cc
@@ -4,6 +4,7 @@
 // you can obtain one at http://mozilla.org/MPL/2.0/.
 
 #include <string>
+#include <string_view>
 
 #include "base/memory/raw_ptr.h"
 #include "base/run_loop.h"
@@ -196,10 +197,10 @@ class WalletPanelUIBrowserTest : public InProcessBrowserTest {
                                 const std::string& chain_id) {
     url_loader_factory_.SetInterceptor(base::BindLambdaForTesting(
         [=](const network::ResourceRequest& request) {
-          base::StringPiece request_string(request.request_body->elements()
-                                               ->at(0)
-                                               .As<network::DataElementBytes>()
-                                               .AsStringPiece());
+          std::string_view request_string(request.request_body->elements()
+                                              ->at(0)
+                                              .As<network::DataElementBytes>()
+                                              .AsStringPiece());
           url_loader_factory_.ClearResponses();
           if (request_string.find("eth_chainId") != std::string::npos) {
             const std::string response = base::StringPrintf(

--- a/browser/ui/webui/settings/brave_wallet_handler_unittest.cc
+++ b/browser/ui/webui/settings/brave_wallet_handler_unittest.cc
@@ -5,6 +5,7 @@
 
 #include <memory>
 #include <string>
+#include <string_view>
 #include <utility>
 #include <vector>
 
@@ -82,10 +83,10 @@ class TestBraveWalletHandler : public BraveWalletHandler {
                                 const std::string& chain_id) {
     url_loader_factory_.SetInterceptor(base::BindLambdaForTesting(
         [&, network_url, chain_id](const network::ResourceRequest& request) {
-          base::StringPiece request_string(request.request_body->elements()
-                                               ->at(0)
-                                               .As<network::DataElementBytes>()
-                                               .AsStringPiece());
+          std::string_view request_string(request.request_body->elements()
+                                              ->at(0)
+                                              .As<network::DataElementBytes>()
+                                              .AsStringPiece());
           url_loader_factory_.ClearResponses();
           if (request_string.find("eth_chainId") != std::string::npos) {
             url_loader_factory_.AddResponse(

--- a/chromium_src/chrome/browser/extensions/chrome_content_verifier_delegate.cc
+++ b/chromium_src/chrome/browser/extensions/chrome_content_verifier_delegate.cc
@@ -14,7 +14,6 @@
 #include "base/metrics/field_trial.h"
 #include "base/metrics/histogram_macros.h"
 #include "base/no_destructor.h"
-#include "base/strings/string_piece.h"
 #include "base/strings/string_util.h"
 #include "base/syslog_logging.h"
 #include "base/version.h"

--- a/chromium_src/chrome/browser/sync/prefs/chrome_syncable_prefs_database.cc
+++ b/chromium_src/chrome/browser/sync/prefs/chrome_syncable_prefs_database.cc
@@ -5,8 +5,9 @@
 
 #include "chrome/browser/sync/prefs/chrome_syncable_prefs_database.h"
 
+#include <string_view>
+
 #include "base/containers/fixed_flat_map.h"
-#include "base/strings/string_piece.h"
 
 namespace browser_sync {
 namespace {
@@ -40,7 +41,7 @@ enum {
 
 const auto& BraveSyncablePreferences() {
   static const auto kBraveSyncablePrefsAllowList = base::MakeFixedFlatMap<
-      base::StringPiece, sync_preferences::SyncablePrefMetadata>({
+      std::string_view, sync_preferences::SyncablePrefMetadata>({
       {"profile.content_settings.exceptions.shieldsAds",
        {brave_syncable_prefs_ids::kProfileContentSettingsExceptionsShieldsAds,
         syncer::PREFERENCES, /*is_history_opt_in_required*/ false}},

--- a/chromium_src/chrome/browser/ui/browser_navigator.cc
+++ b/chromium_src/chrome/browser/ui/browser_navigator.cc
@@ -21,7 +21,7 @@ void UpdateBraveScheme(NavigateParams* params) {
   }
 }
 
-bool IsHostAllowedInIncognitoBraveImpl(const std::string_view& host) {
+bool IsHostAllowedInIncognitoBraveImpl(const std::string_view host) {
   if (host == kWalletPageHost || host == kWalletPanelHost ||
       host == kRewardsPageHost || host == chrome::kChromeUISyncInternalsHost ||
       host == chrome::kChromeUISyncHost || host == kAdblockHost ||

--- a/chromium_src/chrome/browser/ui/browser_navigator.cc
+++ b/chromium_src/chrome/browser/ui/browser_navigator.cc
@@ -3,6 +3,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+#include <string_view>
+
 #include "brave/components/constants/webui_url_constants.h"
 #include "chrome/browser/profiles/profile.h"
 #include "chrome/browser/ui/browser_navigator_params.h"
@@ -19,7 +21,7 @@ void UpdateBraveScheme(NavigateParams* params) {
   }
 }
 
-bool IsHostAllowedInIncognitoBraveImpl(const base::StringPiece& host) {
+bool IsHostAllowedInIncognitoBraveImpl(const std::string_view& host) {
   if (host == kWalletPageHost || host == kWalletPanelHost ||
       host == kRewardsPageHost || host == chrome::kChromeUISyncInternalsHost ||
       host == chrome::kChromeUISyncHost || host == kAdblockHost ||

--- a/chromium_src/chrome/browser/ui/toolbar/recent_tabs_sub_menu_model_unittest.cc
+++ b/chromium_src/chrome/browser/ui/toolbar/recent_tabs_sub_menu_model_unittest.cc
@@ -3,6 +3,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+#include <string_view>
+
 // Disabling these tests because they refer g_brave_browser_process which is not
 // initialized in unit tests, is null and so they are crashing.
 // Not related to change in RecentTabsSubMenuModel for additional `More...`
@@ -38,7 +40,7 @@ void RecentTabsSubMenuModelTest::VerifyModel(
     base::span<const ModelData> data) {
   std::vector<ModelData> v_data{data.begin(), data.end()};
   v_data.insert(v_data.begin() + 1, {ui::MenuModel::TYPE_COMMAND, true});
-  const base::StringPiece test_name =
+  const std::string_view test_name =
       testing::UnitTest::GetInstance()->current_test_info()->name();
   if (test_name == "MaxTabsPerSessionAndRecency") {
     v_data.push_back({ui::MenuModel::TYPE_COMMAND, true});

--- a/chromium_src/chrome/browser/ui/webui/about_ui.cc
+++ b/chromium_src/chrome/browser/ui/webui/about_ui.cc
@@ -3,6 +3,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+#include <string_view>
+
 #include "base/containers/contains.h"
 #include "base/strings/string_split.h"
 #include "third_party/re2/src/re2/re2.h"
@@ -32,7 +34,7 @@ std::string AboutUIHTMLSource::ChromeURLs() const {
   // Remove some URLs.
   auto html_lines = base::SplitStringPiece(
       chrome_urls, "\n", base::KEEP_WHITESPACE, base::SPLIT_WANT_ALL);
-  const base::flat_set<base::StringPiece> kURLsToRemove{
+  const base::flat_set<std::string_view> kURLsToRemove{
       "brave://memories",
   };
   // URLs in html should be sorted so it's okay to iterate over sorted

--- a/chromium_src/chrome/browser/ui/webui/settings/site_settings_helper.cc
+++ b/chromium_src/chrome/browser/ui/webui/settings/site_settings_helper.cc
@@ -5,6 +5,8 @@
 
 #include "chrome/browser/ui/webui/settings/site_settings_helper.h"
 
+#include <string_view>
+
 #include "base/containers/cxx20_erase_vector.h"
 #include "brave/components/brave_shields/common/brave_shield_constants.h"
 #include "third_party/blink/public/common/features.h"
@@ -75,7 +77,7 @@ bool HasRegisteredGroupName(ContentSettingsType type) {
   return HasRegisteredGroupName_ChromiumImpl(type);
 }
 
-base::StringPiece ContentSettingsTypeToGroupName(ContentSettingsType type) {
+std::string_view ContentSettingsTypeToGroupName(ContentSettingsType type) {
   if (type == ContentSettingsType::AUTOPLAY)
     return "autoplay";
   if (type == ContentSettingsType::BRAVE_GOOGLE_SIGN_IN)

--- a/chromium_src/chrome/common/channel_info_posix.cc
+++ b/chromium_src/chrome/common/channel_info_posix.cc
@@ -4,6 +4,8 @@
 
 #include "chrome/common/channel_info.h"
 
+#include <string_view>
+
 #include "base/environment.h"
 #include "base/strings/strcat.h"
 #include "base/strings/string_util.h"
@@ -43,7 +45,7 @@ std::string GetChannelSuffixForExtraFlagsEnvVarName() {
   const char* const channel_name = getenv("CHROME_VERSION_EXTRA");
   return channel_name
              ? base::StrCat(
-                   {"_", base::ToUpperASCII(base::StringPiece(channel_name))})
+                   {"_", base::ToUpperASCII(std::string_view(channel_name))})
              : std::string();
 #endif  // defined(OFFICIAL_BUILD)
 }

--- a/chromium_src/chrome/installer/setup/brave_behaviors.cc
+++ b/chromium_src/chrome/installer/setup/brave_behaviors.cc
@@ -5,6 +5,8 @@
 
 #include "chrome/installer/setup/brand_behaviors.h"
 
+#include <string_view>
+
 #define DoPostUninstallOperations DoPostUninstallOperations_UNUSED
 #include "src/chrome/installer/setup/google_chrome_behaviors.cc"
 #undef DoPostUninstallOperations
@@ -20,7 +22,7 @@ namespace {
 // - `distribution_data` not appended as Brave does not record histograms.
 // - `kBraveUninstallSurveyUrl` used instead of `kUninstallSurveyUrl`
 
-constexpr base::WStringPiece kBraveUninstallSurveyUrl(
+constexpr std::wstring_view kBraveUninstallSurveyUrl(
     L"https://brave.com/uninstall-survey/?p=brave_uninstall_survey");
 
 }  // namespace

--- a/chromium_src/chrome/test/base/chrome_test_suite.cc
+++ b/chromium_src/chrome/test/base/chrome_test_suite.cc
@@ -5,6 +5,8 @@
 
 #include "chrome/test/base/chrome_test_suite.h"
 
+#include <string_view>
+
 #define ChromeTestSuite ChromeTestSuite_ChromiumImpl
 #include "src/chrome/test/base/chrome_test_suite.cc"
 #undef ChromeTestSuite
@@ -20,7 +22,7 @@ namespace {
 class BraveChromeTestSetupHelper : public testing::EmptyTestEventListener {
  public:
   struct TestAdjustments {
-    std::vector<base::StringPiece> test_patterns;
+    std::vector<std::string_view> test_patterns;
 
     std::vector<std::string> enable_features;
     std::vector<std::string> disable_features;

--- a/chromium_src/components/browsing_data/core/browsing_data_utils.cc
+++ b/chromium_src/components/browsing_data/core/browsing_data_utils.cc
@@ -5,6 +5,8 @@
 
 #include "brave/chromium_src/components/browsing_data/core/browsing_data_utils.h"
 
+#include <string_view>
+
 #include "base/containers/fixed_flat_map.h"
 
 #if BUILDFLAG(ENABLE_AI_CHAT)
@@ -45,7 +47,7 @@ bool GetDeletionPreferenceFromDataType(
 absl::optional<BrowsingDataType> GetDataTypeFromDeletionPreference(
     const std::string& pref_name) {
   static constexpr auto kPreferenceToDataType =
-      base::MakeFixedFlatMap<base::StringPiece, BrowsingDataType>({
+      base::MakeFixedFlatMap<std::string_view, BrowsingDataType>({
           {prefs::kDeleteBraveLeoHistory, BrowsingDataType::BRAVE_AI_CHAT},
           {prefs::kDeleteBraveLeoHistoryOnExit,
            BrowsingDataType::BRAVE_AI_CHAT},

--- a/chromium_src/components/flags_ui/flags_state.cc
+++ b/chromium_src/components/flags_ui/flags_state.cc
@@ -5,6 +5,8 @@
 
 #include "components/flags_ui/flags_state.h"
 
+#include <string_view>
+
 #include "base/strings/strcat.h"
 
 #include "src/components/flags_ui/flags_state.cc"
@@ -32,14 +34,14 @@ void AppendCurrentFeatureStateIfDefault(
   DCHECK(entry.feature.feature);
   const auto& feature = *entry.feature.feature;
   const bool is_feature_enabled_now = base::FeatureList::IsEnabled(feature);
-  const base::StringPiece current_state =
-      is_feature_enabled_now ? kGenericExperimentChoiceEnabled
-                             : kGenericExperimentChoiceDisabled;
+  const std::string_view current_state = is_feature_enabled_now
+                                             ? kGenericExperimentChoiceEnabled
+                                             : kGenericExperimentChoiceDisabled;
 
   const bool is_feature_enabled_by_default =
       base::FeatureList::GetCompileTimeFeatureState(feature) ==
       base::FeatureState::FEATURE_ENABLED_BY_DEFAULT;
-  const base::StringPiece current_state_flag =
+  const std::string_view current_state_flag =
       is_feature_enabled_now != is_feature_enabled_by_default ? "*" : "";
 
   // Add current state to "Default" selector and append "*" if the state differs

--- a/chromium_src/components/flags_ui/flags_state_unittest.cc
+++ b/chromium_src/components/flags_ui/flags_state_unittest.cc
@@ -5,6 +5,8 @@
 
 #include "src/components/flags_ui/flags_state_unittest.cc"
 
+#include <string_view>
+
 #include "base/ranges/algorithm.h"
 
 namespace flags_ui {
@@ -28,7 +30,7 @@ TEST_F(FlagsStateTest, ShowDefaultState) {
   ASSERT_EQ(11u, supported_entries.size());
 
   auto check_default_option_description =
-      [&](base::StringPiece name, base::StringPiece expected_description) {
+      [&](std::string_view name, std::string_view expected_description) {
         SCOPED_TRACE(name);
         auto entry_it = base::ranges::find_if(
             supported_entries, [&](const base::Value& entry) {

--- a/chromium_src/components/search_engines/template_url_starter_pack_data.cc
+++ b/chromium_src/components/search_engines/template_url_starter_pack_data.cc
@@ -3,6 +3,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+#include <string_view>
+
 #include "components/search_engines/template_url_starter_pack_data.h"
 #include "base/strings/strcat.h"
 #include "base/strings/string_util.h"
@@ -25,7 +27,7 @@ std::vector<std::unique_ptr<TemplateURLData>> GetStarterPackEngines() {
 
   // It is necessary to correct urls for the brave schema
   for (auto& t_url : t_urls) {
-    base::StringPiece url(t_url->url());
+    std::string_view url(t_url->url());
     if (base::StartsWith(url, kChromeSchema,
                          base::CompareCase::INSENSITIVE_ASCII)) {
       t_url->SetURL(base::StrCat(

--- a/chromium_src/components/sync_device_info/device_info_sync_bridge_unittest.cc
+++ b/chromium_src/components/sync_device_info/device_info_sync_bridge_unittest.cc
@@ -3,6 +3,8 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this file,
 // you can obtain one at http://mozilla.org/MPL/2.0/.
 
+#include <string_view>
+
 #include "base/system/sys_info.h"
 #include "base/test/task_environment.h"
 #include "testing/gtest/include/gtest/gtest.h"
@@ -22,7 +24,7 @@ class TaskEnvironmentOptionalMockTime : public TaskEnvironment {
                 ? TimeSource::MOCK_TIME
                 : TimeSource::DEFAULT) {}
 
-  static bool IsMockTimedTest(base::StringPiece test_name) {
+  static bool IsMockTimedTest(std::string_view test_name) {
     return test_name == "LocalDeleteWhenOffline";
   }
 };

--- a/chromium_src/components/sync_preferences/common_syncable_prefs_database.cc
+++ b/chromium_src/components/sync_preferences/common_syncable_prefs_database.cc
@@ -5,8 +5,9 @@
 
 #include "components/sync_preferences/common_syncable_prefs_database.h"
 
+#include <string_view>
+
 #include "base/containers/fixed_flat_map.h"
-#include "base/strings/string_piece.h"
 #include "components/search_engines/search_engines_pref_names.h"
 // "//components/sync_preferences:common_syncable_prefs_database" already
 // depends on "//components/search_engines"
@@ -22,7 +23,7 @@ enum {
 
 const auto& BraveSyncablePreferences() {
   static const auto kBraveCommonSyncablePrefsAllowlist =
-      base::MakeFixedFlatMap<base::StringPiece, SyncablePrefMetadata>(
+      base::MakeFixedFlatMap<std::string_view, SyncablePrefMetadata>(
           {{prefs::kSyncedDefaultPrivateSearchProviderGUID,
             {brave_syncable_prefs_ids::kSyncedDefaultPrivateSearchProviderGUID,
              syncer::PREFERENCES, /*is_history_opt_in_required*/ false}},

--- a/chromium_src/components/translate/core/browser/translate_prefs.cc
+++ b/chromium_src/components/translate/core/browser/translate_prefs.cc
@@ -7,6 +7,8 @@
 // chromium_src/chrome/browser/prefs/browser_prefs.cc
 #include "components/translate/core/browser/translate_prefs.h"
 
+#include <string_view>
+
 #include "brave/components/translate/core/common/brave_translate_features.h"
 
 #define TranslatePrefs TranslatePrefs_ChromiumImpl
@@ -15,7 +17,7 @@
 
 namespace translate {
 
-bool TranslatePrefs::ShouldAutoTranslate(base::StringPiece source_language,
+bool TranslatePrefs::ShouldAutoTranslate(std::string_view source_language,
                                          std::string* target_language) {
   if (!IsBraveAutoTranslateEnabled()) {
     return false;

--- a/chromium_src/components/translate/core/browser/translate_prefs.h
+++ b/chromium_src/components/translate/core/browser/translate_prefs.h
@@ -6,6 +6,8 @@
 #ifndef BRAVE_CHROMIUM_SRC_COMPONENTS_TRANSLATE_CORE_BROWSER_TRANSLATE_PREFS_H_
 #define BRAVE_CHROMIUM_SRC_COMPONENTS_TRANSLATE_CORE_BROWSER_TRANSLATE_PREFS_H_
 
+#include <string_view>
+
 // This is done to allow the same renaming in
 // chromium_src/chrome/browser/prefs/browser_prefs.cc
 #define TranslatePrefs TranslatePrefs_ChromiumImpl
@@ -19,7 +21,7 @@ class TranslatePrefs : public TranslatePrefs_ChromiumImpl {
 
   // Override to control by Brave features. No virtual because TranslatePrefs
   // doesn't have a virtual dtor and the method isn't used inside the impl.
-  bool ShouldAutoTranslate(base::StringPiece source_language,
+  bool ShouldAutoTranslate(std::string_view source_language,
                            std::string* target_language);
 };
 }  // namespace translate

--- a/chromium_src/components/version_info/version_info.h
+++ b/chromium_src/components/version_info/version_info.h
@@ -6,6 +6,8 @@
 #ifndef BRAVE_CHROMIUM_SRC_COMPONENTS_VERSION_INFO_VERSION_INFO_H_
 #define BRAVE_CHROMIUM_SRC_COMPONENTS_VERSION_INFO_VERSION_INFO_H_
 
+#include <string_view>
+
 #include "brave/components/version_info/version_info_values.h"
 
 #define GetChannelString GetChannelString_ChromiumImpl
@@ -23,7 +25,7 @@ constexpr std::string GetProductNameAndVersionForUserAgent() {
 }
 
 // We use |nightly| instead of |canary|.
-constexpr base::StringPiece GetChannelString(Channel channel) {
+constexpr std::string_view GetChannelString(Channel channel) {
   if (channel == Channel::CANARY) {
     return "nightly";
   }

--- a/chromium_src/net/base/host_port_pair.cc
+++ b/chromium_src/net/base/host_port_pair.cc
@@ -6,6 +6,7 @@
 #include "net/base/host_port_pair.h"
 
 #include <string>
+#include <string_view>
 #include <vector>
 
 #include "base/strings/string_split.h"
@@ -19,19 +20,19 @@ bool HasAuthentication(const GURL& url) {
   return url.has_username() || url.has_password();
 }
 
-bool HasAuthentication(base::StringPiece str) {
-  std::vector<base::StringPiece> auth_host = base::SplitStringPiece(
+bool HasAuthentication(std::string_view str) {
+  std::vector<std::string_view> auth_host = base::SplitStringPiece(
       str, "@", base::TRIM_WHITESPACE, base::SPLIT_WANT_ALL);
   return auth_host.size() == 2;
 }
 
-HostPortPair FromStringWithAuthentication(base::StringPiece str) {
-  std::vector<base::StringPiece> auth_host = base::SplitStringPiece(
+HostPortPair FromStringWithAuthentication(std::string_view str) {
+  std::vector<std::string_view> auth_host = base::SplitStringPiece(
       str, "@", base::TRIM_WHITESPACE, base::SPLIT_WANT_ALL);
   HostPortPair host_port_pair =
       HostPortPair::FromString(std::string(auth_host[1]));
 
-  std::vector<base::StringPiece> user_pass = base::SplitStringPiece(
+  std::vector<std::string_view> user_pass = base::SplitStringPiece(
       str, ":", base::TRIM_WHITESPACE, base::SPLIT_WANT_ALL);
 
   host_port_pair.set_username(std::string(user_pass[0]));
@@ -81,9 +82,9 @@ namespace net {
 HostPortPair::~HostPortPair() = default;
 HostPortPair::HostPortPair(const HostPortPair& host_port) = default;
 
-HostPortPair::HostPortPair(base::StringPiece username,
-                           base::StringPiece password,
-                           base::StringPiece in_host,
+HostPortPair::HostPortPair(std::string_view username,
+                           std::string_view password,
+                           std::string_view in_host,
                            uint16_t in_port)
     : username_(username),
       password_(password),

--- a/chromium_src/net/base/host_port_pair.h
+++ b/chromium_src/net/base/host_port_pair.h
@@ -7,23 +7,24 @@
 #define BRAVE_CHROMIUM_SRC_NET_BASE_HOST_PORT_PAIR_H_
 
 #include <string>
+#include <string_view>
 
 // Nudges HostPortPair past Chromium's style
 // threshold for in-line constructors and destructors.
-#define BRAVE_HOST_PORT_PAIR_H_                                        \
-  HostPortPair(base::StringPiece username, base::StringPiece password, \
-               base::StringPiece in_host, uint16_t in_port);           \
-  ~HostPortPair();                                                     \
-  HostPortPair(const HostPortPair&);                                   \
-  const std::string& username() const;                                 \
-  const std::string& password() const;                                 \
-  void set_username(const std::string& username);                      \
-  void set_password(const std::string& password);                      \
-  bool operator<(const HostPortPair& other) const;                     \
-  bool Equals(const HostPortPair& other) const;                        \
-                                                                       \
- private:                                                              \
-  std::string username_;                                               \
+#define BRAVE_HOST_PORT_PAIR_H_                                      \
+  HostPortPair(std::string_view username, std::string_view password, \
+               std::string_view in_host, uint16_t in_port);          \
+  ~HostPortPair();                                                   \
+  HostPortPair(const HostPortPair&);                                 \
+  const std::string& username() const;                               \
+  const std::string& password() const;                               \
+  void set_username(const std::string& username);                    \
+  void set_password(const std::string& password);                    \
+  bool operator<(const HostPortPair& other) const;                   \
+  bool Equals(const HostPortPair& other) const;                      \
+                                                                     \
+ private:                                                            \
+  std::string username_;                                             \
   std::string password_;
 
 #include "src/net/base/host_port_pair.h"  // IWYU pragma: export

--- a/chromium_src/net/base/lookup_string_in_fixed_set.cc
+++ b/chromium_src/net/base/lookup_string_in_fixed_set.cc
@@ -5,6 +5,8 @@
 
 #include "net/base/lookup_string_in_fixed_set.h"
 
+#include <string_view>
+
 #define LookupSuffixInReversedSet LookupSuffixInReversedSet_ChromiumImpl
 #include "src/net/base/lookup_string_in_fixed_set.cc"
 #undef LookupSuffixInReversedSet
@@ -24,7 +26,7 @@ namespace net {
 int LookupSuffixInReversedSet(const unsigned char* graph,
                               size_t length,
                               bool include_private,
-                              base::StringPiece host,
+                              std::string_view host,
                               size_t* suffix_length) {
   constexpr char kIpfsLocalhost[] = ".ipfs.localhost";
   constexpr char kIpnsLocalhost[] = ".ipns.localhost";

--- a/chromium_src/net/base/proxy_server.cc
+++ b/chromium_src/net/base/proxy_server.cc
@@ -5,6 +5,8 @@
 
 #include "net/base/proxy_server.h"
 
+#include <string_view>
+
 #include "net/base/url_util.h"
 
 namespace {
@@ -12,9 +14,9 @@ namespace {
 // We need to call this before url::CanonicalizeHost() to extract the username
 // and password needed to create the HostPortPair later on, as well as to be
 // able to pass the hostname only to url::CanonicalizeHost(), or it will fail.
-void ParseAuthInfoAndHostname(base::StringPiece* hostname,
-                              base::StringPiece* username,
-                              base::StringPiece* password) {
+void ParseAuthInfoAndHostname(std::string_view* hostname,
+                              std::string_view* username,
+                              std::string_view* password) {
   url::Component user_component, password_component;
   url::Component host_component, port_component;
   url::ParseAuthority(hostname->data(), url::Component(0, hostname->size()),
@@ -41,7 +43,7 @@ void ParseAuthInfoAndHostname(base::StringPiece* hostname,
 }  // namespace
 
 #define BRAVE_PROXY_SERVER_FROM_SCHEME_HOST_AND_PORT_EXTRACT_AUTH_INFO \
-  base::StringPiece username, password;                                \
+  std::string_view username, password;                                 \
   ParseAuthInfoAndHostname(&host, &username, &password);
 
 #define BRAVE_PROXY_SERVER_FROM_SCHEME_HOST_AND_PORT_RETURN_HOST_PORT_PAIR     \

--- a/chromium_src/net/base/proxy_string_util.cc
+++ b/chromium_src/net/base/proxy_string_util.cc
@@ -17,7 +17,7 @@ namespace {
 // information when creating a ProxyServer, instead of bailing out.
 ProxyServer CreateProxyServerWithAuthInfo(
     const ProxyServer::Scheme& scheme,
-    const std::string_view& host_and_port) {
+    const std::string_view host_and_port) {
   url::Component username_component;
   url::Component password_component;
   url::Component hostname_component;

--- a/chromium_src/net/base/proxy_string_util.cc
+++ b/chromium_src/net/base/proxy_string_util.cc
@@ -5,6 +5,8 @@
 
 #include "net/base/proxy_string_util.h"
 
+#include <string_view>
+
 #include "base/strings/strcat.h"
 #include "url/third_party/mozilla/url_parse.h"
 
@@ -15,7 +17,7 @@ namespace {
 // information when creating a ProxyServer, instead of bailing out.
 ProxyServer CreateProxyServerWithAuthInfo(
     const ProxyServer::Scheme& scheme,
-    const base::StringPiece& host_and_port) {
+    const std::string_view& host_and_port) {
   url::Component username_component;
   url::Component password_component;
   url::Component hostname_component;
@@ -25,11 +27,11 @@ ProxyServer CreateProxyServerWithAuthInfo(
                       &username_component, &password_component,
                       &hostname_component, &port_component);
 
-  base::StringPiece hostname =
+  std::string_view hostname =
       host_and_port.substr(hostname_component.begin, hostname_component.len);
   if (port_component.is_valid() && !port_component.is_nonempty())
     return ProxyServer();
-  base::StringPiece port =
+  std::string_view port =
       port_component.is_nonempty()
           ? host_and_port.substr(port_component.begin, port_component.len)
           : "";

--- a/chromium_src/net/tools/transport_security_state_generator/input_file_parsers.cc
+++ b/chromium_src/net/tools/transport_security_state_generator/input_file_parsers.cc
@@ -3,6 +3,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+#include <string_view>
+
 #define ParseJSON ParseJSON_ChromiumImpl
 #define ParseCertificatesFile ParseCertificatesFile_ChromiumImpl
 #include "src/net/tools/transport_security_state_generator/input_file_parsers.cc"
@@ -10,7 +12,7 @@
 #undef ParseJSON
 
 namespace {
-constexpr base::StringPiece kBravePinsJson = R"brave_pins_json({
+constexpr std::string_view kBravePinsJson = R"brave_pins_json({
   "pinsets": [
     {
       "name": "brave",
@@ -124,7 +126,7 @@ constexpr base::StringPiece kBravePinsJson = R"brave_pins_json({
     { "name": "ssl-pinning.someblog.org", "pins" : "brave"}
  ]})brave_pins_json";
 
-constexpr base::StringPiece kBraveHstsJson = R"brave_hsts_json({
+constexpr std::string_view kBraveHstsJson = R"brave_hsts_json({
   "entries": [
     // Critical endpoints that should remain unpinned so that they
     // always work.
@@ -537,10 +539,10 @@ namespace net {
 
 namespace transport_security_state {
 
-bool ParseCertificatesFile(base::StringPiece certs_input,
+bool ParseCertificatesFile(std::string_view certs_input,
                            Pinsets* pinsets,
                            base::Time* timestamp) {
-  constexpr base::StringPiece brave_certs = R"brave_certs(
+  constexpr std::string_view brave_certs = R"brave_certs(
 # Last updated: Thu Sep 21 23:38:51 UTC 2023
 PinsListTimestamp
 1695339531
@@ -882,8 +884,8 @@ tL4ndQavEi51mI38AjEAi/V3bNTIZargCyzuFJ0nN6T5U6VR5CmD1/iQMVtCnwr1
   return ParseCertificatesFile_ChromiumImpl(brave_certs, pinsets, timestamp);
 }
 
-bool ParseJSON(base::StringPiece hsts_json,
-               base::StringPiece pins_json,
+bool ParseJSON(std::string_view hsts_json,
+               std::string_view pins_json,
                TransportSecurityStateEntries* entries,
                Pinsets* pinsets) {
   Pinsets chromium_pinsets;

--- a/chromium_src/third_party/blink/common/origin_trials/origin_trials.cc
+++ b/chromium_src/third_party/blink/common/origin_trials/origin_trials.cc
@@ -5,11 +5,13 @@
 
 #include "third_party/blink/public/common/origin_trials/origin_trials.h"
 
+#include <string_view>
+
 #include "base/containers/contains.h"
 
 namespace blink {
 namespace origin_trials {
-bool IsTrialValid_ChromiumImpl(base::StringPiece trial_name);
+bool IsTrialValid_ChromiumImpl(std::string_view trial_name);
 }  // namespace origin_trials
 }  // namespace blink
 
@@ -20,7 +22,7 @@ bool IsTrialValid_ChromiumImpl(base::StringPiece trial_name);
 namespace blink {
 namespace origin_trials {
 
-bool IsTrialDisabledInBrave(base::StringPiece trial_name) {
+bool IsTrialDisabledInBrave(std::string_view trial_name) {
   // When updating also update the array in the overload below.
   // clang-format off
   static const char* const kBraveDisabledTrialNames[] = {
@@ -69,7 +71,7 @@ bool IsTrialDisabledInBrave(OriginTrialFeature feature) {
   return base::Contains(kBraveDisabledTrialFeatures, feature);
 }
 
-bool IsTrialValid(base::StringPiece trial_name) {
+bool IsTrialValid(std::string_view trial_name) {
   if (IsTrialDisabledInBrave(trial_name))
     return false;
 

--- a/chromium_src/third_party/blink/public/common/origin_trials/origin_trials.h
+++ b/chromium_src/third_party/blink/public/common/origin_trials/origin_trials.h
@@ -6,12 +6,14 @@
 #ifndef BRAVE_CHROMIUM_SRC_THIRD_PARTY_BLINK_PUBLIC_COMMON_ORIGIN_TRIALS_ORIGIN_TRIALS_H_
 #define BRAVE_CHROMIUM_SRC_THIRD_PARTY_BLINK_PUBLIC_COMMON_ORIGIN_TRIALS_ORIGIN_TRIALS_H_
 
+#include <string_view>
+
 #include "src/third_party/blink/public/common/origin_trials/origin_trials.h"  // IWYU pragma: export
 
 namespace blink {
 namespace origin_trials {
 
-BLINK_COMMON_EXPORT bool IsTrialDisabledInBrave(base::StringPiece trial_name);
+BLINK_COMMON_EXPORT bool IsTrialDisabledInBrave(std::string_view trial_name);
 BLINK_COMMON_EXPORT bool IsTrialDisabledInBrave(OriginTrialFeature feature);
 
 }  // namespace origin_trials

--- a/chromium_src/third_party/blink/renderer/platform/bindings/idl_member_installer.cc
+++ b/chromium_src/third_party/blink/renderer/platform/bindings/idl_member_installer.cc
@@ -5,7 +5,8 @@
 
 #include "src/third_party/blink/renderer/platform/bindings/idl_member_installer.cc"
 
-#include "base/strings/string_piece.h"
+#include <string_view>
+
 #include "third_party/blink/public/common/features.h"
 
 namespace blink {
@@ -15,7 +16,7 @@ namespace bindings {
 namespace {
 
 bool IsConnectionConfig(const IDLMemberInstaller::AttributeConfig& config) {
-  constexpr base::StringPiece kConnection = "connection";
+  constexpr std::string_view kConnection = "connection";
   return kConnection == config.name;
 }
 

--- a/common/extensions/brave_extensions_api_provider.cc
+++ b/common/extensions/brave_extensions_api_provider.cc
@@ -5,6 +5,8 @@
 
 #include "brave/common/extensions/brave_extensions_api_provider.h"
 
+#include <string_view>
+
 #include "brave/common/extensions/api/generated_includes.h"
 #include "extensions/common/features/json_feature_provider_source.h"
 #include "extensions/common/permissions/permissions_info.h"
@@ -43,7 +45,7 @@ bool BraveExtensionsAPIProvider::IsAPISchemaGenerated(
   return api::BraveGeneratedSchemas::IsGenerated(name);
 }
 
-base::StringPiece BraveExtensionsAPIProvider::GetAPISchema(
+std::string_view BraveExtensionsAPIProvider::GetAPISchema(
     const std::string& name) {
   return api::BraveGeneratedSchemas::Get(name);
 }

--- a/common/extensions/brave_extensions_api_provider.h
+++ b/common/extensions/brave_extensions_api_provider.h
@@ -7,6 +7,7 @@
 #define BRAVE_COMMON_EXTENSIONS_BRAVE_EXTENSIONS_API_PROVIDER_H_
 
 #include <string>
+#include <string_view>
 
 #include "extensions/common/extensions_api_provider.h"
 
@@ -27,7 +28,7 @@ class BraveExtensionsAPIProvider : public ExtensionsAPIProvider {
   void AddBehaviorFeatures(FeatureProvider* provider) override;
   void AddAPIJSONSources(JSONFeatureProviderSource* json_source) override;
   bool IsAPISchemaGenerated(const std::string& name) override;
-  base::StringPiece GetAPISchema(const std::string& name) override;
+  std::string_view GetAPISchema(const std::string& name) override;
   void RegisterPermissions(PermissionsInfo* permissions_info) override;
   void RegisterManifestHandlers() override;
 

--- a/components/ai_chat/browser/ai_chat_tab_helper.cc
+++ b/components/ai_chat/browser/ai_chat_tab_helper.cc
@@ -7,6 +7,7 @@
 
 #include <memory>
 #include <string>
+#include <string_view>
 #include <utility>
 
 #include "base/containers/contains.h"
@@ -39,7 +40,7 @@ using ai_chat::mojom::ConversationTurn;
 using ai_chat::mojom::ConversationTurnVisibility;
 
 namespace {
-static const auto kAllowedSchemes = base::MakeFixedFlatSet<base::StringPiece>(
+static const auto kAllowedSchemes = base::MakeFixedFlatSet<std::string_view>(
     {url::kHttpsScheme, url::kHttpScheme, url::kFileScheme, url::kDataScheme});
 }  // namespace
 

--- a/components/ai_chat/browser/engine/engine_consumer_claude.cc
+++ b/components/ai_chat/browser/engine/engine_consumer_claude.cc
@@ -7,6 +7,7 @@
 
 #include <memory>
 #include <string>
+#include <string_view>
 #include <utility>
 #include <vector>
 
@@ -17,7 +18,6 @@
 #include "base/memory/weak_ptr.h"
 #include "base/strings/pattern.h"
 #include "base/strings/strcat.h"
-#include "base/strings/string_piece.h"
 #include "base/strings/string_split.h"
 #include "base/strings/string_util.h"
 #include "base/types/expected.h"
@@ -54,7 +54,7 @@ constexpr char kHumanPromptPlaceholder[] = "\nH: ";
 constexpr char kAIPromptPlaceholder[] = "\n\nA: ";
 
 static constexpr auto kStopSequences =
-    base::MakeFixedFlatSet<base::StringPiece>({kHumanPromptSequence});
+    base::MakeFixedFlatSet<std::string_view>({kHumanPromptSequence});
 
 std::string GetConversationHistoryString(
     const std::vector<ConversationTurn>& conversation_history) {
@@ -123,8 +123,8 @@ EngineConsumerClaudeRemote::EngineConsumerClaudeRemote(
   // likley it will be chosen by the server and the general string "claude"
   // provided here.
   const auto model_name = ai_chat::features::kAIModelName.Get();
-  base::flat_set<base::StringPiece> stop_sequences(kStopSequences.begin(),
-                                                   kStopSequences.end());
+  base::flat_set<std::string_view> stop_sequences(kStopSequences.begin(),
+                                                  kStopSequences.end());
   api_ = std::make_unique<RemoteCompletionClient>(model_name, stop_sequences,
                                                   url_loader_factory);
 }

--- a/components/ai_chat/browser/engine/engine_consumer_llama.cc
+++ b/components/ai_chat/browser/engine/engine_consumer_llama.cc
@@ -7,6 +7,7 @@
 
 #include <memory>
 #include <string>
+#include <string_view>
 #include <utility>
 #include <vector>
 
@@ -18,7 +19,6 @@
 #include "base/memory/raw_ptr.h"
 #include "base/memory/weak_ptr.h"
 #include "base/strings/strcat.h"
-#include "base/strings/string_piece.h"
 #include "base/strings/string_split.h"
 #include "base/strings/string_util.h"
 #include "base/strings/utf_string_conversions.h"
@@ -43,7 +43,7 @@ constexpr char kLlama2BSys[] = "<<SYS>>\n";
 constexpr char kLlama2ESys[] = "\n<</SYS>>\n\n";
 
 static constexpr auto kStopSequences =
-    base::MakeFixedFlatSet<base::StringPiece>({kLlama2Eos});
+    base::MakeFixedFlatSet<std::string_view>({kLlama2Eos});
 
 std::string BuildLlama2InstructionPrompt(const std::string& instruction) {
   return base::ReplaceStringPlaceholders(
@@ -246,8 +246,8 @@ EngineConsumerLlamaRemote::EngineConsumerLlamaRemote(
   // likely it will be chosen by the server and the general string "leo"
   // provided here.
   const auto model_name = ai_chat::features::kAIModelName.Get();
-  base::flat_set<base::StringPiece> stop_sequences(kStopSequences.begin(),
-                                                   kStopSequences.end());
+  base::flat_set<std::string_view> stop_sequences(kStopSequences.begin(),
+                                                  kStopSequences.end());
   api_ = std::make_unique<RemoteCompletionClient>(model_name, stop_sequences,
                                                   url_loader_factory);
 }

--- a/components/ai_chat/browser/engine/remote_completion_client.cc
+++ b/components/ai_chat/browser/engine/remote_completion_client.cc
@@ -7,6 +7,7 @@
 
 #include <base/containers/flat_map.h>
 
+#include <string_view>
 #include <utility>
 
 #include "base/containers/flat_set.h"
@@ -15,7 +16,6 @@
 #include "base/json/json_writer.h"
 #include "base/no_destructor.h"
 #include "base/strings/strcat.h"
-#include "base/strings/string_piece.h"
 #include "base/values.h"
 #include "brave/components/ai_chat/browser/constants.h"
 #include "brave/components/ai_chat/common/buildflags/buildflags.h"
@@ -56,7 +56,7 @@ net::NetworkTrafficAnnotationTag GetNetworkTrafficAnnotationTag() {
 base::Value::Dict CreateApiParametersDict(
     const std::string& prompt,
     const std::string& model_name,
-    const base::flat_set<base::StringPiece>& stop_sequences,
+    const base::flat_set<std::string_view>& stop_sequences,
     const std::vector<std::string> additional_stop_sequences,
     const bool is_sse_enabled) {
   base::Value::Dict dict;
@@ -115,7 +115,7 @@ const GURL GetEndpointBaseUrl() {
 
 RemoteCompletionClient::RemoteCompletionClient(
     std::string model_name,
-    const base::flat_set<base::StringPiece>& stop_sequences,
+    const base::flat_set<std::string_view>& stop_sequences,
     scoped_refptr<network::SharedURLLoaderFactory> url_loader_factory)
     : model_name_(model_name),
       stop_sequences_(stop_sequences),

--- a/components/ai_chat/browser/engine/remote_completion_client.h
+++ b/components/ai_chat/browser/engine/remote_completion_client.h
@@ -8,12 +8,12 @@
 
 #include <memory>
 #include <string>
+#include <string_view>
 #include <vector>
 
 #include "base/containers/flat_set.h"
 #include "base/functional/callback_forward.h"
 #include "base/memory/weak_ptr.h"
-#include "base/strings/string_piece_forward.h"
 #include "base/types/expected.h"
 #include "brave/components/ai_chat/browser/engine/engine_consumer.h"
 #include "brave/components/ai_chat/common/mojom/ai_chat.mojom.h"
@@ -31,7 +31,7 @@ class RemoteCompletionClient {
  public:
   RemoteCompletionClient(
       std::string model_name,
-      const base::flat_set<base::StringPiece>& stop_sequences,
+      const base::flat_set<std::string_view>& stop_sequences,
       scoped_refptr<network::SharedURLLoaderFactory> url_loader_factory);
 
   RemoteCompletionClient(const RemoteCompletionClient&) = delete;
@@ -56,7 +56,7 @@ class RemoteCompletionClient {
                         APIRequestResult result);
 
   std::string model_name_;
-  const base::flat_set<base::StringPiece> stop_sequences_;
+  const base::flat_set<std::string_view> stop_sequences_;
   api_request_helper::APIRequestHelper api_request_helper_;
 
   base::WeakPtrFactory<RemoteCompletionClient> weak_ptr_factory_{this};

--- a/components/ai_chat/renderer/page_content_extractor.cc
+++ b/components/ai_chat/renderer/page_content_extractor.cc
@@ -6,13 +6,13 @@
 #include "brave/components/ai_chat/renderer/page_content_extractor.h"
 
 #include <string>
+#include <string_view>
 #include <utility>
 
 #include "base/containers/contains.h"
 #include "base/containers/fixed_flat_set.h"
 #include "base/containers/span.h"
 #include "base/functional/bind.h"
-#include "base/strings/string_piece_forward.h"
 #include "base/values.h"
 #include "brave/components/ai_chat/common/mojom/page_content_extractor.mojom-shared.h"
 #include "brave/components/ai_chat/common/mojom/page_content_extractor.mojom.h"
@@ -72,13 +72,13 @@ const char16_t kVideoTrackTranscriptUrlExtractionScript[] =
       })()
     )JS";
 
-constexpr auto kYouTubeHosts = base::MakeFixedFlatSet<base::StringPiece>(
+constexpr auto kYouTubeHosts = base::MakeFixedFlatSet<std::string_view>(
     {"www.youtube.com", "m.youtube.com"});
 
 // TODO(petemill): Use heuristics to determine if page's main focus is
 // a video, and not a hard-coded list of Url hosts.
 constexpr auto kVideoTrackHosts =
-    base::MakeFixedFlatSet<base::StringPiece>({"www.ted.com"});
+    base::MakeFixedFlatSet<std::string_view>({"www.ted.com"});
 
 }  // namespace
 

--- a/components/api_request_helper/api_request_helper.h
+++ b/components/api_request_helper/api_request_helper.h
@@ -9,6 +9,7 @@
 #include <list>
 #include <memory>
 #include <string>
+#include <string_view>
 
 #include "base/containers/flat_map.h"
 #include "base/files/file_path.h"
@@ -109,7 +110,7 @@ class APIRequestHelper {
     void SetResultCallback(ResultCallback result_callback);
     base::WeakPtr<URLLoaderHandler> GetWeakPtr();
 
-    void send_sse_data_for_testing(base::StringPiece string_piece,
+    void send_sse_data_for_testing(std::string_view string_piece,
                                    bool is_sse,
                                    DataReceivedCallback callback);
 
@@ -122,10 +123,10 @@ class APIRequestHelper {
     // If Cancel is needed even if url or data operations are in progress,
     // then call |APIRequestHelper::Cancel|.
     void MaybeSendResult();
-    void ParseSSE(base::StringPiece string_piece);
+    void ParseSSE(std::string_view string_piece);
 
     // network::SimpleURLLoaderStreamConsumer implementation:
-    void OnDataReceived(base::StringPiece string_piece,
+    void OnDataReceived(std::string_view string_piece,
                         base::OnceClosure resume) override;
     void OnComplete(bool success) override;
     void OnRetry(base::OnceClosure start_retry) override;

--- a/components/api_request_helper/api_request_helper_unittest.cc
+++ b/components/api_request_helper/api_request_helper_unittest.cc
@@ -6,6 +6,7 @@
 #include "brave/components/api_request_helper/api_request_helper.h"
 
 #include <memory>
+#include <string_view>
 #include <utility>
 
 #include "base/functional/callback.h"
@@ -115,13 +116,13 @@ class ApiRequestHelperUnitTest : public testing::Test {
     base::RunLoop().RunUntilIdle();
   }
 
-  void SendMessageSSEJSON(base::StringPiece string_piece,
+  void SendMessageSSEJSON(std::string_view string_piece,
                           APIRequestHelper::DataReceivedCallback callback) {
     loader_wrapper_handler_->send_sse_data_for_testing(string_piece, true,
                                                        std::move(callback));
   }
 
-  void SendMessageSSE(base::StringPiece string_piece,
+  void SendMessageSSE(std::string_view string_piece,
                       APIRequestHelper::DataReceivedCallback callback) {
     loader_wrapper_handler_->send_sse_data_for_testing(string_piece, false,
                                                        std::move(callback));

--- a/components/brave_ads/core/internal/serving/targeting/top_segments_unittest.cc
+++ b/components/brave_ads/core/internal/serving/targeting/top_segments_unittest.cc
@@ -78,7 +78,7 @@ struct ParamInfo final {
 SegmentList GetSegmentList() {
   SegmentList segments;
   base::ranges::transform(GetSegments(), std::back_inserter(segments),
-                          [](const std::string_view& segment) {
+                          [](const std::string_view segment) {
                             return static_cast<std::string>(segment);
                           });
   return segments;

--- a/components/brave_ads/core/internal/targeting/behavioral/multi_armed_bandits/model/epsilon_greedy_bandit_model_unittest.cc
+++ b/components/brave_ads/core/internal/targeting/behavioral/multi_armed_bandits/model/epsilon_greedy_bandit_model_unittest.cc
@@ -26,7 +26,7 @@ namespace {
 SegmentList GetSegmentList() {
   SegmentList segments;
   base::ranges::transform(GetSegments(), std::back_inserter(segments),
-                          [](const std::string_view& segment) {
+                          [](const std::string_view segment) {
                             return static_cast<std::string>(segment);
                           });
   return segments;

--- a/components/brave_news/browser/brave_news_controller.cc
+++ b/components/brave_news/browser/brave_news_controller.cc
@@ -9,6 +9,7 @@
 #include <cmath>
 #include <memory>
 #include <string>
+#include <string_view>
 #include <unordered_set>
 #include <utility>
 #include <vector>
@@ -383,7 +384,7 @@ void BraveNewsController::GetImageData(const GURL& padded_image_url,
             // Handle the response
             VLOG(3) << "getimagedata response code: " << response_code;
             // Attempt to remove byte padding if applicable
-            base::StringPiece body_payload(body.data(), body.size());
+            std::string_view body_payload(body.data(), body.size());
             if (response_code < 200 || response_code >= 300 ||
                 (is_padded &&
                  !brave::PrivateCdnHelper::GetInstance()->RemovePadding(

--- a/components/brave_news/browser/html_parsing.cc
+++ b/components/brave_news/browser/html_parsing.cc
@@ -6,13 +6,13 @@
 #include "brave/components/brave_news/browser/html_parsing.h"
 
 #include <string>
+#include <string_view>
 #include <vector>
 
 #include "base/containers/contains.h"
 #include "base/containers/fixed_flat_set.h"
 #include "base/i18n/icu_string_conversions.h"
 #include "base/logging.h"
-#include "base/strings/string_piece.h"
 #include "base/strings/string_util.h"
 #include "third_party/re2/src/re2/re2.h"
 #include "third_party/re2/src/re2/stringpiece.h"
@@ -22,12 +22,12 @@ namespace brave_news {
 
 namespace {
 
-constexpr auto kSupportedFeedTypes = base::MakeFixedFlatSet<base::StringPiece>(
+constexpr auto kSupportedFeedTypes = base::MakeFixedFlatSet<std::string_view>(
     {"application/rss+xml", "application/atom+xml", "application/xml",
      "application/rss+atom", "application/json"});
 
 constexpr auto kSupportedRels =
-    base::MakeFixedFlatSet<base::StringPiece>({"alternate", "service.feed"});
+    base::MakeFixedFlatSet<std::string_view>({"alternate", "service.feed"});
 
 }  // namespace
 

--- a/components/brave_news/browser/locales_helper.cc
+++ b/components/brave_news/browser/locales_helper.cc
@@ -6,6 +6,7 @@
 #include "brave/components/brave_news/browser/locales_helper.h"
 
 #include <string>
+#include <string_view>
 #include <vector>
 
 #include "base/containers/contains.h"
@@ -32,10 +33,10 @@ namespace {
 // list of matches for enabling Brave News on the NTP and prompting the user
 // to opt-in.
 constexpr auto kEnabledLanguages =
-    base::MakeFixedFlatSet<base::StringPiece>({"en", "ja"});
+    base::MakeFixedFlatSet<std::string_view>({"en", "ja"});
 // We can add to this list as new locales become available to have Brave News
 // show when it's ready for those users.
-constexpr auto kEnabledLocales = base::MakeFixedFlatSet<base::StringPiece>(
+constexpr auto kEnabledLocales = base::MakeFixedFlatSet<std::string_view>(
     {"es_ES", "es_MX", "pt_BR", "fr_FR", "de_DE"});
 
 bool HasAnyLocale(const base::flat_set<std::string>& locales,

--- a/components/brave_perf_predictor/browser/named_third_party_registry.cc
+++ b/components/brave_perf_predictor/browser/named_third_party_registry.cc
@@ -5,6 +5,7 @@
 
 #include "brave/components/brave_perf_predictor/browser/named_third_party_registry.h"
 
+#include <string_view>
 #include <tuple>
 
 #include "base/containers/flat_set.h"
@@ -12,7 +13,6 @@
 #include "base/json/json_reader.h"
 #include "base/logging.h"
 #include "base/metrics/histogram_macros.h"
-#include "base/strings/string_piece.h"
 #include "base/strings/string_util.h"
 #include "base/task/thread_pool.h"
 #include "base/values.h"
@@ -29,7 +29,7 @@ namespace {
 
 std::tuple<base::flat_map<std::string, std::string>,
            base::flat_map<std::string, std::string>>
-ParseMappings(const base::StringPiece entities, bool discard_irrelevant) {
+ParseMappings(const std::string_view entities, bool discard_irrelevant) {
   base::flat_map<std::string, std::string> entity_by_domain;
   base::flat_map<std::string, std::string> entity_by_root_domain;
 
@@ -59,7 +59,7 @@ ParseMappings(const base::StringPiece entities, bool discard_irrelevant) {
       if (!entity_domain_it.is_string()) {
         continue;
       }
-      const base::StringPiece entity_domain(entity_domain_it.GetString());
+      const std::string_view entity_domain(entity_domain_it.GetString());
 
       const auto inserted =
           entity_by_domain.emplace(entity_domain, *entity_name);
@@ -101,7 +101,7 @@ ParseFromResource(int resource_id) {
 
 }  // namespace
 
-bool NamedThirdPartyRegistry::LoadMappings(const base::StringPiece entities,
+bool NamedThirdPartyRegistry::LoadMappings(const std::string_view entities,
                                            bool discard_irrelevant) {
   // Reset previous mappings
   entity_by_domain_.clear();
@@ -127,7 +127,7 @@ void NamedThirdPartyRegistry::UpdateMappings(
 }
 
 absl::optional<std::string> NamedThirdPartyRegistry::GetThirdParty(
-    const base::StringPiece request_url) const {
+    const std::string_view request_url) const {
   if (!IsInitialized()) {
     VLOG(2) << "Named Third Party Registry not initialized";
     return absl::nullopt;

--- a/components/brave_perf_predictor/browser/named_third_party_registry.h
+++ b/components/brave_perf_predictor/browser/named_third_party_registry.h
@@ -7,6 +7,7 @@
 #define BRAVE_COMPONENTS_BRAVE_PERF_PREDICTOR_BROWSER_NAMED_THIRD_PARTY_REGISTRY_H_
 
 #include <string>
+#include <string_view>
 #include <tuple>
 
 #include "base/containers/flat_map.h"
@@ -30,11 +31,11 @@ class NamedThirdPartyRegistry : public KeyedService {
   // Parse the provided mappings (in JSON format), potentially discarding
   // entities not relevant to the bandwith prediction model (i.e. those not
   // seen in training the model).
-  bool LoadMappings(const base::StringPiece entities, bool discard_irrelevant);
+  bool LoadMappings(const std::string_view entities, bool discard_irrelevant);
   // Default initialization - asynchronously load from bundled resource
   void InitializeDefault();
   absl::optional<std::string> GetThirdParty(
-      const base::StringPiece domain) const;
+      const std::string_view domain) const;
 
  private:
   bool IsInitialized() const { return initialized_; }

--- a/components/brave_private_cdn/private_cdn_helper.cc
+++ b/components/brave_private_cdn/private_cdn_helper.cc
@@ -5,6 +5,8 @@
 
 #include "brave/components/brave_private_cdn/private_cdn_helper.h"
 
+#include <string_view>
+
 #include "base/big_endian.h"
 #include "base/no_destructor.h"
 
@@ -16,7 +18,7 @@ PrivateCdnHelper* PrivateCdnHelper::GetInstance() {
   return instance.get();
 }
 
-bool PrivateCdnHelper::RemovePadding(base::StringPiece* padded_string) const {
+bool PrivateCdnHelper::RemovePadding(std::string_view* padded_string) const {
   if (!padded_string) {
     return false;
   }

--- a/components/brave_private_cdn/private_cdn_helper.h
+++ b/components/brave_private_cdn/private_cdn_helper.h
@@ -6,7 +6,7 @@
 #ifndef BRAVE_COMPONENTS_BRAVE_PRIVATE_CDN_PRIVATE_CDN_HELPER_H_
 #define BRAVE_COMPONENTS_BRAVE_PRIVATE_CDN_PRIVATE_CDN_HELPER_H_
 
-#include "base/strings/string_piece.h"
+#include <string_view>
 
 namespace base {
 template <typename T>
@@ -22,7 +22,7 @@ class PrivateCdnHelper final {
 
   static PrivateCdnHelper* GetInstance();
 
-  bool RemovePadding(base::StringPiece* padded_string) const;
+  bool RemovePadding(std::string_view* padded_string) const;
 
  private:
   friend base::NoDestructor<PrivateCdnHelper>;

--- a/components/brave_private_cdn/private_cdn_helper_unittest.cc
+++ b/components/brave_private_cdn/private_cdn_helper_unittest.cc
@@ -4,6 +4,7 @@
  * You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 #include <string>
+#include <string_view>
 
 #include "brave/components/brave_private_cdn/private_cdn_helper.h"
 #include "testing/gtest/include/gtest/gtest.h"
@@ -25,7 +26,7 @@ TEST(BravePrivateCdnHelper, RemovePadding) {
   };
 
   for (auto& invalid_input : invalid_inputs) {
-    base::StringPiece padded_string(invalid_input);
+    std::string_view padded_string(invalid_input);
     EXPECT_FALSE(helper->RemovePadding(&padded_string));
   }
 
@@ -73,7 +74,7 @@ TEST(BravePrivateCdnHelper, RemovePadding) {
                 "Inputs and outputs must have the same number of elements.");
 
   for (size_t i = 0; i < input_count; i++) {
-    base::StringPiece padded_string(inputs[i]);
+    std::string_view padded_string(inputs[i]);
     EXPECT_TRUE(helper->RemovePadding(&padded_string));
     EXPECT_EQ(padded_string, outputs[i]);
   }

--- a/components/brave_rewards/browser/rewards_protocol_handler.cc
+++ b/components/brave_rewards/browser/rewards_protocol_handler.cc
@@ -7,13 +7,13 @@
 
 #include <map>
 #include <string>
+#include <string_view>
 #include <utility>
 #include <vector>
 
 #include "base/ranges/algorithm.h"
 #include "base/strings/escape.h"
 #include "base/strings/strcat.h"
-#include "base/strings/string_piece.h"
 #include "base/strings/string_split.h"
 #include "base/strings/string_util.h"
 #include "brave/components/brave_rewards/core/buildflags.h"
@@ -55,7 +55,7 @@ bool IsValidWalletProviderRedirect(
           allowed_referrer_urls.contains(wallet_provider)
               ? allowed_referrer_urls.at(wallet_provider)
               : std::vector<GURL>{},
-          [&](base::StringPiece host_piece) {
+          [&](std::string_view host_piece) {
             return referrer_url.DomainIs(host_piece);
           },
           &GURL::host_piece)) {

--- a/components/brave_rewards/core/common/brotli_util.cc
+++ b/components/brave_rewards/core/common/brotli_util.cc
@@ -6,8 +6,10 @@
 #include "brave/components/brave_rewards/core/common/brotli_util.h"
 
 #include <memory>
+#include <string_view>
 #include <vector>
 
+#include "base/check_op.h"
 #include "third_party/brotli/include/brotli/decode.h"
 
 namespace {
@@ -75,7 +77,7 @@ class BrotliStreamDecoder {
 namespace brave_rewards::internal {
 namespace util {
 
-bool DecodeBrotliString(base::StringPiece input,
+bool DecodeBrotliString(std::string_view input,
                         size_t uncompressed_size,
                         std::string* output) {
   DCHECK(output);
@@ -92,7 +94,7 @@ bool DecodeBrotliString(base::StringPiece input,
   return result == BROTLI_DECODER_RESULT_SUCCESS;
 }
 
-bool DecodeBrotliStringWithBuffer(base::StringPiece input,
+bool DecodeBrotliStringWithBuffer(std::string_view input,
                                   size_t buffer_size,
                                   std::string* output) {
   DCHECK(output);

--- a/components/brave_rewards/core/common/brotli_util.h
+++ b/components/brave_rewards/core/common/brotli_util.h
@@ -7,17 +7,16 @@
 #define BRAVE_COMPONENTS_BRAVE_REWARDS_CORE_COMMON_BROTLI_UTIL_H_
 
 #include <string>
-
-#include "base/strings/string_piece.h"
+#include <string_view>
 
 namespace brave_rewards::internal {
 namespace util {
 
-bool DecodeBrotliString(base::StringPiece input,
+bool DecodeBrotliString(std::string_view input,
                         size_t uncompressed_size,
                         std::string* output);
 
-bool DecodeBrotliStringWithBuffer(base::StringPiece input,
+bool DecodeBrotliStringWithBuffer(std::string_view input,
                                   size_t buffer_size,
                                   std::string* output);
 

--- a/components/brave_rewards/core/database/database_publisher_prefix_list_unittest.cc
+++ b/components/brave_rewards/core/database/database_publisher_prefix_list_unittest.cc
@@ -8,7 +8,6 @@
 #include <vector>
 
 #include "base/big_endian.h"
-#include "base/strings/string_piece.h"
 #include "base/test/task_environment.h"
 #include "brave/components/brave_rewards/core/database/database_publisher_prefix_list.h"
 #include "brave/components/brave_rewards/core/publisher/protos/publisher_prefix_list.pb.h"

--- a/components/brave_rewards/core/endpoint/gemini/post_balance/post_balance_gemini.cc
+++ b/components/brave_rewards/core/endpoint/gemini/post_balance/post_balance_gemini.cc
@@ -5,6 +5,7 @@
 
 #include "brave/components/brave_rewards/core/endpoint/gemini/post_balance/post_balance_gemini.h"
 
+#include <string_view>
 #include <utility>
 
 #include "base/json/json_reader.h"
@@ -54,7 +55,7 @@ mojom::Result PostBalance::ParseBody(const std::string& body,
     }
 
     const bool result =
-        base::StringToDouble(base::StringPiece(*available_value), available);
+        base::StringToDouble(std::string_view(*available_value), available);
     if (!result) {
       BLOG(0, "Invalid balance");
       return mojom::Result::FAILED;

--- a/components/brave_rewards/core/endpoint/private_cdn/get_publisher/get_publisher.cc
+++ b/components/brave_rewards/core/endpoint/private_cdn/get_publisher/get_publisher.cc
@@ -4,6 +4,7 @@
  * You can obtain one at https://mozilla.org/MPL/2.0/. */
 #include "brave/components/brave_rewards/core/endpoint/private_cdn/get_publisher/get_publisher.h"
 
+#include <string_view>
 #include <utility>
 
 #include "base/strings/string_util.h"
@@ -139,7 +140,7 @@ mojom::Result ServerPublisherInfoFromMessage(
   return mojom::Result::FAILED;
 }
 
-bool DecompressMessage(base::StringPiece payload, std::string* output) {
+bool DecompressMessage(std::string_view payload, std::string* output) {
   constexpr size_t buffer_size = 32 * 1024;
   return util::DecodeBrotliStringWithBuffer(payload, buffer_size, output);
 }
@@ -183,7 +184,7 @@ mojom::Result GetPublisher::ParseBody(const std::string& body,
     return mojom::Result::FAILED;
   }
 
-  base::StringPiece body_payload(body.data(), body.size());
+  std::string_view body_payload(body.data(), body.size());
   if (!brave::PrivateCdnHelper::GetInstance()->RemovePadding(&body_payload)) {
     BLOG(0, "Publisher data response has invalid padding");
     return mojom::Result::FAILED;

--- a/components/brave_rewards/core/legacy/report_balance_properties.cc
+++ b/components/brave_rewards/core/legacy/report_balance_properties.cc
@@ -5,6 +5,8 @@
 
 #include "brave/components/brave_rewards/core/legacy/report_balance_properties.h"
 
+#include <string_view>
+
 #include "base/check.h"
 #include "base/json/json_reader.h"
 #include "base/json/json_writer.h"
@@ -24,7 +26,7 @@ const char kOneTimeDonationsKey[] = "one_time_donation";
 const char kRecurringDonationsKey[] = "recurring_donation";
 
 bool GetPropertyFromDict(const base::Value::Dict& dict,
-                         base::StringPiece key,
+                         std::string_view key,
                          double* value) {
   DCHECK(value);
 

--- a/components/brave_rewards/core/publisher/prefix_iterator.h
+++ b/components/brave_rewards/core/publisher/prefix_iterator.h
@@ -7,8 +7,7 @@
 #define BRAVE_COMPONENTS_BRAVE_REWARDS_CORE_PUBLISHER_PREFIX_ITERATOR_H_
 
 #include <iterator>
-
-#include "base/strings/string_piece.h"
+#include <string_view>
 
 namespace brave_rewards::internal {
 namespace publisher {
@@ -18,7 +17,7 @@ namespace publisher {
 class PrefixIterator {
  public:
   using iterator_category = std::random_access_iterator_tag;
-  using value_type = base::StringPiece;
+  using value_type = std::string_view;
   using difference_type = std::ptrdiff_t;
   using reference = value_type&;
   using const_reference = const value_type&;
@@ -31,14 +30,14 @@ class PrefixIterator {
   PrefixIterator(const PrefixIterator& rhs)
       : data_(rhs.data_), index_(rhs.index_), size_(rhs.size_) {}
 
-  base::StringPiece operator*() const {
+  std::string_view operator*() const {
     size_t offset = index_ * size_;
-    return base::StringPiece(data_ + offset, size_);
+    return std::string_view(data_ + offset, size_);
   }
 
-  base::StringPiece operator[](const int& rhs) const {
+  std::string_view operator[](const int& rhs) const {
     size_t offset = (index_ + rhs) * size_;
-    return base::StringPiece(data_ + offset, size_);
+    return std::string_view(data_ + offset, size_);
   }
 
   PrefixIterator& operator=(const PrefixIterator& rhs) {

--- a/components/brave_rewards/core/publisher/server_publisher_fetcher.cc
+++ b/components/brave_rewards/core/publisher/server_publisher_fetcher.cc
@@ -10,7 +10,6 @@
 
 #include "base/big_endian.h"
 #include "base/json/json_reader.h"
-#include "base/strings/string_piece.h"
 #include "base/strings/stringprintf.h"
 #include "base/time/time.h"
 #include "brave/components/brave_rewards/core/database/database.h"

--- a/components/brave_search/common/brave_search_utils.cc
+++ b/components/brave_search/common/brave_search_utils.cc
@@ -6,19 +6,19 @@
 #include "brave/components/brave_search/common/brave_search_utils.h"
 
 #include <string>
+#include <string_view>
 #include <vector>
 
 #include "base/containers/contains.h"
 #include "base/containers/fixed_flat_set.h"
 #include "base/feature_list.h"
-#include "base/strings/string_piece_forward.h"
 #include "brave/components/brave_search/common/features.h"
 #include "url/gurl.h"
 #include "url/url_constants.h"
 
 namespace {
 
-constexpr auto kVettedHosts = base::MakeFixedFlatSet<base::StringPiece>(
+constexpr auto kVettedHosts = base::MakeFixedFlatSet<std::string_view>(
     {"search.brave.com", "search.brave.software", "search.bravesoftware.com",
      "safesearch.brave.com", "safesearch.brave.software",
      "safesearch.bravesoftware.com", "search-dev-local.brave.com"});

--- a/components/brave_shields/browser/ad_block_subscription_service_manager.cc
+++ b/components/brave_shields/browser/ad_block_subscription_service_manager.cc
@@ -6,6 +6,7 @@
 #include "brave/components/brave_shields/browser/ad_block_subscription_service_manager.h"
 
 #include <memory>
+#include <string_view>
 #include <utility>
 #include <vector>
 
@@ -39,7 +40,7 @@ namespace {
 
 const uint16_t kSubscriptionMaxExpiresHours = 14 * 24;
 
-bool SkipGURLField(base::StringPiece value, GURL* field) {
+bool SkipGURLField(std::string_view value, GURL* field) {
   return true;
 }
 

--- a/components/brave_stats/browser/brave_stats_updater_util.cc
+++ b/components/brave_stats/browser/brave_stats_updater_util.cc
@@ -5,12 +5,12 @@
 
 #include <ctime>
 #include <memory>
+#include <string_view>
 
 #include "brave/components/brave_stats/browser/brave_stats_updater_util.h"
 
 #include "base/environment.h"
 #include "base/strings/string_number_conversions.h"
-#include "base/strings/string_piece.h"
 #include "base/strings/string_split.h"
 #include "base/strings/stringprintf.h"
 #include "brave/components/brave_stats/browser/buildflags.h"
@@ -81,7 +81,7 @@ base::Time GetLastMondayTime(const base::Time& time) {
   return last_monday;
 }
 
-base::Time GetYMDAsDate(const base::StringPiece& ymd) {
+base::Time GetYMDAsDate(const std::string_view& ymd) {
   const auto pieces = base::SplitStringPiece(ymd, "-", base::TRIM_WHITESPACE,
                                              base::SPLIT_WANT_NONEMPTY);
   DCHECK_EQ(pieces.size(), 3ull);

--- a/components/brave_stats/browser/brave_stats_updater_util.cc
+++ b/components/brave_stats/browser/brave_stats_updater_util.cc
@@ -81,7 +81,7 @@ base::Time GetLastMondayTime(const base::Time& time) {
   return last_monday;
 }
 
-base::Time GetYMDAsDate(const std::string_view& ymd) {
+base::Time GetYMDAsDate(const std::string_view ymd) {
   const auto pieces = base::SplitStringPiece(ymd, "-", base::TRIM_WHITESPACE,
                                              base::SPLIT_WANT_NONEMPTY);
   DCHECK_EQ(pieces.size(), 3ull);

--- a/components/brave_stats/browser/brave_stats_updater_util.h
+++ b/components/brave_stats/browser/brave_stats_updater_util.h
@@ -7,8 +7,8 @@
 #define BRAVE_COMPONENTS_BRAVE_STATS_BROWSER_BRAVE_STATS_UPDATER_UTIL_H_
 
 #include <string>
+#include <string_view>
 
-#include "base/strings/string_piece.h"
 #include "base/system/sys_info.h"
 #include "base/time/time.h"
 
@@ -28,7 +28,7 @@ int GetIsoWeekNumber(const base::Time& time);
 
 base::Time GetLastMondayTime(const base::Time& time);
 
-base::Time GetYMDAsDate(const base::StringPiece& ymd);
+base::Time GetYMDAsDate(const std::string_view& ymd);
 
 std::string GetAPIKey();
 

--- a/components/brave_stats/browser/brave_stats_updater_util.h
+++ b/components/brave_stats/browser/brave_stats_updater_util.h
@@ -28,7 +28,7 @@ int GetIsoWeekNumber(const base::Time& time);
 
 base::Time GetLastMondayTime(const base::Time& time);
 
-base::Time GetYMDAsDate(const std::string_view& ymd);
+base::Time GetYMDAsDate(const std::string_view ymd);
 
 std::string GetAPIKey();
 

--- a/components/brave_sync/qr_code_validator.cc
+++ b/components/brave_sync/qr_code_validator.cc
@@ -6,6 +6,7 @@
 #include "brave/components/brave_sync/qr_code_validator.h"
 
 #include <string>
+#include <string_view>
 #include <vector>
 
 #include "base/logging.h"
@@ -103,7 +104,7 @@ bool QrCodeDataValidator::IsValidSeedHex(const std::string& seed_hex) {
     return false;
   }
 
-  const std::vector<base::StringPiece> words = base::SplitStringPiece(
+  const std::vector<std::string_view> words = base::SplitStringPiece(
       sync_code_words, " ", base::WhitespaceHandling::TRIM_WHITESPACE,
       base::SplitResult::SPLIT_WANT_NONEMPTY);
 

--- a/components/brave_vpn/renderer/android/vpn_render_frame_observer.cc
+++ b/components/brave_vpn/renderer/android/vpn_render_frame_observer.cc
@@ -6,6 +6,7 @@
 #include "brave/components/brave_vpn/renderer/android/vpn_render_frame_observer.h"
 
 #include <string>
+#include <string_view>
 #include <vector>
 
 #include "base/feature_list.h"
@@ -95,7 +96,7 @@ std::string VpnRenderFrameObserver::ExtractParam(
       value;
   while (url::ExtractQueryKeyValue(url.query_piece().data(), &query, &key,
                                    &value)) {
-    base::StringPiece key_str = url.query_piece().substr(key.begin, key.len);
+    std::string_view key_str = url.query_piece().substr(key.begin, key.len);
     if (key_str != name) {
       continue;
     }

--- a/components/brave_wallet/browser/android_page_appearing_browsertest.cc
+++ b/components/brave_wallet/browser/android_page_appearing_browsertest.cc
@@ -3,6 +3,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+#include <string_view>
+
 #include "base/files/scoped_temp_dir.h"
 #include "base/strings/pattern.h"
 #include "base/test/bind.h"
@@ -311,10 +313,10 @@ class AndroidPageAppearingBrowserTest : public PlatformBrowserTest {
             return;
           }
 
-          base::StringPiece request_string(request.request_body->elements()
-                                               ->at(0)
-                                               .As<network::DataElementBytes>()
-                                               .AsStringPiece());
+          std::string_view request_string(request.request_body->elements()
+                                              ->at(0)
+                                              .As<network::DataElementBytes>()
+                                              .AsStringPiece());
           url_loader_factory_.ClearResponses();
           if (request_string.find("eth_getBalance") != std::string::npos) {
             url_loader_factory_.AddResponse(request.url.spec(),

--- a/components/brave_wallet/browser/asset_discovery_task.cc
+++ b/components/brave_wallet/browser/asset_discovery_task.cc
@@ -6,6 +6,7 @@
 #include "brave/components/brave_wallet/browser/asset_discovery_task.h"
 
 #include <map>
+#include <string_view>
 #include <utility>
 
 #include "base/base64.h"
@@ -122,7 +123,7 @@ void AssetDiscoveryTask::DiscoverERC20sFromRegistry(
 
   // Create set of all user assets per chain to use to ensure we don't
   // include assets the user has already added in the call to the BalanceScanner
-  base::flat_map<std::string, base::flat_set<base::StringPiece>>
+  base::flat_map<std::string, base::flat_set<std::string_view>>
       user_assets_per_chain;
   for (const auto& user_asset : user_assets) {
     user_assets_per_chain[user_asset->chain_id].insert(
@@ -227,7 +228,7 @@ void AssetDiscoveryTask::MergeDiscoveredERC20s(
   std::vector<mojom::BlockchainTokenPtr> discovered_tokens;
 
   // Keep track of which contract addresses have been seen per chain
-  base::flat_map<std::string, base::flat_set<base::StringPiece>>
+  base::flat_map<std::string, base::flat_set<std::string_view>>
       seen_contract_addresses;
   for (const auto& discovered_assets_result : discovered_assets_results) {
     for (const auto& [chain_id, contract_addresses] :

--- a/components/brave_wallet/browser/eth_tx_manager_unittest.cc
+++ b/components/brave_wallet/browser/eth_tx_manager_unittest.cc
@@ -8,6 +8,7 @@
 #include <map>
 #include <memory>
 #include <string>
+#include <string_view>
 #include <utility>
 #include <vector>
 
@@ -202,10 +203,10 @@ class EthTxManagerUnitTest : public testing::Test {
     url_loader_factory_.SetInterceptor(base::BindLambdaForTesting(
         [&](const network::ResourceRequest& request) {
           url_loader_factory_.ClearResponses();
-          base::StringPiece request_string(request.request_body->elements()
-                                               ->at(0)
-                                               .As<network::DataElementBytes>()
-                                               .AsStringPiece());
+          std::string_view request_string(request.request_body->elements()
+                                              ->at(0)
+                                              .As<network::DataElementBytes>()
+                                              .AsStringPiece());
           base::Value::Dict request_value = ParseJsonDict(request_string);
           std::string* method = request_value.FindString("method");
           ASSERT_TRUE(method);
@@ -2265,10 +2266,10 @@ TEST_F(EthTxManagerUnitTest, MakeERC721TransferFromDataTxType) {
 
   url_loader_factory_.SetInterceptor(
       base::BindLambdaForTesting([&](const network::ResourceRequest& request) {
-        base::StringPiece request_string(request.request_body->elements()
-                                             ->at(0)
-                                             .As<network::DataElementBytes>()
-                                             .AsStringPiece());
+        std::string_view request_string(request.request_body->elements()
+                                            ->at(0)
+                                            .As<network::DataElementBytes>()
+                                            .AsStringPiece());
         if (request_string.find(contract_safe_transfer_from) !=
             std::string::npos) {
           url_loader_factory_.AddResponse(

--- a/components/brave_wallet/browser/json_rpc_requests_helper.cc
+++ b/components/brave_wallet/browser/json_rpc_requests_helper.cc
@@ -6,6 +6,7 @@
 #include "brave/components/brave_wallet/browser/json_rpc_requests_helper.h"
 
 #include <memory>
+#include <string_view>
 #include <utility>
 
 #include "base/environment.h"
@@ -20,7 +21,7 @@ namespace brave_wallet {
 
 namespace internal {
 
-base::Value::Dict ComposeRpcDict(base::StringPiece method) {
+base::Value::Dict ComposeRpcDict(std::string_view method) {
   base::Value::Dict dict;
   dict.Set("jsonrpc", "2.0");
   dict.Set("method", method);
@@ -39,8 +40,8 @@ std::string GetJSON(base::ValueView dict) {
 }
 
 void AddKeyIfNotEmpty(base::Value::Dict* dict,
-                      base::StringPiece name,
-                      base::StringPiece val) {
+                      std::string_view name,
+                      std::string_view val) {
   if (!val.empty()) {
     dict->Set(name, val);
   }

--- a/components/brave_wallet/browser/json_rpc_requests_helper.h
+++ b/components/brave_wallet/browser/json_rpc_requests_helper.h
@@ -7,6 +7,7 @@
 #define BRAVE_COMPONENTS_BRAVE_WALLET_BROWSER_JSON_RPC_REQUESTS_HELPER_H_
 
 #include <string>
+#include <string_view>
 #include <utility>
 
 #include "base/containers/flat_map.h"
@@ -17,12 +18,12 @@ namespace brave_wallet {
 
 namespace internal {
 
-base::Value::Dict ComposeRpcDict(base::StringPiece method);
+base::Value::Dict ComposeRpcDict(std::string_view method);
 
 }  // namespace internal
 
 template <typename T>
-base::Value::Dict GetJsonRpcDictionary(base::StringPiece method, T&& params) {
+base::Value::Dict GetJsonRpcDictionary(std::string_view method, T&& params) {
   auto dict = internal::ComposeRpcDict(method);
   dict.Set("params", std::move(params));
   return dict;
@@ -31,15 +32,15 @@ base::Value::Dict GetJsonRpcDictionary(base::StringPiece method, T&& params) {
 std::string GetJSON(base::ValueView dict);
 
 template <typename... Args>
-std::string GetJsonRpcString(base::StringPiece method, Args&&... args) {
+std::string GetJsonRpcString(std::string_view method, Args&&... args) {
   base::Value::List params;
   (params.Append(std::forward<Args&&>(args)), ...);
   return GetJSON(GetJsonRpcDictionary(method, std::move(params)));
 }
 
 void AddKeyIfNotEmpty(base::Value::Dict* dict,
-                      base::StringPiece name,
-                      base::StringPiece val);
+                      std::string_view name,
+                      std::string_view val);
 
 base::flat_map<std::string, std::string> MakeCommonJsonRpcHeaders(
     const std::string& json_payload);

--- a/components/brave_wallet/browser/json_rpc_service_unittest.cc
+++ b/components/brave_wallet/browser/json_rpc_service_unittest.cc
@@ -7,6 +7,7 @@
 #include <algorithm>
 #include <map>
 #include <memory>
+#include <string_view>
 #include <utility>
 #include <vector>
 
@@ -296,10 +297,10 @@ constexpr char https_metadata_response[] =
     R"({"attributes":[{"trait_type":"Feet","value":"Green Shoes"},{"trait_type":"Legs","value":"Tan Pants"},{"trait_type":"Suspenders","value":"White Suspenders"},{"trait_type":"Upper Body","value":"Indigo Turtleneck"},{"trait_type":"Sleeves","value":"Long Sleeves"},{"trait_type":"Hat","value":"Yellow / Blue Pointy Beanie"},{"trait_type":"Eyes","value":"White Nerd Glasses"},{"trait_type":"Mouth","value":"Toothpick"},{"trait_type":"Ears","value":"Bing Bong Stick"},{"trait_type":"Right Arm","value":"Swinging"},{"trait_type":"Left Arm","value":"Diamond Hand"},{"trait_type":"Background","value":"Blue"}],"description":"5,000 animated Invisible Friends hiding in the metaverse. A collection by Markus Magnusson & Random Character Collective.","image":"https://rcc.mypinata.cloud/ipfs/QmXmuSenZRnofhGMz2NyT3Yc4Zrty1TypuiBKDcaBsNw9V/1817.gif","name":"Invisible Friends #1817"})";
 
 absl::optional<base::Value> ToValue(const network::ResourceRequest& request) {
-  base::StringPiece request_string(request.request_body->elements()
-                                       ->at(0)
-                                       .As<network::DataElementBytes>()
-                                       .AsStringPiece());
+  std::string_view request_string(request.request_body->elements()
+                                      ->at(0)
+                                      .As<network::DataElementBytes>()
+                                      .AsStringPiece());
   return base::JSONReader::Read(request_string,
                                 base::JSONParserOptions::JSON_PARSE_RFC);
 }
@@ -753,10 +754,10 @@ class JsonRpcServiceUnitTest : public testing::Test {
                                 const std::string& chain_id) {
     url_loader_factory_.SetInterceptor(base::BindLambdaForTesting(
         [&, network_url, chain_id](const network::ResourceRequest& request) {
-          base::StringPiece request_string(request.request_body->elements()
-                                               ->at(0)
-                                               .As<network::DataElementBytes>()
-                                               .AsStringPiece());
+          std::string_view request_string(request.request_body->elements()
+                                              ->at(0)
+                                              .As<network::DataElementBytes>()
+                                              .AsStringPiece());
           url_loader_factory_.ClearResponses();
           if (request_string.find("eth_chainId") != std::string::npos) {
             url_loader_factory_.AddResponse(
@@ -769,10 +770,10 @@ class JsonRpcServiceUnitTest : public testing::Test {
   void SetEthChainIdInterceptorWithBrokenResponse(const GURL& network_url) {
     url_loader_factory_.SetInterceptor(base::BindLambdaForTesting(
         [&, network_url](const network::ResourceRequest& request) {
-          base::StringPiece request_string(request.request_body->elements()
-                                               ->at(0)
-                                               .As<network::DataElementBytes>()
-                                               .AsStringPiece());
+          std::string_view request_string(request.request_body->elements()
+                                              ->at(0)
+                                              .As<network::DataElementBytes>()
+                                              .AsStringPiece());
           url_loader_factory_.ClearResponses();
           if (request_string.find("eth_chainId") != std::string::npos) {
             url_loader_factory_.AddResponse(network_url.spec(),
@@ -787,10 +788,10 @@ class JsonRpcServiceUnitTest : public testing::Test {
     ASSERT_TRUE(network_url.is_valid());
     url_loader_factory_.SetInterceptor(base::BindLambdaForTesting(
         [&, network_url](const network::ResourceRequest& request) {
-          base::StringPiece request_string(request.request_body->elements()
-                                               ->at(0)
-                                               .As<network::DataElementBytes>()
-                                               .AsStringPiece());
+          std::string_view request_string(request.request_body->elements()
+                                              ->at(0)
+                                              .As<network::DataElementBytes>()
+                                              .AsStringPiece());
           url_loader_factory_.ClearResponses();
           if (request_string.find(GetFunctionHash("resolver(bytes32)")) !=
               std::string::npos) {
@@ -839,10 +840,10 @@ class JsonRpcServiceUnitTest : public testing::Test {
     ASSERT_TRUE(network_url.is_valid());
     url_loader_factory_.SetInterceptor(base::BindLambdaForTesting(
         [&, network_url](const network::ResourceRequest& request) {
-          base::StringPiece request_string(request.request_body->elements()
-                                               ->at(0)
-                                               .As<network::DataElementBytes>()
-                                               .AsStringPiece());
+          std::string_view request_string(request.request_body->elements()
+                                              ->at(0)
+                                              .As<network::DataElementBytes>()
+                                              .AsStringPiece());
           url_loader_factory_.ClearResponses();
           if (request_string.find(GetFunctionHash("resolver(bytes32)")) !=
               std::string::npos) {
@@ -884,11 +885,10 @@ class JsonRpcServiceUnitTest : public testing::Test {
           url_loader_factory_.ClearResponses();
           if (request.method ==
               "POST") {  // An eth_call, either to supportsInterface or tokenURI
-            base::StringPiece request_string(
-                request.request_body->elements()
-                    ->at(0)
-                    .As<network::DataElementBytes>()
-                    .AsStringPiece());
+            std::string_view request_string(request.request_body->elements()
+                                                ->at(0)
+                                                .As<network::DataElementBytes>()
+                                                .AsStringPiece());
             bool is_supports_interface_req =
                 request_string.find(GetFunctionHash(
                     "supportsInterface(bytes4)")) != std::string::npos;
@@ -928,10 +928,10 @@ class JsonRpcServiceUnitTest : public testing::Test {
         [&, expected_url,
          interface_id_to_response](const network::ResourceRequest& request) {
           EXPECT_EQ(request.url, expected_url);
-          base::StringPiece request_string(request.request_body->elements()
-                                               ->at(0)
-                                               .As<network::DataElementBytes>()
-                                               .AsStringPiece());
+          std::string_view request_string(request.request_body->elements()
+                                              ->at(0)
+                                              .As<network::DataElementBytes>()
+                                              .AsStringPiece());
           // Check if any of the interface ids are in the request
           // if so, return the response for that interface id
           // if not, do nothing

--- a/components/brave_wallet/browser/keyring_service.cc
+++ b/components/brave_wallet/browser/keyring_service.cc
@@ -8,6 +8,7 @@
 #include <map>
 #include <set>
 #include <string>
+#include <string_view>
 #include <utility>
 
 #include "base/base64.h"
@@ -205,7 +206,7 @@ absl::optional<uint32_t> ExtractAccountIndex(mojom::KeyringId keyring_id,
 
   // For all types remove root path and slash. For Solana also remove '/0'.
 
-  auto account_index = base::StringPiece(path);
+  auto account_index = std::string_view(path);
   auto root_path = GetRootPath(keyring_id);
   if (!base::StartsWith(account_index, root_path)) {
     return absl::nullopt;
@@ -232,8 +233,8 @@ absl::optional<uint32_t> ExtractAccountIndex(mojom::KeyringId keyring_id,
   return result;
 }
 
-static base::span<const uint8_t> ToSpan(base::StringPiece sp) {
-  return base::as_bytes(base::make_span(sp));
+static base::span<const uint8_t> ToSpan(std::string_view sv) {
+  return base::as_bytes(base::make_span(sv));
 }
 
 std::string GetAccountName(size_t number) {

--- a/components/brave_wallet/browser/nft_metadata_fetcher_unittest.cc
+++ b/components/brave_wallet/browser/nft_metadata_fetcher_unittest.cc
@@ -6,6 +6,7 @@
 #include "brave/components/brave_wallet/browser/nft_metadata_fetcher.h"
 
 #include <memory>
+#include <string_view>
 
 #include "base/base64.h"
 #include "base/json/json_reader.h"
@@ -226,11 +227,10 @@ class NftMetadataFetcherUnitTest : public testing::Test {
           url_loader_factory_.ClearResponses();
           if (request.method ==
               "POST") {  // An eth_call, either to supportsInterface or tokenURI
-            base::StringPiece request_string(
-                request.request_body->elements()
-                    ->at(0)
-                    .As<network::DataElementBytes>()
-                    .AsStringPiece());
+            std::string_view request_string(request.request_body->elements()
+                                                ->at(0)
+                                                .As<network::DataElementBytes>()
+                                                .AsStringPiece());
             bool is_supports_interface_req =
                 request_string.find(GetFunctionHash(
                     "supportsInterface(bytes4)")) != std::string::npos;

--- a/components/brave_wallet/browser/password_encryptor_unittest.cc
+++ b/components/brave_wallet/browser/password_encryptor_unittest.cc
@@ -3,16 +3,17 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+#include <string_view>
+
 #include "brave/components/brave_wallet/browser/password_encryptor.h"
-#include "base/strings/string_piece.h"
 #include "crypto/aead.h"
 #include "testing/gtest/include/gtest/gtest.h"
 
 namespace brave_wallet {
 
 namespace {
-base::span<const uint8_t> ToSpan(base::StringPiece sp) {
-  return base::as_bytes(base::make_span(sp));
+base::span<const uint8_t> ToSpan(std::string_view sv) {
+  return base::as_bytes(base::make_span(sv));
 }
 std::string ToString(const std::vector<uint8_t>& v) {
   return std::string(v.begin(), v.end());

--- a/components/brave_wallet/browser/solana_tx_manager_unittest.cc
+++ b/components/brave_wallet/browser/solana_tx_manager_unittest.cc
@@ -6,6 +6,7 @@
 #include "brave/components/brave_wallet/browser/solana_tx_manager.h"
 
 #include <memory>
+#include <string_view>
 #include <utility>
 
 #include "base/base64.h"
@@ -124,10 +125,10 @@ class SolanaTxManagerUnitTest : public testing::Test {
          last_valid_block_height, block_height,
          get_null_signature_statuses](const network::ResourceRequest& request) {
           url_loader_factory_.ClearResponses();
-          base::StringPiece request_string(request.request_body->elements()
-                                               ->at(0)
-                                               .As<network::DataElementBytes>()
-                                               .AsStringPiece());
+          std::string_view request_string(request.request_body->elements()
+                                              ->at(0)
+                                              .As<network::DataElementBytes>()
+                                              .AsStringPiece());
           base::Value::Dict request_root =
               base::test::ParseJsonDict(request_string);
 

--- a/components/brave_wallet/common/fil_address.cc
+++ b/components/brave_wallet/common/fil_address.cc
@@ -5,6 +5,8 @@
 
 #include "brave/components/brave_wallet/common/fil_address.h"
 
+#include <string_view>
+
 #include "base/logging.h"
 #include "base/strings/string_number_conversions.h"
 #include "base/strings/string_util.h"
@@ -210,8 +212,8 @@ FilAddress FilAddress::FromFEVMAddress(bool is_mainnet,
   payload.insert(payload.end(), checksum.begin(), checksum.end());
 
   std::string encoded = base32::Base32Encode(
-      base::StringPiece(reinterpret_cast<const char*>(payload.data()),
-                        payload.size()),
+      std::string_view(reinterpret_cast<const char*>(payload.data()),
+                       payload.size()),
       base32::Base32EncodePolicy::OMIT_PADDING);
   return FilAddress::FromAddress((is_mainnet ? "f410f" : "t410f") + encoded);
 }

--- a/components/brave_wallet/common/hex_utils_unittest.cc
+++ b/components/brave_wallet/common/hex_utils_unittest.cc
@@ -6,16 +6,16 @@
 #include "brave/components/brave_wallet/common/hex_utils.h"
 
 #include <limits>
+#include <string_view>
 #include <vector>
 
 #include "base/logging.h"
-#include "base/strings/string_piece.h"
 #include "testing/gtest/include/gtest/gtest.h"
 
 namespace brave_wallet {
 
 TEST(HexUtilsUnitTest, ToHex) {
-  const base::StringPiece str = "hello world";
+  const std::string_view str = "hello world";
   ASSERT_EQ(ToHex(""), "0x0");
   ASSERT_EQ(ToHex(std::string(str)), "0x68656c6c6f20776f726c64");
   ASSERT_EQ(ToHex(base::as_bytes(base::make_span(str))),

--- a/components/brave_wallet/renderer/v8_helper.cc
+++ b/components/brave_wallet/renderer/v8_helper.cc
@@ -19,7 +19,7 @@ namespace brave_wallet {
 
 v8::MaybeLocal<v8::Value> GetProperty(v8::Local<v8::Context> context,
                                       v8::Local<v8::Value> object,
-                                      const std::string_view& name) {
+                                      const std::string_view name) {
   v8::Local<v8::String> name_str = gin::StringToV8(context->GetIsolate(), name);
   v8::Local<v8::Object> object_obj;
   if (!object->ToObject(context).ToLocal(&object_obj)) {
@@ -31,7 +31,7 @@ v8::MaybeLocal<v8::Value> GetProperty(v8::Local<v8::Context> context,
 
 v8::Maybe<bool> CreateDataProperty(v8::Local<v8::Context> context,
                                    v8::Local<v8::Object> object,
-                                   const std::string_view& name,
+                                   const std::string_view name,
                                    v8::Local<v8::Value> value) {
   v8::Local<v8::String> name_str = gin::StringToV8(context->GetIsolate(), name);
 
@@ -40,8 +40,8 @@ v8::Maybe<bool> CreateDataProperty(v8::Local<v8::Context> context,
 
 v8::MaybeLocal<v8::Value> CallMethodOfObject(
     blink::WebLocalFrame* web_frame,
-    const std::string_view& object_name,
-    const std::string_view& method_name,
+    const std::string_view object_name,
+    const std::string_view method_name,
     std::vector<v8::Local<v8::Value>>&& args) {
   if (web_frame->IsProvisional()) {
     return v8::Local<v8::Value>();
@@ -61,7 +61,7 @@ v8::MaybeLocal<v8::Value> CallMethodOfObject(
 v8::MaybeLocal<v8::Value> CallMethodOfObject(
     blink::WebLocalFrame* web_frame,
     v8::Local<v8::Value> object,
-    const std::string_view& method_name,
+    const std::string_view method_name,
     std::vector<v8::Local<v8::Value>>&& args) {
   if (web_frame->IsProvisional()) {
     return v8::Local<v8::Value>();

--- a/components/brave_wallet/renderer/v8_helper.cc
+++ b/components/brave_wallet/renderer/v8_helper.cc
@@ -5,6 +5,7 @@
 
 #include "brave/components/brave_wallet/renderer/v8_helper.h"
 
+#include <string_view>
 #include <utility>
 
 #include "brave/components/safe_builtins/renderer/safe_builtins_helpers.h"
@@ -18,7 +19,7 @@ namespace brave_wallet {
 
 v8::MaybeLocal<v8::Value> GetProperty(v8::Local<v8::Context> context,
                                       v8::Local<v8::Value> object,
-                                      const base::StringPiece& name) {
+                                      const std::string_view& name) {
   v8::Local<v8::String> name_str = gin::StringToV8(context->GetIsolate(), name);
   v8::Local<v8::Object> object_obj;
   if (!object->ToObject(context).ToLocal(&object_obj)) {
@@ -30,7 +31,7 @@ v8::MaybeLocal<v8::Value> GetProperty(v8::Local<v8::Context> context,
 
 v8::Maybe<bool> CreateDataProperty(v8::Local<v8::Context> context,
                                    v8::Local<v8::Object> object,
-                                   const base::StringPiece& name,
+                                   const std::string_view& name,
                                    v8::Local<v8::Value> value) {
   v8::Local<v8::String> name_str = gin::StringToV8(context->GetIsolate(), name);
 
@@ -39,8 +40,8 @@ v8::Maybe<bool> CreateDataProperty(v8::Local<v8::Context> context,
 
 v8::MaybeLocal<v8::Value> CallMethodOfObject(
     blink::WebLocalFrame* web_frame,
-    const base::StringPiece& object_name,
-    const base::StringPiece& method_name,
+    const std::string_view& object_name,
+    const std::string_view& method_name,
     std::vector<v8::Local<v8::Value>>&& args) {
   if (web_frame->IsProvisional()) {
     return v8::Local<v8::Value>();
@@ -60,7 +61,7 @@ v8::MaybeLocal<v8::Value> CallMethodOfObject(
 v8::MaybeLocal<v8::Value> CallMethodOfObject(
     blink::WebLocalFrame* web_frame,
     v8::Local<v8::Value> object,
-    const base::StringPiece& method_name,
+    const std::string_view& method_name,
     std::vector<v8::Local<v8::Value>>&& args) {
   if (web_frame->IsProvisional()) {
     return v8::Local<v8::Value>();

--- a/components/brave_wallet/renderer/v8_helper.h
+++ b/components/brave_wallet/renderer/v8_helper.h
@@ -7,9 +7,9 @@
 #define BRAVE_COMPONENTS_BRAVE_WALLET_RENDERER_V8_HELPER_H_
 
 #include <string>
+#include <string_view>
 #include <vector>
 
-#include "base/strings/string_piece.h"
 #include "third_party/abseil-cpp/absl/types/optional.h"
 #include "v8/include/v8-context.h"
 #include "v8/include/v8-local-handle.h"
@@ -23,22 +23,22 @@ namespace brave_wallet {
 
 v8::MaybeLocal<v8::Value> GetProperty(v8::Local<v8::Context> context,
                                       v8::Local<v8::Value> object,
-                                      const base::StringPiece& name);
+                                      const std::string_view& name);
 v8::Maybe<bool> CreateDataProperty(v8::Local<v8::Context> context,
                                    v8::Local<v8::Object> object,
-                                   const base::StringPiece& name,
+                                   const std::string_view& name,
                                    v8::Local<v8::Value> value);
 
 v8::MaybeLocal<v8::Value> CallMethodOfObject(
     blink::WebLocalFrame* web_frame,
-    const base::StringPiece& object_name,
-    const base::StringPiece& method_name,
+    const std::string_view& object_name,
+    const std::string_view& method_name,
     std::vector<v8::Local<v8::Value>>&& args);
 
 v8::MaybeLocal<v8::Value> CallMethodOfObject(
     blink::WebLocalFrame* web_frame,
     v8::Local<v8::Value> object,
-    const base::StringPiece& method_name,
+    const std::string_view& method_name,
     std::vector<v8::Local<v8::Value>>&& args);
 
 v8::MaybeLocal<v8::Value> ExecuteScript(blink::WebLocalFrame* web_frame,

--- a/components/brave_wallet/renderer/v8_helper.h
+++ b/components/brave_wallet/renderer/v8_helper.h
@@ -23,22 +23,22 @@ namespace brave_wallet {
 
 v8::MaybeLocal<v8::Value> GetProperty(v8::Local<v8::Context> context,
                                       v8::Local<v8::Value> object,
-                                      const std::string_view& name);
+                                      const std::string_view name);
 v8::Maybe<bool> CreateDataProperty(v8::Local<v8::Context> context,
                                    v8::Local<v8::Object> object,
-                                   const std::string_view& name,
+                                   const std::string_view name,
                                    v8::Local<v8::Value> value);
 
 v8::MaybeLocal<v8::Value> CallMethodOfObject(
     blink::WebLocalFrame* web_frame,
-    const std::string_view& object_name,
-    const std::string_view& method_name,
+    const std::string_view object_name,
+    const std::string_view method_name,
     std::vector<v8::Local<v8::Value>>&& args);
 
 v8::MaybeLocal<v8::Value> CallMethodOfObject(
     blink::WebLocalFrame* web_frame,
     v8::Local<v8::Value> object,
-    const std::string_view& method_name,
+    const std::string_view method_name,
     std::vector<v8::Local<v8::Value>>&& args);
 
 v8::MaybeLocal<v8::Value> ExecuteScript(blink::WebLocalFrame* web_frame,

--- a/components/brave_wayback_machine/brave_wayback_machine_utils.cc
+++ b/components/brave_wayback_machine/brave_wayback_machine_utils.cc
@@ -6,6 +6,7 @@
 #include "brave/components/brave_wayback_machine/brave_wayback_machine_utils.h"
 
 #include <string>
+#include <string_view>
 #include <vector>
 
 #include "base/strings/string_util.h"
@@ -49,7 +50,7 @@ GURL FixupWaybackQueryURL(const GURL& url) {
                                   url::DecodeURLMode::kUTF8OrIsomorphic,
                                   &canonOutput);
     const std::string decoded_key = base::UTF16ToUTF8(
-        base::StringPiece16(canonOutput.data(), canonOutput.length()));
+        std::u16string_view(canonOutput.data(), canonOutput.length()));
     // Skip target keys.
     if (decoded_key == kTimeStampKey || decoded_key == kCallbackKey)
       continue;

--- a/components/commander/common/constants.cc
+++ b/components/commander/common/constants.cc
@@ -5,8 +5,9 @@
 
 #include "brave/components/commander/common/constants.h"
 
+#include <string_view>
+
 namespace commander {
 
-const base::StringPiece16 kCommandPrefix(u":>");
-
+const std::u16string_view kCommandPrefix(u":>");
 }

--- a/components/commander/common/constants.h
+++ b/components/commander/common/constants.h
@@ -7,14 +7,14 @@
 #define BRAVE_COMPONENTS_COMMANDER_COMMON_CONSTANTS_H_
 
 #include <iterator>
+#include <string_view>
 
 #include "base/component_export.h"
-#include "base/strings/string_piece.h"
 
 namespace commander {
 
 COMPONENT_EXPORT(COMMANDER_COMMON)
-extern const base::StringPiece16 kCommandPrefix;
+extern const std::u16string_view kCommandPrefix;
 
 }  // namespace commander
 

--- a/components/commands/common/accelerator_parsing.cc
+++ b/components/commands/common/accelerator_parsing.cc
@@ -7,6 +7,7 @@
 
 #include <cstddef>
 #include <string>
+#include <string_view>
 #include <vector>
 
 #include "base/check.h"
@@ -37,7 +38,7 @@ constexpr char kRMenu[] = "AltGr";
 
 struct ModifierName {
   const ui::KeyEventFlags modifier;
-  const base::StringPiece name;
+  const std::string_view name;
 };
 
 const std::vector<ModifierName>& GetAllModifierNames() {

--- a/components/content_settings/core/browser/brave_content_settings_pref_provider_unittest.cc
+++ b/components/content_settings/core/browser/brave_content_settings_pref_provider_unittest.cc
@@ -4,6 +4,7 @@
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 #include <memory>
+#include <string_view>
 #include <utility>
 
 #include "base/json/values_util.h"
@@ -104,7 +105,7 @@ void InitializeUnsupportedShieldSettingInDictionary(
 
 void CheckMigrationFromResourceIdentifierForDictionary(
     const base::Value::Dict& dict,
-    base::StringPiece patterns_string,
+    std::string_view patterns_string,
     const absl::optional<base::Time> expected_last_modified,
     absl::optional<int> expected_setting_value) {
   const base::Value::Dict* settings_dict = dict.FindDict(patterns_string);

--- a/components/content_settings/renderer/brave_content_settings_agent_impl_browsertest.cc
+++ b/components/content_settings/renderer/brave_content_settings_agent_impl_browsertest.cc
@@ -4,6 +4,7 @@
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 #include <memory>
+#include <string_view>
 
 #include "base/feature_list.h"
 #include "base/path_service.h"
@@ -354,12 +355,12 @@ class BraveContentSettingsAgentImplBrowserTest : public InProcessBrowserTest {
   }
 
   template <typename T>
-  void CheckCookie(T* frame, base::StringPiece cookie) {
+  void CheckCookie(T* frame, std::string_view cookie) {
     EXPECT_EQ(cookie, EvalJs(frame, kCookieScript));
   }
 
   template <typename T>
-  void Check3PCookie(T* frame, base::StringPiece cookie) {
+  void Check3PCookie(T* frame, std::string_view cookie) {
     EXPECT_EQ(cookie, EvalJs(frame, kCookie3PScript));
   }
 

--- a/components/debounce/browser/debounce_rule.cc
+++ b/components/debounce/browser/debounce_rule.cc
@@ -6,6 +6,7 @@
 #include "brave/components/debounce/browser/debounce_rule.h"
 
 #include <memory>
+#include <string_view>
 #include <utility>
 #include <vector>
 
@@ -43,7 +44,7 @@ const int64_t kMaxLengthRegexPattern = 200;
 
 // Removes trailing dot from |host_piece| if any.
 // Copied from extensions/common/url_pattern.cc
-base::StringPiece CanonicalizeHostForMatching(base::StringPiece host_piece) {
+std::string_view CanonicalizeHostForMatching(std::string_view host_piece) {
   if (base::EndsWith(host_piece, ".")) {
     host_piece.remove_suffix(1);
   }
@@ -60,7 +61,7 @@ DebounceRule::DebounceRule()
 DebounceRule::~DebounceRule() = default;
 
 // static
-bool DebounceRule::ParseDebounceAction(base::StringPiece value,
+bool DebounceRule::ParseDebounceAction(std::string_view value,
                                        DebounceAction* field) {
   if (value == "redirect") {
     *field = kDebounceRedirectToParam;
@@ -76,7 +77,7 @@ bool DebounceRule::ParseDebounceAction(base::StringPiece value,
 }
 
 // static
-bool DebounceRule::ParsePrependScheme(base::StringPiece value,
+bool DebounceRule::ParsePrependScheme(std::string_view value,
                                       DebouncePrependScheme* field) {
   if (value == "http") {
     *field = kDebounceSchemePrependHttp;
@@ -128,7 +129,7 @@ void DebounceRule::RegisterJSONConverter(
 // All eTLD+1 calculations for debouncing should flow through here so they
 // are consistent in their private registries configuration.
 const std::string DebounceRule::GetETLDForDebounce(const std::string& host) {
-  base::StringPiece host_piece = CanonicalizeHostForMatching(host);
+  std::string_view host_piece = CanonicalizeHostForMatching(host);
   return net::registry_controlled_domains::GetDomainAndRegistry(
       host_piece, net::registry_controlled_domains::PrivateRegistryFilter::
                       EXCLUDE_PRIVATE_REGISTRIES);

--- a/components/debounce/browser/debounce_rule.h
+++ b/components/debounce/browser/debounce_rule.h
@@ -8,6 +8,7 @@
 
 #include <memory>
 #include <string>
+#include <string_view>
 #include <utility>
 #include <vector>
 
@@ -45,9 +46,9 @@ class DebounceRule {
   // class.
   static void RegisterJSONConverter(
       base::JSONValueConverter<DebounceRule>* converter);
-  static bool ParseDebounceAction(base::StringPiece value,
+  static bool ParseDebounceAction(std::string_view value,
                                   DebounceAction* field);
-  static bool ParsePrependScheme(base::StringPiece value,
+  static bool ParsePrependScheme(std::string_view value,
                                  DebouncePrependScheme* field);
   static base::expected<std::pair<std::vector<std::unique_ptr<DebounceRule>>,
                                   base::flat_set<std::string>>,

--- a/components/decentralized_dns/core/utils.cc
+++ b/components/decentralized_dns/core/utils.cc
@@ -41,7 +41,7 @@ void MigrateObsoleteLocalStatePrefs(PrefService* local_state) {
   }
 }
 
-bool IsUnstoppableDomainsTLD(const std::string_view& host) {
+bool IsUnstoppableDomainsTLD(const std::string_view host) {
   for (auto* domain : kUnstoppableDomains) {
     if (base::EndsWith(host, domain))
       return true;
@@ -79,7 +79,7 @@ bool IsUnstoppableDomainsResolveMethodEnabled(PrefService* local_state) {
          ResolveMethodTypes::ENABLED;
 }
 
-bool IsENSTLD(const std::string_view& host) {
+bool IsENSTLD(const std::string_view host) {
   return base::EndsWith(host, kEthDomain);
 }
 
@@ -118,7 +118,7 @@ EnsOffchainResolveMethod GetEnsOffchainResolveMethod(PrefService* local_state) {
       local_state->GetInteger(kEnsOffchainResolveMethod));
 }
 
-bool IsSnsTLD(const std::string_view& host) {
+bool IsSnsTLD(const std::string_view host) {
   return base::EndsWith(host, kSolDomain);
 }
 

--- a/components/decentralized_dns/core/utils.cc
+++ b/components/decentralized_dns/core/utils.cc
@@ -5,6 +5,8 @@
 
 #include "brave/components/decentralized_dns/core/utils.h"
 
+#include <string_view>
+
 #include "base/strings/string_util.h"
 #include "brave/components/decentralized_dns/core/constants.h"
 #include "brave/components/decentralized_dns/core/pref_names.h"
@@ -39,7 +41,7 @@ void MigrateObsoleteLocalStatePrefs(PrefService* local_state) {
   }
 }
 
-bool IsUnstoppableDomainsTLD(const base::StringPiece& host) {
+bool IsUnstoppableDomainsTLD(const std::string_view& host) {
   for (auto* domain : kUnstoppableDomains) {
     if (base::EndsWith(host, domain))
       return true;
@@ -77,7 +79,7 @@ bool IsUnstoppableDomainsResolveMethodEnabled(PrefService* local_state) {
          ResolveMethodTypes::ENABLED;
 }
 
-bool IsENSTLD(const base::StringPiece& host) {
+bool IsENSTLD(const std::string_view& host) {
   return base::EndsWith(host, kEthDomain);
 }
 
@@ -116,7 +118,7 @@ EnsOffchainResolveMethod GetEnsOffchainResolveMethod(PrefService* local_state) {
       local_state->GetInteger(kEnsOffchainResolveMethod));
 }
 
-bool IsSnsTLD(const base::StringPiece& host) {
+bool IsSnsTLD(const std::string_view& host) {
   return base::EndsWith(host, kSolDomain);
 }
 

--- a/components/decentralized_dns/core/utils.h
+++ b/components/decentralized_dns/core/utils.h
@@ -19,14 +19,14 @@ namespace decentralized_dns {
 void RegisterLocalStatePrefs(PrefRegistrySimple* registry);
 void MigrateObsoleteLocalStatePrefs(PrefService* local_state);
 
-bool IsUnstoppableDomainsTLD(const std::string_view& host);
+bool IsUnstoppableDomainsTLD(const std::string_view host);
 void SetUnstoppableDomainsResolveMethod(PrefService* local_state,
                                         ResolveMethodTypes method);
 ResolveMethodTypes GetUnstoppableDomainsResolveMethod(PrefService* local_state);
 bool IsUnstoppableDomainsResolveMethodAsk(PrefService* local_state);
 bool IsUnstoppableDomainsResolveMethodEnabled(PrefService* local_state);
 
-bool IsENSTLD(const std::string_view& host);
+bool IsENSTLD(const std::string_view host);
 void SetENSResolveMethod(PrefService* local_state, ResolveMethodTypes method);
 ResolveMethodTypes GetENSResolveMethod(PrefService* local_state);
 bool IsENSResolveMethodAsk(PrefService* local_state);
@@ -36,7 +36,7 @@ void SetEnsOffchainResolveMethod(PrefService* local_state,
                                  EnsOffchainResolveMethod method);
 EnsOffchainResolveMethod GetEnsOffchainResolveMethod(PrefService* local_state);
 
-bool IsSnsTLD(const std::string_view& host);
+bool IsSnsTLD(const std::string_view host);
 void SetSnsResolveMethod(PrefService* local_state, ResolveMethodTypes method);
 ResolveMethodTypes GetSnsResolveMethod(PrefService* local_state);
 bool IsSnsResolveMethodAsk(PrefService* local_state);

--- a/components/decentralized_dns/core/utils.h
+++ b/components/decentralized_dns/core/utils.h
@@ -6,7 +6,8 @@
 #ifndef BRAVE_COMPONENTS_DECENTRALIZED_DNS_CORE_UTILS_H_
 #define BRAVE_COMPONENTS_DECENTRALIZED_DNS_CORE_UTILS_H_
 
-#include "base/strings/string_piece.h"
+#include <string_view>
+
 #include "brave/components/decentralized_dns/core/constants.h"
 
 class GURL;
@@ -18,14 +19,14 @@ namespace decentralized_dns {
 void RegisterLocalStatePrefs(PrefRegistrySimple* registry);
 void MigrateObsoleteLocalStatePrefs(PrefService* local_state);
 
-bool IsUnstoppableDomainsTLD(const base::StringPiece& host);
+bool IsUnstoppableDomainsTLD(const std::string_view& host);
 void SetUnstoppableDomainsResolveMethod(PrefService* local_state,
                                         ResolveMethodTypes method);
 ResolveMethodTypes GetUnstoppableDomainsResolveMethod(PrefService* local_state);
 bool IsUnstoppableDomainsResolveMethodAsk(PrefService* local_state);
 bool IsUnstoppableDomainsResolveMethodEnabled(PrefService* local_state);
 
-bool IsENSTLD(const base::StringPiece& host);
+bool IsENSTLD(const std::string_view& host);
 void SetENSResolveMethod(PrefService* local_state, ResolveMethodTypes method);
 ResolveMethodTypes GetENSResolveMethod(PrefService* local_state);
 bool IsENSResolveMethodAsk(PrefService* local_state);
@@ -35,7 +36,7 @@ void SetEnsOffchainResolveMethod(PrefService* local_state,
                                  EnsOffchainResolveMethod method);
 EnsOffchainResolveMethod GetEnsOffchainResolveMethod(PrefService* local_state);
 
-bool IsSnsTLD(const base::StringPiece& host);
+bool IsSnsTLD(const std::string_view& host);
 void SetSnsResolveMethod(PrefService* local_state, ResolveMethodTypes method);
 ResolveMethodTypes GetSnsResolveMethod(PrefService* local_state);
 bool IsSnsResolveMethodAsk(PrefService* local_state);

--- a/components/greaselion/browser/greaselion_service_impl.cc
+++ b/components/greaselion/browser/greaselion_service_impl.cc
@@ -8,6 +8,7 @@
 #include <stddef.h>
 #include <memory>
 #include <string>
+#include <string_view>
 #include <utility>
 #include <vector>
 
@@ -107,7 +108,7 @@ ConvertGreaselionRuleToExtensionOnTaskRunner(
     crypto::SHA256HashString(BUILDFLAG(UPDATER_PROD_ENDPOINT) + script_name,
                              raw, crypto::kSHA256Length);
   }
-  base::Base64Encode(base::StringPiece(raw, crypto::kSHA256Length), &key);
+  base::Base64Encode(std::string_view(raw, crypto::kSHA256Length), &key);
 
   root.SetByDottedPath(extensions::manifest_keys::kName, script_name);
   root.SetByDottedPath(extensions::manifest_keys::kVersion, "1.0");

--- a/components/https_upgrade_exceptions/browser/https_upgrade_exceptions_service.h
+++ b/components/https_upgrade_exceptions/browser/https_upgrade_exceptions_service.h
@@ -11,7 +11,6 @@
 #include <string>
 
 #include "base/files/file_path.h"
-#include "base/strings/string_piece.h"
 #include "brave/components/brave_component_updater/browser/local_data_files_observer.h"
 #include "brave/components/brave_component_updater/browser/local_data_files_service.h"
 

--- a/components/ipfs/ipfs_utils.cc
+++ b/components/ipfs/ipfs_utils.cc
@@ -6,10 +6,10 @@
 #include "brave/components/ipfs/ipfs_utils.h"
 
 #include <string>
+#include <string_view>
 #include <vector>
 
 #include "base/feature_list.h"
-#include "base/strings/string_piece_forward.h"
 #include "base/strings/string_split.h"
 #include "base/strings/string_util.h"
 #include "base/strings/stringprintf.h"
@@ -499,7 +499,7 @@ GURL ContentHashToCIDv1URL(base::span<const uint8_t> contenthash) {
     return GURL();
   if (code != kIpnsNSCodec && code != kIpfsNSCodec)
     return GURL();
-  std::string encoded = base32::Base32Encode(base::StringPiece(
+  std::string encoded = base32::Base32Encode(std::string_view(
       reinterpret_cast<const char*>(contenthash.data()), contenthash.size()));
   if (encoded.empty())
     return GURL();

--- a/components/l10n/common/ofac_sanction_util.cc
+++ b/components/l10n/common/ofac_sanction_util.cc
@@ -5,20 +5,21 @@
 
 #include "brave/components/l10n/common/ofac_sanction_util.h"
 
+#include <string_view>
+
 #include "base/containers/contains.h"
-#include "base/strings/string_piece.h"
 #include "base/strings/string_util.h"
 #include "brave/components/l10n/common/ofac_sanctioned_iso_3166_1_country_code_constants.h"
 #include "brave/components/l10n/common/ofac_sanctioned_un_m49_code_constants.h"
 
 namespace brave_l10n {
 
-bool IsISOCountryCodeOFACSanctioned(const base::StringPiece country_code) {
+bool IsISOCountryCodeOFACSanctioned(const std::string_view country_code) {
   return base::Contains(kOFACSactionedISO31661CountryCodes,
                         base::ToUpperASCII(country_code));
 }
 
-bool IsUNM49CodeOFACSanctioned(const base::StringPiece code) {
+bool IsUNM49CodeOFACSanctioned(const std::string_view code) {
   return base::Contains(kOFACSactionedUnM49Codes, code);
 }
 

--- a/components/l10n/common/ofac_sanction_util.h
+++ b/components/l10n/common/ofac_sanction_util.h
@@ -6,7 +6,7 @@
 #ifndef BRAVE_COMPONENTS_L10N_COMMON_OFAC_SANCTION_UTIL_H_
 #define BRAVE_COMPONENTS_L10N_COMMON_OFAC_SANCTION_UTIL_H_
 
-#include "base/strings/string_piece_forward.h"
+#include <string_view>
 
 namespace brave_l10n {
 
@@ -16,7 +16,7 @@ namespace brave_l10n {
 // https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2,
 // https://en.wikipedia.org/wiki/ISO_3166-1_alpha-3, and
 // https://en.wikipedia.org/wiki/ISO_3166-1_numeric.
-bool IsISOCountryCodeOFACSanctioned(base::StringPiece country_code);
+bool IsISOCountryCodeOFACSanctioned(std::string_view country_code);
 
 // Returns |true| if the given |code| is on the OFAC sanctioned list, otherwise
 // |false|. |code| supports UN M.49 codes. See
@@ -24,7 +24,7 @@ bool IsISOCountryCodeOFACSanctioned(base::StringPiece country_code);
 //
 // NOTE: Sanctioning UN M.49 codes will also block all other countries that are
 // part of the same code.
-bool IsUNM49CodeOFACSanctioned(base::StringPiece code);
+bool IsUNM49CodeOFACSanctioned(std::string_view code);
 
 }  // namespace brave_l10n
 

--- a/components/l10n/common/ofac_sanctioned_iso_3166_1_country_code_constants.h
+++ b/components/l10n/common/ofac_sanctioned_iso_3166_1_country_code_constants.h
@@ -6,15 +6,16 @@
 #ifndef BRAVE_COMPONENTS_L10N_COMMON_OFAC_SANCTIONED_ISO_3166_1_COUNTRY_CODE_CONSTANTS_H_
 #define BRAVE_COMPONENTS_L10N_COMMON_OFAC_SANCTIONED_ISO_3166_1_COUNTRY_CODE_CONSTANTS_H_
 
+#include <string_view>
+
 #include "base/containers/fixed_flat_set.h"
-#include "base/strings/string_piece.h"
 
 namespace brave_l10n {
 
 // See https://orpa.princeton.edu/export-controls/sanctioned-countries.
 
 constexpr auto kOFACSactionedISO31661CountryCodes =
-    base::MakeFixedFlatSet<base::StringPiece>({
+    base::MakeFixedFlatSet<std::string_view>({
         // List of Comprehensively Sanctioned Countries. Most transactions,
         // including those involving persons or entities "ordinarily resident"
         // in the following countries, require an Office of Foreign Assets

--- a/components/l10n/common/ofac_sanctioned_un_m49_code_constants.h
+++ b/components/l10n/common/ofac_sanctioned_un_m49_code_constants.h
@@ -6,15 +6,16 @@
 #ifndef BRAVE_COMPONENTS_L10N_COMMON_OFAC_SANCTIONED_UN_M49_CODE_CONSTANTS_H_
 #define BRAVE_COMPONENTS_L10N_COMMON_OFAC_SANCTIONED_UN_M49_CODE_CONSTANTS_H_
 
+#include <string_view>
+
 #include "base/containers/fixed_flat_set.h"
-#include "base/strings/string_piece.h"
 
 namespace brave_l10n {
 
 // See https://orpa.princeton.edu/export-controls/sanctioned-countries.
 
 constexpr auto kOFACSactionedUnM49Codes =
-    base::MakeFixedFlatSet<base::StringPiece>({
+    base::MakeFixedFlatSet<std::string_view>({
         // See https://en.wikipedia.org/wiki/UN_M49.
 
         "001",  // World which includes sanctioned Cuba, Iran, North Korea,

--- a/components/l10n/common/un_m49_code_constants.h
+++ b/components/l10n/common/un_m49_code_constants.h
@@ -6,14 +6,15 @@
 #ifndef BRAVE_COMPONENTS_L10N_COMMON_UN_M49_CODE_CONSTANTS_H_
 #define BRAVE_COMPONENTS_L10N_COMMON_UN_M49_CODE_CONSTANTS_H_
 
+#include <string_view>
+
 #include "base/containers/fixed_flat_set.h"
-#include "base/strings/string_piece.h"
 
 namespace brave_l10n {
 
 // See https://en.wikipedia.org/wiki/UN_M49.
 
-constexpr auto kUnM49Codes = base::MakeFixedFlatSet<base::StringPiece>({
+constexpr auto kUnM49Codes = base::MakeFixedFlatSet<std::string_view>({
     "001",  // World
     "002",  // Africa
     "003",  // North America

--- a/components/l10n/common/un_m49_code_util.cc
+++ b/components/l10n/common/un_m49_code_util.cc
@@ -5,13 +5,14 @@
 
 #include "brave/components/l10n/common/un_m49_code_util.h"
 
+#include <string_view>
+
 #include "base/containers/contains.h"
-#include "base/strings/string_piece.h"
 #include "brave/components/l10n/common/un_m49_code_constants.h"
 
 namespace brave_l10n {
 
-bool IsUNM49Code(const base::StringPiece code) {
+bool IsUNM49Code(const std::string_view code) {
   return base::Contains(kUnM49Codes, code);
 }
 

--- a/components/l10n/common/un_m49_code_util.h
+++ b/components/l10n/common/un_m49_code_util.h
@@ -6,13 +6,13 @@
 #ifndef BRAVE_COMPONENTS_L10N_COMMON_UN_M49_CODE_UTIL_H_
 #define BRAVE_COMPONENTS_L10N_COMMON_UN_M49_CODE_UTIL_H_
 
-#include "base/strings/string_piece_forward.h"
+#include <string_view>
 
 namespace brave_l10n {
 
 // Returns |true| if the given code is a UN M.49 code otherwise returns |false|.
 // See https://en.wikipedia.org/wiki/UN_M49.
-bool IsUNM49Code(base::StringPiece code);
+bool IsUNM49Code(std::string_view code);
 
 }  // namespace brave_l10n
 

--- a/components/ntp_background_images/browser/sponsored_images_component_data.h
+++ b/components/ntp_background_images/browser/sponsored_images_component_data.h
@@ -7,16 +7,16 @@
 #define BRAVE_COMPONENTS_NTP_BACKGROUND_IMAGES_BROWSER_SPONSORED_IMAGES_COMPONENT_DATA_H_
 
 #include <string>
+#include <string_view>
 
-#include "base/strings/string_piece.h"
 #include "third_party/abseil-cpp/absl/types/optional.h"
 
 namespace ntp_background_images {
 
 struct SponsoredImagesComponentData {
-  base::StringPiece region;
-  base::StringPiece component_base64_public_key;
-  base::StringPiece component_id;
+  std::string_view region;
+  std::string_view component_base64_public_key;
+  std::string_view component_id;
 };
 
 absl::optional<SponsoredImagesComponentData> GetSponsoredImagesComponentData(

--- a/components/ntp_widget_utils/browser/ntp_widget_utils_oauth.cc
+++ b/components/ntp_widget_utils/browser/ntp_widget_utils_oauth.cc
@@ -6,6 +6,7 @@
 #include "brave/components/ntp_widget_utils/browser/ntp_widget_utils_oauth.h"
 
 #include <string>
+#include <string_view>
 
 #include "base/base64.h"
 #include "base/containers/adapters.h"
@@ -35,9 +36,8 @@ std::string GetCodeChallenge(
   crypto::SHA256HashString(code_verifier,
                            raw,
                            crypto::kSHA256Length);
-  base::Base64Encode(base::StringPiece(raw,
-                                       crypto::kSHA256Length),
-                                       &code_challenge);
+  base::Base64Encode(std::string_view(raw, crypto::kSHA256Length),
+                     &code_challenge);
 
   if (strip_chars) {
     std::replace(code_challenge.begin(), code_challenge.end(), '+', '-');

--- a/components/omnibox/browser/brave_bookmark_provider_unittest.cc
+++ b/components/omnibox/browser/brave_bookmark_provider_unittest.cc
@@ -6,9 +6,9 @@
 #include "brave/components/omnibox/browser/brave_bookmark_provider.h"
 
 #include <memory>
+#include <string_view>
 
 #include "base/memory/scoped_refptr.h"
-#include "base/strings/string_piece_forward.h"
 #include "base/strings/utf_string_conversions.h"
 #include "brave/components/omnibox/browser/brave_fake_autocomplete_provider_client.h"
 #include "brave/components/omnibox/browser/brave_omnibox_prefs.h"
@@ -27,7 +27,7 @@ class BraveBookmarkProviderTest : public testing::Test {
   BraveBookmarkProviderTest()
       : model_(bookmarks::TestBookmarkClient::CreateModel()) {}
 
-  AutocompleteInput CreateAutocompleteInput(base::StringPiece text) {
+  AutocompleteInput CreateAutocompleteInput(std::string_view text) {
     AutocompleteInput input(base::UTF8ToUTF16(text),
                             metrics::OmniboxEventProto::OTHER, classifier_);
     return input;

--- a/components/omnibox/browser/brave_history_url_provider_unittest.cc
+++ b/components/omnibox/browser/brave_history_url_provider_unittest.cc
@@ -9,6 +9,7 @@
 
 #include <algorithm>
 #include <memory>
+#include <string_view>
 #include <utility>
 
 #include "base/run_loop.h"
@@ -43,7 +44,7 @@ class BraveHistoryURLProviderTest : public testing::Test,
   BraveHistoryURLProviderTest& operator=(const BraveHistoryURLProviderTest&) =
       delete;
 
-  AutocompleteInput CreateAutocompleteInput(base::StringPiece text) {
+  AutocompleteInput CreateAutocompleteInput(std::string_view text) {
     AutocompleteInput input(base::UTF8ToUTF16(text),
                             metrics::OmniboxEventProto::OTHER,
                             TestSchemeClassifier());

--- a/components/omnibox/browser/brave_local_history_zero_suggest_provider_unittest.cc
+++ b/components/omnibox/browser/brave_local_history_zero_suggest_provider_unittest.cc
@@ -8,6 +8,7 @@
 #include <algorithm>
 #include <memory>
 #include <string>
+#include <string_view>
 #include <utility>
 
 #include "base/memory/ref_counted.h"
@@ -46,7 +47,7 @@ class BraveLocalHistoryZeroSuggestProviderTest
   BraveLocalHistoryZeroSuggestProviderTest& operator=(
       const BraveLocalHistoryZeroSuggestProviderTest&) = delete;
 
-  AutocompleteInput CreateAutocompleteInput(base::StringPiece text) {
+  AutocompleteInput CreateAutocompleteInput(std::string_view text) {
     AutocompleteInput input(u"", metrics::OmniboxEventProto::NTP_REALBOX,
                             TestSchemeClassifier());
     input.set_focus_type(metrics::OmniboxFocusType::INTERACTION_FOCUS);

--- a/components/omnibox/browser/brave_shortcuts_provider_unittest.cc
+++ b/components/omnibox/browser/brave_shortcuts_provider_unittest.cc
@@ -4,6 +4,7 @@
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 #include <memory>
+#include <string_view>
 #include <vector>
 
 #include "base/files/file_path.h"
@@ -35,7 +36,7 @@ class BraveShortcutsProviderTest : public testing::Test {
  public:
   BraveShortcutsProviderTest() = default;
 
-  AutocompleteInput CreateAutocompleteInput(base::StringPiece text) {
+  AutocompleteInput CreateAutocompleteInput(std::string_view text) {
     AutocompleteInput input(base::UTF8ToUTF16(text),
                             metrics::OmniboxEventProto::OTHER, classifier_);
     input.set_focus_type(metrics::OmniboxFocusType::INTERACTION_DEFAULT);

--- a/components/omnibox/browser/topsites_provider_unittest.cc
+++ b/components/omnibox/browser/topsites_provider_unittest.cc
@@ -5,6 +5,8 @@
 
 #include "brave/components/omnibox/browser/topsites_provider.h"
 
+#include <string_view>
+
 #include "base/strings/utf_string_conversions.h"
 #include "brave/components/omnibox/browser/brave_fake_autocomplete_provider_client.h"
 #include "brave/components/omnibox/browser/brave_omnibox_prefs.h"
@@ -18,7 +20,7 @@ class TopSitesProviderTest : public testing::Test {
   TopSitesProviderTest() : provider_(new TopSitesProvider(&client_)) {
   }
 
-  AutocompleteInput CreateAutocompleteInput(base::StringPiece text) {
+  AutocompleteInput CreateAutocompleteInput(std::string_view text) {
     AutocompleteInput input(base::UTF8ToUTF16(text),
                             metrics::OmniboxEventProto::OTHER,
                             classifier_);

--- a/components/p3a/constellation_helper.h
+++ b/components/p3a/constellation_helper.h
@@ -11,7 +11,6 @@
 
 #include "base/functional/callback.h"
 #include "base/memory/ref_counted.h"
-#include "base/strings/string_piece_forward.h"
 #include "brave/components/p3a/constellation/rs/cxx/src/lib.rs.h"
 #include "brave/components/p3a/star_randomness_meta.h"
 #include "brave/components/p3a/star_randomness_points.h"

--- a/components/p3a/constellation_log_store.cc
+++ b/components/p3a/constellation_log_store.cc
@@ -7,6 +7,7 @@
 
 #include <memory>
 #include <set>
+#include <string_view>
 
 #include "base/logging.h"
 #include "base/metrics/histogram_macros.h"
@@ -133,7 +134,7 @@ void ConstellationLogStore::StageNextLog() {
           << ", histogram_name = " << staged_entry_key_->histogram_name;
 }
 
-void ConstellationLogStore::DiscardStagedLog(base::StringPiece reason) {
+void ConstellationLogStore::DiscardStagedLog(std::string_view reason) {
   if (!has_staged_log()) {
     return;
   }

--- a/components/p3a/constellation_log_store.h
+++ b/components/p3a/constellation_log_store.h
@@ -8,12 +8,12 @@
 
 #include <memory>
 #include <string>
+#include <string_view>
 #include <vector>
 
 #include "base/containers/flat_map.h"
 #include "base/containers/flat_set.h"
 #include "base/memory/raw_ref.h"
-#include "base/strings/string_piece.h"
 #include "base/time/time.h"
 #include "components/metrics/log_store.h"
 #include "third_party/abseil-cpp/absl/types/optional.h"
@@ -52,7 +52,7 @@ class ConstellationLogStore : public metrics::LogStore {
   const std::string& staged_log_signature() const override;
   absl::optional<uint64_t> staged_log_user_id() const override;
   void StageNextLog() override;
-  void DiscardStagedLog(base::StringPiece reason = "") override;
+  void DiscardStagedLog(std::string_view reason = "") override;
   void MarkStagedLogAsSent() override;
 
   // |TrimAndPersistUnsentLogs| should not be used, since we persist everything

--- a/components/p3a/message_manager.cc
+++ b/components/p3a/message_manager.cc
@@ -5,6 +5,8 @@
 
 #include "brave/components/p3a/message_manager.h"
 
+#include <string_view>
+
 #include "base/functional/bind.h"
 #include "base/json/json_writer.h"
 #include "base/logging.h"
@@ -111,7 +113,7 @@ void MessageManager::Init(
   }
 }
 
-void MessageManager::UpdateMetricValue(base::StringPiece histogram_name,
+void MessageManager::UpdateMetricValue(std::string_view histogram_name,
                                        size_t bucket) {
   MetricLogType log_type = GetLogTypeForHistogram(histogram_name);
   if (features::IsConstellationEnabled()) {
@@ -126,7 +128,7 @@ void MessageManager::UpdateMetricValue(base::StringPiece histogram_name,
                                                 bucket);
 }
 
-void MessageManager::RemoveMetricValue(base::StringPiece histogram_name) {
+void MessageManager::RemoveMetricValue(std::string_view histogram_name) {
   for (MetricLogType log_type : kAllMetricLogTypes) {
     json_log_stores_[log_type]->RemoveValueIfExists(
         std::string(histogram_name));
@@ -308,7 +310,7 @@ void MessageManager::StartScheduledConstellationPrep() {
 }
 
 MetricLogType MessageManager::GetLogTypeForHistogram(
-    base::StringPiece histogram_name) {
+    std::string_view histogram_name) {
   std::string histogram_name_str = std::string(histogram_name);
   MetricLogType result = MetricLogType::kTypical;
   if (p3a::kCollectedExpressHistograms.contains(histogram_name) ||
@@ -323,7 +325,7 @@ MetricLogType MessageManager::GetLogTypeForHistogram(
   return result;
 }
 
-std::string MessageManager::SerializeLog(base::StringPiece histogram_name,
+std::string MessageManager::SerializeLog(std::string_view histogram_name,
                                          const uint64_t value,
                                          MetricLogType log_type,
                                          bool is_constellation,

--- a/components/p3a/message_manager.h
+++ b/components/p3a/message_manager.h
@@ -8,13 +8,13 @@
 
 #include <memory>
 #include <string>
+#include <string_view>
 
 #include "base/containers/flat_map.h"
 #include "base/functional/callback.h"
 #include "base/memory/raw_ptr.h"
 #include "base/memory/raw_ref.h"
 #include "base/memory/ref_counted.h"
-#include "base/strings/string_piece_forward.h"
 #include "base/timer/timer.h"
 #include "brave/components/p3a/metric_log_store.h"
 #include "brave/components/p3a/metric_log_type.h"
@@ -76,15 +76,15 @@ class MessageManager : public MetricLogStore::Delegate {
 
   void Init(scoped_refptr<network::SharedURLLoaderFactory> url_loader_factory);
 
-  void UpdateMetricValue(base::StringPiece histogram_name, size_t bucket);
+  void UpdateMetricValue(std::string_view histogram_name, size_t bucket);
 
-  void RemoveMetricValue(base::StringPiece histogram_name);
+  void RemoveMetricValue(std::string_view histogram_name);
 
  private:
   void StartScheduledUpload(bool is_constellation, MetricLogType log_type);
   void StartScheduledConstellationPrep();
 
-  MetricLogType GetLogTypeForHistogram(base::StringPiece histogram_name);
+  MetricLogType GetLogTypeForHistogram(std::string_view histogram_name);
 
   void OnLogUploadComplete(bool is_ok,
                            int response_code,
@@ -104,7 +104,7 @@ class MessageManager : public MetricLogStore::Delegate {
   void DoConstellationRotation();
 
   // MetricLogStore::Delegate
-  std::string SerializeLog(base::StringPiece histogram_name,
+  std::string SerializeLog(std::string_view histogram_name,
                            const uint64_t value,
                            MetricLogType log_type,
                            bool is_constellation,

--- a/components/p3a/message_manager_unittest.cc
+++ b/components/p3a/message_manager_unittest.cc
@@ -165,7 +165,7 @@ class P3AMessageManagerTest : public testing::Test,
     std::vector<std::string> result;
     size_t p3a_i = 0;
     size_t p2a_i = 0;
-    for (const std::string_view& histogram_name :
+    for (const std::string_view histogram_name :
          p3a::kCollectedTypicalHistograms) {
       if (histogram_name.rfind(kP2APrefix, 0) == 0) {
         if (p2a_i < p2a_count) {

--- a/components/p3a/message_manager_unittest.cc
+++ b/components/p3a/message_manager_unittest.cc
@@ -8,6 +8,7 @@
 #include <map>
 #include <memory>
 #include <set>
+#include <string_view>
 #include <vector>
 
 #include "base/strings/string_number_conversions.h"
@@ -164,7 +165,7 @@ class P3AMessageManagerTest : public testing::Test,
     std::vector<std::string> result;
     size_t p3a_i = 0;
     size_t p2a_i = 0;
-    for (const base::StringPiece& histogram_name :
+    for (const std::string_view& histogram_name :
          p3a::kCollectedTypicalHistograms) {
       if (histogram_name.rfind(kP2APrefix, 0) == 0) {
         if (p2a_i < p2a_count) {
@@ -207,7 +208,7 @@ class P3AMessageManagerTest : public testing::Test,
   base::Time next_epoch_time;
 
  private:
-  base::StringPiece ExtractBodyFromRequest(
+  std::string_view ExtractBodyFromRequest(
       const network::ResourceRequest& request) {
     return request.request_body->elements()
         ->at(0)
@@ -217,7 +218,7 @@ class P3AMessageManagerTest : public testing::Test,
 
   void StoreJsonMetricInMap(const network::ResourceRequest& request,
                             bool is_p2a) {
-    base::StringPiece body = ExtractBodyFromRequest(request);
+    std::string_view body = ExtractBodyFromRequest(request);
     base::Value::Dict parsed_log = base::test::ParseJsonDict(body);
     std::string* metric_name = parsed_log.FindString("metric_name");
     ASSERT_TRUE(metric_name);

--- a/components/p3a/metric_log_store.cc
+++ b/components/p3a/metric_log_store.cc
@@ -5,6 +5,7 @@
 
 #include "brave/components/p3a/metric_log_store.h"
 
+#include <string_view>
 #include <vector>
 
 #include "base/check_op.h"
@@ -231,7 +232,7 @@ void MetricLogStore::StageNextLog() {
   VLOG(2) << "MetricLogStore::StageNextLog: staged " << staged_entry_key_;
 }
 
-void MetricLogStore::DiscardStagedLog(base::StringPiece reason) {
+void MetricLogStore::DiscardStagedLog(std::string_view reason) {
   if (!has_staged_log()) {
     return;
   }

--- a/components/p3a/metric_log_store.h
+++ b/components/p3a/metric_log_store.h
@@ -7,11 +7,11 @@
 #define BRAVE_COMPONENTS_P3A_METRIC_LOG_STORE_H_
 
 #include <string>
+#include <string_view>
 
 #include "base/containers/flat_map.h"
 #include "base/containers/flat_set.h"
 #include "base/memory/raw_ref.h"
-#include "base/strings/string_piece.h"
 #include "base/time/time.h"
 #include "brave/components/p3a/metric_log_type.h"
 #include "components/metrics/log_store.h"
@@ -31,7 +31,7 @@ class MetricLogStore : public metrics::LogStore {
   class Delegate {
    public:
     // Prepares a string representaion of an entry.
-    virtual std::string SerializeLog(base::StringPiece histogram_name,
+    virtual std::string SerializeLog(std::string_view histogram_name,
                                      uint64_t value,
                                      MetricLogType log_type,
                                      bool is_constellation,
@@ -69,7 +69,7 @@ class MetricLogStore : public metrics::LogStore {
   const std::string& staged_log_signature() const override;
   absl::optional<uint64_t> staged_log_user_id() const override;
   void StageNextLog() override;
-  void DiscardStagedLog(base::StringPiece reason = "") override;
+  void DiscardStagedLog(std::string_view reason = "") override;
   void MarkStagedLogAsSent() override;
 
   // |TrimAndPersistUnsentLogs| should not be used, since we persist everything
@@ -103,7 +103,7 @@ class MetricLogStore : public metrics::LogStore {
 
   MetricLogType type_;
 
-  // TODO(iefremov): Try to replace with base::StringPiece?
+  // TODO(iefremov): Try to replace with std::string_view?
   base::flat_map<std::string, LogEntry> log_;
   base::flat_set<std::string> unsent_entries_;
 

--- a/components/p3a/metric_log_store_unittest.cc
+++ b/components/p3a/metric_log_store_unittest.cc
@@ -7,6 +7,7 @@
 
 #include <memory>
 #include <set>
+#include <string_view>
 
 #include "base/strings/string_number_conversions.h"
 #include "brave/components/p3a/metric_log_type.h"
@@ -22,7 +23,7 @@ class P3AMetricLogStoreTest : public testing::Test,
   P3AMetricLogStoreTest() {}
   ~P3AMetricLogStoreTest() override {}
 
-  std::string SerializeLog(base::StringPiece histogram_name,
+  std::string SerializeLog(std::string_view histogram_name,
                            uint64_t value,
                            MetricLogType log_type,
                            bool is_constellation,

--- a/components/p3a/metric_names.h
+++ b/components/p3a/metric_names.h
@@ -6,8 +6,9 @@
 #ifndef BRAVE_COMPONENTS_P3A_METRIC_NAMES_H_
 #define BRAVE_COMPONENTS_P3A_METRIC_NAMES_H_
 
+#include <string_view>
+
 #include "base/containers/fixed_flat_set.h"
-#include "base/strings/string_piece.h"
 
 namespace p3a {
 
@@ -23,7 +24,7 @@ namespace p3a {
 //
 // clang-format off
 constexpr inline auto kCollectedTypicalHistograms =
-  base::MakeFixedFlatSet<base::StringPiece>({
+  base::MakeFixedFlatSet<std::string_view>({
     "Brave.AIChat.AvgPromptCount",
     "Brave.AIChat.ChatCount",
     "Brave.AIChat.Enabled",
@@ -190,7 +191,7 @@ constexpr inline auto kCollectedTypicalHistograms =
 });
 
 constexpr inline auto kCollectedSlowHistograms =
-  base::MakeFixedFlatSet<base::StringPiece>({
+  base::MakeFixedFlatSet<std::string_view>({
     "Brave.Accessibility.DisplayZoomEnabled",
     "Brave.Core.DocumentsDirectorySizeMB",
     "Brave.Core.ProfileCount",
@@ -210,7 +211,7 @@ constexpr inline auto kCollectedSlowHistograms =
 });
 
 constexpr inline auto kCollectedExpressHistograms =
-  base::MakeFixedFlatSet<base::StringPiece>({
+  base::MakeFixedFlatSet<std::string_view>({
     "Brave.AIChat.UsageDaily",
     "Brave.Core.UsageDaily",
     "Brave.Rewards.EnabledInstallationTime",
@@ -222,7 +223,7 @@ constexpr inline auto kCollectedExpressHistograms =
 // List of metrics that should only be sent once per latest histogram update.
 // Once the metric value has been sent, the value will be removed from the log store.
 constexpr inline auto kEphemeralHistograms =
-  base::MakeFixedFlatSet<base::StringPiece>({
+  base::MakeFixedFlatSet<std::string_view>({
     "Brave.AIChat.AvgPromptCount",
     "Brave.AIChat.ChatCount",
     "Brave.AIChat.UsageDaily",

--- a/components/p3a/network_annotations.cc
+++ b/components/p3a/network_annotations.cc
@@ -5,6 +5,8 @@
 
 #include "brave/components/p3a/network_annotations.h"
 
+#include <string_view>
+
 #include "brave/components/p3a/uploader.h"
 
 namespace p3a {
@@ -59,7 +61,7 @@ net::NetworkTrafficAnnotationTag GetRandomnessServerInfoAnnotation() {
 }
 
 net::NetworkTrafficAnnotationTag GetP3AUploadAnnotation(
-    base::StringPiece upload_type,
+    std::string_view upload_type,
     bool is_constellation) {
   if (is_constellation) {
     if (upload_type == kP3ACreativeUploadType ||

--- a/components/p3a/network_annotations.h
+++ b/components/p3a/network_annotations.h
@@ -6,7 +6,8 @@
 #ifndef BRAVE_COMPONENTS_P3A_NETWORK_ANNOTATIONS_H_
 #define BRAVE_COMPONENTS_P3A_NETWORK_ANNOTATIONS_H_
 
-#include "base/strings/string_piece.h"
+#include <string_view>
+
 #include "net/traffic_annotation/network_traffic_annotation.h"
 
 namespace p3a {
@@ -15,7 +16,7 @@ net::NetworkTrafficAnnotationTag GetRandomnessRequestAnnotation();
 net::NetworkTrafficAnnotationTag GetRandomnessServerInfoAnnotation();
 
 net::NetworkTrafficAnnotationTag GetP3AUploadAnnotation(
-    base::StringPiece upload_type,
+    std::string_view upload_type,
     bool is_constellation);
 
 }  // namespace p3a

--- a/components/p3a/nitro_utils/attestation.cc
+++ b/components/p3a/nitro_utils/attestation.cc
@@ -10,6 +10,7 @@
 #include <iterator>
 #include <memory>
 #include <string>
+#include <string_view>
 #include <utility>
 #include <vector>
 
@@ -217,7 +218,7 @@ void ParseAndVerifyDocument(
     return;
   }
 
-  base::StringPiece trimmed_body =
+  std::string_view trimmed_body =
       base::TrimWhitespaceASCII(*response_body, base::TrimPositions::TRIM_ALL);
   absl::optional<std::vector<uint8_t>> cose_encoded =
       base::Base64Decode(trimmed_body);

--- a/components/p3a/nitro_utils/cose.cc
+++ b/components/p3a/nitro_utils/cose.cc
@@ -6,6 +6,7 @@
 #include "brave/components/p3a/nitro_utils/cose.h"
 
 #include <set>
+#include <string_view>
 
 #include "base/logging.h"
 #include "base/strings/string_number_conversions.h"
@@ -218,7 +219,7 @@ bool CoseSign1::Verify(const net::ParsedCertificateList& cert_chain) {
       cbor::Writer::Write(sig_data);
   CHECK(encoded_sig_data.has_value());
 
-  base::StringPiece low_cert_spki;
+  std::string_view low_cert_spki;
   if (!net::asn1::ExtractSPKIFromDERCert(
           cert_chain.front()->der_cert().AsStringView(), &low_cert_spki)) {
     LOG(ERROR) << "COSE verification: could not extract SPKI from cert";

--- a/components/p3a/p3a_message.cc
+++ b/components/p3a/p3a_message.cc
@@ -7,6 +7,7 @@
 
 #include <algorithm>
 #include <array>
+#include <string_view>
 #include <vector>
 
 #include "base/containers/flat_set.h"
@@ -29,7 +30,7 @@ constexpr std::size_t kP3AConstellationAttributeCount = 8;
 MessageMetainfo::MessageMetainfo() = default;
 MessageMetainfo::~MessageMetainfo() = default;
 
-base::Value::Dict GenerateP3AMessageDict(base::StringPiece metric_name,
+base::Value::Dict GenerateP3AMessageDict(std::string_view metric_name,
                                          uint64_t metric_value,
                                          MetricLogType log_type,
                                          const MessageMetainfo& meta,
@@ -99,7 +100,7 @@ base::Value::Dict GenerateP3AMessageDict(base::StringPiece metric_name,
   return result;
 }
 
-std::string GenerateP3AConstellationMessage(base::StringPiece metric_name,
+std::string GenerateP3AConstellationMessage(std::string_view metric_name,
                                             uint64_t metric_value,
                                             const MessageMetainfo& meta) {
   base::Time::Exploded exploded;

--- a/components/p3a/p3a_message.h
+++ b/components/p3a/p3a_message.h
@@ -8,6 +8,7 @@
 
 #include <cstdint>
 #include <string>
+#include <string_view>
 
 #include "base/time/time.h"
 #include "base/values.h"
@@ -49,13 +50,13 @@ class MessageMetainfo {
   void MaybeStripCountry();
 };
 
-base::Value::Dict GenerateP3AMessageDict(base::StringPiece metric_name,
+base::Value::Dict GenerateP3AMessageDict(std::string_view metric_name,
                                          uint64_t metric_value,
                                          MetricLogType log_type,
                                          const MessageMetainfo& meta,
                                          const std::string& upload_type);
 
-std::string GenerateP3AConstellationMessage(base::StringPiece metric_name,
+std::string GenerateP3AConstellationMessage(std::string_view metric_name,
                                             uint64_t metric_value,
                                             const MessageMetainfo& meta);
 

--- a/components/p3a/p3a_service.cc
+++ b/components/p3a/p3a_service.cc
@@ -94,7 +94,7 @@ void P3AService::RegisterPrefs(PrefRegistrySimple* registry, bool first_run) {
   registry->RegisterDictionaryPref(kDynamicMetricsDictPref);
 }
 
-void P3AService::InitCallback(const std::string_view& histogram_name) {
+void P3AService::InitCallback(const std::string_view histogram_name) {
   histogram_sample_callbacks_.push_back(
       std::make_unique<base::StatisticsRecorder::ScopedHistogramSampleObserver>(
           std::string(histogram_name),
@@ -103,15 +103,15 @@ void P3AService::InitCallback(const std::string_view& histogram_name) {
 }
 
 void P3AService::InitCallbacks() {
-  for (const std::string_view& histogram_name :
+  for (const std::string_view histogram_name :
        p3a::kCollectedTypicalHistograms) {
     InitCallback(histogram_name);
   }
-  for (const std::string_view& histogram_name :
+  for (const std::string_view histogram_name :
        p3a::kCollectedExpressHistograms) {
     InitCallback(histogram_name);
   }
-  for (const std::string_view& histogram_name : p3a::kCollectedSlowHistograms) {
+  for (const std::string_view histogram_name : p3a::kCollectedSlowHistograms) {
     InitCallback(histogram_name);
   }
   LoadDynamicMetrics();

--- a/components/p3a/p3a_service.cc
+++ b/components/p3a/p3a_service.cc
@@ -6,6 +6,7 @@
 #include "brave/components/p3a/p3a_service.h"
 
 #include <string>
+#include <string_view>
 #include <utility>
 
 #include "base/logging.h"
@@ -16,7 +17,6 @@
 #include "base/no_destructor.h"
 #include "base/notreached.h"
 #include "base/rand_util.h"
-#include "base/strings/string_piece_forward.h"
 #include "base/timer/wall_clock_timer.h"
 #include "base/trace_event/trace_event.h"
 #include "brave/components/brave_stats/browser/brave_stats_updater_util.h"
@@ -51,8 +51,7 @@ const uint64_t kSuspendedMetricBucket = INT_MAX - 1;
 
 constexpr char kDynamicMetricsDictPref[] = "p3a.dynamic_metrics";
 
-bool IsSuspendedMetric(base::StringPiece metric_name,
-                       uint64_t value_or_bucket) {
+bool IsSuspendedMetric(std::string_view metric_name, uint64_t value_or_bucket) {
   return value_or_bucket == kSuspendedMetricBucket;
 }
 
@@ -95,7 +94,7 @@ void P3AService::RegisterPrefs(PrefRegistrySimple* registry, bool first_run) {
   registry->RegisterDictionaryPref(kDynamicMetricsDictPref);
 }
 
-void P3AService::InitCallback(const base::StringPiece& histogram_name) {
+void P3AService::InitCallback(const std::string_view& histogram_name) {
   histogram_sample_callbacks_.push_back(
       std::make_unique<base::StatisticsRecorder::ScopedHistogramSampleObserver>(
           std::string(histogram_name),
@@ -104,16 +103,15 @@ void P3AService::InitCallback(const base::StringPiece& histogram_name) {
 }
 
 void P3AService::InitCallbacks() {
-  for (const base::StringPiece& histogram_name :
+  for (const std::string_view& histogram_name :
        p3a::kCollectedTypicalHistograms) {
     InitCallback(histogram_name);
   }
-  for (const base::StringPiece& histogram_name :
+  for (const std::string_view& histogram_name :
        p3a::kCollectedExpressHistograms) {
     InitCallback(histogram_name);
   }
-  for (const base::StringPiece& histogram_name :
-       p3a::kCollectedSlowHistograms) {
+  for (const std::string_view& histogram_name : p3a::kCollectedSlowHistograms) {
     InitCallback(histogram_name);
   }
   LoadDynamicMetrics();
@@ -279,7 +277,7 @@ void P3AService::OnHistogramChangedOnUI(const char* histogram_name,
   }
 }
 
-void P3AService::HandleHistogramChange(base::StringPiece histogram_name,
+void P3AService::HandleHistogramChange(std::string_view histogram_name,
                                        size_t bucket) {
   if (IsSuspendedMetric(histogram_name, bucket)) {
     message_manager_->RemoveMetricValue(std::string(histogram_name));

--- a/components/p3a/p3a_service.h
+++ b/components/p3a/p3a_service.h
@@ -8,6 +8,7 @@
 
 #include <memory>
 #include <string>
+#include <string_view>
 #include <vector>
 
 #include "base/callback_list.h"
@@ -16,7 +17,6 @@
 #include "base/memory/ref_counted.h"
 #include "base/metrics/histogram_base.h"
 #include "base/metrics/statistics_recorder.h"
-#include "base/strings/string_piece_forward.h"
 #include "brave/components/p3a/message_manager.h"
 #include "brave/components/p3a/metric_log_type.h"
 #include "brave/components/p3a/p3a_config.h"
@@ -98,7 +98,7 @@ class P3AService : public base::RefCountedThreadSafe<P3AService>,
   friend class base::RefCountedThreadSafe<P3AService>;
   ~P3AService() override;
 
-  void InitCallback(const base::StringPiece& histogram_name);
+  void InitCallback(const std::string_view& histogram_name);
 
   void LoadDynamicMetrics();
 
@@ -107,7 +107,7 @@ class P3AService : public base::RefCountedThreadSafe<P3AService>,
                               size_t bucket);
 
   // Updates or removes a metric from the log.
-  void HandleHistogramChange(base::StringPiece histogram_name, size_t bucket);
+  void HandleHistogramChange(std::string_view histogram_name, size_t bucket);
 
   // General prefs:
   bool initialized_ = false;
@@ -126,7 +126,7 @@ class P3AService : public base::RefCountedThreadSafe<P3AService>,
 
   // Used to store histogram values that are produced between constructing
   // the service and its initialization.
-  base::flat_map<base::StringPiece, size_t> histogram_values_;
+  base::flat_map<std::string_view, size_t> histogram_values_;
 
   std::vector<
       std::unique_ptr<base::StatisticsRecorder::ScopedHistogramSampleObserver>>

--- a/components/p3a/p3a_service.h
+++ b/components/p3a/p3a_service.h
@@ -98,7 +98,7 @@ class P3AService : public base::RefCountedThreadSafe<P3AService>,
   friend class base::RefCountedThreadSafe<P3AService>;
   ~P3AService() override;
 
-  void InitCallback(const std::string_view& histogram_name);
+  void InitCallback(const std::string_view histogram_name);
 
   void LoadDynamicMetrics();
 

--- a/components/p3a/p3a_service_unittest.cc
+++ b/components/p3a/p3a_service_unittest.cc
@@ -100,7 +100,7 @@ class P3AServiceTest : public testing::Test {
     std::vector<std::string> result;
     size_t p3a_i = 0;
     size_t p2a_i = 0;
-    for (const std::string_view& histogram_name :
+    for (const std::string_view histogram_name :
          p3a::kCollectedTypicalHistograms) {
       if (histogram_name.rfind(kP2APrefix, 0) == 0) {
         if (p2a_i < p2a_count) {

--- a/components/p3a/p3a_service_unittest.cc
+++ b/components/p3a/p3a_service_unittest.cc
@@ -6,6 +6,7 @@
 #include "brave/components/p3a/p3a_service.h"
 
 #include <set>
+#include <string_view>
 #include <utility>
 #include <vector>
 
@@ -99,7 +100,7 @@ class P3AServiceTest : public testing::Test {
     std::vector<std::string> result;
     size_t p3a_i = 0;
     size_t p2a_i = 0;
-    for (const base::StringPiece& histogram_name :
+    for (const std::string_view& histogram_name :
          p3a::kCollectedTypicalHistograms) {
       if (histogram_name.rfind(kP2APrefix, 0) == 0) {
         if (p2a_i < p2a_count) {
@@ -132,7 +133,7 @@ class P3AServiceTest : public testing::Test {
   std::set<std::string> p3a_creative_sent_metrics_;
 
  private:
-  base::StringPiece ExtractBodyFromRequest(
+  std::string_view ExtractBodyFromRequest(
       const network::ResourceRequest& request) {
     return request.request_body->elements()
         ->at(0)
@@ -142,7 +143,7 @@ class P3AServiceTest : public testing::Test {
 
   void StoreJsonMetricInMap(const network::ResourceRequest& request,
                             const GURL& url) {
-    base::StringPiece body = ExtractBodyFromRequest(request);
+    std::string_view body = ExtractBodyFromRequest(request);
     base::Value::Dict parsed_log = base::test::ParseJsonDict(body);
     std::string* metric_name = parsed_log.FindString("metric_name");
     ASSERT_TRUE(metric_name);

--- a/components/p3a/star_randomness_test_util.cc
+++ b/components/p3a/star_randomness_test_util.cc
@@ -6,6 +6,7 @@
 #include "brave/components/p3a/star_randomness_test_util.h"
 
 #include <algorithm>
+#include <string_view>
 #include <utility>
 #include <vector>
 
@@ -23,10 +24,10 @@ namespace p3a {
 std::string HandleRandomnessRequest(const network::ResourceRequest& request,
                                     uint8_t expected_epoch) {
   EXPECT_EQ(request.method, net::HttpRequestHeaders::kPostMethod);
-  base::StringPiece request_string(request.request_body->elements()
-                                       ->at(0)
-                                       .As<network::DataElementBytes>()
-                                       .AsStringPiece());
+  std::string_view request_string(request.request_body->elements()
+                                      ->at(0)
+                                      .As<network::DataElementBytes>()
+                                      .AsStringPiece());
 
   base::Value::Dict req_parsed_val = base::test::ParseJsonDict(request_string);
 

--- a/components/permissions/permission_expirations.cc
+++ b/components/permissions/permission_expirations.cc
@@ -7,6 +7,7 @@
 
 #include <algorithm>
 #include <memory>
+#include <string_view>
 #include <utility>
 
 #include "base/stl_util.h"
@@ -27,9 +28,9 @@ namespace permissions {
 namespace {
 
 // Pref data keys.
-constexpr base::StringPiece kRequestingOriginKey = "ro";
-constexpr base::StringPiece kEmbeddingOriginKey = "eo";
-constexpr base::StringPiece kContentSettingKey = "cs";
+constexpr std::string_view kRequestingOriginKey = "ro";
+constexpr std::string_view kEmbeddingOriginKey = "eo";
+constexpr std::string_view kContentSettingKey = "cs";
 
 template <typename Container, typename ConstIterator>
 typename Container::iterator ConstCastIterator(Container& c, ConstIterator it) {

--- a/components/permissions/permission_expirations_unittest.cc
+++ b/components/permissions/permission_expirations_unittest.cc
@@ -7,6 +7,7 @@
 
 #include <algorithm>
 #include <memory>
+#include <string_view>
 
 #include "base/stl_util.h"
 #include "base/strings/strcat.h"
@@ -27,7 +28,7 @@ namespace permissions {
 
 namespace {
 
-constexpr base::StringPiece kOneTypeOneExpirationPrefValue = R"({
+constexpr std::string_view kOneTypeOneExpirationPrefValue = R"({
   "$1": {
     "$2": [
       {"ro": "$3", "cs": 1}
@@ -35,7 +36,7 @@ constexpr base::StringPiece kOneTypeOneExpirationPrefValue = R"({
   }
 })";
 
-constexpr base::StringPiece kOneTypeOneExpirationWithAllDataPrefValue = R"({
+constexpr std::string_view kOneTypeOneExpirationWithAllDataPrefValue = R"({
   "$1": {
     "$2": [
       {"ro": "$3", "eo": "$4", "cs": $5}
@@ -43,7 +44,7 @@ constexpr base::StringPiece kOneTypeOneExpirationWithAllDataPrefValue = R"({
   }
 })";
 
-constexpr base::StringPiece kOneTypeTwoExpirationsPrefValue = R"({
+constexpr std::string_view kOneTypeTwoExpirationsPrefValue = R"({
   "$1": {
     "$2": [
       {"ro": "$3", "cs": 1}
@@ -54,7 +55,7 @@ constexpr base::StringPiece kOneTypeTwoExpirationsPrefValue = R"({
   }
 })";
 
-constexpr base::StringPiece kOneTypeThreeExpirationsPrefValue = R"({
+constexpr std::string_view kOneTypeThreeExpirationsPrefValue = R"({
   "$1": {
     "$2": [
       {"ro": "$3", "cs": 1}
@@ -68,7 +69,7 @@ constexpr base::StringPiece kOneTypeThreeExpirationsPrefValue = R"({
   }
 })";
 
-constexpr base::StringPiece kTwoTypesOneExpirationPrefValue = R"({
+constexpr std::string_view kTwoTypesOneExpirationPrefValue = R"({
   "$1": {
     "$2": [
       {"ro": "$3", "cs": 1}
@@ -129,7 +130,7 @@ class PermissionExpirationsTest : public testing::Test {
   }
 
   void CheckExpirationsPref(const base::Location& location,
-                            base::StringPiece pref_value_template,
+                            std::string_view pref_value_template,
                             const std::vector<std::string>& subst = {}) {
     SCOPED_TRACE(testing::Message() << location.ToString());
     const auto& expirations =

--- a/components/playlist/browser/playlist_media_file_downloader.cc
+++ b/components/playlist/browser/playlist_media_file_downloader.cc
@@ -6,6 +6,7 @@
 #include "brave/components/playlist/browser/playlist_media_file_downloader.h"
 
 #include <algorithm>
+#include <string_view>
 #include <utility>
 
 #include "base/containers/fixed_flat_map.h"
@@ -42,8 +43,8 @@ namespace playlist {
 // * Mimetype to extension
 //   * https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types/Common_types
 constexpr auto kMimeTypeToExtension =
-    base::MakeFixedFlatMap<base::StringPiece /*mime_type*/,
-                           base::StringPiece /*extension*/>({
+    base::MakeFixedFlatMap<std::string_view /*mime_type*/,
+                           std::string_view /*extension*/>({
         {"audio/wav", "wav"},
         {"audio/x-wav", "wav"},
         {"audio/webm", "weba"},

--- a/components/query_filter/utils.cc
+++ b/components/query_filter/utils.cc
@@ -6,11 +6,11 @@
 #include "brave/components/query_filter/utils.h"
 
 #include <string>
+#include <string_view>
 #include <vector>
 
 #include "base/containers/fixed_flat_map.h"
 #include "base/containers/fixed_flat_set.h"
-#include "base/strings/string_piece.h"
 #include "base/strings/string_split.h"
 #include "base/strings/string_util.h"
 #include "net/base/registry_controlled_domains/registry_controlled_domain.h"
@@ -19,7 +19,7 @@
 namespace query_filter {
 
 static constexpr auto kSimpleQueryStringTrackers =
-    base::MakeFixedFlatSet<base::StringPiece>(
+    base::MakeFixedFlatSet<std::string_view>(
         {// https://github.com/brave/brave-browser/issues/4239
          "fbclid", "gclid", "msclkid", "mc_eid",
          // https://github.com/brave/brave-browser/issues/9879
@@ -63,7 +63,7 @@ static constexpr auto kSimpleQueryStringTrackers =
          "vgo_ee"});
 
 static constexpr auto kConditionalQueryStringTrackers =
-    base::MakeFixedFlatMap<base::StringPiece, base::StringPiece>({
+    base::MakeFixedFlatMap<std::string_view, std::string_view>({
         // https://github.com/brave/brave-browser/issues/9018
         {"mkt_tok", "([uU]nsubscribe|emailWebview)"},
         // https://github.com/brave/brave-browser/issues/30731
@@ -72,7 +72,7 @@ static constexpr auto kConditionalQueryStringTrackers =
     });
 
 static constexpr auto kScopedQueryStringTrackers =
-    base::MakeFixedFlatMap<base::StringPiece, base::StringPiece>({
+    base::MakeFixedFlatMap<std::string_view, std::string_view>({
         // https://github.com/brave/brave-browser/issues/11580
         {"igshid", "instagram.com"},
         // https://github.com/brave/brave-browser/issues/26966
@@ -82,7 +82,7 @@ static constexpr auto kScopedQueryStringTrackers =
 
 // Remove tracking query parameters from a GURL, leaving all
 // other parts untouched.
-absl::optional<std::string> StripQueryParameter(const base::StringPiece& query,
+absl::optional<std::string> StripQueryParameter(const std::string_view& query,
                                                 const std::string& spec) {
   // We are using custom query string parsing code here. See
   // https://github.com/brave/brave-core/pull/13726#discussion_r897712350
@@ -91,14 +91,14 @@ absl::optional<std::string> StripQueryParameter(const base::StringPiece& query,
   // Split query string by ampersands, remove tracking parameters,
   // then join the remaining query parameters, untouched, back into
   // a single query string.
-  const std::vector<base::StringPiece> input_kv_strings =
+  const std::vector<std::string_view> input_kv_strings =
       SplitStringPiece(query, "&", base::KEEP_WHITESPACE, base::SPLIT_WANT_ALL);
-  std::vector<base::StringPiece> output_kv_strings;
+  std::vector<std::string_view> output_kv_strings;
   int disallowed_count = 0;
   for (const auto& kv_string : input_kv_strings) {
-    const std::vector<base::StringPiece> pieces = SplitStringPiece(
+    const std::vector<std::string_view> pieces = SplitStringPiece(
         kv_string, "=", base::KEEP_WHITESPACE, base::SPLIT_WANT_NONEMPTY);
-    const base::StringPiece& key = pieces.empty() ? "" : pieces[0];
+    const std::string_view& key = pieces.empty() ? "" : pieces[0];
     if (pieces.size() >= 2 &&
         (kSimpleQueryStringTrackers.count(key) == 1 ||
          (kScopedQueryStringTrackers.count(key) == 1 &&

--- a/components/query_filter/utils.cc
+++ b/components/query_filter/utils.cc
@@ -82,7 +82,7 @@ static constexpr auto kScopedQueryStringTrackers =
 
 // Remove tracking query parameters from a GURL, leaving all
 // other parts untouched.
-absl::optional<std::string> StripQueryParameter(const std::string_view& query,
+absl::optional<std::string> StripQueryParameter(const std::string_view query,
                                                 const std::string& spec) {
   // We are using custom query string parsing code here. See
   // https://github.com/brave/brave-core/pull/13726#discussion_r897712350
@@ -98,7 +98,7 @@ absl::optional<std::string> StripQueryParameter(const std::string_view& query,
   for (const auto& kv_string : input_kv_strings) {
     const std::vector<std::string_view> pieces = SplitStringPiece(
         kv_string, "=", base::KEEP_WHITESPACE, base::SPLIT_WANT_NONEMPTY);
-    const std::string_view& key = pieces.empty() ? "" : pieces[0];
+    const std::string_view key = pieces.empty() ? "" : pieces[0];
     if (pieces.size() >= 2 &&
         (kSimpleQueryStringTrackers.count(key) == 1 ||
          (kScopedQueryStringTrackers.count(key) == 1 &&

--- a/components/request_otr/browser/request_otr_rule.cc
+++ b/components/request_otr/browser/request_otr_rule.cc
@@ -6,6 +6,7 @@
 #include "brave/components/request_otr/browser/request_otr_rule.h"
 
 #include <memory>
+#include <string_view>
 #include <utility>
 #include <vector>
 
@@ -26,7 +27,7 @@ const char kExclude[] = "exclude";
 
 // Removes trailing dot from |host_piece| if any.
 // Copied from extensions/common/url_pattern.cc
-base::StringPiece CanonicalizeHostForMatching(base::StringPiece host_piece) {
+std::string_view CanonicalizeHostForMatching(std::string_view host_piece) {
   if (base::EndsWith(host_piece, ".")) {
     host_piece.remove_suffix(1);
   }
@@ -74,7 +75,7 @@ void RequestOTRRule::RegisterJSONConverter(
 // are consistent in their private registries configuration.
 const std::string RequestOTRRule::GetETLDForRequestOTR(
     const std::string& host) {
-  base::StringPiece host_piece = CanonicalizeHostForMatching(host);
+  std::string_view host_piece = CanonicalizeHostForMatching(host);
   return net::registry_controlled_domains::GetDomainAndRegistry(
       host_piece, net::registry_controlled_domains::PrivateRegistryFilter::
                       EXCLUDE_PRIVATE_REGISTRIES);

--- a/components/sidebar/sidebar_service_unittest.cc
+++ b/components/sidebar/sidebar_service_unittest.cc
@@ -162,7 +162,7 @@ constexpr char sidebar_builtin_ai_chat_not_listed_json[] = R"({
          "sidebar_show_option": 0
       })";
 
-base::Value::Dict ParseTestJson(const std::string_view& json) {
+base::Value::Dict ParseTestJson(const std::string_view json) {
   absl::optional<base::Value> potential_response_dict_val =
       base::JSONReader::Read(json, base::JSON_PARSE_CHROMIUM_EXTENSIONS |
                                        base::JSONParserOptions::JSON_PARSE_RFC);

--- a/components/sidebar/sidebar_service_unittest.cc
+++ b/components/sidebar/sidebar_service_unittest.cc
@@ -4,6 +4,7 @@
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 #include <memory>
+#include <string_view>
 #include <utility>
 
 #include "base/containers/contains.h"
@@ -161,7 +162,7 @@ constexpr char sidebar_builtin_ai_chat_not_listed_json[] = R"({
          "sidebar_show_option": 0
       })";
 
-base::Value::Dict ParseTestJson(const base::StringPiece& json) {
+base::Value::Dict ParseTestJson(const std::string_view& json) {
   absl::optional<base::Value> potential_response_dict_val =
       base::JSONReader::Read(json, base::JSON_PARSE_CHROMIUM_EXTENSIONS |
                                        base::JSONParserOptions::JSON_PARSE_RFC);

--- a/components/url_sanitizer/browser/url_sanitizer_service.h
+++ b/components/url_sanitizer/browser/url_sanitizer_service.h
@@ -15,7 +15,6 @@
 #include "base/functional/callback.h"
 #include "base/gtest_prod_util.h"
 #include "base/memory/weak_ptr.h"
-#include "base/strings/string_piece.h"
 #include "brave/components/url_sanitizer/browser/url_sanitizer_component_installer.h"
 #include "brave/components/url_sanitizer/common/mojom/url_sanitizer.mojom.h"
 #include "components/keyed_service/core/keyed_service.h"

--- a/ios/browser/api/bookmarks/exporter/bookmark_html_writer.cc
+++ b/ios/browser/api/bookmarks/exporter/bookmark_html_writer.cc
@@ -12,6 +12,7 @@
 #include <map>
 #include <memory>
 #include <string>
+#include <string_view>
 #include <utility>
 
 #include "base/base64.h"
@@ -333,7 +334,7 @@ class Writer : public base::RefCountedThreadSafe<Writer> {
         scoped_refptr<base::RefCountedMemory> data(itr->second.get());
         std::string favicon_base64_encoded;
         base::Base64Encode(
-            base::StringPiece(data->front_as<char>(), data->size()),
+            std::string_view(data->front_as<char>(), data->size()),
             &favicon_base64_encoded);
         GURL favicon_url("data:image/png;base64," + favicon_base64_encoded);
         favicon_string = favicon_url.spec();

--- a/ios/browser/api/certificate/brave_certificate.mm
+++ b/ios/browser/api/certificate/brave_certificate.mm
@@ -6,7 +6,6 @@
 #include "brave/ios/browser/api/certificate/brave_certificate.h"
 #include "base/logging.h"
 #include "base/strings/string_number_conversions.h"
-#include "base/strings/string_piece.h"
 #include "base/strings/sys_string_conversions.h"
 #include "base/time/time.h"
 #include "brave/ios/browser/api/certificate/models/brave_certificate_enums.h"

--- a/ios/browser/api/certificate/utils/brave_certificate_x509_utils.cc
+++ b/ios/browser/api/certificate/utils/brave_certificate_x509_utils.cc
@@ -4,8 +4,10 @@
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 #include "brave/ios/browser/api/certificate/utils/brave_certificate_x509_utils.h"
+
+#include <string_view>
+
 #include "base/memory/ref_counted.h"
-#include "base/strings/string_piece.h"
 #include "base/time/time.h"
 #include "net/base/net_export.h"
 #include "net/cert/ct_objects_extractor.h"
@@ -57,7 +59,7 @@ bool ExtractEmbeddedSCT(
     return false;
   }
 
-  std::vector<base::StringPiece> parsed_scts;
+  std::vector<std::string_view> parsed_scts;
   if (!net::ct::DecodeSCTList(sct_list, &parsed_scts)) {
     return false;
   }

--- a/ios/browser/api/url/url_utils.mm
+++ b/ios/browser/api/url/url_utils.mm
@@ -5,7 +5,6 @@
 
 #include "brave/ios/browser/api/url/url_utils.h"
 #include "base/strings/string_number_conversions.h"
-#include "base/strings/string_piece.h"
 #include "base/strings/sys_string_conversions.h"
 #import "net/base/mac/url_conversions.h"
 #include "net/base/registry_controlled_domains/registry_controlled_domain.h"

--- a/ios/browser/api/web/web_state/web_state_native.h
+++ b/ios/browser/api/web/web_state/web_state_native.h
@@ -5,7 +5,6 @@
 
 #include <memory>
 #include "base/memory/weak_ptr.h"
-#include "base/strings/string_piece.h"
 #include "components/sessions/core/session_id.h"
 #include "ios/web/public/web_state_observer.h"
 

--- a/ios/browser/brave_web_client.h
+++ b/ios/browser/brave_web_client.h
@@ -8,6 +8,7 @@
 
 #include <memory>
 #include <string>
+#include <string_view>
 #include <vector>
 
 #include "base/compiler_specific.h"
@@ -30,7 +31,7 @@ class BraveWebClient : public web::WebClient {
 
   std::unique_ptr<web::WebMainParts> CreateWebMainParts() override;
   std::string GetUserAgent(web::UserAgentType type) const override;
-  base::StringPiece GetDataResource(
+  std::string_view GetDataResource(
       int resource_id,
       ui::ResourceScaleFactor scale_factor) const override;
   base::RefCountedMemory* GetDataResourceBytes(int resource_id) const override;

--- a/ios/browser/brave_web_client.mm
+++ b/ios/browser/brave_web_client.mm
@@ -6,6 +6,7 @@
 #import "brave/ios/browser/brave_web_client.h"
 
 #include <string>
+#include <string_view>
 
 #include "base/functional/bind.h"
 #include "brave/ios/browser/brave_web_main_parts.h"
@@ -46,7 +47,7 @@ std::string BraveWebClient::GetUserAgent(web::UserAgentType type) const {
   return user_agent_;
 }
 
-base::StringPiece BraveWebClient::GetDataResource(
+std::string_view BraveWebClient::GetDataResource(
     int resource_id,
     ui::ResourceScaleFactor scale_factor) const {
   return ui::ResourceBundle::GetSharedInstance().GetRawDataResourceForScale(

--- a/net/http/partitioned_host_state_map_unittest.cc
+++ b/net/http/partitioned_host_state_map_unittest.cc
@@ -7,6 +7,7 @@
 
 #include <map>
 #include <string>
+#include <string_view>
 
 #include "base/containers/span.h"
 #include "crypto/sha2.h"
@@ -19,7 +20,7 @@ namespace {
 using HostHash = std::array<uint8_t, crypto::kSHA256Length>;
 using PartitionedMap = PartitionedHostStateMap<std::map<HostHash, std::string>>;
 
-HostHash HashHost(base::StringPiece canonicalized_host) {
+HostHash HashHost(std::string_view canonicalized_host) {
   if (canonicalized_host.empty()) {
     return {};
   }

--- a/sandbox/win/src/module_file_name_interception.cc
+++ b/sandbox/win/src/module_file_name_interception.cc
@@ -8,20 +8,20 @@
 #include <string.h>
 #include <algorithm>
 #include <string>
+#include <string_view>
 
-#include "base/strings/string_piece.h"
 #include "base/strings/string_util.h"
 #include "base/win/windows_types.h"
 #include "third_party/abseil-cpp/absl/types/optional.h"
 
 namespace {
 
-void ReplaceAt(char* dest, size_t dest_size, base::StringPiece src) {
+void ReplaceAt(char* dest, size_t dest_size, std::string_view src) {
   ::strncpy_s(dest, dest_size, src.data(),
               std::min(dest_size - 1, src.length()));
 }
 
-void ReplaceAt(wchar_t* dest, size_t dest_size, base::WStringPiece src) {
+void ReplaceAt(wchar_t* dest, size_t dest_size, std::wstring_view src) {
   ::wcsncpy_s(dest, dest_size, src.data(),
               std::min(dest_size - 1, src.length()));
 }
@@ -31,14 +31,14 @@ struct BraveToChrome;
 
 template <>
 struct BraveToChrome<char> {
-  static constexpr const base::StringPiece kBrave = "brave.exe";
-  static constexpr const base::StringPiece kChrome = "chrome.exe";
+  static constexpr const std::string_view kBrave = "brave.exe";
+  static constexpr const std::string_view kChrome = "chrome.exe";
 };
 
 template <>
 struct BraveToChrome<wchar_t> {
-  static constexpr const base::WStringPiece kBrave = L"brave.exe";
-  static constexpr const base::WStringPiece kChrome = L"chrome.exe";
+  static constexpr const std::wstring_view kBrave = L"brave.exe";
+  static constexpr const std::wstring_view kChrome = L"chrome.exe";
 };
 
 template <typename CharT>
@@ -46,14 +46,14 @@ struct TestBraveToChrome;
 
 template <>
 struct TestBraveToChrome<char> {
-  static constexpr const base::StringPiece kBrave = "brave_browser_tests.exe";
-  static constexpr const base::StringPiece kChrome = "chrome_browser_tests.exe";
+  static constexpr const std::string_view kBrave = "brave_browser_tests.exe";
+  static constexpr const std::string_view kChrome = "chrome_browser_tests.exe";
 };
 
 template <>
 struct TestBraveToChrome<wchar_t> {
-  static constexpr const base::WStringPiece kBrave = L"brave_browser_tests.exe";
-  static constexpr const base::WStringPiece kChrome =
+  static constexpr const std::wstring_view kBrave = L"brave_browser_tests.exe";
+  static constexpr const std::wstring_view kChrome =
       L"chrome_browser_tests.exe";
 };
 

--- a/test/views/snapshot/widget_snapshot_checker.cc
+++ b/test/views/snapshot/widget_snapshot_checker.cc
@@ -6,6 +6,7 @@
 #include "brave/test/views/snapshot/widget_snapshot_checker.h"
 
 #include <string>
+#include <string_view>
 
 #include "base/files/file_util.h"
 #include "base/path_service.h"
@@ -28,7 +29,7 @@ namespace {
 
 constexpr char kSnapshotFileName[] = "snapshot.png";
 
-base::StringPiece GetPlatformName() {
+std::string_view GetPlatformName() {
 #if BUILDFLAG(IS_WIN)
   return "win";
 #elif BUILDFLAG(IS_MAC)

--- a/third_party/blink/renderer/brave_font_whitelist.cc
+++ b/third_party/blink/renderer/brave_font_whitelist.cc
@@ -5,20 +5,21 @@
 
 #include "brave/third_party/blink/renderer/brave_font_whitelist.h"
 
+#include <string_view>
 #include <vector>
 
 namespace brave {
 
 namespace {
 
-base::flat_set<base::StringPiece> kEmptyFontSet =
-    base::MakeFlatSet<base::StringPiece>(std::vector<base::StringPiece>{});
+base::flat_set<std::string_view> kEmptyFontSet =
+    base::MakeFlatSet<std::string_view>(std::vector<std::string_view>{});
 
 #if BUILDFLAG(IS_MAC)
 bool kCanRestrictFonts = true;
 // This list covers the fonts installed by default on Mac OS as of Mac OS 12.3.
-base::flat_set<base::StringPiece> kFontWhitelist =
-    base::MakeFlatSet<base::StringPiece>(std::vector<base::StringPiece>{
+base::flat_set<std::string_view> kFontWhitelist =
+    base::MakeFlatSet<std::string_view>(std::vector<std::string_view>{
         "-apple-system",
         "academy engraved let",
         "al bayan",
@@ -310,8 +311,8 @@ base::flat_set<base::StringPiece> kFontWhitelist =
 bool kCanRestrictFonts = true;
 // This list covers the fonts installed by default on Windows 11.
 // See <https://docs.microsoft.com/en-us/typography/fonts/windows_11_font_list>
-base::flat_set<base::StringPiece> kFontWhitelist =
-    base::MakeFlatSet<base::StringPiece>(std::vector<base::StringPiece>{
+base::flat_set<std::string_view> kFontWhitelist =
+    base::MakeFlatSet<std::string_view>(std::vector<std::string_view>{
         "arial",
         "arial black",
         "arial bold",
@@ -634,168 +635,167 @@ bool kCanRestrictFonts = true;
 // This list covers the fonts and font aliases listed in data/fonts/fonts.xml of
 // the Android Open Source Project. To reduce memory and maintenance, most
 // region-specific Noto fonts are handled by wildcards outside this list.
-base::flat_set<base::StringPiece> kFontWhitelist =
-    base::MakeFlatSet<base::StringPiece>(
-        std::vector<base::StringPiece>{"androidclock",
-                                       "arial",
-                                       "baskerville",
-                                       "carrois gothic",
-                                       "coming soon",
-                                       "courier",
-                                       "courier new",
-                                       "cutive mono",
-                                       "dancing script",
-                                       "droid sans",
-                                       "droid sans mono",
-                                       "erif-bold",
-                                       "fantasy",
-                                       "georgia",
-                                       "goudy",
-                                       "helvetica",
-                                       "itc stone serif",
-                                       "monaco",
-                                       "noto color emoji",
-                                       "noto kufi arabic",
-                                       "noto naskh arabic",
-                                       "noto nastaliq urdu",
-                                       "noto sans",
-                                       "noto serif",
-                                       "palatino",
-                                       "roboto",
-                                       "roboto static",
-                                       "sans-serif-black",
-                                       "sans-serif-condensed-light",
-                                       "sans-serif-condensed-medium",
-                                       "sans-serif-light",
-                                       "sans-serif-medium",
-                                       "sans-serif-monospace",
-                                       "sans-serif-thin",
-                                       "source sans pro",
-                                       "source-sans-pro-semi-bold",
-                                       "tahoma",
-                                       "times",
-                                       "times new roman",
-                                       "verdana"});
+base::flat_set<std::string_view> kFontWhitelist =
+    base::MakeFlatSet<std::string_view>(
+        std::vector<std::string_view>{"androidclock",
+                                      "arial",
+                                      "baskerville",
+                                      "carrois gothic",
+                                      "coming soon",
+                                      "courier",
+                                      "courier new",
+                                      "cutive mono",
+                                      "dancing script",
+                                      "droid sans",
+                                      "droid sans mono",
+                                      "erif-bold",
+                                      "fantasy",
+                                      "georgia",
+                                      "goudy",
+                                      "helvetica",
+                                      "itc stone serif",
+                                      "monaco",
+                                      "noto color emoji",
+                                      "noto kufi arabic",
+                                      "noto naskh arabic",
+                                      "noto nastaliq urdu",
+                                      "noto sans",
+                                      "noto serif",
+                                      "palatino",
+                                      "roboto",
+                                      "roboto static",
+                                      "sans-serif-black",
+                                      "sans-serif-condensed-light",
+                                      "sans-serif-condensed-medium",
+                                      "sans-serif-light",
+                                      "sans-serif-medium",
+                                      "sans-serif-monospace",
+                                      "sans-serif-thin",
+                                      "source sans pro",
+                                      "source-sans-pro-semi-bold",
+                                      "tahoma",
+                                      "times",
+                                      "times new roman",
+                                      "verdana"});
 #else
 bool kCanRestrictFonts = false;
-base::flat_set<base::StringPiece> kFontWhitelist =
-    base::MakeFlatSet<base::StringPiece>(std::vector<base::StringPiece>{});
+base::flat_set<std::string_view> kFontWhitelist =
+    base::MakeFlatSet<std::string_view>(std::vector<std::string_view>{});
 #endif
 
 #if BUILDFLAG(IS_WIN)
-base::flat_set<base::StringPiece> kFontWhitelistAR =
-    base::MakeFlatSet<base::StringPiece>(std::vector<base::StringPiece>{
+base::flat_set<std::string_view> kFontWhitelistAR =
+    base::MakeFlatSet<std::string_view>(std::vector<std::string_view>{
         "aldhabi", "andalus", "arabic typesetting", "microsoft uighur",
         "microsoft uighur bold", "sakkal majalla", "sakkal majalla bold",
         "simplified arabic", "simplified arabic bold",
         "simplified arabic fixed", "traditional arabic",
         "traditional arabic bold", "urdu typesetting",
         "urdu typesetting bold"});
-base::flat_set<base::StringPiece> kFontWhitelistAS =
-    base::MakeFlatSet<base::StringPiece>(std::vector<base::StringPiece>{
+base::flat_set<std::string_view> kFontWhitelistAS =
+    base::MakeFlatSet<std::string_view>(std::vector<std::string_view>{
         "shonar bangla", "shonar bangla bold", "vrinda", "vrinda bold"});
-base::flat_set<base::StringPiece> kFontWhitelistIU =
-    base::MakeFlatSet<base::StringPiece>(
-        std::vector<base::StringPiece>{"euphemia"});
-base::flat_set<base::StringPiece> kFontWhitelistHI =
-    base::MakeFlatSet<base::StringPiece>(std::vector<base::StringPiece>{
+base::flat_set<std::string_view> kFontWhitelistIU =
+    base::MakeFlatSet<std::string_view>(
+        std::vector<std::string_view>{"euphemia"});
+base::flat_set<std::string_view> kFontWhitelistHI =
+    base::MakeFlatSet<std::string_view>(std::vector<std::string_view>{
         "aparajita", "aparajita italic", "aparajita bold",
         "aparajita bold italic", "kokila", "kokila italic", "kokila bold",
         "kokila bold italic", "mangal", "mangal bold", "sanskrit text",
         "utsaah", "utsaah italic", "utsaah bold", "utsaah bold italic"});
-base::flat_set<base::StringPiece> kFontWhitelistAM =
-    base::MakeFlatSet<base::StringPiece>(
-        std::vector<base::StringPiece>{"nyala"});
-base::flat_set<base::StringPiece> kFontWhitelistGU =
-    base::MakeFlatSet<base::StringPiece>(
-        std::vector<base::StringPiece>{"shruti", "shruti bold"});
-base::flat_set<base::StringPiece> kFontWhitelistPA =
-    base::MakeFlatSet<base::StringPiece>(
-        std::vector<base::StringPiece>{"raavi", "raavi bold"});
-base::flat_set<base::StringPiece> kFontWhitelistZH =
-    base::MakeFlatSet<base::StringPiece>(std::vector<base::StringPiece>{
+base::flat_set<std::string_view> kFontWhitelistAM =
+    base::MakeFlatSet<std::string_view>(std::vector<std::string_view>{"nyala"});
+base::flat_set<std::string_view> kFontWhitelistGU =
+    base::MakeFlatSet<std::string_view>(
+        std::vector<std::string_view>{"shruti", "shruti bold"});
+base::flat_set<std::string_view> kFontWhitelistPA =
+    base::MakeFlatSet<std::string_view>(
+        std::vector<std::string_view>{"raavi", "raavi bold"});
+base::flat_set<std::string_view> kFontWhitelistZH =
+    base::MakeFlatSet<std::string_view>(std::vector<std::string_view>{
         "dengxian light", "dengxian", "dengxian bold", "fangsong", "kaiti",
         "simhei", "dfkai-sb", "mingliu", "mingliu_hkscs", "pmingliu"});
-base::flat_set<base::StringPiece> kFontWhitelistHE =
-    base::MakeFlatSet<base::StringPiece>(std::vector<base::StringPiece>{
+base::flat_set<std::string_view> kFontWhitelistHE =
+    base::MakeFlatSet<std::string_view>(std::vector<std::string_view>{
         "aharoni bold", "david", "david bold", "frankruehl", "gisha",
         "gisha bold", "levenim mt", "levenim mt bold", "miriam", "miriam fixed",
         "narkisim", "rod"});
-base::flat_set<base::StringPiece> kFontWhitelistJA =
-    base::MakeFlatSet<base::StringPiece>(
-        std::vector<base::StringPiece>{"biz udgothic",
-                                       "biz udgothic bold",
-                                       "biz udpgothic",
-                                       "biz udpgothic bold",
-                                       "biz udmincho medium",
-                                       "biz udpmincho medium",
-                                       "meiryo",
-                                       "meiryo italic",
-                                       "meiryo bold",
-                                       "meiryo bold italic",
-                                       "meiryo ui",
-                                       "meiryo ui italic",
-                                       "meiryo ui bold",
-                                       "meiryo ui bold italic",
-                                       "ms mincho",
-                                       "ms pmincho",
-                                       "ud digi kyokasho",
-                                       "ud digi kyokasho n-b",
-                                       "ud digi kyokasho nk-b",
-                                       "ud digi kyokasho nk-r",
-                                       "ud digi kyokasho np-b",
-                                       "ud digi kyokasho np-r",
-                                       "ud digi kyokasho n-r",
-                                       "yu mincho light",
-                                       "yu mincho regular",
-                                       "yu mincho demibold"});
-base::flat_set<base::StringPiece> kFontWhitelistKN =
-    base::MakeFlatSet<base::StringPiece>(
-        std::vector<base::StringPiece>{"tunga", "tunga bold"});
-base::flat_set<base::StringPiece> kFontWhitelistKM =
-    base::MakeFlatSet<base::StringPiece>(std::vector<base::StringPiece>{
+base::flat_set<std::string_view> kFontWhitelistJA =
+    base::MakeFlatSet<std::string_view>(
+        std::vector<std::string_view>{"biz udgothic",
+                                      "biz udgothic bold",
+                                      "biz udpgothic",
+                                      "biz udpgothic bold",
+                                      "biz udmincho medium",
+                                      "biz udpmincho medium",
+                                      "meiryo",
+                                      "meiryo italic",
+                                      "meiryo bold",
+                                      "meiryo bold italic",
+                                      "meiryo ui",
+                                      "meiryo ui italic",
+                                      "meiryo ui bold",
+                                      "meiryo ui bold italic",
+                                      "ms mincho",
+                                      "ms pmincho",
+                                      "ud digi kyokasho",
+                                      "ud digi kyokasho n-b",
+                                      "ud digi kyokasho nk-b",
+                                      "ud digi kyokasho nk-r",
+                                      "ud digi kyokasho np-b",
+                                      "ud digi kyokasho np-r",
+                                      "ud digi kyokasho n-r",
+                                      "yu mincho light",
+                                      "yu mincho regular",
+                                      "yu mincho demibold"});
+base::flat_set<std::string_view> kFontWhitelistKN =
+    base::MakeFlatSet<std::string_view>(
+        std::vector<std::string_view>{"tunga", "tunga bold"});
+base::flat_set<std::string_view> kFontWhitelistKM =
+    base::MakeFlatSet<std::string_view>(std::vector<std::string_view>{
         "daunpenh", "khmer ui", "khmer ui bold", "moolboran"});
-base::flat_set<base::StringPiece> kFontWhitelistKO =
-    base::MakeFlatSet<base::StringPiece>(std::vector<base::StringPiece>{
+base::flat_set<std::string_view> kFontWhitelistKO =
+    base::MakeFlatSet<std::string_view>(std::vector<std::string_view>{
         "batang", "batangche", "dotum", "dotumche", "gulim", "gulimche",
         "gungsuh", "gungsuhche"});
-base::flat_set<base::StringPiece> kFontWhitelistLO =
-    base::MakeFlatSet<base::StringPiece>(
-        std::vector<base::StringPiece>{"dokchampa", "lao ui", "lao ui bold"});
-base::flat_set<base::StringPiece> kFontWhitelistML =
-    base::MakeFlatSet<base::StringPiece>(
-        std::vector<base::StringPiece>{"kartika", "kartika bold"});
+base::flat_set<std::string_view> kFontWhitelistLO =
+    base::MakeFlatSet<std::string_view>(
+        std::vector<std::string_view>{"dokchampa", "lao ui", "lao ui bold"});
+base::flat_set<std::string_view> kFontWhitelistML =
+    base::MakeFlatSet<std::string_view>(
+        std::vector<std::string_view>{"kartika", "kartika bold"});
 #else
-base::flat_set<base::StringPiece> kFontWhitelistAR =
-    base::MakeFlatSet<base::StringPiece>(std::vector<base::StringPiece>{});
-base::flat_set<base::StringPiece> kFontWhitelistAS =
-    base::MakeFlatSet<base::StringPiece>(std::vector<base::StringPiece>{});
-base::flat_set<base::StringPiece> kFontWhitelistIU =
-    base::MakeFlatSet<base::StringPiece>(std::vector<base::StringPiece>{});
-base::flat_set<base::StringPiece> kFontWhitelistHI =
-    base::MakeFlatSet<base::StringPiece>(std::vector<base::StringPiece>{});
-base::flat_set<base::StringPiece> kFontWhitelistAM =
-    base::MakeFlatSet<base::StringPiece>(std::vector<base::StringPiece>{});
-base::flat_set<base::StringPiece> kFontWhitelistGU =
-    base::MakeFlatSet<base::StringPiece>(std::vector<base::StringPiece>{});
-base::flat_set<base::StringPiece> kFontWhitelistPA =
-    base::MakeFlatSet<base::StringPiece>(std::vector<base::StringPiece>{});
-base::flat_set<base::StringPiece> kFontWhitelistZH =
-    base::MakeFlatSet<base::StringPiece>(std::vector<base::StringPiece>{});
-base::flat_set<base::StringPiece> kFontWhitelistHE =
-    base::MakeFlatSet<base::StringPiece>(std::vector<base::StringPiece>{});
-base::flat_set<base::StringPiece> kFontWhitelistJA =
-    base::MakeFlatSet<base::StringPiece>(std::vector<base::StringPiece>{});
-base::flat_set<base::StringPiece> kFontWhitelistKN =
-    base::MakeFlatSet<base::StringPiece>(std::vector<base::StringPiece>{});
-base::flat_set<base::StringPiece> kFontWhitelistKM =
-    base::MakeFlatSet<base::StringPiece>(std::vector<base::StringPiece>{});
-base::flat_set<base::StringPiece> kFontWhitelistKO =
-    base::MakeFlatSet<base::StringPiece>(std::vector<base::StringPiece>{});
-base::flat_set<base::StringPiece> kFontWhitelistLO =
-    base::MakeFlatSet<base::StringPiece>(std::vector<base::StringPiece>{});
-base::flat_set<base::StringPiece> kFontWhitelistML =
-    base::MakeFlatSet<base::StringPiece>(std::vector<base::StringPiece>{});
+base::flat_set<std::string_view> kFontWhitelistAR =
+    base::MakeFlatSet<std::string_view>(std::vector<std::string_view>{});
+base::flat_set<std::string_view> kFontWhitelistAS =
+    base::MakeFlatSet<std::string_view>(std::vector<std::string_view>{});
+base::flat_set<std::string_view> kFontWhitelistIU =
+    base::MakeFlatSet<std::string_view>(std::vector<std::string_view>{});
+base::flat_set<std::string_view> kFontWhitelistHI =
+    base::MakeFlatSet<std::string_view>(std::vector<std::string_view>{});
+base::flat_set<std::string_view> kFontWhitelistAM =
+    base::MakeFlatSet<std::string_view>(std::vector<std::string_view>{});
+base::flat_set<std::string_view> kFontWhitelistGU =
+    base::MakeFlatSet<std::string_view>(std::vector<std::string_view>{});
+base::flat_set<std::string_view> kFontWhitelistPA =
+    base::MakeFlatSet<std::string_view>(std::vector<std::string_view>{});
+base::flat_set<std::string_view> kFontWhitelistZH =
+    base::MakeFlatSet<std::string_view>(std::vector<std::string_view>{});
+base::flat_set<std::string_view> kFontWhitelistHE =
+    base::MakeFlatSet<std::string_view>(std::vector<std::string_view>{});
+base::flat_set<std::string_view> kFontWhitelistJA =
+    base::MakeFlatSet<std::string_view>(std::vector<std::string_view>{});
+base::flat_set<std::string_view> kFontWhitelistKN =
+    base::MakeFlatSet<std::string_view>(std::vector<std::string_view>{});
+base::flat_set<std::string_view> kFontWhitelistKM =
+    base::MakeFlatSet<std::string_view>(std::vector<std::string_view>{});
+base::flat_set<std::string_view> kFontWhitelistKO =
+    base::MakeFlatSet<std::string_view>(std::vector<std::string_view>{});
+base::flat_set<std::string_view> kFontWhitelistLO =
+    base::MakeFlatSet<std::string_view>(std::vector<std::string_view>{});
+base::flat_set<std::string_view> kFontWhitelistML =
+    base::MakeFlatSet<std::string_view>(std::vector<std::string_view>{});
 #endif
 }  // namespace
 
@@ -819,7 +819,7 @@ bool AllowFontByFamilyName(const AtomicString& family_name,
   return false;
 }
 
-const base::flat_set<base::StringPiece>& GetAdditionalFontWhitelistByLocale(
+const base::flat_set<std::string_view>& GetAdditionalFontWhitelistByLocale(
     WTF::String locale_language) {
   if (locale_language == "ar" || locale_language == "fa" ||
       locale_language == "ur")
@@ -857,7 +857,7 @@ const base::flat_set<base::StringPiece>& GetAdditionalFontWhitelistByLocale(
 
 void set_font_whitelist_for_testing(
     bool can_restrict_fonts,
-    const base::flat_set<base::StringPiece>& font_whitelist) {
+    const base::flat_set<std::string_view>& font_whitelist) {
   kCanRestrictFonts = can_restrict_fonts;
   kFontWhitelist = font_whitelist;
 }
@@ -866,7 +866,7 @@ bool get_can_restrict_fonts_for_testing() {
   return kCanRestrictFonts;
 }
 
-const base::flat_set<base::StringPiece>& get_font_whitelist_for_testing() {
+const base::flat_set<std::string_view>& get_font_whitelist_for_testing() {
   return kFontWhitelist;
 }
 

--- a/third_party/blink/renderer/brave_font_whitelist.h
+++ b/third_party/blink/renderer/brave_font_whitelist.h
@@ -7,9 +7,9 @@
 #define BRAVE_THIRD_PARTY_BLINK_RENDERER_BRAVE_FONT_WHITELIST_H_
 
 #include <string>
+#include <string_view>
 
 #include "base/containers/flat_set.h"
-#include "base/strings/string_piece.h"
 #include "third_party/blink/public/platform/web_common.h"
 #include "third_party/blink/renderer/platform/wtf/text/atomic_string.h"
 #include "third_party/blink/renderer/platform/wtf/text/wtf_string.h"
@@ -21,17 +21,17 @@ BLINK_EXPORT bool AllowFontByFamilyName(const AtomicString& family_name,
 
 // Public for testing but other callers should call
 // AllowFontByFamilyName instead.
-BLINK_EXPORT const base::flat_set<base::StringPiece>&
+BLINK_EXPORT const base::flat_set<std::string_view>&
 GetAdditionalFontWhitelistByLocale(WTF::String default_language);
 
 // Testing-only functions
 BLINK_EXPORT void set_font_whitelist_for_testing(
     bool can_restrict_fonts,
-    const base::flat_set<base::StringPiece>& font_whitelist);
+    const base::flat_set<std::string_view>& font_whitelist);
 
 BLINK_EXPORT bool get_can_restrict_fonts_for_testing();
 
-BLINK_EXPORT const base::flat_set<base::StringPiece>&
+BLINK_EXPORT const base::flat_set<std::string_view>&
 get_font_whitelist_for_testing();
 
 }  // namespace brave

--- a/third_party/blink/renderer/brave_font_whitelist_unittest.cc
+++ b/third_party/blink/renderer/brave_font_whitelist_unittest.cc
@@ -4,27 +4,27 @@
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 #include <string>
+#include <string_view>
 #include <tuple>
 #include <vector>
 
 #include "brave/third_party/blink/renderer/brave_font_whitelist.h"
 
 #include "base/containers/flat_set.h"
-#include "base/strings/string_piece.h"
 #include "testing/gtest/include/gtest/gtest.h"
 #include "third_party/blink/renderer/platform/wtf/text/atomic_string.h"
 
 namespace {
 
-base::flat_set<base::StringPiece> kTestFontWhitelist =
-    base::MakeFlatSet<base::StringPiece>(std::vector<base::StringPiece>{
+base::flat_set<std::string_view> kTestFontWhitelist =
+    base::MakeFlatSet<std::string_view>(std::vector<std::string_view>{
         "roboto",
         "caro",
         "tenso",
         "elfo",
     });
-base::flat_set<base::StringPiece> kEmptyFontSet =
-    base::MakeFlatSet<base::StringPiece>(std::vector<base::StringPiece>{});
+base::flat_set<std::string_view> kEmptyFontSet =
+    base::MakeFlatSet<std::string_view>(std::vector<std::string_view>{});
 
 }  // namespace
 
@@ -39,7 +39,7 @@ class BraveFontWhitelistTest : public testing::Test {
 };
 
 TEST(BraveFontWhitelistTest, Platforms) {
-  base::flat_set<base::StringPiece> allowed(
+  base::flat_set<std::string_view> allowed(
       brave::get_font_whitelist_for_testing());
 
 #if BUILDFLAG(IS_MAC)
@@ -102,7 +102,7 @@ TEST(BraveFontWhitelistTest, Locales) {
     std::make_tuple<>("la", 0UL),
   };
   for (const auto& c : test_cases) {
-    base::flat_set<base::StringPiece> allowed(
+    base::flat_set<std::string_view> allowed(
         brave::GetAdditionalFontWhitelistByLocale(std::get<0>(c)));
     EXPECT_EQ(allowed.size(), std::get<1>(c));
   }
@@ -210,14 +210,14 @@ TEST(BraveFontWhitelistTest, API) {
   brave::set_font_whitelist_for_testing(true /* can_restrict_fonts */,
                                         kTestFontWhitelist);
   EXPECT_EQ(brave::get_can_restrict_fonts_for_testing(), true);
-  base::flat_set<base::StringPiece> allowed(
+  base::flat_set<std::string_view> allowed(
       brave::get_font_whitelist_for_testing());
   EXPECT_EQ(allowed.size(), 4UL);
   EXPECT_EQ(allowed.contains("elfo"), true);
   brave::set_font_whitelist_for_testing(false /* can_restrict_fonts */,
                                         kEmptyFontSet);
   EXPECT_EQ(brave::get_can_restrict_fonts_for_testing(), false);
-  base::flat_set<base::StringPiece> allowed2(
+  base::flat_set<std::string_view> allowed2(
       brave::get_font_whitelist_for_testing());
   EXPECT_EQ(allowed2.size(), 0UL);
 }

--- a/third_party/blink/renderer/core/brave_page_graph/graphml.cc
+++ b/third_party/blink/renderer/core/brave_page_graph/graphml.cc
@@ -9,6 +9,7 @@
 #include <libxml/tree.h>
 
 #include <string>
+#include <string_view>
 
 #include "base/no_destructor.h"
 #include "base/strings/string_number_conversions.h"
@@ -43,7 +44,7 @@ void GraphMLAttr::AddDefinitionNode(xmlNodePtr parent_node) const {
 
 void GraphMLAttr::AddValueNode(xmlDocPtr doc,
                                xmlNodePtr parent_node,
-                               base::StringPiece value) const {
+                               std::string_view value) const {
   AddValueNodeXmlChar(doc, parent_node, XmlUtf8String(value).get());
 }
 

--- a/third_party/blink/renderer/core/brave_page_graph/graphml.h
+++ b/third_party/blink/renderer/core/brave_page_graph/graphml.h
@@ -8,8 +8,9 @@
 
 #include <libxml/tree.h>
 
+#include <string_view>
+
 #include "base/containers/flat_map.h"
-#include "base/strings/string_piece.h"
 #include "base/time/time.h"
 #include "brave/third_party/blink/renderer/core/brave_page_graph/types.h"
 #include "third_party/blink/renderer/platform/wtf/text/wtf_string.h"
@@ -26,7 +27,7 @@ class GraphMLAttr {
   void AddDefinitionNode(xmlNodePtr parent_node) const;
   void AddValueNode(xmlDocPtr doc,
                     xmlNodePtr parent_node,
-                    base::StringPiece value) const;
+                    std::string_view value) const;
   void AddValueNode(xmlDocPtr doc,
                     xmlNodePtr parent_node,
                     const String& value) const;

--- a/third_party/blink/renderer/core/brave_page_graph/libxml_utils.cc
+++ b/third_party/blink/renderer/core/brave_page_graph/libxml_utils.cc
@@ -8,6 +8,7 @@
 #include <libxml/tree.h>
 
 #include <string>
+#include <string_view>
 
 #include "base/numerics/safe_conversions.h"
 #include "base/strings/string_util.h"
@@ -16,7 +17,7 @@
 
 namespace brave_page_graph {
 
-XmlUtf8String::XmlUtf8String(base::StringPiece str) {
+XmlUtf8String::XmlUtf8String(std::string_view str) {
   // XML doesn't allow invalid UTF-8 characters. Process it manually and replace
   // all invalid characters with a replacement code point.
   std::string xml_supported_utf8;

--- a/third_party/blink/renderer/core/brave_page_graph/libxml_utils.h
+++ b/third_party/blink/renderer/core/brave_page_graph/libxml_utils.h
@@ -8,7 +8,8 @@
 
 #include <libxml/xmlstring.h>
 
-#include "base/strings/string_piece.h"
+#include <string_view>
+
 #include "third_party/blink/renderer/platform/wtf/text/wtf_string.h"
 
 namespace brave_page_graph {
@@ -17,7 +18,7 @@ namespace brave_page_graph {
 // UTF-8 characters).
 class XmlUtf8String {
  public:
-  explicit XmlUtf8String(base::StringPiece str);
+  explicit XmlUtf8String(std::string_view str);
   explicit XmlUtf8String(const String& str);
   ~XmlUtf8String();
 

--- a/third_party/blink/renderer/core/brave_page_graph/page_graph.cc
+++ b/third_party/blink/renderer/core/brave_page_graph/page_graph.cc
@@ -15,6 +15,7 @@
 #include <set>
 #include <sstream>
 #include <string>
+#include <string_view>
 #include <utility>
 #include <vector>
 
@@ -744,7 +745,7 @@ void PageGraph::RegisterPageGraphWebAPICallWithResult(
     blink::PageGraphBlinkArgs args,
     const blink::ExceptionState* exception_state,
     const absl::optional<String>& result) {
-  const base::StringPiece name_piece(name);
+  const std::string_view name_piece(name);
   if (base::StartsWith(name_piece, "Document.")) {
     if (name_piece == "Document.cookie.get") {
       RegisterStorageRead(execution_context, receiver_data.at("cookie_url"),

--- a/third_party/blink/renderer/core/brave_page_graph/type_name_to_string.h
+++ b/third_party/blink/renderer/core/brave_page_graph/type_name_to_string.h
@@ -8,16 +8,15 @@
 
 #include <array>
 #include <string>
+#include <string_view>
 #include <utility>
-
-#include "base/strings/string_piece.h"
 
 namespace blink {
 namespace internal {
 
 // https://bitwizeshift.github.io/posts/2021/03/09/getting-an-unmangled-type-name-at-compile-time/
 template <std::size_t... Idxs>
-constexpr auto substring_as_array(base::StringPiece str,
+constexpr auto substring_as_array(std::string_view str,
                                   std::index_sequence<Idxs...>) {
   return std::array{str[Idxs]..., '\n'};
 }
@@ -25,17 +24,17 @@ constexpr auto substring_as_array(base::StringPiece str,
 template <typename T>
 constexpr auto type_name_array() {
 #if defined(__clang__)
-  constexpr auto prefix = base::StringPiece{"[T = "};
-  constexpr auto suffix = base::StringPiece{"]"};
-  constexpr auto function = base::StringPiece{__PRETTY_FUNCTION__};
+  constexpr auto prefix = std::string_view{"[T = "};
+  constexpr auto suffix = std::string_view{"]"};
+  constexpr auto function = std::string_view{__PRETTY_FUNCTION__};
 #elif defined(__GNUC__)
-  constexpr auto prefix = base::StringPiece{"with T = "};
-  constexpr auto suffix = base::StringPiece{"]"};
-  constexpr auto function = base::StringPiece{__PRETTY_FUNCTION__};
+  constexpr auto prefix = std::string_view{"with T = "};
+  constexpr auto suffix = std::string_view{"]"};
+  constexpr auto function = std::string_view{__PRETTY_FUNCTION__};
 #elif defined(_MSC_VER)
-  constexpr auto prefix = base::StringPiece{"type_name_array<"};
-  constexpr auto suffix = base::StringPiece{">(void)"};
-  constexpr auto function = base::StringPiece{__FUNCSIG__};
+  constexpr auto prefix = std::string_view{"type_name_array<"};
+  constexpr auto suffix = std::string_view{">(void)"};
+  constexpr auto function = std::string_view{__FUNCSIG__};
 #else
 #error Unsupported compiler
 #endif
@@ -57,9 +56,9 @@ struct type_name_holder {
 }  // namespace internal
 
 template <typename T>
-constexpr base::StringPiece type_name_to_string() {
+constexpr std::string_view type_name_to_string() {
   constexpr auto& value = internal::type_name_holder<T>::value;
-  return base::StringPiece(value.data(), value.size());
+  return std::string_view(value.data(), value.size());
 }
 
 }  // namespace blink

--- a/third_party/blink/renderer/core/farbling/brave_session_cache.cc
+++ b/third_party/blink/renderer/core/farbling/brave_session_cache.cc
@@ -5,6 +5,8 @@
 
 #include "brave/third_party/blink/renderer/core/farbling/brave_session_cache.h"
 
+#include <string_view>
+
 #include "base/command_line.h"
 #include "base/feature_list.h"
 #include "base/numerics/safe_conversions.h"
@@ -251,7 +253,7 @@ void BraveSessionCache::PerturbPixelsInternal(const unsigned char* data,
     return;
 
   uint8_t* pixels = const_cast<uint8_t*>(data);
-  // This needs to be type size_t because we pass it to base::StringPiece
+  // This needs to be type size_t because we pass it to std::string_view
   // later for content hashing. This is safe because the maximum canvas
   // dimensions are less than SIZE_T_MAX. (Width and height are each
   // limited to 32,767 pixels.)
@@ -265,7 +267,7 @@ void BraveSessionCache::PerturbPixelsInternal(const unsigned char* data,
   CHECK(h.Init(reinterpret_cast<const unsigned char*>(&session_plus_domain_key),
                sizeof session_plus_domain_key));
   uint8_t canvas_key[32];
-  CHECK(h.Sign(base::StringPiece(reinterpret_cast<const char*>(pixels), size),
+  CHECK(h.Sign(std::string_view(reinterpret_cast<const char*>(pixels), size),
                canvas_key, sizeof canvas_key));
   uint64_t v = *reinterpret_cast<uint64_t*>(canvas_key);
   uint64_t pixel_index;

--- a/tools/redirect_cc/redirect_cc.cc
+++ b/tools/redirect_cc/redirect_cc.cc
@@ -5,6 +5,7 @@
 
 #include <iostream>
 #include <string>
+#include <string_view>
 
 #include "base/containers/contains.h"
 #include "base/files/file_path.h"
@@ -187,7 +188,7 @@ class RedirectCC {
 
  private:
   static base::FilePath::StringType UTF8ToFilePathString(
-      base::StringPiece utf8) {
+      std::string_view utf8) {
 #if BUILDFLAG(IS_WIN)
     return base::UTF8ToWide(utf8);
 #else   // BUILDFLAG(IS_WIN)


### PR DESCRIPTION
Upstream is set to deprecated, and delete all occurrences of `base::StringPiece`, and replace it with `std::string_view`, and according correspondent types.

This change removes the use of `base::StringPiece`, and of the headers as well across the Brave codebase.

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/33164

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-arm64, CI/skip-linux-x64, CI/skip-android, CI/skip-macos, CI/skip-ios, CI/skip-windows-arm64, CI/skip-windows-x64, CI/skip-windows-x86 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [ ] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

