### PR TITLE
Use `PrefService` with `MigrateObsoleteProfilePrefs`

### DIFF
--- a/browser/brave_wallet/brave_wallet_prefs_unittest.cc
+++ b/browser/brave_wallet/brave_wallet_prefs_unittest.cc
@@ -57,7 +57,7 @@ TEST_F(BraveWalletPrefsUnitTest, MigrateObsoleteProfilePrefsWeb3Provider) {
   // AskDeprecated changes to BraveWalletPreferExtension
   GetPrefs()->SetInteger(kBraveWalletWeb3ProviderDeprecated,
                          static_cast<int>(mojom::DefaultWallet::AskDeprecated));
-  MigrateObsoleteProfilePrefs(GetPrefs());
+  brave_wallet::MigrateObsoleteProfilePrefs(GetPrefs());
   EXPECT_EQ(mojom::DefaultWallet::BraveWalletPreferExtension,
             static_cast<mojom::DefaultWallet>(
                 GetPrefs()->GetInteger(kDefaultEthereumWallet)));
@@ -65,7 +65,7 @@ TEST_F(BraveWalletPrefsUnitTest, MigrateObsoleteProfilePrefsWeb3Provider) {
   // BraveWallet changes to BraveWalletPreferExtension
   GetPrefs()->SetInteger(kBraveWalletWeb3ProviderDeprecated,
                          static_cast<int>(mojom::DefaultWallet::BraveWallet));
-  MigrateObsoleteProfilePrefs(GetPrefs());
+  brave_wallet::MigrateObsoleteProfilePrefs(GetPrefs());
   EXPECT_EQ(mojom::DefaultWallet::BraveWalletPreferExtension,
             static_cast<mojom::DefaultWallet>(
                 GetPrefs()->GetInteger(kDefaultEthereumWallet)));
@@ -74,7 +74,7 @@ TEST_F(BraveWalletPrefsUnitTest, MigrateObsoleteProfilePrefsWeb3Provider) {
   GetPrefs()->SetInteger(
       kBraveWalletWeb3ProviderDeprecated,
       static_cast<int>(mojom::DefaultWallet::BraveWalletPreferExtension));
-  MigrateObsoleteProfilePrefs(GetPrefs());
+  brave_wallet::MigrateObsoleteProfilePrefs(GetPrefs());
   EXPECT_EQ(mojom::DefaultWallet::BraveWalletPreferExtension,
             static_cast<mojom::DefaultWallet>(
                 GetPrefs()->GetInteger(kDefaultEthereumWallet)));
@@ -82,7 +82,7 @@ TEST_F(BraveWalletPrefsUnitTest, MigrateObsoleteProfilePrefsWeb3Provider) {
   // Ask changes to BraveWalletPreferExtension
   GetPrefs()->SetInteger(kBraveWalletWeb3ProviderDeprecated,
                          static_cast<int>(mojom::DefaultWallet::AskDeprecated));
-  MigrateObsoleteProfilePrefs(GetPrefs());
+  brave_wallet::MigrateObsoleteProfilePrefs(GetPrefs());
   EXPECT_EQ(mojom::DefaultWallet::BraveWalletPreferExtension,
             static_cast<mojom::DefaultWallet>(
                 GetPrefs()->GetInteger(kDefaultEthereumWallet)));
@@ -90,7 +90,7 @@ TEST_F(BraveWalletPrefsUnitTest, MigrateObsoleteProfilePrefsWeb3Provider) {
   // CryptoWallets changes to BraveWalletPreferExtension
   GetPrefs()->SetInteger(kBraveWalletWeb3ProviderDeprecated,
                          static_cast<int>(mojom::DefaultWallet::CryptoWallets));
-  MigrateObsoleteProfilePrefs(GetPrefs());
+  brave_wallet::MigrateObsoleteProfilePrefs(GetPrefs());
   EXPECT_EQ(mojom::DefaultWallet::BraveWalletPreferExtension,
             static_cast<mojom::DefaultWallet>(
                 GetPrefs()->GetInteger(kDefaultEthereumWallet)));
@@ -98,7 +98,7 @@ TEST_F(BraveWalletPrefsUnitTest, MigrateObsoleteProfilePrefsWeb3Provider) {
   // None remains None
   GetPrefs()->SetInteger(kBraveWalletWeb3ProviderDeprecated,
                          static_cast<int>(mojom::DefaultWallet::None));
-  MigrateObsoleteProfilePrefs(GetPrefs());
+  brave_wallet::MigrateObsoleteProfilePrefs(GetPrefs());
   EXPECT_EQ(mojom::DefaultWallet::None,
             static_cast<mojom::DefaultWallet>(
                 GetPrefs()->GetInteger(kDefaultEthereumWallet)));
@@ -109,7 +109,7 @@ TEST_F(BraveWalletPrefsUnitTest,
   // AskDeprecated changes to BraveWalletPreferExtension
   GetPrefs()->SetInteger(kDefaultWalletDeprecated,
                          static_cast<int>(mojom::DefaultWallet::AskDeprecated));
-  MigrateObsoleteProfilePrefs(GetPrefs());
+  brave_wallet::MigrateObsoleteProfilePrefs(GetPrefs());
   EXPECT_EQ(mojom::DefaultWallet::BraveWalletPreferExtension,
             static_cast<mojom::DefaultWallet>(
                 GetPrefs()->GetInteger(kDefaultEthereumWallet)));
@@ -117,7 +117,7 @@ TEST_F(BraveWalletPrefsUnitTest,
   // BraveWallet changes to BraveWalletPreferExtension
   GetPrefs()->SetInteger(kDefaultWalletDeprecated,
                          static_cast<int>(mojom::DefaultWallet::BraveWallet));
-  MigrateObsoleteProfilePrefs(GetPrefs());
+  brave_wallet::MigrateObsoleteProfilePrefs(GetPrefs());
   EXPECT_EQ(mojom::DefaultWallet::BraveWalletPreferExtension,
             static_cast<mojom::DefaultWallet>(
                 GetPrefs()->GetInteger(kDefaultEthereumWallet)));
@@ -126,7 +126,7 @@ TEST_F(BraveWalletPrefsUnitTest,
   GetPrefs()->SetInteger(
       kDefaultWalletDeprecated,
       static_cast<int>(mojom::DefaultWallet::BraveWalletPreferExtension));
-  MigrateObsoleteProfilePrefs(GetPrefs());
+  brave_wallet::MigrateObsoleteProfilePrefs(GetPrefs());
   EXPECT_EQ(mojom::DefaultWallet::BraveWalletPreferExtension,
             static_cast<mojom::DefaultWallet>(
                 GetPrefs()->GetInteger(kDefaultEthereumWallet)));
@@ -134,7 +134,7 @@ TEST_F(BraveWalletPrefsUnitTest,
   // Ask changes to BraveWalletPreferExtension
   GetPrefs()->SetInteger(kDefaultWalletDeprecated,
                          static_cast<int>(mojom::DefaultWallet::AskDeprecated));
-  MigrateObsoleteProfilePrefs(GetPrefs());
+  brave_wallet::MigrateObsoleteProfilePrefs(GetPrefs());
   EXPECT_EQ(mojom::DefaultWallet::BraveWalletPreferExtension,
             static_cast<mojom::DefaultWallet>(
                 GetPrefs()->GetInteger(kDefaultEthereumWallet)));
@@ -142,7 +142,7 @@ TEST_F(BraveWalletPrefsUnitTest,
   // CryptoWallets changes to BraveWalletPreferExtension
   GetPrefs()->SetInteger(kDefaultWalletDeprecated,
                          static_cast<int>(mojom::DefaultWallet::CryptoWallets));
-  MigrateObsoleteProfilePrefs(GetPrefs());
+  brave_wallet::MigrateObsoleteProfilePrefs(GetPrefs());
   EXPECT_EQ(mojom::DefaultWallet::BraveWalletPreferExtension,
             static_cast<mojom::DefaultWallet>(
                 GetPrefs()->GetInteger(kDefaultEthereumWallet)));
@@ -150,7 +150,7 @@ TEST_F(BraveWalletPrefsUnitTest,
   // None remains None
   GetPrefs()->SetInteger(kDefaultWalletDeprecated,
                          static_cast<int>(mojom::DefaultWallet::None));
-  MigrateObsoleteProfilePrefs(GetPrefs());
+  brave_wallet::MigrateObsoleteProfilePrefs(GetPrefs());
   EXPECT_EQ(mojom::DefaultWallet::None,
             static_cast<mojom::DefaultWallet>(
                 GetPrefs()->GetInteger(kDefaultEthereumWallet)));
@@ -164,7 +164,7 @@ TEST_F(BraveWalletPrefsUnitTest,
       GetPrefs()->GetBoolean(kBraveWalletEthereumTransactionsCoinTypeMigrated));
   auto* pref = GetPrefs()->FindPreference(kBraveWalletTransactions);
   ASSERT_TRUE(pref && pref->IsDefaultValue());
-  MigrateObsoleteProfilePrefs(GetPrefs());
+  brave_wallet::MigrateObsoleteProfilePrefs(GetPrefs());
   EXPECT_TRUE(pref && pref->IsDefaultValue());
   EXPECT_TRUE(
       GetPrefs()->GetBoolean(kBraveWalletEthereumTransactionsCoinTypeMigrated));
@@ -190,7 +190,7 @@ TEST_F(BraveWalletPrefsUnitTest,
     update->SetByDottedPath("ropsten.meta3", tx1.Clone());
   }
 
-  MigrateObsoleteProfilePrefs(GetPrefs());
+  brave_wallet::MigrateObsoleteProfilePrefs(GetPrefs());
   const auto& dict = GetPrefs()->GetDict(kBraveWalletTransactions);
   const auto* tx1_value = dict.FindDictByDottedPath("ethereum.mainnet.meta1");
   const auto* tx2_value = dict.FindDictByDottedPath("ethereum.mainnet.meta2");
@@ -217,7 +217,7 @@ TEST_F(BraveWalletPrefsUnitTest,
   EXPECT_TRUE(pref && !pref->IsDefaultValue());
   EXPECT_TRUE(GetPrefs()->GetDict(kBraveWalletTransactions).empty());
 
-  MigrateObsoleteProfilePrefs(GetPrefs());
+  brave_wallet::MigrateObsoleteProfilePrefs(GetPrefs());
   EXPECT_TRUE(pref && pref->IsDefaultValue());
   EXPECT_TRUE(
       GetPrefs()->GetBoolean(kBraveWalletEthereumTransactionsCoinTypeMigrated));
@@ -241,7 +241,7 @@ TEST_F(BraveWalletPrefsUnitTest, MigrateShowTestNetworksToggle) {
               ElementsAreArray({mojom::kSolanaDevnet, mojom::kSolanaTestnet,
                                 mojom::kLocalhostChainId}));
 
-  MigrateObsoleteProfilePrefs(GetPrefs());
+  brave_wallet::MigrateObsoleteProfilePrefs(GetPrefs());
   // Still same when nothing to migrate.
   EXPECT_THAT(GetHiddenNetworks(GetPrefs(), mojom::CoinType::ETH),
               ElementsAreArray({mojom::kGoerliChainId, mojom::kSepoliaChainId,
@@ -256,7 +256,7 @@ TEST_F(BraveWalletPrefsUnitTest, MigrateShowTestNetworksToggle) {
 
   GetPrefs()->SetBoolean(kShowWalletTestNetworksDeprecated, false);
 
-  MigrateObsoleteProfilePrefs(GetPrefs());
+  brave_wallet::MigrateObsoleteProfilePrefs(GetPrefs());
   // Still same when test networks toggle was explicitly off.
   EXPECT_THAT(GetHiddenNetworks(GetPrefs(), mojom::CoinType::ETH),
               ElementsAreArray({mojom::kGoerliChainId, mojom::kSepoliaChainId,
@@ -272,7 +272,7 @@ TEST_F(BraveWalletPrefsUnitTest, MigrateShowTestNetworksToggle) {
 
   GetPrefs()->SetBoolean(kShowWalletTestNetworksDeprecated, true);
 
-  MigrateObsoleteProfilePrefs(GetPrefs());
+  brave_wallet::MigrateObsoleteProfilePrefs(GetPrefs());
   // Test networks are removed from hidden list after successfull migration.
   EXPECT_THAT(GetHiddenNetworks(GetPrefs(), mojom::CoinType::ETH), SizeIs(0));
   EXPECT_THAT(GetHiddenNetworks(GetPrefs(), mojom::CoinType::FIL),
@@ -310,7 +310,7 @@ TEST_F(BraveWalletPrefsUnitTest, MigrateAddChainIdToTransactionInfo) {
     update->SetByDottedPath("solana", std::move(tx2));
     update->SetByDottedPath("filecoin", std::move(tx3));
   }
-  MigrateObsoleteProfilePrefs(GetPrefs());
+  brave_wallet::MigrateObsoleteProfilePrefs(GetPrefs());
 
   EXPECT_TRUE(GetPrefs()->HasPrefPath(kBraveWalletTransactionsChainIdMigrated));
   EXPECT_TRUE(GetPrefs()->GetBoolean(kBraveWalletTransactionsChainIdMigrated));

--- a/browser/gcm_driver/brave_gcm_utils.cc
+++ b/browser/gcm_driver/brave_gcm_utils.cc
@@ -7,7 +7,6 @@
 
 #include "base/values.h"
 #include "brave/components/constants/pref_names.h"
-#include "chrome/browser/profiles/profile.h"
 #include "components/pref_registry/pref_registry_syncable.h"
 #include "components/prefs/pref_service.h"
 
@@ -23,8 +22,7 @@ void RegisterGCMProfilePrefs(user_prefs::PrefRegistrySyncable* registry) {
   registry->RegisterBooleanPref(kBraveGCMChannelStatus, false);
 }
 
-void MigrateGCMPrefs(Profile* profile) {
-  PrefService* prefs = profile->GetPrefs();
+void MigrateGCMPrefs(PrefService* prefs) {
   // The default was false (see above).
   auto* pref = prefs->FindPreference(kGCMChannelStatus);
   if (pref && !pref->IsDefaultValue())

--- a/browser/gcm_driver/brave_gcm_utils.h
+++ b/browser/gcm_driver/brave_gcm_utils.h
@@ -6,7 +6,7 @@
 #ifndef BRAVE_BROWSER_GCM_DRIVER_BRAVE_GCM_UTILS_H_
 #define BRAVE_BROWSER_GCM_DRIVER_BRAVE_GCM_UTILS_H_
 
-class Profile;
+class PrefService;
 
 namespace user_prefs {
 class PrefRegistrySyncable;
@@ -15,7 +15,7 @@ class PrefRegistrySyncable;
 namespace gcm {
 
 void RegisterGCMProfilePrefs(user_prefs::PrefRegistrySyncable* registry);
-void MigrateGCMPrefs(Profile* profile);
+void MigrateGCMPrefs(PrefService* prefs);
 
 }  // namespace gcm
 

--- a/browser/search/ntp_utils.cc
+++ b/browser/search/ntp_utils.cc
@@ -15,8 +15,7 @@
 
 namespace {
 
-void ClearNewTabPageProfilePrefs(Profile* profile) {
-  PrefService* prefs = profile->GetPrefs();
+void ClearNewTabPageProfilePrefs(PrefService* prefs) {
   prefs->ClearPref(kNewTabPageShowTopSites);
 }
 
@@ -27,10 +26,9 @@ const char* const kWidgetPrefNames[] = {kNewTabPageShowRewards,
 
 namespace new_tab_page {
 
-void MigrateNewTabPagePrefs(Profile* profile) {
+void MigrateNewTabPagePrefs(PrefService* prefs) {
   // Migrate over to the Chromium setting for shortcuts visible
   // Only sets the value if user has changed it
-  auto* prefs = profile->GetPrefs();
   const PrefService::Preference* top_sites_pref =
       prefs->FindPreference(kNewTabPageShowTopSites);
   if (top_sites_pref->HasUserSetting()) {
@@ -79,7 +77,7 @@ void MigrateNewTabPagePrefs(Profile* profile) {
   }
 
   // Clear deprecated prefs.
-  ClearNewTabPageProfilePrefs(profile);
+  ClearNewTabPageProfilePrefs(prefs);
 }
 
 void RegisterNewTabPagePrefsForMigration(

--- a/browser/search/ntp_utils.h
+++ b/browser/search/ntp_utils.h
@@ -6,7 +6,7 @@
 #ifndef BRAVE_BROWSER_SEARCH_NTP_UTILS_H_
 #define BRAVE_BROWSER_SEARCH_NTP_UTILS_H_
 
-class Profile;
+class PrefService;
 
 namespace user_prefs {
 class PrefRegistrySyncable;
@@ -15,7 +15,7 @@ class PrefRegistrySyncable;
 namespace new_tab_page {
 
 // APIs for prefs.
-void MigrateNewTabPagePrefs(Profile* profile);
+void MigrateNewTabPagePrefs(PrefService* prefs);
 void RegisterNewTabPagePrefsForMigration(
     user_prefs::PrefRegistrySyncable* registry);
 

--- a/browser/search/ntp_utils_unittest.cc
+++ b/browser/search/ntp_utils_unittest.cc
@@ -25,6 +25,8 @@ class NTPUtilsTest : public ::testing::Test {
 
   Profile* profile() { return profile_.get(); }
 
+  PrefService* GetPrefs() { return profile_->GetPrefs(); }
+
  protected:
   // BrowserTaskEnvironment is needed before TestingProfile
   content::BrowserTaskEnvironment task_environment_;
@@ -34,22 +36,22 @@ class NTPUtilsTest : public ::testing::Test {
 
 TEST_F(NTPUtilsTest, MigratesHideWidgetTrue) {
   // Manually turn all off
-  auto* prefs = profile()->GetPrefs();
+  auto* prefs = GetPrefs();
   prefs->SetBoolean(kNewTabPageShowRewards, false);
   prefs->SetBoolean(kNewTabPageShowBraveTalk, false);
   // Migrate
-  new_tab_page::MigrateNewTabPagePrefs(profile());
+  new_tab_page::MigrateNewTabPagePrefs(GetPrefs());
   // Expect migrated to off
   EXPECT_TRUE(prefs->GetBoolean(kNewTabPageHideAllWidgets));
 }
 
 TEST_F(NTPUtilsTest, MigratesHideWidgetFalse) {
   // Manually turn some off
-  auto* prefs = profile()->GetPrefs();
+  auto* prefs = GetPrefs();
   prefs->SetBoolean(kNewTabPageShowRewards, false);
   prefs->SetBoolean(kNewTabPageShowBraveTalk, true);
   // Migrate
-  new_tab_page::MigrateNewTabPagePrefs(profile());
+  new_tab_page::MigrateNewTabPagePrefs(GetPrefs());
   // Expect not migrated
   EXPECT_FALSE(prefs->GetBoolean(kNewTabPageHideAllWidgets));
 }
@@ -57,8 +59,8 @@ TEST_F(NTPUtilsTest, MigratesHideWidgetFalse) {
 TEST_F(NTPUtilsTest, MigratesHideWidgetFalseDefault) {
   // Don't manually change any settings
   // Migrate
-  new_tab_page::MigrateNewTabPagePrefs(profile());
+  new_tab_page::MigrateNewTabPagePrefs(GetPrefs());
   // Expect not migrated
-  auto* prefs = profile()->GetPrefs();
+  auto* prefs = GetPrefs();
   EXPECT_FALSE(prefs->GetBoolean(kNewTabPageHideAllWidgets));
 }

--- a/browser/search_engines/search_engine_provider_util.cc
+++ b/browser/search_engines/search_engine_provider_util.cc
@@ -48,8 +48,7 @@ void RegisterSearchEngineProviderPrefsForMigration(
       kShowAlternativePrivateSearchEngineProviderToggle, false);
 }
 
-void MigrateSearchEngineProviderPrefs(Profile* profile) {
-  auto* prefs = profile->GetPrefs();
+void MigrateSearchEngineProviderPrefs(PrefService* prefs) {
   const bool need_migrate =
       prefs->GetBoolean(kShowAlternativePrivateSearchEngineProviderToggle) &&
       prefs->GetBoolean(kUseAlternativePrivateSearchEngineProvider);

--- a/browser/search_engines/search_engine_provider_util.h
+++ b/browser/search_engines/search_engine_provider_util.h
@@ -21,7 +21,7 @@ void SetBraveAsDefaultPrivateSearchProvider(PrefService* prefs);
 // For prefs migration.
 void RegisterSearchEngineProviderPrefsForMigration(
     user_prefs::PrefRegistrySyncable* registry);
-void MigrateSearchEngineProviderPrefs(Profile* profile);
+void MigrateSearchEngineProviderPrefs(PrefService* prefs);
 
 // Initialize default provider for private profile.
 void PrepareDefaultPrivateSearchProviderDataIfNeeded(Profile* profile);

--- a/browser/themes/brave_dark_mode_prefs_migration_browsertest.cc
+++ b/browser/themes/brave_dark_mode_prefs_migration_browsertest.cc
@@ -24,7 +24,7 @@ IN_PROC_BROWSER_TEST_F(DarkModePrefsMigrationTest, PrefMigrationTest) {
   browser()->profile()->GetPrefs()->SetInteger(kBraveThemeType, dark_mode_type);
 
   // Migrate and check it's done properly with previous profile prefs value.
-  dark_mode::MigrateBraveDarkModePrefs(browser()->profile());
+  dark_mode::MigrateBraveDarkModePrefs(browser()->profile()->GetPrefs());
   EXPECT_FALSE(g_browser_process->local_state()->
       FindPreference(kBraveDarkMode)->IsDefaultValue());
   EXPECT_EQ(dark_mode_type,

--- a/browser/themes/brave_dark_mode_utils.cc
+++ b/browser/themes/brave_dark_mode_utils.cc
@@ -16,7 +16,6 @@
 #include "brave/components/l10n/common/localization_util.h"
 #include "brave/grit/brave_generated_resources.h"
 #include "chrome/browser/browser_process.h"
-#include "chrome/browser/profiles/profile.h"
 #include "chrome/common/channel_info.h"
 #include "components/pref_registry/pref_registry_syncable.h"
 #include "components/prefs/pref_registry_simple.h"
@@ -29,8 +28,7 @@ namespace {
 bool g_is_test_ = false;
 bool g_system_dark_mode_enabled_in_test_ = false;
 
-void ClearBraveDarkModeProfilePrefs(Profile* profile) {
-  PrefService* prefs = profile->GetPrefs();
+void ClearBraveDarkModeProfilePrefs(PrefService* prefs) {
   prefs->ClearPref(kBraveThemeType);
   prefs->ClearPref(kUseOverriddenBraveThemeType);
 }
@@ -69,19 +67,18 @@ dark_mode::BraveDarkModeType GetDarkModeSwitchValue(
 
 namespace dark_mode {
 
-void MigrateBraveDarkModePrefs(Profile* profile) {
+void MigrateBraveDarkModePrefs(PrefService* prefs) {
   auto* local_state = g_browser_process->local_state();
   // If migration is done, local state doesn't have default value because
   // they were explicitly set by primary prefs' value. After that, we don't
   // need to try migration again and prefs from profiles are already cleared.
   if (local_state->FindPreference(kBraveDarkMode)->IsDefaultValue()) {
-    PrefService* prefs = profile->GetPrefs();
     local_state->SetInteger(kBraveDarkMode,
                             prefs->GetInteger(kBraveThemeType));
   }
 
   // Clear deprecated prefs.
-  ClearBraveDarkModeProfilePrefs(profile);
+  ClearBraveDarkModeProfilePrefs(prefs);
 }
 
 void RegisterBraveDarkModeLocalStatePrefs(PrefRegistrySimple* registry) {

--- a/browser/themes/brave_dark_mode_utils.h
+++ b/browser/themes/brave_dark_mode_utils.h
@@ -12,7 +12,7 @@
 #include "build/build_config.h"
 
 class PrefRegistrySimple;
-class Profile;
+class PrefService;
 
 namespace user_prefs {
 class PrefRegistrySyncable;
@@ -32,7 +32,7 @@ enum class BraveDarkModeType {
 };
 
 // APIs for prefs.
-void MigrateBraveDarkModePrefs(Profile* profile);
+void MigrateBraveDarkModePrefs(PrefService* prefs);
 void RegisterBraveDarkModePrefsForMigration(
     user_prefs::PrefRegistrySyncable* registry);
 void RegisterBraveDarkModeLocalStatePrefs(PrefRegistrySimple* registry);

--- a/browser/themes/brave_dark_mode_utils_android.cc
+++ b/browser/themes/brave_dark_mode_utils_android.cc
@@ -7,8 +7,7 @@
 
 namespace dark_mode {
 
-void MigrateBraveDarkModePrefs(Profile* profile) {
-}
+void MigrateBraveDarkModePrefs(PrefService* prefs) {}
 
 void RegisterBraveDarkModeLocalStatePrefs(PrefRegistrySimple* registry) {
 }

--- a/browser/widevine/widevine_prefs_migration_browsertest.cc
+++ b/browser/widevine/widevine_prefs_migration_browsertest.cc
@@ -29,7 +29,7 @@ IN_PROC_BROWSER_TEST_F(WidevinePrefsMigrationTest, PrefMigrationTest) {
                                                kWidevineEnabledTestValue);
 
   // Migrate and check it's done properly with previous profile prefs value.
-  MigrateWidevinePrefs(browser()->profile());
+  MigrateWidevinePrefs(browser()->profile()->GetPrefs());
   EXPECT_FALSE(g_browser_process->local_state()
                    ->FindPreference(kWidevineEnabled)
                    ->IsDefaultValue());

--- a/browser/widevine/widevine_utils.cc
+++ b/browser/widevine/widevine_utils.cc
@@ -20,7 +20,6 @@
 #include "chrome/browser/browser_process.h"
 #include "chrome/browser/component_updater/component_updater_utils.h"
 #include "chrome/browser/component_updater/widevine_cdm_component_installer.h"
-#include "chrome/browser/profiles/profile.h"
 #include "chrome/common/chrome_paths.h"
 #include "components/component_updater/component_updater_service.h"
 #include "components/permissions/permission_request_manager.h"
@@ -72,8 +71,7 @@ void DeleteOldWidevineBinary() {
 }
 #endif
 
-void ClearWidevinePrefs(Profile* profile) {
-  PrefService* prefs = profile->GetPrefs();
+void ClearWidevinePrefs(PrefService* prefs) {
   prefs->ClearPref(kWidevineEnabled);
 }
 
@@ -143,7 +141,7 @@ void SetWidevineEnabled(bool opted_in) {
   g_browser_process->local_state()->SetBoolean(kWidevineEnabled, opted_in);
 }
 
-void MigrateWidevinePrefs(Profile* profile) {
+void MigrateWidevinePrefs(PrefService* prefs) {
   DCHECK_CURRENTLY_ON(BrowserThread::UI);
 
   auto* local_state = g_browser_process->local_state();
@@ -151,13 +149,12 @@ void MigrateWidevinePrefs(Profile* profile) {
   // they were explicitly set by primary prefs' value. After that, we don't
   // need to try migration again and prefs from profiles are already cleared.
   if (local_state->FindPreference(kWidevineEnabled)->IsDefaultValue()) {
-    PrefService* prefs = profile->GetPrefs();
     local_state->SetBoolean(kWidevineEnabled,
                             prefs->GetBoolean(kWidevineEnabled));
   }
 
   // Clear deprecated prefs.
-  ClearWidevinePrefs(profile);
+  ClearWidevinePrefs(prefs);
 }
 
 void RegisterWidevineLocalstatePrefsForMigration(PrefRegistrySimple* registry) {

--- a/browser/widevine/widevine_utils.h
+++ b/browser/widevine/widevine_utils.h
@@ -16,7 +16,6 @@ class PrefRegistrySyncable;
 
 class PrefRegistrySimple;
 class PrefService;
-class Profile;
 
 // On Android, kWidevineEnabled is written through EnableWidevineCdm() for the
 // permission prompt, but r/w through BraveLocalState.java on preference screen
@@ -31,7 +30,7 @@ void RegisterWidevineLocalstatePrefs(PrefRegistrySimple* registry);
 void RegisterWidevineLocalstatePrefsForMigration(PrefRegistrySimple* registry);
 bool IsWidevineEnabled();
 void SetWidevineEnabled(bool opted_in);
-void MigrateWidevinePrefs(Profile* profile);
+void MigrateWidevinePrefs(PrefService* prefs);
 void MigrateObsoleteWidevineLocalStatePrefs(PrefService* local_state);
 
 #endif  // BRAVE_BROWSER_WIDEVINE_WIDEVINE_UTILS_H_

--- a/chromium_src/chrome/browser/prefs/browser_prefs.cc
+++ b/chromium_src/chrome/browser/prefs/browser_prefs.cc
@@ -71,95 +71,94 @@
 // This method should be periodically pruned of year+ old migrations.
 void MigrateObsoleteProfilePrefs(Profile* profile) {
   // BEGIN_MIGRATE_OBSOLETE_PROFILE_PREFS
+  PrefService* profile_prefs = profile->GetPrefs();
 #if !BUILDFLAG(USE_GCM_FROM_PLATFORM)
   // Added 02/2020.
   // Must be called before ChromiumImpl because it's migrating a Chromium pref
   // to Brave pref.
-  gcm::MigrateGCMPrefs(profile);
+  gcm::MigrateGCMPrefs(profile_prefs);
 #endif
 
   MigrateObsoleteProfilePrefs_ChromiumImpl(profile);
 
 #if BUILDFLAG(ENABLE_WIDEVINE)
   // Added 11/2019.
-  MigrateWidevinePrefs(profile);
+  MigrateWidevinePrefs(profile_prefs);
 #endif
-  brave_sync::MigrateBraveSyncPrefs(profile->GetPrefs());
+  brave_sync::MigrateBraveSyncPrefs(profile_prefs);
 
   // Added 12/2019.
-  dark_mode::MigrateBraveDarkModePrefs(profile);
+  dark_mode::MigrateBraveDarkModePrefs(profile_prefs);
 
 #if !BUILDFLAG(IS_ANDROID)
   // Added 9/2020
-  new_tab_page::MigrateNewTabPagePrefs(profile);
+  new_tab_page::MigrateNewTabPagePrefs(profile_prefs);
 
   // Added 06/2022
-  brave::MigrateSearchEngineProviderPrefs(profile);
+  brave::MigrateSearchEngineProviderPrefs(profile_prefs);
 
   // Added 10/2022
-  profile->GetPrefs()->ClearPref(kDefaultBrowserLaunchingCount);
+  profile_prefs->ClearPref(kDefaultBrowserLaunchingCount);
 #endif
 
 #if BUILDFLAG(ENABLE_EXTENSIONS)
   // Added 11/2022
-  profile->GetPrefs()->ClearPref(kDontAskEnableWebDiscovery);
-  profile->GetPrefs()->ClearPref(kBraveSearchVisitCount);
+  profile_prefs->ClearPref(kDontAskEnableWebDiscovery);
+  profile_prefs->ClearPref(kBraveSearchVisitCount);
 #endif
 
-  brave_wallet::KeyringService::MigrateObsoleteProfilePrefs(
-      profile->GetPrefs());
-  brave_wallet::MigrateObsoleteProfilePrefs(profile->GetPrefs());
+  brave_wallet::KeyringService::MigrateObsoleteProfilePrefs(profile_prefs);
+  brave_wallet::MigrateObsoleteProfilePrefs(profile_prefs);
 
   // Added 05/2021
-  profile->GetPrefs()->ClearPref(kBraveNewsIntroDismissed);
+  profile_prefs->ClearPref(kBraveNewsIntroDismissed);
   // Added 07/2021
-  profile->GetPrefs()->ClearPref(prefs::kNetworkPredictionOptions);
+  profile_prefs->ClearPref(prefs::kNetworkPredictionOptions);
 
   // Added 01/2022
-  brave_rewards::MigrateObsoleteProfilePrefs(profile->GetPrefs());
+  brave_rewards::MigrateObsoleteProfilePrefs(profile_prefs);
 
   // Added 05/2022
-  translate::ClearMigrationBraveProfilePrefs(profile->GetPrefs());
+  translate::ClearMigrationBraveProfilePrefs(profile_prefs);
 
   // Added 06/2022
 #if BUILDFLAG(ENABLE_CUSTOM_BACKGROUND)
-  NTPBackgroundPrefs(profile->GetPrefs()).MigrateOldPref();
+  NTPBackgroundPrefs(profile_prefs).MigrateOldPref();
 #endif
 
   // Added 24/11/2022: https://github.com/brave/brave-core/pull/16027
 #if !BUILDFLAG(IS_IOS) && !BUILDFLAG(IS_ANDROID)
-  profile->GetPrefs()->ClearPref(kFTXAccessToken);
-  profile->GetPrefs()->ClearPref(kFTXOauthHost);
-  profile->GetPrefs()->ClearPref(kFTXNewTabPageShowFTX);
-  profile->GetPrefs()->ClearPref(kCryptoDotComNewTabPageShowCryptoDotCom);
-  profile->GetPrefs()->ClearPref(kCryptoDotComHasBoughtCrypto);
-  profile->GetPrefs()->ClearPref(kCryptoDotComHasInteracted);
-  profile->GetPrefs()->ClearPref(kGeminiAccessToken);
-  profile->GetPrefs()->ClearPref(kGeminiRefreshToken);
-  profile->GetPrefs()->ClearPref(kNewTabPageShowGemini);
+  profile_prefs->ClearPref(kFTXAccessToken);
+  profile_prefs->ClearPref(kFTXOauthHost);
+  profile_prefs->ClearPref(kFTXNewTabPageShowFTX);
+  profile_prefs->ClearPref(kCryptoDotComNewTabPageShowCryptoDotCom);
+  profile_prefs->ClearPref(kCryptoDotComHasBoughtCrypto);
+  profile_prefs->ClearPref(kCryptoDotComHasInteracted);
+  profile_prefs->ClearPref(kGeminiAccessToken);
+  profile_prefs->ClearPref(kGeminiRefreshToken);
+  profile_prefs->ClearPref(kNewTabPageShowGemini);
 #endif
 
   // Added 24/11/2022: https://github.com/brave/brave-core/pull/16027
 #if !BUILDFLAG(IS_IOS)
-  profile->GetPrefs()->ClearPref(kBinanceAccessToken);
-  profile->GetPrefs()->ClearPref(kBinanceRefreshToken);
-  profile->GetPrefs()->ClearPref(kNewTabPageShowBinance);
-  profile->GetPrefs()->ClearPref(kBraveSuggestedSiteSuggestionsEnabled);
+  profile_prefs->ClearPref(kBinanceAccessToken);
+  profile_prefs->ClearPref(kBinanceRefreshToken);
+  profile_prefs->ClearPref(kNewTabPageShowBinance);
+  profile_prefs->ClearPref(kBraveSuggestedSiteSuggestionsEnabled);
 #endif
 
 #if defined(TOOLKIT_VIEWS)
   // Added May 2023
-  if (profile->GetPrefs()->GetBoolean(
-          sidebar::kSidebarAlignmentChangedTemporarily)) {
+  if (profile_prefs->GetBoolean(sidebar::kSidebarAlignmentChangedTemporarily)) {
     // If temporarily changed, it means sidebar is set to right.
     // Just clear alignment prefs as default alignment is changed to right.
-    profile->GetPrefs()->ClearPref(prefs::kSidePanelHorizontalAlignment);
+    profile_prefs->ClearPref(prefs::kSidePanelHorizontalAlignment);
   }
 
-  profile->GetPrefs()->ClearPref(sidebar::kSidebarAlignmentChangedTemporarily);
+  profile_prefs->ClearPref(sidebar::kSidebarAlignmentChangedTemporarily);
 #endif
 
-  brave_news::p3a::MigrateObsoleteProfilePrefs(profile->GetPrefs());
+  brave_news::p3a::MigrateObsoleteProfilePrefs(profile_prefs);
 
   // Added September 2023
 #if !BUILDFLAG(IS_IOS)
@@ -227,13 +226,13 @@ void MigrateObsoleteProfilePrefs(Profile* profile) {
       "Brave.P2A.AdImpressionsPerSegment.weather",
       "Brave.P2A.AdImpressionsPerSegment.untargeted"};
   for (const char* const pref : kLegacyBraveP2AAdPrefs) {
-    profile->GetPrefs()->ClearPref(pref);
+    profile_prefs->ClearPref(pref);
   }
 #endif
 
   // Added 2023-09
   ntp_background_images::ViewCounterService::MigrateObsoleteProfilePrefs(
-      profile->GetPrefs());
+      profile_prefs);
 
   // END_MIGRATE_OBSOLETE_PROFILE_PREFS
 }


### PR DESCRIPTION
Upstream is changing `MigrateObsoleteProfilePrefs` to take a `PrefService` pointer, rather than `Profile`, as this is more expressive of the data actually being accessed.

This change aligns all places where we have procedures similar to `MigrateObsoleteProfilePrefs`, to receive a `PrefService*` instance as well.

Chromium change:
https://chromium.googlesource.com/chromium/src/+/d848587fe1f19123940de4e4c0cec328bc23001f

    commit d848587fe1f19123940de4e4c0cec328bc23001f
    Author: Mikel Astiz <mastiz@chromium.org>
    Date:   Mon Oct 2 09:28:03 2023 +0000
    
        [sync] Remove legacy SyncRequested pref
    
        It has been practically unused for some time, and most of it is dead
        code ever since the feature toggle was cleaned up in
        https://crrev.com/c/4886256.
    
        On Ash, it needs to be migrated to a newly-introduced preference
        tailored to the actual underlying need, which is being able to remember
        that the server returned DISABLE_SYNC_ON_CLIENT (i.e. the user reset
        sync via dashboard).
    
        Change-Id: I0239447173b32d7d007ebf733dde23a5de1859e1
        Bug: 1443446, 1219990

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves 

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [ ] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

