### PR TITLE
Fix adblock default ruleset reparsing on startup

### DIFF
--- a/browser/brave_shields/ad_block_service_browsertest.cc
+++ b/browser/brave_shields/ad_block_service_browsertest.cc
@@ -15,6 +15,7 @@
 #include "base/memory/raw_ptr.h"
 #include "base/path_service.h"
 #include "base/strings/stringprintf.h"
+#include "base/test/metrics/histogram_tester.h"
 #include "base/test/scoped_feature_list.h"
 #include "base/test/thread_test_helper.h"
 #include "brave/browser/brave_browser_process.h"
@@ -463,6 +464,40 @@ IN_PROC_BROWSER_TEST_F(AdBlockServiceTest,
                          "setExpectations(1, 0, 0, 0);"
                          "addImage('logo.png')"));
   EXPECT_EQ(browser()->profile()->GetPrefs()->GetUint64(kAdsBlocked), 0ULL);
+}
+
+class AdBlockServiceEngineUpdateCountTest : public AdBlockServiceTest {
+ protected:
+  const base::HistogramTester histogram_tester_;
+};
+
+// The test verifies the number of expected engine updating during normal
+// startup.
+// Warning: each engine updating is a CPU-heavy thing and degrades startup
+// performance.
+IN_PROC_BROWSER_TEST_F(AdBlockServiceEngineUpdateCountTest,
+                       DefaultStartupWithCookieList) {
+  // The empty ruleset building until the components are loaded.
+  // TODO: remove that excessive work.
+  histogram_tester_.ExpectTotalCount(
+      "Brave.Adblock.MakeEngineWithRules.Default", 1);
+  histogram_tester_.ExpectTotalCount(
+      "Brave.Adblock.MakeEngineWithRules.Additional", 1);
+
+  // Loads the default list first, then the additional cookie list.
+  ASSERT_TRUE(
+      InstallRegionalAdBlockExtension(brave_shields::kCookieListUuid, true));
+
+  // Only one new rebuild is expected. Loading the extra list must not
+  // trigger another rebuilding of the default engine.
+  histogram_tester_.ExpectTotalCount(
+      "Brave.Adblock.MakeEngineWithRules.Default", 2);
+
+  // Currently, the extra engine depends on the default, so we expect an extra
+  // unnecessary update.
+  // TODO: remove that dependency and change 3 => 2.
+  histogram_tester_.ExpectTotalCount(
+      "Brave.Adblock.MakeEngineWithRules.Additional", 3);
 }
 
 // Load a page with an ad image, and make sure it is blocked by the

