### PR TITLE
AIChat: show premium prompt after 24h

### DIFF
--- a/android/java/org/chromium/chrome/browser/settings/BraveLeoResetPreference.java
+++ b/android/java/org/chromium/chrome/browser/settings/BraveLeoResetPreference.java
@@ -73,7 +73,7 @@ public class BraveLeoResetPreference
                     return;
                 }
                 UserPrefs.get(profile)
-                        .setBoolean(BravePref.BRAVE_CHAT_HAS_SEEN_DISCLAIMER, false);
+                        .clearPref(BravePref.LAST_ACCEPTED_DISCLAIMER);
                 UserPrefs.get(profile)
                         .setBoolean(BravePref.BRAVE_CHAT_AUTO_GENERATE_QUESTIONS, false);
             } else {

--- a/browser/prefs/brave_pref_service_incognito_allowlist.cc
+++ b/browser/prefs/brave_pref_service_incognito_allowlist.cc
@@ -38,7 +38,7 @@ const std::vector<const char*>& GetBravePersistentPrefNames() {
         sidebar::kSidePanelWidth,
 #endif
 #if BUILDFLAG(ENABLE_AI_CHAT)
-        ai_chat::prefs::kBraveChatHasSeenDisclaimer,
+        ai_chat::prefs::kBravekLastSeenDisclaimer,
         ai_chat::prefs::kBraveChatAutoGenerateQuestions,
         ai_chat::prefs::kBraveChatAutocompleteProviderEnabled,
 #endif  // BUILDFLAG(ENABLE_AI_CHAT)

--- a/browser/prefs/brave_pref_service_incognito_allowlist.cc
+++ b/browser/prefs/brave_pref_service_incognito_allowlist.cc
@@ -38,7 +38,7 @@ const std::vector<const char*>& GetBravePersistentPrefNames() {
         sidebar::kSidePanelWidth,
 #endif
 #if BUILDFLAG(ENABLE_AI_CHAT)
-        ai_chat::prefs::kBravekLastSeenDisclaimer,
+        ai_chat::prefs::kLastAcceptedDisclaimer,
         ai_chat::prefs::kBraveChatAutoGenerateQuestions,
         ai_chat::prefs::kBraveChatAutocompleteProviderEnabled,
 #endif  // BUILDFLAG(ENABLE_AI_CHAT)

--- a/browser/ui/webui/ai_chat/ai_chat_ui.cc
+++ b/browser/ui/webui/ai_chat/ai_chat_ui.cc
@@ -74,7 +74,7 @@ AIChatUI::AIChatUI(content::WebUI* web_ui)
 
   base::Time last_seen_disclaimer =
       profile_->GetOriginalProfile()->GetPrefs()->GetTime(
-          ai_chat::prefs::kBravekLastSeenDisclaimer);
+          ai_chat::prefs::kLastAcceptedDisclaimer);
 
   untrusted_source->AddBoolean("hasSeenAgreement",
                                !last_seen_disclaimer.is_null());

--- a/browser/ui/webui/ai_chat/ai_chat_ui.cc
+++ b/browser/ui/webui/ai_chat/ai_chat_ui.cc
@@ -77,7 +77,7 @@ AIChatUI::AIChatUI(content::WebUI* web_ui)
           ai_chat::prefs::kBravekLastSeenDisclaimer);
 
   untrusted_source->AddBoolean("hasSeenAgreement",
-                               last_seen_disclaimer.is_null() ? false : true);
+                               !last_seen_disclaimer.is_null());
 
   untrusted_source->AddBoolean(
       "hasUserDismissedPremiumPrompt",

--- a/browser/ui/webui/ai_chat/ai_chat_ui.cc
+++ b/browser/ui/webui/ai_chat/ai_chat_ui.cc
@@ -72,10 +72,12 @@ AIChatUI::AIChatUI(content::WebUI* web_ui)
         str.name, brave_l10n::GetLocalizedResourceUTF16String(str.id));
   }
 
-  untrusted_source->AddBoolean(
-      "hasSeenAgreement",
-      profile_->GetOriginalProfile()->GetPrefs()->GetBoolean(
-          ai_chat::prefs::kBraveChatHasSeenDisclaimer));
+  base::Time last_seen_disclaimer =
+      profile_->GetOriginalProfile()->GetPrefs()->GetTime(
+          ai_chat::prefs::kBravekLastSeenDisclaimer);
+
+  untrusted_source->AddBoolean("hasSeenAgreement",
+                               last_seen_disclaimer.is_null() ? false : true);
 
   untrusted_source->AddBoolean(
       "hasUserDismissedPremiumPrompt",

--- a/browser/ui/webui/ai_chat/ai_chat_ui.cc
+++ b/browser/ui/webui/ai_chat/ai_chat_ui.cc
@@ -72,12 +72,12 @@ AIChatUI::AIChatUI(content::WebUI* web_ui)
         str.name, brave_l10n::GetLocalizedResourceUTF16String(str.id));
   }
 
-  base::Time last_seen_disclaimer =
+  base::Time last_accepted_disclaimer =
       profile_->GetOriginalProfile()->GetPrefs()->GetTime(
           ai_chat::prefs::kLastAcceptedDisclaimer);
 
