### PR TITLE
`Label::CalculatePreferredSize()` marked as `final`

### DIFF
--- a/browser/ui/views/toolbar/brave_vpn_status_label.cc
+++ b/browser/ui/views/toolbar/brave_vpn_status_label.cc
@@ -75,8 +75,9 @@ void BraveVPNStatusLabel::OnConnectionStateChanged(ConnectionState state) {
   UpdateState();
 }
 
-gfx::Size BraveVPNStatusLabel::CalculatePreferredSize() const {
-  auto size = views::Label::CalculatePreferredSize();
+gfx::Size BraveVPNStatusLabel::CalculatePreferredSize(
+    const views::SizeBounds& available_size) const {
+  auto size = views::Label::CalculatePreferredSize(available_size);
   if (longest_state_string_id_ == -1)
     return size;
   auto text =

--- a/browser/ui/views/toolbar/brave_vpn_status_label.h
+++ b/browser/ui/views/toolbar/brave_vpn_status_label.h
@@ -25,7 +25,8 @@ class BraveVPNStatusLabel : public views::Label,
   BraveVPNStatusLabel(const BraveVPNStatusLabel&) = delete;
   BraveVPNStatusLabel& operator=(const BraveVPNStatusLabel&) = delete;
 
-  gfx::Size CalculatePreferredSize() const override;
+  gfx::Size CalculatePreferredSize(
+      const views::SizeBounds& available_size) const override;
 
  private:
   // brave_vpn::BraveVPNServiceObserver overrides:


### PR DESCRIPTION
This function is now marked as `final`, however there is another entry in the overload set that can be used in its place for the override in `BraveVPNStatusLabel`.

Chromium change:
https://chromium.googlesource.com/chromium/src/+/bf2f84a8c4f27e399e05bf4730a29152f6a8b0b6

    commit bf2f84a8c4f27e399e05bf4730a29152f6a8b0b6
    Author: weidongliu <liuwd8@gmail.com>
    Date:   Mon Oct 30 15:59:03 2023 +0000
    
        views: Mark CalculatePreferredSize() of views::Label as final
    
        Views::Label now has two functions to calculate the preferred size. This
        can cause some unexpected errors. CalculatePreferredSize() is now
        expected to be deprecated. Therefore, mark it as final to prevent
        overrided by subclasses.
    
        Bug: 1346889

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves 

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-arm64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-x64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [ ] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

