### PR TITLE
DNSLink names in ipns:// should be normalized to DNS form

### DIFF
--- a/browser/ipfs/content_browser_client_helper.cc
+++ b/browser/ipfs/content_browser_client_helper.cc
@@ -132,13 +132,15 @@ bool HandleIPFSURLReverseRewrite(GURL* url,
     return false;
   GURL::Replacements scheme_replacements;
   GURL::Replacements host_replacements;
+  auto decoded_host = ipfs::DecodeSingleLabelForm(
+      std::string(url->host_piece().substr(0, ipns_pos)));
   if (ipfs_pos != std::string::npos) {
     scheme_replacements.SetSchemeStr(kIPFSScheme);
     host_replacements.SetHostStr(url->host_piece().substr(0, ipfs_pos));
     host_replacements.ClearPort();
   } else {  // ipns
     scheme_replacements.SetSchemeStr(kIPNSScheme);
-    host_replacements.SetHostStr(url->host_piece().substr(0, ipns_pos));
+    host_replacements.SetHostStr(decoded_host);
     host_replacements.ClearPort();
   }
 

--- a/browser/ipfs/content_browser_client_helper_unittest.cc
+++ b/browser/ipfs/content_browser_client_helper_unittest.cc
@@ -263,6 +263,16 @@ TEST_F(ContentBrowserClientHelperUnitTest, HandleIPFSURLReverseRewriteLocal) {
   ASSERT_EQ(ipns_uri.spec(),
             "ipns://en.wikipedia-on-ipfs.org/wiki/Architecture");
 
+  source =
+      "http://"
+      "bafkreiedqfhqvarz2y4c2s3vrbrcq427sawhzbewzksegopavnmwbz4zyq.ipfs."
+      "localhost";
+  ipns_uri = GURL(source).ReplaceComponents(replacements);
+  ASSERT_TRUE(HandleIPFSURLReverseRewrite(&ipns_uri, browser_context()));
+  ASSERT_EQ(
+      ipns_uri.spec(),
+      "ipfs://bafkreiedqfhqvarz2y4c2s3vrbrcq427sawhzbewzksegopavnmwbz4zyq/");
+
   source = "http://test.com.ipns.localhost:8000/";
   ipns_uri = GURL(source);
   ASSERT_FALSE(HandleIPFSURLReverseRewrite(&ipns_uri, browser_context()));
@@ -328,6 +338,11 @@ TEST_F(ContentBrowserClientHelperUnitTest, HandleIPFSURLReverseRewriteGateway) {
   ipns_uri = GURL(source);
   ASSERT_FALSE(HandleIPFSURLReverseRewrite(&ipns_uri, browser_context()));
   ASSERT_EQ(ipns_uri.spec(), source);
+
+  source = "http://en-wikipedia--on--ipfs-org.ipns.localhost:8080/wiki/";
+  ipns_uri = GURL(source);
+  ASSERT_TRUE(HandleIPFSURLReverseRewrite(&ipns_uri, browser_context()));
+  ASSERT_EQ(ipns_uri.spec(), "ipns://en.wikipedia-on-ipfs.org/wiki/");
 
   ipns_uri = GURL(
       "https://bafybeiemxf5abjwjbikoz4mc3a3dla6ual3jsgpdr4cjr3oz3evfyavhwq"

--- a/browser/ipfs/content_browser_client_helper_unittest.cc
+++ b/browser/ipfs/content_browser_client_helper_unittest.cc
@@ -261,7 +261,7 @@ TEST_F(ContentBrowserClientHelperUnitTest, HandleIPFSURLReverseRewriteLocal) {
   ipns_uri = GURL(source).ReplaceComponents(replacements);
   ASSERT_TRUE(HandleIPFSURLReverseRewrite(&ipns_uri, browser_context()));
   ASSERT_EQ(ipns_uri.spec(),
-            "ipns://en-wikipedia--on--ipfs-org/wiki/Architecture");
+            "ipns://en.wikipedia-on-ipfs.org/wiki/Architecture");
 
   source = "http://test.com.ipns.localhost:8000/";
   ipns_uri = GURL(source);


### PR DESCRIPTION
Fixed showing of DNSLink identifiers in address bar, as single-label encoded

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/33158

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-arm64, CI/skip-linux-x64, CI/skip-android, CI/skip-macos, CI/skip-ios, CI/skip-windows-arm64, CI/skip-windows-x64, CI/skip-windows-x86 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

Steps:
1. Open `ipns://en.wikipedia-on-ipfs.org` with embedded IPFS node
2. When page is loaded, check the URL in the address bar

**Expected result:**
Address bar contains: `ipns://en.wikipedia-on-ipfs.org/wiki/ `


