### PR TITLE
Add chain_id to AddUnapprovedTransaction API

### DIFF
--- a/browser/ui/views/toolbar/wallet_button_notification_source_browsertest.cc
+++ b/browser/ui/views/toolbar/wallet_button_notification_source_browsertest.cc
@@ -186,7 +186,11 @@ IN_PROC_BROWSER_TEST_F(WalletButtonNotificationSourceTest,
             "" /* nonce */, "10" /* gas_premium */, "10" /* gas_fee_cap */,
             "100" /* gas_limit */, "" /* max_fee */, to_account, "11"));
     tx_service()->AddUnapprovedTransaction(
-        std::move(tx_data), from_account->account_id.Clone(),
+        std::move(tx_data),
+        brave_wallet::GetCurrentChainId(browser()->profile()->GetPrefs(),
+                                        brave_wallet::mojom::CoinType::FIL,
+                                        absl::nullopt),
+        from_account->account_id.Clone(),
         base::BindLambdaForTesting([&](bool success, const std::string& id,
                                        const std::string& err_message) {
           first_tx_meta_id = id;
@@ -229,6 +233,9 @@ IN_PROC_BROWSER_TEST_F(WalletButtonNotificationSourceTest,
         std::vector<uint8_t>(), false, absl::nullopt);
     tx_service()->AddUnapprovedTransaction(
         brave_wallet::mojom::TxDataUnion::NewEthTxData(std::move(tx_data)),
+        brave_wallet::GetCurrentChainId(browser()->profile()->GetPrefs(),
+                                        brave_wallet::mojom::CoinType::ETH,
+                                        absl::nullopt),
         from_account->account_id.Clone(),
         base::BindLambdaForTesting([&](bool success, const std::string& id,
                                        const std::string& err_message) {
@@ -262,6 +269,9 @@ IN_PROC_BROWSER_TEST_F(WalletButtonNotificationSourceTest,
 
     tx_service()->AddUnapprovedTransaction(
         brave_wallet::mojom::TxDataUnion::NewSolanaTxData(std::move(tx_data)),
+        brave_wallet::GetCurrentChainId(browser()->profile()->GetPrefs(),
+                                        brave_wallet::mojom::CoinType::SOL,
+                                        absl::nullopt),
         from_account->account_id.Clone(),
         base::BindLambdaForTesting([&](bool success, const std::string& id,
                                        const std::string& err_message) {
@@ -359,7 +369,11 @@ IN_PROC_BROWSER_TEST_F(WalletButtonNotificationSourceTest,
             "" /* nonce */, "10" /* gas_premium */, "10" /* gas_fee_cap */,
             "100" /* gas_limit */, "" /* max_fee */, to_account, "11"));
     tx_service()->AddUnapprovedTransaction(
-        std::move(tx_data), from_account->account_id.Clone(),
+        std::move(tx_data),
+        brave_wallet::GetCurrentChainId(browser()->profile()->GetPrefs(),
+                                        brave_wallet::mojom::CoinType::FIL,
+                                        absl::nullopt),
+        from_account->account_id.Clone(),
         base::BindLambdaForTesting([&](bool success, const std::string& id,
                                        const std::string& err_message) {
           tx_meta_id = id;

--- a/components/brave_wallet/browser/ethereum_provider_impl.cc
+++ b/components/brave_wallet/browser/ethereum_provider_impl.cc
@@ -290,14 +290,14 @@ void EthereumProviderImpl::SendOrSignTransactionInternal(
     tx_data_1559->chain_id = chain->chain_id;
     tx_service_->AddUnapprovedTransactionWithOrigin(
         mojom::TxDataUnion::NewEthTxData1559(std::move(tx_data_1559)),
-        account_id.Clone(), origin,
+        chain->chain_id, account_id.Clone(), origin,
         base::BindOnce(&EthereumProviderImpl::OnAddUnapprovedTransactionAdapter,
                        weak_factory_.GetWeakPtr(), std::move(callback),
                        std::move(id)));
   } else {
     tx_service_->AddUnapprovedTransactionWithOrigin(
         mojom::TxDataUnion::NewEthTxData(std::move(tx_data_1559->base_data)),
-        account_id.Clone(), origin,
+        chain->chain_id, account_id.Clone(), origin,
         base::BindOnce(&EthereumProviderImpl::OnAddUnapprovedTransactionAdapter,
                        weak_factory_.GetWeakPtr(), std::move(callback),
                        std::move(id)));

--- a/components/brave_wallet/browser/solana_provider_impl.cc
+++ b/components/brave_wallet/browser/solana_provider_impl.cc
@@ -522,6 +522,8 @@ void SolanaProviderImpl::SignAndSendTransaction(
 
   tx_service_->AddUnapprovedTransactionWithOrigin(
       mojom::TxDataUnion::NewSolanaTxData(tx.ToSolanaTxData()),
+      json_rpc_service_->GetChainIdSync(mojom::CoinType::SOL,
+                                        delegate_->GetOrigin()),
       account->account_id.Clone(), delegate_->GetOrigin(),
       base::BindOnce(&SolanaProviderImpl::OnAddUnapprovedTransaction,
                      weak_factory_.GetWeakPtr(), std::move(callback)));

--- a/components/brave_wallet/browser/tx_service.cc
+++ b/components/brave_wallet/browser/tx_service.cc
@@ -202,14 +202,17 @@ void TxService::BindFilTxManagerProxy(
 
 void TxService::AddUnapprovedTransaction(
     mojom::TxDataUnionPtr tx_data_union,
+    const std::string& chain_id,
     mojom::AccountIdPtr from,
     AddUnapprovedTransactionCallback callback) {
-  AddUnapprovedTransactionWithOrigin(std::move(tx_data_union), std::move(from),
-                                     absl::nullopt, std::move(callback));
+  AddUnapprovedTransactionWithOrigin(std::move(tx_data_union), chain_id,
+                                     std::move(from), absl::nullopt,
+                                     std::move(callback));
 }
 
 void TxService::AddUnapprovedTransactionWithOrigin(
     mojom::TxDataUnionPtr tx_data_union,
+    const std::string& chain_id,
     mojom::AccountIdPtr from,
     const absl::optional<url::Origin>& origin,
     AddUnapprovedTransactionCallback callback) {
@@ -229,8 +232,7 @@ void TxService::AddUnapprovedTransactionWithOrigin(
 
   auto coin_type = GetCoinTypeFromTxDataUnion(*tx_data_union);
   GetTxManager(coin_type)->AddUnapprovedTransaction(
-      json_rpc_service_->GetChainIdSync(coin_type, origin),
-      std::move(tx_data_union), from, origin, std::move(callback));
+      chain_id, std::move(tx_data_union), from, origin, std::move(callback));
 }
 
 void TxService::ApproveTransaction(mojom::CoinType coin_type,

--- a/components/brave_wallet/browser/tx_service.h
+++ b/components/brave_wallet/browser/tx_service.h
@@ -79,10 +79,12 @@ class TxService : public KeyedService,
 
   // mojom::TxService
   void AddUnapprovedTransaction(mojom::TxDataUnionPtr tx_data_union,
+                                const std::string& chain_id,
                                 mojom::AccountIdPtr from,
                                 AddUnapprovedTransactionCallback) override;
   void AddUnapprovedTransactionWithOrigin(
       mojom::TxDataUnionPtr tx_data_union,
+      const std::string& chain_id,
       mojom::AccountIdPtr from,
       const absl::optional<url::Origin>& origin,
       AddUnapprovedTransactionCallback);

--- a/components/brave_wallet/common/brave_wallet.mojom
+++ b/components/brave_wallet/common/brave_wallet.mojom
@@ -1560,7 +1560,9 @@ interface TxServiceObserver {
 // For transaction management such as creation, broadcasting, and storing
 // transactions.
 interface TxService {
-  AddUnapprovedTransaction(TxDataUnion tx_data_union, AccountId from)
+  AddUnapprovedTransaction(TxDataUnion tx_data_union,
+                           string chain_id,
+                           AccountId from)
     => (bool success, string tx_meta_id, string error_message);
 
   // Used to approve a transaction

--- a/components/brave_wallet_ui/common/async/lib.ts
+++ b/components/brave_wallet_ui/common/async/lib.ts
@@ -318,12 +318,14 @@ export async function sendEthTransaction(payload: SendEthTransactionParams) {
     }
     return await apiProxy.txService.addUnapprovedTransaction(
       toTxDataUnion({ ethTxData1559: txData1559 }),
+      payload.network.chainId,
       payload.fromAccount.accountId
     )
   }
 
   return await apiProxy.txService.addUnapprovedTransaction(
     toTxDataUnion({ ethTxData: txData }),
+    payload.network.chainId,
     payload.fromAccount.accountId
   )
 }
@@ -341,6 +343,7 @@ export async function sendFilTransaction(payload: SendFilTransactionParams) {
   }
   return await apiProxy.txService.addUnapprovedTransaction(
     toTxDataUnion({ filTxData: filTxData }),
+    payload.network.chainId,
     payload.fromAccount.accountId
   )
 }
@@ -354,6 +357,7 @@ export async function sendSolTransaction(payload: SendSolTransactionParams) {
   )
   return await txService.addUnapprovedTransaction(
     toTxDataUnion({ solanaTxData: value.txData ?? undefined }),
+    payload.network.chainId,
     payload.fromAccount.accountId
   )
 }
@@ -375,6 +379,7 @@ export async function sendSolanaSerializedTransaction(
 
   return await txService.addUnapprovedTransaction(
     toTxDataUnion({ solanaTxData: result.txData ?? undefined }),
+    payload.chainId,
     payload.accountId
   )
 }

--- a/components/brave_wallet_ui/common/slices/api.slice.ts
+++ b/components/brave_wallet_ui/common/slices/api.slice.ts
@@ -1791,6 +1791,7 @@ export function createWalletApi() {
                       isEIP1559
                         ? toTxDataUnion({ ethTxData1559: txData1559 })
                         : toTxDataUnion({ ethTxData: txData }),
+                      payload.network.chainId,
                       payload.fromAccount.accountId
                     )
 
@@ -1850,6 +1851,7 @@ export function createWalletApi() {
                   const { errorMessage, success } =
                     await txService.addUnapprovedTransaction(
                       toTxDataUnion({ filTxData: filTxData }),
+                      payload.network.chainId,
                       payload.fromAccount.accountId
                     )
 
@@ -1917,6 +1919,7 @@ export function createWalletApi() {
                   const { errorMessage, success } =
                     await txService.addUnapprovedTransaction(
                       toTxDataUnion({ solanaTxData: txData ?? undefined }),
+                      payload.network.chainId,
                       payload.fromAccount.accountId
                     )
 
@@ -1972,6 +1975,7 @@ export function createWalletApi() {
                   const { errorMessage, success } =
                     await txService.addUnapprovedTransaction(
                       toTxDataUnion({ btcTxData }),
+                      payload.network.chainId,
                       payload.fromAccount.accountId
                     )
 
@@ -2023,6 +2027,7 @@ export function createWalletApi() {
                   const { errorMessage, success } =
                     await txService.addUnapprovedTransaction(
                       toTxDataUnion({ zecTxData }),
+                      payload.network.chainId,
                       payload.fromAccount.accountId
                     )
 
@@ -2226,6 +2231,7 @@ export function createWalletApi() {
                   const { errorMessage, success } =
                     await txService.addUnapprovedTransaction(
                       toTxDataUnion({ solanaTxData: txData }),
+                      payload.network.chainId,
                       payload.fromAccount.accountId
                     )
 

--- a/components/brave_wallet_ui/constants/types.ts
+++ b/components/brave_wallet_ui/constants/types.ts
@@ -387,6 +387,7 @@ export interface SPLTransferFromParams extends BaseTransactionParams {
 
 export interface SolanaSerializedTransactionParams {
   encodedTransaction: string
+  chainId: string
   accountId: BraveWallet.AccountId
   txType: BraveWallet.TransactionType
   sendOptions?: BraveWallet.SolanaSendTransactionOptions

--- a/components/brave_wallet_ui/page/screens/swap/hooks/useJupiter.ts
+++ b/components/brave_wallet_ui/page/screens/swap/hooks/useJupiter.ts
@@ -248,6 +248,7 @@ export function useJupiter(params: SwapParams) {
         const { success, errorMessage } = await sendSolanaSerializedTransaction(
           {
             encodedTransaction: swapTransaction,
+            chainId: selectedNetwork.chainId,
             accountId: selectedAccount.accountId,
             txType: BraveWallet.TransactionType.SolanaSwap,
             sendOptions: {


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/30287

Frontend calls still using selected network atm, this PR is just for enabling the possibility for frontend to update the calls for creating transactions without switching selected network.

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-arm64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-x64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

