### PR TITLE
[Brave News]: Add `Following` feed

### DIFF
--- a/components/brave_news/browser/brave_news_controller.cc
+++ b/components/brave_news/browser/brave_news_controller.cc
@@ -192,6 +192,15 @@ void BraveNewsController::GetFeed(GetFeedCallback callback) {
   feed_controller_.GetOrFetchFeed(std::move(callback));
 }
 
+void BraveNewsController::GetFollowingFeed(GetFollowingFeedCallback callback) {
+  if (!MaybeInitFeedV2()) {
+    std::move(callback).Run(mojom::FeedV2::New());
+    return;
+  }
+
+  feed_v2_builder_->BuildFollowingFeed(std::move(callback));
+}
+
 void BraveNewsController::GetChannelFeed(const std::string& channel,
                                          GetChannelFeedCallback callback) {
   if (!MaybeInitFeedV2()) {

--- a/components/brave_news/browser/brave_news_controller.h
+++ b/components/brave_news/browser/brave_news_controller.h
@@ -93,6 +93,7 @@ class BraveNewsController : public KeyedService,
   // mojom::BraveNewsController
   void GetLocale(GetLocaleCallback callback) override;
   void GetFeed(GetFeedCallback callback) override;
+  void GetFollowingFeed(GetFollowingFeedCallback callback) override;
   void GetChannelFeed(const std::string& channel,
                       GetChannelFeedCallback callback) override;
   void GetPublisherFeed(const std::string& publisher_id,

--- a/components/brave_news/browser/feed_v2_builder.h
+++ b/components/brave_news/browser/feed_v2_builder.h
@@ -49,6 +49,7 @@ class FeedV2Builder {
 
   void AddListener(mojo::PendingRemote<mojom::FeedListener> listener);
 
+  void BuildFollowingFeed(BuildFeedCallback callback);
   void BuildChannelFeed(const std::string& channel, BuildFeedCallback callback);
   void BuildPublisherFeed(const std::string& publisher_id,
                           BuildFeedCallback callback);
@@ -125,6 +126,7 @@ class FeedV2Builder {
                     base::OnceCallback<mojom::FeedV2Ptr()> build_feed,
                     BuildFeedCallback callback);
 
+  mojom::FeedV2Ptr GenerateBasicFeed(const FeedItems& items);
   mojom::FeedV2Ptr GenerateAllFeed();
 
   raw_ref<PublishersController> publishers_controller_;

--- a/components/brave_news/browser/resources/FeedNavigation.tsx
+++ b/components/brave_news/browser/resources/FeedNavigation.tsx
@@ -130,6 +130,7 @@ export default function Sidebar() {
   return <Container>
     <Heading>My Feed</Heading>
     <Item id='all' name="All" />
+    <Item id='following' name="Following" />
     <Section open>
       <summary>
         {Marker}

--- a/components/brave_news/browser/resources/feed/Ad.tsx
+++ b/components/brave_news/browser/resources/feed/Ad.tsx
@@ -2,7 +2,7 @@
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this file,
 // You can obtain one at https://mozilla.org/MPL/2.0/.
-import SecureLink, { validateScheme } from '$web-common/SecureLink';
+import SecureLink, { handleOpenURLClick } from '$web-common/SecureLink';
 import { useOnVisibleCallback } from '$web-common/useVisible';
 import VisibilityTimer from '$web-common/visibilityTimer';
 import Button from '@brave/leo/react/button';
@@ -41,11 +41,6 @@ const CtaButton = styled(Button)`
   align-self: flex-start;
 `
 
-const openLink = (link: string) => {
-  validateScheme(link)
-  window.location.href = link
-}
-
 export const useVisibleFor = (callback: () => void, timeout: number) => {
   const [el, setEl] = React.useState<HTMLElement | null>(null)
   const callbackRef = React.useRef<() => void>()
@@ -82,12 +77,12 @@ export default function Advert(props: Props) {
 
   const { setEl: setAdEl } = useVisibleFor(onDisplayAdViewed, 1000)
 
-  const onDisplayAdVisited = React.useCallback(async () => {
+  const onDisplayAdVisited = React.useCallback(async (e: React.MouseEvent) => {
     if (!advert) return
 
     console.debug(`Brave News: Visited display ad: ${advert.uuid}`)
     await getBraveNewsController().onDisplayAdVisit(advert.uuid, advert.creativeInstanceId)
-    openLink(advert.targetUrl.url)
+    handleOpenURLClick(advert.targetUrl.url, e);
   }, [advert])
 
   const { setElementRef: setTriggerRef } = useOnVisibleCallback(async () => {
@@ -101,7 +96,7 @@ export default function Advert(props: Props) {
   })
 
   // Advert is null if we didn't manage to load an advertisement
-  if (advert === null) return null
+  if (advert === null) return <div style={{color: 'white'}}>Advert</div>
 
   // Otherwise, render a placeholder div - when close to the viewport we'll
   // request an ad.

--- a/components/brave_news/browser/resources/feed/Article.tsx
+++ b/components/brave_news/browser/resources/feed/Article.tsx
@@ -3,9 +3,9 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this file,
 // You can obtain one at https://mozilla.org/MPL/2.0/.
 import Flex from '$web-common/Flex';
-import SecureLink, { validateScheme } from '$web-common/SecureLink';
+import SecureLink, { linkClickHandler } from '$web-common/SecureLink';
 import { spacing } from '@brave/leo/tokens/css';
-import { FeedItemMetadata, Article as Info } from 'gen/brave/components/brave_news/common/brave_news.mojom.m';
+import { Article as Info } from 'gen/brave/components/brave_news/common/brave_news.mojom.m';
 import * as React from 'react';
 import styled from 'styled-components';
 import { useLazyUnpaddedImageUrl } from '../shared/useUnpaddedImageUrl';
@@ -22,21 +22,15 @@ const Container = styled(Card)`
   flex-direction: column;
 `
 
-export const openArticle = (article: FeedItemMetadata) => {
-  const href = article.url.url
-  validateScheme(href)
-  window.location.href = href
-}
-
 export default function Article({ info, hideChannel }: Props) {
   const { url: imageUrl, setElementRef } = useLazyUnpaddedImageUrl(info.data.image.paddedImageUrl?.url ?? info.data.image.imageUrl?.url, { useCache: true })
   const url = info.data.url.url;
 
-  return <Container ref={setElementRef} onClick={() => openArticle(info.data)}>
+  return <Container ref={setElementRef} onClick={linkClickHandler(url)}>
     <ArticleMetaRow article={info.data} hideChannel={hideChannel} />
     <Flex direction='row' gap={spacing.m} justify='space-between'>
       <Title>
-        <SecureLink href={url}>{info.data.title}{('isDiscover' in info && info.isDiscover) && " (discovering)"}</SecureLink>
+        <SecureLink onClick={e => e.stopPropagation()} href={url}>{info.data.title}{('isDiscover' in info && info.isDiscover) && " (discovering)"}</SecureLink>
       </Title>
       <SmallImage src={imageUrl} />
     </Flex>

--- a/components/brave_news/browser/resources/feed/Hero.tsx
+++ b/components/brave_news/browser/resources/feed/Hero.tsx
@@ -2,11 +2,10 @@
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this file,
 // You can obtain one at https://mozilla.org/MPL/2.0/.
-import SecureLink from '$web-common/SecureLink';
+import SecureLink, { linkClickHandler } from '$web-common/SecureLink';
 import { HeroArticle as Info } from 'gen/brave/components/brave_news/common/brave_news.mojom.m';
 import * as React from 'react';
 import { useLazyUnpaddedImageUrl } from '../shared/useUnpaddedImageUrl';
-import { openArticle } from './Article';
 import ArticleMetaRow from './ArticleMetaRow';
 import Card, { LargeImage, Title } from './Card';
 
@@ -20,11 +19,11 @@ export default function HeroArticle({ info }: Props) {
     rootElement: document.body,
     rootMargin: '0px 0px 200px 0px'
   })
-  return <Card onClick={() => openArticle(info.data)} ref={setElementRef}>
+  return <Card onClick={linkClickHandler(info.data.url.url)} ref={setElementRef}>
     <LargeImage src={url} />
     <ArticleMetaRow article={info.data} />
     <Title>
-      <SecureLink href={info.data.url.url}>{info.data.title}</SecureLink>
+      <SecureLink onClick={e => e.stopPropagation()} href={info.data.url.url}>{info.data.title}</SecureLink>
     </Title>
   </Card>
 }

--- a/components/brave_news/browser/resources/shared/useFeedV2.ts
+++ b/components/brave_news/browser/resources/shared/useFeedV2.ts
@@ -7,7 +7,7 @@ import usePromise from "$web-common/usePromise";
 import { useEffect, useState } from "react";
 import getBraveNewsController, { FeedV2, FeedV2Type } from "./api";
 
-export type FeedView = 'all' | `publishers/${string}` | `channels/${string}`
+export type FeedView = 'all' | 'following' | `publishers/${string}` | `channels/${string}`
 
 const feedTypeToFeedView = (type: FeedV2Type | undefined): FeedView => {
   if (type?.channel) return `channels/${type.channel.channel}`
@@ -53,6 +53,8 @@ export const useFeedV2 = () => {
       promise = getBraveNewsController().getPublisherFeed(feedView.split('/')[1]);
     } else if (feedView.startsWith('channels/')) {
       promise = getBraveNewsController().getChannelFeed(feedView.split('/')[1])
+    } else if (feedView === 'following') {
+      promise = getBraveNewsController().getFollowingFeed()
     } else {
       promise = getBraveNewsController().getFeedV2()
     }

--- a/components/brave_news/common/brave_news.mojom
+++ b/components/brave_news/common/brave_news.mojom
@@ -194,6 +194,7 @@ union FeedItemV2 {
 };
 
 struct FeedV2AllType {};
+struct FeedV2FollowingType {};
 struct FeedV2PublisherType {
   string publisher_id;
 };
@@ -202,6 +203,7 @@ struct FeedV2ChannelType {
 };
 union FeedV2Type {
   FeedV2AllType all;
+  FeedV2FollowingType following;
   FeedV2PublisherType publisher;
   FeedV2ChannelType channel;
 };
@@ -265,6 +267,7 @@ interface BraveNewsController {
   GetLocale() => (string locale);
 
   GetFeed() => (Feed feed);
+  GetFollowingFeed() => (FeedV2 feed);
   GetChannelFeed(string channel) => (FeedV2 feed);
   GetPublisherFeed(string publisher_id) => (FeedV2 feed);
   GetFeedV2() => (FeedV2 feed);

--- a/components/common/SecureLink.tsx
+++ b/components/common/SecureLink.tsx
@@ -21,6 +21,31 @@ export const validateScheme = (href: string | undefined, allowedSchemes: string[
 }
 
 /**
+ * Endeavors to do the right thing when triggering a link via a mouse click.
+ * Left click should open the link in the current tab, while
+ * Control/Command/Middle click should open the link in a new tab.
+ * @param href The href to open
+ * @param e The mouse event
+ */
+export const handleOpenURLClick = (href: string | undefined, e: React.MouseEvent) => {
+  validateScheme(href)
+
+  // Control click, command click or middle click
+  if (e.ctrlKey || e.metaKey || e.buttons & 4) {
+    window.open(href, '_blank', 'noopener noreferrer')
+  } else {
+    window.location.href = href!
+  }
+}
+
+/**
+ * A curried version of handleOpenURLClick, for use in React event handlers.
+ * @param href The href the click handler should open
+ * @returns A click event handler
+ */
+export const linkClickHandler = (href: string | undefined) => (e: React.MouseEvent) => handleOpenURLClick(href, e)
+
+/**
  * Identical to the `a` element, except that it validates the HREF points
  * to an allowed scheme. By default, allowed schemes are http: or https:,
  * but this can be overridden.


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/34143

In addition:
- Use Block ranking for Channel feeds
- Don't include Discover articles in Channel blocks
- Fixes for Link click handling (enabling Control/Command/Middle click for open in new tab)

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-arm64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-x64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [ ] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

