### PR TITLE
User is not rewarded for viewing Brave News inline ads after changing tabs

### DIFF
--- a/android/java/org/chromium/chrome/browser/ntp/BraveNewTabPageLayout.java
+++ b/android/java/org/chromium/chrome/browser/ntp/BraveNewTabPageLayout.java
@@ -108,7 +108,6 @@ import org.chromium.chrome.browser.ui.native_page.TouchEnabledDelegate;
 import org.chromium.chrome.browser.util.TabUtils;
 import org.chromium.components.browser_ui.settings.SettingsLauncher;
 import org.chromium.components.browser_ui.widget.displaystyle.UiConfig;
-import org.chromium.components.embedder_support.util.UrlUtilities;
 import org.chromium.components.user_prefs.UserPrefs;
 import org.chromium.mojo.bindings.ConnectionErrorHandler;
 import org.chromium.mojo.system.MojoException;
@@ -295,27 +294,6 @@ public class BraveNewTabPageLayout
         if (mBadgeAnimationView != null
                 && !OnboardingPrefManager.getInstance().shouldShowBadgeAnimation()) {
             mBadgeAnimationView.setVisibility(View.INVISIBLE);
-        }
-        initBraveNewsController();
-        if (BravePrefServiceBridge.getInstance().getNewsOptIn()) {
-            new Handler(Looper.getMainLooper()).post(() -> {
-                try {
-                    Tab tab = BraveActivity.getBraveActivity().getActivityTab();
-                    if (tab != null && tab.getUrl().getSpec() != null
-                            && UrlUtilities.isNTPUrl(tab.getUrl().getSpec())) {
-                        // purges display ads on tab change
-                        if (BraveActivity.getBraveActivity().getLastTabId() != tab.getId()) {
-                            if (mBraveNewsController != null) {
-                                mBraveNewsController.onDisplayAdPurgeOrphanedEvents();
-                            }
-                        }
-
-                        BraveActivity.getBraveActivity().setLastTabId(tab.getId());
-                    }
-                } catch (BraveActivity.BraveActivityNotFoundException e) {
-                    Log.e(TAG, "onAttachedToWindow " + e);
-                }
-            });
         }
 
         mIsDisplayNewsOptin = BraveNewsUtils.shouldDisplayNewsOptin();

--- a/components/brave_news/browser/brave_news_controller.cc
+++ b/components/brave_news/browser/brave_news_controller.cc
@@ -634,18 +634,6 @@ void BraveNewsController::OnDisplayAdView(
   p3a::RecordWeeklyDisplayAdsViewedCount(prefs_, true);
 }
 
-void BraveNewsController::OnDisplayAdPurgeOrphanedEvents() {
-  if (!ads_service_) {
-    VLOG(1) << "News: Asked to purge orphaned ad events but there is no ads "
-               "service for"
-               "this profile!";
-    return;
-  }
-  ads_service_->PurgeOrphanedAdEventsForType(
-      brave_ads::mojom::AdType::kInlineContentAd,
-      /*intentional*/ base::DoNothing());
-}
-
 void BraveNewsController::CheckForPublishersUpdate() {
   if (!GetIsEnabled(prefs_)) {
     return;

--- a/components/brave_news/browser/brave_news_controller.h
+++ b/components/brave_news/browser/brave_news_controller.h
@@ -134,7 +134,6 @@ class BraveNewsController : public KeyedService,
                         const std::string& creative_instance_id) override;
   void OnDisplayAdView(const std::string& item_id,
                        const std::string& creative_instance_id) override;
-  void OnDisplayAdPurgeOrphanedEvents() override;
 
   // PublishersController::Observer:
   void OnPublishersUpdated(brave_news::PublishersController*) override;

--- a/components/brave_news/common/brave_news.mojom
+++ b/components/brave_news/common/brave_news.mojom
@@ -287,5 +287,4 @@ interface BraveNewsController {
   OnPromotedItemVisit(string item_id, string creative_instance_id);
   OnDisplayAdVisit(string item_id, string creative_instance_id);
   OnDisplayAdView(string item_id, string creative_instance_id);
-  OnDisplayAdPurgeOrphanedEvents();
 };


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/33578

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

