### PR TITLE
Fixed vpn button still has connected state for not purchased user

### DIFF
--- a/browser/ui/BUILD.gn
+++ b/browser/ui/BUILD.gn
@@ -1096,8 +1096,10 @@ source_set("unit_tests") {
       sources += [ "views/toolbar/brave_vpn_button_unittest.cc" ]
       deps += [
         "//base",
+        "//brave/components/brave_vpn/browser",
         "//brave/components/brave_vpn/browser/connection:api",
         "//brave/components/brave_vpn/browser/connection/ikev2:sim",
+        "//brave/components/skus/browser",
         "//chrome/test:test_support",
         "//skia",
         "//testing/gtest",

--- a/browser/ui/views/toolbar/brave_vpn_button.cc
+++ b/browser/ui/views/toolbar/brave_vpn_button.cc
@@ -146,6 +146,7 @@ BraveVPNButton::BraveVPNButton(Browser* browser)
       service_(brave_vpn::BraveVpnServiceFactory::GetForProfile(
           browser_->profile())) {
   CHECK(service_);
+  UpdateButtonState();
   Observe(service_);
 
   // Replace ToolbarButton's highlight path generator.
@@ -211,15 +212,14 @@ void BraveVPNButton::OnConnectionStateChanged(ConnectionState state) {
 
 void BraveVPNButton::UpdateButtonState() {
   is_error_state_ = IsConnectError();
+  is_connected_ = IsConnected();
 }
 
 void BraveVPNButton::OnPurchasedStateChanged(
     brave_vpn::mojom::PurchasedState state,
     const absl::optional<std::string>& description) {
   UpdateButtonState();
-  if (IsPurchased()) {
-    UpdateColorsAndInsets();
-  }
+  UpdateColorsAndInsets();
 }
 
 std::unique_ptr<views::Border> BraveVPNButton::GetBorder(
@@ -256,13 +256,12 @@ void BraveVPNButton::UpdateColorsAndInsets() {
     image()->SetBackground(std::make_unique<ConnectErrorIconBackground>(
         cp->GetColor(kColorBraveVpnButtonIconErrorInner)));
   } else {
-    const bool is_connected = IsConnected();
-    SetImage(
-        views::Button::STATE_NORMAL,
-        gfx::CreateVectorIcon(
-            is_connected ? kVpnIndicatorOnIcon : kVpnIndicatorOffIcon,
-            cp->GetColor(is_connected ? kColorBraveVpnButtonIconConnected
-                                      : kColorBraveVpnButtonIconDisconnected)));
+    SetImage(views::Button::STATE_NORMAL,
+             gfx::CreateVectorIcon(
+                 is_connected_ ? kVpnIndicatorOnIcon : kVpnIndicatorOffIcon,
+                 cp->GetColor(is_connected_
+                                  ? kColorBraveVpnButtonIconConnected
+                                  : kColorBraveVpnButtonIconDisconnected)));
 
     // Use background for inner color of button image.
     // Adjusted border thickness to make invisible to the outside of the icon.

--- a/browser/ui/views/toolbar/brave_vpn_button.h
+++ b/browser/ui/views/toolbar/brave_vpn_button.h
@@ -66,6 +66,7 @@ class BraveVPNButton : public ToolbarButton,
   void UpdateButtonState();
 
   bool is_error_state_ = false;
+  bool is_connected_ = false;
   absl::optional<brave_vpn::mojom::ConnectionState>
       connection_state_for_testing_;
   raw_ptr<Browser> browser_ = nullptr;

--- a/browser/ui/webui/skus_internals_ui.cc
+++ b/browser/ui/webui/skus_internals_ui.cc
@@ -31,6 +31,8 @@
 #include "ui/base/clipboard/scoped_clipboard_writer.h"
 
 #if BUILDFLAG(ENABLE_BRAVE_VPN)
+#include "brave/browser/brave_vpn/brave_vpn_service_factory.h"
+#include "brave/components/brave_vpn/browser/brave_vpn_service.h"
 #include "brave/components/brave_vpn/browser/brave_vpn_service_helper.h"
 #include "brave/components/brave_vpn/browser/connection/brave_vpn_os_connection_api.h"
 #include "brave/components/brave_vpn/common/brave_vpn_utils.h"
@@ -156,6 +158,10 @@ void SkusInternalsUI::ResetSkusState() {
   auto* profile = Profile::FromWebUI(web_ui());
   if (brave_vpn::IsBraveVPNEnabled(profile->GetPrefs())) {
     brave_vpn::ClearSubscriberCredential(local_state_);
+    if (auto* service =
+            brave_vpn::BraveVpnServiceFactory::GetForProfile(profile)) {
+      service->ReloadPurchasedState();
+    }
   }
 #endif
 

--- a/components/brave_vpn/browser/brave_vpn_service.h
+++ b/components/brave_vpn/browser/brave_vpn_service.h
@@ -157,6 +157,7 @@ class BraveVpnService :
 
  private:
   friend class BraveVPNServiceTest;
+  friend class BraveVpnButtonUnitTest;
 
 #if !BUILDFLAG(IS_ANDROID)
   friend class ::BraveAppMenuBrowserTest;

--- a/components/brave_vpn/browser/connection/brave_vpn_os_connection_api.h
+++ b/components/brave_vpn/browser/connection/brave_vpn_os_connection_api.h
@@ -98,6 +98,8 @@ class BraveVPNOSConnectionAPI
       net::NetworkChangeNotifier::ConnectionType type) override;
 
  private:
+  friend class BraveVpnButtonUnitTest;
+
   FRIEND_TEST_ALL_PREFIXES(BraveVPNOSConnectionAPIUnitTest, NeedsConnectTest);
   FRIEND_TEST_ALL_PREFIXES(BraveVPNOSConnectionAPIUnitTest, ConnectionInfoTest);
   FRIEND_TEST_ALL_PREFIXES(BraveVPNOSConnectionAPIUnitTest,


### PR DESCRIPTION
fix https://github.com/brave/brave-browser/issues/33023

When purchased state is changed to *not* purchased during the runtime, button should not show as connected.

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves 

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

See the linked issue for manual test.
`BraveVpnButtonUnitTest.ButtonStateTestWithPurchasedState`