### PR TITLE
Adjusted app menu item's spacing and padding

### DIFF
--- a/chromium_src/ui/views/controls/menu/menu_config.cc
+++ b/chromium_src/ui/views/controls/menu/menu_config.cc
@@ -1,0 +1,35 @@
+// Copyright (c) 2023 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#include "ui/views/controls/menu/menu_config.h"
+
+#define instance instance_ChromiumImpl
+
+#include "src/ui/views/controls/menu/menu_config.cc"
+
+#undef instance
+
+namespace views {
+
+MenuConfig::MenuConfig(const MenuConfig&) = default;
+
+// static
+const MenuConfig& MenuConfig::instance() {
+  const auto& config = instance_ChromiumImpl();
+  static class RunOnce {
+   public:
+    RunOnce(const MenuConfig& config) {
+      auto& mutable_config = const_cast<MenuConfig&>(config);
+      // Each platform sets its own config in its Init().
+      // Apply our config globally at once after Init() is done.
+      mutable_config.item_vertical_margin = 9;
+      mutable_config.item_horizontal_padding = 16;
+    }
+  } const run_once(config);
+
+  return config;
+}
+
+}  // namespace views

--- a/chromium_src/ui/views/controls/menu/menu_config.h
+++ b/chromium_src/ui/views/controls/menu/menu_config.h
@@ -1,0 +1,24 @@
+// Copyright (c) 2023 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#ifndef BRAVE_CHROMIUM_SRC_UI_VIEWS_CONTROLS_MENU_MENU_CONFIG_H_
+#define BRAVE_CHROMIUM_SRC_UI_VIEWS_CONTROLS_MENU_MENU_CONFIG_H_
+
+#include "ui/gfx/font_list.h"
+#include "ui/views/style/typography_provider.h"
+
+// Added default copy ctor as defining instance gives below chromium style
+// complains. "Complex class/struct needs an explicit out-of-line copy
+// constructor"
+#define instance                 \
+  instance_ChromiumImpl();       \
+  MenuConfig(const MenuConfig&); \
+  static const MenuConfig& instance
+
+#include "src/ui/views/controls/menu/menu_config.h"  // IWYU pragma: export
+
+#undef instance
+
+#endif  // BRAVE_CHROMIUM_SRC_UI_VIEWS_CONTROLS_MENU_MENU_CONFIG_H_

--- a/test/BUILD.gn
+++ b/test/BUILD.gn
@@ -441,6 +441,7 @@ test("brave_unit_tests") {
       "//brave/components/brave_wallet/common:test_support",
       "//brave/components/commands/browser:unit_tests",
       "//brave/components/commands/common:unit_tests",
+      "//brave/ui/views:unit_tests",
       "//components/favicon/content",
     ]
   }

--- a/ui/views/BUILD.gn
+++ b/ui/views/BUILD.gn
@@ -1,0 +1,15 @@
+# Copyright (c) 2023 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+
+source_set("unit_tests") {
+  testonly = true
+  sources = [ "menu_config_unittest.cc" ]
+
+  deps = [
+    "//testing/gtest",
+    "//ui/views",
+    "//ui/views:test_support",
+  ]
+}

--- a/ui/views/DEPS
+++ b/ui/views/DEPS
@@ -1,0 +1,1 @@
+include_rules = [ "+ui/views" ]

--- a/ui/views/menu_config_unittest.cc
+++ b/ui/views/menu_config_unittest.cc
@@ -1,0 +1,19 @@
+/* Copyright (c) 2023 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "ui/views/controls/menu/menu_config.h"
+#include "testing/gtest/include/gtest/gtest.h"
+#include "ui/views/test/views_test_base.h"
+
+namespace views {
+
+using MenuConfigTest = ViewsTestBase;
+
+TEST_F(MenuConfigTest, ChangedValueTest) {
+  EXPECT_EQ(9, views::MenuConfig::instance().item_vertical_margin);
+  EXPECT_EQ(16, views::MenuConfig::instance().item_horizontal_padding);
+}
+
+}  // namespace views


### PR DESCRIPTION
fix https://github.com/brave/brave-browser/issues/33315

<img width="586" alt="image" src="https://github.com/brave/brave-core/assets/6786187/990d91a1-9b25-48c2-b90f-e3f35a60a53b">

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves 

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-arm64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-x64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

`MenuConfigTest.ChangedValueTest`
Click app menu button and check menu bubble's spacing