### PR TITLE
Fix: deposit & buy screen asset options and default accounts

### DIFF
--- a/components/brave_wallet_ui/common/async/base-query-cache.ts
+++ b/components/brave_wallet_ui/common/async/base-query-cache.ts
@@ -150,6 +150,7 @@ export class BaseQueryCache {
       const idsByCoinType: Record<EntityId, EntityId[]> = {}
       const hiddenIdsByCoinType: Record<EntityId, string[]> = {}
       const mainnetIds: string[] = []
+      const testnetIds: string[] = []
       const onRampIds: string[] = []
       const offRampIds: string[] = []
 
@@ -196,8 +197,9 @@ export class BaseQueryCache {
               })
               .toString()
 
-            if (!SupportedTestNetworks.includes(chainId)) {
-              // skip testnet & localhost chains
+            if (SupportedTestNetworks.includes(chainId)) {
+              testnetIds.push(networkId)
+            } else {
               mainnetIds.push(networkId)
             }
 
@@ -238,7 +240,8 @@ export class BaseQueryCache {
           visibleIds,
           onRampIds,
           offRampIds,
-          mainnetIds
+          mainnetIds,
+          testnetIds
         },
         networksList
       )

--- a/components/brave_wallet_ui/common/slices/api.slice.ts
+++ b/components/brave_wallet_ui/common/slices/api.slice.ts
@@ -48,8 +48,7 @@ import {
   selectAllNetworksFromQueryResult,
   selectOffRampNetworksFromQueryResult,
   selectOnRampNetworksFromQueryResult,
-  selectVisibleNetworksFromQueryResult,
-  selectTestNetworksFromQueryResult
+  selectVisibleNetworksFromQueryResult
 } from './entities/network.entity'
 import { AccountInfoEntityState } from './entities/account-info.entity'
 import {
@@ -3635,19 +3634,6 @@ export const useGetNetworksQuery = (opts?: { skip?: boolean }) => {
       isLoading: res.isLoading,
       error: res.error,
       data: selectAllNetworksFromQueryResult(res)
-    }),
-    skip: opts?.skip
-  })
-
-  return queryResults
-}
-
-export const useGetTestnetsQuery = (opts?: { skip?: boolean }) => {
-  const queryResults = useGetNetworksRegistryQuery(undefined, {
-    selectFromResult: (res) => ({
-      isLoading: res.isLoading,
-      error: res.error,
-      data: selectTestNetworksFromQueryResult(res)
     }),
     skip: opts?.skip
   })

--- a/components/brave_wallet_ui/common/slices/api.slice.ts
+++ b/components/brave_wallet_ui/common/slices/api.slice.ts
@@ -48,7 +48,8 @@ import {
   selectAllNetworksFromQueryResult,
   selectOffRampNetworksFromQueryResult,
   selectOnRampNetworksFromQueryResult,
-  selectVisibleNetworksFromQueryResult
+  selectVisibleNetworksFromQueryResult,
+  selectTestNetworksFromQueryResult
 } from './entities/network.entity'
 import { AccountInfoEntityState } from './entities/account-info.entity'
 import {
@@ -3634,6 +3635,19 @@ export const useGetNetworksQuery = (opts?: { skip?: boolean }) => {
       isLoading: res.isLoading,
       error: res.error,
       data: selectAllNetworksFromQueryResult(res)
+    }),
+    skip: opts?.skip
+  })
+
+  return queryResults
+}
+
+export const useGetTestnetsQuery = (opts?: { skip?: boolean }) => {
+  const queryResults = useGetNetworksRegistryQuery(undefined, {
+    selectFromResult: (res) => ({
+      isLoading: res.isLoading,
+      error: res.error,
+      data: selectTestNetworksFromQueryResult(res)
     }),
     skip: opts?.skip
   })

--- a/components/brave_wallet_ui/common/slices/entities/network.entity.ts
+++ b/components/brave_wallet_ui/common/slices/entities/network.entity.ts
@@ -88,13 +88,6 @@ export const selectMainnetNetworksFromQueryResult = createDraftSafeSelector(
   (registry) => getEntitiesListFromEntityState(registry, registry.mainnetIds)
 )
 
-export const selectTestNetworksFromQueryResult = createDraftSafeSelector(
-  // inputs
-  [selectNetworksRegistryFromQueryResult],
-  // output
-  (registry) => getEntitiesListFromEntityState(registry, registry.testnetIds)
-)
-
 export const selectOnRampNetworksFromQueryResult = createDraftSafeSelector(
   // inputs
   [selectNetworksRegistryFromQueryResult],

--- a/components/brave_wallet_ui/common/slices/entities/network.entity.ts
+++ b/components/brave_wallet_ui/common/slices/entities/network.entity.ts
@@ -34,6 +34,7 @@ export type NetworksRegistry = ReturnType<
   hiddenIdsByCoinType: Record<BraveWallet.CoinType, EntityId[]>
   idsByCoinType: Record<BraveWallet.CoinType, EntityId[]>
   mainnetIds: string[]
+  testnetIds: string[]
   onRampIds: string[]
   offRampIds: string[]
   visibleIds: string[]
@@ -45,6 +46,7 @@ export const emptyNetworksRegistry: NetworksRegistry = {
   hiddenIdsByCoinType: {},
   idsByCoinType: {},
   mainnetIds: [],
+  testnetIds: [],
   onRampIds: [],
   offRampIds: [],
   visibleIds: []
@@ -84,6 +86,13 @@ export const selectMainnetNetworksFromQueryResult = createDraftSafeSelector(
   [selectNetworksRegistryFromQueryResult],
   // output
   (registry) => getEntitiesListFromEntityState(registry, registry.mainnetIds)
+)
+
+export const selectTestNetworksFromQueryResult = createDraftSafeSelector(
+  // inputs
+  [selectNetworksRegistryFromQueryResult],
+  // output
+  (registry) => getEntitiesListFromEntityState(registry, registry.testnetIds)
 )
 
 export const selectOnRampNetworksFromQueryResult = createDraftSafeSelector(

--- a/components/brave_wallet_ui/page/screens/fund-wallet/deposit-funds.tsx
+++ b/components/brave_wallet_ui/page/screens/fund-wallet/deposit-funds.tsx
@@ -500,7 +500,7 @@ function DepositAccount() {
           )
         : accounts.filter((a) => a.accountId.coin === selectedAsset.coin)
       : []
-  }, [selectedAsset, selectedAssetNetwork, accounts])
+  }, [selectedAsset, accounts])
 
   // search
   const [showAccountSearch, setShowAccountSearch] =
