### PR TITLE
Disable net::features::kTpcdMetadataGrants (uplift to 1.61.x)

### DIFF
--- a/app/brave_main_delegate_browsertest.cc
+++ b/app/brave_main_delegate_browsertest.cc
@@ -259,6 +259,7 @@ IN_PROC_BROWSER_TEST_F(BraveMainDelegateBrowserTest, DisabledFeatures) {
     &net::features::kPartitionedCookies,
     &net::features::kThirdPartyPartitionedStorageAllowedByDefault,
     &net::features::kThirdPartyStoragePartitioning,
+    &net::features::kTpcdMetadataGrants,
     &net::features::kWaitForFirstPartySetsInit,
     &network::features::kFledgePst,
     &network::features::kPrivateStateTokens,

--- a/chromium_src/net/base/features.cc
+++ b/chromium_src/net/base/features.cc
@@ -28,6 +28,7 @@ OVERRIDE_FEATURE_DEFAULT_STATES({{
     {kThirdPartyPartitionedStorageAllowedByDefault,
      base::FEATURE_DISABLED_BY_DEFAULT},
     {kThirdPartyStoragePartitioning, base::FEATURE_DISABLED_BY_DEFAULT},
+    {kTpcdMetadataGrants, base::FEATURE_DISABLED_BY_DEFAULT},
     {kWaitForFirstPartySetsInit, base::FEATURE_DISABLED_BY_DEFAULT},
 }});
 


### PR DESCRIPTION
Uplift of #20742
Resolves https://github.com/brave/brave-browser/issues/33996

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.