### PR TITLE
[Android] Add google-java-format to DEPS

### DIFF
--- a/patches/DEPS.patch
+++ b/patches/DEPS.patch
@@ -1,0 +1,23 @@
+diff --git a/DEPS b/DEPS
+index 53d0c0fa5f5fac72954d749a6d77b5dab6878f3c..05a8c723ec41653bbd69db4113ef5f1bba46ba06 100644
+--- a/DEPS
++++ b/DEPS
+@@ -1450,6 +1450,18 @@ deps = {
+       'dep_type': 'cipd',
+   },
+ 
++  'src/third_party/google-java-format': {
++      'packages': [
++          {
++              'package': 'chromium/third_party/google-java-format',
++              'version': 'AQn4F5NfPAs_GKX-z3OW_Q7-yJ9N6tPrDnmnDScjkTEC',
++          },
++      ],
++      # Needed on Linux for use on chromium_presubmit.
++      'condition': 'checkout_android or checkout_linux',
++      'dep_type': 'cipd',
++  },
++
+   'src/third_party/hamcrest': {
+       'packages': [
+           {

--- a/patches/third_party-.gitignore.patch
+++ b/patches/third_party-.gitignore.patch
@@ -1,0 +1,12 @@
+diff --git a/third_party/.gitignore b/third_party/.gitignore
+index 628eed67792444b49985c28697dd02e592ca7c75..03488291a2fcf5c8ce7e2fce71e143ad4802252b 100644
+--- a/third_party/.gitignore
++++ b/third_party/.gitignore
+@@ -120,6 +120,7 @@
+ /glfw/src
+ /gn/
+ /gnu_binutils/
++/google-java-format/*.jar
+ /google-truth/lib/
+ /google_benchmark/src
+ /google_toolbox_for_mac/src


### PR DESCRIPTION
This is a temp patch of the following commit, we will remove it in C119.

https://github.com/brave/chromium/commit/9d01a086351823d75182797ffee4fb5fee9c7fb8
Add google-java-format to DEPS
depot_tools will be update to use it for java formatting.

Bug: 1462204

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/33407

There is a known issue of mismatching the newest `depot_tools` and older Chromium versions (older than `C119`) https://bugs.chromium.org/p/chromium/issues/detail?id=1462204#c15
The problem is that requirement for `google-java-format` is already in `depot_tools`, but DEPS for it added only in `C119`.
So we need temporarily add this dependency to unblock PRs on older Chromium versions.

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [ ] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

