### PR TITLE
[Android] Don't show brave news optin card for unsupported regions

### DIFF
--- a/android/java/org/chromium/chrome/browser/brave_news/BraveNewsUtils.java
+++ b/android/java/org/chromium/chrome/browser/brave_news/BraveNewsUtils.java
@@ -5,6 +5,7 @@
 
 package org.chromium.chrome.browser.brave_news;
 
+import org.chromium.base.ContextUtils;
 import org.chromium.base.Log;
 import org.chromium.base.task.PostTask;
 import org.chromium.base.task.TaskTraits;
@@ -26,6 +27,7 @@ import org.chromium.chrome.browser.brave_news.models.FeedItemCard;
 import org.chromium.chrome.browser.brave_news.models.FeedItemsCard;
 import org.chromium.chrome.browser.preferences.BravePrefServiceBridge;
 import org.chromium.chrome.browser.settings.BraveNewsPreferencesDataListener;
+import org.chromium.chrome.browser.settings.BraveNewsPreferencesV2;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -126,9 +128,16 @@ public class BraveNewsUtils {
         }
     }
 
-    public static boolean shouldDisplayNews() {
+    public static boolean shouldDisplayNewsFeed() {
         return BravePrefServiceBridge.getInstance().getShowNews()
                 && BravePrefServiceBridge.getInstance().getNewsOptIn();
+    }
+
+    public static boolean shouldDisplayNewsOptin() {
+        return BravePrefServiceBridge.getInstance().getShowNews()
+                && !BravePrefServiceBridge.getInstance().getNewsOptIn()
+                && ContextUtils.getAppSharedPreferences().getBoolean(
+                        BraveNewsPreferencesV2.PREF_SHOW_OPTIN, true);
     }
 
     public static void setChannelIcons() {

--- a/android/java/org/chromium/chrome/browser/ntp/BraveNewTabPageLayout.java
+++ b/android/java/org/chromium/chrome/browser/ntp/BraveNewTabPageLayout.java
@@ -185,7 +185,7 @@ public class BraveNewTabPageLayout
     private boolean mComesFromNewTab;
     private boolean mIsTopSitesEnabled;
     private boolean mIsBraveStatsEnabled;
-    private boolean mIsDisplayNews;
+    private boolean mIsDisplayNewsFeed;
     private boolean mIsDisplayNewsOptin;
     private boolean mNewsFeedViewedOnce;
 
@@ -213,7 +213,7 @@ public class BraveNewTabPageLayout
         mFeedHash = "";
         initBraveNewsController();
         try {
-            if (BraveNewsUtils.shouldDisplayNews()
+            if (BraveNewsUtils.shouldDisplayNewsFeed()
                     && BraveActivity.getBraveActivity().isLoadedFeed()) {
                 CopyOnWriteArrayList<FeedItemsCard> existingNewsFeedObject =
                         BraveActivity.getBraveActivity().getNewsItemsFeedCards();
@@ -318,8 +318,8 @@ public class BraveNewTabPageLayout
             });
         }
 
-        mIsDisplayNewsOptin = shouldDisplayNewsOptin();
-        mIsDisplayNews = BraveNewsUtils.shouldDisplayNews();
+        mIsDisplayNewsOptin = BraveNewsUtils.shouldDisplayNewsOptin();
+        mIsDisplayNewsFeed = BraveNewsUtils.shouldDisplayNewsFeed();
 
         initPreferenceObserver();
         if (mPreferenceObserver != null) {
@@ -394,7 +394,7 @@ public class BraveNewTabPageLayout
                         mNewsItemsFeedCard, mBraveNewsController, mMvTilesContainerLayout,
                         mNtpImageGlobal, mSponsoredTab, mWallpaper, mSponsoredLogo,
                         mNTPBackgroundImagesBridge, false, mRecyclerView.getHeight(),
-                        mIsTopSitesEnabled, mIsBraveStatsEnabled, mIsDisplayNews,
+                        mIsTopSitesEnabled, mIsBraveStatsEnabled, mIsDisplayNewsFeed,
                         mIsDisplayNewsOptin);
 
                 mRecyclerView.setAdapter(mNtpAdapter);
@@ -411,12 +411,12 @@ public class BraveNewTabPageLayout
             mNtpAdapter.setRecyclerViewHeight(mRecyclerView.getHeight());
             mNtpAdapter.setTopSitesEnabled(mIsTopSitesEnabled);
             mNtpAdapter.setBraveStatsEnabled(mIsBraveStatsEnabled);
-            mNtpAdapter.setDisplayNews(mIsDisplayNews);
+            mNtpAdapter.setDisplayNewsFeed(mIsDisplayNewsFeed);
         }
 
         if (mNtpAdapter == null) return;
 
-        if (mIsDisplayNews) {
+        if (mIsDisplayNewsFeed) {
             try {
                 boolean isFeedLoaded = BraveActivity.getBraveActivity().isLoadedFeed();
                 boolean isFromNewTab = BraveActivity.getBraveActivity().isComesFromNewTab();
@@ -487,7 +487,7 @@ public class BraveNewTabPageLayout
                         Log.e(TAG, "onScrollStateChanged " + e);
                     }
                 }
-                if (mIsDisplayNews && firstVisibleItemPosition >= newsFeedPosition - 1) {
+                if (mIsDisplayNewsFeed && firstVisibleItemPosition >= newsFeedPosition - 1) {
                     if (!mNewsFeedViewedOnce && mBraveNewsController != null) {
                         // Brave News interaction started
                         mBraveNewsController.onInteractionSessionStarted();
@@ -677,7 +677,7 @@ public class BraveNewTabPageLayout
             public void onScrolled(@NonNull RecyclerView recyclerView, int dx, int dy) {
                 super.onScrolled(recyclerView, dx, dy);
 
-                if (mIsDisplayNews) {
+                if (mIsDisplayNewsFeed) {
                     int lastVisibleItemPosition =
                             linearLayoutManager.findLastCompletelyVisibleItemPosition();
 
@@ -776,19 +776,14 @@ public class BraveNewTabPageLayout
         BravePrefServiceBridge.getInstance().setShowNews(isOptin);
 
         mIsDisplayNewsOptin = false;
-        mIsDisplayNews = isOptin;
+        mIsDisplayNewsFeed = isOptin;
         mNtpAdapter.removeNewsOptin();
         mNtpAdapter.setImageCreditAlpha(1f);
-        mNtpAdapter.setDisplayNews(mIsDisplayNews);
+        mNtpAdapter.setDisplayNewsFeed(mIsDisplayNewsFeed);
 
         if (isOptin && mBraveNewsController != null && BraveNewsUtils.getLocale() == null) {
             BraveNewsUtils.getBraveNewsSettingsData(mBraveNewsController, null);
         }
-    }
-
-    private boolean shouldDisplayNewsOptin() {
-        return ContextUtils.getAppSharedPreferences().getBoolean(
-                BraveNewsPreferencesV2.PREF_SHOW_OPTIN, true);
     }
 
     private void initPreferenceObserver() {
@@ -1005,9 +1000,9 @@ public class BraveNewTabPageLayout
 
     private void refreshFeed() {
         boolean isShowNewsOn = BravePrefServiceBridge.getInstance().getShowNews();
-        mIsDisplayNews = BraveNewsUtils.shouldDisplayNews();
+        mIsDisplayNewsFeed = BraveNewsUtils.shouldDisplayNewsFeed();
         if (!isShowNewsOn) {
-            mNtpAdapter.setDisplayNews(mIsDisplayNews);
+            mNtpAdapter.setDisplayNewsFeed(false);
 
             if (mNtpAdapter.isNewContent()) {
                 mPrevVisibleNewsCardPosition = mPrevVisibleNewsCardPosition - 1;
@@ -1018,13 +1013,13 @@ public class BraveNewTabPageLayout
             return;
         }
 
-        if (mIsDisplayNews) {
+        if (mIsDisplayNewsFeed) {
             if (mIsDisplayNewsOptin) {
                 mIsDisplayNewsOptin = false;
                 mNtpAdapter.removeNewsOptin();
                 mNtpAdapter.setImageCreditAlpha(1f);
             }
-            mNtpAdapter.setDisplayNews(mIsDisplayNews);
+            mNtpAdapter.setDisplayNewsFeed(mIsDisplayNewsFeed);
             getFeed(false);
         }
     }

--- a/android/java/org/chromium/chrome/browser/ntp/BraveNtpAdapter.java
+++ b/android/java/org/chromium/chrome/browser/ntp/BraveNtpAdapter.java
@@ -72,7 +72,7 @@ public class BraveNtpAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolde
     private Wallpaper mWallpaper;
     private NTPBackgroundImagesBridge mNTPBackgroundImagesBridge;
     private OnBraveNtpListener mOnBraveNtpListener;
-    private boolean mIsDisplayNews;
+    private boolean mIsDisplayNewsFeed;
     private boolean mIsDisplayNewsOptin;
     private boolean mIsNewsLoading;
     private boolean mIsNewContent;
@@ -105,7 +105,7 @@ public class BraveNtpAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolde
             SponsoredTab sponsoredTab, Wallpaper wallpaper, Bitmap sponsoredLogo,
             NTPBackgroundImagesBridge nTPBackgroundImagesBridge, boolean isNewsLoading,
             int recyclerViewHeight, boolean isTopSitesEnabled, boolean isBraveStatsEnabled,
-            boolean isDisplayNews, boolean isDisplayNewsOptin) {
+            boolean isDisplayNewsFeed, boolean isDisplayNewsOptin) {
         mActivity = activity;
         mOnBraveNtpListener = onBraveNtpListener;
         mGlide = glide;
@@ -121,7 +121,7 @@ public class BraveNtpAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolde
         mRecyclerViewHeight = recyclerViewHeight;
         mIsTopSitesEnabled = isTopSitesEnabled;
         mIsBraveStatsEnabled = isBraveStatsEnabled;
-        mIsDisplayNews = isDisplayNews;
+        mIsDisplayNewsFeed = isDisplayNewsFeed;
         mIsDisplayNewsOptin = isDisplayNewsOptin;
     }
 
@@ -257,7 +257,7 @@ public class BraveNtpAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolde
                                 LinearLayout.LayoutParams.WRAP_CONTENT);
 
                 int extraMarginForNews =
-                        (mIsDisplayNewsOptin || shouldDisplayNewsLoading() || mIsDisplayNews)
+                        (mIsDisplayNewsOptin || shouldDisplayNewsLoading() || mIsDisplayNewsFeed)
                         ? dpToPx(mActivity, 30)
                         : 0;
 
@@ -349,7 +349,7 @@ public class BraveNtpAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolde
         int newsLoadingCount = shouldDisplayNewsLoading() ? 1 : 0;
         if (mIsDisplayNewsOptin) {
             return statsCount + topSitesCount + TWO_ITEMS_SPACE + newsLoadingCount;
-        } else if (mIsDisplayNews) {
+        } else if (mIsDisplayNewsFeed) {
             int newsCount = 0;
             if (mNewsItems.size() > 0) {
                 newsCount = mNewsItems.size();
@@ -471,11 +471,11 @@ public class BraveNtpAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolde
         }
     }
 
-    public void setDisplayNews(boolean isDisplayNews) {
-        if (mIsDisplayNews != isDisplayNews) {
-            mIsDisplayNews = isDisplayNews;
+    public void setDisplayNewsFeed(boolean isDisplayNewsFeed) {
+        if (mIsDisplayNewsFeed != isDisplayNewsFeed) {
+            mIsDisplayNewsFeed = isDisplayNewsFeed;
 
-            if (mIsDisplayNews) {
+            if (mIsDisplayNewsFeed) {
                 notifyItemRangeChanged(getStatsCount() + getTopSitesCount(), TWO_ITEMS_SPACE);
             } else {
                 notifyItemRangeRemoved(
@@ -490,7 +490,7 @@ public class BraveNtpAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolde
     }
 
     public boolean shouldDisplayNewsLoading() {
-        return mIsNewsLoading && mIsDisplayNews;
+        return mIsNewsLoading && mIsDisplayNewsFeed;
     }
 
     public int getTopMarginImageCredit() {

--- a/android/java/org/chromium/chrome/browser/settings/BraveNewsPreferencesV2.java
+++ b/android/java/org/chromium/chrome/browser/settings/BraveNewsPreferencesV2.java
@@ -142,7 +142,7 @@ public class BraveNewsPreferencesV2 extends BravePreferenceFragment
             mIsSuggestionAvailable = true;
         }
 
-        boolean isNewsEnable = BraveNewsUtils.shouldDisplayNews();
+        boolean isNewsEnable = BraveNewsUtils.shouldDisplayNewsFeed();
         mSwitchShowNews.setChecked(isNewsEnable);
         onShowNewsToggle(isNewsEnable);
     }


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/33267

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
**`Prerequisites before launching Brave:`** Set the OS language to either `Hindi` or `Italiano - Italia` or any unsupported regions

1. launch Brave and run through onboarding (doesn't really matter what you select/skip)
2. Brave News optin card should not be visible