### PR TITLE
[Uplift 1.59]: [App Menu]: Add key icon for password manager

### DIFF
--- a/browser/ui/toolbar/app_menu_icons.cc
+++ b/browser/ui/toolbar/app_menu_icons.cc
@@ -33,6 +33,7 @@ const std::map<int, const gfx::VectorIcon&>& GetCommandIcons() {
           {IDC_APP_MENU_IPFS, kLeoProductIpfsOutlineIcon},
           {IDC_RECENT_TABS_MENU, kLeoHistoryIcon},
           {IDC_BOOKMARKS_MENU, kLeoProductBookmarksIcon},
+          {IDC_VIEW_PASSWORDS, kLeoKeyIcon},
           {IDC_SHOW_DOWNLOADS, kLeoDownloadIcon},
           {IDC_MANAGE_EXTENSIONS, kLeoBrowserExtensionsIcon},
           {IDC_ZOOM_MENU, kLeoSearchZoomInIcon},

--- a/browser/ui/toolbar/brave_app_menu_model_browsertest.cc
+++ b/browser/ui/toolbar/brave_app_menu_model_browsertest.cc
@@ -494,7 +494,6 @@ void CheckMenuIcons(ui::MenuModel* menu,
                     int submenu_depth,
                     std::u16string path = u"") {
   constexpr int kIconlessCommands[] = {
-      IDC_VIEW_PASSWORDS,
       // Header, with no icon
       IDC_RECENT_TABS_NO_DEVICE_TABS,
       // Header, with no icon

--- a/components/vector_icons/BUILD.gn
+++ b/components/vector_icons/BUILD.gn
@@ -43,6 +43,7 @@ aggregate_vector_icons("brave_components_vector_icons") {
     "leo_history.icon",
     "leo_import_arrow.icon",
     "leo_info_outline.icon",
+    "leo_key.icon",
     "leo_launch.icon",
     "leo_message_heart.icon",
     "leo_network_speed_fast.icon",


### PR DESCRIPTION
Uplift of https://github.com/brave/brave-core/pull/20034
Resolves https://github.com/brave/brave-browser/issues/32817
