### PR TITLE
Fixed app name at menubar on macOS 14 (uplift to 1.61.x)

### DIFF
--- a/patches/chrome-browser-app_controller_mac.mm.patch
+++ b/patches/chrome-browser-app_controller_mac.mm.patch
@@ -1,5 +1,5 @@
 diff --git a/chrome/browser/app_controller_mac.mm b/chrome/browser/app_controller_mac.mm
-index f477e7d102c33c55d29f3c71593283c9cd70f878..0583d55aea5f552f15c6b44a4bbe22fa5dfca6c7 100644
+index f477e7d102c33c55d29f3c71593283c9cd70f878..481a9cd3f1e9bdf7176b7c1d8cb457e5238d4aa8 100644
 --- a/chrome/browser/app_controller_mac.mm
 +++ b/chrome/browser/app_controller_mac.mm
 @@ -645,7 +645,7 @@ class AppControllerNativeThemeObserver : public ui::NativeThemeObserver {
@@ -11,7 +11,30 @@ index f477e7d102c33c55d29f3c71593283c9cd70f878..0583d55aea5f552f15c6b44a4bbe22fa
      NSApp.delegate = sharedController;
      return sharedController;
    }();
-@@ -1181,7 +1181,7 @@ class AppControllerNativeThemeObserver : public ui::NativeThemeObserver {
+@@ -726,6 +726,22 @@ class AppControllerNativeThemeObserver : public ui::NativeThemeObserver {
+ 
+   // Initialize the Profile menu.
+   [self initProfileMenu];
++
++  // Work around a bug in macOS 14. The application name shown in the menu bar
++  // should be the CFBundleName, but a bug in the menu rewrite causes the
++  // CFBundleDisplayName to be swapped in. What's happening here is that the
++  // NSMenuBarDisplayManager registers for a notification that the app name
++  // changed, and then, when the notification comes in, it calls a Process
++  // Manager API that returns the CFBundleDisplayName which is not appropriate
++  // for this use. Work around this by unregistering the NSMenuBarDisplayManager
++  // for the notification. See https://crbug.com/1487224 and FB13192263.
++  if (id sharedMenuBarDisplayManager = [NSClassFromString(
++          @"NSMenuBarDisplayManager") performSelector:@selector(shared)]) {
++    [NSWorkspace.sharedWorkspace.notificationCenter
++        removeObserver:sharedMenuBarDisplayManager
++                  name:@"NSWorkspaceApplicationNameDidChangeNotification"
++                object:nil];
++  }
+ }
+ 
+ - (void)unregisterEventHandlers {
+@@ -1181,7 +1197,7 @@ class AppControllerNativeThemeObserver : public ui::NativeThemeObserver {
    }
  
    auto it = _profileBookmarkMenuBridgeMap.find(profilePath);


### PR DESCRIPTION
Uplift of #20791
fix https://github.com/brave/brave-browser/issues/33987

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.