@@ -601,6 +601,12 @@ function DepositAccount() {
     [copyAddressToClipboard]
   )
 
+  // effects
+  React.useEffect(() => {
+    // force selected account option state
+    setSelectedAccount(accountsForSelectedAssetCoinType[0])
+  }, [accountsForSelectedAssetCoinType[0]])
+
   // render
   if (!selectedDepositAssetId) {
     return <Redirect to={WalletRoutes.DepositFundsPageStart} />
@@ -621,7 +627,7 @@ function DepositAccount() {
     )
   }
 
-  if (showAccountSearch) {
+  if (!selectedAccount || showAccountSearch) {
     return (
       <SearchWrapper>
         <SelectHeader
@@ -680,7 +686,7 @@ function DepositAccount() {
         <AddressTextLabel>Address:</AddressTextLabel>
 
         <Row gap={'12px'}>
-          <AddressText>{selectedAccount?.address}</AddressText>
+          <AddressText>{selectedAccount.address}</AddressText>
           <CopyButton
             iconColor={'interactive05'}
             onKeyPress={onCopyKeyPress}

--- a/components/brave_wallet_ui/utils/asset-utils.ts
+++ b/components/brave_wallet_ui/utils/asset-utils.ts
@@ -169,7 +169,8 @@ export const getNativeTokensFromList = (
 export const getBatTokensFromList = (
   tokenList: BraveWallet.BlockchainToken[]
 ) => {
-  // separate BAT from other tokens in the list so they can be placed higher in the list
+  // separate BAT from other tokens in the list so they can be placed higher in
+  // the list
   const { bat, nonBat, testnetAssets } = tokenList.reduce(
     (acc, t) => {
       if (SupportedTestNetworks.includes(t.chainId)) {

--- a/components/brave_wallet_ui/utils/asset-utils.ts
+++ b/components/brave_wallet_ui/utils/asset-utils.ts
@@ -4,7 +4,7 @@
  * You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 // Types
-import * as BraveWallet from 'gen/brave/components/brave_wallet/common/brave_wallet.mojom.m.js'
+import { BraveWallet, SupportedTestNetworks } from '../constants/types'
 
 // utils
 import Amount from './amount'
@@ -169,30 +169,36 @@ export const getNativeTokensFromList = (
 export const getBatTokensFromList = (
   tokenList: BraveWallet.BlockchainToken[]
 ) => {
-  // separate BAT from other tokens in the list so they can be placed higher in
-  // the list
-  const { bat, nonBat } = tokenList.reduce(
+  // separate BAT from other tokens in the list so they can be placed higher in the list
+  const { bat, nonBat, testnetAssets } = tokenList.reduce(
     (acc, t) => {
-      if (
-        t.symbol.toLowerCase() === 'bat' ||
-        t.symbol.toLowerCase() === 'wbat' || // wormhole BAT
-        t.symbol.toLowerCase() === 'bat.e' // Avalanche C-Chain BAT
-      ) {
-        acc.bat.push(t)
+      if (SupportedTestNetworks.includes(t.chainId)) {
+        acc.testnetAssets.push(t)
+        return acc
+      } else {
+        if (
+          t.symbol.toLowerCase() === 'bat' ||
+          t.symbol.toLowerCase() === 'wbat' || // wormhole BAT
+          t.symbol.toLowerCase() === 'bat.e' // Avalanche C-Chain BAT
+        ) {
+          acc.bat.push(t)
+          return acc
+        }
+        acc.nonBat.push(t)
         return acc
       }
-      acc.nonBat.push(t)
-      return acc
     },
     {
       bat: [] as BraveWallet.BlockchainToken[],
-      nonBat: [] as BraveWallet.BlockchainToken[]
+      nonBat: [] as BraveWallet.BlockchainToken[],
+      testnetAssets: [] as BraveWallet.BlockchainToken[]
     }
   )
 
   return {
     bat,
-    nonBat
+    nonBat,
+    testnetAssets
   }
 }
 
@@ -208,12 +214,12 @@ export type GetBlockchainTokenIdArg = Pick<
 export const getAssetIdKey = (
   asset: Pick<
     GetBlockchainTokenIdArg,
-    'contractAddress' | 'chainId' | 'tokenId'
+    'contractAddress' | 'chainId' | 'tokenId' | 'coin'
   >
 ) => {
   return asset.tokenId
-    ? `${asset.contractAddress}-${asset.tokenId}-${asset.chainId}`
-    : `${asset.contractAddress}-${asset.chainId}`
+    ? `${asset.coin}-${asset.contractAddress}-${asset.tokenId}-${asset.chainId}`
+    : `${asset.coin}-${asset.contractAddress}-${asset.chainId}`
 }
 
 export const findTokenByContractAddress = <


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/34065

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-arm64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-x64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

- Testnet FIL should not be an available option when the deposit assets list is filtered to Filecoin mainnet. 
- Testnet FIL deposits should preload a testnet Filecoin address if an account is present during deposit flow
- Mainnet FIL should not be an available option when the deposit assets list is filtered to Filecoin testnet.
- Mainnet FIL deposits should preload a mainnet Filecoin address if an account is present during deposit flow