### PR TITLE
Fix notification ad serving on iOS

### DIFF
--- a/ios/browser/api/ads/brave_ads.mm
+++ b/ios/browser/api/ads/brave_ads.mm
@@ -37,6 +37,7 @@
 #include "brave/components/brave_ads/core/public/units/notification_ad/notification_ad_info.h"
 #include "brave/components/brave_ads/core/public/user/user_interaction/ad_events/ad_event_cache.h"
 #include "brave/components/brave_news/common/pref_names.h"
+#include "brave/components/brave_rewards/common/pref_names.h"
 #include "brave/components/brave_rewards/common/rewards_flags.h"
 #include "brave/components/l10n/common/locale_util.h"
 #include "brave/components/l10n/common/prefs.h"
@@ -74,7 +75,8 @@ static const NSInteger kDefaultNumberOfAdsPerHour = 2;
 
 static const int kCurrentAdsResourceManifestSchemaVersion = 1;
 
-static NSString* const kLegacyAdsEnabledPrefKey = @"BATAdsEnabled";
+static NSString* const kLegacyOptedInToNotificationAdsPrefKey =
+    @"BATAdsEnabled";
 static NSString* const kLegacyNumberOfAdsPerHourKey = @"BATNumberOfAdsPerHour";
 static NSString* const kLegacyShouldAllowAdsSubdivisionTargetingPrefKey =
     @"BATShouldAllowAdsSubdivisionTargetingPrefKey";
@@ -83,8 +85,10 @@ static NSString* const kLegacyAdsSubdivisionTargetingCodePrefKey =
 static NSString* const kLegacyAutoDetectedAdsSubdivisionTargetingCodePrefKey =
     @"BATAutoDetectedAdsSubdivisionTargetingCodePrefKey";
 
-static NSString* const kEnabledPrefKey =
+static NSString* const kOptedInToNotificationAdsPrefKey =
     base::SysUTF8ToNSString(brave_ads::prefs::kOptedInToNotificationAds);
+static NSString* const kRewardsEnabledPrefKey =
+    base::SysUTF8ToNSString(brave_rewards::prefs::kEnabled);
 static NSString* const kMaximumNotificationAdsPerHourPrefKey =
     base::SysUTF8ToNSString(brave_ads::prefs::kMaximumNotificationAdsPerHour);
 static NSString* const kShouldAllowSubdivisionTargetingPrefKey =
@@ -95,16 +99,6 @@ static NSString* const kSubdivisionTargetingAutoDetectedSubdivisionPrefKey =
     base::SysUTF8ToNSString(
         brave_ads::prefs::kSubdivisionTargetingAutoDetectedSubdivision);
 static NSString* const kAdsResourceMetadataPrefKey = @"BATAdsResourceMetadata";
