### PR TITLE
Get refcode on MacOS from xattr.

### DIFF
--- a/components/brave_referrals/browser/BUILD.gn
+++ b/components/brave_referrals/browser/BUILD.gn
@@ -29,6 +29,13 @@ static_library("browser") {
     "//services/network/public/cpp",
   ]
 
+  if (is_mac) {
+    sources += [
+      "file_extended_attribute.cc",
+      "file_extended_attribute.h",
+    ]
+  }
+
   if (is_android) {
     sources += [
       "android_brave_referrer.cc",
@@ -45,5 +52,21 @@ static_library("browser") {
 if (is_android) {
   generate_jni("jni_headers") {
     sources = [ "//brave/android/java/org/chromium/chrome/browser/util/BraveReferrer.java" ]
+  }
+}
+
+source_set("unit_tests") {
+  testonly = true
+  sources = []
+  deps = []
+
+  if (is_mac) {
+    sources += [ "file_extended_attribute_unittest.cc" ]
+    deps += [
+      ":browser",
+      "//base",
+      "//base/test:test_support",
+      "//testing/gtest",
+    ]
   }
 }

--- a/components/brave_referrals/browser/file_extended_attribute.cc
+++ b/components/brave_referrals/browser/file_extended_attribute.cc
@@ -1,0 +1,39 @@
+/* Copyright (c) 2023 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "brave/components/brave_referrals/browser/file_extended_attribute.h"
+
+#include <sys/xattr.h>
+
+#include "base/logging.h"
+
+namespace brave {
+
+int GetFileExtendedAttribute(const base::FilePath& path,
+                             const char* name,
+                             std::vector<char>* value) {
+  // Pass nullptr for value to retrieve the length needed.
+  ssize_t expected_length =
+      getxattr(path.value().c_str(), name, /*value=*/nullptr,
+               /*size =*/0, /*position=*/0, /*options=*/0);
+  if (expected_length < 0) {
+    return errno;
+  }
+
+  value->resize(expected_length);
+  ssize_t length = getxattr(path.value().c_str(), name, value->data(),
+                            expected_length, /*position=*/0,
+                            /*options=*/0);
+  if (length != expected_length) {
+    VLOG(0) << "Failed to retrieve extended attribute " << name << " from file "
+            << path << ". The expected data length (" << expected_length
+            << ") and actual data length (" << length << ") do not match.";
+    return ENODATA;
+  }
+
+  return 0;
+}
+
+}  // namespace brave

--- a/components/brave_referrals/browser/file_extended_attribute.h
+++ b/components/brave_referrals/browser/file_extended_attribute.h
@@ -1,0 +1,28 @@
+/* Copyright (c) 2023 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_COMPONENTS_BRAVE_REFERRALS_BROWSER_FILE_EXTENDED_ATTRIBUTE_H_
+#define BRAVE_COMPONENTS_BRAVE_REFERRALS_BROWSER_FILE_EXTENDED_ATTRIBUTE_H_
+
+#include <vector>
+
+#include "base/files/file_path.h"
+
+namespace brave {
+
+// Extracts the value of an extended file attribute specified by |name| from the
+// file specified by the |path|. The result is placed in the |value|. On
+// success returns 0. Otherwise, returns ERRNO value. Error values of
+// interest:
+// ENOATTR - the attribute with the given |name| was not found.
+// ENOTSUP - the file system doesn't support (or disabled) extended attributes.
+// ENODATA - the value could not be retrieved.
+int GetFileExtendedAttribute(const base::FilePath& path,
+                             const char* name,
+                             std::vector<char>* value);
+
+}  // namespace brave
+
+#endif  // BRAVE_COMPONENTS_BRAVE_REFERRALS_BROWSER_FILE_EXTENDED_ATTRIBUTE_H_

--- a/components/brave_referrals/browser/file_extended_attribute_unittest.cc
+++ b/components/brave_referrals/browser/file_extended_attribute_unittest.cc
@@ -1,0 +1,60 @@
+/* Copyright (c) 2023 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include <sys/xattr.h>
+#include <string>
+#include <vector>
+
+#include "base/files/file_path.h"
+#include "base/files/file_util.h"
+#include "base/files/scoped_temp_dir.h"
+#include "brave/components/brave_referrals/browser/file_extended_attribute.h"
+#include "testing/gtest/include/gtest/gtest.h"
+
+namespace {
+constexpr char kXattrName[] = "com.brave.refcode";
+constexpr char kXattrValue[] = "0xDEADFACE";
+}  // namespace
+
+class BraveFileExtendedAttributeTest : public testing::Test {
+ public:
+  BraveFileExtendedAttributeTest() = default;
+  ~BraveFileExtendedAttributeTest() override = default;
+
+  void SetUp() override {
+    ASSERT_TRUE(temp_dir_.CreateUniqueTempDir());
+    ASSERT_TRUE(
+        base::CreateTemporaryFileInDir(temp_dir_.GetPath(), &test_file_path_));
+    ASSERT_EQ(0,
+              setxattr(test_file_path_.value().c_str(), kXattrName, kXattrValue,
+                       strlen(kXattrValue), /*position=*/0, /*options=*/0));
+  }
+
+  void TearDown() override { base::DeletePathRecursively(temp_dir_.GetPath()); }
+
+  const base::FilePath& test_file_path() { return test_file_path_; }
+
+ private:
+  base::ScopedTempDir temp_dir_;
+  base::FilePath test_file_path_;
+};
+
+TEST_F(BraveFileExtendedAttributeTest, GetPromoCodeAttribute) {
+  std::vector<char> value;
+  // Test file has this extended attribute
+  int result_errno =
+      brave::GetFileExtendedAttribute(test_file_path(), kXattrName, &value);
+  EXPECT_EQ(0, result_errno);
+  std::string xattr_value(value.begin(), value.end());
+  EXPECT_EQ(kXattrValue, xattr_value);
+}
+
+TEST_F(BraveFileExtendedAttributeTest, GetNonexistentAttribute) {
+  std::vector<char> value;
+  // Test file does NOT have this extended attribute
+  int result_errno = brave::GetFileExtendedAttribute(
+      test_file_path(), "com.brave.MadSheep", &value);
+  EXPECT_EQ(ENOATTR, result_errno);
+}

--- a/test/BUILD.gn
+++ b/test/BUILD.gn
@@ -206,6 +206,7 @@ test("brave_unit_tests") {
     "//brave/components/brave_news/browser/test:brave_news_unit_tests",
     "//brave/components/brave_perf_predictor/browser",
     "//brave/components/brave_private_cdn",
+    "//brave/components/brave_referrals/browser:unit_tests",
     "//brave/components/brave_rewards/common",
     "//brave/components/brave_rewards/common:features",
     "//brave/components/brave_rewards/core/test",


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/32316

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-arm64, CI/skip-linux-x64, CI/skip-android, CI/skip-macos, CI/skip-ios, CI/skip-windows-arm64, CI/skip-windows-x64, CI/skip-windows-x86 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [ ] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

