### PR TITLE
Handle Brave Ads components unregister event

### DIFF
--- a/components/brave_ads/browser/ads_service.h
+++ b/components/brave_ads/browser/ads_service.h
@@ -76,10 +76,6 @@ class AdsService : public KeyedService {
   // argument - |base::Value::List| containing info of the obtained diagnostics.
   virtual void GetDiagnostics(GetDiagnosticsCallback callback) = 0;
 
-  // Called when a resource component has been updated.
-  virtual void OnDidUpdateResourceComponent(const std::string& manifest_version,
-                                            const std::string& id) = 0;
-
   // Called to get the statement of accounts. The callback takes one argument -
   // |mojom::StatementInfo| containing info of the obtained statement of
   // accounts.

--- a/components/brave_ads/browser/ads_service_impl.cc
+++ b/components/brave_ads/browser/ads_service_impl.cc
@@ -1906,6 +1906,12 @@ void AdsServiceImpl::OnDidUpdateResourceComponent(
   }
 }
 
+void AdsServiceImpl::OnDidUnregisterResourceComponent(const std::string& id) {
+  if (bat_ads_client_notifier_.is_bound()) {
+    bat_ads_client_notifier_->NotifyDidUnregisterResourceComponent(id);
+  }
+}
+
 void AdsServiceImpl::OnRewardsWalletCreated() {
   GetRewardsWallet();
 }

--- a/components/brave_ads/browser/ads_service_impl.h
+++ b/components/brave_ads/browser/ads_service_impl.h
@@ -401,6 +401,7 @@ class AdsServiceImpl : public AdsService,
   // ResourceComponentObserver:
   void OnDidUpdateResourceComponent(const std::string& manifest_version,
                                     const std::string& id) override;
+  void OnDidUnregisterResourceComponent(const std::string& id) override;
 
   // RewardsServiceObserver:
   void OnRewardsWalletCreated() override;

