### PR TITLE
Enhance A11y for Playlist

### DIFF
--- a/app/brave_generated_resources.grd
+++ b/app/brave_generated_resources.grd
@@ -1261,6 +1261,36 @@ Or change later at <ph name="SETTINGS_EXTENIONS_LINK">$2<ex>brave://settings/ext
         <message name="IDS_PLAYLIST_EMPTY_FOLDER_MESSAGE" desc="A message that shows up when a playlist folder is empty">
           The fun starts when you have something to play. Add your favorite media and playback anytime, anywhere. Even offline.
         </message>
+        <message name="IDS_PLAYLIST_A11Y_CREATE_PLAYLIST_FOLDER" desc="An a11y name for a button to create new playlist folder">
+          Create a new folder
+        </message>
+        <message name="IDS_PLAYLIST_A11Y_OPEN_PLAYLIST_SETTINGS" desc="An a11y name for a button to open playlist settings">
+          Open Playlist settings
+        </message>
+        <message name="IDS_PLAYLIST_A11Y_PLAY" desc="An a11y name for a 'play' button in media player">
+          Play
+        </message>
+        <message name="IDS_PLAYLIST_A11Y_PAUSE" desc="An a11y name for a 'pause' button in media player">
+          Pause
+        </message>
+        <message name="IDS_PLAYLIST_A11Y_NEXT" desc="An a11y name for a 'next' button in media player">
+          Next Track
+        </message>
+        <message name="IDS_PLAYLIST_A11Y_PREVIOUS" desc="An a11y name for a 'prev' button in media player">
+          Previous Track
+        </message>
+        <message name="IDS_PLAYLIST_A11Y_SHUFFLE" desc="An a11y name for a 'shuffle' button in media player">
+          Shuffle
+        </message>
+        <message name="IDS_PLAYLIST_A11Y_REWIND" desc="An a11y name for a 'rewind' button in media player">
+          Rewind
+        </message>
+        <message name="IDS_PLAYLIST_A11Y_FORWARD" desc="An a11y name for a 'forward' button in media player">
+          Forward
+        </message>
+        <message name="IDS_PLAYLIST_A11Y_CLOSE" desc="An a11y name for a 'close' button in media player when it's mini player mode">
+          Close
+        </message>
       </if> <!-- enable_playlist_webui -->
       <!--Add new items to the appropriate sections above -->
     </messages>

