### PR TITLE
Updated sidebar panel resize browser test

### DIFF
--- a/browser/ui/sidebar/sidebar_browsertest.cc
+++ b/browser/ui/sidebar/sidebar_browsertest.cc
@@ -521,24 +521,27 @@ IN_PROC_BROWSER_TEST_F(SidebarBrowserTest, PrefsMigrationTest) {
                   ->IsDefaultValue());
 }
 
-IN_PROC_BROWSER_TEST_F(SidebarBrowserTest, PRE_SidePanelResizeTest) {
+IN_PROC_BROWSER_TEST_F(SidebarBrowserTest, SidePanelResizeTest) {
   auto* prefs = browser()->profile()->GetPrefs();
   EXPECT_EQ(kDefaultSidePanelWidth,
             prefs->GetInteger(sidebar::kSidePanelWidth));
 
   browser()->command_controller()->ExecuteCommand(IDC_TOGGLE_SIDEBAR);
 
+  int expected_panel_width = kDefaultSidePanelWidth;
+
   // Wait till sidebar animation ends.
   WaitUntil(base::BindLambdaForTesting(
-      [&]() { return GetSidePanel()->width() == kDefaultSidePanelWidth; }));
+      [&]() { return GetSidePanel()->width() == expected_panel_width; }));
 
   // Test smaller panel width than default(minimum) and check smaller than
   // default is not applied. Positive offset value is for reducing width in
   // right-sided sidebar.
   GetSidePanel()->OnResize(30, true);
   // Check panel width is not changed.
-  EXPECT_EQ(kDefaultSidePanelWidth,
-            prefs->GetInteger(sidebar::kSidePanelWidth));
+  EXPECT_EQ(expected_panel_width, prefs->GetInteger(sidebar::kSidePanelWidth));
+  WaitUntil(base::BindLambdaForTesting(
+      [&]() { return GetSidePanel()->width() == kDefaultSidePanelWidth; }));
 
   // On right-side sidebar position, side panel's x and resize widget's x is
   // same.
@@ -549,8 +552,10 @@ IN_PROC_BROWSER_TEST_F(SidebarBrowserTest, PRE_SidePanelResizeTest) {
   // Negative offset value is for increasing width in right-sided
   // sidebar.
   GetSidePanel()->OnResize(-20, true);
-  EXPECT_EQ(kDefaultSidePanelWidth + 20,
-            prefs->GetInteger(sidebar::kSidePanelWidth));
+  expected_panel_width += 20;
+  EXPECT_EQ(expected_panel_width, prefs->GetInteger(sidebar::kSidePanelWidth));
+  WaitUntil(base::BindLambdaForTesting(
+      [&]() { return GetSidePanel()->width() == expected_panel_width; }));
   EXPECT_EQ(GetSidePanel()->GetBoundsInScreen().x(),
             GetSidePanelResizeWidget()->GetWindowBoundsInScreen().x());
 
@@ -559,27 +564,25 @@ IN_PROC_BROWSER_TEST_F(SidebarBrowserTest, PRE_SidePanelResizeTest) {
   EXPECT_EQ(GetSidePanel()->GetBoundsInScreen().right(),
             GetSidePanelResizeWidget()->GetWindowBoundsInScreen().right());
 
-  // Increse panel width and check width and resize handle position .
+  // Increase panel width and check width and resize handle position.
   // Positive offset value is for increasing width in left-sided sidebar.
   GetSidePanel()->OnResize(20, true);
-  EXPECT_EQ(kDefaultSidePanelWidth + 40,
-            prefs->GetInteger(sidebar::kSidePanelWidth));
+  expected_panel_width += 20;
+  EXPECT_EQ(expected_panel_width, prefs->GetInteger(sidebar::kSidePanelWidth));
+  WaitUntil(base::BindLambdaForTesting(
+      [&]() { return GetSidePanel()->width() == expected_panel_width; }));
   EXPECT_EQ(GetSidePanel()->GetBoundsInScreen().right(),
             GetSidePanelResizeWidget()->GetWindowBoundsInScreen().right());
-}
 
-IN_PROC_BROWSER_TEST_F(SidebarBrowserTest, SidePanelResizeTest) {
-  auto* prefs = browser()->profile()->GetPrefs();
-  // Check that 40px increased width is persisted properly.
-  constexpr int kExpectedPanelWidth = kDefaultSidePanelWidth + 40;
-  EXPECT_EQ(kExpectedPanelWidth, prefs->GetInteger(sidebar::kSidePanelWidth));
-
+  // Close side panel.
   browser()->command_controller()->ExecuteCommand(IDC_TOGGLE_SIDEBAR);
-
-  // Wait till sidebar animation ends.
   WaitUntil(base::BindLambdaForTesting(
-      [&]() { return GetSidePanel()->width() == kExpectedPanelWidth; }));
-  EXPECT_EQ(kExpectedPanelWidth, GetSidePanel()->width());
+      [&]() { return !GetSidePanel()->GetVisible(); }));
+
+  // Re-open side panel and check it's opened as wide as lastly used width.
+  browser()->command_controller()->ExecuteCommand(IDC_TOGGLE_SIDEBAR);
+  WaitUntil(base::BindLambdaForTesting(
+      [&]() { return GetSidePanel()->width() == expected_panel_width; }));
 }
 
 IN_PROC_BROWSER_TEST_F(SidebarBrowserTest, UnManagedPanelEntryTest) {


### PR DESCRIPTION
fix brave/brave-browser#33340

Updated resize test w/o restarting. Very rarely but sometime prefs doesn't give latest value after spanning restart during the test. And restarting is not necessary for this testing.

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves 

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

`SidebarBrowserTest.SidePanelResizeTest`