### PR TITLE
Update Widevine DLL on Arm64 Windows to 4.10.2710.0 (uplift to 1.60.x)

### DIFF
--- a/chromium_src/chrome/browser/component_updater/widevine_cdm_component_installer.cc
+++ b/chromium_src/chrome/browser/component_updater/widevine_cdm_component_installer.cc
@@ -109,7 +109,7 @@ constexpr net::NetworkTrafficAnnotationTag kTrafficAnnotation =
 BASE_DECLARE_FEATURE(kBraveWidevineArm64DllFix);
 constexpr base::FeatureParam<std::string> kBraveWidevineArm64DllUrl{
     &kBraveWidevineArm64DllFix, "widevine_arm64_dll_url",
-    "https://dl.google.com/widevine-cdm/4.10.2662.3-win-arm64.zip"};
+    "https://dl.google.com/widevine-cdm/4.10.2710.0-win-arm64.zip"};
 BASE_FEATURE(kBraveWidevineArm64DllFix,
              "BraveWidevineArm64DllFix",
              base::FEATURE_ENABLED_BY_DEFAULT);


### PR DESCRIPTION
Uplift of #20507
Resolves https://github.com/brave/brave-browser/issues/33594

Pre-approval checklist: 
- [x] You have tested your change on Nightly (via a [test-brave-browser-build from CI](https://ci.brave.com/job/test-brave-browser-build-windows-arm64/129/).)
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.