### PR TITLE
Move uptime monitor to misc_metrics, add uptime monitoring P3A metric for Android

### DIFF
--- a/android/brave_java_sources.gni
+++ b/android/brave_java_sources.gni
@@ -461,6 +461,7 @@ brave_java_sources = [
   "../../brave/android/java/org/chromium/chrome/browser/util/TabUtils.java",
   "../../brave/android/java/org/chromium/chrome/browser/util/TouchDelegateComposite.java",
   "../../brave/android/java/org/chromium/chrome/browser/util/Triple.java",
+  "../../brave/android/java/org/chromium/chrome/browser/util/UsageMonitor.java",
   "../../brave/android/java/org/chromium/chrome/browser/vpn/BraveVpnNativeWorker.java",
   "../../brave/android/java/org/chromium/chrome/browser/vpn/BraveVpnObserver.java",
   "../../brave/android/java/org/chromium/chrome/browser/vpn/DisconnectVpnBroadcastReceiver.java",

--- a/android/java/org/chromium/chrome/browser/app/BraveActivity.java
+++ b/android/java/org/chromium/chrome/browser/app/BraveActivity.java
@@ -170,6 +170,7 @@ import org.chromium.chrome.browser.util.BraveDbUtil;
 import org.chromium.chrome.browser.util.ConfigurationUtils;
 import org.chromium.chrome.browser.util.LiveDataUtil;
 import org.chromium.chrome.browser.util.PackageUtils;
+import org.chromium.chrome.browser.util.UsageMonitor;
 import org.chromium.chrome.browser.vpn.BraveVpnNativeWorker;
 import org.chromium.chrome.browser.vpn.BraveVpnObserver;
 import org.chromium.chrome.browser.vpn.activities.BraveVpnProfileActivity;
@@ -275,6 +276,7 @@ public abstract class BraveActivity extends ChromeActivity
     private boolean mNativeInitialized;
     private boolean mSafeBrowsingFlagEnabled;
     private NewTabPageManager mNewTabPageManager;
+    private UsageMonitor mUsageMonitor;
     private NotificationPermissionController mNotificationPermissionController;
     private BraveNewsController mBraveNewsController;
     private BraveNewsConnectionErrorHandler mBraveNewsConnectionErrorHandler;
@@ -329,6 +331,9 @@ public abstract class BraveActivity extends ChromeActivity
 
     @Override
     public void onPauseWithNative() {
+        if (mUsageMonitor != null) {
+            mUsageMonitor.stop();
+        }
         if (BraveVpnUtils.isVpnFeatureSupported(BraveActivity.this)) {
             BraveVpnNativeWorker.getInstance().removeObserver(this);
         }
@@ -850,6 +855,9 @@ public abstract class BraveActivity extends ChromeActivity
                     BravePreferenceKeys.BRAVE_APP_OPEN_COUNT_FOR_WIDGET_PROMO,
                     appOpenCountForWidgetPromo + 1);
         } */
+        if (mUsageMonitor != null) {
+            mUsageMonitor.start();
+        }
     }
 
     @Override
@@ -1122,6 +1130,9 @@ public abstract class BraveActivity extends ChromeActivity
             SharedPreferencesManager.getInstance().writeBoolean(
                     BravePrivacySettings.PREF_APP_LINKS_RESET, false);
         }
