### PR TITLE
Fix adblock default ruleset reparsing on startup (uplift to 1.60.x)

### DIFF
--- a/components/brave_component_updater/browser/dat_file_util.cc
+++ b/components/brave_component_updater/browser/dat_file_util.cc
@@ -8,9 +8,10 @@
 #include <memory>
 #include <string>
 
-#include "base/logging.h"
 #include "base/files/file_path.h"
 #include "base/files/file_util.h"
+#include "base/logging.h"
+#include "base/trace_event/trace_event.h"
 
 namespace {
 
@@ -40,8 +41,11 @@ void GetDATFileData(const base::FilePath& file_path,
 namespace brave_component_updater {
 
 DATFileDataBuffer ReadDATFileData(const base::FilePath& dat_file_path) {
+  TRACE_EVENT_BEGIN1("brave.adblock", "ReadDATFileData", "path",
+                     dat_file_path.MaybeAsASCII());
   DATFileDataBuffer buffer;
   GetDATFileData(dat_file_path, &buffer);
+  TRACE_EVENT_END1("brave.adblock", "ReadDATFileData", "size", buffer.size());
   return buffer;
 }
 

--- a/components/brave_shields/browser/ad_block_component_filters_provider.cc
+++ b/components/brave_shields/browser/ad_block_component_filters_provider.cc
@@ -66,7 +66,7 @@ void AdBlockComponentFiltersProvider::OnComponentReady(
     const base::FilePath& path) {
   component_path_ = path;
 
-  NotifyObservers();
+  NotifyObservers(engine_is_default_);
 }
 
 void AdBlockComponentFiltersProvider::LoadDATBuffer(

--- a/components/brave_shields/browser/ad_block_custom_filters_provider.cc
+++ b/components/brave_shields/browser/ad_block_custom_filters_provider.cc
@@ -54,7 +54,7 @@ bool AdBlockCustomFiltersProvider::UpdateCustomFilters(
     return false;
   local_state_->SetString(prefs::kAdBlockCustomFilters, custom_filters);
 
-  NotifyObservers();
+  NotifyObservers(engine_is_default_);
 
   return true;
 }
@@ -78,7 +78,7 @@ void AdBlockCustomFiltersProvider::LoadDATBuffer(
 void AdBlockCustomFiltersProvider::AddObserver(
     AdBlockFiltersProvider::Observer* observer) {
   AdBlockFiltersProvider::AddObserver(observer);
-  NotifyObservers();
+  NotifyObservers(engine_is_default_);
 }
 
 }  // namespace brave_shields

--- a/components/brave_shields/browser/ad_block_filters_provider.cc
+++ b/components/brave_shields/browser/ad_block_filters_provider.cc
@@ -36,9 +36,9 @@ void AdBlockFiltersProvider::RemoveObserver(
     observers_.RemoveObserver(observer);
 }
 
-void AdBlockFiltersProvider::NotifyObservers() {
+void AdBlockFiltersProvider::NotifyObservers(bool is_for_default_engine) {
   for (auto& observer : observers_) {
-    observer.OnChanged();
+    observer.OnChanged(is_for_default_engine);
   }
 }
 

--- a/components/brave_shields/browser/ad_block_filters_provider.h
+++ b/components/brave_shields/browser/ad_block_filters_provider.h
@@ -24,7 +24,7 @@ class AdBlockFiltersProvider {
  public:
   class Observer : public base::CheckedObserver {
    public:
-    virtual void OnChanged() = 0;
+    virtual void OnChanged(bool is_for_default_engine) = 0;
   };
 
   explicit AdBlockFiltersProvider(bool engine_is_default);
@@ -50,7 +50,7 @@ class AdBlockFiltersProvider {
   virtual void LoadDATBuffer(
       base::OnceCallback<void(bool deserialize,
                               const DATFileDataBuffer& dat_buf)>) = 0;
-  void NotifyObservers();
+  void NotifyObservers(bool is_for_default_engine);
 
  private:
   base::ObserverList<Observer> observers_;

--- a/components/brave_shields/browser/ad_block_filters_provider_manager.cc
+++ b/components/brave_shields/browser/ad_block_filters_provider_manager.cc
@@ -63,15 +63,15 @@ void AdBlockFiltersProviderManager::RemoveProvider(
   auto it = filters_providers.find(provider);
   DCHECK(it != filters_providers.end());
   filters_providers.erase(it);
-  NotifyObservers();
+  NotifyObservers(is_for_default_engine);
 }
 
 std::string AdBlockFiltersProviderManager::GetNameForDebugging() {
   return "AdBlockCustomFiltersProvider";
 }
 
-void AdBlockFiltersProviderManager::OnChanged() {
-  NotifyObservers();
+void AdBlockFiltersProviderManager::OnChanged(bool is_for_default_engine) {
+  NotifyObservers(is_for_default_engine);
 }
 
 // Use LoadDATBufferForEngine instead, for Filter Provider Manager.

--- a/components/brave_shields/browser/ad_block_filters_provider_manager.h
+++ b/components/brave_shields/browser/ad_block_filters_provider_manager.h
@@ -51,7 +51,7 @@ class AdBlockFiltersProviderManager : public AdBlockFiltersProvider,
                               const DATFileDataBuffer& dat_buf)> cb);
 
   // AdBlockFiltersProvider::Observer
-  void OnChanged() override;
+  void OnChanged(bool is_default_engine) override;
 
   void AddProvider(AdBlockFiltersProvider* provider,
                    bool is_for_default_engine);

--- a/components/brave_shields/browser/ad_block_localhost_filters_provider.cc
+++ b/components/brave_shields/browser/ad_block_localhost_filters_provider.cc
@@ -50,7 +50,7 @@ void AdBlockLocalhostFiltersProvider::LoadDATBuffer(
 void AdBlockLocalhostFiltersProvider::AddObserver(
     AdBlockFiltersProvider::Observer* observer) {
   AdBlockFiltersProvider::AddObserver(observer);
-  NotifyObservers();
+  NotifyObservers(engine_is_default_);
 }
 
 }  // namespace brave_shields

--- a/components/brave_shields/browser/ad_block_service.cc
+++ b/components/brave_shields/browser/ad_block_service.cc
@@ -96,7 +96,11 @@ AdBlockService::SourceProviderObserver::~SourceProviderObserver() {
   resource_provider_->RemoveObserver(this);
 }
 
-void AdBlockService::SourceProviderObserver::OnChanged() {
+void AdBlockService::SourceProviderObserver::OnChanged(bool is_default_engine) {
+  if (adblock_engine_->IsDefaultEngine() != is_default_engine) {
+    // Skip updates of another engine.
+    return;
+  }
   if (is_filter_provider_manager_) {
     static_cast<AdBlockFiltersProviderManager*>(filters_provider_.get())
         ->LoadDATBufferForEngine(

--- a/components/brave_shields/browser/ad_block_service.h
+++ b/components/brave_shields/browser/ad_block_service.h
@@ -70,7 +70,7 @@ class AdBlockService {
     void OnDATLoaded(bool deserialize, const DATFileDataBuffer& dat_buf);
 
     // AdBlockFiltersProvider::Observer
-    void OnChanged() override;
+    void OnChanged(bool is_default_engine) override;
 
     // AdBlockResourceProvider::Observer
     void OnResourcesLoaded(const std::string& resources_json) override;

--- a/components/brave_shields/browser/ad_block_subscription_filters_provider.cc
+++ b/components/brave_shields/browser/ad_block_subscription_filters_provider.cc
@@ -51,7 +51,7 @@ void AdBlockSubscriptionFiltersProvider::OnDATFileDataReady(
 }
 
 void AdBlockSubscriptionFiltersProvider::OnListAvailable() {
-  NotifyObservers();
+  NotifyObservers(engine_is_default_);
 }
 
 }  // namespace brave_shields


### PR DESCRIPTION
Uplift of #20585
Resolves https://github.com/brave/brave-browser/issues/33718
Resolves https://github.com/brave/brave-browser/issues/33532

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.