### PR TITLE
Remove cross-origin .onion origins from location.ancestorOrigins

### DIFF
--- a/chromium_src/third_party/blink/renderer/core/frame/location.cc
+++ b/chromium_src/third_party/blink/renderer/core/frame/location.cc
@@ -1,0 +1,39 @@
+/* Copyright (c) 2023 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "third_party/blink/renderer/core/frame/location.h"
+
+#define ancestorOrigins ancestorOrigins_ChromiumImpl
+#include "src/third_party/blink/renderer/core/frame/location.cc"
+#undef ancestorOrigins
+
+namespace blink {
+
+DOMStringList* Location::ancestorOrigins() const {
+  auto* filtered_origins = MakeGarbageCollected<DOMStringList>();
+  const auto* innermost_origin =
+      DomWindow()->GetFrame()->GetSecurityContext()->GetSecurityOrigin();
+
+  auto is_onion_service = [](const SecurityOrigin* origin) {
+    return origin->Host().EndsWith(".onion", kTextCaseASCIIInsensitive);
+  };
+
+  auto* raw_origins = ancestorOrigins_ChromiumImpl();
+  for (uint32_t i = 0; i < raw_origins->length(); ++i) {
+    const String raw_origin = raw_origins->item(i);
+    const scoped_refptr<SecurityOrigin> origin =
+        SecurityOrigin::CreateFromString(raw_origin);
+    if (is_onion_service(origin.get()) &&
+        !origin->IsSameOriginWith(innermost_origin)) {
+      filtered_origins->Append("\"null\"");
+    } else {
+      filtered_origins->Append(raw_origin);
+    }
+  }
+
+  return filtered_origins;
+}
+
+}  // namespace blink

--- a/chromium_src/third_party/blink/renderer/core/frame/location.h
+++ b/chromium_src/third_party/blink/renderer/core/frame/location.h
@@ -1,0 +1,17 @@
+/* Copyright (c) 2023 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_CHROMIUM_SRC_THIRD_PARTY_BLINK_RENDERER_CORE_FRAME_LOCATION_H_
+#define BRAVE_CHROMIUM_SRC_THIRD_PARTY_BLINK_RENDERER_CORE_FRAME_LOCATION_H_
+
+#define ancestorOrigins()               \
+  ancestorOrigins_ChromiumImpl() const; \
+  DOMStringList* ancestorOrigins()
+
+#include "src/third_party/blink/renderer/core/frame/location.h"  // IWYU pragma: export
+
+#undef ancestorOrigins
+
+#endif  // BRAVE_CHROMIUM_SRC_THIRD_PARTY_BLINK_RENDERER_CORE_FRAME_LOCATION_H_

--- a/test/data/iframe_load.html
+++ b/test/data/iframe_load.html
@@ -1,0 +1,13 @@
+<html><head><title>iframe test</title></head>
+<body>
+<iframe src="about:blank" id="test"></iframe>
+<script>
+function requestedUrl() {
+    const urlParams = new URLSearchParams(window.location.search);
+    const url = urlParams.get('url');
+    return atob(url);
+}
+var iframe = document.getElementById("test");
+iframe.src = requestedUrl();
+</script>
+</body></html>

--- a/test/data/reflect-referrer.html
+++ b/test/data/reflect-referrer.html
@@ -1,9 +1,21 @@
 <html>
 <body>
 <p>Referrer (JS): <code id="referrer"></code></p>
+<p>AncestorOrigins (JS): <code id="ancestors"></code></p>
 <script>
+
+function getAncestors() {
+  let a = "";
+  for (origin of document.location.ancestorOrigins) {
+    a += '[' + origin + ']';
+  }
+  return a;
+}
+
 var referrer = document.getElementById("referrer");
 referrer.innerText = document.referrer;
+var ancestors = document.getElementById("ancestors");
+ancestors.innerText = getAncestors();
 </script>
 </body>
 </html>


### PR DESCRIPTION
Fixes brave/brave-browser#32421
Sec review: https://github.com/brave/reviews/issues/1436

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [x] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
1. Open <http://ixrdj3iwwhkuau5tby5jh3a536a2rdhpbdbu6ldhng43r47kim7a3lid.onion/referrer/onion.html> in a Tor window.
2. Look at the **iframe** _Sub-resources_ test cases only.
3. The _Same-origin_ iframes should show:
   - `AncestorOrigins (JS): [http://ixrdj3iwwhkuau5tby5jh3a536a2rdhpbdbu6ldhng43r47kim7a3lid.onion]` (single iframe)
   - `AncestorOrigins (JS): [http://ixrdj3iwwhkuau5tby5jh3a536a2rdhpbdbu6ldhng43r47kim7a3lid.onion][http://ixrdj3iwwhkuau5tby5jh3a536a2rdhpbdbu6ldhng43r47kim7a3lid.onion][http://ixrdj3iwwhkuau5tby5jh3a536a2rdhpbdbu6ldhng43r47kim7a3lid.onion][http://ixrdj3iwwhkuau5tby5jh3a536a2rdhpbdbu6ldhng43r47kim7a3lid.onion]` (**blue** innermost iframe)
![Screenshot from 2023-10-20 14-15-46](https://github.com/brave/brave-core/assets/167821/ff6f2b1c-62cd-481c-9047-8ec3f5fcbef1)
4. The _Cross-origin_ iframes should show:
   - `AncestorOrigins (JS): ["null"]` (single iframe)
   - `AncestorOrigins=[https://fmarier.com]["null"]["null"]` (**red** middle iframe)
   - `AncestorOrigins (JS): [https://fmarier.com][https://fmarier.com][http://ixrdj3iwwhkuau5tby5jh3a536a2rdhpbdbu6ldhng43r47kim7a3lid.onion][http://ixrdj3iwwhkuau5tby5jh3a536a2rdhpbdbu6ldhng43r47kim7a3lid.onion]` (**blue** innermost iframe)
![Screenshot from 2023-10-20 14-16-03](https://github.com/brave/brave-core/assets/167821/e5f29141-eb64-417c-a9a5-0b39e10b2930)
