### PR TITLE
[Android] fix crash in BraveNewTabPageLayout from gps (uplift to 1.60.x)

### DIFF
--- a/android/java/org/chromium/chrome/browser/ntp/BraveNewTabPageLayout.java
+++ b/android/java/org/chromium/chrome/browser/ntp/BraveNewTabPageLayout.java
@@ -897,8 +897,11 @@ public class BraveNewTabPageLayout
             mNtpAdapter.setNewsLoading(true);
         }
         initBraveNewsController();
-        PostTask.postTask(TaskTraits.BEST_EFFORT_MAY_BLOCK,
-                () -> { mBraveNewsController.getFeed(feed -> { runFeed(isNewContent, feed); }); });
+        PostTask.postTask(TaskTraits.BEST_EFFORT_MAY_BLOCK, () -> {
+            if (mBraveNewsController != null) {
+                mBraveNewsController.getFeed(feed -> { runFeed(isNewContent, feed); });
+            }
+        });
     }
 
     private void runFeed(boolean isNewContent, Feed feed) {


### PR DESCRIPTION
Uplift of #20383
Resolves https://github.com/brave/brave-browser/issues/33385

Pre-approval checklist: 
- [ ] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.