### PR TITLE
Fix crash when vertical tabs are displayed with certain themes (uplift to 1.60.x)

### DIFF
--- a/browser/ui/views/frame/vertical_tab_strip_region_view.cc
+++ b/browser/ui/views/frame/vertical_tab_strip_region_view.cc
@@ -334,13 +334,6 @@ class VerticalTabNewTabButton : public BraveNewTabButton {
   }
 
   void OnPaintFill(gfx::Canvas* canvas) const override {
-    if (tab_strip()
-            ->GetCustomBackgroundId(BrowserFrameActiveState::kUseCurrent)
-            .has_value()) {
-      BraveNewTabButton::OnPaintFill(canvas);
-      return;
-    }
-
     auto* cp = GetColorProvider();
     CHECK(cp);
 

--- a/browser/ui/views/tabs/brave_tab_style_views.inc.cc
+++ b/browser/ui/views/tabs/brave_tab_style_views.inc.cc
@@ -256,7 +256,15 @@ int BraveVerticalTabStyle::GetStrokeThickness(
 }
 
 void BraveVerticalTabStyle::PaintTab(gfx::Canvas* canvas) const {
-  BraveGM2TabStyle::PaintTab(canvas);
+  if (ShouldShowVerticalTabs()) {
+    // For vertical tabs, bypass the upstream logic to paint theme backgrounds,
+    // as this can cause crashes due to the vertical tabstrip living in a
+    // different widget hierarchy.
+    PaintTabBackground(canvas, GetSelectionState(), IsHoverAnimationActive(),
+                       absl::nullopt, 0);
+  } else {
+    BraveGM2TabStyle::PaintTab(canvas);
+  }
 
   if (!HorizontalTabsUpdateEnabled() && !ShouldShowVerticalTabs()) {
     return;


### PR DESCRIPTION
Uplift of https://github.com/brave/brave-core/pull/20508
Resolves https://github.com/brave/brave-browser/issues/33598

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.