### PR TITLE
Fixes [ads] next payment token redemption date is not persisted across browser launches (uplift to 1.60.x)

### DIFF
--- a/components/brave_ads/core/internal/account/utility/redeem_payment_tokens/redeem_payment_tokens.cc
+++ b/components/brave_ads/core/internal/account/utility/redeem_payment_tokens/redeem_payment_tokens.cc
@@ -46,6 +46,7 @@ void RedeemPaymentTokens::MaybeRedeemAfterDelay(const WalletInfo& wallet) {
   const base::Time redeem_at = timer_.Start(
       FROM_HERE, CalculateDelayBeforeRedeemingTokens(),
       base::BindOnce(&RedeemPaymentTokens::Redeem, base::Unretained(this)));
+  SetNextTokenRedemptionAt(redeem_at);
 
   BLOG(1, "Redeem payment tokens " << FriendlyDateAndTime(redeem_at));
 }


### PR DESCRIPTION
Uplift of #20609
Resolves https://github.com/brave/brave-browser/issues/33756

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.