### PR TITLE
Extend tab hit box to top of tabstrip when maximized

### DIFF
--- a/browser/ui/brave_layout_constants.cc
+++ b/browser/ui/brave_layout_constants.cc
@@ -5,6 +5,7 @@
 
 #include "brave/browser/ui/brave_layout_constants.h"
 
+#include "brave/browser/ui/tabs/brave_tab_layout_constants.h"
 #include "brave/browser/ui/tabs/features.h"
 #include "chrome/browser/ui/layout_constants.h"
 #include "ui/base/pointer/touch_ui_controller.h"
@@ -21,9 +22,10 @@ absl::optional<int> GetBraveLayoutConstant(LayoutConstant constant) {
   //     ui::MaterialDesignController::IsNewerMaterialUi();
   switch (constant) {
     case TAB_HEIGHT: {
-      const int tab_height = HorizontalTabsUpdateEnabled() ? 36 : 30;
-      return (touch ? 41 : tab_height) +
-             GetLayoutConstant(TABSTRIP_TOOLBAR_OVERLAP);
+      if (HorizontalTabsUpdateEnabled()) {
+        return brave_tabs::kHorizontalTabViewHeight;
+      }
+      return (touch ? 41 : 30) + GetLayoutConstant(TABSTRIP_TOOLBAR_OVERLAP);
     }
     case TABSTRIP_TOOLBAR_OVERLAP: {
       if (!HorizontalTabsUpdateEnabled()) {

--- a/browser/ui/tabs/brave_tab_layout_constants.h
+++ b/browser/ui/tabs/brave_tab_layout_constants.h
@@ -15,13 +15,18 @@ namespace brave_tabs {
 // are given a small overlap. Rounded tab rectangles are drawn centered and
 // inset horizontally by an amount that will create the required visual gap.
 
+// The height of tab views in horizontal tabs mode. Note that the height of the
+// view may be greater than the visual height of the tab shape. See also
+// `kHorizontalTabVerticalSpacing`.
+constexpr int kHorizontalTabViewHeight = 44;
+
 // The amount of space before the first tab.
 constexpr int kHorizontalTabStripLeftMargin = 8;
 
-// The amount of vertical spacing between the top and bottom of tabs and the
+// The amount of visual spacing between the top and bottom of tabs and the
 // bounds of the tab strip region. The portion of this space below tabs will be
 // occupied by tab group underlines.
-constexpr int kHorizontalTabStripVerticalSpacing = 4;
+constexpr int kHorizontalTabVerticalSpacing = 4;
 
 // The visual gap between tabs.
 constexpr int kHorizontalTabGap = 4;

--- a/browser/ui/tabs/brave_tab_style.h
+++ b/browser/ui/tabs/brave_tab_style.h
@@ -50,7 +50,9 @@ class BraveTabStyle : public TabStyleBase {
     if (!tabs::features::HorizontalTabsUpdateEnabled()) {
       return TabStyleBase::GetPinnedWidth();
     }
-    return GetLayoutConstant(TAB_HEIGHT) + brave_tabs::kHorizontalTabInset * 2;
+    const int shape_height = GetLayoutConstant(TAB_HEIGHT) -
+                             brave_tabs::kHorizontalTabVerticalSpacing * 2;
+    return shape_height + brave_tabs::kHorizontalTabInset * 2;
   }
 
   int GetDragHandleExtension(int height) const override {

--- a/browser/ui/views/tabs/brave_tab.cc
+++ b/browser/ui/views/tabs/brave_tab.cc
@@ -200,7 +200,8 @@ void BraveTab::UpdateShadowForActiveTab() {
     if (!tabs::utils::ShouldShowVerticalTabs(controller()->GetBrowser())) {
       // For horizontal tabs, inset the shadow layer to match the visual rounded
       // rectangle of the tab, which is inset from the tab view.
-      shadow_insets = gfx::Insets::VH(0, brave_tabs::kHorizontalTabInset);
+      shadow_insets = gfx::Insets::VH(brave_tabs::kHorizontalTabVerticalSpacing,
+                                      brave_tabs::kHorizontalTabInset);
     }
     view_shadow_->SetInsets(shadow_insets);
   } else if (view_shadow_) {

--- a/browser/ui/views/tabs/brave_tab_container.cc
+++ b/browser/ui/views/tabs/brave_tab_container.cc
@@ -11,9 +11,7 @@
 
 #include "base/check_is_test.h"
 #include "base/containers/flat_map.h"
-#include "brave/browser/ui/tabs/brave_tab_layout_constants.h"
 #include "brave/browser/ui/tabs/brave_tab_prefs.h"
-#include "brave/browser/ui/tabs/features.h"
 #include "brave/browser/ui/views/frame/brave_browser_view.h"
 #include "brave/browser/ui/views/frame/vertical_tab_strip_widget_delegate_view.h"
 #include "brave/browser/ui/views/tabs/brave_tab_group_header.h"
@@ -32,20 +30,6 @@
 #include "ui/gfx/image/image_skia_operations.h"
 #include "ui/gfx/skbitmap_operations.h"
 #include "ui/views/view_utils.h"
-
-namespace {
-
-gfx::Size AddHorizontalTabStripSpacing(gfx::Size size) {
-  if (!tabs::features::HorizontalTabsUpdateEnabled()) {
-    return size;
-  }
-  // Allow for a small space at the top and bottom of the tab strip. Tab group
-  // underlines will partially occupy the space below tabs.
-  size.Enlarge(0, brave_tabs::kHorizontalTabStripVerticalSpacing * 2);
-  return size;
-}
-
-}  // namespace
 
 BraveTabContainer::BraveTabContainer(
     TabContainerController& controller,
@@ -106,14 +90,6 @@ base::OnceClosure BraveTabContainer::LockLayout() {
                         base::Unretained(this));
 }
 
-gfx::Size BraveTabContainer::GetMinimumSize() const {
-  gfx::Size size = TabContainerImpl::GetMinimumSize();
-  if (tabs::utils::ShouldShowVerticalTabs(tab_slot_controller_->GetBrowser())) {
-    return size;
-  }
-  return AddHorizontalTabStripSpacing(size);
-}
-
 gfx::Size BraveTabContainer::CalculatePreferredSize() const {
   // Note that we check this before checking currently we're in vertical tab
   // strip mode. We might be in the middle of changing orientation.
@@ -123,8 +99,7 @@ gfx::Size BraveTabContainer::CalculatePreferredSize() const {
 
   if (!tabs::utils::ShouldShowVerticalTabs(
           tab_slot_controller_->GetBrowser())) {
-    return AddHorizontalTabStripSpacing(
-        TabContainerImpl::CalculatePreferredSize());
+    return TabContainerImpl::CalculatePreferredSize();
   }
 
   const int tab_count = tabs_view_model_.view_size();

--- a/browser/ui/views/tabs/brave_tab_container.h
+++ b/browser/ui/views/tabs/brave_tab_container.h
@@ -32,7 +32,6 @@ class BraveTabContainer : public TabContainerImpl {
   base::OnceClosure LockLayout();
 
   // TabContainerImpl:
-  gfx::Size GetMinimumSize() const override;
   gfx::Size CalculatePreferredSize() const override;
   void UpdateClosingModeOnRemovedTab(int model_index, bool was_active) override;
   gfx::Rect GetTargetBoundsForClosingTab(Tab* tab,

--- a/browser/ui/views/tabs/brave_tab_group_highlight.cc
+++ b/browser/ui/views/tabs/brave_tab_group_highlight.cc
@@ -10,6 +10,7 @@
 #include "brave/browser/ui/views/tabs/brave_tab_group_header.h"
 #include "brave/browser/ui/views/tabs/vertical_tab_utils.h"
 #include "chrome/browser/ui/views/tabs/tab_group_views.h"
+#include "ui/gfx/geometry/skia_conversions.h"
 
 BraveTabGroupHighlight::~BraveTabGroupHighlight() = default;
 
@@ -25,13 +26,12 @@ SkPath BraveTabGroupHighlight::GetPath() const {
 
   // Draw a rounded rect that encloses the header and all tabs within the
   // group.
-  float tab_top = 0;
-  float tab_left = brave_tabs::kHorizontalTabInset;
-  float tab_right = bounds().width() - brave_tabs::kHorizontalTabInset;
-  float tab_bottom = bounds().height();
+  gfx::Rect shape_rect(0, 0, width(), height());
+  shape_rect.Inset(gfx::Insets::VH(brave_tabs::kHorizontalTabVerticalSpacing,
+                                   brave_tabs::kHorizontalTabInset));
   float radius = brave_tabs::kTabBorderRadius;
 
   SkPath path;
-  path.addRoundRect({tab_left, tab_top, tab_right, tab_bottom}, radius, radius);
+  path.addRoundRect(gfx::RectToSkRect(shape_rect), radius, radius);
   return path;
 }

--- a/browser/ui/views/tabs/brave_tab_group_underline.cc
+++ b/browser/ui/views/tabs/brave_tab_group_underline.cc
@@ -69,17 +69,8 @@ gfx::Rect BraveTabGroupUnderline::CalculateTabGroupUnderlineBounds(
     const views::View* const leading_view,
     const views::View* const trailing_view) const {
   if (!ShouldShowVerticalTabs()) {
-    auto bounds = TabGroupUnderline::CalculateTabGroupUnderlineBounds(
+    return TabGroupUnderline::CalculateTabGroupUnderlineBounds(
         underline_view, leading_view, trailing_view);
-
-    if (tabs::features::HorizontalTabsUpdateEnabled()) {
-      // Upstream places the underline at the bottom tab border. Push the
-      // underline down to the bottom of the tab strip, so that it will appear
-      // below the tabs.
-      bounds.Offset(0, brave_tabs::kHorizontalTabStripVerticalSpacing);
-    }
-
-    return bounds;
   }
 
   // override bounds for vertical tabs mode.

--- a/browser/ui/views/tabs/brave_tab_strip.cc
+++ b/browser/ui/views/tabs/brave_tab_strip.cc
@@ -390,10 +390,6 @@ void BraveTabStrip::UpdateTabStripMargins() {
     margins.set_left(brave_tabs::kHorizontalTabStripLeftMargin -
                      brave_tabs::kHorizontalTabInset);
     DCHECK_GE(margins.left(), 0);
-
-    // Set a top margin to match the space under tabs (where the group underline
-    // is rendered), so that everything remains centered.
-    margins.set_top(brave_tabs::kHorizontalTabStripVerticalSpacing);
   }
 
   SetProperty(views::kMarginsKey, margins);

--- a/browser/ui/views/tabs/brave_tab_strip_layout_helper.cc
+++ b/browser/ui/views/tabs/brave_tab_strip_layout_helper.cc
@@ -137,22 +137,6 @@ std::vector<gfx::Rect> CalculateVerticalTabBounds(
   return bounds;
 }
 
-std::vector<gfx::Rect> CalculateBoundsForHorizontalDraggedViews(
-    const std::vector<TabSlotView*>& views,
-    TabStrip* tab_strip) {
-  // Chromium aligns the dragged tabs to the bottom of the tab strip, whereas we
-  // need to keep the tabs aligned to the top.
-  std::vector<gfx::Rect> bounds;
-  const int overlap = TabStyle::Get()->GetTabOverlap();
-  int x = 0;
-  for (const TabSlotView* view : views) {
-    const int width = view->width();
-    bounds.emplace_back(x, 0, width, view->height());
-    x += width - overlap;
-  }
-  return bounds;
-}
-
 std::vector<gfx::Rect> CalculateBoundsForVerticalDraggedViews(
     const std::vector<TabSlotView*>& views,
     TabStrip* tab_strip) {

--- a/browser/ui/views/tabs/brave_tab_strip_layout_helper.h
+++ b/browser/ui/views/tabs/brave_tab_strip_layout_helper.h
@@ -40,10 +40,6 @@ std::vector<gfx::Rect> CalculateVerticalTabBounds(
     absl::optional<int> width,
     bool is_floating_mode);
 
-std::vector<gfx::Rect> CalculateBoundsForHorizontalDraggedViews(
-    const std::vector<TabSlotView*>& views,
-    TabStrip* tab_strip);
-
 std::vector<gfx::Rect> CalculateBoundsForVerticalDraggedViews(
     const std::vector<TabSlotView*>& views,
     TabStrip* tab_strip);

--- a/browser/ui/views/tabs/brave_tab_style_views.inc.cc
+++ b/browser/ui/views/tabs/brave_tab_style_views.inc.cc
@@ -96,15 +96,6 @@ SkPath BraveVerticalTabStyle::GetPath(
     return {};
   }
 
-  // Horizontal tabs should have a visual gap between them, even if their view
-  // bounds are touching or slightly overlapping. Create a visual gap by
-  // insetting the bounds of the tab by the required gap plus overlap before
-  // drawing the rectangle.
-  if (!ShouldShowVerticalTabs()) {
-    aligned_bounds.Inset(
-        gfx::InsetsF::VH(0, brave_tabs::kHorizontalTabInset * scale));
-  }
-
 #if DCHECK_IS_ON()
   if (tab()->bounds().height() != std::round(aligned_bounds.height() / scale)) {
     DLOG(ERROR) << "We don't want it to be off by 1 dip\n|height|: "
@@ -112,6 +103,24 @@ SkPath BraveVerticalTabStyle::GetPath(
                 << std::round(aligned_bounds.height() / scale);
   }
 #endif
+
+  if (!ShouldShowVerticalTabs()) {
+    // Horizontal tabs should have a visual gap between them, even if their view
+    // bounds are touching or slightly overlapping. Create a visual gap by
+    // insetting the bounds of the tab by the required gap plus overlap before
+    // drawing the rectangle.
+    aligned_bounds.Inset(
+        gfx::InsetsF::VH(brave_tabs::kHorizontalTabVerticalSpacing * scale,
+                         brave_tabs::kHorizontalTabInset * scale));
+
+    // For maximized and fullscreen windows, extend the tab hit test to the top
+    // of the tab, encompassing the top spacing. This makes it easy to click on
+    // tabs by moving the mouse to the top of the screen.
+    if (path_type == TabStyle::PathType::kHitTest && ShouldExtendHitTest()) {
+      aligned_bounds.Outset(gfx::OutsetsF::TLBR(
+          brave_tabs::kHorizontalTabVerticalSpacing * scale, 0, 0, 0));
+    }
+  }
 
   const bool is_pinned = tab()->data().pinned;
 

--- a/chromium_src/chrome/browser/ui/views/tabs/tab_strip.cc
+++ b/chromium_src/chrome/browser/ui/views/tabs/tab_strip.cc
@@ -7,7 +7,6 @@
 
 #include <cmath>
 
-#include "brave/browser/ui/tabs/features.h"
 #include "brave/browser/ui/views/tabs/brave_compound_tab_container.h"
 #include "brave/browser/ui/views/tabs/brave_tab.h"
 #include "brave/browser/ui/views/tabs/brave_tab_group_header.h"
@@ -47,9 +46,6 @@
 #define BRAVE_TAB_DRAG_CONTEXT_IMPL_CALCULATE_BOUNDS_FOR_DRAGGED_VIEWS        \
   if (tabs::utils::ShouldShowVerticalTabs(tab_strip_->GetBrowser())) {        \
     return tabs::CalculateBoundsForVerticalDraggedViews(views, tab_strip_);   \
-  }                                                                           \
-  if (tabs::features::HorizontalTabsUpdateEnabled()) {                        \
-    return tabs::CalculateBoundsForHorizontalDraggedViews(views, tab_strip_); \
   }
 
 #define BRAVE_TAB_DRAG_CONTEXT_IMPL_PAINT_CHILDREN                      \


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/34038

Currently, tab views are inset vertically from the tab strip in order to create the upper and lower margins. With this change, tab views occupy the full vertical space of the tab strip; the upper and lower margins are created in the tab path-drawing procedure. This allows us to extend the hit boxes to the top of the screen when the window is maximized.

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-arm64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-x64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [ ] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