--- a/components/brave_ads/browser/ads_service_mock.h
+++ b/components/brave_ads/browser/ads_service_mock.h
@@ -41,9 +41,6 @@ class AdsServiceMock : public AdsService {
 
   MOCK_METHOD1(GetDiagnostics, void(GetDiagnosticsCallback));
 
-  MOCK_METHOD2(OnDidUpdateResourceComponent,
-               void(const std::string&, const std::string&));
-
   MOCK_METHOD1(GetStatementOfAccounts, void(GetStatementOfAccountsCallback));
 
   MOCK_METHOD2(MaybeServeInlineContentAd,

--- a/components/brave_ads/browser/component_updater/resource_component.cc
+++ b/components/brave_ads/browser/component_updater/resource_component.cc
@@ -71,14 +71,6 @@ void ResourceComponent::RegisterComponentForLanguageCode(
       language_code);
 }
 
-void ResourceComponent::NotifyDidUpdateResourceComponent(
-    const std::string& manifest_version,
-    const std::string& id) {
-  for (auto& observer : observers_) {
-    observer.OnDidUpdateResourceComponent(manifest_version, id);
-  }
-}
-
 absl::optional<base::FilePath> ResourceComponent::GetPath(const std::string& id,
                                                           const int version) {
   const std::string index = GetResourceKey(id, version);
@@ -113,6 +105,11 @@ void ResourceComponent::OnResourceComponentRegistered(
       base::BindOnce(&LoadFile, install_dir.Append(kManifestFile)),
       base::BindOnce(&ResourceComponent::LoadManifestCallback,
                      weak_factory_.GetWeakPtr(), component_id, install_dir));
+}
+
+void ResourceComponent::OnResourceComponentUnregistered(
+    const std::string& component_id) {
+  NotifyDidUnregisterResourceComponent(component_id);
 }
 
 void ResourceComponent::LoadManifestCallback(const std::string& component_id,
@@ -214,6 +211,21 @@ void ResourceComponent::LoadResourceCallback(
 
   VLOG(1) << "Notifying resource component observers";
   NotifyDidUpdateResourceComponent(manifest_version, component_id);
+}
+
+void ResourceComponent::NotifyDidUpdateResourceComponent(
+    const std::string& manifest_version,
+    const std::string& id) {
+  for (auto& observer : observers_) {
+    observer.OnDidUpdateResourceComponent(manifest_version, id);
+  }
+}
+
+void ResourceComponent::NotifyDidUnregisterResourceComponent(
+    const std::string& id) {
+  for (auto& observer : observers_) {
+    observer.OnDidUnregisterResourceComponent(id);
+  }
 }
 
 }  // namespace brave_ads

--- a/components/brave_ads/browser/component_updater/resource_component.h
+++ b/components/brave_ads/browser/component_updater/resource_component.h
@@ -40,8 +40,6 @@ class ResourceComponent : public ResourceComponentRegistrarDelegate {
   void RegisterComponentForCountryCode(const std::string& country_code);
   void RegisterComponentForLanguageCode(const std::string& language_code);
 
-  void NotifyDidUpdateResourceComponent(const std::string& manifest_version,
-                                        const std::string& id);
   absl::optional<base::FilePath> GetPath(const std::string& id, int version);
 
  private:
@@ -54,10 +52,16 @@ class ResourceComponent : public ResourceComponentRegistrarDelegate {
                             const base::FilePath& install_dir,
                             const std::string& json);
 
+  void NotifyDidUpdateResourceComponent(const std::string& manifest_version,
+                                        const std::string& id);
+  void NotifyDidUnregisterResourceComponent(const std::string& id);
+
   // ResourceComponentRegistrarDelegate:
   void OnResourceComponentRegistered(
       const std::string& component_id,
       const base::FilePath& install_dir) override;
+  void OnResourceComponentUnregistered(
+      const std::string& component_id) override;
 
   ResourceComponentRegistrar country_resource_component_registrar_;
   ResourceComponentRegistrar language_resource_component_registrar_;

--- a/components/brave_ads/browser/component_updater/resource_component_observer.h
+++ b/components/brave_ads/browser/component_updater/resource_component_observer.h
@@ -18,6 +18,9 @@ class ResourceComponentObserver : public base::CheckedObserver {
   // |manifest_version|.
   virtual void OnDidUpdateResourceComponent(const std::string& manifest_version,
                                             const std::string& id) = 0;
+
+  // Invoked when the resource for the given |id| has been unregistered
+  virtual void OnDidUnregisterResourceComponent(const std::string& id) = 0;
 };
 
 }  // namespace brave_ads

--- a/components/brave_ads/browser/component_updater/resource_component_registrar.cc
+++ b/components/brave_ads/browser/component_updater/resource_component_registrar.cc
@@ -40,6 +40,7 @@ void ResourceComponentRegistrar::RegisterResourceComponent(
   if (resource_component_id_ &&
       resource_component_id_ != component->id.data()) {
     Unregister();
+    OnComponentUnregistered(*resource_component_id_);
   }
   resource_component_id_ = component->id.data();
 
@@ -59,6 +60,12 @@ void ResourceComponentRegistrar::OnComponentReady(
     const std::string& /*resource*/) {
   resource_component_registrar_delegate_->OnResourceComponentRegistered(
       component_id, install_dir);
+}
+
+void ResourceComponentRegistrar::OnComponentUnregistered(
+    const std::string& component_id) {
+  resource_component_registrar_delegate_->OnResourceComponentUnregistered(
+      component_id);
 }
 
 }  // namespace brave_ads

--- a/components/brave_ads/browser/component_updater/resource_component_registrar.h
+++ b/components/brave_ads/browser/component_updater/resource_component_registrar.h
@@ -44,6 +44,8 @@ class ResourceComponentRegistrar
                         const base::FilePath& install_dir,
                         const std::string& manifest) override;
 
+  void OnComponentUnregistered(const std::string& component_id);
+
   raw_ref<ResourceComponentRegistrarDelegate>
       resource_component_registrar_delegate_;
   absl::optional<std::string> resource_component_id_;

--- a/components/brave_ads/browser/component_updater/resource_component_registrar_delegate.h
+++ b/components/brave_ads/browser/component_updater/resource_component_registrar_delegate.h
@@ -21,6 +21,9 @@ class ResourceComponentRegistrarDelegate {
   virtual void OnResourceComponentRegistered(
       const std::string& component_id,
       const base::FilePath& install_dir) = 0;
+
+  virtual void OnResourceComponentUnregistered(
+      const std::string& component_id) = 0;
 };
 
 }  // namespace brave_ads

