### PR TITLE
Add BraveVPN WireGuard feature flag for OSX

### DIFF
--- a/browser/about_flags.cc
+++ b/browser/about_flags.cc
@@ -110,15 +110,26 @@
       kOsWin,                                                            \
       FEATURE_VALUE_TYPE(brave_vpn::features::kBraveVPNDnsProtection),   \
   })
-#else
+#elif BUILDFLAG(IS_MAC)
+#define BRAVE_VPN_DNS_FEATURE_ENTRIES
+
+#define BRAVE_VPN_WIREGUARD_FEATURE_ENTRIES                                    \
+  EXPAND_FEATURE_ENTRIES({                                                     \
+      kBraveVPNWireguardForOSXFeatureInternalName,                             \
+      "Enable experimental WireGuard Brave VPN for OSX",                       \
+      "Experimental WireGuard VPN support.",                                   \
+      kOsMac,                                                                  \
+      FEATURE_VALUE_TYPE(brave_vpn::features::kBraveVPNEnableWireguardForOSX), \
+  })
+#else  // BUILDFLAG(IS_MAC)
 #define BRAVE_VPN_DNS_FEATURE_ENTRIES
 #define BRAVE_VPN_WIREGUARD_FEATURE_ENTRIES
-#endif
-#else
+#endif  // BUILDFLAG(IS_WIN)
+#else   // BUILDFLAG(ENABLE_BRAVE_VPN)
 #define BRAVE_VPN_FEATURE_ENTRIES
 #define BRAVE_VPN_DNS_FEATURE_ENTRIES
 #define BRAVE_VPN_WIREGUARD_FEATURE_ENTRIES
