### PR TITLE
Fix EphemeralStorageForgetByDefaultBrowserTest flakiness. (uplift to 1.61.x)

### DIFF
--- a/browser/ephemeral_storage/ephemeral_storage_forget_by_default_browsertest.cc
+++ b/browser/ephemeral_storage/ephemeral_storage_forget_by_default_browsertest.cc
@@ -214,13 +214,8 @@ IN_PROC_BROWSER_TEST_F(EphemeralStorageForgetByDefaultBrowserTest,
                                  GetValuesFromFrames(incognito_web_contents));
 }
 
-#if BUILDFLAG(IS_MAC)
-#define MAYBE_NavigationCookiesAreCleared DISABLED_NavigationCookiesAreCleared
-#else
-#define MAYBE_NavigationCookiesAreCleared NavigationCookiesAreCleared
-#endif
 IN_PROC_BROWSER_TEST_F(EphemeralStorageForgetByDefaultBrowserTest,
-                       MAYBE_NavigationCookiesAreCleared) {
+                       NavigationCookiesAreCleared) {
   brave_shields::SetForgetFirstPartyStorageEnabled(
       content_settings(), true, a_site_ephemeral_storage_url_);
   brave_shields::SetForgetFirstPartyStorageEnabled(


### PR DESCRIPTION
Uplift of #20712
Resolves https://github.com/brave/brave-browser/issues/31806

Pre-approval checklist: 
- [ ] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [ ] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [ ] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [ ] The associated issue milestone is set to the smallest version that the changes is landed on.