### PR TITLE
Remove padding and rounded corners in fullscreen video mode

### DIFF
--- a/browser/ui/views/frame/brave_browser_view.h
+++ b/browser/ui/views/frame/brave_browser_view.h
@@ -132,6 +132,8 @@ class BraveBrowserView : public BrowserView,
       Browser::DownloadCloseType dialog_type,
       base::OnceCallback<void(bool)> callback) override;
   void MaybeShowReadingListInSidePanelIPH() override;
+  void FullscreenStateChanging() override;
+  void FullscreenStateChanged() override;
   void UpdateDevToolsForContents(content::WebContents* web_contents,
                                  bool update_devtools_web_contents) override;
   void OnWidgetActivationChanged(views::Widget* widget, bool active) override;

--- a/browser/ui/views/frame/brave_browser_view_layout.cc
+++ b/browser/ui/views/frame/brave_browser_view_layout.cc
@@ -14,6 +14,8 @@
 #include "brave/browser/ui/views/tabs/vertical_tab_utils.h"
 #include "chrome/browser/profiles/profile.h"
 #include "chrome/browser/ui/browser.h"
+#include "chrome/browser/ui/exclusive_access/exclusive_access_manager.h"
+#include "chrome/browser/ui/exclusive_access/fullscreen_controller.h"
 #include "chrome/browser/ui/views/bookmarks/bookmark_bar_view.h"
 #include "chrome/browser/ui/views/frame/browser_view.h"
 #include "chrome/browser/ui/views/frame/browser_view_layout_delegate.h"
@@ -260,6 +262,10 @@ gfx::Insets BraveBrowserViewLayout::GetContentsMargins() const {
     return {};
   }
 
+  if (IsFullscreenForTab()) {
+    return {};
+  }
+
   gfx::Insets margins(BraveContentsViewUtil::kMarginThickness);
 
   // If there is a visible view above the contents container, then there is no
@@ -276,6 +282,17 @@ gfx::Insets BraveBrowserViewLayout::GetContentsMargins() const {
 
 bool BraveBrowserViewLayout::IsReaderModeToolbarVisible() const {
   return reader_mode_toolbar_ && reader_mode_toolbar_->GetVisible();
+}
+
+bool BraveBrowserViewLayout::IsFullscreenForTab() const {
+  auto* exclusive_access_manager = browser_view_->GetExclusiveAccessManager();
+  if (!exclusive_access_manager) {
+    return false;
+  }
+  auto* fullscreen_controller =
+      exclusive_access_manager->fullscreen_controller();
+  return fullscreen_controller &&
+         fullscreen_controller->IsWindowFullscreenForTabOrPending();
 }
 
 bool BraveBrowserViewLayout::ShouldPushBookmarkBarForVerticalTabs() {

--- a/browser/ui/views/frame/brave_browser_view_layout.h
+++ b/browser/ui/views/frame/brave_browser_view_layout.h
@@ -55,6 +55,7 @@ class BraveBrowserViewLayout : public BrowserViewLayout {
   void LayoutReaderModeToolbar(gfx::Rect& contents_bounds);
   gfx::Insets GetContentsMargins() const;
   bool IsReaderModeToolbarVisible() const;
+  bool IsFullscreenForTab() const;
   bool ShouldPushBookmarkBarForVerticalTabs();
   gfx::Insets GetInsetsConsideringVerticalTabHost();
 

--- a/chromium_src/chrome/browser/ui/views/frame/browser_view.h
+++ b/chromium_src/chrome/browser/ui/views/frame/browser_view.h
@@ -24,6 +24,8 @@
   virtual MaybeShowReadingListInSidePanelIPH
 
 #define UpdateDevToolsForContents virtual UpdateDevToolsForContents
+#define FullscreenStateChanging virtual FullscreenStateChanging
+#define FullscreenStateChanged virtual FullscreenStateChanged
 #define GetTabStripVisible virtual GetTabStripVisible
 
 #define GetTabSearchBubbleHost     \
@@ -48,12 +50,14 @@
 #endif
 
 #undef GetTabSearchBubbleHost
-#undef BrowserViewLayout
-#undef UpdateDevToolsForContents
 #undef GetTabStripVisible
-#undef BrowserViewLayoutDelegateImpl
-#undef BrowserWindow
+#undef FullscreenStateChanged
+#undef FullscreenStateChanging
+#undef UpdateDevToolsForContents
 #undef MaybeShowReadingListInSidePanelIPH
 #undef SidePanel
+#undef BrowserViewLayout
+#undef BrowserWindow
+#undef BrowserViewLayoutDelegateImpl
 
 #endif  // BRAVE_CHROMIUM_SRC_CHROME_BROWSER_UI_VIEWS_FRAME_BROWSER_VIEW_H_


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/33879

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [ ] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

* Enable the feature flag `#brave-web-view-rounded-corners` and restart.
* Visit a page containing a video player (e.g. some page on YouTube.
* Expand the video to fullscreen.
* Verify that the video occupies the full screen.

*This change does not remove padding from undocked devtools windows.*
