### PR TITLE
Add first-party exception list to the correct adblock engine (uplift to 1.60.x)

### DIFF
--- a/components/brave_shields/browser/ad_block_service.cc
+++ b/components/brave_shields/browser/ad_block_service.cc
@@ -338,7 +338,7 @@ AdBlockService::AdBlockService(
       std::make_unique<AdBlockComponentFiltersProvider>(
           component_update_service_, kAdBlockExceptionComponentId,
           kAdBlockExceptionComponentBase64PublicKey,
-          kAdBlockExceptionComponentName);
+          kAdBlockExceptionComponentName, false);
   regional_service_manager_ = std::make_unique<AdBlockRegionalServiceManager>(
       local_state_, locale_, component_update_service_,
       filter_list_catalog_provider_.get());


### PR DESCRIPTION
Uplift of #20826
Resolves https://github.com/brave/brave-browser/issues/34081

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.