--- a/browser/ui/webui/playlist_ui.cc
+++ b/browser/ui/webui/playlist_ui.cc
@@ -53,6 +53,18 @@ void AddLocalizedStrings(content::WebUIDataSource* source) {
       {"bravePlaylistContextMenuViewOriginalPage",
        IDS_PLAYLIST_CONTEXT_MENU_VIEW_ORIGINAL_PAGE},
       {"bravePlaylistEmptyFolderMessage", IDS_PLAYLIST_EMPTY_FOLDER_MESSAGE},
+      {"bravePlaylistA11YCreatePlaylistFolder",
+       IDS_PLAYLIST_A11Y_CREATE_PLAYLIST_FOLDER},
+      {"bravePlaylistA11YOpenPlaylistSettings",
+       IDS_PLAYLIST_A11Y_OPEN_PLAYLIST_SETTINGS},
+      {"bravePlaylistA11YPlay", IDS_PLAYLIST_A11Y_PLAY},
+      {"bravePlaylistA11YPause", IDS_PLAYLIST_A11Y_PAUSE},
+      {"bravePlaylistA11YNext", IDS_PLAYLIST_A11Y_NEXT},
+      {"bravePlaylistA11YPrevious", IDS_PLAYLIST_A11Y_PREVIOUS},
+      {"bravePlaylistA11YShuffle", IDS_PLAYLIST_A11Y_SHUFFLE},
+      {"bravePlaylistA11YRewind", IDS_PLAYLIST_A11Y_REWIND},
+      {"bravePlaylistA11YForward", IDS_PLAYLIST_A11Y_FORWARD},
+      {"bravePlaylistA11YClose", IDS_PLAYLIST_A11Y_CLOSE},
   };
 
   for (const auto& [name, id] : kLocalizedStrings) {
@@ -89,6 +101,8 @@ class UntrustedPlayerUI : public ui::UntrustedWebUIController {
     source->OverrideContentSecurityPolicy(
         network::mojom::CSPDirectiveName::FontSrc,
         std::string("font-src 'self' chrome-untrusted://resources;"));
+
+    AddLocalizedStrings(source);
   }
 
   UntrustedPlayerUI(const UntrustedPlayerUI&) = delete;

--- a/components/playlist/browser/resources/components/header.tsx
+++ b/components/playlist/browser/resources/components/header.tsx
@@ -46,7 +46,7 @@ const GradientIcon = styled(Icon)`
     #a78aff 99.51%
   );
   ${iconSize}
-  margin-right: calc(-1 * (${spacing.xl} - ${spacing.m}))
+  margin-right: calc(-1 * (${spacing.xl} - ${spacing.m}));
 `
 
 const ColoredIcon = styled(Icon)<{ color: string }>`
@@ -79,9 +79,8 @@ const StyledPlaylistInfo = styled(PlaylistInfo)`
   flex-grow: 1;
 `
 
-const LeoButtonContainer = styled.button`
-  display: contents;
-  cursor: pointer;
+const StyledButton = styled(LeoButton)`
+  flex: 0 0 auto;
 `
 
 const StyledInput = styled.input`
@@ -94,7 +93,7 @@ const StyledInput = styled.input`
   padding: 10px 8px;
 `
 
-const SaveButton = styled(LeoButton)`
+const SaveButton = styled(StyledButton)`
   width: fit-content;
   min-width: 72px;
   flex-grow: 0;
@@ -107,11 +106,13 @@ function BackButton ({
   playlistEditMode?: PlaylistEditMode
 }) {
   return playlistEditMode === PlaylistEditMode.BULK_EDIT ? (
-    <LeoButtonContainer
+    <StyledButton
+      size='large'
+      kind='plain'
       onClick={() => getPlaylistActions().setPlaylistEditMode(undefined)}
     >
       <ColoredIcon name='arrow-left' color={color.icon.default} />
-    </LeoButtonContainer>
+    </StyledButton>
   ) : (
     <StyledLink to='/'>
       <ColoredIcon name='arrow-left' color={color.icon.default} />
@@ -262,21 +263,29 @@ function PlaylistHeader ({ playlistId }: { playlistId: string }) {
 
 function NewPlaylistButton () {
   return (
-    <LeoButtonContainer
+    <StyledButton
+      size='large'
+      kind='plain'
+      title={getLocalizedString('bravePlaylistA11YCreatePlaylistFolder')}
       onClick={() => {
         getPlaylistAPI().showCreatePlaylistUI()
       }}
     >
       <ColoredIcon name='plus-add' color={color.icon.default} />
-    </LeoButtonContainer>
+    </StyledButton>
   )
 }
 
 function SettingButton () {
   return (
-    <LeoButtonContainer onClick={() => {}}>
+    <StyledButton
+      size='large'
+      kind='plain'
+      title={getLocalizedString('bravePlaylistA11YOpenPlaylistSettings')}
+      onClick={() => {}}
+    >
       <ColoredIcon name='settings' color={color.icon.default} />
-    </LeoButtonContainer>
+    </StyledButton>
   )
 }
 

--- a/components/playlist/browser/resources/components/player.tsx
+++ b/components/playlist/browser/resources/components/player.tsx
@@ -86,7 +86,7 @@ const ControlsContainer = styled.div`
   }
 
   @media ${playerTypes.miniPlayer} {
-    max-width: calc(100vw - var(--mini-player-video-width));
+    max-width: calc(100% - var(--mini-player-video-width) - ${spacing.xl});
     flex: 1 1 auto;
     flex-direction: row;
     gap: ${spacing.xl};
@@ -122,7 +122,8 @@ const PlayerContainer = styled.div<{ backgroundUrl?: string }>`
       visibility: hidden;
     }
 
-    &:hover {
+    &:hover,
+    &:focus-within {
       ${ControlsContainer} {
         visibility: visible;
       }
@@ -258,6 +259,8 @@ export default function Player () {
     <PlayerContainer backgroundUrl={currentItem?.thumbnailPath.url}>
       <VideoContainer>
         <StyledVideo
+          tabIndex={0}
+          onKeyDown={e => e.key === 'Enter' && e.currentTarget.click()}
           ref={setVideoElement}
           autoPlay
           onPlay={() =>
@@ -309,6 +312,8 @@ export default function Player () {
               `chrome-untrusted://playlist-data/${currentItem.id}/favicon`
             }
             clickable={!!currentItem}
