### PR TITLE
Replaced chrome dark logo with channel product logo from settings drawer menu (uplift to 1.59.x)

### DIFF
--- a/build/commands/lib/config.js
+++ b/build/commands/lib/config.js
@@ -284,6 +284,20 @@ Config.prototype.getBrandingPathProduct = function () {
   return this.isOfficialBuild() ? "brave" : "brave-development"
 }
 
+Config.prototype.getBraveLogoIconName = function () {
+  let iconName = "brave-icon-debug-color.svg"
+  if (this.isBraveReleaseBuild()) {
+    if (this.channel === "beta") {
+      iconName = "brave-icon-beta-color.svg"
+    } else if (this.channel === "nightly") {
+      iconName = "brave-icon-nightly-color.svg"
+    } else {
+      iconName = "brave-icon-release-color.svg"
+    }
+  }
+  return iconName
+}
+
 Config.prototype.buildArgs = function () {
   const version = this.braveVersion
   let version_parts = version.split('+')[0]

--- a/build/commands/lib/util.js
+++ b/build/commands/lib/util.js
@@ -276,6 +276,12 @@ const util = {
     // Replace webui CSS to use our fonts.
     fileMap.add([path.join(config.braveCoreDir, 'ui', 'webui', 'resources', 'css', 'text_defaults_md.css'),
                  path.join(config.srcDir, 'ui', 'webui', 'resources', 'css', 'text_defaults_md.css')])
+    // Replace chrome dark logo with channel specific brave logo.
+    fileMap.add([
+      path.join(config.braveCoreDir, 'node_modules', '@brave', 'leo', 'icons',
+          config.getBraveLogoIconName()),
+      path.join(config.srcDir, 'ui', 'webui', 'resources', 'images',
+          'chrome_logo_dark.svg')])
 
     let explicitSourceFiles = new Set()
     if (config.getTargetOS() === 'mac') {


### PR DESCRIPTION
Uplift of #20215
fix https://github.com/brave/brave-browser/issues/31355

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.