### PR TITLE
Support variations on Windows first run

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -9,7 +9,7 @@ deps = {
   "vendor/boto": "https://github.com/boto/boto@f7574aa6cc2c819430c1f05e9a1a1a666ef8169b",
   "vendor/python-patch": "https://github.com/brave/python-patch@d8880110be6554686bc08261766538c2926d4e82",
   "vendor/omaha": {
-    "url": "https://github.com/brave/omaha.git@138c95d58f9c41113f7e0dd5acdbcaab8be20df9",
+    "url": "https://github.com/brave/omaha.git@80293cd8212bdb8cc0ad38cf90551b1ee2fcd4c5",
     "condition": "checkout_win",
   },
   "vendor/sparkle": {

--- a/build/commands/lib/config.js
+++ b/build/commands/lib/config.js
@@ -461,6 +461,7 @@ Config.prototype.buildArgs = function () {
   if (process.platform === 'win32' && this.build_omaha) {
     args.build_omaha = this.build_omaha
     args.tag_ap = this.tag_ap
+    args.tag_installdataindex = this.tag_installdataindex
   }
 
   if ((process.platform === 'win32' || process.platform === 'darwin') && this.build_delta_installer) {
@@ -1080,6 +1081,7 @@ Config.prototype.update = function (options) {
   if (process.platform === 'win32' && options.build_omaha) {
     this.build_omaha = true
     this.tag_ap = options.tag_ap
+    this.tag_installdataindex = options.tag_installdataindex
   }
 
   if (options.skip_signing) {

--- a/build/commands/scripts/commands.js
+++ b/build/commands/scripts/commands.js
@@ -214,6 +214,7 @@ program
   .option('--channel <target_channel>', 'target channel to build', /^(beta|dev|nightly|release)$/i)
   .option('--build_omaha', 'build omaha stub/standalone installer')
   .option('--tag_ap <ap>', 'ap for stub/standalone installer')
+  .option('--tag_installdataindex <index>', 'installdataindex for stub/standalone installer')
   .option('--skip_signing', 'skip signing dmg/brave_installer.exe')
   .option('--build_delta_installer', 'build delta mini installer')
   .option('--last_chrome_installer <last_chrome_installer>', 'folder contains previous version uncompressed chrome.7z pack file. This folder should be in out dir.')

--- a/build/config.gni
+++ b/build/config.gni
@@ -32,6 +32,7 @@ declare_args() {
   chrome_version_string = ""
   build_omaha = false
   tag_ap = ""
+  tag_installdataindex = ""
   target_android_base = ""
   target_android_output_format = ""
   brave_android_keystore_path = "."


### PR DESCRIPTION
For https://github.com/brave/brave-browser/issues/34150, to be completed by a [devops PR](https://github.com/brave/devops/pull/10782) that turns on the new implementation.

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-arm64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-x64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

