### PR TITLE
[1.59.x] Uplift: News: add "es_AR", "fr_FR" and "de_DE" to default enabled locales

### DIFF
--- a/components/brave_news/browser/locales_helper.cc
+++ b/components/brave_news/browser/locales_helper.cc
@@ -36,7 +36,7 @@ constexpr auto kEnabledLanguages =
 // We can add to this list as new locales become available to have Brave News
 // show when it's ready for those users.
 constexpr auto kEnabledLocales = base::MakeFixedFlatSet<base::StringPiece>(
-    {"es_ES", "es_MX", "pt_BR", "fr_FR", "de_DE"});
+    {"es_ES", "es_MX", "es_AR", "pt_BR", "fr_FR", "de_DE"});
 
 bool HasAnyLocale(const base::flat_set<std::string>& locales,
                   const mojom::Publisher* publisher) {

--- a/components/brave_news/browser/locales_helper.cc
+++ b/components/brave_news/browser/locales_helper.cc
@@ -35,8 +35,8 @@ constexpr auto kEnabledLanguages =
     base::MakeFixedFlatSet<base::StringPiece>({"en", "ja"});
 // We can add to this list as new locales become available to have Brave News
 // show when it's ready for those users.
-constexpr auto kEnabledLocales =
-    base::MakeFixedFlatSet<base::StringPiece>({"es_ES", "es_MX", "pt_BR"});
+constexpr auto kEnabledLocales = base::MakeFixedFlatSet<base::StringPiece>(
+    {"es_ES", "es_MX", "pt_BR", "fr_FR", "de_DE"});
 
 bool HasAnyLocale(const base::flat_set<std::string>& locales,
                   const mojom::Publisher* publisher) {


### PR DESCRIPTION
Uplift https://github.com/brave/brave-browser/issues/32416 via https://github.com/brave/brave-core/pull/20197 to 1.59.x
Uplift https://github.com/brave/brave-browser/issues/33251 via https://github.com/brave/brave-core/pull/20286 to 1.59.x