### PR TITLE
Fix #2560: Add multiline version information in brave://settings/help

### DIFF
--- a/browser/resources/settings/brave_overrides/about_page.ts
+++ b/browser/resources/settings/brave_overrides/about_page.ts
@@ -24,6 +24,33 @@ RegisterStyleOverride(
   `
 )
 
+const extractVersions = (versionElement: Element) => {
+  const [ _, braveVersion, chromiumVersion, build ] = versionElement
+    .innerHTML
+    .match(/^Version\s([\d+\.?]+)\sChromium:\s([\d+\.?]+)\s(.*)$/) ?? []
+
+  return { braveVersion, build, chromiumVersion }
+}
+
+const buildBraveVersionLink = (braveVersion: string, build: string) => {
+  const wrapper = document.createElement('a')
+  wrapper.setAttribute('id', 'release-notes')
+  wrapper.setAttribute('target', '_blank')
+  wrapper.setAttribute('rel', 'noopener noreferrer')
+  wrapper.setAttribute('href', 'https://brave.com/latest/')
+  wrapper.textContent = `Brave ${braveVersion} ${build}`
+
+  return wrapper
+}
+
+const buildChromiumVersionElement = (chromiumVersion:string) => {
+  const chromiumElement = document.createElement('div')
+  chromiumElement.classList.add("secondary")
+  chromiumElement.textContent = `Chromium: ${chromiumVersion}`
+
+  return chromiumElement
+}
+
 RegisterPolymerTemplateModifications({
   'settings-about-page': (templateContent) => {
     const section = getSectionElement(templateContent, 'about')
@@ -50,6 +77,13 @@ RegisterPolymerTemplateModifications({
       const parent = version.parentNode
       parent?.replaceChild(wrapper, version)
       wrapper.appendChild(version)
+
+      const { braveVersion, build, chromiumVersion } = extractVersions(version)
+      const braveVersionLink = buildBraveVersionLink(braveVersion, build)
+      version.parentNode?.replaceChild(braveVersionLink, version)
+
+      const chromiumVersionElement = buildChromiumVersionElement(chromiumVersion)
+      braveVersionLink.after(chromiumVersionElement)
     }
 
     // Help link shown if update fails


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/2560

Adds multiline version information on the `brave://settings/help` page. This uses the browser version string that is currently being used, the template that is used to pull the string version information is here: [chrome/browser/resources/settings/about_page/about_page.html#L89](https://github.com/brave/chromium/blob/main/chrome/browser/resources/settings/about_page/about_page.html#L89). The Brave browser version, chromium version, and the build details are pulled from a regex match on the string.

Here are details on the regex pattern:
- Regex: `/^Version\s([\d+\.?]+)\sChromium:\s([\d+\.?]+)\s(.*)$/`
- From this string: `Version 1.59.117 Chromium: 118.0.5993.70 (Official Build)  (64-bit)`
- Extracts this information `Brave 1.59.117`, `Chromium: 118.0.5993.70`, and `(Official Build)  (64-bit)` for the build.

This regex is different from the reverted approach in https://github.com/brave/brave-core/pull/4480, which looked like this: `/([0-9]+\.[0-9]+\.[0-9]+\.[0-9]+)\s(.*)/` and I think it will work because it is looking for more than just the Chromium version in the string, fixing the issue for which this revert occurred: https://github.com/brave/brave-core/pull/5258

### Screenshot
#### DevBuild
![image](https://github.com/benjaminknox/brave-core/assets/5668789/12cdb726-5051-4a76-9276-fbb1a1ea2a2e)
![image](https://github.com/benjaminknox/brave-core/assets/5668789/bf4886d1-adbc-4e95-b80c-2b252e50bc04)


<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [X] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [X] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [X] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

