### PR TITLE
Fix autofill related crash due to our disabling of optimization hints (uplift to 1.59.x)

### DIFF
--- a/chromium_src/chrome/browser/ui/autofill/chrome_autofill_client.cc
+++ b/chromium_src/chrome/browser/ui/autofill/chrome_autofill_client.cc
@@ -4,11 +4,13 @@
 // You can obtain one at https://mozilla.org/MPL/2.0/.
 
 #include "chrome/browser/ui/autofill/chrome_autofill_client.h"
+
 #include "base/memory/ptr_util.h"
 #include "brave/components/constants/pref_names.h"
 #include "chrome/browser/profiles/profile.h"
 #include "chrome/browser/ui/autofill/payments/webauthn_dialog_controller_impl.h"
 #include "chrome/browser/ui/page_info/page_info_dialog.h"
+#include "components/optimization_guide/core/optimization_guide_features.h"
 #include "mojo/public/cpp/bindings/associated_receiver.h"
 
 namespace autofill {
@@ -33,6 +35,13 @@ bool IsPrivateProfile(content::WebContents* web_contents) {
 class BraveChromeAutofillClient : public ChromeAutofillClient {
  public:
   using ChromeAutofillClient::ChromeAutofillClient;
+
+  AutofillOptimizationGuide* GetAutofillOptimizationGuide() const override {
+    if (optimization_guide::features::IsOptimizationHintsEnabled()) {
+      return ChromeAutofillClient::GetAutofillOptimizationGuide();
+    }
+    return nullptr;
+  }
 
   bool IsAutocompleteEnabled() const override {
     auto enabled = ChromeAutofillClient::IsAutocompleteEnabled();


### PR DESCRIPTION
Uplift of #20415
Resolves https://github.com/brave/brave-browser/issues/33426

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.