### PR TITLE
Null check for is vpn feature supported (uplift to 1.58.x)

### DIFF
--- a/android/java/org/chromium/chrome/browser/appmenu/BraveTabbedAppMenuPropertiesDelegate.java
+++ b/android/java/org/chromium/chrome/browser/appmenu/BraveTabbedAppMenuPropertiesDelegate.java
@@ -238,9 +238,7 @@ public class BraveTabbedAppMenuPropertiesDelegate extends TabbedAppMenuPropertie
         mMenu.removeItem(R.id.brave_playlist_id);
         mMenu.removeItem(R.id.brave_speedreader_id);
         mMenu.removeItem(R.id.exit_id);
-        if (BraveVpnUtils.isVpnFeatureSupported(mContext)) {
-            mMenu.removeItem(R.id.request_brave_vpn_row_menu_id);
-        }
+        mMenu.removeItem(R.id.request_brave_vpn_row_menu_id);
     }
 
     @Override

--- a/android/java/org/chromium/chrome/browser/settings/BraveMainPreferencesBase.java
+++ b/android/java/org/chromium/chrome/browser/settings/BraveMainPreferencesBase.java
@@ -248,9 +248,11 @@ public class BraveMainPreferencesBase
     private void rearrangePreferenceOrders() {
         int firstSectionOrder = 0;
 
-        if (BraveVpnPrefUtils.shouldShowCallout() && !BraveVpnPrefUtils.isSubscriptionPurchase()
+        if (getActivity() != null && !getActivity().isFinishing()
+                && BraveVpnPrefUtils.shouldShowCallout()
+                && !BraveVpnPrefUtils.isSubscriptionPurchase()
                 && BraveVpnUtils.isVpnFeatureSupported(getActivity())) {
-            if (getActivity() != null && mVpnCalloutPreference == null) {
+            if (mVpnCalloutPreference == null) {
                 mVpnCalloutPreference = new VpnCalloutPreference(getActivity());
             }
             if (mVpnCalloutPreference != null) {
@@ -277,7 +279,8 @@ public class BraveMainPreferencesBase
             removePreferenceIfPresent(PREF_BRAVE_PLAYLIST);
         }
 
-        if (BraveVpnUtils.isVpnFeatureSupported(getActivity())) {
+        if (getActivity() != null && !getActivity().isFinishing()
+                && BraveVpnUtils.isVpnFeatureSupported(getActivity())) {
             findPreference(PREF_BRAVE_VPN).setOrder(++firstSectionOrder);
         } else {
             removePreferenceIfPresent(PREF_BRAVE_VPN);


### PR DESCRIPTION
Uplift of #20281
Resolves https://github.com/brave/brave-browser/issues/33235

Pre-approval checklist: 
- [ ] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.