-  untrusted_source->AddBoolean("hasSeenAgreement",
-                               !last_seen_disclaimer.is_null());
+  untrusted_source->AddBoolean("hasAcceptedAgreement",
+                               !last_accepted_disclaimer.is_null());
 
   untrusted_source->AddBoolean(
       "hasUserDismissedPremiumPrompt",

--- a/browser/ui/webui/ai_chat/ai_chat_ui_page_handler.cc
+++ b/browser/ui/webui/ai_chat/ai_chat_ui_page_handler.cc
@@ -226,15 +226,32 @@ void AIChatUIPageHandler::GetAPIResponseError(
   std::move(callback).Run(active_chat_tab_helper_->GetCurrentAPIError());
 }
 
-void AIChatUIPageHandler::GetHasUserDismissedPremiumPrompt(
-    GetHasUserDismissedPremiumPromptCallback callback) {
-  std::move(callback).Run(profile_->GetPrefs()->GetBoolean(
-      ai_chat::prefs::kUserDismissedPremiumPrompt));
+void AIChatUIPageHandler::MaybeShowPremiumPrompt(
+    MaybeShowPremiumPromptCallback callback) {
+  bool has_user_dismissed = profile_->GetPrefs()->GetBoolean(
+      ai_chat::prefs::kUserDismissedPremiumPrompt);
+
+  if (has_user_dismissed) {
+    std::move(callback).Run(false);
+    return;
+  }
+
+  base::Time last_seen_disclaimer =
+      profile_->GetPrefs()->GetTime(ai_chat::prefs::kBravekLastSeenDisclaimer);
+  base::Time time_1_day_ago = base::Time::Now() - base::Days(1);
+  bool is_more_than_24h_since_last_seen = last_seen_disclaimer < time_1_day_ago;
+
+  if (is_more_than_24h_since_last_seen && !has_user_dismissed) {
+    std::move(callback).Run(true);
+    return;
+  }
+
+  std::move(callback).Run(false);
 }
 
-void AIChatUIPageHandler::SetHasUserDismissedPremiumPrompt(bool has_dismissed) {
+void AIChatUIPageHandler::DismissPremiumPrompt() {
   profile_->GetPrefs()->SetBoolean(ai_chat::prefs::kUserDismissedPremiumPrompt,
-                                   has_dismissed);
+                                   true);
 }
 
 void AIChatUIPageHandler::RateMessage(bool is_liked,

--- a/browser/ui/webui/ai_chat/ai_chat_ui_page_handler.cc
+++ b/browser/ui/webui/ai_chat/ai_chat_ui_page_handler.cc
@@ -228,20 +228,21 @@ void AIChatUIPageHandler::GetAPIResponseError(
 
 void AIChatUIPageHandler::GetCanShowPremiumPrompt(
     GetCanShowPremiumPromptCallback callback) {
-  bool has_user_dismissed = profile_->GetPrefs()->GetBoolean(
+  bool has_user_dismissed_prompt = profile_->GetPrefs()->GetBoolean(
       ai_chat::prefs::kUserDismissedPremiumPrompt);
 
-  if (has_user_dismissed) {
+  if (has_user_dismissed_prompt) {
     std::move(callback).Run(false);
     return;
   }
 
-  base::Time last_seen_disclaimer =
+  base::Time last_accepted_disclaimer =
       profile_->GetPrefs()->GetTime(ai_chat::prefs::kLastAcceptedDisclaimer);
   base::Time time_1_day_ago = base::Time::Now() - base::Days(1);
-  bool is_more_than_24h_since_last_seen = last_seen_disclaimer < time_1_day_ago;
+  bool is_more_than_24h_since_last_seen =
+      last_accepted_disclaimer < time_1_day_ago;
 
-  if (is_more_than_24h_since_last_seen && !has_user_dismissed) {
+  if (is_more_than_24h_since_last_seen && !has_user_dismissed_prompt) {
     std::move(callback).Run(true);
     return;
   }

--- a/browser/ui/webui/ai_chat/ai_chat_ui_page_handler.cc
+++ b/browser/ui/webui/ai_chat/ai_chat_ui_page_handler.cc
@@ -294,8 +294,8 @@ void AIChatUIPageHandler::SendFeedback(const std::string& category,
 }
 
 void AIChatUIPageHandler::MarkAgreementAccepted() {
-  profile_->GetPrefs()->SetBoolean(ai_chat::prefs::kBraveChatHasSeenDisclaimer,
-                                   true);
+  profile_->GetPrefs()->SetTime(ai_chat::prefs::kBravekLastSeenDisclaimer,
+                                base::Time::Now());
 }
 
 void AIChatUIPageHandler::OnHistoryUpdate() {

--- a/browser/ui/webui/ai_chat/ai_chat_ui_page_handler.cc
+++ b/browser/ui/webui/ai_chat/ai_chat_ui_page_handler.cc
@@ -226,8 +226,8 @@ void AIChatUIPageHandler::GetAPIResponseError(
   std::move(callback).Run(active_chat_tab_helper_->GetCurrentAPIError());
 }
 
-void AIChatUIPageHandler::MaybeShowPremiumPrompt(
-    MaybeShowPremiumPromptCallback callback) {
+void AIChatUIPageHandler::GetCanShowPremiumPrompt(
+    GetCanShowPremiumPromptCallback callback) {
   bool has_user_dismissed = profile_->GetPrefs()->GetBoolean(
       ai_chat::prefs::kUserDismissedPremiumPrompt);
 
@@ -237,7 +237,7 @@ void AIChatUIPageHandler::MaybeShowPremiumPrompt(
   }
 
   base::Time last_seen_disclaimer =
-      profile_->GetPrefs()->GetTime(ai_chat::prefs::kBravekLastSeenDisclaimer);
+      profile_->GetPrefs()->GetTime(ai_chat::prefs::kLastAcceptedDisclaimer);
   base::Time time_1_day_ago = base::Time::Now() - base::Days(1);
   bool is_more_than_24h_since_last_seen = last_seen_disclaimer < time_1_day_ago;
 
@@ -311,7 +311,7 @@ void AIChatUIPageHandler::SendFeedback(const std::string& category,
 }
 
 void AIChatUIPageHandler::MarkAgreementAccepted() {
-  profile_->GetPrefs()->SetTime(ai_chat::prefs::kBravekLastSeenDisclaimer,
+  profile_->GetPrefs()->SetTime(ai_chat::prefs::kLastAcceptedDisclaimer,
                                 base::Time::Now());
 }
 

--- a/browser/ui/webui/ai_chat/ai_chat_ui_page_handler.h
+++ b/browser/ui/webui/ai_chat/ai_chat_ui_page_handler.h
@@ -66,9 +66,8 @@ class AIChatUIPageHandler : public ai_chat::mojom::PageHandler,
   void ClearConversationHistory() override;
   void RetryAPIRequest() override;
   void GetAPIResponseError(GetAPIResponseErrorCallback callback) override;
-  void GetHasUserDismissedPremiumPrompt(
-      GetHasUserDismissedPremiumPromptCallback callback) override;
-  void SetHasUserDismissedPremiumPrompt(bool has_dismissed) override;
+  void MaybeShowPremiumPrompt(MaybeShowPremiumPromptCallback callback) override;
+  void DismissPremiumPrompt() override;
   void RateMessage(bool is_liked,
                    uint32_t turn_id,
                    RateMessageCallback callback) override;

--- a/browser/ui/webui/ai_chat/ai_chat_ui_page_handler.h
+++ b/browser/ui/webui/ai_chat/ai_chat_ui_page_handler.h
@@ -66,7 +66,8 @@ class AIChatUIPageHandler : public ai_chat::mojom::PageHandler,
   void ClearConversationHistory() override;
   void RetryAPIRequest() override;
   void GetAPIResponseError(GetAPIResponseErrorCallback callback) override;
-  void MaybeShowPremiumPrompt(MaybeShowPremiumPromptCallback callback) override;
+  void GetCanShowPremiumPrompt(
+      GetCanShowPremiumPromptCallback callback) override;
   void DismissPremiumPrompt() override;
   void RateMessage(bool is_liked,
                    uint32_t turn_id,

--- a/browser/ui/webui/settings/brave_settings_leo_assistant_handler.cc
+++ b/browser/ui/webui/settings/brave_settings_leo_assistant_handler.cc
@@ -133,7 +133,7 @@ void BraveLeoAssistantHandler::HandleResetLeoData(
   auto* service = sidebar::SidebarServiceFactory::GetForProfile(profile_);
 
   ShowLeoAssistantIconVisibleIfNot(service);
-  profile_->GetPrefs()->SetBoolean(ai_chat::prefs::kBravekLastSeenDisclaimer,
+  profile_->GetPrefs()->SetTime(ai_chat::prefs::kBravekLastSeenDisclaimer,
                                    {});
   profile_->GetPrefs()->SetBoolean(
       ai_chat::prefs::kBraveChatAutoGenerateQuestions, false);

--- a/browser/ui/webui/settings/brave_settings_leo_assistant_handler.cc
+++ b/browser/ui/webui/settings/brave_settings_leo_assistant_handler.cc
@@ -133,8 +133,8 @@ void BraveLeoAssistantHandler::HandleResetLeoData(
   auto* service = sidebar::SidebarServiceFactory::GetForProfile(profile_);
 
   ShowLeoAssistantIconVisibleIfNot(service);
-  profile_->GetPrefs()->SetBoolean(ai_chat::prefs::kBraveChatHasSeenDisclaimer,
-                                   false);
+  profile_->GetPrefs()->SetBoolean(ai_chat::prefs::kBravekLastSeenDisclaimer,
+                                   {});
   profile_->GetPrefs()->SetBoolean(
       ai_chat::prefs::kBraveChatAutoGenerateQuestions, false);
 

--- a/browser/ui/webui/settings/brave_settings_leo_assistant_handler.cc
+++ b/browser/ui/webui/settings/brave_settings_leo_assistant_handler.cc
@@ -133,8 +133,7 @@ void BraveLeoAssistantHandler::HandleResetLeoData(
   auto* service = sidebar::SidebarServiceFactory::GetForProfile(profile_);
 
   ShowLeoAssistantIconVisibleIfNot(service);
-  profile_->GetPrefs()->SetTime(ai_chat::prefs::kBravekLastSeenDisclaimer,
-                                   {});
+  profile_->GetPrefs()->SetTime(ai_chat::prefs::kLastAcceptedDisclaimer, {});
   profile_->GetPrefs()->SetBoolean(
       ai_chat::prefs::kBraveChatAutoGenerateQuestions, false);
 

--- a/browser/ui/webui/settings/brave_settings_leo_assistant_handler.cc
+++ b/browser/ui/webui/settings/brave_settings_leo_assistant_handler.cc
@@ -133,7 +133,7 @@ void BraveLeoAssistantHandler::HandleResetLeoData(
   auto* service = sidebar::SidebarServiceFactory::GetForProfile(profile_);
 
   ShowLeoAssistantIconVisibleIfNot(service);
-  profile_->GetPrefs()->SetTime(ai_chat::prefs::kLastAcceptedDisclaimer, {});
+  profile_->GetPrefs()->ClearPref(ai_chat::prefs::kLastAcceptedDisclaimer);
   profile_->GetPrefs()->SetBoolean(
       ai_chat::prefs::kBraveChatAutoGenerateQuestions, false);
 

--- a/components/ai_chat/browser/ai_chat_tab_helper.cc
+++ b/components/ai_chat/browser/ai_chat_tab_helper.cc
@@ -153,9 +153,9 @@ void AIChatTabHelper::InitEngine() {
 }
 
 bool AIChatTabHelper::HasUserOptedIn() {
-  base::Time last_seen_disclaimer =
+  base::Time last_accepted_disclaimer =
       pref_service_->GetTime(ai_chat::prefs::kLastAcceptedDisclaimer);
-  return !last_seen_disclaimer.is_null();
+  return !last_accepted_disclaimer.is_null();
 }
 
 void AIChatTabHelper::OnUserOptedIn() {

--- a/components/ai_chat/browser/ai_chat_tab_helper.cc
+++ b/components/ai_chat/browser/ai_chat_tab_helper.cc
@@ -61,7 +61,7 @@ AIChatTabHelper::AIChatTabHelper(
   DCHECK(pref_service_);
   pref_change_registrar_.Init(pref_service_);
   pref_change_registrar_.Add(
-      prefs::kBravekLastSeenDisclaimer,
+      prefs::kLastAcceptedDisclaimer,
       base::BindRepeating(&AIChatTabHelper::OnUserOptedIn,
                           weak_ptr_factory_.GetWeakPtr()));
   pref_change_registrar_.Add(
@@ -154,7 +154,7 @@ void AIChatTabHelper::InitEngine() {
 
 bool AIChatTabHelper::HasUserOptedIn() {
   base::Time last_seen_disclaimer =
-      pref_service_->GetTime(ai_chat::prefs::kBravekLastSeenDisclaimer);
+      pref_service_->GetTime(ai_chat::prefs::kLastAcceptedDisclaimer);
   return !last_seen_disclaimer.is_null();
 }
 

--- a/components/ai_chat/browser/ai_chat_tab_helper.cc
+++ b/components/ai_chat/browser/ai_chat_tab_helper.cc
@@ -61,7 +61,7 @@ AIChatTabHelper::AIChatTabHelper(
   DCHECK(pref_service_);
   pref_change_registrar_.Init(pref_service_);
   pref_change_registrar_.Add(
-      prefs::kBraveChatHasSeenDisclaimer,
+      prefs::kBravekLastSeenDisclaimer,
       base::BindRepeating(&AIChatTabHelper::OnUserOptedIn,
                           weak_ptr_factory_.GetWeakPtr()));
   pref_change_registrar_.Add(
@@ -153,7 +153,9 @@ void AIChatTabHelper::InitEngine() {
 }
 
 bool AIChatTabHelper::HasUserOptedIn() {
-  return pref_service_->GetBoolean(ai_chat::prefs::kBraveChatHasSeenDisclaimer);
+  base::Time last_seen_disclaimer =
+      pref_service_->GetTime(ai_chat::prefs::kBravekLastSeenDisclaimer);
+  return last_seen_disclaimer.is_null() ? false : true;
 }
 
 void AIChatTabHelper::OnUserOptedIn() {

--- a/components/ai_chat/browser/ai_chat_tab_helper.cc
+++ b/components/ai_chat/browser/ai_chat_tab_helper.cc
@@ -155,7 +155,7 @@ void AIChatTabHelper::InitEngine() {
 bool AIChatTabHelper::HasUserOptedIn() {
   base::Time last_seen_disclaimer =
       pref_service_->GetTime(ai_chat::prefs::kBravekLastSeenDisclaimer);
-  return last_seen_disclaimer.is_null() ? false : true;
+  return !last_seen_disclaimer.is_null();
 }
 
 void AIChatTabHelper::OnUserOptedIn() {

--- a/components/ai_chat/common/mojom/ai_chat.mojom
+++ b/components/ai_chat/common/mojom/ai_chat.mojom
@@ -108,7 +108,7 @@ interface PageHandler {
   ClearConversationHistory();
   RetryAPIRequest();
   GetAPIResponseError() => (APIError error);
-  MaybeShowPremiumPrompt() => (bool should_show);
+  GetCanShowPremiumPrompt() => (bool can_show);
   DismissPremiumPrompt();
 
   // Send a user-rating for a chat

--- a/components/ai_chat/common/mojom/ai_chat.mojom
+++ b/components/ai_chat/common/mojom/ai_chat.mojom
@@ -108,10 +108,10 @@ interface PageHandler {
   ClearConversationHistory();
   RetryAPIRequest();
   GetAPIResponseError() => (APIError error);
-  GetHasUserDismissedPremiumPrompt() => (bool has_dismissed);
-  SetHasUserDismissedPremiumPrompt(bool has_dismissed);
+  MaybeShowPremiumPrompt() => (bool should_show);
+  DismissPremiumPrompt();
 
-  // Send a user-rating for a chat 
+  // Send a user-rating for a chat
   // message. |turn_id| is the index of the message in the
   // current conversation.
   RateMessage(bool is_liked, uint32 turn_id) => (string? rating_id);

--- a/components/ai_chat/common/pref_names.cc
+++ b/components/ai_chat/common/pref_names.cc
@@ -10,7 +10,7 @@
 namespace ai_chat::prefs {
 
 void RegisterProfilePrefs(PrefRegistrySimple* registry) {
-  registry->RegisterBooleanPref(kBraveChatHasSeenDisclaimer, false);
+  registry->RegisterTimePref(kBravekLastSeenDisclaimer, {});
   registry->RegisterBooleanPref(kBraveChatAutoGenerateQuestions, false);
   registry->RegisterBooleanPref(kBraveChatAutocompleteProviderEnabled, true);
   registry->RegisterBooleanPref(kUserDismissedPremiumPrompt, false);

--- a/components/ai_chat/common/pref_names.cc
+++ b/components/ai_chat/common/pref_names.cc
@@ -10,7 +10,7 @@
 namespace ai_chat::prefs {
 
 void RegisterProfilePrefs(PrefRegistrySimple* registry) {
-  registry->RegisterTimePref(kBravekLastSeenDisclaimer, {});
+  registry->RegisterTimePref(kLastAcceptedDisclaimer, {});
   registry->RegisterBooleanPref(kBraveChatAutoGenerateQuestions, false);
   registry->RegisterBooleanPref(kBraveChatAutocompleteProviderEnabled, true);
   registry->RegisterBooleanPref(kUserDismissedPremiumPrompt, false);

--- a/components/ai_chat/common/pref_names.h
+++ b/components/ai_chat/common/pref_names.h
@@ -10,7 +10,7 @@ class PrefRegistrySimple;
 
 namespace ai_chat::prefs {
 
-constexpr char kBraveChatHasSeenDisclaimer[] =
+constexpr char kBravekLastSeenDisclaimer[] =
     "brave.ai_chat.has_seen_disclaimer";
 constexpr char kBraveChatAutoGenerateQuestions[] =
     "brave.ai_chat.auto_generate_questions";

--- a/components/ai_chat/common/pref_names.h
+++ b/components/ai_chat/common/pref_names.h
@@ -10,8 +10,8 @@ class PrefRegistrySimple;
 
 namespace ai_chat::prefs {
 
-constexpr char kBravekLastSeenDisclaimer[] =
-    "brave.ai_chat.has_seen_disclaimer";
+constexpr char kLastAcceptedDisclaimer[] =
+    "brave.ai_chat.last_accepted_disclaimer";
 constexpr char kBraveChatAutoGenerateQuestions[] =
     "brave.ai_chat.auto_generate_questions";
 constexpr char kBraveChatAutocompleteProviderEnabled[] =

--- a/components/ai_chat/resources/page/components/input_box/index.tsx
+++ b/components/ai_chat/resources/page/components/input_box/index.tsx
@@ -25,7 +25,7 @@ function InputBox () {
 
   const isInputDisabled = context.shouldDisableUserInput || isCharLimitExceeded || (!context.isPremiumUser && context.currentModel?.isPremium)
 
-  if (!context.hasSeenAgreement) {
+  if (!context.hasAcceptedAgreement) {
     return (
       <div className={styles.container}>
         <button className={styles.buttonAgree} onClick={context.handleAgreeClick}>{getLocale('acceptButtonLabel')}</button>

--- a/components/ai_chat/resources/page/components/main/index.tsx
+++ b/components/ai_chat/resources/page/components/main/index.tsx
@@ -44,7 +44,7 @@ function Main() {
     hasSeenAgreement &&
     !shouldShowPremiumSuggestionForModel && // Don't show 2 premium prompts
     shouldPromptSuggestQuestions && // Don't show premium prompt and question prompt
-    !context.hasUserDissmisedPremiumPrompt &&
+    !context.shouldShowPremiumPrompt &&
     !siteInfo &&
     !context.isPremiumUser
 

--- a/components/ai_chat/resources/page/components/main/index.tsx
+++ b/components/ai_chat/resources/page/components/main/index.tsx
@@ -27,7 +27,7 @@ function Main() {
   const {
     siteInfo,
     userAutoGeneratePref,
-    hasSeenAgreement,
+    hasAcceptedAgreement: hasSeenAgreement,
     currentError,
     apiHasError
   } = context

--- a/components/ai_chat/resources/page/components/main/index.tsx
+++ b/components/ai_chat/resources/page/components/main/index.tsx
@@ -27,7 +27,7 @@ function Main() {
   const {
     siteInfo,
     userAutoGeneratePref,
-    hasAcceptedAgreement: hasSeenAgreement,
+    hasAcceptedAgreement,
     currentError,
     apiHasError
   } = context
@@ -36,15 +36,15 @@ function Main() {
     getPageHandlerInstance().pageHandler.clearConversationHistory()
   }
 
-  const shouldPromptSuggestQuestions = hasSeenAgreement && userAutoGeneratePref === mojom.AutoGenerateQuestionsPref.Unset
+  const shouldPromptSuggestQuestions = hasAcceptedAgreement && userAutoGeneratePref === mojom.AutoGenerateQuestionsPref.Unset
 
-  const shouldShowPremiumSuggestionForModel = hasSeenAgreement && !context.isPremiumUser && context.currentModel?.isPremium
+  const shouldShowPremiumSuggestionForModel = hasAcceptedAgreement && !context.isPremiumUser && context.currentModel?.isPremium
 
   const shouldShowPremiumSuggestionStandalone =
-    hasSeenAgreement &&
+    hasAcceptedAgreement &&
     !shouldShowPremiumSuggestionForModel && // Don't show 2 premium prompts
-    shouldPromptSuggestQuestions && // Don't show premium prompt and question prompt
-    !context.canShowPremiumPrompt &&
+    !shouldPromptSuggestQuestions && // Don't show premium prompt and question prompt
+    context.canShowPremiumPrompt &&
     !siteInfo &&
     !context.isPremiumUser
 
@@ -54,7 +54,7 @@ function Main() {
   let siteTitleElement = null
   let currentErrorElement = null
 
-  if (hasSeenAgreement) {
+  if (hasAcceptedAgreement) {
     conversationListElement = <ConversationList />
 
     if (siteInfo) {
@@ -89,7 +89,7 @@ function Main() {
           {context.isPremiumUser && <div className={styles.badgePremium}>PREMIUM</div>}
         </div>
         <div className={styles.actions}>
-          {hasSeenAgreement && (
+          {hasAcceptedAgreement && (
             <>
             {shouldDisplayEraseAction && (
               <Button

--- a/components/ai_chat/resources/page/components/main/index.tsx
+++ b/components/ai_chat/resources/page/components/main/index.tsx
@@ -44,7 +44,7 @@ function Main() {
     hasSeenAgreement &&
     !shouldShowPremiumSuggestionForModel && // Don't show 2 premium prompts
     shouldPromptSuggestQuestions && // Don't show premium prompt and question prompt
-    !context.shouldShowPremiumPrompt &&
+    !context.canShowPremiumPrompt &&
     !siteInfo &&
     !context.isPremiumUser
 

--- a/components/ai_chat/resources/page/components/site_title/index.tsx
+++ b/components/ai_chat/resources/page/components/site_title/index.tsx
@@ -37,7 +37,7 @@ function Tooltip(props: ToolTipProps) {
 function SiteTitle () {
   const [isTooltipVisible, setIsTooltipVisible] = React.useState(false)
   const timerId = React.useRef<Timer | undefined>();
-  const { siteInfo, favIconUrl } = React.useContext(DataContext)
+  const context = React.useContext(DataContext)
 
   const showTooltipWithDelay = () => {
     timerId.current = setTimeout(() => {
@@ -58,16 +58,18 @@ function SiteTitle () {
 
   const handlePageContentDisconnect = () => {
     getPageHandlerInstance().pageHandler.disconnectPageContents()
+     // Refetch the preference to ensure the user sees the prompt without waiting for a new runtime.
+    context.maybeShowPremiumPrompt()
   }
 
    return (
     <div className={styles.box}>
       <Tooltip isVisible={isTooltipVisible} />
       <div className={styles.favIconBox}>
-        { favIconUrl && <img src={favIconUrl} /> }
+        { context.favIconUrl && <img src={context.favIconUrl} /> }
       </div>
       <div className={styles.titleBox}>
-        <p className={styles.title}>{siteInfo?.title}</p>
+        <p className={styles.title}>{context.siteInfo?.title}</p>
       </div>
       <div
         aria-describedby='page-content-warning-tooltip'

--- a/components/ai_chat/resources/page/components/site_title/index.tsx
+++ b/components/ai_chat/resources/page/components/site_title/index.tsx
@@ -58,8 +58,6 @@ function SiteTitle () {
 
   const handlePageContentDisconnect = () => {
     getPageHandlerInstance().pageHandler.disconnectPageContents()
-     // Refetch the preference to ensure the user sees the prompt without waiting for a new runtime.
-    context.maybeShowPremiumPrompt()
   }
 
    return (

--- a/components/ai_chat/resources/page/state/context.ts
+++ b/components/ai_chat/resources/page/state/context.ts
@@ -23,7 +23,7 @@ export interface AIChatContext {
   shouldDisableUserInput: boolean
   isPremiumUser: boolean
   isPremiumUserDisconnected: boolean
-  hasUserDissmisedPremiumPrompt: boolean
+  shouldShowPremiumPrompt: boolean | undefined
   setCurrentModel: (model: mojom.Model) => void,
   switchToDefaultModel: () => void,
   generateSuggestedQuestions: () => void
@@ -48,7 +48,7 @@ export const defaultContext = {
   siteInfo: null,
   favIconUrl: undefined,
   currentError: mojom.APIError.None,
-  hasUserDissmisedPremiumPrompt: false,
+  shouldShowPremiumPrompt: undefined,
   setCurrentModel: () => {},
   switchToDefaultModel: () => {},
   generateSuggestedQuestions: () => {},

--- a/components/ai_chat/resources/page/state/context.ts
+++ b/components/ai_chat/resources/page/state/context.ts
@@ -14,7 +14,7 @@ export interface AIChatContext {
   suggestedQuestions: string[]
   isGenerating: boolean
   canGenerateQuestions: boolean
-  hasSeenAgreement: boolean
+  hasAcceptedAgreement: boolean
   userAutoGeneratePref: mojom.AutoGenerateQuestionsPref | undefined
   siteInfo: mojom.SiteInfo | null
   favIconUrl: string | undefined
@@ -33,14 +33,14 @@ export interface AIChatContext {
   getCanShowPremiumPrompt: () => void
 }
 
-export const defaultContext = {
+export const defaultContext: AIChatContext = {
   allModels: [],
   hasChangedModel: false,
   conversationHistory: [],
   suggestedQuestions: [],
   isGenerating: false,
   canGenerateQuestions: false,
-  hasSeenAgreement: false,
+  hasAcceptedAgreement: false,
   apiHasError: false,
   shouldDisableUserInput: false,
   isPremiumUser: false,

--- a/components/ai_chat/resources/page/state/context.ts
+++ b/components/ai_chat/resources/page/state/context.ts
@@ -23,14 +23,14 @@ export interface AIChatContext {
   shouldDisableUserInput: boolean
   isPremiumUser: boolean
   isPremiumUserDisconnected: boolean
-  shouldShowPremiumPrompt: boolean | undefined
+  canShowPremiumPrompt?: boolean
   setCurrentModel: (model: mojom.Model) => void,
   switchToDefaultModel: () => void,
   generateSuggestedQuestions: () => void
   setUserAllowsAutoGenerating: (value: boolean) => void
   handleAgreeClick: () => void
   dismissPremiumPrompt: () => void
-  maybeShowPremiumPrompt: () => void
+  getCanShowPremiumPrompt: () => void
 }
 
 export const defaultContext = {
@@ -49,14 +49,14 @@ export const defaultContext = {
   siteInfo: null,
   favIconUrl: undefined,
   currentError: mojom.APIError.None,
-  shouldShowPremiumPrompt: undefined,
+  canShowPremiumPrompt: undefined,
   setCurrentModel: () => {},
   switchToDefaultModel: () => {},
   generateSuggestedQuestions: () => {},
   setUserAllowsAutoGenerating: () => {},
   handleAgreeClick: () => {},
   dismissPremiumPrompt: () => {},
-  maybeShowPremiumPrompt: () => {}
+  getCanShowPremiumPrompt: () => {}
 }
 
 export default React.createContext<AIChatContext>(defaultContext)

--- a/components/ai_chat/resources/page/state/context.ts
+++ b/components/ai_chat/resources/page/state/context.ts
@@ -30,6 +30,7 @@ export interface AIChatContext {
   setUserAllowsAutoGenerating: (value: boolean) => void
   handleAgreeClick: () => void
   dismissPremiumPrompt: () => void
+  maybeShowPremiumPrompt: () => void
 }
 
 export const defaultContext = {
@@ -54,7 +55,8 @@ export const defaultContext = {
   generateSuggestedQuestions: () => {},
   setUserAllowsAutoGenerating: () => {},
   handleAgreeClick: () => {},
-  dismissPremiumPrompt: () => {}
+  dismissPremiumPrompt: () => {},
+  maybeShowPremiumPrompt: () => {}
 }
 
 export default React.createContext<AIChatContext>(defaultContext)

--- a/components/ai_chat/resources/page/state/data-context-provider.tsx
+++ b/components/ai_chat/resources/page/state/data-context-provider.tsx
@@ -34,8 +34,7 @@ function DataContextProvider (props: DataContextProviderProps) {
   const [currentError, setCurrentError] = React.useState<mojom.APIError>(mojom.APIError.None)
   const [hasSeenAgreement, setHasSeenAgreement] = React.useState(loadTimeData.getBoolean("hasSeenAgreement"))
   const [premiumStatus, setPremiumStatus] = React.useState<mojom.PremiumStatus>(mojom.PremiumStatus.Inactive)
-
-  const [hasUserDissmisedPremiumPrompt, setHasUserDissmisedPremiumPrompt] = React.useState(loadTimeData.getBoolean("hasUserDismissedPremiumPrompt"))
+  const [shouldShowPremiumPrompt, setShouldShowPremiumPrompt] = React.useState<boolean | undefined>()
 
   // Provide a custom handler for setCurrentModel instead of a useEffect
   // so that we can track when the user has changed a model in
@@ -103,14 +102,14 @@ function DataContextProvider (props: DataContextProviderProps) {
     getPageHandlerInstance().pageHandler.markAgreementAccepted()
   }
 
-  const getHasUserDismissedPremiumPrompt = () => {
-    getPageHandlerInstance().pageHandler.getHasUserDismissedPremiumPrompt()
-      .then(resp => setHasUserDissmisedPremiumPrompt(resp.hasDismissed))
+  const maybeShowPremiumPrompt = () => {
+    getPageHandlerInstance().pageHandler.maybeShowPremiumPrompt()
+      .then(resp => setShouldShowPremiumPrompt(resp.shouldShow))
   }
 
   const dismissPremiumPrompt = () => {
-    getPageHandlerInstance().pageHandler.setHasUserDismissedPremiumPrompt(true)
-    setHasUserDissmisedPremiumPrompt(true)
+    getPageHandlerInstance().pageHandler.dismissPremiumPrompt()
+    setShouldShowPremiumPrompt(false)
   }
 
   const switchToDefaultModel = () => {
@@ -141,7 +140,7 @@ function DataContextProvider (props: DataContextProviderProps) {
     getSiteInfo()
     getFaviconData()
     getCurrentAPIError()
-    getHasUserDismissedPremiumPrompt()
+    maybeShowPremiumPrompt()
   }
 
   React.useEffect(() => {
@@ -201,7 +200,7 @@ function DataContextProvider (props: DataContextProviderProps) {
     shouldDisableUserInput,
     isPremiumUser: premiumStatus !== mojom.PremiumStatus.Inactive,
     isPremiumUserDisconnected: premiumStatus === mojom.PremiumStatus.ActiveDisconnected,
-    hasUserDissmisedPremiumPrompt,
+    shouldShowPremiumPrompt,
     setCurrentModel,
     switchToDefaultModel,
     generateSuggestedQuestions,

--- a/components/ai_chat/resources/page/state/data-context-provider.tsx
+++ b/components/ai_chat/resources/page/state/data-context-provider.tsx
@@ -34,7 +34,7 @@ function DataContextProvider (props: DataContextProviderProps) {
   const [currentError, setCurrentError] = React.useState<mojom.APIError>(mojom.APIError.None)
   const [hasSeenAgreement, setHasSeenAgreement] = React.useState(loadTimeData.getBoolean("hasSeenAgreement"))
   const [premiumStatus, setPremiumStatus] = React.useState<mojom.PremiumStatus>(mojom.PremiumStatus.Inactive)
-  const [shouldShowPremiumPrompt, setShouldShowPremiumPrompt] = React.useState<boolean | undefined>()
+  const [canShowPremiumPrompt, setCanShowPremiumPrompt] = React.useState<boolean | undefined>()
 
   // Provide a custom handler for setCurrentModel instead of a useEffect
   // so that we can track when the user has changed a model in
@@ -102,14 +102,14 @@ function DataContextProvider (props: DataContextProviderProps) {
     getPageHandlerInstance().pageHandler.markAgreementAccepted()
   }
 
-  const maybeShowPremiumPrompt = () => {
-    getPageHandlerInstance().pageHandler.maybeShowPremiumPrompt()
-      .then(resp => setShouldShowPremiumPrompt(resp.shouldShow))
+  const getCanShowPremiumPrompt = () => {
+    getPageHandlerInstance().pageHandler.getCanShowPremiumPrompt()
+      .then(resp => setCanShowPremiumPrompt(resp.canShow))
   }
 
   const dismissPremiumPrompt = () => {
     getPageHandlerInstance().pageHandler.dismissPremiumPrompt()
-    setShouldShowPremiumPrompt(false)
+    setCanShowPremiumPrompt(false)
   }
 
   const switchToDefaultModel = () => {
@@ -140,7 +140,7 @@ function DataContextProvider (props: DataContextProviderProps) {
     getSiteInfo()
     getFaviconData()
     getCurrentAPIError()
-    maybeShowPremiumPrompt()
+    getCanShowPremiumPrompt()
   }
 
   React.useEffect(() => {
@@ -200,14 +200,14 @@ function DataContextProvider (props: DataContextProviderProps) {
     shouldDisableUserInput,
     isPremiumUser: premiumStatus !== mojom.PremiumStatus.Inactive,
     isPremiumUserDisconnected: premiumStatus === mojom.PremiumStatus.ActiveDisconnected,
-    shouldShowPremiumPrompt,
+    canShowPremiumPrompt,
     setCurrentModel,
     switchToDefaultModel,
     generateSuggestedQuestions,
     setUserAllowsAutoGenerating,
     handleAgreeClick,
     dismissPremiumPrompt,
-    maybeShowPremiumPrompt
+    getCanShowPremiumPrompt
   }
 
   return (

--- a/components/ai_chat/resources/page/state/data-context-provider.tsx
+++ b/components/ai_chat/resources/page/state/data-context-provider.tsx
@@ -7,7 +7,7 @@ import * as React from 'react'
 import { loadTimeData } from '$web-common/loadTimeData'
 
 import getPageHandlerInstance, * as mojom from '../api/page_handler'
-import DataContext from './context'
+import DataContext, { AIChatContext } from './context'
 
 function toBlobURL(data: number[] | null) {
   if (!data) return undefined
@@ -32,7 +32,7 @@ function DataContextProvider (props: DataContextProviderProps) {
   const [siteInfo, setSiteInfo] = React.useState<mojom.SiteInfo | null>(null)
   const [favIconUrl, setFavIconUrl] = React.useState<string>()
   const [currentError, setCurrentError] = React.useState<mojom.APIError>(mojom.APIError.None)
-  const [hasSeenAgreement, setHasSeenAgreement] = React.useState(loadTimeData.getBoolean("hasSeenAgreement"))
+  const [hasAcceptedAgreement, setHasAcceptedAgreement] = React.useState(loadTimeData.getBoolean("hasAcceptedAgreement"))
   const [premiumStatus, setPremiumStatus] = React.useState<mojom.PremiumStatus>(mojom.PremiumStatus.Inactive)
   const [canShowPremiumPrompt, setCanShowPremiumPrompt] = React.useState<boolean | undefined>()
 
@@ -98,7 +98,7 @@ function DataContextProvider (props: DataContextProviderProps) {
   }
 
   const handleAgreeClick = () => {
-    setHasSeenAgreement(true)
+    setHasAcceptedAgreement(true)
     getPageHandlerInstance().pageHandler.markAgreementAccepted()
   }
 
@@ -183,7 +183,7 @@ function DataContextProvider (props: DataContextProviderProps) {
     })
   }, [])
 
-  const store = {
+  const store: AIChatContext = {
     allModels,
     currentModel,
     hasChangedModel,
@@ -195,7 +195,7 @@ function DataContextProvider (props: DataContextProviderProps) {
     siteInfo,
     favIconUrl,
     currentError,
-    hasSeenAgreement,
+    hasAcceptedAgreement,
     apiHasError,
     shouldDisableUserInput,
     isPremiumUser: premiumStatus !== mojom.PremiumStatus.Inactive,

--- a/components/ai_chat/resources/page/state/data-context-provider.tsx
+++ b/components/ai_chat/resources/page/state/data-context-provider.tsx
@@ -206,7 +206,8 @@ function DataContextProvider (props: DataContextProviderProps) {
     generateSuggestedQuestions,
     setUserAllowsAutoGenerating,
     handleAgreeClick,
-    dismissPremiumPrompt
+    dismissPremiumPrompt,
+    maybeShowPremiumPrompt
   }
 
   return (

--- a/components/ai_chat/resources/page/stories/components_panel.tsx
+++ b/components/ai_chat/resources/page/stories/components_panel.tsx
@@ -76,7 +76,7 @@ const SITE_INFO = {
 
 interface StoryArgs {
   hasQuestions: boolean
-  hasSeenAgreement: boolean
+  hasAcceptedAgreement: boolean
   currentErrorState: mojom.APIError
 }
 
@@ -88,7 +88,7 @@ export default {
   args: {
     hasQuestions: true,
     hasChangedModel: false,
-    hasSeenAgreement: true,
+    hasAcceptedAgreement: true,
     currentErrorState: select(
       'Current Status',
       mojom.APIError,
@@ -109,7 +109,7 @@ export default {
       const [currentError] = React.useState<mojom.APIError>(
         options.args.currentErrorState
       )
-      const [hasSeenAgreement] = React.useState(options.args.hasSeenAgreement)
+      const [hasAcceptedAgreement] = React.useState(options.args.hasAcceptedAgreement)
       const [isPremiumUser] = React.useState(options.args.isPremiumUser)
 
       const apiHasError = currentError !== mojom.APIError.None
@@ -129,7 +129,7 @@ export default {
         siteInfo,
         favIconUrl,
         currentError,
-        hasSeenAgreement,
+        hasAcceptedAgreement,
         apiHasError,
         shouldDisableUserInput,
         isPremiumUser


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/33602

This PR changes the pref for initial agreement for AIChat to a timestamp. Additionally, we compute if 24h has passed to show the user a standalone premium prompt.

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [ ] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

