### PR TITLE
invalidate ai chat privacy policy translations for consistency

### DIFF
--- a/components/resources/ai_chat_ui_strings.grdp
+++ b/components/resources/ai_chat_ui_strings.grdp
@@ -16,10 +16,10 @@
     About Leo
   </message>
    <message name="IDS_CHAT_UI_ABOUT_DESCRIPTION" desc="Outlining the functioning of AIChat (paragraph 1 of 3)">
-    Brave Leo is an AI smart assistant that can summarize web pages, transcribe videos, and answer questions. Brave Leo Premium uses advanced <ph name="LINK_BEFORE">$1</ph>AI models<ph name="LINK_AFTER">$2</ph> for even more nuanced replies, and gives early access to new features.
+    Brave Leo is an AI smart assistant that can summarize web pages, transcribe videos, and answer questions.  Brave Leo Premium uses advanced <ph name="LINK_BEFORE">$1</ph>AI models<ph name="LINK_AFTER">$2</ph> for even more nuanced replies, and gives early access to new features.
   </message>
   <message name="IDS_CHAT_UI_ABOUT_DESCRIPTION_2" desc="Outlining the functioning of AIChat (paragraph 2 of 3)">
-    The accuracy of responses is not guaranteed, and may include inaccurate, misleading, or false information. Don't submit sensitive or private info, and use caution with any answers related to health, finance, personal safety, or similar.
+    The accuracy of responses is not guaranteed, and may include inaccurate, misleading, or false information.  Don't submit sensitive or private info, and use caution with any answers related to health, finance, personal safety, or similar.
   </message>
   <message name="IDS_CHAT_UI_ABOUT_DESCRIPTION_3" desc="Outlining the functioning of AIChat (paragraph 3 of 3)">
     Leo does not collect identifiers such as your IP Address that can be linked to you. No personal data is retained by the AI model or any 3rd-party model providers.


### PR DESCRIPTION
Avoids partial translations on AI Chat privacy policy by making meaningless changes to the other paragraphs so that their translations are invalidated. The double-space is not perceivable in the UI.

### Was:
![image](https://github.com/brave/brave-core/assets/741836/7627b1da-5ff0-4cc3-b70e-253ac81fcf11)

### With this change:
![image](https://github.com/brave/brave-core/assets/741836/37f70325-5ae9-4947-9c12-df94ddda6181)
