### PR TITLE
Fixed dcheck failure while sidebar item dnd for dev build

### DIFF
--- a/browser/ui/sidebar/sidebar_browsertest.cc
+++ b/browser/ui/sidebar/sidebar_browsertest.cc
@@ -217,6 +217,14 @@ class SidebarBrowserTest : public InProcessBrowserTest {
     return scroll_view->NeedScrollForItemAt(index);
   }
 
+  void VerifyTargetDragIndicatorIndexCalc(const gfx::Point& screen_position) {
+    auto sidebar_items_contents_view = GetSidebarItemsContentsView(
+        static_cast<BraveBrowser*>(browser())->sidebar_controller());
+    EXPECT_NE(absl::nullopt,
+              sidebar_items_contents_view->CalculateTargetDragIndicatorIndex(
+                  screen_position));
+  }
+
   base::RunLoop* run_loop() const { return run_loop_.get(); }
 
   raw_ptr<views::View> item_added_bubble_anchor_ = nullptr;
@@ -403,6 +411,23 @@ IN_PROC_BROWSER_TEST_F(SidebarBrowserTest, InitialHorizontalOptionTest) {
   // Check horizontal option is right-sided.
   EXPECT_FALSE(prefs->GetBoolean(prefs::kSidePanelHorizontalAlignment));
   EXPECT_TRUE(IsSidebarUIOnLeft());
+}
+
+IN_PROC_BROWSER_TEST_F(SidebarBrowserTest, ItemDragIndicatorCalcTest) {
+  auto sidebar_items_contents_view = GetSidebarItemsContentsView(
+      static_cast<BraveBrowser*>(browser())->sidebar_controller());
+  gfx::Rect contents_view_rect = sidebar_items_contents_view->GetLocalBounds();
+  views::View::ConvertRectToScreen(sidebar_items_contents_view,
+                                   &contents_view_rect);
+  gfx::Point screen_position = contents_view_rect.origin();
+  screen_position.Offset(5, 0);
+
+  // Any point from items contents view should have proper drag indicator index.
+  for (int i = 0; i < contents_view_rect.height(); ++i) {
+    gfx::Point simulated_mouse_drag_point = screen_position;
+    simulated_mouse_drag_point.Offset(0, i);
+    VerifyTargetDragIndicatorIndexCalc(simulated_mouse_drag_point);
+  }
 }
 
 IN_PROC_BROWSER_TEST_F(SidebarBrowserTest, EventDetectWidgetTest) {

--- a/browser/ui/views/sidebar/sidebar_items_contents_view.cc
+++ b/browser/ui/views/sidebar/sidebar_items_contents_view.cc
@@ -389,6 +389,23 @@ SidebarItemsContentsView::CalculateTargetDragIndicatorIndex(
     views::View* child_view = children()[i];
     gfx::Rect child_view_rect = child_view->GetLocalBounds();
     views::View::ConvertRectToScreen(child_view, &child_view_rect);
+    // We use |SidebarButtonView::kMargin|px for spacing between items.
+    // This spacing should be considered as each item's area to know
+    // which item contains |screen_position|. Added half of margin
+    // to items' top & bottom. For first and last items, includes whole
+    // margin to its top & bottom.
+    const bool is_first_item = (i == 0);
+    const bool is_last_item = (i == (child_count - 1));
+
+    // Re-visit when |kMargin| is odd number.
+    CHECK_EQ(0, SidebarButtonView::kMargin % 2);
+    child_view_rect.Outset(
+        gfx::Outsets::TLBR(is_first_item ? SidebarButtonView::kMargin
+                                         : SidebarButtonView::kMargin / 2,
+                           0,
+                           is_last_item ? SidebarButtonView::kMargin
+                                        : SidebarButtonView::kMargin / 2,
+                           0));
 
     if (child_view_rect.Contains(screen_position)) {
       const gfx::Point center_point = child_view_rect.CenterPoint();


### PR DESCRIPTION
When calculating target drag indicator, the space between items also should be treated as item's area.

fix https://github.com/brave/brave-browser/issues/33050

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves 

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

`SidebarBrowserTest.ItemDragIndicatorCalcTest`