### PR TITLE
Add third-party adblock extension P3A metric

### DIFF
--- a/browser/browser_context_keyed_service_factories.cc
+++ b/browser/browser_context_keyed_service_factories.cc
@@ -26,6 +26,7 @@
 #include "brave/browser/debounce/debounce_service_factory.h"
 #include "brave/browser/ephemeral_storage/ephemeral_storage_service_factory.h"
 #include "brave/browser/ethereum_remote_client/buildflags/buildflags.h"
+#include "brave/browser/misc_metrics/extension_metrics_service_factory.h"
 #include "brave/browser/misc_metrics/page_metrics_service_factory.h"
 #include "brave/browser/ntp_background/view_counter_service_factory.h"
 #include "brave/browser/permissions/permission_lifetime_manager_factory.h"
@@ -209,6 +210,7 @@ void EnsureBrowserContextKeyedServiceFactoriesBuilt() {
   if (base::FeatureList::IsEnabled(tabs::features::kBraveSharedPinnedTabs)) {
     SharedPinnedTabServiceFactory::GetInstance();
   }
+  misc_metrics::ExtensionMetricsServiceFactory::GetInstance();
 #endif
 
 #if defined(TOOLKIT_VIEWS)

--- a/browser/misc_metrics/BUILD.gn
+++ b/browser/misc_metrics/BUILD.gn
@@ -12,6 +12,10 @@ source_set("unit_tests") {
     "uptime_monitor_unittest.cc",
   ]
 
+  if (!is_android) {
+    sources += [ "extension_metrics_service_unittest.cc" ]
+  }
+
   deps = [
     "//base",
     "//base/test:test_support",

--- a/browser/misc_metrics/extension_metrics_service.cc
+++ b/browser/misc_metrics/extension_metrics_service.cc
@@ -1,0 +1,87 @@
+/* Copyright (c) 2023 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "brave/browser/misc_metrics/extension_metrics_service.h"
+
+#include "base/containers/fixed_flat_set.h"
+#include "base/metrics/histogram_macros.h"
+#include "extensions/browser/extension_registry.h"
+
+namespace misc_metrics {
+
+namespace {
+
+constexpr auto kPopularAdBlockExtensions =
+    base::MakeFixedFlatSet<std::string_view>({
+        // uBO
+        "cjpalhdlnbpafiamejdnhcphjbkeiagm",
+        // Ghostery
+        "mlomiejdfkolichcflejclcbmpeaniij",
+        // AdGuard
+        "bgnkhhnnamicmpeenaelnjfhikgbkllg",
+        // AdBlocker Ultimate
+        "ohahllgiabjaoigichmmfljhkcfikeof",
+    });
+constexpr base::TimeDelta kReportDebounceTime = base::Seconds(10);
+
+}  // namespace
+
+constexpr char kAdblockExtensionsHistogramName[] = "Brave.Extensions.AdBlock";
+
+ExtensionMetricsService::ExtensionMetricsService(
+    extensions::ExtensionRegistry* extension_registry)
+    : extension_registry_(extension_registry), observation_(this) {
+  CHECK(extension_registry);
+  for (const auto& extension : extension_registry_->enabled_extensions()) {
+    OnExtensionLoaded(extension_registry_->browser_context(), extension.get());
+  }
+  if (extension_registry) {
+    observation_.Observe(extension_registry);
+  }
+  ScheduleAdBlockMetricReport();
+}
+
+ExtensionMetricsService::~ExtensionMetricsService() = default;
+
+void ExtensionMetricsService::Shutdown() {
+  report_debounce_timer_.Stop();
+  if (extension_registry_) {
+    observation_.Reset();
+    extension_registry_ = nullptr;
+  }
+}
+
+void ExtensionMetricsService::OnExtensionLoaded(
+    content::BrowserContext* browser_context,
+    const extensions::Extension* extension) {
+  if (kPopularAdBlockExtensions.contains(extension->id())) {
+    adblock_extensions_loaded_.insert(extension->id());
+    ScheduleAdBlockMetricReport();
+  }
+}
+
+void ExtensionMetricsService::OnExtensionUninstalled(
+    content::BrowserContext* browser_context,
+    const extensions::Extension* extension,
+    extensions::UninstallReason reason) {
+  if (kPopularAdBlockExtensions.contains(extension->id())) {
+    adblock_extensions_loaded_.erase(extension->id());
+    ScheduleAdBlockMetricReport();
+  }
+}
+
+void ExtensionMetricsService::ScheduleAdBlockMetricReport() {
+  report_debounce_timer_.Start(
+      FROM_HERE, kReportDebounceTime,
+      base::BindOnce(&ExtensionMetricsService::ReportAdBlockMetric,
+                     base::Unretained(this)));
+}
+
+void ExtensionMetricsService::ReportAdBlockMetric() {
+  UMA_HISTOGRAM_BOOLEAN(kAdblockExtensionsHistogramName,
+                        !adblock_extensions_loaded_.empty());
+}
+
+}  // namespace misc_metrics

--- a/browser/misc_metrics/extension_metrics_service.h
+++ b/browser/misc_metrics/extension_metrics_service.h
@@ -1,0 +1,68 @@
+/* Copyright (c) 2023 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_BROWSER_MISC_METRICS_EXTENSION_METRICS_SERVICE_H_
+#define BRAVE_BROWSER_MISC_METRICS_EXTENSION_METRICS_SERVICE_H_
+
+#include <string>
+
+#include "base/containers/flat_set.h"
+#include "base/memory/raw_ptr.h"
+#include "base/scoped_observation.h"
+#include "base/timer/timer.h"
+#include "components/keyed_service/core/keyed_service.h"
+#include "extensions/browser/extension_registry_observer.h"
+#include "extensions/browser/uninstall_reason.h"
+
+namespace content {
+class BrowserContext;
+}
+
+namespace extensions {
+class Extension;
+class ExtensionRegistry;
+}  // namespace extensions
+
+namespace misc_metrics {
+
+extern const char kAdblockExtensionsHistogramName[];
+
+// Monitors installation/uninstallation of third-party extensions
+// and reports relevant metrics via P3A.
+class ExtensionMetricsService : public KeyedService,
+                                public extensions::ExtensionRegistryObserver {
+ public:
+  explicit ExtensionMetricsService(
+      extensions::ExtensionRegistry* extension_registry);
+  ~ExtensionMetricsService() override;
+
+  ExtensionMetricsService(const ExtensionMetricsService&) = delete;
+  ExtensionMetricsService& operator=(const ExtensionMetricsService&) = delete;
+
+  void Shutdown() override;
+
+ private:
+  // extensions::ExtensionRegistryObserver:
+  void OnExtensionLoaded(content::BrowserContext* browser_context,
+                         const extensions::Extension* extension) override;
+  void OnExtensionUninstalled(content::BrowserContext* browser_context,
+                              const extensions::Extension* extension,
+                              extensions::UninstallReason reason) override;
+
+  void ScheduleAdBlockMetricReport();
+  void ReportAdBlockMetric();
+
+  base::flat_set<std::string> adblock_extensions_loaded_;
+  raw_ptr<extensions::ExtensionRegistry> extension_registry_;
+  base::ScopedObservation<extensions::ExtensionRegistry,
+                          ExtensionMetricsService>
+      observation_;
+
+  base::OneShotTimer report_debounce_timer_;
+};
+
+}  // namespace misc_metrics
+
+#endif  // BRAVE_BROWSER_MISC_METRICS_EXTENSION_METRICS_SERVICE_H_

--- a/browser/misc_metrics/extension_metrics_service_factory.cc
+++ b/browser/misc_metrics/extension_metrics_service_factory.cc
@@ -1,0 +1,53 @@
+/* Copyright (c) 2023 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "brave/browser/misc_metrics/extension_metrics_service_factory.h"
+
+#include "base/no_destructor.h"
+#include "brave/browser/misc_metrics/extension_metrics_service.h"
+#include "components/keyed_service/content/browser_context_dependency_manager.h"
+#include "extensions/browser/extension_registry_factory.h"
+
+namespace misc_metrics {
+
+// static
+ExtensionMetricsServiceFactory* ExtensionMetricsServiceFactory::GetInstance() {
+  static base::NoDestructor<ExtensionMetricsServiceFactory> instance;
+  return instance.get();
+}
+
+// static
+ExtensionMetricsService* ExtensionMetricsServiceFactory::GetServiceForContext(
+    content::BrowserContext* context) {
+  return static_cast<ExtensionMetricsService*>(
+      GetInstance()->GetServiceForBrowserContext(context, true));
+}
+
+ExtensionMetricsServiceFactory::ExtensionMetricsServiceFactory()
+    : BrowserContextKeyedServiceFactory(
+          "ExtensionMetricsService",
+          BrowserContextDependencyManager::GetInstance()) {
+  DependsOn(extensions::ExtensionRegistryFactory::GetInstance());
+}
+
+ExtensionMetricsServiceFactory::~ExtensionMetricsServiceFactory() = default;
+
+KeyedService* ExtensionMetricsServiceFactory::BuildServiceInstanceFor(
+    content::BrowserContext* context) const {
+  auto* extension_registry =
+      extensions::ExtensionRegistryFactory::GetForBrowserContext(context);
+  return new ExtensionMetricsService(extension_registry);
+}
+
+content::BrowserContext* ExtensionMetricsServiceFactory::GetBrowserContextToUse(
+    content::BrowserContext* context) const {
+  if (context->IsOffTheRecord() ||
+      !extensions::ExtensionRegistryFactory::GetForBrowserContext(context)) {
+    return nullptr;
+  }
+  return context;
+}
+
+}  // namespace misc_metrics

--- a/browser/misc_metrics/extension_metrics_service_factory.h
+++ b/browser/misc_metrics/extension_metrics_service_factory.h
@@ -1,0 +1,48 @@
+/* Copyright (c) 2023 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_BROWSER_MISC_METRICS_EXTENSION_METRICS_SERVICE_FACTORY_H_
+#define BRAVE_BROWSER_MISC_METRICS_EXTENSION_METRICS_SERVICE_FACTORY_H_
+
+#include "components/keyed_service/content/browser_context_keyed_service_factory.h"
+#include "components/keyed_service/core/keyed_service.h"
+#include "content/public/browser/browser_context.h"
+
+namespace base {
+template <typename T>
+class NoDestructor;
+}  // namespace base
+
+namespace misc_metrics {
+
+class ExtensionMetricsService;
+
+class ExtensionMetricsServiceFactory
+    : public BrowserContextKeyedServiceFactory {
+ public:
+  static ExtensionMetricsService* GetServiceForContext(
+      content::BrowserContext* context);
+  static ExtensionMetricsServiceFactory* GetInstance();
+
+ private:
+  friend base::NoDestructor<ExtensionMetricsServiceFactory>;
+
+  ExtensionMetricsServiceFactory();
+  ~ExtensionMetricsServiceFactory() override;
+
+  ExtensionMetricsServiceFactory(const ExtensionMetricsServiceFactory&) =
+      delete;
+  ExtensionMetricsServiceFactory& operator=(
+      const ExtensionMetricsServiceFactory&) = delete;
+
+  KeyedService* BuildServiceInstanceFor(
+      content::BrowserContext* context) const override;
+  content::BrowserContext* GetBrowserContextToUse(
+      content::BrowserContext* context) const override;
+};
+
+}  // namespace misc_metrics
+
+#endif  // BRAVE_BROWSER_MISC_METRICS_EXTENSION_METRICS_SERVICE_FACTORY_H_

--- a/browser/misc_metrics/extension_metrics_service_unittest.cc
+++ b/browser/misc_metrics/extension_metrics_service_unittest.cc
@@ -1,0 +1,103 @@
+/* Copyright (c) 2023 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "brave/browser/misc_metrics/extension_metrics_service.h"
+
+#include <memory>
+
+#include "base/test/metrics/histogram_tester.h"
+#include "content/public/test/browser_task_environment.h"
+#include "extensions/browser/extension_registry.h"
+#include "extensions/browser/uninstall_reason.h"
+#include "extensions/common/extension_builder.h"
+#include "testing/gtest/include/gtest/gtest.h"
+
+namespace misc_metrics {
+
+namespace {
+constexpr char kUBOExtensionName[] = "uBO";
+constexpr char kUBOExtensionId[] = "cjpalhdlnbpafiamejdnhcphjbkeiagm";
+}  // namespace
+
+class ExtensionMetricsServiceTest : public testing::Test {
+ public:
+  ExtensionMetricsServiceTest()
+      : task_environment_(base::test::TaskEnvironment::TimeSource::MOCK_TIME) {}
+
+ protected:
+  void SetUp() override {
+    ubo_extension_ = extensions::ExtensionBuilder(kUBOExtensionName)
+                         .SetID(kUBOExtensionId)
+                         .Build();
+    extension_registry_ =
+        std::make_unique<extensions::ExtensionRegistry>(nullptr);
+  }
+
+  void SetUpMetrics() {
+    extension_metrics_ =
+        std::make_unique<ExtensionMetricsService>(extension_registry_.get());
+  }
+
+  scoped_refptr<const extensions::Extension> ubo_extension_;
+  std::unique_ptr<extensions::ExtensionRegistry> extension_registry_;
+  std::unique_ptr<ExtensionMetricsService> extension_metrics_;
+  base::HistogramTester histogram_tester_;
+  content::BrowserTaskEnvironment task_environment_;
+};
+
+TEST_F(ExtensionMetricsServiceTest, InstallAtRuntime) {
+  SetUpMetrics();
+  histogram_tester_.ExpectTotalCount(kAdblockExtensionsHistogramName, 0);
+
+  task_environment_.FastForwardBy(base::Seconds(11));
+
+  // Report once after init
+  histogram_tester_.ExpectUniqueSample(kAdblockExtensionsHistogramName, 0, 1);
+
+  // Ensure metric is recorded only once after init
+  task_environment_.FastForwardBy(base::Seconds(11));
+  histogram_tester_.ExpectUniqueSample(kAdblockExtensionsHistogramName, 0, 1);
+
+  extension_registry_->AddEnabled(ubo_extension_);
+  extension_registry_->TriggerOnLoaded(ubo_extension_.get());
+
+  // Should wait at least 10 seconds for metric to update
+  histogram_tester_.ExpectTotalCount(kAdblockExtensionsHistogramName, 1);
+  task_environment_.FastForwardBy(base::Seconds(11));
+  histogram_tester_.ExpectBucketCount(kAdblockExtensionsHistogramName, 1, 1);
+
+  extension_registry_->RemoveEnabled(kUBOExtensionId);
+  extension_registry_->TriggerOnUninstalled(
+      ubo_extension_.get(),
+      extensions::UninstallReason::UNINSTALL_REASON_USER_INITIATED);
+
+  histogram_tester_.ExpectTotalCount(kAdblockExtensionsHistogramName, 2);
+  task_environment_.FastForwardBy(base::Seconds(11));
+  histogram_tester_.ExpectBucketCount(kAdblockExtensionsHistogramName, 0, 2);
+  histogram_tester_.ExpectTotalCount(kAdblockExtensionsHistogramName, 3);
+}
+
+TEST_F(ExtensionMetricsServiceTest, LoadedAtInit) {
+  extension_registry_->AddEnabled(ubo_extension_);
+  SetUpMetrics();
+  histogram_tester_.ExpectTotalCount(kAdblockExtensionsHistogramName, 0);
+
+  task_environment_.FastForwardBy(base::Seconds(11));
+
+  // Report once after init
+  histogram_tester_.ExpectUniqueSample(kAdblockExtensionsHistogramName, 1, 1);
+
+  extension_registry_->RemoveEnabled(kUBOExtensionId);
+  extension_registry_->TriggerOnUninstalled(
+      ubo_extension_.get(),
+      extensions::UninstallReason::UNINSTALL_REASON_USER_INITIATED);
+
+  histogram_tester_.ExpectTotalCount(kAdblockExtensionsHistogramName, 1);
+  task_environment_.FastForwardBy(base::Seconds(11));
+  histogram_tester_.ExpectBucketCount(kAdblockExtensionsHistogramName, 0, 1);
+  histogram_tester_.ExpectTotalCount(kAdblockExtensionsHistogramName, 2);
+}
+
+}  // namespace misc_metrics

--- a/browser/misc_metrics/sources.gni
+++ b/browser/misc_metrics/sources.gni
@@ -20,6 +20,10 @@ brave_browser_misc_metrics_sources = [
 
 if (!is_android) {
   brave_browser_misc_metrics_sources += [
+    "//brave/browser/misc_metrics/extension_metrics_service.cc",
+    "//brave/browser/misc_metrics/extension_metrics_service.h",
+    "//brave/browser/misc_metrics/extension_metrics_service_factory.cc",
+    "//brave/browser/misc_metrics/extension_metrics_service_factory.h",
     "//brave/browser/misc_metrics/vertical_tab_metrics.cc",
     "//brave/browser/misc_metrics/vertical_tab_metrics.h",
   ]

--- a/browser/profiles/brave_profile_manager.cc
+++ b/browser/profiles/brave_profile_manager.cc
@@ -16,6 +16,7 @@
 #include "brave/browser/brave_news/brave_news_controller_factory.h"
 #include "brave/browser/brave_rewards/rewards_service_factory.h"
 #include "brave/browser/brave_wallet/brave_wallet_service_factory.h"
+#include "brave/browser/misc_metrics/extension_metrics_service_factory.h"
 #include "brave/browser/perf/brave_perf_features_processor.h"
 #include "brave/browser/profiles/profile_util.h"
 #include "brave/browser/url_sanitizer/url_sanitizer_service_factory.h"
@@ -123,6 +124,9 @@ void BraveProfileManager::DoFinalInitForServices(Profile* profile,
   brave_news::BraveNewsControllerFactory::GetForContext(profile);
   brave_federated::BraveFederatedServiceFactory::GetForBrowserContext(profile);
   brave::URLSanitizerServiceFactory::GetForBrowserContext(profile);
+#if !BUILDFLAG(IS_ANDROID)
+  misc_metrics::ExtensionMetricsServiceFactory::GetServiceForContext(profile);
+#endif
 }
 
 bool BraveProfileManager::IsAllowedProfilePath(

--- a/components/p3a/metric_names.h
+++ b/components/p3a/metric_names.h
@@ -44,6 +44,7 @@ constexpr inline auto kCollectedTypicalHistograms =
     "Brave.Core.WindowCount.2",
     "Brave.DNS.AutoSecureRequests",
     "Brave.DNS.SecureSetting",
+    "Brave.Extensions.AdBlock",
     "Brave.Importer.ImporterSource.2",
     "Brave.NTP.CustomizeUsageStatus",
     "Brave.NTP.NewTabsCreated.2",


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/34006

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [ ] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

0. Start with fresh profile, wait 10 seconds
1. Check local state, ensure metric value is 0
2. Install one of the listed extensions. Ensure metric value is updated to 1 after waiting 10 seconds.
3. Restart the browser, wait 10 seconds, ensure metric value is still 1.
4. Uninstall extension, wait 10 seconds, ensure metric value is 0.