### PR TITLE
[WebTorrent]: Remove web accessible urls

### DIFF
--- a/browser/net/BUILD.gn
+++ b/browser/net/BUILD.gn
@@ -147,6 +147,7 @@ source_set("browser_tests") {
     "brave_service_key_network_delegate_helper_browsertest.cc",
     "brave_site_hacks_network_delegate_helper_browsertest.cc",
     "brave_system_request_handler_browsertest.cc",
+    "brave_torrent_redirect_network_delegate_helper_browsertest.cc",
     "global_privacy_control_network_delegate_helper_browsertest.cc",
   ]
   deps = [

--- a/browser/net/brave_torrent_redirect_network_delegate_helper.cc
+++ b/browser/net/brave_torrent_redirect_network_delegate_helper.cc
@@ -70,11 +70,17 @@ int OnHeadersReceived_TorrentRedirectWork(
 
   auto* contents =
       content::WebContents::FromFrameTreeNodeId(ctx->frame_tree_node_id);
+  if (!contents) {
+    return net::OK;
+  }
+
+  // We don't allow websites to directly link to the WebTorrent extension.
+  // However, this means that we can't simply redirect here (as that would be
+  // blocked), and instead, we need to create a new navigation.
   GURL url(base::StrCat(
       {extensions::kExtensionScheme, "://", brave_webtorrent_extension_id,
        "/extension/brave_webtorrent2.html?", ctx->request_url.spec()}));
   content::NavigationController::LoadURLParams params(url);
-  params.is_renderer_initiated = true;
   params.initiator_origin = url::Origin::Create(url);
   params.source_site_instance = content::SiteInstance::CreateForURL(
       contents->GetBrowserContext(), params.initiator_origin->GetURL());

--- a/browser/net/brave_torrent_redirect_network_delegate_helper.cc
+++ b/browser/net/brave_torrent_redirect_network_delegate_helper.cc
@@ -12,25 +12,29 @@
 #include "base/strings/string_util.h"
 #include "brave/components/brave_webtorrent/browser/webtorrent_util.h"
 #include "brave/components/constants/network_constants.h"
+#include "content/public/browser/navigation_controller.h"
+#include "content/public/browser/site_instance.h"
+#include "content/public/browser/web_contents.h"
 #include "extensions/common/constants.h"
 #include "net/http/http_content_disposition.h"
 #include "net/http/http_response_headers.h"
 #include "net/url_request/url_request.h"
 #include "third_party/blink/public/mojom/loader/resource_load_info.mojom-shared.h"
+#include "ui/base/page_transition_types.h"
+#include "url/origin.h"
 
 namespace {
 
 // Returns true if the URL contains a URL fragment that starts with "ix=". For
 // example, https://webtorrent.io/torrents/big-buck-bunny.torrent#ix=1.
 bool IsViewerURL(const GURL& url) {
-  return base::StartsWith(url.ref(), "ix=",
-      base::CompareCase::INSENSITIVE_ASCII);
+  return base::StartsWith(url.ref(),
+                          "ix=", base::CompareCase::INSENSITIVE_ASCII);
 }
-
 
 bool IsWebtorrentInitiated(std::shared_ptr<brave::BraveRequestInfo> ctx) {
   return ctx->initiator_url.scheme() == extensions::kExtensionScheme &&
-      ctx->initiator_url.host() == brave_webtorrent_extension_id;
+         ctx->initiator_url.host() == brave_webtorrent_extension_id;
 }
 
 // Returns true if the resource type is a frame (i.e. a top level page) or a
@@ -50,9 +54,7 @@ int OnHeadersReceived_TorrentRedirectWork(
     GURL* allowed_unsafe_redirect_url,
     const brave::ResponseCallback& next_callback,
     std::shared_ptr<brave::BraveRequestInfo> ctx) {
-
-  if (!original_response_headers ||
-      !IsMainFrameResource(ctx) ||
+  if (!original_response_headers || !IsMainFrameResource(ctx) ||
       ctx->is_webtorrent_disabled ||
       // download .torrent, do not redirect
       (IsWebtorrentInitiated(ctx) && !IsViewerURL(ctx->request_url)) ||
@@ -60,18 +62,20 @@ int OnHeadersReceived_TorrentRedirectWork(
     return net::OK;
   }
 
-  *override_response_headers =
-    new net::HttpResponseHeaders(original_response_headers->raw_headers());
-  (*override_response_headers)
-      ->ReplaceStatusLine("HTTP/1.1 307 Temporary Redirect");
-  (*override_response_headers)->RemoveHeader("Location");
-  GURL url(
-      base::StrCat({extensions::kExtensionScheme, "://",
-      brave_webtorrent_extension_id,
-      "/extension/brave_webtorrent2.html?",
-      ctx->request_url.spec()}));
-  (*override_response_headers)->AddHeader("Location", url.spec());
-  *allowed_unsafe_redirect_url = url;
+  auto* contents =
+      content::WebContents::FromFrameTreeNodeId(ctx->frame_tree_node_id);
+  GURL url(base::StrCat(
+      {extensions::kExtensionScheme, "://", brave_webtorrent_extension_id,
+       "/extension/brave_webtorrent2.html?", ctx->request_url.spec()}));
+  content::NavigationController::LoadURLParams params(url);
+  params.is_renderer_initiated = true;
+  params.initiator_origin = url::Origin::Create(url);
+  params.source_site_instance = content::SiteInstance::CreateForURL(
+      contents->GetBrowserContext(), params.initiator_origin->GetURL());
+  params.transition_type = ui::PAGE_TRANSITION_FROM_API;
+
+  contents->GetController().LoadURLWithParams(params);
+
   return net::OK;
 }
 

--- a/browser/net/brave_torrent_redirect_network_delegate_helper.cc
+++ b/browser/net/brave_torrent_redirect_network_delegate_helper.cc
@@ -48,14 +48,14 @@ bool IsMainFrameResource(std::shared_ptr<brave::BraveRequestInfo> ctx) {
 
 namespace webtorrent {
 
-bool IsNonWebTorrentRequest(
+bool ShouldRedirectRequest(
     const net::HttpResponseHeaders* original_response_headers,
     std::shared_ptr<brave::BraveRequestInfo> ctx) {
-  return !original_response_headers || !IsMainFrameResource(ctx) ||
-         ctx->is_webtorrent_disabled ||
-         // download .torrent, do not redirect
-         (IsWebtorrentInitiated(ctx) && !IsViewerURL(ctx->request_url)) ||
-         !IsTorrentFile(ctx->request_url, original_response_headers);
+  return !(!original_response_headers || !IsMainFrameResource(ctx) ||
+           ctx->is_webtorrent_disabled ||
+           // download .torrent, do not redirect
+           (IsWebtorrentInitiated(ctx) && !IsViewerURL(ctx->request_url)) ||
+           !IsTorrentFile(ctx->request_url, original_response_headers));
 }
 
 int OnHeadersReceived_TorrentRedirectWork(
@@ -64,7 +64,7 @@ int OnHeadersReceived_TorrentRedirectWork(
     GURL* allowed_unsafe_redirect_url,
     const brave::ResponseCallback& next_callback,
     std::shared_ptr<brave::BraveRequestInfo> ctx) {
-  if (IsNonWebTorrentRequest(original_response_headers, ctx)) {
+  if (!ShouldRedirectRequest(original_response_headers, ctx)) {
     return net::OK;
   }
 

--- a/browser/net/brave_torrent_redirect_network_delegate_helper.h
+++ b/browser/net/brave_torrent_redirect_network_delegate_helper.h
@@ -20,6 +20,13 @@ class URLRequest;
 
 namespace webtorrent {
 
+// Determines whether a request should be redirected to a torrent file. This
+// will occur if the following conditions are met:
+// 1. The request succeeded
+// 2. The request is
+// 3. WebTorrent is enabled
+// 4. The request is for a torrent file / or the WebTorrent extension initiated
+// the request.
 bool ShouldRedirectRequest(
     const net::HttpResponseHeaders* original_response_headers,
     std::shared_ptr<brave::BraveRequestInfo> ctx);

--- a/browser/net/brave_torrent_redirect_network_delegate_helper.h
+++ b/browser/net/brave_torrent_redirect_network_delegate_helper.h
@@ -20,7 +20,7 @@ class URLRequest;
 
 namespace webtorrent {
 
-bool IsNonWebTorrentRequest(
+bool ShouldRedirectRequest(
     const net::HttpResponseHeaders* original_response_headers,
     std::shared_ptr<brave::BraveRequestInfo> ctx);
 

--- a/browser/net/brave_torrent_redirect_network_delegate_helper.h
+++ b/browser/net/brave_torrent_redirect_network_delegate_helper.h
@@ -23,7 +23,7 @@ namespace webtorrent {
 // Determines whether a request should be redirected to a torrent file. This
 // will occur if the following conditions are met:
 // 1. The request succeeded
-// 2. The request is
+// 2. The request is in the Main frame
 // 3. WebTorrent is enabled
 // 4. The request is for a torrent file / or the WebTorrent extension initiated
 // the request.

--- a/browser/net/brave_torrent_redirect_network_delegate_helper.h
+++ b/browser/net/brave_torrent_redirect_network_delegate_helper.h
@@ -20,6 +20,10 @@ class URLRequest;
 
 namespace webtorrent {
 
+bool IsNonWebTorrentRequest(
+    const net::HttpResponseHeaders* original_response_headers,
+    std::shared_ptr<brave::BraveRequestInfo> ctx);
+
 int OnHeadersReceived_TorrentRedirectWork(
     const net::HttpResponseHeaders* original_response_headers,
     scoped_refptr<net::HttpResponseHeaders>* override_response_headers,

--- a/browser/net/brave_torrent_redirect_network_delegate_helper_browsertest.cc
+++ b/browser/net/brave_torrent_redirect_network_delegate_helper_browsertest.cc
@@ -1,0 +1,131 @@
+// Copyright (c) 2023 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#include <memory>
+#include <string>
+
+#include "base/command_line.h"
+#include "base/strings/string_util.h"
+#include "brave/browser/net/url_context.h"
+#include "chrome/browser/profiles/profile.h"
+#include "chrome/browser/ui/browser.h"
+#include "chrome/browser/ui/browser_navigator.h"
+#include "chrome/browser/ui/browser_navigator_params.h"
+#include "chrome/test/base/in_process_browser_test.h"
+#include "chrome/test/base/ui_test_utils.h"
+#include "content/public/browser/navigation_entry.h"
+#include "content/public/browser/notification_service.h"
+#include "content/public/browser/web_contents.h"
+#include "content/public/common/page_type.h"
+#include "content/public/test/browser_test.h"
+#include "content/public/test/browser_test_utils.h"
+#include "content/public/test/content_mock_cert_verifier.h"
+#include "net/dns/mock_host_resolver.h"
+#include "net/test/embedded_test_server/http_request.h"
+#include "net/test/embedded_test_server/http_response.h"
+#include "testing/gtest/include/gtest/gtest.h"
+#include "url/gurl.h"
+
+using brave::ResponseCallback;
+
+class BraveTorrentRedirectNetworkDelegateHelperTest
+    : public InProcessBrowserTest {
+ public:
+  BraveTorrentRedirectNetworkDelegateHelperTest()
+      : https_server_(net::EmbeddedTestServer::TYPE_HTTPS) {}
+
+  void SetUpOnMainThread() override {
+    InProcessBrowserTest::SetUpOnMainThread();
+    mock_cert_verifier_.mock_cert_verifier()->set_default_result(net::OK);
+    host_resolver()->AddRule("*", "127.0.0.1");
+
+    https_server_.RegisterRequestHandler(base::BindRepeating(
+        &BraveTorrentRedirectNetworkDelegateHelperTest::HandleRequest,
+        base::Unretained(this)));
+
+    ASSERT_TRUE(https_server_.Start());
+  }
+
+  std::unique_ptr<net::test_server::HttpResponse> HandleRequest(
+      const net::test_server::HttpRequest& request) {
+    auto relative_url = request.relative_url;
+    if (base::EndsWith(relative_url, ".torrent")) {
+      auto response = std::make_unique<net::test_server::BasicHttpResponse>();
+      response->set_code(net::HTTP_OK);
+      response->set_content("a torrent file");
+      response->set_content_type("application/x-bittorrent");
+      return response;
+    }
+    return nullptr;
+  }
+
+  void SetUpCommandLine(base::CommandLine* command_line) override {
+    InProcessBrowserTest::SetUpCommandLine(command_line);
+    mock_cert_verifier_.SetUpCommandLine(command_line);
+  }
+
+  void SetUpInProcessBrowserTestFixture() override {
+    InProcessBrowserTest::SetUpInProcessBrowserTestFixture();
+    mock_cert_verifier_.SetUpInProcessBrowserTestFixture();
+  }
+
+  void TearDownInProcessBrowserTestFixture() override {
+    mock_cert_verifier_.TearDownInProcessBrowserTestFixture();
+    InProcessBrowserTest::TearDownInProcessBrowserTestFixture();
+  }
+
+  GURL torrent_url() {
+    return https_server_.GetURL("webtorrent.io", "/sintel.torrent");
+  }
+
+  GURL torrent_extension_url() {
+    return GURL(
+        "chrome-extension://lgjmpdmojkpocjcopdikifhejkkjglho/extension/"
+        "brave_webtorrent2.html?https://webtorrent.io/torrents/sintel.torrent");
+  }
+
+  content::WebContents* contents() {
+    return browser()->tab_strip_model()->GetActiveWebContents();
+  }
+
+  void NavigateToURLAndWaitForRedirects(const GURL& original_url) {
+    ui_test_utils::UrlLoadObserver load_complete(
+        original_url, content::NotificationService::AllSources());
+    ASSERT_TRUE(ui_test_utils::NavigateToURL(browser(), original_url));
+    EXPECT_EQ(contents()->GetPrimaryMainFrame()->GetLastCommittedURL(),
+              original_url);
+    load_complete.Wait();
+  }
+
+ private:
+  content::ContentMockCertVerifier mock_cert_verifier_;
+  net::test_server::EmbeddedTestServer https_server_;
+};
+
+IN_PROC_BROWSER_TEST_F(BraveTorrentRedirectNetworkDelegateHelperTest,
+                       TorrentFileIsRedirected) {
+  auto* contents = browser()->tab_strip_model()->GetActiveWebContents();
+
+  NavigateParams params(browser(), torrent_url(),
+                        ui::PageTransition::PAGE_TRANSITION_LINK);
+
+  Navigate(&params);
+  content::WaitForLoadStop(contents);
+  EXPECT_EQ("webtorrent:" + torrent_url().spec(), contents->GetVisibleURL());
+}
+
+IN_PROC_BROWSER_TEST_F(BraveTorrentRedirectNetworkDelegateHelperTest,
+                       LinkToExtensionFails) {
+  auto* contents = browser()->tab_strip_model()->GetActiveWebContents();
+
+  NavigateParams params(browser(), torrent_extension_url(),
+                        ui::PageTransition::PAGE_TRANSITION_LINK);
+
+  Navigate(&params);
+  content::WaitForLoadStop(contents);
+
+  EXPECT_EQ(content::PageType::PAGE_TYPE_ERROR,
+            contents->GetController().GetLastCommittedEntry()->GetPageType());
+}

--- a/browser/net/brave_torrent_redirect_network_delegate_helper_unittest.cc
+++ b/browser/net/brave_torrent_redirect_network_delegate_helper_unittest.cc
@@ -98,7 +98,7 @@ TEST_F(BraveTorrentRedirectNetworkDelegateHelperTest,
   auto request_info = std::make_shared<brave::BraveRequestInfo>(torrent_url());
   request_info->resource_type = blink::mojom::ResourceType::kMainFrame;
 
-  auto will_redirect = !webtorrent::IsNonWebTorrentRequest(
+  auto will_redirect = webtorrent::ShouldRedirectRequest(
       orig_response_headers.get(), request_info);
   EXPECT_TRUE(will_redirect);
 }
@@ -118,7 +118,7 @@ TEST_F(BraveTorrentRedirectNetworkDelegateHelperTest,
   auto request_info = std::make_shared<brave::BraveRequestInfo>(torrent_url());
   request_info->resource_type = blink::mojom::ResourceType::kMainFrame;
 
-  auto will_redirect = !webtorrent::IsNonWebTorrentRequest(
+  auto will_redirect = webtorrent::ShouldRedirectRequest(
       orig_response_headers.get(), request_info);
   EXPECT_TRUE(will_redirect);
 }
@@ -144,7 +144,7 @@ TEST_F(BraveTorrentRedirectNetworkDelegateHelperTest,
       std::make_shared<brave::BraveRequestInfo>(non_torrent_url());
   request_info->resource_type = blink::mojom::ResourceType::kMainFrame;
 
-  auto will_redirect = !webtorrent::IsNonWebTorrentRequest(
+  auto will_redirect = webtorrent::ShouldRedirectRequest(
       orig_response_headers.get(), request_info);
   EXPECT_TRUE(will_redirect);
 }
@@ -165,7 +165,7 @@ TEST_F(BraveTorrentRedirectNetworkDelegateHelperTest,
       std::make_shared<brave::BraveRequestInfo>(non_torrent_url());
   request_info->resource_type = blink::mojom::ResourceType::kMainFrame;
 
-  EXPECT_TRUE(webtorrent::IsNonWebTorrentRequest(orig_response_headers.get(),
+  EXPECT_FALSE(webtorrent::ShouldRedirectRequest(orig_response_headers.get(),
                                                  request_info));
 }
 
@@ -183,7 +183,7 @@ TEST_F(BraveTorrentRedirectNetworkDelegateHelperTest, MimeTypeNoRedirect) {
   auto request_info = std::make_shared<brave::BraveRequestInfo>(torrent_url());
   request_info->resource_type = blink::mojom::ResourceType::kMainFrame;
 
-  EXPECT_TRUE(webtorrent::IsNonWebTorrentRequest(orig_response_headers.get(),
+  EXPECT_FALSE(webtorrent::ShouldRedirectRequest(orig_response_headers.get(),
                                                  request_info));
 }
 
@@ -203,7 +203,7 @@ TEST_F(BraveTorrentRedirectNetworkDelegateHelperTest,
   request_info->initiator_url = torrent_extension_url();
   request_info->resource_type = blink::mojom::ResourceType::kMainFrame;
 
-  EXPECT_TRUE(webtorrent::IsNonWebTorrentRequest(orig_response_headers.get(),
+  EXPECT_FALSE(webtorrent::ShouldRedirectRequest(orig_response_headers.get(),
                                                  request_info));
 }
 
@@ -224,7 +224,7 @@ TEST_F(BraveTorrentRedirectNetworkDelegateHelperTest,
   request_info->initiator_url = torrent_extension_url();
   request_info->resource_type = blink::mojom::ResourceType::kMainFrame;
 
-  auto will_redirect = !webtorrent::IsNonWebTorrentRequest(
+  auto will_redirect = webtorrent::ShouldRedirectRequest(
       orig_response_headers.get(), request_info);
   EXPECT_TRUE(will_redirect);
 }
@@ -244,6 +244,6 @@ TEST_F(BraveTorrentRedirectNetworkDelegateHelperTest,
   auto request_info = std::make_shared<brave::BraveRequestInfo>(torrent_url());
   request_info->resource_type = blink::mojom::ResourceType::kXhr;
 
-  EXPECT_TRUE(webtorrent::IsNonWebTorrentRequest(orig_response_headers.get(),
+  EXPECT_FALSE(webtorrent::ShouldRedirectRequest(orig_response_headers.get(),
                                                  request_info));
 }

--- a/browser/net/brave_torrent_redirect_network_delegate_helper_unittest.cc
+++ b/browser/net/brave_torrent_redirect_network_delegate_helper_unittest.cc
@@ -88,9 +88,9 @@ TEST_F(BraveTorrentRedirectNetworkDelegateHelperTest,
   scoped_refptr<net::HttpResponseHeaders> orig_response_headers =
       new net::HttpResponseHeaders(std::string());
   orig_response_headers->AddHeader("Content-Type", kBittorrentMimeType);
-  std::string mimeType;
-  ASSERT_TRUE(orig_response_headers->GetMimeType(&mimeType));
-  ASSERT_EQ(mimeType, kBittorrentMimeType);
+  std::string mime_type;
+  ASSERT_TRUE(orig_response_headers->GetMimeType(&mime_type));
+  ASSERT_EQ(mime_type, kBittorrentMimeType);
 
   scoped_refptr<net::HttpResponseHeaders> overwrite_response_headers =
       new net::HttpResponseHeaders(std::string());
@@ -98,18 +98,9 @@ TEST_F(BraveTorrentRedirectNetworkDelegateHelperTest,
   auto request_info = std::make_shared<brave::BraveRequestInfo>(torrent_url());
   request_info->resource_type = blink::mojom::ResourceType::kMainFrame;
 
-  int rc = webtorrent::OnHeadersReceived_TorrentRedirectWork(
-      orig_response_headers.get(), &overwrite_response_headers,
-      &allowed_unsafe_redirect_url, ResponseCallback(), request_info);
-
-  EXPECT_EQ(overwrite_response_headers->GetStatusLine(),
-            "HTTP/1.1 307 Temporary Redirect");
-  std::string location;
-  EXPECT_TRUE(overwrite_response_headers->EnumerateHeader(nullptr, "Location",
-                                                          &location));
-  EXPECT_EQ(location, torrent_extension_url().spec());
-  EXPECT_EQ(allowed_unsafe_redirect_url.spec(), torrent_extension_url().spec());
-  EXPECT_EQ(rc, net::OK);
+  auto will_redirect = !webtorrent::IsNonWebTorrentRequest(
+      orig_response_headers.get(), request_info);
+  EXPECT_TRUE(will_redirect);
 }
 
 TEST_F(BraveTorrentRedirectNetworkDelegateHelperTest,
@@ -127,18 +118,9 @@ TEST_F(BraveTorrentRedirectNetworkDelegateHelperTest,
   auto request_info = std::make_shared<brave::BraveRequestInfo>(torrent_url());
   request_info->resource_type = blink::mojom::ResourceType::kMainFrame;
 
-  int rc = webtorrent::OnHeadersReceived_TorrentRedirectWork(
-      orig_response_headers.get(), &overwrite_response_headers,
-      &allowed_unsafe_redirect_url, ResponseCallback(), request_info);
-
-  EXPECT_EQ(overwrite_response_headers->GetStatusLine(),
-            "HTTP/1.1 307 Temporary Redirect");
-  std::string location;
-  EXPECT_TRUE(overwrite_response_headers->EnumerateHeader(nullptr, "Location",
-                                                          &location));
-  EXPECT_EQ(location, torrent_extension_url().spec());
-  EXPECT_EQ(allowed_unsafe_redirect_url.spec(), torrent_extension_url().spec());
-  EXPECT_EQ(rc, net::OK);
+  auto will_redirect = !webtorrent::IsNonWebTorrentRequest(
+      orig_response_headers.get(), request_info);
+  EXPECT_TRUE(will_redirect);
 }
 
 TEST_F(BraveTorrentRedirectNetworkDelegateHelperTest,
@@ -162,19 +144,9 @@ TEST_F(BraveTorrentRedirectNetworkDelegateHelperTest,
       std::make_shared<brave::BraveRequestInfo>(non_torrent_url());
   request_info->resource_type = blink::mojom::ResourceType::kMainFrame;
 
-  int rc = webtorrent::OnHeadersReceived_TorrentRedirectWork(
-      orig_response_headers.get(), &overwrite_response_headers,
-      &allowed_unsafe_redirect_url, ResponseCallback(), request_info);
-
-  EXPECT_EQ(overwrite_response_headers->GetStatusLine(),
-            "HTTP/1.1 307 Temporary Redirect");
-  std::string location;
-  EXPECT_TRUE(overwrite_response_headers->EnumerateHeader(nullptr, "Location",
-                                                          &location));
-  EXPECT_EQ(location, non_torrent_extension_url().spec());
-  EXPECT_EQ(allowed_unsafe_redirect_url.spec(),
-            non_torrent_extension_url().spec());
-  EXPECT_EQ(rc, net::OK);
+  auto will_redirect = !webtorrent::IsNonWebTorrentRequest(
+      orig_response_headers.get(), request_info);
+  EXPECT_TRUE(will_redirect);
 }
 
 TEST_F(BraveTorrentRedirectNetworkDelegateHelperTest,
@@ -182,9 +154,9 @@ TEST_F(BraveTorrentRedirectNetworkDelegateHelperTest,
   scoped_refptr<net::HttpResponseHeaders> orig_response_headers =
       new net::HttpResponseHeaders(std::string());
   orig_response_headers->AddHeader("Content-Type", kOctetStreamMimeType);
-  std::string mimeType;
-  ASSERT_TRUE(orig_response_headers->GetMimeType(&mimeType));
-  ASSERT_EQ(mimeType, kOctetStreamMimeType);
+  std::string mime_type;
+  ASSERT_TRUE(orig_response_headers->GetMimeType(&mime_type));
+  ASSERT_EQ(mime_type, kOctetStreamMimeType);
 
   scoped_refptr<net::HttpResponseHeaders> overwrite_response_headers =
       new net::HttpResponseHeaders(std::string());
@@ -193,25 +165,17 @@ TEST_F(BraveTorrentRedirectNetworkDelegateHelperTest,
       std::make_shared<brave::BraveRequestInfo>(non_torrent_url());
   request_info->resource_type = blink::mojom::ResourceType::kMainFrame;
 
-  int rc = webtorrent::OnHeadersReceived_TorrentRedirectWork(
-      orig_response_headers.get(), &overwrite_response_headers,
-      &allowed_unsafe_redirect_url, ResponseCallback(), request_info);
-
-  EXPECT_EQ(overwrite_response_headers->GetStatusLine(), "HTTP/1.0 200 OK");
-  std::string location;
-  EXPECT_FALSE(overwrite_response_headers->EnumerateHeader(nullptr, "Location",
-                                                           &location));
-  EXPECT_EQ(allowed_unsafe_redirect_url, GURL());
-  EXPECT_EQ(rc, net::OK);
+  EXPECT_TRUE(webtorrent::IsNonWebTorrentRequest(orig_response_headers.get(),
+                                                 request_info));
 }
 
 TEST_F(BraveTorrentRedirectNetworkDelegateHelperTest, MimeTypeNoRedirect) {
   scoped_refptr<net::HttpResponseHeaders> orig_response_headers =
       new net::HttpResponseHeaders(std::string());
   orig_response_headers->AddHeader("Content-Type", "text/html");
-  std::string mimeType;
-  ASSERT_TRUE(orig_response_headers->GetMimeType(&mimeType));
-  ASSERT_EQ(mimeType, "text/html");
+  std::string mime_type;
+  ASSERT_TRUE(orig_response_headers->GetMimeType(&mime_type));
+  ASSERT_EQ(mime_type, "text/html");
 
   scoped_refptr<net::HttpResponseHeaders> overwrite_response_headers =
       new net::HttpResponseHeaders(std::string());
@@ -219,16 +183,8 @@ TEST_F(BraveTorrentRedirectNetworkDelegateHelperTest, MimeTypeNoRedirect) {
   auto request_info = std::make_shared<brave::BraveRequestInfo>(torrent_url());
   request_info->resource_type = blink::mojom::ResourceType::kMainFrame;
 
-  int rc = webtorrent::OnHeadersReceived_TorrentRedirectWork(
-      orig_response_headers.get(), &overwrite_response_headers,
-      &allowed_unsafe_redirect_url, ResponseCallback(), request_info);
-
-  EXPECT_EQ(overwrite_response_headers->GetStatusLine(), "HTTP/1.0 200 OK");
-  std::string location;
-  EXPECT_FALSE(overwrite_response_headers->EnumerateHeader(nullptr, "Location",
-                                                           &location));
-  EXPECT_EQ(allowed_unsafe_redirect_url, GURL());
-  EXPECT_EQ(rc, net::OK);
+  EXPECT_TRUE(webtorrent::IsNonWebTorrentRequest(orig_response_headers.get(),
+                                                 request_info));
 }
 
 TEST_F(BraveTorrentRedirectNetworkDelegateHelperTest,
@@ -236,9 +192,9 @@ TEST_F(BraveTorrentRedirectNetworkDelegateHelperTest,
   scoped_refptr<net::HttpResponseHeaders> orig_response_headers =
       new net::HttpResponseHeaders(std::string());
   orig_response_headers->AddHeader("Content-Type", kBittorrentMimeType);
-  std::string mimeType;
-  ASSERT_TRUE(orig_response_headers->GetMimeType(&mimeType));
-  ASSERT_EQ(mimeType, kBittorrentMimeType);
+  std::string mime_type;
+  ASSERT_TRUE(orig_response_headers->GetMimeType(&mime_type));
+  ASSERT_EQ(mime_type, kBittorrentMimeType);
 
   scoped_refptr<net::HttpResponseHeaders> overwrite_response_headers =
       new net::HttpResponseHeaders(std::string());
@@ -247,16 +203,8 @@ TEST_F(BraveTorrentRedirectNetworkDelegateHelperTest,
   request_info->initiator_url = torrent_extension_url();
   request_info->resource_type = blink::mojom::ResourceType::kMainFrame;
 
-  int rc = webtorrent::OnHeadersReceived_TorrentRedirectWork(
-      orig_response_headers.get(), &overwrite_response_headers,
-      &allowed_unsafe_redirect_url, ResponseCallback(), request_info);
-
-  EXPECT_EQ(overwrite_response_headers->GetStatusLine(), "HTTP/1.0 200 OK");
-  std::string location;
-  EXPECT_FALSE(overwrite_response_headers->EnumerateHeader(nullptr, "Location",
-                                                           &location));
-  EXPECT_EQ(allowed_unsafe_redirect_url, GURL());
-  EXPECT_EQ(rc, net::OK);
+  EXPECT_TRUE(webtorrent::IsNonWebTorrentRequest(orig_response_headers.get(),
+                                                 request_info));
 }
 
 TEST_F(BraveTorrentRedirectNetworkDelegateHelperTest,
@@ -264,9 +212,9 @@ TEST_F(BraveTorrentRedirectNetworkDelegateHelperTest,
   scoped_refptr<net::HttpResponseHeaders> orig_response_headers =
       new net::HttpResponseHeaders(std::string());
   orig_response_headers->AddHeader("Content-Type", kBittorrentMimeType);
-  std::string mimeType;
-  ASSERT_TRUE(orig_response_headers->GetMimeType(&mimeType));
-  ASSERT_EQ(mimeType, kBittorrentMimeType);
+  std::string mime_type;
+  ASSERT_TRUE(orig_response_headers->GetMimeType(&mime_type));
+  ASSERT_EQ(mime_type, kBittorrentMimeType);
 
   scoped_refptr<net::HttpResponseHeaders> overwrite_response_headers =
       new net::HttpResponseHeaders(std::string());
@@ -276,19 +224,9 @@ TEST_F(BraveTorrentRedirectNetworkDelegateHelperTest,
   request_info->initiator_url = torrent_extension_url();
   request_info->resource_type = blink::mojom::ResourceType::kMainFrame;
 
-  int rc = webtorrent::OnHeadersReceived_TorrentRedirectWork(
-      orig_response_headers.get(), &overwrite_response_headers,
-      &allowed_unsafe_redirect_url, ResponseCallback(), request_info);
-
-  EXPECT_EQ(overwrite_response_headers->GetStatusLine(),
-            "HTTP/1.1 307 Temporary Redirect");
-  std::string location;
-  EXPECT_TRUE(overwrite_response_headers->EnumerateHeader(nullptr, "Location",
-                                                          &location));
-  EXPECT_EQ(location, torrent_viewer_extension_url().spec());
-  EXPECT_EQ(allowed_unsafe_redirect_url.spec(),
-            torrent_viewer_extension_url().spec());
-  EXPECT_EQ(rc, net::OK);
+  auto will_redirect = !webtorrent::IsNonWebTorrentRequest(
+      orig_response_headers.get(), request_info);
+  EXPECT_TRUE(will_redirect);
 }
 
 TEST_F(BraveTorrentRedirectNetworkDelegateHelperTest,
@@ -296,9 +234,9 @@ TEST_F(BraveTorrentRedirectNetworkDelegateHelperTest,
   scoped_refptr<net::HttpResponseHeaders> orig_response_headers =
       new net::HttpResponseHeaders(std::string());
   orig_response_headers->AddHeader("Content-Type", kBittorrentMimeType);
-  std::string mimeType;
-  ASSERT_TRUE(orig_response_headers->GetMimeType(&mimeType));
-  ASSERT_EQ(mimeType, kBittorrentMimeType);
+  std::string mime_type;
+  ASSERT_TRUE(orig_response_headers->GetMimeType(&mime_type));
+  ASSERT_EQ(mime_type, kBittorrentMimeType);
 
   scoped_refptr<net::HttpResponseHeaders> overwrite_response_headers =
       new net::HttpResponseHeaders(std::string());
@@ -306,26 +244,6 @@ TEST_F(BraveTorrentRedirectNetworkDelegateHelperTest,
   auto request_info = std::make_shared<brave::BraveRequestInfo>(torrent_url());
   request_info->resource_type = blink::mojom::ResourceType::kXhr;
 
-  int rc = webtorrent::OnHeadersReceived_TorrentRedirectWork(
-      orig_response_headers.get(), &overwrite_response_headers,
-      &allowed_unsafe_redirect_url, ResponseCallback(), request_info);
-
-  EXPECT_EQ(overwrite_response_headers->GetStatusLine(), "HTTP/1.0 200 OK");
-  std::string location;
-  EXPECT_FALSE(overwrite_response_headers->EnumerateHeader(nullptr, "Location",
-                                                           &location));
-  EXPECT_EQ(allowed_unsafe_redirect_url, GURL());
-  EXPECT_EQ(rc, net::OK);
-
-  request_info->resource_type = blink::mojom::ResourceType::kSubFrame;
-
-  rc = webtorrent::OnHeadersReceived_TorrentRedirectWork(
-      orig_response_headers.get(), &overwrite_response_headers,
-      &allowed_unsafe_redirect_url, ResponseCallback(), request_info);
-
-  EXPECT_EQ(overwrite_response_headers->GetStatusLine(), "HTTP/1.0 200 OK");
-  EXPECT_FALSE(overwrite_response_headers->EnumerateHeader(nullptr, "Location",
-                                                           &location));
-  EXPECT_EQ(allowed_unsafe_redirect_url, GURL());
-  EXPECT_EQ(rc, net::OK);
+  EXPECT_TRUE(webtorrent::IsNonWebTorrentRequest(orig_response_headers.get(),
+                                                 request_info));
 }

--- a/browser/net/brave_torrent_redirect_network_delegate_helper_unittest.cc
+++ b/browser/net/brave_torrent_redirect_network_delegate_helper_unittest.cc
@@ -1,7 +1,7 @@
-/* Copyright 2019 The Brave Authors. All rights reserved.
- * This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this file,
- * You can obtain one at http://mozilla.org/MPL/2.0/. */
+// Copyright (c) 2019 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
 
 #include "brave/browser/net/brave_torrent_redirect_network_delegate_helper.h"
 

--- a/components/brave_webtorrent/extension/manifest.json
+++ b/components/brave_webtorrent/extension/manifest.json
@@ -7,10 +7,6 @@
     "scripts": ["extension/out/brave_webtorrent_background.bundle.js"],
     "persistent": false
   },
-  "web_accessible_resources": [
-    "extension/brave_webtorrent.html",
-    "extension/brave_webtorrent2.html"
-  ],
   "permissions": [
     "downloads",
     "dns",


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/33163

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [ ] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

1. Open https://webtorrent.io/free-torrents
2. The torrent file & magnet link links should trigger webtorrent to open
3. Open https://j5q9w7.csb.app/ (my fake phising site)
4. Clicking the "Check for viruses" link should result in the page being blocked
5. Clicking the "Check for viruses (direct)" link should result in a 404 page on microsoft.com