### PR TITLE
Disable secondary ABI in Android bundles

### DIFF
--- a/build/android/BUILD.gn
+++ b/build/android/BUILD.gn
@@ -18,7 +18,7 @@ action("sign_app_convert_aab_to_apk") {
 
   deps = [ ":sign_app" ]
 
-  target_aab_path = "$root_out_dir/apks/MonochromePublic6432.aab"
+  target_aab_path = "$root_out_dir/apks/MonochromePublic64.aab"
   output_apk_path = "$root_out_dir/apks/Bravearm64Universal.apk"
   output_path = "$root_out_dir/apks/"
   bundletool = "//third_party/android_build_tools/bundletool/bundletool.jar"
@@ -47,7 +47,7 @@ action("sign_app") {
 
   if (target_cpu == "arm64" || target_cpu == "x64") {
     if (target_android_output_format == "aab") {
-      target_sign_app_path = "$root_out_dir/apks/MonochromePublic6432.aab"
+      target_sign_app_path = "$root_out_dir/apks/MonochromePublic64.aab"
     } else {
       target_sign_app_path = "$root_out_dir/apks/MonochromePublic.apk"
     }
@@ -88,8 +88,8 @@ copy("brave") {
   sources = []
   if (target_cpu == "arm64" || target_cpu == "x64") {
     if (target_android_output_format == "aab") {
-      deps += [ "//chrome/android:monochrome_64_32_public_bundle" ]
-      sources += [ "$root_out_dir/apks/MonochromePublic6432.aab" ]
+      deps += [ "//chrome/android:monochrome_64_public_bundle" ]
+      sources += [ "$root_out_dir/apks/MonochromePublic64.aab" ]
     } else {
       # There is no 64-bit apk target for Mono
       deps += [ "//chrome/android:monochrome_public_apk" ]

--- a/patches/chrome-android-chrome_public_apk_tmpl.gni.patch
+++ b/patches/chrome-android-chrome_public_apk_tmpl.gni.patch
@@ -1,5 +1,5 @@
 diff --git a/chrome/android/chrome_public_apk_tmpl.gni b/chrome/android/chrome_public_apk_tmpl.gni
-index 13ab7ec536d429e3444ab640c790b51af183be33..e9dbce7b59158cfd76a62bae84f8f5c4a118fb19 100644
+index 13ab7ec536d429e3444ab640c790b51af183be33..90da902b31d995ab8626b03b99426763f2f331bd 100644
 --- a/chrome/android/chrome_public_apk_tmpl.gni
 +++ b/chrome/android/chrome_public_apk_tmpl.gni
 @@ -309,6 +309,7 @@ template("chrome_common_apk_or_module_tmpl") {
@@ -22,7 +22,7 @@ index 13ab7ec536d429e3444ab640c790b51af183be33..e9dbce7b59158cfd76a62bae84f8f5c4
                                   "version_code",
                                   "version_name",
                                 ])
-+    _wireguard_target = "//brave/third_party/android_deps:com_wireguard_android_J__unpack_aar" deps += [ _wireguard_target] _libwireguard_dir = get_label_info("//brave/third_party/android_deps:com_wireguard_android($default_toolchain)","target_out_dir") + "/com_wireguard_android_java/jni" if (android_64bit_target_cpu) {loadable_modules +=[ "$_libwireguard_dir/$android_app_abi/libwg-go.so" ] secondary_abi_loadable_modules +=[ "$_libwireguard_dir/$android_app_secondary_abi/libwg-go.so" ]} else {loadable_modules +=[ "$_libwireguard_dir/$android_app_abi/libwg-go.so" ]}
++    _wireguard_target = "//brave/third_party/android_deps:com_wireguard_android_J__unpack_aar" deps += [ _wireguard_target] _libwireguard_dir = get_label_info("//brave/third_party/android_deps:com_wireguard_android($default_toolchain)","target_out_dir") + "/com_wireguard_android_java/jni" loadable_modules +=[ "$_libwireguard_dir/$android_app_abi/libwg-go.so" ]
    }
  }
  


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/34126

This PR is another attempt to reduce the app size after failed https://github.com/brave/brave-core/pull/19592 .

The main change - is build of `//chrome/android:monochrome_64_public_bundle` instead of `//chrome/android:monochrome_64_32_public_bundle` plus fixups for signing paths and omit include of 32-bit wireguard libs for 64-bit bundle.

It was tested manually at internal test track for Nightly.
Versions `1.62.200`-`1.62.204`.
In worse case this PR can be reverted and the app can still be upgraded to pre-PR aab version.
The size gain is ~40..50 MB of download size and 80..100MB for installed size of the storage, see the screenshots below.

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-arm64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-x64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] TBD Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [X] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Size comparison



Device|Before PR|with PR
--|--|--
|Emulator Intel x64|![Screenshot from 2023-11-03 20-12-40](https://github.com/brave/brave-core/assets/24739341/28f42ff0-a2e6-43cd-8ad7-40f6a7265e20)|![Screenshot from 2023-11-03 21-26-27](https://github.com/brave/brave-core/assets/24739341/5a0cbfbf-8681-4e55-a7d9-e7a0bf3c9bfe)|
|App info - storage|![Screenshot from 2023-11-03 20-13-57](https://github.com/brave/brave-core/assets/24739341/3b66f754-ff33-49f1-ba2a-cc0bcdf1ed88)|![Screenshot from 2023-11-03 21-28-43](https://github.com/brave/brave-core/assets/24739341/af58b8f2-0b3a-44a0-90a7-a28cdbb2fb4a)|
|Real device arm64|![Screenshot_20231103-201455](https://github.com/brave/brave-core/assets/24739341/5e3a8105-1dea-40bd-9b6f-9c8699567906)|![Screenshot_20231103-212932](https://github.com/brave/brave-core/assets/24739341/28516c98-f937-4f0d-90b8-c00c29aa717d)|
|App info - storage|![Screenshot_20231103-201836](https://github.com/brave/brave-core/assets/24739341/11e22cd1-163a-41e2-8868-bdc74f0f48af)|![Screenshot_20231103-214039](https://github.com/brave/brave-core/assets/24739341/c869bdb6-1ebd-4ac3-97cd-20666917d101)|







## Test Plan:

I. Main line

0. Wait till CI bot will build upload Nightly with this PR into GP. This is the most important step. Manual upload into the internal testing track succeeded, but we need to ensure it will succeed for the production Nightly track.
1. Ensure you can update Nightly build with the one from GP which contains this PR.
2. Uninstall Nightly build and install from scratch from GP the one containing this PR.

II. Universal apk is not broken
1. Build universal apk
```
npm run create_dist -- Release --target_os=android --target_arch=arm64 --target_android_output_format=aab --target_android_base=mono --channel=nightly --android_aab_to_apk
```
2. Install universal apk
```
./src/third_party/android_sdk/public/platform-tools/adb   install ./src/out/android_Release_arm64/apks/Bravearm64Universal.apk
```
