### PR TITLE
Make NTP SI kCountsResetTimeDelay configurable via griffin/feature (uplift to 1.60.x)

### DIFF
--- a/components/ntp_background_images/browser/features.h
+++ b/components/ntp_background_images/browser/features.h
@@ -26,6 +26,10 @@ constexpr base::FeatureParam<int> kInitialCountToBrandedWallpaper{
 constexpr base::FeatureParam<int> kCountToBrandedWallpaper{
     &kBraveNTPBrandedWallpaper, "count_to_branded_wallpaper", 2};
 
+// Reset counter when a specific amount of time has elapsed in SI mode.
+constexpr base::FeatureParam<base::TimeDelta> kResetCounterAfter{
+    &kBraveNTPBrandedWallpaper, "reset_counter_after", base::Days(1)};
+
 }  // namespace features
 }  // namespace ntp_background_images
 

--- a/components/ntp_background_images/browser/view_counter_model.cc
+++ b/components/ntp_background_images/browser/view_counter_model.cc
@@ -4,23 +4,15 @@
 // you can obtain one at http://mozilla.org/MPL/2.0/.
 
 #include "brave/components/ntp_background_images/browser/view_counter_model.h"
+
 #include <algorithm>
 
 #include "base/check.h"
-#include "base/logging.h"
 #include "base/rand_util.h"
-#include "base/time/time.h"
 #include "brave/components/ntp_background_images/browser/features.h"
-#include "brave/components/ntp_background_images/common/pref_names.h"
 #include "components/prefs/pref_service.h"
 
 namespace ntp_background_images {
-
-namespace {
-
-constexpr base::TimeDelta kCountsResetTimeDelay = base::Days(1);
-
-}  // namespace
 
 ViewCounterModel::ViewCounterModel(PrefService* prefs) : prefs_(prefs) {
   CHECK(prefs);
@@ -30,7 +22,7 @@ ViewCounterModel::ViewCounterModel(PrefService* prefs) : prefs_(prefs) {
   count_to_branded_wallpaper_ = features::kInitialCountToBrandedWallpaper.Get();
 
   // We also reset when a specific amount of time is elapsed when in SI mode
-  timer_counts_reset_.Start(FROM_HERE, kCountsResetTimeDelay, this,
+  timer_counts_reset_.Start(FROM_HERE, features::kResetCounterAfter.Get(), this,
                             &ViewCounterModel::OnTimerCountsResetExpired);
 }
 

--- a/components/ntp_background_images/browser/view_counter_model_unittest.cc
+++ b/components/ntp_background_images/browser/view_counter_model_unittest.cc
@@ -8,7 +8,6 @@
 #include "base/time/time.h"
 #include "brave/components/ntp_background_images/browser/features.h"
 #include "brave/components/ntp_background_images/browser/view_counter_service.h"
-#include "brave/components/ntp_background_images/common/pref_names.h"
 #include "components/sync_preferences/testing_pref_service_syncable.h"
 #include "content/public/test/browser_task_environment.h"
 #include "testing/gtest/include/gtest/gtest.h"
@@ -173,7 +172,7 @@ TEST_F(ViewCounterModelTest, NTPSponsoredImagesCountResetTimerTest) {
   model.RegisterPageView();
   EXPECT_FALSE(model.ShouldShowBrandedWallpaper());
   EXPECT_EQ(model.count_to_branded_wallpaper_, 3);
-  task_environment_.FastForwardBy(base::Days(1));
+  task_environment_.FastForwardBy(features::kResetCounterAfter.Get());
   EXPECT_EQ(model.count_to_branded_wallpaper_, 1);
 }
 


### PR DESCRIPTION
Uplift of #20628
Resolves https://github.com/brave/brave-browser/issues/33571

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.