### PR TITLE
Fixed empty side panel is visible after active tab changed

### DIFF
--- a/browser/ui/sidebar/sidebar_browsertest.cc
+++ b/browser/ui/sidebar/sidebar_browsertest.cc
@@ -151,6 +151,10 @@ class SidebarBrowserTest : public InProcessBrowserTest {
     return static_cast<SidebarContainerView*>(controller()->sidebar());
   }
 
+  void CheckOperationFromActiveTabChangedFlagCleared() const {
+    EXPECT_FALSE(GetSidebarContainerView()->operation_from_active_tab_change_);
+  }
+
   BraveSidePanel* GetSidePanel() const {
     return GetSidebarContainerView()->side_panel_;
   }
@@ -683,6 +687,8 @@ IN_PROC_BROWSER_TEST_F(SidebarBrowserTestWithAIChat, TabSpecificPanel) {
   ASSERT_EQ(tab_model()->GetTabCount(), 3);
   // Open a "global" panel from Tab 0
   tab_model()->ActivateTabAt(0);
+  // Tab changed flag should be cleared after ActivateTabAt() executed.
+  CheckOperationFromActiveTabChangedFlagCleared();
   SimulateSidebarItemClickAt(global_item_index.value());
   // Open a "tab specific" panel from Tab 1
   tab_model()->ActivateTabAt(1);

--- a/browser/ui/views/side_panel/brave_side_panel_coordinator.cc
+++ b/browser/ui/views/side_panel/brave_side_panel_coordinator.cc
@@ -45,13 +45,20 @@ void BraveSidePanelCoordinator::OnTabStripModelChanged(
     TabStripModel* tab_strip_model,
     const TabStripModelChange& change,
     const TabStripSelectionChange& selection) {
-  if (selection.active_tab_changed()) {
-    static_cast<BraveBrowserView*>(browser_view_)
-        ->SetSidePanelOperationByActiveTabChange(true);
+  auto* brave_browser_view = static_cast<BraveBrowserView*>(browser_view_);
+  const bool active_tab_changed = selection.active_tab_changed();
+  if (active_tab_changed) {
+    brave_browser_view->SetSidePanelOperationByActiveTabChange(true);
   }
 
   SidePanelCoordinator::OnTabStripModelChanged(tab_strip_model, change,
                                                selection);
+
+  // Clear as this flag is only used for show/hide operation triggered by above
+  // SidePanelCoordinator::OnTabStripModelChanged().
+  if (active_tab_changed) {
+    brave_browser_view->SetSidePanelOperationByActiveTabChange(false);
+  }
 }
 
 std::unique_ptr<views::View> BraveSidePanelCoordinator::CreateHeader() {

--- a/browser/ui/views/sidebar/sidebar_container_view.cc
+++ b/browser/ui/views/sidebar/sidebar_container_view.cc
@@ -9,7 +9,6 @@
 #include <limits>
 #include <utility>
 
-#include "base/auto_reset.h"
 #include "base/functional/bind.h"
 #include "base/time/time.h"
 #include "brave/browser/ui/brave_browser.h"
@@ -677,12 +676,8 @@ void SidebarContainerView::HideSidebarForShowOption() {
   }
 }
 
-bool SidebarContainerView::GetIsPanelOperationFromActiveTabChangeAndReset() {
-  return std::exchange(operation_from_active_tab_change_, false);
-}
-
 bool SidebarContainerView::ShouldUseAnimation() {
-  return !GetIsPanelOperationFromActiveTabChangeAndReset() &&
+  return !operation_from_active_tab_change_ &&
          gfx::Animation::ShouldRenderRichAnimation();
 }
 

--- a/browser/ui/views/sidebar/sidebar_container_view.h
+++ b/browser/ui/views/sidebar/sidebar_container_view.h
@@ -180,7 +180,6 @@ class SidebarContainerView
   void StartObservingContextualSidePanelRegistry(
       content::WebContents* contents);
   void StopObservingContextualSidePanelRegistry(content::WebContents* contents);
-  bool GetIsPanelOperationFromActiveTabChangeAndReset();
 
   raw_ptr<BraveBrowser> browser_ = nullptr;
   raw_ptr<SidePanelCoordinator> side_panel_coordinator_ = nullptr;


### PR DESCRIPTION
fix https://github.com/brave/brave-browser/issues/33224

Active tab changed flag should not be persisted.
As that flag is only used by the show/hide side panel operations that triggered from SidePanelCoordinator::OnTabStripModelChanged(), it should be cleared after it's called.

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves 

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-arm64, CI/skip-linux-x64, CI/skip-android, CI/skip-macos, CI/skip-ios, CI/skip-windows-arm64, CI/skip-windows-x64, CI/skip-windows-x86 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

`SidebarBrowserTest*`