### PR TITLE
Reduce the window drag area at the top of inactive tabs (uplift to 1.60.x)

### DIFF
--- a/browser/ui/tabs/brave_tab_style.h
+++ b/browser/ui/tabs/brave_tab_style.h
@@ -52,6 +52,16 @@ class BraveTabStyle : public TabStyleBase {
     }
     return GetLayoutConstant(TAB_HEIGHT) + brave_tabs::kHorizontalTabInset * 2;
   }
+
+  int GetDragHandleExtension(int height) const override {
+    if (!tabs::features::HorizontalTabsUpdateEnabled()) {
+      return TabStyleBase::GetDragHandleExtension(height);
+    }
+    // The "drag handle extension" is the amount of space in DIP at the top of
+    // inactive tabs where mouse clicks are treated as clicks in the "caption"
+    // area, i.e. the draggable part of the window frame.
+    return 4;
+  }
 };
 
 #endif  // BRAVE_BROWSER_UI_TABS_BRAVE_TAB_STYLE_H_


### PR DESCRIPTION
Uplift of #20651
Resolves https://github.com/brave/brave-browser/issues/33844

Pre-approval checklist: 
- [ ] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [ ] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [ ] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [ ] The associated issue milestone is set to the smallest version that the changes is landed on.