-#endif
+#endif  // BUILDFLAG(ENABLE_BRAVE_VPN)
 
 #define BRAVE_SKU_SDK_FEATURE_ENTRIES                   \
   EXPAND_FEATURE_ENTRIES({                              \

--- a/browser/brave_features_internal_names.h
+++ b/browser/brave_features_internal_names.h
@@ -17,6 +17,9 @@ constexpr char kBraveVPNFeatureInternalName[] = "brave-vpn";
 constexpr char kBraveVPNDnsFeatureInternalName[] = "brave-vpn-dns";
 constexpr char kBraveVPNWireguardFeatureInternalName[] = "brave-vpn-wireguard";
 #endif
+#if BUILDFLAG(IS_MAC)
+constexpr char kBraveVPNWireguardForOSXFeatureInternalName[] =
+    "brave-vpn-wireguard-osx";
 #endif
-
+#endif  // BUILDFLAG(ENABLE_BRAVE_VPN)
 #endif  // BRAVE_BROWSER_BRAVE_FEATURES_INTERNAL_NAMES_H_

--- a/browser/resources/settings/brave_system_page/brave_vpn_page.ts
+++ b/browser/resources/settings/brave_system_page/brave_vpn_page.ts
@@ -97,7 +97,12 @@ export class SettingsBraveVpnPageElement
   }
 
   private showVpnPage_(): boolean {
-    return loadTimeData.getBoolean('isBraveVPNEnabled')
+    let showVpnPage = loadTimeData.getBoolean('isBraveVPNEnabled')
+    // <if expr="is_macosx">
+    showVpnPage = showVpnPage &&
+                  loadTimeData.getBoolean('isBraveVPNWireguardEnabledOnMac')
+    // </if>
+    return showVpnPage
   }
 
   private isWireguardServiceRegistered(success: boolean) {

--- a/browser/ui/webui/brave_settings_ui.cc
+++ b/browser/ui/webui/brave_settings_ui.cc
@@ -28,6 +28,7 @@
 #include "brave/browser/ui/webui/settings/default_brave_shields_handler.h"
 #include "brave/components/ai_chat/common/buildflags/buildflags.h"
 #include "brave/components/brave_vpn/common/buildflags/buildflags.h"
+#include "brave/components/brave_vpn/common/features.h"
 #include "brave/components/brave_wallet/common/features.h"
 #include "brave/components/commands/common/commands.mojom.h"
 #include "brave/components/commands/common/features.h"
@@ -156,7 +157,13 @@ void BraveSettingsUI::AddResources(content::WebUIDataSource* html_source,
 #if BUILDFLAG(ENABLE_BRAVE_VPN)
   html_source->AddBoolean("isBraveVPNEnabled",
                           brave_vpn::IsBraveVPNEnabled(profile));
-#endif
+#if BUILDFLAG(IS_MAC) && BUILDFLAG(ENABLE_BRAVE_VPN_WIREGUARD)
+  html_source->AddBoolean(
+      "isBraveVPNWireguardEnabledOnMac",
+      base::FeatureList::IsEnabled(
+          brave_vpn::features::kBraveVPNEnableWireguardForOSX));
+#endif  // BUILDFLAG(IS_MAC) && BUILDFLAG(ENABLE_BRAVE_VPN_WIREGUARD)
+#endif  // BUILDFLAG(ENABLE_BRAVE_VPN)
 #if BUILDFLAG(ENABLE_SPEEDREADER)
   html_source->AddBoolean(
       "isSpeedreaderFeatureEnabled",

--- a/chromium_src/chrome/browser/unexpire_flags.cc
+++ b/chromium_src/chrome/browser/unexpire_flags.cc
@@ -35,7 +35,7 @@ bool IsFlagExpired(const flags_ui::FlagsStorage* storage,
     return true;
   }
 #endif  // BUILDFLAG(ENABLE_PLAYLIST) && BUILDFLAG(IS_ANDROID)
-#if BUILDFLAG(ENABLE_BRAVE_VPN_WIREGUARD)
+#if BUILDFLAG(ENABLE_BRAVE_VPN_WIREGUARD) && BUILDFLAG(IS_WIN)
   // It's deprecated. Hide from brave://flags.
   if (base::EqualsCaseInsensitiveASCII(kBraveVPNWireguardFeatureInternalName,
                                        internal_name)) {

--- a/components/brave_vpn/common/brave_vpn_utils.cc
+++ b/components/brave_vpn/common/brave_vpn_utils.cc
@@ -55,7 +55,12 @@ void RegisterVPNLocalStatePrefs(PrefRegistrySimple* registry) {
 bool IsBraveVPNWireguardEnabled(PrefService* local_state) {
   DCHECK(IsBraveVPNFeatureEnabled());
 #if BUILDFLAG(ENABLE_BRAVE_VPN_WIREGUARD)
-  return local_state->GetBoolean(prefs::kBraveVPNWireguardEnabled);
+  auto enabled = local_state->GetBoolean(prefs::kBraveVPNWireguardEnabled);
+#if BUILDFLAG(IS_MAC)
+  enabled = enabled && base::FeatureList::IsEnabled(
+                           brave_vpn::features::kBraveVPNEnableWireguardForOSX);
+#endif  // BUILDFLAG(IS_MAC)
+  return enabled;
 #else
   return false;
 #endif

--- a/components/brave_vpn/common/brave_vpn_utils_unittest.cc
+++ b/components/brave_vpn/common/brave_vpn_utils_unittest.cc
@@ -223,3 +223,50 @@ TEST(BraveVPNUtilsUnitTest, FeatureTest) {
   EXPECT_FALSE(brave_vpn::IsBraveVPNFeatureEnabled());
 #endif
 }
+
+#if BUILDFLAG(IS_MAC)
+TEST(BraveVPNUtilsUnitTest, IsBraveVPNWireguardEnabledMac) {
+  {
+    TestingPrefServiceSimple local_state_pref_service;
+    brave_vpn::RegisterLocalStatePrefs(local_state_pref_service.registry());
+
+    // Prefs are in default state, the wireguard feature is disabled.
+    base::test::ScopedFeatureList scoped_feature_list;
+    scoped_feature_list.InitWithFeatures(
+        {brave_vpn::features::kBraveVPN, skus::features::kSkusFeature}, {});
+    EXPECT_FALSE(local_state_pref_service.GetBoolean(
+        brave_vpn::prefs::kBraveVPNWireguardEnabled));
+    EXPECT_FALSE(
+        brave_vpn::IsBraveVPNWireguardEnabled(&local_state_pref_service));
+
+    // The pref is enabled but the feature is disabled
+    local_state_pref_service.SetBoolean(
+        brave_vpn::prefs::kBraveVPNWireguardEnabled, true);
+    EXPECT_FALSE(
+        brave_vpn::IsBraveVPNWireguardEnabled(&local_state_pref_service));
+  }
+
+  {
+    TestingPrefServiceSimple local_state_pref_service;
+    brave_vpn::RegisterLocalStatePrefs(local_state_pref_service.registry());
+
+    // // Prefs are in default state, the wireguard feature is enabled.
+    base::test::ScopedFeatureList scoped_feature_list;
+    scoped_feature_list.InitWithFeatures(
+        {brave_vpn::features::kBraveVPN, skus::features::kSkusFeature,
+         brave_vpn::features::kBraveVPNEnableWireguardForOSX},
+        {});
+
+    EXPECT_FALSE(local_state_pref_service.GetBoolean(
+        brave_vpn::prefs::kBraveVPNWireguardEnabled));
+    EXPECT_FALSE(
+        brave_vpn::IsBraveVPNWireguardEnabled(&local_state_pref_service));
+
+    // The pref is enabled but the feature is enabled.
+    local_state_pref_service.SetBoolean(
+        brave_vpn::prefs::kBraveVPNWireguardEnabled, true);
+    EXPECT_TRUE(
+        brave_vpn::IsBraveVPNWireguardEnabled(&local_state_pref_service));
+  }
+}
+#endif

--- a/components/brave_vpn/common/buildflags/buildflags.gni
+++ b/components/brave_vpn/common/buildflags/buildflags.gni
@@ -13,5 +13,5 @@ declare_args() {
 
 declare_args() {
   # Wireguard is available only on Windows.
-  enable_brave_vpn_wireguard = is_win && enable_brave_vpn
+  enable_brave_vpn_wireguard = (is_mac || is_win) && enable_brave_vpn
 }

--- a/components/brave_vpn/common/features.cc
+++ b/components/brave_vpn/common/features.cc
@@ -33,6 +33,11 @@ BASE_FEATURE(kBraveVPNUseWireguardService,
              "BraveVPNUseWireguardService",
              base::FEATURE_ENABLED_BY_DEFAULT);
 #endif
+#if BUILDFLAG(IS_MAC)
+BASE_FEATURE(kBraveVPNEnableWireguardForOSX,
+             "kBraveVPNEnableWireguardForOSX",
+             base::FEATURE_DISABLED_BY_DEFAULT);
+#endif
 }  // namespace features
 
 }  // namespace brave_vpn

--- a/components/brave_vpn/common/features.h
+++ b/components/brave_vpn/common/features.h
@@ -18,6 +18,9 @@ BASE_DECLARE_FEATURE(kBraveVPNLinkSubscriptionAndroidUI);
 BASE_DECLARE_FEATURE(kBraveVPNDnsProtection);
 BASE_DECLARE_FEATURE(kBraveVPNUseWireguardService);
 #endif
+#if BUILDFLAG(IS_MAC)
+BASE_DECLARE_FEATURE(kBraveVPNEnableWireguardForOSX);
+#endif
 }  // namespace features
 }  // namespace brave_vpn
 


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/33367

- Added a new feature flag for OSX WireGuard implementation, disabled by default
- Show/hide brave://settings/system on OSX if the flag enabled/disabled


<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

- Mac: 
 - if the new flag is disabled -> it should not show the wireguard option on brave://settings/system and IKEv2 protocol used by VPN.
 - if the new flag is enabled -> it should show Brave VPN option on brave://settings/system and by default the wireguard option should be initialied to false.
 
 Important notice: The wireguard protocol is in development and it will not connect to the VPN with the flag and the option enabled. It should not crash browser though.