--- a/components/brave_ads/core/internal/client/ads_client_notifier.cc
+++ b/components/brave_ads/core/internal/client/ads_client_notifier.cc
@@ -102,6 +102,20 @@ void AdsClientNotifier::NotifyDidUpdateResourceComponent(
   }
 }
 
+void AdsClientNotifier::NotifyDidUnregisterResourceComponent(
+    const std::string& id) const {
+  if (should_queue_notifications_) {
+    pending_notifier_queue_->Add(
+        base::BindOnce(&AdsClientNotifier::NotifyDidUnregisterResourceComponent,
+                       weak_factory_.GetWeakPtr(), id));
+    return;
+  }
+
+  for (auto& observer : observers_) {
+    observer.OnNotifyDidUnregisterResourceComponent(id);
+  }
+}
+
 void AdsClientNotifier::NotifyTabTextContentDidChange(
     const int32_t tab_id,
     const std::vector<GURL>& redirect_chain,

--- a/components/brave_ads/core/internal/client/ads_client_notifier_observer_mock.h
+++ b/components/brave_ads/core/internal/client/ads_client_notifier_observer_mock.h
@@ -36,6 +36,9 @@ class AdsClientNotifierObserverMock : public AdsClientNotifierObserver {
               OnNotifyDidUpdateResourceComponent,
               (const std::string&, const std::string&));
   MOCK_METHOD(void,
+              OnNotifyDidUnregisterResourceComponent,
+              (const std::string&));
+  MOCK_METHOD(void,
               OnNotifyRewardsWalletDidUpdate,
               (const std::string&, const std::string&));
   MOCK_METHOD(void,

--- a/components/brave_ads/core/internal/client/ads_client_notifier_unittest.cc
+++ b/components/brave_ads/core/internal/client/ads_client_notifier_unittest.cc
@@ -40,6 +40,7 @@ void Notify(const AdsClientNotifier& queued_notifier) {
   queued_notifier.NotifyPrefDidChange(kPrefPath);
   queued_notifier.NotifyDidUpdateResourceComponent(kManifestVersion,
                                                    kResourceId);
+  queued_notifier.NotifyDidUnregisterResourceComponent(kResourceId);
   queued_notifier.NotifyRewardsWalletDidUpdate(kPaymentId, kRecoverySeed);
   queued_notifier.NotifyTabTextContentDidChange(
       kTabId, {GURL(kRedirectChainUrl)}, kText);
@@ -69,6 +70,8 @@ void ExpectNotifierCalls(AdsClientNotifierObserverMock& observer,
       .Times(expected_calls_count);
   EXPECT_CALL(observer,
               OnNotifyDidUpdateResourceComponent(kManifestVersion, kResourceId))
+      .Times(expected_calls_count);
+  EXPECT_CALL(observer, OnNotifyDidUnregisterResourceComponent(kResourceId))
       .Times(expected_calls_count);
   EXPECT_CALL(observer,
               OnNotifyRewardsWalletDidUpdate(kPaymentId, kRecoverySeed))

--- a/components/brave_ads/core/internal/targeting/behavioral/anti_targeting/resource/anti_targeting_resource.cc
+++ b/components/brave_ads/core/internal/targeting/behavioral/anti_targeting/resource/anti_targeting_resource.cc
@@ -139,4 +139,15 @@ void AntiTargetingResource::OnNotifyDidUpdateResourceComponent(
   MaybeLoad();
 }
 
+void AntiTargetingResource::OnNotifyDidUnregisterResourceComponent(
+    const std::string& id) {
+  if (!IsValidCountryComponentId(id)) {
+    return;
+  }
+
+  manifest_version_.reset();
+
+  Reset();
+}
+
 }  // namespace brave_ads

--- a/components/brave_ads/core/internal/targeting/behavioral/anti_targeting/resource/anti_targeting_resource.h
+++ b/components/brave_ads/core/internal/targeting/behavioral/anti_targeting/resource/anti_targeting_resource.h
@@ -48,6 +48,7 @@ class AntiTargetingResource final : public AdsClientNotifierObserver {
   void OnNotifyPrefDidChange(const std::string& path) override;
   void OnNotifyDidUpdateResourceComponent(const std::string& manifest_version,
                                           const std::string& id) override;
+  void OnNotifyDidUnregisterResourceComponent(const std::string& id) override;
 
   absl::optional<AntiTargetingInfo> anti_targeting_;
 

--- a/components/brave_ads/core/internal/targeting/behavioral/purchase_intent/resource/purchase_intent_resource.cc
+++ b/components/brave_ads/core/internal/targeting/behavioral/purchase_intent/resource/purchase_intent_resource.cc
@@ -123,4 +123,15 @@ void PurchaseIntentResource::OnNotifyDidUpdateResourceComponent(
   MaybeLoad();
 }
 
+void PurchaseIntentResource::OnNotifyDidUnregisterResourceComponent(
+    const std::string& id) {
+  if (!IsValidCountryComponentId(id)) {
+    return;
+  }
+
+  manifest_version_.reset();
+
+  Reset();
+}
+
 }  // namespace brave_ads

--- a/components/brave_ads/core/internal/targeting/behavioral/purchase_intent/resource/purchase_intent_resource.h
+++ b/components/brave_ads/core/internal/targeting/behavioral/purchase_intent/resource/purchase_intent_resource.h
@@ -50,6 +50,7 @@ class PurchaseIntentResource final : public AdsClientNotifierObserver {
   void OnNotifyPrefDidChange(const std::string& path) override;
   void OnNotifyDidUpdateResourceComponent(const std::string& manifest_version,
                                           const std::string& id) override;
+  void OnNotifyDidUnregisterResourceComponent(const std::string& id) override;
 
   absl::optional<PurchaseIntentInfo> purchase_intent_;
 

--- a/components/brave_ads/core/internal/targeting/contextual/text_classification/resource/text_classification_resource.cc
+++ b/components/brave_ads/core/internal/targeting/contextual/text_classification/resource/text_classification_resource.cc
@@ -124,4 +124,15 @@ void TextClassificationResource::OnNotifyDidUpdateResourceComponent(
   MaybeLoad();
 }
 
+void TextClassificationResource::OnNotifyDidUnregisterResourceComponent(
+    const std::string& id) {
+  if (!IsValidLanguageComponentId(id)) {
+    return;
+  }
+
+  manifest_version_.reset();
+
+  Reset();
+}
+
 }  // namespace brave_ads

--- a/components/brave_ads/core/internal/targeting/contextual/text_classification/resource/text_classification_resource.h
+++ b/components/brave_ads/core/internal/targeting/contextual/text_classification/resource/text_classification_resource.h
@@ -53,6 +53,7 @@ class TextClassificationResource final : public AdsClientNotifierObserver {
   void OnNotifyPrefDidChange(const std::string& path) override;
   void OnNotifyDidUpdateResourceComponent(const std::string& manifest_version,
                                           const std::string& id) override;
+  void OnNotifyDidUnregisterResourceComponent(const std::string& id) override;
 
   absl::optional<ml::pipeline::TextProcessing> text_processing_pipeline_;
 

--- a/components/brave_ads/core/internal/targeting/contextual/text_embedding/resource/text_embedding_resource.cc
+++ b/components/brave_ads/core/internal/targeting/contextual/text_embedding/resource/text_embedding_resource.cc
@@ -120,4 +120,15 @@ void TextEmbeddingResource::OnNotifyDidUpdateResourceComponent(
   MaybeLoad();
 }
 
+void TextEmbeddingResource::OnNotifyDidUnregisterResourceComponent(
+    const std::string& id) {
+  if (!IsValidLanguageComponentId(id)) {
+    return;
+  }
+
+  manifest_version_.reset();
+
+  Reset();
+}
+
 }  // namespace brave_ads

--- a/components/brave_ads/core/internal/targeting/contextual/text_embedding/resource/text_embedding_resource.h
+++ b/components/brave_ads/core/internal/targeting/contextual/text_embedding/resource/text_embedding_resource.h
@@ -51,6 +51,7 @@ class TextEmbeddingResource final : public AdsClientNotifierObserver {
   void OnNotifyPrefDidChange(const std::string& path) override;
   void OnNotifyDidUpdateResourceComponent(const std::string& manifest_version,
                                           const std::string& id) override;
+  void OnNotifyDidUnregisterResourceComponent(const std::string& id) override;
 
   absl::optional<ml::pipeline::EmbeddingProcessing> embedding_processing_;
 

--- a/components/brave_ads/core/internal/transfer/transfer.cc
+++ b/components/brave_ads/core/internal/transfer/transfer.cc
@@ -120,7 +120,9 @@ void Transfer::LogAdEventCallback(const AdInfo& ad, const bool success) {
 }
 
 void Transfer::Cancel(const int32_t tab_id) {
-  CHECK(last_clicked_ad_);
+  if (!last_clicked_ad_) {
+    return;
+  }
 
   if (transferring_ad_tab_id_ != tab_id) {
     return;

--- a/components/brave_ads/core/public/client/ads_client_notifier.h
+++ b/components/brave_ads/core/public/client/ads_client_notifier.h
@@ -56,6 +56,9 @@ class AdsClientNotifier {
   void NotifyDidUpdateResourceComponent(const std::string& manifest_version,
                                         const std::string& id) const;
 
+  // Invoked when a resource component with |id| has been unregistered.
+  void NotifyDidUnregisterResourceComponent(const std::string& id) const;
+
   // Invoked when the page for |tab_id| has loaded and the content is available
   // for analysis. |redirect_chain| containing a list of redirect URLs that
   // occurred on the way to the current page. The current page is the last one

--- a/components/brave_ads/core/public/client/ads_client_notifier_observer.h
+++ b/components/brave_ads/core/public/client/ads_client_notifier_observer.h
@@ -48,6 +48,9 @@ class AdsClientNotifierObserver : public base::CheckedObserver {
       const std::string& manifest_version,
       const std::string& id) {}
 
+  // Invoked when a resource component with |id| has been unregistered.
+  virtual void OnNotifyDidUnregisterResourceComponent(const std::string& id) {}
+
   // Called when the Brave Rewards wallet did update.
   virtual void OnNotifyRewardsWalletDidUpdate(
       const std::string& payment_id,

--- a/components/services/bat_ads/bat_ads_client_notifier_impl.cc
+++ b/components/services/bat_ads/bat_ads_client_notifier_impl.cc
@@ -51,6 +51,11 @@ void BatAdsClientNotifierImpl::NotifyDidUpdateResourceComponent(
   notifier_.NotifyDidUpdateResourceComponent(manifest_version, id);
 }
 
+void BatAdsClientNotifierImpl::NotifyDidUnregisterResourceComponent(
+    const std::string& id) {
+  notifier_.NotifyDidUnregisterResourceComponent(id);
+}
+
 void BatAdsClientNotifierImpl::NotifyRewardsWalletDidUpdate(
     const std::string& payment_id,
     const std::string& recovery_seed) {

--- a/components/services/bat_ads/bat_ads_client_notifier_impl.h
+++ b/components/services/bat_ads/bat_ads_client_notifier_impl.h
@@ -53,6 +53,9 @@ class BatAdsClientNotifierImpl : public bat_ads::mojom::BatAdsClientNotifier {
   void NotifyDidUpdateResourceComponent(const std::string& manifest_version,
                                         const std::string& id) override;
 
+  // Invoked when a resource component with |id| has been unregistered.
+  void NotifyDidUnregisterResourceComponent(const std::string& id) override;
+
   // Invoked when the Brave Reward wallet did change.
   void NotifyRewardsWalletDidUpdate(const std::string& payment_id,
                                     const std::string& recovery_seed) override;

--- a/components/services/bat_ads/public/interfaces/bat_ads.mojom
+++ b/components/services/bat_ads/public/interfaces/bat_ads.mojom
@@ -30,6 +30,8 @@ interface BatAdsClientNotifier {
 
   NotifyDidUpdateResourceComponent(string manifest_version, string id);
 
+  NotifyDidUnregisterResourceComponent(string id);
+
   NotifyRewardsWalletDidUpdate(string payment_id, string recovery_seed);
 
   NotifyTabHtmlContentDidChange(int32 tab_id,


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/33394

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

* Start with a fresh profile with `--enable-features=Subdivision:fetch_interval_minutes/1m`
* Join Brave Rewards
* Make sure that Brave Ads resources (`purchase intent`, `conversion` and `anti-targeting`) resources were loaded.
* Change the device geo location
* Make sure that Brave Ads resources (`purchase intent`, `conversion` and `anti-targeting`) resources were re-loaded.
