### PR TITLE
Fix misaligned new tab icon in updated horizontal tabs (uplift to 1.61.x)

### DIFF
--- a/browser/ui/views/tabs/brave_new_tab_button.cc
+++ b/browser/ui/views/tabs/brave_new_tab_button.cc
@@ -84,8 +84,7 @@ void BraveNewTabButton::PaintIcon(gfx::Canvas* canvas) {
     // the canvas in the center of the view.
     constexpr int kIconSize = 16;
     gfx::Rect bounds = GetContentsBounds();
-    canvas->Translate(bounds.OffsetFromOrigin() +
-                      gfx::Vector2d((bounds.width() - kIconSize) / 2,
+    canvas->Translate(gfx::Vector2d((bounds.width() - kIconSize) / 2,
                                     (bounds.height() - kIconSize) / 2));
     gfx::PaintVectorIcon(canvas, kLeoPlusAddIcon, kIconSize,
                          GetForegroundColor());


### PR DESCRIPTION
Uplift of #20724
Resolves https://github.com/brave/brave-browser/issues/33976

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.