+
+        mUsageMonitor = new UsageMonitor(mMiscAndroidMetrics);
+        mUsageMonitor.start();
     }
 
     private void handleDeepLinkVpn() {

--- a/android/java/org/chromium/chrome/browser/util/UsageMonitor.java
+++ b/android/java/org/chromium/chrome/browser/util/UsageMonitor.java
@@ -1,0 +1,46 @@
+/* Copyright (c) 2023 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+package org.chromium.chrome.browser.util;
+
+import org.chromium.misc_metrics.mojom.MiscAndroidMetrics;
+import org.chromium.mojo_base.mojom.TimeDelta;
+
+import java.util.Timer;
+import java.util.TimerTask;
+
+public class UsageMonitor {
+    private static final long REPORT_INTERVAL_MS = 15000;
+
+    private MiscAndroidMetrics mMiscAndroidMetrics;
+    private Timer mTimer;
+
+    public UsageMonitor(MiscAndroidMetrics miscAndroidMetrics) {
+        mMiscAndroidMetrics = miscAndroidMetrics;
+    }
+
+    public void start() {
+        if (mTimer != null) {
+            mTimer.cancel();
+        }
+        mTimer = new Timer();
+        mTimer.scheduleAtFixedRate(
+                new TimerTask() {
+                    @Override
+                    public void run() {
+                        TimeDelta duration = new TimeDelta();
+                        duration.microseconds = REPORT_INTERVAL_MS * 1000;
+                        mMiscAndroidMetrics.recordBrowserUsageDuration(duration);
+                    }
+                },
+                REPORT_INTERVAL_MS,
+                REPORT_INTERVAL_MS);
+    }
+
+    public void stop() {
+        mTimer.cancel();
+        mTimer = null;
+    }
+}

--- a/browser/brave_browser_main_extra_parts.cc
+++ b/browser/brave_browser_main_extra_parts.cc
@@ -83,6 +83,5 @@ void BraveBrowserMainExtraParts::PreMainMessageLoopRun() {
   // The code below is not supported on android.
 #if !BUILDFLAG(IS_ANDROID)
   brave::BraveWindowTracker::CreateInstance(g_browser_process->local_state());
-  brave::BraveUptimeTracker::CreateInstance(g_browser_process->local_state());
 #endif  // !BUILDFLAG(IS_ANDROID)
 }

--- a/browser/brave_local_state_prefs.cc
+++ b/browser/brave_local_state_prefs.cc
@@ -13,6 +13,7 @@
 #include "brave/browser/metrics/buildflags/buildflags.h"
 #include "brave/browser/metrics/metrics_reporting_util.h"
 #include "brave/browser/misc_metrics/process_misc_metrics.h"
+#include "brave/browser/misc_metrics/uptime_monitor.h"
 #include "brave/browser/ntp_background/ntp_p3a_helper_impl.h"
 #include "brave/browser/playlist/playlist_service_factory.h"
 #include "brave/browser/search_engines/search_engine_tracker.h"
@@ -76,9 +77,9 @@ void RegisterLocalStatePrefsForMigration(PrefRegistrySimple* registry) {
 #if !BUILDFLAG(IS_ANDROID)
   // Added 10/2022
   registry->RegisterBooleanPref(kDefaultBrowserPromptEnabled, true);
-  BraveUptimeTracker::RegisterPrefsForMigration(registry);
 #endif
 
+  misc_metrics::UptimeMonitor::RegisterPrefsForMigration(registry);
   brave_wallet::RegisterLocalStatePrefsForMigration(registry);
   brave_search_conversion::p3a::RegisterLocalStatePrefsForMigration(registry);
   brave_stats::RegisterLocalStatePrefsForMigration(registry);
@@ -117,7 +118,6 @@ void RegisterLocalStatePrefs(PrefRegistrySimple* registry) {
 #if !BUILDFLAG(IS_ANDROID)
   BraveNewTabMessageHandler::RegisterLocalStatePrefs(registry);
   BraveWindowTracker::RegisterPrefs(registry);
-  BraveUptimeTracker::RegisterPrefs(registry);
   dark_mode::RegisterBraveDarkModeLocalStatePrefs(registry);
   whats_new::RegisterLocalStatePrefs(registry);
 #endif

--- a/browser/misc_metrics/BUILD.gn
+++ b/browser/misc_metrics/BUILD.gn
@@ -9,6 +9,7 @@ source_set("unit_tests") {
   sources = [
     "doh_metrics_unittest.cc",
     "page_metrics_service_unittest.cc",
+    "uptime_monitor_unittest.cc",
   ]
 
   deps = [

--- a/browser/misc_metrics/misc_android_metrics.cc
+++ b/browser/misc_metrics/misc_android_metrics.cc
@@ -5,6 +5,7 @@
 
 #include "brave/browser/misc_metrics/misc_android_metrics.h"
 #include "brave/browser/misc_metrics/process_misc_metrics.h"
+#include "brave/browser/misc_metrics/uptime_monitor.h"
 #include "brave/browser/search_engines/search_engine_tracker.h"
 #include "brave/components/misc_metrics/privacy_hub_metrics.h"
 
@@ -35,6 +36,10 @@ void MiscAndroidMetrics::RecordPrivacyHubEnabledStatus(bool is_enabled) {
 
 void MiscAndroidMetrics::RecordLocationBarQuery() {
   search_engine_tracker_->RecordLocationBarQuery();
+}
+
+void MiscAndroidMetrics::RecordBrowserUsageDuration(base::TimeDelta duration) {
+  misc_metrics_->uptime_monitor()->ReportUsageDuration(duration);
 }
 
 }  // namespace misc_metrics

--- a/browser/misc_metrics/misc_android_metrics.h
+++ b/browser/misc_metrics/misc_android_metrics.h
@@ -7,6 +7,7 @@
 #define BRAVE_BROWSER_MISC_METRICS_MISC_ANDROID_METRICS_H_
 
 #include "base/memory/raw_ptr.h"
+#include "base/time/time.h"
 #include "brave/components/misc_metrics/common/misc_metrics.mojom.h"
 #include "components/keyed_service/core/keyed_service.h"
 #include "mojo/public/cpp/bindings/receiver_set.h"
@@ -33,6 +34,7 @@ class MiscAndroidMetrics : public KeyedService,
   void RecordPrivacyHubView() override;
   void RecordPrivacyHubEnabledStatus(bool is_enabled) override;
   void RecordLocationBarQuery() override;
+  void RecordBrowserUsageDuration(base::TimeDelta duration) override;
 
  private:
   raw_ptr<ProcessMiscMetrics> misc_metrics_;

--- a/browser/misc_metrics/process_misc_metrics.cc
+++ b/browser/misc_metrics/process_misc_metrics.cc
@@ -5,6 +5,7 @@
 
 #include "brave/browser/misc_metrics/process_misc_metrics.h"
 
+#include "brave/browser/misc_metrics/uptime_monitor.h"
 #include "components/prefs/pref_registry_simple.h"
 #include "components/prefs/pref_service.h"
 
@@ -33,6 +34,7 @@ ProcessMiscMetrics::ProcessMiscMetrics(PrefService* local_state) {
   ai_chat_metrics_ = std::make_unique<ai_chat::AIChatMetrics>(local_state);
 #endif
   doh_metrics_ = std::make_unique<misc_metrics::DohMetrics>(local_state);
+  uptime_monitor_ = std::make_unique<misc_metrics::UptimeMonitor>(local_state);
 }
 
 ProcessMiscMetrics::~ProcessMiscMetrics() = default;
@@ -48,6 +50,10 @@ VerticalTabMetrics* ProcessMiscMetrics::vertical_tab_metrics() {
 #else
 PrivacyHubMetrics* ProcessMiscMetrics::privacy_hub_metrics() {
   return privacy_hub_metrics_.get();
+}
+
+UptimeMonitor* ProcessMiscMetrics::uptime_monitor() {
+  return uptime_monitor_.get();
 }
 #endif
 
@@ -68,6 +74,7 @@ void ProcessMiscMetrics::RegisterPrefs(PrefRegistrySimple* registry) {
   ai_chat::AIChatMetrics::RegisterPrefs(registry);
 #endif
   DohMetrics::RegisterPrefs(registry);
+  UptimeMonitor::RegisterPrefs(registry);
 }
 
 }  // namespace misc_metrics

--- a/browser/misc_metrics/process_misc_metrics.h
+++ b/browser/misc_metrics/process_misc_metrics.h
@@ -29,6 +29,7 @@ class VerticalTabMetrics;
 class PrivacyHubMetrics;
 #endif
 class DohMetrics;
+class UptimeMonitor;
 
 class ProcessMiscMetrics {
  public:
@@ -46,6 +47,7 @@ class ProcessMiscMetrics {
 #else
   PrivacyHubMetrics* privacy_hub_metrics();
 #endif
+  UptimeMonitor* uptime_monitor();
 #if BUILDFLAG(ENABLE_AI_CHAT)
   ai_chat::AIChatMetrics* ai_chat_metrics();
 #endif
@@ -61,6 +63,7 @@ class ProcessMiscMetrics {
   std::unique_ptr<ai_chat::AIChatMetrics> ai_chat_metrics_;
 #endif
   std::unique_ptr<DohMetrics> doh_metrics_;
+  std::unique_ptr<UptimeMonitor> uptime_monitor_;
 };
 
 }  // namespace misc_metrics

--- a/browser/misc_metrics/sources.gni
+++ b/browser/misc_metrics/sources.gni
@@ -14,6 +14,8 @@ brave_browser_misc_metrics_sources = [
   "//brave/browser/misc_metrics/page_metrics_tab_helper.h",
   "//brave/browser/misc_metrics/process_misc_metrics.cc",
   "//brave/browser/misc_metrics/process_misc_metrics.h",
+  "//brave/browser/misc_metrics/uptime_monitor.cc",
+  "//brave/browser/misc_metrics/uptime_monitor.h",
 ]
 
 if (!is_android) {

--- a/browser/misc_metrics/uptime_monitor.cc
+++ b/browser/misc_metrics/uptime_monitor.cc
@@ -1,0 +1,104 @@
+/* Copyright (c) 2023 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "brave/browser/misc_metrics/uptime_monitor.h"
+#include "base/time/time.h"
+#include "brave/components/misc_metrics/pref_names.h"
+#include "brave/components/p3a_utils/bucket.h"
+#include "components/prefs/pref_registry_simple.h"
+#include "components/prefs/pref_service.h"
+
+namespace misc_metrics {
+
+namespace {
+
+#if !BUILDFLAG(IS_ANDROID)
+constexpr base::TimeDelta kUsageTimeQueryInterval = base::Minutes(1);
+#endif
+constexpr base::TimeDelta kUsageTimeReportInterval = base::Days(1);
+
+const int kBrowserOpenTimeBuckets[] = {30, 60, 120, 180, 300, 420, 600};
+
+}  // namespace
+
+const char kBrowserOpenTimeHistogramName[] = "Brave.Uptime.BrowserOpenTime";
+
+UptimeMonitor::UptimeMonitor(PrefService* local_state)
+    : local_state_(local_state),
+      report_frame_start_time_(
+          local_state->GetTime(kDailyUptimeFrameStartTimePrefName)),
+      report_frame_time_sum_(
+          local_state_->GetTimeDelta(kDailyUptimeSumPrefName)) {
+  if (report_frame_start_time_.is_null()) {
+    // If today is the first time monitoring uptime, set the frame start time
+    // to now.
+    ResetReportFrame();
+  }
+  RecordP3A();
+#if !BUILDFLAG(IS_ANDROID)
+  timer_.Start(
+      FROM_HERE, kUsageTimeQueryInterval,
+      base::BindRepeating(&UptimeMonitor::RecordUsage, base::Unretained(this)));
+#endif
+}
+
+void UptimeMonitor::ReportUsageDuration(base::TimeDelta duration) {
+  report_frame_time_sum_ += duration;
+  local_state_->SetTimeDelta(kDailyUptimeSumPrefName, report_frame_time_sum_);
+  RecordP3A();
+}
+
+#if !BUILDFLAG(IS_ANDROID)
+void UptimeMonitor::RecordUsage() {
+  const base::TimeDelta new_total = usage_clock_.GetTotalUsageTime();
+  const base::TimeDelta total_diff = new_total - current_total_usage_;
+  if (total_diff > base::TimeDelta()) {
+    report_frame_time_sum_ += total_diff;
+    current_total_usage_ = new_total;
+    local_state_->SetTimeDelta(kDailyUptimeSumPrefName, report_frame_time_sum_);
+
+    RecordP3A();
+  }
+}
+#endif
+
+void UptimeMonitor::RecordP3A() {
+  if ((base::Time::Now() - report_frame_start_time_) <
+      kUsageTimeReportInterval) {
+    // Do not report, since 1 day has not passed.
+    return;
+  }
+  p3a_utils::RecordToHistogramBucket(kBrowserOpenTimeHistogramName,
+                                     kBrowserOpenTimeBuckets,
+                                     report_frame_time_sum_.InMinutes());
+  ResetReportFrame();
+}
+
+void UptimeMonitor::ResetReportFrame() {
+  report_frame_time_sum_ = base::TimeDelta();
+  report_frame_start_time_ = base::Time::Now();
+  local_state_->SetTimeDelta(kDailyUptimeSumPrefName, report_frame_time_sum_);
+  local_state_->SetTime(kDailyUptimeFrameStartTimePrefName,
+                        report_frame_start_time_);
+}
+
+UptimeMonitor::~UptimeMonitor() = default;
+
+void UptimeMonitor::RegisterPrefs(PrefRegistrySimple* registry) {
+  registry->RegisterTimeDeltaPref(kDailyUptimeSumPrefName, base::TimeDelta());
+  registry->RegisterTimePref(kDailyUptimeFrameStartTimePrefName, base::Time());
+}
+
+void UptimeMonitor::RegisterPrefsForMigration(PrefRegistrySimple* registry) {
+  // Added 10/2023
+  registry->RegisterListPref(kDailyUptimesListPrefName);
+}
+
+void UptimeMonitor::MigrateObsoletePrefs(PrefService* local_state) {
+  // Added 10/2023
+  local_state->ClearPref(kDailyUptimesListPrefName);
+}
+
+}  // namespace misc_metrics

--- a/browser/misc_metrics/uptime_monitor.h
+++ b/browser/misc_metrics/uptime_monitor.h
@@ -1,0 +1,61 @@
+/* Copyright (c) 2023 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_BROWSER_MISC_METRICS_UPTIME_MONITOR_H_
+#define BRAVE_BROWSER_MISC_METRICS_UPTIME_MONITOR_H_
+
+#include "base/memory/raw_ptr.h"
+#include "base/timer/timer.h"
+
+#if !BUILDFLAG(IS_ANDROID)
+#include "chrome/browser/resource_coordinator/usage_clock.h"
+#endif
+
+class PrefService;
+class PrefRegistrySimple;
+
+namespace misc_metrics {
+
+extern const char kBrowserOpenTimeHistogramName[];
+
+class UptimeMonitor {
+ public:
+  explicit UptimeMonitor(PrefService* local_state);
+  UptimeMonitor(const UptimeMonitor&) = delete;
+  UptimeMonitor& operator=(const UptimeMonitor&) = delete;
+  ~UptimeMonitor();
+
+  static void RegisterPrefs(PrefRegistrySimple* registry);
+  static void RegisterPrefsForMigration(PrefRegistrySimple* registry);
+  static void MigrateObsoletePrefs(PrefService* local_state);
+
+  // Used on Android only.
+  void ReportUsageDuration(base::TimeDelta duration);
+
+ private:
+  void RecordP3A();
+#if !BUILDFLAG(IS_ANDROID)
+  // Used on Desktop only.
+  void RecordUsage();
+#endif
+
+  void ResetReportFrame();
+
+  raw_ptr<PrefService> local_state_;
+
+#if !BUILDFLAG(IS_ANDROID)
+  resource_coordinator::UsageClock usage_clock_;
+
+  base::TimeDelta current_total_usage_;
+  base::RepeatingTimer timer_;
+#endif
+
+  base::Time report_frame_start_time_;
+  base::TimeDelta report_frame_time_sum_;
+};
+
+}  // namespace misc_metrics
+
+#endif  // BRAVE_BROWSER_MISC_METRICS_UPTIME_MONITOR_H_

--- a/browser/misc_metrics/uptime_monitor_unittest.cc
+++ b/browser/misc_metrics/uptime_monitor_unittest.cc
@@ -1,0 +1,82 @@
+/* Copyright (c) 2022 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include <memory>
+
+#include "base/test/metrics/histogram_tester.h"
+#include "brave/browser/misc_metrics/uptime_monitor.h"
+#include "components/prefs/testing_pref_service.h"
+#include "content/public/test/browser_task_environment.h"
+#include "testing/gtest/include/gtest/gtest.h"
+
+namespace misc_metrics {
+
+class UptimeMonitorUnitTest : public testing::Test {
+ public:
+  UptimeMonitorUnitTest()
+      : task_environment_(base::test::TaskEnvironment::TimeSource::MOCK_TIME) {}
+
+  void SetUp() override {
+    misc_metrics::UptimeMonitor::RegisterPrefs(local_state_.registry());
+
+    ResetMonitor();
+  }
+
+ protected:
+  void ResetMonitor() {
+    usage_monitor_ = std::make_unique<UptimeMonitor>(&local_state_);
+  }
+
+  content::BrowserTaskEnvironment task_environment_;
+  TestingPrefServiceSimple local_state_;
+  base::HistogramTester histogram_tester_;
+  std::unique_ptr<UptimeMonitor> usage_monitor_;
+};
+
+#if BUILDFLAG(IS_ANDROID)
+#define MAYBE_ReportUsageDuration ReportUsageDuration
+#else
+#define MAYBE_ReportUsageDuration DISABLED_ReportUsageDuration
+#endif
+
+TEST_F(UptimeMonitorUnitTest, MAYBE_ReportUsageDuration) {
+  histogram_tester_.ExpectTotalCount(kBrowserOpenTimeHistogramName, 0);
+
+  usage_monitor_->ReportUsageDuration(base::Minutes(15));
+  task_environment_.FastForwardBy(base::Hours(15));
+  usage_monitor_->ReportUsageDuration(base::Minutes(4));
+
+  histogram_tester_.ExpectTotalCount(kBrowserOpenTimeHistogramName, 0);
+
+  task_environment_.FastForwardBy(base::Hours(9));
+  usage_monitor_->ReportUsageDuration(base::Minutes(1));
+
+  histogram_tester_.ExpectUniqueSample(kBrowserOpenTimeHistogramName, 0, 1);
+
+  usage_monitor_->ReportUsageDuration(base::Minutes(40));
+  task_environment_.FastForwardBy(base::Hours(15));
+  usage_monitor_->ReportUsageDuration(base::Minutes(1));
+
+  histogram_tester_.ExpectUniqueSample(kBrowserOpenTimeHistogramName, 0, 1);
+
+  task_environment_.FastForwardBy(base::Hours(9));
+  usage_monitor_->ReportUsageDuration(base::Minutes(1));
+
+  histogram_tester_.ExpectBucketCount(kBrowserOpenTimeHistogramName, 1, 1);
+  histogram_tester_.ExpectTotalCount(kBrowserOpenTimeHistogramName, 2);
+
+  task_environment_.FastForwardBy(base::Hours(15));
+  usage_monitor_->ReportUsageDuration(base::Minutes(170));
+  histogram_tester_.ExpectTotalCount(kBrowserOpenTimeHistogramName, 2);
+
+  ResetMonitor();
+  task_environment_.FastForwardBy(base::Hours(9));
+  usage_monitor_->ReportUsageDuration(base::Minutes(1));
+
+  histogram_tester_.ExpectBucketCount(kBrowserOpenTimeHistogramName, 3, 1);
+  histogram_tester_.ExpectTotalCount(kBrowserOpenTimeHistogramName, 3);
+}
+
+}  // namespace misc_metrics

--- a/browser/p3a/p3a_core_metrics.cc
+++ b/browser/p3a/p3a_core_metrics.cc
@@ -9,7 +9,6 @@
 
 #include "base/metrics/histogram_macros.h"
 #include "base/time/time.h"
-#include "brave/components/p3a_utils/bucket.h"
 #include "chrome/browser/profiles/profile.h"
 #include "chrome/browser/ui/browser.h"
 #include "chrome/browser/ui/browser_list.h"
@@ -50,91 +49,7 @@ const char* GetPrefNameForProfile(Profile* profile) {
   return nullptr;
 }
 
-BraveUptimeTracker* g_brave_uptime_tracker_instance = nullptr;
-
-constexpr base::TimeDelta kUsageTimeQueryInterval = base::Minutes(1);
-constexpr base::TimeDelta kUsageTimeReportInterval = base::Days(1);
-constexpr char kDailyUptimesListPrefName[] = "daily_uptimes";  // DEPRECATED
-constexpr char kDailyUptimeSumPrefName[] = "brave.misc_metrics.uptime_sum";
-constexpr char kDailyUptimeFrameStartTimePrefName[] =
-    "brave.misc_metrics.uptime_frame_start_time";
-
-constexpr char kBrowserOpenTimeHistogramName[] = "Brave.Uptime.BrowserOpenTime";
-
-constexpr int kBrowserOpenTimeBuckets[] = {30, 60, 120, 180, 300, 420, 600};
-
 }  // namespace
-
-BraveUptimeTracker::BraveUptimeTracker(PrefService* local_state)
-    : local_state_(local_state),
-      report_frame_start_time_(
-          local_state->GetTime(kDailyUptimeFrameStartTimePrefName)),
-      report_frame_time_sum_(
-          local_state_->GetTimeDelta(kDailyUptimeSumPrefName)) {
-  if (report_frame_start_time_.is_null()) {
-    // If today is the first time monitoring uptime, set the frame start time
-    // to now.
-    ResetReportFrame();
-  }
-  RecordP3A();
-  timer_.Start(FROM_HERE, kUsageTimeQueryInterval,
-               base::BindRepeating(&BraveUptimeTracker::RecordUsage,
-                                   base::Unretained(this)));
-}
-
-void BraveUptimeTracker::RecordUsage() {
-  const base::TimeDelta new_total = usage_clock_.GetTotalUsageTime();
-  const base::TimeDelta total_diff = new_total - current_total_usage_;
-  if (total_diff > base::TimeDelta()) {
-    report_frame_time_sum_ += total_diff;
-    current_total_usage_ = new_total;
-    local_state_->SetTimeDelta(kDailyUptimeSumPrefName, report_frame_time_sum_);
-
-    RecordP3A();
-  }
-}
-
-void BraveUptimeTracker::RecordP3A() {
-  if ((base::Time::Now() - report_frame_start_time_) <
-      kUsageTimeReportInterval) {
-    // Do not report, since 1 day has not passed.
-    return;
-  }
-  p3a_utils::RecordToHistogramBucket(kBrowserOpenTimeHistogramName,
-                                     kBrowserOpenTimeBuckets,
-                                     report_frame_time_sum_.InMinutes());
-  ResetReportFrame();
-}
-
-void BraveUptimeTracker::ResetReportFrame() {
-  report_frame_time_sum_ = base::TimeDelta();
-  report_frame_start_time_ = base::Time::Now();
-  local_state_->SetTimeDelta(kDailyUptimeSumPrefName, report_frame_time_sum_);
-  local_state_->SetTime(kDailyUptimeFrameStartTimePrefName,
-                        report_frame_start_time_);
-}
-
-BraveUptimeTracker::~BraveUptimeTracker() = default;
-
-void BraveUptimeTracker::CreateInstance(PrefService* local_state) {
-  g_brave_uptime_tracker_instance = new BraveUptimeTracker(local_state);
-}
-
-void BraveUptimeTracker::RegisterPrefs(PrefRegistrySimple* registry) {
-  registry->RegisterTimeDeltaPref(kDailyUptimeSumPrefName, base::TimeDelta());
-  registry->RegisterTimePref(kDailyUptimeFrameStartTimePrefName, base::Time());
-}
-
-void BraveUptimeTracker::RegisterPrefsForMigration(
-    PrefRegistrySimple* registry) {
-  // Added 10/2023
-  registry->RegisterListPref(kDailyUptimesListPrefName);
-}
-
-void BraveUptimeTracker::MigrateObsoletePrefs(PrefService* local_state) {
-  // Added 10/2023
-  local_state->ClearPref(kDailyUptimesListPrefName);
-}
 
 BraveWindowTracker::BraveWindowTracker(PrefService* local_state)
     : local_state_(local_state) {

--- a/browser/p3a/p3a_core_metrics.h
+++ b/browser/p3a/p3a_core_metrics.h
@@ -6,9 +6,9 @@
 #ifndef BRAVE_BROWSER_P3A_P3A_CORE_METRICS_H_
 #define BRAVE_BROWSER_P3A_P3A_CORE_METRICS_H_
 
-// The classes below can be used on desktop only
+// The class below can be used on desktop only
 // because BrowserListObserver is available on desktop only
-// Brave.Uptime.BrowserOpenMinutes, Brave.Core.LastTimeIncognitoUsed and
+// Brave.Core.LastTimeIncognitoUsed and
 // Brave.Core.TorEverUsed don't work on Android
 
 #include "build/build_config.h"
@@ -19,41 +19,12 @@
 
 #include "base/memory/raw_ptr.h"
 #include "base/timer/timer.h"
-#include "chrome/browser/resource_coordinator/usage_clock.h"
 #include "chrome/browser/ui/browser_list_observer.h"
 
 class PrefService;
 class PrefRegistrySimple;
 
 namespace brave {
-
-class BraveUptimeTracker {
- public:
-  explicit BraveUptimeTracker(PrefService* local_state);
-  BraveUptimeTracker(const BraveUptimeTracker&) = delete;
-  BraveUptimeTracker& operator=(const BraveUptimeTracker&) = delete;
-  ~BraveUptimeTracker();
-
-  static void CreateInstance(PrefService* local_state);
-
-  static void RegisterPrefs(PrefRegistrySimple* registry);
-  static void RegisterPrefsForMigration(PrefRegistrySimple* registry);
-  static void MigrateObsoletePrefs(PrefService* local_state);
-
- private:
-  void RecordUsage();
-  void RecordP3A();
-
-  void ResetReportFrame();
-
-  raw_ptr<PrefService> local_state_;
-  resource_coordinator::UsageClock usage_clock_;
-  base::RepeatingTimer timer_;
-  base::TimeDelta current_total_usage_;
-
-  base::Time report_frame_start_time_;
-  base::TimeDelta report_frame_time_sum_;
-};
 
 // BraveWindowTracker is under !OS_ANDROID guard because
 // BrowserListObserver should only be only on desktop

--- a/chromium_src/chrome/browser/prefs/browser_prefs.cc
+++ b/chromium_src/chrome/browser/prefs/browser_prefs.cc
@@ -7,6 +7,7 @@
 #include "brave/browser/brave_profile_prefs.h"
 #include "brave/browser/brave_rewards/rewards_prefs_util.h"
 #include "brave/browser/brave_stats/brave_stats_updater.h"
+#include "brave/browser/misc_metrics/uptime_monitor.h"
 #include "brave/browser/search/ntp_utils.h"
 #include "brave/browser/themes/brave_dark_mode_utils.h"
 #include "brave/browser/translate/brave_translate_prefs_migration.h"
@@ -30,7 +31,6 @@
 #include "third_party/widevine/cdm/buildflags.h"
 
 #if !BUILDFLAG(IS_ANDROID)
-#include "brave/browser/p3a/p3a_core_metrics.h"
 #include "brave/browser/search_engines/search_engine_provider_util.h"
 #endif
 
@@ -263,9 +263,9 @@ void MigrateObsoleteLocalStatePrefs(PrefService* local_state) {
 #if !BUILDFLAG(IS_ANDROID)
   // Added 10/2022
   local_state->ClearPref(kDefaultBrowserPromptEnabled);
-  brave::BraveUptimeTracker::MigrateObsoletePrefs(local_state);
 #endif
 
+  misc_metrics::UptimeMonitor::MigrateObsoletePrefs(local_state);
   brave_search_conversion::p3a::MigrateObsoleteLocalStatePrefs(local_state);
   brave_stats::MigrateObsoleteLocalStatePrefs(local_state);
 

--- a/components/misc_metrics/common/misc_metrics.mojom
+++ b/components/misc_metrics/common/misc_metrics.mojom
@@ -5,6 +5,8 @@
 
 module misc_metrics.mojom;
 
+import "mojo/public/mojom/base/time.mojom";
+
 // Handler for Android misc metric events from UI.
 interface MiscAndroidMetrics {
   // Records view of Privacy Hub report.
@@ -15,4 +17,7 @@ interface MiscAndroidMetrics {
 
   // Records a location bar search query event, for measuring "queries before churn".
   RecordLocationBarQuery();
+
+  // Records browser usage duration, for measuring usage time per day.
+  RecordBrowserUsageDuration(mojo_base.mojom.TimeDelta duration);
 };

--- a/components/misc_metrics/pref_names.cc
+++ b/components/misc_metrics/pref_names.cc
@@ -31,4 +31,10 @@ const char kMiscMetricsTotalDnsRequestStorage[] =
     "brave.misc_metrics.total_dns_requests";
 const char kMiscMetricsUpgradedDnsRequestStorage[] =
     "brave.misc_metrics.upgraded_dns_requests";
+
+const char kDailyUptimesListPrefName[] = "daily_uptimes";  // DEPRECATED
+const char kDailyUptimeSumPrefName[] = "brave.misc_metrics.uptime_sum";
+const char kDailyUptimeFrameStartTimePrefName[] =
+    "brave.misc_metrics.uptime_frame_start_time";
+
 }  // namespace misc_metrics

--- a/components/misc_metrics/pref_names.h
+++ b/components/misc_metrics/pref_names.h
@@ -24,6 +24,11 @@ extern const char kMiscMetricsSearchSwitchedAwayFromBrave[];
 extern const char kMiscMetricsSearchBraveQueryCount[];
 extern const char kMiscMetricsTotalDnsRequestStorage[];
 extern const char kMiscMetricsUpgradedDnsRequestStorage[];
+
+extern const char kDailyUptimesListPrefName[];  // DEPRECATED
+extern const char kDailyUptimeSumPrefName[];
+extern const char kDailyUptimeFrameStartTimePrefName[];
+
 }  // namespace misc_metrics
 
 #endif  // BRAVE_COMPONENTS_MISC_METRICS_PREF_NAMES_H_


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/33687

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [ ] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

0. Start with fresh profile, ensure metric does not exist.
1. Use the browser actively for a certain amount of time.
2. Close browser, advance system time by one day, open browser.
3. Verify that the metric has the correct value.
4. Steps 1-3 may be repeated for different time values.