### PR TITLE
Fix crash for Guest profiles (uplift to 1.59.x)

### DIFF
--- a/browser/ui/webui/brave_settings_ui.cc
+++ b/browser/ui/webui/brave_settings_ui.cc
@@ -111,8 +111,10 @@ BraveSettingsUI::BraveSettingsUI(content::WebUI* web_ui,
   web_ui->AddMessageHandler(std::make_unique<PinShortcutHandler>());
 #endif
 #if BUILDFLAG(IS_WIN) && BUILDFLAG(ENABLE_BRAVE_VPN)
-  web_ui->AddMessageHandler(
-      std::make_unique<BraveVpnHandler>(Profile::FromWebUI(web_ui)));
+  if (brave_vpn::IsBraveVPNEnabled(Profile::FromWebUI(web_ui))) {
+    web_ui->AddMessageHandler(
+        std::make_unique<BraveVpnHandler>(Profile::FromWebUI(web_ui)));
+  }
 #endif
 }
 


### PR DESCRIPTION
Uplift of #20041
Resolves https://github.com/brave/brave-browser/issues/32825
Resolves https://github.com/brave/brave-browser/issues/33581

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.