### PR TITLE
Fixed dcheck failure when loading settings after disabled vpn feature

### DIFF
--- a/browser/resources/settings/brave_overrides/system_page.ts
+++ b/browser/resources/settings/brave_overrides/system_page.ts
@@ -83,12 +83,19 @@ RegisterPolymerTemplateModifications({
       `
     )
     // <if expr="enable_brave_vpn_wireguard">
-    templateContent.appendChild(
-      html`
-        <settings-brave-vpn-page prefs="{{prefs}}">
-        </settings-brave-vpn-page>
-      `
-    )
+    let showVpnPage = loadTimeData.getBoolean('isBraveVPNEnabled')
+    // <if expr="is_macosx">
+    showVpnPage = showVpnPage &&
+                  loadTimeData.getBoolean('isBraveVPNWireguardEnabledOnMac')
+    // </if>
+    if (showVpnPage) {
+      templateContent.appendChild(
+        html`
+          <settings-brave-vpn-page prefs="{{prefs}}">
+          </settings-brave-vpn-page>
+        `
+      )
+    }
     // </if>
 
     templateContent.appendChild(

--- a/browser/resources/settings/brave_system_page/brave_vpn_page.html
+++ b/browser/resources/settings/brave_system_page/brave_vpn_page.html
@@ -7,23 +7,21 @@
   }
 </style>
 
-<template is="dom-if" if="[[showVpnPage_()]]">
-  <div class="cr-row title">$i18n{vpnPageTitle}</div>
-  <settings-vpn-page prefs="{{prefs}}">
+<div class="cr-row title">$i18n{vpnPageTitle}</div>
+<settings-vpn-page prefs="{{prefs}}">
 
-    <settings-toggle-button id="toggleWireguardButton"
-        pref="{{prefs.brave.brave_vpn.wireguard_enabled}}"
-        label="$i18n{useWireguardLabel}"
-        sub-label="[[toggleWireguardSubLabel_]]"
-        disabled="[[braveVpnConnected_]]"
-        on-change="onChange_">
-      <template is="dom-if" if="[[shouldShowRestart_]]">
-        <cr-button on-click="onRestartClick_" slot="more-actions">
-          $i18n{restart}
-        </cr-button>
-      </template>
-    </settings-toggle-button>
+  <settings-toggle-button id="toggleWireguardButton"
+      pref="{{prefs.brave.brave_vpn.wireguard_enabled}}"
+      label="$i18n{useWireguardLabel}"
+      sub-label="[[toggleWireguardSubLabel_]]"
+      disabled="[[braveVpnConnected_]]"
+      on-change="onChange_">
+    <template is="dom-if" if="[[shouldShowRestart_]]">
+      <cr-button on-click="onRestartClick_" slot="more-actions">
+        $i18n{restart}
+      </cr-button>
+    </template>
+  </settings-toggle-button>
 
-  </settings-vpn-page>
-</template>
+</settings-vpn-page>
 </if>

--- a/browser/resources/settings/brave_system_page/brave_vpn_page.ts
+++ b/browser/resources/settings/brave_system_page/brave_vpn_page.ts
@@ -96,15 +96,6 @@ export class SettingsBraveVpnPageElement
       this.initialProtocolValue_)
   }
 
-  private showVpnPage_(): boolean {
-    let showVpnPage = loadTimeData.getBoolean('isBraveVPNEnabled')
-    // <if expr="is_macosx">
-    showVpnPage = showVpnPage &&
-                  loadTimeData.getBoolean('isBraveVPNWireguardEnabledOnMac')
-    // </if>
-    return showVpnPage
-  }
-
   private isWireguardServiceRegistered(success: boolean) {
     if (success)
       return;


### PR DESCRIPTION
fix https://github.com/brave/brave-browser/issues/33612

Don't need to add vpn page options when vpn is disabled.

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves 

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

