### PR TITLE
fix(wallet): Accounts Tab Zero Fiat Value

### DIFF
--- a/components/brave_wallet_ui/components/desktop/account-list-item/index.tsx
+++ b/components/brave_wallet_ui/components/desktop/account-list-item/index.tsx
@@ -119,14 +119,18 @@ interface Props {
   onClick: (account: BraveWallet.AccountInfo) => void
   account: BraveWallet.AccountInfo
   tokenBalancesRegistry: TokenBalancesRegistry | undefined
+  isLoadingBalances: boolean
   spotPriceRegistry: SpotPriceRegistry | undefined
+  isLoadingSpotPrices: boolean
 }
 
 export const AccountListItem = ({
   account,
   onClick,
   tokenBalancesRegistry,
-  spotPriceRegistry
+  spotPriceRegistry,
+  isLoadingBalances,
+  isLoadingSpotPrices
 }: Props) => {
   // redux
   const dispatch = useDispatch()
@@ -249,7 +253,9 @@ export const AccountListItem = ({
     // assets to display.
     if (
       accountsFungibleTokens
-        .length === 0
+        .length === 0 &&
+      !isLoadingBalances &&
+      !isLoadingSpotPrices
     ) {
       return new Amount(0)
     }
@@ -284,14 +290,16 @@ export const AccountListItem = ({
 
     return !reducedAmounts.isUndefined()
       ? reducedAmounts
-      : new Amount(0)
+      : Amount.empty()
   }, [
     account,
     userVisibleTokensInfo,
     accountsFungibleTokens,
     tokenBalancesRegistry,
     spotPriceRegistry,
-    rewardsBalance
+    rewardsBalance,
+    isLoadingBalances,
+    isLoadingSpotPrices
   ])
 
   const buttonOptions = React.useMemo((): AccountButtonOptionsObjectType[] => {

--- a/components/brave_wallet_ui/components/desktop/views/accounts/accounts.tsx
+++ b/components/brave_wallet_ui/components/desktop/views/accounts/accounts.tsx
@@ -123,7 +123,8 @@ export const Accounts = () => {
   const { data: defaultFiatCurrency } = useGetDefaultFiatCurrencyQuery()
 
   const {
-    data: tokenBalancesRegistry
+    data: tokenBalancesRegistry,
+    isLoading: isLoadingBalances
   } = useBalancesFetcher({
     accounts,
     networks
@@ -136,7 +137,10 @@ export const Accounts = () => {
     [userVisibleTokensInfo]
   )
 
-  const { data: spotPriceRegistry } = useGetTokenSpotPricesQuery(
+  const {
+    data: spotPriceRegistry,
+    isLoading: isLoadingSpotPrices
+  } = useGetTokenSpotPricesQuery(
     tokenPriceIds.length && defaultFiatCurrency
       ? { ids: tokenPriceIds, toCurrency: defaultFiatCurrency }
       : skipToken,
@@ -160,7 +164,9 @@ export const Accounts = () => {
             onClick={onSelectAccount}
             account={account}
             tokenBalancesRegistry={tokenBalancesRegistry}
+            isLoadingBalances={isLoadingBalances}
             spotPriceRegistry={spotPriceRegistry}
+            isLoadingSpotPrices={isLoadingSpotPrices}
           />
         )}
     </Column>
@@ -168,7 +174,11 @@ export const Accounts = () => {
   }, [
     trezorKeys,
     trezorAccounts,
-    onSelectAccount
+    onSelectAccount,
+    tokenBalancesRegistry,
+    spotPriceRegistry,
+    isLoadingBalances,
+    isLoadingSpotPrices
   ])
 
   const ledgerKeys = React.useMemo(() => {
@@ -188,7 +198,9 @@ export const Accounts = () => {
             onClick={onSelectAccount}
             account={account}
             tokenBalancesRegistry={tokenBalancesRegistry}
+            isLoadingBalances={isLoadingBalances}
             spotPriceRegistry={spotPriceRegistry}
+            isLoadingSpotPrices={isLoadingSpotPrices}
           />
         )}
     </Column>
@@ -196,7 +208,11 @@ export const Accounts = () => {
   }, [
     ledgerKeys,
     ledgerAccounts,
-    onSelectAccount
+    onSelectAccount,
+    tokenBalancesRegistry,
+    spotPriceRegistry,
+    isLoadingBalances,
+    isLoadingSpotPrices
   ])
 
 
@@ -232,7 +248,9 @@ export const Accounts = () => {
             onClick={onSelectAccount}
             account={account}
             tokenBalancesRegistry={tokenBalancesRegistry}
+            isLoadingBalances={isLoadingBalances}
             spotPriceRegistry={spotPriceRegistry}
+            isLoadingSpotPrices={isLoadingSpotPrices}
           />
         )}
       </Column>
@@ -258,7 +276,9 @@ export const Accounts = () => {
                 onClick={onSelectAccount}
                 account={account}
                 tokenBalancesRegistry={tokenBalancesRegistry}
+                isLoadingBalances={isLoadingBalances}
                 spotPriceRegistry={spotPriceRegistry}
+                isLoadingSpotPrices={isLoadingSpotPrices}
               />
             )}
           </Column>
@@ -306,7 +326,9 @@ export const Accounts = () => {
               onClick={onSelectAccount}
               account={externalRewardsAccount}
               tokenBalancesRegistry={tokenBalancesRegistry}
+              isLoadingBalances={isLoadingBalances}
               spotPriceRegistry={spotPriceRegistry}
+              isLoadingSpotPrices={isLoadingSpotPrices}
             />
           </Column>
         </>


### PR DESCRIPTION
## Description 
Fixes a bug where the `Accounts` tab was showing `$0.00` for account fiat values briefly before the actual fiat value was returned

<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves <https://github.com/brave/brave-browser/issues/33993>

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-arm64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-x64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

   1. Open the Wallet and navigate to the `Accounts` tab
   2. The fiat value for every account should show a `Loading Skeleton` until the actual `Fiat` value is returned.

Before:

https://github.com/brave/brave-core/assets/40611140/2c498602-c772-4415-81fc-865d7a929ec0

After:

https://github.com/brave/brave-core/assets/40611140/bd31624c-7699-4ff1-a944-27d9c3d5feaf
