### PR TITLE
Remove remaining `re2::StringPiece` uses

### DIFF
--- a/components/brave_ads/core/internal/common/unittest/unittest_tag_parser_util.cc
+++ b/components/brave_ads/core/internal/common/unittest/unittest_tag_parser_util.cc
@@ -5,6 +5,7 @@
 
 #include "brave/components/brave_ads/core/internal/common/unittest/unittest_tag_parser_util.h"
 
+#include <string_view>
 #include <vector>
 
 #include "base/check.h"
@@ -84,7 +85,7 @@ absl::optional<std::string> ParseTimeTagValue(const std::string& value) {
 }
 
 std::vector<std::string> ParseTagsForText(const std::string& text) {
-  re2::StringPiece text_string_piece(text);
+  std::string_view text_string_piece(text);
   const RE2 r("<(.*)>");
 
   std::vector<std::string> tags;

--- a/components/brave_ads/core/internal/conversions/types/verifiable_conversion/verifiable_conversion_id_pattern/parsers/verifiable_conversion_id_html_meta_tag_parser_util.cc
+++ b/components/brave_ads/core/internal/conversions/types/verifiable_conversion/verifiable_conversion_id_pattern/parsers/verifiable_conversion_id_html_meta_tag_parser_util.cc
@@ -5,6 +5,8 @@
 
 #include "brave/components/brave_ads/core/internal/conversions/types/verifiable_conversion/verifiable_conversion_id_pattern/parsers/verifiable_conversion_id_html_meta_tag_parser_util.h"
 
+#include <string_view>
+
 #include "brave/components/brave_ads/core/internal/common/logging_util.h"
 #include "brave/components/brave_ads/core/internal/conversions/conversions_feature.h"
 #include "third_party/re2/src/re2/re2.h"
@@ -15,7 +17,7 @@ absl::optional<std::string> MaybeParseVerifableConversionIdFromHtmlMetaTag(
     const std::string& html) {
   const std::string id_pattern = kHtmlMetaTagConversionIdPattern.Get();
 
-  re2::StringPiece html_string_piece(html);
+  std::string_view html_string_piece(html);
   const RE2 r(id_pattern);
   std::string verifiable_conversion_id;
 

--- a/components/brave_ads/core/internal/conversions/types/verifiable_conversion/verifiable_conversion_id_pattern/parsers/verifiable_conversion_id_html_parser_util.cc
+++ b/components/brave_ads/core/internal/conversions/types/verifiable_conversion/verifiable_conversion_id_pattern/parsers/verifiable_conversion_id_html_parser_util.cc
@@ -5,6 +5,8 @@
 
 #include "brave/components/brave_ads/core/internal/conversions/types/verifiable_conversion/verifiable_conversion_id_pattern/parsers/verifiable_conversion_id_html_parser_util.h"
 
+#include <string_view>
+
 #include "brave/components/brave_ads/core/internal/common/logging_util.h"
 #include "brave/components/brave_ads/core/internal/conversions/resource/conversion_resource_id_pattern_info.h"
 #include "third_party/re2/src/re2/re2.h"
@@ -14,7 +16,7 @@ namespace brave_ads {
 absl::optional<std::string> MaybeParseVerifableConversionIdFromHtml(
     const std::string& html,
     const ConversionResourceIdPatternInfo& resource_id_pattern) {
-  re2::StringPiece html_string_piece(html);
+  std::string_view html_string_piece(html);
   const RE2 r(resource_id_pattern.id_pattern);
   std::string verifiable_conversion_id;
 

--- a/components/brave_ads/core/internal/conversions/types/verifiable_conversion/verifiable_conversion_id_pattern/parsers/verifiable_conversion_id_url_redirects_parser_util.cc
+++ b/components/brave_ads/core/internal/conversions/types/verifiable_conversion/verifiable_conversion_id_pattern/parsers/verifiable_conversion_id_url_redirects_parser_util.cc
@@ -5,6 +5,8 @@
 
 #include "brave/components/brave_ads/core/internal/conversions/types/verifiable_conversion/verifiable_conversion_id_pattern/parsers/verifiable_conversion_id_url_redirects_parser_util.h"
 
+#include <string_view>
+
 #include "base/ranges/algorithm.h"
 #include "brave/components/brave_ads/core/internal/common/logging_util.h"
 #include "brave/components/brave_ads/core/internal/common/url/url_util.h"
@@ -27,7 +29,7 @@ absl::optional<std::string> MaybeParseVerifableConversionIdFromUrlRedirects(
     return absl::nullopt;
   }
 
-  re2::StringPiece url_string_piece(iter->spec());
+  std::string_view url_string_piece(iter->spec());
   const RE2 r(resource_id_pattern.id_pattern);
   std::string verifiable_conversion_id;
 

--- a/components/brave_news/browser/html_parsing.cc
+++ b/components/brave_news/browser/html_parsing.cc
@@ -15,7 +15,6 @@
 #include "base/logging.h"
 #include "base/strings/string_util.h"
 #include "third_party/re2/src/re2/re2.h"
-#include "third_party/re2/src/re2/stringpiece.h"
 #include "url/gurl.h"
 
 namespace brave_news {
@@ -44,7 +43,7 @@ std::vector<GURL> GetFeedURLsFromHTMLDocument(const std::string& charset,
   // Find most `<link` elements from most types of html documents
   static const re2::RE2 link_pattern("(?i)(<\\s*link [^>]+>)");
   std::string link_text;
-  re2::StringPiece input(html_body);
+  std::string_view input(html_body);
   while (re2::RE2::FindAndConsume(&input, link_pattern, &link_text)) {
     VLOG(1) << "Found link: " << link_text;
     // Extract rel

--- a/components/brave_wallet/browser/permission_utils.cc
+++ b/components/brave_wallet/browser/permission_utils.cc
@@ -5,6 +5,8 @@
 
 #include "brave/components/brave_wallet/browser/permission_utils.h"
 
+#include <string_view>
+
 #include "base/no_destructor.h"
 #include "base/strings/strcat.h"
 #include "base/strings/string_util.h"
@@ -52,7 +54,7 @@ void ExtractAddresses(permissions::RequestType type,
   DCHECK(!origin.opaque() && address_queue);
 
   std::string origin_string(origin.Serialize());
-  re2::StringPiece input(origin_string);
+  std::string_view input(origin_string);
   std::string match;
   re2::RE2* regex;
   if (type == permissions::RequestType::kBraveEthereum) {

--- a/components/debounce/browser/debounce_rule.cc
+++ b/components/debounce/browser/debounce_rule.cc
@@ -222,7 +222,7 @@ bool DebounceRule::ValidateAndParsePatternRegex(
   // Get matching capture groups by applying regex to the path
   size_t number_of_capturing_groups =
       pattern_regex.NumberOfCapturingGroups() + 1;
-  std::vector<re2::StringPiece> match_results(number_of_capturing_groups);
+  std::vector<std::string_view> match_results(number_of_capturing_groups);
 
   if (!pattern_regex.Match(path, 0, path.size(), RE2::UNANCHORED,
                            match_results.data(), match_results.size())) {
@@ -237,7 +237,7 @@ bool DebounceRule::ValidateAndParsePatternRegex(
   // Build parsed_value string by appending matches, ignoring the first match
   // which will be the whole match
   std::for_each(std::begin(match_results) + 1, std::end(match_results),
-                [parsed_value](re2::StringPiece matched_string) {
+                [parsed_value](std::string_view matched_string) {
                   if (!matched_string.empty()) {
                     parsed_value->append(matched_string);
                   }

--- a/components/services/ipfs/ipfs_service_utils.cc
+++ b/components/services/ipfs/ipfs_service_utils.cc
@@ -6,6 +6,7 @@
 #include "brave/components/services/ipfs/ipfs_service_utils.h"
 
 #include <memory>
+#include <string_view>
 #include <utility>
 #include <vector>
 
@@ -101,7 +102,7 @@ bool UpdateConfigJSON(const std::string& source,
 
 std::string GetVersionFromNodeFilename(const std::string& filename) {
   static const RE2 version_pattern(kExecutableRegEx);
-  std::vector<re2::StringPiece> matched_groups(
+  std::vector<std::string_view> matched_groups(
       version_pattern.NumberOfCapturingGroups() + 1);
   if (!version_pattern.Match(filename, 0, filename.size(), RE2::ANCHOR_START,
                              matched_groups.data(), matched_groups.size()) ||


### PR DESCRIPTION
All occurrences of `StringPiece` have been replaced with `string_view` in a previous PR, however the ones relating to `re2` somehow were left behind.

This change removes all the remaining ones.

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves 

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-arm64, CI/skip-linux-x64, CI/skip-android, CI/skip-macos, CI/skip-ios, CI/skip-windows-arm64, CI/skip-windows-x64, CI/skip-windows-x86 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [ ] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

