### PR TITLE
Adjusted some adblock components update check interval

### DIFF
--- a/components/brave_shields/browser/ad_block_component_installer.cc
+++ b/components/brave_shields/browser/ad_block_component_installer.cc
@@ -199,6 +199,11 @@ void RegisterAdBlockDefaultResourceComponent(
       cus, base::BindOnce(&OnRegistered, kAdBlockResourceComponentId));
 }
 
+void CheckAdBlockDefaultResourceComponentUpdate() {
+  BraveOnDemandUpdater::GetInstance()->OnDemandUpdate(
+      kAdBlockResourceComponentId);
+}
+
 void RegisterAdBlockFilterListCatalogComponent(
     component_updater::ComponentUpdateService* cus,
     OnComponentReadyCallback callback) {

--- a/components/brave_shields/browser/ad_block_component_installer.cc
+++ b/components/brave_shields/browser/ad_block_component_installer.cc
@@ -12,6 +12,9 @@
 #include "base/base64.h"
 #include "base/functional/bind.h"
 #include "base/functional/callback.h"
+#include "base/rand_util.h"
+#include "base/task/sequenced_task_runner.h"
+#include "base/time/time.h"
 #include "brave/components/brave_component_updater/browser/brave_on_demand_updater.h"
 #include "components/component_updater/component_installer.h"
 #include "components/component_updater/component_updater_service.h"
@@ -199,9 +202,20 @@ void RegisterAdBlockDefaultResourceComponent(
       cus, base::BindOnce(&OnRegistered, kAdBlockResourceComponentId));
 }
 
