### PR TITLE
Fixed wrong leo omnibox result separator color

### DIFF
--- a/browser/ui/color/brave_color_mixer.cc
+++ b/browser/ui/color/brave_color_mixer.cc
@@ -50,6 +50,15 @@ SkColor GetToolbarInkDropColor(const ui::ColorMixer& mixer) {
                      0xFF * kToolbarInkDropHighlightVisibleOpacity);
 }
 
+SkColor PickColorContrastingToOmniboxResultsBackground(
+    const ui::ColorProviderKey& key,
+    const ui::ColorMixer& mixer,
+    SkColor color1,
+    SkColor color2) {
+  auto bg_color = mixer.GetResultColor(kColorOmniboxResultsBackground);
+  return color_utils::PickContrastingColor(color1, color2, bg_color);
+}
+
 SkColor PickColorContrastingToToolbar(const ui::ColorProviderKey& key,
                                       const ui::ColorMixer& mixer,
                                       SkColor color1,
@@ -633,6 +642,19 @@ void AddBraveOmniboxLightThemeColorMixer(ui::ColorProvider* provider,
                                          const ui::ColorProviderKey& key) {
   ui::ColorMixer& mixer = provider->AddMixer();
 
+  mixer[kColorBraveOmniboxResultViewSeparator] = {
+      leo::GetColor(leo::Color::kColorDividerSubtle, leo::Theme::kLight)};
+
+  if (key.custom_theme) {
+    mixer[kColorBraveOmniboxResultViewSeparator] = {
+        PickColorContrastingToOmniboxResultsBackground(
+            key, mixer,
+            leo::GetColor(leo::Color::kColorDividerSubtle, leo::Theme::kLight),
+            leo::GetColor(leo::Color::kColorDividerSubtle, leo::Theme::kDark))};
+    return;
+  }
+
+  // Apply bravified color when there is no custom theme.
   mixer[kColorToolbarBackgroundSubtleEmphasis] = {GetLocationBarBackground(
       /*dark*/ false, /*private*/ false, /*hover*/ false)};
   mixer[kColorToolbarBackgroundSubtleEmphasisHovered] = {
@@ -648,15 +670,25 @@ void AddBraveOmniboxLightThemeColorMixer(ui::ColorProvider* provider,
   mixer[kColorOmniboxResultsBackgroundSelected] = {
       GetOmniboxResultBackground(kColorOmniboxResultsBackgroundSelected,
                                  /*dark*/ false, /*incognito*/ false)};
-
-  mixer[kColorBraveOmniboxResultViewSeparator] = {
-      leo::GetColor(leo::Color::kColorDividerSubtle, leo::Theme::kLight)};
 }
 
 void AddBraveOmniboxDarkThemeColorMixer(ui::ColorProvider* provider,
                                         const ui::ColorProviderKey& key) {
   ui::ColorMixer& mixer = provider->AddMixer();
 
+  mixer[kColorBraveOmniboxResultViewSeparator] = {
+      leo::GetColor(leo::Color::kColorDividerSubtle, leo::Theme::kDark)};
+
+  if (key.custom_theme) {
+    mixer[kColorBraveOmniboxResultViewSeparator] = {
+        PickColorContrastingToOmniboxResultsBackground(
+            key, mixer,
+            leo::GetColor(leo::Color::kColorDividerSubtle, leo::Theme::kLight),
+            leo::GetColor(leo::Color::kColorDividerSubtle, leo::Theme::kDark))};
+    return;
+  }
+
+  // Apply bravified color when there is no custom theme.
   mixer[kColorToolbarBackgroundSubtleEmphasis] = {GetLocationBarBackground(
       /*dark*/ true, /*private*/ false, /*hover*/ false)};
   mixer[kColorToolbarBackgroundSubtleEmphasisHovered] = {
@@ -672,9 +704,6 @@ void AddBraveOmniboxDarkThemeColorMixer(ui::ColorProvider* provider,
   mixer[kColorOmniboxResultsBackgroundSelected] = {
       GetOmniboxResultBackground(kColorOmniboxResultsBackgroundSelected,
                                  /*dark*/ true, /*incognito*/ false)};
-
-  mixer[kColorBraveOmniboxResultViewSeparator] = {
-      leo::GetColor(leo::Color::kColorDividerSubtle, leo::Theme::kDark)};
 }
 
 void AddBraveOmniboxPrivateThemeColorMixer(ui::ColorProvider* provider,

--- a/chromium_src/chrome/browser/ui/color/omnibox_color_mixer.cc
+++ b/chromium_src/chrome/browser/ui/color/omnibox_color_mixer.cc
@@ -15,9 +15,6 @@ namespace {
 
 void AddBraveOmniboxColorMixer(ui::ColorProvider* provider,
                                const ui::ColorProviderKey& key) {
-  // Apply brave theme when there is no custom theme.
-  if (key.custom_theme)
-    return;
 #if !BUILDFLAG(IS_ANDROID)
   key.color_mode == ui::ColorProviderKey::ColorMode::kDark
       ? AddBraveOmniboxDarkThemeColorMixer(provider, key)


### PR DESCRIPTION
fix https://github.com/brave/brave-browser/issues/34029

<img width="889" alt="Screenshot 2023-11-01 at 11 46 19 AM" src="https://github.com/brave/brave-core/assets/6786187/3a9c515b-8993-4cc5-8e1e-e87e20230dc8">


<!-- Add brave-browser issue below that this PR will resolve -->
Resolves 

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-arm64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-x64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [ ] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

