### PR TITLE
[Android] Temporarily disable java lint checks (uplift to 1.60.x)

### DIFF
--- a/build/commands/scripts/lint.py
+++ b/build/commands/scripts/lint.py
@@ -22,7 +22,8 @@ import git_common
 
 def HasFormatErrors():
     # For more options, see vendor/depot_tools/git_cl.py
-    cmd = ['cl', 'format', '--diff']
+    # Temporarily disable java until we get necessary DEPS in C119.
+    cmd = ['cl', 'format', '--diff', '--no-java']
     diff = git_cl.RunGit(cmd).encode('utf-8')
     if diff:
         # Verify that git cl format generates a diff


### PR DESCRIPTION
Uplift of #20389
Resolves https://github.com/brave/brave-browser/issues/33407

Pre-approval checklist: 
- [ ] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.