-void CheckAdBlockDefaultResourceComponentUpdate() {
-  BraveOnDemandUpdater::GetInstance()->OnDemandUpdate(
-      kAdBlockResourceComponentId);
+void CheckAdBlockComponentsUpdate() {
+  auto runner = base::SequencedTaskRunner::GetCurrentDefault();
+
+  runner->PostDelayedTask(FROM_HERE, base::BindOnce([]() {
+                            BraveOnDemandUpdater::GetInstance()->OnDemandUpdate(
+                                kAdBlockResourceComponentId);
+                          }),
+                          base::Seconds(base::RandInt(0, 10)));
+
+  runner->PostDelayedTask(FROM_HERE, base::BindOnce([]() {
+                            BraveOnDemandUpdater::GetInstance()->OnDemandUpdate(
+                                kAdBlockDefaultComponentId);
+                          }),
+                          base::Seconds(base::RandInt(0, 10)));
 }
 
 void RegisterAdBlockFilterListCatalogComponent(

--- a/components/brave_shields/browser/ad_block_component_installer.h
+++ b/components/brave_shields/browser/ad_block_component_installer.h
@@ -27,7 +27,7 @@ void RegisterAdBlockDefaultComponent(
 void RegisterAdBlockDefaultResourceComponent(
     component_updater::ComponentUpdateService* cus,
     OnComponentReadyCallback callback);
-void CheckAdBlockDefaultResourceComponentUpdate();
+void CheckAdBlockComponentsUpdate();
 
 void RegisterAdBlockFilterListCatalogComponent(
     component_updater::ComponentUpdateService* cus,

--- a/components/brave_shields/browser/ad_block_component_installer.h
+++ b/components/brave_shields/browser/ad_block_component_installer.h
@@ -27,6 +27,7 @@ void RegisterAdBlockDefaultComponent(
 void RegisterAdBlockDefaultResourceComponent(
     component_updater::ComponentUpdateService* cus,
     OnComponentReadyCallback callback);
+void CheckAdBlockDefaultResourceComponentUpdate();
 
 void RegisterAdBlockFilterListCatalogComponent(
     component_updater::ComponentUpdateService* cus,

--- a/components/brave_shields/browser/ad_block_default_resource_provider.cc
+++ b/components/brave_shields/browser/ad_block_default_resource_provider.cc
@@ -19,7 +19,7 @@ constexpr char kAdBlockResourcesFilename[] = "resources.json";
 
 BASE_DECLARE_FEATURE(kAdBlockDefaultResourceUpdateInterval);
 constexpr base::FeatureParam<int> kComponentUpdateCheckIntervalMins{
-    &kAdBlockDefaultResourceUpdateInterval, "update_interval_mins", 120};
+    &kAdBlockDefaultResourceUpdateInterval, "update_interval_mins", 100};
 BASE_FEATURE(kAdBlockDefaultResourceUpdateInterval,
              "AdBlockDefaultResourceUpdateInterval",
              base::FEATURE_ENABLED_BY_DEFAULT);

--- a/components/brave_shields/browser/ad_block_default_resource_provider.cc
+++ b/components/brave_shields/browser/ad_block_default_resource_provider.cc
@@ -13,6 +13,7 @@
 #include "base/metrics/field_trial_params.h"
 #include "base/task/thread_pool.h"
 #include "brave/components/brave_shields/browser/ad_block_component_installer.h"
+#include "brave/components/brave_shields/browser/ad_block_service.h"
 
 namespace {
 constexpr char kAdBlockResourcesFilename[] = "resources.json";
@@ -41,7 +42,12 @@ AdBlockDefaultResourceProvider::AdBlockDefaultResourceProvider(
                           weak_factory_.GetWeakPtr()));
   update_check_timer_.Start(
       FROM_HERE, base::Minutes(kComponentUpdateCheckIntervalMins.Get()),
-      base::BindRepeating(&CheckAdBlockDefaultResourceComponentUpdate));
+      base::BindRepeating([]() {
+        // Separated into two methods as exception component is not available in
+        // iOS. So can't check it from CheckAdBlockComponentsUpdate() together.
+        CheckAdBlockComponentsUpdate();
+        CheckAdBlockExceptionComponentsUpdate();
+      }));
 }
 
 AdBlockDefaultResourceProvider::~AdBlockDefaultResourceProvider() = default;

--- a/components/brave_shields/browser/ad_block_default_resource_provider.cc
+++ b/components/brave_shields/browser/ad_block_default_resource_provider.cc
@@ -8,23 +8,40 @@
 #include <string>
 #include <utility>
 
+#include "base/feature_list.h"
 #include "base/files/file_path.h"
+#include "base/metrics/field_trial_params.h"
 #include "base/task/thread_pool.h"
 #include "brave/components/brave_shields/browser/ad_block_component_installer.h"
 
-const char kAdBlockResourcesFilename[] = "resources.json";
+namespace {
+constexpr char kAdBlockResourcesFilename[] = "resources.json";
+
+BASE_DECLARE_FEATURE(kAdBlockDefaultResourceUpdateInterval);
+constexpr base::FeatureParam<int> kComponentUpdateCheckIntervalMins{
+    &kAdBlockDefaultResourceUpdateInterval, "update_interval_mins", 120};
+BASE_FEATURE(kAdBlockDefaultResourceUpdateInterval,
+             "AdBlockDefaultResourceUpdateInterval",
+             base::FEATURE_ENABLED_BY_DEFAULT);
+
+}  // namespace
 
 namespace brave_shields {
 
 AdBlockDefaultResourceProvider::AdBlockDefaultResourceProvider(
     component_updater::ComponentUpdateService* cus) {
   // Can be nullptr in unit tests
-  if (cus) {
-    RegisterAdBlockDefaultResourceComponent(
-        cus,
-        base::BindRepeating(&AdBlockDefaultResourceProvider::OnComponentReady,
-                            weak_factory_.GetWeakPtr()));
+  if (!cus) {
+    return;
   }
+
+  RegisterAdBlockDefaultResourceComponent(
+      cus,
+      base::BindRepeating(&AdBlockDefaultResourceProvider::OnComponentReady,
+                          weak_factory_.GetWeakPtr()));
+  update_check_timer_.Start(
+      FROM_HERE, base::Minutes(kComponentUpdateCheckIntervalMins.Get()),
+      base::BindRepeating(&CheckAdBlockDefaultResourceComponentUpdate));
 }
 
 AdBlockDefaultResourceProvider::~AdBlockDefaultResourceProvider() = default;

--- a/components/brave_shields/browser/ad_block_default_resource_provider.h
+++ b/components/brave_shields/browser/ad_block_default_resource_provider.h
@@ -9,6 +9,7 @@
 #include <string>
 
 #include "base/functional/callback.h"
+#include "base/timer/timer.h"
 #include "brave/components/brave_shields/browser/ad_block_resource_provider.h"
 
 namespace component_updater {
@@ -38,6 +39,7 @@ class AdBlockDefaultResourceProvider : public AdBlockResourceProvider {
   void OnComponentReady(const base::FilePath&);
 
   base::FilePath component_path_;
+  base::RepeatingTimer update_check_timer_;
 
   base::WeakPtrFactory<AdBlockDefaultResourceProvider> weak_factory_{this};
 };

--- a/components/brave_shields/browser/ad_block_service.cc
+++ b/components/brave_shields/browser/ad_block_service.cc
@@ -13,7 +13,10 @@
 #include "base/files/file_path.h"
 #include "base/functional/bind.h"
 #include "base/logging.h"
+#include "base/rand_util.h"
 #include "base/threading/thread_restrictions.h"
+#include "base/time/time.h"
+#include "brave/components/brave_component_updater/browser/brave_on_demand_updater.h"
 #include "brave/components/brave_shields/adblock/rs/src/lib.rs.h"
 #include "brave/components/brave_shields/browser/ad_block_component_filters_provider.h"
 #include "brave/components/brave_shields/browser/ad_block_custom_filters_provider.h"
@@ -32,6 +35,8 @@
 #include "net/base/registry_controlled_domains/registry_controlled_domain.h"
 #include "third_party/abseil-cpp/absl/types/optional.h"
 #include "url/origin.h"
+
+using brave_component_updater::BraveOnDemandUpdater;
 
 namespace {
 
@@ -467,6 +472,15 @@ void AdBlockService::TagExistsForTest(const std::string& tag,
       base::BindOnce(&AdBlockEngine::TagExists,
                      base::Unretained(default_engine_.get()), tag),
       std::move(cb));
+}
+
+void CheckAdBlockExceptionComponentsUpdate() {
+  base::SequencedTaskRunner::GetCurrentDefault()->PostDelayedTask(
+      FROM_HERE, base::BindOnce([]() {
+        BraveOnDemandUpdater::GetInstance()->OnDemandUpdate(
+            kAdBlockExceptionComponentId);
+      }),
+      base::Seconds(base::RandInt(0, 10)));
 }
 
 // static

--- a/components/brave_shields/browser/ad_block_service.h
+++ b/components/brave_shields/browser/ad_block_service.h
@@ -199,6 +199,8 @@ class AdBlockService {
   base::WeakPtrFactory<AdBlockService> weak_factory_{this};
 };
 
+void CheckAdBlockExceptionComponentsUpdate();
+
 // Registers the local_state preferences used by Adblock
 void RegisterPrefsForAdBlockService(PrefRegistrySimple* registry);
 


### PR DESCRIPTION
fix https://github.com/brave/brave-browser/issues/32274

Check below three adblock components update every 100mins. and this value can be updated via griffin.
* Brave Ad Block Resources Library
* Brave Ad Block Updater
* Brave Ad Block First Party Filters

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves 

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

Open brave://components and check `adblock default resource component` is updated every 100mins.