### PR TITLE
Redefine upstream build flag in a safer way

### DIFF
--- a/chromium_src/chrome/browser/active_use_util.cc
+++ b/chromium_src/chrome/browser/active_use_util.cc
@@ -7,12 +7,12 @@
 #include "chrome/install_static/buildflags.h"
 
 #if BUILDFLAG(IS_WIN) && defined(OFFICIAL_BUILD)
-#undef BUILDFLAG_INTERNAL_USE_GOOGLE_UPDATE_INTEGRATION
+#include "chrome/install_static/brave_stash_google_update_integration.h"
 #define BUILDFLAG_INTERNAL_USE_GOOGLE_UPDATE_INTEGRATION() (1)
 #endif
 
 #include "src/chrome/browser/active_use_util.cc"
 
 #if BUILDFLAG(IS_WIN) && defined(OFFICIAL_BUILD)
-#undef BUILDFLAG_INTERNAL_USE_GOOGLE_UPDATE_INTEGRATION
+#include "chrome/install_static/brave_restore_google_update_integration.h"
 #endif

--- a/chromium_src/chrome/browser/metrics/google_update_metrics_provider_win.cc
+++ b/chromium_src/chrome/browser/metrics/google_update_metrics_provider_win.cc
@@ -9,12 +9,12 @@
 #include "chrome/install_static/install_constants.h"
 
 #if defined(OFFICIAL_BUILD)
-#undef BUILDFLAG_INTERNAL_USE_GOOGLE_UPDATE_INTEGRATION
+#include "chrome/install_static/brave_stash_google_update_integration.h"
 #define BUILDFLAG_INTERNAL_USE_GOOGLE_UPDATE_INTEGRATION() (0)
 #endif
 
 #include "src/chrome/browser/metrics/google_update_metrics_provider_win.cc"
 
 #if defined(OFFICIAL_BUILD)
-#undef BUILDFLAG_INTERNAL_USE_GOOGLE_UPDATE_INTEGRATION
+#include "chrome/install_static/brave_restore_google_update_integration.h"
 #endif

--- a/chromium_src/chrome/install_static/brave_restore_google_update_integration.h
+++ b/chromium_src/chrome/install_static/brave_restore_google_update_integration.h
@@ -1,0 +1,22 @@
+/* Copyright (c) 2023 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+// Include this file to restore BUILDFLAG_INTERNAL_USE_GOOGLE_UPDATE_INTEGRATION
+// after stashing its value via brave_stash_google_update_integration.h.
+
+// NOLINT(build/header_guard)
+// no-include-guard-because-multiply-included
+
+#undef BUILDFLAG_INTERNAL_USE_GOOGLE_UPDATE_INTEGRATION
+
+#ifdef BUILDFLAG_INTERNAL_USE_GOOGLE_UPDATE_INTEGRATION_WAS_0
+#define BUILDFLAG_INTERNAL_USE_GOOGLE_UPDATE_INTEGRATION() (0)
+#undef BUILDFLAG_INTERNAL_USE_GOOGLE_UPDATE_INTEGRATION_WAS_0
+#endif
+
+#ifdef BUILDFLAG_INTERNAL_USE_GOOGLE_UPDATE_INTEGRATION_WAS_1
+#define BUILDFLAG_INTERNAL_USE_GOOGLE_UPDATE_INTEGRATION() (1)
+#undef BUILDFLAG_INTERNAL_USE_GOOGLE_UPDATE_INTEGRATION_WAS_1
+#endif

--- a/chromium_src/chrome/install_static/brave_stash_google_update_integration.h
+++ b/chromium_src/chrome/install_static/brave_stash_google_update_integration.h
@@ -1,0 +1,31 @@
+/* Copyright (c) 2023 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+// This file is a helper for temporarily changing or setting the value of
+// BUILDFLAG_INTERNAL_USE_GOOGLE_UPDATE_INTEGRATION. To use it, include this
+// file and define a new value for the flag. Later, you can then restore the
+// flag's original value by including brave_restore_google_update_integration.h.
+
+// NOLINT(build/header_guard)
+// no-include-guard-because-multiply-included
+
+#ifdef BUILDFLAG_INTERNAL_USE_GOOGLE_UPDATE_INTEGRATION
+
+#if defined(BUILDFLAG_INTERNAL_USE_GOOGLE_UPDATE_INTEGRATION_WAS_0) || \
+    defined(BUILDFLAG_INTERNAL_USE_GOOGLE_UPDATE_INTEGRATION_WAS_1)
+#error This helper template does not support nesting.
+#endif
+
+#if BUILDFLAG_INTERNAL_USE_GOOGLE_UPDATE_INTEGRATION() == 0
+#define BUILDFLAG_INTERNAL_USE_GOOGLE_UPDATE_INTEGRATION_WAS_0
+#elif BUILDFLAG_INTERNAL_USE_GOOGLE_UPDATE_INTEGRATION() == 1
+#define BUILDFLAG_INTERNAL_USE_GOOGLE_UPDATE_INTEGRATION_WAS_1
+#else
+#error Unexpected value.
+#endif
+
+#undef BUILDFLAG_INTERNAL_USE_GOOGLE_UPDATE_INTEGRATION
+
+#endif  // BUILDFLAG_INTERNAL_USE_GOOGLE_UPDATE_INTEGRATION

--- a/chromium_src/chrome/install_static/install_constants.h
+++ b/chromium_src/chrome/install_static/install_constants.h
@@ -1,7 +1,7 @@
-/* Copyright 2021 The Brave Authors. All rights reserved.
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
- * You can obtain one at http://mozilla.org/MPL/2.0/. */
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 // Brand-specific types and constants for Google Chrome.
 
