### PR TITLE
Only allow farbling of a subset of user-installed fonts

### DIFF
--- a/third_party/blink/renderer/brave_font_whitelist.cc
+++ b/third_party/blink/renderer/brave_font_whitelist.cc
@@ -15,6 +15,61 @@ namespace {
 base::flat_set<std::string_view> kEmptyFontSet =
     base::MakeFlatSet<std::string_view>(std::vector<std::string_view>{});
 
+base::flat_set<std::string_view> kFontFarblingSet =
+    base::MakeFlatSet<std::string_view>(
+        std::vector<std::string_view>{"sans-serif-thin",
+                                      "arno pro",
+                                      "agency fb",
+                                      "arabic typesetting",
+                                      "arial unicode ms",
+                                      "avantgarde bk bt",
+                                      "bankgothic md bt",
+                                      "batang",
+                                      "bitstream vera sans mono",
+                                      "calibri",
+                                      "century",
+                                      "century gothic",
+                                      "clarendon",
+                                      "eurostile",
+                                      "franklin gothic",
+                                      "futura bk bt",
+                                      "futura md bt",
+                                      "gotham",
+                                      "gill sans",
+                                      "helv",
+                                      "haettenschweiler",
+                                      "helvetica neue",
+                                      "humanst521 bt",
+                                      "leelawadee",
+                                      "letter gothic",
+                                      "levenim mt",
+                                      "lucida bright",
+                                      "lucida sans",
+                                      "menlo",
+                                      "ms mincho",
+                                      "ms outlook",
+                                      "ms reference specialty",
+                                      "ms ui gothic",
+                                      "mt extra",
+                                      "myriad pro",
+                                      "marlett",
+                                      "meiryo ui",
+                                      "microsoft uighur",
+                                      "minion pro",
+                                      "monotype corsiva",
+                                      "pmingliu",
+                                      "pristina",
+                                      "scriptina",
+                                      "segoe ui light",
+                                      "serifa",
+                                      "simhei",
+                                      "small fonts",
+                                      "staccato222 bt",
+                                      "trajan pro",
+                                      "univers ce 55 medium",
+                                      "vrinda",
+                                      "zwadobef"});
+
 #if BUILDFLAG(IS_MAC)
 bool kCanRestrictFonts = true;
 // This list covers the fonts installed by default on Mac OS as of Mac OS 12.3.
@@ -817,6 +872,11 @@ bool AllowFontByFamilyName(const AtomicString& family_name,
     return true;
 #endif
   return false;
+}
+
+bool IsFontAllowedForFarbling(const AtomicString& family_name) {
+  std::string lower_ascii_name = family_name.LowerASCII().Ascii();
+  return kFontFarblingSet.contains(lower_ascii_name);
 }
 
 const base::flat_set<std::string_view>& GetAdditionalFontWhitelistByLocale(

--- a/third_party/blink/renderer/brave_font_whitelist.h
+++ b/third_party/blink/renderer/brave_font_whitelist.h
@@ -19,6 +19,8 @@ namespace brave {
 BLINK_EXPORT bool AllowFontByFamilyName(const AtomicString& family_name,
                                         WTF::String default_language);
 
+BLINK_EXPORT bool IsFontAllowedForFarbling(const AtomicString& family_name);
+
 // Public for testing but other callers should call
 // AllowFontByFamilyName instead.
 BLINK_EXPORT const base::flat_set<std::string_view>&

--- a/third_party/blink/renderer/core/farbling/brave_session_cache.cc
+++ b/third_party/blink/renderer/core/farbling/brave_session_cache.cc
@@ -357,9 +357,13 @@ bool BraveSessionCache::AllowFontFamily(
       if (AllowFontByFamilyName(family_name,
                                 blink::DefaultLanguage().GetString().Left(2)))
         return true;
-      FarblingPRNG prng = MakePseudoRandomGenerator();
-      prng.discard(family_name.Impl()->GetHash() % 16);
-      return ((prng() % 20) == 0);
+      if (IsFontAllowedForFarbling(family_name)) {
+        FarblingPRNG prng = MakePseudoRandomGenerator();
+        prng.discard(family_name.Impl()->GetHash() % 16);
+        return ((prng() % 20) == 0);
+      } else {
+        return false;
+      }
     }
     default:
       NOTREACHED();


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/34043

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-arm64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-x64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

