### PR TITLE
Hide Brave VPN Wireguard flag on brave://flags page (uplift to 1.60.x)

### DIFF
--- a/browser/about_flags.cc
+++ b/browser/about_flags.cc
@@ -7,6 +7,7 @@
 
 #include <initializer_list>
 
+#include "base/strings/string_util.h"
 #include "brave/browser/brave_browser_features.h"
 #include "brave/browser/brave_features_internal_names.h"
 #include "brave/browser/ethereum_remote_client/buildflags/buildflags.h"
@@ -947,6 +948,20 @@ namespace {
   static_assert(
       std::initializer_list<FeatureEntry>{BRAVE_ABOUT_FLAGS_FEATURE_ENTRIES}
           .size());
+}
+
+// Called to skip feature entries on brave://flags page without affecting
+// features state.
+bool BraveShouldSkipConditionalFeatureEntry(
+    const flags_ui::FlagsStorage* storage,
+    const FeatureEntry& entry) {
+#if BUILDFLAG(ENABLE_BRAVE_VPN_WIREGUARD) && BUILDFLAG(IS_WIN)
+  if (base::EqualsCaseInsensitiveASCII(kBraveVPNWireguardFeatureInternalName,
+                                       entry.internal_name)) {
+    return true;
+  }
+#endif
+  return false;
 }
 
 }  // namespace

--- a/chromium_src/chrome/browser/about_flags.cc
+++ b/chromium_src/chrome/browser/about_flags.cc
@@ -5,6 +5,8 @@
 
 #include "brave/browser/about_flags.cc"
 #include "brave/components/commander/common/buildflags/buildflags.h"
+#include "chrome/common/channel_info.h"
+#include "components/autofill/core/browser/autofill_experiments.h"
 
 #if BUILDFLAG(ENABLE_COMMANDER)
 #include "brave/components/commander/common/features.h"
@@ -14,5 +16,12 @@
 #define kQuickCommands kBraveCommander
 #endif
 
+#define GetChannel                                                        \
+  GetChannel();                                                           \
+  if (flags_ui::BraveShouldSkipConditionalFeatureEntry(storage, entry)) { \
+    return true;                                                          \
+  }                                                                       \
+  chrome::GetChannel
 #include "src/chrome/browser/about_flags.cc"
+#undef GetChannel
 #undef kQuickCommands

--- a/chromium_src/chrome/browser/unexpire_flags.cc
+++ b/chromium_src/chrome/browser/unexpire_flags.cc
@@ -5,15 +5,10 @@
 
 #include "base/strings/string_util.h"
 #include "brave/browser/brave_features_internal_names.h"
-#include "brave/components/brave_vpn/common/buildflags/buildflags.h"
 #include "brave/components/playlist/common/buildflags/buildflags.h"
 #include "chrome/browser/flag_descriptions.h"
 #include "chrome/common/channel_info.h"
 #include "components/version_info/version_info.h"
-
-#if BUILDFLAG(ENABLE_BRAVE_VPN_WIREGUARD)
-#include "brave/browser/brave_features_internal_names.h"
-#endif
 
 #define IsFlagExpired IsFlagExpired_ChromiumImpl
 #include "src/chrome/browser/unexpire_flags.cc"
@@ -35,13 +30,6 @@ bool IsFlagExpired(const flags_ui::FlagsStorage* storage,
     return true;
   }
 #endif  // BUILDFLAG(ENABLE_PLAYLIST) && BUILDFLAG(IS_ANDROID)
-#if BUILDFLAG(ENABLE_BRAVE_VPN_WIREGUARD) && BUILDFLAG(IS_WIN)
-  // It's deprecated. Hide from brave://flags.
-  if (base::EqualsCaseInsensitiveASCII(kBraveVPNWireguardFeatureInternalName,
-                                       internal_name)) {
-    return true;
-  }
-#endif
   if (base::EqualsCaseInsensitiveASCII(flag_descriptions::kHttpsUpgradesName,
                                        internal_name)) {
     return true;


### PR DESCRIPTION
Uplift of #20392
Resolves https://github.com/brave/brave-browser/issues/33418

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.