### PR TITLE
fix(wallet) Fix NFT image flashing HTML broken before the image is loaded

### DIFF
--- a/components/brave_wallet_ui/components/desktop/views/portfolio/components/nft-grid-view/nft-grid-view-item-skeleton.stories.tsx
+++ b/components/brave_wallet_ui/components/desktop/views/portfolio/components/nft-grid-view/nft-grid-view-item-skeleton.stories.tsx
@@ -1,0 +1,15 @@
+// Copyright (c) 2023 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import * as React from 'react'
+import { NftGridViewItemSkeleton } from "./nft-grid-view-item-skeleton"
+
+export const _NftGridViewItemSkeleton = () => {
+  return (
+    <NftGridViewItemSkeleton />
+  )
+}
+
+export default _NftGridViewItemSkeleton

--- a/components/brave_wallet_ui/components/desktop/views/portfolio/components/nft-grid-view/nft-grid-view-item-skeleton.tsx
+++ b/components/brave_wallet_ui/components/desktop/views/portfolio/components/nft-grid-view/nft-grid-view-item-skeleton.tsx
@@ -5,15 +5,16 @@
 import * as React from 'react'
 import { LoadingSkeleton } from '../../../../../shared/loading-skeleton/index'
 import { VerticalSpace } from '../../../../../shared/style'
+import { NFTWrapper } from './style'
 
 export const NftGridViewItemSkeleton = () => {
   return (
-    <>
+    <NFTWrapper>
       <LoadingSkeleton height={222} />
       <VerticalSpace space='8px' />
       <LoadingSkeleton width='80%' height={20} />
       <VerticalSpace space='8px' />
       <LoadingSkeleton width={40} height={20} />
-    </>
+    </NFTWrapper>
   )
 }

--- a/components/brave_wallet_ui/nft/components/nft-content/nft-content.tsx
+++ b/components/brave_wallet_ui/nft/components/nft-content/nft-content.tsx
@@ -5,9 +5,6 @@
 
 import * as React from 'react'
 
-// components
-import { Image, ImageWrapper } from './nft-content-styles'
-
 // types
 import { NFTMetadataReturnType } from '../../../constants/types'
 import { DisplayMode } from '../../nft-ui-messages'
@@ -16,6 +13,8 @@ import { DisplayMode } from '../../nft-ui-messages'
 import Placeholder from '../../../assets/svg-icons/nft-placeholder.svg'
 import { NftMultimedia } from '../nft-multimedia/nft-multimedia'
 import { stripChromeImageURL } from '../../../utils/string-utils'
+import { ImageWrapper } from './nft-content-styles'
+import { ImageLoader } from '../nft-image/image-loader'
 
 interface Props {
   isLoading?: boolean
@@ -57,7 +56,7 @@ export const NftContent = (props: Props) => {
       <div ref={wrapperRef}>
         {url && displayMode === 'icon' && isInView ? (
           <ImageWrapper>
-            <Image src={url} />
+            <ImageLoader src={url} />
           </ImageWrapper>
         ) : null}
       </div>

--- a/components/brave_wallet_ui/nft/components/nft-image/image-loader.tsx
+++ b/components/brave_wallet_ui/nft/components/nft-image/image-loader.tsx
@@ -1,0 +1,44 @@
+// Copyright (c) 2023 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import * as React from 'react'
+
+// styles
+import { Image } from './nft-image.styles'
+
+interface ImageLoaderProps {
+  src: string
+  width?: string
+  height?: string
+  lazyLoad?: 'lazy' | 'eager'
+  onLoaded?: () => void
+}
+
+export const ImageLoader = ({
+  src,
+  width,
+  height,
+  lazyLoad,
+  onLoaded
+}: ImageLoaderProps) => {
+  const [loaded, setLoaded] = React.useState(false)
+
+  const handleImageLoaded = () => {
+    setLoaded(true)
+    if (onLoaded) onLoaded()
+  }
+
+  return (
+    <>
+      {loaded && <Image src={src} customWidth={width} customHeight={height} />}
+      <img
+        src={src}
+        style={{ display: 'none' }}
+        loading={lazyLoad}
+        onLoad={handleImageLoaded}
+      />
+    </>
+  )
+}

--- a/components/brave_wallet_ui/nft/components/nft-image/nft-image.styles.ts
+++ b/components/brave_wallet_ui/nft/components/nft-image/nft-image.styles.ts
@@ -4,15 +4,19 @@
 // you can obtain one at https://mozilla.org/MPL/2.0/.
 import styled from 'styled-components'
 
-export const Image = styled.img`
+export const Image = styled.img<{
+  customWidth?: string
+  customHeight?: string
+}>`
   display: block;
-  width: 100%;
-  height: auto;
-  object-fit: contain;
   border: transparent;
   border-radius: 8px;
-  width: auto;
-  height: 360px;
+  max-width: 100%;
+  max-height: 100%;
+  position: relative;
+  object-fit: contain;
+  width: ${(props) => props.customWidth || 'auto'};
+  height: ${(props) => props.customHeight || 'auto'};
 `
 
 export const ImageWrapper = styled.div`

--- a/components/brave_wallet_ui/nft/components/nft-image/nft-image.tsx
+++ b/components/brave_wallet_ui/nft/components/nft-image/nft-image.tsx
@@ -4,12 +4,16 @@
 // you can obtain one at https://mozilla.org/MPL/2.0/.
 import * as React from 'react'
 
+// components
+import { ImageLoader } from './image-loader'
+
 // styles
+import { ImageWrapper } from './nft-image.styles'
 import {
-  ImageWrapper,
-  Image
-} from './nft-image.styles'
-import { NftUiCommand, UpdateNftImageLoadingMessage, sendMessageToWalletUi } from '../../nft-ui-messages'
+  NftUiCommand,
+  UpdateNftImageLoadingMessage,
+  sendMessageToWalletUi
+} from '../../nft-ui-messages'
 
 interface Props {
   imageUrl: string
@@ -28,10 +32,13 @@ export const NftImage = (props: Props) => {
   }, [])
 
   return (
-    <>
-      <ImageWrapper>
-        <Image src={imageUrl} onLoad={onImageLoaded} loading='lazy' />
-      </ImageWrapper>
-    </>
+    <ImageWrapper>
+      <ImageLoader
+        src={imageUrl}
+        onLoaded={onImageLoaded}
+        width='auto'
+        height='360px'
+      />
+    </ImageWrapper>
   )
 }


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/33261

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
#### Before

https://github.com/brave/brave-core/assets/48117473/da9eb7f7-c065-4486-ac47-51a3c1e9b7db

#### After

https://github.com/brave/brave-core/assets/48117473/920a5c15-8b41-4244-a54d-4cc838c9e819
