### PR TITLE
Don't show hide icon/button menu from vpn app menu (uplift to 1.59.x)

### DIFF
--- a/app/brave_generated_resources.grd
+++ b/app/brave_generated_resources.grd
@@ -1007,9 +1007,6 @@ Or change later at <ph name="SETTINGS_EXTENIONS_LINK">$2<ex>brave://settings/ext
           <message name="IDS_BRAVE_VPN_SHOW_VPN_TRAY_ICON_MENU_ITEM" desc="The menu item for showing vpn tray icon in windows">
             Show VPN Tray Icon
           </message>
-          <message name="IDS_BRAVE_VPN_HIDE_VPN_TRAY_ICON_MENU_ITEM" desc="The menu item for hiding vpn tray icon in windows">
-            Hide VPN Tray Icon
-          </message>
           <message name="IDS_BRAVE_VPN_SHOW_FEEDBACK_MENU_ITEM" desc="The menu item for sending feedback">
             Send Feedback
           </message>
@@ -1026,9 +1023,6 @@ Or change later at <ph name="SETTINGS_EXTENIONS_LINK">$2<ex>brave://settings/ext
           </message>
           <message name="IDS_BRAVE_VPN_SHOW_VPN_TRAY_ICON_MENU_ITEM" desc="The menu item for showing vpn tray icon in windows">
             Show VPN tray icon
-          </message>
-          <message name="IDS_BRAVE_VPN_HIDE_VPN_TRAY_ICON_MENU_ITEM" desc="The menu item for hiding vpn tray icon in windows">
-            Hide VPN tray icon
           </message>
           <message name="IDS_BRAVE_VPN_SHOW_FEEDBACK_MENU_ITEM" desc="The menu item for sending feedback">
             Send feedback

--- a/browser/ui/toolbar/brave_vpn_menu_model.cc
+++ b/browser/ui/toolbar/brave_vpn_menu_model.cc
@@ -31,15 +31,15 @@ BraveVPNMenuModel::~BraveVPNMenuModel() = default;
 void BraveVPNMenuModel::Build() {
   AddItemWithStringId(IDC_TOGGLE_BRAVE_VPN, IDS_BRAVE_VPN_MENU);
   AddSeparator(ui::NORMAL_SEPARATOR);
-  AddItemWithStringId(IDC_TOGGLE_BRAVE_VPN_TOOLBAR_BUTTON,
-                      IsBraveVPNButtonVisible()
-                          ? IDS_BRAVE_VPN_HIDE_VPN_BUTTON_MENU_ITEM
-                          : IDS_BRAVE_VPN_SHOW_VPN_BUTTON_MENU_ITEM);
+  if (!IsBraveVPNButtonVisible()) {
+    AddItemWithStringId(IDC_TOGGLE_BRAVE_VPN_TOOLBAR_BUTTON,
+                        IDS_BRAVE_VPN_SHOW_VPN_BUTTON_MENU_ITEM);
+  }
 #if BUILDFLAG(IS_WIN)
-  AddItemWithStringId(IDC_TOGGLE_BRAVE_VPN_TRAY_ICON,
-                      IsTrayIconEnabled()
-                          ? IDS_BRAVE_VPN_HIDE_VPN_TRAY_ICON_MENU_ITEM
-                          : IDS_BRAVE_VPN_SHOW_VPN_TRAY_ICON_MENU_ITEM);
+  if (!IsTrayIconEnabled()) {
+    AddItemWithStringId(IDC_TOGGLE_BRAVE_VPN_TRAY_ICON,
+                        IDS_BRAVE_VPN_SHOW_VPN_TRAY_ICON_MENU_ITEM);
+  }
 #endif  // BUILDFLAG(IS_WIN)
   AddItemWithStringId(IDC_SEND_BRAVE_VPN_FEEDBACK,
                       IDS_BRAVE_VPN_SHOW_FEEDBACK_MENU_ITEM);

--- a/browser/ui/toolbar/brave_vpn_menu_model_unittest.cc
+++ b/browser/ui/toolbar/brave_vpn_menu_model_unittest.cc
@@ -58,12 +58,9 @@ TEST_F(BraveVPNMenuModelUnitTest, TrayIconEnabled) {
   menu_model.Build();
   EXPECT_NE(menu_model.GetItemCount(), 0u);
   {
-    auto tray_index =
-        menu_model.GetIndexOfCommandId(IDC_TOGGLE_BRAVE_VPN_TRAY_ICON);
-    EXPECT_TRUE(tray_index);
-    EXPECT_EQ(
-        menu_model.GetLabelAt(tray_index.value()),
-        l10n_util::GetStringUTF16(IDS_BRAVE_VPN_HIDE_VPN_TRAY_ICON_MENU_ITEM));
+    // Don't show toggle menu when tray icon is visible.
+    EXPECT_FALSE(
+        menu_model.GetIndexOfCommandId(IDC_TOGGLE_BRAVE_VPN_TRAY_ICON));
   }
 
   // Wireguard protocol disbled in the setting.
@@ -73,7 +70,9 @@ TEST_F(BraveVPNMenuModelUnitTest, TrayIconEnabled) {
   menu_model.Build();
   EXPECT_NE(menu_model.GetItemCount(), 0u);
   {
-    EXPECT_TRUE(menu_model.GetIndexOfCommandId(IDC_TOGGLE_BRAVE_VPN_TRAY_ICON));
+    // Still toggle menu is hidden.
+    EXPECT_FALSE(
+        menu_model.GetIndexOfCommandId(IDC_TOGGLE_BRAVE_VPN_TRAY_ICON));
   }
 
   // Cases with Disabled value.
@@ -107,12 +106,9 @@ TEST_F(BraveVPNMenuModelUnitTest, ToolbarVPNButton) {
   menu_model.Build();
   EXPECT_NE(menu_model.GetItemCount(), 0u);
   {
-    auto toolbar_index =
-        menu_model.GetIndexOfCommandId(IDC_TOGGLE_BRAVE_VPN_TOOLBAR_BUTTON);
-    EXPECT_TRUE(toolbar_index);
-    EXPECT_EQ(
-        menu_model.GetLabelAt(toolbar_index.value()),
-        l10n_util::GetStringUTF16(IDS_BRAVE_VPN_HIDE_VPN_BUTTON_MENU_ITEM));
+    // Don't show toggle menu when button is visible.
+    EXPECT_FALSE(
+        menu_model.GetIndexOfCommandId(IDC_TOGGLE_BRAVE_VPN_TOOLBAR_BUTTON));
   }
 
   // Cases with Disabled value.


### PR DESCRIPTION
Uplift of #20183
fix https://github.com/brave/brave-browser/issues/33027

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.