### PR TITLE
[Icons]: Don't allow sites to connect to HID devices Icon (#20449)

### DIFF
--- a/ui/webui/resources/BUILD.gn
+++ b/ui/webui/resources/BUILD.gn
@@ -302,6 +302,7 @@ leo_icons = [
   "sort-asc.svg",
   "sort-desc.svg",
   "sparkles.svg",
+  "sparkles-off.svg",
   "stack.svg",
   "swap-horizontal.svg",
   "sync.svg",


### PR DESCRIPTION
Uplift of https://github.com/brave/brave-core/pull/20449 which fixes https://github.com/brave/brave-browser/issues/33380 to 1.60.x