### PR TITLE
Fix tests when Playlist feature is enabled

### DIFF
--- a/browser/ui/sidebar/sidebar_browsertest.cc
+++ b/browser/ui/sidebar/sidebar_browsertest.cc
@@ -227,6 +227,23 @@ class SidebarBrowserTest : public InProcessBrowserTest {
 
   base::RunLoop* run_loop() const { return run_loop_.get(); }
 
+  size_t GetDefaultItemCount() const {
+    auto item_count = std::size(SidebarService::kDefaultBuiltInItemTypes) -
+                      1 /* for history*/;
+#if BUILDFLAG(ENABLE_PLAYLIST)
+    if (!base::FeatureList::IsEnabled(playlist::features::kPlaylist)) {
+      item_count -= 1;
+    }
+#endif
+
+#if BUILDFLAG(ENABLE_AI_CHAT)
+    if (!ai_chat::features::IsAIChatEnabled()) {
+      item_count -= 1;
+    }
+#endif
+    return item_count;
+  }
+
   raw_ptr<views::View> item_added_bubble_anchor_ = nullptr;
   std::unique_ptr<base::RunLoop> run_loop_;
   base::WeakPtrFactory<SidebarBrowserTest> weak_factory_{this};
@@ -251,8 +268,8 @@ IN_PROC_BROWSER_TEST_F(SidebarBrowserTest, BasicTest) {
   // Check active index is null.
   EXPECT_THAT(model()->active_index(), Eq(absl::nullopt));
 
-  // Currently we have 4 default items.
-  EXPECT_EQ(4UL, model()->GetAllSidebarItems().size());
+  auto expected_count = GetDefaultItemCount();
+  EXPECT_EQ(expected_count, model()->GetAllSidebarItems().size());
   // Activate item that opens in panel.
   controller()->ActivateItemAt(2);
   EXPECT_THAT(model()->active_index(), Optional(2u));
@@ -274,7 +291,7 @@ IN_PROC_BROWSER_TEST_F(SidebarBrowserTest, BasicTest) {
 
   // Remove Item at index 0 change active index from 3 to 2.
   SidebarServiceFactory::GetForProfile(browser()->profile())->RemoveItemAt(0);
-  EXPECT_EQ(3UL, model()->GetAllSidebarItems().size());
+  EXPECT_EQ(--expected_count, model()->GetAllSidebarItems().size());
   EXPECT_THAT(model()->active_index(), Optional(1u));
 
   // If current active tab is not NTP, we can add current url to sidebar.
@@ -294,8 +311,8 @@ IN_PROC_BROWSER_TEST_F(SidebarBrowserTest, BasicTest) {
 }
 
 IN_PROC_BROWSER_TEST_F(SidebarBrowserTest, WebTypePanelTest) {
-  // By default, sidebar has 4 items.
-  EXPECT_EQ(4UL, model()->GetAllSidebarItems().size());
+  auto expected_count = GetDefaultItemCount();
+  EXPECT_EQ(expected_count, model()->GetAllSidebarItems().size());
 
   // Add an item
   ASSERT_TRUE(
@@ -305,7 +322,7 @@ IN_PROC_BROWSER_TEST_F(SidebarBrowserTest, WebTypePanelTest) {
   EXPECT_TRUE(CanAddCurrentActiveTabToSidebar(browser()));
   controller()->AddItemWithCurrentTab();
   // Verify new size
-  EXPECT_EQ(5UL, model()->GetAllSidebarItems().size());
+  EXPECT_EQ(++expected_count, model()->GetAllSidebarItems().size());
 
   // Load NTP in a new tab and activate it. (tab index 1)
   ASSERT_TRUE(ui_test_utils::NavigateToURLWithDisposition(
@@ -317,16 +334,21 @@ IN_PROC_BROWSER_TEST_F(SidebarBrowserTest, WebTypePanelTest) {
 
   // Activate sidebar item(brave://settings) and check existing first tab is
   // activated.
-  auto item = model()->GetAllSidebarItems()[4];
-  controller()->ActivateItemAt(4);
+  auto items = model()->GetAllSidebarItems();
+  auto iter =
+      base::ranges::find(items, GURL("chrome://settings/"), &SidebarItem::url);
+  EXPECT_NE(items.end(), iter);
+  controller()->ActivateItemAt(std::distance(items.begin(), iter));
   EXPECT_EQ(0, tab_model()->active_index());
-  EXPECT_EQ(tab_model()->GetWebContentsAt(0)->GetVisibleURL(), item.url);
+  EXPECT_EQ(tab_model()->GetWebContentsAt(0)->GetVisibleURL(), iter->url);
 
   // Activate second sidebar item(wallet) and check it's loaded at current tab.
-  item = model()->GetAllSidebarItems()[1];
-  controller()->ActivateItemAt(1);
+  iter = base::ranges::find(items, SidebarItem::BuiltInItemType::kWallet,
+                            &SidebarItem::built_in_item_type);
+  EXPECT_NE(items.end(), iter);
+  controller()->ActivateItemAt(std::distance(items.begin(), iter));
   EXPECT_EQ(0, tab_model()->active_index());
-  EXPECT_EQ(tab_model()->GetWebContentsAt(0)->GetVisibleURL(), item.url);
+  EXPECT_EQ(tab_model()->GetWebContentsAt(0)->GetVisibleURL(), iter->url);
   // New tab is not created.
   EXPECT_EQ(2, tab_model()->count());
 }

--- a/browser/ui/views/page_action/brave_page_action_icon_container_view.cc
+++ b/browser/ui/views/page_action/brave_page_action_icon_container_view.cc
@@ -5,6 +5,7 @@
 
 #include "brave/browser/ui/views/page_action/brave_page_action_icon_container_view.h"
 
+#include "base/check_is_test.h"
 #include "brave/browser/ui/page_action/brave_page_action_icon_type.h"
 #include "brave/components/playlist/common/features.h"
 #include "chrome/browser/profiles/profile.h"
@@ -15,9 +16,18 @@
 namespace {
 
 PageActionIconParams& ModifyIconParamsForBrave(PageActionIconParams& params) {
+  if (!base::FeatureList::IsEnabled(playlist::features::kPlaylist)) {
+    return params;
+  }
+
+  if (!params.browser) {
+    // Browser could be null if the location bar was created for
+    // PresentationReceiverWindowView.
+    return params;
+  }
+
   // Add actions for Brave
-  if (base::FeatureList::IsEnabled(playlist::features::kPlaylist) &&
-      params.browser->is_type_normal() &&
+  if (params.browser->is_type_normal() &&
       !params.browser->profile()->IsOffTheRecord()) {
     // Insert Playlist action before sharing hub or at the end of the vector.
     params.types_enabled.insert(

--- a/browser/ui/views/playlist/playlist_action_icon_view.cc
+++ b/browser/ui/views/playlist/playlist_action_icon_view.cc
@@ -47,7 +47,7 @@ void PlaylistActionIconView::ShowPlaylistBubble() {
     return;
   }
 
-  auto* playlist_tab_helper = this->playlist_tab_helper();
+  auto* playlist_tab_helper = GetPlaylistTabHelper();
   if (!playlist_tab_helper || playlist_tab_helper->is_adding_items()) {
     return;
   }
@@ -94,7 +94,7 @@ void PlaylistActionIconView::UpdateImpl() {
   }
   playlist_tab_helper_observation_.Reset();
 
-  auto* playlist_tab_helper = this->playlist_tab_helper();
+  auto* playlist_tab_helper = GetPlaylistTabHelper();
   if (!playlist_tab_helper) {
     UpdateState(/* has_saved= */ false, /* found_items= */ false);
     return;
@@ -112,18 +112,30 @@ void PlaylistActionIconView::PlaylistTabHelperWillBeDestroyed() {
 
 void PlaylistActionIconView::OnSavedItemsChanged(
     const std::vector<playlist::mojom::PlaylistItemPtr>& saved_items) {
-  auto* playlist_tab_helper = this->playlist_tab_helper();
-  CHECK(playlist_tab_helper);
+  auto* playlist_tab_helper = GetPlaylistTabHelper();
+  if (!playlist_tab_helper) {
+    return;
+  }
 
   UpdateState(saved_items.size(), playlist_tab_helper->found_items().size());
 }
 
 void PlaylistActionIconView::OnFoundItemsChanged(
     const std::vector<playlist::mojom::PlaylistItemPtr>& found_items) {
-  auto* playlist_tab_helper = this->playlist_tab_helper();
-  CHECK(playlist_tab_helper);
+  auto* playlist_tab_helper = GetPlaylistTabHelper();
+  if (!playlist_tab_helper) {
+    return;
+  }
 
   UpdateState(playlist_tab_helper->saved_items().size(), found_items.size());
+}
+
+playlist::PlaylistTabHelper* PlaylistActionIconView::GetPlaylistTabHelper() {
+  if (auto* contents = GetWebContents()) {
+    return playlist::PlaylistTabHelper::FromWebContents(contents);
+  }
+
+  return nullptr;
 }
 
 void PlaylistActionIconView::UpdateState(bool has_saved, bool found_items) {

--- a/browser/ui/views/playlist/playlist_action_icon_view.h
+++ b/browser/ui/views/playlist/playlist_action_icon_view.h
@@ -42,9 +42,7 @@ class PlaylistActionIconView : public PageActionIconView,
  private:
   enum class State { kNone, kAdded, kFound };
 
-  playlist::PlaylistTabHelper* playlist_tab_helper() {
-    return playlist::PlaylistTabHelper::FromWebContents(GetWebContents());
-  }
+  playlist::PlaylistTabHelper* GetPlaylistTabHelper();
 
   void UpdateState(bool has_saved, bool found_items);
   void UpdateVisibilityPerState();


### PR DESCRIPTION
* Remove hard coded number from Sidebar tests
* Fix CHECK failure from PlaylistActionIconView

* The tests result with the flag enabled could be found at https://github.com/brave/brave-core/pull/20481

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/33561

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [ ] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