-static NSString* const kBraveNewsOptedInPrefKey =
-    base::SysUTF8ToNSString(brave_news::prefs::kBraveNewsOptedIn);
-static NSString* const kNewTabPageShowTodayPrefKey =
-    base::SysUTF8ToNSString(brave_news::prefs::kNewTabPageShowToday);
-static NSString* const kNewTabPageShowBackgroundImagePrefKey =
-    base::SysUTF8ToNSString(
-        ntp_background_images::prefs::kNewTabPageShowBackgroundImage);
-static NSString* const kNewTabPageShowSponsoredImagesBackgroundImagePrefKey =
-    base::SysUTF8ToNSString(ntp_background_images::prefs::
-                                kNewTabPageShowSponsoredImagesBackgroundImage);
 
 namespace {
 
@@ -177,14 +171,6 @@ brave_ads::mojom::DBCommandResponseInfoPtr RunDBTransactionOnTaskRunner(
     } else {
       [self migratePrefs];
     }
-
-    // TODO(https://github.com/brave/brave-browser/issues/32112): Remove the
-    // code that permanently enables Brave Today and New Tab Page preferences
-    // when the issue is resolved.
-    self.prefs[kBraveNewsOptedInPrefKey] = @(true);
-    self.prefs[kNewTabPageShowTodayPrefKey] = @(true);
-    self.prefs[kNewTabPageShowBackgroundImagePrefKey] = @(true);
-    self.prefs[kNewTabPageShowSponsoredImagesBackgroundImagePrefKey] = @(true);
 
     [self setupNetworkMonitoring];
 
@@ -377,12 +363,14 @@ brave_ads::mojom::DBCommandResponseInfoPtr RunDBTransactionOnTaskRunner(
 #pragma mark - Configuration
 
 - (BOOL)isEnabled {
-  return [self.prefs[kEnabledPrefKey] boolValue];
+  return [self.prefs[kRewardsEnabledPrefKey] boolValue];
 }
 
 - (void)setEnabled:(BOOL)enabled {
-  self.prefs[kEnabledPrefKey] = @(enabled);
-  [self savePref:kEnabledPrefKey];
+  self.prefs[kRewardsEnabledPrefKey] = @(enabled);
+  [self savePref:kRewardsEnabledPrefKey];
+  self.prefs[kOptedInToNotificationAdsPrefKey] = @(enabled);
+  [self savePref:kOptedInToNotificationAdsPrefKey];
 }
 
 - (NSInteger)numberOfAllowableAdsPerHour {
@@ -430,11 +418,11 @@ brave_ads::mojom::DBCommandResponseInfoPtr RunDBTransactionOnTaskRunner(
 }
 
 - (void)savePref:(NSString*)name {
+  [self savePrefs];
+
   if ([self isAdsServiceRunning]) {
     adsClientNotifier->NotifyPrefDidChange(base::SysNSStringToUTF8(name));
   }
-
-  [self savePrefs];
 }
 
 - (void)savePrefs {
@@ -450,9 +438,16 @@ brave_ads::mojom::DBCommandResponseInfoPtr RunDBTransactionOnTaskRunner(
 #pragma mark -
 
 - (void)migratePrefs {
-  if ([self.prefs objectForKey:kLegacyAdsEnabledPrefKey]) {
-    self.prefs[kEnabledPrefKey] = self.prefs[kLegacyAdsEnabledPrefKey];
-    [self.prefs removeObjectForKey:kLegacyAdsEnabledPrefKey];
+  if ([self.prefs objectForKey:kLegacyOptedInToNotificationAdsPrefKey]) {
+    self.prefs[kOptedInToNotificationAdsPrefKey] =
+        self.prefs[kLegacyOptedInToNotificationAdsPrefKey];
+    [self.prefs removeObjectForKey:kLegacyOptedInToNotificationAdsPrefKey];
+  }
+
+  if (![self.prefs objectForKey:kRewardsEnabledPrefKey] &&
+      [self.prefs objectForKey:kOptedInToNotificationAdsPrefKey]) {
+    self.prefs[kRewardsEnabledPrefKey] =
+        self.prefs[kOptedInToNotificationAdsPrefKey];
   }
 
   if ([self.prefs objectForKey:kLegacyNumberOfAdsPerHourKey]) {
@@ -1434,6 +1429,17 @@ brave_ads::mojom::DBCommandResponseInfoPtr RunDBTransactionOnTaskRunner(
 }
 
 - (bool)getBooleanPref:(const std::string&)path {
+  // TODO(https://github.com/brave/brave-browser/issues/32112): Remove the
+  // code that permanently sets values for preferences when the issue is
+  // resolved.
+  if (path == brave_news::prefs::kBraveNewsOptedIn ||
+      path == brave_news::prefs::kNewTabPageShowToday ||
+      path == ntp_background_images::prefs::kNewTabPageShowBackgroundImage ||
+      path == ntp_background_images::prefs::
+                  kNewTabPageShowSponsoredImagesBackgroundImage) {
+    return true;
+  }
+
   const auto key = base::SysUTF8ToNSString(path);
   return [self.prefs[key] boolValue];
 }
@@ -1445,6 +1451,13 @@ brave_ads::mojom::DBCommandResponseInfoPtr RunDBTransactionOnTaskRunner(
 }
 
 - (int)getIntegerPref:(const std::string&)path {
+  // TODO(https://github.com/brave/brave-browser/issues/32112): Remove the
+  // code that permanently sets values for preferences when the issue is
+  // resolved.
+  if (path == brave_ads::prefs::kIssuerPing && ![self hasPrefPath:path]) {
+    return 7'200'000;
+  }
+
   const auto key = base::SysUTF8ToNSString(path);
   return [self.prefs[key] intValue];
 }
@@ -1467,6 +1480,13 @@ brave_ads::mojom::DBCommandResponseInfoPtr RunDBTransactionOnTaskRunner(
 }
 
 - (std::string)getStringPref:(const std::string&)path {
+  // TODO(https://github.com/brave/brave-browser/issues/32112): Remove the
+  // code that permanently sets values for preferences when the issue is
+  // resolved.
+  if (path == brave_ads::prefs::kSubdivisionTargetingSubdivision) {
+    return "AUTO";
+  }
+
   const auto key = base::SysUTF8ToNSString(path);
   const auto value = (NSString*)self.prefs[key];
   if (!value) {


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/33609

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [ ] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

### Test case 1
Update path check:

1) Install Brave version 1.57
2) Enable Brave Rewards
3) Install Brave version 1.58
4) Check that Brave Rewards are enabled
5) Check that Notification ads can be served and viewed

### Test case 2

Sanity testing of different types of ads. 
These things should be checked for the first launch and browser restart:

- New tab takeover ads are served if Brave Rewards is disabled
- New tab takeover ads are served if Brave Rewards is enabled
- New tab takeover ads are served if Brave Rewards is enabled and then disabled
- Newsfeed ads are served if Brave Rewards is disabled
- Newsfeed ads are served if Brave Rewards is enabled
- Newsfeed ads are served if Brave Rewards is enabled and then disabled
- Notification ads are not served if Brave Rewards is disabled
- Notification ads are served if Brave Rewards is enabled
- Notification ads are not served if Brave Rewards is enabled and then disabled
