### PR TITLE
Fix Wireguard feature migration (uplift to 1.59.x)

### DIFF
--- a/browser/about_flags.cc
+++ b/browser/about_flags.cc
@@ -92,6 +92,14 @@
   })
 #if BUILDFLAG(IS_WIN)
 
+#define BRAVE_VPN_WIREGUARD_FEATURE_ENTRIES                                  \
+  EXPAND_FEATURE_ENTRIES({                                                   \
+      kBraveVPNWireguardFeatureInternalName,                                 \
+      "Enable experimental WireGuard Brave VPN service",                     \
+      "Experimental WireGuard VPN support. Deprecated.",                     \
+      kOsWin,                                                                \
+      FEATURE_VALUE_TYPE(brave_vpn::features::kBraveVPNUseWireguardService), \
+  })
 #define BRAVE_VPN_DNS_FEATURE_ENTRIES                                    \
   EXPAND_FEATURE_ENTRIES({                                               \
       kBraveVPNDnsFeatureInternalName,                                   \
@@ -103,10 +111,12 @@
   })
 #else
 #define BRAVE_VPN_DNS_FEATURE_ENTRIES
+#define BRAVE_VPN_WIREGUARD_FEATURE_ENTRIES
 #endif
 #else
 #define BRAVE_VPN_FEATURE_ENTRIES
 #define BRAVE_VPN_DNS_FEATURE_ENTRIES
+#define BRAVE_VPN_WIREGUARD_FEATURE_ENTRIES
 #endif
 
 #define BRAVE_SKU_SDK_FEATURE_ENTRIES                   \
@@ -899,6 +909,7 @@
   BRAVE_REWARDS_GEMINI_FEATURE_ENTRIES                                         \
   BRAVE_VPN_FEATURE_ENTRIES                                                    \
   BRAVE_VPN_DNS_FEATURE_ENTRIES                                                \
+  BRAVE_VPN_WIREGUARD_FEATURE_ENTRIES                                          \
   BRAVE_SKU_SDK_FEATURE_ENTRIES                                                \
   SPEEDREADER_FEATURE_ENTRIES                                                  \
   REQUEST_OTR_FEATURE_ENTRIES                                                  \

--- a/browser/about_flags.cc
+++ b/browser/about_flags.cc
@@ -7,6 +7,7 @@
 
 #include <initializer_list>
 
+#include "base/strings/string_util.h"
 #include "brave/browser/brave_browser_features.h"
 #include "brave/browser/brave_features_internal_names.h"
 #include "brave/browser/ethereum_remote_client/buildflags/buildflags.h"
@@ -939,6 +940,20 @@ namespace {
   static_assert(
       std::initializer_list<FeatureEntry>{BRAVE_ABOUT_FLAGS_FEATURE_ENTRIES}
           .size());
+}
+
+// Called to skip feature entries on brave://flags page without affecting
+// features state.
+bool BraveShouldSkipConditionalFeatureEntry(
+    const flags_ui::FlagsStorage* storage,
+    const FeatureEntry& entry) {
+#if BUILDFLAG(ENABLE_BRAVE_VPN_WIREGUARD) && BUILDFLAG(IS_WIN)
+  if (base::EqualsCaseInsensitiveASCII(kBraveVPNWireguardFeatureInternalName,
+                                       entry.internal_name)) {
+    return true;
+  }
+#endif
+  return false;
 }
 
 }  // namespace

--- a/browser/brave_features_internal_names.h
+++ b/browser/brave_features_internal_names.h
@@ -15,6 +15,7 @@ constexpr char kPlaylistFakeUAFeatureInternalName[] = "playlist-fake-ua";
 constexpr char kBraveVPNFeatureInternalName[] = "brave-vpn";
 #if BUILDFLAG(IS_WIN)
 constexpr char kBraveVPNDnsFeatureInternalName[] = "brave-vpn-dns";
+constexpr char kBraveVPNWireguardFeatureInternalName[] = "brave-vpn-wireguard";
 #endif
 #endif
 

--- a/browser/brave_vpn/win/brave_vpn_wireguard_service/service/install_utils.cc
+++ b/browser/brave_vpn/win/brave_vpn_wireguard_service/service/install_utils.cc
@@ -19,7 +19,7 @@
 #include "brave/components/brave_vpn/common/wireguard/win/service_constants.h"
 #include "brave/components/brave_vpn/common/wireguard/win/service_details.h"
 #include "brave/components/brave_vpn/common/wireguard/win/storage_utils.h"
