### PR TITLE
Fix crash in AIChatCredentialManager

### DIFF
--- a/components/ai_chat/core/ai_chat_credential_manager_unittest.cc
+++ b/components/ai_chat/core/ai_chat_credential_manager_unittest.cc
@@ -172,6 +172,24 @@ TEST_F(AIChatCredentialManagerUnitTest, FetchPremiumCredential) {
       prefs_service_.GetDict(ai_chat::prefs::kBraveChatPremiumCredentialCache);
   EXPECT_EQ(cached_creds_list4.size(), 1u);
   TestFetchPremiumCredential(entry);
+
+  // Add two invalid credentials to the cache, and one valid
+  EXPECT_EQ(cached_creds_list4.size(),
+            0u);  // Verify cache is empty before this test case.
+  CredentialCacheEntry entry3;
+  entry3.credential = "credential3";
+  entry3.expires_at = base::Time();
+  CredentialCacheEntry entry4;
+  entry4.credential = "credential4";
+  entry4.expires_at = base::Time();
+  CredentialCacheEntry entry5;
+  entry5.credential = "credential5";
+  entry5.expires_at = base::Time::Now() + base::Hours(2);
+  ai_chat_credential_manager_->PutCredentialInCache(entry3);
+  ai_chat_credential_manager_->PutCredentialInCache(entry4);
+  ai_chat_credential_manager_->PutCredentialInCache(entry5);
+  TestFetchPremiumCredential(entry5);
+  EXPECT_EQ(cached_creds_list4.size(), 0u);
 }
 
 }  // namespace ai_chat


### PR DESCRIPTION
Resolves https://github.com/brave/brave-browser/issues/33999

Ensure we do not call dict.erase(it) on invalidated iterators by using dict.Remove on keys (not iterators) instead.

The test I added crashed under the original code, but passes with this change.

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-arm64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-x64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [ ] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
1. On a Leo premium enabled browser, manually edit the premium credential cache key in Local State file (on Ubuntu this is located at ~/.config/BraveSoftware/Brave-Browser-Development/Local\ State) to this: `"premium_credential_cache":{ "eyJ0eXBlIjoidGltZS1saW1pdGVkLXYyIiwidmVyc2lvbiI6Miwic2t1IjoiYnJhdmUtbGVvLXByZW1pdW0iLCJwcmVzZW50YXRpb24iOiJleUoyWVd4cFpFWnliMjBpT2lJeU1ESXpMVEV3TFRJNFZESXdPakU0T2pBMklpd2lkbUZzYVdSVWJ5STZJakl3TWpNdE1UQXRNamxVTWpBNk1UZzZNRFlpTENKcGMzTjFaWElpT2lKaWNtRjJaUzVqYjIwL2MydDFQV0p5WVhabExXeGxieTF3Y21WdGFYVnRJaXdpZENJNkltSlZibmRFYTIxak55dDFibU5DT0VOWmRETlhWamh1ZWs0eFZrcHdMelZMY21kcVdYbEVPV05uU2pWdUszbEZSbGxNV2xkREwxcEJka3RhTVVGMmFtVXJSVnBSUkdkVlp6VTNjSFp1YUd4YVFYbERUSGhSUFQwaUxDSnphV2R1WVhSMWNtVWlPaUo1ZERKellUZE1Mek4zYUZaMVlUSnJWbE5wUkZad1ZXWmFURmt4VjNoUVp5dHBUMDUyYlRoTVNtSnVUM2c1ZVRGcWMzbzNia2RTYm5wRVMwdHVVR2R1VFVNNWFtTnZjams1Y3paRmJIbHlkeXRxZVRVdmR6MDlJbjA9In0=": "13343084286000000", "eyJ0eXBlIjoidGltZS1saW1pdGVkLXYyIiwidmVyc2lvbiI6Miwic2t1IjoiYnJhdmUtbGVvLXByZW1pdW0iLCJwcmVzZW50YXRpb24iOiJleUoyWVd4cFpFWnliMjBpT2lJeU1ESXpMVEV3TFRJNFZESXdPakU0T2pBMklpd2lkbUZzYVdSVWJ5STZJakl3TWpNdE1UQXRNamxVTWpBNk1UZzZNRFlpTENKcGMzTjFaWElpT2lKaWNtRjJaUzVqYjIwL2MydDFQV0p5WVhabExXeGxieTF3Y21WdGFYVnRJaXdpZENJNkltWnZWRzA1YzA1YVZFUmxSVGRpWTJWWVNXTXpjbGRYV1RkM2ExY3dSVVJZZWk5NVFVaHJhWEpJWmtOUFdWVlJSbVJrVHpGT2JqbGtiWFJ1WjJKSmJrcHZaaXN2WlN0dVVsRnhkMHhQV21GdU9HZFROV0YzUFQwaUxDSnphV2R1WVhSMWNtVWlPaUpZV2t0UFRXUTJZbm92UVdaSWFIUm5TV28wTTBSVGVVNW5WSFI2Y1dnclFWa3JjMUE0VEVWTWVEQnZNRTlMTTFCSGNHRm1lRTlzYjFwSE5VaHJhSFZGY25ScFlXUmpWQzkxVURaWGJIbG9NbEpCU2xCNFVUMDlJbjA9In0=": "13343084286000000" }`
2. Send a chat with Claude
3. Browser should not crash