### PR TITLE
Reset wallet permissions when wallet is being reset

### DIFF
--- a/browser/brave_wallet/BUILD.gn
+++ b/browser/brave_wallet/BUILD.gn
@@ -76,6 +76,8 @@ source_set("brave_wallet_delegate") {
   sources = [
     "brave_wallet_provider_delegate_impl.cc",
     "brave_wallet_provider_delegate_impl.h",
+    "brave_wallet_service_delegate_base.cc",
+    "brave_wallet_service_delegate_base.h",
     "brave_wallet_service_delegate_helper.cc",
   ]
   deps = [

--- a/browser/brave_wallet/brave_wallet_service_delegate_base.cc
+++ b/browser/brave_wallet/brave_wallet_service_delegate_base.cc
@@ -1,0 +1,63 @@
+/* Copyright (c) 2023 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "brave/browser/brave_wallet/brave_wallet_service_delegate_base.h"
+
+#include "brave/components/brave_wallet/browser/permission_utils.h"
+#include "brave/components/permissions/contexts/brave_wallet_permission_context.h"
+#include "content/public/browser/browser_context.h"
+
+namespace brave_wallet {
+
+BraveWalletServiceDelegateBase::BraveWalletServiceDelegateBase(
+    content::BrowserContext* context)
+    : context_(context) {}
+
+BraveWalletServiceDelegateBase::~BraveWalletServiceDelegateBase() = default;
+
+bool BraveWalletServiceDelegateBase::HasPermission(mojom::CoinType coin,
+                                                   const url::Origin& origin,
+                                                   const std::string& account) {
+  bool has_permission = false;
+  auto type = CoinTypeToPermissionType(coin);
+  if (!type) {
+    return false;
+  }
+
+  bool success = permissions::BraveWalletPermissionContext::HasPermission(
+      *type, context_, origin, account, &has_permission);
+  return success && has_permission;
+}
+
+bool BraveWalletServiceDelegateBase::ResetPermission(
+    mojom::CoinType coin,
+    const url::Origin& origin,
+    const std::string& account) {
+  auto type = CoinTypeToPermissionType(coin);
+  if (!type) {
+    return false;
+  }
+
+  return permissions::BraveWalletPermissionContext::ResetPermission(
+      *type, context_, origin, account);
+}
+
+bool BraveWalletServiceDelegateBase::IsPermissionDenied(
+    mojom::CoinType coin,
+    const url::Origin& origin) {
+  auto type = CoinTypeToPermissionType(coin);
+  if (!type) {
+    return false;
+  }
+
+  return permissions::BraveWalletPermissionContext::IsPermissionDenied(
+      *type, context_, origin);
+}
+
+void BraveWalletServiceDelegateBase::ResetAllPermissions() {
+  permissions::BraveWalletPermissionContext::ResetAllPermissions(context_);
+}
+
+}  // namespace brave_wallet

--- a/browser/brave_wallet/brave_wallet_service_delegate_base.h
+++ b/browser/brave_wallet/brave_wallet_service_delegate_base.h
@@ -1,0 +1,51 @@
+/* Copyright (c) 2023 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_BROWSER_BRAVE_WALLET_BRAVE_WALLET_SERVICE_DELEGATE_BASE_H_
+#define BRAVE_BROWSER_BRAVE_WALLET_BRAVE_WALLET_SERVICE_DELEGATE_BASE_H_
+
+#include <string>
+
+#include "base/memory/raw_ptr.h"
+#include "brave/components/brave_wallet/browser/brave_wallet_service_delegate.h"
+#include "brave/components/brave_wallet/common/brave_wallet.mojom.h"
+
+namespace content {
+class BrowserContext;
+}
+
+namespace url {
+class Origin;
+}
+
+namespace brave_wallet {
+
+// Shared BraveWalletServiceDelegate implementation between Desktop and Android.
+class BraveWalletServiceDelegateBase : public BraveWalletServiceDelegate {
+ public:
+  explicit BraveWalletServiceDelegateBase(content::BrowserContext* context);
+  BraveWalletServiceDelegateBase(const BraveWalletServiceDelegateBase&) =
+      delete;
+  BraveWalletServiceDelegateBase& operator=(
+      const BraveWalletServiceDelegateBase&) = delete;
+  ~BraveWalletServiceDelegateBase() override;
+
+  bool HasPermission(mojom::CoinType coin,
+                     const url::Origin& origin,
+                     const std::string& account) override;
+  bool ResetPermission(mojom::CoinType coin,
+                       const url::Origin& origin,
+                       const std::string& account) override;
+  bool IsPermissionDenied(mojom::CoinType coin,
+                          const url::Origin& origin) override;
+  void ResetAllPermissions() override;
+
+ protected:
+  raw_ptr<content::BrowserContext> context_ = nullptr;
+};
+
+}  // namespace brave_wallet
+
+#endif  // BRAVE_BROWSER_BRAVE_WALLET_BRAVE_WALLET_SERVICE_DELEGATE_BASE_H_

--- a/browser/brave_wallet/brave_wallet_service_delegate_impl.cc
+++ b/browser/brave_wallet/brave_wallet_service_delegate_impl.cc
@@ -51,7 +51,7 @@ void ClearWalletStoragePartition(content::BrowserContext* context,
 
 BraveWalletServiceDelegateImpl::BraveWalletServiceDelegateImpl(
     content::BrowserContext* context)
-    : context_(context),
+    : BraveWalletServiceDelegateBase(context),
       browser_tab_strip_tracker_(this, this),
       weak_ptr_factory_(this) {
   browser_tab_strip_tracker_.Init();
@@ -147,45 +147,6 @@ void BraveWalletServiceDelegateImpl::ContinueGetImportInfoFromExternalWallet(
   } else {
     std::move(callback).Run(false, ImportInfo(), ImportError::kInternalError);
   }
-}
-
-bool BraveWalletServiceDelegateImpl::HasPermission(mojom::CoinType coin,
-                                                   const url::Origin& origin,
-                                                   const std::string& account) {
-  bool has_permission = false;
-  auto type = CoinTypeToPermissionType(coin);
-  if (!type) {
-    return false;
-  }
-
-  bool success = permissions::BraveWalletPermissionContext::HasPermission(
-      *type, context_, origin, account, &has_permission);
-  return success && has_permission;
-}
-
-bool BraveWalletServiceDelegateImpl::ResetPermission(
-    mojom::CoinType coin,
-    const url::Origin& origin,
-    const std::string& account) {
-  auto type = CoinTypeToPermissionType(coin);
-  if (!type) {
-    return false;
-  }
-
-  return permissions::BraveWalletPermissionContext::ResetPermission(
-      *type, context_, origin, account);
-}
-
-bool BraveWalletServiceDelegateImpl::IsPermissionDenied(
-    mojom::CoinType coin,
-    const url::Origin& origin) {
-  auto type = CoinTypeToPermissionType(coin);
-  if (!type) {
-    return false;
-  }
-
-  return permissions::BraveWalletPermissionContext::IsPermissionDenied(
-      *type, context_, origin);
 }
 
 void BraveWalletServiceDelegateImpl::OnTabStripModelChanged(

--- a/browser/brave_wallet/brave_wallet_service_delegate_impl.h
+++ b/browser/brave_wallet/brave_wallet_service_delegate_impl.h
@@ -13,6 +13,7 @@
 #include "base/memory/raw_ptr.h"
 #include "base/memory/weak_ptr.h"
 #include "base/observer_list.h"
+#include "brave/browser/brave_wallet/brave_wallet_service_delegate_base.h"
 #include "brave/browser/brave_wallet/external_wallets_importer.h"
 #include "brave/components/brave_wallet/browser/brave_wallet_service_delegate.h"
 #include "brave/components/brave_wallet/common/brave_wallet.mojom.h"
@@ -27,7 +28,7 @@ class WebContents;
 
 namespace brave_wallet {
 
-class BraveWalletServiceDelegateImpl : public BraveWalletServiceDelegate,
+class BraveWalletServiceDelegateImpl : public BraveWalletServiceDelegateBase,
                                        public TabStripModelObserver,
                                        public BrowserTabStripTrackerDelegate {
  public:
@@ -49,15 +50,6 @@ class BraveWalletServiceDelegateImpl : public BraveWalletServiceDelegate,
   void GetImportInfoFromExternalWallet(mojom::ExternalWalletType type,
                                        const std::string& password,
                                        GetImportInfoCallback callback) override;
-
-  bool HasPermission(mojom::CoinType coin,
-                     const url::Origin& origin,
-                     const std::string& account) override;
-  bool ResetPermission(mojom::CoinType coin,
-                       const url::Origin& origin,
-                       const std::string& account) override;
-  bool IsPermissionDenied(mojom::CoinType coin,
-                          const url::Origin& origin) override;
 
   absl::optional<url::Origin> GetActiveOrigin() override;
 
@@ -92,7 +84,6 @@ class BraveWalletServiceDelegateImpl : public BraveWalletServiceDelegate,
   absl::optional<url::Origin> GetActiveOriginInternal();
   void FireActiveOriginChanged();
 
-  raw_ptr<content::BrowserContext> context_ = nullptr;
   base::flat_map<mojom::ExternalWalletType,
                  std::unique_ptr<ExternalWalletsImporter>>
       importers_;

--- a/browser/brave_wallet/brave_wallet_service_delegate_impl_android.cc
+++ b/browser/brave_wallet/brave_wallet_service_delegate_impl_android.cc
@@ -41,7 +41,7 @@ content::WebContents* GetActiveWebContents(content::BrowserContext* context) {
 
 BraveWalletServiceDelegateImpl::BraveWalletServiceDelegateImpl(
     content::BrowserContext* context)
-    : context_(context), weak_ptr_factory_(this) {}
+    : BraveWalletServiceDelegateBase(context), weak_ptr_factory_(this) {}
 
 BraveWalletServiceDelegateImpl::~BraveWalletServiceDelegateImpl() = default;
 
@@ -55,45 +55,6 @@ bool BraveWalletServiceDelegateImpl::AddPermission(mojom::CoinType coin,
 
   return permissions::BraveWalletPermissionContext::AddPermission(
       *type, context_, origin, account);
-}
-
-bool BraveWalletServiceDelegateImpl::HasPermission(mojom::CoinType coin,
-                                                   const url::Origin& origin,
-                                                   const std::string& account) {
-  bool has_permission = false;
-  auto type = CoinTypeToPermissionType(coin);
-  if (!type) {
-    return false;
-  }
-
-  bool success = permissions::BraveWalletPermissionContext::HasPermission(
-      *type, context_, origin, account, &has_permission);
-  return success && has_permission;
-}
-
-bool BraveWalletServiceDelegateImpl::ResetPermission(
-    mojom::CoinType coin,
-    const url::Origin& origin,
-    const std::string& account) {
-  auto type = CoinTypeToPermissionType(coin);
-  if (!type) {
-    return false;
-  }
-
-  return permissions::BraveWalletPermissionContext::ResetPermission(
-      *type, context_, origin, account);
-}
-
-bool BraveWalletServiceDelegateImpl::IsPermissionDenied(
-    mojom::CoinType coin,
-    const url::Origin& origin) {
-  auto type = CoinTypeToPermissionType(coin);
-  if (!type) {
-    return false;
-  }
-
-  return permissions::BraveWalletPermissionContext::IsPermissionDenied(
-      *type, context_, origin);
 }
 
 void BraveWalletServiceDelegateImpl::GetWebSitesWithPermission(

--- a/browser/brave_wallet/brave_wallet_service_delegate_impl_android.h
+++ b/browser/brave_wallet/brave_wallet_service_delegate_impl_android.h
@@ -13,7 +13,7 @@
 #include "base/memory/weak_ptr.h"
 #include "base/observer_list.h"
 
-#include "brave/components/brave_wallet/browser/brave_wallet_service_delegate.h"
+#include "brave/browser/brave_wallet/brave_wallet_service_delegate_base.h"
 #include "brave/components/brave_wallet/common/brave_wallet.mojom.h"
 
 namespace content {
@@ -24,7 +24,7 @@ namespace brave_wallet {
 
 class ExternalWalletsImporter;
 
-class BraveWalletServiceDelegateImpl : public BraveWalletServiceDelegate {
+class BraveWalletServiceDelegateImpl : public BraveWalletServiceDelegateBase {
  public:
   explicit BraveWalletServiceDelegateImpl(content::BrowserContext* context);
   BraveWalletServiceDelegateImpl(const BraveWalletServiceDelegateImpl&) =
@@ -36,14 +36,6 @@ class BraveWalletServiceDelegateImpl : public BraveWalletServiceDelegate {
   bool AddPermission(mojom::CoinType coin,
                      const url::Origin& origin,
                      const std::string& account) override;
-  bool HasPermission(mojom::CoinType coin,
-                     const url::Origin& origin,
-                     const std::string& account) override;
-  bool ResetPermission(mojom::CoinType coin,
-                       const url::Origin& origin,
-                       const std::string& account) override;
-  bool IsPermissionDenied(mojom::CoinType coin,
-                          const url::Origin& origin) override;
   void GetWebSitesWithPermission(
       mojom::CoinType coin,
       GetWebSitesWithPermissionCallback callback) override;
@@ -53,7 +45,6 @@ class BraveWalletServiceDelegateImpl : public BraveWalletServiceDelegate {
   absl::optional<url::Origin> GetActiveOrigin() override;
 
  private:
-  raw_ptr<content::BrowserContext> context_ = nullptr;
   base::ObserverList<BraveWalletServiceDelegate::Observer> observer_list_;
 
   base::WeakPtrFactory<BraveWalletServiceDelegateImpl> weak_ptr_factory_;

--- a/browser/permissions/brave_wallet_permission_context_unittest.cc
+++ b/browser/permissions/brave_wallet_permission_context_unittest.cc
@@ -151,6 +151,44 @@ TEST_F(BraveWalletPermissionContextUnitTest, ResetPermission) {
   }
 }
 
+TEST_F(BraveWalletPermissionContextUnitTest, ResetAllPermissions) {
+  url::Origin origin = url::Origin::Create(GURL("https://www.brave.com/"));
+  const struct {
+    const char* address;
+    blink::PermissionType type;
+  } cases[] = {{"0x407637cC04893DA7FA4A7C0B58884F82d69eD448",
+                blink::PermissionType::BRAVE_ETHEREUM},
+               {"BrG44HdsEhzapvs8bEqzvkq4egwevS3fRE6ze2ENo6S8",
+                blink::PermissionType::BRAVE_SOLANA}};
+  for (auto entry : cases) {
+    SCOPED_TRACE(entry.address);
+    bool success = permissions::BraveWalletPermissionContext::AddPermission(
+        entry.type, browser_context(), origin, entry.address);
+    EXPECT_TRUE(success);
+
+    // Verify the permission is set
+    bool has_permission;
+    success = permissions::BraveWalletPermissionContext::HasPermission(
+        entry.type, browser_context(), origin, entry.address, &has_permission);
+    EXPECT_TRUE(success);
+    EXPECT_TRUE(has_permission);
+  }
+
+  // Reset all permissions
+  permissions::BraveWalletPermissionContext::ResetAllPermissions(
+      browser_context());
+
+  // Verify permissions are reset
+  for (auto entry : cases) {
+    SCOPED_TRACE(entry.address);
+    bool has_permission;
+    bool success = permissions::BraveWalletPermissionContext::HasPermission(
+        entry.type, browser_context(), origin, entry.address, &has_permission);
+    EXPECT_TRUE(success);
+    EXPECT_FALSE(has_permission);
+  }
+}
+
 TEST_F(BraveWalletPermissionContextUnitTest, GetWebSitesWithPermission) {
   url::Origin origin = url::Origin::Create(GURL("https://www.brave.com/"));
   const struct {

--- a/chromium_src/chrome/browser/permissions/permission_manager_factory.h
+++ b/chromium_src/chrome/browser/permissions/permission_manager_factory.h
@@ -11,6 +11,7 @@
 namespace brave_wallet {
 class EthereumProviderImplUnitTest;
 class SolanaProviderImplUnitTest;
+class BraveWalletServiceUnitTest;
 }  // namespace brave_wallet
 
 namespace permissions {
@@ -22,6 +23,7 @@ class BraveWalletPermissionContextUnitTest;
       content::BrowserContext* profile) const;              \
   friend brave_wallet::EthereumProviderImplUnitTest;        \
   friend brave_wallet::SolanaProviderImplUnitTest;          \
+  friend brave_wallet::BraveWalletServiceUnitTest;          \
   friend permissions::BraveWalletPermissionContextUnitTest; \
   std::unique_ptr<KeyedService> BuildServiceInstanceForBrowserContext
 

--- a/components/brave_wallet/browser/brave_wallet_service.cc
+++ b/components/brave_wallet/browser/brave_wallet_service.cc
@@ -2211,6 +2211,7 @@ void BraveWalletService::OnNetworkChanged() {
 
 void BraveWalletService::Reset() {
   delegate_->ClearWalletUIStoragePartition();
+  delegate_->ResetAllPermissions();
 
   if (eth_allowance_manager_) {
     eth_allowance_manager_->Reset();

--- a/components/brave_wallet/browser/brave_wallet_service.h
+++ b/components/brave_wallet/browser/brave_wallet_service.h
@@ -314,6 +314,10 @@ class BraveWalletService : public KeyedService,
     sign_all_txs_request_added_cb_for_testing_ = std::move(callback);
   }
 
+  BraveWalletServiceDelegate* GetDelegateForTesting() {
+    return delegate_.get();
+  }
+
  protected:
   // For tests
   BraveWalletService();

--- a/components/brave_wallet/browser/brave_wallet_service_delegate.h
+++ b/components/brave_wallet/browser/brave_wallet_service_delegate.h
@@ -65,6 +65,7 @@ class BraveWalletServiceDelegate {
                                const std::string& account);
   virtual bool IsPermissionDenied(mojom::CoinType coin,
                                   const url::Origin& origin);
+  virtual void ResetAllPermissions() {}
   virtual void GetWebSitesWithPermission(
       mojom::CoinType coin,
       GetWebSitesWithPermissionCallback callback);

--- a/components/permissions/contexts/brave_wallet_permission_context.cc
+++ b/components/permissions/contexts/brave_wallet_permission_context.cc
@@ -406,4 +406,12 @@ bool BraveWalletPermissionContext::ResetWebSitePermission(
   return true;
 }
 
+void BraveWalletPermissionContext::ResetAllPermissions(
+    content::BrowserContext* context) {
+  HostContentSettingsMap* map =
+      PermissionsClient::Get()->GetSettingsMap(context);
+  map->ClearSettingsForOneType(ContentSettingsType::BRAVE_ETHEREUM);
+  map->ClearSettingsForOneType(ContentSettingsType::BRAVE_SOLANA);
+}
+
 }  // namespace permissions

--- a/components/permissions/contexts/brave_wallet_permission_context.h
+++ b/components/permissions/contexts/brave_wallet_permission_context.h
@@ -85,6 +85,7 @@ class BraveWalletPermissionContext : public PermissionContextBase {
                               content::BrowserContext* context,
                               const url::Origin& origin,
                               const std::string& account);
+  static void ResetAllPermissions(content::BrowserContext* context);
 
   static std::vector<std::string> GetWebSitesWithPermission(
       blink::PermissionType permission,


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/20966

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-arm64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-x64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
1. Have a profile with existing connected ethereum and solana dApp sites. (Should have entries in brave://settings/content/ethereum and brave://settings/content/solana.)
2. Click `Reset and clear wallet data` in brave://settings/web3
3. brave://settings/content/ethereum and brave://settings/content/solana should now have 0 entries.