+            tabIndex={0}
+            onKeyDown={e => e.key === 'Enter' && e.currentTarget.click()}
             onClick={() => {
               if (currentItem) {
                 notifyEventsToTopFrame({
@@ -328,6 +333,8 @@ export default function Player () {
                 })
               }
             }}
+            tabIndex={0}
+            onKeyDown={e => e.key === 'Enter' && e.currentTarget.click()}
           >
             {currentItem?.name}
           </StyledTitle>

--- a/components/playlist/browser/resources/components/playerControls.tsx
+++ b/components/playlist/browser/resources/components/playerControls.tsx
@@ -14,6 +14,7 @@ import { spacing } from '@brave/leo/tokens/css'
 import { getPlayerActions } from '../api/getPlayerActions'
 import { ApplicationState } from '../reducers/states'
 import { hiddenOnMiniPlayer, hiddenOnNormalPlayer } from '../constants/style'
+import { getLocalizedString } from '../utils/l10n'
 
 interface Props {
   videoElement?: HTMLVideoElement | null
@@ -49,9 +50,11 @@ function Control ({
   iconName,
   size,
   visibility,
+  title,
   onClick
 }: {
   iconName: string
+  title: string
   size: 'jumbo' | 'large'
   visibility: 'mini' | 'normal' | 'both'
   onClick: () => void
@@ -63,7 +66,7 @@ function Control ({
       ? MiniPlayerButton
       : NormalPlayerButton
   return (
-    <Button kind='plain-faint' size={size} onClick={onClick}>
+    <Button kind='plain-faint' size={size} onClick={onClick} title={title}>
       <Icon name={iconName}></Icon>
     </Button>
   )
@@ -106,6 +109,7 @@ export default function PlayerControls ({ videoElement, className }: Props) {
           iconName='previous-outline'
           size='jumbo'
           visibility='normal'
+          title={getLocalizedString('bravePlaylistA11YPrevious')}
           onClick={() => {
             if (!videoElement) return
 
@@ -115,54 +119,61 @@ export default function PlayerControls ({ videoElement, className }: Props) {
               getPlayerActions().playPreviousItem()
             }
           }}
-        ></Control>
+        />
         <Control
           iconName='rewind-15'
           size='jumbo'
           visibility='normal'
+          title={getLocalizedString('bravePlaylistA11YRewind')}
           onClick={() => videoElement && (videoElement.currentTime -= 15)}
-        ></Control>
+        />
         {isPlaying ? (
           <Control
             iconName='pause-filled'
             size='jumbo'
             visibility='both'
+            title={getLocalizedString('bravePlaylistA11YPlay')}
             onClick={() => videoElement?.pause()}
-          ></Control>
+          />
         ) : (
           <Control
             iconName='play-filled'
             size='jumbo'
             visibility='both'
+            title={getLocalizedString('bravePlaylistA11YPause')}
             onClick={() => videoElement?.play()}
-          ></Control>
+          />
         )}
         <Control
           iconName='forward-15'
           size='jumbo'
           visibility='normal'
+          title={getLocalizedString('bravePlaylistA11YForward')}
           onClick={() => videoElement && (videoElement.currentTime += 15)}
-        ></Control>
+        />
         <Control
           iconName='next-outline'
           size='jumbo'
           visibility='normal'
+          title={getLocalizedString('bravePlaylistA11YNext')}
           onClick={() => getPlayerActions().playNextItem()}
-        ></Control>
+        />
         <Control
           iconName='close'
           size='jumbo'
           visibility='mini'
+          title={getLocalizedString('bravePlaylistA11YClose')}
           onClick={() => getPlayerActions().unloadPlaylist()}
-        ></Control>
+        />
       </div>
       <div>
         <Control
           iconName={shuffleEnabled ? 'shuffle-on' : 'shuffle-off'}
           size='large'
           visibility='normal'
+          title={getLocalizedString('bravePlaylistA11YShuffle')}
           onClick={() => getPlayerActions().toggleShuffle()}
-        ></Control>
+        />
         {/* TODO(sko) We disabled PIP and fullscreen button at the moment */}
       </div>
     </Container>

--- a/components/playlist/browser/resources/components/playlistItem.tsx
+++ b/components/playlist/browser/resources/components/playlistItem.tsx
@@ -35,6 +35,7 @@ interface Props {
   isSelected?: boolean
   isHighlighted?: boolean
   canReorder: boolean
+  forwardedRef?: React.ForwardedRef<HTMLAnchorElement>
   shouldBeHidden: boolean
   onClick: (item: PlaylistItemMojo) => void
 }
@@ -87,9 +88,6 @@ const PlaylistItemContainer = styled.li<{
   align-items: center;
   gap: ${spacing.xl};
   user-select: none;
-  & > a {
-    margin-right: calc(-1 * ${spacing.xl});
-  }
 
   ${p =>
     p.shouldBeHidden &&
@@ -248,6 +246,8 @@ export function PlaylistItem ({
       isActive={(isEditing && isSelected) || isPlaying}
       isHighlighted={isHighlighted}
       shouldBeHidden={shouldBeHidden}
+      tabIndex={0}
+      onKeyDown={e => e.key === 'Enter' && onClick(item)}
       onClick={() => onClick(item)}
     >
       {isEditing && (
@@ -351,8 +351,20 @@ export const SortablePlaylistItem = React.forwardRef(
     })
 
     return (
-      <div ref={setNodeRef} style={style} {...attributes} {...listeners}>
-        <a ref={forwardedRef} href={`#${itemId}`} />
+      <div
+        ref={setNodeRef}
+        style={style}
+        {...attributes}
+        {...listeners}
+        tabIndex={-1} // disables tab traversal for sortable as we have our own tab traversal logic
+        aria-hidden='true'
+      >
+        <a
+          ref={forwardedRef}
+          href={`#${itemId}`}
+          tabIndex={-1} // disables tab traversal for <a> as we only use this for auto scrolling.
+          aria-hidden='true'
+        />
         <PlaylistItem {...props} />
       </div>
     )

--- a/components/playlist/browser/resources/components/playlistsCatalog.tsx
+++ b/components/playlist/browser/resources/components/playlistsCatalog.tsx
@@ -215,7 +215,14 @@ function SortablePlaylistCard (props: PlaylistCardProps) {
   })
 
   return (
-    <div ref={setNodeRef} style={style} {...attributes} {...listeners}>
+    <div
+      ref={setNodeRef}
+      style={style}
+      {...attributes}
+      {...listeners}
+      tabIndex={-1} // Disables tab traversal for sortable as we have StyledLink in PlaylistCard.
+      aria-hidden='true'
+    >
       <PlaylistCard {...props} />
     </div>
   )

--- a/components/playlist/browser/resources/utils/l10n.ts
+++ b/components/playlist/browser/resources/utils/l10n.ts
@@ -18,6 +18,17 @@ export type Message =
   | 'bravePlaylistContextMenuDeletePlaylist'
   | 'bravePlaylistContextMenuViewOriginalPage'
   | 'bravePlaylistEmptyFolderMessage'
+  | 'bravePlaylistA11YCreatePlaylistFolder'
+  | 'bravePlaylistA11YOpenPlaylistSettings'
+  | 'bravePlaylistA11YOpenPlaylistSettings'
+  | 'bravePlaylistA11YPlay'
+  | 'bravePlaylistA11YPause'
+  | 'bravePlaylistA11YNext'
+  | 'bravePlaylistA11YPrevious'
+  | 'bravePlaylistA11YShuffle'
+  | 'bravePlaylistA11YRewind'
+  | 'bravePlaylistA11YForward'
+  | 'bravePlaylistA11YClose'
 
 export function getLocalizedString (message: Message) {
   return getLocale(message)

--- a/components/playlist/browser/resources/video_frame_contents.html
+++ b/components/playlist/browser/resources/video_frame_contents.html
@@ -9,6 +9,8 @@
 <meta charset="utf-8">
 <title>Brave Playlist Player</title>
 <link rel="stylesheet" href="chrome-untrusted://resources/brave/fonts/poppins.css">
+<script src="chrome-untrusted://resources/js/load_time_data_deprecated.js"></script>
+<script src="/strings.js"></script>
 <script src="/videoFrameContents.bundle.js"></script>
 </head>
 <style>


### PR DESCRIPTION
* Add a11y texts for labeless buttons
* add tab-index for components
* Replace contextual menu with `buttonMenu` from Nala - which allows us to have TABable items in the menu.
* Replace some buttons with Nala button.

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/32600

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [ ] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