--- a/browser/brave_shields/ad_block_service_browsertest.cc
+++ b/browser/brave_shields/ad_block_service_browsertest.cc
@@ -478,7 +478,7 @@ class AdBlockServiceEngineUpdateCountTest : public AdBlockServiceTest {
 IN_PROC_BROWSER_TEST_F(AdBlockServiceEngineUpdateCountTest,
                        DefaultStartupWithCookieList) {
   // The empty ruleset building until the components are loaded.
-  // TODO: remove that excessive work.
+  // TODO(matuchin): remove that excessive work.
   histogram_tester_.ExpectTotalCount(
       "Brave.Adblock.MakeEngineWithRules.Default", 1);
   histogram_tester_.ExpectTotalCount(
@@ -495,7 +495,7 @@ IN_PROC_BROWSER_TEST_F(AdBlockServiceEngineUpdateCountTest,
 
   // Currently, the extra engine depends on the default, so we expect an extra
   // unnecessary update.
-  // TODO: remove that dependency and change 3 => 2.
+  // TODO(matuchin): remove that dependency and change 3 => 2.
   histogram_tester_.ExpectTotalCount(
       "Brave.Adblock.MakeEngineWithRules.Additional", 3);
 }

--- a/browser/brave_shields/ad_block_service_browsertest.cc
+++ b/browser/brave_shields/ad_block_service_browsertest.cc
@@ -273,8 +273,7 @@ class EngineTestObserver : public brave_shields::AdBlockEngine::TestObserver {
 bool AdBlockServiceTest::InstallRegionalAdBlockExtension(
     const std::string& uuid,
     bool enable_list) {
-  // The regional adblock engines depend on the default engine for resource
-  // loads.
+  // Install the default engine first.
   EXPECT_TRUE(InstallDefaultAdBlockExtension());
   auto* default_engine =
       g_brave_browser_process->ad_block_service()->default_engine_.get();
@@ -489,15 +488,11 @@ IN_PROC_BROWSER_TEST_F(AdBlockServiceEngineUpdateCountTest,
       InstallRegionalAdBlockExtension(brave_shields::kCookieListUuid, true));
 
   // Only one new rebuild is expected. Loading the extra list must not
-  // trigger another rebuilding of the default engine.
+  // trigger another rebuilding of the default engine and vice versa.
   histogram_tester_.ExpectTotalCount(
       "Brave.Adblock.MakeEngineWithRules.Default", 2);
-
-  // Currently, the extra engine depends on the default, so we expect an extra
-  // unnecessary update.
-  // TODO(matuchin): remove that dependency and change 3 => 2.
   histogram_tester_.ExpectTotalCount(
-      "Brave.Adblock.MakeEngineWithRules.Additional", 3);
+      "Brave.Adblock.MakeEngineWithRules.Additional", 2);
 }
 
 // Load a page with an ad image, and make sure it is blocked by the

--- a/components/brave_component_updater/browser/dat_file_util.cc
+++ b/components/brave_component_updater/browser/dat_file_util.cc
@@ -8,9 +8,10 @@
 #include <memory>
 #include <string>
 
-#include "base/logging.h"
 #include "base/files/file_path.h"
 #include "base/files/file_util.h"
+#include "base/logging.h"
+#include "base/trace_event/trace_event.h"
 
 namespace {
 
@@ -40,8 +41,11 @@ void GetDATFileData(const base::FilePath& file_path,
 namespace brave_component_updater {
 
 DATFileDataBuffer ReadDATFileData(const base::FilePath& dat_file_path) {
+  TRACE_EVENT_BEGIN1("brave.adblock", "ReadDATFileData", "path",
+                     dat_file_path.MaybeAsASCII());
   DATFileDataBuffer buffer;
   GetDATFileData(dat_file_path, &buffer);
+  TRACE_EVENT_END1("brave.adblock", "ReadDATFileData", "size", buffer.size());
   return buffer;
 }
 

--- a/components/brave_shields/browser/ad_block_component_filters_provider.cc
+++ b/components/brave_shields/browser/ad_block_component_filters_provider.cc
@@ -66,7 +66,7 @@ void AdBlockComponentFiltersProvider::OnComponentReady(
     const base::FilePath& path) {
   component_path_ = path;
 
-  NotifyObservers();
+  NotifyObservers(engine_is_default_);
 }
 
 void AdBlockComponentFiltersProvider::LoadDATBuffer(

--- a/components/brave_shields/browser/ad_block_custom_filters_provider.cc
+++ b/components/brave_shields/browser/ad_block_custom_filters_provider.cc
@@ -54,7 +54,7 @@ bool AdBlockCustomFiltersProvider::UpdateCustomFilters(
     return false;
   local_state_->SetString(prefs::kAdBlockCustomFilters, custom_filters);
 
-  NotifyObservers();
+  NotifyObservers(engine_is_default_);
 
   return true;
 }
@@ -78,7 +78,7 @@ void AdBlockCustomFiltersProvider::LoadDATBuffer(
 void AdBlockCustomFiltersProvider::AddObserver(
     AdBlockFiltersProvider::Observer* observer) {
   AdBlockFiltersProvider::AddObserver(observer);
-  NotifyObservers();
+  NotifyObservers(engine_is_default_);
 }
 
 }  // namespace brave_shields

--- a/components/brave_shields/browser/ad_block_filters_provider.cc
+++ b/components/brave_shields/browser/ad_block_filters_provider.cc
@@ -36,9 +36,9 @@ void AdBlockFiltersProvider::RemoveObserver(
     observers_.RemoveObserver(observer);
 }
 
-void AdBlockFiltersProvider::NotifyObservers() {
+void AdBlockFiltersProvider::NotifyObservers(bool is_for_default_engine) {
   for (auto& observer : observers_) {
-    observer.OnChanged();
+    observer.OnChanged(is_for_default_engine);
   }
 }
 

--- a/components/brave_shields/browser/ad_block_filters_provider.h
+++ b/components/brave_shields/browser/ad_block_filters_provider.h
@@ -24,7 +24,7 @@ class AdBlockFiltersProvider {
  public:
   class Observer : public base::CheckedObserver {
    public:
-    virtual void OnChanged() = 0;
+    virtual void OnChanged(bool is_for_default_engine) = 0;
   };
 
   explicit AdBlockFiltersProvider(bool engine_is_default);
@@ -50,7 +50,7 @@ class AdBlockFiltersProvider {
   virtual void LoadDATBuffer(
       base::OnceCallback<void(bool deserialize,
                               const DATFileDataBuffer& dat_buf)>) = 0;
-  void NotifyObservers();
+  void NotifyObservers(bool is_for_default_engine);
 
  private:
   base::ObserverList<Observer> observers_;

--- a/components/brave_shields/browser/ad_block_filters_provider_manager.cc
+++ b/components/brave_shields/browser/ad_block_filters_provider_manager.cc
@@ -63,15 +63,15 @@ void AdBlockFiltersProviderManager::RemoveProvider(
   auto it = filters_providers.find(provider);
   DCHECK(it != filters_providers.end());
   filters_providers.erase(it);
-  NotifyObservers();
+  NotifyObservers(is_for_default_engine);
 }
 
 std::string AdBlockFiltersProviderManager::GetNameForDebugging() {
   return "AdBlockCustomFiltersProvider";
 }
 
-void AdBlockFiltersProviderManager::OnChanged() {
-  NotifyObservers();
+void AdBlockFiltersProviderManager::OnChanged(bool is_for_default_engine) {
+  NotifyObservers(is_for_default_engine);
 }
 
 // Use LoadDATBufferForEngine instead, for Filter Provider Manager.

--- a/components/brave_shields/browser/ad_block_filters_provider_manager.h
+++ b/components/brave_shields/browser/ad_block_filters_provider_manager.h
@@ -51,7 +51,7 @@ class AdBlockFiltersProviderManager : public AdBlockFiltersProvider,
                               const DATFileDataBuffer& dat_buf)> cb);
 
   // AdBlockFiltersProvider::Observer
-  void OnChanged() override;
+  void OnChanged(bool is_default_engine) override;
 
   void AddProvider(AdBlockFiltersProvider* provider,
                    bool is_for_default_engine);

--- a/components/brave_shields/browser/ad_block_localhost_filters_provider.cc
+++ b/components/brave_shields/browser/ad_block_localhost_filters_provider.cc
@@ -50,7 +50,7 @@ void AdBlockLocalhostFiltersProvider::LoadDATBuffer(
 void AdBlockLocalhostFiltersProvider::AddObserver(
     AdBlockFiltersProvider::Observer* observer) {
   AdBlockFiltersProvider::AddObserver(observer);
-  NotifyObservers();
+  NotifyObservers(engine_is_default_);
 }
 
 }  // namespace brave_shields

--- a/components/brave_shields/browser/ad_block_service.cc
+++ b/components/brave_shields/browser/ad_block_service.cc
@@ -97,8 +97,8 @@ AdBlockService::SourceProviderObserver::~SourceProviderObserver() {
 }
 
 void AdBlockService::SourceProviderObserver::OnChanged(bool is_default_engine) {
-  if (adblock_engine_->IsDefaultEngine() && !is_default_engine) {
-    // Skip updates of the additional engine for the default.
+  if (adblock_engine_->IsDefaultEngine() != is_default_engine) {
+    // Skip updates of another engine.
     return;
   }
   if (is_filter_provider_manager_) {

--- a/components/brave_shields/browser/ad_block_service.cc
+++ b/components/brave_shields/browser/ad_block_service.cc
@@ -96,7 +96,11 @@ AdBlockService::SourceProviderObserver::~SourceProviderObserver() {
   resource_provider_->RemoveObserver(this);
 }
 
-void AdBlockService::SourceProviderObserver::OnChanged() {
+void AdBlockService::SourceProviderObserver::OnChanged(bool is_default_engine) {
+  if (adblock_engine_->IsDefaultEngine() && !is_default_engine) {
+    // Skip updates of the additional engine for the default.
+    return;
+  }
   if (is_filter_provider_manager_) {
     static_cast<AdBlockFiltersProviderManager*>(filters_provider_.get())
         ->LoadDATBufferForEngine(

--- a/components/brave_shields/browser/ad_block_service.h
+++ b/components/brave_shields/browser/ad_block_service.h
@@ -70,7 +70,7 @@ class AdBlockService {
     void OnDATLoaded(bool deserialize, const DATFileDataBuffer& dat_buf);
 
     // AdBlockFiltersProvider::Observer
-    void OnChanged() override;
+    void OnChanged(bool is_default_engine) override;
 
     // AdBlockResourceProvider::Observer
     void OnResourcesLoaded(const std::string& resources_json) override;

--- a/components/brave_shields/browser/ad_block_subscription_filters_provider.cc
+++ b/components/brave_shields/browser/ad_block_subscription_filters_provider.cc
@@ -51,7 +51,7 @@ void AdBlockSubscriptionFiltersProvider::OnDATFileDataReady(
 }
 
 void AdBlockSubscriptionFiltersProvider::OnListAvailable() {
-  NotifyObservers();
+  NotifyObservers(engine_is_default_);
 }
 
 }  // namespace brave_shields


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/33718
Resolves https://github.com/brave/brave-browser/issues/33532

The root of the issue is `AdBlockFiltersProviderManager` singleton. It subscribes to all the providers (in `AdBlockFiltersProviderManager::AddProvider`) => it gets notifications about an update in every provider.

Also, `AdBlockFiltersProviderManager` implements both `AdBlockFiltersProvider` and `AdBlockFiltersProvider::Observer` interfaces, acting like a decorator and proxying all the `OnChanged` to the listeners. The listeners are instances of `SourceProviderObserver` for the both engines (the manager is passed as `AdBlockFiltersProvider*` [here](https://github.com/brave/brave-core/blob/master/components/brave_shields/browser/ad_block_service.cc#L355)
As a result, both engine observers get notifications about all the updates and rebuild the combined list of every update.

The PR fixes it in safe and straightforward way: adding to `Observer::OnChange()` extra information about what kind of source was updated. This allows us to filter out unnecessary notifications.

The PR:
* implement a logic to suppress rebuilding the default engine on notifications about additional engine updates;
* adds extra traces and UMA to track the number of engine rebuilding;
* adds a browser test to verify the number of updates.

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
1. Verify that adblock engine works correctly (QA team);
2. Verify the startup performance (perf team).