@@ -9,15 +9,19 @@
 #define BRAVE_CHROMIUM_SRC_CHROME_INSTALL_STATIC_INSTALL_CONSTANTS_H_
 
 #if defined(OFFICIAL_BUILD)
+// clang-format off
+// NOLINTBEGIN(sort-order)
 #include "chrome/install_static/buildflags.h"
-#undef BUILDFLAG_INTERNAL_USE_GOOGLE_UPDATE_INTEGRATION
+#include "chrome/install_static/brave_stash_google_update_integration.h"
 #define BUILDFLAG_INTERNAL_USE_GOOGLE_UPDATE_INTEGRATION() (1)
-#endif
+// NOLINTEND(sort-order)
+// clang-format on
+#endif  // defined(OFFICIAL_BUILD)
 
 #include "src/chrome/install_static/install_constants.h"  // IWYU pragma: export
 
 #if defined(OFFICIAL_BUILD)
-#undef BUILDFLAG_INTERNAL_USE_GOOGLE_UPDATE_INTEGRATION
+#include "chrome/install_static/brave_restore_google_update_integration.h"
 #endif
 
 #endif  // BRAVE_CHROMIUM_SRC_CHROME_INSTALL_STATIC_INSTALL_CONSTANTS_H_

--- a/chromium_src/chrome/install_static/install_util.cc
+++ b/chromium_src/chrome/install_static/install_util.cc
@@ -18,7 +18,7 @@
 #if defined(OFFICIAL_BUILD)
 #undef BUILDFLAG_INTERNAL_GOOGLE_CHROME_BRANDING
 #define BUILDFLAG_INTERNAL_GOOGLE_CHROME_BRANDING() (1)
-#undef BUILDFLAG_INTERNAL_USE_GOOGLE_UPDATE_INTEGRATION
+#include "chrome/install_static/brave_stash_google_update_integration.h"
 #define BUILDFLAG_INTERNAL_USE_GOOGLE_UPDATE_INTEGRATION() (1)
 #endif
 
