### PR TITLE
AI Chat: fix premium prompt showing before siteinfo decision (uplift to 1.61.x)

### DIFF
--- a/components/ai_chat/resources/page/state/context.ts
+++ b/components/ai_chat/resources/page/state/context.ts
@@ -16,7 +16,7 @@ export interface AIChatContext {
   canGenerateQuestions: boolean
   hasAcceptedAgreement: boolean
   userAutoGeneratePref: mojom.AutoGenerateQuestionsPref | undefined
-  siteInfo: mojom.SiteInfo | null
+  siteInfo?: mojom.SiteInfo | null
   favIconUrl: string | undefined
   currentError: mojom.APIError | undefined
   apiHasError: boolean
@@ -55,7 +55,7 @@ export const defaultContext: AIChatContext = {
   isPremiumUser: false,
   isPremiumUserDisconnected: false,
   userAutoGeneratePref: undefined,
-  siteInfo: null,
+  siteInfo: undefined,
   favIconUrl: undefined,
   currentError: mojom.APIError.None,
   canShowPremiumPrompt: undefined,

--- a/components/ai_chat/resources/page/state/data-context-provider.tsx
+++ b/components/ai_chat/resources/page/state/data-context-provider.tsx
@@ -292,7 +292,7 @@ function DataContextProvider (props: DataContextProviderProps) {
     suggestedQuestions,
     canGenerateQuestions,
     userAutoGeneratePref,
-    siteInfo: siteInfo || null,
+    siteInfo: siteInfo,
     favIconUrl,
     currentError,
     hasAcceptedAgreement,


### PR DESCRIPTION
Uplift of #20780
Resolves https://github.com/brave/brave-browser/issues/33946

Pre-approval checklist: 
- [ ] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [ ] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [ ] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [ ] The associated issue milestone is set to the smallest version that the changes is landed on.