### PR TITLE
Fix notification ad serving on iOS (uplift to 1.59.x)

### DIFF
--- a/ios/browser/api/ads/BUILD.gn
+++ b/ios/browser/api/ads/BUILD.gn
@@ -35,6 +35,7 @@ source_set("ads") {
     "//brave/components/brave_federated/public/interfaces",
     "//brave/components/brave_news/common",
     "//brave/components/brave_rewards/common",
+    "//brave/components/ntp_background_images/common",
     "//brave/ios/browser/api/common",
   ]
 

--- a/ios/browser/api/ads/brave_ads.mm
+++ b/ios/browser/api/ads/brave_ads.mm
@@ -40,7 +40,9 @@
 #include "brave/components/brave_ads/core/public/history/history_item_info.h"
 #include "brave/components/brave_ads/core/public/history/history_sort_types.h"
 #include "brave/components/brave_ads/core/public/prefs/pref_names.h"
+#include "brave/components/brave_rewards/common/pref_names.h"
 #include "brave/components/brave_rewards/common/rewards_flags.h"
+#include "brave/components/ntp_background_images/common/pref_names.h"
 #import "brave/ios/browser/api/ads/brave_ads.mojom.objc+private.h"
 #import "brave/ios/browser/api/common/common_operations.h"
 #import "brave_ads.h"
@@ -72,7 +74,8 @@ static const NSInteger kDefaultNumberOfAdsPerHour = 2;
 
 static const int kCurrentAdsResourceManifestSchemaVersion = 1;
 
-static NSString* const kLegacyAdsEnabledPrefKey = @"BATAdsEnabled";
+static NSString* const kLegacyOptedInToNotificationAdsPrefKey =
+    @"BATAdsEnabled";
 static NSString* const kLegacyNumberOfAdsPerHourKey = @"BATNumberOfAdsPerHour";
 static NSString* const kLegacyShouldAllowAdsSubdivisionTargetingPrefKey =
     @"BATShouldAllowAdsSubdivisionTargetingPrefKey";
@@ -81,8 +84,10 @@ static NSString* const kLegacyAdsSubdivisionTargetingCodePrefKey =
 static NSString* const kLegacyAutoDetectedAdsSubdivisionTargetingCodePrefKey =
     @"BATAutoDetectedAdsSubdivisionTargetingCodePrefKey";
 
-static NSString* const kEnabledPrefKey =
+static NSString* const kOptedInToNotificationAdsPrefKey =
     base::SysUTF8ToNSString(brave_ads::prefs::kOptedInToNotificationAds);
+static NSString* const kRewardsEnabledPrefKey =
+    base::SysUTF8ToNSString(brave_rewards::prefs::kEnabled);
 static NSString* const kMaximumNotificationAdsPerHourPrefKey =
     base::SysUTF8ToNSString(brave_ads::prefs::kMaximumNotificationAdsPerHour);
 static NSString* const kShouldAllowSubdivisionTargetingPrefKey =
@@ -93,10 +98,6 @@ static NSString* const kSubdivisionTargetingAutoDetectedSubdivisionPrefKey =
     base::SysUTF8ToNSString(
         brave_ads::prefs::kSubdivisionTargetingAutoDetectedSubdivision);
 static NSString* const kAdsResourceMetadataPrefKey = @"BATAdsResourceMetadata";
