### PR TITLE
Fixed active index is not updated properly when new item added (uplift to 1.60.x)

### DIFF
--- a/browser/ui/sidebar/sidebar_model.cc
+++ b/browser/ui/sidebar/sidebar_model.cc
@@ -91,8 +91,9 @@ void SidebarModel::AddItem(const SidebarItem& item,
   }
 
   // Check this addition affects active index.
-  if (active_index_ >= index)
-    UpdateActiveIndexAndNotify(index);
+  if (active_index_ >= index) {
+    UpdateActiveIndexAndNotify(*active_index_ + 1);
+  }
 
   // Web type uses site favicon as button's image.
   if (sidebar::IsWebType(item))
@@ -181,7 +182,7 @@ void SidebarModel::RemoveItemAt(size_t index) {
   }
 }
 
-void SidebarModel::SetActiveIndex(absl::optional<size_t> index, bool load) {
+void SidebarModel::SetActiveIndex(absl::optional<size_t> index) {
   if (index == active_index_)
     return;
 

--- a/browser/ui/sidebar/sidebar_model.h
+++ b/browser/ui/sidebar/sidebar_model.h
@@ -80,8 +80,7 @@ class SidebarModel : public SidebarService::Observer,
   void AddObserver(Observer* observer);
   void RemoveObserver(Observer* observer);
 
-  // |false| is used in unit test.
-  void SetActiveIndex(absl::optional<size_t> index, bool load = true);
+  void SetActiveIndex(absl::optional<size_t> index);
   // Returns true if webcontents of item at |index| already loaded url.
   bool IsSidebarHasAllBuiltInItems() const;
   absl::optional<size_t> GetIndexOf(const SidebarItem& item) const;
@@ -108,6 +107,7 @@ class SidebarModel : public SidebarService::Observer,
 
  private:
   FRIEND_TEST_ALL_PREFIXES(SidebarModelTest, ItemsChangedTest);
+  FRIEND_TEST_ALL_PREFIXES(SidebarModelTest, ActiveIndexChangedAfterItemAdded);
 
   // Add item at last.
   void AddItem(const SidebarItem& item, size_t index, bool user_gesture);

--- a/browser/ui/sidebar/sidebar_unittest.cc
+++ b/browser/ui/sidebar/sidebar_unittest.cc
@@ -136,7 +136,7 @@ TEST_F(SidebarModelTest, ItemsChangedTest) {
   EXPECT_THAT(model()->active_index(), Eq(absl::nullopt));
   EXPECT_EQ(items_size, service()->items().size());
 
-  model()->SetActiveIndex(1, false);
+  model()->SetActiveIndex(1);
   EXPECT_THAT(model()->active_index(), Optional(1u));
 
   // Move item at 1 to 2. This causes active index change because item at 1 was
@@ -175,6 +175,27 @@ TEST_F(SidebarModelTest, CanUseNotAddedBuiltInItemInsteadOfTest) {
   // instead of adding |talk| url.
   service()->RemoveItemAt(0);
   EXPECT_TRUE(HiddenDefaultSidebarItemsContains(service(), talk));
+}
+
+TEST_F(SidebarModelTest, ActiveIndexChangedAfterItemAdded) {
+  model()->SetActiveIndex(1);
+  EXPECT_THAT(model()->active_index(), Optional(1u));
+
+  SidebarItem item_1 = SidebarItem::Create(
+      GURL("https://www.brave.com/"), u"brave software",
+      SidebarItem::Type::kTypeWeb, SidebarItem::BuiltInItemType::kNone, false);
+
+  // Check active index is still 1 when new item is added at 2.
+  model()->AddItem(item_1, 2, true);
+  EXPECT_THAT(model()->active_index(), Optional(1u));
+
+  SidebarItem item_2 = SidebarItem::Create(
+      GURL("https://www.braves.com/"), u"brave software",
+      SidebarItem::Type::kTypeWeb, SidebarItem::BuiltInItemType::kNone, false);
+
+  // Check active index is changed to 2 when new item is added at 1.
+  model()->AddItem(item_2, 1, true);
+  EXPECT_THAT(model()->active_index(), Optional(2u));
 }
 
 TEST(SidebarUtilTest, ConvertURLToBuiltInItemURLTest) {


### PR DESCRIPTION
Uplift of #20456
fix https://github.com/brave/brave-browser/issues/33516

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.