-#include "brave/components/brave_vpn/common/wireguard/win/wireguard_utils.h"
+#include "brave/components/brave_vpn/common/wireguard/win/wireguard_utils_win.h"
 #include "chrome/installer/util/install_service_work_item.h"
 
 namespace brave_vpn {

--- a/browser/brave_vpn/win/brave_vpn_wireguard_service/service/wireguard_service_runner.cc
+++ b/browser/brave_vpn/win/brave_vpn_wireguard_service/service/wireguard_service_runner.cc
@@ -27,7 +27,7 @@
 #include "base/win/scoped_com_initializer.h"
 #include "brave/browser/brave_vpn/win/brave_vpn_wireguard_service/service/brave_wireguard_manager.h"
 #include "brave/components/brave_vpn/common/wireguard/win/service_details.h"
-#include "brave/components/brave_vpn/common/wireguard/win/wireguard_utils.h"
+#include "brave/components/brave_vpn/common/wireguard/win/wireguard_utils_win.h"
 
 namespace brave_vpn {
 

--- a/browser/brave_vpn/win/brave_vpn_wireguard_service/status_tray/status_tray_runner.cc
+++ b/browser/brave_vpn/win/brave_vpn_wireguard_service/status_tray/status_tray_runner.cc
@@ -28,7 +28,7 @@
 #include "brave/components/brave_vpn/common/win/utils.h"
 #include "brave/components/brave_vpn/common/wireguard/win/service_details.h"
 #include "brave/components/brave_vpn/common/wireguard/win/storage_utils.h"
-#include "brave/components/brave_vpn/common/wireguard/win/wireguard_utils.h"
+#include "brave/components/brave_vpn/common/wireguard/win/wireguard_utils_win.h"
 #include "components/grit/brave_components_strings.h"
 #include "third_party/abseil-cpp/absl/types/optional.h"
 #include "ui/base/l10n/l10n_util.h"

--- a/browser/extensions/api/settings_private/brave_prefs_util.cc
+++ b/browser/extensions/api/settings_private/brave_prefs_util.cc
@@ -166,7 +166,7 @@ const PrefsUtil::TypedPrefMap& BravePrefsUtil::GetAllowlistedKeys() {
 #if BUILDFLAG(ENABLE_BRAVE_VPN)
   (*s_brave_allowlist)[brave_vpn::prefs::kBraveVPNShowButton] =
       settings_api::PrefType::PREF_TYPE_BOOLEAN;
-#if BUILDFLAG(IS_WIN)
+#if BUILDFLAG(ENABLE_BRAVE_VPN_WIREGUARD)
   (*s_brave_allowlist)[brave_vpn::prefs::kBraveVPNWireguardEnabled] =
       settings_api::PrefType::PREF_TYPE_BOOLEAN;
 #endif

--- a/browser/resources/settings/BUILD.gn
+++ b/browser/resources/settings/BUILD.gn
@@ -72,6 +72,7 @@ preprocess_if_expr("preprocess") {
     "enable_tor=$enable_tor",
     "enable_brave_wayback_machine=$enable_brave_wayback_machine",
     "enable_brave_vpn=$enable_brave_vpn",
+    "enable_brave_vpn_wireguard=$enable_brave_vpn_wireguard",
     "enable_extensions=$enable_extensions",
     "enable_pin_shortcut=$enable_pin_shortcut",
   ]

--- a/browser/resources/settings/brave_appearance_page/toolbar.html
+++ b/browser/resources/settings/brave_appearance_page/toolbar.html
@@ -50,7 +50,7 @@
   <settings-brave-appearance-tabs prefs="{{prefs}}""></settings-brave-appearance-tabs>
   <settings-brave-appearance-sidebar prefs="{{prefs}}"></settings-brave-appearance-sidebar>
 </if>
-<if expr="enable_brave_vpn">
+<if expr="enable_brave_vpn_wireguard">
   <template is="dom-if" if="[[showBraveVPNOption_()]]">
     <settings-toggle-button
       pref="{{prefs.brave.brave_vpn.show_button}}"

--- a/browser/resources/settings/brave_overrides/system_page.ts
+++ b/browser/resources/settings/brave_overrides/system_page.ts
@@ -10,7 +10,7 @@ import {
 } from 'chrome://resources/brave/polymer_overriding.js'
 import { loadTimeData } from '../i18n_setup.js'
 import '../brave_system_page/brave_performance_page.js'
-// <if expr="enable_brave_vpn and is_win">
+// <if expr="enable_brave_vpn_wireguard">
 import '../brave_system_page/brave_vpn_page.js'
 // </if>
 import '../shortcuts_page/shortcuts_page.js'
@@ -81,8 +81,7 @@ RegisterPolymerTemplateModifications({
         </settings-toggle-button>
       `
     )
-
-    // <if expr="enable_brave_vpn and is_win">
+    // <if expr="enable_brave_vpn_wireguard">
     templateContent.appendChild(
       html`
         <settings-brave-vpn-page prefs="{{prefs}}">

--- a/browser/resources/settings/brave_system_page/brave_vpn_page.html
+++ b/browser/resources/settings/brave_system_page/brave_vpn_page.html
@@ -1,4 +1,4 @@
-<if expr="enable_brave_vpn and is_win">
+<if expr="enable_brave_vpn_wireguard">
 <style include="settings-shared cr-shared-style iron-flex">
   .title {
     font-size: 14px;

--- a/browser/resources/settings/brave_system_page/brave_vpn_page.ts
+++ b/browser/resources/settings/brave_system_page/brave_vpn_page.ts
@@ -66,7 +66,9 @@ export class SettingsBraveVpnPageElement
     this.initialProtocolValue_ = this.getCurrentPrefValue()
     this.updateState()
     this.addWebUiListener('brave-vpn-state-change', this.onVpnStateChange.bind(this))
+    // <if expr="is_win">
     this.vpnBrowserProxy_.isBraveVpnConnected().then(this.onVpnStateChange.bind(this))
+    // </if>
   }
 
   private onVpnStateChange(connected: boolean) {
@@ -116,9 +118,11 @@ export class SettingsBraveVpnPageElement
     this.updateState();
     if (!this.getCurrentPrefValue())
       return
+    // <if expr="is_win">
     // If user enabled Wireguard service we have to check if it was registered.
     this.vpnBrowserProxy_.isWireguardServiceRegistered().then(
       this.isWireguardServiceRegistered.bind(this))
+    // </if>
   }
 
   private onRestartClick_(e: Event) {

--- a/browser/resources/settings/sources.gni
+++ b/browser/resources/settings/sources.gni
@@ -120,7 +120,7 @@ brave_settings_non_web_component_files = [
   "shortcuts_page/shortcuts_page.ts",
 ]
 
-if (enable_brave_vpn && is_win) {
+if (enable_brave_vpn_wireguard) {
   brave_settings_web_component_files +=
       [ "brave_system_page/brave_vpn_page.ts" ]
   brave_settings_non_web_component_files +=

--- a/browser/ui/browser_commands.cc
+++ b/browser/ui/browser_commands.cc
@@ -71,7 +71,7 @@
 
 #if BUILDFLAG(IS_WIN)
 #include "brave/components/brave_vpn/common/wireguard/win/storage_utils.h"
-#include "brave/components/brave_vpn/common/wireguard/win/wireguard_utils.h"
+#include "brave/components/brave_vpn/common/wireguard/win/wireguard_utils_win.h"
 #endif  // BUILDFLAG(ENABLE_BRAVE_VPN)
 
 #endif  // BUILDFLAG(ENABLE_BRAVE_VPN)

--- a/browser/ui/webui/settings/brave_vpn/brave_vpn_handler.cc
+++ b/browser/ui/webui/settings/brave_vpn/brave_vpn_handler.cc
@@ -19,7 +19,7 @@
 #include "brave/components/brave_vpn/common/wireguard/win/service_constants.h"
 #include "brave/components/brave_vpn/common/wireguard/win/service_details.h"
 #include "brave/components/brave_vpn/common/wireguard/win/storage_utils.h"
-#include "brave/components/brave_vpn/common/wireguard/win/wireguard_utils.h"
+#include "brave/components/brave_vpn/common/wireguard/win/wireguard_utils_win.h"
 #include "chrome/browser/browser_process.h"
 #include "components/prefs/pref_service.h"
 #include "components/version_info/version_info.h"

--- a/chromium_src/chrome/browser/about_flags.cc
+++ b/chromium_src/chrome/browser/about_flags.cc
@@ -5,6 +5,8 @@
 
 #include "brave/browser/about_flags.cc"
 #include "brave/components/commander/common/buildflags/buildflags.h"
+#include "chrome/common/channel_info.h"
+#include "components/autofill/core/browser/autofill_experiments.h"
 
 #if BUILDFLAG(ENABLE_COMMANDER)
 #include "brave/components/commander/common/features.h"
@@ -14,5 +16,12 @@
 #define kQuickCommands kBraveCommander
 #endif
 
+#define GetChannel                                                        \
+  GetChannel();                                                           \
+  if (flags_ui::BraveShouldSkipConditionalFeatureEntry(storage, entry)) { \
+    return true;                                                          \
+  }                                                                       \
+  chrome::GetChannel
 #include "src/chrome/browser/about_flags.cc"
+#undef GetChannel
 #undef kQuickCommands

--- a/chromium_src/chrome/browser/unexpire_flags.cc
+++ b/chromium_src/chrome/browser/unexpire_flags.cc
@@ -5,7 +5,6 @@
 
 #include "base/strings/string_util.h"
 #include "brave/browser/brave_features_internal_names.h"
-#include "brave/components/brave_vpn/common/buildflags/buildflags.h"
 #include "brave/components/playlist/common/buildflags/buildflags.h"
 #include "chrome/browser/flag_descriptions.h"
 #include "chrome/common/channel_info.h"
@@ -35,13 +34,6 @@ bool IsFlagExpired(const flags_ui::FlagsStorage* storage,
     return true;
   }
 #endif  // BUILDFLAG(ENABLE_PLAYLIST) && BUILDFLAG(IS_ANDROID)
-#if BUILDFLAG(ENABLE_BRAVE_VPN_WIREGUARD)
-  // It's deprecated. Hide from brave://flags.
-  if (base::EqualsCaseInsensitiveASCII(kBraveVPNWireguardFeatureInternalName,
-                                       internal_name)) {
-    return true;
-  }
-#endif
   if (base::EqualsCaseInsensitiveASCII(flag_descriptions::kHttpsUpgradesName,
                                        internal_name)) {
     return true;

--- a/chromium_src/chrome/browser/unexpire_flags.cc
+++ b/chromium_src/chrome/browser/unexpire_flags.cc
@@ -5,10 +5,15 @@
 
 #include "base/strings/string_util.h"
 #include "brave/browser/brave_features_internal_names.h"
+#include "brave/components/brave_vpn/common/buildflags/buildflags.h"
 #include "brave/components/playlist/common/buildflags/buildflags.h"
 #include "chrome/browser/flag_descriptions.h"
 #include "chrome/common/channel_info.h"
 #include "components/version_info/version_info.h"
+
+#if BUILDFLAG(ENABLE_BRAVE_VPN_WIREGUARD)
+#include "brave/browser/brave_features_internal_names.h"
+#endif
 
 #define IsFlagExpired IsFlagExpired_ChromiumImpl
 #include "src/chrome/browser/unexpire_flags.cc"
@@ -30,7 +35,13 @@ bool IsFlagExpired(const flags_ui::FlagsStorage* storage,
     return true;
   }
 #endif  // BUILDFLAG(ENABLE_PLAYLIST) && BUILDFLAG(IS_ANDROID)
-
+#if BUILDFLAG(ENABLE_BRAVE_VPN_WIREGUARD)
+  // It's deprecated. Hide from brave://flags.
+  if (base::EqualsCaseInsensitiveASCII(kBraveVPNWireguardFeatureInternalName,
+                                       internal_name)) {
+    return true;
+  }
+#endif
   if (base::EqualsCaseInsensitiveASCII(flag_descriptions::kHttpsUpgradesName,
                                        internal_name)) {
     return true;

--- a/components/brave_vpn/browser/brave_vpn_service.cc
+++ b/components/brave_vpn/browser/brave_vpn_service.cc
@@ -38,7 +38,7 @@
 #include "url/url_util.h"
 
 #if BUILDFLAG(IS_WIN)
-#include "brave/components/brave_vpn/common/wireguard/win/wireguard_utils.h"
+#include "brave/components/brave_vpn/common/wireguard/win/wireguard_utils_win.h"
 #endif
 
 namespace brave_vpn {

--- a/components/brave_vpn/browser/connection/BUILD.gn
+++ b/components/brave_vpn/browser/connection/BUILD.gn
@@ -18,6 +18,7 @@ source_set("api") {
     "//brave/components/brave_vpn/browser/api",
     "//brave/components/brave_vpn/browser/connection:common",
     "//brave/components/brave_vpn/common",
+    "//brave/components/brave_vpn/common/buildflags",
     "//brave/components/brave_vpn/common/mojom",
     "//components/prefs",
     "//services/network/public/cpp",
@@ -36,6 +37,7 @@ group("connection") {
 
   if (is_mac) {
     deps += [ "ikev2/mac" ]
+    deps += [ "wireguard/mac" ]
   }
 }
 

--- a/components/brave_vpn/browser/connection/brave_vpn_os_connection_api.cc
+++ b/components/brave_vpn/browser/connection/brave_vpn_os_connection_api.cc
@@ -14,6 +14,7 @@
 #include "brave/components/brave_vpn/browser/api/brave_vpn_api_helper.h"
 #include "brave/components/brave_vpn/common/brave_vpn_data_types.h"
 #include "brave/components/brave_vpn/common/brave_vpn_utils.h"
+#include "brave/components/brave_vpn/common/buildflags/buildflags.h"
 #include "brave/components/brave_vpn/common/features.h"
 #include "brave/components/brave_vpn/common/pref_names.h"
 #include "build/build_config.h"
@@ -36,13 +37,12 @@ std::unique_ptr<BraveVPNOSConnectionAPI> CreateBraveVPNConnectionAPI(
     scoped_refptr<network::SharedURLLoaderFactory> url_loader_factory,
     PrefService* local_prefs,
     version_info::Channel channel) {
-#if BUILDFLAG(IS_WIN)
+#if BUILDFLAG(ENABLE_BRAVE_VPN_WIREGUARD)
   if (IsBraveVPNWireguardEnabled(local_prefs)) {
     return CreateBraveVPNWireguardConnectionAPI(url_loader_factory, local_prefs,
                                                 channel);
   }
 #endif
-
 #if BUILDFLAG(IS_ANDROID)
   // Android doesn't use connection api.
   return nullptr;

--- a/components/brave_vpn/browser/connection/wireguard/brave_vpn_wireguard_connection_api_base.h
+++ b/components/brave_vpn/browser/connection/wireguard/brave_vpn_wireguard_connection_api_base.h
@@ -10,7 +10,7 @@
 
 #include "brave/components/brave_vpn/browser/connection/brave_vpn_os_connection_api.h"
 #include "brave/components/brave_vpn/browser/connection/wireguard/credentials/brave_vpn_wireguard_profile_credentials.h"
-#include "brave/components/brave_vpn/common/wireguard/constants.h"
+#include "brave/components/brave_vpn/common/wireguard/wireguard_utils.h"
 
 class PrefService;
 

--- a/components/brave_vpn/browser/connection/wireguard/mac/BUILD.gn
+++ b/components/brave_vpn/browser/connection/wireguard/mac/BUILD.gn
@@ -1,4 +1,4 @@
-# Copyright (c) 2022 The Brave Authors. All rights reserved.
+# Copyright (c) 2023 The Brave Authors. All rights reserved.
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this file,
 # You can obtain one at https://mozilla.org/MPL/2.0/.
@@ -6,28 +6,21 @@
 import("//brave/components/brave_vpn/common/buildflags/buildflags.gni")
 
 assert(enable_brave_vpn)
-assert(is_win)
+assert(is_mac)
 
-source_set("win") {
+source_set("mac") {
   visibility = [ "//brave/components/brave_vpn/browser/connection/*" ]
 
   sources = [
-    "brave_vpn_wireguard_connection_api.cc",
-    "brave_vpn_wireguard_connection_api.h",
+    "brave_vpn_wireguard_connection_api_mac.h",
+    "brave_vpn_wireguard_connection_api_mac.mm",
   ]
 
   deps = [
     "//base",
-    "//brave/components/brave_vpn/browser/api",
-    "//brave/components/brave_vpn/browser/connection:api",
-    "//brave/components/brave_vpn/browser/connection:common",
     "//brave/components/brave_vpn/browser/connection/wireguard",
     "//brave/components/brave_vpn/browser/connection/wireguard/credentials",
-    "//brave/components/brave_vpn/common",
-    "//brave/components/brave_vpn/common/buildflags",
-    "//brave/components/brave_vpn/common/win",
-    "//brave/components/brave_vpn/common/wireguard/win",
-    "//net",
     "//services/network/public/cpp",
+    "//third_party/boringssl",
   ]
 }

--- a/components/brave_vpn/browser/connection/wireguard/mac/brave_vpn_wireguard_connection_api_mac.h
+++ b/components/brave_vpn/browser/connection/wireguard/mac/brave_vpn_wireguard_connection_api_mac.h
@@ -1,0 +1,40 @@
+/* Copyright (c) 2023 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_COMPONENTS_BRAVE_VPN_BROWSER_CONNECTION_WIREGUARD_MAC_BRAVE_VPN_WIREGUARD_CONNECTION_API_MAC_H_
+#define BRAVE_COMPONENTS_BRAVE_VPN_BROWSER_CONNECTION_WIREGUARD_MAC_BRAVE_VPN_WIREGUARD_CONNECTION_API_MAC_H_
+
+#include "base/memory/scoped_refptr.h"
+#include "brave/components/brave_vpn/browser/connection/wireguard/brave_vpn_wireguard_connection_api_base.h"
+#include "brave/components/brave_vpn/browser/connection/wireguard/credentials/brave_vpn_wireguard_profile_credentials.h"
+#include "services/network/public/cpp/shared_url_loader_factory.h"
+
+namespace brave_vpn {
+
+class WireguardOSConnectionAPIMac : public BraveVPNWireguardConnectionAPIBase {
+ public:
+  WireguardOSConnectionAPIMac(
+      scoped_refptr<network::SharedURLLoaderFactory> url_loader_factory,
+      PrefService* local_prefs);
+
+  WireguardOSConnectionAPIMac(const WireguardOSConnectionAPIMac&) = delete;
+  WireguardOSConnectionAPIMac& operator=(const WireguardOSConnectionAPIMac&) =
+      delete;
+  ~WireguardOSConnectionAPIMac() override;
+
+ private:
+  // BraveVPNOSConnectionAPI
+  void Disconnect() override;
+  void CheckConnection() override;
+
+  // BraveVPNWireguardConnectionAPIBase overrides:
+  void RequestNewProfileCredentials() override;
+  void PlatformConnectImpl(
+      const wireguard::WireguardProfileCredentials& credentials) override;
+};
+
+}  // namespace brave_vpn
+
+#endif  // BRAVE_COMPONENTS_BRAVE_VPN_BROWSER_CONNECTION_WIREGUARD_MAC_BRAVE_VPN_WIREGUARD_CONNECTION_API_MAC_H_

--- a/components/brave_vpn/browser/connection/wireguard/mac/brave_vpn_wireguard_connection_api_mac.mm
+++ b/components/brave_vpn/browser/connection/wireguard/mac/brave_vpn_wireguard_connection_api_mac.mm
@@ -1,0 +1,71 @@
+/* Copyright (c) 2023 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "brave/components/brave_vpn/browser/connection/wireguard/mac/brave_vpn_wireguard_connection_api_mac.h"
+
+#include <memory>
+
+#include "base/base64.h"
+#include "base/notreached.h"
+#include "third_party/abseil-cpp/absl/types/optional.h"
+
+namespace brave_vpn {
+
+std::unique_ptr<WireguardOSConnectionAPIMac>
+CreateBraveVPNWireguardConnectionAPI(
+    scoped_refptr<network::SharedURLLoaderFactory> url_loader_factory,
+    PrefService* local_prefs,
+    version_info::Channel channel) {
+  return std::make_unique<WireguardOSConnectionAPIMac>(url_loader_factory,
+                                                       local_prefs);
+}
+
+WireguardOSConnectionAPIMac::WireguardOSConnectionAPIMac(
+    scoped_refptr<network::SharedURLLoaderFactory> url_loader_factory,
+    PrefService* local_prefs)
+    : BraveVPNWireguardConnectionAPIBase(url_loader_factory, local_prefs) {}
+
+WireguardOSConnectionAPIMac::~WireguardOSConnectionAPIMac() = default;
+
+void WireguardOSConnectionAPIMac::RequestNewProfileCredentials() {
+  NOTIMPLEMENTED();
+}
+
+void WireguardOSConnectionAPIMac::PlatformConnectImpl(
+    const wireguard::WireguardProfileCredentials& credentials) {
+  if (credentials.IsValid()) {
+    VLOG(1) << __func__ << " : failed to get correct credentials";
+    UpdateAndNotifyConnectionStateChange(
+        mojom::ConnectionState::CONNECT_FAILED);
+    return;
+  }
+  auto vpn_server_hostname = GetHostname();
+  auto config = brave_vpn::wireguard::CreateWireguardConfig(
+      credentials.client_private_key, credentials.server_public_key,
+      vpn_server_hostname, credentials.mapped_ip4_address);
+  if (!config.has_value()) {
+    VLOG(1) << __func__ << " : failed to get correct credentials";
+    UpdateAndNotifyConnectionStateChange(
+        mojom::ConnectionState::CONNECT_FAILED);
+    return;
+  }
+  NOTIMPLEMENTED();
+}
+
+void WireguardOSConnectionAPIMac::Disconnect() {
+  if (GetConnectionState() == mojom::ConnectionState::DISCONNECTED) {
+    VLOG(2) << __func__ << " : already disconnected";
+    return;
+  }
+  VLOG(2) << __func__ << " : Start stopping the service";
+  UpdateAndNotifyConnectionStateChange(mojom::ConnectionState::DISCONNECTING);
+  NOTIMPLEMENTED();
+}
+
+void WireguardOSConnectionAPIMac::CheckConnection() {
+  NOTIMPLEMENTED();
+}
+
+}  // namespace brave_vpn

--- a/components/brave_vpn/browser/connection/wireguard/win/brave_vpn_wireguard_connection_api.cc
+++ b/components/brave_vpn/browser/connection/wireguard/win/brave_vpn_wireguard_connection_api.cc
@@ -11,12 +11,11 @@
 #include "brave/components/brave_vpn/browser/connection/wireguard/brave_vpn_wireguard_connection_api_base.h"
 #include "brave/components/brave_vpn/common/win/utils.h"
 #include "brave/components/brave_vpn/common/wireguard/win/service_details.h"
-#include "brave/components/brave_vpn/common/wireguard/win/wireguard_utils.h"
+#include "brave/components/brave_vpn/common/wireguard/win/wireguard_utils_win.h"
 
 namespace brave_vpn {
 
 namespace {
-constexpr char kCloudflareIPv4[] = "1.1.1.1";
 // Timer to recheck the service launch after some time.
 constexpr int kWireguardServiceRestartTimeoutSec = 5;
 }  // namespace
@@ -70,7 +69,7 @@ void BraveVPNWireguardConnectionAPI::PlatformConnectImpl(
   auto vpn_server_hostname = GetHostname();
   auto config = brave_vpn::wireguard::CreateWireguardConfig(
       credentials.client_private_key, credentials.server_public_key,
-      vpn_server_hostname, credentials.mapped_ip4_address, kCloudflareIPv4);
+      vpn_server_hostname, credentials.mapped_ip4_address);
   if (!config.has_value()) {
     VLOG(1) << __func__ << " : failed to get correct credentials";
     UpdateAndNotifyConnectionStateChange(ConnectionState::CONNECT_FAILED);

--- a/components/brave_vpn/browser/connection/wireguard/win/brave_vpn_wireguard_connection_api.h
+++ b/components/brave_vpn/browser/connection/wireguard/win/brave_vpn_wireguard_connection_api.h
@@ -11,7 +11,6 @@
 #include "base/memory/raw_ptr.h"
 #include "base/memory/scoped_refptr.h"
 #include "base/memory/weak_ptr.h"
-
 #include "brave/components/brave_vpn/browser/connection/wireguard/brave_vpn_wireguard_connection_api_base.h"
 #include "brave/components/brave_vpn/browser/connection/wireguard/credentials/brave_vpn_wireguard_profile_credentials.h"
 #include "brave/components/brave_vpn/common/win/brave_windows_service_watcher.h"

--- a/components/brave_vpn/common/BUILD.gn
+++ b/components/brave_vpn/common/BUILD.gn
@@ -19,6 +19,7 @@ source_set("common") {
     "pref_names.h",
   ]
   deps = [
+    "//brave/components/brave_vpn/common/buildflags",
     "//brave/components/p3a_utils",
     "//brave/components/skus/browser",
     "//brave/components/skus/common",

--- a/components/brave_vpn/common/brave_vpn_utils.cc
+++ b/components/brave_vpn/common/brave_vpn_utils.cc
@@ -25,7 +25,7 @@
 #include "components/version_info/channel.h"
 
 #if BUILDFLAG(IS_WIN)
-#include "brave/components/brave_vpn/common/wireguard/win/wireguard_utils.h"
+#include "brave/components/brave_vpn/common/wireguard/win/wireguard_utils_win.h"
 #endif
 
 namespace brave_vpn {
@@ -45,19 +45,22 @@ void RegisterVPNLocalStatePrefs(PrefRegistrySimple* registry) {
   registry->RegisterDictionaryPref(prefs::kBraveVPNSubscriberCredential);
   registry->RegisterBooleanPref(prefs::kBraveVPNLocalStateMigrated, false);
   registry->RegisterTimePref(prefs::kBraveVPNSessionExpiredDate, {});
-#if BUILDFLAG(IS_WIN)
+#if BUILDFLAG(ENABLE_BRAVE_VPN_WIREGUARD)
   registry->RegisterBooleanPref(prefs::kBraveVPNWireguardEnabled, false);
 #endif
 }
 
 }  // namespace
 
-#if BUILDFLAG(IS_WIN)
 bool IsBraveVPNWireguardEnabled(PrefService* local_state) {
   DCHECK(IsBraveVPNFeatureEnabled());
+#if BUILDFLAG(ENABLE_BRAVE_VPN_WIREGUARD)
   return local_state->GetBoolean(prefs::kBraveVPNWireguardEnabled);
+#else
+  return false;
+#endif
 }
-
+#if BUILDFLAG(IS_WIN)
 void MigrateWireguardFeatureFlag(PrefService* local_prefs) {
   auto* wireguard_enabled_pref =
       local_prefs->FindPreference(prefs::kBraveVPNWireguardEnabled);
@@ -68,7 +71,7 @@ void MigrateWireguardFeatureFlag(PrefService* local_prefs) {
             brave_vpn::wireguard::IsWireguardServiceRegistered());
   }
 }
-#endif
+#endif  // BUILDFLAG(IS_WIN)
 void MigrateVPNSettings(PrefService* profile_prefs, PrefService* local_prefs) {
   if (local_prefs->GetBoolean(prefs::kBraveVPNLocalStateMigrated)) {
     return;

--- a/components/brave_vpn/common/brave_vpn_utils.h
+++ b/components/brave_vpn/common/brave_vpn_utils.h
@@ -36,10 +36,10 @@ bool HasValidSubscriberCredential(PrefService* local_prefs);
 std::string GetSubscriberCredential(PrefService* local_prefs);
 bool HasValidSkusCredential(PrefService* local_prefs);
 std::string GetSkusCredential(PrefService* local_prefs);
-#if BUILDFLAG(IS_WIN)
 bool IsBraveVPNWireguardEnabled(PrefService* local_state);
+#if BUILDFLAG(IS_WIN)
 void MigrateWireguardFeatureFlag(PrefService* local_prefs);
-#endif
+#endif  // BUILDFLAG(IS_WIN)
 }  // namespace brave_vpn
 
 #endif  // BRAVE_COMPONENTS_BRAVE_VPN_COMMON_BRAVE_VPN_UTILS_H_

--- a/components/brave_vpn/common/buildflags/BUILD.gn
+++ b/components/brave_vpn/common/buildflags/BUILD.gn
@@ -9,7 +9,10 @@ import("buildflags.gni")
 
 buildflag_header("buildflags") {
   header = "buildflags.h"
-  flags = [ "ENABLE_BRAVE_VPN=$enable_brave_vpn" ]
+  flags = [
+    "ENABLE_BRAVE_VPN=$enable_brave_vpn",
+    "ENABLE_BRAVE_VPN_WIREGUARD=$enable_brave_vpn_wireguard",
+  ]
 
   if (is_win) {
     if (brave_channel == "development") {

--- a/components/brave_vpn/common/buildflags/buildflags.gni
+++ b/components/brave_vpn/common/buildflags/buildflags.gni
@@ -10,3 +10,8 @@ declare_args() {
   # vpn panel is desktop specific UI.
   enable_brave_vpn_panel = is_win || is_mac
 }
+
+declare_args() {
+  # Wireguard is available only on Windows.
+  enable_brave_vpn_wireguard = is_win && enable_brave_vpn
+}

--- a/components/brave_vpn/common/pref_names.h
+++ b/components/brave_vpn/common/pref_names.h
@@ -6,6 +6,7 @@
 #ifndef BRAVE_COMPONENTS_BRAVE_VPN_COMMON_PREF_NAMES_H_
 #define BRAVE_COMPONENTS_BRAVE_VPN_COMMON_PREF_NAMES_H_
 
+#include "brave/components/brave_vpn/common/buildflags/buildflags.h"
 #include "build/build_config.h"
 
 namespace brave_vpn {
@@ -29,9 +30,11 @@ constexpr char kBraveVPNShowNotificationDialog[] =
     "brave.brave_vpn.show_notification_dialog";
 constexpr char kBraveVPNWireguardFallbackDialog[] =
     "brave.brave_vpn.show_wireguard_fallback_dialog";
+#endif  // BUILDFLAG(IS_WIN)
+#if BUILDFLAG(ENABLE_BRAVE_VPN_WIREGUARD)
 constexpr char kBraveVPNWireguardEnabled[] =
     "brave.brave_vpn.wireguard_enabled";
-#endif  // BUILDFLAG(IS_WIN)
+#endif
 constexpr char kBraveVPNWireguardProfileCredentials[] =
     "brave.brave_vpn.wireguard.profile_credentials";
 constexpr char kBraveVPNEnvironment[] = "brave.brave_vpn.env";

--- a/components/brave_vpn/common/wireguard/BUILD.gn
+++ b/components/brave_vpn/common/wireguard/BUILD.gn
@@ -8,7 +8,10 @@ import("//brave/components/brave_vpn/common/buildflags/buildflags.gni")
 assert(enable_brave_vpn)
 
 source_set("wireguard") {
-  sources = [ "constants.h" ]
+  sources = [
+    "wireguard_utils.cc",
+    "wireguard_utils.h",
+  ]
   deps = [
     "//base",
     "//third_party/abseil-cpp:absl",

--- a/components/brave_vpn/common/wireguard/win/BUILD.gn
+++ b/components/brave_vpn/common/wireguard/win/BUILD.gn
@@ -25,8 +25,8 @@ source_set("win") {
     "service_details.h",
     "storage_utils.cc",
     "storage_utils.h",
-    "wireguard_utils.cc",
-    "wireguard_utils.h",
+    "wireguard_utils_win.cc",
+    "wireguard_utils_win.h",
   ]
   deps = [
     ":brave_wireguard_manager_idl",

--- a/components/brave_vpn/common/wireguard/win/storage_utils.cc
+++ b/components/brave_vpn/common/wireguard/win/storage_utils.cc
@@ -9,7 +9,7 @@
 #include "base/win/registry.h"
 #include "brave/components/brave_vpn/common/wireguard/win/service_constants.h"
 #include "brave/components/brave_vpn/common/wireguard/win/service_details.h"
-#include "brave/components/brave_vpn/common/wireguard/win/wireguard_utils.h"
+#include "brave/components/brave_vpn/common/wireguard/win/wireguard_utils_win.h"
 
 namespace brave_vpn {
 

--- a/components/brave_vpn/common/wireguard/win/storage_utils_unittest.cc
+++ b/components/brave_vpn/common/wireguard/win/storage_utils_unittest.cc
@@ -6,7 +6,7 @@
 #include "brave/components/brave_vpn/common/wireguard/win/storage_utils.h"
 #include "base/test/test_reg_util_win.h"
 #include "base/win/registry.h"
-#include "brave/components/brave_vpn/common/wireguard/win/wireguard_utils.h"
+#include "brave/components/brave_vpn/common/wireguard/win/wireguard_utils_win.h"
 #include "testing/gmock/include/gmock/gmock.h"
 #include "testing/gtest/include/gtest/gtest.h"
 

--- a/components/brave_vpn/common/wireguard/win/wireguard_utils_win.cc
+++ b/components/brave_vpn/common/wireguard/win/wireguard_utils_win.cc
@@ -3,7 +3,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-#include "brave/components/brave_vpn/common/wireguard/win/wireguard_utils.h"
+#include "brave/components/brave_vpn/common/wireguard/win/wireguard_utils_win.h"
 
 #include <objbase.h>
 #include <stdint.h>
@@ -15,7 +15,6 @@
 #include "base/files/file_path.h"
 #include "base/logging.h"
 #include "base/process/launch.h"
-#include "base/strings/string_util.h"
 #include "base/strings/utf_string_conversions.h"
 #include "base/task/single_thread_task_runner.h"
 #include "base/task/thread_pool.h"
@@ -30,19 +29,6 @@
 namespace brave_vpn {
 
 namespace {
-
-// Template for wireguard config generation.
-constexpr char kWireguardConfigTemplate[] = R"(
-  [Interface]
-  PrivateKey = {client_private_key}
-  Address = {mapped_ipv4_address}
-  DNS = {dns_servers}
-  [Peer]
-  PublicKey = {server_public_key}
-  AllowedIPs = 0.0.0.0/0, ::/0
-  Endpoint = {vpn_server_hostname}:51821
-)";
-
 absl::optional<bool> g_wireguard_service_registered_for_testing;
 }  // namespace
 
@@ -69,30 +55,6 @@ bool IsBraveVPNWireguardTunnelServiceRunning() {
   }
   return status.value() == SERVICE_RUNNING ||
          status.value() == SERVICE_START_PENDING;
-}
-
-absl::optional<std::string> CreateWireguardConfig(
-    const std::string& client_private_key,
-    const std::string& server_public_key,
-    const std::string& vpn_server_hostname,
-    const std::string& mapped_ipv4_address,
-    const std::string& dns_servers) {
-  if (client_private_key.empty() || server_public_key.empty() ||
-      vpn_server_hostname.empty() || mapped_ipv4_address.empty() ||
-      dns_servers.empty()) {
-    return absl::nullopt;
-  }
-  std::string config = kWireguardConfigTemplate;
-  base::ReplaceSubstringsAfterOffset(&config, 0, "{client_private_key}",
-                                     client_private_key);
-  base::ReplaceSubstringsAfterOffset(&config, 0, "{server_public_key}",
-                                     server_public_key);
-  base::ReplaceSubstringsAfterOffset(&config, 0, "{vpn_server_hostname}",
-                                     vpn_server_hostname);
-  base::ReplaceSubstringsAfterOffset(&config, 0, "{mapped_ipv4_address}",
-                                     mapped_ipv4_address);
-  base::ReplaceSubstringsAfterOffset(&config, 0, "{dns_servers}", dns_servers);
-  return config;
 }
 
 bool EnableBraveVpnWireguardServiceImpl(const std::string& config) {

--- a/components/brave_vpn/common/wireguard/win/wireguard_utils_win.h
+++ b/components/brave_vpn/common/wireguard/win/wireguard_utils_win.h
@@ -3,13 +3,14 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-#ifndef BRAVE_COMPONENTS_BRAVE_VPN_COMMON_WIREGUARD_WIN_WIREGUARD_UTILS_H_
-#define BRAVE_COMPONENTS_BRAVE_VPN_COMMON_WIREGUARD_WIN_WIREGUARD_UTILS_H_
+#ifndef BRAVE_COMPONENTS_BRAVE_VPN_COMMON_WIREGUARD_WIN_WIREGUARD_UTILS_WIN_H_
+#define BRAVE_COMPONENTS_BRAVE_VPN_COMMON_WIREGUARD_WIN_WIREGUARD_UTILS_WIN_H_
 
 #include <string>
+#include <tuple>
 
 #include "base/functional/callback.h"
-#include "brave/components/brave_vpn/common/wireguard/constants.h"
+#include "brave/components/brave_vpn/common/wireguard/wireguard_utils.h"
 #include "third_party/abseil-cpp/absl/types/optional.h"
 
 namespace brave_vpn {
@@ -36,4 +37,4 @@ void ShowBraveVpnStatusTrayIcon();
 
 }  // namespace brave_vpn
 
-#endif  // BRAVE_COMPONENTS_BRAVE_VPN_COMMON_WIREGUARD_WIN_WIREGUARD_UTILS_H_
+#endif  // BRAVE_COMPONENTS_BRAVE_VPN_COMMON_WIREGUARD_WIN_WIREGUARD_UTILS_WIN_H_

--- a/components/brave_vpn/common/wireguard/wireguard_utils.cc
+++ b/components/brave_vpn/common/wireguard/wireguard_utils.cc
@@ -1,0 +1,55 @@
+/* Copyright (c) 2023 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "brave/components/brave_vpn/common/wireguard/wireguard_utils.h"
+
+#include "base/strings/string_util.h"
+
+namespace brave_vpn {
+
+namespace wireguard {
+
+namespace {
+constexpr char kCloudflareIPv4[] = "1.1.1.1";
+// Template for wireguard config generation.
+constexpr char kWireguardConfigTemplate[] = R"(
+  [Interface]
+  PrivateKey = {client_private_key}
+  Address = {mapped_ipv4_address}
+  DNS = {dns_servers}
+  [Peer]
+  PublicKey = {server_public_key}
+  AllowedIPs = 0.0.0.0/0, ::/0
+  Endpoint = {vpn_server_hostname}:51821
+)";
+
+}  // namespace
+
+absl::optional<std::string> CreateWireguardConfig(
+    const std::string& client_private_key,
+    const std::string& server_public_key,
+    const std::string& vpn_server_hostname,
+    const std::string& mapped_ipv4_address) {
+  if (client_private_key.empty() || server_public_key.empty() ||
+      vpn_server_hostname.empty() || mapped_ipv4_address.empty()) {
+    return absl::nullopt;
+  }
+  std::string config = kWireguardConfigTemplate;
+  base::ReplaceSubstringsAfterOffset(&config, 0, "{client_private_key}",
+                                     client_private_key);
+  base::ReplaceSubstringsAfterOffset(&config, 0, "{server_public_key}",
+                                     server_public_key);
+  base::ReplaceSubstringsAfterOffset(&config, 0, "{vpn_server_hostname}",
+                                     vpn_server_hostname);
+  base::ReplaceSubstringsAfterOffset(&config, 0, "{mapped_ipv4_address}",
+                                     mapped_ipv4_address);
+  base::ReplaceSubstringsAfterOffset(&config, 0, "{dns_servers}",
+                                     kCloudflareIPv4);
+  return config;
+}
+
+}  // namespace wireguard
+
+}  // namespace brave_vpn

--- a/components/brave_vpn/common/wireguard/wireguard_utils.h
+++ b/components/brave_vpn/common/wireguard/wireguard_utils.h
@@ -3,8 +3,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-#ifndef BRAVE_COMPONENTS_BRAVE_VPN_COMMON_WIREGUARD_CONSTANTS_H_
-#define BRAVE_COMPONENTS_BRAVE_VPN_COMMON_WIREGUARD_CONSTANTS_H_
+#ifndef BRAVE_COMPONENTS_BRAVE_VPN_COMMON_WIREGUARD_WIREGUARD_UTILS_H_
+#define BRAVE_COMPONENTS_BRAVE_VPN_COMMON_WIREGUARD_WIREGUARD_UTILS_H_
 
 #include <string>
 #include <tuple>
@@ -21,8 +21,14 @@ using WireguardKeyPair = absl::optional<std::tuple<std::string, std::string>>;
 using WireguardGenerateKeypairCallback =
     base::OnceCallback<void(WireguardKeyPair)>;
 
+absl::optional<std::string> CreateWireguardConfig(
+    const std::string& client_private_key,
+    const std::string& server_public_key,
+    const std::string& vpn_server_hostname,
+    const std::string& mapped_ipv4_address);
+
 }  // namespace wireguard
 
 }  // namespace brave_vpn
 
-#endif  // BRAVE_COMPONENTS_BRAVE_VPN_COMMON_WIREGUARD_CONSTANTS_H_
+#endif  // BRAVE_COMPONENTS_BRAVE_VPN_COMMON_WIREGUARD_WIREGUARD_UTILS_H_


### PR DESCRIPTION
Uplift of https://github.com/brave/brave-core/pull/20126
Fixes https://github.com/brave/brave-browser/issues/32934

Uplift of #20295
Resolves https://github.com/brave/brave-browser/issues/33244
Resolves https://github.com/brave/brave-browser/issues/33382

Uplift of https://github.com/brave/brave-core/pull/20392
Resolves https://github.com/brave/brave-browser/issues/33418

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.