### PR TITLE
Prevent view-source scheme url for wayback machine

### DIFF
--- a/components/brave_wayback_machine/BUILD.gn
+++ b/components/brave_wayback_machine/BUILD.gn
@@ -1,3 +1,8 @@
+# Copyright (c) 2019 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+
 import("//brave/components/brave_wayback_machine/buildflags/buildflags.gni")
 
 assert(enable_brave_wayback_machine)
@@ -29,6 +34,7 @@ static_library("brave_wayback_machine") {
     "//components/prefs",
     "//components/user_prefs",
     "//content/public/browser",
+    "//content/public/common",
     "//net",
     "//services/network/public/cpp",
     "//url",

--- a/components/brave_wayback_machine/DEPS
+++ b/components/brave_wayback_machine/DEPS
@@ -1,4 +1,5 @@
 include_rules = [
   "+content/public/browser",
+  "+content/public/common",
   "+services/network/public",
 ]

--- a/components/brave_wayback_machine/brave_wayback_machine_tab_helper.cc
+++ b/components/brave_wayback_machine/brave_wayback_machine_tab_helper.cc
@@ -43,8 +43,15 @@ void BraveWaybackMachineTabHelper::DidFinishNavigation(
   if (!IsWaybackMachineEnabled())
     return;
 
-  if (IsWaybackMachineDisabledFor(navigation_handle->GetURL()))
+  if (IsWaybackMachineDisabledFor(navigation_handle->GetURL())) {
     return;
+  }
+
+  // Double check with user visible url to check user visible only schemes such
+  // as "view-source:"
+  if (IsWaybackMachineDisabledFor(web_contents()->GetLastCommittedURL())) {
+    return;
+  }
 
   if (!navigation_handle->IsInMainFrame() ||
       navigation_handle->IsSameDocument()) {

--- a/components/brave_wayback_machine/brave_wayback_machine_utils.cc
+++ b/components/brave_wayback_machine/brave_wayback_machine_utils.cc
@@ -13,6 +13,7 @@
 #include "base/strings/stringprintf.h"
 #include "base/strings/utf_string_conversions.h"
 #include "brave/components/brave_wayback_machine/url_constants.h"
+#include "content/public/common/url_constants.h"
 #include "net/base/url_util.h"
 #include "url/gurl.h"
 #include "url/url_util.h"
@@ -30,6 +31,10 @@ bool IsWaybackMachineDisabledFor(const GURL& url) {
   // Disable on web.archive.org
   if (url.host() == kWaybackHost)
     return true;
+
+  if (url.SchemeIs(content::kViewSourceScheme)) {
+    return true;
+  }
 
   return false;
 }

--- a/components/brave_wayback_machine/brave_wayback_machine_utils_unittest.cc
+++ b/components/brave_wayback_machine/brave_wayback_machine_utils_unittest.cc
@@ -11,7 +11,7 @@
 #include "testing/gtest/include/gtest/gtest.h"
 #include "url/gurl.h"
 
-TEST(BraveWaybackMachineUtilsTest, LocalHostDisabledTest) {
+TEST(BraveWaybackMachineUtilsTest, DisabledURLTest) {
   EXPECT_TRUE(
       IsWaybackMachineDisabledFor(GURL("https://web.archive.org/foobar.html")));
   EXPECT_TRUE(IsWaybackMachineDisabledFor(GURL("http://localhost/index.html")));
@@ -21,6 +21,8 @@ TEST(BraveWaybackMachineUtilsTest, LocalHostDisabledTest) {
   EXPECT_TRUE(IsWaybackMachineDisabledFor(GURL("http://[::1]")));
   EXPECT_TRUE(IsWaybackMachineDisabledFor(
       GURL("http://127.0045.1.2:8080/index.html")));
+  EXPECT_TRUE(
+      IsWaybackMachineDisabledFor(GURL("view-source:https://www.brave.com")));
   EXPECT_FALSE(IsWaybackMachineDisabledFor(GURL("http://www.local-news.com")));
   EXPECT_FALSE(IsWaybackMachineDisabledFor(GURL("http://www.onion-news.com")));
   EXPECT_FALSE(IsWaybackMachineDisabledFor(GURL("http://www.brave.com")));


### PR DESCRIPTION
fix https://github.com/brave/brave-browser/issues/33685

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves 

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

1. Launch brave and enable wayback machine
2. Load https://www.brave.com/bo
3. Check wayback machine infor bar is shown
4. Open view page source via page's context menu (or ctrl + u)
5. Check wayback machine info bar is not shown for view source page

`BraveWaybackMachineUtilsTest.DisabledURLTest`