### PR TITLE
Fix notification ad serving on iOS (uplift to 1.58.x)

### DIFF
--- a/ios/browser/api/ads/BUILD.gn
+++ b/ios/browser/api/ads/BUILD.gn
@@ -35,6 +35,7 @@ source_set("ads") {
     "//brave/components/brave_federated/public/interfaces",
     "//brave/components/brave_news/common",
     "//brave/components/brave_rewards/common",
+    "//brave/components/ntp_background_images/common",
     "//brave/ios/browser/api/common",
   ]
 


### PR DESCRIPTION
Uplift of https://github.com/brave/brave-core/pull/20511
Resolves https://github.com/brave/brave-browser/issues/33609

Pre-approval checklist: 
- [ ] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.