### PR TITLE
[iOS] Add missed prefs registration for l10n country code

### DIFF
--- a/chromium_src/ios/chrome/browser/shared/model/prefs/BUILD.gn
+++ b/chromium_src/ios/chrome/browser/shared/model/prefs/BUILD.gn
@@ -11,6 +11,7 @@ group("prefs") {
     "//brave/components/brave_wallet/browser",
     "//brave/components/decentralized_dns/core",
     "//brave/components/ipfs/buildflags",
+    "//brave/components/l10n/common",
     "//brave/components/ntp_background_images/browser",
     "//brave/components/p3a",
     "//brave/components/p3a:buildflags",

--- a/chromium_src/ios/chrome/browser/shared/model/prefs/DEPS
+++ b/chromium_src/ios/chrome/browser/shared/model/prefs/DEPS
@@ -3,6 +3,7 @@ include_rules = [
   "+brave/components/brave_wallet/browser",
   "+brave/components/decentralized_dns/core",
   "+brave/components/ipfs",
+  "+brave/components/l10n/common",
   "+brave/components/ntp_background_images/browser",
   "+brave/components/p3a",
   "+brave/ios/browser/brave_stats",

--- a/chromium_src/ios/chrome/browser/shared/model/prefs/browser_prefs.mm
+++ b/chromium_src/ios/chrome/browser/shared/model/prefs/browser_prefs.mm
@@ -8,6 +8,7 @@
 #include "brave/components/brave_wallet/browser/keyring_service.h"
 #include "brave/components/decentralized_dns/core/utils.h"
 #include "brave/components/ipfs/buildflags/buildflags.h"
+#include "brave/components/l10n/common/prefs.h"
 #include "brave/components/ntp_background_images/browser/ntp_background_images_service.h"
 #include "brave/components/p3a/buildflags.h"
 #include "brave/components/p3a/p3a_service.h"
@@ -38,6 +39,7 @@ void BraveRegisterLocalStatePrefs(PrefRegistrySimple* registry) {
 #endif
   ntp_background_images::NTPBackgroundImagesService::RegisterLocalStatePrefs(
       registry);
+  brave_l10n::RegisterL10nLocalStatePrefs(registry);
 }
 
 void BraveMigrateObsoleteBrowserStatePrefs(PrefService* prefs) {


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Missed a registration in https://github.com/brave/brave-core/pull/19964

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

