### PR TITLE
fix(wallet): Confirm Transaction Panel Styles

### DIFF
--- a/components/brave_wallet_ui/components/extension/confirm-transaction-panel/common/footer.tsx
+++ b/components/brave_wallet_ui/components/extension/confirm-transaction-panel/common/footer.tsx
@@ -87,6 +87,7 @@ export function Footer (props: Props) {
           }
           onSubmit={onReject}
           disabled={transactionConfirmed}
+          minWidth='45%'
         />
         {transactionConfirmed ? (
           <ConfirmingButton>
@@ -101,6 +102,7 @@ export function Footer (props: Props) {
             text={getLocale('braveWalletAllowSpendConfirmButton')}
             onSubmit={onClickConfirmTransaction}
             disabled={isConfirmButtonDisabled}
+            minWidth='45%'
           />
         )}
       </ButtonRow>

--- a/components/brave_wallet_ui/components/extension/confirm-transaction-panel/common/style.tsx
+++ b/components/brave_wallet_ui/components/extension/confirm-transaction-panel/common/style.tsx
@@ -13,6 +13,7 @@ export const FooterContainer = styled.div`
   flex-direction: column;
   align-items: center;
   margin-top: 12px;
+  width: 90%;
 `
 
 export const QueueStepRow = styled.div`

--- a/components/brave_wallet_ui/components/extension/confirm-transaction-panel/confirm-bitcoin-transaction-panel.tsx
+++ b/components/brave_wallet_ui/components/extension/confirm-transaction-panel/confirm-bitcoin-transaction-panel.tsx
@@ -166,7 +166,6 @@ export const ConfirmBitcoinTransactionPanel = () => {
 
       <MessageBox
         isDetails={selectedTab === 'details'}
-        isApprove={false}
       >
 
         {selectedTab === 'transaction'

--- a/components/brave_wallet_ui/components/extension/confirm-transaction-panel/confirm-solana-transaction-panel.tsx
+++ b/components/brave_wallet_ui/components/extension/confirm-transaction-panel/confirm-solana-transaction-panel.tsx
@@ -203,7 +203,6 @@ export const ConfirmSolanaTransactionPanel = () => {
 
       <MessageBox
         isDetails={selectedTab === 'details'}
-        isApprove={false}
       >
 
         {selectedTab === 'transaction'

--- a/components/brave_wallet_ui/components/extension/confirm-transaction-panel/confirm-transaction-panel.tsx
+++ b/components/brave_wallet_ui/components/extension/confirm-transaction-panel/confirm-transaction-panel.tsx
@@ -197,20 +197,6 @@ export const ConfirmTransactionPanel = () => {
     <StyledWrapper>
       <TopRow>
         <NetworkText>{transactionsNetwork?.chainName ?? ''}</NetworkText>
-        {isERC20Approve && (
-          <AddressAndOrb>
-            <Tooltip
-              text={transactionDetails.recipient}
-              isAddress={true}
-              position={'right'}
-            >
-              <AddressText>
-                {reduceAddress(transactionDetails.recipient)}
-              </AddressText>
-            </Tooltip>
-            <AccountCircle orb={toOrb} />
-          </AddressAndOrb>
-        )}
 
         <TransactionQueueSteps
           queueNextTransaction={queueNextTransaction}
@@ -228,6 +214,18 @@ export const ConfirmTransactionPanel = () => {
               foundTokenInfoByContractAddress?.symbol ?? ''
             )}
           </PanelTitle>
+          <AddressAndOrb>
+            <Tooltip
+              text={transactionDetails.recipient}
+              isAddress={true}
+              position={'right'}
+            >
+              <AddressText>
+                {reduceAddress(transactionDetails.recipient)}
+              </AddressText>
+            </Tooltip>
+            <AccountCircle orb={toOrb} />
+          </AddressAndOrb>
           <Description>
             {getLocale('braveWalletAllowSpendDescription').replace(
               '$1',
@@ -362,7 +360,6 @@ export const ConfirmTransactionPanel = () => {
 
       <MessageBox
         isDetails={selectedTab === 'details'}
-        isApprove={isERC20Approve}
       >
         {selectedTab === 'transaction' ? (
           <>

--- a/components/brave_wallet_ui/components/extension/confirm-transaction-panel/confirm_zcash_transaction_panel.tsx
+++ b/components/brave_wallet_ui/components/extension/confirm-transaction-panel/confirm_zcash_transaction_panel.tsx
@@ -167,7 +167,6 @@ export const ConfirmZCashTransactionPanel = () => {
 
       <MessageBox
         isDetails={selectedTab === 'details'}
-        isApprove={false}
       >
 
         {selectedTab === 'transaction'

--- a/components/brave_wallet_ui/components/extension/confirm-transaction-panel/style.ts
+++ b/components/brave_wallet_ui/components/extension/confirm-transaction-panel/style.ts
@@ -100,7 +100,7 @@ export const TransactionFiatAmountBig = styled.span`
   margin-bottom: 10px;
 `
 
-export const MessageBox = styled.div<{ isApprove: boolean, isDetails: boolean }>`
+export const MessageBox = styled.div<{ isDetails: boolean }>`
   display: flex;
   align-items: flex-start;
   justify-content: 'flex-start';
@@ -108,10 +108,9 @@ export const MessageBox = styled.div<{ isApprove: boolean, isDetails: boolean }>
   border: 1px solid ${(p) => p.theme.color.divider01};
   box-sizing: border-box;
   border-radius: 4px;
-  width: 255px;
-  height: ${(p) => p.isApprove ? '120px' : '140px'};
+  width: 90%;
+  height: 140px;
   padding: ${(p) => p.isDetails ? '14px' : '4px 14px'};
-  margin-bottom: 14px;
   overflow-y: scroll;
   overflow-x: hidden;
   position: relative;

--- a/components/brave_wallet_ui/components/extension/edit-allowance/style.ts
+++ b/components/brave_wallet_ui/components/extension/edit-allowance/style.ts
@@ -70,7 +70,7 @@ export const ButtonRow = styled.div`
 `
 
 export const Description = styled.span`
-  width: 275px;
+  width: 100%;
   font-family: Poppins;
   font-size: 12px;
   line-height: 18px;
@@ -81,7 +81,7 @@ export const Description = styled.span`
 
 export const AllowanceOption = styled.div`
   display: block;
-  width: 239px;
+  width: 90%;
 `
 
 export const AllowanceTitle = styled.div`

--- a/components/brave_wallet_ui/components/extension/edit-gas/edit-gas.styles.ts
+++ b/components/brave_wallet_ui/components/extension/edit-gas/edit-gas.styles.ts
@@ -91,7 +91,7 @@ export const ButtonRow = styled.div`
 `
 
 export const Description = styled.span`
-  width: 275px;
+  width: 100%;
   font-family: Poppins;
   font-size: 12px;
   line-height: 18px;

--- a/components/brave_wallet_ui/components/extension/panel-header/style.ts
+++ b/components/brave_wallet_ui/components/extension/panel-header/style.ts
@@ -27,7 +27,6 @@ export const HeaderWrapper = styled.div<StyleProps>`
   justify-content: center;
   border-bottom: ${(p) => `1px solid ${p.theme.color.divider01}`};
   padding: 0px 12px;
-  max-width: 300px;
   margin-bottom: ${(p) => p.hasSearch ? '0px' : '8px'};
 `
 

--- a/components/brave_wallet_ui/components/extension/shared-panel-styles.ts
+++ b/components/brave_wallet_ui/components/extension/shared-panel-styles.ts
@@ -86,7 +86,7 @@ export const PanelTitle = styled.span`
 `
 
 export const Description = styled.span`
-  width: 275px;
+  width: 90%;
   font-family: Poppins;
   font-size: 12px;
   line-height: 18px;
@@ -94,7 +94,6 @@ export const Description = styled.span`
   text-align: center;
   color: ${(p) => p.theme.color.text02};
   margin-bottom: 12px;
-  width: 60%;
 `
 
 export const TabRow = styled.div`
@@ -102,7 +101,7 @@ export const TabRow = styled.div`
   align-items: flex-end;
   justify-content: center;
   flex-direction: row;
-  width: 255px;
+  width: 90%;
   margin-bottom: 10px;
 `
 
@@ -152,7 +151,7 @@ export const WarningBox = styled.div<Partial<StyleProps>>`
   flex-direction: column;
   box-sizing: border-box;
   border-radius: 4px;
-  width: 255px;
+  width: 90%;
   padding: 10px;
   margin-bottom: 14px;
   background-color: ${(p) =>

--- a/components/brave_wallet_ui/panel/container.tsx
+++ b/components/brave_wallet_ui/panel/container.tsx
@@ -437,7 +437,7 @@ function Container () {
 
   if (selectedPendingTransaction) {
     return (
-      <PanelWrapper isLonger={true}>
+      <PanelWrapper width={390} height={650}>
         <LongWrapper>
           {isBitcoinTransaction(selectedPendingTransaction) && (
             <ConfirmBitcoinTransactionPanel />


### PR DESCRIPTION
## Description 
Increases the size of the `Confirm Transaction Panel` and addresses some styling bugs.

<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves <https://github.com/brave/brave-browser/issues/32996>

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

1. Go to the `Swap` page and create a `Swap` transaction with a token that doesn't have an `Approve Spend` yet.
2. Everything should be visible and nothing should be squished.

Before:

![Screenshot 9](https://github.com/brave/brave-browser/assets/40611140/55837611-5f75-4111-8f73-fb6d21c83884)

After:

![Screenshot 30](https://github.com/brave/brave-core/assets/40611140/9f32a20c-c778-46af-b162-b374d005601e)
