### PR TITLE
Send Constellation P3A metrics early

### DIFF
--- a/components/p3a/constellation_log_store.cc
+++ b/components/p3a/constellation_log_store.cc
@@ -53,11 +53,9 @@ void ConstellationLogStore::UpdateMessage(const std::string& histogram_name,
   base::Value::Dict* epoch_dict = update->EnsureDict(epoch_key);
   epoch_dict->Set(histogram_name, msg);
 
-  if (current_epoch_ != epoch) {
-    LogKey key(epoch, histogram_name);
-    log_[key] = msg;
-    unsent_entries_.insert(key);
-  }
+  LogKey key(epoch, histogram_name);
+  log_[key] = msg;
+  unsent_entries_.insert(key);
 }
 
 void ConstellationLogStore::RemoveMessageIfExists(const LogKey& key) {
@@ -167,11 +165,6 @@ void ConstellationLogStore::LoadPersistedUnsentLogs() {
       continue;
     }
     uint8_t item_epoch = (uint8_t)parsed_epoch;
-
-    if (current_epoch_ == item_epoch) {
-      // Do not load/send messages from the current epoch
-      continue;
-    }
 
     if ((current_epoch_ - item_epoch) >= keep_epoch_count_) {
       // If epoch is too old, delete it

--- a/components/p3a/constellation_log_store_unittest.cc
+++ b/components/p3a/constellation_log_store_unittest.cc
@@ -73,16 +73,11 @@ class P3AConstellationLogStoreTest : public testing::Test {
   TestingPrefServiceSimple local_state;
 };
 
-TEST_F(P3AConstellationLogStoreTest, CurrentEpochNoStage) {
+TEST_F(P3AConstellationLogStoreTest, CurrentEpochStaging) {
   log_store->SetCurrentEpoch(1);
 
-  ASSERT_FALSE(log_store->has_unsent_logs());
-  ASSERT_FALSE(log_store->has_staged_log());
-
-  UpdateSomeMessages(1, 5);
-
-  ASSERT_FALSE(log_store->has_unsent_logs());
-  ASSERT_FALSE(log_store->has_staged_log());
+  UpdateSomeMessages(1, 8);
+  ConsumeMessages(8);
 }
 
 TEST_F(P3AConstellationLogStoreTest, PreviousEpochStaging) {
@@ -113,7 +108,7 @@ TEST_F(P3AConstellationLogStoreTest, PreviousEpochsStaging) {
   UpdateSomeMessages(4, 10);
 
   // Should consume messages from first three epochs
-  ConsumeMessages(14);
+  ConsumeMessages(24);
 }
 
 TEST_F(P3AConstellationLogStoreTest, UpdatePreviousEpochMessage) {

--- a/components/p3a/message_manager_unittest.cc
+++ b/components/p3a/message_manager_unittest.cc
@@ -312,8 +312,7 @@ TEST_F(P3AMessageManagerTest, UpdateLogsAndSendConstellation) {
   task_environment_.FastForwardBy(base::Seconds(kUploadIntervalSeconds * 100));
 
   EXPECT_EQ(points_requests_made, 7U);
-  // Should not send metrics, since they are in current epoch
-  EXPECT_EQ(p3a_constellation_sent_messages.size(), 0U);
+  EXPECT_EQ(p3a_constellation_sent_messages.size(), 7U);
 
   ResetInterceptorStores();
   current_epoch++;


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/33359

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [ ] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

0. Start with fresh profile, use MITM proxy.
1. Ensure multiple requests are being sent to both `https://star-randsrv.bsg.brave.com/randomness` and `https://collector.bsg.brave.com`.
2. Once all typical/weekly metrics have been sent, ensure that no more requests are made.