### PR TITLE
Add `--disable-vertical-tabs` cmd switch

### DIFF
--- a/browser/ui/BUILD.gn
+++ b/browser/ui/BUILD.gn
@@ -376,6 +376,7 @@ source_set("ui") {
       "views/tabs/brave_tab_strip.h",
       "views/tabs/brave_tab_strip_layout_helper.cc",
       "views/tabs/brave_tab_strip_layout_helper.h",
+      "views/tabs/switches.h",
       "views/tabs/tab_drag_controller.cc",
       "views/tabs/tab_drag_controller.h",
       "views/tabs/vertical_tab_utils.cc",

--- a/browser/ui/views/tabs/switches.h
+++ b/browser/ui/views/tabs/switches.h
@@ -1,0 +1,17 @@
+/* Copyright (c) 2023 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_BROWSER_UI_VIEWS_TABS_SWITCHES_H_
+#define BRAVE_BROWSER_UI_VIEWS_TABS_SWITCHES_H_
+
+namespace tabs::switches {
+
+// This switch disables vertical tab strip regardless of the pref. This could be
+// useful when vertical tab strip causes browser to crash on start up.
+constexpr char kDisableVerticalTabsSwitch[] = "disable-vertical-tabs";
+
+}  // namespace tabs::switches
+
+#endif  // BRAVE_BROWSER_UI_VIEWS_TABS_SWITCHES_H_

--- a/browser/ui/views/tabs/vertical_tab_strip_browsertest.cc
+++ b/browser/ui/views/tabs/vertical_tab_strip_browsertest.cc
@@ -874,3 +874,25 @@ VERTICAL_TAB_STRIP_DPI_TEST(3.00f, Dpi300)
 VERTICAL_TAB_STRIP_DPI_TEST(3.50f, Dpi350)
 
 #undef VERTICAL_TAB_STRIP_DPI_TEST
+
+class VerticalTabStripSwitchTest : public VerticalTabStripBrowserTest {
+ public:
+  using VerticalTabStripBrowserTest::VerticalTabStripBrowserTest;
+  ~VerticalTabStripSwitchTest() override = default;
+
+  // VerticalTabStripBrowserTest:
+  void SetUp() override {
+    base::CommandLine::ForCurrentProcess()->AppendSwitch(
+        tabs::utils::kDisableVerticalTabsSwitch);
+    VerticalTabStripBrowserTest::SetUp();
+  }
+};
+
+IN_PROC_BROWSER_TEST_F(VerticalTabStripSwitchTest, DisableSwitch) {
+  EXPECT_FALSE(tabs::utils::SupportsVerticalTabs(browser()));
+
+  EXPECT_FALSE(tabs::utils::ShouldShowVerticalTabs(browser()));
+  // Even when we toggle on the tab strip, this state should persist.
+  ToggleVerticalTabStrip();
+  EXPECT_FALSE(tabs::utils::ShouldShowVerticalTabs(browser()));
+}

--- a/browser/ui/views/tabs/vertical_tab_strip_browsertest.cc
+++ b/browser/ui/views/tabs/vertical_tab_strip_browsertest.cc
@@ -13,6 +13,7 @@
 #include "brave/browser/ui/views/frame/vertical_tab_strip_widget_delegate_view.h"
 #include "brave/browser/ui/views/tabs/brave_browser_tab_strip_controller.h"
 #include "brave/browser/ui/views/tabs/brave_tab_context_menu_contents.h"
+#include "brave/browser/ui/views/tabs/switches.h"
 #include "brave/browser/ui/views/tabs/vertical_tab_utils.h"
 #include "brave/components/constants/pref_names.h"
 #include "build/build_config.h"
@@ -883,7 +884,7 @@ class VerticalTabStripSwitchTest : public VerticalTabStripBrowserTest {
   // VerticalTabStripBrowserTest:
   void SetUp() override {
     base::CommandLine::ForCurrentProcess()->AppendSwitch(
-        tabs::utils::kDisableVerticalTabsSwitch);
+        tabs::switches::kDisableVerticalTabsSwitch);
     VerticalTabStripBrowserTest::SetUp();
   }
 };

--- a/browser/ui/views/tabs/vertical_tab_utils.cc
+++ b/browser/ui/views/tabs/vertical_tab_utils.cc
@@ -8,6 +8,7 @@
 #include "base/check_is_test.h"
 #include "base/command_line.h"
 #include "brave/browser/ui/tabs/brave_tab_prefs.h"
+#include "brave/browser/ui/views/tabs/switches.h"
 #include "chrome/browser/profiles/profile.h"
 #include "chrome/browser/ui/browser.h"
 #include "components/prefs/pref_service.h"
@@ -36,7 +37,7 @@ namespace tabs::utils {
 
 bool SupportsVerticalTabs(const Browser* browser) {
   if (base::CommandLine::ForCurrentProcess()->HasSwitch(
-          kDisableVerticalTabsSwitch)) {
+          switches::kDisableVerticalTabsSwitch)) {
     return false;
   }
 

--- a/browser/ui/views/tabs/vertical_tab_utils.cc
+++ b/browser/ui/views/tabs/vertical_tab_utils.cc
@@ -6,6 +6,7 @@
 #include "brave/browser/ui/views/tabs/vertical_tab_utils.h"
 
 #include "base/check_is_test.h"
+#include "base/command_line.h"
 #include "brave/browser/ui/tabs/brave_tab_prefs.h"
 #include "chrome/browser/profiles/profile.h"
 #include "chrome/browser/ui/browser.h"
@@ -34,6 +35,11 @@
 namespace tabs::utils {
 
 bool SupportsVerticalTabs(const Browser* browser) {
+  if (base::CommandLine::ForCurrentProcess()->HasSwitch(
+          kDisableVerticalTabsSwitch)) {
+    return false;
+  }
+
   if (!browser) {
     // During unit tests, |browser| can be null.
     CHECK_IS_TEST();

--- a/browser/ui/views/tabs/vertical_tab_utils.h
+++ b/browser/ui/views/tabs/vertical_tab_utils.h
@@ -13,6 +13,10 @@ class BrowserFrame;
 
 namespace tabs::utils {
 
+// This switch disables vertical tab strip regardless of the pref. This could be
+// useful when vertical tab strip causes browser to crash on start up.
+constexpr char kDisableVerticalTabsSwitch[] = "disable-vertical-tabs";
+
 // Returns true if the current |browser| might ever support vertical tabs.
 bool SupportsVerticalTabs(const Browser* browser);
 

--- a/browser/ui/views/tabs/vertical_tab_utils.h
+++ b/browser/ui/views/tabs/vertical_tab_utils.h
@@ -13,10 +13,6 @@ class BrowserFrame;
 
 namespace tabs::utils {
 
-// This switch disables vertical tab strip regardless of the pref. This could be
-// useful when vertical tab strip causes browser to crash on start up.
-constexpr char kDisableVerticalTabsSwitch[] = "disable-vertical-tabs";
-
 // Returns true if the current |browser| might ever support vertical tabs.
 bool SupportsVerticalTabs(const Browser* browser);
 


### PR DESCRIPTION
Recently, vertical tab strip caused crash on start-up. In this case, users can't disable vertical tabs without launching it. it'd be good to have a command line switch for cases like this so that users can turn off the pref

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/33711

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [ ] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