@@ -30,7 +30,7 @@
 
 #if defined(OFFICIAL_BUILD)
 #undef BUILDFLAG_INTERNAL_GOOGLE_CHROME_BRANDING
-#undef BUILDFLAG_INTERNAL_USE_GOOGLE_UPDATE_INTEGRATION
+#include "chrome/install_static/brave_restore_google_update_integration.h"
 #endif
 
 namespace install_static {

--- a/chromium_src/chrome/installer/setup/install_worker.cc
+++ b/chromium_src/chrome/installer/setup/install_worker.cc
@@ -23,10 +23,14 @@
 #include "chrome/installer/util/work_item_list.h"
 
 #if defined(OFFICIAL_BUILD)
+// clang-format off
+// NOLINTBEGIN(sort-order)
 #include "chrome/install_static/buildflags.h"
 #include "chrome/install_static/install_constants.h"
-#undef BUILDFLAG_INTERNAL_USE_GOOGLE_UPDATE_INTEGRATION
+#include "chrome/install_static/brave_stash_google_update_integration.h"
 #define BUILDFLAG_INTERNAL_USE_GOOGLE_UPDATE_INTEGRATION() (1)
+// NOLINTEND(sort-order)
+// clang-format on
 #endif
 
 #if BUILDFLAG(ENABLE_BRAVE_VPN)
@@ -110,5 +114,5 @@ void AddBraveVPNWireguardServiceWorkItems(
 #undef GetElevationServicePath
 #endif  // BUILDFLAG(ENABLE_BRAVE_VPN)
 #if defined(OFFICIAL_BUILD)
-#undef BUILDFLAG_INTERNAL_USE_GOOGLE_UPDATE_INTEGRATION
+#include "chrome/install_static/brave_restore_google_update_integration.h"
 #endif

--- a/chromium_src/chrome/installer/setup/user_experiment.cc
+++ b/chromium_src/chrome/installer/setup/user_experiment.cc
@@ -6,12 +6,12 @@
 #include "chrome/install_static/buildflags.h"
 
 #if defined(OFFICIAL_BUILD)
-#undef BUILDFLAG_INTERNAL_USE_GOOGLE_UPDATE_INTEGRATION
+#include "chrome/install_static/brave_stash_google_update_integration.h"
 #define BUILDFLAG_INTERNAL_USE_GOOGLE_UPDATE_INTEGRATION() (1)
 #endif
 
 #include "src/chrome/installer/setup/user_experiment.cc"
 
 #if defined(OFFICIAL_BUILD)
-#undef BUILDFLAG_INTERNAL_USE_GOOGLE_UPDATE_INTEGRATION
+#include "chrome/install_static/brave_restore_google_update_integration.h"
 #endif


### PR DESCRIPTION
Resolves https://github.com/brave/brave-browser/issues/33321

The trailing `#undef` in the previous implementation caused problems. Specifically, our build recently broke because upstream transitively included install_constants.h in a file that then relied on the build flag being set. Because we undefined the flag, the code did not compile.

[Test release build](https://ci.brave.com/job/test-brave-browser-build-windows-x64/1104/)

## Why this PR is marked as QA/No

I marked this PR as `QA/No` because I don't think special testing is necessary. First, its changes affect the auto-update functionality and potentially installer, which get tested with every release. Second, according to my reasoning below, the changes should have no functional effect:

The PR replaces every first `#undef BUILDFLAG_INTERNAL_USE_GOOGLE_UPDATE_INTEGRATION` by `#include "brave_stash_google_update_integration.h"`. This header has the same observable effect as the `#undef`.

It also replaces the second `#undef` by `#include brave_restore_google_update_integration.h`. This has a different effect because now `BUILDFLAG_INTERNAL_USE_GOOGLE_UPDATE_INTEGRATION` is defined (instead of undefined). However, no other code is reading that value: no code ever uses `#ifdef` on the flag and if any code were to read the flag then we would have had compilation failures before this PR. So here too the effect is the same.

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

