### PR TITLE
Remove use of std::list and code that copies its iterator from thumbnail downloader

### DIFF
--- a/components/playlist/browser/playlist_thumbnail_downloader.h
+++ b/components/playlist/browser/playlist_thumbnail_downloader.h
@@ -74,19 +74,17 @@ class PlaylistThumbnailDownloader {
  private:
   FRIEND_TEST_ALL_PREFIXES(PlaylistServiceUnitTest, ResetAll);
 
-  using URLLoaders = std::list<std::unique_ptr<network::SimpleURLLoader>>;
-  using URLLoaderIter = URLLoaders::iterator;
-  using IDToURLLoaderIterMap = base::flat_map<std::string, URLLoaderIter>;
+  using URLLoaderMap =
+      base::flat_map<std::string, std::unique_ptr<network::SimpleURLLoader>>;
 
-  URLLoaderIter CreateURLLoaderHandler(const GURL& url);
-  void Cancel(const URLLoaderIter& ticket);
+  network::SimpleURLLoader* CreateURLLoader(const std::string& id,
+                                            const GURL& url);
+  void Cancel(const std::string& id);
 
-  void SaveResponseToFile(URLLoaderIter iter,
-                          const std::string& id,
+  void SaveResponseToFile(const std::string& id,
                           base::FilePath path,
                           std::unique_ptr<std::string> response_body);
-  void ConvertResponseToImage(URLLoaderIter iter,
-                              const std::string& id,
+  void ConvertResponseToImage(const std::string& id,
                               base::OnceCallback<void(gfx::Image)> callback,
                               std::unique_ptr<std::string> response_body);
 
@@ -97,8 +95,7 @@ class PlaylistThumbnailDownloader {
   scoped_refptr<base::SequencedTaskRunner> GetOrCreateTaskRunner();
 
   scoped_refptr<network::SharedURLLoaderFactory> url_loader_factory_;
-  URLLoaders url_loaders_;
-  IDToURLLoaderIterMap url_loader_map_;
+  URLLoaderMap url_loader_map_;
 
   scoped_refptr<base::SequencedTaskRunner> task_runner_;
 


### PR DESCRIPTION
We were copying the iterator around, but it seems to cause ASAN failure. The behavior might not be guaranteed when we copy iterators. Furthermore, we don't need it as we already have a map for the loader.

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/internal/issues/1077

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [ ] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