-static NSString* const kBraveNewsOptedInPrefKey =
-    base::SysUTF8ToNSString(brave_news::prefs::kBraveNewsOptedIn);
-static NSString* const kNewTabPageShowTodayPrefKey =
-    base::SysUTF8ToNSString(brave_news::prefs::kNewTabPageShowToday);
 
 namespace {
 
@@ -169,12 +170,6 @@ brave_ads::mojom::DBCommandResponseInfoPtr RunDBTransactionOnTaskRunner(
     } else {
       [self migratePrefs];
     }
-
-    // TODO(https://github.com/brave/brave-browser/issues/32112): Remove the
-    // code that permanently enables Brave Today preferences when the issue is
-    // resolved.
-    self.prefs[kBraveNewsOptedInPrefKey] = @(true);
-    self.prefs[kNewTabPageShowTodayPrefKey] = @(true);
 
     [self setupNetworkMonitoring];
 
@@ -367,12 +362,14 @@ brave_ads::mojom::DBCommandResponseInfoPtr RunDBTransactionOnTaskRunner(
 #pragma mark - Configuration
 
 - (BOOL)isEnabled {
-  return [self.prefs[kEnabledPrefKey] boolValue];
+  return [self.prefs[kRewardsEnabledPrefKey] boolValue];
 }
 
 - (void)setEnabled:(BOOL)enabled {
-  self.prefs[kEnabledPrefKey] = @(enabled);
-  [self savePref:kEnabledPrefKey];
+  self.prefs[kRewardsEnabledPrefKey] = @(enabled);
+  [self savePref:kRewardsEnabledPrefKey];
+  self.prefs[kOptedInToNotificationAdsPrefKey] = @(enabled);
+  [self savePref:kOptedInToNotificationAdsPrefKey];
 }
 
 - (NSInteger)numberOfAllowableAdsPerHour {
@@ -420,11 +417,11 @@ brave_ads::mojom::DBCommandResponseInfoPtr RunDBTransactionOnTaskRunner(
 }
 
 - (void)savePref:(NSString*)name {
+  [self savePrefs];
+
   if ([self isAdsServiceRunning]) {
     adsClientNotifier->NotifyPrefDidChange(base::SysNSStringToUTF8(name));
   }
-
-  [self savePrefs];
 }
 
 - (void)savePrefs {
@@ -440,9 +437,16 @@ brave_ads::mojom::DBCommandResponseInfoPtr RunDBTransactionOnTaskRunner(
 #pragma mark -
 
 - (void)migratePrefs {
-  if ([self.prefs objectForKey:kLegacyAdsEnabledPrefKey]) {
-    self.prefs[kEnabledPrefKey] = self.prefs[kLegacyAdsEnabledPrefKey];
-    [self.prefs removeObjectForKey:kLegacyAdsEnabledPrefKey];
+  if ([self.prefs objectForKey:kLegacyOptedInToNotificationAdsPrefKey]) {
+    self.prefs[kOptedInToNotificationAdsPrefKey] =
+        self.prefs[kLegacyOptedInToNotificationAdsPrefKey];
+    [self.prefs removeObjectForKey:kLegacyOptedInToNotificationAdsPrefKey];
+  }
+
+  if (![self.prefs objectForKey:kRewardsEnabledPrefKey] &&
+      [self.prefs objectForKey:kOptedInToNotificationAdsPrefKey]) {
+    self.prefs[kRewardsEnabledPrefKey] =
+        self.prefs[kOptedInToNotificationAdsPrefKey];
   }
 
   if ([self.prefs objectForKey:kLegacyNumberOfAdsPerHourKey]) {
@@ -1424,6 +1428,17 @@ brave_ads::mojom::DBCommandResponseInfoPtr RunDBTransactionOnTaskRunner(
 }
 
 - (bool)getBooleanPref:(const std::string&)path {
+  // TODO(https://github.com/brave/brave-browser/issues/32112): Remove the
+  // code that permanently sets values for preferences when the issue is
+  // resolved.
+  if (path == brave_news::prefs::kBraveNewsOptedIn ||
+      path == brave_news::prefs::kNewTabPageShowToday ||
+      path == ntp_background_images::prefs::kNewTabPageShowBackgroundImage ||
+      path == ntp_background_images::prefs::
+                  kNewTabPageShowSponsoredImagesBackgroundImage) {
+    return true;
+  }
+
   const auto key = base::SysUTF8ToNSString(path);
   return [self.prefs[key] boolValue];
 }
@@ -1435,6 +1450,13 @@ brave_ads::mojom::DBCommandResponseInfoPtr RunDBTransactionOnTaskRunner(
 }
 
 - (int)getIntegerPref:(const std::string&)path {
+  // TODO(https://github.com/brave/brave-browser/issues/32112): Remove the
+  // code that permanently sets values for preferences when the issue is
+  // resolved.
+  if (path == brave_ads::prefs::kIssuerPing && ![self hasPrefPath:path]) {
+    return 7'200'000;
+  }
+
   const auto key = base::SysUTF8ToNSString(path);
   return [self.prefs[key] intValue];
 }
@@ -1457,6 +1479,13 @@ brave_ads::mojom::DBCommandResponseInfoPtr RunDBTransactionOnTaskRunner(
 }
 
 - (std::string)getStringPref:(const std::string&)path {
+  // TODO(https://github.com/brave/brave-browser/issues/32112): Remove the
+  // code that permanently sets values for preferences when the issue is
+  // resolved.
+  if (path == brave_ads::prefs::kSubdivisionTargetingSubdivision) {
+    return "AUTO";
+  }
+
   const auto key = base::SysUTF8ToNSString(path);
   const auto value = (NSString*)self.prefs[key];
   if (!value) {


### PR DESCRIPTION
Uplift of https://github.com/brave/brave-core/pull/20511
Resolves https://github.com/brave/brave-browser/issues/33609

Pre-approval checklist: 
- [ ] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.