### PR TITLE
[1.60.x] Uplift AI Chat: feature flag is enabled by default for desktop (#20559)

### DIFF
--- a/browser/ui/views/page_action/brave_page_action_icon_container_view.cc
+++ b/browser/ui/views/page_action/brave_page_action_icon_container_view.cc
@@ -5,6 +5,7 @@
 
 #include "brave/browser/ui/views/page_action/brave_page_action_icon_container_view.h"
 
+#include "base/check_is_test.h"
 #include "brave/browser/ui/page_action/brave_page_action_icon_type.h"
 #include "brave/components/playlist/common/features.h"
 #include "chrome/browser/profiles/profile.h"
@@ -15,9 +16,18 @@
 namespace {
 
 PageActionIconParams& ModifyIconParamsForBrave(PageActionIconParams& params) {
+  if (!base::FeatureList::IsEnabled(playlist::features::kPlaylist)) {
+    return params;
+  }
+
+  if (!params.browser) {
+    // Browser could be null if the location bar was created for
+    // PresentationReceiverWindowView.
+    return params;
+  }
+
   // Add actions for Brave
-  if (base::FeatureList::IsEnabled(playlist::features::kPlaylist) &&
-      params.browser->is_type_normal() &&
+  if (params.browser->is_type_normal() &&
       !params.browser->profile()->IsOffTheRecord()) {
     // Insert Playlist action before sharing hub or at the end of the vector.
     params.types_enabled.insert(

--- a/browser/ui/views/playlist/playlist_action_icon_view.cc
+++ b/browser/ui/views/playlist/playlist_action_icon_view.cc
@@ -47,7 +47,7 @@ void PlaylistActionIconView::ShowPlaylistBubble() {
     return;
   }
 
-  auto* playlist_tab_helper = this->playlist_tab_helper();
+  auto* playlist_tab_helper = GetPlaylistTabHelper();
   if (!playlist_tab_helper || playlist_tab_helper->is_adding_items()) {
     return;
   }
@@ -94,7 +94,7 @@ void PlaylistActionIconView::UpdateImpl() {
   }
   playlist_tab_helper_observation_.Reset();
 
-  auto* playlist_tab_helper = this->playlist_tab_helper();
+  auto* playlist_tab_helper = GetPlaylistTabHelper();
   if (!playlist_tab_helper) {
     UpdateState(/* has_saved= */ false, /* found_items= */ false);
     return;
@@ -112,18 +112,30 @@ void PlaylistActionIconView::PlaylistTabHelperWillBeDestroyed() {
 
 void PlaylistActionIconView::OnSavedItemsChanged(
     const std::vector<playlist::mojom::PlaylistItemPtr>& saved_items) {
-  auto* playlist_tab_helper = this->playlist_tab_helper();
-  CHECK(playlist_tab_helper);
+  auto* playlist_tab_helper = GetPlaylistTabHelper();
+  if (!playlist_tab_helper) {
+    return;
+  }
 
   UpdateState(saved_items.size(), playlist_tab_helper->found_items().size());
 }
 
 void PlaylistActionIconView::OnFoundItemsChanged(
     const std::vector<playlist::mojom::PlaylistItemPtr>& found_items) {
-  auto* playlist_tab_helper = this->playlist_tab_helper();
-  CHECK(playlist_tab_helper);
+  auto* playlist_tab_helper = GetPlaylistTabHelper();
+  if (!playlist_tab_helper) {
+    return;
+  }
 
   UpdateState(playlist_tab_helper->saved_items().size(), found_items.size());
+}
+
+playlist::PlaylistTabHelper* PlaylistActionIconView::GetPlaylistTabHelper() {
+  if (auto* contents = GetWebContents()) {
+    return playlist::PlaylistTabHelper::FromWebContents(contents);
+  }
+
+  return nullptr;
 }
 
 void PlaylistActionIconView::UpdateState(bool has_saved, bool found_items) {

--- a/browser/ui/views/playlist/playlist_action_icon_view.h
+++ b/browser/ui/views/playlist/playlist_action_icon_view.h
@@ -42,9 +42,7 @@ class PlaylistActionIconView : public PageActionIconView,
  private:
   enum class State { kNone, kAdded, kFound };
 
-  playlist::PlaylistTabHelper* playlist_tab_helper() {
-    return playlist::PlaylistTabHelper::FromWebContents(GetWebContents());
-  }
+  playlist::PlaylistTabHelper* GetPlaylistTabHelper();
 
   void UpdateState(bool has_saved, bool found_items);
   void UpdateVisibilityPerState();

--- a/components/ai_chat/common/buildflags/BUILD.gn
+++ b/components/ai_chat/common/buildflags/BUILD.gn
@@ -11,7 +11,9 @@ buildflag_header("buildflags") {
   header = "buildflags.h"
   flags = [ "ENABLE_AI_CHAT=$enable_ai_chat" ]
 
-  if (is_android &&
+  # Enable for desktop (all channels) and android (only dev and
+  # nightly channels).
+  if (!is_android ||
       (brave_channel == "nightly" || brave_channel == "development")) {
     flags += [ "ENABLE_AI_CHAT_FEATURE_FLAG=true" ]
   } else {

--- a/components/ai_chat/common/features.cc
+++ b/components/ai_chat/common/features.cc
@@ -15,8 +15,7 @@ namespace ai_chat::features {
 
 BASE_FEATURE(kAIChat,
              "AIChat",
-// Enable the feature flag on Android dev and nightly channels
-#if BUILDFLAG(IS_ANDROID) && BUILDFLAG(ENABLE_AI_CHAT_FEATURE_FLAG)
+#if BUILDFLAG(ENABLE_AI_CHAT_FEATURE_FLAG)
              base::FEATURE_ENABLED_BY_DEFAULT
 #else
              base::FEATURE_DISABLED_BY_DEFAULT


### PR DESCRIPTION
Uplift  to 1.60.x:
- https://github.com/brave/brave-browser/issues/33674
  -  https://github.com/brave/brave-core/pull/20559 to 1.60.x

Also needed to uplift this as it fixes the tests. This is marked `QA/No`:
- https://github.com/brave/brave-browser/issues/33561
  - https://github.com/brave/brave-core/pull/20501 as it fixes the tests. This is marked `QA/No`.

This is dependent on:
- https://github.com/brave/brave-core/pull/20646