### PR TITLE
fix(wallet) Fix formatting bug on Market Tab Panel

### DIFF
--- a/components/brave_wallet_ui/components/asset-name-and-icon/style.ts
+++ b/components/brave_wallet_ui/components/asset-name-and-icon/style.ts
@@ -5,18 +5,24 @@
 
 import styled from 'styled-components'
 import * as leo from '@brave/leo/tokens/css'
+import { layoutPanelWidth } from '../desktop/wallet-page-wrapper/wallet-page-wrapper.style'
 
 export const StyledWrapper = styled.div`
   display: flex;
   flex-direction: row;
-  height: 40px;
-
+  height: auto;
+  align-items: center;
 `
 
 export const AssetIcon = styled.img`
   width: 40px;
   height: auto;
-  margin-right: 12px;
+  margin-right: 16px;
+
+  @media screen and (max-width: ${layoutPanelWidth}px) {
+    width: 32px;
+    margin-right: 12px;
+  }
 `
 
 export const NameAndSymbolWrapper = styled.div`
@@ -40,14 +46,18 @@ export const AssetName = styled.span`
   white-space: nowrap;
   width: 160px;
   text-align: left;
+
+  @media screen and (max-width: ${layoutPanelWidth}px) {
+    width: 140px;
+  }
 `
 
 export const AssetSymbol = styled.span`
-  color: ${leo.color.text.secondary};
+  color: ${leo.color.text.tertiary};
   font-family: Poppins;
   font-size: 12px;
   font-style: normal;
-  font-weight: 500;
+  font-weight: 400;
   line-height: 18px;
   text-transform: uppercase;
   text-align: left;

--- a/components/brave_wallet_ui/components/asset-price-change/style.ts
+++ b/components/brave_wallet_ui/components/asset-price-change/style.ts
@@ -6,6 +6,7 @@
 import styled from 'styled-components'
 import * as leo from '@brave/leo/tokens/css'
 import Icon from '@brave/leo/react/icon'
+import { layoutPanelWidth } from '../desktop/wallet-page-wrapper/wallet-page-wrapper.style'
 
 export const StyledWrapper = styled.span`
   display: flex;
@@ -22,11 +23,16 @@ export const PriceChange = styled.span<{
   font-style: normal;
   font-weight: 500;
   line-height: normal;
-  letter-spacing: 0.14px;
   color: ${(p) =>
     p.isDown
       ? leo.color.systemfeedback.successIcon
       : leo.color.systemfeedback.errorIcon};
+
+
+  @media screen and (max-width: ${layoutPanelWidth}px) {
+    font-size: 12px;
+    font-weight: 400;
+  }
 `
 
 export const Arrow = styled(Icon)<{

--- a/components/brave_wallet_ui/components/desktop/views/portfolio/components/coin-stats/coin-stats-styles.ts
+++ b/components/brave_wallet_ui/components/desktop/views/portfolio/components/coin-stats/coin-stats-styles.ts
@@ -14,7 +14,6 @@ export const StyledWrapper = styled.div`
 export const StatWrapper = styled.div`
   display: flex;
   flex-direction: column;
-  margin-right: 95px;
  `
 
 export const StatValue = styled.div`
@@ -50,6 +49,7 @@ export const Row = styled.div`
   display: flex;
   flex-direction: row;
   margin: 16px 0 16px 0;
+  justify-content: space-between;
 `
 
 export const Currency = styled.sup`

--- a/components/brave_wallet_ui/components/shared/market-grid/market-grid.style.ts
+++ b/components/brave_wallet_ui/components/shared/market-grid/market-grid.style.ts
@@ -88,7 +88,7 @@ export const GridRow = styled.div<{ templateColumns: string }>`
   display: grid;
   grid-template-columns: ${({ templateColumns }) => templateColumns};
   gap: 5px;
-  padding: 16px 0;
+  padding-top: 16px;
   cursor: pointer;
 `
 
@@ -157,6 +157,10 @@ export const TextWrapper = styled.div<{
   font-weight: 500;
   line-height: normal;
   color: ${leo.color.text.primary};
+
+  @media screen and (max-width: ${layoutPanelWidth}px) {
+    font-size: 12px;
+  }
 `
 
 export const ButtonsRow = styled.div`

--- a/components/brave_wallet_ui/components/shared/market-grid/market-grid.tsx
+++ b/components/brave_wallet_ui/components/shared/market-grid/market-grid.tsx
@@ -58,7 +58,7 @@ export type MarketGridProps = {
 }
 
 const defaultVisibleRows = 15
-const defaultRowHeight = 72
+const defaultRowHeight = 65
 const defaultOverScanCount = 15
 
 export const MarketGrid = ({

--- a/components/brave_wallet_ui/options/market-data-headers.ts
+++ b/components/brave_wallet_ui/options/market-data-headers.ts
@@ -23,6 +23,7 @@ export const marketGridHeaders: MarketGridHeader[] = [
     id: 'priceChangePercentage24h',
     label: getLocale('braveWalletMarketData24HrColumn'),
     sortable: true,
+    width: '80px'
   },
   {
     id: 'marketCap',


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/33331

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
<img width="395" alt="Screenshot 2023-10-03 at 10 34 15" src="https://github.com/brave/brave-core/assets/48117473/81820f06-9494-42a2-89f1-10eb50fc9e49">
<img width="397" alt="Screenshot 2023-10-03 at 10 33 54" src="https://github.com/brave/brave-core/assets/48117473/9a361977-cc18-4f17-88d5-3a339230d1a3">

